### PR TITLE
feat: /btw command and Slack slash command handler

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -908,6 +908,25 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 
 	session := sessions.GetOrCreateActive(msg.SessionKey)
 	if !session.TryLock() {
+		// Check for /btw — inject into the running session mid-turn
+		trimmed := strings.TrimSpace(content)
+		if isBtwCommand(trimmed) {
+			btw := strings.TrimSpace(trimmed[len(matchBtwPrefix(trimmed)):])
+			if btw != "" {
+				e.interactiveMu.Lock()
+				state, ok := e.interactiveStates[msg.SessionKey]
+				e.interactiveMu.Unlock()
+				if ok && state.agentSession != nil && state.agentSession.Alive() {
+					if err := state.agentSession.Send(btw, nil, nil); err != nil {
+						slog.Error("btw: send failed", "error", err)
+						e.reply(p, msg.ReplyCtx, "Failed to send btw message.")
+					} else {
+						e.reply(p, msg.ReplyCtx, "btw sent")
+					}
+					return
+				}
+			}
+		}
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
 		return
 	}
@@ -1871,6 +1890,26 @@ var builtinCommands = []struct {
 	{[]string{"shell", "sh", "exec", "run"}, "shell"},
 	{[]string{"tts"}, "tts"},
 	{[]string{"workspace", "ws"}, "workspace"},
+}
+
+// isBtwCommand checks if a trimmed message starts with a /btw command.
+func isBtwCommand(trimmed string) bool {
+	return matchBtwPrefix(trimmed) != ""
+}
+
+// matchBtwPrefix returns the prefix portion (e.g. "/btw ") if the
+// message starts with a btw command, or "" if it doesn't match.
+func matchBtwPrefix(trimmed string) string {
+	lower := strings.ToLower(trimmed)
+	for _, prefix := range []string{"/btw"} {
+		if strings.HasPrefix(lower, prefix) {
+			rest := trimmed[len(prefix):]
+			if rest == "" || rest[0] == ' ' {
+				return trimmed[:len(prefix)]
+			}
+		}
+	}
+	return ""
 }
 
 // matchPrefix finds a unique command matching the given prefix.

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -501,11 +501,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "No hay ejecución en progreso.",
 	},
 	MsgPreviousProcessing: {
-		LangEnglish:            "⏳ Previous request still processing, please wait...",
-		LangChinese:            "⏳ 上一个请求仍在处理中，请稍候...",
-		LangTraditionalChinese: "⏳ 上一個請求仍在處理中，請稍候...",
-		LangJapanese:           "⏳ 前のリクエストを処理中です。お待ちください...",
-		LangSpanish:            "⏳ La solicitud anterior aún se está procesando, por favor espere...",
+		LangEnglish:            "⏳ Previous request still processing. Use `/btw <message>` to add context to the current turn.",
+		LangChinese:            "⏳ 上一个请求仍在处理中。使用 `/btw <消息>` 可向当前轮次追加上下文。",
+		LangTraditionalChinese: "⏳ 上一個請求仍在處理中。使用 `/btw <訊息>` 可向當前輪次追加上下文。",
+		LangJapanese:           "⏳ 前のリクエストを処理中です。`/btw <メッセージ>` で現在のターンにコンテキストを追加できます。",
+		LangSpanish:            "⏳ La solicitud anterior aún se está procesando. Use `/btw <mensaje>` para agregar contexto al turno actual.",
 	},
 	MsgNoToolsAllowed: {
 		LangEnglish:            "No tools pre-allowed.\nUsage: `/allow <tool_name>`\nExample: `/allow Bash`",

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -224,6 +224,45 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 			}
 		}
 
+	case socketmode.EventTypeSlashCommand:
+		cmd, ok := evt.Data.(slack.SlashCommand)
+		if !ok {
+			slog.Debug("slack: slash command type assertion failed")
+			return
+		}
+		if evt.Request != nil {
+			p.socket.Ack(*evt.Request)
+		}
+
+		if !core.AllowList(p.allowFrom, cmd.UserID) {
+			slog.Debug("slack: slash command from unauthorized user", "user", cmd.UserID)
+			return
+		}
+
+		// Convert slash command to a regular message with / prefix so the
+		// engine's command handling picks it up.
+		cmdName := strings.TrimPrefix(cmd.Command, "/")
+		content := "/" + cmdName
+		if cmd.Text != "" {
+			content += " " + cmd.Text
+		}
+
+		var sessionKey string
+		if p.shareSessionInChannel {
+			sessionKey = fmt.Sprintf("slack:%s", cmd.ChannelID)
+		} else {
+			sessionKey = fmt.Sprintf("slack:%s:%s", cmd.ChannelID, cmd.UserID)
+		}
+
+		msg := &core.Message{
+			SessionKey: sessionKey, Platform: "slack",
+			UserID: cmd.UserID, UserName: cmd.UserName,
+			Content:  content,
+			ReplyCtx: replyContext{channel: cmd.ChannelID},
+		}
+		slog.Debug("slack: slash command", "command", cmd.Command, "text", cmd.Text, "user", cmd.UserID)
+		p.handler(p, msg)
+
 	case socketmode.EventTypeConnecting:
 		slog.Debug("slack: connecting...")
 	case socketmode.EventTypeConnected:


### PR DESCRIPTION
## Summary

- **`/btw` command**: When the agent is busy processing, users can send `/btw <message>` to inject additional context into the running session mid-turn, instead of getting the "still processing" rejection
- **Updated busy message**: Now tells users about `/btw` in all 5 languages
- **Slack slash command handler**: Handles `socketmode.EventTypeSlashCommand` events so native Slack slash commands (e.g. `/btw`) work without text prefixes

This is **part of breaking up the large `feat/multi-workspace` PR** into smaller, focused PRs. This PR is ~88 LOC.

## Changes

| File | What |
|------|------|
| `core/engine.go` | `isBtwCommand()`/`matchBtwPrefix()` helpers, btw injection at TryLock point |
| `core/i18n.go` | Updated `MsgPreviousProcessing` strings to mention `/btw` (all 5 languages) |
| `platform/slack/slack.go` | `EventTypeSlashCommand` handler with allowlist and session key support |

## Test plan

- [x] Full test suite passes (`go test ./...`)
- [x] Manual: send `/btw additional context` while agent is processing — should inject and reply "btw sent"
- [x] Manual: Slack `/btw` slash command triggers the handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)