### PR TITLE
fix(daemon): retry launchd bootstrap after bootout to avoid race condition

### DIFF
--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -90,7 +91,20 @@ func (*launchdManager) Restart() error {
 	runLaunchctl("bootout", target)
 
 	plistPath := launchdPlistPath()
-	out, err := runLaunchctl("bootstrap", domain, plistPath)
+
+	// launchd bootout is asynchronous; retry bootstrap with backoff
+	// to avoid "Bootstrap failed: 5" race condition.
+	var out string
+	var err error
+	for i := 0; i < 3; i++ {
+		if i > 0 {
+			time.Sleep(500 * time.Millisecond)
+		}
+		out, err = runLaunchctl("bootstrap", domain, plistPath)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("restart: %s (%w)", out, err)
 	}


### PR DESCRIPTION
## Summary
- Fixes #35: macOS launchd restart fails with "Bootstrap failed: 5" on first run
- Added retry loop (up to 3 attempts with 500ms backoff) for `launchctl bootstrap` after `bootout` in the `Restart()` method
- This works around launchd's asynchronous cleanup after bootout, which is the standard pattern for avoiding the race condition

## Test plan
- [ ] Verify `cc-connect daemon restart` no longer fails with "Bootstrap failed: 5" on macOS
- [ ] Confirm the retry loop backs off correctly (500ms between attempts)
- [ ] Test that restart still works normally when bootstrap succeeds on first attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)