### PR TITLE
fix(config): let explicit WorkDir override cloned agent work_dir

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -719,9 +719,7 @@ func EnsureProjectWithFeishuPlatform(opts EnsureProjectWithFeishuOptions) (*Ensu
 	}
 	workDir := strings.TrimSpace(opts.WorkDir)
 	if workDir != "" {
-		if _, ok := proj.Agent.Options["work_dir"]; !ok {
-			proj.Agent.Options["work_dir"] = workDir
-		}
+		proj.Agent.Options["work_dir"] = workDir
 	}
 
 	lines, hadTrailing := splitConfigLines(raw)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -214,8 +214,8 @@ func TestEnsureProjectWithFeishuPlatform_CreatesMissingProject(t *testing.T) {
 	if proj.Platforms[0].Type != "lark" {
 		t.Fatalf("platform type = %q, want %q", proj.Platforms[0].Type, "lark")
 	}
-	if got := stringMapValue(proj.Agent.Options, "work_dir"); got != "/tmp/alpha" {
-		t.Fatalf("work_dir = %q, want cloned source %q", got, "/tmp/alpha")
+	if got := stringMapValue(proj.Agent.Options, "work_dir"); got != "/tmp/gamma" {
+		t.Fatalf("work_dir = %q, want explicit override %q", got, "/tmp/gamma")
 	}
 }
 


### PR DESCRIPTION
## Summary

- When creating a new project via `EnsureProjectWithFeishuPlatform`, the agent config is cloned from an existing project (including `work_dir`). If the caller passes an explicit `WorkDir`, it was silently ignored because of an `if _, ok := ...; !ok` guard.
- Remove the guard so an explicitly provided `WorkDir` always takes precedence over the cloned value.

## Root cause

`pickAgentTemplateForNewProject` clones the agent config from the first existing project, which copies `work_dir` into the new project's options map. Then at line 722, the code checks `if _, ok := proj.Agent.Options["work_dir"]; !ok` — since `work_dir` already exists from the clone, the user-provided value is never set.

**Example:** User calls `EnsureProjectWithFeishuPlatform` with `WorkDir: "/tmp/gamma"`, but the new project gets `work_dir: "/tmp/alpha"` (from the cloned source) instead.

## Test plan

- [x] Updated `TestEnsureProjectWithFeishuPlatform_CreatesMissingProject` to expect the explicit WorkDir value
- [x] `go test ./config/` — all 6 tests pass
- [x] `go test ./...` — full suite passes