### PR TITLE
fix(engine): stop idle timer during permission wait

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1078,8 +1078,20 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			state.pending = pending
 			state.mu.Unlock()
 
+			// Stop idle timer while waiting for user permission response;
+			// the user may take a long time to decide, and we don't want
+			// the idle timeout to kill the session during that wait.
+			if idleTimer != nil {
+				idleTimer.Stop()
+			}
+
 			<-pending.Resolved
 			slog.Info("permission resolved", "request_id", event.RequestID)
+
+			// Restart idle timer after permission is resolved
+			if idleTimer != nil {
+				idleTimer.Reset(e.eventIdleTimeout)
+			}
 
 		case EventResult:
 			if event.SessionID != "" {


### PR DESCRIPTION
## Summary
- Fix idle timer firing during permission wait, which kills active sessions unexpectedly

## Problem
The idle timer in `processInteractiveEvents` keeps running while the event loop blocks on `<-pending.Resolved` waiting for user permission response. If the user takes longer than `eventIdleTimeout` to decide, the timer fires. When the permission is finally resolved and the loop returns to the `select`, Go may pick the `idleCh` case — killing an active session that the user is interacting with.

## Fix
Stop the idle timer before blocking on `pending.Resolved`, and restart it after permission is resolved.

## Test plan
- [x] `go test ./...` all packages pass
- [ ] Manual: trigger permission prompt, wait longer than idle timeout, respond — session should survive