### PR TITLE
fix(daemon): prevent nil pointer panic in RotatingWriter after failed log rotation

### DIFF
--- a/daemon/logrotate.go
+++ b/daemon/logrotate.go
@@ -42,6 +42,10 @@ func (w *RotatingWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	if w.file == nil {
+		return 0, os.ErrClosed
+	}
+
 	n, err := w.file.Write(p)
 	w.curSize += int64(n)
 
@@ -60,7 +64,11 @@ func (w *RotatingWriter) rotate() {
 
 	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		f, _ = os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		// If we cannot open the new log file, w.file will be nil.
+		// Write() checks for nil and returns os.ErrClosed instead of panicking.
+		w.file = nil
+		w.curSize = 0
+		return
 	}
 	w.file = f
 	w.curSize = 0


### PR DESCRIPTION
## Summary

- Fix a nil pointer dereference panic in `RotatingWriter.Write()` that occurs when `rotate()` fails to open the new log file (e.g. disk full, permission denied)
- The original `rotate()` had a useless retry (calling `os.OpenFile` with identical arguments on failure), after which `w.file` could be set to `nil`. The next `Write()` call would then panic on `w.file.Write(p)`
- Add a nil guard in `Write()` that returns `os.ErrClosed` gracefully instead of panicking
- Remove the dead retry code in `rotate()` and handle the error path explicitly

## Root Cause

In `daemon/logrotate.go`, the `rotate()` method:
1. Closes the current file
2. Renames it to `.1` backup
3. Opens a new file — if this fails, it retries with the **exact same call**, which also fails
4. Sets `w.file = f` where `f` is `nil` (from the failed second `OpenFile`)
5. Next `Write()` dereferences `w.file` → **nil pointer panic**

## Test plan

- [x] Existing `TestRotatingWriter` passes
- [x] `go test ./...` all pass
- [x] `go build ./...` compiles cleanly