### PR TITLE
fix: close agent session in HandleRelay to prevent resource leak

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -6557,6 +6557,7 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 	if err != nil {
 		return "", fmt.Errorf("start relay session: %w", err)
 	}
+	defer agentSession.Close()
 
 	if session.CompareAndSetAgentSessionID(agentSession.CurrentSessionID()) {
 		e.sessions.Save()


### PR DESCRIPTION
## Summary

- `HandleRelay` starts an agent session via `agent.StartSession()` but never calls `agentSession.Close()` on any return path (normal completion, error, or context cancellation)
- This leaks the underlying OS process, goroutines, and file descriptors for every relay message processed
- Added `defer agentSession.Close()` immediately after successful session start to ensure cleanup

## Root Cause

In `core/engine.go`, the `HandleRelay` function creates a local `agentSession` variable that is never stored in `interactiveStates` (unlike the interactive message path) and never closed. Every other code path that starts an agent session properly closes it via `cleanupInteractiveState` or direct `.Close()` calls.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify relay messages work correctly after the fix
- [ ] Confirm no process/goroutine leak after repeated relay sends