### PR TITLE
fix(discord): deduplicate gateway MessageCreate events

### DIFF
--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -49,6 +49,7 @@ type Platform struct {
 	botID                 string
 	appID                 string
 	readyCh               chan struct{}
+	seenMsgs              sync.Map // message ID dedup: prevents duplicate MessageCreate events
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -308,6 +309,13 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 	})
 
 	session.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
+		// Deduplicate: Discord gateway may deliver the same event twice
+		if _, loaded := p.seenMsgs.LoadOrStore(m.ID, struct{}{}); loaded {
+			slog.Debug("discord: ignoring duplicate message", "msg_id", m.ID)
+			return
+		}
+		time.AfterFunc(2*time.Minute, func() { p.seenMsgs.Delete(m.ID) })
+
 		if m.Author.Bot || m.Author.ID == p.botID {
 			return
 		}

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -1,10 +1,16 @@
 package discord
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/chenhg5/cc-connect/core"
 )
+
+// ── Thread tests (upstream) ──────────────────────────────────
 
 type fakeThreadOps struct {
 	resolveChannel func(channelID string) (*discordgo.Channel, error)
@@ -150,5 +156,181 @@ func TestReconstructReplyCtx_ThreadSessionKey(t *testing.T) {
 	rc := rctx.(replyContext)
 	if rc.channelID != "thread-7" || rc.threadID != "thread-7" {
 		t.Fatalf("replyContext = %#v, want thread reply context", rc)
+	}
+}
+
+// ── Dedup tests ──────────────────────────────────────────────
+
+// simulateHandlerCall mimics the dedup + dispatch logic in the MessageCreate
+// handler registered by Platform.Start.  It returns true when the message
+// was dispatched (not a duplicate).
+func (p *Platform) simulateHandlerCall(msgID, userID, userName, channelID, content string) bool {
+	// --- dedup (same logic as Start handler) ---
+	if _, loaded := p.seenMsgs.LoadOrStore(msgID, struct{}{}); loaded {
+		return false
+	}
+	time.AfterFunc(2*time.Minute, func() { p.seenMsgs.Delete(msgID) })
+
+	msg := &core.Message{
+		SessionKey: p.makeSessionKey(channelID, userID),
+		Platform:   "discord",
+		MessageID:  msgID,
+		UserID:     userID,
+		UserName:   userName,
+		Content:    content,
+	}
+	p.handler(p, msg)
+	return true
+}
+
+// newTestPlatform creates a Platform suitable for unit tests (no real Discord
+// connection).  The provided handler records every dispatched message.
+func newTestPlatform(handler core.MessageHandler) *Platform {
+	return &Platform{
+		token:     "test-token",
+		allowFrom: "*",
+		handler:   handler,
+		botID:     "BOT_ID",
+		readyCh:   make(chan struct{}),
+	}
+}
+
+// TestDuplicateMessage_SameIDDeduped reproduces GitHub issue #122:
+// Discord gateway delivers the same MessageCreate event twice within ~1 ms.
+// The second delivery must be silently dropped.
+func TestDuplicateMessage_SameIDDeduped(t *testing.T) {
+	var calls int32
+	p := newTestPlatform(func(_ core.Platform, _ *core.Message) {
+		atomic.AddInt32(&calls, 1)
+	})
+
+	const msgID = "1482313396505411717"
+
+	// First delivery — must be processed.
+	if !p.simulateHandlerCall(msgID, "user1", "quabug", "ch1", "hello") {
+		t.Fatal("first delivery was incorrectly treated as duplicate")
+	}
+
+	// Second delivery (same msg_id, ~1 ms later) — must be dropped.
+	if p.simulateHandlerCall(msgID, "user1", "quabug", "ch1", "hello") {
+		t.Fatal("second delivery was not caught as duplicate")
+	}
+
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Fatalf("handler called %d times, want 1", n)
+	}
+}
+
+// TestDuplicateMessage_DifferentIDsProcessed ensures distinct messages are
+// not incorrectly suppressed by dedup.
+func TestDuplicateMessage_DifferentIDsProcessed(t *testing.T) {
+	var calls int32
+	p := newTestPlatform(func(_ core.Platform, _ *core.Message) {
+		atomic.AddInt32(&calls, 1)
+	})
+
+	if !p.simulateHandlerCall("msg-1", "user1", "quabug", "ch1", "first") {
+		t.Fatal("msg-1 should be processed")
+	}
+	if !p.simulateHandlerCall("msg-2", "user1", "quabug", "ch1", "second") {
+		t.Fatal("msg-2 should be processed")
+	}
+	if !p.simulateHandlerCall("msg-3", "user1", "quabug", "ch1", "third") {
+		t.Fatal("msg-3 should be processed")
+	}
+
+	if n := atomic.LoadInt32(&calls); n != 3 {
+		t.Fatalf("handler called %d times, want 3", n)
+	}
+}
+
+// TestDuplicateMessage_ConcurrentRace fires N goroutines that all try to
+// deliver the same message simultaneously — exactly one must win.
+func TestDuplicateMessage_ConcurrentRace(t *testing.T) {
+	var calls int32
+	p := newTestPlatform(func(_ core.Platform, _ *core.Message) {
+		atomic.AddInt32(&calls, 1)
+	})
+
+	const (
+		msgID      = "race-msg-1"
+		goroutines = 50
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	start := make(chan struct{}) // barrier so all goroutines race together
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			p.simulateHandlerCall(msgID, "user1", "quabug", "ch1", "race")
+		}()
+	}
+
+	close(start) // release all goroutines at once
+	wg.Wait()
+
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Fatalf("handler called %d times under race, want exactly 1", n)
+	}
+}
+
+// TestDuplicateMessage_MultipleDuplicateBursts sends multiple distinct
+// messages, each duplicated, and verifies that each unique message is
+// processed exactly once.
+func TestDuplicateMessage_MultipleDuplicateBursts(t *testing.T) {
+	received := make(map[string]int)
+	var mu sync.Mutex
+	p := newTestPlatform(func(_ core.Platform, msg *core.Message) {
+		mu.Lock()
+		received[msg.MessageID]++
+		mu.Unlock()
+	})
+
+	// Simulate 10 messages, each delivered twice (as observed in logs).
+	for i := 0; i < 10; i++ {
+		id := "burst-" + string(rune('A'+i))
+		p.simulateHandlerCall(id, "user1", "quabug", "ch1", "msg")
+		p.simulateHandlerCall(id, "user1", "quabug", "ch1", "msg") // duplicate
+	}
+
+	for id, count := range received {
+		if count != 1 {
+			t.Errorf("message %q processed %d times, want 1", id, count)
+		}
+	}
+	if len(received) != 10 {
+		t.Errorf("got %d unique messages, want 10", len(received))
+	}
+}
+
+// ── Mention tests ────────────────────────────────────────────
+
+// TestStripDiscordMention verifies mention stripping helper.
+func TestStripDiscordMention(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		botID   string
+		want    string
+	}{
+		{"strips bot mention at start", "<@123456> hello", "123456", "hello"},
+		{"strips bot mention with ! prefix", "<@!123456> hello", "123456", "hello"},
+		{"strips bot mention in middle", "hey <@123456> do this", "123456", "hey  do this"},
+		{"no mention", "hello world", "123456", "hello world"},
+		{"only mention", "<@123456>", "123456", ""},
+		{"different bot ID unchanged", "<@999999> hello", "123456", "<@999999> hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripDiscordMention(tt.content, tt.botID)
+			if got != tt.want {
+				t.Errorf("stripDiscordMention(%q, %q) = %q, want %q",
+					tt.content, tt.botID, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #122 — Discord bot receives every message twice, causing duplicate agent responses.

- Add `sync.Map`-based dedup on message ID to the Discord `MessageCreate` handler
- Second delivery of the same `msg_id` is silently dropped (logged at DEBUG level)
- Entries auto-expire after 2 minutes via `time.AfterFunc`
- Add 5 unit tests with `-race` coverage

## Root Cause

Discord's gateway can redeliver `MessageCreate` events during WebSocket reconnect/resume. Since `discordgo.AddHandler` registers persistent handlers that survive reconnects, both the original delivery and the replay fire the same callback within ~1-2ms.

Confirmed via production logs: the affected channel is a **DM channel** (type=1), ruling out multi-bot cross-talk. A single bot connection was receiving each event twice.

Related references:
- [discordgo #513](https://github.com/bwmarrin/discordgo/issues/513) — reconnect event dispatch behavior
- [discord-api-docs #5392](https://github.com/discord/discord-api-docs/issues/5392) — gateway duplicate event delivery
- [discord.js #473](https://github.com/discordjs/discord.js/issues/473) — same class of bug in JS library

## Changes

| File | Change |
|---|---|
| `platform/discord/discord.go` | Add `seenMsgs sync.Map` field + dedup check before handler dispatch |
| `platform/discord/discord_test.go` | 5 new tests: basic dedup, distinct IDs, concurrent race (50 goroutines), burst patterns, mention stripping |

## Test Plan

- [x] `go test ./platform/discord/ -v -race` — all 5 tests pass
- [x] `go test ./...` — no regressions
- [x] Verified in production: after deploying, duplicate messages stopped completely

🤖 Generated with [Claude Code](https://claude.com/claude-code)