### PR TITLE
fix: support codex image attachments

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -63,15 +64,17 @@ func newCodexSession(ctx context.Context, workDir, model, effort, mode, resumeID
 // If a threadID exists (from a prior turn or resume), uses `codex exec resume <id> <prompt>`.
 // Otherwise uses `codex exec <prompt>` to start a new conversation.
 func (cs *codexSession) Send(prompt string, images []core.ImageAttachment) error {
-	if len(images) > 0 {
-		slog.Warn("codexSession: images not supported by Codex, ignoring")
-	}
 	if !cs.alive.Load() {
 		return fmt.Errorf("session is closed")
 	}
 
+	prompt, imagePaths, err := cs.stageImages(prompt, images)
+	if err != nil {
+		return err
+	}
+
 	isResume := cs.CurrentSessionID() != ""
-	args := cs.buildExecArgs(prompt)
+	args := cs.buildExecArgs(prompt, imagePaths)
 
 	slog.Debug("codexSession: launching", "resume", isResume, "args", core.RedactArgs(args))
 
@@ -99,7 +102,35 @@ func (cs *codexSession) Send(prompt string, images []core.ImageAttachment) error
 	return nil
 }
 
-func (cs *codexSession) buildExecArgs(prompt string) []string {
+func (cs *codexSession) stageImages(prompt string, images []core.ImageAttachment) (string, []string, error) {
+	if len(images) == 0 {
+		return prompt, nil, nil
+	}
+
+	imgDir := filepath.Join(cs.workDir, ".cc-connect", "images")
+	if err := os.MkdirAll(imgDir, 0o755); err != nil {
+		return "", nil, fmt.Errorf("codexSession: create image dir: %w", err)
+	}
+
+	imagePaths := make([]string, 0, len(images))
+	for i, img := range images {
+		ext := codexImageExt(img.MimeType)
+		fname := fmt.Sprintf("img_%d_%d%s", time.Now().UnixMilli(), i, ext)
+		fpath := filepath.Join(imgDir, fname)
+		if err := os.WriteFile(fpath, img.Data, 0o644); err != nil {
+			return "", nil, fmt.Errorf("codexSession: save image: %w", err)
+		}
+		imagePaths = append(imagePaths, fpath)
+	}
+
+	if strings.TrimSpace(prompt) == "" {
+		prompt = "Please analyze the attached image(s)."
+	}
+
+	return prompt, imagePaths, nil
+}
+
+func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []string {
 	tid := cs.CurrentSessionID()
 	isResume := tid != ""
 
@@ -125,11 +156,31 @@ func (cs *codexSession) buildExecArgs(prompt string) []string {
 	}
 
 	if isResume {
-		args = append(args, tid, prompt)
+		args = append(args, tid)
+		for _, imagePath := range imagePaths {
+			args = append(args, "--image", imagePath)
+		}
+		args = append(args, prompt)
 	} else {
+		for _, imagePath := range imagePaths {
+			args = append(args, "--image", imagePath)
+		}
 		args = append(args, "--cd", cs.workDir, prompt)
 	}
 	return args
+}
+
+func codexImageExt(mime string) string {
+	switch mime {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	default:
+		return ".png"
+	}
 }
 
 func (cs *codexSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -2,7 +2,13 @@ package codex
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
 )
 
 func TestNormalizeReasoningEffort_RejectsMinimal(t *testing.T) {
@@ -34,7 +40,7 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 		t.Fatalf("newCodexSession: %v", err)
 	}
 
-	args := cs.buildExecArgs("hello")
+	args := cs.buildExecArgs("hello", nil)
 
 	want := []string{
 		"exec",
@@ -57,4 +63,158 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 			t.Fatalf("args[%d] = %q, want %q, args=%v", i, args[i], want[i], args)
 		}
 	}
+}
+
+func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	argsFile := filepath.Join(workDir, "args.txt")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > \"$CODEX_ARGS_FILE\"\n" +
+		"printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"thread-1\"}'\n" +
+		"printf '%s\\n' '{\"type\":\"turn.completed\"}'\n"
+	scriptPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	t.Setenv("CODEX_ARGS_FILE", argsFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer cs.Close()
+
+	img := core.ImageAttachment{
+		MimeType: "image/png",
+		Data:     []byte("png-bytes"),
+		FileName: "sample.png",
+	}
+	if err := cs.Send("", []core.ImageAttachment{img}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	args := waitForArgsFile(t, argsFile)
+	if !containsSequence(args, []string{"exec", "--json", "--skip-git-repo-check"}) {
+		t.Fatalf("args missing exec prelude: %v", args)
+	}
+	imagePath := valueAfter(args, "--image")
+	if imagePath == "" {
+		t.Fatalf("args missing --image: %v", args)
+	}
+	if !strings.HasPrefix(imagePath, filepath.Join(workDir, ".cc-connect", "images")+string(filepath.Separator)) {
+		t.Fatalf("image path = %q, want under work dir image cache", imagePath)
+	}
+	data, err := os.ReadFile(imagePath)
+	if err != nil {
+		t.Fatalf("read staged image: %v", err)
+	}
+	if string(data) != string(img.Data) {
+		t.Fatalf("staged image content = %q, want %q", string(data), string(img.Data))
+	}
+	if got := args[len(args)-1]; got != "Please analyze the attached image(s)." {
+		t.Fatalf("prompt = %q, want default image prompt; args=%v", got, args)
+	}
+}
+
+func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	argsFile := filepath.Join(workDir, "args.txt")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > \"$CODEX_ARGS_FILE\"\n" +
+		"printf '%s\\n' '{\"type\":\"turn.completed\"}'\n"
+	scriptPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	t.Setenv("CODEX_ARGS_FILE", argsFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "thread-123", nil)
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer cs.Close()
+
+	if err := cs.Send("describe this", []core.ImageAttachment{{MimeType: "image/jpeg", Data: []byte("jpg")}}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	args := waitForArgsFile(t, argsFile)
+	if !containsSequence(args, []string{"exec", "resume", "--json", "--skip-git-repo-check"}) {
+		t.Fatalf("args missing resume prelude: %v", args)
+	}
+	tidIndex := indexOf(args, "thread-123")
+	imageIndex := indexOf(args, "--image")
+	promptIndex := indexOf(args, "describe this")
+	if tidIndex == -1 || imageIndex == -1 || promptIndex == -1 {
+		t.Fatalf("missing resume/image/prompt args: %v", args)
+	}
+	if !(tidIndex < imageIndex && imageIndex < promptIndex) {
+		t.Fatalf("unexpected arg order: %v", args)
+	}
+}
+
+func waitForArgsFile(t *testing.T, path string) []string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+			return lines
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for args file: %s", path)
+	return nil
+}
+
+func containsSequence(args, want []string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	for i := 0; i+len(want) <= len(args); i++ {
+		match := true
+		for j := range want {
+			if args[i+j] != want[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func valueAfter(args []string, key string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == key {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func indexOf(args []string, target string) int {
+	for i, arg := range args {
+		if arg == target {
+			return i
+		}
+	}
+	return -1
 }

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/BurntSushi/toml v1.6.0 h1:MEaUJLQJKFxTNo0xg+dKyOJA2Nu4O8kPVKuJ/gBiyjc=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=


### PR DESCRIPTION
## Summary
- add Codex image attachment support by staging IM images locally and forwarding them via `codex exec --image`
- add regression tests covering staged image files, default prompt for image-only turns, and resume argument ordering
- fix the incorrect `github.com/BurntSushi/toml v1.6.0` checksum in `go.sum` so builds/tests can resolve dependencies again

## Test Plan
- [x] go test ./...
- [x] make build