### PR TITLE
fix(sessions): show actual username instead of generic "user" label

### DIFF
--- a/cmd/cc-connect/sessions_tui.go
+++ b/cmd/cc-connect/sessions_tui.go
@@ -278,7 +278,11 @@ func renderDetailContent(record sessionRecord) string {
 		var roleTag string
 		switch entry.Role {
 		case "user":
-			roleTag = userStyle.Render(" user ")
+			name := record.UserName
+			if name == "" {
+				name = "user"
+			}
+			roleTag = userStyle.Render(" " + name + " ")
 		case "assistant":
 			roleTag = assistantStyle.Render(" assistant ")
 		default:
@@ -287,8 +291,8 @@ func renderDetailContent(record sessionRecord) string {
 
 		// Wrap content lines
 		content := entry.Content
-		// Indent continuation lines (time=5 + space=2 + role≈12 + space=2 ≈ 21)
-		const indent = 21
+		// Indent continuation lines: time(5) + sep(2) + roleTag visual width + sep(2)
+		indent := 5 + 2 + lipgloss.Width(roleTag) + 2
 		lines := strings.Split(content, "\n")
 		prefix := strings.Repeat(" ", indent)
 


### PR DESCRIPTION
## Problem

In the session detail view, all incoming messages are labeled with the
literal role string `user` instead of the sender's actual name.

## Root Cause

`renderDetailContent()` hardcodes the role badge as `" user "` without
looking at `sessionRecord.UserName`, which is already populated from
`UserMeta` during `loadAllSessions()`.

Additionally, the continuation-line indent was hardcoded as `const
indent = 21`, which doesn't account for varying label widths (e.g.
`" user "` = 6 chars vs `" assistant "` = 11 chars), causing
pre-existing misalignment.

## Fix

- Use `record.UserName` for the `"user"` role badge (falls back to
  `"user"` when empty)
- Compute the indent dynamically via `lipgloss.Width(roleTag)` so it
  stays correct for any username length

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] Manual: open `sessions` TUI → select a session → confirm the
  sender's name appears instead of `user`