### PR TITLE
fix(agent): always close events channel on session Close timeout

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -519,10 +519,10 @@ func (cs *codexSession) Close() error {
 	}()
 	select {
 	case <-done:
-		close(cs.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("codexSession: close timed out, abandoning wg.Wait")
 	}
+	close(cs.events)
 	return nil
 }
 

--- a/agent/cursor/session.go
+++ b/agent/cursor/session.go
@@ -464,10 +464,10 @@ func (cs *cursorSession) Close() error {
 	}()
 	select {
 	case <-done:
-		close(cs.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("cursorSession: close timed out, abandoning wg.Wait")
 	}
+	close(cs.events)
 	return nil
 }
 

--- a/agent/gemini/session.go
+++ b/agent/gemini/session.go
@@ -469,10 +469,10 @@ func (gs *geminiSession) Close() error {
 	}()
 	select {
 	case <-done:
-		close(gs.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("geminiSession: close timed out, abandoning wg.Wait")
 	}
+	close(gs.events)
 	return nil
 }
 

--- a/agent/iflow/session.go
+++ b/agent/iflow/session.go
@@ -897,9 +897,9 @@ func (s *iflowSession) Close() error {
 	}()
 	select {
 	case <-done:
-		close(s.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("iflowSession: close timed out, abandoning wg.Wait")
 	}
+	close(s.events)
 	return nil
 }

--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -393,10 +393,10 @@ func (s *opencodeSession) Close() error {
 	}()
 	select {
 	case <-done:
-		close(s.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("opencodeSession: close timed out, abandoning wg.Wait")
 	}
+	close(s.events)
 	return nil
 }
 

--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -288,10 +288,10 @@ func (qs *qoderSession) Close() error {
 	}()
 	select {
 	case <-done:
-		close(qs.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("qoderSession: close timed out, abandoning wg.Wait")
 	}
+	close(qs.events)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Six agent session adapters (codex, cursor, gemini, iflow, opencode, qoder) only close the `events` channel when `wg.Wait()` completes within the 8-second timeout. If the timeout fires, the channel is left open.
- Move `close(events)` after the select block so it always executes, matching the pattern already used by `piSession`.

## Root cause

The `Close()` method uses a select with a timeout to wait for goroutines to finish. The `close(events)` call was placed inside `case <-done:`, so it only runs on the happy path. On timeout, the channel stays open, which means:

1. Any consumer ranging over the channel or waiting for it to close will block indefinitely
2. The engine's `drainEvents()` (recently fixed in #152 to handle closed channels) won't detect session termination
3. The `cleanupInteractiveState` path in the engine relies on the events channel being closed to break out of `processInteractiveEvents`

## Affected adapters

| Adapter | File |
|---------|------|
| codex | `agent/codex/session.go` |
| cursor | `agent/cursor/session.go` |
| gemini | `agent/gemini/session.go` |
| iflow | `agent/iflow/session.go` |
| opencode | `agent/opencode/session.go` |
| qoder | `agent/qoder/session.go` |

`piSession` already closes the channel unconditionally (correct pattern). `claudeSession` uses a different mechanism (`<-cs.done` after process kill).

## Test plan

- [x] `go test ./agent/codex/ ./agent/cursor/ ./agent/gemini/ ./agent/iflow/ ./agent/qoder/` — all pass
- [x] `go test ./...` — full suite passes