### PR TITLE
feat(session): support per-session workdir and /delete command

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -31,14 +31,15 @@ func init() {
 //   - "plan":              plan only, no execution until approved
 //   - "bypassPermissions": auto-approve everything (YOLO mode)
 type Agent struct {
-	workDir      string
-	model        string
-	mode         string // "default" | "acceptEdits" | "plan" | "bypassPermissions"
-	allowedTools []string
-	providers    []core.ProviderConfig
-	activeIdx    int // -1 = no provider set
-	sessionEnv   []string
-	mu           sync.Mutex
+	workDir         string
+	overrideWorkDir string // per-session override, cleared after use
+	model           string
+	mode            string // "default" | "acceptEdits" | "plan" | "bypassPermissions"
+	allowedTools    []string
+	providers       []core.ProviderConfig
+	activeIdx       int // -1 = no provider set
+	sessionEnv      []string
+	mu              sync.Mutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -190,9 +191,27 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 			model = m
 		}
 	}
+	dir := a.workDir
+	if a.overrideWorkDir != "" {
+		dir = a.overrideWorkDir
+	}
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, a.workDir, model, sessionID, a.mode, tools, extraEnv)
+	return newClaudeSession(ctx, dir, model, sessionID, a.mode, tools, extraEnv)
+}
+
+// SetWorkDir sets a per-session working directory override.
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = dir
+}
+
+// ResetWorkDir clears the per-session working directory override.
+func (a *Agent) ResetWorkDir() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = ""
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -28,13 +28,14 @@ func init() {
 //   - "full-auto": --full-auto (sandbox-protected auto execution)
 //   - "yolo":      --dangerously-bypass-approvals-and-sandbox
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string // "suggest" | "auto-edit" | "full-auto" | "yolo"
-	providers  []core.ProviderConfig
-	activeIdx  int // -1 = no provider set
-	sessionEnv []string
-	mu         sync.Mutex
+	workDir         string
+	overrideWorkDir string // per-session override, cleared after use
+	model           string
+	mode            string // "suggest" | "auto-edit" | "full-auto" | "yolo"
+	providers       []core.ProviderConfig
+	activeIdx       int // -1 = no provider set
+	sessionEnv      []string
+	mu              sync.Mutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -183,9 +184,27 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 			model = m
 		}
 	}
+	dir := a.workDir
+	if a.overrideWorkDir != "" {
+		dir = a.overrideWorkDir
+	}
 	a.mu.Unlock()
 
-	return newCodexSession(ctx, a.workDir, model, mode, sessionID, extraEnv)
+	return newCodexSession(ctx, dir, model, mode, sessionID, extraEnv)
+}
+
+// SetWorkDir sets a per-session working directory override.
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = dir
+}
+
+// ResetWorkDir clears the per-session working directory override.
+func (a *Agent) ResetWorkDir() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = ""
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -30,14 +30,15 @@ func init() {
 //   - "plan":     --trust --mode plan (read-only analysis)
 //   - "ask":      --trust --mode ask (Q&A style, read-only)
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string
-	cmd        string // CLI binary name, default "agent"
-	providers  []core.ProviderConfig
-	activeIdx  int
-	sessionEnv []string
-	mu         sync.Mutex
+	workDir         string
+	overrideWorkDir string // per-session override, cleared after use
+	model           string
+	mode            string
+	cmd             string // CLI binary name, default "agent"
+	providers       []core.ProviderConfig
+	activeIdx       int
+	sessionEnv      []string
+	mu              sync.Mutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -122,9 +123,13 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 			model = m
 		}
 	}
+	dir := a.workDir
+	if a.overrideWorkDir != "" {
+		dir = a.overrideWorkDir
+	}
 	a.mu.Unlock()
 
-	return newCursorSession(ctx, cmd, a.workDir, model, mode, sessionID, extraEnv)
+	return newCursorSession(ctx, cmd, dir, model, mode, sessionID, extraEnv)
 }
 
 // ListSessions reads sessions from ~/.cursor/chats/<workspace_hash>/.
@@ -133,6 +138,20 @@ func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error)
 }
 
 func (a *Agent) Stop() error { return nil }
+
+// SetWorkDir sets a per-session working directory override.
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = dir
+}
+
+// ResetWorkDir clears the per-session working directory override.
+func (a *Agent) ResetWorkDir() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = ""
+}
 
 // ── SkillProvider implementation ──────────────────────────────
 

--- a/agent/gemini/gemini.go
+++ b/agent/gemini/gemini.go
@@ -30,14 +30,15 @@ func init() {
 //   - "yolo":      auto-approve all tools (-y / --approval-mode yolo)
 //   - "plan":      read-only plan mode (--approval-mode plan)
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string
-	cmd        string // CLI binary name, default "gemini"
-	providers  []core.ProviderConfig
-	activeIdx  int
-	sessionEnv []string
-	mu         sync.Mutex
+	workDir         string
+	overrideWorkDir string // per-session override, cleared after use
+	model           string
+	mode            string
+	cmd             string // CLI binary name, default "gemini"
+	providers       []core.ProviderConfig
+	activeIdx       int
+	sessionEnv      []string
+	mu              sync.Mutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -165,6 +166,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	mode := a.mode
 	cmd := a.cmd
 	workDir := a.workDir
+	if a.overrideWorkDir != "" {
+		workDir = a.overrideWorkDir
+	}
 	extraEnv := a.providerEnvLocked()
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
@@ -183,6 +187,20 @@ func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error)
 }
 
 func (a *Agent) Stop() error { return nil }
+
+// SetWorkDir sets a per-session working directory override.
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = dir
+}
+
+// ResetWorkDir clears the per-session working directory override.
+func (a *Agent) ResetWorkDir() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = ""
+}
 
 // ── ModeSwitcher ────────────────────────────────────────────────
 

--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -24,14 +24,15 @@ func init() {
 //   - "default": standard mode
 //   - "yolo":    auto mode (opencode run is auto by default in non-interactive mode)
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string
-	cmd        string // CLI binary name, default "opencode"
-	providers  []core.ProviderConfig
-	activeIdx  int
-	sessionEnv []string
-	mu         sync.Mutex
+	workDir         string
+	overrideWorkDir string // per-session override, cleared after use
+	model           string
+	mode            string
+	cmd             string // CLI binary name, default "opencode"
+	providers       []core.ProviderConfig
+	activeIdx       int
+	sessionEnv      []string
+	mu              sync.Mutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -105,6 +106,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	mode := a.mode
 	cmd := a.cmd
 	workDir := a.workDir
+	if a.overrideWorkDir != "" {
+		workDir = a.overrideWorkDir
+	}
 	extraEnv := a.providerEnvLocked()
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
@@ -123,6 +127,20 @@ func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error)
 }
 
 func (a *Agent) Stop() error { return nil }
+
+// SetWorkDir sets a per-session working directory override.
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = dir
+}
+
+// ResetWorkDir clears the per-session working directory override.
+func (a *Agent) ResetWorkDir() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = ""
+}
 
 // -- ModeSwitcher --
 

--- a/agent/qoder/qoder.go
+++ b/agent/qoder/qoder.go
@@ -19,11 +19,12 @@ func init() {
 
 // Agent drives Qoder CLI using `qodercli -p <prompt> -f stream-json`.
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string // "default" | "yolo"
-	sessionEnv []string
-	mu         sync.Mutex
+	workDir         string
+	overrideWorkDir string // per-session override, cleared after use
+	model           string
+	mode            string // "default" | "yolo"
+	sessionEnv      []string
+	mu              sync.Mutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -90,10 +91,14 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	a.mu.Lock()
 	mode := a.mode
 	model := a.model
+	dir := a.workDir
+	if a.overrideWorkDir != "" {
+		dir = a.overrideWorkDir
+	}
 	extraEnv := append([]string{}, a.sessionEnv...)
 	a.mu.Unlock()
 
-	return newQoderSession(ctx, a.workDir, model, mode, sessionID, extraEnv)
+	return newQoderSession(ctx, dir, model, mode, sessionID, extraEnv)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
@@ -101,6 +106,20 @@ func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error)
 }
 
 func (a *Agent) Stop() error { return nil }
+
+// SetWorkDir sets a per-session working directory override.
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = dir
+}
+
+// ResetWorkDir clears the per-session working directory override.
+func (a *Agent) ResetWorkDir() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.overrideWorkDir = ""
+}
 
 // ── ModeSwitcher ─────────────────────────────────────────────
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -527,6 +527,14 @@ func (e *Engine) getOrCreateInteractiveState(sessionKey string, p Platform, repl
 		inj.SetSessionEnv(envVars)
 	}
 
+	// Apply per-session working directory override if available.
+	if session.WorkDir != "" {
+		if wdo, ok := e.agent.(WorkDirOverrider); ok {
+			wdo.SetWorkDir(session.WorkDir)
+			defer wdo.ResetWorkDir()
+		}
+	}
+
 	startAt := time.Now()
 	agentSession, err := e.agent.StartSession(e.ctx, session.AgentSessionID)
 	startElapsed := time.Since(startAt)
@@ -732,6 +740,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) {
 		e.cmdList(p, msg)
 	case "/switch":
 		e.cmdSwitch(p, msg, args)
+	case "/delete":
+		e.cmdDelete(p, msg, args)
 	case "/current":
 		e.cmdCurrent(p, msg)
 	case "/status":
@@ -786,57 +796,154 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) {
 
 func (e *Engine) cmdNew(p Platform, msg *Message, args []string) {
 	e.cleanupInteractiveState(msg.SessionKey)
+
 	name := "session"
+	workDir := ""
+
 	if len(args) > 0 {
-		name = strings.Join(args, " ")
+		arg := strings.Join(args, " ")
+		// Detect if the argument is a directory path
+		if strings.HasPrefix(arg, "/") || strings.HasPrefix(arg, ".") || strings.HasPrefix(arg, "~") {
+			// Expand ~ to home directory
+			expanded := arg
+			if strings.HasPrefix(expanded, "~") {
+				if home, err := os.UserHomeDir(); err == nil {
+					expanded = filepath.Join(home, expanded[1:])
+				}
+			}
+			absPath, err := filepath.Abs(expanded)
+			if err == nil {
+				if info, statErr := os.Stat(absPath); statErr == nil && info.IsDir() {
+					workDir = absPath
+					name = filepath.Base(absPath)
+				} else {
+					e.reply(p, msg.ReplyCtx, fmt.Sprintf("❌ Directory not found: %s", arg))
+					return
+				}
+			} else {
+				e.reply(p, msg.ReplyCtx, fmt.Sprintf("❌ Invalid path: %s", arg))
+				return
+			}
+		} else {
+			name = arg
+		}
 	}
-	s := e.sessions.NewSession(msg.SessionKey, name)
-	e.reply(p, msg.ReplyCtx,
-		fmt.Sprintf("✅ New session created: %s (id: %s)", s.Name, s.ID))
+
+	var s *Session
+	if workDir != "" {
+		s = e.sessions.NewSessionWithWorkDir(msg.SessionKey, name, workDir)
+	} else {
+		s = e.sessions.NewSession(msg.SessionKey, name)
+	}
+
+	reply := fmt.Sprintf("✅ New session created: %s (id: %s)", s.Name, s.ID)
+	if workDir != "" {
+		reply += fmt.Sprintf("\n📁 %s", workDir)
+	}
+	e.reply(p, msg.ReplyCtx, reply)
+}
+
+func (e *Engine) cmdDelete(p Platform, msg *Message, args []string) {
+	var target string
+	if len(args) > 0 {
+		target = strings.TrimSpace(args[0])
+	} else {
+		// Delete the current active session
+		s := e.sessions.GetOrCreateActive(msg.SessionKey)
+		target = s.ID
+	}
+
+	// Cleanup interactive state if the session being deleted has one
+	localSessions := e.sessions.ListSessions(msg.SessionKey)
+	for _, s := range localSessions {
+		if s.ID == target || s.Name == target {
+			e.cleanupInteractiveState(msg.SessionKey)
+			break
+		}
+	}
+
+	deleted, err := e.sessions.DeleteSession(msg.SessionKey, target)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf("❌ %v", err))
+		return
+	}
+	e.reply(p, msg.ReplyCtx, fmt.Sprintf("🗑 Session deleted: %s (id: %s)", deleted.Name, deleted.ID))
 }
 
 func (e *Engine) cmdList(p Platform, msg *Message) {
+	// Show local cc-connect sessions first
+	localSessions := e.sessions.ListSessions(msg.SessionKey)
+	activeID := e.sessions.ActiveSessionID(msg.SessionKey)
+
+	var sb strings.Builder
+	if len(localSessions) > 0 {
+		sb.WriteString("📋 **Local Sessions**\n")
+		for _, s := range localSessions {
+			marker := "◻"
+			if s.ID == activeID {
+				marker = "▶"
+			}
+			line := fmt.Sprintf("%s `%s` · %s", marker, s.ID, s.Name)
+			if s.WorkDir != "" {
+				line += fmt.Sprintf(" · 📁 %s", s.WorkDir)
+			}
+			if s.AgentSessionID != "" {
+				shortAgent := s.AgentSessionID
+				if len(shortAgent) > 12 {
+					shortAgent = shortAgent[:12]
+				}
+				line += fmt.Sprintf(" · %s:%s", e.agent.Name(), shortAgent)
+			}
+			sb.WriteString(line + "\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	// Show agent backend sessions
 	agentSessions, err := e.agent.ListSessions(e.ctx)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgListError), err))
 		return
 	}
-	if len(agentSessions) == 0 {
+
+	if len(agentSessions) == 0 && len(localSessions) == 0 {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgListEmpty))
 		return
 	}
 
-	agentName := e.agent.Name()
-	activeSession := e.sessions.GetOrCreateActive(msg.SessionKey)
-	activeAgentID := activeSession.AgentSessionID
+	if len(agentSessions) > 0 {
+		agentName := e.agent.Name()
+		activeSession := e.sessions.GetOrCreateActive(msg.SessionKey)
+		activeAgentID := activeSession.AgentSessionID
 
-	limit := 20
-	if len(agentSessions) < limit {
-		limit = len(agentSessions)
+		limit := 20
+		if len(agentSessions) < limit {
+			limit = len(agentSessions)
+		}
+
+		sb.WriteString(fmt.Sprintf(e.i18n.T(MsgListTitle), agentName, len(agentSessions)))
+		for i := 0; i < limit; i++ {
+			s := agentSessions[i]
+			marker := "◻"
+			if s.ID == activeAgentID {
+				marker = "▶"
+			}
+			shortID := s.ID
+			if len(shortID) > 12 {
+				shortID = shortID[:12]
+			}
+			summary := s.Summary
+			if summary == "" {
+				summary = "(empty)"
+			}
+			sb.WriteString(fmt.Sprintf("%s `%s` · %s · **%d** msgs · %s\n",
+				marker, shortID, summary, s.MessageCount, s.ModifiedAt.Format("01-02 15:04")))
+		}
+		if len(agentSessions) > limit {
+			sb.WriteString(fmt.Sprintf(e.i18n.T(MsgListMore), len(agentSessions)-limit))
+		}
 	}
 
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf(e.i18n.T(MsgListTitle), agentName, len(agentSessions)))
-	for i := 0; i < limit; i++ {
-		s := agentSessions[i]
-		marker := "◻"
-		if s.ID == activeAgentID {
-			marker = "▶"
-		}
-		shortID := s.ID
-		if len(shortID) > 12 {
-			shortID = shortID[:12]
-		}
-		summary := s.Summary
-		if summary == "" {
-			summary = "(empty)"
-		}
-		sb.WriteString(fmt.Sprintf("%s `%s` · %s · **%d** msgs · %s\n",
-			marker, shortID, summary, s.MessageCount, s.ModifiedAt.Format("01-02 15:04")))
-	}
-	if len(agentSessions) > limit {
-		sb.WriteString(fmt.Sprintf(e.i18n.T(MsgListMore), len(agentSessions)-limit))
-	}
 	sb.WriteString(e.i18n.T(MsgListSwitchHint))
 	e.reply(p, msg.ReplyCtx, sb.String())
 }
@@ -888,9 +995,13 @@ func (e *Engine) cmdCurrent(p Platform, msg *Message) {
 	if agentID == "" {
 		agentID = "(new — not yet started)"
 	}
-	e.reply(p, msg.ReplyCtx, fmt.Sprintf(
-		"📌 Current session\nName: %s\nClaude Session: %s\nLocal messages: %d",
-		s.Name, agentID, len(s.History)))
+	info := fmt.Sprintf(
+		"📌 Current session\nName: %s\nID: %s\n%s Session: %s\nLocal messages: %d",
+		s.Name, s.ID, e.agent.Name(), agentID, len(s.History))
+	if s.WorkDir != "" {
+		info += fmt.Sprintf("\nWork Dir: %s", s.WorkDir)
+	}
+	e.reply(p, msg.ReplyCtx, info)
 }
 
 func (e *Engine) cmdStatus(p Platform, msg *Message) {

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -432,8 +432,9 @@ var messages = map[MsgKey]map[Language]string{
 	},
 	MsgHelp: {
 		LangEnglish: "📖 Available Commands\n\n" +
-			"/new [name]\n  Start a new session\n\n" +
-			"/list\n  List agent sessions\n\n" +
+			"/new [name|path]\n  Start a new session (path creates session with custom work dir)\n\n" +
+			"/delete [id|name]\n  Delete a session (default: current)\n\n" +
+			"/list\n  List local & agent sessions\n\n" +
 			"/switch <id>\n  Resume an existing session\n\n" +
 			"/current\n  Show current active session\n\n" +
 			"/history [n]\n  Show last n messages (default 10)\n\n" +
@@ -458,8 +459,9 @@ var messages = map[MsgKey]map[Language]string{
 			"Agent skills: auto-discovered from .claude/skills/<name>/SKILL.md etc.\n" +
 			"Permission modes: default / edit / plan / yolo",
 		LangChinese: "📖 可用命令\n\n" +
-			"/new [名称]\n  创建新会话\n\n" +
-			"/list\n  列出 Agent 会话列表\n\n" +
+			"/new [名称|路径]\n  创建新会话（路径参数可指定工作目录）\n\n" +
+			"/delete [id|名称]\n  删除会话（默认删除当前会话）\n\n" +
+			"/list\n  列出本地和 Agent 会话列表\n\n" +
 			"/switch <id>\n  恢复已有会话\n\n" +
 			"/current\n  查看当前活跃会话\n\n" +
 			"/history [n]\n  查看最近 n 条消息（默认 10）\n\n" +
@@ -484,8 +486,9 @@ var messages = map[MsgKey]map[Language]string{
 			"Agent Skills：自动发现自 .claude/skills/<name>/SKILL.md 等目录。\n" +
 			"权限模式：default / edit / plan / yolo",
 		LangTraditionalChinese: "📖 可用命令\n\n" +
-			"/new [名稱]\n  建立新會話\n\n" +
-			"/list\n  列出 Agent 會話列表\n\n" +
+			"/new [名稱|路徑]\n  建立新會話（路徑參數可指定工作目錄）\n\n" +
+			"/delete [id|名稱]\n  刪除會話（預設刪除當前會話）\n\n" +
+			"/list\n  列出本地和 Agent 會話列表\n\n" +
 			"/switch <id>\n  恢復已有會話\n\n" +
 			"/current\n  查看當前活躍會話\n\n" +
 			"/history [n]\n  查看最近 n 條訊息（預設 10）\n\n" +
@@ -510,8 +513,9 @@ var messages = map[MsgKey]map[Language]string{
 			"Agent Skills：自動發現自 .claude/skills/<name>/SKILL.md 等目錄。\n" +
 			"權限模式：default / edit / plan / yolo",
 		LangJapanese: "📖 利用可能なコマンド\n\n" +
-			"/new [名前]\n  新しいセッションを開始\n\n" +
-			"/list\n  エージェントセッション一覧\n\n" +
+			"/new [名前|パス]\n  新しいセッションを開始（パスで作業ディレクトリを指定）\n\n" +
+			"/delete [id|名前]\n  セッションを削除（デフォルト: 現在のセッション）\n\n" +
+			"/list\n  ローカル＆エージェントセッション一覧\n\n" +
 			"/switch <id>\n  既存セッションに切り替え\n\n" +
 			"/current\n  現在のアクティブセッションを表示\n\n" +
 			"/history [n]\n  直近 n 件のメッセージを表示（デフォルト 10）\n\n" +
@@ -536,8 +540,9 @@ var messages = map[MsgKey]map[Language]string{
 			"エージェントスキル: .claude/skills/<name>/SKILL.md などから自動検出。\n" +
 			"権限モード: default / edit / plan / yolo",
 		LangSpanish: "📖 Comandos disponibles\n\n" +
-			"/new [nombre]\n  Iniciar una nueva sesión\n\n" +
-			"/list\n  Listar sesiones del agente\n\n" +
+			"/new [nombre|ruta]\n  Iniciar una nueva sesión (ruta para directorio de trabajo personalizado)\n\n" +
+			"/delete [id|nombre]\n  Eliminar una sesión (por defecto: actual)\n\n" +
+			"/list\n  Listar sesiones locales y del agente\n\n" +
 			"/switch <id>\n  Reanudar una sesión existente\n\n" +
 			"/current\n  Mostrar sesión activa actual\n\n" +
 			"/history [n]\n  Mostrar últimos n mensajes (por defecto 10)\n\n" +

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -30,6 +30,14 @@ type SessionEnvInjector interface {
 	SetSessionEnv(env []string)
 }
 
+// WorkDirOverrider is an optional interface for agents that support
+// per-session working directory override. The engine calls SetWorkDir
+// before StartSession and ResetWorkDir after to restore the default.
+type WorkDirOverrider interface {
+	SetWorkDir(dir string)
+	ResetWorkDir()
+}
+
 // AgentSystemPrompt returns the system prompt fragment that informs agents about
 // cc-connect capabilities (cron scheduling, etc.).
 // The prompt is designed to be appended to the agent's existing system prompt.

--- a/core/interfaces_test.go
+++ b/core/interfaces_test.go
@@ -1,0 +1,18 @@
+package core
+
+// Compile-time interface checks for WorkDirOverrider.
+// These are tested via the agent-specific test files, but we verify
+// the interface shape here.
+
+func ExampleWorkDirOverrider() {
+	// This function exists to verify the interface compiles correctly.
+	var _ WorkDirOverrider = (*mockWorkDirAgent)(nil)
+}
+
+type mockWorkDirAgent struct {
+	workDir         string
+	overrideWorkDir string
+}
+
+func (m *mockWorkDirAgent) SetWorkDir(dir string)  { m.overrideWorkDir = dir }
+func (m *mockWorkDirAgent) ResetWorkDir()           { m.overrideWorkDir = "" }

--- a/core/session.go
+++ b/core/session.go
@@ -14,6 +14,7 @@ import (
 type Session struct {
 	ID             string         `json:"id"`
 	Name           string         `json:"name"`
+	WorkDir        string         `json:"work_dir,omitempty"`
 	AgentSessionID string         `json:"agent_session_id"`
 	History        []HistoryEntry `json:"history"`
 	CreatedAt      time.Time      `json:"created_at"`
@@ -115,23 +116,32 @@ func (sm *SessionManager) GetOrCreateActive(userKey string) *Session {
 			return s
 		}
 	}
-	return sm.createLocked(userKey, "default")
+	return sm.createLocked(userKey, "default", "")
 }
 
 func (sm *SessionManager) NewSession(userKey, name string) *Session {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	s := sm.createLocked(userKey, name)
+	s := sm.createLocked(userKey, name, "")
 	sm.saveLocked()
 	return s
 }
 
-func (sm *SessionManager) createLocked(userKey, name string) *Session {
+func (sm *SessionManager) NewSessionWithWorkDir(userKey, name, workDir string) *Session {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	s := sm.createLocked(userKey, name, workDir)
+	sm.saveLocked()
+	return s
+}
+
+func (sm *SessionManager) createLocked(userKey, name, workDir string) *Session {
 	id := sm.nextID()
 	now := time.Now()
 	s := &Session{
 		ID:        id,
 		Name:      name,
+		WorkDir:   workDir,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -139,6 +149,45 @@ func (sm *SessionManager) createLocked(userKey, name string) *Session {
 	sm.activeSession[userKey] = id
 	sm.userSessions[userKey] = append(sm.userSessions[userKey], id)
 	return s
+}
+
+// DeleteSession removes a session by ID or name. If the deleted session is active,
+// it switches to the most recent remaining session.
+func (sm *SessionManager) DeleteSession(userKey, target string) (*Session, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	var found *Session
+	var foundIdx int = -1
+	for i, sid := range sm.userSessions[userKey] {
+		s := sm.sessions[sid]
+		if s != nil && (s.ID == target || s.Name == target) {
+			found = s
+			foundIdx = i
+			break
+		}
+	}
+	if found == nil {
+		return nil, fmt.Errorf("session %q not found", target)
+	}
+
+	// Remove from maps
+	delete(sm.sessions, found.ID)
+	ids := sm.userSessions[userKey]
+	sm.userSessions[userKey] = append(ids[:foundIdx], ids[foundIdx+1:]...)
+
+	// If deleted session was active, switch to the last remaining session
+	if sm.activeSession[userKey] == found.ID {
+		remaining := sm.userSessions[userKey]
+		if len(remaining) > 0 {
+			sm.activeSession[userKey] = remaining[len(remaining)-1]
+		} else {
+			delete(sm.activeSession, userKey)
+		}
+	}
+
+	sm.saveLocked()
+	return found, nil
 }
 
 func (sm *SessionManager) SwitchSession(userKey, target string) (*Session, error) {

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -1,0 +1,222 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewSessionWithWorkDir(t *testing.T) {
+	sm := NewSessionManager("")
+
+	s := sm.NewSessionWithWorkDir("user1", "test-project", "/tmp/test-project")
+	if s.WorkDir != "/tmp/test-project" {
+		t.Errorf("expected WorkDir=/tmp/test-project, got %q", s.WorkDir)
+	}
+	if s.Name != "test-project" {
+		t.Errorf("expected Name=test-project, got %q", s.Name)
+	}
+	if s.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+
+	// Verify it's active
+	active := sm.GetOrCreateActive("user1")
+	if active.ID != s.ID {
+		t.Errorf("expected active session ID=%s, got %s", s.ID, active.ID)
+	}
+}
+
+func TestNewSessionWithoutWorkDir(t *testing.T) {
+	sm := NewSessionManager("")
+
+	s := sm.NewSession("user1", "regular")
+	if s.WorkDir != "" {
+		t.Errorf("expected empty WorkDir, got %q", s.WorkDir)
+	}
+}
+
+func TestDeleteSession(t *testing.T) {
+	sm := NewSessionManager("")
+
+	s1 := sm.NewSession("user1", "first")
+	s2 := sm.NewSession("user1", "second")
+	s3 := sm.NewSession("user1", "third")
+
+	// s3 should be active (last created)
+	activeID := sm.ActiveSessionID("user1")
+	if activeID != s3.ID {
+		t.Errorf("expected active=%s, got %s", s3.ID, activeID)
+	}
+
+	// Delete non-active session by ID
+	deleted, err := sm.DeleteSession("user1", s1.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted.ID != s1.ID {
+		t.Errorf("expected deleted ID=%s, got %s", s1.ID, deleted.ID)
+	}
+
+	// s3 should still be active
+	activeID = sm.ActiveSessionID("user1")
+	if activeID != s3.ID {
+		t.Errorf("expected active=%s after deleting non-active, got %s", s3.ID, activeID)
+	}
+
+	// Should have 2 sessions left
+	sessions := sm.ListSessions("user1")
+	if len(sessions) != 2 {
+		t.Errorf("expected 2 sessions, got %d", len(sessions))
+	}
+
+	// Delete active session by name
+	deleted, err = sm.DeleteSession("user1", "third")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted.ID != s3.ID {
+		t.Errorf("expected deleted ID=%s, got %s", s3.ID, deleted.ID)
+	}
+
+	// s2 should now be active (last remaining)
+	activeID = sm.ActiveSessionID("user1")
+	if activeID != s2.ID {
+		t.Errorf("expected active=%s after deleting active, got %s", s2.ID, activeID)
+	}
+
+	// Delete last session
+	_, err = sm.DeleteSession("user1", s2.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No active session
+	activeID = sm.ActiveSessionID("user1")
+	if activeID != "" {
+		t.Errorf("expected empty active after deleting all, got %s", activeID)
+	}
+}
+
+func TestDeleteSessionNotFound(t *testing.T) {
+	sm := NewSessionManager("")
+	sm.NewSession("user1", "test")
+
+	_, err := sm.DeleteSession("user1", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent session")
+	}
+}
+
+func TestDeleteSessionByName(t *testing.T) {
+	sm := NewSessionManager("")
+	s := sm.NewSessionWithWorkDir("user1", "my-project", "/tmp/project")
+
+	deleted, err := sm.DeleteSession("user1", "my-project")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted.WorkDir != "/tmp/project" {
+		t.Errorf("expected WorkDir=/tmp/project, got %q", deleted.WorkDir)
+	}
+	if deleted.ID != s.ID {
+		t.Errorf("expected ID=%s, got %s", s.ID, deleted.ID)
+	}
+}
+
+func TestSessionPersistenceWithWorkDir(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "sessions.json")
+
+	// Create and save
+	sm1 := NewSessionManager(storePath)
+	sm1.NewSessionWithWorkDir("user1", "proj", "/home/user/project")
+	sm1.NewSession("user1", "plain")
+
+	// Reload
+	sm2 := NewSessionManager(storePath)
+	sessions := sm2.ListSessions("user1")
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 sessions after reload, got %d", len(sessions))
+	}
+
+	var foundWorkDir bool
+	for _, s := range sessions {
+		if s.Name == "proj" && s.WorkDir == "/home/user/project" {
+			foundWorkDir = true
+		}
+	}
+	if !foundWorkDir {
+		t.Error("WorkDir not persisted correctly")
+	}
+}
+
+func TestSessionPersistenceDeleteAndReload(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "sessions.json")
+
+	sm1 := NewSessionManager(storePath)
+	sm1.NewSession("user1", "keep")
+	sm1.NewSession("user1", "remove")
+
+	_, err := sm1.DeleteSession("user1", "remove")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Reload and verify
+	sm2 := NewSessionManager(storePath)
+	sessions := sm2.ListSessions("user1")
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session after reload, got %d", len(sessions))
+	}
+	if sessions[0].Name != "keep" {
+		t.Errorf("expected session name=keep, got %q", sessions[0].Name)
+	}
+}
+
+func TestWorkDirDetection(t *testing.T) {
+	// Create a temp directory to test path detection
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		input     string
+		isPath    bool
+		dirExists bool
+	}{
+		{"/tmp", true, true},
+		{tmpDir, true, true},
+		{"/nonexistent-dir-xyz", true, false},
+		{"my-session", false, false},
+		{".", true, true},
+		{"~", true, true},
+	}
+
+	for _, tc := range tests {
+		arg := tc.input
+		isPath := false
+		if len(arg) > 0 && (arg[0] == '/' || arg[0] == '.' || arg[0] == '~') {
+			isPath = true
+		}
+		if isPath != tc.isPath {
+			t.Errorf("input %q: expected isPath=%v, got %v", tc.input, tc.isPath, isPath)
+		}
+
+		if isPath && tc.dirExists {
+			expanded := arg
+			if expanded[0] == '~' {
+				home, _ := os.UserHomeDir()
+				expanded = filepath.Join(home, expanded[1:])
+			}
+			absPath, err := filepath.Abs(expanded)
+			if err != nil {
+				t.Errorf("input %q: filepath.Abs error: %v", tc.input, err)
+				continue
+			}
+			info, err := os.Stat(absPath)
+			if err != nil || !info.IsDir() {
+				t.Errorf("input %q: expected existing directory at %s", tc.input, absPath)
+			}
+		}
+	}
+}


### PR DESCRIPTION
解决 #3 提到的需求：不用每个目录都配一个 project，直接 `/new /path/to/dir` 就能创建带独立工作目录的会话。

改动点：
- `/new` 支持传入目录路径，自动检测参数是路径还是名称
- 新增 `/delete [id|name]` 删除本地会话
- `/list` `/current` 补充 workdir 显示
- 新增 `WorkDirOverrider` 可选接口，6 个 agent 都实现了
- 补了 session 相关的单测