### PR TITLE
feat(agent/pi): implement session management and additional interfaces

### DIFF
--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -1,12 +1,15 @@
 package pi
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -23,6 +26,7 @@ type Agent struct {
 	workDir    string
 	model      string
 	mode       string // "default" | "yolo"
+	thinking   string // reasoning effort: off, minimal, low, medium, high, xhigh
 	sessionEnv []string
 	mu         sync.Mutex
 }
@@ -96,11 +100,67 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	extraEnv := append([]string{}, a.sessionEnv...)
 	a.mu.Unlock()
 
-	return newPiSession(ctx, a.cmd, a.workDir, model, mode, sessionID, extraEnv)
+	thinking := a.thinking
+	return newPiSession(ctx, a.cmd, a.workDir, model, mode, thinking, sessionID, extraEnv)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
-	return nil, nil
+	sessDir := piSessionDir(a.workDir)
+	if sessDir == "" {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(sessDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("pi: read session dir: %w", err)
+	}
+
+	var sessions []core.AgentSessionInfo
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		sessionID, summary, msgCount := scanPiSession(filepath.Join(sessDir, name))
+		if sessionID == "" {
+			continue
+		}
+
+		sessions = append(sessions, core.AgentSessionInfo{
+			ID:           sessionID,
+			Summary:      summary,
+			MessageCount: msgCount,
+			ModifiedAt:   info.ModTime(),
+		})
+	}
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].ModifiedAt.After(sessions[j].ModifiedAt)
+	})
+
+	return sessions, nil
+}
+
+func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
+	sessDir := piSessionDir(a.workDir)
+	if sessDir == "" {
+		return fmt.Errorf("pi: cannot determine session directory")
+	}
+
+	path := findSessionFile(sessDir, sessionID)
+	if path == "" {
+		return fmt.Errorf("pi: session %q not found", sessionID)
+	}
+	return os.Remove(path)
 }
 
 func (a *Agent) Stop() error { return nil }
@@ -143,4 +203,210 @@ func (a *Agent) GlobalMemoryFile() string {
 		return ""
 	}
 	return filepath.Join(homeDir, ".pi", "AGENTS.md")
+}
+
+// ── ReasoningEffortSwitcher ──────────────────────────────────
+
+func (a *Agent) SetReasoningEffort(effort string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.thinking = effort
+	slog.Info("pi: thinking level changed", "level", effort)
+}
+
+func (a *Agent) GetReasoningEffort() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.thinking
+}
+
+func (a *Agent) AvailableReasoningEfforts() []string {
+	return []string{"off", "minimal", "low", "medium", "high", "xhigh"}
+}
+
+// ── GetWorkDir (for /status display) ─────────────────────────
+
+func (a *Agent) GetWorkDir() string { return a.workDir }
+
+// ── HistoryProvider ──────────────────────────────────────────
+
+func (a *Agent) GetSessionHistory(_ context.Context, sessionID string, limit int) ([]core.HistoryEntry, error) {
+	sessDir := piSessionDir(a.workDir)
+	if sessDir == "" {
+		return nil, nil
+	}
+
+	sessFile := findSessionFile(sessDir, sessionID)
+	if sessFile == "" {
+		return nil, nil
+	}
+
+	return readPiHistory(sessFile, limit)
+}
+
+// ── SkillProvider ────────────────────────────────────────────
+
+func (a *Agent) SkillDirs() []string {
+	absDir, err := filepath.Abs(a.workDir)
+	if err != nil {
+		absDir = a.workDir
+	}
+	dirs := []string{filepath.Join(absDir, ".pi", "skills")}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".pi", "skills"))
+	}
+	return dirs
+}
+
+// ── Session helpers ──────────────────────────────────────────
+
+// findSessionFile locates the .jsonl file for a given session UUID in sessDir.
+// Session files are named: <timestamp>_<uuid>.jsonl — this function extracts
+// the UUID portion and matches exactly to avoid partial-match vulnerabilities.
+func findSessionFile(sessDir, sessionID string) string {
+	entries, err := os.ReadDir(sessDir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		// Extract UUID: strip .jsonl, then take everything after the last "_".
+		base := strings.TrimSuffix(name, ".jsonl")
+		if idx := strings.LastIndex(base, "_"); idx >= 0 {
+			if base[idx+1:] == sessionID {
+				return filepath.Join(sessDir, name)
+			}
+		}
+	}
+	return ""
+}
+
+// piSessionDir returns the pi session directory for the given workDir.
+// Pi encodes the absolute path as: replace "/" with "-", wrap with "--".
+// e.g. /home/user/project → --home-user-project--
+func piSessionDir(workDir string) string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	absDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return ""
+	}
+	encoded := "--" + strings.ReplaceAll(strings.TrimPrefix(absDir, "/"), "/", "-") + "--"
+	return filepath.Join(homeDir, ".pi", "agent", "sessions", encoded)
+}
+
+// scanPiSession reads a pi session .jsonl file and extracts the session ID,
+// a summary (first user message), and a message count.
+func scanPiSession(path string) (sessionID, summary string, msgCount int) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", "", 0
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1*1024*1024)
+
+	for scanner.Scan() {
+		var entry map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		switch entry["type"] {
+		case "session":
+			if id, ok := entry["id"].(string); ok {
+				sessionID = id
+			}
+		case "message":
+			msg, _ := entry["message"].(map[string]any)
+			if msg == nil {
+				continue
+			}
+			role, _ := msg["role"].(string)
+			if role == "user" || role == "assistant" {
+				msgCount++
+			}
+			// Use first user message as summary.
+			if role == "user" && summary == "" {
+				content, _ := msg["content"].([]any)
+				for _, c := range content {
+					item, _ := c.(map[string]any)
+					if item != nil {
+						if text, ok := item["text"].(string); ok && text != "" {
+							summary = text
+							runes := []rune(summary)
+							if len(runes) > 80 {
+								summary = string(runes[:80]) + "..."
+							}
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		slog.Warn("pi: scan session error", "path", path, "error", err)
+	}
+	return
+}
+
+// readPiHistory reads user/assistant messages from a pi session file.
+func readPiHistory(path string, limit int) ([]core.HistoryEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1*1024*1024)
+
+	var all []core.HistoryEntry
+	for scanner.Scan() {
+		var entry map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry["type"] != "message" {
+			continue
+		}
+		msg, _ := entry["message"].(map[string]any)
+		if msg == nil {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if role != "user" && role != "assistant" {
+			continue
+		}
+
+		var text string
+		content, _ := msg["content"].([]any)
+		for _, c := range content {
+			item, _ := c.(map[string]any)
+			if item != nil {
+				if t, ok := item["text"].(string); ok && t != "" {
+					text = t
+					break
+				}
+			}
+		}
+		if text == "" {
+			continue
+		}
+		all = append(all, core.HistoryEntry{Role: role, Content: text})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("pi: read history: %w", err)
+	}
+
+	if limit > 0 && len(all) > limit {
+		all = all[len(all)-limit:]
+	}
+	return all, nil
 }

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -903,7 +903,7 @@ func TestHandleMessageEnd_UserRole(t *testing.T) {
 // ── piSession lifecycle ──────────────────────────────────────
 
 func TestPiSession_NewWithResumeID(t *testing.T) {
-	s, err := newPiSession(context.Background(), "echo", "/tmp", "model", "default", "resume-id", nil)
+	s, err := newPiSession(context.Background(), "echo", "/tmp", "model", "default", "", "resume-id", nil)
 	if err != nil {
 		t.Fatalf("newPiSession: %v", err)
 	}
@@ -915,7 +915,7 @@ func TestPiSession_NewWithResumeID(t *testing.T) {
 }
 
 func TestPiSession_NewWithoutResumeID(t *testing.T) {
-	s, err := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", nil)
+	s, err := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", "", nil)
 	if err != nil {
 		t.Fatalf("newPiSession: %v", err)
 	}
@@ -927,7 +927,7 @@ func TestPiSession_NewWithoutResumeID(t *testing.T) {
 }
 
 func TestPiSession_SendWhenClosed(t *testing.T) {
-	s, _ := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", nil)
+	s, _ := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", "", nil)
 	s.Close()
 
 	err := s.Send("hello", nil, nil)
@@ -956,7 +956,7 @@ func TestPiSession_Events(t *testing.T) {
 }
 
 func TestPiSession_Close(t *testing.T) {
-	s, _ := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", nil)
+	s, _ := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", "", nil)
 
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
@@ -1064,7 +1064,7 @@ func TestPiSession_ReadLoopWithEcho(t *testing.T) {
 	line1, _ := json.Marshal(sessionEvent)
 	line2, _ := json.Marshal(textEvent)
 
-	s, err := newPiSession(context.Background(), "sh", "/tmp", "", "default", "", nil)
+	s, err := newPiSession(context.Background(), "sh", "/tmp", "", "default", "", "", nil)
 	if err != nil {
 		t.Fatalf("newPiSession: %v", err)
 	}

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -28,6 +28,7 @@ type piSession struct {
 	workDir   string
 	model     string
 	mode      string
+	thinking  string // reasoning effort level for --thinking flag
 	extraEnv  []string
 	events    chan core.Event
 	sessionID atomic.Value // stores string
@@ -39,7 +40,7 @@ type piSession struct {
 	thinkingBuf strings.Builder // accumulates thinking_delta chunks
 }
 
-func newPiSession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string) (*piSession, error) {
+func newPiSession(ctx context.Context, cmd, workDir, model, mode, thinking, resumeID string, extraEnv []string) (*piSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	s := &piSession{
@@ -47,6 +48,7 @@ func newPiSession(ctx context.Context, cmd, workDir, model, mode, resumeID strin
 		workDir:  workDir,
 		model:    model,
 		mode:     mode,
+		thinking: thinking,
 		extraEnv: extraEnv,
 		events:   make(chan core.Event, 64),
 		ctx:      sessionCtx,
@@ -90,6 +92,10 @@ func (s *piSession) Send(prompt string, images []core.ImageAttachment, files []c
 
 	if s.mode == "yolo" {
 		args = append(args, "--auto-approve")
+	}
+
+	if s.thinking != "" {
+		args = append(args, "--thinking", s.thinking)
 	}
 
 	// Pass attachments as @file arguments


### PR DESCRIPTION
## Summary

- Implement `ListSessions` / `SessionDeleter`: read and delete pi session `.jsonl` files, enabling `/list` and `/delete` commands
- Implement `HistoryProvider`: read conversation history from pi session files, enabling `/history` command
- Implement `ReasoningEffortSwitcher`: map to pi's `--thinking` flag with levels off/minimal/low/medium/high/xhigh, enabling `/reasoning` command
- Implement `SkillProvider`: expose `.pi/skills/` directories, enabling `/skills` command
- Implement `GetWorkDir`: expose work directory for `/status` display

Session file discovery uses pi's path encoding convention where absolute paths are encoded as `--path-segments--` directory names under `~/.pi/agent/sessions/`.

## Related

- #145 — Pi session corrupted by large file embeds — no way to recover without /new

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./agent/pi/ -count=1` passes
- [x] Manual test: pi agent works end-to-end via Discord with text, images, tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)