### PR TITLE
fix(core): reserve space for closing fence in SplitMessageCodeFenceAware

### DIFF
--- a/core/markdown_html.go
+++ b/core/markdown_html.go
@@ -325,6 +325,8 @@ func SplitMessageCodeFenceAware(text string, maxLen int) []string {
 		return []string{text}
 	}
 
+	const closingFence = "\n```" // 4 bytes appended when splitting inside a code block
+
 	lines := strings.Split(text, "\n")
 	var chunks []string
 	var current []string
@@ -334,10 +336,17 @@ func SplitMessageCodeFenceAware(text string, maxLen int) []string {
 	for _, line := range lines {
 		lineLen := len(line) + 1 // +1 for newline
 
-		if currentLen+lineLen > maxLen && len(current) > 0 {
+		// Reserve space for the closing fence when inside a code block,
+		// so the final chunk length stays within maxLen.
+		limit := maxLen
+		if openFence != "" {
+			limit -= len(closingFence)
+		}
+
+		if currentLen+lineLen > limit && len(current) > 0 {
 			chunk := strings.Join(current, "\n")
 			if openFence != "" {
-				chunk += "\n```"
+				chunk += closingFence
 			}
 			chunks = append(chunks, chunk)
 

--- a/core/markdown_html_test.go
+++ b/core/markdown_html_test.go
@@ -415,6 +415,28 @@ func TestSplitMessageCodeFenceAware_NoCodeBlock(t *testing.T) {
 	}
 }
 
+func TestSplitMessageCodeFenceAware_ChunkDoesNotExceedMaxLen(t *testing.T) {
+	// Build text: a code block long enough to force splitting
+	var sb strings.Builder
+	sb.WriteString("```go\n")
+	for i := 0; i < 30; i++ {
+		sb.WriteString(fmt.Sprintf("line %d: some code content here\n", i))
+	}
+	sb.WriteString("```\n")
+	text := sb.String()
+
+	maxLen := 100
+	chunks := SplitMessageCodeFenceAware(text, maxLen)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for i, chunk := range chunks {
+		if len(chunk) > maxLen {
+			t.Errorf("chunk %d exceeds maxLen (%d): len=%d, content=%q", i, maxLen, len(chunk), chunk)
+		}
+	}
+}
+
 func TestMarkdownToSimpleHTML_BoldItalic(t *testing.T) {
 	out := MarkdownToSimpleHTML("this is ***bold italic*** text")
 	if !strings.Contains(out, "<b><i>bold italic</i></b>") {


### PR DESCRIPTION
## Summary

- `SplitMessageCodeFenceAware` appends a closing fence (`\n` `` ``` ``) when splitting inside a code block, but the length check doesn't account for these extra 4 bytes. Chunks can exceed `maxLen` by up to 4 bytes.
- Reserve closing fence space in the length check when inside a code block.

## Root cause

The flush condition at line 337 checks `currentLen+lineLen > maxLen`, but when inside a code block, the flushed chunk gets `"\n` `` ``` `` `"` appended (4 extra bytes) at line 340. This means the final chunk length is `currentLen + 4`, which can exceed `maxLen`.

**Example:** For Discord (`maxLen=2000`), a chunk accumulated to 1998 bytes would not trigger a flush when adding a 1-byte line (`1998 + 2 = 2000 <= 2000`). But the closing fence makes it `1998 + 2 + 4 = 2004` bytes — exceeding Discord's 2000-character limit and causing an API error.

## Fix

Subtract `len("\n` `` ``` `` `")` from the effective limit when inside a code block, ensuring the final chunk (with closing fence) stays within `maxLen`.

## Test plan

- [x] `TestSplitMessageCodeFenceAware_ChunkDoesNotExceedMaxLen` — verifies no chunk exceeds maxLen with code blocks
- [x] All existing `SplitMessageCodeFenceAware` tests pass
- [x] `go test ./...` — full suite passes