### PR TITLE
fix(agent): prevent send-on-closed-channel panic in session Close()

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -497,10 +497,10 @@ func (cs *codexSession) Close() error {
 	}()
 	select {
 	case <-done:
+		close(cs.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("codexSession: close timed out, abandoning wg.Wait")
 	}
-	close(cs.events)
 	return nil
 }
 

--- a/agent/cursor/session.go
+++ b/agent/cursor/session.go
@@ -464,10 +464,10 @@ func (cs *cursorSession) Close() error {
 	}()
 	select {
 	case <-done:
+		close(cs.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("cursorSession: close timed out, abandoning wg.Wait")
 	}
-	close(cs.events)
 	return nil
 }
 

--- a/agent/gemini/session.go
+++ b/agent/gemini/session.go
@@ -469,10 +469,10 @@ func (gs *geminiSession) Close() error {
 	}()
 	select {
 	case <-done:
+		close(gs.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("geminiSession: close timed out, abandoning wg.Wait")
 	}
-	close(gs.events)
 	return nil
 }
 

--- a/agent/iflow/session.go
+++ b/agent/iflow/session.go
@@ -897,9 +897,9 @@ func (s *iflowSession) Close() error {
 	}()
 	select {
 	case <-done:
+		close(s.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("iflowSession: close timed out, abandoning wg.Wait")
 	}
-	close(s.events)
 	return nil
 }

--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -393,10 +393,10 @@ func (s *opencodeSession) Close() error {
 	}()
 	select {
 	case <-done:
+		close(s.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("opencodeSession: close timed out, abandoning wg.Wait")
 	}
-	close(s.events)
 	return nil
 }
 

--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -288,10 +288,10 @@ func (qs *qoderSession) Close() error {
 	}()
 	select {
 	case <-done:
+		close(qs.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("qoderSession: close timed out, abandoning wg.Wait")
 	}
-	close(qs.events)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Fix a race condition in 6 agent session implementations (codex, opencode, qoder, iflow, cursor, gemini) where `Close()` unconditionally calls `close(events)` after an 8-second timeout, even when the readLoop goroutine may still be running and attempting to send events to the channel
- Due to Go's `select` non-determinism, the readLoop goroutine can pick the send case over the `ctx.Done()` case, causing a **"send on closed channel" panic**
- Move `close(events)` into the `case <-done` branch (where `wg.Wait()` has succeeded) so the channel is only closed after readLoop has fully exited, matching the safe pattern already used in `claudeSession`

## Root Cause

In `Close()`:
```go
select {
case <-done:        // wg.Wait() completed — readLoop exited
case <-time.After(8 * time.Second):
    slog.Warn("...close timed out, abandoning wg.Wait")
}
close(events) // BUG: readLoop may still be sending after timeout
```

When the timeout fires, `readLoop` may still be executing its defer block which sends error events to the channel. Go's `select` statement picks randomly among ready cases, so even though `ctx.Done()` is also ready, the send case can be chosen — hitting the closed channel.

## Fix

```go
select {
case <-done:
    close(events) // Safe: readLoop has fully exited
case <-time.After(8 * time.Second):
    slog.Warn("...close timed out, abandoning wg.Wait")
}
```

## Affected Files

- `agent/codex/session.go`
- `agent/opencode/session.go`
- `agent/qoder/session.go`
- `agent/iflow/session.go`
- `agent/cursor/session.go`
- `agent/gemini/session.go`

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] Verified `claudeSession` already uses the correct pattern (closes events in readLoop defer)