### PR TITLE
fix(security): harden socket permissions, redact token, warn on open allow_from

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -47,7 +47,7 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listen unix socket: %w", err)
 	}
-	os.Chmod(sockPath, 0o660)
+	os.Chmod(sockPath, 0o600)
 
 	s := &APIServer{
 		socketPath: sockPath,

--- a/core/message.go
+++ b/core/message.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"log/slog"
 	"strings"
 	"time"
 )
@@ -23,6 +24,16 @@ func MergeEnv(base, extra []string) []string {
 		merged = append(merged, e)
 	}
 	return append(merged, extra...)
+}
+
+// CheckAllowFrom logs a security warning at startup when allow_from is not
+// configured (defaults to permit-all). Platforms should call this during init.
+func CheckAllowFrom(platform, allowFrom string) {
+	if strings.TrimSpace(allowFrom) == "" {
+		slog.Warn("allow_from is not set — all users are permitted. "+
+			"Set allow_from in config to restrict access.",
+			"platform", platform)
+	}
 }
 
 // AllowList checks whether a user ID is permitted based on a comma-separated

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/BurntSushi/toml v1.6.0 h1:MEaUJLQJKFxTNo0xg+dKyOJA2Nu4O8kPVKuJ/gBiyjc=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -38,6 +38,7 @@ func New(opts map[string]any) (core.Platform, error) {
 	clientID, _ := opts["client_id"].(string)
 	clientSecret, _ := opts["client_secret"].(string)
 	allowFrom, _ := opts["allow_from"].(string)
+	core.CheckAllowFrom("dingtalk", allowFrom)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	if clientID == "" || clientSecret == "" {
 		return nil, fmt.Errorf("dingtalk: client_id and client_secret are required")

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -54,6 +54,7 @@ func New(opts map[string]any) (core.Platform, error) {
 		return nil, fmt.Errorf("discord: token is required")
 	}
 	allowFrom, _ := opts["allow_from"].(string)
+	core.CheckAllowFrom("discord", allowFrom)
 	guildID, _ := opts["guild_id"].(string)
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -71,6 +71,7 @@ func New(opts map[string]any) (core.Platform, error) {
 		reactionEmoji = ""
 	}
 	allowFrom, _ := opts["allow_from"].(string)
+	core.CheckAllowFrom("feishu", allowFrom)
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	replyInThread, _ := opts["reply_in_thread"].(bool)

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -41,6 +41,7 @@ func New(opts map[string]any) (core.Platform, error) {
 	botToken, _ := opts["bot_token"].(string)
 	appToken, _ := opts["app_token"].(string)
 	allowFrom, _ := opts["allow_from"].(string)
+	core.CheckAllowFrom("slack", allowFrom)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	if botToken == "" || appToken == "" {
 		return nil, fmt.Errorf("slack: bot_token and app_token are required")

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -42,6 +42,7 @@ func New(opts map[string]any) (core.Platform, error) {
 		return nil, fmt.Errorf("telegram: token is required")
 	}
 	allowFrom, _ := opts["allow_from"].(string)
+	core.CheckAllowFrom("telegram", allowFrom)
 
 	// Build HTTP client with optional proxy support
 	httpClient := &http.Client{Timeout: 60 * time.Second}
@@ -521,7 +522,9 @@ func (p *Platform) downloadFile(fileID string) ([]byte, error) {
 
 	resp, err := p.httpClient.Get(link)
 	if err != nil {
-		return nil, fmt.Errorf("download: %w", err)
+		// Redact bot token from error message to prevent token leakage in logs
+		errMsg := strings.ReplaceAll(err.Error(), p.bot.Token, "[REDACTED]")
+		return nil, fmt.Errorf("download file %s: %s", fileID, errMsg)
 	}
 	defer resp.Body.Close()
 	return io.ReadAll(resp.Body)


### PR DESCRIPTION
## Summary
- **Unix socket permissions**: `0o660` → `0o600` (owner-only), preventing same-group processes from injecting messages via the local API socket
- **Telegram token redaction**: bot token is now replaced with `[REDACTED]` in file download error messages, preventing token leakage in logs
- **Startup warning for open `allow_from`**: all platforms now log a `WARN` message at startup when `allow_from` is not configured, making the fail-open default visible to operators

## Test plan
- [ ] Verify API socket is created with `0600` permissions (`ls -la ~/.cc-connect/run/api.sock`)
- [ ] Trigger a Telegram file download failure → verify bot token is NOT in the error log
- [ ] Start with empty `allow_from` → verify WARN log appears
- [ ] Start with `allow_from = "user1,user2"` → verify no WARN log
- [ ] All existing tests pass (`go test ./...`)

Ref #60