### PR TITLE
feat: add /dir command for dynamic agent work directory switching

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -107,6 +107,19 @@ func (a *Agent) Name() string           { return "claudecode" }
 func (a *Agent) CLIBinaryName() string  { return "claude" }
 func (a *Agent) CLIDisplayName() string { return "Claude" }
 
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("claudecode: work_dir changed", "work_dir", dir)
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+
 func (a *Agent) SetModel(model string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -93,6 +93,19 @@ func normalizeReasoningEffort(raw string) string {
 
 func (a *Agent) Name() string { return "codex" }
 
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("codex: work_dir changed", "work_dir", dir)
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+
 func (a *Agent) SetModel(model string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -83,6 +83,19 @@ func (a *Agent) Name() string           { return "cursor" }
 func (a *Agent) CLIBinaryName() string  { return "agent" }
 func (a *Agent) CLIDisplayName() string { return "Cursor Agent" }
 
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("cursor: work_dir changed", "work_dir", dir)
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+
 func (a *Agent) SetModel(model string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/gemini/gemini.go
+++ b/agent/gemini/gemini.go
@@ -101,6 +101,19 @@ func normalizeMode(raw string) string {
 
 func (a *Agent) Name() string { return "gemini" }
 
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("gemini: work_dir changed", "work_dir", dir)
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+
 func (a *Agent) SetModel(model string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/iflow/iflow.go
+++ b/agent/iflow/iflow.go
@@ -94,6 +94,19 @@ func normalizeMode(raw string) string {
 
 func (a *Agent) Name() string { return "iflow" }
 
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("iflow: work_dir changed", "work_dir", dir)
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+
 func (a *Agent) SetModel(model string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -72,6 +72,19 @@ func normalizeMode(raw string) string {
 
 func (a *Agent) Name() string { return "opencode" }
 
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("opencode: work_dir changed", "work_dir", dir)
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+
 func (a *Agent) SetModel(model string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/qoder/qoder.go
+++ b/agent/qoder/qoder.go
@@ -59,6 +59,19 @@ func (a *Agent) Name() string           { return "qoder" }
 func (a *Agent) CLIBinaryName() string  { return "qodercli" }
 func (a *Agent) CLIDisplayName() string { return "Qoder" }
 
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("qoder: work_dir changed", "work_dir", dir)
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+
 func (a *Agent) SetModel(model string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/core/engine.go
+++ b/core/engine.go
@@ -454,7 +454,7 @@ func (e *Engine) SetDisabledCommands(cmds []string) {
 func (e *Engine) SetAdminFrom(adminFrom string) {
 	e.adminFrom = strings.TrimSpace(adminFrom)
 	if e.adminFrom == "" && !e.disabledCmds["shell"] {
-		slog.Warn("admin_from is not set — privileged commands (/shell, /restart, /upgrade) are blocked. "+
+		slog.Warn("admin_from is not set — privileged commands (/shell, /dir, /restart, /upgrade) are blocked. "+
 			"Set admin_from in config to enable them, or use disabled_commands to hide them.",
 			"project", e.name)
 	}
@@ -463,6 +463,7 @@ func (e *Engine) SetAdminFrom(adminFrom string) {
 // privilegedCommands are commands that require admin_from authorization.
 var privilegedCommands = map[string]bool{
 	"shell":   true,
+	"dir":     true,
 	"restart": true,
 	"upgrade": true,
 }
@@ -1895,6 +1896,7 @@ var builtinCommands = []struct {
 	{[]string{"bind"}, "bind"},
 	{[]string{"search", "find"}, "search"},
 	{[]string{"shell", "sh", "exec", "run"}, "shell"},
+	{[]string{"dir", "cd", "chdir", "workdir"}, "dir"},
 	{[]string{"tts"}, "tts"},
 	{[]string{"workspace", "ws"}, "workspace"},
 }
@@ -2035,6 +2037,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdSearch(p, msg, args)
 	case "shell":
 		e.cmdShell(p, msg, raw)
+	case "dir":
+		e.cmdDir(p, msg, args)
 	case "tts":
 		e.cmdTTS(p, msg, args)
 	case "workspace":
@@ -2437,6 +2441,56 @@ func (e *Engine) cmdShell(p Platform, msg *Message, raw string) {
 
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf("$ %s\n```\n%s\n```", shellCmd, result))
 	}()
+}
+
+func (e *Engine) cmdDir(p Platform, msg *Message, args []string) {
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+	switcher, ok := agent.(WorkDirSwitcher)
+	if !ok {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgDirNotSupported))
+		return
+	}
+
+	if len(args) == 0 {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgDirCurrent, switcher.GetWorkDir()))
+		return
+	}
+	if len(args) == 1 {
+		switch strings.ToLower(strings.TrimSpace(args[0])) {
+		case "help", "-h", "--help":
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgDirUsage))
+			return
+		}
+	}
+
+	newDir := filepath.Clean(strings.Join(args, " "))
+	if !filepath.IsAbs(newDir) {
+		baseDir := switcher.GetWorkDir()
+		if baseDir == "" {
+			baseDir, _ = os.Getwd()
+		}
+		newDir = filepath.Join(baseDir, newDir)
+	}
+
+	info, err := os.Stat(newDir)
+	if err != nil || !info.IsDir() {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgDirInvalidPath, newDir))
+		return
+	}
+
+	switcher.SetWorkDir(newDir)
+	e.cleanupInteractiveState(interactiveKey)
+
+	s := sessions.GetOrCreateActive(msg.SessionKey)
+	s.SetAgentSessionID("", "")
+	s.ClearHistory()
+	sessions.Save()
+
+	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgDirChanged, newDir))
 }
 
 // cmdSearch searches sessions by name or message content.

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -162,6 +162,19 @@ func (a *stubModelModeAgent) AvailableReasoningEfforts() []string {
 	return []string{"low", "medium", "high", "xhigh"}
 }
 
+type stubWorkDirAgent struct {
+	stubAgent
+	workDir string
+}
+
+func (a *stubWorkDirAgent) SetWorkDir(dir string) {
+	a.workDir = dir
+}
+
+func (a *stubWorkDirAgent) GetWorkDir() string {
+	return a.workDir
+}
+
 type stubListAgent struct {
 	stubAgent
 	sessions []AgentSessionInfo
@@ -1429,6 +1442,123 @@ func TestCmdModel_UsesInlineButtonsOnButtonOnlyPlatform(t *testing.T) {
 	}
 	if got := p.buttonRows[0][0].Data; got != "cmd:/model 1" {
 		t.Fatalf("first /model button = %q, want %q", got, "cmd:/model 1")
+	}
+}
+
+func TestCmdDir_ShowsCurrentDirectory(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubWorkDirAgent{workDir: "/tmp/project-a"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	e.cmdDir(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, nil)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "/tmp/project-a") {
+		t.Fatalf("sent = %q, want current work dir", p.sent[0])
+	}
+}
+
+func TestCmdDir_SwitchesDirectoryAndResetsSession(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	tempDir := t.TempDir()
+	nextDir := filepath.Join(tempDir, "next")
+	if err := os.Mkdir(nextDir, 0o755); err != nil {
+		t.Fatalf("mkdir next dir: %v", err)
+	}
+
+	agent := &stubWorkDirAgent{workDir: tempDir}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s.SetAgentSessionID("existing-session", "test")
+	s.AddHistory("user", "hello")
+
+	e.cmdDir(p, msg, []string{"next"})
+
+	if agent.workDir != nextDir {
+		t.Fatalf("workDir = %q, want %q", agent.workDir, nextDir)
+	}
+	if s.GetAgentSessionID() != "" {
+		t.Fatalf("AgentSessionID = %q, want cleared", s.GetAgentSessionID())
+	}
+	if len(s.History) != 0 {
+		t.Fatalf("history length = %d, want 0", len(s.History))
+	}
+	if len(p.sent) != 1 || !strings.Contains(p.sent[0], nextDir) {
+		t.Fatalf("sent = %v, want directory changed message", p.sent)
+	}
+}
+
+func TestCmdDir_RejectsMissingDirectory(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	tempDir := t.TempDir()
+	missingDir := filepath.Join(tempDir, "missing")
+	agent := &stubWorkDirAgent{workDir: tempDir}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	e.cmdDir(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, []string{"missing"})
+
+	if agent.workDir != tempDir {
+		t.Fatalf("workDir = %q, want unchanged %q", agent.workDir, tempDir)
+	}
+	if len(p.sent) != 1 || !strings.Contains(p.sent[0], missingDir) {
+		t.Fatalf("sent = %v, want invalid path message", p.sent)
+	}
+}
+
+func TestCmdDir_AliasCdStillWorks(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	tempDir := t.TempDir()
+	nextDir := filepath.Join(tempDir, "next")
+	if err := os.Mkdir(nextDir, 0o755); err != nil {
+		t.Fatalf("mkdir next dir: %v", err)
+	}
+	agent := &stubWorkDirAgent{workDir: tempDir}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetAdminFrom("admin1")
+
+	e.handleCommand(p, &Message{SessionKey: "test:user1", UserID: "admin1", ReplyCtx: "ctx"}, "/cd next")
+
+	if agent.workDir != nextDir {
+		t.Fatalf("workDir = %q, want %q", agent.workDir, nextDir)
+	}
+}
+
+func TestCmdDir_HelpShowsUsage(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubWorkDirAgent{workDir: "/tmp/project-a"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	e.cmdDir(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, []string{"help"})
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "/dir <path>") {
+		t.Fatalf("sent = %q, want /dir usage", p.sent[0])
+	}
+}
+
+func TestEngine_AdminFrom_GatesDir(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	tempDir := t.TempDir()
+	agent := &stubWorkDirAgent{workDir: tempDir}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	msg := &Message{SessionKey: "test:u1", UserID: "user1", ReplyCtx: "ctx"}
+	e.handleCommand(p, msg, "/dir .")
+
+	if len(p.sent) != 1 {
+		t.Fatalf("expected 1 reply, got %d", len(p.sent))
+	}
+	if !strings.Contains(strings.ToLower(p.sent[0]), "admin") {
+		t.Fatalf("expected admin required message, got: %s", p.sent[0])
+	}
+	if agent.workDir != tempDir {
+		t.Fatalf("workDir = %q, want unchanged %q", agent.workDir, tempDir)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -450,6 +450,13 @@ const (
 	MsgBuiltinCmdHelp      MsgKey = "help"
 	MsgBuiltinCmdBind      MsgKey = "bind"
 	MsgBuiltinCmdShell     MsgKey = "shell"
+	MsgBuiltinCmdDir       MsgKey = "dir"
+
+	MsgDirChanged      MsgKey = "dir_changed"
+	MsgDirCurrent      MsgKey = "dir_current"
+	MsgDirUsage        MsgKey = "dir_usage"
+	MsgDirNotSupported MsgKey = "dir_not_supported"
+	MsgDirInvalidPath  MsgKey = "dir_invalid_path"
 
 	// Multi-workspace messages
 	MsgWsNotEnabled        MsgKey = "ws_not_enabled"
@@ -705,6 +712,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  Compress conversation context\n\n" +
 			"/tts [always|voice_only]\n  View/switch text-to-speech mode\n\n" +
 			"/shell <command>\n  Run a shell command and return the output\n\n" +
+			"/dir [path]\n  Show or switch agent working directory\n\n" +
 			"/stop\n  Stop current execution\n\n" +
 			"/cron [add|list|del|enable|disable]\n  Manage scheduled tasks\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  Manage heartbeat\n\n" +
@@ -746,6 +754,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  压缩会话上下文\n\n" +
 			"/tts [always|voice_only]\n  查看/切换语音合成模式\n\n" +
 			"/shell <命令>\n  执行 Shell 命令并返回结果\n\n" +
+			"/dir [路径]\n  查看或切换 Agent 工作目录\n\n" +
 			"/stop\n  停止当前执行\n\n" +
 			"/cron [add|list|del|enable|disable]\n  管理定时任务\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  管理心跳\n\n" +
@@ -787,6 +796,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  壓縮會話上下文\n\n" +
 			"/tts [always|voice_only]\n  查看/切換語音合成模式\n\n" +
 			"/shell <命令>\n  執行 Shell 命令並返回結果\n\n" +
+			"/dir [路徑]\n  查看或切換 Agent 工作目錄\n\n" +
 			"/stop\n  停止當前執行\n\n" +
 			"/cron [add|list|del|enable|disable]\n  管理定時任務\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  管理心跳\n\n" +
@@ -827,6 +837,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  会話コンテキストを圧縮\n\n" +
 			"/tts [always|voice_only]\n  音声合成モードの表示/切り替え\n\n" +
 			"/shell <コマンド>\n  シェルコマンドを実行して結果を返す\n\n" +
+			"/dir [パス]\n  エージェントの作業ディレクトリを表示/切り替え\n\n" +
 			"/stop\n  現在の実行を停止\n\n" +
 			"/cron [add|list|del|enable|disable]\n  スケジュールタスク管理\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  ハートビート管理\n\n" +
@@ -867,6 +878,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  Comprimir contexto de conversación\n\n" +
 			"/tts [always|voice_only]\n  Ver/cambiar modo de síntesis de voz\n\n" +
 			"/shell <comando>\n  Ejecutar un comando shell y devolver la salida\n\n" +
+			"/dir [ruta]\n  Ver o cambiar el directorio de trabajo del agente\n\n" +
 			"/stop\n  Detener ejecución actual\n\n" +
 			"/cron [add|list|del|enable|disable]\n  Gestionar tareas programadas\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  Gestionar heartbeat\n\n" +
@@ -988,6 +1000,7 @@ var messages = map[MsgKey]map[Language]string{
 	MsgHelpToolsSection: {
 		LangEnglish: "**Tools & Automation**\n" +
 			"/shell <command> — Run a shell command\n" +
+			"/dir [path] — Show or switch work directory\n" +
 			"/cron [add|list|del|...] — Scheduled tasks\n" +
 			"/commands [add|del] — Custom commands\n" +
 			"/alias [add|del] — Command aliases\n" +
@@ -996,6 +1009,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/stop — Stop current execution",
 		LangChinese: "**工具与自动化**\n" +
 			"/shell <命令> — 执行 Shell 命令\n" +
+			"/dir [路径] — 查看或切换工作目录\n" +
 			"/cron [add|list|del|...] — 定时任务\n" +
 			"/commands [add|del] — 自定义命令\n" +
 			"/alias [add|del] — 命令别名\n" +
@@ -1004,6 +1018,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/stop — 停止当前执行",
 		LangTraditionalChinese: "**工具與自動化**\n" +
 			"/shell <命令> — 執行 Shell 命令\n" +
+			"/dir [路徑] — 查看或切換工作目錄\n" +
 			"/cron [add|list|del|...] — 定時任務\n" +
 			"/commands [add|del] — 自訂命令\n" +
 			"/alias [add|del] — 命令別名\n" +
@@ -1012,6 +1027,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/stop — 停止當前執行",
 		LangJapanese: "**ツール・自動化**\n" +
 			"/shell <コマンド> — シェルコマンド実行\n" +
+			"/dir [パス] — 作業ディレクトリの表示/切り替え\n" +
 			"/cron [add|list|del|...] — スケジュールタスク\n" +
 			"/commands [add|del] — カスタムコマンド\n" +
 			"/alias [add|del] — コマンドエイリアス\n" +
@@ -1020,6 +1036,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/stop — 現在の実行を停止",
 		LangSpanish: "**Herramientas y automatización**\n" +
 			"/shell <comando> — Ejecutar comando shell\n" +
+			"/dir [ruta] — Ver o cambiar directorio de trabajo\n" +
 			"/cron [add|list|del|...] — Tareas programadas\n" +
 			"/commands [add|del] — Comandos personalizados\n" +
 			"/alias [add|del] — Alias de comandos\n" +
@@ -2932,6 +2949,48 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "執行 Shell 命令，參數: <命令>",
 		LangJapanese:           "シェルコマンドを実行、引数: <コマンド>",
 		LangSpanish:            "Ejecutar un comando shell, arg: <comando>",
+	},
+	MsgBuiltinCmdDir: {
+		LangEnglish:            "Show or switch agent working directory, arg: <path>",
+		LangChinese:            "查看或切换 Agent 工作目录，参数: <路径>",
+		LangTraditionalChinese: "查看或切換 Agent 工作目錄，參數: <路徑>",
+		LangJapanese:           "エージェントの作業ディレクトリを表示/変更、引数: <パス>",
+		LangSpanish:            "Ver o cambiar el directorio de trabajo del agente, arg: <ruta>",
+	},
+	MsgDirChanged: {
+		LangEnglish:            "✅ Work directory changed to: `%s`\nThe next session will start in this directory.",
+		LangChinese:            "✅ 工作目录已切换为: `%s`\n下次会话将在此目录下启动。",
+		LangTraditionalChinese: "✅ 工作目錄已切換為: `%s`\n下次會話將在此目錄下啟動。",
+		LangJapanese:           "✅ 作業ディレクトリを変更しました: `%s`\n次のセッションはこのディレクトリで起動します。",
+		LangSpanish:            "✅ Directorio de trabajo cambiado a: `%s`\nLa próxima sesión iniciará en este directorio.",
+	},
+	MsgDirCurrent: {
+		LangEnglish:            "📂 Current work directory: `%s`",
+		LangChinese:            "📂 当前工作目录: `%s`",
+		LangTraditionalChinese: "📂 當前工作目錄: `%s`",
+		LangJapanese:           "📂 現在の作業ディレクトリ: `%s`",
+		LangSpanish:            "📂 Directorio de trabajo actual: `%s`",
+	},
+	MsgDirUsage: {
+		LangEnglish:            "Usage: `/dir <path>`\nExample: `/dir ../project`",
+		LangChinese:            "用法: `/dir <路径>`\n示例: `/dir ../project`",
+		LangTraditionalChinese: "用法: `/dir <路徑>`\n範例: `/dir ../project`",
+		LangJapanese:           "使い方: `/dir <パス>`\n例: `/dir ../project`",
+		LangSpanish:            "Uso: `/dir <ruta>`\nEjemplo: `/dir ../project`",
+	},
+	MsgDirNotSupported: {
+		LangEnglish:            "This agent does not support dynamic work directory switching.",
+		LangChinese:            "当前 Agent 不支持动态切换工作目录。",
+		LangTraditionalChinese: "當前 Agent 不支援動態切換工作目錄。",
+		LangJapanese:           "このエージェントは動的な作業ディレクトリの切り替えをサポートしていません。",
+		LangSpanish:            "Este agente no soporta el cambio dinámico de directorio de trabajo.",
+	},
+	MsgDirInvalidPath: {
+		LangEnglish:            "❌ Directory does not exist: `%s`",
+		LangChinese:            "❌ 目录不存在: `%s`",
+		LangTraditionalChinese: "❌ 目錄不存在: `%s`",
+		LangJapanese:           "❌ ディレクトリが存在しません: `%s`",
+		LangSpanish:            "❌ El directorio no existe: `%s`",
 	},
 
 	// Multi-workspace messages

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -290,6 +290,14 @@ type SessionDeleter interface {
 	DeleteSession(ctx context.Context, sessionID string) error
 }
 
+// WorkDirSwitcher is an optional interface for agents that support runtime
+// work directory switching. The change takes effect on the next session start;
+// the current running session is terminated automatically by the engine.
+type WorkDirSwitcher interface {
+	SetWorkDir(dir string)
+	GetWorkDir() string
+}
+
 // ModeSwitcher is an optional interface for agents that support runtime permission mode switching.
 type ModeSwitcher interface {
 	SetMode(mode string)


### PR DESCRIPTION
## Summary

Adds a `/dir` command that lets users switch the agent's working directory at runtime without restarting `cc-connect`.

## Notes

- Primary command: `/dir`
- Power-user aliases kept for compatibility: `/cd`, `/chdir`, `/workdir`
- `/dir` now follows the same `admin_from` gate as other sensitive commands like `/shell`

## Behavior

- `/dir` — show current working directory
- `/dir <path>` — switch to a target path
- `/dir help` — show usage
- Relative paths are resolved against the current agent work directory
- On successful switch, the current interactive session is cleaned up and the active agent session ID/history are reset so the next turn starts fresh in the new directory

## Changes

- Added `WorkDirSwitcher` interface in `core/interfaces.go`
- Implemented `WorkDirSwitcher` for all 7 supported agents
- Renamed the engine command handler and i18n symbols from `cd` to `dir`
- Registered `/dir` as the primary command while preserving `/cd`, `/chdir`, `/workdir` aliases
- Added admin permission gating for the directory-switch command
- Added targeted unit tests for `/dir`, alias compatibility, usage handling, and admin gating

## Verification

- `go build ./...`
- `go test -run ^$ ./...`
- `go test ./core -run "TestCmdDir|TestEngine_AdminFrom_GatesDir" -count=1`

## Follow-up ideas

Not included in this PR:
- persistence across restarts
- saved directory bookmarks / subcommands such as `/dir add|list|switch|del`