### PR TITLE
fix: sync local session snapshot after /delete

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -6984,6 +6984,8 @@ func (e *Engine) deleteSingleSessionReply(msg *Message, deleter SessionDeleter, 
 		return fmt.Sprintf("❌ %s: %v", displayName, err)
 	}
 
+	// Keep local session snapshot aligned with agent-side deletion.
+	sessions.DeleteByAgentSessionID(matched.ID)
 	sessions.SetSessionName(matched.ID, "")
 	return fmt.Sprintf(e.i18n.T(MsgDeleteSuccess), displayName)
 }

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1048,6 +1048,33 @@ func TestCmdDelete_SingleSessionPrefixStillWorks(t *testing.T) {
 	}
 }
 
+func TestCmdDelete_SyncsLocalSessionSnapshot(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubDeleteAgent{stubListAgent: stubListAgent{sessions: []AgentSessionInfo{
+		{ID: "session-1", Summary: "One"},
+		{ID: "session-2", Summary: "Two"},
+	}}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	victim := e.sessions.NewSession("test:user2", "victim")
+	victim.SetAgentSessionID("session-1", "stub")
+	keep := e.sessions.NewSession("test:user3", "keep")
+	keep.SetAgentSessionID("session-2", "stub")
+
+	e.cmdDelete(p, msg, []string{"1"})
+
+	if got, want := strings.Join(agent.deleted, ","), "session-1"; got != want {
+		t.Fatalf("deleted = %q, want %q", got, want)
+	}
+	if got := e.sessions.FindByID(victim.ID); got != nil {
+		t.Fatalf("victim session should be removed, got %+v", got)
+	}
+	if got := e.sessions.FindByID(keep.ID); got == nil {
+		t.Fatal("keep session should remain")
+	}
+}
+
 func TestCmdDelete_NoArgsOnCardPlatformShowsDeleteModeCard(t *testing.T) {
 	p := &stubCardPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
 	agent := &stubDeleteAgent{stubListAgent: stubListAgent{sessions: []AgentSessionInfo{

--- a/core/session.go
+++ b/core/session.go
@@ -315,6 +315,39 @@ func (sm *SessionManager) DeleteByID(id string) bool {
 	if _, ok := sm.sessions[id]; !ok {
 		return false
 	}
+	sm.deleteByIDLocked(id)
+	sm.saveLocked()
+	return true
+}
+
+// DeleteByAgentSessionID removes all local sessions mapped to the given
+// agent session ID. It returns the number of removed local sessions.
+func (sm *SessionManager) DeleteByAgentSessionID(agentSessionID string) int {
+	if agentSessionID == "" {
+		return 0
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	removed := 0
+	for id, s := range sm.sessions {
+		s.mu.Lock()
+		matched := s.AgentSessionID == agentSessionID
+		s.mu.Unlock()
+		if !matched {
+			continue
+		}
+		sm.deleteByIDLocked(id)
+		removed++
+	}
+	if removed > 0 {
+		sm.saveLocked()
+	}
+	return removed
+}
+
+func (sm *SessionManager) deleteByIDLocked(id string) {
 	delete(sm.sessions, id)
 	for userKey, ids := range sm.userSessions {
 		for i, sid := range ids {
@@ -327,8 +360,6 @@ func (sm *SessionManager) DeleteByID(id string) bool {
 			delete(sm.activeSession, userKey)
 		}
 	}
-	sm.saveLocked()
-	return true
 }
 
 // Save persists current state to disk. Safe to call from outside (e.g. after message processing).

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -308,6 +308,45 @@ func TestSessionManager_UserMetaPersistence(t *testing.T) {
 	}
 }
 
+func TestSessionManager_DeleteByAgentSessionID(t *testing.T) {
+	sm := NewSessionManager("")
+
+	s1 := sm.NewSession("user1", "one")
+	s1.SetAgentSessionID("agent-1", "codex")
+
+	s2 := sm.NewSession("user2", "two")
+	s2.SetAgentSessionID("agent-2", "codex")
+
+	s3 := sm.NewSession("user3", "three")
+	s3.SetAgentSessionID("agent-1", "codex")
+
+	if removed := sm.DeleteByAgentSessionID("agent-1"); removed != 2 {
+		t.Fatalf("removed = %d, want 2", removed)
+	}
+	if got := sm.FindByID(s1.ID); got != nil {
+		t.Fatalf("expected s1 removed, got %+v", got)
+	}
+	if got := sm.FindByID(s3.ID); got != nil {
+		t.Fatalf("expected s3 removed, got %+v", got)
+	}
+	if got := sm.FindByID(s2.ID); got == nil {
+		t.Fatal("expected s2 preserved")
+	}
+	if got := sm.ActiveSessionID("user1"); got != "" {
+		t.Fatalf("user1 active session = %q, want empty", got)
+	}
+	if got := sm.ActiveSessionID("user3"); got != "" {
+		t.Fatalf("user3 active session = %q, want empty", got)
+	}
+	if list := sm.ListSessions("user2"); len(list) != 1 || list[0].ID != s2.ID {
+		t.Fatalf("user2 sessions = %+v, want only s2", list)
+	}
+
+	if removed := sm.DeleteByAgentSessionID("missing"); removed != 0 {
+		t.Fatalf("removed missing = %d, want 0", removed)
+	}
+}
+
 func TestSession_ConcurrentGetSet(t *testing.T) {
 	s := &Session{}
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Summary
- sync local SessionManager snapshot with agent-side deletion in /delete flow
- add SessionManager.DeleteByAgentSessionID to remove local sessions by agent session id
- add regression tests for SessionManager and /delete command

## Verification
- go test ./...
