### PR TITLE
fix(codex): handle large stdout json lines

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -207,33 +208,54 @@ func (cs *codexSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf 
 		}
 	}()
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
+	if err := readJSONLines(stdout, func(line []byte) error {
+		lineText := string(line)
+		if lineText == "" {
+			return nil
 		}
 
-		slog.Debug("codexSession: raw", "line", truncate(line, 500))
+		slog.Debug("codexSession: raw", "line", truncate(lineText, 500))
 
 		var raw map[string]any
-		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			slog.Debug("codexSession: non-JSON line", "line", line)
-			continue
+		if err := json.Unmarshal(line, &raw); err != nil {
+			slog.Debug("codexSession: non-JSON line", "line", lineText)
+			return nil
 		}
 
 		cs.handleEvent(raw)
-	}
-
-	if err := scanner.Err(); err != nil {
-		slog.Error("codexSession: scanner error", "error", err)
+		return nil
+	}); err != nil {
+		slog.Error("codexSession: read stdout error", "error", err)
 		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
 		select {
 		case cs.events <- evt:
 		case <-cs.ctx.Done():
 			return
+		}
+	}
+}
+
+func readJSONLines(r io.Reader, handle func([]byte) error) error {
+	reader := bufio.NewReader(r)
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		if errors.Is(err, io.EOF) && len(line) == 0 {
+			return nil
+		}
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+
+		line = bytes.TrimRight(line, "\r\n")
+		if len(line) > 0 {
+			if err := handle(line); err != nil {
+				return err
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			return nil
 		}
 	}
 }

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -164,6 +165,78 @@ func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
 	}
 	if !(tidIndex < imageIndex && imageIndex < promptIndex) {
 		t.Fatalf("unexpected arg order: %v", args)
+	}
+}
+
+func TestSend_HandlesLargeJSONLines(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	largeText := strings.Repeat("x", 11*1024*1024)
+	encodedText, err := json.Marshal(largeText)
+	if err != nil {
+		t.Fatalf("marshal large text: %v", err)
+	}
+
+	payload := strings.Join([]string{
+		`{"type":"thread.started","thread_id":"thread-large"}`,
+		`{"type":"item.completed","item":{"type":"agent_message","content":[{"type":"output_text","text":` + string(encodedText) + `}]}}`,
+		`{"type":"turn.completed"}`,
+	}, "\n") + "\n"
+
+	payloadFile := filepath.Join(workDir, "payload.jsonl")
+	if err := os.WriteFile(payloadFile, []byte(payload), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	script := "#!/bin/sh\ncat \"$CODEX_PAYLOAD_FILE\"\n"
+	scriptPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	t.Setenv("CODEX_PAYLOAD_FILE", payloadFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer cs.Close()
+
+	if err := cs.Send("hello", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var gotTextLen int
+	var gotResult bool
+	timeout := time.After(5 * time.Second)
+
+	for !gotResult {
+		select {
+		case evt := <-cs.Events():
+			if evt.Type == core.EventError {
+				t.Fatalf("unexpected error event: %v", evt.Error)
+			}
+			if evt.Type == core.EventText {
+				gotTextLen = len(evt.Content)
+			}
+			if evt.Type == core.EventResult && evt.Done {
+				gotResult = true
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for large JSON line events")
+		}
+	}
+
+	if gotTextLen != len(largeText) {
+		t.Fatalf("text len = %d, want %d", gotTextLen, len(largeText))
+	}
+	if got := cs.CurrentSessionID(); got != "thread-large" {
+		t.Fatalf("CurrentSessionID() = %q, want thread-large", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

This fixes a Codex session failure when the Codex CLI emits a very large single JSON line on stdout.

Previously `agent/codex/session.go` used `bufio.Scanner` to read `codex exec --json` output line by line. Even with a larger scanner buffer, very large JSONL events can still fail with:

`bufio.Scanner: token too long`

This change replaces that scanner-based read path with a `bufio.Reader`-based line reader for the Codex session only.

## What changed

- replace the scanner-based stdout reader in `agent/codex/session.go`
- preserve the existing JSONL handling behavior
- add a regression test that simulates a single JSON line larger than 10MB

## Reproduction

A Codex CLI turn may emit a very large JSONL event on stdout, for example when a tool result or agent message becomes unusually large.

In that case the previous implementation could fail with:

`read stdout: bufio.Scanner: token too long`

## Notes

This still assumes line-delimited JSON output from the Codex CLI; it only removes the previous scanner token limit for large single-line events.

## Validation

I ran:

```bash
go test ./agent/codex
go build ./...
```
