### PR TITLE
fix(feishu): always reply to original message

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -105,7 +105,6 @@ type Platform struct {
 	allowFrom             string
 	groupReplyAll         bool
 	shareSessionInChannel bool
-	replyInThread         bool
 	threadIsolation       bool
 	client                *lark.Client
 	wsClient              *larkws.Client
@@ -153,7 +152,6 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	core.CheckAllowFrom(name, allowFrom)
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
-	replyInThread, _ := opts["reply_in_thread"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
 	useInteractiveCard := true
 	if v, ok := opts["enable_feishu_card"].(bool); ok {
@@ -186,7 +184,6 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		allowFrom:             allowFrom,
 		groupReplyAll:         groupReplyAll,
 		shareSessionInChannel: shareSessionInChannel,
-		replyInThread:         replyInThread,
 		threadIsolation:       threadIsolation,
 		client:                lark.NewClient(appID, appSecret, clientOpts...),
 		port:                  port,
@@ -1048,15 +1045,16 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	return nil
 }
 
-// Send sends a new message to the same chat (not a reply to original message).
-// When reply_in_thread is enabled, threads the message to the original message instead.
+// Send sends a message. When the original message ID is available, the message
+// is sent as a reply (quoting the original) so the conversation stays threaded.
+// Falls back to creating a standalone message when no message ID exists.
 func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 	rc, ok := rctx.(replyContext)
 	if !ok {
 		return fmt.Errorf("%s: invalid reply context type %T", p.tag(), rctx)
 	}
 
-	if p.shouldReplyInThread(rc) {
+	if rc.messageID != "" {
 		return p.Reply(ctx, rctx, content)
 	}
 
@@ -1152,7 +1150,7 @@ func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachm
 }
 
 func (p *Platform) sendMediaMessage(ctx context.Context, rc replyContext, msgType, content string) error {
-	if p.shouldReplyInThread(rc) {
+	if rc.messageID != "" {
 		replyResp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
 			MessageId(rc.messageID).
 			Body(p.buildReplyMessageReqBody(rc, msgType, content)).
@@ -1660,9 +1658,6 @@ func (p *Platform) shouldReplyInThread(rc replyContext) bool {
 	if rc.messageID == "" {
 		return false
 	}
-	if p.replyInThread {
-		return true
-	}
 	return p.threadIsolation && isThreadSessionKey(rc.sessionKey)
 }
 
@@ -1765,7 +1760,7 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 	cardJSON := buildCardJSON(sanitizeMarkdownURLs(content))
 
 	var msgID string
-	if p.shouldReplyInThread(rc) {
+	if rc.messageID != "" {
 		resp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
 			MessageId(rc.messageID).
 			Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeInteractive, cardJSON)).
@@ -1894,8 +1889,8 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 		return fmt.Errorf("%s: build audio message: %w", p.tag(), err)
 	}
 
-	// Send audio message to chat or thread.
-	if p.shouldReplyInThread(rc) {
+	// Send audio message — reply to original message when possible.
+	if rc.messageID != "" {
 		replyResp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
 			MessageId(rc.messageID).
 			Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeAudio, audioContent)).

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -594,12 +594,6 @@ func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 			wantThreading: false,
 		},
 		{
-			name:          "reply_in_thread enabled",
-			platform:      &Platform{replyInThread: true},
-			replyCtx:      replyContext{messageID: "om_reply"},
-			wantThreading: true,
-		},
-		{
 			name:          "plain reply remains non-threaded",
 			platform:      &Platform{},
 			replyCtx:      replyContext{messageID: "om_reply"},


### PR DESCRIPTION
## Summary
- All responses (text, preview cards, audio) are now sent as replies to the original user message, keeping conversations threaded
- Previously this only happened when `reply_in_thread` was explicitly set in config; now it's the default behavior
- Removed the `replyInThread` config option as it's no longer needed

## Test plan
- [ ] Send a text message to the Feishu bot and verify the response quotes the original message
- [ ] Send an image and verify the response is threaded
- [ ] Send audio and verify the audio reply is threaded
- [ ] Verify streaming preview (card) messages are also threaded
- [ ] Verify fallback to standalone message works when messageID is empty (e.g. reconstructed sessions)