### PR TITLE
feat: persist /dir work directory overrides across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ cp config.example.toml ~/.cc-connect/config.toml
 vim ~/.cc-connect/config.toml
 ```
 
+Set `admin_from = "alice,bob"` in a project to allow those user IDs to run privileged commands such as `/dir` and `/shell`.
+When a user runs `/dir reset`, cc-connect restores the configured `work_dir` and clears the persisted override stored under `data_dir/projects/<project>.state.json`.
+
 ---
 
 ### ▶️ Run
@@ -220,6 +223,7 @@ cc-connect update --pre     # Beta (includes pre-releases)
 /list             List all sessions
 /switch <id>      Switch session
 /current          Show current session
+/dir [path|reset] Show, switch, or reset work directory
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -147,6 +147,9 @@ cp config.example.toml ~/.cc-connect/config.toml
 vim ~/.cc-connect/config.toml
 ```
 
+在项目配置里设置 `admin_from = "alice,bob"` 后，只有这些用户 ID 才能执行 `/dir`、`/shell` 等特权命令。
+执行 `/dir reset` 时，cc-connect 会恢复配置中的 `work_dir`，并清除保存在 `data_dir/projects/<project>.state.json` 里的目录覆盖状态。
+
 ---
 
 ### ▶️ 运行
@@ -220,6 +223,7 @@ cc-connect update --pre     # Beta 版（含 pre-release）
 /list                  列出所有会话
 /switch <id>           切换会话
 /current               查看当前会话
+/dir [路径|reset]      查看、切换或重置工作目录
 ```
 
 ---

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -128,6 +128,7 @@ func main() {
 	setupLogger(cfg.Log.Level, logWriter)
 
 	engines := make([]*core.Engine, 0, len(cfg.Projects))
+	effectiveWorkDirs := make([]string, 0, len(cfg.Projects))
 
 	for _, proj := range cfg.Projects {
 		agent, err := core.CreateAgent(proj.Agent.Type, proj.Agent.Options)
@@ -173,7 +174,9 @@ func main() {
 		}
 
 		workDir, _ := proj.Agent.Options["work_dir"].(string)
-		sessionFile := sessionStorePath(cfg.DataDir, proj.Name, workDir)
+		projectState := core.NewProjectStateStore(projectStatePath(cfg.DataDir, proj.Name))
+		effectiveWorkDir := applyProjectStateOverride(proj.Name, agent, workDir, projectState)
+		sessionFile := sessionStorePath(cfg.DataDir, proj.Name, effectiveWorkDir)
 
 		// Parse language setting
 		var lang core.Language
@@ -194,6 +197,8 @@ func main() {
 
 		engine := core.NewEngine(proj.Name, agent, platforms, sessionFile, lang)
 		engine.SetAttachmentSendEnabled(cfg.AttachmentSend != "off")
+		engine.SetBaseWorkDir(workDir)
+		engine.SetProjectStateStore(projectState)
 
 		// Wire multi-workspace mode
 		if proj.Mode == "multi-workspace" {
@@ -500,6 +505,7 @@ func main() {
 		})
 
 		engines = append(engines, engine)
+		effectiveWorkDirs = append(effectiveWorkDirs, effectiveWorkDir)
 	}
 
 	// Start cron scheduler
@@ -524,8 +530,7 @@ func main() {
 	for i, proj := range cfg.Projects {
 		hbCfg := buildHeartbeatConfig(proj.Heartbeat)
 		if hbCfg.Enabled {
-			workDir, _ := proj.Agent.Options["work_dir"].(string)
-			heartbeatSched.Register(proj.Name, hbCfg, engines[i], workDir)
+			heartbeatSched.Register(proj.Name, hbCfg, engines[i], effectiveWorkDirs[i])
 		}
 		engines[i].SetHeartbeatScheduler(heartbeatSched)
 	}
@@ -635,7 +640,7 @@ func main() {
 			e.SetDirHistory(dirHistory)
 
 			// Ensure initial work_dir is in history
-			if initWorkDir, _ := cfg.Projects[i].Agent.Options["work_dir"].(string); initWorkDir != "" {
+			if initWorkDir := effectiveWorkDirs[i]; initWorkDir != "" {
 				if !dirHistory.Contains(cfg.Projects[i].Name, initWorkDir) {
 					dirHistory.Add(cfg.Projects[i].Name, initWorkDir)
 				}
@@ -751,6 +756,56 @@ func sessionStorePath(dataDir, name, workDir string) string {
 	}
 
 	return filepath.Join(dataDir, "sessions", filename)
+}
+
+func projectStatePath(dataDir, projectName string) string {
+	replacer := strings.NewReplacer(
+		"\\", "_",
+		"/", "_",
+		":", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+	)
+	name := strings.TrimSpace(projectName)
+	name = replacer.Replace(name)
+	if name == "" {
+		name = "project"
+	}
+	return filepath.Join(dataDir, "projects", name+".state.json")
+}
+
+func applyProjectStateOverride(projectName string, agent core.Agent, configuredWorkDir string, store *core.ProjectStateStore) string {
+	effectiveWorkDir := configuredWorkDir
+	if store == nil {
+		return effectiveWorkDir
+	}
+
+	switcher, ok := agent.(core.WorkDirSwitcher)
+	if !ok {
+		return effectiveWorkDir
+	}
+
+	override := store.WorkDirOverride()
+	if override == "" {
+		return effectiveWorkDir
+	}
+	if abs, err := filepath.Abs(override); err == nil {
+		override = abs
+	}
+
+	info, err := os.Stat(override)
+	if err != nil || !info.IsDir() {
+		slog.Warn("project_state: ignoring invalid work_dir override", "project", projectName, "work_dir", override)
+		return effectiveWorkDir
+	}
+
+	switcher.SetWorkDir(override)
+	slog.Info("project_state: applied work_dir override", "project", projectName, "work_dir", override)
+	return override
 }
 
 // resolveConfigPath determines which config file to use.

--- a/cmd/cc-connect/main_test.go
+++ b/cmd/cc-connect/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+type stubMainAgent struct {
+	workDir string
+}
+
+func (a *stubMainAgent) Name() string { return "stub-main" }
+
+func (a *stubMainAgent) StartSession(_ context.Context, _ string) (core.AgentSession, error) {
+	return &stubMainAgentSession{}, nil
+}
+
+func (a *stubMainAgent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
+	return nil, nil
+}
+
+func (a *stubMainAgent) Stop() error { return nil }
+
+func (a *stubMainAgent) SetWorkDir(dir string) {
+	a.workDir = dir
+}
+
+func (a *stubMainAgent) GetWorkDir() string {
+	return a.workDir
+}
+
+type stubMainAgentSession struct{}
+
+func (s *stubMainAgentSession) Send(string, []core.ImageAttachment, []core.FileAttachment) error {
+	return nil
+}
+func (s *stubMainAgentSession) RespondPermission(string, core.PermissionResult) error { return nil }
+func (s *stubMainAgentSession) Events() <-chan core.Event                             { return nil }
+func (s *stubMainAgentSession) Close() error                                          { return nil }
+func (s *stubMainAgentSession) CurrentSessionID() string                              { return "" }
+func (s *stubMainAgentSession) Alive() bool                                           { return true }
+
+func TestProjectStatePath(t *testing.T) {
+	dataDir := t.TempDir()
+	got := projectStatePath(dataDir, "my/project:one")
+	want := filepath.Join(dataDir, "projects", "my_project_one.state.json")
+	if got != want {
+		t.Fatalf("projectStatePath() = %q, want %q", got, want)
+	}
+}
+
+func TestApplyProjectStateOverride(t *testing.T) {
+	baseDir := t.TempDir()
+	overrideDir := filepath.Join(t.TempDir(), "override")
+	if err := os.Mkdir(overrideDir, 0o755); err != nil {
+		t.Fatalf("mkdir override dir: %v", err)
+	}
+
+	store := core.NewProjectStateStore(filepath.Join(t.TempDir(), "projects", "demo.state.json"))
+	store.SetWorkDirOverride(overrideDir)
+
+	agent := &stubMainAgent{workDir: baseDir}
+	got := applyProjectStateOverride("demo", agent, baseDir, store)
+
+	if got != overrideDir {
+		t.Fatalf("applyProjectStateOverride() = %q, want %q", got, overrideDir)
+	}
+	if agent.workDir != overrideDir {
+		t.Fatalf("agent workDir = %q, want %q", agent.workDir, overrideDir)
+	}
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -427,8 +427,8 @@ name = "my-backend"
 # disabled_commands = ["restart", "upgrade", "cron"]  # Disable specific commands for this project
 #                                                     # 禁用该项目的指定命令
 #
-# admin_from controls who can run privileged commands (/shell, /restart, /upgrade, /commands addexec).
-# admin_from 控制谁可以执行特权命令（/shell, /restart, /upgrade, /commands addexec）。
+# admin_from controls who can run privileged commands (/dir, /shell, /restart, /upgrade, /commands addexec).
+# admin_from 控制谁可以执行特权命令（/dir, /shell, /restart, /upgrade, /commands addexec）。
 #
 # 💡 TIP: Send /whoami or /status to the bot to get your User ID for allow_from / admin_from.
 # 💡 提示：向机器人发送 /whoami 或者 /status  即可获取你的 User ID，用于填写 allow_from / admin_from。

--- a/core/engine.go
+++ b/core/engine.go
@@ -179,6 +179,8 @@ type Engine struct {
 	relayManager     *RelayManager
 	eventIdleTimeout time.Duration
 	dirHistory       *DirHistory
+	baseWorkDir      string
+	projectState     *ProjectStateStore
 
 	// Auto-compress settings
 	autoCompressEnabled   bool
@@ -676,6 +678,14 @@ func (e *Engine) RelayManager() *RelayManager {
 
 func (e *Engine) SetDirHistory(dh *DirHistory) {
 	e.dirHistory = dh
+}
+
+func (e *Engine) SetBaseWorkDir(dir string) {
+	e.baseWorkDir = dir
+}
+
+func (e *Engine) SetProjectStateStore(store *ProjectStateStore) {
+	e.projectState = store
 }
 
 // RemoveCommand removes a custom command by name. Returns false if not found.
@@ -3226,6 +3236,36 @@ func (e *Engine) cmdDir(p Platform, msg *Message, args []string) {
 		case "help", "-h", "--help":
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgDirUsage))
 			return
+		case "reset":
+			baseDir := strings.TrimSpace(e.baseWorkDir)
+			if baseDir == "" {
+				baseDir = currentDir
+			}
+			if baseDir == "" {
+				baseDir, _ = os.Getwd()
+			}
+			if absDir, err := filepath.Abs(baseDir); err == nil {
+				baseDir = absDir
+			}
+
+			switcher.SetWorkDir(baseDir)
+			e.cleanupInteractiveState(interactiveKey)
+
+			s := sessions.GetOrCreateActive(msg.SessionKey)
+			s.SetAgentSessionID("", "")
+			s.ClearHistory()
+			sessions.Save()
+
+			if e.projectState != nil {
+				e.projectState.ClearWorkDirOverride()
+				e.projectState.Save()
+			}
+			if e.dirHistory != nil {
+				e.dirHistory.Add(e.name, baseDir)
+			}
+
+			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgDirReset, baseDir))
+			return
 		}
 	}
 
@@ -3267,6 +3307,9 @@ func (e *Engine) cmdDir(p Platform, msg *Message, args []string) {
 			newDir = filepath.Join(baseDir, newDir)
 		}
 	}
+	if absDir, err := filepath.Abs(newDir); err == nil {
+		newDir = absDir
+	}
 
 	info, err := os.Stat(newDir)
 	if err != nil || !info.IsDir() {
@@ -3285,6 +3328,10 @@ func (e *Engine) cmdDir(p Platform, msg *Message, args []string) {
 	// Add to history
 	if e.dirHistory != nil {
 		e.dirHistory.Add(e.name, newDir)
+	}
+	if e.projectState != nil {
+		e.projectState.SetWorkDirOverride(newDir)
+		e.projectState.Save()
 	}
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgDirChanged, newDir))

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2357,6 +2357,75 @@ func TestCmdDir_HelpShowsUsage(t *testing.T) {
 	}
 }
 
+func TestCmdDir_PersistsAbsoluteOverride(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	baseDir := t.TempDir()
+	nextDir := filepath.Join(baseDir, "next")
+	if err := os.Mkdir(nextDir, 0o755); err != nil {
+		t.Fatalf("mkdir next dir: %v", err)
+	}
+	statePath := filepath.Join(t.TempDir(), "projects", "test.state.json")
+	store := NewProjectStateStore(statePath)
+
+	agent := &stubWorkDirAgent{workDir: baseDir}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetBaseWorkDir(baseDir)
+	e.SetProjectStateStore(store)
+
+	e.cmdDir(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, []string{"next"})
+
+	reloaded := NewProjectStateStore(statePath)
+	if got := reloaded.WorkDirOverride(); got != nextDir {
+		t.Fatalf("WorkDirOverride() = %q, want %q", got, nextDir)
+	}
+}
+
+func TestCmdDir_ResetRestoresBaseWorkDirAndClearsState(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	baseDir := t.TempDir()
+	overrideDir := filepath.Join(baseDir, "override")
+	if err := os.Mkdir(overrideDir, 0o755); err != nil {
+		t.Fatalf("mkdir override dir: %v", err)
+	}
+	statePath := filepath.Join(t.TempDir(), "projects", "test.state.json")
+	store := NewProjectStateStore(statePath)
+	store.SetWorkDirOverride(overrideDir)
+	store.Save()
+
+	agent := &stubWorkDirAgent{workDir: overrideDir}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetBaseWorkDir(baseDir)
+	e.SetProjectStateStore(store)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s.SetAgentSessionID("existing-session", "test")
+	s.Name = "old"
+	s.AddHistory("user", "hello")
+
+	e.cmdDir(p, msg, []string{"reset"})
+
+	if agent.workDir != baseDir {
+		t.Fatalf("workDir = %q, want %q", agent.workDir, baseDir)
+	}
+	reloaded := NewProjectStateStore(statePath)
+	if got := reloaded.WorkDirOverride(); got != "" {
+		t.Fatalf("WorkDirOverride() = %q, want empty", got)
+	}
+	if s.GetAgentSessionID() != "" {
+		t.Fatalf("AgentSessionID = %q, want cleared", s.GetAgentSessionID())
+	}
+	if s.Name != "old" {
+		t.Fatalf("Name = %q, want unchanged", s.Name)
+	}
+	if len(s.History) != 0 {
+		t.Fatalf("history length = %d, want 0", len(s.History))
+	}
+	if len(p.sent) != 1 || !strings.Contains(strings.ToLower(p.sent[0]), "default") {
+		t.Fatalf("sent = %v, want reset success message", p.sent)
+	}
+}
+
 func TestCmdDir_SwitchesByHistoryIndex(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	tempDir := t.TempDir()

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -477,6 +477,7 @@ const (
 
 	MsgDirChanged      MsgKey = "dir_changed"
 	MsgDirCurrent      MsgKey = "dir_current"
+	MsgDirReset        MsgKey = "dir_reset"
 	MsgDirUsage        MsgKey = "dir_usage"
 	MsgDirNotSupported MsgKey = "dir_not_supported"
 	MsgDirInvalidPath  MsgKey = "dir_invalid_path"
@@ -761,7 +762,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  Compress conversation context\n\n" +
 			"/tts [always|voice_only]\n  View/switch text-to-speech mode\n\n" +
 			"/shell <command>\n  Run a shell command and return the output\n\n" +
-			"/dir [path]\n  Show or switch agent working directory\n\n" +
+			"/dir [path|reset]\n  Show, switch, or reset agent working directory\n\n" +
 			"/stop\n  Stop current execution\n\n" +
 			"/cron [add|list|del|enable|disable]\n  Manage scheduled tasks\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  Manage heartbeat\n\n" +
@@ -804,7 +805,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  压缩会话上下文\n\n" +
 			"/tts [always|voice_only]\n  查看/切换语音合成模式\n\n" +
 			"/shell <命令>\n  执行 Shell 命令并返回结果\n\n" +
-			"/dir [路径]\n  查看或切换 Agent 工作目录\n\n" +
+			"/dir [路径|reset]\n  查看、切换或重置 Agent 工作目录\n\n" +
 			"/stop\n  停止当前执行\n\n" +
 			"/cron [add|list|del|enable|disable]\n  管理定时任务\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  管理心跳\n\n" +
@@ -847,7 +848,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  壓縮會話上下文\n\n" +
 			"/tts [always|voice_only]\n  查看/切換語音合成模式\n\n" +
 			"/shell <命令>\n  執行 Shell 命令並返回結果\n\n" +
-			"/dir [路徑]\n  查看或切換 Agent 工作目錄\n\n" +
+			"/dir [路徑|reset]\n  查看、切換或重置 Agent 工作目錄\n\n" +
 			"/stop\n  停止當前執行\n\n" +
 			"/cron [add|list|del|enable|disable]\n  管理定時任務\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  管理心跳\n\n" +
@@ -889,7 +890,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  会話コンテキストを圧縮\n\n" +
 			"/tts [always|voice_only]\n  音声合成モードの表示/切り替え\n\n" +
 			"/shell <コマンド>\n  シェルコマンドを実行して結果を返す\n\n" +
-			"/dir [パス]\n  エージェントの作業ディレクトリを表示/切り替え\n\n" +
+			"/dir [パス|reset]\n  エージェントの作業ディレクトリを表示/切り替え/リセット\n\n" +
 			"/stop\n  現在の実行を停止\n\n" +
 			"/cron [add|list|del|enable|disable]\n  スケジュールタスク管理\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  ハートビート管理\n\n" +
@@ -931,7 +932,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/compress\n  Comprimir contexto de conversación\n\n" +
 			"/tts [always|voice_only]\n  Ver/cambiar modo de síntesis de voz\n\n" +
 			"/shell <comando>\n  Ejecutar un comando shell y devolver la salida\n\n" +
-			"/dir [ruta]\n  Ver o cambiar el directorio de trabajo del agente\n\n" +
+			"/dir [ruta|reset]\n  Ver, cambiar o restablecer el directorio de trabajo del agente\n\n" +
 			"/stop\n  Detener ejecución actual\n\n" +
 			"/cron [add|list|del|enable|disable]\n  Gestionar tareas programadas\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  Gestionar heartbeat\n\n" +
@@ -1054,7 +1055,7 @@ var messages = map[MsgKey]map[Language]string{
 	MsgHelpToolsSection: {
 		LangEnglish: "**Tools & Automation**\n" +
 			"/shell <command> — Run a shell command\n" +
-			"/dir [path] — Show or switch work directory\n" +
+			"/dir [path|reset] — Show, switch, or reset work directory\n" +
 			"/cron [add|list|del|...] — Scheduled tasks\n" +
 			"/commands [add|del] — Custom commands\n" +
 			"/alias [add|del] — Command aliases\n" +
@@ -1063,7 +1064,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/stop — Stop current execution",
 		LangChinese: "**工具与自动化**\n" +
 			"/shell <命令> — 执行 Shell 命令\n" +
-			"/dir [路径] — 查看或切换工作目录\n" +
+			"/dir [路径|reset] — 查看、切换或重置工作目录\n" +
 			"/cron [add|list|del|...] — 定时任务\n" +
 			"/commands [add|del] — 自定义命令\n" +
 			"/alias [add|del] — 命令别名\n" +
@@ -1072,7 +1073,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/stop — 停止当前执行",
 		LangTraditionalChinese: "**工具與自動化**\n" +
 			"/shell <命令> — 執行 Shell 命令\n" +
-			"/dir [路徑] — 查看或切換工作目錄\n" +
+			"/dir [路徑|reset] — 查看、切換或重置工作目錄\n" +
 			"/cron [add|list|del|...] — 定時任務\n" +
 			"/commands [add|del] — 自訂命令\n" +
 			"/alias [add|del] — 命令別名\n" +
@@ -1081,7 +1082,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/stop — 停止當前執行",
 		LangJapanese: "**ツール・自動化**\n" +
 			"/shell <コマンド> — シェルコマンド実行\n" +
-			"/dir [パス] — 作業ディレクトリの表示/切り替え\n" +
+			"/dir [パス|reset] — 作業ディレクトリの表示/切り替え/リセット\n" +
 			"/cron [add|list|del|...] — スケジュールタスク\n" +
 			"/commands [add|del] — カスタムコマンド\n" +
 			"/alias [add|del] — コマンドエイリアス\n" +
@@ -1090,7 +1091,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/stop — 現在の実行を停止",
 		LangSpanish: "**Herramientas y automatización**\n" +
 			"/shell <comando> — Ejecutar comando shell\n" +
-			"/dir [ruta] — Ver o cambiar directorio de trabajo\n" +
+			"/dir [ruta|reset] — Ver, cambiar o restablecer directorio de trabajo\n" +
 			"/cron [add|list|del|...] — Tareas programadas\n" +
 			"/commands [add|del] — Comandos personalizados\n" +
 			"/alias [add|del] — Alias de comandos\n" +
@@ -3143,11 +3144,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Ejecutar un comando shell, arg: <comando>",
 	},
 	MsgBuiltinCmdDir: {
-		LangEnglish:            "Show or switch agent working directory, arg: <path>",
-		LangChinese:            "查看或切换 Agent 工作目录，参数: <路径>",
-		LangTraditionalChinese: "查看或切換 Agent 工作目錄，參數: <路徑>",
-		LangJapanese:           "エージェントの作業ディレクトリを表示/変更、引数: <パス>",
-		LangSpanish:            "Ver o cambiar el directorio de trabajo del agente, arg: <ruta>",
+		LangEnglish:            "Show, switch, or reset agent working directory, arg: <path>",
+		LangChinese:            "查看、切换或重置 Agent 工作目录，参数: <路径>",
+		LangTraditionalChinese: "查看、切換或重置 Agent 工作目錄，參數: <路徑>",
+		LangJapanese:           "エージェントの作業ディレクトリを表示/変更/リセット、引数: <パス>",
+		LangSpanish:            "Ver, cambiar o restablecer el directorio de trabajo del agente, arg: <ruta>",
 	},
 	MsgDirChanged: {
 		LangEnglish:            "✅ Work directory changed to: `%s`\nThe next session will start in this directory.",
@@ -3163,12 +3164,19 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "📂 現在の作業ディレクトリ: `%s`",
 		LangSpanish:            "📂 Directorio de trabajo actual: `%s`",
 	},
+	MsgDirReset: {
+		LangEnglish:            "✅ Work directory reset to the configured default: `%s`",
+		LangChinese:            "✅ 工作目录已重置为配置的默认目录: `%s`",
+		LangTraditionalChinese: "✅ 工作目錄已重置為設定的預設目錄: `%s`",
+		LangJapanese:           "✅ 作業ディレクトリを設定済みのデフォルトに戻しました: `%s`",
+		LangSpanish:            "✅ El directorio de trabajo se restauró al valor predeterminado configurado: `%s`",
+	},
 	MsgDirUsage: {
-		LangEnglish:            "Usage: `/dir <path>`\nExample: `/dir ../project`",
-		LangChinese:            "用法: `/dir <路径>`\n示例: `/dir ../project`",
-		LangTraditionalChinese: "用法: `/dir <路徑>`\n範例: `/dir ../project`",
-		LangJapanese:           "使い方: `/dir <パス>`\n例: `/dir ../project`",
-		LangSpanish:            "Uso: `/dir <ruta>`\nEjemplo: `/dir ../project`",
+		LangEnglish:            "Usage: `/dir <path>`\n       `/dir reset`\nExample: `/dir ../project`",
+		LangChinese:            "用法: `/dir <路径>`\n      `/dir reset`\n示例: `/dir ../project`",
+		LangTraditionalChinese: "用法: `/dir <路徑>`\n      `/dir reset`\n範例: `/dir ../project`",
+		LangJapanese:           "使い方: `/dir <パス>`\n       `/dir reset`\n例: `/dir ../project`",
+		LangSpanish:            "Uso: `/dir <ruta>`\n      `/dir reset`\nEjemplo: `/dir ../project`",
 	},
 	MsgDirNotSupported: {
 		LangEnglish:            "This agent does not support dynamic work directory switching.",

--- a/core/projectstate.go
+++ b/core/projectstate.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type projectStateData struct {
+	WorkDirOverride string `json:"work_dir_override,omitempty"`
+}
+
+// ProjectStateStore persists lightweight runtime state for one project.
+type ProjectStateStore struct {
+	mu        sync.RWMutex
+	storePath string
+	state     projectStateData
+}
+
+func NewProjectStateStore(path string) *ProjectStateStore {
+	ps := &ProjectStateStore{storePath: path}
+	if path != "" {
+		ps.load()
+	}
+	return ps
+}
+
+func (ps *ProjectStateStore) WorkDirOverride() string {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	return ps.state.WorkDirOverride
+}
+
+func (ps *ProjectStateStore) SetWorkDirOverride(dir string) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	ps.state.WorkDirOverride = dir
+}
+
+func (ps *ProjectStateStore) ClearWorkDirOverride() {
+	ps.SetWorkDirOverride("")
+}
+
+func (ps *ProjectStateStore) Save() {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	ps.saveLocked()
+}
+
+func (ps *ProjectStateStore) saveLocked() {
+	if ps.storePath == "" {
+		return
+	}
+
+	data, err := json.MarshalIndent(ps.state, "", "  ")
+	if err != nil {
+		slog.Error("project_state: failed to marshal", "error", err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(ps.storePath), 0o755); err != nil {
+		slog.Error("project_state: failed to create dir", "path", ps.storePath, "error", err)
+		return
+	}
+	if err := AtomicWriteFile(ps.storePath, data, 0o644); err != nil {
+		slog.Error("project_state: failed to write", "path", ps.storePath, "error", err)
+	}
+}
+
+func (ps *ProjectStateStore) load() {
+	data, err := os.ReadFile(ps.storePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Error("project_state: failed to read", "path", ps.storePath, "error", err)
+		}
+		return
+	}
+
+	var state projectStateData
+	if err := json.Unmarshal(data, &state); err != nil {
+		slog.Error("project_state: failed to unmarshal", "path", ps.storePath, "error", err)
+		return
+	}
+	ps.state = state
+}

--- a/core/projectstate_test.go
+++ b/core/projectstate_test.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestProjectState_SaveLoadAndClear(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "projects", "demo.state.json")
+
+	store := NewProjectStateStore(statePath)
+	store.SetWorkDirOverride("/tmp/demo")
+	store.Save()
+
+	reloaded := NewProjectStateStore(statePath)
+	if got := reloaded.WorkDirOverride(); got != "/tmp/demo" {
+		t.Fatalf("WorkDirOverride() = %q, want %q", got, "/tmp/demo")
+	}
+
+	reloaded.ClearWorkDirOverride()
+	reloaded.Save()
+
+	cleared := NewProjectStateStore(statePath)
+	if got := cleared.WorkDirOverride(); got != "" {
+		t.Fatalf("WorkDirOverride() after clear = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary
- persist `/dir` overrides in `data_dir/projects/<project>.state.json` instead of writing back to `config.toml`
- apply the saved override on startup and use the effective work directory for both session store selection and heartbeat wiring
- add `/dir reset` to clear the override and restore the configured default work directory

## Verification
- `go test ./core -run "TestProjectState|TestCmdDir|TestEngine_AdminFrom_GatesDir" -count=1`
- `go test ./cmd/cc-connect -run "Test(ProjectStatePath|ApplyProjectStateOverride)" -count=1`
- `go test -run ^$ ./...`

## Notes
- override paths are normalized to absolute paths before persistence so restart behavior does not depend on the process cwd
- current scope is intentionally limited to work directory persistence; bookmarks / `/dir add|list|switch|del` can build on the same project state file in a follow-up PR