### PR TITLE
fix(core): protect adminFrom field with userRolesMu to prevent data race

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -162,7 +162,7 @@ type Engine struct {
 	disabledCmds map[string]bool
 	adminFrom    string // comma-separated user IDs for privileged commands; "*" = all allowed users; "" = deny
 	userRoles    *UserRoleManager // nil = legacy mode (no per-user policies)
-	userRolesMu  sync.RWMutex    // protects userRoles and disabledCmds
+	userRolesMu  sync.RWMutex    // protects userRoles, disabledCmds, and adminFrom
 
 	rateLimiter      *RateLimiter
 	streamPreview    StreamPreviewCfg
@@ -476,11 +476,12 @@ func (e *Engine) SetUserRoles(urm *UserRoleManager) {
 // "*" means all users who pass allow_from are admins.
 // Empty string means privileged commands are denied for everyone.
 func (e *Engine) SetAdminFrom(adminFrom string) {
+	e.userRolesMu.Lock()
 	e.adminFrom = strings.TrimSpace(adminFrom)
-	e.userRolesMu.RLock()
+	af := e.adminFrom
 	shellDisabled := e.disabledCmds["shell"]
-	e.userRolesMu.RUnlock()
-	if e.adminFrom == "" && !shellDisabled {
+	e.userRolesMu.Unlock()
+	if af == "" && !shellDisabled {
 		slog.Warn("admin_from is not set — privileged commands (/shell, /dir, /restart, /upgrade) are blocked. "+
 			"Set admin_from in config to enable them, or use disabled_commands to hide them.",
 			"project", e.name)
@@ -498,7 +499,9 @@ var privilegedCommands = map[string]bool{
 // isAdmin checks whether the given user ID is authorized for privileged commands.
 // Unlike AllowList, empty adminFrom means deny-all (fail-closed).
 func (e *Engine) isAdmin(userID string) bool {
-	af := strings.TrimSpace(e.adminFrom)
+	e.userRolesMu.RLock()
+	af := e.adminFrom
+	e.userRolesMu.RUnlock()
 	if af == "" {
 		return false
 	}


### PR DESCRIPTION
## Summary

- `SetAdminFrom` writes `e.adminFrom` without any lock, while `isAdmin` reads it concurrently from message handler goroutines. This is a data race when the management API's PATCH endpoint updates `admin_from` while messages are being processed.
- Protect both the write in `SetAdminFrom` and the read in `isAdmin` with the existing `userRolesMu`, which already guards the related `disabledCmds` and `userRoles` fields.

## Root cause

The `adminFrom` field was added alongside `disabledCmds` and `userRoles` (all access-control state), but unlike the other two, it was not guarded by `userRolesMu`. The management API PATCH handler at `handleProjectDetail` calls `e.SetAdminFrom()` from an HTTP goroutine, while `isAdmin` runs in the message processing goroutine — a classic concurrent read/write race on a string field.

## Changes

- `SetAdminFrom`: acquire `userRolesMu.Lock()` before writing, copy to local before using after unlock
- `isAdmin`: acquire `userRolesMu.RLock()` before reading `e.adminFrom`
- Updated comment on `userRolesMu` to document it also protects `adminFrom`

## Test plan

- [x] All existing admin/role tests pass (`TestEngine_AdminFrom_*`, `TestEngine_RoleBasedACL_*`)
- [x] `go test ./core/` — all tests pass
- [x] `go test ./...` — full suite passes (only pre-existing codex timeout)