### PR TITLE
fix: use interactiveKey in delete mode functions for multi-workspace mode

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -4760,11 +4760,12 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 }
 
 func (e *Engine) getOrCreateDeleteModeState(sessionKey string, p Platform, replyCtx any) *deleteModeState {
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 	e.interactiveMu.Lock()
-	state, ok := e.interactiveStates[sessionKey]
+	state, ok := e.interactiveStates[interactiveKey]
 	if !ok || state == nil {
 		state = &interactiveState{platform: p, replyCtx: replyCtx}
-		e.interactiveStates[sessionKey] = state
+		e.interactiveStates[interactiveKey] = state
 	} else {
 		state.platform = p
 		state.replyCtx = replyCtx
@@ -4786,8 +4787,9 @@ func (e *Engine) getOrCreateDeleteModeState(sessionKey string, p Platform, reply
 }
 
 func (e *Engine) getDeleteModeState(sessionKey string) *deleteModeState {
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 	e.interactiveMu.Lock()
-	state := e.interactiveStates[sessionKey]
+	state := e.interactiveStates[interactiveKey]
 	e.interactiveMu.Unlock()
 	if state == nil {
 		return nil
@@ -4811,8 +4813,9 @@ func (e *Engine) getDeleteModeState(sessionKey string) *deleteModeState {
 }
 
 func (e *Engine) clearDeleteModeState(sessionKey string) {
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 	e.interactiveMu.Lock()
-	state := e.interactiveStates[sessionKey]
+	state := e.interactiveStates[interactiveKey]
 	e.interactiveMu.Unlock()
 	if state == nil {
 		return
@@ -4953,8 +4956,9 @@ func (e *Engine) deleteModeSelectionNames(sessions *SessionManager, dm *deleteMo
 }
 
 func (e *Engine) executeDeleteModeAction(sessionKey, args string) {
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 	e.interactiveMu.Lock()
-	state := e.interactiveStates[sessionKey]
+	state := e.interactiveStates[interactiveKey]
 	e.interactiveMu.Unlock()
 	if state == nil {
 		return


### PR DESCRIPTION
## Summary

- In multi-workspace mode, interactive states are stored under a workspace-prefixed key (`interactiveKey`), not the raw `sessionKey`. The delete mode functions (`getOrCreateDeleteModeState`, `getDeleteModeState`, `clearDeleteModeState`, `executeDeleteModeAction`) were using `sessionKey` directly to access `interactiveStates`, causing delete mode to silently fail in multi-workspace mode.
- Fix by resolving `sessionKey` → `interactiveKey` via `interactiveKeyForSessionKey()` before accessing `interactiveStates`, consistent with how all other interactive state functions work.
- This is the same class of bug fixed in #141 for `executeCardAction`, but affecting the delete mode code path which was missed.

## Test plan

- [ ] Verify `go test ./...` passes
- [ ] Test `/delete` command in multi-workspace mode to confirm delete mode card renders correctly
- [ ] Test session selection/deselection and deletion work in multi-workspace mode
- [ ] Verify single-workspace mode is unaffected (interactiveKey == sessionKey in that case)