### PR TITLE
fix: support daemon install config flag and correct go.sum checksum

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -635,7 +635,13 @@ You can run cc-connect as a daemon managed by the OS init system (Linux systemd 
 cc-connect daemon install --config ~/.cc-connect/config.toml
 ```
 
-Optional flags: `--log-file PATH`, `--log-max-size N` (MB), `--work-dir DIR`, `--force` (overwrite existing unit).
+You can also point the daemon at the directory that contains `config.toml`:
+
+```bash
+cc-connect daemon install --work-dir ~/.cc-connect
+```
+
+Optional flags: `--config PATH`, `--log-file PATH`, `--log-max-size N` (MB), `--work-dir DIR`, `--force` (overwrite existing unit). `--config` points to a config file, while `--work-dir` points to the directory containing `config.toml`.
 
 ### Control the service
 

--- a/README.md
+++ b/README.md
@@ -715,6 +715,7 @@ Run cc-connect as a background service managed by the OS init system (Linux syst
 
 ```bash
 cc-connect daemon install --config ~/.cc-connect/config.toml   # install service
+cc-connect daemon install --work-dir ~/.cc-connect             # same, using config dir
 cc-connect daemon start
 cc-connect daemon stop
 cc-connect daemon restart
@@ -723,7 +724,7 @@ cc-connect daemon logs [-f] [-n N] [--log-file PATH]
 cc-connect daemon uninstall
 ```
 
-**Install flags:** `--log-file PATH`, `--log-max-size N` (MB), `--work-dir DIR`, `--force`. Logs auto-rotate at the size limit and keep one backup.
+**Install flags:** `--config PATH`, `--log-file PATH`, `--log-max-size N` (MB), `--work-dir DIR`, `--force`. `--config` points to a config file; `--work-dir` points to the directory containing `config.toml`. Logs auto-rotate at the size limit and keep one backup.
 
 ## Session Management
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -666,6 +666,7 @@ For short single-line messages:
 
 ```bash
 cc-connect daemon install --config ~/.cc-connect/config.toml   # 安装服务
+cc-connect daemon install --work-dir ~/.cc-connect             # 等价写法：指定配置目录
 cc-connect daemon start
 cc-connect daemon stop
 cc-connect daemon restart
@@ -674,7 +675,7 @@ cc-connect daemon logs [-f] [-n N] [--log-file PATH]
 cc-connect daemon uninstall
 ```
 
-**install 参数：** `--log-file PATH`、`--log-max-size N`（MB）、`--work-dir DIR`、`--force`。日志在达到大小限制时自动轮转，保留 1 个备份。
+**install 参数：** `--config PATH`、`--log-file PATH`、`--log-max-size N`（MB）、`--work-dir DIR`、`--force`。`--config` 传入配置文件路径，`--work-dir` 传入包含 `config.toml` 的目录。日志在达到大小限制时自动轮转，保留 1 个备份。
 
 ## 会话管理
 

--- a/cmd/cc-connect/daemon.go
+++ b/cmd/cc-connect/daemon.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -43,34 +44,10 @@ func runDaemon(args []string) {
 // ── install ─────────────────────────────────────────────────
 
 func daemonInstall(args []string) {
-	var cfg daemon.Config
-	var force bool
-
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "--log-file":
-			i++
-			if i < len(args) {
-				cfg.LogFile = args[i]
-			}
-		case "--log-max-size":
-			i++
-			if i < len(args) {
-				if mb, err := strconv.Atoi(args[i]); err == nil {
-					cfg.LogMaxSize = int64(mb) * 1024 * 1024
-				}
-			}
-		case "--work-dir":
-			i++
-			if i < len(args) {
-				cfg.WorkDir = args[i]
-			}
-		case "--force":
-			force = true
-		default:
-			fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", args[i])
-			os.Exit(1)
-		}
+	cfg, force, err := parseDaemonInstallArgs(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	if err := daemon.Resolve(&cfg); err != nil {
@@ -81,7 +58,7 @@ func daemonInstall(args []string) {
 	configPath := cfg.WorkDir + "/config.toml"
 	if _, err := os.Stat(configPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: config.toml not found in %s\n", cfg.WorkDir)
-		fmt.Fprintf(os.Stderr, "  Use --work-dir to specify the directory containing config.toml\n")
+		fmt.Fprintf(os.Stderr, "  Use --work-dir to specify the config directory or --config to point to the config file\n")
 		os.Exit(1)
 	}
 
@@ -126,6 +103,78 @@ func daemonInstall(args []string) {
 	fmt.Println("  cc-connect daemon restart   - Restart")
 	fmt.Println("  cc-connect daemon stop      - Stop")
 	fmt.Println("  cc-connect daemon uninstall - Remove")
+}
+
+func parseDaemonInstallArgs(args []string) (daemon.Config, bool, error) {
+	var cfg daemon.Config
+	var force bool
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--force":
+			force = true
+		case arg == "--log-file":
+			value, next, err := daemonInstallFlagValue(args, i, "--log-file")
+			if err != nil {
+				return daemon.Config{}, false, err
+			}
+			cfg.LogFile = value
+			i = next
+		case strings.HasPrefix(arg, "--log-file="):
+			cfg.LogFile = strings.TrimPrefix(arg, "--log-file=")
+		case arg == "--log-max-size":
+			value, next, err := daemonInstallFlagValue(args, i, "--log-max-size")
+			if err != nil {
+				return daemon.Config{}, false, err
+			}
+			mb, err := strconv.Atoi(value)
+			if err != nil {
+				return daemon.Config{}, false, fmt.Errorf("invalid value for --log-max-size: %s", value)
+			}
+			cfg.LogMaxSize = int64(mb) * 1024 * 1024
+			i = next
+		case strings.HasPrefix(arg, "--log-max-size="):
+			value := strings.TrimPrefix(arg, "--log-max-size=")
+			mb, err := strconv.Atoi(value)
+			if err != nil {
+				return daemon.Config{}, false, fmt.Errorf("invalid value for --log-max-size: %s", value)
+			}
+			cfg.LogMaxSize = int64(mb) * 1024 * 1024
+		case arg == "--work-dir":
+			value, next, err := daemonInstallFlagValue(args, i, "--work-dir")
+			if err != nil {
+				return daemon.Config{}, false, err
+			}
+			cfg.WorkDir = value
+			i = next
+		case strings.HasPrefix(arg, "--work-dir="):
+			cfg.WorkDir = strings.TrimPrefix(arg, "--work-dir=")
+		case arg == "--config" || arg == "-config":
+			value, next, err := daemonInstallFlagValue(args, i, arg)
+			if err != nil {
+				return daemon.Config{}, false, err
+			}
+			cfg.WorkDir = filepath.Dir(value)
+			i = next
+		case strings.HasPrefix(arg, "--config="):
+			cfg.WorkDir = filepath.Dir(strings.TrimPrefix(arg, "--config="))
+		case strings.HasPrefix(arg, "-config="):
+			cfg.WorkDir = filepath.Dir(strings.TrimPrefix(arg, "-config="))
+		default:
+			return daemon.Config{}, false, fmt.Errorf("Unknown flag: %s", arg)
+		}
+	}
+
+	return cfg, force, nil
+}
+
+func daemonInstallFlagValue(args []string, index int, flagName string) (string, int, error) {
+	next := index + 1
+	if next >= len(args) {
+		return "", index, fmt.Errorf("missing value for %s", flagName)
+	}
+	return args[next], next, nil
 }
 
 // ── uninstall ───────────────────────────────────────────────
@@ -350,6 +399,7 @@ Commands:
   logs        View log output
 
 Install flags:
+  --config PATH         Path to config.toml (uses its parent as work dir)
   --log-file PATH       Log file path (default: ~/.cc-connect/logs/cc-connect.log)
   --log-max-size N      Max log file size in MB (default: 10)
   --work-dir DIR        Directory containing config.toml (default: current dir)

--- a/cmd/cc-connect/daemon_test.go
+++ b/cmd/cc-connect/daemon_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseDaemonInstallArgs_ConfigSetsWorkDir(t *testing.T) {
+	cfg, force, err := parseDaemonInstallArgs([]string{"--config", "/tmp/example/config.toml"})
+	if err != nil {
+		t.Fatalf("parseDaemonInstallArgs returned error: %v", err)
+	}
+	if force {
+		t.Fatalf("force = true, want false")
+	}
+
+	want := filepath.Clean("/tmp/example")
+	if cfg.WorkDir != want {
+		t.Fatalf("cfg.WorkDir = %q, want %q", cfg.WorkDir, want)
+	}
+}
+
+func TestParseDaemonInstallArgs_ConfigEqualsFormSetsWorkDir(t *testing.T) {
+	cfg, _, err := parseDaemonInstallArgs([]string{"--config=/tmp/example/config.toml"})
+	if err != nil {
+		t.Fatalf("parseDaemonInstallArgs returned error: %v", err)
+	}
+
+	want := filepath.Clean("/tmp/example")
+	if cfg.WorkDir != want {
+		t.Fatalf("cfg.WorkDir = %q, want %q", cfg.WorkDir, want)
+	}
+}
+
+func TestParseDaemonInstallArgs_WorkDirOverridesConfig(t *testing.T) {
+	cfg, force, err := parseDaemonInstallArgs([]string{
+		"--config", "/tmp/example/config.toml",
+		"--work-dir", "/tmp/override",
+		"--force",
+	})
+	if err != nil {
+		t.Fatalf("parseDaemonInstallArgs returned error: %v", err)
+	}
+	if !force {
+		t.Fatalf("force = false, want true")
+	}
+
+	want := filepath.Clean("/tmp/override")
+	if cfg.WorkDir != want {
+		t.Fatalf("cfg.WorkDir = %q, want %q", cfg.WorkDir, want)
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/BurntSushi/toml v1.6.0 h1:MEaUJLQJKFxTNo0xg+dKyOJA2Nu4O8kPVKuJ/gBiyjc=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=


### PR DESCRIPTION
## Summary
- support `cc-connect daemon install --config /path/to/config.toml`
- keep `--work-dir` support and document how it differs from `--config`
- align English and Chinese daemon install docs with actual behavior
- correct the `github.com/BurntSushi/toml` checksum recorded in `go.sum` so local builds and tests can resolve modules normally

## Verification
- `go test ./daemon -count=1`
- `go test ./cmd/cc-connect -run TestParseDaemonInstallArgs -count=1`
- `go test ./...`
- `make build`
