### PR TITLE
feat: workspace path normalization to prevent pool key mismatches

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1282,6 +1282,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 }
 
 // getOrCreateWorkspaceAgent returns (or creates) a per-workspace agent and session manager.
+// workspace must be a normalized path (from resolveWorkspace or normalizeWorkspacePath).
 func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionManager, error) {
 	ws := e.workspacePool.GetOrCreate(workspace)
 	ws.mu.Lock()
@@ -2070,7 +2071,7 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 		if resolver, ok := p.(ChannelNameResolver); ok {
 			channelName, _ = resolver.ResolveChannelName(channelID)
 		}
-		e.workspaceBindings.Bind(projectKey, channelID, channelName, wsPath)
+		e.workspaceBindings.Bind(projectKey, channelID, channelName, normalizeWorkspacePath(wsPath))
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsBindSuccess, wsName))
 
 	case "init":
@@ -2092,7 +2093,7 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 			if resolver, ok := p.(ChannelNameResolver); ok {
 				channelName, _ = resolver.ResolveChannelName(channelID)
 			}
-			e.workspaceBindings.Bind(projectKey, channelID, channelName, cloneTo)
+			e.workspaceBindings.Bind(projectKey, channelID, channelName, normalizeWorkspacePath(cloneTo))
 			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsCloneSuccess, cloneTo))
 			return
 		}
@@ -2108,7 +2109,7 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 		if resolver, ok := p.(ChannelNameResolver); ok {
 			channelName, _ = resolver.ResolveChannelName(channelID)
 		}
-		e.workspaceBindings.Bind(projectKey, channelID, channelName, cloneTo)
+		e.workspaceBindings.Bind(projectKey, channelID, channelName, normalizeWorkspacePath(cloneTo))
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsCloneSuccess, cloneTo))
 
 	case "unbind":
@@ -7366,7 +7367,7 @@ func (e *Engine) resolveWorkspace(p Platform, channelID string) (string, string,
 			e.workspaceBindings.Unbind(projectKey, channelID)
 			return "", b.ChannelName, nil
 		}
-		return b.Workspace, b.ChannelName, nil
+		return normalizeWorkspacePath(b.Workspace), b.ChannelName, nil
 	}
 
 	// Step 2: Resolve channel name for convention match
@@ -7388,10 +7389,11 @@ func (e *Engine) resolveWorkspace(p Platform, channelID string) (string, string,
 	candidate := filepath.Join(e.baseDir, channelName)
 	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
 		// Auto-bind
-		e.workspaceBindings.Bind(projectKey, channelID, channelName, candidate)
+		normalized := normalizeWorkspacePath(candidate)
+		e.workspaceBindings.Bind(projectKey, channelID, channelName, normalized)
 		slog.Info("workspace auto-bound by convention",
-			"channel", channelName, "workspace", candidate)
-		return candidate, channelName, nil
+			"channel", channelName, "workspace", normalized)
+		return normalized, channelName, nil
 	}
 
 	return "", channelName, nil
@@ -7460,7 +7462,7 @@ func (e *Engine) handleWorkspaceInitFlow(p Platform, msg *Message, channelID, ch
 		}
 
 		projectKey := "project:" + e.name
-		e.workspaceBindings.Bind(projectKey, channelID, flow.channelName, flow.cloneTo)
+		e.workspaceBindings.Bind(projectKey, channelID, flow.channelName, normalizeWorkspacePath(flow.cloneTo))
 
 		e.initFlowsMu.Lock()
 		delete(e.initFlows, channelID)

--- a/core/workspace_state.go
+++ b/core/workspace_state.go
@@ -1,9 +1,27 @@
 package core
 
 import (
+	"log/slog"
+	"path/filepath"
 	"sync"
 	"time"
 )
+
+// normalizeWorkspacePath cleans and resolves a workspace path to prevent
+// mismatches caused by trailing slashes, symlinks, or relative segments.
+// If the path cannot be resolved (e.g. doesn't exist yet), falls back to
+// filepath.Clean only.
+func normalizeWorkspacePath(path string) string {
+	cleaned := filepath.Clean(path)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return cleaned
+	}
+	if resolved != path {
+		slog.Debug("workspace path normalized", "original", path, "normalized", resolved)
+	}
+	return resolved
+}
 
 // workspaceState holds the runtime state for a single workspace.
 type workspaceState struct {
@@ -47,12 +65,16 @@ func newWorkspacePool(idleTimeout time.Duration) *workspacePool {
 	}
 }
 
+// Get returns the state for a workspace. Callers must pass a normalized path
+// (use normalizeWorkspacePath or resolveWorkspace which normalizes on return).
 func (p *workspacePool) Get(workspace string) *workspaceState {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.states[workspace]
 }
 
+// GetOrCreate returns or creates state for a workspace. Callers must pass a
+// normalized path (see Get).
 func (p *workspacePool) GetOrCreate(workspace string) *workspaceState {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/core/workspace_state_test.go
+++ b/core/workspace_state_test.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -47,6 +49,57 @@ func TestWorkspacePool_ReapIdle(t *testing.T) {
 
 	if s := pool.Get("/workspace/a"); s != nil {
 		t.Error("expected workspace removed after reap")
+	}
+}
+
+func TestNormalizeWorkspacePath(t *testing.T) {
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "real-project")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(tmp, "link-project")
+	if err := os.Symlink(realDir, symlink); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"trailing slash", realDir + "/", realDir},
+		{"double slash", filepath.Join(tmp, "real-project") + "//", realDir},
+		{"dot segment", filepath.Join(tmp, ".", "real-project"), realDir},
+		{"dotdot segment", filepath.Join(tmp, "real-project", "subdir", ".."), realDir},
+		{"symlink resolved", symlink, realDir},
+		{"nonexistent uses Clean only", "/nonexistent/path/./foo/../bar", "/nonexistent/path/bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeWorkspacePath(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeWorkspacePath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeBeforePoolProducesSameKey(t *testing.T) {
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "project")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pool := newWorkspacePool(15 * time.Minute)
+
+	// Callers normalize before pool access (as resolveWorkspace does)
+	ws1 := pool.GetOrCreate(normalizeWorkspacePath(realDir + "/"))
+	ws2 := pool.GetOrCreate(normalizeWorkspacePath(realDir))
+
+	if ws1 != ws2 {
+		t.Error("normalized trailing slash produced a different workspace state")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **`normalizeWorkspacePath()`**: Cleans and resolves workspace paths (trailing slashes, symlinks, relative segments) to prevent duplicate pool entries for the same workspace directory
- **Bind call-site fixes**: All `workspaceBindings.Bind()` calls now normalize paths before storing, preventing mismatches between `/path/to/project/` and `/path/to/project`
- **Doc comments**: Annotated pool methods that require normalized paths

This is **part of breaking up the large `feat/multi-workspace` PR** into smaller, focused PRs. This PR is ~93 LOC.

## Changes

| File | What |
|------|------|
| `core/workspace_state.go` | `normalizeWorkspacePath()` helper + doc comments on `Get`/`GetOrCreate` |
| `core/workspace_state_test.go` | Tests for symlinks, trailing slashes, dot segments, pool key consistency |
| `core/engine.go` | Normalize at all 6 Bind/resolve call sites |

## Test plan

- [x] `TestNormalizeWorkspacePath` — symlinks, trailing slashes, dot segments, nonexistent paths
- [x] `TestNormalizeBeforePoolProducesSameKey` — verifies pool key consistency
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)