### PR TITLE
fix(qqbot): handle json.Unmarshal and WriteJSON errors

### DIFF
--- a/platform/qqbot/qqbot.go
+++ b/platform/qqbot/qqbot.go
@@ -375,7 +375,9 @@ func (p *Platform) waitForHello(conn *websocket.Conn) error {
 	var hello struct {
 		HeartbeatInterval int `json:"heartbeat_interval"`
 	}
-	json.Unmarshal(msg.D, &hello)
+	if err := json.Unmarshal(msg.D, &hello); err != nil {
+		slog.Warn("qqbot: failed to parse Hello payload", "error", err)
+	}
 	if hello.HeartbeatInterval > 0 {
 		p.heartbeatMs = hello.HeartbeatInterval
 	} else {
@@ -417,7 +419,9 @@ func (p *Platform) waitForReady(conn *websocket.Conn) error {
 	var ready struct {
 		SessionID string `json:"session_id"`
 	}
-	json.Unmarshal(msg.D, &ready)
+	if err := json.Unmarshal(msg.D, &ready); err != nil {
+		slog.Warn("qqbot: failed to parse READY payload", "error", err)
+	}
 	p.sessionID = ready.SessionID
 	if msg.S != nil {
 		p.lastSeq.Store(*msg.S)
@@ -459,7 +463,9 @@ func (p *Platform) sendHeartbeat() {
 	p.wsMu.Lock()
 	defer p.wsMu.Unlock()
 	if p.wsConn != nil {
-		p.wsConn.WriteJSON(wsPayload{Op: opHeartbeat, D: d})
+		if err := p.wsConn.WriteJSON(wsPayload{Op: opHeartbeat, D: d}); err != nil {
+			slog.Debug("qqbot: heartbeat send failed", "error", err)
+		}
 	}
 }
 
@@ -504,7 +510,9 @@ func (p *Platform) readLoop(ctx context.Context) {
 			return
 		case opInvalidSession:
 			var resumable bool
-			json.Unmarshal(msg.D, &resumable)
+			if err := json.Unmarshal(msg.D, &resumable); err != nil {
+				slog.Warn("qqbot: failed to parse InvalidSession payload", "error", err)
+			}
 			if resumable {
 				slog.Info("qqbot: invalid session (resumable), attempting resume")
 			} else {


### PR DESCRIPTION
## Summary
- Fix 4 silently ignored errors in QQBot gateway protocol handling

## Problem
The QQBot WebSocket gateway handler has multiple `json.Unmarshal` and `WriteJSON` calls whose errors are silently discarded. This causes:

1. **Hello** (heartbeat_interval): parse failure silently falls back to hardcoded 41250ms, which may not match server expectation — connection can die from heartbeat mismatch
2. **READY** (session_id): parse failure stores empty session ID, breaking gateway resume on reconnect
3. **InvalidSession** (resumable): parse failure defaults to `false`, causing unnecessary full re-identify when the session was actually resumable
4. **Heartbeat WriteJSON**: write failure is never logged, making connection issues impossible to diagnose

## Fix
Add error logging for all 4 cases. No behavior change beyond making failures visible in logs.

## Test plan
- [x] `go test ./...` all packages pass
- [x] No behavior change for success paths