### PR TITLE
feat(claudecode): add dontAsk permission mode support

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -35,7 +35,7 @@ func init() {
 type Agent struct {
 	workDir      string
 	model        string
-	mode         string // "default" | "acceptEdits" | "plan" | "bypassPermissions"
+	mode         string // "default" | "acceptEdits" | "plan" | "bypassPermissions" | "dontAsk"
 	allowedTools []string
 	providers    []core.ProviderConfig
 	activeIdx    int // -1 = no provider set
@@ -96,6 +96,8 @@ func normalizePermissionMode(raw string) string {
 	case "bypasspermissions", "bypass-permissions", "bypass_permissions",
 		"yolo", "auto":
 		return "bypassPermissions"
+	case "dontask", "dont-ask", "dont_ask":
+		return "dontAsk"
 	default:
 		return "default"
 	}
@@ -456,6 +458,7 @@ func (a *Agent) PermissionModes() []core.PermissionModeInfo {
 		{Key: "acceptEdits", Name: "Accept Edits", NameZh: "接受编辑", Desc: "Auto-approve file edits, ask for others", DescZh: "自动允许文件编辑，其他需确认"},
 		{Key: "plan", Name: "Plan Mode", NameZh: "计划模式", Desc: "Plan only, no execution until approved", DescZh: "只做规划不执行，审批后再执行"},
 		{Key: "bypassPermissions", Name: "YOLO", NameZh: "YOLO 模式", Desc: "Auto-approve everything", DescZh: "全部自动通过"},
+		{Key: "dontAsk", Name: "Don't Ask", NameZh: "静默拒绝", Desc: "Auto-deny tools unless pre-approved via allowed_tools or settings.json allow rules", DescZh: "未预授权的工具自动拒绝，不弹确认"},
 	}
 }
 

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -84,6 +84,36 @@ func TestParseUserQuestions_MultiSelect(t *testing.T) {
 	}
 }
 
+func TestNormalizePermissionMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// dontAsk aliases
+		{"dontAsk", "dontAsk"},
+		{"dontask", "dontAsk"},
+		{"dont-ask", "dontAsk"},
+		{"dont_ask", "dontAsk"},
+		// bypassPermissions aliases
+		{"bypassPermissions", "bypassPermissions"},
+		{"yolo", "bypassPermissions"},
+		// acceptEdits aliases
+		{"acceptEdits", "acceptEdits"},
+		{"edit", "acceptEdits"},
+		// plan
+		{"plan", "plan"},
+		// default fallback
+		{"", "default"},
+		{"unknown", "default"},
+	}
+	for _, tt := range tests {
+		got := normalizePermissionMode(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizePermissionMode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestSummarizeInput_AskUserQuestion(t *testing.T) {
 	input := map[string]any{
 		"questions": []any{

--- a/config.example.toml
+++ b/config.example.toml
@@ -423,6 +423,7 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "bypassPermission
 # - "acceptEdits" (edit): File edit tools auto-approved; other tools still ask. / 文件编辑自动通过，其他仍需确认。
 # - "plan":               Claude only plans — no execution until you approve. / 只做规划不执行，审批后再执行。
 # - "bypassPermissions" (yolo): All tool calls auto-approved. Use with caution. / 全部自动通过，请谨慎使用。
+# - "dontAsk" (dont-ask): Auto-deny tools unless pre-approved via allowed_tools or settings allow rules. / 未预授权的工具自动拒绝，安全推荐。
 #
 # When using IM platforms, you can reply "允许"/"allow" to grant permission.
 # 在 IM 平台中，可回复"允许"或"allow"来授权操作。


### PR DESCRIPTION
## Summary

Add support for Claude Code's `dontAsk` permission mode, which auto-denies tools unless pre-approved via `allowed_tools` or `settings.json` allow rules.

### Why this matters

Currently cc-connect only supports 4 permission modes: `default`, `acceptEdits`, `plan`, `bypassPermissions`. Claude Code has a 5th mode — `dontAsk` — that implements "default deny, explicit allow":

| Mode | Non-whitelisted tools | Bot-safe? |
|------|----------------------|-----------|
| `default` | Prompts user (forwarded to chat — **any group member can approve**) | No |
| `bypassPermissions` | Auto-approved | No |
| **`dontAsk`** | **Auto-denied** | **Yes** |

For bot deployments (Feishu, Telegram, etc.), `dontAsk` is the recommended mode because:
- Only tools in `allowed_tools` or `settings.json` allow rules execute
- Everything else is silently rejected (no prompt forwarded to chat)
- PreToolUse hooks are active (hooks are **skipped** in `bypassPermissions` mode)
- Combined with allow rules and hooks, this provides defense-in-depth

### What's wrong with `bypassPermissions` for bots?

`bypassPermissions` auto-approves ALL tool calls. A user could ask the bot to `rm -rf /`, read `~/.ssh/id_rsa`, or modify project scripts. Deny rules help but are a blacklist approach — easily bypassed via command chaining or aliases.

### What's wrong with `default` for bots?

In `default` mode, non-whitelisted tools trigger a permission prompt. cc-connect forwards this prompt to the chat as an interactive card. **Any group member** can click "Allow" — this is worse than `bypassPermissions` because it gives untrusted users explicit authorization power.

### Changes

- `agent/claudecode/claudecode.go`: Add `dontAsk` + aliases (`dont-ask`, `dont_ask`) to `normalizePermissionMode` and `PermissionModes()`
- `config.example.toml`: Add `dontAsk` documentation
- `agent/claudecode/claudecode_test.go`: Add `TestNormalizePermissionMode`

### Example config

```toml
[projects.agent.options]
mode = "dontAsk"
allowed_tools = ["Read", "Grep", "Glob", "Skill"]
```

Ref: [Claude Code Permissions docs](https://code.claude.com/docs/en/permissions)