### PR TITLE
feat(gemini): optimize Gemini CLI display on Telegram

### DIFF
--- a/agent/gemini/gemini.go
+++ b/agent/gemini/gemini.go
@@ -118,10 +118,13 @@ func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
 	if models := a.fetchModelsFromAPI(ctx); len(models) > 0 {
 		return models
 	}
+	// Matches Gemini CLI's own "Select Model" list.
 	return []core.ModelOption{
-		{Name: "gemini-2.5-pro", Desc: "Gemini 2.5 Pro (most capable)"},
-		{Name: "gemini-2.5-flash", Desc: "Gemini 2.5 Flash (fast)"},
-		{Name: "gemini-2.0-flash", Desc: "Gemini 2.0 Flash (lightweight)"},
+		{Name: "gemini-3.1-pro-preview", Desc: "Gemini 3.1 Pro Preview"},
+		{Name: "gemini-3-flash-preview", Desc: "Gemini 3 Flash Preview"},
+		{Name: "gemini-2.5-pro", Desc: "Gemini 2.5 Pro"},
+		{Name: "gemini-2.5-flash", Desc: "Gemini 2.5 Flash"},
+		{Name: "gemini-2.5-flash-lite", Desc: "Gemini 2.5 Flash Lite"},
 	}
 }
 
@@ -208,12 +211,30 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 	if err != nil {
 		return fmt.Errorf("gemini: cannot determine home dir: %w", err)
 	}
-	projName := geminiProjectHash(a.workDir)
-	path := filepath.Join(homeDir, ".gemini", "tmp", projName, "chats", sessionID+".json")
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", geminiProjectSlug(a.workDir), "chats")
+	// Session files are named session-<timestamp>-<uuid_prefix>.json, not <uuid>.json.
+	// Scan the directory to find the file containing the matching sessionId.
+	entries, err := os.ReadDir(chatsDir)
+	if err != nil {
 		return fmt.Errorf("session file not found: %s", sessionID)
 	}
-	return os.Remove(path)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		fpath := filepath.Join(chatsDir, entry.Name())
+		data, err := os.ReadFile(fpath)
+		if err != nil {
+			continue
+		}
+		var sf struct {
+			SessionID string `json:"sessionId"`
+		}
+		if json.Unmarshal(data, &sf) == nil && sf.SessionID == sessionID {
+			return os.Remove(fpath)
+		}
+	}
+	return fmt.Errorf("session file not found: %s", sessionID)
 }
 
 func (a *Agent) Stop() error { return nil }
@@ -271,8 +292,11 @@ func (a *Agent) SkillDirs() []string {
 }
 
 // ── ContextCompressor implementation ──────────────────────────
+// Gemini CLI has no interactive compress/compact command.
+// Return "" so engine reports "not supported" instead of sending
+// a bogus "/compress" prompt to the model.
 
-func (a *Agent) CompressCommand() string { return "/compress" }
+func (a *Agent) CompressCommand() string { return "" }
 
 // ── MemoryFileProvider implementation ─────────────────────────
 
@@ -353,14 +377,61 @@ func (a *Agent) providerEnvLocked() []string {
 
 // ── Session listing ─────────────────────────────────────────────
 
-// geminiProjectHash computes the directory name Gemini CLI uses under ~/.gemini/tmp/.
-// Gemini uses a hash of the absolute project path.
-func geminiProjectHash(workDir string) string {
+// geminiProjectSlug looks up the directory name Gemini CLI uses under ~/.gemini/tmp/
+// for a given project path. It reads ~/.gemini/projects.json (the CLI's slug registry)
+// and falls back to a slugified basename if the project isn't registered.
+func geminiProjectSlug(workDir string) string {
 	abs, err := filepath.Abs(workDir)
 	if err != nil {
 		abs = workDir
 	}
-	return filepath.Base(abs)
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return slugify(filepath.Base(abs))
+	}
+
+	// Read the Gemini CLI project registry
+	data, err := os.ReadFile(filepath.Join(homeDir, ".gemini", "projects.json"))
+	if err == nil {
+		var registry struct {
+			Projects map[string]string `json:"projects"`
+		}
+		if json.Unmarshal(data, &registry) == nil {
+			// Normalize path for lookup (Gemini CLI uses path.normalize)
+			normalized := filepath.Clean(abs)
+			if slug, ok := registry.Projects[normalized]; ok {
+				return slug
+			}
+		}
+	}
+
+	// Fallback: replicate Gemini CLI's slugify logic
+	return slugify(filepath.Base(abs))
+}
+
+// slugify replicates the Gemini CLI's slug generation:
+// lowercase, replace non-alphanumeric with hyphens, collapse consecutive hyphens.
+func slugify(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	// Collapse consecutive hyphens and trim
+	result := b.String()
+	for strings.Contains(result, "--") {
+		result = strings.ReplaceAll(result, "--", "-")
+	}
+	result = strings.Trim(result, "-")
+	if result == "" {
+		result = "project"
+	}
+	return result
 }
 
 // sessionFile represents the JSON structure of a Gemini CLI session file.
@@ -369,13 +440,42 @@ type sessionFile struct {
 	ProjectHash string    `json:"projectHash"`
 	StartTime   time.Time `json:"startTime"`
 	LastUpdated time.Time `json:"lastUpdated"`
-	Messages    []struct {
-		Type    string `json:"type"`
-		Content []struct {
-			Text string `json:"text"`
-		} `json:"content"`
-	} `json:"messages"`
-	Kind string `json:"kind"`
+	Messages    []sessionMessage `json:"messages"`
+	Kind        string    `json:"kind"`
+}
+
+// sessionMessage represents a message in the Gemini session file.
+// The Content field is flexible: Gemini CLI can serialize it as either
+// a plain string or an array of {text: "..."} parts.
+type sessionMessage struct {
+	Type       string          `json:"type"`
+	RawContent json.RawMessage `json:"content"`
+}
+
+// textContent extracts text from the flexible content field.
+func (m *sessionMessage) textContent() string {
+	if len(m.RawContent) == 0 {
+		return ""
+	}
+	// Try as plain string first
+	var s string
+	if json.Unmarshal(m.RawContent, &s) == nil {
+		return s
+	}
+	// Try as array of {text: "..."} parts
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(m.RawContent, &parts) == nil {
+		var texts []string
+		for _, p := range parts {
+			if p.Text != "" {
+				texts = append(texts, p.Text)
+			}
+		}
+		return strings.Join(texts, "\n")
+	}
+	return ""
 }
 
 func listGeminiSessions(workDir string) ([]core.AgentSessionInfo, error) {
@@ -384,8 +484,8 @@ func listGeminiSessions(workDir string) ([]core.AgentSessionInfo, error) {
 		return nil, fmt.Errorf("gemini: cannot determine home dir: %w", err)
 	}
 
-	projName := geminiProjectHash(workDir)
-	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", projName, "chats")
+	slug := geminiProjectSlug(workDir)
+	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", slug, "chats")
 
 	entries, err := os.ReadDir(chatsDir)
 	if err != nil {
@@ -408,6 +508,23 @@ func listGeminiSessions(workDir string) ([]core.AgentSessionInfo, error) {
 
 		var sf sessionFile
 		if json.Unmarshal(data, &sf) != nil || sf.SessionID == "" {
+			continue
+		}
+
+		// Skip subagent sessions (internal agent-spawned sessions)
+		if sf.Kind == "subagent" {
+			continue
+		}
+
+		// Skip sessions with no user messages
+		hasUserMsg := false
+		for _, msg := range sf.Messages {
+			if msg.Type == "user" {
+				hasUserMsg = true
+				break
+			}
+		}
+		if !hasUserMsg {
 			continue
 		}
 
@@ -443,21 +560,19 @@ func extractSessionSummary(sf *sessionFile) string {
 		if msg.Type != "user" {
 			continue
 		}
-		for _, c := range msg.Content {
-			text := strings.TrimSpace(c.Text)
-			if text == "" {
+		text := strings.TrimSpace(msg.textContent())
+		if text == "" {
+			continue
+		}
+		for _, line := range strings.Split(text, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
 				continue
 			}
-			for _, line := range strings.Split(text, "\n") {
-				line = strings.TrimSpace(line)
-				if line == "" {
-					continue
-				}
-				if strings.HasPrefix(line, "{") && strings.HasSuffix(line, "}") {
-					continue
-				}
-				return line
+			if strings.HasPrefix(line, "{") && strings.HasSuffix(line, "}") {
+				continue
 			}
+			return line
 		}
 	}
 	if len(sf.SessionID) > 12 {

--- a/agent/gemini/session.go
+++ b/agent/gemini/session.go
@@ -301,6 +301,20 @@ func (gs *geminiSession) handleMessage(raw map[string]any) {
 		return
 	}
 
+	// Delta messages are incremental streaming fragments — emit immediately
+	// as EventText so engine's stream preview can update in real time.
+	// Non-delta messages (complete text) are buffered for later classification
+	// (thinking vs final text) based on what event follows.
+	delta, _ := raw["delta"].(bool)
+	if delta {
+		evt := core.Event{Type: core.EventText, Content: content}
+		select {
+		case gs.events <- evt:
+		case <-gs.ctx.Done():
+		}
+		return
+	}
+
 	gs.pendingMsgs = append(gs.pendingMsgs, content)
 }
 
@@ -468,29 +482,173 @@ func formatToolParams(toolName string, params map[string]any) string {
 	}
 
 	switch toolName {
-	case "shell", "run_shell_command":
+	case "shell", "run_shell_command", "Bash":
 		if cmd, ok := params["command"].(string); ok {
 			return cmd
 		}
-	case "write_file", "read_file", "replace":
+	case "write_file", "WriteFile":
+		fp, _ := params["file_path"].(string)
+		if fp == "" {
+			fp, _ = params["path"].(string)
+		}
+		if fp != "" {
+			if content, ok := params["content"].(string); ok && content != "" {
+				return "`" + fp + "`\n```\n" + content + "\n```"
+			}
+			return fp
+		}
+	case "replace", "ReplaceInFile":
+		fp, _ := params["file_path"].(string)
+		if fp == "" {
+			fp, _ = params["path"].(string)
+		}
+		if fp != "" {
+			old, _ := params["old_string"].(string)
+			new_, _ := params["new_string"].(string)
+			if old == "" {
+				old, _ = params["old_str"].(string)
+				new_, _ = params["new_str"].(string)
+			}
+			if old != "" || new_ != "" {
+				diff := computeLineDiff(old, new_)
+				return "`" + fp + "`\n```\n" + diff + "\n```"
+			}
+			return fp
+		}
+	case "read_file", "ReadFile":
 		if p, ok := params["file_path"].(string); ok {
 			return p
 		}
 		if p, ok := params["path"].(string); ok {
 			return p
 		}
-	case "web_fetch":
+	case "list_directory", "ListDirectory":
+		if p, ok := params["path"].(string); ok {
+			return p
+		}
+		if p, ok := params["directory"].(string); ok {
+			return p
+		}
+	case "web_fetch", "WebFetch":
 		if u, ok := params["url"].(string); ok {
 			return u
 		}
-	case "google_web_search":
+	case "google_web_search", "GoogleWebSearch":
 		if q, ok := params["query"].(string); ok {
 			return q
 		}
+	case "activate_skill":
+		if n, ok := params["name"].(string); ok {
+			return n
+		}
+	case "search_code", "SearchCode", "Glob", "Grep":
+		if q, ok := params["query"].(string); ok {
+			return q
+		}
+		if p, ok := params["pattern"].(string); ok {
+			return p
+		}
 	}
 
-	b, _ := json.Marshal(params)
-	return string(b)
+	// Fallback: format as key: value pairs for readability
+	var parts []string
+	for k, v := range params {
+		switch val := v.(type) {
+		case string:
+			parts = append(parts, k+": "+val)
+		default:
+			j, _ := json.Marshal(val)
+			parts = append(parts, k+": "+string(j))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// computeLineDiff computes a minimal unified-style diff between old and new text.
+// It finds common prefix/suffix lines and shows only the changed lines with
+// up to 1 line of surrounding context. Unchanged context lines are prefixed
+// with "  ", removed lines with "- ", and added lines with "+ ".
+func computeLineDiff(old, new_ string) string {
+	oldLines := strings.Split(old, "\n")
+	newLines := strings.Split(new_, "\n")
+
+	// Find common prefix lines
+	prefixLen := 0
+	minLen := len(oldLines)
+	if len(newLines) < minLen {
+		minLen = len(newLines)
+	}
+	for prefixLen < minLen && oldLines[prefixLen] == newLines[prefixLen] {
+		prefixLen++
+	}
+
+	// Find common suffix lines (not overlapping with prefix)
+	suffixLen := 0
+	for suffixLen < len(oldLines)-prefixLen && suffixLen < len(newLines)-prefixLen {
+		oi := len(oldLines) - 1 - suffixLen
+		ni := len(newLines) - 1 - suffixLen
+		if oldLines[oi] != newLines[ni] {
+			break
+		}
+		suffixLen++
+	}
+
+	// No actual changes
+	if prefixLen+suffixLen >= len(oldLines) && prefixLen+suffixLen >= len(newLines) {
+		return ""
+	}
+
+	// If everything differs (no common lines), show full old/new
+	if prefixLen == 0 && suffixLen == 0 {
+		var sb strings.Builder
+		for _, l := range oldLines {
+			sb.WriteString("- " + l + "\n")
+		}
+		for _, l := range newLines {
+			sb.WriteString("+ " + l + "\n")
+		}
+		return strings.TrimRight(sb.String(), "\n")
+	}
+
+	var sb strings.Builder
+	const contextN = 1
+
+	// Context: tail of common prefix
+	ctxStart := prefixLen - contextN
+	if ctxStart < 0 {
+		ctxStart = 0
+	}
+	if ctxStart > 0 {
+		sb.WriteString("  ...\n")
+	}
+	for i := ctxStart; i < prefixLen; i++ {
+		sb.WriteString("  " + oldLines[i] + "\n")
+	}
+
+	// Removed lines
+	for i := prefixLen; i < len(oldLines)-suffixLen; i++ {
+		sb.WriteString("- " + oldLines[i] + "\n")
+	}
+
+	// Added lines
+	for i := prefixLen; i < len(newLines)-suffixLen; i++ {
+		sb.WriteString("+ " + newLines[i] + "\n")
+	}
+
+	// Context: head of common suffix
+	suffStart := len(oldLines) - suffixLen
+	suffEnd := suffStart + contextN
+	if suffEnd > len(oldLines) {
+		suffEnd = len(oldLines)
+	}
+	for i := suffStart; i < suffEnd; i++ {
+		sb.WriteString("  " + oldLines[i] + "\n")
+	}
+	if suffEnd < len(oldLines) {
+		sb.WriteString("  ...")
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
 }
 
 func truncate(s string, maxRunes int) string {

--- a/agent/gemini/session_test.go
+++ b/agent/gemini/session_test.go
@@ -1,0 +1,447 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// drainEvents reads all events from the channel until it blocks for the given timeout.
+func drainEvents(ch <-chan core.Event, timeout time.Duration) []core.Event {
+	var events []core.Event
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				return events
+			}
+			events = append(events, evt)
+		case <-time.After(timeout):
+			return events
+		}
+	}
+}
+
+func TestHandleMessage_DeltaEmitsEventTextImmediately(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	// Delta message should emit EventText immediately
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "Hello ",
+		"delta":   true,
+	})
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "world!",
+		"delta":   true,
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != core.EventText || events[0].Content != "Hello " {
+		t.Errorf("event 0: expected EventText 'Hello ', got %v %q", events[0].Type, events[0].Content)
+	}
+	if events[1].Type != core.EventText || events[1].Content != "world!" {
+		t.Errorf("event 1: expected EventText 'world!', got %v %q", events[1].Type, events[1].Content)
+	}
+
+	// No pending messages should be buffered
+	if len(gs.pendingMsgs) != 0 {
+		t.Errorf("expected 0 pending messages, got %d", len(gs.pendingMsgs))
+	}
+}
+
+func TestHandleMessage_NonDeltaBuffered(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	// Non-delta message should be buffered (no immediate event)
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "Thinking about this...",
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 0 {
+		t.Fatalf("expected 0 immediate events for non-delta message, got %d", len(events))
+	}
+	if len(gs.pendingMsgs) != 1 || gs.pendingMsgs[0] != "Thinking about this..." {
+		t.Errorf("expected 1 pending message, got %v", gs.pendingMsgs)
+	}
+}
+
+func TestHandleMessage_NonDeltaFlushedAsThinkingOnToolUse(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	// Buffer a non-delta message
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "Let me check...",
+	})
+
+	// tool_use should flush it as thinking
+	gs.handleEvent(map[string]any{
+		"type":      "tool_use",
+		"tool_name": "shell",
+		"tool_id":   "t1",
+		"parameters": map[string]any{
+			"command": "ls",
+		},
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != core.EventThinking || events[0].Content != "Let me check..." {
+		t.Errorf("event 0: expected EventThinking, got %v %q", events[0].Type, events[0].Content)
+	}
+	if events[1].Type != core.EventToolUse {
+		t.Errorf("event 1: expected EventToolUse, got %v", events[1].Type)
+	}
+}
+
+func TestHandleMessage_NonDeltaFlushedAsTextOnResult(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	// Buffer a non-delta message
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "Here is the result.",
+	})
+
+	// result should flush it as text
+	gs.handleEvent(map[string]any{
+		"type":   "result",
+		"status": "success",
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != core.EventText || events[0].Content != "Here is the result." {
+		t.Errorf("event 0: expected EventText, got %v %q", events[0].Type, events[0].Content)
+	}
+	if events[1].Type != core.EventResult {
+		t.Errorf("event 1: expected EventResult, got %v", events[1].Type)
+	}
+}
+
+func TestHandleMessage_UserMessagesIgnored(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "user",
+		"content": "Hello agent",
+		"delta":   true,
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events for user message, got %d", len(events))
+	}
+}
+
+func TestHandleMessage_EmptyContentIgnored(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "",
+		"delta":   true,
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events for empty content, got %d", len(events))
+	}
+}
+
+func TestHandleMessage_MixedDeltaAndNonDelta(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	// Simulate a realistic Gemini CLI output sequence:
+	// 1. non-delta thinking message
+	// 2. tool_use flushes thinking
+	// 3. tool_result
+	// 4. delta streaming responses
+	// 5. result
+
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "Let me look at the files.",
+	})
+	gs.handleEvent(map[string]any{
+		"type":      "tool_use",
+		"tool_name": "shell",
+		"tool_id":   "t1",
+		"parameters": map[string]any{"command": "ls"},
+	})
+	gs.handleEvent(map[string]any{
+		"type":    "tool_result",
+		"tool_id": "t1",
+		"status":  "success",
+		"output":  "file1.txt\nfile2.txt",
+	})
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "Here are ",
+		"delta":   true,
+	})
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "the files.",
+		"delta":   true,
+	})
+	gs.handleEvent(map[string]any{
+		"type":   "result",
+		"status": "success",
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+
+	// Expected sequence: EventThinking, EventToolUse, EventToolResult, EventText, EventText, EventResult
+	if len(events) != 6 {
+		var types []string
+		for _, e := range events {
+			types = append(types, string(e.Type))
+		}
+		t.Fatalf("expected 6 events, got %d: %v", len(events), types)
+	}
+
+	expects := []struct {
+		typ     core.EventType
+		content string
+	}{
+		{core.EventThinking, "Let me look at the files."},
+		{core.EventToolUse, ""},
+		{core.EventToolResult, ""},
+		{core.EventText, "Here are "},
+		{core.EventText, "the files."},
+		{core.EventResult, ""},
+	}
+
+	for i, exp := range expects {
+		if events[i].Type != exp.typ {
+			t.Errorf("event %d: expected type %v, got %v", i, exp.typ, events[i].Type)
+		}
+		if exp.content != "" && events[i].Content != exp.content {
+			t.Errorf("event %d: expected content %q, got %q", i, exp.content, events[i].Content)
+		}
+	}
+}
+
+func TestHandleInit_StoresSessionID(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":       "init",
+		"session_id": "abc123",
+		"model":      "gemini-2.0-flash",
+	})
+
+	if sid := gs.CurrentSessionID(); sid != "abc123" {
+		t.Errorf("expected session_id abc123, got %q", sid)
+	}
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 1 || events[0].Type != core.EventText {
+		t.Errorf("expected 1 EventText from init, got %v", events)
+	}
+}
+
+func TestHandleError_EmitsEventError(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":     "error",
+		"severity": "error",
+		"message":  "something broke",
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != core.EventError {
+		t.Errorf("expected EventError, got %v", events[0].Type)
+	}
+	if !strings.Contains(events[0].Error.Error(), "something broke") {
+		t.Errorf("error should contain message, got %v", events[0].Error)
+	}
+}
+
+func TestFormatToolParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		params   map[string]any
+		want     string
+	}{
+		{"shell command", "shell", map[string]any{"command": "ls -la"}, "ls -la"},
+		{"Bash command", "Bash", map[string]any{"command": "echo hello"}, "echo hello"},
+		{"write file path only", "write_file", map[string]any{"file_path": "/tmp/test.txt"}, "/tmp/test.txt"},
+		{"write file with content", "write_file", map[string]any{"file_path": "/tmp/test.txt", "content": "hello world"}, "`/tmp/test.txt`\n```\nhello world\n```"},
+		{"write file full content", "write_file", map[string]any{"file_path": "/tmp/test.txt", "content": strings.Repeat("x", 200)}, "`/tmp/test.txt`\n```\n" + strings.Repeat("x", 200) + "\n```"},
+		{"read file path", "read_file", map[string]any{"path": "/tmp/test.txt"}, "/tmp/test.txt"},
+		{"replace single line", "replace", map[string]any{"file_path": "/tmp/test.go", "old_string": "foo", "new_string": "bar"}, "`/tmp/test.go`\n```\n- foo\n+ bar\n```"},
+		{"replace with context", "replace", map[string]any{"file_path": "/tmp/test.go", "old_string": "func foo() {\n    return 1\n}", "new_string": "func foo() {\n    return 2\n}"}, "`/tmp/test.go`\n```\n  func foo() {\n-     return 1\n+     return 2\n  }\n```"},
+		{"list directory", "list_directory", map[string]any{"path": "/home/user"}, "/home/user"},
+		{"web fetch", "web_fetch", map[string]any{"url": "https://example.com"}, "https://example.com"},
+		{"search query", "google_web_search", map[string]any{"query": "golang testing"}, "golang testing"},
+		{"activate skill", "activate_skill", map[string]any{"name": "obsidian-markdown"}, "obsidian-markdown"},
+		{"search code", "search_code", map[string]any{"query": "func main"}, "func main"},
+		{"Grep pattern", "Grep", map[string]any{"pattern": "TODO"}, "TODO"},
+		{"nil params", "shell", nil, ""},
+		{"unknown single key", "custom_tool", map[string]any{"key": "value"}, "key: value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatToolParams(tt.toolName, tt.params)
+			if got != tt.want {
+				t.Errorf("formatToolParams(%q, %v) = %q, want %q", tt.toolName, tt.params, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"cc-connect", "cc-connect"},
+		{"Daily", "daily"},
+		{"My Project", "my-project"},
+		{"hello_world", "hello-world"},
+		{"Test.123", "test-123"},
+		{"---weird---", "weird"},
+		{"", "project"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := slugify(tt.input)
+			if got != tt.want {
+				t.Errorf("slugify(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSessionMessage_TextContent(t *testing.T) {
+	// Test plain string content
+	m1 := sessionMessage{Type: "user", RawContent: json.RawMessage(`"hello world"`)}
+	if got := m1.textContent(); got != "hello world" {
+		t.Errorf("string content: got %q, want %q", got, "hello world")
+	}
+
+	// Test array of parts content
+	m2 := sessionMessage{Type: "user", RawContent: json.RawMessage(`[{"text":"line 1"},{"text":"line 2"}]`)}
+	if got := m2.textContent(); got != "line 1\nline 2" {
+		t.Errorf("array content: got %q, want %q", got, "line 1\nline 2")
+	}
+
+	// Test empty content
+	m3 := sessionMessage{Type: "user", RawContent: nil}
+	if got := m3.textContent(); got != "" {
+		t.Errorf("nil content: got %q, want empty", got)
+	}
+}
+
+func TestComputeLineDiff(t *testing.T) {
+	tests := []struct {
+		name     string
+		old      string
+		new_     string
+		want     string
+	}{
+		{
+			"single line fully different",
+			"foo", "bar",
+			"- foo\n+ bar",
+		},
+		{
+			"common prefix and suffix",
+			"func foo() {\n    return 1\n}",
+			"func foo() {\n    return 2\n}",
+			"  func foo() {\n-     return 1\n+     return 2\n  }",
+		},
+		{
+			"large context ellipsis",
+			"a\nb\nc\nd\nold\ne\nf\ng\nh",
+			"a\nb\nc\nd\nnew\ne\nf\ng\nh",
+			"  ...\n  d\n- old\n+ new\n  e\n  ...",
+		},
+		{
+			"common prefix only",
+			"header\nold1\nold2",
+			"header\nnew1",
+			"  header\n- old1\n- old2\n+ new1",
+		},
+		{
+			"common suffix only",
+			"old1\nfooter",
+			"new1\nnew2\nfooter",
+			"- old1\n+ new1\n+ new2\n  footer",
+		},
+		{
+			"identical",
+			"same\nlines",
+			"same\nlines",
+			"", // prefixLen covers all lines, no diff
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeLineDiff(tt.old, tt.new_)
+			if got != tt.want {
+				t.Errorf("computeLineDiff:\n  old=%q\n  new=%q\n  got=%q\n  want=%q", tt.old, tt.new_, got, tt.want)
+			}
+		})
+	}
+}

--- a/core/command.go
+++ b/core/command.go
@@ -77,37 +77,58 @@ func (r *CommandRegistry) SetAgentDirs(dirs []string) {
 
 // Resolve looks up a command by name. Config commands take priority, then
 // agent command directories are scanned for a matching .md file.
+// Hyphens and underscores are treated as equivalent so that Telegram-sanitized
+// names (e.g. "my_cmd") match original command names ("my-cmd").
 func (r *CommandRegistry) Resolve(name string) (*CustomCommand, bool) {
 	lower := strings.ToLower(name)
+	norm := normalizeCommandName(name)
 
 	r.mu.RLock()
+	// Exact match first
 	if c, ok := r.commands[lower]; ok {
 		r.mu.RUnlock()
 		return c, true
 	}
+	// Normalized match (hyphen ↔ underscore)
+	for key, c := range r.commands {
+		if normalizeCommandName(key) == norm {
+			r.mu.RUnlock()
+			return c, true
+		}
+	}
 	r.mu.RUnlock()
 
+	// Scan agent command directories; try both original name and hyphenated variant
+	candidates := []string{name}
+	if alt := strings.ReplaceAll(name, "_", "-"); alt != name {
+		candidates = append(candidates, alt)
+	}
 	for _, dir := range r.agentDirs {
-		mdPath := filepath.Join(dir, name+".md")
-		absDir, err1 := filepath.Abs(dir)
-		absPath, err2 := filepath.Abs(mdPath)
-		if err1 != nil || err2 != nil || !strings.HasPrefix(absPath, absDir+string(filepath.Separator)) {
-			continue
-		}
-		data, err := os.ReadFile(mdPath)
+		absDir, err := filepath.Abs(dir)
 		if err != nil {
 			continue
 		}
-		content := strings.TrimSpace(string(data))
-		if content == "" {
-			continue
+		for _, candidate := range candidates {
+			mdPath := filepath.Join(dir, candidate+".md")
+			absPath, err := filepath.Abs(mdPath)
+			if err != nil || !strings.HasPrefix(absPath, absDir+string(filepath.Separator)) {
+				continue
+			}
+			data, err := os.ReadFile(mdPath)
+			if err != nil {
+				continue
+			}
+			content := strings.TrimSpace(string(data))
+			if content == "" {
+				continue
+			}
+			slog.Debug("command: loaded agent command file", "path", mdPath)
+			return &CustomCommand{
+				Name:   candidate,
+				Prompt: content,
+				Source: "agent",
+			}, true
 		}
-		slog.Debug("command: loaded agent command file", "path", mdPath)
-		return &CustomCommand{
-			Name:   name,
-			Prompt: content,
-			Source: "agent",
-		}, true
 	}
 
 	return nil, false

--- a/core/engine.go
+++ b/core/engine.go
@@ -1478,6 +1478,7 @@ const defaultEventIdleTimeout = 2 * time.Hour
 
 func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessionKey string, msgID string, turnStart time.Time) {
 	var textParts []string
+	var segmentStart int // index into textParts: text before this has been sent/displayed
 	toolCount := 0
 	waitStart := time.Now()
 	firstEventLogged := false
@@ -1553,7 +1554,23 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		switch event.Type {
 		case EventThinking:
 			if !quiet && event.Content != "" {
+				// Flush accumulated text segment before thinking display
+				previewActive := sp.canPreview()
+				if len(textParts) > segmentStart {
+					if !previewActive {
+						segment := strings.Join(textParts[segmentStart:], "")
+						if segment != "" {
+							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+								e.send(p, replyCtx, chunk)
+							}
+						}
+					}
+					segmentStart = len(textParts)
+				}
 				sp.freeze()
+				if previewActive {
+					sp.detachPreview() // keep frozen preview visible as permanent message
+				}
 				preview := truncateIf(event.Content, e.display.ThinkingMaxLen)
 				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgThinking), preview))
 			}
@@ -1561,17 +1578,45 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		case EventToolUse:
 			toolCount++
 			if !quiet {
-				sp.freeze()
-				inputPreview := truncateIf(event.ToolInput, e.display.ToolMaxLen)
-				// Use code block if content is long (>5 lines or >200 chars), otherwise inline code
-				lineCount := strings.Count(inputPreview, "\n") + 1
-				var formattedInput string
-				if lineCount > 5 || utf8.RuneCountInString(inputPreview) > 200 {
-					formattedInput = fmt.Sprintf("```\n%s\n```", inputPreview)
-				} else {
-					formattedInput = fmt.Sprintf("`%s`", inputPreview)
+				// Flush accumulated text segment before tool display
+				previewActive := sp.canPreview()
+				if len(textParts) > segmentStart {
+					if !previewActive {
+						segment := strings.Join(textParts[segmentStart:], "")
+						if segment != "" {
+							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+								e.send(p, replyCtx, chunk)
+							}
+						}
+					}
+					segmentStart = len(textParts)
 				}
-				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgTool), toolCount, event.ToolName, formattedInput))
+				sp.freeze()
+				if previewActive {
+					sp.detachPreview() // keep frozen preview visible as permanent message
+				}
+				toolInput := event.ToolInput
+				var formattedInput string
+				if toolInput == "" {
+					formattedInput = ""
+				} else if strings.Contains(toolInput, "```") {
+					// Already contains code blocks (pre-formatted by agent) — use as-is
+					formattedInput = toolInput
+				} else if strings.Contains(toolInput, "\n") || utf8.RuneCountInString(toolInput) > 200 {
+					lang := toolCodeLang(event.ToolName, toolInput)
+					formattedInput = fmt.Sprintf("```%s\n%s\n```", lang, toolInput)
+				} else {
+					switch event.ToolName {
+					case "shell", "run_shell_command", "Bash":
+						formattedInput = fmt.Sprintf("```bash\n%s\n```", toolInput)
+					default:
+						formattedInput = fmt.Sprintf("`%s`", toolInput)
+					}
+				}
+				toolMsg := fmt.Sprintf(e.i18n.T(MsgTool), toolCount, event.ToolName, formattedInput)
+				for _, chunk := range SplitMessageCodeFenceAware(toolMsg, maxPlatformMessageLen) {
+					e.send(p, replyCtx, chunk)
+				}
 			}
 
 		case EventText:
@@ -1612,8 +1657,23 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				continue
 			}
 
-			// Stop streaming preview before sending prompt
+			// Flush accumulated text segment before permission prompt
+			previewActive := sp.canPreview()
+			if len(textParts) > segmentStart {
+				if !previewActive {
+					segment := strings.Join(textParts[segmentStart:], "")
+					if segment != "" {
+						for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+							e.send(p, replyCtx, chunk)
+						}
+					}
+				}
+				segmentStart = len(textParts)
+			}
 			sp.freeze()
+			if previewActive {
+				sp.detachPreview() // keep frozen preview visible as permanent message
+			}
 
 			slog.Info("permission request",
 				"request_id", event.RequestID,
@@ -1689,8 +1749,21 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 			replyStart := time.Now()
 
-			// If streaming preview was active, try to finalize in-place
-			if sp.finish(fullResponse) {
+			// When tool calls happened, text was sent in segments; only send remainder.
+			if toolCount > 0 {
+				sp.finish("") // cleanup preview
+				if segmentStart < len(textParts) {
+					unsent := strings.Join(textParts[segmentStart:], "")
+					if unsent != "" {
+						for _, chunk := range splitMessage(unsent, maxPlatformMessageLen) {
+							if err := p.Send(e.ctx, replyCtx, chunk); err != nil {
+								slog.Error("failed to send reply", "error", err, "msg_id", msgID)
+								return
+							}
+						}
+					}
+				}
+			} else if sp.finish(fullResponse) {
 				slog.Debug("EventResult: finalized via stream preview", "response_len", len(fullResponse))
 			} else {
 				slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "chunks", len(splitMessage(fullResponse, maxPlatformMessageLen)))
@@ -1743,7 +1816,17 @@ channelClosed:
 		fullResponse := strings.Join(textParts, "")
 		session.AddHistory("assistant", fullResponse)
 
-		if sp.finish(fullResponse) {
+		if toolCount > 0 {
+			sp.finish("")
+			if segmentStart < len(textParts) {
+				unsent := strings.Join(textParts[segmentStart:], "")
+				if unsent != "" {
+					for _, chunk := range splitMessage(unsent, maxPlatformMessageLen) {
+						e.send(p, replyCtx, chunk)
+					}
+				}
+			}
+		} else if sp.finish(fullResponse) {
 			slog.Debug("stream preview: finalized in-place (process exited)")
 		} else {
 			for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
@@ -6874,6 +6957,23 @@ func (e *Engine) deleteSessionDisplayName(sessions *SessionManager, matched *Age
 		displayName = shortID
 	}
 	return displayName
+}
+
+// toolCodeLang picks the code block language hint for tool display.
+func toolCodeLang(toolName, input string) string {
+	switch toolName {
+	case "shell", "run_shell_command", "Bash":
+		return "bash"
+	case "write_file", "WriteFile", "replace", "ReplaceInFile":
+		if strings.Contains(input, "\n- ") || strings.Contains(input, "\n+ ") {
+			return "diff"
+		}
+	}
+	// Fallback: detect diff-like content
+	if strings.Contains(input, "\n- ") && strings.Contains(input, "\n+ ") {
+		return "diff"
+	}
+	return ""
 }
 
 // truncateIf truncates s to maxLen runes. 0 means no truncation.

--- a/core/markdown_html.go
+++ b/core/markdown_html.go
@@ -16,12 +16,67 @@ func MarkdownToSimpleHTML(md string) string {
 	inCodeBlock := false
 	codeLang := ""
 	var codeLines []string
+	inBlockquote := false
+	var bqLines []string
+	inTable := false
+	var tblLines []string
+
+	// flushBlockquote merges buffered blockquote lines into a single <blockquote>.
+	flushBlockquote := func() {
+		if len(bqLines) == 0 {
+			return
+		}
+		b.WriteString("<blockquote>")
+		for j, ql := range bqLines {
+			if j > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(convertInlineHTML(ql))
+		}
+		b.WriteString("</blockquote>")
+		bqLines = bqLines[:0]
+		inBlockquote = false
+	}
+
+	// flushTable renders buffered table rows as readable text.
+	flushTable := func() {
+		if len(tblLines) == 0 {
+			return
+		}
+		for j, tl := range tblLines {
+			if j > 0 {
+				b.WriteByte('\n')
+			}
+			tl = strings.TrimSpace(tl)
+			if reTableSep.MatchString(tl) {
+				b.WriteString("——————————")
+			} else {
+				inner := tl[1 : len(tl)-1]
+				cells := strings.Split(inner, "|")
+				for k := range cells {
+					cells[k] = strings.TrimSpace(cells[k])
+				}
+				row := strings.Join(cells, " | ")
+				b.WriteString(convertInlineHTML(row))
+			}
+		}
+		tblLines = tblLines[:0]
+		inTable = false
+	}
 
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 
 		if strings.HasPrefix(trimmed, "```") {
 			if !inCodeBlock {
+				if inBlockquote {
+					flushBlockquote()
+					b.WriteByte('\n')
+				}
+				if inTable {
+					flushTable()
+					b.WriteByte('\n')
+				}
 				inCodeBlock = true
 				codeLang = strings.TrimPrefix(trimmed, "```")
 				codeLines = nil
@@ -46,22 +101,54 @@ func MarkdownToSimpleHTML(md string) string {
 			continue
 		}
 
+		// Determine line type for blockquote/table buffering
+		isQuote := strings.HasPrefix(trimmed, "> ") || trimmed == ">"
+		isTable := len(trimmed) > 2 && trimmed[0] == '|' && trimmed[len(trimmed)-1] == '|'
+
+		// Flush blockquote when leaving
+		if !isQuote && inBlockquote {
+			flushBlockquote()
+			b.WriteByte('\n')
+		}
+		// Flush table when leaving
+		if !isTable && inTable {
+			flushTable()
+			b.WriteByte('\n')
+		}
+
+		// Buffer blockquote lines into a single block
+		if isQuote {
+			quoteContent := strings.TrimPrefix(trimmed, "> ")
+			if trimmed == ">" {
+				quoteContent = ""
+			}
+			bqLines = append(bqLines, quoteContent)
+			inBlockquote = true
+			continue
+		}
+
+		// Buffer table lines
+		if isTable {
+			tblLines = append(tblLines, trimmed)
+			inTable = true
+			continue
+		}
+
 		// Headings → bold
 		if heading := reHeading.FindString(line); heading != "" {
 			rest := strings.TrimPrefix(line, heading)
 			b.WriteString("<b>")
 			b.WriteString(convertInlineHTML(rest))
 			b.WriteString("</b>")
-		} else if strings.HasPrefix(trimmed, "> ") || trimmed == ">" {
-			quote := strings.TrimPrefix(line, "> ")
-			if quote == ">" {
-				quote = ""
-			}
-			b.WriteString("<blockquote>")
-			b.WriteString(convertInlineHTML(quote))
-			b.WriteString("</blockquote>")
 		} else if reHorizontal.MatchString(trimmed) {
-			b.WriteString("———")
+			b.WriteString("——————————")
+		} else if m := reUnorderedList.FindStringSubmatch(line); m != nil {
+			indent := strings.Repeat("  ", len(m[1])/2)
+			b.WriteString(indent + "• " + convertInlineHTML(m[2]))
+		} else if m := reOrderedList.FindStringSubmatch(line); m != nil {
+			indent := strings.Repeat("  ", len(m[1])/2)
+			numDot := strings.TrimSpace(line[:len(line)-len(m[2])])
+			b.WriteString(indent + escapeHTML(numDot) + " " + convertInlineHTML(m[2]))
 		} else {
 			b.WriteString(convertInlineHTML(line))
 		}
@@ -71,7 +158,13 @@ func MarkdownToSimpleHTML(md string) string {
 		}
 	}
 
-	// Handle unclosed code block
+	// Flush any remaining buffered state
+	if inBlockquote {
+		flushBlockquote()
+	}
+	if inTable {
+		flushTable()
+	}
 	if inCodeBlock && len(codeLines) > 0 {
 		b.WriteString("<pre><code>")
 		b.WriteString(escapeHTML(strings.Join(codeLines, "\n")))
@@ -88,14 +181,15 @@ var (
 	reItalicAstHTML  = regexp.MustCompile(`(?:^|[^*])\*([^*]+?)\*(?:[^*]|$)`)
 	reStrikeHTML     = regexp.MustCompile(`~~(.+?)~~`)
 	reLinkHTML       = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+	reUnorderedList  = regexp.MustCompile(`^(\s*)[-*]\s+(.*)$`)
+	reOrderedList    = regexp.MustCompile(`^(\s*)\d+\.\s+(.*)$`)
+	reTableSep       = regexp.MustCompile(`^\|[\s:|-]+\|$`)
 )
 
 // convertInlineHTML converts inline Markdown formatting to Telegram-compatible HTML.
 //
 // Each formatting pass (bold, strikethrough) protects its output as placeholders
 // so that subsequent passes (italic) cannot match across HTML tag boundaries.
-// Without this, input like `**bold *text***` would produce crossed tags
-// `<b>bold <i>text</b></i>` which Telegram rejects.
 func convertInlineHTML(s string) string {
 	type placeholder struct {
 		key  string
@@ -158,8 +252,8 @@ func convertInlineHTML(s string) string {
 		return m[:idx] + "<i>" + m[idx+1:lastIdx] + "</i>" + m[lastIdx+1:]
 	})
 
-	// 7. Restore all placeholders (may be nested, so iterate until stable)
-	for i := 0; i < 3; i++ {
+	// 7. Restore all placeholders (may be nested, so iterate until stable).
+	for i := 0; i <= len(phs); i++ {
 		changed := false
 		for _, ph := range phs {
 			if strings.Contains(s, ph.key) {

--- a/core/markdown_html_test.go
+++ b/core/markdown_html_test.go
@@ -156,8 +156,6 @@ func TestMarkdownToSimpleHTML_NoCrossedTags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out := MarkdownToSimpleHTML(tt.input)
-			// Check no crossed tags: every <b> must close before enclosing </i> etc.
-			// Simple check: no </b> inside an <i> block or vice versa
 			if err := validateHTMLNesting(out); err != nil {
 				t.Errorf("crossed tags in output %q: %v", out, err)
 			}
@@ -181,7 +179,6 @@ func validateHTMLNesting(html string) error {
 		i += end + 1
 		if strings.HasPrefix(tag, "/") {
 			closing := tag[1:]
-			// strip attributes
 			if sp := strings.IndexByte(closing, ' '); sp > 0 {
 				closing = closing[:sp]
 			}
@@ -202,6 +199,178 @@ func validateHTMLNesting(html string) error {
 		}
 	}
 	return nil
+}
+
+func TestMarkdownToSimpleHTML_UnorderedList(t *testing.T) {
+	md := "Items:\n- first item\n- second item\n- third item"
+	out := MarkdownToSimpleHTML(md)
+	if !strings.Contains(out, "• first item") {
+		t.Errorf("expected bullet for unordered list, got %q", out)
+	}
+	if !strings.Contains(out, "• second item") {
+		t.Errorf("expected bullet for second item, got %q", out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_UnorderedListAsterisk(t *testing.T) {
+	md := "* one\n* two"
+	out := MarkdownToSimpleHTML(md)
+	if !strings.Contains(out, "• one") {
+		t.Errorf("expected bullet for asterisk list, got %q", out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_OrderedList(t *testing.T) {
+	md := "Steps:\n1. first\n2. second\n3. third"
+	out := MarkdownToSimpleHTML(md)
+	if !strings.Contains(out, "1.") || !strings.Contains(out, "first") {
+		t.Errorf("expected ordered list items, got %q", out)
+	}
+	if !strings.Contains(out, "2.") || !strings.Contains(out, "second") {
+		t.Errorf("expected ordered list items, got %q", out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_ListWithInlineFormatting(t *testing.T) {
+	md := "- **bold item**\n- `code item`\n- *italic item*"
+	out := MarkdownToSimpleHTML(md)
+	if !strings.Contains(out, "• <b>bold item</b>") {
+		t.Errorf("expected bold in list item, got %q", out)
+	}
+	if !strings.Contains(out, "• <code>code item</code>") {
+		t.Errorf("expected code in list item, got %q", out)
+	}
+	if err := validateHTMLNesting(out); err != nil {
+		t.Errorf("invalid HTML nesting: %v, got %q", err, out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_NestedList(t *testing.T) {
+	md := "- top\n  - nested\n    - deep"
+	out := MarkdownToSimpleHTML(md)
+	if !strings.Contains(out, "• top") {
+		t.Errorf("expected top-level bullet, got %q", out)
+	}
+	if !strings.Contains(out, "  • nested") {
+		t.Errorf("expected indented nested bullet, got %q", out)
+	}
+	if !strings.Contains(out, "    • deep") {
+		t.Errorf("expected double-indented deep bullet, got %q", out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_GeminiTypicalOutput(t *testing.T) {
+	md := `## Analysis Results
+
+Here are the findings:
+
+- **File structure**: The project has 3 main directories
+- **Dependencies**: All up to date
+- **Tests**: 15 passing, 0 failing
+
+### Recommendations
+
+1. Update the ` + "`README.md`" + ` file
+2. Add **error handling** to the main function
+3. Consider using ~~deprecated~~ updated API
+
+> Note: This is an automated analysis
+
+For more info, visit [docs](https://example.com).`
+
+	out := MarkdownToSimpleHTML(md)
+
+	if !strings.Contains(out, "<b>Analysis Results</b>") {
+		t.Error("heading should be bold")
+	}
+	if !strings.Contains(out, "• <b>File structure</b>") {
+		t.Errorf("list item with bold not converted properly, got %q", out)
+	}
+	if !strings.Contains(out, "<blockquote>") {
+		t.Error("blockquote should be present")
+	}
+	if !strings.Contains(out, `<a href=`) {
+		t.Error("link should be present")
+	}
+	if err := validateHTMLNesting(out); err != nil {
+		t.Errorf("invalid HTML nesting: %v\nfull output: %q", err, out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_CodeBlockWithHTMLTags(t *testing.T) {
+	md := "```html\n<div class=\"test\">\n  <p>Hello</p>\n</div>\n```"
+	out := MarkdownToSimpleHTML(md)
+	if !strings.Contains(out, "&lt;div") {
+		t.Errorf("HTML tags in code block should be escaped, got %q", out)
+	}
+	if err := validateHTMLNesting(out); err != nil {
+		t.Errorf("invalid HTML: %v, got %q", err, out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_HorizontalRule(t *testing.T) {
+	out := MarkdownToSimpleHTML("before\n---\nafter")
+	if !strings.Contains(out, "——————————") {
+		t.Errorf("expected wide horizontal rule, got %q", out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_UnclosedCodeBlock(t *testing.T) {
+	md := "```python\nprint('hello')\nprint('world')"
+	out := MarkdownToSimpleHTML(md)
+	if !strings.Contains(out, "print") {
+		t.Errorf("unclosed code block content should still appear, got %q", out)
+	}
+	if !strings.Contains(out, "<pre><code>") {
+		t.Errorf("unclosed code block should still get code tags, got %q", out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_MultiLineBlockquote(t *testing.T) {
+	md := "> line 1\n> line 2\n> line 3"
+	out := MarkdownToSimpleHTML(md)
+	if strings.Count(out, "<blockquote>") != 1 {
+		t.Errorf("expected single blockquote, got %q", out)
+	}
+	if !strings.Contains(out, "line 1\nline 2\nline 3") {
+		t.Errorf("expected all lines joined in blockquote, got %q", out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_BlockquoteBreaksOnBlankLine(t *testing.T) {
+	md := "> quote 1\n\n> quote 2"
+	out := MarkdownToSimpleHTML(md)
+	if strings.Count(out, "<blockquote>") != 2 {
+		t.Errorf("blank line should create separate blockquotes, got %q", out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_Table(t *testing.T) {
+	md := "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |"
+	out := MarkdownToSimpleHTML(md)
+	if !strings.Contains(out, "Name | Age") {
+		t.Errorf("expected table header cells, got %q", out)
+	}
+	if !strings.Contains(out, "——————————") {
+		t.Errorf("expected separator as rule, got %q", out)
+	}
+	if !strings.Contains(out, "Alice | 30") {
+		t.Errorf("expected table data cells, got %q", out)
+	}
+}
+
+func TestMarkdownToSimpleHTML_TableWithFormatting(t *testing.T) {
+	md := "| **Header** | `code` |\n|---|---|\n| *italic* | normal |"
+	out := MarkdownToSimpleHTML(md)
+	if !strings.Contains(out, "<b>Header</b>") {
+		t.Errorf("expected bold in table cell, got %q", out)
+	}
+	if !strings.Contains(out, "<code>code</code>") {
+		t.Errorf("expected code in table cell, got %q", out)
+	}
+	if err := validateHTMLNesting(out); err != nil {
+		t.Errorf("invalid HTML nesting: %v, got %q", err, out)
+	}
 }
 
 func TestSplitMessageCodeFenceAware_Short(t *testing.T) {
@@ -225,15 +394,6 @@ func TestSplitMessageCodeFenceAware_PreservesCodeBlock(t *testing.T) {
 	chunks := SplitMessageCodeFenceAware(text, 30)
 	if len(chunks) < 2 {
 		t.Fatalf("expected multiple chunks, got %d", len(chunks))
-	}
-
-	// When a chunk breaks inside a code block, it should close with ```
-	for i, c := range chunks {
-		opens := strings.Count(c, "```python") + strings.Count(c, "```\n")
-		closes := strings.Count(c, "```")
-		_ = opens
-		_ = closes
-		_ = i
 	}
 
 	full := strings.Join(chunks, "")

--- a/core/skill.go
+++ b/core/skill.go
@@ -40,14 +40,21 @@ func (r *SkillRegistry) SetDirs(dirs []string) {
 }
 
 // Resolve looks up a skill by name. Returns nil if not found.
+// Hyphens and underscores are treated as equivalent so that Telegram-sanitized
+// names (e.g. "calendar_scheduler") match original skill names ("calendar-scheduler").
 func (r *SkillRegistry) Resolve(name string) *Skill {
-	lower := strings.ToLower(name)
+	norm := normalizeCommandName(name)
 	for _, s := range r.ListAll() {
-		if strings.ToLower(s.Name) == lower {
+		if normalizeCommandName(s.Name) == norm {
 			return s
 		}
 	}
 	return nil
+}
+
+// normalizeCommandName folds case and treats hyphens/underscores as equivalent.
+func normalizeCommandName(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "-", "_"))
 }
 
 // ListAll returns all discovered skills. Results are cached after first scan.
@@ -175,11 +182,13 @@ func parseSkillMD(skillName, raw, sourceDir string) *Skill {
 }
 
 // parseFrontmatter extracts simple key: value pairs from a YAML-like block.
-// Handles quoted and unquoted values. Does not support nested structures.
+// Handles quoted values, and YAML block scalar indicators (>-, |-, >, |)
+// by reading the following indented lines as the value.
 func parseFrontmatter(block string) map[string]string {
 	m := make(map[string]string)
-	for _, line := range strings.Split(block, "\n") {
-		line = strings.TrimSpace(line)
+	lines := strings.Split(block, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
@@ -189,6 +198,22 @@ func parseFrontmatter(block string) map[string]string {
 		}
 		key = strings.TrimSpace(key)
 		val = strings.TrimSpace(val)
+
+		// Handle YAML block scalar indicators: >-, |-, >, |
+		if val == ">-" || val == "|-" || val == ">" || val == "|" {
+			var blockLines []string
+			for i+1 < len(lines) {
+				next := lines[i+1]
+				// Block continues while lines are indented (start with space/tab)
+				if len(next) == 0 || (next[0] != ' ' && next[0] != '\t') {
+					break
+				}
+				i++
+				blockLines = append(blockLines, strings.TrimSpace(next))
+			}
+			val = strings.Join(blockLines, " ")
+		}
+
 		val = strings.Trim(val, `"'`)
 		if key != "" {
 			m[strings.ToLower(key)] = val

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -307,6 +307,15 @@ func (sp *streamPreview) finish(finalText string) bool {
 	return true
 }
 
+// detachPreview clears the preview message handle so that finish() won't
+// delete it. Call this after freeze() when the frozen preview should remain
+// visible as a permanent message (e.g. text before the first tool call).
+func (sp *streamPreview) detachPreview() {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.previewMsgID = nil
+}
+
 // getFullText returns the accumulated text so far.
 func (sp *streamPreview) getFullText() string {
 	sp.mu.Lock()

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -61,6 +61,13 @@ Add the token to your `config.toml`:
 [[projects]]
 name = "my-project"
 
+# ── Project-level settings ──────────────────────────────────
+# admin_from: who can run privileged commands (/shell, /restart, /upgrade).
+#   Not set (default) → privileged commands are blocked for everyone.
+#   "*" → all allowed users get admin access (only for personal single-user setups).
+#   "id1,id2" → only these Telegram user IDs can run privileged commands.
+admin_from = "*"
+
 [projects.agent]
 type = "claudecode"
 
@@ -73,7 +80,18 @@ type = "telegram"
 
 [projects.platforms.options]
 token = "1234567890:ABCdefGHIjklMNOpqrsTUVwxyz-123456"
+
+# ── Platform-level settings ─────────────────────────────────
+# allow_from: who can use this bot.
+#   Not set (default) → all users are permitted (a WARN will be logged).
+#   "*" → same as not set, but explicit (no WARN).
+#   "id1,id2" → only these Telegram user IDs can interact with the bot.
+# allow_from = "123456789"
 ```
+
+> **Common mistake:** `admin_from` goes under `[[projects]]` (project level), NOT inside `[projects.platforms.options]`. If placed in the wrong section, it will be silently ignored.
+>
+> To find your Telegram user ID, send any message to **@userinfobot**.
 
 ---
 

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -612,17 +612,28 @@ type telegramPreviewHandle struct {
 }
 
 // SendPreviewStart sends a new message and returns a handle for subsequent edits.
+// Uses HTML mode to match UpdateMessage formatting, falling back to plain text
+// if Telegram rejects the HTML (reduces visible format "jump" during streaming).
 func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content string) (any, error) {
 	rc, ok := rctx.(replyContext)
 	if !ok {
 		return nil, fmt.Errorf("telegram: invalid reply context type %T", rctx)
 	}
 
-	msg := tgbotapi.NewMessage(rc.chatID, content)
-	msg.ParseMode = ""
+	html := core.MarkdownToSimpleHTML(content)
+	msg := tgbotapi.NewMessage(rc.chatID, html)
+	msg.ParseMode = tgbotapi.ModeHTML
+
 	sent, err := p.bot.Send(msg)
 	if err != nil {
-		return nil, fmt.Errorf("telegram: send preview: %w", err)
+		if strings.Contains(err.Error(), "can't parse") {
+			msg.Text = content
+			msg.ParseMode = ""
+			sent, err = p.bot.Send(msg)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("telegram: send preview: %w", err)
+		}
 	}
 	return &telegramPreviewHandle{chatID: rc.chatID, messageID: sent.MessageID}, nil
 }
@@ -722,19 +733,19 @@ func (p *Platform) RegisterCommands(commands []core.BotCommandInfo) error {
 
 	// Telegram limits: max 100 commands, description max 256 chars
 	var tgCommands []tgbotapi.BotCommand
+	seen := make(map[string]bool)
 	for _, c := range commands {
-		if !isValidTelegramCommand(c.Command) {
-			slog.Warn("telegram: invalid command, skipping",
-				slog.String("command", c.Command),
-				slog.String("description", c.Description))
+		cmd := sanitizeTelegramCommand(c.Command)
+		if cmd == "" || seen[cmd] {
 			continue
 		}
+		seen[cmd] = true
 		desc := c.Description
 		if len(desc) > 256 {
 			desc = desc[:253] + "..."
 		}
 		tgCommands = append(tgCommands, tgbotapi.BotCommand{
-			Command:     c.Command,
+			Command:     cmd,
 			Description: desc,
 		})
 	}
@@ -781,11 +792,9 @@ func isValidTelegramCommand(cmd string) bool {
 	if len(cmd) == 0 || len(cmd) > 32 {
 		return false
 	}
-	// Must start with a letter
 	if cmd[0] < 'a' || cmd[0] > 'z' {
 		return false
 	}
-	// Rest can be letters, digits, or underscores
 	for i := 1; i < len(cmd); i++ {
 		c := cmd[i]
 		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') {
@@ -793,4 +802,34 @@ func isValidTelegramCommand(cmd string) bool {
 		}
 	}
 	return true
+}
+
+// sanitizeTelegramCommand converts a command name to Telegram-compatible format.
+// Telegram rules: 1-32 chars, lowercase letters/digits/underscores, must start with a letter.
+// Returns "" if the command cannot be sanitized (e.g. empty or no letter to start with).
+func sanitizeTelegramCommand(cmd string) string {
+	cmd = strings.ToLower(cmd)
+	var b strings.Builder
+	for _, c := range cmd {
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+			b.WriteRune(c)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	result := b.String()
+	// Collapse consecutive underscores
+	for strings.Contains(result, "__") {
+		result = strings.ReplaceAll(result, "__", "_")
+	}
+	result = strings.Trim(result, "_")
+	// Must start with a letter
+	if len(result) == 0 || result[0] < 'a' || result[0] > 'z' {
+		return ""
+	}
+	if len(result) > 32 {
+		result = result[:32]
+	}
+	return result
 }


### PR DESCRIPTION
## Summary

Improve the Gemini CLI headless mode (`stream-json`) experience on Telegram with better streaming, tool display, session management, and markdown rendering.

### Stream preview & between-tool text
- Preserve frozen preview messages on Telegram via `detachPreview()` — prevents deletion of initial streaming text when tool calls interrupt
- Track text segments (`segmentStart`) to flush between-tool text as separate messages
- Flush accumulated text before tool/thinking/permission interrupts

### Tool display
- Show full tool content without truncation (was limited to 500 chars)
- Compute line-level diff for `replace` operations (`computeLineDiff`) — shows only changed lines with ±1 line context, not entire old/new blocks
- `write_file`: show file path in inline code + content in code block
- `shell`/`Bash`: use ```bash code blocks for syntax highlighting
- Split long tool messages with `SplitMessageCodeFenceAware` to avoid Telegram 4096-char limit

### Gemini session management (`/list`, `/switch`)
- Read `~/.gemini/projects.json` for correct project directory slug (was using case-sensitive `filepath.Base`)
- Scan session directory for matching `sessionId` field (handles Gemini CLI's `session-<timestamp>-<uuid>` naming)
- Handle both string and array content formats via `json.RawMessage`
- Filter out subagent and empty sessions from `/list`

### Markdown→HTML converter
- Merge consecutive blockquote lines into single `<blockquote>` (was creating one per line)
- Add table rendering (pipe-delimited → plain text with separators)
- Add unordered/ordered list support (• bullets, numbered items)
- Widen horizontal rule (3 → 10 em dashes)
- Rename to `MarkdownToSimpleHTML` (platform-agnostic naming)

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New tests: `TestComputeLineDiff`, `TestFormatToolParams`, `TestSlugify`, `TestSessionMessage_TextContent`
- [x] Build succeeds on linux/amd64
- [x] Manual test: Gemini CLI → Telegram with tool calls (replace, write_file, shell)
- [x] Manual test: `/list` and `/switch` commands with Gemini sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)