### PR TITLE
fix(agent/pi): move thinking field read inside mutex in StartSession

### DIFF
--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -97,10 +97,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	a.mu.Lock()
 	mode := a.mode
 	model := a.model
+	thinking := a.thinking
 	extraEnv := append([]string{}, a.sessionEnv...)
 	a.mu.Unlock()
-
-	thinking := a.thinking
 	return newPiSession(ctx, a.cmd, a.workDir, model, mode, thinking, sessionID, extraEnv)
 }
 


### PR DESCRIPTION
## Summary

- `StartSession()` reads `a.thinking` outside the mutex (line 103), but `SetReasoningEffort()` writes it under `a.mu`. This is a data race when a user changes the reasoning effort concurrently with a new session starting.
- Fix: move the `a.thinking` read inside the existing `a.mu.Lock()` / `a.mu.Unlock()` critical section, alongside `mode`, `model`, and `sessionEnv`.

## Root cause

All other mutable fields (`mode`, `model`, `sessionEnv`) are correctly copied under the lock in `StartSession()`, but `thinking` was accidentally left outside. `SetReasoningEffort()` and `GetReasoningEffort()` both use the mutex, so any read of this field must also hold the lock.

## Test plan

- [x] `go test ./agent/pi/ -v` — all 55 tests pass
- [x] `go test ./...` — full suite passes (only pre-existing codex timeout failures)
- [x] `go test -race ./agent/pi/` — no race detected