### PR TITLE
fix(core): prevent infinite loop in drainEvents on closed channel

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -4406,7 +4406,11 @@ func drainEvents(ch <-chan Event) {
 	drained := 0
 	for {
 		select {
-		case <-ch:
+		case _, ok := <-ch:
+			if !ok {
+				// Channel is closed; stop immediately to avoid an infinite loop.
+				return
+			}
 			drained++
 		default:
 			if drained > 0 {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2726,3 +2726,49 @@ func TestCmdBindSetup_UsesSharedLogic(t *testing.T) {
 		t.Error("expected instructions written to file")
 	}
 }
+
+func TestDrainEventsClosedChannel(t *testing.T) {
+	ch := make(chan Event, 2)
+	ch <- Event{Type: EventToolUse, Content: "a"}
+	ch <- Event{Type: EventToolUse, Content: "b"}
+	close(ch)
+
+	done := make(chan struct{})
+	go func() {
+		drainEvents(ch)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok — returned promptly
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainEvents did not return on closed channel (infinite loop)")
+	}
+}
+
+func TestDrainEventsOpenChannel(t *testing.T) {
+	ch := make(chan Event, 3)
+	ch <- Event{Type: EventToolUse, Content: "a"}
+	ch <- Event{Type: EventToolUse, Content: "b"}
+
+	done := make(chan struct{})
+	go func() {
+		drainEvents(ch)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainEvents did not return on open channel with buffered events")
+	}
+
+	// Channel should now be empty.
+	select {
+	case <-ch:
+		t.Fatal("expected channel to be drained")
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

- `drainEvents()` uses a `select` with a `default` case to drain buffered events from a channel. When the channel is closed, receives always succeed immediately (returning the zero value), so the `default` branch never executes and the function spins in an infinite CPU loop.
- Fix: check the `ok` value from the channel receive and return immediately when the channel is closed.
- Add regression tests for both closed-channel and open-channel scenarios.

## Root cause

A closed Go channel is always ready for receive, returning the zero value. The existing code assumed that an empty channel would fall through to `default`, but a **closed** channel never does — it just keeps yielding zero values forever.

`drainEvents` is called at two points in `engine.go` (lines 1245, 3845) before sending new prompts or compress commands to an agent session. If the agent session's event channel was already closed (e.g., the agent process exited), this would lock up the engine goroutine.

## Test plan

- [x] `TestDrainEventsClosedChannel` — verifies the function returns promptly on a closed channel
- [x] `TestDrainEventsOpenChannel` — verifies normal drain behavior still works
- [x] Full `go test ./core/` passes