### PR TITLE
fix(feishu): add nil checks for SenderId.OpenId and msg.Content

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -192,7 +192,7 @@ func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
 	}
 	userID := ""
 	userName := ""
-	if sender.SenderId != nil {
+	if sender.SenderId != nil && sender.SenderId.OpenId != nil {
 		userID = *sender.SenderId.OpenId
 	}
 	if sender.SenderType != nil {
@@ -233,6 +233,11 @@ func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
 
 	if !core.AllowList(p.allowFrom, userID) {
 		slog.Debug("feishu: message from unauthorized user", "user", userID)
+		return nil
+	}
+
+	if msg.Content == nil {
+		slog.Debug("feishu: message content is nil", "message_id", messageID, "type", msgType)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- Add nil check for `sender.SenderId.OpenId` before dereference (line 196)
- Add nil check for `msg.Content` before the switch block that dereferences it in 4 places (text/image/audio/post)

## Problem
Feishu API can send events where `SenderId.OpenId` or `msg.Content` is nil. The current code checks `sender.SenderId != nil` but not `OpenId`, causing a nil pointer panic. Similarly, `*msg.Content` is dereferenced in all 4 message type handlers without a nil guard.

## Test plan
- [x] `go test ./...` all packages pass
- [x] Existing `platform/feishu` tests pass