### PR TITLE
fix(iflow): increase scanner buffer from 1MB to 10MB

### DIFF
--- a/agent/iflow/iflow.go
+++ b/agent/iflow/iflow.go
@@ -366,7 +366,7 @@ func parseIFlowSessionFile(path string) (sid, summary string, msgCount int, modi
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1024*64), 1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())


### PR DESCRIPTION
## Summary
- Increase `bufio.Scanner` buffer max size from 1MB to 10MB in `agent/iflow/iflow.go` to match other session file scanners
- Fixes "bufio.Scanner: token too long" errors when agent output is large

Closes #71