### PR TITLE
fix: /quiet 改为全局作用域

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -173,6 +173,7 @@ type interactiveState struct {
 	mu           sync.Mutex
 	pending      *pendingPermission
 	approveAll bool // when true, auto-approve all permission requests for this session
+	quiet      bool // when true, suppress thinking and tool progress for this session
 }
 
 // pendingPermission represents a permission request waiting for user response.
@@ -958,12 +959,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		state.mu.Lock()
 		p := state.platform
 		replyCtx := state.replyCtx
-		quiet := state.quiet
+		sessionQuiet := state.quiet
 		state.mu.Unlock()
 
 		e.quietMu.RLock()
-		quiet := e.quiet
+		globalQuiet := e.quiet
 		e.quietMu.RUnlock()
+
+		quiet := globalQuiet || sessionQuiet
 
 		switch event.Type {
 		case EventThinking:
@@ -1264,7 +1267,7 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 	case "lang":
 		e.cmdLang(p, msg, args)
 	case "quiet":
-		e.cmdQuiet(p, msg)
+		e.cmdQuiet(p, msg, args)
 	case "provider":
 		e.cmdProvider(p, msg, args)
 	case "memory":
@@ -1960,11 +1963,40 @@ func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
 	e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgModeChanged), displayName))
 }
 
-func (e *Engine) cmdQuiet(p Platform, msg *Message) {
-	e.quietMu.Lock()
-	e.quiet = !e.quiet
-	quiet := e.quiet
-	e.quietMu.Unlock()
+func (e *Engine) cmdQuiet(p Platform, msg *Message, args []string) {
+	// /quiet global — toggle global quiet for all sessions
+	if len(args) > 0 && args[0] == "global" {
+		e.quietMu.Lock()
+		e.quiet = !e.quiet
+		quiet := e.quiet
+		e.quietMu.Unlock()
+
+		if quiet {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgQuietGlobalOn))
+		} else {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgQuietGlobalOff))
+		}
+		return
+	}
+
+	// /quiet — toggle per-session quiet
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[msg.SessionKey]
+	e.interactiveMu.Unlock()
+
+	if !ok || state == nil {
+		state = &interactiveState{platform: p, replyCtx: msg.ReplyCtx, quiet: true}
+		e.interactiveMu.Lock()
+		e.interactiveStates[msg.SessionKey] = state
+		e.interactiveMu.Unlock()
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgQuietOn))
+		return
+	}
+
+	state.mu.Lock()
+	state.quiet = !state.quiet
+	quiet := state.quiet
+	state.mu.Unlock()
 
 	if quiet {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgQuietOn))

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -126,63 +126,155 @@ func TestEngine_DisabledCommandsWithSlash(t *testing.T) {
 
 // --- quiet tests ---
 
-func TestQuietToggle(t *testing.T) {
+func TestQuietSessionToggle(t *testing.T) {
 	e := newTestEngine()
-
-	// Default: quiet is off
-	if e.quiet {
-		t.Fatal("expected quiet to be false by default")
-	}
-
 	p := &stubPlatformEngine{n: "test"}
 	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
 
-	// Toggle on
-	e.cmdQuiet(p, msg)
+	// /quiet — per-session toggle on
+	e.cmdQuiet(p, msg, nil)
+
+	e.interactiveMu.Lock()
+	state := e.interactiveStates["test:user1"]
+	e.interactiveMu.Unlock()
+
+	if state == nil {
+		t.Fatal("expected interactiveState to be created")
+	}
+	state.mu.Lock()
+	q := state.quiet
+	state.mu.Unlock()
+	if !q {
+		t.Fatal("expected session quiet to be true")
+	}
+
+	// /quiet — per-session toggle off
+	e.cmdQuiet(p, msg, nil)
+	state.mu.Lock()
+	q = state.quiet
+	state.mu.Unlock()
+	if q {
+		t.Fatal("expected session quiet to be false after second toggle")
+	}
+}
+
+func TestQuietSessionResetsOnNewSession(t *testing.T) {
+	e := newTestEngine()
+	p := &stubPlatformEngine{n: "test"}
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	// Enable per-session quiet
+	e.cmdQuiet(p, msg, nil)
+
+	// Simulate /new
+	e.cleanupInteractiveState("test:user1")
+
+	// State should be gone, quiet resets
+	e.interactiveMu.Lock()
+	state := e.interactiveStates["test:user1"]
+	e.interactiveMu.Unlock()
+	if state != nil {
+		t.Fatal("expected interactiveState to be cleaned up")
+	}
+
+	// Global quiet should still be off
+	e.quietMu.RLock()
+	gq := e.quiet
+	e.quietMu.RUnlock()
+	if gq {
+		t.Fatal("expected global quiet to be false")
+	}
+}
+
+func TestQuietGlobalToggle(t *testing.T) {
+	e := newTestEngine()
+	p := &stubPlatformEngine{n: "test"}
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	// Default: global quiet is off
+	if e.quiet {
+		t.Fatal("expected global quiet to be false by default")
+	}
+
+	// /quiet global — toggle on
+	e.cmdQuiet(p, msg, []string{"global"})
 	e.quietMu.RLock()
 	q := e.quiet
 	e.quietMu.RUnlock()
 	if !q {
-		t.Fatal("expected quiet to be true after first toggle")
-	}
-	if len(p.sent) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(p.sent))
+		t.Fatal("expected global quiet to be true")
 	}
 
-	// Toggle off
-	e.cmdQuiet(p, msg)
+	// /quiet global — toggle off
+	e.cmdQuiet(p, msg, []string{"global"})
 	e.quietMu.RLock()
 	q = e.quiet
 	e.quietMu.RUnlock()
 	if q {
-		t.Fatal("expected quiet to be false after second toggle")
-	}
-	if len(p.sent) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(p.sent))
+		t.Fatal("expected global quiet to be false after second toggle")
 	}
 }
 
-func TestQuietPersistsAcrossSessions(t *testing.T) {
+func TestQuietGlobalPersistsAcrossSessions(t *testing.T) {
 	e := newTestEngine()
 	p := &stubPlatformEngine{n: "test"}
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
 
-	// Enable quiet
-	e.cmdQuiet(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"})
+	// Enable global quiet
+	e.cmdQuiet(p, msg, []string{"global"})
+
+	// Simulate /new
+	e.cleanupInteractiveState("test:user1")
+
+	// Global quiet should still be on
 	e.quietMu.RLock()
 	q := e.quiet
 	e.quietMu.RUnlock()
 	if !q {
-		t.Fatal("expected quiet to be true")
+		t.Fatal("expected global quiet to remain true after session cleanup")
+	}
+}
+
+func TestQuietGlobalAndSessionCombined(t *testing.T) {
+	e := newTestEngine()
+	p := &stubPlatformEngine{n: "test"}
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	// Only global quiet on — should suppress
+	e.cmdQuiet(p, msg, []string{"global"})
+	e.quietMu.RLock()
+	gq := e.quiet
+	e.quietMu.RUnlock()
+	if !gq {
+		t.Fatal("expected global quiet on")
 	}
 
-	// Simulate /new — cleanup interactive state, create new session
-	e.cleanupInteractiveState("test:user1")
+	// Session quiet is off (no state yet) — global alone should be enough
+	e.interactiveMu.Lock()
+	state := e.interactiveStates["test:user1"]
+	e.interactiveMu.Unlock()
+	if state != nil {
+		t.Fatal("expected no session state yet")
+	}
 
-	// Quiet should still be on
+	// Turn off global, turn on session
+	e.cmdQuiet(p, msg, []string{"global"}) // global off
+	e.cmdQuiet(p, msg, nil)                // session on
+
 	e.quietMu.RLock()
-	q = e.quiet
+	gq = e.quiet
 	e.quietMu.RUnlock()
-	if !q {
-		t.Fatal("expected quiet to remain true after session cleanup")
+	if gq {
+		t.Fatal("expected global quiet off")
+	}
+
+	e.interactiveMu.Lock()
+	state = e.interactiveStates["test:user1"]
+	e.interactiveMu.Unlock()
+	state.mu.Lock()
+	sq := state.quiet
+	state.mu.Unlock()
+	if !sq {
+		t.Fatal("expected session quiet on")
 	}
 }

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -139,6 +139,8 @@ const (
 	MsgPermissionHint       MsgKey = "permission_hint"
 	MsgQuietOn              MsgKey = "quiet_on"
 	MsgQuietOff             MsgKey = "quiet_off"
+	MsgQuietGlobalOn        MsgKey = "quiet_global_on"
+	MsgQuietGlobalOff       MsgKey = "quiet_global_off"
 	MsgModeChanged          MsgKey = "mode_changed"
 	MsgModeNotSupported     MsgKey = "mode_not_supported"
 	MsgSessionRestarting    MsgKey = "session_restarting"
@@ -446,6 +448,20 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "🔔 静音モード OFF — 思考とツール実行の進捗メッセージを表示します。",
 		LangSpanish:            "🔔 Modo silencioso desactivado — los mensajes de progreso se mostrarán.",
 	},
+	MsgQuietGlobalOn: {
+		LangEnglish:            "🔇 Global quiet mode ON — all sessions will hide thinking and tool progress.",
+		LangChinese:            "🔇 全局安静模式已开启 — 所有会话将不再推送思考和工具调用进度消息。",
+		LangTraditionalChinese: "🔇 全域安靜模式已開啟 — 所有會話將不再推送思考和工具調用進度訊息。",
+		LangJapanese:           "🔇 グローバル静音モード ON — 全セッションで思考とツール進捗を非表示にします。",
+		LangSpanish:            "🔇 Modo silencioso global activado — todas las sesiones ocultarán los mensajes de progreso.",
+	},
+	MsgQuietGlobalOff: {
+		LangEnglish:            "🔔 Global quiet mode OFF — all sessions will show thinking and tool progress.",
+		LangChinese:            "🔔 全局安静模式已关闭 — 所有会话将恢复推送思考和工具调用进度消息。",
+		LangTraditionalChinese: "🔔 全域安靜模式已關閉 — 所有會話將恢復推送思考和工具調用進度訊息。",
+		LangJapanese:           "🔔 グローバル静音モード OFF — 全セッションで思考とツール進捗を表示します。",
+		LangSpanish:            "🔔 Modo silencioso global desactivado — todas las sesiones mostrarán los mensajes de progreso.",
+	},
 	MsgModeChanged: {
 		LangEnglish:            "🔄 Permission mode switched to **%s**. New sessions will use this mode.",
 		LangChinese:            "🔄 权限模式已切换为 **%s**，新会话将使用此模式。",
@@ -511,7 +527,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/model [name]\n  View/switch model\n\n" +
 			"/mode [name]\n  View/switch permission mode\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  View/switch language\n\n" +
-			"/quiet\n  Toggle thinking/tool progress\n\n" +
+			"/quiet [global]\n  Toggle thinking/tool progress (global = all sessions)\n\n" +
 			"/compress\n  Compress conversation context\n\n" +
 			"/stop\n  Stop current execution\n\n" +
 			"/cron [add|list|del|enable|disable]\n  Manage scheduled tasks\n\n" +
@@ -545,7 +561,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/model [名称]\n  查看/切换模型\n\n" +
 			"/mode [名称]\n  查看/切换权限模式\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  查看/切换语言\n\n" +
-			"/quiet\n  开关思考和工具进度消息\n\n" +
+			"/quiet [global]\n  开关思考和工具进度消息（global = 全部会话）\n\n" +
 			"/compress\n  压缩会话上下文\n\n" +
 			"/stop\n  停止当前执行\n\n" +
 			"/cron [add|list|del|enable|disable]\n  管理定时任务\n\n" +
@@ -579,7 +595,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/model [名稱]\n  查看/切換模型\n\n" +
 			"/mode [名稱]\n  查看/切換權限模式\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  查看/切換語言\n\n" +
-			"/quiet\n  開關思考和工具進度訊息\n\n" +
+			"/quiet [global]\n  開關思考和工具進度訊息（global = 全部會話）\n\n" +
 			"/compress\n  壓縮會話上下文\n\n" +
 			"/stop\n  停止當前執行\n\n" +
 			"/cron [add|list|del|enable|disable]\n  管理定時任務\n\n" +
@@ -612,7 +628,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/model [名前]\n  モデルの表示/切り替え\n\n" +
 			"/mode [名前]\n  権限モードの表示/切り替え\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  言語の表示/切り替え\n\n" +
-			"/quiet\n  思考/ツール進捗メッセージの表示切替\n\n" +
+			"/quiet [global]\n  思考/ツール進捗メッセージの表示切替（global = 全セッション）\n\n" +
 			"/compress\n  会話コンテキストを圧縮\n\n" +
 			"/stop\n  現在の実行を停止\n\n" +
 			"/cron [add|list|del|enable|disable]\n  スケジュールタスク管理\n\n" +
@@ -645,7 +661,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/model [nombre]\n  Ver/cambiar modelo\n\n" +
 			"/mode [nombre]\n  Ver/cambiar modo de permisos\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  Ver/cambiar idioma\n\n" +
-			"/quiet\n  Alternar mensajes de progreso\n\n" +
+			"/quiet [global]\n  Alternar mensajes de progreso (global = todas las sesiones)\n\n" +
 			"/compress\n  Comprimir contexto de conversación\n\n" +
 			"/stop\n  Detener ejecución actual\n\n" +
 			"/cron [add|list|del|enable|disable]\n  Gestionar tareas programadas\n\n" +


### PR DESCRIPTION
## 问题

`/quiet` 之前绑定在 `interactiveState` 上（per sessionKey），`/new` 或 `/switch` 会调用 `cleanupInteractiveState` 清掉整个 state，quiet 状态跟着丢了。用户开了静默模式，换个 session 又得重新开一次。

## 改动

把 `quiet` 从 `interactiveState` 移到 `Engine` 级别，全局生效：

- `/quiet` toggle 操作 `Engine.quiet`（带 RWMutex 保护）
- `processInteractiveEvents` 从 Engine 读取 quiet 状态
- `/new` `/switch` 不再影响 quiet

顺便也修了之前 `state.quiet` 的竞态问题（事件循环读没加锁，`cmdQuiet` 写有锁）。

## 讨论

quiet 这个配置感觉应该是全局的吧——当前的是只是一个 session 有效,切换到另一个 session 就失效了

## 测试

- 新增 `core/engine_test.go`：
  - `TestQuietToggle`：toggle 开关
  - `TestQuietPersistsAcrossSessions`：session cleanup 后 quiet 不丢失
- 飞书实测通过