### PR TITLE
feat(codex): fallback /model list to local models cache

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -90,6 +90,9 @@ func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
 	if models := a.fetchModelsFromAPI(ctx); len(models) > 0 {
 		return models
 	}
+	if models := readCodexCachedModels(); len(models) > 0 {
+		return models
+	}
 	return []core.ModelOption{
 		{Name: "o4-mini", Desc: "O4 Mini (fast reasoning)"},
 		{Name: "o3", Desc: "O3 (most capable reasoning)"},
@@ -163,6 +166,61 @@ func (a *Agent) fetchModelsFromAPI(ctx context.Context) []core.ModelOption {
 		}
 	}
 	sort.Slice(models, func(i, j int) bool { return models[i].Name < models[j].Name })
+	return models
+}
+
+func readCodexCachedModels() []core.ModelOption {
+	codexHome := os.Getenv("CODEX_HOME")
+	if codexHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		codexHome = filepath.Join(home, ".codex")
+	}
+	path := filepath.Join(codexHome, "models_cache.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var payload struct {
+		Models []struct {
+			Slug           string `json:"slug"`
+			DisplayName    string `json:"display_name"`
+			Description    string `json:"description"`
+			Visibility     string `json:"visibility"`
+			SupportedInAPI bool   `json:"supported_in_api"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(b, &payload); err != nil {
+		return nil
+	}
+
+	var models []core.ModelOption
+	seen := make(map[string]struct{}, len(payload.Models))
+	for _, m := range payload.Models {
+		name := strings.TrimSpace(m.Slug)
+		if name == "" {
+			name = strings.TrimSpace(m.DisplayName)
+		}
+		if name == "" {
+			continue
+		}
+		if m.Visibility != "" && m.Visibility != "list" {
+			continue
+		}
+		if !m.SupportedInAPI {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		models = append(models, core.ModelOption{
+			Name: name,
+			Desc: strings.TrimSpace(m.Description),
+		})
+	}
 	return models
 }
 

--- a/agent/codex/codex_cache_test.go
+++ b/agent/codex/codex_cache_test.go
@@ -1,0 +1,43 @@
+package codex
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestAvailableModels_FallbackToModelsCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	cache := `{
+  "models": [
+    {"slug":"gpt-5.4","description":"Latest frontier agentic coding model.","visibility":"list","supported_in_api":true},
+    {"slug":"gpt-5.3-codex","description":"Great for coding","visibility":"list","supported_in_api":true},
+    {"slug":"hidden-internal","visibility":"hidden","supported_in_api":true},
+    {"slug":"tool-only","visibility":"list","supported_in_api":false}
+  ]
+}`
+	if err := os.WriteFile(tmp+"/models_cache.json", []byte(cache), 0o600); err != nil {
+		t.Fatalf("write models_cache.json: %v", err)
+	}
+
+	t.Setenv("CODEX_HOME", tmp)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENAI_BASE_URL", srv.URL)
+
+	a := &Agent{activeIdx: -1}
+	models := a.AvailableModels(context.Background())
+	if len(models) != 2 {
+		t.Fatalf("models length = %d, want 2, models=%v", len(models), models)
+	}
+	if models[0].Name != "gpt-5.4" || models[1].Name != "gpt-5.3-codex" {
+		t.Fatalf("models = %v, want [gpt-5.4 gpt-5.3-codex]", models)
+	}
+}
+


### PR DESCRIPTION
## Summary
- keep existing /v1/models fetch path
- when API fetch fails, fallback to local ~/.codex/models_cache.json
- keep existing static fallback list as last resort

## Why
Codex OAuth users may not have api.model.read on direct API calls, which makes /model fall back to old static models. Using local Codex models cache preserves fresh model list for chat platforms.

## Test
- go test ./agent/codex
- go test ./core -run TestCmdModel_UsesInlineButtonsOnButtonOnlyPlatform -count=1
