### PR TITLE
fix(cron): validate session_key to prevent silent runtime failures

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -240,10 +240,29 @@ func (s *APIServer) handleCronAdd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve session_key: use provided, or auto-detect from active sessions
+	sessionKey := req.SessionKey
+	if sessionKey == "" {
+		s.mu.RLock()
+		engine := s.engines[project]
+		s.mu.RUnlock()
+		if engine != nil {
+			keys := engine.ActiveSessionKeys()
+			if len(keys) == 1 {
+				sessionKey = keys[0]
+				slog.Debug("auto-detected session_key for cron job", "session_key", sessionKey)
+			}
+		}
+	}
+	if sessionKey == "" {
+		http.Error(w, "session_key is required: set CC_SESSION_KEY env, pass --session-key, or ensure exactly one active session exists", http.StatusBadRequest)
+		return
+	}
+
 	job := &CronJob{
 		ID:          GenerateCronID(),
 		Project:     project,
-		SessionKey:  req.SessionKey,
+		SessionKey:  sessionKey,
 		CronExpr:    req.CronExpr,
 		Prompt:      req.Prompt,
 		Exec:        req.Exec,

--- a/core/engine.go
+++ b/core/engine.go
@@ -529,6 +529,19 @@ func (e *Engine) ProjectName() string {
 	return e.name
 }
 
+// ActiveSessionKeys returns the session keys of all active interactive sessions.
+func (e *Engine) ActiveSessionKeys() []string {
+	e.interactiveMu.Lock()
+	defer e.interactiveMu.Unlock()
+	var keys []string
+	for key, state := range e.interactiveStates {
+		if state.platform != nil {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
 // ExecuteCronJob runs a cron job by injecting a synthetic message into the engine.
 // It finds the platform that owns the session key, reconstructs a reply context,
 // and processes the message as if the user sent it.


### PR DESCRIPTION
## Summary

- `cc-connect cron add` allowed creating cron jobs with empty `session_key` when `CC_SESSION_KEY` env var is not set
- At runtime, `ExecuteCronJob` silently fails with `platform "" not found for session ""`
- Added server-side validation and auto-detection: if exactly one active session exists, it is used automatically; otherwise returns a clear error message

## Changes

- `core/engine.go`: Add `ActiveSessionKeys()` method to expose active interactive session keys
- `core/api.go`: Add session_key auto-detection and validation in `handleCronAdd`

## Test plan

- [ ] Create cron job with `CC_SESSION_KEY` set → works as before
- [ ] Create cron job without `CC_SESSION_KEY` with one active session → auto-detects
- [ ] Create cron job without `CC_SESSION_KEY` with no active sessions → returns clear error