### PR TITLE
feat(feishu): add reaction cleanup on turn completion

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -943,12 +943,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
 				if err := p.Send(e.ctx, replyCtx, chunk); err != nil {
 					slog.Error("failed to send reply", "error", err)
+					e.removeReaction(p, replyCtx)
 					return
 				}
 			}
 			if elapsed := time.Since(replyStart); elapsed >= slowPlatformSend {
 				slog.Warn("slow final reply send", "platform", p.Name(), "elapsed", elapsed, "response_len", len(fullResponse))
 			}
+			e.removeReaction(p, replyCtx)
 			return
 
 		case EventError:
@@ -956,6 +958,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				slog.Error("agent error", "error", event.Error)
 				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), event.Error))
 			}
+			e.removeReaction(p, replyCtx)
 			return
 		}
 	}
@@ -975,6 +978,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
 			e.send(p, replyCtx, chunk)
 		}
+		e.removeReaction(p, replyCtx)
 	}
 }
 
@@ -1276,7 +1280,7 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 
 func (e *Engine) cmdName(p Platform, msg *Message, args []string) {
 	if len(args) == 0 {
-		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgNameUsage)))
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgNameUsage))
 		return
 	}
 
@@ -1287,7 +1291,7 @@ func (e *Engine) cmdName(p Platform, msg *Message, args []string) {
 	if idx, err := strconv.Atoi(args[0]); err == nil && idx >= 1 {
 		// /name <number> <name...>
 		if len(args) < 2 {
-			e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgNameUsage)))
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgNameUsage))
 			return
 		}
 		agentSessions, err := e.agent.ListSessions(e.ctx)
@@ -1314,7 +1318,7 @@ func (e *Engine) cmdName(p Platform, msg *Message, args []string) {
 
 	name = strings.TrimSpace(name)
 	if name == "" {
-		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgNameUsage)))
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgNameUsage))
 		return
 	}
 
@@ -2067,6 +2071,14 @@ func (e *Engine) reply(p Platform, replyCtx any, content string) {
 	}
 }
 
+func (e *Engine) removeReaction(p Platform, replyCtx any) {
+	if rc, ok := p.(ReactionCleaner); ok {
+		if err := rc.RemoveReaction(e.ctx, replyCtx); err != nil {
+			slog.Debug("remove reaction failed", "error", err)
+		}
+	}
+}
+
 // ──────────────────────────────────────────────────────────────
 // /memory command
 // ──────────────────────────────────────────────────────────────
@@ -2739,7 +2751,7 @@ func (e *Engine) cmdAlias(p Platform, msg *Message, args []string) {
 	case "del", "delete", "remove":
 		e.cmdAliasDel(p, msg, args[1:])
 	default:
-		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgAliasUsage)))
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgAliasUsage))
 	}
 }
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -74,6 +74,12 @@ type InlineButtonSender interface {
 	SendWithButtons(ctx context.Context, replyCtx any, content string, buttons [][]ButtonOption) error
 }
 
+// ReactionCleaner is an optional interface for platforms that add processing
+// indicators (e.g. emoji reactions) and need to remove them when the turn completes.
+type ReactionCleaner interface {
+	RemoveReaction(ctx context.Context, replyCtx any) error
+}
+
 // MessageHandler is called by platforms when a new message arrives.
 type MessageHandler func(p Platform, msg *Message)
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -22,8 +22,9 @@ func init() {
 }
 
 type replyContext struct {
-	messageID string
-	chatID    string
+	messageID  string
+	chatID     string
+	reactionID string // set by addReaction, used by RemoveReaction
 }
 
 type Platform struct {
@@ -115,27 +116,52 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 	return nil
 }
 
-func (p *Platform) addReaction(messageID string) {
+func (p *Platform) addReaction(messageID string) string {
 	if p.reactionEmoji == "" {
-		return
+		return ""
 	}
 	emojiType := p.reactionEmoji
-	go func() {
-		resp, err := p.client.Im.MessageReaction.Create(context.Background(),
-			larkim.NewCreateMessageReactionReqBuilder().
-				MessageId(messageID).
-				Body(larkim.NewCreateMessageReactionReqBodyBuilder().
-					ReactionType(&larkim.Emoji{EmojiType: &emojiType}).
-					Build()).
-				Build())
-		if err != nil {
-			slog.Debug("feishu: add reaction failed", "error", err)
-			return
-		}
-		if !resp.Success() {
-			slog.Debug("feishu: add reaction failed", "code", resp.Code, "msg", resp.Msg)
-		}
-	}()
+	resp, err := p.client.Im.MessageReaction.Create(context.Background(),
+		larkim.NewCreateMessageReactionReqBuilder().
+			MessageId(messageID).
+			Body(larkim.NewCreateMessageReactionReqBodyBuilder().
+				ReactionType(&larkim.Emoji{EmojiType: &emojiType}).
+				Build()).
+			Build())
+	if err != nil {
+		slog.Debug("feishu: add reaction failed", "error", err)
+		return ""
+	}
+	if !resp.Success() {
+		slog.Debug("feishu: add reaction failed", "code", resp.Code, "msg", resp.Msg)
+		return ""
+	}
+	if resp.Data != nil && resp.Data.ReactionId != nil {
+		return *resp.Data.ReactionId
+	}
+	return ""
+}
+
+func (p *Platform) RemoveReaction(ctx context.Context, rctx any) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return fmt.Errorf("feishu: invalid reply context type %T", rctx)
+	}
+	if rc.reactionID == "" || rc.messageID == "" {
+		return nil
+	}
+	resp, err := p.client.Im.MessageReaction.Delete(ctx,
+		larkim.NewDeleteMessageReactionReqBuilder().
+			MessageId(rc.messageID).
+			ReactionId(rc.reactionID).
+			Build())
+	if err != nil {
+		return fmt.Errorf("feishu: delete reaction: %w", err)
+	}
+	if !resp.Success() {
+		slog.Debug("feishu: delete reaction failed", "code", resp.Code, "msg", resp.Msg)
+	}
+	return nil
 }
 
 func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
@@ -187,12 +213,13 @@ func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
 		return nil
 	}
 
+	var reactionID string
 	if msgType != "" && messageID != "" {
-		p.addReaction(messageID)
+		reactionID = p.addReaction(messageID)
 	}
 
 	sessionKey := fmt.Sprintf("feishu:%s:%s", chatID, userID)
-	rctx := replyContext{messageID: messageID, chatID: chatID}
+	rctx := replyContext{messageID: messageID, chatID: chatID, reactionID: reactionID}
 
 	switch msgType {
 	case "text":


### PR DESCRIPTION
## Summary
- Add `ReactionCleaner` interface and implement `RemoveReaction` for Feishu platform to remove processing indicator emoji when a turn completes
- Fix missing `removeReaction` call on Send failure and agent process unexpected exit, which left emoji reactions stuck on messages indefinitely
- Fix `fmt.Sprintf` with non-constant format string in `cmdName` and `cmdAlias` (caused `go vet` build failure)

## Changes
- `core/interfaces.go`: Add `ReactionCleaner` optional interface
- `core/engine.go`: Add `removeReaction` helper; call it on all exit paths in `processInteractiveEvents` (normal completion, error, send failure, process crash); fix 4x `fmt.Sprintf` vet errors
- `platform/feishu/feishu.go`: Change `addReaction` from async to sync (returns reactionID); add `RemoveReaction` method; store `reactionID` in `replyContext`

## Test plan
- [x] `go test ./...` passes (all packages)
- [ ] Manual test: send message in Feishu group, verify emoji reaction appears during processing and is removed on completion
- [ ] Manual test: simulate send failure / agent crash, verify emoji reaction is still cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)