### PR TITLE
fix: protect Session.AgentSessionID writes with mutex

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3456,7 +3456,7 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 	e.cleanupInteractiveState(msg.SessionKey)
 
 	s := e.sessions.GetOrCreateActive(msg.SessionKey)
-	s.AgentSessionID = ""
+	s.SetAgentSessionID("")
 	s.ClearHistory()
 	e.sessions.Save()
 
@@ -3537,7 +3537,7 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 	e.cleanupInteractiveState(msg.SessionKey)
 
 	s := e.sessions.GetOrCreateActive(msg.SessionKey)
-	s.AgentSessionID = ""
+	s.SetAgentSessionID("")
 	s.ClearHistory()
 	e.sessions.Save()
 
@@ -4509,7 +4509,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		switcher.SetModel(target)
 		e.cleanupInteractiveState(sessionKey)
 		s := e.sessions.GetOrCreateActive(sessionKey)
-		s.AgentSessionID = ""
+		s.SetAgentSessionID("")
 		s.ClearHistory()
 		e.sessions.Save()
 
@@ -4531,7 +4531,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 				switcher.SetReasoningEffort(target)
 				e.cleanupInteractiveState(sessionKey)
 				s := e.sessions.GetOrCreateActive(sessionKey)
-				s.AgentSessionID = ""
+				s.SetAgentSessionID("")
 				s.ClearHistory()
 				e.sessions.Save()
 				return


### PR DESCRIPTION
## Summary

- **Data race fix**: `cmdModel`, `cmdReasoning`, and `executeCardAction` in `core/engine.go` write `s.AgentSessionID = ""` without holding the session mutex, while `processInteractiveEvents` reads/writes the same field under lock in a separate goroutine.
- Replaced all 4 bare assignments with `s.SetAgentSessionID("")` which properly acquires the mutex before writing.

## Details

The `Session` struct protects its fields with `mu sync.Mutex` and provides `SetAgentSessionID()` for safe writes. However, four call sites bypassed the accessor and wrote directly to the field. This creates a data race window when `cleanupInteractiveState` closes the agent session asynchronously — the event processing goroutine may still be running and accessing `AgentSessionID` under the lock while the command handler writes without the lock.

Affected locations (all in `core/engine.go`):
1. `cmdModel` — after switching model
2. `cmdReasoning` — after switching reasoning level
3. `executeCardAction` — model switch via card button
4. `executeCardAction` — reasoning switch via card button

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Minimal change — only replaces bare field writes with the existing mutex-protected accessor