### PR TITLE
feat: add usage command for codex oauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Beta release with major new features and security improvements.
 
 ### New Features
+- **`/usage` Command**: Add a built-in quota usage command with a generic agent usage-reporting interface; Codex now supports ChatGPT OAuth usage lookup via `~/.codex/auth.json`
 - **Feishu Interactive Cards**: Beautiful card-based UI for slash commands (/help, /list, /status, etc.) with tabbed navigation and in-place updates
 - **Lark Platform Support**: Added support for Lark (飞书国际版) with proper domain handling
 - **Codex Reasoning Effort**: New `/reasoning` command to switch reasoning effort levels (low/medium/high)

--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ Each user gets an independent session with full conversation context. Manage ses
 /switch <id>      Switch to a different session
 /current          Show current session info
 /history [n]      Show last n messages (default 10)
+/usage            Show account/model quota usage (if supported by the current agent)
 /provider [...]   Manage API providers (list/add/remove/switch)
 /allow <tool>     Pre-allow a tool (takes effect on next session)
 /reasoning [level] View or switch reasoning effort (Codex)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -697,6 +697,7 @@ cc-connect daemon uninstall
 /switch <id>           切换到指定会话
 /current               查看当前活跃会话
 /history [n]           查看最近 n 条消息（默认 10）
+/usage                 查看账号/模型限额使用情况（当前 Agent 支持时）
 /provider [list|add|remove|switch] 管理 API Provider
 /allow <工具名>         预授权工具（下次会话生效）
 /reasoning [等级]      查看或切换推理强度（Codex）

--- a/agent/codex/usage.go
+++ b/agent/codex/usage.go
@@ -1,0 +1,195 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+const codexUsageURL = "https://chatgpt.com/backend-api/wham/usage"
+
+type codexOAuthTokens struct {
+	AccessToken string
+	AccountID   string
+}
+
+type codexUsageResponse struct {
+	UserID              string             `json:"user_id"`
+	AccountID           string             `json:"account_id"`
+	Email               string             `json:"email"`
+	PlanType            string             `json:"plan_type"`
+	RateLimit           *codexUsageBucket  `json:"rate_limit"`
+	CodeReviewRateLimit *codexUsageBucket  `json:"code_review_rate_limit"`
+	Credits             *codexUsageCredits `json:"credits"`
+}
+
+type codexUsageBucket struct {
+	Allowed         bool              `json:"allowed"`
+	LimitReached    bool              `json:"limit_reached"`
+	PrimaryWindow   *codexUsageWindow `json:"primary_window"`
+	SecondaryWindow *codexUsageWindow `json:"secondary_window"`
+}
+
+type codexUsageWindow struct {
+	UsedPercent        int   `json:"used_percent"`
+	LimitWindowSeconds int   `json:"limit_window_seconds"`
+	ResetAfterSeconds  int   `json:"reset_after_seconds"`
+	ResetAt            int64 `json:"reset_at"`
+}
+
+type codexUsageCredits struct {
+	HasCredits bool `json:"has_credits"`
+	Unlimited  bool `json:"unlimited"`
+	Balance    any  `json:"balance"`
+}
+
+func (a *Agent) GetUsage(ctx context.Context) (*core.UsageReport, error) {
+	tokens, err := a.readOAuthTokens(os.ReadFile)
+	if err != nil {
+		return nil, err
+	}
+	return a.fetchUsage(ctx, http.DefaultClient, tokens)
+}
+
+func (a *Agent) readOAuthTokens(readFile func(string) ([]byte, error)) (codexOAuthTokens, error) {
+	path, err := codexAuthPath()
+	if err != nil {
+		return codexOAuthTokens{}, err
+	}
+	data, err := readFile(path)
+	if err != nil {
+		return codexOAuthTokens{}, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var payload struct {
+		Tokens struct {
+			AccessToken string `json:"access_token"`
+			AccountID   string `json:"account_id"`
+		} `json:"tokens"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return codexOAuthTokens{}, fmt.Errorf("parse auth.json: %w", err)
+	}
+	if strings.TrimSpace(payload.Tokens.AccessToken) == "" {
+		return codexOAuthTokens{}, fmt.Errorf("auth.json missing tokens.access_token")
+	}
+	if strings.TrimSpace(payload.Tokens.AccountID) == "" {
+		return codexOAuthTokens{}, fmt.Errorf("auth.json missing tokens.account_id")
+	}
+
+	return codexOAuthTokens{
+		AccessToken: payload.Tokens.AccessToken,
+		AccountID:   payload.Tokens.AccountID,
+	}, nil
+}
+
+func (a *Agent) fetchUsage(ctx context.Context, client *http.Client, tokens codexOAuthTokens) (*core.UsageReport, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, codexUsageURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	req.Header.Set("ChatGPT-Account-Id", tokens.AccountID)
+	req.Header.Set("User-Agent", "codex-cli")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request usage endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("usage endpoint returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload codexUsageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode usage response: %w", err)
+	}
+
+	return mapCodexUsage(payload), nil
+}
+
+func mapCodexUsage(payload codexUsageResponse) *core.UsageReport {
+	report := &core.UsageReport{
+		Provider:  "codex",
+		AccountID: payload.AccountID,
+		UserID:    payload.UserID,
+		Email:     payload.Email,
+		Plan:      payload.PlanType,
+	}
+
+	if payload.RateLimit != nil {
+		report.Buckets = append(report.Buckets, core.UsageBucket{
+			Name:         "Rate limit",
+			Allowed:      payload.RateLimit.Allowed,
+			LimitReached: payload.RateLimit.LimitReached,
+			Windows:      mapCodexUsageWindows(payload.RateLimit),
+		})
+	}
+	if payload.CodeReviewRateLimit != nil {
+		report.Buckets = append(report.Buckets, core.UsageBucket{
+			Name:         "Code review",
+			Allowed:      payload.CodeReviewRateLimit.Allowed,
+			LimitReached: payload.CodeReviewRateLimit.LimitReached,
+			Windows:      mapCodexUsageWindows(payload.CodeReviewRateLimit),
+		})
+	}
+	if payload.Credits != nil {
+		report.Credits = &core.UsageCredits{
+			HasCredits: payload.Credits.HasCredits,
+			Unlimited:  payload.Credits.Unlimited,
+		}
+		if payload.Credits.Balance != nil {
+			report.Credits.Balance = fmt.Sprintf("%v", payload.Credits.Balance)
+		}
+	}
+
+	return report
+}
+
+func mapCodexUsageWindows(bucket *codexUsageBucket) []core.UsageWindow {
+	if bucket == nil {
+		return nil
+	}
+	var windows []core.UsageWindow
+	if bucket.PrimaryWindow != nil {
+		windows = append(windows, core.UsageWindow{
+			Name:              "Primary",
+			UsedPercent:       bucket.PrimaryWindow.UsedPercent,
+			WindowSeconds:     bucket.PrimaryWindow.LimitWindowSeconds,
+			ResetAfterSeconds: bucket.PrimaryWindow.ResetAfterSeconds,
+			ResetAtUnix:       bucket.PrimaryWindow.ResetAt,
+		})
+	}
+	if bucket.SecondaryWindow != nil {
+		windows = append(windows, core.UsageWindow{
+			Name:              "Secondary",
+			UsedPercent:       bucket.SecondaryWindow.UsedPercent,
+			WindowSeconds:     bucket.SecondaryWindow.LimitWindowSeconds,
+			ResetAfterSeconds: bucket.SecondaryWindow.ResetAfterSeconds,
+			ResetAtUnix:       bucket.SecondaryWindow.ResetAt,
+		})
+	}
+	return windows
+}
+
+func codexAuthPath() (string, error) {
+	codexHome := os.Getenv("CODEX_HOME")
+	if codexHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		codexHome = filepath.Join(home, ".codex")
+	}
+	return filepath.Join(codexHome, "auth.json"), nil
+}

--- a/agent/codex/usage_test.go
+++ b/agent/codex/usage_test.go
@@ -1,0 +1,139 @@
+package codex
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestFetchUsage_Success(t *testing.T) {
+	agent := &Agent{}
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.URL.String(); got != "https://chatgpt.com/backend-api/wham/usage" {
+				t.Fatalf("request URL = %q", got)
+			}
+			if got := req.Header.Get("Authorization"); got != "Bearer token-123" {
+				t.Fatalf("authorization = %q", got)
+			}
+			if got := req.Header.Get("ChatGPT-Account-Id"); got != "acct-123" {
+				t.Fatalf("account id header = %q", got)
+			}
+			body := `{
+			  "user_id": "user-1",
+			  "account_id": "acct-123",
+			  "email": "dev@example.com",
+			  "plan_type": "team",
+			  "rate_limit": {
+			    "allowed": true,
+			    "limit_reached": false,
+			    "primary_window": {
+			      "used_percent": 23,
+			      "limit_window_seconds": 18000,
+			      "reset_after_seconds": 6665,
+			      "reset_at": 1773292109
+			    },
+			    "secondary_window": {
+			      "used_percent": 42,
+			      "limit_window_seconds": 604800,
+			      "reset_after_seconds": 512698,
+			      "reset_at": 1773798142
+			    }
+			  },
+			  "code_review_rate_limit": {
+			    "allowed": true,
+			    "limit_reached": false,
+			    "primary_window": {
+			      "used_percent": 0,
+			      "limit_window_seconds": 604800,
+			      "reset_after_seconds": 604800,
+			      "reset_at": 1773890244
+			    },
+			    "secondary_window": null
+			  },
+			  "credits": {
+			    "has_credits": false,
+			    "unlimited": false,
+			    "balance": null
+			  }
+			}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	}
+
+	report, err := agent.fetchUsage(context.Background(), client, codexOAuthTokens{
+		AccessToken: "token-123",
+		AccountID:   "acct-123",
+	})
+	if err != nil {
+		t.Fatalf("fetchUsage returned error: %v", err)
+	}
+	if report.Provider != "codex" {
+		t.Fatalf("provider = %q, want codex", report.Provider)
+	}
+	if report.Plan != "team" {
+		t.Fatalf("plan = %q, want team", report.Plan)
+	}
+	if len(report.Buckets) != 2 {
+		t.Fatalf("buckets = %d, want 2", len(report.Buckets))
+	}
+	if got := report.Buckets[0].Windows[0].UsedPercent; got != 23 {
+		t.Fatalf("primary used percent = %d, want 23", got)
+	}
+	if got := report.Buckets[0].Windows[1].UsedPercent; got != 42 {
+		t.Fatalf("secondary used percent = %d, want 42", got)
+	}
+}
+
+func TestFetchUsage_HTTPError(t *testing.T) {
+	agent := &Agent{}
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"unauthorized"}`)),
+			}, nil
+		}),
+	}
+
+	_, err := agent.fetchUsage(context.Background(), client, codexOAuthTokens{
+		AccessToken: "token-123",
+		AccountID:   "acct-123",
+	})
+	if err == nil || !strings.Contains(err.Error(), "status 401") {
+		t.Fatalf("err = %v, want status 401", err)
+	}
+}
+
+func TestReadOAuthTokens_MissingFields(t *testing.T) {
+	agent := &Agent{}
+	_, err := agent.readOAuthTokens(func(string) ([]byte, error) {
+		return []byte(`{"tokens":{"access_token":"token-only"}}`), nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "account_id") {
+		t.Fatalf("err = %v, want missing account_id", err)
+	}
+}
+
+func TestReadOAuthTokens_InvalidJSON(t *testing.T) {
+	agent := &Agent{}
+	_, err := agent.readOAuthTokens(func(string) ([]byte, error) {
+		return []byte(`{`), nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "parse") {
+		t.Fatalf("err = %v, want parse error", err)
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -1285,6 +1285,7 @@ var builtinCommands = []struct {
 	{[]string{"name", "rename"}, "name"},
 	{[]string{"current"}, "current"},
 	{[]string{"status"}, "status"},
+	{[]string{"usage", "quota"}, "usage"},
 	{[]string{"history"}, "history"},
 	{[]string{"allow"}, "allow"},
 	{[]string{"model"}, "model"},
@@ -1395,6 +1396,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdCurrent(p, msg)
 	case "status":
 		e.cmdStatus(p, msg)
+	case "usage":
+		e.cmdUsage(p, msg)
 	case "history":
 		e.cmdHistory(p, msg, args)
 	case "allow":
@@ -1943,6 +1946,274 @@ func (e *Engine) cmdStatus(p Platform, msg *Message) {
 	e.replyWithCard(p, msg.ReplyCtx, e.renderStatusCard(msg.SessionKey))
 }
 
+func (e *Engine) cmdUsage(p Platform, msg *Message) {
+	reporter, ok := e.agent.(UsageReporter)
+	if !ok {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgUsageNotSupported))
+		return
+	}
+
+	fetchCtx, cancel := context.WithTimeout(e.ctx, 10*time.Second)
+	defer cancel()
+
+	report, err := reporter.GetUsage(fetchCtx)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgUsageFetchFailed, err))
+		return
+	}
+
+	if p.Name() == "feishu" && supportsCards(p) {
+		e.replyWithCard(p, msg.ReplyCtx, e.renderUsageCard(report))
+		return
+	}
+
+	e.reply(p, msg.ReplyCtx, formatUsageReport(report, e.i18n.CurrentLang()))
+}
+
+func formatUsageReport(report *UsageReport, lang Language) string {
+	if report == nil {
+		return usageUnavailableText(lang)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(usageAccountLabel(lang))
+	sb.WriteString(accountDisplay(report))
+	sb.WriteString(formatUsageBlocks(report, lang))
+
+	return strings.TrimSpace(sb.String())
+}
+
+func formatUsageBlocks(report *UsageReport, lang Language) string {
+	primary, secondary := selectUsageWindows(report)
+	var sections []string
+	if primary != nil {
+		sections = append(sections, formatUsageBlock(lang, primary))
+	}
+	if secondary != nil {
+		sections = append(sections, formatUsageBlock(lang, secondary))
+	}
+	if len(sections) == 0 {
+		return ""
+	}
+	return "\n\n" + strings.Join(sections, "\n\n")
+}
+
+func accountDisplay(report *UsageReport) string {
+	var base string
+	if report.Email != "" {
+		base = report.Email
+	} else if report.AccountID != "" {
+		base = report.AccountID
+	} else if report.UserID != "" {
+		base = report.UserID
+	} else {
+		base = "-"
+	}
+	if report.Plan != "" {
+		return fmt.Sprintf("%s (%s)", base, report.Plan)
+	}
+	return base
+}
+
+func selectUsageWindows(report *UsageReport) (*UsageWindow, *UsageWindow) {
+	for _, bucket := range report.Buckets {
+		if len(bucket.Windows) == 0 {
+			continue
+		}
+		var primary, secondary *UsageWindow
+		for i := range bucket.Windows {
+			window := &bucket.Windows[i]
+			switch window.WindowSeconds {
+			case 18000:
+				primary = window
+			case 604800:
+				if secondary == nil {
+					secondary = window
+				}
+			}
+		}
+		if primary == nil && len(bucket.Windows) > 0 {
+			primary = &bucket.Windows[0]
+		}
+		if secondary == nil && len(bucket.Windows) > 1 {
+			secondary = &bucket.Windows[1]
+		}
+		if primary != nil || secondary != nil {
+			return primary, secondary
+		}
+	}
+	return nil, nil
+}
+
+func formatUsageBlock(lang Language, window *UsageWindow) string {
+	remaining := 100 - window.UsedPercent
+	if remaining < 0 {
+		remaining = 0
+	}
+	var sb strings.Builder
+	sb.WriteString(usageWindowLabel(lang, window.WindowSeconds))
+	sb.WriteString("\n")
+	sb.WriteString(usageRemainingLabel(lang))
+	sb.WriteString(usageColon(lang))
+	sb.WriteString(fmt.Sprintf("%d%%", remaining))
+	sb.WriteString("\n")
+	sb.WriteString(usageResetLabel(lang))
+	sb.WriteString(usageColon(lang))
+	sb.WriteString(formatUsageResetTime(lang, window.ResetAfterSeconds))
+	return sb.String()
+}
+
+func (e *Engine) renderUsageCard(report *UsageReport) *Card {
+	lang := e.i18n.CurrentLang()
+	return NewCard().
+		Title(usageCardTitle(lang), "indigo").
+		Markdown(strings.TrimSpace(formatUsageReport(report, lang))).
+		Buttons(e.cardBackButton()).
+		Build()
+}
+
+func formatUsageResetTime(lang Language, resetAfterSeconds int) string {
+	if resetAfterSeconds <= 0 {
+		switch lang {
+		case LangChinese, LangTraditionalChinese:
+			return "-"
+		case LangJapanese:
+			return "-"
+		case LangSpanish:
+			return "-"
+		default:
+			return "-"
+		}
+	}
+	return formatDurationI18n(time.Duration(resetAfterSeconds)*time.Second, lang)
+}
+
+func usageAccountLabel(lang Language) string {
+	switch lang {
+	case LangChinese:
+		return "账号："
+	case LangTraditionalChinese:
+		return "帳號："
+	case LangJapanese:
+		return "アカウント: "
+	case LangSpanish:
+		return "Cuenta: "
+	default:
+		return "Account: "
+	}
+}
+
+func usageWindowLabel(lang Language, seconds int) string {
+	switch seconds {
+	case 18000:
+		switch lang {
+		case LangChinese:
+			return "5小时限额"
+		case LangTraditionalChinese:
+			return "5小時限額"
+		case LangJapanese:
+			return "5時間枠"
+		case LangSpanish:
+			return "Límite 5h"
+		default:
+			return "5h limit"
+		}
+	case 604800:
+		switch lang {
+		case LangChinese:
+			return "7日限额"
+		case LangTraditionalChinese:
+			return "7日限額"
+		case LangJapanese:
+			return "7日枠"
+		case LangSpanish:
+			return "Límite 7d"
+		default:
+			return "7d limit"
+		}
+	default:
+		switch lang {
+		case LangChinese, LangTraditionalChinese:
+			return formatDurationI18n(time.Duration(seconds)*time.Second, lang) + "限额"
+		case LangJapanese:
+			return formatDurationI18n(time.Duration(seconds)*time.Second, lang) + "枠"
+		case LangSpanish:
+			return "Límite " + formatDurationI18n(time.Duration(seconds)*time.Second, lang)
+		default:
+			return formatDurationI18n(time.Duration(seconds)*time.Second, lang) + " limit"
+		}
+	}
+}
+
+func usageRemainingLabel(lang Language) string {
+	switch lang {
+	case LangChinese:
+		return "剩余"
+	case LangTraditionalChinese:
+		return "剩餘"
+	case LangJapanese:
+		return "残り"
+	case LangSpanish:
+		return "restante"
+	default:
+		return "Remaining"
+	}
+}
+
+func usageResetLabel(lang Language) string {
+	switch lang {
+	case LangChinese:
+		return "重置"
+	case LangTraditionalChinese:
+		return "重置"
+	case LangJapanese:
+		return "リセット"
+	case LangSpanish:
+		return "Reinicio"
+	default:
+		return "Resets"
+	}
+}
+
+func usageColon(lang Language) string {
+	switch lang {
+	case LangChinese, LangTraditionalChinese:
+		return "："
+	default:
+		return ": "
+	}
+}
+
+func usageCardTitle(lang Language) string {
+	switch lang {
+	case LangChinese:
+		return "Usage"
+	case LangTraditionalChinese:
+		return "Usage"
+	case LangJapanese:
+		return "Usage"
+	case LangSpanish:
+		return "Usage"
+	default:
+		return "Usage"
+	}
+}
+
+func usageUnavailableText(lang Language) string {
+	switch lang {
+	case LangChinese:
+		return "暂无 usage 信息。"
+	case LangTraditionalChinese:
+		return "暫無 usage 資訊。"
+	case LangJapanese:
+		return "usage 情報はありません。"
+	case LangSpanish:
+		return "No hay datos de usage."
+	default:
+		return "Usage unavailable."
+	}
+}
+
 func splitCardTitleBody(content string) (string, string) {
 	content = strings.TrimSpace(content)
 	parts := strings.SplitN(content, "\n\n", 2)
@@ -2306,6 +2577,7 @@ func helpCardGroups() []helpCardGroup {
 			items: []helpCardItem{
 				{command: "/status", action: "nav:/status"},
 				{command: "/doctor", action: "nav:/doctor"},
+				{command: "/usage", action: "cmd:/usage"},
 				{command: "/config", action: "nav:/config"},
 				{command: "/version", action: "nav:/version"},
 				{command: "/upgrade", action: "nav:/upgrade"},

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -193,6 +193,16 @@ func (a *stubProviderAgent) SetActiveProvider(name string) bool {
 	return false
 }
 
+type stubUsageAgent struct {
+	stubAgent
+	report *UsageReport
+	err    error
+}
+
+func (a *stubUsageAgent) GetUsage(_ context.Context) (*UsageReport, error) {
+	return a.report, a.err
+}
+
 func newTestEngine() *Engine {
 	return NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
 }
@@ -1318,6 +1328,173 @@ func TestCmdStatus_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	}
 	if strings.Contains(p.sent[0], "[← Back]") {
 		t.Fatalf("status text = %q, should not be card fallback text", p.sent[0])
+	}
+}
+
+func TestCmdUsage_UnsupportedAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	e.handleCommand(p, msg, "/usage")
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(strings.ToLower(p.sent[0]), "does not support") {
+		t.Fatalf("sent = %q, want unsupported usage message", p.sent[0])
+	}
+}
+
+func TestCmdUsage_Success(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubUsageAgent{
+		report: &UsageReport{
+			Provider: "codex",
+			Email:    "dev@example.com",
+			Plan:     "team",
+			Buckets: []UsageBucket{
+				{
+					Name:         "Rate limit",
+					Allowed:      true,
+					LimitReached: false,
+					Windows: []UsageWindow{
+						{Name: "Primary", UsedPercent: 23, WindowSeconds: 18000, ResetAfterSeconds: 6665},
+						{Name: "Secondary", UsedPercent: 42, WindowSeconds: 604800, ResetAfterSeconds: 512698},
+					},
+				},
+				{
+					Name:         "Code review",
+					Allowed:      true,
+					LimitReached: false,
+					Windows: []UsageWindow{
+						{Name: "Primary", UsedPercent: 0, WindowSeconds: 604800, ResetAfterSeconds: 604800},
+					},
+				},
+			},
+			Credits: &UsageCredits{
+				HasCredits: false,
+				Unlimited:  false,
+			},
+		},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	e.handleCommand(p, msg, "/usage")
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	got := p.sent[0]
+	for _, want := range []string{
+		"Account: dev@example.com (team)",
+		"5h limit",
+		"Remaining: 77%",
+		"Resets: 1h 51m",
+		"5h limit",
+		"7d limit",
+		"Remaining: 58%",
+		"Resets: 5d 22h 24m",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("usage text = %q, want substring %q", got, want)
+		}
+	}
+	if strings.Contains(got, "```") {
+		t.Fatalf("usage text = %q, should not use code block on plain platform", got)
+	}
+}
+
+func TestCmdUsage_UsesCardOnCardPlatform(t *testing.T) {
+	p := &stubCardPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	agent := &stubUsageAgent{
+		report: &UsageReport{
+			Email: "dev@example.com",
+			Plan:  "team",
+			Buckets: []UsageBucket{
+				{
+					Name:         "Rate limit",
+					Allowed:      true,
+					LimitReached: false,
+					Windows: []UsageWindow{
+						{Name: "Primary", UsedPercent: 23, WindowSeconds: 18000, ResetAfterSeconds: 6665},
+						{Name: "Secondary", UsedPercent: 42, WindowSeconds: 604800, ResetAfterSeconds: 512698},
+					},
+				},
+			},
+		},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangChinese)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	e.handleCommand(p, msg, "/usage")
+
+	if len(p.repliedCards) != 1 {
+		t.Fatalf("replied cards = %d, want 1", len(p.repliedCards))
+	}
+	if len(p.sent) != 0 {
+		t.Fatalf("sent text = %v, want no plain text fallback", p.sent)
+	}
+	text := p.repliedCards[0].RenderText()
+	for _, want := range []string{
+		"账号：dev@example.com (team)",
+		"5小时限额",
+		"剩余：77%",
+		"重置：1小时 51分钟",
+		"7日限额",
+		"剩余：58%",
+		"重置：5天 22小时 24分钟",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("card text = %q, want substring %q", text, want)
+		}
+	}
+}
+
+func TestCmdUsage_LocalizedChinese(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubUsageAgent{
+		report: &UsageReport{
+			Email: "dev@example.com",
+			Plan:  "team",
+			Buckets: []UsageBucket{
+				{
+					Name:         "Rate limit",
+					Allowed:      true,
+					LimitReached: false,
+					Windows: []UsageWindow{
+						{Name: "Primary", UsedPercent: 23, WindowSeconds: 18000, ResetAfterSeconds: 6665},
+						{Name: "Secondary", UsedPercent: 42, WindowSeconds: 604800, ResetAfterSeconds: 512698},
+					},
+				},
+			},
+		},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangChinese)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	e.handleCommand(p, msg, "/usage")
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	got := p.sent[0]
+	for _, want := range []string{
+		"账号：dev@example.com (team)",
+		"5小时限额",
+		"剩余：77%",
+		"重置：1小时 51分钟",
+		"7日限额",
+		"剩余：58%",
+		"重置：5天 22小时 24分钟",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("usage text = %q, want substring %q", got, want)
+		}
+	}
+	if strings.Contains(got, "```") {
+		t.Fatalf("usage text = %q, should not use code block on plain platform", got)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -229,6 +229,8 @@ const (
 	MsgMemoryAdded        MsgKey = "memory_added"
 	MsgMemoryAddFailed    MsgKey = "memory_add_failed"
 	MsgMemoryAddUsage     MsgKey = "memory_add_usage"
+	MsgUsageNotSupported  MsgKey = "usage_not_supported"
+	MsgUsageFetchFailed   MsgKey = "usage_fetch_failed"
 
 	// Inline strings previously hardcoded in engine.go
 	MsgStatusMode    MsgKey = "status_mode"
@@ -288,9 +290,9 @@ const (
 	MsgPermBtnAllow    MsgKey = "perm_btn_allow"
 	MsgPermBtnDeny     MsgKey = "perm_btn_deny"
 	MsgPermBtnAllowAll MsgKey = "perm_btn_allow_all"
-	MsgPermCardTitle MsgKey = "perm_card_title"
-	MsgPermCardBody  MsgKey = "perm_card_body"
-	MsgPermCardNote  MsgKey = "perm_card_note"
+	MsgPermCardTitle   MsgKey = "perm_card_title"
+	MsgPermCardBody    MsgKey = "perm_card_body"
+	MsgPermCardNote    MsgKey = "perm_card_note"
 
 	MsgCommandsTitle        MsgKey = "commands_title"
 	MsgCommandsEmpty        MsgKey = "commands_empty"
@@ -422,6 +424,7 @@ const (
 	MsgBuiltinCmdUpgrade   MsgKey = "upgrade"
 	MsgBuiltinCmdRestart   MsgKey = "restart"
 	MsgBuiltinCmdStatus    MsgKey = "status"
+	MsgBuiltinCmdUsage     MsgKey = "usage"
 	MsgBuiltinCmdVersion   MsgKey = "version"
 	MsgBuiltinCmdHelp      MsgKey = "help"
 	MsgBuiltinCmdBind      MsgKey = "bind"
@@ -670,6 +673,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/skills\n  List agent skills (from SKILL.md)\n\n" +
 			"/config [get|set|reload] [key] [value]\n  View/update runtime configuration\n\n" +
 			"/doctor\n  Run system diagnostics\n\n" +
+			"/usage\n  Show account/model quota usage\n\n" +
 			"/upgrade\n  Check for updates and self-update\n\n" +
 			"/restart\n  Restart cc-connect service\n\n" +
 			"/status\n  Show system status\n\n" +
@@ -706,6 +710,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/skills\n  列出 Agent Skills（来自 SKILL.md）\n\n" +
 			"/config [get|set|reload] [key] [value]\n  查看/修改运行时配置\n\n" +
 			"/doctor\n  运行系统诊断\n\n" +
+			"/usage\n  查看账号/模型限额使用情况\n\n" +
 			"/upgrade\n  检查更新并自动升级\n\n" +
 			"/restart\n  重启 cc-connect 服务\n\n" +
 			"/status\n  查看系统状态\n\n" +
@@ -742,6 +747,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/skills\n  列出 Agent Skills（來自 SKILL.md）\n\n" +
 			"/config [get|set|reload] [key] [value]\n  查看/修改執行階段配置\n\n" +
 			"/doctor\n  執行系統診斷\n\n" +
+			"/usage\n  查看帳號/模型限額使用情況\n\n" +
 			"/upgrade\n  檢查更新並自動升級\n\n" +
 			"/restart\n  重啟 cc-connect 服務\n\n" +
 			"/status\n  查看系統狀態\n\n" +
@@ -777,6 +783,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/skills\n  エージェントスキル一覧（SKILL.md から）\n\n" +
 			"/config [get|set|reload] [key] [value]\n  ランタイム設定の表示/変更\n\n" +
 			"/doctor\n  システム診断を実行\n\n" +
+			"/usage\n  アカウント/モデル使用量を表示\n\n" +
 			"/upgrade\n  アップデートを確認して自動更新\n\n" +
 			"/restart\n  cc-connect サービスを再起動\n\n" +
 			"/status\n  システム状態を表示\n\n" +
@@ -812,6 +819,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/skills\n  Listar skills del agente (desde SKILL.md)\n\n" +
 			"/config [get|set|reload] [key] [value]\n  Ver/actualizar configuración en tiempo de ejecución\n\n" +
 			"/doctor\n  Ejecutar diagnósticos del sistema\n\n" +
+			"/usage\n  Mostrar uso de cuota de cuenta/modelo\n\n" +
 			"/upgrade\n  Buscar actualizaciones y auto-actualizar\n\n" +
 			"/restart\n  Reiniciar el servicio cc-connect\n\n" +
 			"/status\n  Mostrar estado del sistema\n\n" +
@@ -965,6 +973,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangEnglish: "**System**\n" +
 			"/config [get|set|reload] — Runtime configuration\n" +
 			"/doctor — System diagnostics\n" +
+			"/usage — Account/model quota usage\n" +
 			"/upgrade — Check for updates\n" +
 			"/restart — Restart service\n" +
 			"/status — System status\n" +
@@ -972,6 +981,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangChinese: "**系统**\n" +
 			"/config [get|set|reload] — 运行时配置\n" +
 			"/doctor — 系统诊断\n" +
+			"/usage — 账号/模型限额\n" +
 			"/upgrade — 检查更新\n" +
 			"/restart — 重启服务\n" +
 			"/status — 系统状态\n" +
@@ -979,6 +989,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "**系統**\n" +
 			"/config [get|set|reload] — 執行階段配置\n" +
 			"/doctor — 系統診斷\n" +
+			"/usage — 帳號/模型限額\n" +
 			"/upgrade — 檢查更新\n" +
 			"/restart — 重啟服務\n" +
 			"/status — 系統狀態\n" +
@@ -986,6 +997,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese: "**システム**\n" +
 			"/config [get|set|reload] — ランタイム設定\n" +
 			"/doctor — システム診断\n" +
+			"/usage — アカウント/モデル使用量\n" +
 			"/upgrade — アップデート確認\n" +
 			"/restart — サービス再起動\n" +
 			"/status — システム状態\n" +
@@ -993,6 +1005,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish: "**Sistema**\n" +
 			"/config [get|set|reload] — Configuración\n" +
 			"/doctor — Diagnósticos del sistema\n" +
+			"/usage — Uso de cuota de cuenta/modelo\n" +
 			"/upgrade — Buscar actualizaciones\n" +
 			"/restart — Reiniciar servicio\n" +
 			"/status — Estado del sistema\n" +
@@ -1469,6 +1482,20 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "❌ 寫入記憶檔案失敗: %v",
 		LangJapanese:           "❌ メモリファイルの書き込みに失敗しました: %v",
 		LangSpanish:            "❌ Error al escribir archivo de memoria: %v",
+	},
+	MsgUsageNotSupported: {
+		LangEnglish:            "Current agent does not support `/usage`.",
+		LangChinese:            "当前 Agent 不支持 `/usage`。",
+		LangTraditionalChinese: "目前 Agent 不支援 `/usage`。",
+		LangJapanese:           "現在のエージェントは `/usage` をサポートしていません。",
+		LangSpanish:            "El agente actual no admite `/usage`.",
+	},
+	MsgUsageFetchFailed: {
+		LangEnglish:            "Failed to fetch usage: %v",
+		LangChinese:            "获取 usage 失败：%v",
+		LangTraditionalChinese: "取得 usage 失敗：%v",
+		LangJapanese:           "usage の取得に失敗しました: %v",
+		LangSpanish:            "No se pudo obtener usage: %v",
 	},
 	MsgMemoryAddUsage: {
 		LangEnglish: "Usage:\n" +
@@ -2642,6 +2669,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "查看系統狀態",
 		LangJapanese:           "システム状態を表示",
 		LangSpanish:            "Mostrar estado del sistema",
+	},
+	MsgBuiltinCmdUsage: {
+		LangEnglish:            "Show account/model quota usage",
+		LangChinese:            "查看账号/模型限额使用情况",
+		LangTraditionalChinese: "查看帳號/模型限額使用情況",
+		LangJapanese:           "アカウント/モデル使用量を表示",
+		LangSpanish:            "Mostrar uso de cuota de cuenta/modelo",
 	},
 	MsgBuiltinCmdVersion: {
 		LangEnglish:            "Show cc-connect version",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -221,6 +221,47 @@ type ModelOption struct {
 	Desc string // short description (display_name or empty)
 }
 
+// UsageReporter is an optional interface for agents that can report account or
+// model quota usage from their backing provider.
+type UsageReporter interface {
+	GetUsage(ctx context.Context) (*UsageReport, error)
+}
+
+// UsageReport is a provider-neutral quota snapshot returned by UsageReporter.
+type UsageReport struct {
+	Provider  string
+	AccountID string
+	UserID    string
+	Email     string
+	Plan      string
+	Buckets   []UsageBucket
+	Credits   *UsageCredits
+}
+
+// UsageBucket groups one logical quota, such as standard requests or code review.
+type UsageBucket struct {
+	Name         string
+	Allowed      bool
+	LimitReached bool
+	Windows      []UsageWindow
+}
+
+// UsageWindow describes a single quota window.
+type UsageWindow struct {
+	Name              string
+	UsedPercent       int
+	WindowSeconds     int
+	ResetAfterSeconds int
+	ResetAtUnix       int64
+}
+
+// UsageCredits contains optional credit/balance metadata.
+type UsageCredits struct {
+	HasCredits bool
+	Unlimited  bool
+	Balance    string
+}
+
 // ContextCompressor is an optional interface for agents that support
 // compressing/compacting the conversation context within a running session.
 // CompressCommand returns the native slash command (e.g. "/compact", "/compress")

--- a/docs/plans/2026-03-12-usage-design.md
+++ b/docs/plans/2026-03-12-usage-design.md
@@ -1,0 +1,139 @@
+# Usage Command Design
+
+**Date:** 2026-03-12
+
+**Goal:** Add a built-in `/usage` command that reports model/account quota usage, starting with Codex running under ChatGPT OAuth, while keeping the retrieval path generic so other agents can plug in later.
+
+## Scope
+
+- Add a new built-in slash command: `/usage`.
+- The command is independent from `/status` and `/doctor`.
+- Usage retrieval is exposed as an optional agent capability, not hardcoded into the engine for a single vendor.
+- First implementation targets the Codex agent when local ChatGPT OAuth credentials are available in `~/.codex/auth.json`.
+- Unsupported agents should return a clear “not supported” style message rather than failing the whole command system.
+
+## Architecture
+
+### Command Layer
+
+`core/engine.go` will register and dispatch `/usage` as a normal built-in command. The engine should not know how ChatGPT, Gemini, or any future provider exposes quota data. It only detects whether the current agent implements a usage-reporting interface and formats the response.
+
+### Agent Capability Layer
+
+Add a new optional interface in `core/interfaces.go`, for example:
+
+- `UsageReporter`
+- a method such as `GetUsage(context.Context) (*UsageReport, error)`
+
+The report type should be generic enough to cover multiple providers:
+
+- provider/agent name
+- subject or account label
+- plan type / tier if available
+- one or more rate-limit buckets/windows
+- optional credits/balance fields
+- raw provider-specific metadata only if needed for debugging
+
+This keeps future integrations local to each agent package.
+
+### Codex Implementation
+
+`agent/codex` will implement the new interface by:
+
+1. Reading `~/.codex/auth.json`
+2. Extracting:
+   - `tokens.access_token`
+   - `tokens.account_id`
+3. Calling:
+   - `GET https://chatgpt.com/backend-api/wham/usage`
+4. Passing headers:
+   - `Authorization: Bearer <access_token>`
+   - `ChatGPT-Account-Id: <account_id>`
+   - `User-Agent: codex-cli`
+5. Mapping the JSON response into the generic usage report
+
+If `auth.json` is missing, fields are absent, or the HTTP call fails, the agent should return a normal error so `/usage` can present a concise failure message.
+
+## Data Model
+
+The generic report should support at least:
+
+- identity:
+  - provider
+  - account_id
+  - user/email if available
+- plan:
+  - plan_type
+- standard rate limits:
+  - allowed
+  - limit_reached
+  - primary window
+  - secondary window
+- review/code-review limits:
+  - same window shape when available
+- credits:
+  - has_credits
+  - unlimited
+  - balance
+
+Each window should preserve:
+
+- used percent
+- total window seconds
+- reset-after seconds
+- reset timestamp if supplied
+
+This is enough for the current ChatGPT OAuth response and still general enough for other providers with multiple quota windows.
+
+## Output Format
+
+The first output version should be plain text and compact. Suggested shape:
+
+- title line with agent/provider
+- plan line
+- standard usage section
+- code review usage section if present
+- credits section if present
+
+For each window:
+
+- whether requests are currently allowed
+- whether the limit is reached
+- used percent
+- reset timing
+
+Prefer rendering both relative time and absolute time if easy to do consistently. If absolute rendering is added, it should use local time formatting already used by the project, or a simple RFC3339 fallback.
+
+## Error Handling
+
+- Agent does not implement usage reporting:
+  - reply with a user-facing “current agent does not support `/usage`”
+- Codex auth file missing:
+  - explain that ChatGPT OAuth login data was not found
+- Token/account id missing:
+  - explain credentials are incomplete
+- HTTP non-200:
+  - include status code in logs; show concise failure text to user
+- JSON decode failure:
+  - report provider response parse failure
+
+Do not expose bearer tokens or raw auth file contents in user-visible output or logs.
+
+## Testing
+
+Minimum tests should cover:
+
+- command dispatch recognizes `/usage`
+- engine returns unsupported message when agent lacks the interface
+- engine formats a successful generic usage report
+- Codex usage fetch maps a representative `wham/usage` payload correctly
+- Codex usage fetch errors on missing auth file / missing token fields
+
+Network-dependent tests should use injected transport or `httptest`, not live requests.
+
+## Non-Goals
+
+- No merging into `/status` or `/doctor`
+- No card UI in the first version
+- No polling or background caching in the first version
+- No support for non-Codex agents in this change beyond the shared interface

--- a/docs/plans/2026-03-12-usage.md
+++ b/docs/plans/2026-03-12-usage.md
@@ -1,0 +1,155 @@
+# Usage Command Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a built-in `/usage` command with a generic agent usage-reporting interface, and implement the first provider-backed version for Codex using ChatGPT OAuth quota data.
+
+**Architecture:** The engine gains a new built-in command that depends only on an optional `UsageReporter` interface. Agents that implement the interface return a generic `UsageReport`; the engine formats that into text. The Codex agent reads ChatGPT OAuth credentials from `~/.codex/auth.json`, calls the `wham/usage` endpoint, and maps the response into the generic structure.
+
+**Tech Stack:** Go, built-in command dispatch in `core/engine.go`, optional agent interfaces in `core/interfaces.go`, HTTP/JSON via Go standard library, table-driven tests.
+
+---
+
+### Task 1: Add generic usage-reporting types
+
+**Files:**
+- Modify: `core/interfaces.go`
+
+**Step 1: Add the failing interface usage surface**
+
+Define:
+
+- `UsageReporter`
+- `UsageReport`
+- `UsageBucket`
+- `UsageWindow`
+- `UsageCredits`
+
+The structure should cover provider identity, plan/tier, generic allowed/limit-reached flags, one or more windows, and credits metadata.
+
+**Step 2: Run targeted compile check**
+
+Run: `go test ./core/...`
+Expected: compile failures in engine/tests until the command layer is wired.
+
+**Step 3: Keep the types minimal**
+
+Do not add provider-specific fields unless they are broadly useful.
+
+**Step 4: Re-run compile check**
+
+Run: `go test ./core/...`
+Expected: still failing only because `/usage` command is not yet fully integrated.
+
+### Task 2: Add `/usage` built-in command and output formatter
+
+**Files:**
+- Modify: `core/engine.go`
+- Modify: `core/i18n.go`
+- Test: `core/engine_test.go`
+
+**Step 1: Write/extend failing tests**
+
+Add tests for:
+
+- `/usage` dispatch to a supporting agent
+- unsupported-agent message
+- successful output formatting with representative report data
+
+**Step 2: Run the targeted tests**
+
+Run: `go test ./core/... -run 'Test.*Usage|TestHandleCommand'`
+Expected: FAIL because the command is not registered yet.
+
+**Step 3: Implement command plumbing**
+
+Update:
+
+- built-in command registration
+- command dispatch switch
+- bot command listing
+- help/i18n text
+
+Add a `cmdUsage` implementation that:
+
+- type-asserts `UsageReporter`
+- fetches usage with timeout
+- formats a concise text response
+
+**Step 4: Run the targeted tests again**
+
+Run: `go test ./core/... -run 'Test.*Usage|TestHandleCommand'`
+Expected: PASS
+
+### Task 3: Implement Codex usage retrieval against ChatGPT OAuth
+
+**Files:**
+- Modify: `agent/codex/codex.go`
+- Add or Modify: `agent/codex/usage.go`
+- Test: `agent/codex/usage_test.go`
+
+**Step 1: Write failing tests for the mapper/fetcher**
+
+Cover:
+
+- successful parsing of a representative `wham/usage` payload
+- missing `auth.json`
+- missing token/account fields
+- HTTP error response
+
+**Step 2: Run the targeted tests**
+
+Run: `go test ./agent/codex -run 'Test.*Usage'`
+Expected: FAIL because the implementation does not exist yet.
+
+**Step 3: Implement minimal production code**
+
+Add:
+
+- auth file path resolver
+- auth JSON loader
+- HTTP request builder
+- response DTOs
+- mapping into `core.UsageReport`
+
+Prefer dependency injection for:
+
+- auth file path / reader
+- HTTP client / transport
+
+So tests avoid live network and real user files.
+
+**Step 4: Run the targeted tests again**
+
+Run: `go test ./agent/codex -run 'Test.*Usage'`
+Expected: PASS
+
+### Task 4: End-to-end verification and cleanup
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `CHANGELOG.md`
+
+**Step 1: Document the new command**
+
+Add `/usage` to command lists and a short explanation that support depends on the current agent.
+
+**Step 2: Run focused test suites**
+
+Run: `go test ./core/... ./agent/codex`
+Expected: PASS
+
+**Step 3: Run broader verification**
+
+Run: `go test ./...`
+Expected: PASS, or identify unrelated pre-existing failures clearly.
+
+**Step 4: Commit**
+
+Run:
+
+```bash
+git add core/interfaces.go core/engine.go core/i18n.go core/engine_test.go agent/codex/codex.go agent/codex/usage.go agent/codex/usage_test.go README.md README.zh-CN.md CHANGELOG.md docs/plans/2026-03-12-usage-design.md docs/plans/2026-03-12-usage.md
+git commit -m "feat: add usage command for codex oauth"
+```

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/BurntSushi/toml v1.6.0 h1:MEaUJLQJKFxTNo0xg+dKyOJA2Nu4O8kPVKuJ/gBiyjc=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=


### PR DESCRIPTION
## Summary
- add a built-in `/usage` command via a generic `UsageReporter` agent interface
- implement ChatGPT OAuth usage lookup for the Codex agent using `~/.codex/auth.json`
- add localized help/docs updates and platform-specific usage presentation (Feishu card, other platforms block layout)

## Test Plan
- [x] `go test ./...`
