### PR TITLE
fix(feishu): 修复 /delete 卡片回退为右侧选择按钮

### DIFF
--- a/platform/feishu/card.go
+++ b/platform/feishu/card.go
@@ -243,9 +243,8 @@ func renderDeleteModeCheckerCard(card *core.Card, base map[string]any) (map[stri
 		return nil, false
 	}
 
-	rows := make([]deleteModeCheckerRow, 0)
 	formRowElements := make([]map[string]any, 0)
-	notes := make([]core.CardNote, 0)
+	preludeElements := make([]map[string]any, 0)
 	navRows := make([]core.CardActions, 0)
 	submitText := ""
 	cancelText := ""
@@ -270,7 +269,6 @@ func renderDeleteModeCheckerCard(card *core.Card, base map[string]any) (map[stri
 				text:    text,
 				checked: strings.Contains(e.Text, "☑"),
 			}
-			rows = append(rows, row)
 			formRowElements = append(formRowElements, map[string]any{
 				"tag":     "checker",
 				"name":    deleteModeCheckerName(row.id),
@@ -281,7 +279,25 @@ func renderDeleteModeCheckerCard(card *core.Card, base map[string]any) (map[stri
 				},
 			})
 		case core.CardNote:
-			notes = append(notes, e)
+			if e.Text == "" || e.Tag == "delete-mode-selected-count" {
+				continue
+			}
+			preludeElements = append(preludeElements, map[string]any{
+				"tag":      "note",
+				"elements": []map[string]any{plainText(e.Text)},
+			})
+		case core.CardMarkdown:
+			if e.Content == "" {
+				continue
+			}
+			preludeElements = append(preludeElements, map[string]any{
+				"tag":     "markdown",
+				"content": e.Content,
+			})
+		case core.CardDivider:
+			preludeElements = append(preludeElements, map[string]any{
+				"tag": "hr",
+			})
 		case core.CardActions:
 			remaining := make([]core.CardButton, 0, len(e.Buttons))
 			for _, btn := range e.Buttons {
@@ -297,7 +313,7 @@ func renderDeleteModeCheckerCard(card *core.Card, base map[string]any) (map[stri
 			if len(remaining) > 0 {
 				navRows = append(navRows, core.CardActions{Buttons: remaining, Layout: e.Layout})
 			}
-		case core.CardMarkdown, core.CardDivider, core.CardSelect:
+		case core.CardSelect:
 			return nil, false
 		}
 	}
@@ -306,19 +322,8 @@ func renderDeleteModeCheckerCard(card *core.Card, base map[string]any) (map[stri
 		return nil, false
 	}
 
-	elements := make([]map[string]any, 0, len(notes)+1+len(navRows))
-	for _, n := range notes {
-		if n.Text == "" {
-			continue
-		}
-		if n.Tag == "delete-mode-selected-count" {
-			continue
-		}
-		elements = append(elements, map[string]any{
-			"tag":      "note",
-			"elements": []map[string]any{plainText(n.Text)},
-		})
-	}
+	elements := make([]map[string]any, 0, len(preludeElements)+1+len(navRows))
+	elements = append(elements, preludeElements...)
 	formElements := append([]map[string]any{}, formRowElements...)
 
 	buttonColumns := []map[string]any{

--- a/platform/feishu/card_test.go
+++ b/platform/feishu/card_test.go
@@ -227,3 +227,30 @@ func TestRenderCardMap_DeleteModeUsesCheckerForm(t *testing.T) {
 		t.Fatalf("expected no toggle buttons in rendered card, got %s", s)
 	}
 }
+
+func TestRenderCardMap_DeleteModeWithMarkdownHintStillUsesCheckerForm(t *testing.T) {
+	card := core.NewCard().
+		Title("删除会话", "carmine").
+		Markdown("请选择需要删除的会话").
+		ListItemBtn("◻ **1.** One · **10** msgs · 03-13 20:00", "选择", "default", "act:/delete-mode toggle session-1").
+		ListItemBtn("▶ **2.** Active · **30** msgs · 03-13 20:01", "当前会话", "primary", "act:/delete-mode noop session-2").
+		Buttons(
+			core.DangerBtn("删除已选", "act:/delete-mode confirm"),
+			core.DefaultBtn("取消", "act:/delete-mode cancel"),
+		).
+		Build()
+
+	got := decodeRenderedCard(t, card)
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal rendered card failed: %v", err)
+	}
+	s := string(raw)
+
+	if !strings.Contains(s, `"tag":"form"`) || !strings.Contains(s, `"tag":"checker"`) {
+		t.Fatalf("expected checker form even with markdown hint, got %s", s)
+	}
+	if strings.Contains(s, `act:/delete-mode toggle`) {
+		t.Fatalf("expected no right-side toggle buttons, got %s", s)
+	}
+}


### PR DESCRIPTION
## 背景与原因
- 在 `feat(feishu): improve /delete card multi-select flow` 之后，`/delete` 期望使用飞书原生 form checker（勾选框）模式。
- 近期当 delete-mode 卡片里出现额外文案（例如 Markdown 提示）时，`renderDeleteModeCheckerCard` 会直接放弃转换并回退到旧的右侧按钮模式。
- 这会导致用户每次点“选择”都要等待卡片刷新，连续多选体验变差。

## 本次修改
- 放宽 `renderDeleteModeCheckerCard` 的识别条件：允许 `CardMarkdown`、`CardDivider`、`CardNote` 作为前置元素。
- 继续保持 `CardSelect` 不参与该转换，避免误判为 delete-mode。
- 保留 delete-mode 勾选框 form 渲染与提交链路（`delete_mode_submit` / `act:/delete-mode form-submit`）。
- 新增回归测试，覆盖“带 Markdown 提示时仍保持勾选框模式”的场景。

## 多选框模式的收益
- 连续勾选时不需要每次点“选择”后等待整卡返回。
- 一次性提交已选项，交互往返更少，操作更流畅。
- 更符合“批量选择”的心智模型，降低误操作成本。

## 测试
- `go test ./platform/feishu -run DeleteMode -v`
- `go test ./core -run DeleteMode -v`
- `go test ./...`
