### PR TITLE
feat: add image sending support via send --image

### DIFF
--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -14,7 +14,7 @@ import (
 )
 
 func runSend(args []string) {
-	var project, sessionKey, dataDir, message string
+	var project, sessionKey, dataDir, message, imagePath string
 	var useStdin bool
 
 	var positional []string
@@ -34,6 +34,11 @@ func runSend(args []string) {
 			if i+1 < len(args) {
 				i++
 				message = args[i]
+			}
+		case "--image":
+			if i+1 < len(args) {
+				i++
+				imagePath = args[i]
 			}
 		case "--stdin":
 			useStdin = true
@@ -61,8 +66,23 @@ func runSend(args []string) {
 	if message == "" {
 		message = strings.Join(positional, " ")
 	}
-	if message == "" {
-		fmt.Fprintln(os.Stderr, "Error: message is required")
+
+	// Resolve image path to absolute.
+	if imagePath != "" {
+		abs, err := filepath.Abs(imagePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid image path: %v\n", err)
+			os.Exit(1)
+		}
+		if _, err := os.Stat(abs); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Error: image file not found: %s\n", abs)
+			os.Exit(1)
+		}
+		imagePath = abs
+	}
+
+	if message == "" && imagePath == "" {
+		fmt.Fprintln(os.Stderr, "Error: message or --image is required")
 		printSendUsage()
 		os.Exit(1)
 	}
@@ -73,11 +93,17 @@ func runSend(args []string) {
 		os.Exit(1)
 	}
 
-	payload, _ := json.Marshal(map[string]string{
+	reqBody := map[string]string{
 		"project":     project,
 		"session_key": sessionKey,
-		"message":     message,
-	})
+	}
+	if message != "" {
+		reqBody["message"] = message
+	}
+	if imagePath != "" {
+		reqBody["image_path"] = imagePath
+	}
+	payload, _ := json.Marshal(reqBody)
 
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -100,7 +126,13 @@ func runSend(args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Println("Message sent successfully.")
+	if imagePath != "" && message != "" {
+		fmt.Println("Image and message sent successfully.")
+	} else if imagePath != "" {
+		fmt.Println("Image sent successfully.")
+	} else {
+		fmt.Println("Message sent successfully.")
+	}
 }
 
 func resolveSocketPath(dataDir string) string {
@@ -116,13 +148,15 @@ func resolveSocketPath(dataDir string) string {
 func printSendUsage() {
 	fmt.Println(`Usage: cc-connect send [options] <message>
        cc-connect send [options] -m <message>
+       cc-connect send [options] --image <path>
        cc-connect send [options] --stdin < file
        echo "msg" | cc-connect send [options] --stdin
 
-Send a message to an active cc-connect session.
+Send a message or image to an active cc-connect session.
 
 Options:
   -m, --message <text>     Message to send (preferred over positional args)
+      --image <path>       Send a local image file (platform must support images)
       --stdin              Read message from stdin (best for long/special-char messages)
   -p, --project <name>     Target project (optional if only one project)
   -s, --session <key>      Target session key (optional, picks first active)
@@ -132,6 +166,8 @@ Options:
 Examples:
   cc-connect send "Daily summary: ..."
   cc-connect send -m "Build completed successfully"
+  cc-connect send --image /tmp/screenshot.png
+  cc-connect send --image /tmp/chart.png -m "Here's the latest chart"
   cc-connect send --stdin <<'EOF'
     Long message with "special" chars, $variables, and newlines
   EOF`)

--- a/core/api.go
+++ b/core/api.go
@@ -30,6 +30,7 @@ type SendRequest struct {
 	Project    string `json:"project"`
 	SessionKey string `json:"session_key"`
 	Message    string `json:"message"`
+	ImagePath  string `json:"image_path,omitempty"`
 }
 
 // NewAPIServer creates an API server on a Unix socket.
@@ -118,8 +119,8 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	if req.Message == "" {
-		http.Error(w, "message is required", http.StatusBadRequest)
+	if req.Message == "" && req.ImagePath == "" {
+		http.Error(w, "message or image_path is required", http.StatusBadRequest)
 		return
 	}
 
@@ -144,9 +145,20 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := engine.SendToSession(req.SessionKey, req.Message); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	// Send image if image_path is provided.
+	if req.ImagePath != "" {
+		if err := engine.SendImageToSession(req.SessionKey, req.ImagePath); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Send text message if provided.
+	if req.Message != "" {
+		if err := engine.SendToSession(req.SessionKey, req.Message); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/core/engine.go
+++ b/core/engine.go
@@ -4252,6 +4252,43 @@ func (e *Engine) SendToSession(sessionKey, message string) error {
 	return p.Send(e.ctx, replyCtx, message)
 }
 
+// SendImageToSession sends an image to an active session from an external caller (API/CLI).
+// The platform must implement the ImageSender interface.
+func (e *Engine) SendImageToSession(sessionKey, imagePath string) error {
+	e.interactiveMu.Lock()
+	defer e.interactiveMu.Unlock()
+
+	var state *interactiveState
+	if sessionKey != "" {
+		state = e.interactiveStates[sessionKey]
+	} else {
+		for _, s := range e.interactiveStates {
+			state = s
+			break
+		}
+	}
+
+	if state == nil {
+		return fmt.Errorf("no active session found (key=%q)", sessionKey)
+	}
+
+	state.mu.Lock()
+	p := state.platform
+	replyCtx := state.replyCtx
+	state.mu.Unlock()
+
+	if p == nil {
+		return fmt.Errorf("no active session found (key=%q)", sessionKey)
+	}
+
+	imgSender, ok := p.(ImageSender)
+	if !ok {
+		return fmt.Errorf("platform %q does not support sending images", p.Name())
+	}
+
+	return imgSender.SendImage(e.ctx, replyCtx, imagePath)
+}
+
 // sendPermissionPrompt sends a permission prompt with interactive buttons when
 // the platform supports them. Fallback chain: InlineButtonSender → CardSender → plain text.
 func (e *Engine) sendPermissionPrompt(p Platform, replyCtx any, prompt, toolName, toolInput string) {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -103,6 +103,13 @@ type InlineButtonSender interface {
 	SendWithButtons(ctx context.Context, replyCtx any, content string, buttons [][]ButtonOption) error
 }
 
+// ImageSender is an optional interface for platforms that support sending
+// images. The imagePath is an absolute local file path; the platform is
+// responsible for uploading and delivering it.
+type ImageSender interface {
+	SendImage(ctx context.Context, replyCtx any, imagePath string) error
+}
+
 // CardSender is an optional interface for platforms that support sending
 // structured rich cards (e.g. Feishu Interactive Card). Platforms that do not
 // implement this interface will receive a plain-text fallback via Card.RenderText().

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -5,9 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -32,6 +37,11 @@ type Platform struct {
 	streamClient          *dingtalkClient.StreamClient
 	handler               core.MessageHandler
 	dedup                 core.MessageDedup
+
+	// access token cache
+	tokenMu      sync.Mutex
+	accessToken  string
+	tokenExpires time.Time
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -207,4 +217,155 @@ func preprocessDingTalkMarkdown(s string) string {
 		}
 	}
 	return sb.String()
+}
+
+// ── Image sending (implements core.ImageSender) ────────────────
+
+// SendImage uploads a local image file to DingTalk and sends it via sessionWebhook.
+func (p *Platform) SendImage(ctx context.Context, rctx any, imagePath string) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return fmt.Errorf("dingtalk: invalid reply context type %T", rctx)
+	}
+
+	mediaID, err := p.uploadMedia(ctx, imagePath, "image")
+	if err != nil {
+		return fmt.Errorf("dingtalk: upload image: %w", err)
+	}
+
+	// DingTalk sessionWebhook does not support mediaId-based image messages.
+	// Use markdown with the DingTalk media URL instead.
+	downloadURL := fmt.Sprintf("https://oapi.dingtalk.com/media/download?access_token=%s&media_id=%s", p.cachedToken(), mediaID)
+	payload := map[string]any{
+		"msgtype":  "markdown",
+		"markdown": map[string]string{"title": "image", "text": fmt.Sprintf("![](%s)", downloadURL)},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("dingtalk: marshal image message: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rc.sessionWebhook, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("dingtalk: create image request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := core.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("dingtalk: send image: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("dingtalk: send image returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// getAccessToken returns a valid access token, fetching a new one if expired.
+func (p *Platform) getAccessToken(ctx context.Context) (string, error) {
+	p.tokenMu.Lock()
+	defer p.tokenMu.Unlock()
+
+	if p.accessToken != "" && time.Now().Before(p.tokenExpires) {
+		return p.accessToken, nil
+	}
+
+	payload, _ := json.Marshal(map[string]string{
+		"appKey":    p.clientID,
+		"appSecret": p.clientSecret,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.dingtalk.com/v1.0/oauth2/accessToken",
+		bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := core.HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch access token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		AccessToken string `json:"accessToken"`
+		ExpireIn    int64  `json:"expireIn"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode access token response: %w", err)
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("empty access token returned")
+	}
+
+	p.accessToken = result.AccessToken
+	// Refresh 5 minutes before actual expiry.
+	p.tokenExpires = time.Now().Add(time.Duration(result.ExpireIn)*time.Second - 5*time.Minute)
+	slog.Debug("dingtalk: access token refreshed", "expires_in", result.ExpireIn)
+	return p.accessToken, nil
+}
+
+// cachedToken returns the cached token (best-effort, no refresh).
+func (p *Platform) cachedToken() string {
+	p.tokenMu.Lock()
+	defer p.tokenMu.Unlock()
+	return p.accessToken
+}
+
+// uploadMedia uploads a local file to DingTalk and returns the media_id.
+func (p *Platform) uploadMedia(ctx context.Context, filePath, fileType string) (string, error) {
+	token, err := p.getAccessToken(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("open file: %w", err)
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	_ = w.WriteField("type", fileType)
+	part, err := w.CreateFormFile("media", filepath.Base(filePath))
+	if err != nil {
+		return "", fmt.Errorf("create form file: %w", err)
+	}
+	if _, err := io.Copy(part, f); err != nil {
+		return "", fmt.Errorf("copy file data: %w", err)
+	}
+	w.Close()
+
+	uploadURL := fmt.Sprintf("https://oapi.dingtalk.com/media/upload?access_token=%s", token)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, &buf)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := core.HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("upload request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		ErrCode  int    `json:"errcode"`
+		ErrMsg   string `json:"errmsg"`
+		MediaID  string `json:"media_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode upload response: %w", err)
+	}
+	if result.ErrCode != 0 {
+		return "", fmt.Errorf("upload failed: %s (code %d)", result.ErrMsg, result.ErrCode)
+	}
+	slog.Debug("dingtalk: media uploaded", "media_id", result.MediaID, "file", filePath)
+	return result.MediaID, nil
 }


### PR DESCRIPTION
## Summary

- Add `ImageSender` optional interface to `core/interfaces.go` for platforms that support sending images
- Implement DingTalk image sending: access_token caching → media upload API → markdown image via sessionWebhook
- Extend `/send` API endpoint to accept `image_path` field
- Add `--image <path>` CLI flag to `cc-connect send`

## How it works

```
cc-connect send --image /tmp/screenshot.png
cc-connect send --image /tmp/chart.png -m "Here's the latest chart"
```

Full pipeline for DingTalk:
1. Get access_token using existing `client_id`/`client_secret` (cached with auto-refresh)
2. Upload local image via `POST https://oapi.dingtalk.com/media/upload` → get `media_id`
3. Build download URL and send as markdown image via sessionWebhook

## Files changed (5 files, +266/-13)

| File | Change |
|------|--------|
| `core/interfaces.go` | Add `ImageSender` optional interface |
| `core/engine.go` | Add `SendImageToSession()` method |
| `core/api.go` | Extend `/send` to accept `image_path` |
| `cmd/cc-connect/send.go` | Add `--image` CLI flag |
| `platform/dingtalk/dingtalk.go` | Implement access_token + media upload + image sending |

## Design decisions

- **Optional interface pattern**: Follows existing patterns (`CardSender`, `InlineButtonSender`, etc.). Platforms that don't support images simply don't implement `ImageSender`.
- **Markdown fallback**: DingTalk's sessionWebhook doesn't directly support `msgtype: "image"` with `mediaId`, so we use markdown `![]()` with the media download URL.
- **Token caching**: Access token is cached and refreshed 5 minutes before expiry to avoid unnecessary API calls.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Manual test: send image via DingTalk
- [ ] Other platforms gracefully return "not supported" error

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)