### PR TITLE
fix(slack): handle AppMentionEvent for channel @mention support

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/BurntSushi/toml v1.6.0 h1:MEaUJLQJKFxTNo0xg+dKyOJA2Nu4O8kPVKuJ/gBiyjc=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -100,6 +100,45 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 
 		if data.Type == slackevents.CallbackEvent {
 			switch ev := data.InnerEvent.Data.(type) {
+			case *slackevents.AppMentionEvent:
+				if ev.BotID != "" || ev.User == "" {
+					return
+				}
+
+				if ts := ev.TimeStamp; ts != "" {
+					if dotIdx := strings.IndexByte(ts, '.'); dotIdx > 0 {
+						if sec, err := strconv.ParseInt(ts[:dotIdx], 10, 64); err == nil {
+							if core.IsOldMessage(time.Unix(sec, 0)) {
+								slog.Debug("slack: ignoring old app_mention after restart", "ts", ts)
+								return
+							}
+						}
+					}
+				}
+
+				slog.Debug("slack: app_mention received", "user", ev.User, "channel", ev.Channel)
+
+				if !core.AllowList(p.allowFrom, ev.User) {
+					slog.Debug("slack: app_mention from unauthorized user", "user", ev.User)
+					return
+				}
+
+				var sessionKey string
+				if p.shareSessionInChannel {
+					sessionKey = fmt.Sprintf("slack:%s", ev.Channel)
+				} else {
+					sessionKey = fmt.Sprintf("slack:%s:%s", ev.Channel, ev.User)
+				}
+
+				msg := &core.Message{
+					SessionKey: sessionKey, Platform: "slack",
+					UserID: ev.User, UserName: ev.User,
+					Content: ev.Text,
+					MessageID: ev.TimeStamp,
+					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: ev.TimeStamp},
+				}
+				p.handler(p, msg)
+
 			case *slackevents.MessageEvent:
 				if ev.BotID != "" || ev.User == "" {
 					return


### PR DESCRIPTION
## Summary
- Add `*slackevents.AppMentionEvent` handler to `handleEvent` so the bot responds to @mentions in channels
- Previously only `*slackevents.MessageEvent` was handled, meaning channel @mentions were silently dropped (only DMs worked)
- The new handler follows the same validation pipeline: bot filter, old-message guard, AllowList check, session key generation

## Prerequisite
Slack App needs:
- **OAuth Scopes**: `app_mentions:read`, `groups:history` (for private channels)
- **Event Subscriptions**: `app_mention`
- Bot must be invited to the target channel

## Test plan
- [ ] @mention the bot in a public channel → bot responds
- [ ] @mention the bot in a private channel → bot responds (with `groups:history` scope)
- [ ] DM the bot → still works as before (MessageEvent path)
- [ ] Unauthorized user @mentions bot → message ignored

Closes #48