### PR TITLE
feat(claudecode): add Claude Code Router integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,105 @@ Adding, removing, and switching providers all persist to `config.toml` automatic
 
 The `env` map in provider config lets you set arbitrary environment variables for any setup (Bedrock, Vertex, Azure, custom proxies, etc.).
 
+## Claude Code Router Integration
+
+[Claude Code Router](https://github.com/musistudio/claude-code-router) is a powerful tool that routes Claude Code requests to different model providers (OpenRouter, DeepSeek, Gemini, etc.) with custom transformations. cc-connect now supports seamless integration with Claude Code Router.
+
+### Why Use Claude Code Router?
+
+- **Multi-Provider Support**: Route requests to OpenRouter, DeepSeek, Ollama, Gemini, Volcengine, SiliconFlow, and more
+- **Model Routing**: Use different models for different tasks (background, thinking, long context, web search)
+- **Request/Response Transformation**: Automatic adaptation for different provider APIs
+- **Dynamic Model Switching**: Switch models on-the-fly without restarting
+
+### Setup
+
+1. **Install Claude Code Router**:
+
+```bash
+npm install -g @musistudio/claude-code-router
+```
+
+2. **Configure Router** (create `~/.claude-code-router/config.json`):
+
+```json
+{
+  "APIKEY": "your-secret-key",
+  "Providers": [
+    {
+      "name": "openrouter",
+      "api_base_url": "https://openrouter.ai/api/v1/chat/completions",
+      "api_key": "sk-xxx",
+      "models": ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro-preview"],
+      "transformer": { "use": ["openrouter"] }
+    },
+    {
+      "name": "deepseek",
+      "api_base_url": "https://api.deepseek.com/chat/completions",
+      "api_key": "sk-xxx",
+      "models": ["deepseek-chat", "deepseek-reasoner"],
+      "transformer": { "use": ["deepseek"] }
+    }
+  ],
+  "Router": {
+    "default": "deepseek,deepseek-chat",
+    "think": "deepseek,deepseek-reasoner",
+    "longContext": "openrouter,google/gemini-2.5-pro-preview"
+  }
+}
+```
+
+3. **Start Router**:
+
+```bash
+ccr start
+```
+
+4. **Configure cc-connect** (in `config.toml`):
+
+```toml
+[projects.agent.options]
+work_dir = "/path/to/project"
+mode = "default"
+
+# Router integration
+router_url = "http://127.0.0.1:3456"        # Router URL (default port)
+router_api_key = "your-secret-key"          # Optional: if router requires auth
+```
+
+### How It Works
+
+When `router_url` is configured, cc-connect automatically:
+
+- Sets `ANTHROPIC_BASE_URL` to the router URL
+- Sets `NO_PROXY=127.0.0.1` to prevent proxy interference
+- Disables telemetry and cost warnings for cleaner integration
+
+All Claude Code requests are then routed through the router, which handles model selection and provider communication.
+
+### Usage
+
+Once configured, use cc-connect as usual. The router transparently handles model routing:
+
+```
+You: Help me refactor this code
+Router → DeepSeek (default model)
+
+You: Think through this architecture decision
+Router → DeepSeek Reasoner (thinking model)
+
+You: Analyze this large codebase
+Router → Gemini Pro (long context model)
+```
+
+### Important Notes
+
+- **Provider settings are ignored**: When using router, the `[[projects.agent.providers]]` settings are bypassed as the router manages model selection
+- **Router must be running**: Ensure `ccr start` is executed before starting cc-connect
+- **Configuration changes**: After modifying router config, restart with `ccr restart`
+
+For more details, see the [Claude Code Router documentation](https://github.com/musistudio/claude-code-router).
+
 ## Voice Messages (Speech-to-Text)
 
 Send voice messages directly — cc-connect transcribes them to text using a configurable STT provider, then forwards the text to the agent.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -396,6 +396,105 @@ cc-connect provider import --db-path ~/.cc-switch/cc-switch.db    # 指定数据
 
 Provider 配置中的 `env` 字段支持设置任意环境变量，可用于 Bedrock、Vertex、Azure、自定义代理等各种场景。
 
+## Claude Code Router 集成
+
+[Claude Code Router](https://github.com/musistudio/claude-code-router) 是一个强大的工具，可以将 Claude Code 请求路由到不同的模型提供商（OpenRouter、DeepSeek、Gemini 等），并支持自定义请求转换。cc-connect 现已支持与 Claude Code Router 无缝集成。
+
+### 为什么使用 Claude Code Router？
+
+- **多提供商支持**：路由请求到 OpenRouter、DeepSeek、Ollama、Gemini、火山引擎、SiliconFlow 等
+- **模型路由**：针对不同任务使用不同模型（后台任务、思考、长上下文、网络搜索）
+- **请求/响应转换**：自动适配不同提供商的 API
+- **动态模型切换**：无需重启即可切换模型
+
+### 安装配置
+
+1. **安装 Claude Code Router**：
+
+```bash
+npm install -g @musistudio/claude-code-router
+```
+
+2. **配置 Router**（创建 `~/.claude-code-router/config.json`）：
+
+```json
+{
+  "APIKEY": "your-secret-key",
+  "Providers": [
+    {
+      "name": "openrouter",
+      "api_base_url": "https://openrouter.ai/api/v1/chat/completions",
+      "api_key": "sk-xxx",
+      "models": ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro-preview"],
+      "transformer": { "use": ["openrouter"] }
+    },
+    {
+      "name": "deepseek",
+      "api_base_url": "https://api.deepseek.com/chat/completions",
+      "api_key": "sk-xxx",
+      "models": ["deepseek-chat", "deepseek-reasoner"],
+      "transformer": { "use": ["deepseek"] }
+    }
+  ],
+  "Router": {
+    "default": "deepseek,deepseek-chat",
+    "think": "deepseek,deepseek-reasoner",
+    "longContext": "openrouter,google/gemini-2.5-pro-preview"
+  }
+}
+```
+
+3. **启动 Router**：
+
+```bash
+ccr start
+```
+
+4. **配置 cc-connect**（在 `config.toml` 中）：
+
+```toml
+[projects.agent.options]
+work_dir = "/path/to/project"
+mode = "default"
+
+# Router 集成
+router_url = "http://127.0.0.1:3456"        # Router URL（默认端口）
+router_api_key = "your-secret-key"          # 可选：如果 router 需要认证
+```
+
+### 工作原理
+
+配置 `router_url` 后，cc-connect 会自动：
+
+- 设置 `ANTHROPIC_BASE_URL` 为 router URL
+- 设置 `NO_PROXY=127.0.0.1` 防止代理干扰
+- 禁用遥测和成本警告以获得更清洁的集成
+
+所有 Claude Code 请求都会通过 router 路由，由 router 处理模型选择和提供商通信。
+
+### 使用方式
+
+配置完成后，像往常一样使用 cc-connect。Router 会透明地处理模型路由：
+
+```
+你：帮我重构这段代码
+Router → DeepSeek（默认模型）
+
+你：思考一下这个架构决策
+Router → DeepSeek Reasoner（思考模型）
+
+你：分析这个大型代码库
+Router → Gemini Pro（长上下文模型）
+```
+
+### 重要说明
+
+- **Provider 设置被忽略**：使用 router 时，`[[projects.agent.providers]]` 设置会被绕过，因为 router 管理模型选择
+- **Router 必须运行**：确保在启动 cc-connect 之前执行 `ccr start`
+- **配置更改**：修改 router 配置后，需要重启：`ccr restart`
+
+更多详情请参考 [Claude Code Router 文档](https://github.com/musistudio/claude-code-router)。
+
 ## 语音消息（语音转文字）
 
 直接发送语音消息 — cc-connect 自动将语音转为文字，再将文字转发给 Agent 处理。

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -38,6 +38,8 @@ type Agent struct {
 	providers    []core.ProviderConfig
 	activeIdx    int // -1 = no provider set
 	sessionEnv   []string
+	routerURL    string // Claude Code Router URL (e.g., "http://127.0.0.1:3456")
+	routerAPIKey string // Claude Code Router API key (optional)
 	mu           sync.Mutex
 }
 
@@ -59,6 +61,10 @@ func New(opts map[string]any) (core.Agent, error) {
 		}
 	}
 
+	// Claude Code Router support
+	routerURL, _ := opts["router_url"].(string)
+	routerAPIKey, _ := opts["router_api_key"].(string)
+
 	if _, err := exec.LookPath("claude"); err != nil {
 		return nil, fmt.Errorf("claudecode: 'claude' CLI not found in PATH, please install Claude Code first")
 	}
@@ -69,6 +75,8 @@ func New(opts map[string]any) (core.Agent, error) {
 		mode:         mode,
 		allowedTools: allowedTools,
 		activeIdx:    -1,
+		routerURL:    routerURL,
+		routerAPIKey: routerAPIKey,
 	}, nil
 }
 
@@ -185,6 +193,20 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	extraEnv := a.providerEnvLocked()
 	extraEnv = append(extraEnv, a.sessionEnv...)
+
+	// Add Claude Code Router environment variables if configured
+	if a.routerURL != "" {
+		extraEnv = append(extraEnv, "ANTHROPIC_BASE_URL="+a.routerURL)
+		// When using router, we need to prevent proxy interference
+		extraEnv = append(extraEnv, "NO_PROXY=127.0.0.1")
+		// Disable telemetry and cost warnings for cleaner router integration
+		extraEnv = append(extraEnv, "DISABLE_TELEMETRY=true")
+		extraEnv = append(extraEnv, "DISABLE_COST_WARNINGS=true")
+	}
+	if a.routerAPIKey != "" {
+		extraEnv = append(extraEnv, "ANTHROPIC_API_KEY="+a.routerAPIKey)
+	}
+
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
 			model = m

--- a/config.example.toml
+++ b/config.example.toml
@@ -157,6 +157,23 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "bypassPermission
 # Optional: specify a model / 可选：指定模型
 # model = "claude-sonnet-4-20250514"
 
+# Claude Code Router Integration / Claude Code Router 集成
+# Route Claude Code requests through Claude Code Router to use different model providers.
+# 通过 Claude Code Router 路由 Claude Code 请求，使用不同的模型提供商。
+# See: https://github.com/musistudio/claude-code-router
+#
+# router_url = "http://127.0.0.1:3456"  # Claude Code Router URL (default: http://127.0.0.1:3456)
+# router_api_key = "your-router-api-key" # Optional: API key if router requires authentication / 可选：如果 router 需要认证
+#
+# When router_url is set, cc-connect will automatically:
+# 设置 router_url 后，cc-connect 会自动：
+#   - Set ANTHROPIC_BASE_URL to router_url
+#   - Set NO_PROXY=127.0.0.1 to prevent proxy interference
+#   - Disable telemetry and cost warnings for cleaner integration
+#
+# Note: When using router, provider settings below are ignored as the router handles model selection.
+# 注意：使用 router 时，下方的 provider 设置将被忽略，因为 router 负责模型选择。
+
 # Active provider (matches a name in [[projects.agent.providers]])
 # 当前激活的 provider（对应下方 providers 中的 name）
 # provider = "anthropic"


### PR DESCRIPTION
Add support for routing Claude Code requests through Claude Code Router, enabling multi-provider support (OpenRouter, DeepSeek, Gemini, etc.) and dynamic model switching.

Changes:
- Add router_url and router_api_key configuration options
- Automatically set ANTHROPIC_BASE_URL when router is configured
- Set NO_PROXY, DISABLE_TELEMETRY, DISABLE_COST_WARNINGS for clean integration
- Update documentation with setup guide and usage examples
- Add configuration examples in config.example.toml

The integration is backward compatible - when router_url is not configured, the agent behaves exactly as before. When configured, all requests are transparently routed through Claude Code Router.