### PR TITLE
feat(slack): add /cc slash command gateway and harden command parsing

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -785,6 +785,11 @@ func (e *Engine) resolveAlias(content string) string {
 	if cmd, ok := e.aliases[content]; ok {
 		return cmd
 	}
+	if strings.HasPrefix(content, "/") {
+		if cmd, ok := e.aliases[strings.TrimPrefix(content, "/")]; ok {
+			return cmd
+		}
+	}
 
 	// Match first word, append remaining args
 	parts := strings.SplitN(content, " ", 2)
@@ -793,6 +798,14 @@ func (e *Engine) resolveAlias(content string) string {
 			return cmd + " " + parts[1]
 		}
 		return cmd
+	}
+	if strings.HasPrefix(parts[0], "/") {
+		if cmd, ok := e.aliases[strings.TrimPrefix(parts[0], "/")]; ok {
+			if len(parts) > 1 {
+				return cmd + " " + parts[1]
+			}
+			return cmd
+		}
 	}
 	return content
 }

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -290,6 +290,16 @@ func TestEngine_Alias(t *testing.T) {
 	if got != "random text" {
 		t.Errorf("resolveAlias should not modify unmatched content, got %q", got)
 	}
+
+	got = e.resolveAlias("/帮助")
+	if got != "/help" {
+		t.Errorf("resolveAlias('/帮助') = %q, want /help", got)
+	}
+
+	got = e.resolveAlias("/新建 my-session")
+	if got != "/new my-session" {
+		t.Errorf("resolveAlias('/新建 my-session') = %q, want '/new my-session'", got)
+	}
 }
 
 func TestEngine_ClearAliases(t *testing.T) {

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -69,6 +69,7 @@ Under "Scopes" → "Bot Token Scopes", add:
 |-------|---------|
 | `app_mentions:read` | Read @mention messages |
 | `chat:write` | Send messages |
+| `commands` | Receive native Slack slash commands like `/cc` |
 | `im:history` | Read DM history |
 | `im:read` | Read DM list |
 | `im:write` | Send DMs |
@@ -127,6 +128,25 @@ Under "Subscribe to bot events", add:
 ### 5.4 Save Changes
 
 Click "Save Changes".
+
+### 5.5 Configure a Native Slash Command (Optional but Recommended)
+
+If you want to run cc-connect commands directly from Slack's slash-command UI, create a gateway command named `/cc`.
+
+1. In the left sidebar, click "Slash Commands"
+2. Click "Create New Command"
+3. Fill in:
+
+| Field | Suggested Value |
+|-------|----------------|
+| Command | `/cc` |
+| Request URL | Not required with Socket Mode |
+| Short Description | `Run cc-connect commands` |
+| Usage Hint | `help`, `model`, `status`, `mycustom` |
+
+4. Click "Save"
+
+> 💡 With Socket Mode, Slack can deliver slash command payloads over the WebSocket connection, so a public Request URL is not required.
 
 ---
 
@@ -208,17 +228,41 @@ level=INFO msg="cc-connect is running" projects=1
 
 ## Step 9: Start Chatting
 
+cc-connect supports three Slack input styles:
+
+1. Native Slack slash-command gateway: `/cc model`
+2. Channel mention: `@cc_connect /model`
+3. DM plain-text fallback: ` /model` (leading space so Slack does not treat it as a native Slack command)
+
 ### 9.1 Direct Message
 
 1. Search for your bot name in Slack
 2. Open a DM conversation
 3. Send a message
 
+Example:
+
+```
+ /model
+```
+
 ### 9.2 Channel Usage
 
 1. Add the bot to a channel (`/invite @cc_connect`)
 2. @mention the bot: `@cc_connect help me analyze the code`
 3. The bot will respond
+
+For commands, you can either use:
+
+```text
+/cc model
+```
+
+or:
+
+```text
+@cc_connect /model
+```
 
 ---
 
@@ -303,6 +347,18 @@ Make sure:
 1. You've subscribed to the `app_mention` event
 2. The bot has been added to the channel
 3. You @mentioned the bot in your message
+
+### Q: `/model is not a valid command`?
+
+That message comes from Slack itself. Native Slack slash commands now go through the `/cc` gateway:
+
+1. Use `/cc model` for native slash-command input
+2. Or mention the bot: `@cc_connect /model`
+3. Or in a DM, send ` /model` with a leading space
+
+### Q: Do I need a public webhook URL for `/cc`?
+
+No. When Socket Mode is enabled, Slack sends slash-command payloads over the WebSocket connection instead of requiring a public HTTP endpoint.
 
 ---
 

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/chenhg5/cc-connect/core"
 
@@ -59,6 +60,13 @@ func New(opts map[string]any) (core.Platform, error) {
 }
 
 func (p *Platform) Name() string { return "slack" }
+
+func (p *Platform) makeSessionKey(channelID, userID string) string {
+	if p.shareSessionInChannel {
+		return fmt.Sprintf("slack:%s", channelID)
+	}
+	return fmt.Sprintf("slack:%s:%s", channelID, userID)
+}
 
 func (p *Platform) Start(handler core.MessageHandler) error {
 	p.handler = handler
@@ -131,15 +139,8 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					return
 				}
 
-				var sessionKey string
-				if p.shareSessionInChannel {
-					sessionKey = fmt.Sprintf("slack:%s", ev.Channel)
-				} else {
-					sessionKey = fmt.Sprintf("slack:%s:%s", ev.Channel, ev.User)
-				}
-
 				msg := &core.Message{
-					SessionKey: sessionKey, Platform: "slack",
+					SessionKey: p.makeSessionKey(ev.Channel, ev.User), Platform: "slack",
 					UserID: ev.User, UserName: ev.User,
 					Content:   stripAppMentionText(ev.Text),
 					MessageID: ev.TimeStamp,
@@ -173,12 +174,6 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					return
 				}
 
-				var sessionKey string
-				if p.shareSessionInChannel {
-					sessionKey = fmt.Sprintf("slack:%s", ev.Channel)
-				} else {
-					sessionKey = fmt.Sprintf("slack:%s:%s", ev.Channel, ev.User)
-				}
 				ts := ev.TimeStamp
 
 				var images []core.ImageAttachment
@@ -214,15 +209,48 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 				}
 
 				msg := &core.Message{
-					SessionKey: sessionKey, Platform: "slack",
+					SessionKey: p.makeSessionKey(ev.Channel, ev.User), Platform: "slack",
 					UserID: ev.User, UserName: ev.User,
 					Content: ev.Text, Images: images, Audio: audio,
 					MessageID: ts,
-					ReplyCtx: replyContext{channel: ev.Channel, timestamp: ts},
+					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: ts},
 				}
 				p.handler(p, msg)
 			}
 		}
+
+	case socketmode.EventTypeSlashCommand:
+		cmd, ok := evt.Data.(slack.SlashCommand)
+		if !ok {
+			slog.Debug("slack: slash command type assertion failed")
+			return
+		}
+		if evt.Request != nil && p.socket != nil {
+			p.socket.Ack(*evt.Request)
+		}
+
+		slog.Debug("slack: slash command received", "user", cmd.UserID, "channel", cmd.ChannelID, "command", cmd.Command)
+
+		if !core.AllowList(p.allowFrom, cmd.UserID) {
+			slog.Debug("slack: slash command from unauthorized user", "user", cmd.UserID)
+			return
+		}
+
+		content, ok := normalizeSlashCommandText(cmd)
+		if !ok || content == "" {
+			return
+		}
+
+		msg := &core.Message{
+			SessionKey: p.makeSessionKey(cmd.ChannelID, cmd.UserID),
+			Platform:   "slack",
+			UserID:     cmd.UserID,
+			UserName:   cmd.UserName,
+			Content:    content,
+			MessageID:  cmd.TriggerID,
+			ReplyCtx:   replyContext{channel: cmd.ChannelID},
+		}
+		p.handler(p, msg)
 
 	case socketmode.EventTypeConnecting:
 		slog.Debug("slack: connecting...")
@@ -234,10 +262,27 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 }
 
 func stripAppMentionText(text string) string {
-	if idx := strings.Index(text, "> "); idx != -1 && strings.HasPrefix(text, "<@") {
-		return strings.TrimSpace(text[idx+2:])
+	if strings.HasPrefix(text, "<@") {
+		if idx := strings.IndexByte(text, '>'); idx != -1 {
+			return strings.TrimLeftFunc(text[idx+1:], unicode.IsSpace)
+		}
 	}
 	return text
+}
+
+func normalizeSlashCommandText(cmd slack.SlashCommand) (string, bool) {
+	if cmd.Command != "/cc" {
+		return "", false
+	}
+
+	text := strings.TrimSpace(cmd.Text)
+	if text == "" {
+		return "/help", true
+	}
+	if strings.HasPrefix(text, "/") {
+		return text, true
+	}
+	return "/" + text, true
 }
 
 func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {

--- a/platform/slack/slack_test.go
+++ b/platform/slack/slack_test.go
@@ -1,6 +1,13 @@
 package slack
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/socketmode"
+)
 
 func TestStripAppMentionText(t *testing.T) {
 	tests := []struct {
@@ -23,6 +30,16 @@ func TestStripAppMentionText(t *testing.T) {
 			in:   "run tests",
 			want: "run tests",
 		},
+		{
+			name: "strips bot mention prefix followed by non-breaking space",
+			in:   "<@U0BOT123>\u00a0/model",
+			want: "/model",
+		},
+		{
+			name: "strips bot mention prefix followed by newline",
+			in:   "<@U0BOT123>\n/model",
+			want: "/model",
+		},
 	}
 
 	for _, tt := range tests {
@@ -31,5 +48,89 @@ func TestStripAppMentionText(t *testing.T) {
 				t.Fatalf("stripAppMentionText(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeSlashCommandText(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  slack.SlashCommand
+		want string
+		ok   bool
+	}{
+		{
+			name: "empty cc command falls back to help",
+			cmd:  slack.SlashCommand{Command: "/cc", Text: ""},
+			want: "/help",
+			ok:   true,
+		},
+		{
+			name: "plain text command gets slash prefix",
+			cmd:  slack.SlashCommand{Command: "/cc", Text: "model"},
+			want: "/model",
+			ok:   true,
+		},
+		{
+			name: "existing slash command is preserved",
+			cmd:  slack.SlashCommand{Command: "/cc", Text: "/model"},
+			want: "/model",
+			ok:   true,
+		},
+		{
+			name: "unsupported slash command is ignored",
+			cmd:  slack.SlashCommand{Command: "/model", Text: ""},
+			want: "",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := normalizeSlashCommandText(tt.cmd)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("normalizeSlashCommandText(%+v) = (%q, %v), want (%q, %v)", tt.cmd, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestHandleEventSlashCommand(t *testing.T) {
+	var got *core.Message
+	p := &Platform{
+		allowFrom: "*",
+		handler: func(_ core.Platform, msg *core.Message) {
+			got = msg
+		},
+	}
+
+	p.handleEvent(socketmode.Event{
+		Type: socketmode.EventTypeSlashCommand,
+		Data: slack.SlashCommand{
+			Command:   "/cc",
+			Text:      "model",
+			ChannelID: "C1",
+			UserID:    "U1",
+			UserName:  "son",
+		},
+	})
+
+	if got == nil {
+		t.Fatal("expected slash command to dispatch a message")
+	}
+	if got.SessionKey != "slack:C1:U1" {
+		t.Fatalf("session key = %q, want %q", got.SessionKey, "slack:C1:U1")
+	}
+	if got.Content != "/model" {
+		t.Fatalf("content = %q, want %q", got.Content, "/model")
+	}
+	if got.UserID != "U1" || got.UserName != "son" {
+		t.Fatalf("user = (%q, %q), want (%q, %q)", got.UserID, got.UserName, "U1", "son")
+	}
+	rctx, ok := got.ReplyCtx.(replyContext)
+	if !ok {
+		t.Fatalf("reply ctx type = %T, want replyContext", got.ReplyCtx)
+	}
+	if rctx.channel != "C1" {
+		t.Fatalf("reply channel = %q, want %q", rctx.channel, "C1")
 	}
 }


### PR DESCRIPTION
## Summary

  This PR improves the Slack integration in three related areas:

  1. Add native Slack slash command support through a `/cc` gateway
  2. Harden `@mention` command parsing for non-standard whitespace
  3. Update Slack setup and usage documentation

  ## What Changed

  ### Native Slack slash command gateway

  Slack integration now handles Socket Mode `slash_commands` events and routes `/cc ...` into
  the existing cc-connect command engine.

  Examples:

  - `/cc help`
  - `/cc model`
  - `/cc status`
  - `/cc mycustom`

  This keeps Slack-native command handling aligned with the existing built-in, custom command,
  and skill command paths.

  ### More robust mention command parsing

  `@cc_connect /model` now parses correctly even when Slack inserts non-ASCII whitespace, such
  as:

  - non-breaking spaces
  - newlines after the mention

  This avoids falling through to normal chat handling when the user intended to run a command.

  ### Alias compatibility for slash-style input

  Alias resolution now also works when the input is slash-prefixed, so Slack gateway input
  like `/cc 帮助` can still resolve to alias-backed commands.

  ### Documentation updates

  `docs/slack.md` now documents:

  - required `commands` OAuth scope
  - how to create a `/cc` slash command in Slack
  - the three supported Slack input styles:
    - native slash command: `/cc ...`
    - mention flow: `@cc_connect /model`
    - DM plain-text fallback: ` /model`

  ## Why

  Before this change:

  - Slack users could not use a native slash command path for cc-connect commands
  - direct Slack `/model` usage was confusing because Slack interprets it as a native Slack
  command
  - mention-based commands were brittle when Slack emitted unexpected whitespace
  - docs did not clearly explain the Slack-specific command model

  This PR makes Slack command usage more reliable and much easier to understand.

  ## Implementation Notes

  - Handles `socketmode.EventTypeSlashCommand` in the Slack platform
  - Uses `/cc` as a gateway command and normalizes the payload into the existing engine
  command format
  - Reuses the same session key model as other Slack message flows
  - Keeps replies as normal channel messages rather than ephemeral responses
  - Limits native slash-command handling to `/cc` to avoid overreaching Slack app
  configuration assumptions

  ## Tests

  Added/updated tests for:

  - mention parsing with non-breaking space and newline
  - `/cc` slash command normalization
  - slash command event dispatch into the platform message handler
  - slash-prefixed alias resolution

  Verification run:

  - `go test -count=1 ./platform/slack ./core`
  - `go test -count=1 ./...`

  ## Backward Compatibility

  Existing Slack usage continues to work:

  - `@cc_connect /model`
  - DM plain-text commands like ` /model`

  This PR only adds a native Slack command path via `/cc`.