### PR TITLE
feat(cursor): implement AvailableModels function to fetch models from…

### DIFF
--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -94,7 +94,61 @@ func (a *Agent) GetModel() string {
 	return a.model
 }
 
-func (a *Agent) AvailableModels(_ context.Context) []core.ModelOption {
+func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
+	a.mu.Lock()
+	cmd := a.cmd
+	extraEnv := a.providerEnvLocked()
+	extraEnv = append(extraEnv, a.sessionEnv...)
+	a.mu.Unlock()
+
+	if models := fetchModelsFromAgentCLI(ctx, cmd, extraEnv); len(models) > 0 {
+		return models
+	}
+	return cursorFallbackModels()
+}
+
+// fetchModelsFromAgentCLI runs `agent models` and parses the output.
+// Output format: "model-id - Display Name  (current)" or "model-id - Display Name"
+func fetchModelsFromAgentCLI(ctx context.Context, cmd string, extraEnv []string) []core.ModelOption {
+	c := exec.CommandContext(ctx, cmd, "models")
+	c.Env = append(os.Environ(), extraEnv...)
+	out, err := c.Output()
+	if err != nil {
+		slog.Debug("cursor: agent models failed", "error", err)
+		return nil
+	}
+
+	var models []core.ModelOption
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line == "Available models" || strings.HasPrefix(line, "Tip:") {
+			continue
+		}
+		idx := strings.Index(line, " - ")
+		if idx < 0 {
+			continue
+		}
+		name := strings.TrimSpace(line[:idx])
+		desc := strings.TrimSpace(line[idx+3:])
+		if name == "" {
+			continue
+		}
+		// Remove trailing markers like "(current)", "(default)"
+		desc = strings.TrimSuffix(desc, " (current)")
+		desc = strings.TrimSuffix(desc, " (default)")
+		desc = strings.TrimSpace(desc)
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		models = append(models, core.ModelOption{Name: name, Desc: desc})
+	}
+	sort.Slice(models, func(i, j int) bool { return models[i].Name < models[j].Name })
+	return models
+}
+
+func cursorFallbackModels() []core.ModelOption {
 	return []core.ModelOption{
 		{Name: "claude-sonnet-4-20250514", Desc: "Claude Sonnet 4"},
 		{Name: "claude-opus-4-20250514", Desc: "Claude Opus 4"},

--- a/agent/cursor/cursor_model_test.go
+++ b/agent/cursor/cursor_model_test.go
@@ -1,0 +1,87 @@
+package cursor
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestFetchModelsFromAgentCLI(t *testing.T) {
+	// Skip if agent CLI not available
+	if _, err := exec.LookPath("agent"); err != nil {
+		t.Skip("agent CLI not in PATH")
+	}
+
+	ctx := context.Background()
+	models := fetchModelsFromAgentCLI(ctx, "agent", nil)
+	if len(models) == 0 {
+		t.Fatal("expected models from agent models, got none")
+	}
+
+	// Verify format: each model has non-empty Name
+	for i, m := range models {
+		if m.Name == "" {
+			t.Errorf("models[%d].Name is empty", i)
+		}
+	}
+	// 运行 go test -v 时可见
+	t.Logf("fetched %d models:", len(models))
+	for i, m := range models {
+		t.Logf("  %2d. %s - %s", i+1, m.Name, m.Desc)
+	}
+}
+
+func TestFetchModelsFromAgentCLI_FailsGracefully(t *testing.T) {
+	ctx := context.Background()
+	models := fetchModelsFromAgentCLI(ctx, "nonexistent-agent-xyz", nil)
+	if len(models) != 0 {
+		t.Errorf("expected empty when command fails, got %d models", len(models))
+	}
+}
+
+func TestAvailableModels_Fallback(t *testing.T) {
+	// When agent models fails, should fall back to hardcoded list
+	ctx := context.Background()
+	a := &Agent{cmd: "nonexistent-cmd-that-will-fail"}
+	models := a.AvailableModels(ctx)
+	fallback := cursorFallbackModels()
+	if len(models) != len(fallback) {
+		t.Fatalf("fallback models length = %d, want %d", len(models), len(fallback))
+	}
+	for i := range models {
+		if models[i].Name != fallback[i].Name {
+			t.Errorf("models[%d].Name = %q, want %q", i, models[i].Name, fallback[i].Name)
+		}
+	}
+}
+
+func TestAvailableModels_FetchFromAgent(t *testing.T) {
+	if _, err := exec.LookPath("agent"); err != nil {
+		t.Skip("agent CLI not in PATH")
+	}
+
+	ctx := context.Background()
+	a := &Agent{cmd: "agent"}
+	models := a.AvailableModels(ctx)
+	if len(models) == 0 {
+		t.Fatal("expected models from agent models, got none")
+	}
+
+	t.Logf("AvailableModels returned %d models:", len(models))
+	for i, m := range models {
+		t.Logf("  %2d. %s - %s", i+1, m.Name, m.Desc)
+	}
+
+	// Should have real models like gpt-5.3-codex, opus-4.6-thinking, etc.
+	hasCodex := false
+	for _, m := range models {
+		if m.Name == "gpt-5.3-codex" || m.Name == "opus-4.6-thinking" || m.Name == "auto" {
+			hasCodex = true
+			break
+		}
+	}
+	if !hasCodex {
+		t.Logf("models: %v", models)
+		t.Log("agent models returned models but none of the expected ones (gpt-5.3-codex, opus-4.6-thinking, auto) - may be OK if CLI output format changed")
+	}
+}


### PR DESCRIPTION
## feat: Cursor Agent 支持 AvailableModels / Cursor Agent AvailableModels Support

---

### 变更说明 / Summary

**中文**：为 Cursor Agent 实现 `AvailableModels` 接口，使 `/model` 命令能展示 Cursor 当前可用的模型列表。

**English**: Implements `AvailableModels` for Cursor Agent so the `/model` command can display the list of models currently available in Cursor.

---

### 实现方式 / Implementation

- **动态获取 / Dynamic fetch**: 调用 `agent models` 解析输出（格式：`model-id - Display Name (current)`） / Invokes `agent models` and parses output (format: `model-id - Display Name (current)`)
- **兜底列表 / Fallback list**: CLI 调用失败时使用内置模型列表（如 Claude Sonnet 4、Claude Opus 4、GPT-4o、Gemini 2.5 Pro、Cursor Small） / Uses built-in model list when CLI fails (e.g. Claude Sonnet 4, Claude Opus 4, GPT-4o, Gemini 2.5 Pro, Cursor Small)
- **去重与排序 / Deduplication & sort**: 过滤重复项，按模型名排序 / Filters duplicates and sorts by model name

---

### 测试 / Tests

- `TestFetchModelsFromAgentCLI`: 在 PATH 中有 agent 时验证解析结果 / Verifies parsing when agent is in PATH
- `TestFetchModelsFromAgentCLI_FailsGracefully`: 命令不存在时返回空列表 / Returns empty list when command not found
- `TestAvailableModels_Fallback`: 验证兜底逻辑 / Verifies fallback behavior
- `TestAvailableModels_FetchFromAgent`: 验证与 agent CLI 的集成 / Verifies integration with agent CLI

---

### 相关文件 / Files Changed

- `agent/cursor/cursor.go`: 实现 `AvailableModels`、`fetchModelsFromAgentCLI`、`cursorFallbackModels` / Implements `AvailableModels`, `fetchModelsFromAgentCLI`, `cursorFallbackModels`
- `agent/cursor/cursor_model_test.go`: 新增单元测试 / New unit tests
