### PR TITLE
fix(cron): log json.Unmarshal error instead of ignoring it

### DIFF
--- a/core/cron.go
+++ b/core/cron.go
@@ -53,7 +53,9 @@ func (s *CronStore) load() {
 	if err != nil {
 		return
 	}
-	json.Unmarshal(data, &s.jobs)
+	if err := json.Unmarshal(data, &s.jobs); err != nil {
+		slog.Error("cron: failed to load jobs", "path", s.path, "error", err)
+	}
 }
 
 func (s *CronStore) save() error {


### PR DESCRIPTION
## Summary
- Log `json.Unmarshal` error in `CronStore.load()` instead of silently ignoring it

## Problem
When the cron jobs JSON file is corrupted or malformed, `json.Unmarshal` returns an error that is silently discarded. All cron jobs are lost with no log output, making the issue invisible to operators.

## Test plan
- [x] `go test ./...` all packages pass