### PR TITLE
docs: add design plans, session resilience docs, and Slack app manifest

### DIFF
--- a/docs/plans/2026-03-12-multi-workspace-design.md
+++ b/docs/plans/2026-03-12-multi-workspace-design.md
@@ -1,0 +1,105 @@
+# Multi-Workspace Feature Design
+
+## Overview
+
+Enable a single cc-connect bot (one Slack token) to serve multiple workspaces, with the channel determining which Claude Code working directory and session to use.
+
+## Config
+
+```toml
+[[projects]]
+name = "claude"
+mode = "multi-workspace"
+base_dir = "~/workspace"
+
+[projects.agent]
+type = "claudecode"
+permission_mode = "yolo"
+
+[[projects.platforms]]
+type = "slack"
+bot_token = "xoxb-..."
+app_token = "xapp-..."
+```
+
+- `mode = "multi-workspace"` enables the feature. Omitting or `"single"` preserves current behavior.
+- `base_dir` is the parent directory where workspaces live. Replaces `work_dir` on the agent.
+- Agent config has no `work_dir` — resolved per-channel at runtime.
+
+## Workspace Resolution Flow
+
+When a message arrives in a channel:
+
+1. **Check bindings** — look up `workspace_bindings.json` for an existing channel-to-workspace mapping.
+2. **Convention match** — if no binding, check if `<base_dir>/<channel-name>/` exists. If yes, auto-bind and confirm:
+   > "Found `~/workspace/model-profiler` matching this channel. Binding workspace and starting session... Ready."
+3. **Ask for repo** — if no match, reply:
+   > "No workspace found for this channel. What repo should I clone?"
+   User provides URL, bot confirms:
+   > "I'll clone `org/repo` to `~/workspace/repo-name` and bind to this channel. OK?"
+4. **Clone and bind** — on confirmation, clone the repo, save the binding, spawn agent subprocess. Explicit feedback throughout:
+   > "Cloning `github.com/org/repo` to `~/workspace/repo-name`..."
+   > "Clone complete. Binding workspace to this channel... Ready."
+
+### Binding Storage
+
+Persisted in `~/.cc-connect/workspace_bindings.json`:
+
+```json
+{
+  "project:claude": {
+    "C0AKYKUF75K": {
+      "channel_name": "model-profiler",
+      "workspace": "/home/leigh/workspace/model-profiler",
+      "bound_at": "2026-03-12T10:00:00Z"
+    }
+  }
+}
+```
+
+## Agent Subprocess Management
+
+Engine maintains `workspaceAgents map[string]*workspaceState` keyed by workspace path. Each `workspaceState` holds the agent subprocess, its SessionManager, and a `lastActivity` timestamp.
+
+### Lifecycle
+
+1. **Spawn on first message** — start a Claude Code subprocess with `work_dir` set to the resolved workspace.
+2. **Resume on subsequent messages** — reuse the running subprocess with saved session ID.
+3. **Idle reap** — background goroutine checks `lastActivity` every minute. Subprocesses idle >15 minutes are stopped. Session ID is preserved so the next message transparently restarts.
+4. **Graceful shutdown** — on bot shutdown, stop all subprocesses cleanly.
+
+### Session Management
+
+Each workspace gets its own SessionManager instance with a separate JSON file (same naming scheme as today: `project_hash.json`). Named sessions within a workspace work exactly as they do now.
+
+## Message Routing Changes
+
+In `Engine.handleMessage`, the multi-workspace path inserts before the existing flow:
+
+1. **Extract channel ID** from the message's session key (`slack:channelID:userID`).
+2. **Resolve workspace** — look up binding, convention match, or trigger init flow.
+3. **If no workspace resolved** (init flow in progress) — handle the init conversation directly, don't forward to any agent.
+4. **If workspace resolved** — get or spawn the agent subprocess for that workspace, then continue with existing message processing.
+
+`interactiveStates` gets keyed by workspace+sessionKey (rather than just sessionKey) so the same user in different channels hits different agent processes.
+
+### New Commands
+
+- `/workspace` — show current channel's bound workspace
+- `/workspace init <url>` — clone and bind
+- `/workspace unbind` — remove binding
+- `/workspace list` — show all bindings
+
+Existing commands (`/sessions`, `/model`, etc.) work per-workspace.
+
+## Error Handling & Edge Cases
+
+- **Unbound channel, bot mentioned** — bot asks for repo URL. No agent forwarding until binding is established.
+- **Clone fails** (bad URL, auth, disk) — bot reports error and asks user to try again. No partial binding saved.
+- **Workspace directory deleted externally** — on next message, bot detects missing directory, removes the binding, re-enters init flow: "Workspace `~/workspace/foo` no longer exists. What repo should I clone?"
+- **Agent subprocess crashes** — restart on next message using saved session ID (same as current behavior).
+- **Bot in unwanted channel** — without binding or matching directory, it just asks for a repo. User can ignore or remove the bot.
+
+## Architecture: Approach 1 (Engine-level multiplexing)
+
+The Engine itself handles multi-workspace routing. No new meta-engine or wrapper layers. The multi-workspace logic is gated behind the `mode` config field, so single-workspace projects are completely unaffected.

--- a/docs/plans/2026-03-12-multi-workspace-plan.md
+++ b/docs/plans/2026-03-12-multi-workspace-plan.md
@@ -1,0 +1,1354 @@
+# Multi-Workspace Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable a single cc-connect bot to serve multiple workspaces, routing messages to different Claude Code sessions based on Slack channel.
+
+**Architecture:** Engine-level multiplexing. Add workspace resolution to Engine.handleMessage that maps channel → workspace directory, spawns/resumes per-workspace agent subprocesses, and manages idle reaping. Gated behind `mode = "multi-workspace"` in ProjectConfig so existing single-workspace projects are unaffected.
+
+**Tech Stack:** Go, Slack API (conversations.info for channel name resolution), JSON file persistence
+
+**Design Doc:** `docs/plans/2026-03-12-multi-workspace-design.md`
+
+---
+
+### Task 1: Add config fields
+
+**Files:**
+- Modify: `config/config.go` (ProjectConfig struct ~line 103, validate() ~line 177)
+- Modify: `config.example.toml` (add multi-workspace example)
+
+**Step 1: Add Mode and BaseDir to ProjectConfig**
+
+In `config/config.go`, add two fields to ProjectConfig (after line 105):
+
+```go
+type ProjectConfig struct {
+	Name             string           `toml:"name"`
+	Mode             string           `toml:"mode,omitempty"`     // "" or "multi-workspace"
+	BaseDir          string           `toml:"base_dir,omitempty"` // parent dir for workspaces
+	Agent            AgentConfig      `toml:"agent"`
+	Platforms        []PlatformConfig `toml:"platforms"`
+	Quiet            *bool            `toml:"quiet,omitempty"`
+	DisabledCommands []string         `toml:"disabled_commands,omitempty"`
+}
+```
+
+**Step 2: Add validation for multi-workspace mode**
+
+In `config/config.go` validate(), after the existing platform checks (~line 196), add:
+
+```go
+if proj.Mode == "multi-workspace" {
+	if proj.BaseDir == "" {
+		return fmt.Errorf("project %q: multi-workspace mode requires base_dir", proj.Name)
+	}
+	if _, ok := proj.Agent.Options["work_dir"]; ok {
+		return fmt.Errorf("project %q: multi-workspace mode conflicts with agent work_dir (use base_dir instead)", proj.Name)
+	}
+}
+```
+
+**Step 3: Add example to config.example.toml**
+
+Add a commented multi-workspace example section showing the config pattern from the design doc.
+
+**Step 4: Run existing tests**
+
+Run: `go build ./...`
+Expected: Compiles cleanly
+
+**Step 5: Commit**
+
+```bash
+git add config/config.go config.example.toml
+git commit -m "feat: add multi-workspace mode and base_dir config fields"
+```
+
+---
+
+### Task 2: Workspace binding persistence
+
+**Files:**
+- Create: `core/workspace_binding.go`
+- Create: `core/workspace_binding_test.go`
+
+**Step 1: Write tests for WorkspaceBindingManager**
+
+```go
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkspaceBindingManager_SaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "bindings.json")
+
+	mgr := NewWorkspaceBindingManager(storePath)
+	mgr.Bind("project:claude", "C123", "my-channel", "/home/user/workspace/my-channel")
+
+	b := mgr.Lookup("project:claude", "C123")
+	if b == nil {
+		t.Fatal("expected binding, got nil")
+	}
+	if b.ChannelName != "my-channel" {
+		t.Errorf("expected channel name 'my-channel', got %q", b.ChannelName)
+	}
+	if b.Workspace != "/home/user/workspace/my-channel" {
+		t.Errorf("expected workspace path, got %q", b.Workspace)
+	}
+
+	// Reload from disk
+	mgr2 := NewWorkspaceBindingManager(storePath)
+	b2 := mgr2.Lookup("project:claude", "C123")
+	if b2 == nil {
+		t.Fatal("expected binding after reload, got nil")
+	}
+	if b2.Workspace != "/home/user/workspace/my-channel" {
+		t.Errorf("expected workspace path after reload, got %q", b2.Workspace)
+	}
+}
+
+func TestWorkspaceBindingManager_Unbind(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "bindings.json")
+
+	mgr := NewWorkspaceBindingManager(storePath)
+	mgr.Bind("project:claude", "C123", "chan", "/path")
+	mgr.Unbind("project:claude", "C123")
+
+	if b := mgr.Lookup("project:claude", "C123"); b != nil {
+		t.Error("expected nil after unbind")
+	}
+}
+
+func TestWorkspaceBindingManager_ListByProject(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewWorkspaceBindingManager(filepath.Join(dir, "bindings.json"))
+	mgr.Bind("project:claude", "C1", "chan1", "/path1")
+	mgr.Bind("project:claude", "C2", "chan2", "/path2")
+	mgr.Bind("project:other", "C3", "chan3", "/path3")
+
+	list := mgr.ListByProject("project:claude")
+	if len(list) != 2 {
+		t.Errorf("expected 2 bindings, got %d", len(list))
+	}
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/ -run TestWorkspaceBinding -v`
+Expected: FAIL (types not defined)
+
+**Step 3: Implement WorkspaceBindingManager**
+
+```go
+package core
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+)
+
+// WorkspaceBinding maps a channel to a workspace directory.
+type WorkspaceBinding struct {
+	ChannelName string    `json:"channel_name"`
+	Workspace   string    `json:"workspace"`
+	BoundAt     time.Time `json:"bound_at"`
+}
+
+// WorkspaceBindingManager persists channel→workspace mappings.
+// Top-level key is "project:<name>", second-level key is channel ID.
+type WorkspaceBindingManager struct {
+	mu        sync.RWMutex
+	bindings  map[string]map[string]*WorkspaceBinding // projectKey → channelID → binding
+	storePath string
+}
+
+func NewWorkspaceBindingManager(storePath string) *WorkspaceBindingManager {
+	m := &WorkspaceBindingManager{
+		bindings:  make(map[string]map[string]*WorkspaceBinding),
+		storePath: storePath,
+	}
+	if storePath != "" {
+		m.load()
+	}
+	return m
+}
+
+func (m *WorkspaceBindingManager) Bind(projectKey, channelID, channelName, workspace string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.bindings[projectKey] == nil {
+		m.bindings[projectKey] = make(map[string]*WorkspaceBinding)
+	}
+	m.bindings[projectKey][channelID] = &WorkspaceBinding{
+		ChannelName: channelName,
+		Workspace:   workspace,
+		BoundAt:     time.Now(),
+	}
+	m.saveLocked()
+}
+
+func (m *WorkspaceBindingManager) Unbind(projectKey, channelID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if proj := m.bindings[projectKey]; proj != nil {
+		delete(proj, channelID)
+		if len(proj) == 0 {
+			delete(m.bindings, projectKey)
+		}
+	}
+	m.saveLocked()
+}
+
+func (m *WorkspaceBindingManager) Lookup(projectKey, channelID string) *WorkspaceBinding {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if proj := m.bindings[projectKey]; proj != nil {
+		return proj[channelID]
+	}
+	return nil
+}
+
+func (m *WorkspaceBindingManager) ListByProject(projectKey string) map[string]*WorkspaceBinding {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make(map[string]*WorkspaceBinding)
+	if proj := m.bindings[projectKey]; proj != nil {
+		for k, v := range proj {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func (m *WorkspaceBindingManager) saveLocked() {
+	if m.storePath == "" {
+		return
+	}
+	data, err := json.MarshalIndent(m.bindings, "", "  ")
+	if err != nil {
+		slog.Error("workspace bindings: marshal error", "err", err)
+		return
+	}
+	if err := AtomicWriteFile(m.storePath, data, 0o644); err != nil {
+		slog.Error("workspace bindings: save error", "err", err)
+	}
+}
+
+func (m *WorkspaceBindingManager) load() {
+	data, err := os.ReadFile(m.storePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Error("workspace bindings: load error", "err", err)
+		}
+		return
+	}
+	if err := json.Unmarshal(data, &m.bindings); err != nil {
+		slog.Error("workspace bindings: unmarshal error", "err", err)
+	}
+}
+```
+
+Note: This follows the exact same pattern as `core/relay.go` RelayManager persistence.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/ -run TestWorkspaceBinding -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add core/workspace_binding.go core/workspace_binding_test.go
+git commit -m "feat: add WorkspaceBindingManager for channel-to-workspace persistence"
+```
+
+---
+
+### Task 3: Workspace state and idle reaper
+
+**Files:**
+- Create: `core/workspace_state.go`
+- Create: `core/workspace_state_test.go`
+
+**Step 1: Write tests for workspacePool**
+
+```go
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWorkspacePool_GetOrCreate(t *testing.T) {
+	pool := newWorkspacePool(15 * time.Minute)
+
+	state1 := pool.GetOrCreate("/workspace/a")
+	state2 := pool.GetOrCreate("/workspace/a")
+	state3 := pool.GetOrCreate("/workspace/b")
+
+	if state1 != state2 {
+		t.Error("expected same state for same workspace")
+	}
+	if state1 == state3 {
+		t.Error("expected different state for different workspace")
+	}
+}
+
+func TestWorkspacePool_Touch(t *testing.T) {
+	pool := newWorkspacePool(15 * time.Minute)
+	state := pool.GetOrCreate("/workspace/a")
+
+	before := state.LastActivity()
+	time.Sleep(10 * time.Millisecond)
+	state.Touch()
+	after := state.LastActivity()
+
+	if !after.After(before) {
+		t.Error("expected lastActivity to advance after Touch()")
+	}
+}
+
+func TestWorkspacePool_ReapIdle(t *testing.T) {
+	pool := newWorkspacePool(50 * time.Millisecond)
+	pool.GetOrCreate("/workspace/a")
+
+	time.Sleep(100 * time.Millisecond)
+	reaped := pool.ReapIdle()
+
+	if len(reaped) != 1 || reaped[0] != "/workspace/a" {
+		t.Errorf("expected [/workspace/a] reaped, got %v", reaped)
+	}
+
+	if s := pool.Get("/workspace/a"); s != nil {
+		t.Error("expected workspace removed after reap")
+	}
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./core/ -run TestWorkspacePool -v`
+Expected: FAIL
+
+**Step 3: Implement workspacePool and workspaceState**
+
+```go
+package core
+
+import (
+	"sync"
+	"time"
+)
+
+// workspaceState holds the runtime state for a single workspace.
+type workspaceState struct {
+	mu           sync.Mutex
+	workspace    string
+	sessions     *SessionManager
+	lastActivity time.Time
+}
+
+func newWorkspaceState(workspace string, sessions *SessionManager) *workspaceState {
+	return &workspaceState{
+		workspace:    workspace,
+		sessions:     sessions,
+		lastActivity: time.Now(),
+	}
+}
+
+func (ws *workspaceState) Touch() {
+	ws.mu.Lock()
+	ws.lastActivity = time.Now()
+	ws.mu.Unlock()
+}
+
+func (ws *workspaceState) LastActivity() time.Time {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	return ws.lastActivity
+}
+
+// workspacePool manages a set of workspace states with idle reaping.
+type workspacePool struct {
+	mu         sync.RWMutex
+	states     map[string]*workspaceState // workspace path → state
+	idleTimeout time.Duration
+}
+
+func newWorkspacePool(idleTimeout time.Duration) *workspacePool {
+	return &workspacePool{
+		states:      make(map[string]*workspaceState),
+		idleTimeout: idleTimeout,
+	}
+}
+
+func (p *workspacePool) Get(workspace string) *workspaceState {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.states[workspace]
+}
+
+func (p *workspacePool) GetOrCreate(workspace string) *workspaceState {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if s, ok := p.states[workspace]; ok {
+		return s
+	}
+	s := newWorkspaceState(workspace, nil) // SessionManager set later by Engine
+	p.states[workspace] = s
+	return s
+}
+
+// ReapIdle removes and returns workspace paths that have been idle longer than idleTimeout.
+func (p *workspacePool) ReapIdle() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cutoff := time.Now().Add(-p.idleTimeout)
+	var reaped []string
+	for path, state := range p.states {
+		if state.LastActivity().Before(cutoff) {
+			reaped = append(reaped, path)
+			delete(p.states, path)
+		}
+	}
+	return reaped
+}
+
+func (p *workspacePool) All() map[string]*workspaceState {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	result := make(map[string]*workspaceState, len(p.states))
+	for k, v := range p.states {
+		result[k] = v
+	}
+	return result
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./core/ -run TestWorkspacePool -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add core/workspace_state.go core/workspace_state_test.go
+git commit -m "feat: add workspacePool for managing per-workspace agent state"
+```
+
+---
+
+### Task 4: Channel name resolution in Slack platform
+
+**Files:**
+- Modify: `platform/slack/slack.go` (~line 25 replyContext, ~line 102 handleEvent)
+- Modify: `core/interfaces.go` (Platform interface — check if ChannelNameResolver needed)
+
+**Step 1: Add ChannelNameResolver interface**
+
+In `core/interfaces.go`, add a new optional interface:
+
+```go
+// ChannelNameResolver is an optional interface for platforms that can resolve
+// channel IDs to human-readable names.
+type ChannelNameResolver interface {
+	ResolveChannelName(channelID string) (string, error)
+}
+```
+
+**Step 2: Implement in Slack platform**
+
+In `platform/slack/slack.go`, add a channel name cache and resolver:
+
+```go
+// Add to Platform struct:
+channelNameCache map[string]string
+channelCacheMu   sync.RWMutex
+
+// Initialize in New() or Start():
+p.channelNameCache = make(map[string]string)
+
+// Add method:
+func (p *Platform) ResolveChannelName(channelID string) (string, error) {
+	p.channelCacheMu.RLock()
+	if name, ok := p.channelNameCache[channelID]; ok {
+		p.channelCacheMu.RUnlock()
+		return name, nil
+	}
+	p.channelCacheMu.RUnlock()
+
+	info, err := p.client.GetConversationInfo(&slack.GetConversationInfoInput{
+		ChannelID: channelID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("slack: resolve channel name for %s: %w", channelID, err)
+	}
+
+	p.channelCacheMu.Lock()
+	p.channelNameCache[channelID] = info.Name
+	p.channelCacheMu.Unlock()
+
+	return info.Name, nil
+}
+```
+
+**Step 3: Build to verify compilation**
+
+Run: `go build ./...`
+Expected: Compiles cleanly
+
+**Step 4: Commit**
+
+```bash
+git add core/interfaces.go platform/slack/slack.go
+git commit -m "feat: add ChannelNameResolver interface and Slack implementation"
+```
+
+---
+
+### Task 5: Engine multi-workspace fields and constructor
+
+**Files:**
+- Modify: `core/engine.go` (Engine struct ~line 119, NewEngine ~line 200)
+
+**Step 1: Add multi-workspace fields to Engine struct**
+
+After `eventIdleTimeout` (~line 168), add:
+
+```go
+// Multi-workspace mode
+multiWorkspace    bool
+baseDir           string
+workspaceBindings *WorkspaceBindingManager
+workspacePool     *workspacePool
+initFlows         map[string]*workspaceInitFlow // channelID → init state
+initFlowsMu       sync.Mutex
+```
+
+Add the init flow state struct:
+
+```go
+type workspaceInitFlow struct {
+	state    string // "awaiting_url", "awaiting_confirm"
+	repoURL  string
+	cloneTo  string
+}
+```
+
+**Step 2: Add SetMultiWorkspace method**
+
+```go
+func (e *Engine) SetMultiWorkspace(baseDir, bindingStorePath string) {
+	e.multiWorkspace = true
+	e.baseDir = baseDir
+	e.workspaceBindings = NewWorkspaceBindingManager(bindingStorePath)
+	e.workspacePool = newWorkspacePool(15 * time.Minute)
+	e.initFlows = make(map[string]*workspaceInitFlow)
+	go e.runIdleReaper()
+}
+```
+
+**Step 3: Implement idle reaper goroutine**
+
+```go
+func (e *Engine) runIdleReaper() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-e.ctx.Done():
+			return
+		case <-ticker.C:
+			reaped := e.workspacePool.ReapIdle()
+			for _, ws := range reaped {
+				// Stop interactive states for this workspace
+				e.interactiveMu.Lock()
+				for key, state := range e.interactiveStates {
+					if state.workspaceDir == ws {
+						if state.agentSession != nil {
+							state.agentSession.Close()
+						}
+						delete(e.interactiveStates, key)
+					}
+				}
+				e.interactiveMu.Unlock()
+				slog.Info("workspace idle-reaped", "workspace", ws)
+			}
+		}
+	}
+}
+```
+
+Note: This requires adding `workspaceDir string` to the `interactiveState` struct (~line 174).
+
+**Step 4: Build to verify compilation**
+
+Run: `go build ./...`
+Expected: Compiles cleanly
+
+**Step 5: Commit**
+
+```bash
+git add core/engine.go
+git commit -m "feat: add multi-workspace fields, SetMultiWorkspace, and idle reaper to Engine"
+```
+
+---
+
+### Task 6: Workspace resolution logic
+
+**Files:**
+- Modify: `core/engine.go`
+
+**Step 1: Implement resolveWorkspace method**
+
+Add this method to Engine. It returns the workspace path or empty string if init flow is needed:
+
+```go
+// resolveWorkspace resolves a channel to a workspace directory.
+// Returns (workspacePath, channelName, error).
+// If workspacePath is empty, the init flow should be triggered.
+func (e *Engine) resolveWorkspace(p Platform, channelID string) (string, string, error) {
+	projectKey := "project:" + e.name
+
+	// Step 1: Check existing binding
+	if b := e.workspaceBindings.Lookup(projectKey, channelID); b != nil {
+		// Verify workspace directory still exists
+		if _, err := os.Stat(b.Workspace); err != nil {
+			slog.Warn("bound workspace directory missing, removing binding",
+				"workspace", b.Workspace, "channel", channelID)
+			e.workspaceBindings.Unbind(projectKey, channelID)
+			return "", b.ChannelName, nil
+		}
+		return b.Workspace, b.ChannelName, nil
+	}
+
+	// Step 2: Resolve channel name for convention match
+	channelName := ""
+	if resolver, ok := p.(ChannelNameResolver); ok {
+		name, err := resolver.ResolveChannelName(channelID)
+		if err != nil {
+			slog.Warn("failed to resolve channel name", "channel", channelID, "err", err)
+		} else {
+			channelName = name
+		}
+	}
+
+	if channelName == "" {
+		return "", "", nil
+	}
+
+	// Step 3: Convention match — check if base_dir/<channel-name> exists
+	candidate := filepath.Join(e.baseDir, channelName)
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		// Auto-bind with feedback
+		e.workspaceBindings.Bind(projectKey, channelID, channelName, candidate)
+		slog.Info("workspace auto-bound by convention",
+			"channel", channelName, "workspace", candidate)
+		return candidate, channelName, nil
+	}
+
+	return "", channelName, nil
+}
+```
+
+**Step 2: Build to verify**
+
+Run: `go build ./...`
+Expected: Compiles cleanly
+
+**Step 3: Commit**
+
+```bash
+git add core/engine.go
+git commit -m "feat: add resolveWorkspace method for channel-to-directory mapping"
+```
+
+---
+
+### Task 7: Init flow conversation handler
+
+**Files:**
+- Modify: `core/engine.go`
+
+**Step 1: Implement handleInitFlow**
+
+This handles the conversational flow when no workspace is bound for a channel:
+
+```go
+// handleWorkspaceInitFlow manages the conversational workspace setup.
+// Returns true if the message was consumed by the init flow.
+func (e *Engine) handleWorkspaceInitFlow(p Platform, msg *Message, channelID, channelName string) bool {
+	e.initFlowsMu.Lock()
+	flow, exists := e.initFlows[channelID]
+	e.initFlowsMu.Unlock()
+
+	content := strings.TrimSpace(msg.Content)
+
+	if !exists {
+		// Check if user is providing a /workspace init command — handled elsewhere
+		if strings.HasPrefix(content, "/") {
+			return false
+		}
+
+		// Start new init flow
+		e.initFlowsMu.Lock()
+		e.initFlows[channelID] = &workspaceInitFlow{state: "awaiting_url"}
+		e.initFlowsMu.Unlock()
+
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(
+			"No workspace found for this channel. Send me a git repo URL to clone, or use `/workspace init <url>`."))
+		return true
+	}
+
+	switch flow.state {
+	case "awaiting_url":
+		// Validate it looks like a git URL
+		if !looksLikeGitURL(content) {
+			e.reply(p, msg.ReplyCtx, "That doesn't look like a git URL. Please provide a URL like `https://github.com/org/repo` or `git@github.com:org/repo.git`.")
+			return true
+		}
+		repoName := extractRepoName(content)
+		cloneTo := filepath.Join(e.baseDir, repoName)
+
+		e.initFlowsMu.Lock()
+		flow.repoURL = content
+		flow.cloneTo = cloneTo
+		flow.state = "awaiting_confirm"
+		e.initFlowsMu.Unlock()
+
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(
+			"I'll clone `%s` to `%s` and bind it to this channel. OK? (yes/no)", content, cloneTo))
+		return true
+
+	case "awaiting_confirm":
+		lower := strings.ToLower(content)
+		if lower != "yes" && lower != "y" {
+			e.initFlowsMu.Lock()
+			delete(e.initFlows, channelID)
+			e.initFlowsMu.Unlock()
+			e.reply(p, msg.ReplyCtx, "Cancelled. Send a repo URL anytime to try again.")
+			return true
+		}
+
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf("Cloning `%s` to `%s`...", flow.repoURL, flow.cloneTo))
+
+		if err := gitClone(flow.repoURL, flow.cloneTo); err != nil {
+			e.initFlowsMu.Lock()
+			delete(e.initFlows, channelID)
+			e.initFlowsMu.Unlock()
+			e.reply(p, msg.ReplyCtx, fmt.Sprintf("Clone failed: %v\nSend a repo URL to try again.", err))
+			return true
+		}
+
+		projectKey := "project:" + e.name
+		e.workspaceBindings.Bind(projectKey, channelID, channelName, flow.cloneTo)
+
+		e.initFlowsMu.Lock()
+		delete(e.initFlows, channelID)
+		e.initFlowsMu.Unlock()
+
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(
+			"Clone complete. Bound workspace `%s` to this channel. Ready.", flow.cloneTo))
+		return true
+	}
+
+	return false
+}
+
+func looksLikeGitURL(s string) bool {
+	return strings.HasPrefix(s, "https://") ||
+		strings.HasPrefix(s, "http://") ||
+		strings.HasPrefix(s, "git@") ||
+		strings.HasPrefix(s, "ssh://")
+}
+
+func extractRepoName(url string) string {
+	// Handle both https://github.com/org/repo.git and git@github.com:org/repo.git
+	url = strings.TrimSuffix(url, ".git")
+	parts := strings.Split(url, "/")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	// Handle git@ format
+	if idx := strings.LastIndex(url, ":"); idx != -1 {
+		remainder := url[idx+1:]
+		parts = strings.Split(remainder, "/")
+		if len(parts) > 0 {
+			return parts[len(parts)-1]
+		}
+	}
+	return "workspace"
+}
+
+func gitClone(repoURL, dest string) error {
+	cmd := exec.Command("git", "clone", repoURL, dest)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+```
+
+**Step 2: Build to verify**
+
+Run: `go build ./...`
+Expected: Compiles cleanly
+
+**Step 3: Commit**
+
+```bash
+git add core/engine.go
+git commit -m "feat: add workspace init flow for cloning repos and binding channels"
+```
+
+---
+
+### Task 8: Wire multi-workspace routing into handleMessage
+
+**Files:**
+- Modify: `core/engine.go` (handleMessage ~line 574, getOrCreateInteractiveState)
+
+**Step 1: Add workspace routing at the top of handleMessage**
+
+After the banned words check (~line 611) and before command dispatch (~line 613), insert multi-workspace resolution:
+
+```go
+// Multi-workspace resolution
+var resolvedWorkspace string
+if e.multiWorkspace {
+	channelID := extractChannelID(msg.SessionKey)
+	workspace, channelName, err := e.resolveWorkspace(p, channelID)
+	if err != nil {
+		slog.Error("workspace resolution failed", "err", err)
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf("Workspace resolution error: %v", err))
+		return
+	}
+	if workspace == "" {
+		// No workspace — handle init flow (unless it's a /workspace command)
+		if !strings.HasPrefix(content, "/workspace") {
+			if e.handleWorkspaceInitFlow(p, msg, channelID, channelName) {
+				return
+			}
+		}
+		// If init flow didn't consume and no workspace, only /workspace commands work
+		if !strings.HasPrefix(content, "/workspace") {
+			return
+		}
+	} else {
+		resolvedWorkspace = workspace
+		// Touch the workspace pool for idle tracking
+		if ws := e.workspacePool.Get(workspace); ws != nil {
+			ws.Touch()
+		}
+
+		// Auto-bind feedback for convention matches (first message only)
+		if ws := e.workspacePool.Get(workspace); ws == nil {
+			e.reply(p, msg.ReplyCtx, fmt.Sprintf(
+				"Found `%s` matching this channel. Binding workspace and starting session... Ready.", workspace))
+		}
+	}
+}
+```
+
+**Step 2: Add extractChannelID helper**
+
+```go
+func extractChannelID(sessionKey string) string {
+	// Format: "platform:channelID:userID" or "platform:channelID"
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return ""
+}
+```
+
+**Step 3: Modify getOrCreateInteractiveState for multi-workspace**
+
+The existing `getOrCreateInteractiveState` method creates agent sessions using `e.agent`. For multi-workspace, it needs to create an agent session with the resolved workspace's `work_dir`. Find `getOrCreateInteractiveState` and modify it:
+
+- Add `resolvedWorkspace` parameter
+- When `e.multiWorkspace` is true, use a workspace-scoped key and pass the workspace dir to the agent
+- Key `interactiveStates` by `workspace + ":" + sessionKey` instead of just `sessionKey`
+- Set `state.workspaceDir` on the interactive state
+
+This requires the Agent interface to support dynamic work dirs. Add a method:
+
+```go
+// In core/interfaces.go, add optional interface:
+type WorkDirSetter interface {
+	SetWorkDir(dir string)
+}
+```
+
+And in `agent/claudecode/claudecode.go`:
+```go
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+```
+
+However, since a single Agent instance is shared, we can't just SetWorkDir — it would race. Instead, for multi-workspace we need **per-workspace Agent instances**. Store them in the workspaceState:
+
+Add to `workspaceState`:
+```go
+type workspaceState struct {
+	mu           sync.Mutex
+	workspace    string
+	sessions     *SessionManager
+	agent        Agent           // per-workspace agent clone
+	lastActivity time.Time
+}
+```
+
+Add a method to Engine for creating per-workspace agents:
+
+```go
+func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionManager, error) {
+	ws := e.workspacePool.GetOrCreate(workspace)
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	if ws.agent != nil {
+		return ws.agent, ws.sessions, nil
+	}
+
+	// Create agent clone with this workspace's work_dir
+	agentOpts := make(map[string]any)
+	// Copy relevant options from the original agent if it's a claudecode agent
+	if wds, ok := e.agent.(interface{ Options() map[string]any }); ok {
+		for k, v := range wds.Options() {
+			agentOpts[k] = v
+		}
+	}
+	agentOpts["work_dir"] = workspace
+
+	agent, err := CreateAgent("claudecode", agentOpts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create workspace agent: %w", err)
+	}
+
+	// Wire providers if original agent has them
+	if ps, ok := e.agent.(ProviderSwitcher); ok {
+		if ps2, ok := agent.(ProviderSwitcher); ok {
+			ps2.SetProviders(ps.GetProviders())
+		}
+	}
+
+	// Create per-workspace session manager
+	sessionFile := filepath.Join(filepath.Dir(e.sessions.storePath),
+		fmt.Sprintf("%s_ws_%x.json", e.name, sha256Short(workspace)))
+	sessions := NewSessionManager(sessionFile)
+
+	ws.agent = agent
+	ws.sessions = sessions
+	return agent, sessions, nil
+}
+
+func sha256Short(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:4])
+}
+```
+
+**Step 4: Update processInteractiveMessage to use workspace agent**
+
+In the multi-workspace path, before calling `getOrCreateInteractiveState`, swap in the workspace's agent and session manager. The cleanest approach: modify `processInteractiveMessage` to accept optional overrides, or modify `getOrCreateInteractiveState` to accept an agent parameter.
+
+Modify `getOrCreateInteractiveState` signature to optionally accept a workspace agent:
+
+```go
+func (e *Engine) getOrCreateInteractiveState(sessionKey string, p Platform, replyCtx any, session *Session, agent ...Agent) *interactiveState {
+	// ... existing logic, but use agent[0] if provided instead of e.agent
+}
+```
+
+**Step 5: Build to verify**
+
+Run: `go build ./...`
+Expected: Compiles cleanly
+
+**Step 6: Commit**
+
+```bash
+git add core/engine.go core/interfaces.go core/workspace_state.go agent/claudecode/claudecode.go
+git commit -m "feat: wire multi-workspace routing into handleMessage with per-workspace agents"
+```
+
+---
+
+### Task 9: Workspace commands
+
+**Files:**
+- Modify: `core/engine.go` (handleCommand ~line 1320)
+
+**Step 1: Add workspace command handler**
+
+In the `handleCommand` switch statement, add cases for workspace commands:
+
+```go
+case "workspace":
+	if !e.multiWorkspace {
+		e.reply(p, msg.ReplyCtx, "Workspace commands are only available in multi-workspace mode.")
+		return true
+	}
+	e.handleWorkspaceCommand(p, msg, args)
+	return true
+```
+
+**Step 2: Implement handleWorkspaceCommand**
+
+```go
+func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args string) {
+	channelID := extractChannelID(msg.SessionKey)
+	projectKey := "project:" + e.name
+
+	parts := strings.Fields(args)
+	subCmd := ""
+	if len(parts) > 0 {
+		subCmd = parts[0]
+	}
+
+	switch subCmd {
+	case "":
+		// Show current binding
+		b := e.workspaceBindings.Lookup(projectKey, channelID)
+		if b == nil {
+			e.reply(p, msg.ReplyCtx, "No workspace bound to this channel.")
+		} else {
+			e.reply(p, msg.ReplyCtx, fmt.Sprintf("Workspace: `%s`\nBound: %s",
+				b.Workspace, b.BoundAt.Format(time.RFC3339)))
+		}
+
+	case "init":
+		if len(parts) < 2 {
+			e.reply(p, msg.ReplyCtx, "Usage: `/workspace init <git-url>`")
+			return
+		}
+		repoURL := parts[1]
+		if !looksLikeGitURL(repoURL) {
+			e.reply(p, msg.ReplyCtx, "That doesn't look like a git URL.")
+			return
+		}
+
+		repoName := extractRepoName(repoURL)
+		cloneTo := filepath.Join(e.baseDir, repoName)
+
+		// Check if already exists
+		if _, err := os.Stat(cloneTo); err == nil {
+			// Directory exists, just bind
+			channelName := ""
+			if resolver, ok := p.(ChannelNameResolver); ok {
+				channelName, _ = resolver.ResolveChannelName(channelID)
+			}
+			e.workspaceBindings.Bind(projectKey, channelID, channelName, cloneTo)
+			e.reply(p, msg.ReplyCtx, fmt.Sprintf(
+				"Directory `%s` already exists. Bound workspace to this channel. Ready.", cloneTo))
+			return
+		}
+
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf("Cloning `%s` to `%s`...", repoURL, cloneTo))
+
+		if err := gitClone(repoURL, cloneTo); err != nil {
+			e.reply(p, msg.ReplyCtx, fmt.Sprintf("Clone failed: %v", err))
+			return
+		}
+
+		channelName := ""
+		if resolver, ok := p.(ChannelNameResolver); ok {
+			channelName, _ = resolver.ResolveChannelName(channelID)
+		}
+		e.workspaceBindings.Bind(projectKey, channelID, channelName, cloneTo)
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(
+			"Clone complete. Bound workspace `%s` to this channel. Ready.", cloneTo))
+
+	case "unbind":
+		e.workspaceBindings.Unbind(projectKey, channelID)
+		// Clean up workspace pool state
+		if ws := e.workspacePool.Get(channelID); ws != nil {
+			// Stop any running sessions
+		}
+		e.reply(p, msg.ReplyCtx, "Workspace unbound from this channel.")
+
+	case "list":
+		bindings := e.workspaceBindings.ListByProject(projectKey)
+		if len(bindings) == 0 {
+			e.reply(p, msg.ReplyCtx, "No workspaces bound.")
+			return
+		}
+		var sb strings.Builder
+		sb.WriteString("Bound workspaces:\n")
+		for chID, b := range bindings {
+			name := b.ChannelName
+			if name == "" {
+				name = chID
+			}
+			sb.WriteString(fmt.Sprintf("• #%s → `%s`\n", name, b.Workspace))
+		}
+		e.reply(p, msg.ReplyCtx, sb.String())
+
+	default:
+		e.reply(p, msg.ReplyCtx,
+			"Usage: `/workspace [init <url> | unbind | list]`")
+	}
+}
+```
+
+**Step 3: Build to verify**
+
+Run: `go build ./...`
+Expected: Compiles cleanly
+
+**Step 4: Commit**
+
+```bash
+git add core/engine.go
+git commit -m "feat: add /workspace commands (init, unbind, list, status)"
+```
+
+---
+
+### Task 10: Wire multi-workspace in main.go
+
+**Files:**
+- Modify: `cmd/cc-connect/main.go` (~line 139 project setup loop)
+
+**Step 1: Add multi-workspace setup after engine creation**
+
+After `engine := core.NewEngine(...)` (~line 195), add:
+
+```go
+if proj.Mode == "multi-workspace" {
+	baseDir := proj.BaseDir
+	if strings.HasPrefix(baseDir, "~/") {
+		home, _ := os.UserHomeDir()
+		baseDir = filepath.Join(home, baseDir[2:])
+	}
+	// Ensure base dir exists
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		slog.Error("failed to create base_dir", "path", baseDir, "err", err)
+		continue
+	}
+	bindingStore := filepath.Join(cfg.DataDir, "workspace_bindings.json")
+	engine.SetMultiWorkspace(baseDir, bindingStore)
+	slog.Info("multi-workspace mode enabled", "project", proj.Name, "base_dir", baseDir)
+}
+```
+
+**Step 2: Build to verify**
+
+Run: `go build ./...`
+Expected: Compiles cleanly
+
+**Step 3: Commit**
+
+```bash
+git add cmd/cc-connect/main.go
+git commit -m "feat: wire multi-workspace mode setup in main.go"
+```
+
+---
+
+### Task 11: Integration testing
+
+**Files:**
+- Create: `core/multi_workspace_test.go`
+
+**Step 1: Write integration test for full resolution flow**
+
+```go
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMultiWorkspaceResolution_ConventionMatch(t *testing.T) {
+	baseDir := t.TempDir()
+	bindingDir := t.TempDir()
+
+	// Create a directory matching a channel name
+	channelDir := filepath.Join(baseDir, "test-channel")
+	os.MkdirAll(channelDir, 0o755)
+
+	// Create engine with multi-workspace
+	agent := &mockAgent{}
+	engine := NewEngine("test", agent, nil, "", LangEN)
+	engine.SetMultiWorkspace(baseDir, filepath.Join(bindingDir, "bindings.json"))
+
+	// Create a mock platform with channel name resolution
+	mockP := &mockPlatformWithChannelResolver{
+		channelNames: map[string]string{"C123": "test-channel"},
+	}
+
+	workspace, channelName, err := engine.resolveWorkspace(mockP, "C123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if workspace != channelDir {
+		t.Errorf("expected %s, got %s", channelDir, workspace)
+	}
+	if channelName != "test-channel" {
+		t.Errorf("expected test-channel, got %s", channelName)
+	}
+
+	// Verify binding was saved
+	b := engine.workspaceBindings.Lookup("project:test", "C123")
+	if b == nil {
+		t.Fatal("expected binding to be saved")
+	}
+}
+
+func TestMultiWorkspaceResolution_NoMatch(t *testing.T) {
+	baseDir := t.TempDir()
+	bindingDir := t.TempDir()
+
+	agent := &mockAgent{}
+	engine := NewEngine("test", agent, nil, "", LangEN)
+	engine.SetMultiWorkspace(baseDir, filepath.Join(bindingDir, "bindings.json"))
+
+	mockP := &mockPlatformWithChannelResolver{
+		channelNames: map[string]string{"C456": "unknown-channel"},
+	}
+
+	workspace, _, err := engine.resolveWorkspace(mockP, "C456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if workspace != "" {
+		t.Errorf("expected empty workspace for unmatched channel, got %s", workspace)
+	}
+}
+
+func TestMultiWorkspaceResolution_MissingDirRemovesBinding(t *testing.T) {
+	baseDir := t.TempDir()
+	bindingDir := t.TempDir()
+
+	agent := &mockAgent{}
+	engine := NewEngine("test", agent, nil, "", LangEN)
+	engine.SetMultiWorkspace(baseDir, filepath.Join(bindingDir, "bindings.json"))
+
+	// Bind to a non-existent directory
+	engine.workspaceBindings.Bind("project:test", "C789", "deleted-channel", "/nonexistent/path")
+
+	mockP := &mockPlatformWithChannelResolver{
+		channelNames: map[string]string{"C789": "deleted-channel"},
+	}
+
+	workspace, _, err := engine.resolveWorkspace(mockP, "C789")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if workspace != "" {
+		t.Errorf("expected empty workspace for missing dir, got %s", workspace)
+	}
+
+	// Binding should be removed
+	b := engine.workspaceBindings.Lookup("project:test", "C789")
+	if b != nil {
+		t.Error("expected binding to be removed for missing directory")
+	}
+}
+
+// Mock types - adapt to match existing test mocks in the project
+type mockPlatformWithChannelResolver struct {
+	mockPlatform // embed existing mock if available
+	channelNames map[string]string
+}
+
+func (m *mockPlatformWithChannelResolver) ResolveChannelName(channelID string) (string, error) {
+	if name, ok := m.channelNames[channelID]; ok {
+		return name, nil
+	}
+	return "", fmt.Errorf("unknown channel %s", channelID)
+}
+```
+
+Note: The mock types will need to be adapted based on existing test helpers in the codebase. Check `core/*_test.go` for existing mock patterns.
+
+**Step 2: Run tests**
+
+Run: `go test ./core/ -run TestMultiWorkspace -v`
+Expected: PASS
+
+**Step 3: Run full test suite**
+
+Run: `go test ./...`
+Expected: All existing tests still pass
+
+**Step 4: Commit**
+
+```bash
+git add core/multi_workspace_test.go
+git commit -m "test: add integration tests for multi-workspace resolution"
+```
+
+---
+
+### Task 12: Update config.example.toml and verify build
+
+**Files:**
+- Modify: `config.example.toml`
+
+**Step 1: Add multi-workspace example section**
+
+Find the projects section and add a complete multi-workspace example:
+
+```toml
+# Multi-workspace mode: single bot, multiple workspaces
+# Channel name maps to ~/workspace/<channel-name> automatically.
+# Use /workspace init <url> to clone and bind a new repo.
+#
+# [[projects]]
+# name = "claude"
+# mode = "multi-workspace"
+# base_dir = "~/workspace"
+#
+# [projects.agent]
+# type = "claudecode"
+# permission_mode = "yolo"
+#
+# [[projects.platforms]]
+# type = "slack"
+# [projects.platforms.options]
+# bot_token = "xoxb-..."
+# app_token = "xapp-..."
+```
+
+**Step 2: Final build and test**
+
+Run: `go build ./... && go test ./...`
+Expected: Clean build and all tests pass
+
+**Step 3: Commit**
+
+```bash
+git add config.example.toml
+git commit -m "docs: add multi-workspace example to config.example.toml"
+```

--- a/docs/plans/2026-03-12-multi-workspace-plan.md.tasks.json
+++ b/docs/plans/2026-03-12-multi-workspace-plan.md.tasks.json
@@ -1,0 +1,18 @@
+{
+  "planPath": "docs/plans/2026-03-12-multi-workspace-plan.md",
+  "tasks": [
+    {"id": 1, "subject": "Task 1: Add config fields", "status": "pending"},
+    {"id": 2, "subject": "Task 2: Workspace binding persistence", "status": "pending", "blockedBy": [1]},
+    {"id": 3, "subject": "Task 3: Workspace state and idle reaper", "status": "pending", "blockedBy": [1]},
+    {"id": 4, "subject": "Task 4: Channel name resolution in Slack platform", "status": "pending"},
+    {"id": 5, "subject": "Task 5: Engine multi-workspace fields and constructor", "status": "pending", "blockedBy": [2, 3]},
+    {"id": 6, "subject": "Task 6: Workspace resolution logic", "status": "pending", "blockedBy": [4, 5]},
+    {"id": 7, "subject": "Task 7: Init flow conversation handler", "status": "pending", "blockedBy": [6]},
+    {"id": 8, "subject": "Task 8: Wire multi-workspace routing into handleMessage", "status": "pending", "blockedBy": [6, 7]},
+    {"id": 9, "subject": "Task 9: Workspace commands", "status": "pending", "blockedBy": [6]},
+    {"id": 10, "subject": "Task 10: Wire multi-workspace in main.go", "status": "pending", "blockedBy": [5]},
+    {"id": 11, "subject": "Task 11: Integration testing", "status": "pending", "blockedBy": [8, 9, 10]},
+    {"id": 12, "subject": "Task 12: Update config.example.toml and verify build", "status": "pending", "blockedBy": [11]}
+  ],
+  "lastUpdated": "2026-03-12T01:30:00Z"
+}

--- a/docs/plans/2026-03-13-session-resilience-design.md
+++ b/docs/plans/2026-03-13-session-resilience-design.md
@@ -1,0 +1,118 @@
+# Session Resilience Design
+
+**Date:** 2026-03-13
+**Status:** Approved
+**Branch:** feat/multi-workspace
+
+## Problem
+
+Multi-workspace mode introduces long-lived, concurrent Claude Code sessions that are reaped on idle and resumed on demand. Several failure modes cause silent context loss ("context rot"):
+
+1. **CWD mismatch** — workspace paths that differ by trailing slash, symlink, or relative segment map to different Claude Code session directories, causing resume to silently start a fresh session
+2. **Resume failure** — when a session's context is too large, `--resume` fails with "Prompt is too long" and the session becomes permanently broken until manual `!new`
+3. **Invisible context degradation** — users have no signal that context is filling up until Claude starts forgetting things
+4. **Silent failures** — session lifecycle events (spawn, resume, reap, failure) lack diagnostic logging
+
+## Design
+
+### 1. Path Normalization
+
+**Helper:** `normalizeWorkspacePath(path string) string` in `workspace_state.go`
+
+```
+filepath.Clean(path) → filepath.EvalSymlinks(cleanedPath)
+```
+
+If `EvalSymlinks` fails (path doesn't exist yet), fall back to `filepath.Clean` only.
+
+**Applied at two sites:**
+- `workspacePool.GetOrCreate(workspace)` — normalize the key before map lookup/insert
+- Workspace binding resolution — normalize before the workspace string enters the system
+
+**Logging:** `slog.Debug("workspace path normalized", "original", path, "normalized", result)` when normalization changes the input.
+
+### 2. Resume Failure → Fresh Session Fallback
+
+**Location:** `getOrCreateInteractiveStateWith()` in engine.go
+
+**Current behavior:** `StartSession` failure → state with nil `agentSession` → broken until `!new`.
+
+**New behavior:**
+
+1. If `StartSession` fails AND `session.AgentSessionID != ""` (resume attempt):
+   - Log failure with diagnostics: session ID, error message, cwd
+   - Clear `session.AgentSessionID` and save
+   - Retry `agent.StartSession(ctx, "")` for a fresh session
+   - Post platform notification: *"Session context was too large to resume — starting fresh. Project context is preserved in CLAUDE.md."*
+2. If fresh retry also fails → fall through to existing nil-state behavior
+3. If original call was already fresh (`AgentSessionID == ""`) → no retry, fall through as today
+
+**Notification:** Send via `p.Send(ctx, replyCtx, msg)` — both are available on the `interactiveState` being constructed.
+
+### 3. Context Consumption Indicator
+
+**Dual-track approach with logging to compare accuracy over time.**
+
+#### Track A: SDK token counts (accurate, cc-connect-owned)
+
+- In `processInteractiveEvents`, parse `result` events for `input_tokens` usage
+- Store cumulative `input_tokens` on the `interactiveState` (updated each turn)
+- Compute percentage: `input_tokens / 200_000 * 100` (model context window)
+- Append `[ctx: XX%]` to every message relayed to the platform
+
+#### Track B: Claude self-report (approximate, for comparison)
+
+- Add to system prompt via `--append-system-prompt`: instruction to append `[ctx: ~XX%]` to every response
+- Parse the self-reported value from Claude's output before relaying
+
+#### Logging
+
+On every turn that has both values:
+```
+slog.Info("context_usage",
+    "sdk_pct", sdkPct,
+    "self_reported_pct", selfReportedPct,
+    "session_key", sessionKey,
+    "input_tokens", inputTokens)
+```
+
+Over time, compare drift to decide whether the system prompt instruction adds value.
+
+#### Display
+
+Appended to every visible message relayed to the platform:
+```
+Here's the refactored auth module...
+[ctx: 62%]
+```
+
+If no token data available yet (first message), skip the indicator.
+
+### 4. Diagnostic Logging
+
+Structured `slog` logging at key lifecycle points:
+
+| Event | Level | Fields |
+|-------|-------|--------|
+| Session spawn | Info | normalized cwd, session ID (or "new"), model |
+| Session resume | Info | session ID, JSONL file path, file size |
+| Resume failure | Error | session ID, error, stderr, cwd, JSONL file size |
+| Fresh fallback | Warn | original session ID, new session ID, cwd |
+| Idle reap | Info | session key, workspace path, idle duration, token count at reap |
+| Context per-turn | Info | session key, input_tokens, sdk_pct, self_reported_pct |
+| Path normalization | Debug | original path, normalized path (only when changed) |
+
+**JSONL file size:** Resolve via `findProjectDir` + stat at resume time. Log even if file not found (indicates cwd mismatch).
+
+## Non-Goals
+
+- **Proactive compaction** — likely to cause more trouble than it's worth; the context indicator gives users agency to compact manually
+- **Session summary → new session pattern** — more robust but significantly more implementation work; revisit if resume-with-fallback proves insufficient
+- **Disk/memory monitoring** — out of scope; can be added as operational tooling later
+
+## Implementation Order
+
+1. Path normalization (prerequisite for everything else being reliable)
+2. Diagnostic logging (needed to verify the other changes work)
+3. Resume failure fallback (highest-value fix)
+4. Context consumption indicator (most complex, benefits from logging already being in place)

--- a/docs/plans/2026-03-13-session-resilience-plan.md
+++ b/docs/plans/2026-03-13-session-resilience-plan.md
@@ -1,0 +1,793 @@
+# Session Resilience Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate silent session context loss in multi-workspace mode by normalizing paths, handling resume failures gracefully, surfacing context consumption to users, and adding diagnostic logging.
+
+**Architecture:** Four independent changes layered bottom-up: path normalization (prevents mismatches), diagnostic logging (makes failures visible), resume fallback (auto-recovers from broken resumes), context indicator (gives users agency over compaction).
+
+**Tech Stack:** Go, Claude Code CLI (stream-json protocol), slog structured logging
+
+**Design doc:** `docs/plans/2026-03-13-session-resilience-design.md`
+
+---
+
+### Task 1: Add `normalizeWorkspacePath` helper
+
+**Files:**
+- Modify: `core/workspace_state.go`
+- Create: `core/workspace_state_test.go` (add test cases)
+
+**Step 1: Write the failing test**
+
+Add to `core/workspace_state_test.go`:
+
+```go
+func TestNormalizeWorkspacePath(t *testing.T) {
+	// Create a real temp directory for symlink tests
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "real-project")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(tmp, "link-project")
+	if err := os.Symlink(realDir, symlink); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"trailing slash", realDir + "/", realDir},
+		{"double slash", filepath.Join(tmp, "real-project") + "//", realDir},
+		{"dot segment", filepath.Join(tmp, ".", "real-project"), realDir},
+		{"dotdot segment", filepath.Join(tmp, "real-project", "subdir", ".."), realDir},
+		{"symlink resolved", symlink, realDir},
+		{"nonexistent uses Clean only", "/nonexistent/path/./foo/../bar", "/nonexistent/path/bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeWorkspacePath(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeWorkspacePath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./core/ -run TestNormalizeWorkspacePath -v`
+Expected: FAIL — `normalizeWorkspacePath` undefined
+
+**Step 3: Write minimal implementation**
+
+Add to `core/workspace_state.go`:
+
+```go
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// normalizeWorkspacePath cleans and resolves a workspace path to prevent
+// mismatches caused by trailing slashes, symlinks, or relative segments.
+// If the path cannot be resolved (e.g. doesn't exist yet), falls back to
+// filepath.Clean only.
+func normalizeWorkspacePath(path string) string {
+	cleaned := filepath.Clean(path)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		// Path doesn't exist yet — best effort
+		return cleaned
+	}
+	if resolved != path {
+		slog.Debug("workspace path normalized", "original", path, "normalized", resolved)
+	}
+	return resolved
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./core/ -run TestNormalizeWorkspacePath -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add core/workspace_state.go core/workspace_state_test.go
+git commit -m "feat: add normalizeWorkspacePath helper for consistent pool keys"
+```
+
+---
+
+### Task 2: Apply path normalization at entry points
+
+**Files:**
+- Modify: `core/workspace_state.go` — `GetOrCreate`
+- Modify: `core/engine.go:5656,5681` — `resolveWorkspace` return values
+- Modify: `core/engine.go:993` — `getOrCreateWorkspaceAgent`
+
+**Step 1: Write failing tests**
+
+Add to `core/workspace_state_test.go`:
+
+```go
+func TestWorkspacePoolNormalizesKeys(t *testing.T) {
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "project")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pool := newWorkspacePool(15 * time.Minute)
+
+	// Access with trailing slash
+	ws1 := pool.GetOrCreate(realDir + "/")
+	// Access without trailing slash
+	ws2 := pool.GetOrCreate(realDir)
+
+	if ws1 != ws2 {
+		t.Error("trailing slash created a different workspace state")
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./core/ -run TestWorkspacePoolNormalizesKeys -v`
+Expected: FAIL — two different states returned
+
+**Step 3: Normalize in `GetOrCreate` and `Get`**
+
+In `core/workspace_state.go`, modify `GetOrCreate`:
+
+```go
+func (p *workspacePool) GetOrCreate(workspace string) *workspaceState {
+	workspace = normalizeWorkspacePath(workspace)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if s, ok := p.states[workspace]; ok {
+		return s
+	}
+	s := newWorkspaceState(workspace)
+	p.states[workspace] = s
+	return s
+}
+```
+
+Modify `Get` similarly:
+
+```go
+func (p *workspacePool) Get(workspace string) *workspaceState {
+	workspace = normalizeWorkspacePath(workspace)
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.states[workspace]
+}
+```
+
+**Step 4: Normalize in `resolveWorkspace` returns**
+
+In `core/engine.go`, at lines 5656 and 5681 where workspace paths are returned, wrap with normalization:
+
+At line 5656:
+```go
+return normalizeWorkspacePath(b.Workspace), b.ChannelName, nil
+```
+
+At line 5681:
+```go
+normalized := normalizeWorkspacePath(candidate)
+e.workspaceBindings.Bind(projectKey, channelID, channelName, normalized)
+slog.Info("workspace auto-bound by convention",
+    "channel", channelName, "workspace", normalized)
+return normalized, channelName, nil
+```
+
+**Step 5: Run tests**
+
+Run: `go test ./core/ -run TestWorkspacePool -v`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add core/workspace_state.go core/workspace_state_test.go core/engine.go
+git commit -m "feat: normalize workspace paths at pool and resolution entry points"
+```
+
+---
+
+### Task 3: Add token usage fields to Event and parse in session
+
+**Files:**
+- Modify: `core/message.go:87-98` — add `InputTokens`, `OutputTokens` to `Event`
+- Modify: `agent/claudecode/session.go:268-282` — parse usage from result JSON
+
+**Step 1: Write failing test**
+
+Add to a new file or existing test for claudecode session parsing. Since `handleResult` is on the unexported `claudeSession`, test via the event channel:
+
+Create `agent/claudecode/session_test.go` test (or add to existing):
+
+```go
+func TestHandleResultParsesUsage(t *testing.T) {
+	// Simulate a result event JSON with usage data
+	raw := map[string]any{
+		"type":       "result",
+		"result":     "test response",
+		"session_id": "sess-123",
+		"usage": map[string]any{
+			"input_tokens":  float64(50000),
+			"output_tokens": float64(1500),
+		},
+	}
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 1),
+		ctx:    context.Background(),
+		done:   make(chan struct{}),
+	}
+	cs.alive.Store(true)
+
+	cs.handleResult(raw)
+
+	evt := <-cs.events
+	if evt.InputTokens != 50000 {
+		t.Errorf("InputTokens = %d, want 50000", evt.InputTokens)
+	}
+	if evt.OutputTokens != 1500 {
+		t.Errorf("OutputTokens = %d, want 1500", evt.OutputTokens)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./agent/claudecode/ -run TestHandleResultParsesUsage -v`
+Expected: FAIL — `InputTokens` field doesn't exist on Event
+
+**Step 3: Add fields to Event**
+
+In `core/message.go`, add to the `Event` struct:
+
+```go
+InputTokens  int // populated for EventResult — total input tokens this turn
+OutputTokens int // populated for EventResult — output tokens this turn
+```
+
+**Step 4: Parse usage in handleResult**
+
+In `agent/claudecode/session.go`, modify `handleResult`:
+
+```go
+func (cs *claudeSession) handleResult(raw map[string]any) {
+	var content string
+	if result, ok := raw["result"].(string); ok {
+		content = result
+	}
+	if sid, ok := raw["session_id"].(string); ok && sid != "" {
+		cs.sessionID.Store(sid)
+	}
+
+	var inputTokens, outputTokens int
+	if usage, ok := raw["usage"].(map[string]any); ok {
+		if v, ok := usage["input_tokens"].(float64); ok {
+			inputTokens = int(v)
+		}
+		if v, ok := usage["output_tokens"].(float64); ok {
+			outputTokens = int(v)
+		}
+	}
+
+	evt := core.Event{
+		Type:         core.EventResult,
+		Content:      content,
+		SessionID:    cs.CurrentSessionID(),
+		Done:         true,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+	}
+	select {
+	case cs.events <- evt:
+	case <-cs.ctx.Done():
+		return
+	}
+}
+```
+
+**Step 5: Run test to verify it passes**
+
+Run: `go test ./agent/claudecode/ -run TestHandleResultParsesUsage -v`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add core/message.go agent/claudecode/session.go agent/claudecode/session_test.go
+git commit -m "feat: parse token usage from Claude Code result events"
+```
+
+---
+
+### Task 4: Track context percentage on interactiveState and append to messages
+
+**Files:**
+- Modify: `core/engine.go:192-202` — add `inputTokens` field to `interactiveState`
+- Modify: `core/engine.go:1326-1352` — track tokens on EventResult
+- Modify: `core/engine.go:1354+` — append `[ctx: XX%]` to relayed messages
+
+**Step 1: Add field to interactiveState**
+
+In `core/engine.go`, add to the `interactiveState` struct:
+
+```go
+type interactiveState struct {
+	// ... existing fields ...
+	inputTokens int // last known input_tokens from result event (context size proxy)
+}
+```
+
+**Step 2: Update EventResult handler to track tokens and append indicator**
+
+In `processInteractiveEvents`, in the `case EventResult:` block (around line 1326), after the existing session ID handling:
+
+```go
+case EventResult:
+	if event.SessionID != "" {
+		session.mu.Lock()
+		session.AgentSessionID = event.SessionID
+		session.mu.Unlock()
+	}
+
+	// Track context consumption
+	if event.InputTokens > 0 {
+		state.mu.Lock()
+		state.inputTokens = event.InputTokens
+		state.mu.Unlock()
+	}
+
+	fullResponse := event.Content
+	if fullResponse == "" && len(textParts) > 0 {
+		fullResponse = strings.Join(textParts, "")
+	}
+	if fullResponse == "" {
+		fullResponse = e.i18n.T(MsgEmptyResponse)
+	}
+
+	// Append context indicator
+	if event.InputTokens > 0 {
+		pct := event.InputTokens * 100 / 200_000
+		fullResponse += fmt.Sprintf("\n[ctx: %d%%]", pct)
+	}
+
+	// ... rest of existing EventResult handling
+```
+
+**Step 3: Also append indicator to intermediate messages (tool use, thinking)**
+
+For every visible message sent during a turn, we need the indicator. The simplest approach: store the last known percentage on the state, and have a helper:
+
+```go
+func contextIndicator(inputTokens int) string {
+	if inputTokens <= 0 {
+		return ""
+	}
+	pct := inputTokens * 100 / 200_000
+	return fmt.Sprintf("\n[ctx: %d%%]", pct)
+}
+```
+
+Append `contextIndicator(state.inputTokens)` to every `e.send()` call in the event loop for EventThinking, EventToolUse, and EventResult. Read `state.inputTokens` under the state mutex that's already being acquired.
+
+**Step 4: Run existing tests**
+
+Run: `go test ./core/ -v -count=1`
+Expected: PASS (no test changes needed — this is additive to message content)
+
+**Step 5: Commit**
+
+```bash
+git add core/engine.go
+git commit -m "feat: append context consumption indicator [ctx: XX%] to relayed messages"
+```
+
+---
+
+### Task 5: Add system prompt instruction for Claude self-reporting
+
+**Files:**
+- Modify: `core/interfaces.go:36-81` — append context self-report instruction to `AgentSystemPrompt()`
+
+**Step 1: Add instruction to system prompt**
+
+At the end of the `AgentSystemPrompt()` return string, before the closing backtick, add:
+
+```go
+## Context awareness
+At the end of every message you send, append your estimate of your context window consumption as: [ctx: ~XX%]
+This helps the user decide when to run /compact. Be honest — if you're unsure, estimate conservatively.
+```
+
+**Step 2: Run existing tests**
+
+Run: `go test ./core/ -v -count=1`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add core/interfaces.go
+git commit -m "feat: instruct agent to self-report context usage for comparison logging"
+```
+
+---
+
+### Task 6: Add dual-track context logging
+
+**Files:**
+- Modify: `core/engine.go` — EventResult handler, add structured log with both values
+
+**Step 1: Parse self-reported percentage from response**
+
+Add helper in `core/engine.go`:
+
+```go
+import "regexp"
+
+var ctxSelfReportRe = regexp.MustCompile(`\[ctx:\s*~?(\d+)%\]`)
+
+// parseSelfReportedCtx extracts the self-reported context percentage from a response.
+// Returns -1 if not found.
+func parseSelfReportedCtx(response string) int {
+	m := ctxSelfReportRe.FindStringSubmatch(response)
+	if m == nil {
+		return -1
+	}
+	v, _ := strconv.Atoi(m[1])
+	return v
+}
+```
+
+**Step 2: Write test for parser**
+
+```go
+func TestParseSelfReportedCtx(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"some response\n[ctx: ~45%]", 45},
+		{"response [ctx: 80%]", 80},
+		{"no indicator", -1},
+		{"[ctx: ~100%] mid-text", 100},
+	}
+	for _, tt := range tests {
+		got := parseSelfReportedCtx(tt.input)
+		if got != tt.want {
+			t.Errorf("parseSelfReportedCtx(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+```
+
+**Step 3: Run test to verify it fails, implement, verify pass**
+
+Run: `go test ./core/ -run TestParseSelfReportedCtx -v`
+
+**Step 4: Add structured logging in EventResult handler**
+
+After computing the SDK percentage but before appending the indicator, add:
+
+```go
+if event.InputTokens > 0 {
+	sdkPct := event.InputTokens * 100 / 200_000
+	selfPct := parseSelfReportedCtx(fullResponse)
+	slog.Info("context_usage",
+		"session_key", sessionKey,
+		"sdk_pct", sdkPct,
+		"self_reported_pct", selfPct,
+		"input_tokens", event.InputTokens,
+		"output_tokens", event.OutputTokens,
+	)
+}
+```
+
+**Step 5: Strip Claude's self-reported indicator before appending the real one**
+
+So we don't show duplicate indicators, strip the self-reported one from the response before appending the SDK-based one:
+
+```go
+// Strip self-reported indicator (we replace it with the accurate SDK one)
+fullResponse = ctxSelfReportRe.ReplaceAllString(fullResponse, "")
+fullResponse = strings.TrimRight(fullResponse, "\n ")
+fullResponse += fmt.Sprintf("\n[ctx: %d%%]", sdkPct)
+```
+
+**Step 6: Commit**
+
+```bash
+git add core/engine.go core/engine_test.go
+git commit -m "feat: dual-track context usage logging (SDK vs self-reported)"
+```
+
+---
+
+### Task 7: Add diagnostic logging to session lifecycle
+
+**Files:**
+- Modify: `core/engine.go:1097-1119` — spawn/resume logging
+- Modify: `core/engine.go:259-283` — reap logging
+- Modify: `agent/claudecode/session.go:42-117` — spawn logging with JSONL path/size
+- Modify: `agent/claudecode/claudecode.go:195-224` — log cwd at StartSession
+
+**Step 1: Enhanced spawn logging in `getOrCreateInteractiveStateWith`**
+
+Replace the existing log at line 1118 with:
+
+```go
+slog.Info("session spawned",
+	"session_key", sessionKey,
+	"agent_session", session.AgentSessionID,
+	"is_resume", session.AgentSessionID != "",
+	"elapsed", startElapsed,
+)
+```
+
+**Step 2: Add JSONL file size logging in `claudecode.StartSession`**
+
+In `agent/claudecode/claudecode.go`, in `StartSession`, before calling `newClaudeSession`, add:
+
+```go
+if sessionID != "" {
+	// Log session file details for diagnostics
+	homeDir, _ := os.UserHomeDir()
+	absWorkDir, _ := filepath.Abs(a.workDir)
+	if homeDir != "" {
+		projectDir := findProjectDir(homeDir, absWorkDir)
+		sessionFile := filepath.Join(projectDir, sessionID+".jsonl")
+		if info, err := os.Stat(sessionFile); err == nil {
+			slog.Info("session resume attempt",
+				"session_id", sessionID,
+				"jsonl_path", sessionFile,
+				"jsonl_size_bytes", info.Size(),
+				"work_dir", absWorkDir,
+			)
+		} else {
+			slog.Warn("session file not found for resume",
+				"session_id", sessionID,
+				"expected_path", sessionFile,
+				"work_dir", absWorkDir,
+				"error", err,
+			)
+		}
+	}
+}
+```
+
+**Step 3: Enhanced reap logging in `runIdleReaper`**
+
+In `core/engine.go`, in the reap loop (around line 271), add idle duration:
+
+```go
+reaped := e.workspacePool.ReapIdle()
+for _, ws := range reaped {
+	e.interactiveMu.Lock()
+	for key, state := range e.interactiveStates {
+		if state.workspaceDir == ws {
+			state.mu.Lock()
+			tokenCount := state.inputTokens
+			state.mu.Unlock()
+			slog.Info("session idle-reaped",
+				"session_key", key,
+				"workspace", ws,
+				"last_ctx_pct", tokenCount*100/200_000,
+				"input_tokens", tokenCount,
+			)
+			if state.agentSession != nil {
+				state.agentSession.Close()
+			}
+			delete(e.interactiveStates, key)
+		}
+	}
+```
+
+**Step 4: Log stderr on session process failure**
+
+In `agent/claudecode/session.go`, the `readLoop` already logs stderr on failure (line 125). Enhance it:
+
+```go
+slog.Error("claudeSession: process failed",
+	"error", err,
+	"stderr", stderrMsg,
+	"work_dir", cs.workDir,
+	"session_id", cs.CurrentSessionID(),
+)
+```
+
+**Step 5: Run all tests**
+
+Run: `go test ./core/ ./agent/claudecode/ -v -count=1`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add core/engine.go agent/claudecode/session.go agent/claudecode/claudecode.go
+git commit -m "feat: add diagnostic logging for session spawn, resume, reap, and failure"
+```
+
+---
+
+### Task 8: Resume failure fallback with user notification
+
+**Files:**
+- Modify: `core/engine.go:1097-1105` — retry logic in `getOrCreateInteractiveStateWith`
+
+**Step 1: Write failing test**
+
+Add to `core/engine_test.go`:
+
+```go
+func TestResumeFailureFallsBackToFreshSession(t *testing.T) {
+	callCount := 0
+	agent := &stubAgent{
+		startSessionFunc: func(ctx context.Context, sessionID string) (core.AgentSession, error) {
+			callCount++
+			if sessionID != "" {
+				// Simulate resume failure
+				return nil, fmt.Errorf("Prompt is too long")
+			}
+			// Fresh session succeeds
+			return &stubAgentSession{alive: true}, nil
+		},
+	}
+
+	e := newTestEngine(t)
+	e.agent = agent
+
+	session := e.sessions.GetOrCreateActive("test:chan:user")
+	session.AgentSessionID = "old-session-id"
+
+	p := &stubPlatform{}
+	state := e.getOrCreateInteractiveState("test:chan:user", p, nil, session)
+
+	if state.agentSession == nil {
+		t.Fatal("expected agentSession to be non-nil after fallback")
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 StartSession calls (resume + fresh), got %d", callCount)
+	}
+	if session.AgentSessionID != "" {
+		t.Errorf("expected AgentSessionID cleared, got %q", session.AgentSessionID)
+	}
+}
+```
+
+Note: This test may need adjustment to match the actual test helpers in the codebase. Check `core/engine_test.go` for the existing `stubAgent` and `newTestEngine` patterns and adapt accordingly.
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./core/ -run TestResumeFailureFallsBackToFreshSession -v`
+Expected: FAIL — current code doesn't retry
+
+**Step 3: Implement retry logic**
+
+Replace the error handling block in `getOrCreateInteractiveStateWith` (lines 1100-1104):
+
+```go
+startAt := time.Now()
+agentSession, err := agent.StartSession(e.ctx, session.AgentSessionID)
+startElapsed := time.Since(startAt)
+if err != nil {
+	if session.AgentSessionID != "" {
+		// Resume failed — log diagnostics and retry with fresh session
+		slog.Error("session resume failed, falling back to fresh session",
+			"session_key", sessionKey,
+			"failed_session_id", session.AgentSessionID,
+			"error", err,
+			"elapsed", startElapsed,
+		)
+
+		// Clear the stale session ID
+		session.mu.Lock()
+		session.AgentSessionID = ""
+		session.mu.Unlock()
+
+		// Notify user
+		if p != nil {
+			go func() {
+				_ = p.Send(context.Background(), replyCtx,
+					"⚠️ Session context was too large to resume — starting fresh. Project context is preserved in CLAUDE.md.")
+			}()
+		}
+
+		// Retry with fresh session
+		freshStart := time.Now()
+		agentSession, err = agent.StartSession(e.ctx, "")
+		freshElapsed := time.Since(freshStart)
+		if err != nil {
+			slog.Error("fresh session also failed",
+				"session_key", sessionKey,
+				"error", err,
+				"elapsed", freshElapsed,
+			)
+			state = &interactiveState{platform: p, replyCtx: replyCtx, quiet: quietMode}
+			e.interactiveStates[sessionKey] = state
+			return state
+		}
+		slog.Info("fresh session started after resume failure",
+			"session_key", sessionKey,
+			"elapsed", freshElapsed,
+		)
+	} else {
+		slog.Error("failed to start interactive session",
+			"session_key", sessionKey,
+			"error", err,
+			"elapsed", startElapsed,
+		)
+		state = &interactiveState{platform: p, replyCtx: replyCtx, quiet: quietMode}
+		e.interactiveStates[sessionKey] = state
+		return state
+	}
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./core/ -run TestResumeFailureFallsBackToFreshSession -v`
+Expected: PASS
+
+**Step 5: Run full test suite**
+
+Run: `go test ./core/ ./agent/claudecode/ -v -count=1`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add core/engine.go core/engine_test.go
+git commit -m "feat: auto-recover from resume failure with fresh session and user notification"
+```
+
+---
+
+### Task 9: Final integration verification
+
+**Files:** None — verification only
+
+**Step 1: Run full test suite**
+
+Run: `go test ./... -count=1`
+Expected: PASS
+
+**Step 2: Verify build**
+
+Run: `go build ./...`
+Expected: no errors
+
+**Step 3: Review all changes**
+
+Run: `git log --oneline main..HEAD`
+
+Verify the commit sequence matches the plan:
+1. `normalizeWorkspacePath` helper
+2. Apply normalization at entry points
+3. Token usage fields + parsing
+4. Context indicator on messages
+5. System prompt self-report instruction
+6. Dual-track logging
+7. Diagnostic lifecycle logging
+8. Resume failure fallback
+
+**Step 4: Final commit (if any fixups needed)**
+
+```bash
+git add -A && git commit -m "fix: address issues found during integration verification"
+```

--- a/docs/plans/2026-03-13-session-resilience-plan.md.tasks.json
+++ b/docs/plans/2026-03-13-session-resilience-plan.md.tasks.json
@@ -1,0 +1,15 @@
+{
+  "planPath": "docs/plans/2026-03-13-session-resilience-plan.md",
+  "tasks": [
+    {"id": 7, "subject": "Task 1: Add normalizeWorkspacePath helper", "status": "pending"},
+    {"id": 8, "subject": "Task 2: Apply path normalization at entry points", "status": "pending", "blockedBy": [7]},
+    {"id": 9, "subject": "Task 3: Add token usage fields to Event and parse in session", "status": "pending"},
+    {"id": 10, "subject": "Task 4: Track context % on interactiveState and append to messages", "status": "pending", "blockedBy": [9]},
+    {"id": 11, "subject": "Task 5: Add system prompt instruction for self-reporting", "status": "pending"},
+    {"id": 12, "subject": "Task 6: Add dual-track context logging", "status": "pending", "blockedBy": [10, 11]},
+    {"id": 13, "subject": "Task 7: Add diagnostic logging to session lifecycle", "status": "pending"},
+    {"id": 14, "subject": "Task 8: Resume failure fallback with user notification", "status": "pending"},
+    {"id": 15, "subject": "Task 9: Final integration verification", "status": "pending", "blockedBy": [8, 12, 13, 14]}
+  ],
+  "lastUpdated": "2026-03-13T00:00:00Z"
+}

--- a/docs/slack-app-manifest.json
+++ b/docs/slack-app-manifest.json
@@ -1,0 +1,243 @@
+{
+  "_metadata": {
+    "major_version": 2,
+    "minor_version": 1
+  },
+  "display_information": {
+    "name": "CC-Connect",
+    "description": "Bridge between AI coding agents and Slack",
+    "background_color": "#1a1a2e"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "CC-Connect",
+      "always_online": true
+    },
+    "slash_commands": [
+      {
+        "command": "/btw",
+        "description": "Send additional context to agent while it's busy",
+        "usage_hint": "[message]",
+        "should_escape": false
+      },
+      {
+        "command": "/new",
+        "description": "Start a new session",
+        "usage_hint": "[name]",
+        "should_escape": false
+      },
+      {
+        "command": "/list",
+        "description": "List agent sessions",
+        "should_escape": false
+      },
+      {
+        "command": "/switch",
+        "description": "Resume a session by its list number",
+        "usage_hint": "<number>",
+        "should_escape": false
+      },
+      {
+        "command": "/delete",
+        "description": "Delete sessions by list number(s)",
+        "usage_hint": "<number>|1,2,3|3-7|1,3-5,8",
+        "should_escape": false
+      },
+      {
+        "command": "/name",
+        "description": "Name a session for easy identification",
+        "usage_hint": "[number] <text>",
+        "should_escape": false
+      },
+      {
+        "command": "/current",
+        "description": "Show current active session",
+        "should_escape": false
+      },
+      {
+        "command": "/search",
+        "description": "Search sessions by name or ID",
+        "usage_hint": "<keyword>",
+        "should_escape": false
+      },
+      {
+        "command": "/history",
+        "description": "Show last n messages",
+        "usage_hint": "[n]",
+        "should_escape": false
+      },
+      {
+        "command": "/model",
+        "description": "View or switch model",
+        "usage_hint": "[name]",
+        "should_escape": false
+      },
+      {
+        "command": "/mode",
+        "description": "View or switch permission mode",
+        "usage_hint": "[default|edit|plan|yolo]",
+        "should_escape": false
+      },
+      {
+        "command": "/stop",
+        "description": "Stop current execution",
+        "should_escape": false
+      },
+      {
+        "command": "/compress",
+        "description": "Compress conversation context",
+        "should_escape": false
+      },
+      {
+        "command": "/quiet",
+        "description": "Toggle thinking and tool progress display",
+        "usage_hint": "[global]",
+        "should_escape": false
+      },
+      {
+        "command": "/status",
+        "description": "Show system status",
+        "should_escape": false
+      },
+      {
+        "command": "/usage",
+        "description": "Show account and model quota usage",
+        "should_escape": false
+      },
+      {
+        "command": "/help",
+        "description": "Show available commands",
+        "should_escape": false
+      },
+      {
+        "command": "/version",
+        "description": "Show cc-connect version",
+        "should_escape": false
+      },
+      {
+        "command": "/shell",
+        "description": "Run a shell command and return the output",
+        "usage_hint": "<command>",
+        "should_escape": false
+      },
+      {
+        "command": "/provider",
+        "description": "Manage API providers",
+        "usage_hint": "[list|add|remove|switch|clear]",
+        "should_escape": false
+      },
+      {
+        "command": "/memory",
+        "description": "View or edit agent memory files",
+        "usage_hint": "[add|global|global add]",
+        "should_escape": false
+      },
+      {
+        "command": "/allow",
+        "description": "Pre-allow a tool for next session",
+        "usage_hint": "<tool>",
+        "should_escape": false
+      },
+      {
+        "command": "/lang",
+        "description": "View or switch language",
+        "usage_hint": "[en|zh|zh-TW|ja|es|auto]",
+        "should_escape": false
+      },
+      {
+        "command": "/cron",
+        "description": "Manage scheduled tasks",
+        "usage_hint": "[add|list|del|enable|disable]",
+        "should_escape": false
+      },
+      {
+        "command": "/commands",
+        "description": "Manage custom slash commands",
+        "usage_hint": "[add|del]",
+        "should_escape": false
+      },
+      {
+        "command": "/alias",
+        "description": "Manage command aliases",
+        "usage_hint": "[add|del]",
+        "should_escape": false
+      },
+      {
+        "command": "/skills",
+        "description": "List agent skills",
+        "should_escape": false
+      },
+      {
+        "command": "/config",
+        "description": "View or update runtime configuration",
+        "usage_hint": "[get|set|reload] [key] [value]",
+        "should_escape": false
+      },
+      {
+        "command": "/doctor",
+        "description": "Run system diagnostics",
+        "should_escape": false
+      },
+      {
+        "command": "/upgrade",
+        "description": "Check for updates and self-update",
+        "should_escape": false
+      },
+      {
+        "command": "/restart",
+        "description": "Restart cc-connect service",
+        "should_escape": false
+      },
+      {
+        "command": "/reasoning",
+        "description": "View or switch reasoning effort level",
+        "usage_hint": "[low|medium|high]",
+        "should_escape": false
+      },
+      {
+        "command": "/bind",
+        "description": "Manage bot-to-bot relay bindings",
+        "usage_hint": "[project|-project|remove]",
+        "should_escape": false
+      },
+      {
+        "command": "/workspace",
+        "description": "Manage workspaces",
+        "usage_hint": "[list|switch|add|remove]",
+        "should_escape": false
+      }
+    ]
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "channels:history",
+        "channels:read",
+        "chat:write",
+        "commands",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "im:read",
+        "im:write",
+        "reactions:write",
+        "users:read"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": [
+        "app_mention",
+        "message.im"
+      ]
+    },
+    "interactivity": {
+      "is_enabled": true
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": true,
+    "token_rotation_enabled": false
+  }
+}

--- a/docs/slack-feature-inventory.md
+++ b/docs/slack-feature-inventory.md
@@ -1,0 +1,78 @@
+# Slack Platform Feature Inventory
+
+## What Existed Before Our Work (on main)
+
+The Slack platform was added in commit `eaec71f` with basic functionality:
+
+- **Message handling**: Direct messages only (`*slackevents.MessageEvent`)
+- **File attachments**: Image and audio download via `downloadSlackFile()`
+- **Threading**: Reply contexts capture channel + timestamp for threaded replies
+- **Socket Mode**: Connection via `app_token` + `bot_token`
+- **Session keys**: Format `slack:channel:user`
+- **Methods**: `New()`, `Start()`, `Reply()`, `Send()`, `Stop()`, `ReconstructReplyCtx()`
+
+## What We Added (feat/multi-workspace branch)
+
+### 1. App Mention Support
+- Handle `@bot` mentions in channels (`AppMentionEvent`)
+- `stripAppMentionText()` helper to extract clean message text
+- Commits: `ef37f6f`, `abc46cf`, `33cf135`
+
+### 2. Slash Command Support
+- Handle `socketmode.EventTypeSlashCommand` events
+- Converts Slack `/command` to engine command format
+- Enables native `/btw`, `/new`, `/stop`, etc. from Slack
+- Commits: `81c6aec`, `2bd8518`
+
+### 3. Multi-Workspace / Shared Sessions
+- `share_session_in_channel` config option
+- Session key can be channel-only (`slack:channel`) or user-scoped (`slack:channel:user`)
+- `ResolveChannelName()` via `ChannelNameResolver` interface
+- Channel name caching with `sync.RWMutex`
+- Commits: `647398f`, `62def03`
+
+### 4. Typing Indicator (Emoji Reactions)
+- `StartTyping()` adds progressive emoji reactions to user's message
+- Timeline: immediately eyes, after 2min clock, then every 5min random emoji
+- All reactions cleaned up when agent completes
+- Commit: `231883c`
+
+### 5. Security
+- `allow_from` config option with `core.CheckAllowFrom()` validation
+- Token redaction in error messages
+- Old message filtering via `core.IsOldMessage()`
+- Commits: `ae13e23`, `90f0e22`
+
+### 6. Slack mrkdwn Formatting
+- System prompt instructs agent to use Slack's mrkdwn format (not standard Markdown)
+- `*bold*` instead of `**bold**`, no `## headings`, etc.
+- Commit: `b4a1144`
+
+## Uncommitted Work (stashed)
+
+### Context % Fix
+- SDK reports garbage `input_tokens` (single digits like 3, 22)
+- When SDK tokens < 100, falls back to agent's self-reported `[ctx: ~XX%]`
+- Previously: self-reported value was always stripped and replaced with broken SDK value
+
+### --continue on First Connection (hasConnectedOnce)
+- On first session creation after engine startup, always uses `--continue`
+- Picks up most recent CLI session regardless of what's stored in session manager
+- Bridges direct CLI usage and cc-connect sessions
+- `hasConnectedOnce` atomic.Bool prevents subsequent connections from using --continue
+
+## Current Configuration Options
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `bot_token` | Yes | Slack bot OAuth token |
+| `app_token` | Yes | Slack app-level token for Socket Mode |
+| `allow_from` | No | User allowlist |
+| `share_session_in_channel` | No | Share session across all users in channel |
+
+## Architecture Compliance
+
+All Slack-specific code lives in `platform/slack/`. Core uses interface-based capability checks:
+- `ChannelNameResolver` for channel name lookup
+- `StartTyping()` via `TypingIndicator` interface (if implemented)
+- No hardcoded "slack" references in core/


### PR DESCRIPTION
## Summary

- Design and planning documents for multi-workspace support and session resilience features
- Slack app manifest JSON for registering slash commands via Socket Mode
- Slack feature inventory documenting what existed vs what we added

This is **part of breaking up the large `feat/multi-workspace` PR** into smaller, focused PRs as discussed. This first PR covers documentation only (no code changes) to get the planning artifacts checked in.

## Files

| File | Description |
|------|-------------|
| `docs/plans/2026-03-12-multi-workspace-design.md` | Multi-workspace architecture design |
| `docs/plans/2026-03-12-multi-workspace-plan.md` | Multi-workspace implementation plan |
| `docs/plans/2026-03-13-session-resilience-design.md` | Session resilience design |
| `docs/plans/2026-03-13-session-resilience-plan.md` | Session resilience implementation plan |
| `docs/slack-app-manifest.json` | Slack app manifest for slash command registration |
| `docs/slack-feature-inventory.md` | Inventory of Slack platform features (existing vs new) |

## Test plan

- [x] No code changes — docs only, nothing to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)