### PR TITLE
fix: stop RateLimiter cleanup goroutine on replacement and engine shutdown

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -493,7 +493,11 @@ func (e *Engine) SetBannedWords(words []string) {
 }
 
 // SetRateLimitCfg configures per-session message rate limiting.
+// It stops the previous rate limiter's background goroutine before replacing it.
 func (e *Engine) SetRateLimitCfg(cfg RateLimitCfg) {
+	if e.rateLimiter != nil {
+		e.rateLimiter.Stop()
+	}
 	e.rateLimiter = NewRateLimiter(cfg.MaxMessages, cfg.Window)
 }
 
@@ -752,6 +756,10 @@ func (e *Engine) Stop() error {
 			slog.Debug("engine.Stop: closing agent session", "session", key)
 			state.agentSession.Close()
 		}
+	}
+
+	if e.rateLimiter != nil {
+		e.rateLimiter.Stop()
 	}
 
 	if err := e.agent.Stop(); err != nil {

--- a/core/ratelimit.go
+++ b/core/ratelimit.go
@@ -13,6 +13,7 @@ type RateLimiter struct {
 	buckets     map[string]*rateBucket
 	maxMessages int
 	windowMs    int64
+	stopCh      chan struct{}
 }
 
 type rateBucket struct {
@@ -27,11 +28,23 @@ func NewRateLimiter(maxMessages int, window time.Duration) *RateLimiter {
 		buckets:     make(map[string]*rateBucket),
 		maxMessages: maxMessages,
 		windowMs:    window.Milliseconds(),
+		stopCh:      make(chan struct{}),
 	}
 	if maxMessages > 0 {
 		go rl.cleanupLoop()
 	}
 	return rl
+}
+
+// Stop terminates the background cleanup goroutine. It is safe to call
+// multiple times and on a disabled (maxMessages=0) limiter.
+func (rl *RateLimiter) Stop() {
+	select {
+	case <-rl.stopCh:
+		// already stopped
+	default:
+		close(rl.stopCh)
+	}
 }
 
 // Allow checks whether a message from the given key is within the rate limit.
@@ -71,15 +84,20 @@ func (rl *RateLimiter) Allow(key string) bool {
 func (rl *RateLimiter) cleanupLoop() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
-	for range ticker.C {
-		rl.mu.Lock()
-		now := time.Now().UnixMilli()
-		staleThreshold := rl.windowMs * 2
-		for k, b := range rl.buckets {
-			if now-b.lastAccess > staleThreshold {
-				delete(rl.buckets, k)
+	for {
+		select {
+		case <-rl.stopCh:
+			return
+		case <-ticker.C:
+			rl.mu.Lock()
+			now := time.Now().UnixMilli()
+			staleThreshold := rl.windowMs * 2
+			for k, b := range rl.buckets {
+				if now-b.lastAccess > staleThreshold {
+					delete(rl.buckets, k)
+				}
 			}
+			rl.mu.Unlock()
 		}
-		rl.mu.Unlock()
 	}
 }

--- a/core/ratelimit_test.go
+++ b/core/ratelimit_test.go
@@ -75,3 +75,23 @@ func TestRateLimiter_Concurrent(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestRateLimiter_Stop(t *testing.T) {
+	rl := NewRateLimiter(5, time.Minute)
+	rl.Allow("user1")
+
+	// Stop should not panic and should be idempotent
+	rl.Stop()
+	rl.Stop() // second call should be safe
+
+	// Allow should still work after Stop (just no background cleanup)
+	if !rl.Allow("user2") {
+		t.Error("Allow should still work after Stop")
+	}
+}
+
+func TestRateLimiter_StopDisabled(t *testing.T) {
+	// A disabled limiter (maxMessages=0) should also handle Stop gracefully
+	rl := NewRateLimiter(0, time.Minute)
+	rl.Stop()
+}


### PR DESCRIPTION
## Summary

- `RateLimiter.cleanupLoop()` spawns a background goroutine that runs forever with no stop mechanism
- When `SetRateLimitCfg()` is called (e.g. during config reload), a new `RateLimiter` is created with a new cleanup goroutine, but the old goroutine is never stopped — causing a goroutine leak
- Similarly, `Engine.Stop()` does not stop the rate limiter's goroutine

## Changes

- Add a `stopCh` channel and `Stop()` method to `RateLimiter` so the cleanup goroutine can be terminated
- Call `Stop()` on the previous `RateLimiter` in `Engine.SetRateLimitCfg()` before creating the replacement
- Call `Stop()` in `Engine.Stop()` for clean shutdown
- Add tests for `Stop()` including idempotency and disabled-limiter edge case

## Test plan

- [x] `go test ./core/ -run TestRateLimiter -v` — all rate limiter tests pass (including new Stop tests)
- [x] `go test ./...` — full test suite passes
- [x] `go build ./...` — build passes