### PR TITLE
fix(feishu): sanitize non-HTTP URLs in markdown messages

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -645,7 +646,7 @@ func buildReplyContent(content string) (msgType string, body string) {
 	// 2. Many \n\n paragraphs (help, status, etc.) → post rich-text (preserves blank lines)
 	// 3. Other markdown → post md tag (best native rendering)
 	if hasComplexMarkdown(content) {
-		return larkim.MsgTypeInteractive, buildCardJSON(preprocessFeishuMarkdown(content))
+		return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)))
 	}
 	if strings.Count(content, "\n\n") >= 2 {
 		return larkim.MsgTypePost, buildPostJSON(content)
@@ -671,6 +672,7 @@ func hasComplexMarkdown(s string) bool {
 // buildPostMdJSON builds a Feishu post message using the md tag,
 // which renders markdown at normal chat font size.
 func buildPostMdJSON(content string) string {
+	content = sanitizeMarkdownURLs(content)
 	post := map[string]any{
 		"zh_cn": map[string]any{
 			"content": [][]map[string]any{
@@ -785,6 +787,24 @@ func buildPostJSON(content string) string {
 // Feishu rejects non-HTTP(S) URLs with "invalid href" (code 230001).
 func isValidFeishuHref(u string) bool {
 	return strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
+}
+
+var mdLinkRe = regexp.MustCompile(`\[([^\]]*)\]\(([^)]+)\)`)
+
+// sanitizeMarkdownURLs rewrites markdown links with non-HTTP(S) schemes
+// to plain text, preventing Feishu API rejection (code 230001).
+func sanitizeMarkdownURLs(md string) string {
+	return mdLinkRe.ReplaceAllStringFunc(md, func(match string) string {
+		parts := mdLinkRe.FindStringSubmatch(match)
+		if len(parts) < 3 {
+			return match
+		}
+		if isValidFeishuHref(parts[2]) {
+			return match
+		}
+		// Convert invalid-scheme link to "text (url)" plain text
+		return parts[1] + " (" + parts[2] + ")"
+	})
 }
 
 // parseInlineMarkdown parses a single line of markdown into Feishu post elements.
@@ -1015,7 +1035,7 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 		return nil, fmt.Errorf("%s: chatID is empty", p.tag())
 	}
 
-	cardJSON := buildCardJSON(content)
+	cardJSON := buildCardJSON(sanitizeMarkdownURLs(content))
 
 	var msgID string
 	if p.replyInThread && rc.messageID != "" {
@@ -1074,7 +1094,7 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 	if containsMarkdown(content) {
 		processed = preprocessFeishuMarkdown(content)
 	}
-	cardJSON := buildCardJSON(processed)
+	cardJSON := buildCardJSON(sanitizeMarkdownURLs(processed))
 	resp, err := p.client.Im.Message.Patch(ctx, larkim.NewPatchMessageReqBuilder().
 		MessageId(h.messageID).
 		Body(larkim.NewPatchMessageReqBodyBuilder().

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -262,6 +262,58 @@ func TestLark_ReconstructReplyCtx(t *testing.T) {
 	}
 }
 
+func TestSanitizeMarkdownURLs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "http link kept",
+			input: "see [docs](http://example.com)",
+			want:  "see [docs](http://example.com)",
+		},
+		{
+			name:  "https link kept",
+			input: "see [docs](https://example.com/path)",
+			want:  "see [docs](https://example.com/path)",
+		},
+		{
+			name:  "file scheme removed",
+			input: "open [file](file:///tmp/foo.txt)",
+			want:  "open file (file:///tmp/foo.txt)",
+		},
+		{
+			name:  "data scheme removed",
+			input: "img [pic](data:image/png;base64,abc)",
+			want:  "img pic (data:image/png;base64,abc)",
+		},
+		{
+			name:  "mixed links",
+			input: "[ok](https://x.com) and [bad](file:///etc/passwd)",
+			want:  "[ok](https://x.com) and bad (file:///etc/passwd)",
+		},
+		{
+			name:  "no links unchanged",
+			input: "plain text without links",
+			want:  "plain text without links",
+		},
+		{
+			name:  "ftp scheme removed",
+			input: "[dl](ftp://files.example.com/f.zip)",
+			want:  "dl (ftp://files.example.com/f.zip)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeMarkdownURLs(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeMarkdownURLs(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLark_ErrorMessagePrefix(t *testing.T) {
 	_, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{})
 	if err == nil {


### PR DESCRIPTION
## Summary
- Fixes #50: Feishu API rejects messages with non-HTTP(S) URLs (e.g. `file:///`, `data:`, `ftp://`) in markdown links, returning code 230001 "scheme not in scheme whitelist"
- Adds `sanitizeMarkdownURLs()` function that rewrites `[text](non-http-url)` to `text (non-http-url)` plain text, reusing the existing `isValidFeishuHref()` validator
- Applies sanitization in `buildPostMdJSON`, `buildReplyContent` (card path), `SendPreviewStart`, and `UpdateMessage` — all code paths that pass raw markdown to the Feishu API

## Test plan
- [x] Added table-driven unit tests for `sanitizeMarkdownURLs` covering HTTP/HTTPS (kept), file/data/ftp schemes (sanitized), mixed links, and plain text
- [x] `go test ./platform/feishu/...` passes
- [x] `go build ./platform/feishu/...` passes