### PR TITLE
feat (discord, feishu): add thread isolation option

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -552,6 +552,8 @@ app_secret = "your-feishu-app-secret"
 #                           # 设为 true 时，群聊中无需 @机器人 也会响应所有消息（默认 false）
 # share_session_in_channel = false  # If true, all users in a group share one agent session
 #                                   # 设为 true 时，群聊内所有用户共享同一个 Agent 会话
+# thread_isolation = false  # If true, group messages use Feishu reply threads as session boundaries (one thread/root = one agent session)
+#                           # 设为 true 时，群聊按飞书话题/根消息隔离会话（一个 thread/root 对应一个 Agent 会话）
 # reply_in_thread = false  # If true, all responses are threaded to the original message (helps trace which question triggered which reply)
 #                          # 设为 true 时，所有回复都会引用原消息（方便追踪每条回复对应哪条提问）
 
@@ -634,6 +636,8 @@ app_secret = "your-feishu-app-secret"
 #                   # 可选：设置后 slash 命令秒级生效（仅该服务器）
 # group_reply_all = false  # If true, respond to ALL guild messages without @mention / 设为 true 群聊无需 @ 也响应
 # share_session_in_channel = false  # If true, all users in a channel share one agent session / 频道共享会话
+# thread_isolation = false  # If true, cc-connect creates/uses Discord threads as session boundaries when the channel supports threads
+#                           # 设为 true 时，cc-connect 会在支持 thread 的 Discord 频道内按 thread 隔离会话
 
 # LINE (uncomment to enable / 取消注释以启用)
 # 1. Create a channel at https://developers.line.biz/console/ (Messaging API)

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -109,9 +109,11 @@ type = "discord"
 
 [projects.platforms.options]
 token = "MTk4NjIyNDgzNDcOTY3NDUxMg.G8vKqh.xxx..."
+# thread_isolation = true  # Optional: isolate each agent session in its own Discord thread
 ```
 
 > cc-connect automatically configures the required Intents (MESSAGE_CONTENT, GUILD_MESSAGES, DIRECT_MESSAGES).
+> With `thread_isolation = true`, cc-connect creates or reuses a Discord thread for each session and routes follow-up messages by thread channel ID.
 
 ---
 
@@ -134,6 +136,7 @@ Under "Bot Permissions", check:
 |------------|---------|
 | Read Messages/View Channels | Read messages |
 | Send Messages | Send messages |
+| Create Public Threads | Create a new thread for a fresh agent session |
 | Send Messages in Threads | Send messages in threads |
 | Read Message History | Read message history |
 

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -74,9 +74,11 @@ type = "feishu"
 app_id = "cli_axxxxxxxxxxxx"
 app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # enable_feishu_card = true  # 可选：关闭后统一回退纯文本回复
+# thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
 ```
 
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
+> 如果开启 `thread_isolation = true`，群聊里每个根消息 / reply thread 会对应一个独立 agent session；私聊行为保持原样。
 
 ---
 
@@ -303,4 +305,3 @@ cc-connect 内置了自动重连机制，断开后会自动尝试重新连接。
 - [接入 Slack](./slack.md)
 - [接入 Discord](./discord.md)
 - [返回首页](../README.md)
-

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -24,6 +24,7 @@ const maxDiscordLen = 2000
 type replyContext struct {
 	channelID string
 	messageID string
+	threadID  string
 }
 
 // interactionReplyCtx handles Discord slash command (Application Command)
@@ -42,6 +43,7 @@ type Platform struct {
 	guildID               string // optional: per-guild registration (instant) vs global (up to 1h propagation)
 	groupReplyAll         bool
 	shareSessionInChannel bool
+	threadIsolation       bool
 	session               *discordgo.Session
 	handler               core.MessageHandler
 	botID                 string
@@ -59,6 +61,7 @@ func New(opts map[string]any) (core.Platform, error) {
 	guildID, _ := opts["guild_id"].(string)
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
+	threadIsolation, _ := opts["thread_isolation"].(bool)
 	return &Platform{
 		token:                 token,
 		allowFrom:             allowFrom,
@@ -66,17 +69,157 @@ func New(opts map[string]any) (core.Platform, error) {
 		groupReplyAll:         groupReplyAll,
 		shareSessionInChannel: shareSessionInChannel,
 		readyCh:               make(chan struct{}),
+		threadIsolation:       threadIsolation,
 	}, nil
 }
 
 func (p *Platform) Name() string { return "discord" }
 
 func (p *Platform) makeSessionKey(channelID string, userID string) string {
-	if p.shareSessionInChannel {
+	return buildSessionKey(channelID, userID, p.shareSessionInChannel)
+}
+
+func buildSessionKey(channelID string, userID string, shareSessionInChannel bool) string {
+	if shareSessionInChannel {
 		return fmt.Sprintf("discord:%s", channelID)
-	} else {
-		return fmt.Sprintf("discord:%s:%s", channelID, userID)
 	}
+	return fmt.Sprintf("discord:%s:%s", channelID, userID)
+}
+
+// TODO: thread_isolation currently keys each Discord thread as one shared session, so share_session_in_channel=false does not further isolate users within the same thread.
+func buildThreadSessionKey(threadID string) string {
+	return fmt.Sprintf("discord:%s", threadID)
+}
+
+func (rc replyContext) targetChannelID() string {
+	if rc.threadID != "" {
+		return rc.threadID
+	}
+	return rc.channelID
+}
+
+func (rc replyContext) useThreadChannel() bool {
+	return rc.threadID != "" && rc.threadID == rc.channelID
+}
+
+type discordThreadOps interface {
+	ResolveChannel(channelID string) (*discordgo.Channel, error)
+	StartThread(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error)
+	JoinThread(threadID string) error
+}
+
+type sessionThreadOps struct {
+	session *discordgo.Session
+}
+
+func (o sessionThreadOps) ResolveChannel(channelID string) (*discordgo.Channel, error) {
+	if o.session == nil {
+		return nil, fmt.Errorf("discord: session not initialized")
+	}
+	if ch, err := o.session.State.Channel(channelID); err == nil && ch != nil {
+		return ch, nil
+	}
+	return o.session.Channel(channelID)
+}
+
+func (o sessionThreadOps) StartThread(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error) {
+	if o.session == nil {
+		return nil, fmt.Errorf("discord: session not initialized")
+	}
+	return o.session.MessageThreadStart(channelID, messageID, name, archiveDuration)
+}
+
+func (o sessionThreadOps) JoinThread(threadID string) error {
+	if o.session == nil {
+		return fmt.Errorf("discord: session not initialized")
+	}
+	return o.session.ThreadJoin(threadID)
+}
+
+func isThreadChannelType(t discordgo.ChannelType) bool {
+	switch t {
+	case discordgo.ChannelTypeGuildNewsThread,
+		discordgo.ChannelTypeGuildPublicThread,
+		discordgo.ChannelTypeGuildPrivateThread:
+		return true
+	default:
+		return false
+	}
+}
+
+func truncateDiscordThreadName(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return string(runes[:maxRunes])
+}
+
+func threadNameForMessage(m *discordgo.MessageCreate, botID string) string {
+	name := stripDiscordMention(m.Content, botID)
+	name = strings.Join(strings.Fields(strings.ReplaceAll(name, "\n", " ")), " ")
+	if name == "" && m.Author != nil {
+		name = "cc " + m.Author.Username
+	}
+	if name == "" {
+		name = "cc session"
+	}
+	return truncateDiscordThreadName(name, 90)
+}
+
+func resolveSessionKeyForChannel(channelID, userID string, shareSessionInChannel bool, threadIsolation bool, ops discordThreadOps) string {
+	if !threadIsolation {
+		return buildSessionKey(channelID, userID, shareSessionInChannel)
+	}
+	ch, err := ops.ResolveChannel(channelID)
+	if err != nil {
+		slog.Warn("discord: resolve channel for session key failed, falling back", "channel", channelID, "error", err)
+		return buildSessionKey(channelID, userID, shareSessionInChannel)
+	}
+	if isThreadChannelType(ch.Type) {
+		return buildThreadSessionKey(channelID)
+	}
+	return buildSessionKey(channelID, userID, shareSessionInChannel)
+}
+
+func resolveThreadReplyContext(m *discordgo.MessageCreate, botID string, ops discordThreadOps) (string, replyContext, error) {
+	ch, err := ops.ResolveChannel(m.ChannelID)
+	if err != nil {
+		return "", replyContext{}, fmt.Errorf("resolve channel %s: %w", m.ChannelID, err)
+	}
+	if isThreadChannelType(ch.Type) {
+		if err := ops.JoinThread(m.ChannelID); err != nil {
+			slog.Debug("discord: join existing thread failed", "thread", m.ChannelID, "error", err)
+		}
+		rc := replyContext{channelID: m.ChannelID, messageID: m.ID, threadID: m.ChannelID}
+		return buildThreadSessionKey(m.ChannelID), rc, nil
+	}
+	if m.Message != nil && m.Message.Thread != nil && m.Message.Thread.ID != "" {
+		threadID := m.Message.Thread.ID
+		if err := ops.JoinThread(threadID); err != nil {
+			slog.Debug("discord: join attached thread failed", "thread", threadID, "error", err)
+		}
+		rc := replyContext{channelID: threadID, messageID: m.ID, threadID: threadID}
+		return buildThreadSessionKey(threadID), rc, nil
+	}
+	if m.Flags&discordgo.MessageFlagsHasThread != 0 {
+		threadID := m.ID
+		if err := ops.JoinThread(threadID); err != nil {
+			slog.Debug("discord: join message thread failed", "thread", threadID, "error", err)
+		}
+		rc := replyContext{channelID: threadID, messageID: m.ID, threadID: threadID}
+		return buildThreadSessionKey(threadID), rc, nil
+	}
+
+	thread, err := ops.StartThread(m.ChannelID, m.ID, threadNameForMessage(m, botID), 1440)
+	if err != nil {
+		return "", replyContext{}, fmt.Errorf("start thread for message %s: %w", m.ID, err)
+	}
+	if err := ops.JoinThread(thread.ID); err != nil {
+		slog.Debug("discord: join new thread failed", "thread", thread.ID, "error", err)
+	}
+	rc := replyContext{channelID: thread.ID, messageID: m.ID, threadID: thread.ID}
+	return buildThreadSessionKey(thread.ID), rc, nil
 }
 
 // RegisterCommands registers bot commands with Discord for the slash command menu.
@@ -197,6 +340,15 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 
 		sessionKey := p.makeSessionKey(m.ChannelID, m.Author.ID)
 		rctx := replyContext{channelID: m.ChannelID, messageID: m.ID}
+		if p.threadIsolation && m.GuildID != "" {
+			threadSessionKey, threadCtx, err := resolveThreadReplyContext(m, p.botID, sessionThreadOps{session: p.session})
+			if err != nil {
+				slog.Warn("discord: thread isolation setup failed, falling back", "message", m.ID, "channel", m.ChannelID, "error", err)
+			} else {
+				sessionKey = threadSessionKey
+				rctx = threadCtx
+			}
+		}
 
 		var images []core.ImageAttachment
 		var audio *core.AudioAttachment
@@ -291,7 +443,7 @@ func (p *Platform) handleInteraction(s *discordgo.Session, i *discordgo.Interact
 
 	slog.Debug("discord: slash command", "user", userName, "command", cmdText, "channel", channelID)
 
-	sessionKey := p.makeSessionKey(channelID, userID)
+	sessionKey := resolveSessionKeyForChannel(channelID, userID, p.shareSessionInChannel, p.threadIsolation, sessionThreadOps{session: p.session})
 	ictx := &interactionReplyCtx{
 		interaction: i.Interaction,
 		channelID:   channelID,
@@ -392,8 +544,13 @@ func (p *Platform) sendInteraction(ictx *interactionReplyCtx, content string) er
 func (p *Platform) sendChannelReply(rc replyContext, content string) error {
 	chunks := core.SplitMessageCodeFenceAware(content, maxDiscordLen)
 	for _, chunk := range chunks {
-		ref := &discordgo.MessageReference{MessageID: rc.messageID}
-		_, err := p.session.ChannelMessageSendReply(rc.channelID, chunk, ref)
+		var err error
+		if rc.useThreadChannel() {
+			_, err = p.session.ChannelMessageSend(rc.targetChannelID(), chunk)
+		} else {
+			ref := &discordgo.MessageReference{MessageID: rc.messageID}
+			_, err = p.session.ChannelMessageSendReply(rc.channelID, chunk, ref)
+		}
 		if err != nil {
 			return fmt.Errorf("discord: send: %w", err)
 		}
@@ -404,7 +561,7 @@ func (p *Platform) sendChannelReply(rc replyContext, content string) error {
 func (p *Platform) sendChannel(rc replyContext, content string) error {
 	chunks := core.SplitMessageCodeFenceAware(content, maxDiscordLen)
 	for _, chunk := range chunks {
-		_, err := p.session.ChannelMessageSend(rc.channelID, chunk)
+		_, err := p.session.ChannelMessageSend(rc.targetChannelID(), chunk)
 		if err != nil {
 			return fmt.Errorf("discord: send: %w", err)
 		}
@@ -413,12 +570,16 @@ func (p *Platform) sendChannel(rc replyContext, content string) error {
 }
 
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
-	// discord:{channelID}:{userID}
+	// discord:{channelID}:{userID} or discord:{threadID}
 	parts := strings.SplitN(sessionKey, ":", 3)
 	if len(parts) < 2 || parts[0] != "discord" {
 		return nil, fmt.Errorf("discord: invalid session key %q", sessionKey)
 	}
-	return replyContext{channelID: parts[1]}, nil
+	rc := replyContext{channelID: parts[1]}
+	if len(parts) == 2 {
+		rc.threadID = parts[1]
+	}
+	return rc, nil
 }
 
 // discordPreviewHandle stores the IDs needed to edit or delete a preview message.
@@ -432,7 +593,7 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 	var channelID string
 	switch rc := rctx.(type) {
 	case replyContext:
-		channelID = rc.channelID
+		channelID = rc.targetChannelID()
 	case *interactionReplyCtx:
 		channelID = rc.channelID
 	default:
@@ -483,6 +644,9 @@ func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
 		return func() {}
 	}
 	channelID := rc.channelID
+	if rc.targetChannelID() != "" {
+		channelID = rc.targetChannelID()
+	}
 	if channelID == "" {
 		return func() {}
 	}

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -1,0 +1,154 @@
+package discord
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+type fakeThreadOps struct {
+	resolveChannel func(channelID string) (*discordgo.Channel, error)
+	startThread    func(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error)
+	joinThread     func(threadID string) error
+}
+
+func (f fakeThreadOps) ResolveChannel(channelID string) (*discordgo.Channel, error) {
+	if f.resolveChannel == nil {
+		return nil, nil
+	}
+	return f.resolveChannel(channelID)
+}
+
+func (f fakeThreadOps) StartThread(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error) {
+	if f.startThread == nil {
+		return nil, nil
+	}
+	return f.startThread(channelID, messageID, name, archiveDuration)
+}
+
+func (f fakeThreadOps) JoinThread(threadID string) error {
+	if f.joinThread == nil {
+		return nil
+	}
+	return f.joinThread(threadID)
+}
+
+func TestResolveThreadReplyContext_UsesExistingThreadChannel(t *testing.T) {
+	ops := fakeThreadOps{
+		resolveChannel: func(channelID string) (*discordgo.Channel, error) {
+			return &discordgo.Channel{ID: channelID, Type: discordgo.ChannelTypeGuildPublicThread}, nil
+		},
+	}
+
+	joinedThread := ""
+	ops.joinThread = func(threadID string) error {
+		joinedThread = threadID
+		return nil
+	}
+
+	msg := &discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "m1",
+			ChannelID: "thread-1",
+			GuildID:   "guild-1",
+			Author:    &discordgo.User{ID: "u1", Username: "jun"},
+		},
+	}
+
+	sessionKey, rc, err := resolveThreadReplyContext(msg, "bot-1", ops)
+	if err != nil {
+		t.Fatalf("resolveThreadReplyContext() error = %v", err)
+	}
+	if sessionKey != "discord:thread-1" {
+		t.Fatalf("sessionKey = %q, want discord:thread-1", sessionKey)
+	}
+	if rc.channelID != "thread-1" || rc.threadID != "thread-1" {
+		t.Fatalf("replyContext = %#v, want thread channel routing", rc)
+	}
+	if joinedThread != "thread-1" {
+		t.Fatalf("joinedThread = %q, want thread-1", joinedThread)
+	}
+}
+
+func TestResolveThreadReplyContext_CreatesThreadForGuildMessage(t *testing.T) {
+	ops := fakeThreadOps{
+		resolveChannel: func(channelID string) (*discordgo.Channel, error) {
+			return &discordgo.Channel{ID: channelID, Type: discordgo.ChannelTypeGuildText}, nil
+		},
+	}
+
+	var (
+		startChannelID string
+		startMessageID string
+		startName      string
+		joinedThread   string
+	)
+	ops.startThread = func(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error) {
+		startChannelID = channelID
+		startMessageID = messageID
+		startName = name
+		if archiveDuration != 1440 {
+			t.Fatalf("archiveDuration = %d, want 1440", archiveDuration)
+		}
+		return &discordgo.Channel{ID: "thread-99", Type: discordgo.ChannelTypeGuildPublicThread}, nil
+	}
+	ops.joinThread = func(threadID string) error {
+		joinedThread = threadID
+		return nil
+	}
+
+	msg := &discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "msg-42",
+			ChannelID: "channel-1",
+			GuildID:   "guild-1",
+			Content:   "<@bot-1> investigate build failure",
+			Author:    &discordgo.User{ID: "u1", Username: "jun"},
+		},
+	}
+
+	sessionKey, rc, err := resolveThreadReplyContext(msg, "bot-1", ops)
+	if err != nil {
+		t.Fatalf("resolveThreadReplyContext() error = %v", err)
+	}
+	if sessionKey != "discord:thread-99" {
+		t.Fatalf("sessionKey = %q, want discord:thread-99", sessionKey)
+	}
+	if rc.channelID != "thread-99" || rc.threadID != "thread-99" {
+		t.Fatalf("replyContext = %#v, want thread channel routing", rc)
+	}
+	if startChannelID != "channel-1" || startMessageID != "msg-42" {
+		t.Fatalf("thread start args = (%q, %q), want (channel-1, msg-42)", startChannelID, startMessageID)
+	}
+	if startName != "investigate build failure" {
+		t.Fatalf("thread name = %q, want sanitized content", startName)
+	}
+	if joinedThread != "thread-99" {
+		t.Fatalf("joinedThread = %q, want thread-99", joinedThread)
+	}
+}
+
+func TestSessionKeyForChannel_UsesThreadKeyWhenChannelIsThread(t *testing.T) {
+	ops := fakeThreadOps{
+		resolveChannel: func(channelID string) (*discordgo.Channel, error) {
+			return &discordgo.Channel{ID: channelID, Type: discordgo.ChannelTypeGuildPrivateThread}, nil
+		},
+	}
+
+	if got := resolveSessionKeyForChannel("thread-7", "user-1", false, true, ops); got != "discord:thread-7" {
+		t.Fatalf("resolveSessionKeyForChannel() = %q, want discord:thread-7", got)
+	}
+}
+
+func TestReconstructReplyCtx_ThreadSessionKey(t *testing.T) {
+	p := &Platform{}
+
+	rctx, err := p.ReconstructReplyCtx("discord:thread-7")
+	if err != nil {
+		t.Fatalf("ReconstructReplyCtx() error = %v", err)
+	}
+	rc := rctx.(replyContext)
+	if rc.channelID != "thread-7" || rc.threadID != "thread-7" {
+		t.Fatalf("replyContext = %#v, want thread reply context", rc)
+	}
+}

--- a/platform/feishu/card.go
+++ b/platform/feishu/card.go
@@ -22,13 +22,10 @@ func (p *interactivePlatform) ReplyCard(ctx context.Context, rctx any, card *cor
 		return fmt.Errorf("%s: invalid reply context type %T", p.tag(), rctx)
 	}
 
-	cardJSON := renderCard(card)
+	cardJSON := renderCard(card, rc.sessionKey)
 	resp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
 		MessageId(rc.messageID).
-		Body(larkim.NewReplyMessageReqBodyBuilder().
-			MsgType(larkim.MsgTypeInteractive).
-			Content(cardJSON).
-			Build()).
+		Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeInteractive, cardJSON)).
 		Build())
 	if err != nil {
 		return fmt.Errorf("%s: reply card api call: %w", p.tag(), err)
@@ -49,7 +46,11 @@ func (p *interactivePlatform) SendCard(ctx context.Context, rctx any, card *core
 		return fmt.Errorf("%s: chatID is empty, cannot send card", p.tag())
 	}
 
-	cardJSON := renderCard(card)
+	if p.shouldReplyInThread(rc) {
+		return p.ReplyCard(ctx, rctx, card)
+	}
+
+	cardJSON := renderCard(card, rc.sessionKey)
 	resp, err := p.client.Im.Message.Create(ctx, larkim.NewCreateMessageReqBuilder().
 		ReceiveIdType(larkim.ReceiveIdTypeChatId).
 		Body(larkim.NewCreateMessageReqBodyBuilder().
@@ -70,7 +71,7 @@ func (p *interactivePlatform) SendCard(ctx context.Context, rctx any, card *core
 // renderCardMap converts a core.Card into the Feishu Interactive Card map
 // using the v1 format. Used both for message API (via renderCard) and
 // callback responses (CardActionTriggerResponse).
-func renderCardMap(card *core.Card) map[string]any {
+func renderCardMap(card *core.Card, sessionKey string) map[string]any {
 	result := map[string]any{
 		"config": map[string]any{
 			"wide_screen_mode": true,
@@ -114,6 +115,9 @@ func renderCardMap(card *core.Card) map[string]any {
 					btnType = "default"
 				}
 				valMap := map[string]string{"action": btn.Value}
+				if sessionKey != "" {
+					valMap["session_key"] = sessionKey
+				}
 				for k, v := range btn.Extra {
 					valMap[k] = v
 				}
@@ -162,6 +166,9 @@ func renderCardMap(card *core.Card) map[string]any {
 				btnType = "default"
 			}
 			valMap := map[string]string{"action": e.BtnValue}
+			if sessionKey != "" {
+				valMap["session_key"] = sessionKey
+			}
 			for k, v := range e.Extra {
 				valMap[k] = v
 			}
@@ -208,6 +215,9 @@ func renderCardMap(card *core.Card) map[string]any {
 				"tag":         "select_static",
 				"placeholder": plainText(e.Placeholder),
 				"options":     options,
+			}
+			if sessionKey != "" {
+				selectElem["value"] = map[string]string{"session_key": sessionKey}
 			}
 			if e.InitValue != "" {
 				selectElem["initial_option"] = e.InitValue
@@ -428,10 +438,9 @@ func parseDeleteModeListItemAction(action string) (id string, selectable bool, o
 	}
 }
 
-
 // renderCard converts a core.Card into the Feishu Interactive Card JSON string.
-func renderCard(card *core.Card) string {
-	b, err := json.Marshal(renderCardMap(card))
+func renderCard(card *core.Card, sessionKey string) string {
+	b, err := json.Marshal(renderCardMap(card, sessionKey))
 	if err != nil {
 		slog.Error("feishu: renderCard marshal failed", "error", err)
 		return `{"config":{"wide_screen_mode":true},"elements":[]}`

--- a/platform/feishu/card_test.go
+++ b/platform/feishu/card_test.go
@@ -12,7 +12,7 @@ func decodeRenderedCard(t *testing.T, card *core.Card) map[string]any {
 	t.Helper()
 
 	var got map[string]any
-	if err := json.Unmarshal([]byte(renderCard(card)), &got); err != nil {
+	if err := json.Unmarshal([]byte(renderCard(card, "")), &got); err != nil {
 		t.Fatalf("renderCard JSON decode failed: %v", err)
 	}
 	return got
@@ -225,5 +225,43 @@ func TestRenderCardMap_DeleteModeUsesCheckerForm(t *testing.T) {
 	}
 	if strings.Contains(s, `act:/delete-mode toggle`) {
 		t.Fatalf("expected no toggle buttons in rendered card, got %s", s)
+	}
+}
+
+func TestRenderCardMap_InjectsSessionKeyIntoCallbacks(t *testing.T) {
+	card := core.NewCard().
+		Buttons(core.PrimaryBtn("Open", "nav:/help session")).
+		ListItem("Choose", "Confirm", "act:/confirm").
+		Select("Pick one", []core.CardSelectOption{{Text: "A", Value: "askq:0:1"}}, "").
+		Build()
+
+	got := renderCardMap(card, "feishu:oc_chat:root:om_root")
+	elements, ok := got["elements"].([]map[string]any)
+	if !ok || len(elements) != 3 {
+		t.Fatalf("elements = %#v, want 3 elements", got["elements"])
+	}
+
+	actionRow := elements[0]
+	actions := actionRow["actions"].([]map[string]any)
+	firstButton := actions[0]
+	value := firstButton["value"].(map[string]string)
+	if value["session_key"] != "feishu:oc_chat:root:om_root" {
+		t.Fatalf("button session_key = %#v, want thread session key", value["session_key"])
+	}
+
+	listRow := elements[1]
+	columns := listRow["columns"].([]map[string]any)
+	actionCol := columns[1]
+	listBtn := actionCol["elements"].([]map[string]any)[0]
+	listValue := listBtn["value"].(map[string]string)
+	if listValue["session_key"] != "feishu:oc_chat:root:om_root" {
+		t.Fatalf("list item session_key = %#v, want thread session key", listValue["session_key"])
+	}
+
+	selectRow := elements[2]
+	selectActions := selectRow["actions"].([]map[string]any)
+	selectValue := selectActions[0]["value"].(map[string]string)
+	if selectValue["session_key"] != "feishu:oc_chat:root:om_root" {
+		t.Fatalf("select session_key = %#v, want thread session key", selectValue["session_key"])
 	}
 }

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -34,8 +34,9 @@ func init() {
 }
 
 type replyContext struct {
-	messageID string
-	chatID    string
+	messageID  string
+	chatID     string
+	sessionKey string
 }
 
 type Platform struct {
@@ -50,6 +51,7 @@ type Platform struct {
 	groupReplyAll         bool
 	shareSessionInChannel bool
 	replyInThread         bool
+	threadIsolation       bool
 	client                *lark.Client
 	wsClient              *larkws.Client
 	handler               core.MessageHandler
@@ -90,6 +92,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	replyInThread, _ := opts["reply_in_thread"].(bool)
+	threadIsolation, _ := opts["thread_isolation"].(bool)
 	useInteractiveCard := true
 	if v, ok := opts["enable_feishu_card"].(bool); ok {
 		useInteractiveCard = v
@@ -111,6 +114,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		groupReplyAll:         groupReplyAll,
 		shareSessionInChannel: shareSessionInChannel,
 		replyInThread:         replyInThread,
+		threadIsolation:       threadIsolation,
 		client:                lark.NewClient(appID, appSecret, clientOpts...),
 	}
 	if !useInteractiveCard {
@@ -234,7 +238,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 	if chatID == "" {
 		chatID = userID
 	}
-	sessionKey := fmt.Sprintf("%s:%s:%s", p.tag(), chatID, userID)
+	sessionKey := p.sessionKeyFromCardAction(chatID, userID, event.Event.Action.Value)
 
 	// nav: / act: — synchronous card update
 	if strings.HasPrefix(actionVal, "nav:") || strings.HasPrefix(actionVal, "act:") {
@@ -254,7 +258,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 				return &callback.CardActionTriggerResponse{
 					Card: &callback.Card{
 						Type: "raw",
-						Data: renderCardMap(card),
+						Data: renderCardMap(card, sessionKey),
 					},
 				}, nil
 			}
@@ -281,7 +285,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 			return nil, nil
 		}
 
-		rctx := replyContext{messageID: messageID, chatID: chatID}
+		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
 		go p.handler(p.dispatchPlatform(), &core.Message{
 			SessionKey: sessionKey,
 			Platform:   p.platformName,
@@ -303,14 +307,14 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		return &callback.CardActionTriggerResponse{
 			Card: &callback.Card{
 				Type: "raw",
-				Data: renderCardMap(cb.Build()),
+				Data: renderCardMap(cb.Build(), sessionKey),
 			},
 		}, nil
 	}
 
 	// askq: — AskUserQuestion option selected, forward as user message
 	if strings.HasPrefix(actionVal, "askq:") {
-		rctx := replyContext{messageID: messageID, chatID: chatID}
+		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
 		go p.handler(p.dispatchPlatform(), &core.Message{
 			SessionKey: sessionKey,
 			Platform:   p.platformName,
@@ -332,7 +336,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		return &callback.CardActionTriggerResponse{
 			Card: &callback.Card{
 				Type: "raw",
-				Data: renderCardMap(cb.Build()),
+				Data: renderCardMap(cb.Build(), sessionKey),
 			},
 		}, nil
 	}
@@ -340,7 +344,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 	// cmd: — async command dispatch
 	if strings.HasPrefix(actionVal, "cmd:") {
 		cmdText := strings.TrimPrefix(actionVal, "cmd:")
-		rctx := replyContext{messageID: messageID, chatID: chatID}
+		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
 
 		slog.Info(p.tag()+": card action dispatched as command", "cmd", cmdText, "user", userID)
 
@@ -459,6 +463,18 @@ func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
 	if msg.ChatType != nil {
 		chatType = *msg.ChatType
 	}
+	mentionCount := len(msg.Mentions)
+	slog.Debug(p.tag()+": inbound message",
+		"message_id", messageID,
+		"chat_id", chatID,
+		"chat_type", chatType,
+		"root_id", stringValue(msg.RootId),
+		"thread_id", stringValue(msg.ThreadId),
+		"parent_id", stringValue(msg.ParentId),
+		"mentions", mentionCount,
+		"group_reply_all", p.groupReplyAll,
+		"thread_isolation", p.threadIsolation,
+	)
 
 	if chatType == "group" && !p.groupReplyAll && p.botOpenID != "" {
 		if !isBotMentioned(msg.Mentions, p.botOpenID) {
@@ -477,13 +493,13 @@ func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
 		return nil
 	}
 
-	var sessionKey string
-	if p.shareSessionInChannel {
-		sessionKey = fmt.Sprintf("%s:%s", p.tag(), chatID)
-	} else {
-		sessionKey = fmt.Sprintf("%s:%s:%s", p.tag(), chatID, userID)
-	}
-	rctx := replyContext{messageID: messageID, chatID: chatID}
+	sessionKey := p.makeSessionKey(msg, chatID, userID)
+	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+	slog.Debug(p.tag()+": routed inbound message",
+		"message_id", messageID,
+		"session_key", sessionKey,
+		"reply_in_thread", p.shouldReplyInThread(rctx),
+	)
 
 	switch msgType {
 	case "text":
@@ -496,6 +512,11 @@ func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
 		}
 		text := stripMentions(textBody.Text, msg.Mentions, p.botOpenID)
 		if text == "" {
+			slog.Debug(p.tag()+": dropping empty text after mention stripping",
+				"message_id", messageID,
+				"raw_text_len", len(textBody.Text),
+				"mentions", mentionCount,
+			)
 			return nil
 		}
 		p.handler(p.dispatchPlatform(), &core.Message{
@@ -842,10 +863,7 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 
 	resp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
 		MessageId(rc.messageID).
-		Body(larkim.NewReplyMessageReqBodyBuilder().
-			MsgType(msgType).
-			Content(msgBody).
-			Build()).
+		Body(p.buildReplyMessageReqBody(rc, msgType, msgBody)).
 		Build())
 	if err != nil {
 		return fmt.Errorf("%s: reply api call: %w", p.tag(), err)
@@ -864,7 +882,7 @@ func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 		return fmt.Errorf("%s: invalid reply context type %T", p.tag(), rctx)
 	}
 
-	if p.replyInThread && rc.messageID != "" {
+	if p.shouldReplyInThread(rc) {
 		return p.Reply(ctx, rctx, content)
 	}
 
@@ -1309,13 +1327,98 @@ func stripMentions(text string, mentions []*larkim.MentionEvent, botOpenID strin
 	return strings.TrimSpace(text)
 }
 
+// TODO: Session-key derivation and reply-thread behavior are split across multiple code paths here.
+// Should revisit thread/root handling without changing thread_isolation=false behavior.
+func (p *Platform) makeSessionKey(msg *larkim.EventMessage, chatID, userID string) string {
+	if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
+		rootID := stringValue(msg.RootId)
+		if rootID == "" {
+			rootID = stringValue(msg.MessageId)
+		}
+		if rootID != "" {
+			return fmt.Sprintf("%s:%s:root:%s", p.tag(), chatID, rootID)
+		}
+	}
+	if p.shareSessionInChannel {
+		return fmt.Sprintf("%s:%s", p.tag(), chatID)
+	}
+	return fmt.Sprintf("%s:%s:%s", p.tag(), chatID, userID)
+}
+
+func (p *Platform) sessionKeyFromCardAction(chatID, userID string, value map[string]any) string {
+	if value != nil {
+		if sessionKey, _ := value["session_key"].(string); sessionKey != "" {
+			return sessionKey
+		}
+	}
+	if p.shareSessionInChannel {
+		return fmt.Sprintf("%s:%s", p.tag(), chatID)
+	}
+	return fmt.Sprintf("%s:%s:%s", p.tag(), chatID, userID)
+}
+
+func (p *Platform) shouldReplyInThread(rc replyContext) bool {
+	if rc.messageID == "" {
+		return false
+	}
+	if p.replyInThread {
+		return true
+	}
+	return p.threadIsolation && isThreadSessionKey(rc.sessionKey)
+}
+
+func (p *Platform) buildReplyMessageReqBody(rc replyContext, msgType, content string) *larkim.ReplyMessageReqBody {
+	body := larkim.NewReplyMessageReqBodyBuilder().
+		MsgType(msgType).
+		Content(content)
+	if p.shouldReplyInThread(rc) {
+		body.ReplyInThread(true)
+	}
+	return body.Build()
+}
+
+func stringValue(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 	// {platformName}:{chatID}:{userID}
 	parts := strings.SplitN(sessionKey, ":", 3)
 	if len(parts) < 2 || parts[0] != p.platformName {
 		return nil, fmt.Errorf("%s: invalid session key %q", p.tag(), sessionKey)
 	}
-	return replyContext{chatID: parts[1]}, nil
+	rc := replyContext{chatID: parts[1], sessionKey: sessionKey}
+	if len(parts) == 3 {
+		if rootID, ok := parseThreadRootID(parts[2]); ok {
+			rc.messageID = rootID
+		}
+	}
+	return rc, nil
+}
+
+func parseThreadRootID(sessionTail string) (string, bool) {
+	for _, prefix := range []string{"root:", "thread:"} {
+		if strings.HasPrefix(sessionTail, prefix) {
+			rootID := strings.TrimPrefix(sessionTail, prefix)
+			if rootID != "" {
+				return rootID, true
+			}
+			return "", false
+		}
+	}
+	return "", false
+}
+
+func isThreadSessionKey(sessionKey string) bool {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) != 3 {
+		return false
+	}
+	_, ok := parseThreadRootID(parts[2])
+	return ok
 }
 
 // feishuPreviewHandle stores the message ID for an editable preview message.
@@ -1363,13 +1466,10 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 	cardJSON := buildCardJSON(sanitizeMarkdownURLs(content))
 
 	var msgID string
-	if p.replyInThread && rc.messageID != "" {
+	if p.shouldReplyInThread(rc) {
 		resp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
 			MessageId(rc.messageID).
-			Body(larkim.NewReplyMessageReqBodyBuilder().
-				MsgType(larkim.MsgTypeInteractive).
-				Content(cardJSON).
-				Build()).
+			Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeInteractive, cardJSON)).
 			Build())
 		if err != nil {
 			return nil, fmt.Errorf("%s: send preview (reply): %w", p.tag(), err)
@@ -1487,7 +1587,21 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 		return fmt.Errorf("%s: build audio message: %w", p.tag(), err)
 	}
 
-	// Send audio message to chat
+	// Send audio message to chat or thread.
+	if p.shouldReplyInThread(rc) {
+		replyResp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
+			MessageId(rc.messageID).
+			Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeAudio, audioContent)).
+			Build())
+		if err != nil {
+			return fmt.Errorf("%s: send audio message: %w", p.tag(), err)
+		}
+		if !replyResp.Success() {
+			return fmt.Errorf("%s: send audio message code=%d msg=%s", p.tag(), replyResp.Code, replyResp.Msg)
+		}
+		return nil
+	}
+
 	sendResp, err := p.client.Im.Message.Create(ctx, larkim.NewCreateMessageReqBuilder().
 		ReceiveIdType(larkim.ReceiveIdTypeChatId).
 		Body(larkim.NewCreateMessageReqBodyBuilder().

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -324,6 +324,46 @@ func TestInteractivePlatform_CardActionFormCancelUsesActionNameFallback(t *testi
 	}
 }
 
+func TestInteractivePlatform_CardActionUsesCallbackSessionKey(t *testing.T) {
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip := platformAny.(*interactivePlatform)
+
+	wantSessionKey := "feishu:oc_test_chat:root:om_root_thread"
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		msgCh <- msg
+	}
+
+	_, err = ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_test_user"},
+			Action: &callback.CallBackAction{Value: map[string]any{
+				"action":      "cmd:/help",
+				"session_key": wantSessionKey,
+			}},
+			Context: &callback.Context{
+				OpenChatID:    "oc_test_chat",
+				OpenMessageID: "om_any_card_message",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.SessionKey != wantSessionKey {
+			t.Fatalf("SessionKey = %q, want %q", msg.SessionKey, wantSessionKey)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected card action message")
+	}
+}
+
 func TestNewLark_PlatformNameAndDomain(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret",
@@ -410,6 +450,182 @@ func TestLark_SessionKeyPrefix(t *testing.T) {
 	}
 }
 
+func TestLark_ThreadIsolationUsesRootSessionKey(t *testing.T) {
+	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform(lark) error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	messageID := "om_reply"
+	rootID := "om_root"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	content := `{"text":"@bot hello"}`
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	var receivedMsg *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ip.botOpenID = "ou_bot"
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		receivedMsg = msg
+	}
+
+	_ = ip.onMessage(&larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   &messageID,
+				RootId:      &rootID,
+				ChatId:      &chatID,
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     &content,
+				CreateTime:  &createText,
+				Mentions: []*larkim.MentionEvent{
+					{
+						Key: stringPtr("@bot"),
+						Id:  &larkim.UserId{OpenId: stringPtr("ou_bot")},
+					},
+				},
+			},
+		},
+	})
+	wg.Wait()
+
+	if receivedMsg == nil {
+		t.Fatal("handler not called")
+	}
+	if receivedMsg.SessionKey != "lark:oc_test:root:om_root" {
+		t.Fatalf("SessionKey = %q, want lark:oc_test:root:om_root", receivedMsg.SessionKey)
+	}
+}
+
+func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t *testing.T) {
+	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
+		"group_reply_all": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform(lark) error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	messageID := "om_root"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	content := `{"text":"hello from group root"}`
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		msgCh <- msg
+	}
+
+	if err := ip.onMessage(&larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   &messageID,
+				ChatId:      &chatID,
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     &content,
+				CreateTime:  &createText,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("onMessage() error = %v", err)
+	}
+
+	select {
+	case receivedMsg := <-msgCh:
+		if receivedMsg.SessionKey != "lark:oc_test:root:om_root" {
+			t.Fatalf("SessionKey = %q, want lark:oc_test:root:om_root", receivedMsg.SessionKey)
+		}
+		rc, ok := receivedMsg.ReplyCtx.(replyContext)
+		if !ok {
+			t.Fatalf("ReplyCtx type = %T, want replyContext", receivedMsg.ReplyCtx)
+		}
+		if rc.sessionKey != "lark:oc_test:root:om_root" {
+			t.Fatalf("replyContext.sessionKey = %q, want lark:oc_test:root:om_root", rc.sessionKey)
+		}
+		if rc.messageID != "om_root" {
+			t.Fatalf("replyContext.messageID = %q, want om_root", rc.messageID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected group root message to be handled without mention")
+	}
+}
+
+func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		platform      Platform
+		replyCtx      replyContext
+		wantThreading bool
+	}{
+		{
+			name:          "thread isolation enabled",
+			platform:      Platform{threadIsolation: true},
+			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:om_root"},
+			wantThreading: true,
+		},
+		{
+			name:          "thread isolation does not affect p2p session",
+			platform:      Platform{threadIsolation: true},
+			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:ou_user"},
+			wantThreading: false,
+		},
+		{
+			name:          "reply_in_thread enabled",
+			platform:      Platform{replyInThread: true},
+			replyCtx:      replyContext{messageID: "om_reply"},
+			wantThreading: true,
+		},
+		{
+			name:          "plain reply remains non-threaded",
+			platform:      Platform{},
+			replyCtx:      replyContext{messageID: "om_reply"},
+			wantThreading: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := tt.platform.buildReplyMessageReqBody(tt.replyCtx, larkim.MsgTypeText, `{"text":"hello"}`)
+			if body == nil {
+				t.Fatal("Body = nil, want populated reply body")
+			}
+			if body.ReplyInThread == nil {
+				if tt.wantThreading {
+					t.Fatal("ReplyInThread = nil, want true")
+				}
+				return
+			}
+			if got := *body.ReplyInThread; got != tt.wantThreading {
+				t.Fatalf("ReplyInThread = %v, want %v", got, tt.wantThreading)
+			}
+		})
+	}
+}
+
 func TestLark_ReconstructReplyCtx(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": false,
@@ -428,11 +644,25 @@ func TestLark_ReconstructReplyCtx(t *testing.T) {
 		t.Fatalf("chatID = %q, want oc_chat123", rc.chatID)
 	}
 
+	rctx, err = base.ReconstructReplyCtx("lark:oc_chat123:root:om_root456")
+	if err != nil {
+		t.Fatalf("ReconstructReplyCtx(thread) error = %v", err)
+	}
+	rc = rctx.(replyContext)
+	if rc.chatID != "oc_chat123" {
+		t.Fatalf("thread chatID = %q, want oc_chat123", rc.chatID)
+	}
+	if rc.messageID != "om_root456" {
+		t.Fatalf("thread messageID = %q, want om_root456", rc.messageID)
+	}
+
 	_, err = base.ReconstructReplyCtx("feishu:oc_chat:ou_user")
 	if err == nil {
 		t.Fatal("expected error for feishu-prefixed key on lark platform")
 	}
 }
+
+func stringPtr(s string) *string { return &s }
 
 func TestSanitizeMarkdownURLs(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description
This brings the thread isolation idea from [other project](https://github.com/cnrpman/no-claw) into cc-connect as an opt-in platform setting (currently available on Discord and Feishu).
Private chat / DM behavior stays as before.

  Known limitation: with thread_isolation=true, Discord and Feishu currently use one shared agent session
  per thread/root, so share_session_in_channel=false does not further isolate users within the same
  thread. other config combinations might not not fully orthogonal also.

  go test ./... passes.

## Gallery

### Feishu:
![B3E5EE75-D4C2-43CD-9A12-5029C962E263_1_105_c](https://github.com/user-attachments/assets/696ece80-50d5-4ff7-8fd6-bb75a980c516)
![18C21852-4A0F-4B01-A534-45FBA73576BF_1_105_c](https://github.com/user-attachments/assets/2237f3a0-f42c-4c4b-a915-ff6e005e5c38)
![A752D7C8-A61D-46CE-B466-D492AC787738_1_105_c](https://github.com/user-attachments/assets/e59d7e0e-d667-4878-8696-0f507d9eff51)

### Discord (also with group_reply_all = true):
<img width="1158" height="560" alt="Screenshot 2026-03-14 at 04 14 27" src="https://github.com/user-attachments/assets/c3098c07-a26e-482a-829f-a3b59514d385" />

<img width="1150" height="1396" alt="Screenshot 2026-03-14 at 04 14 38" src="https://github.com/user-attachments/assets/3e562324-9f89-4a2a-b358-925d5707c908" />
