### PR TITLE
fix(claudecode): handle underscores in findProjectDir path matching

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -695,12 +695,15 @@ func summarizeInput(tool string, input any) string {
 func findProjectDir(homeDir, absWorkDir string) string {
 	projectsBase := filepath.Join(homeDir, ".claude", "projects")
 
-	// Build candidate keys: different ways Claude Code might encode the path
+	// Build candidate keys: different ways Claude Code might encode the path.
+	// Claude Code replaces path separators, colons, and underscores with "-".
 	candidates := []string{
 		// Unix-style: replace OS separator with "-"
 		strings.ReplaceAll(absWorkDir, string(filepath.Separator), "-"),
 		// Windows: replace both "\" and ":" with "-"
 		strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(absWorkDir),
+		// Claude Code also replaces underscores with "-"
+		strings.NewReplacer("/", "-", "\\", "-", ":", "-", "_", "-").Replace(absWorkDir),
 	}
 	// Also try with forward slashes (config might use forward slashes on Windows)
 	fwd := strings.ReplaceAll(absWorkDir, "\\", "/")
@@ -720,7 +723,7 @@ func findProjectDir(homeDir, absWorkDir string) string {
 		return ""
 	}
 
-	normWork := strings.ToLower(strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(absWorkDir))
+	normWork := strings.ToLower(strings.NewReplacer("/", "-", "\\", "-", ":", "-", "_", "-").Replace(absWorkDir))
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue


### PR DESCRIPTION
## Summary
- Claude Code replaces `_` with `-` when encoding project paths as directory names (e.g. `my_project` → `my-project`)
- `findProjectDir` only replaced path separators and colons, missing underscores
- This caused `/list` to return empty results for projects whose `work_dir` contains underscores
- Added `"_", "-"` replacement to both candidate key generation and fallback directory scan

## Test plan
- [x] Configured a project with `work_dir` containing underscores (e.g. `/path/to/my_project`)
- [x] Verified `/list` now correctly discovers sessions
- [x] Projects without underscores continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)