### PR TITLE
feat(telegram): add proxy support

### DIFF
--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -42,7 +42,7 @@ func New(opts map[string]any) (core.Platform, error) {
 	allowFrom, _ := opts["allow_from"].(string)
 
 	// Build HTTP client with optional proxy support
-	transport := &http.Transport{}
+	httpClient := &http.Client{Timeout: 60 * time.Second}
 	if proxyURL, _ := opts["proxy"].(string); proxyURL != "" {
 		u, err := url.Parse(proxyURL)
 		if err != nil {
@@ -53,10 +53,9 @@ func New(opts map[string]any) (core.Platform, error) {
 		if proxyUser != "" {
 			u.User = url.UserPassword(proxyUser, proxyPass)
 		}
-		transport.Proxy = http.ProxyURL(u)
+		httpClient.Transport = &http.Transport{Proxy: http.ProxyURL(u)}
 		slog.Info("telegram: using proxy", "proxy", u.Host, "auth", proxyUser != "")
 	}
-	httpClient := &http.Client{Timeout: 60 * time.Second, Transport: transport}
 
 	return &Platform{token: token, allowFrom: allowFrom, httpClient: httpClient}, nil
 }


### PR DESCRIPTION
## Summary

Add proxy support for the Telegram platform, so users behind firewalls or in restricted networks can connect to the Telegram Bot API through an HTTP or SOCKS5 proxy.

Follows the same approach already used by the wecom platform.

### Changes

- `platform/telegram/telegram.go`: use `NewBotAPIWithClient` with a custom `http.Client` that respects proxy settings; also route file downloads through the same client

### Config

```toml
[[projects.platforms]]
type = "telegram"

[projects.platforms.options]
token = "your-bot-token"
proxy = "http://proxy.example.com:8080"      # or socks5://...
proxy_username = "user"                       # optional
proxy_password = "pass"                       # optional
```

Without `proxy` set, behavior is unchanged (direct connection).

Closes #6