### PR TITLE
feat(platform): add Ruliu (如流) platform support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -372,6 +372,42 @@ enable_markdown = false  # true = Markdown messages (WeChat Work app only; perso
 
 **Detailed guide:** [docs/wecom.md](docs/wecom.md)
 
+---
+
+### Ruliu (如流自定义机器人) — Requires public URL
+
+Connection: HTTP Webhook (you need a public URL or enterprise gateway for the callback)
+
+**Setup steps:**
+1. Log in to https://qy.baidu.com and open your enterprise group
+2. Add a **custom robot** to the group and copy the generated robot `Webhook`
+3. In the robot's **Receive Message Server** settings, configure:
+   - URL: `https://<your-public-domain>/ruliu/callback`
+   - Token: any random string
+   - EncodingAESKey: generate or paste the 22-char key
+   - Enable messages like **@robot in group chat**
+4. **Start cc-connect FIRST, then save** (to pass URL verification)
+5. Ensure your public URL or gateway forwards callback traffic to local `http://127.0.0.1:8082/ruliu/callback`
+
+**Config:**
+
+```toml
+[[projects.platforms]]
+type = "ruliu"
+
+[projects.platforms.options]
+webhook = "https://openapi.im.baidu.com/your-ruliu-robot-webhook"
+token = "your-callback-token"
+encoding_aes_key = "your-22-char-encoding-aes-key"
+port = "8082"
+callback_path = "/ruliu/callback"
+# allow_from = "*"  # optional: restrict allowed user IDs
+```
+
+**Detailed guide:** [docs/ruliu.md](docs/ruliu.md)
+
+---
+
 ### QQ (via NapCat / OneBot v11) — No public IP needed
 
 QQ integration requires a third-party OneBot v11 implementation (e.g., NapCat) as a bridge.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 **7 AI Agents** — Claude Code, Codex, Cursor Agent, Qoder CLI, Gemini CLI, OpenCode, iFlow CLI. Use whichever fits your workflow, or all of them at once.
 
 ### 📱 Platform Flexibility
-**9 Chat Platforms** — Feishu, DingTalk, Slack, Telegram, Discord, WeChat Work, LINE, QQ, QQ Bot (Official). Most need **zero public IP**.
+**10 Chat Platforms** — Feishu, DingTalk, Slack, Telegram, Discord, WeChat Work, Ruliu, LINE, QQ, QQ Bot (Official). Most need **zero public IP**.
 
 ### 🔄 Multi-Agent Orchestration
 **Multi-Bot Relay** — Bind multiple bots in a group chat and let them communicate with each other. Ask Claude, get insights from Gemini — all in one conversation.
@@ -190,6 +190,7 @@ cc-connect update --pre     # Beta (includes pre-releases)
 | Platform | Discord | ✅ Gateway — no public IP needed |
 | Platform | LINE | ✅ Webhook — public URL required |
 | Platform | WeChat Work | ✅ WebSocket / Webhook |
+| Platform | Ruliu (Hi Enterprise) | ✅ Webhook — public URL or enterprise gateway required |
 | Platform | QQ (NapCat/OneBot) | ✅ WebSocket — Beta |
 | Platform | QQ Bot (Official) | ✅ WebSocket — no public IP needed |
 
@@ -204,8 +205,80 @@ cc-connect update --pre     # Beta (includes pre-releases)
 | Telegram | [docs/telegram.md](docs/telegram.md) | Long Polling | No |
 | Slack | [docs/slack.md](docs/slack.md) | Socket Mode | No |
 | Discord | [docs/discord.md](docs/discord.md) | Gateway | No |
+| LINE | [INSTALL.md](./INSTALL.md#line--requires-public-url) | Webhook | Yes |
 | WeChat Work | [docs/wecom.md](docs/wecom.md) | WebSocket / Webhook | No (WS) / Yes (Webhook) |
-| QQ / QQ Bot | [docs/qq.md](docs/qq.md) | WebSocket | No |
+| Ruliu (Hi Enterprise) | [docs/ruliu.md](docs/ruliu.md) | Webhook | Yes |
+| QQ (NapCat) | [docs/qq.md](docs/qq.md) | WebSocket (OneBot v11) | No |
+| QQ Bot (Official) | [docs/qqbot.md](docs/qqbot.md) | WebSocket (Official API) | No |
+
+### Ruliu Multi-Bot Setup (Multiple Robots in One Group)
+
+Ruliu requires a public callback URL per robot. If you run two robots (e.g. Codex + Claude Code) in the same group, use the built-in `proxy.go` to route both callback paths through a single port, then expose that port via ngrok or a reverse proxy.
+
+**Step 1 — Configure two projects with different ports and callback paths:**
+
+```toml
+# codex bot — listens on :8082/ruliu/callback
+[[projects]]
+name = "codex-ruliu"
+[projects.agent]
+type = "codex"
+[projects.agent.options]
+work_dir = "/path/to/project"
+mode = "full-auto"
+
+[[projects.platforms]]
+type = "ruliu"
+[projects.platforms.options]
+webhook = "https://openapi.im.baidu.com/your-codex-robot-webhook"
+token = "your-codex-token"
+encoding_aes_key = "your-22-char-key"
+port = "8082"
+share_session_in_group = true
+
+# claude code bot — listens on :8083/ruliu/callback
+[[projects]]
+name = "claudecode-ruliu"
+[projects.agent]
+type = "claudecode"
+[projects.agent.options]
+work_dir = "/path/to/project"
+mode = "default"
+
+[[projects.platforms]]
+type = "ruliu"
+[projects.platforms.options]
+webhook = "https://openapi.im.baidu.com/your-claude-robot-webhook"
+token = "your-claude-token"
+encoding_aes_key = "your-22-char-key"
+port = "8083"
+share_session_in_group = true
+```
+
+**Step 2 — Start cc-connect and the reverse proxy:**
+
+```bash
+# Start cc-connect
+./cc-connect
+
+# Start the built-in proxy (routes /ruliu/codex/* → :8082, /ruliu/cc/* → :8083)
+go run proxy.go
+```
+
+**Step 3 — Expose port 8080 via ngrok (free static domain):**
+
+```bash
+ngrok http 8080
+# or with your reserved static domain:
+ngrok http --url=your-static-domain.ngrok-free.dev 8080
+```
+
+**Step 4 — Set callback URLs in Ruliu admin console:**
+
+| Robot | Callback URL |
+|-------|-------------|
+| Codex | `https://your-domain.ngrok-free.dev/ruliu/codex/callback` |
+| Claude Code | `https://your-domain.ngrok-free.dev/ruliu/cc/callback` |
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,6 +39,24 @@
   <b>在任何聊天工具里，远程操控你的本地 AI Agent。随时随地，随心所欲。</b>
 </p>
 
+```
+         你（手机 / 电脑 / 平板）
+                    │
+    ┌───────────────┼───────────────┐
+    ▼               ▼               ▼
+   飞书           Slack         Telegram  ...10 个平台
+    │               │               │
+    └───────────────┼───────────────┘
+                    ▼
+              ┌────────────┐
+              │ cc-connect │  ← 你的开发机
+              └────────────┘
+              ┌─────┼─────┐
+              ▼     ▼     ▼
+         Claude  Gemini  Codex  ...7 个 Agent
+          Code    CLI   OpenCode / iFlow
+```
+
 <p align="center">
   cc-connect 把运行在你机器上的 AI Agent 桥接到你日常使用的即时通讯工具。<br/>
   代码审查、资料研究、自动化任务、数据分析 —— 只要 AI Agent 能做的事，<br/>
@@ -57,7 +75,7 @@
 **7 大 AI Agent** — Claude Code、Codex、Cursor Agent、Qoder CLI、Gemini CLI、OpenCode、iFlow CLI。按需选用，或同时使用全部。
 
 ### 📱 平台灵活性
-**9 大聊天平台** — 飞书、钉钉、Slack、Telegram、Discord、企业微信、LINE、QQ、QQ 官方机器人。大部分**无需公网 IP**。
+**10 大聊天平台** — 飞书、钉钉、Slack、Telegram、Discord、企业微信、如流、LINE、QQ、QQ 官方机器人。大部分**无需公网 IP**。
 
 ### 🔄 多 Agent 编排
 **多机器人中继** — 在群聊中绑定多个机器人，让它们相互协作。问 Claude，再听 Gemini 的见解 — 同一个对话搞定。
@@ -204,14 +222,602 @@ cc-connect update --pre     # Beta 版（含 pre-release）
 | Telegram | [docs/telegram.md](docs/telegram.md) | Long Polling | 不需要 |
 | Slack | [docs/slack.md](docs/slack.md) | Socket Mode | 不需要 |
 | Discord | [docs/discord.md](docs/discord.md) | Gateway | 不需要 |
+| LINE | [INSTALL.md](./INSTALL.md#line--requires-public-url) | Webhook | 需要 |
 | 企业微信 | [docs/wecom.md](docs/wecom.md) | WebSocket / Webhook | 不需要 (WS) / 需要 (Webhook) |
-| QQ / QQ 机器人 | [docs/qq.md](docs/qq.md) | WebSocket | 不需要 |
+| 如流 (企业自研) | [docs/ruliu.md](docs/ruliu.md) | Webhook（公网/企业网关） | 需要 |
+| QQ (NapCat) | [docs/qq.md](docs/qq.md) | WebSocket (OneBot v11) | 不需要 |
+| QQ 官方机器人 | [docs/qqbot.md](docs/qqbot.md) | WebSocket (官方 API) | 不需要 |
+
+### 如流多机器人配置（同一群聊接入多个机器人）
+
+如流每个机器人都需要独立的公网回调地址。如果你在同一群聊中运行两个机器人（如 Codex + Claude Code），可以使用内置的 `proxy.go` 将两个回调路径汇聚到同一端口，再通过 ngrok 或反向代理对外暴露。
+
+**第一步 — 在 config.toml 中配置两个项目，使用不同端口：**
+
+```toml
+# Codex 机器人 — 监听 :8082/ruliu/callback
+[[projects]]
+name = "codex-ruliu"
+[projects.agent]
+type = "codex"
+[projects.agent.options]
+work_dir = "/path/to/project"
+mode = "full-auto"
+
+[[projects.platforms]]
+type = "ruliu"
+[projects.platforms.options]
+webhook = "https://openapi.im.baidu.com/你的-codex-机器人-webhook"
+token = "your-codex-token"
+encoding_aes_key = "your-22-char-key"
+port = "8082"
+share_session_in_group = true
+
+# Claude Code 机器人 — 监听 :8083/ruliu/callback
+[[projects]]
+name = "claudecode-ruliu"
+[projects.agent]
+type = "claudecode"
+[projects.agent.options]
+work_dir = "/path/to/project"
+mode = "default"
+
+[[projects.platforms]]
+type = "ruliu"
+[projects.platforms.options]
+webhook = "https://openapi.im.baidu.com/你的-claude-机器人-webhook"
+token = "your-claude-token"
+encoding_aes_key = "your-22-char-key"
+port = "8083"
+share_session_in_group = true
+```
+
+**第二步 — 启动 cc-connect 和内置反向代理：**
+
+```bash
+# 启动 cc-connect
+./cc-connect
+
+# 启动内置代理（将 /ruliu/codex/* → :8082，/ruliu/cc/* → :8083）
+go run proxy.go
+```
+
+**第三步 — 用 ngrok 暴露 8080 端口（免费静态域名）：**
+
+```bash
+ngrok http 8080
+# 或使用你分配的固定域名：
+ngrok http --url=your-static-domain.ngrok-free.dev 8080
+```
+
+**第四步 — 在如流后台配置两个机器人的回调地址：**
+
+| 机器人 | 回调 URL |
+|--------|---------|
+| Codex | `https://your-domain.ngrok-free.dev/ruliu/codex/callback` |
+| Claude Code | `https://your-domain.ngrok-free.dev/ruliu/cc/callback` |
 
 ---
 
 ## 🎯 核心功能
 
 ### 💬 会话管理
+
+各平台快速配置示例：
+
+```toml
+# 钉钉
+[[projects.platforms]]
+type = "dingtalk"
+[projects.platforms.options]
+client_id = "dingxxxx"
+client_secret = "xxxx"
+
+# Telegram
+[[projects.platforms]]
+type = "telegram"
+[projects.platforms.options]
+token = "123456:ABC-xxx"
+
+# Slack
+[[projects.platforms]]
+type = "slack"
+[projects.platforms.options]
+bot_token = "xoxb-xxx"
+app_token = "xapp-xxx"
+
+# Discord
+[[projects.platforms]]
+type = "discord"
+[projects.platforms.options]
+token = "your-discord-bot-token"
+
+# LINE（需要公网 URL）
+[[projects.platforms]]
+type = "line"
+[projects.platforms.options]
+channel_secret = "xxx"
+channel_token = "xxx"
+port = "8080"
+
+# 企业微信（需要公网 URL）
+[[projects.platforms]]
+type = "wecom"
+[projects.platforms.options]
+corp_id = "wwxxx"
+corp_secret = "xxx"
+agent_id = "1000002"
+callback_token = "xxx"
+callback_aes_key = "xxx"
+port = "8081"
+enable_markdown = false  # 设为 true 则发送 Markdown 消息（仅企业微信应用内可渲染，个人微信显示"暂不支持"）
+
+# 如流（企业自定义机器人）
+[[projects.platforms]]
+type = "ruliu"
+[projects.platforms.options]
+webhook = "https://openapi.im.baidu.com/你的如流机器人Webhook"
+token = "你设置的回调 Token"
+encoding_aes_key = "你的 22 位 EncodingAESKey"
+# port = "8082"
+# callback_path = "/ruliu/callback"
+# allow_from = "user1,user2"
+# share_session_in_group = false  # true = 群内所有用户共享同一 Agent 会话
+
+# QQ（通过 NapCat/OneBot v11，无需公网 IP）
+[[projects.platforms]]
+type = "qq"
+[projects.platforms.options]
+ws_url = "ws://127.0.0.1:3001"
+allow_from = "*"  # 允许的 QQ 号，如 "12345,67890"，"*" 表示所有
+
+# QQ 官方机器人（无需公网 IP，无需第三方适配器）
+[[projects.platforms]]
+type = "qqbot"
+[projects.platforms.options]
+app_id = "your-app-id"
+app_secret = "your-app-secret"
+```
+
+## 权限模式
+
+所有 Agent 均支持权限模式，可在运行时通过 `/mode` 命令切换。
+
+**Claude Code** 模式（对应 `--permission-mode`）：
+
+| 模式 | 配置值 | 行为 |
+|------|--------|------|
+| **默认** | `default` | 每次工具调用都需要用户确认，完全掌控。 |
+| **接受编辑** | `acceptEdits`（别名: `edit`）| 文件编辑类工具自动通过，其他工具仍需确认。 |
+| **计划模式** | `plan` | Claude 只做规划不执行，审批计划后再执行。 |
+| **YOLO 模式** | `bypassPermissions`（别名: `yolo`）| 所有工具调用自动通过。适用于可信/沙箱环境。 |
+
+**Codex** 模式（对应 `--ask-for-approval`）：
+
+| 模式 | 配置值 | 行为 |
+|------|--------|------|
+| **建议** | `suggest` | 仅受信命令（ls、cat...）自动执行，其余需确认。 |
+| **自动编辑** | `auto-edit` | 模型自行决定何时请求批准，沙箱保护。 |
+| **全自动** | `full-auto` | 自动通过，工作区沙箱。推荐日常使用。 |
+| **YOLO 模式** | `yolo` | 跳过所有审批和沙箱。 |
+
+**Cursor Agent** 模式（对应 `--force` / `--mode`）：
+
+| 模式 | 配置值 | 行为 |
+|------|--------|------|
+| **默认** | `default` | 信任工作区，工具调用前询问。 |
+| **强制执行** | `force`（别名: `yolo`）| 自动批准所有工具调用。 |
+| **规划模式** | `plan` | 只读分析，不做修改。 |
+| **问答模式** | `ask` | 问答风格，只读。 |
+
+**Gemini CLI** 模式（对应 `-y` / `--approval-mode`）：
+
+| 模式 | 配置值 | 行为 |
+|------|--------|------|
+| **默认** | `default` | 每次工具调用都需要确认。 |
+| **自动编辑** | `auto_edit`（别名: `edit`）| 编辑工具自动通过，其他仍需确认。 |
+| **全自动** | `yolo` | 自动批准所有工具调用。 |
+| **规划模式** | `plan` | 只读规划模式，不做修改。 |
+
+**Qoder CLI** 模式：
+
+| 模式 | 配置值 | 行为 |
+|------|--------|------|
+| **标准权限** | `default` | 标准权限，每次工具调用需确认。 |
+| **YOLO 模式** | `yolo` | 跳过所有权限检查，自动批准。 |
+
+**OpenCode** 模式：
+
+| 模式 | 配置值 | 行为 |
+|------|--------|------|
+| **默认** | `default` | 标准模式。 |
+| **全自动** | `yolo` | 自动批准所有工具调用。 |
+
+**iFlow CLI** 模式：
+
+| 模式 | 配置值 | 行为 |
+|------|--------|------|
+| **默认** | `default` | 手动审批模式。 |
+| **自动编辑** | `auto-edit` | 自动编辑模式。 |
+| **规划模式** | `plan` | 只读规划模式。 |
+| **全自动** | `yolo` | 自动批准所有工具调用。 |
+
+```toml
+# Claude Code
+[projects.agent.options]
+mode = "default"
+# allowed_tools = ["Read", "Grep", "Glob"]
+
+# Codex
+[projects.agent.options]
+mode = "full-auto"
+# model = "o3"
+# reasoning_effort = "high"
+
+# Cursor Agent
+[projects.agent.options]
+mode = "default"
+
+# Gemini CLI
+[projects.agent.options]
+mode = "default"
+
+# Qoder CLI
+[projects.agent.options]
+mode = "default"
+
+# OpenCode
+[projects.agent.options]
+mode = "default"
+
+# iFlow CLI
+[projects.agent.options]
+mode = "default"
+```
+
+在聊天中切换模式：
+
+```
+/mode          # 查看当前模式和所有可用模式
+/mode yolo     # 切换到 YOLO 模式
+/mode default  # 切换回默认模式
+```
+
+对于 Codex，也可以在聊天中切换推理强度：
+
+```
+/reasoning        # 查看当前推理强度和可用等级
+/reasoning high   # 切换到 high 推理强度
+/reasoning 3      # 用序号快速选择
+```
+
+## API Provider 管理
+
+支持在运行时切换不同的 API Provider（如 Anthropic 直连、中转服务、AWS Bedrock 等），无需重启服务。Provider 凭证通过环境变量注入 Agent 子进程，不会修改本地配置文件。
+
+### 配置 Provider
+
+**在 `config.toml` 中：**
+
+```toml
+[projects.agent.options]
+work_dir = "/path/to/project"
+provider = "anthropic"   # 当前激活的 provider 名称
+
+[[projects.agent.providers]]
+name = "anthropic"
+api_key = "sk-ant-xxx"
+
+[[projects.agent.providers]]
+name = "relay"
+api_key = "sk-xxx"
+base_url = "https://api.relay-service.com"
+model = "claude-sonnet-4-20250514"
+
+# 特殊环境（Bedrock、Vertex 等）使用 env 字段：
+[[projects.agent.providers]]
+name = "bedrock"
+env = { CLAUDE_CODE_USE_BEDROCK = "1", AWS_PROFILE = "bedrock" }
+```
+
+**通过 CLI 命令：**
+
+```bash
+cc-connect provider add --project my-backend --name relay --api-key sk-xxx --base-url https://api.relay.com
+cc-connect provider add --project my-backend --name bedrock --env CLAUDE_CODE_USE_BEDROCK=1,AWS_PROFILE=bedrock
+cc-connect provider list --project my-backend
+cc-connect provider remove --project my-backend --name relay
+```
+
+**从 [cc-switch](https://github.com/SaladDay/cc-switch-cli) 导入：**
+
+如果你已经使用 cc-switch 管理 Provider，一条命令即可导入（需要 `sqlite3`）：
+
+```bash
+cc-connect provider import --project my-backend
+cc-connect provider import --project my-backend --type claude     # 仅 Claude Provider
+cc-connect provider import --db-path ~/.cc-switch/cc-switch.db    # 指定数据库路径
+```
+
+### 在聊天中管理 Provider
+
+```
+/provider                   查看当前 Provider
+/provider list              列出所有可用 Provider
+/provider add <名称> <key> [url] [model]   添加 Provider
+/provider add {"name":"relay","api_key":"sk-xxx","base_url":"https://..."}
+/provider remove <名称>     移除 Provider
+/provider switch <名称>     切换 Provider
+/provider <名称>            switch 的快捷方式
+```
+
+添加、移除、切换操作均自动持久化到 `config.toml`。切换时会自动重启 Agent 会话并加载新凭证。
+
+**各 Agent 的环境变量映射：**
+
+| Agent | api_key → | base_url → |
+|-------|-----------|------------|
+| Claude Code | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| Codex | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
+| Gemini CLI | `GEMINI_API_KEY` | —（使用 `env` 字段）|
+| OpenCode | `ANTHROPIC_API_KEY` | —（使用 `env` 字段）|
+| iFlow CLI | `IFLOW_API_KEY` / `IFLOW_apiKey` | `IFLOW_BASE_URL` / `IFLOW_baseUrl` |
+
+Provider 配置中的 `env` 字段支持设置任意环境变量，可用于 Bedrock、Vertex、Azure、自定义代理等各种场景。
+
+## Claude Code Router 集成
+
+[Claude Code Router](https://github.com/musistudio/claude-code-router) 是一个强大的工具，可以将 Claude Code 请求路由到不同的模型提供商（OpenRouter、DeepSeek、Gemini 等），并支持自定义请求转换。cc-connect 现已支持与 Claude Code Router 无缝集成。
+
+### 为什么使用 Claude Code Router？
+
+- **多提供商支持**：路由请求到 OpenRouter、DeepSeek、Ollama、Gemini、火山引擎、SiliconFlow 等
+- **模型路由**：针对不同任务使用不同模型（后台任务、思考、长上下文、网络搜索）
+- **请求/响应转换**：自动适配不同提供商的 API
+- **动态模型切换**：无需重启即可切换模型
+
+### 安装配置
+
+1. **安装 Claude Code Router**：
+
+```bash
+npm install -g @musistudio/claude-code-router
+```
+
+2. **配置 Router**（创建 `~/.claude-code-router/config.json`）：
+
+```json
+{
+  "APIKEY": "your-secret-key",
+  "Providers": [
+    {
+      "name": "openrouter",
+      "api_base_url": "https://openrouter.ai/api/v1/chat/completions",
+      "api_key": "sk-xxx",
+      "models": ["anthropic/claude-sonnet-4", "google/gemini-2.5-pro-preview"],
+      "transformer": { "use": ["openrouter"] }
+    },
+    {
+      "name": "deepseek",
+      "api_base_url": "https://api.deepseek.com/chat/completions",
+      "api_key": "sk-xxx",
+      "models": ["deepseek-chat", "deepseek-reasoner"],
+      "transformer": { "use": ["deepseek"] }
+    }
+  ],
+  "Router": {
+    "default": "deepseek,deepseek-chat",
+    "think": "deepseek,deepseek-reasoner",
+    "longContext": "openrouter,google/gemini-2.5-pro-preview"
+  }
+}
+```
+
+3. **启动 Router**：
+
+```bash
+ccr start
+```
+
+4. **配置 cc-connect**（在 `config.toml` 中）：
+
+```toml
+[projects.agent.options]
+work_dir = "/path/to/project"
+mode = "default"
+
+# Router 集成
+router_url = "http://127.0.0.1:3456"        # Router URL（默认端口）
+router_api_key = "your-secret-key"          # 可选：如果 router 需要认证
+```
+
+### 工作原理
+
+配置 `router_url` 后，cc-connect 会自动：
+
+- 设置 `ANTHROPIC_BASE_URL` 为 router URL
+- 设置 `NO_PROXY=127.0.0.1` 防止代理干扰
+- 禁用遥测和成本警告以获得更清洁的集成
+
+所有 Claude Code 请求都会通过 router 路由，由 router 处理模型选择和提供商通信。
+
+### 使用方式
+
+配置完成后，像往常一样使用 cc-connect。Router 会透明地处理模型路由：
+
+```
+你：帮我重构这段代码
+Router → DeepSeek（默认模型）
+
+你：思考一下这个架构决策
+Router → DeepSeek Reasoner（思考模型）
+
+你：分析这个大型代码库
+Router → Gemini Pro（长上下文模型）
+```
+
+### 重要说明
+
+- **Provider 设置被忽略**：使用 router 时，`[[projects.agent.providers]]` 设置会被绕过，因为 router 管理模型选择
+- **Router 必须运行**：确保在启动 cc-connect 之前执行 `ccr start`
+- **配置更改**：修改 router 配置后，需要重启：`ccr restart`
+
+更多详情请参考 [Claude Code Router 文档](https://github.com/musistudio/claude-code-router)。
+
+## 语音消息（语音转文字）
+
+直接发送语音消息 — cc-connect 自动将语音转为文字，再将文字转发给 Agent 处理。
+
+**支持平台：** 飞书、企业微信、Telegram、LINE、Discord、Slack
+
+**前置条件：**
+- OpenAI 或 Groq 的 API Key（用于 Whisper 语音识别）
+- 安装 `ffmpeg`（用于音频格式转换 — 大部分平台语音格式为 AMR/OGG，Whisper 不直接支持）
+
+### 配置
+
+```toml
+[speech]
+enabled = true
+provider = "openai"    # "openai" 或 "groq"
+language = ""          # 如 "zh"、"en"；留空自动检测
+
+[speech.openai]
+api_key = "sk-xxx"     # OpenAI API Key
+# base_url = ""        # 自定义端点（可选，兼容 OpenAI 接口的服务）
+# model = "whisper-1"  # 默认模型
+
+# -- 或使用 Groq（更快更便宜） --
+# [speech.groq]
+# api_key = "gsk_xxx"
+# model = "whisper-large-v3-turbo"
+```
+
+### 工作原理
+
+1. 用户在任何支持的平台发送语音消息
+2. cc-connect 从平台下载音频文件
+3. 如需格式转换（AMR、OGG → MP3），由 `ffmpeg` 处理
+4. 音频发送至 Whisper API 进行转录
+5. 转录文字展示给用户，并转发给 Agent
+
+### 安装 ffmpeg
+
+```bash
+# Ubuntu / Debian
+sudo apt install ffmpeg
+
+# macOS
+brew install ffmpeg
+
+# Alpine
+apk add ffmpeg
+```
+
+## 定时任务 (Cron)
+
+创建定时任务，自动执行 — 比如每日代码审查、定期趋势汇总、每周报告等。定时任务触发时，cc-connect 将 prompt 发送给 Agent，并将结果回传到你的聊天会话中。
+
+### 通过斜杠命令管理
+
+```
+/cron                                          列出所有定时任务
+/cron add <分> <时> <日> <月> <周> <任务描述>      创建定时任务
+/cron del <id>                                 删除定时任务
+/cron enable <id>                              启用任务
+/cron disable <id>                             禁用任务
+```
+
+示例：
+
+```
+/cron add 0 6 * * * 帮我收集 GitHub trending 并发送总结
+```
+
+### 通过 CLI 管理
+
+```bash
+cc-connect cron add --cron "0 6 * * *" --prompt "总结 GitHub trending" --desc "每日趋势"
+cc-connect cron list
+cc-connect cron del <job-id>
+```
+
+### 自然语言创建定时任务（通过 Agent）
+
+**Claude Code** 开箱即用 — 直接用自然语言告诉它：
+
+> "每天早上6点帮我总结 GitHub trending"
+> "每周一早上9点，生成周报"
+
+Claude Code 会通过 `--append-system-prompt` 自动将你的请求转为 `cc-connect cron add` 命令。
+
+**其他 Agent**（Codex、Cursor、Gemini CLI、Qoder CLI、OpenCode、iFlow CLI）需要在项目根目录的 Agent 指令文件中添加说明，让 Agent 知道如何创建定时任务。将以下内容添加到对应文件中：
+
+| Agent | 指令文件 |
+|-------|---------|
+| Codex | `AGENTS.md` |
+| Cursor | `.cursorrules` |
+| Qoder CLI | `AGENTS.md`（项目级）、`~/.qoder/AGENTS.md`（全局） |
+| Gemini CLI | `GEMINI.md` |
+| OpenCode | `OPENCODE.md` |
+| iFlow CLI | `IFLOW.md` |
+
+**需要添加的内容：**
+
+```markdown
+# cc-connect Integration
+
+This project is managed via cc-connect, a bridge to messaging platforms.
+
+## Scheduled tasks (cron)
+When the user asks you to do something on a schedule (e.g. "every day at 6am",
+"每天早上6点"), use the Bash/shell tool to run:
+
+  cc-connect cron add --cron "<min> <hour> <day> <month> <weekday>" --prompt "<task description>" --desc "<short label>"
+
+Environment variables CC_PROJECT and CC_SESSION_KEY are already set — do NOT
+specify --project or --session-key.
+
+Examples:
+  cc-connect cron add --cron "0 6 * * *" --prompt "Collect GitHub trending repos and send a summary" --desc "Daily GitHub Trending"
+  cc-connect cron add --cron "0 9 * * 1" --prompt "Generate a weekly project status report" --desc "Weekly Report"
+
+To list or delete cron jobs:
+  cc-connect cron list
+  cc-connect cron del <job-id>
+
+## Send message to current chat
+To proactively send a message back to the user's chat session (use --stdin heredoc for long/multi-line messages):
+
+  cc-connect send --stdin <<'CCEOF'
+  your message here (any special characters are safe)
+  CCEOF
+
+For short single-line messages:
+
+  cc-connect send -m "short message"
+```
+
+## 守护进程模式
+
+将 cc-connect 作为后台服务运行，由系统 init 管理（Linux systemd 用户服务，macOS launchd LaunchAgent）。
+
+```bash
+cc-connect daemon install --config ~/.cc-connect/config.toml   # 安装服务
+cc-connect daemon install --work-dir ~/.cc-connect             # 等价写法：指定配置目录
+cc-connect daemon start
+cc-connect daemon stop
+cc-connect daemon restart
+cc-connect daemon status
+cc-connect daemon logs [-f] [-n N] [--log-file PATH]
+cc-connect daemon uninstall
+```
+
+**install 参数：** `--config PATH`、`--log-file PATH`、`--log-max-size N`（MB）、`--work-dir DIR`、`--force`。`--config` 传入配置文件路径，`--work-dir` 传入包含 `config.toml` 的目录。日志在达到大小限制时自动轮转，保留 1 个备份。
+
+## 会话管理
+
+每个用户拥有独立的会话和完整的对话上下文。通过斜杠命令管理会话：
 
 ```
 /new [名称]            创建新会话
@@ -258,6 +864,78 @@ cc-connect update --pre     # Beta 版（含 pre-release）
 - [config.example.toml](config.example.toml) — 配置模板
 
 ---
+
+## 扩展开发
+
+### 添加新平台
+
+实现 `core.Platform` 接口并注册：
+
+```go
+package myplatform
+
+import "github.com/chenhg5/cc-connect/core"
+
+func init() {
+    core.RegisterPlatform("myplatform", New)
+}
+
+func New(opts map[string]any) (core.Platform, error) {
+    return &MyPlatform{}, nil
+}
+
+// 实现 Name(), Start(), Reply(), Send(), Stop() 方法
+```
+
+然后在 `cmd/cc-connect/main.go` 中添加空导入：
+
+```go
+_ "github.com/chenhg5/cc-connect/platform/myplatform"
+```
+
+### 添加新 Agent
+
+实现 `core.Agent` 接口并注册，方式与平台相同。
+
+## 项目结构
+
+```
+cc-connect/
+├── cmd/cc-connect/          # 程序入口
+│   └── main.go
+├── core/                    # 核心抽象层
+│   ├── interfaces.go        # Platform + Agent 接口定义
+│   ├── registry.go          # 工厂注册表（插件化）
+│   ├── message.go           # 统一消息/事件类型
+│   ├── session.go           # 多会话管理
+│   ├── i18n.go              # 国际化（中/英）
+│   ├── speech.go            # 语音转文字（Whisper API + ffmpeg）
+│   └── engine.go            # 路由引擎 + 斜杠命令
+├── platform/                # 平台适配器
+│   ├── feishu/              # 飞书（WebSocket 长连接）
+│   ├── dingtalk/            # 钉钉（Stream 模式）
+│   ├── telegram/            # Telegram（Long Polling）
+│   ├── slack/               # Slack（Socket Mode）
+│   ├── discord/             # Discord（Gateway WebSocket）
+│   ├── line/                # LINE（HTTP Webhook）
+│   ├── wecom/               # 企业微信（HTTP Webhook）
+│   ├── ruliu/               # 如流（企业自定义机器人 Webhook）
+│   ├── qq/                  # QQ（NapCat / OneBot v11 WebSocket）
+│   └── qqbot/               # QQ 官方机器人（Official API v2 WebSocket）
+├── agent/                   # AI 助手适配器
+│   ├── claudecode/          # Claude Code CLI（交互式会话）
+│   ├── codex/               # OpenAI Codex CLI（exec --json）
+│   ├── cursor/              # Cursor Agent CLI（--print stream-json）
+│   ├── qoder/               # Qoder CLI（-p -f stream-json）
+│   ├── gemini/              # Gemini CLI（-p --output-format stream-json）
+│   ├── opencode/            # OpenCode（run --format json）
+│   └── iflow/               # iFlow CLI（-p, -r, -o）
+├── docs/                    # 平台接入指南
+├── config.example.toml      # 配置模板
+├── INSTALL.md               # AI agent 友好的安装配置指南
+├── Makefile
+└── README.md
+```
 
 ## 👥 社区
 

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -749,7 +749,7 @@ func printUsage() {
 
   Bridge your messaging platforms to local AI coding agents.
   Supports: Claude Code, Codex, Cursor, Gemini CLI, Qoder CLI, OpenCode
-  Platforms: Feishu, Telegram, Slack, DingTalk, Discord, LINE, WeChat Work, QQ, QQ Bot
+  Platforms: Feishu, Telegram, Slack, DingTalk, Discord, LINE, WeChat Work, Ruliu, QQ, QQ Bot
 
   GitHub:  https://github.com/chenhg5/cc-connect
   Docs:    https://github.com/chenhg5/cc-connect/blob/main/INSTALL.md

--- a/cmd/cc-connect/plugin_platform_ruliu.go
+++ b/cmd/cc-connect/plugin_platform_ruliu.go
@@ -1,0 +1,5 @@
+//go:build !no_ruliu
+
+package main
+
+import _ "github.com/chenhg5/cc-connect/platform/ruliu"

--- a/config.example.toml
+++ b/config.example.toml
@@ -746,6 +746,25 @@ app_secret = "your-feishu-app-secret"
 # bot_secret = "your-bot-secret"
 # allow_from = "*"  # Allowed user IDs / 允许的用户 ID
 
+# Ruliu 自定义机器人 (Webhook)
+# 1. 在如流企业群添加机器人，复制生成的 Webhook 地址
+# 2. 在「接收消息服务器」设置页填写 URL/Token/EncodingAESKey，保存前先启动 cc-connect
+# 3. 确保如流系统能访问你暴露出去的回调 URL，并转发到本地 `http://127.0.0.1:8082/ruliu/callback`
+# Connection: HTTP Webhook — requires public URL or enterprise gateway
+# 连接方式：HTTP Webhook — 需要公网 URL 或企业网关
+
+# [[projects.platforms]]
+# type = "ruliu"
+#
+# [projects.platforms.options]
+# webhook = "https://openapi.im.baidu.com/your-ruliu-robot-webhook"
+# token = "your-callback-token"
+# encoding_aes_key = "your-22-char-encoding-aes-key"
+# port = "8082"
+# callback_path = "/ruliu/callback"
+# allow_from = "*"  # Allowed user IDs to interact with the robot / 允许的用户 ID
+# share_session_in_group = false  # If true, all users in a group share one agent session / 设为 true 时，群内所有用户共享同一个 Agent 会话（机器人能感知群聊上下文）
+
 # =============================================================================
 # Project 2: Using Cursor Agent / 项目 2：使用 Cursor Agent (uncomment to enable / 取消注释以启用)
 # =============================================================================

--- a/docs/ruliu.md
+++ b/docs/ruliu.md
@@ -1,0 +1,95 @@
+# Ruliu 自定义机器人接入
+
+本指南聚焦「企业内部开发 - 自定义机器人」模式：通过你配置的回调 URL 接收如流事件，通过机器人提供的 `Webhook` 发送消息，全部跑在企业可达的网络（公网域名或企业网关）上。
+
+## 0. 准备工作
+
+1. 登录 [https://qy.baidu.com](https://qy.baidu.com)，在企业群界面点击右上角「机器人」→「添加机器人」→「创建机器人」。
+2. 记下机器人在群内生成的 `Webhook` 地址，它只在创建时展示一次；稍后用于 cc-connect 出站发送消息。
+3. 在「接收消息服务器」页面配置回调地址、Token 和 EncodingAESKey，启用「用户在群聊中@机器人消息」权限，并保存。
+
+## 1. 配置回调
+
+- **URL**：你的 cc-connect 进程需要有一个稳定可达的外部回调地址，例如 `https://your.domain/ruliu/callback`；HTTPS 可以由反向代理或企业网关终止，再转发到本地 `http://127.0.0.1:8082/ruliu/callback`。
+- **Token**：任意字符串，用于 `signature=md5(rn+timestamp+token)` 校验，cc-connect 会在 HTTP 请求里重新计算并比较。
+- **EncodingAESKey**：22 位 Base64 字符串；解码后得到 AES-128 ECB key，用于解密请求 body 中的密文字符串。
+
+### 接收 URL 验证
+
+如流会向 `URL` 发起 `POST`，并在 query 参数里带上 `signature`/`timestamp`/`rn`/`echostr`。你的服务器必须：
+
+1. `md5(rn + timestamp + token)`，和请求里的 `signature` 比对。
+2. 校验通过后在 3s 内返回 `echostr` 内容（明文）。
+
+## 2. 处理消息事件
+
+只需订阅 `MESSAGE_RECEIVE` 事件即可：
+
+1. 回调请求的原始 body 是一段密文字符串，先做 Base64URL 解码（末尾用 `=` 补齐），再用 `AES-128-ECB-PKCS7` 解密，得到 JSON。
+2. 结构参考：
+   ```json
+   {
+     "eventtype":"MESSAGE_RECEIVE",
+     "agentid":123,
+     "groupid":1609028,
+     "message":{
+       "header":{"fromuserid":"zhoumengqi","msgtype":"MIXED","messageid":166..., ...},
+       "body":[{"type":"AT","robotid":...},{"type":"TEXT","content":"hi"}]
+     }
+   }
+   ```
+3. 只处理 `eventtype=MESSAGE_RECEIVE` 且 `message.header.msgtype`/`body` 有文本部分。如 body 数组里有多个 TEXT/AT，建议按顺序拼出纯文本后统一发送到 agent。
+4. 如果回调不包含文本，直接返回状态码即可，避免重复触发。
+
+## 3. 发送消息
+
+通过创建机器人后生成的 `Webhook` URL 发 `POST`，示例：
+
+```bash
+curl -X POST 'https://openapi.im.baidu.com/your-ruliu-robot-webhook' \
+  -H 'Content-Type:application/json' \
+  -d '{
+    "message":{
+      "header":{
+        "toid":[123456]
+      },
+      "body":[
+        {"type":"TEXT","content":"hi, robot!"}
+      ]
+    }
+  }'
+```
+
+常见字段：
+
+- `message.header.toid`：目标群 ID 数组；数字类型必须是纯数字。
+- `message.body`：按序包含 `TEXT`/`LINK`/`IMAGE` 等子对象；机器人会渲染文本和链接，图片仅支持 base64 字节（<1MB）。
+
+## 4. cc-connect 配置参考
+
+```toml
+[[projects.platforms]]
+type = "ruliu"
+[projects.platforms.options]
+webhook = "https://openapi.im.baidu.com/your-ruliu-robot-webhook"
+token = "your-callback-token"
+encoding_aes_key = "your-22-char-encoding-aes-key"
+# port = "8082"
+# callback_path = "/ruliu/callback"
+# allow_from = "user1,user2"
+```
+
+确保防火墙/网关把外网 `https://your-domain/ruliu/callback` 转发到本地 `cc-connect` 进程（默认监听 `http://127.0.0.1:8082`）。
+
+## 5. 启动与验证
+
+1. 启动 `cc-connect`，查看日志确认：`platform started project=xxx platform=ruliu`。
+2. 在如流后台点击「保存接收服务器」，观察 `/ruliu/callback` 是否收到验证请求；正确返回 `echostr` 表示回调生效。
+3. 在群内 @ 机器人发送消息，或使用 `/命令`，判断 cc-connect 是否收到并将结果投回。
+
+## 6. 常见问题
+
+- **需要公网吗？** 是的，Webhook 默认需要公网地址，可通过企业网关/Cloudflare Tunnel/内网映射暴露。
+- **Token 泄露怎么办？** 令牌用于签名校验，建议与 `cc-connect` 中配置一致，并避免在日志或错误输出中直接打印原值。
+- **为什么收到的 body 带多个 TEXT？** 如流把每段文本、@ 和链接都拆成对象；cc-connect 会跳过 `AT` 和空白占位，保留 `TEXT.content`，并把 `LINK.label` 作为可读文本拼回去。
+- **如何避免重复通知？** 使用 `message.header.messageid` 去重；cc-connect 平台层会对短时间内重复消息做过滤。

--- a/platform/ruliu/ruliu.go
+++ b/platform/ruliu/ruliu.go
@@ -1,0 +1,603 @@
+package ruliu
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+const (
+	defaultPort        = "8082"
+	defaultCallbackURL = "/ruliu/callback"
+	maxTextRunes       = 2000
+)
+
+func init() {
+	core.RegisterPlatform("ruliu", New)
+}
+
+type replyContext struct {
+	groupID int64
+}
+
+type Platform struct {
+	webhook              string
+	token                string
+	aesKey               []byte
+	allowFrom            string
+	port                 string
+	callbackPath         string
+	skipVerify           bool
+	shareSessionInGroup  bool
+	server               *http.Server
+	handler              core.MessageHandler
+	dedup                core.MessageDedup
+}
+
+type callbackEnvelope struct {
+	EventType string          `json:"eventtype"`
+	AgentID   int64           `json:"agentid"`
+	GroupID   int64           `json:"groupid"`
+	CorpID    string          `json:"corpid"`
+	Message   callbackMessage `json:"message"`
+	Time      int64           `json:"time"`
+}
+
+type callbackMessage struct {
+	Header callbackHeader     `json:"header"`
+	Body   []callbackBodyItem `json:"body"`
+}
+
+type callbackHeader struct {
+	FromUserID string        `json:"fromuserid"`
+	ToID       int64         `json:"toid"`
+	ToType     string        `json:"totype"`
+	MsgType    string        `json:"msgtype"`
+	ClientMsg  int64         `json:"clientmsgid"`
+	MessageID  int64         `json:"messageid"`
+	MsgSeqID   string        `json:"msgseqid"`
+	At         callbackAt    `json:"at"`
+	Extra      string        `json:"extra"`
+	ServerTime int64         `json:"servertime"`
+	ClientTime int64         `json:"clienttime"`
+	UpdateTime int64         `json:"updatetime"`
+}
+
+type callbackAt struct {
+	AtRobotIDs []int64  `json:"atrobotids"`
+	AtUserIDs  []string `json:"atuserids"`
+}
+
+type callbackBodyItem struct {
+	Type        string   `json:"type"`
+	Content     string   `json:"content"`
+	Label       string   `json:"label"`
+	Name        string   `json:"name"`
+	DownloadURL string   `json:"downloadurl"`
+	UserID      string   `json:"userid"`
+	AtUserIDs   []string `json:"atuserids"`
+}
+
+type sendRequest struct {
+	Message sendMessage `json:"message"`
+}
+
+type sendMessage struct {
+	Header sendHeader     `json:"header"`
+	Body   []sendBodyItem `json:"body"`
+}
+
+type sendHeader struct {
+	ToID []int64 `json:"toid,omitempty"`
+}
+
+type sendBodyItem struct {
+	Type    string `json:"type"`
+	Content string `json:"content"`
+}
+
+type sendResponse struct {
+	ErrCode   int    `json:"errcode"`
+	ErrorCode int    `json:"errorcode"`
+	ErrMsg    string `json:"errmsg"`
+	Msg       string `json:"msg"`
+}
+
+func New(opts map[string]any) (core.Platform, error) {
+	webhook, _ := opts["webhook"].(string)
+	token, _ := opts["token"].(string)
+	encodingAESKey, _ := opts["encoding_aes_key"].(string)
+	if webhook == "" || token == "" || encodingAESKey == "" {
+		return nil, fmt.Errorf("ruliu: webhook, token, and encoding_aes_key are required")
+	}
+
+	aesKey, err := decodeEncodingAESKey(encodingAESKey)
+	if err != nil {
+		return nil, fmt.Errorf("ruliu: invalid encoding_aes_key: %w", err)
+	}
+
+	port, _ := opts["port"].(string)
+	if port == "" {
+		port = defaultPort
+	}
+	callbackPath, _ := opts["callback_path"].(string)
+	if callbackPath == "" {
+		callbackPath = defaultCallbackURL
+	}
+	allowFrom, _ := opts["allow_from"].(string)
+	skipVerify, _ := opts["skip_signature_check"].(bool)
+	shareSessionInGroup, _ := opts["share_session_in_group"].(bool)
+	core.CheckAllowFrom("ruliu", allowFrom)
+
+	return &Platform{
+		webhook:             webhook,
+		token:               token,
+		aesKey:              aesKey,
+		allowFrom:           allowFrom,
+		port:                port,
+		callbackPath:        callbackPath,
+		skipVerify:          skipVerify,
+		shareSessionInGroup: shareSessionInGroup,
+	}, nil
+}
+
+func (p *Platform) Name() string { return "ruliu" }
+
+func (p *Platform) Start(handler core.MessageHandler) error {
+	p.handler = handler
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(p.callbackPath, p.callbackHandler)
+
+	p.server = &http.Server{
+		Addr:    ":" + p.port,
+		Handler: mux,
+	}
+
+	go func() {
+		slog.Info("ruliu: webhook server listening", "port", p.port, "path", p.callbackPath)
+		if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("ruliu: server error", "error", err)
+		}
+	}()
+
+	return nil
+}
+
+func (p *Platform) callbackHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		slog.Error("ruliu: read callback body failed", "error", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	signature := callbackParam(r, body, "signature")
+	timestamp := callbackParam(r, body, "timestamp")
+	rn := callbackParam(r, body, "rn")
+	echostr := callbackParam(r, body, "echostr")
+	if !p.skipVerify && (signature == "" || timestamp == "" || rn == "") {
+		slog.Warn("ruliu: missing signature params", "raw_query", r.URL.RawQuery, "content_type", r.Header.Get("Content-Type"))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if !p.skipVerify && !p.verifySignature(signature, rn, timestamp) {
+		slog.Warn("ruliu: signature verification failed",
+			"signature", signature,
+			"expected", p.signatureFor(rn, timestamp),
+			"rn", rn,
+			"timestamp", timestamp,
+			"raw_query", r.URL.RawQuery,
+			"content_type", r.Header.Get("Content-Type"),
+		)
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+	if p.skipVerify && signature != "" && timestamp != "" && rn != "" && !p.verifySignature(signature, rn, timestamp) {
+		slog.Warn("ruliu: signature verification skipped",
+			"signature", signature,
+			"expected", p.signatureFor(rn, timestamp),
+			"rn", rn,
+			"timestamp", timestamp,
+			"raw_query", r.URL.RawQuery,
+			"content_type", r.Header.Get("Content-Type"),
+		)
+	}
+
+	if echostr != "" {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, echostr)
+		return
+	}
+
+	raw := strings.TrimSpace(string(body))
+	if raw == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	payload, err := p.decryptPayload(raw)
+	if err != nil {
+		slog.Error("ruliu: decrypt callback body failed", "error", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var envelope callbackEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		slog.Error("ruliu: decode callback payload failed", "error", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	if msgTime, ok := callbackTime(envelope.Time); ok && core.IsOldMessage(msgTime) {
+		slog.Debug("ruliu: ignoring old callback", "time", envelope.Time)
+		return
+	}
+	if envelope.EventType != "MESSAGE_RECEIVE" {
+		slog.Debug("ruliu: ignoring unsupported event", "event_type", envelope.EventType)
+		return
+	}
+
+	fromUserID := envelope.Message.Header.FromUserID
+	if !core.AllowList(p.allowFrom, fromUserID) {
+		slog.Debug("ruliu: message from unauthorized user", "user", fromUserID)
+		return
+	}
+
+	messageID := callbackMessageID(envelope.Message.Header)
+	if messageID != "" && p.dedup.IsDuplicate(messageID) {
+		slog.Debug("ruliu: duplicate message ignored", "message_id", messageID)
+		return
+	}
+
+	content := extractMessageText(envelope.Message.Body)
+	if strings.TrimSpace(content) == "" {
+		slog.Debug("ruliu: ignoring callback without text content", "message_id", messageID)
+		return
+	}
+
+	groupID := callbackGroupID(envelope)
+	if groupID == 0 {
+		slog.Warn("ruliu: missing group id in callback", "message_id", messageID)
+		return
+	}
+
+	var sessionKey string
+	if p.shareSessionInGroup {
+		sessionKey = fmt.Sprintf("ruliu:%d", groupID)
+		content = fmt.Sprintf("[%s]: %s", fromUserID, content)
+	} else {
+		sessionKey = fmt.Sprintf("ruliu:%d:%s", groupID, fromUserID)
+	}
+	p.handler(p, &core.Message{
+		SessionKey: sessionKey,
+		Platform:   "ruliu",
+		MessageID:  messageID,
+		UserID:     fromUserID,
+		UserName:   fromUserID,
+		Content:    content,
+		ReplyCtx:   replyContext{groupID: groupID},
+	})
+}
+
+func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return fmt.Errorf("ruliu: invalid reply context type %T", rctx)
+	}
+	if content == "" {
+		return nil
+	}
+
+	content = core.StripMarkdown(content)
+	for _, chunk := range splitByRunes(content, maxTextRunes) {
+		if strings.TrimSpace(chunk) == "" {
+			continue
+		}
+		if err := p.sendText(ctx, rc.groupID, chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
+	return p.Reply(ctx, rctx, content)
+}
+
+func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) < 2 || parts[0] != "ruliu" {
+		return nil, fmt.Errorf("ruliu: invalid session key %q", sessionKey)
+	}
+	groupID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("ruliu: invalid group id in session key %q: %w", sessionKey, err)
+	}
+	return replyContext{groupID: groupID}, nil
+}
+
+func (p *Platform) Stop() error {
+	if p.server != nil {
+		return p.server.Shutdown(context.Background())
+	}
+	return nil
+}
+
+func (p *Platform) verifySignature(signature, rn, timestamp string) bool {
+	return strings.EqualFold(signature, p.signatureFor(rn, timestamp))
+}
+
+func (p *Platform) signatureFor(rn, timestamp string) string {
+	sum := md5.Sum([]byte(rn + timestamp + p.token))
+	return hex.EncodeToString(sum[:])
+}
+
+func (p *Platform) decryptPayload(raw string) ([]byte, error) {
+	ciphertext, err := decodeURLBase64(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode ciphertext: %w", err)
+	}
+	plaintext, err := decryptECB(ciphertext, p.aesKey)
+	if err != nil {
+		return nil, err
+	}
+	return pkcs7Unpad(plaintext, aes.BlockSize)
+}
+
+func (p *Platform) sendText(ctx context.Context, groupID int64, text string) error {
+	reqBody, err := json.Marshal(sendRequest{
+		Message: sendMessage{
+			Header: sendHeader{ToID: []int64{groupID}},
+			Body: []sendBodyItem{{
+				Type:    "TEXT",
+				Content: text,
+			}},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("ruliu: marshal send request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.webhook, bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("ruliu: build send request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := core.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("ruliu: send message: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("ruliu: read send response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ruliu: send returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result sendResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("ruliu: decode send response: %w", err)
+	}
+	code := result.ErrCode
+	if code == 0 {
+		code = result.ErrorCode
+	}
+	msg := result.ErrMsg
+	if msg == "" {
+		msg = result.Msg
+	}
+	if code != 0 {
+		return fmt.Errorf("ruliu: send failed: %d %s", code, msg)
+	}
+	return nil
+}
+
+func callbackParam(r *http.Request, body []byte, key string) string {
+	if value := rawKVValue(r.URL.RawQuery, key); value != "" {
+		return value
+	}
+	if value := rawBodyValue(r.Header.Get("Content-Type"), body, key); value != "" {
+		return value
+	}
+	return ""
+}
+
+func rawBodyValue(contentType string, body []byte, key string) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	if strings.HasPrefix(contentType, "application/x-www-form-urlencoded") {
+		return rawKVValue(string(body), key)
+	}
+	if strings.HasPrefix(contentType, "application/json") {
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err == nil {
+			if value, ok := payload[key].(string); ok {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func rawKVValue(raw, key string) string {
+	for _, pair := range strings.Split(raw, "&") {
+		if pair == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok || k != key {
+			continue
+		}
+		decoded, err := url.QueryUnescape(v)
+		if err != nil {
+			return v
+		}
+		return decoded
+	}
+	return ""
+}
+
+func callbackGroupID(envelope callbackEnvelope) int64 {
+	if envelope.GroupID > 0 {
+		return envelope.GroupID
+	}
+	if envelope.Message.Header.ToID > 0 {
+		return envelope.Message.Header.ToID
+	}
+	return 0
+}
+
+func callbackMessageID(header callbackHeader) string {
+	switch {
+	case header.MessageID > 0:
+		return strconv.FormatInt(header.MessageID, 10)
+	case header.ClientMsg > 0:
+		return "client:" + strconv.FormatInt(header.ClientMsg, 10)
+	case strings.TrimSpace(header.MsgSeqID) != "":
+		return "seq:" + strings.TrimSpace(header.MsgSeqID)
+	default:
+		return ""
+	}
+}
+
+func extractMessageText(items []callbackBodyItem) string {
+	var parts []string
+	for _, item := range items {
+		switch item.Type {
+		case "TEXT":
+			if text := strings.TrimSpace(item.Content); text != "" {
+				parts = append(parts, text)
+			}
+		case "LINK":
+			if label := strings.TrimSpace(item.Label); label != "" {
+				parts = append(parts, label)
+			}
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n"))
+}
+
+func splitByRunes(s string, maxLen int) []string {
+	if maxLen <= 0 {
+		return []string{s}
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return []string{s}
+	}
+
+	parts := make([]string, 0, len(runes)/maxLen+1)
+	for len(runes) > 0 {
+		end := maxLen
+		if end > len(runes) {
+			end = len(runes)
+		}
+		parts = append(parts, string(runes[:end]))
+		runes = runes[end:]
+	}
+	return parts
+}
+
+func callbackTime(ts int64) (time.Time, bool) {
+	if ts <= 0 {
+		return time.Time{}, false
+	}
+	// 如流文档示例里 time 是时间戳，但未明确固定秒/毫秒；这里兼容两种格式。
+	if ts < 1_000_000_000_000 {
+		return time.Unix(ts, 0), true
+	}
+	return time.UnixMilli(ts), true
+}
+
+func decodeEncodingAESKey(s string) ([]byte, error) {
+	if len(s) != 22 {
+		return nil, fmt.Errorf("expected 22 chars, got %d", len(s))
+	}
+	key, err := base64.StdEncoding.DecodeString(s + "==")
+	if err != nil {
+		return nil, err
+	}
+	if len(key) != aes.BlockSize {
+		return nil, fmt.Errorf("decoded key length %d, want %d", len(key), aes.BlockSize)
+	}
+	return key, nil
+}
+
+func decodeURLBase64(s string) ([]byte, error) {
+	replacer := strings.NewReplacer("-", "+", "_", "/")
+	s = replacer.Replace(s)
+	switch len(s) % 4 {
+	case 0:
+	case 2:
+		s += "=="
+	case 3:
+		s += "="
+	default:
+		return nil, fmt.Errorf("invalid base64 length")
+	}
+	return base64.StdEncoding.DecodeString(s)
+}
+
+func decryptECB(ciphertext, key []byte) ([]byte, error) {
+	if len(ciphertext) == 0 || len(ciphertext)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("invalid ciphertext length %d", len(ciphertext))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+
+	plaintext := make([]byte, len(ciphertext))
+	for start := 0; start < len(ciphertext); start += aes.BlockSize {
+		block.Decrypt(plaintext[start:start+aes.BlockSize], ciphertext[start:start+aes.BlockSize])
+	}
+	return plaintext, nil
+}
+
+func pkcs7Unpad(data []byte, blockSize int) ([]byte, error) {
+	if len(data) == 0 || len(data)%blockSize != 0 {
+		return nil, fmt.Errorf("invalid plaintext length %d", len(data))
+	}
+	padding := int(data[len(data)-1])
+	if padding == 0 || padding > blockSize || padding > len(data) {
+		return nil, fmt.Errorf("invalid padding size %d", padding)
+	}
+	for i := len(data) - padding; i < len(data); i++ {
+		if int(data[i]) != padding {
+			return nil, fmt.Errorf("invalid padding bytes")
+		}
+	}
+	return data[:len(data)-padding], nil
+}

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,40 @@
+//go:build ignore
+
+// proxy routes /ruliu/codex/callback → :8082/ruliu/callback
+//              /ruliu/cc/callback    → :8083/ruliu/callback
+// Run: go run proxy.go
+
+package main
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+func rewriteProxy(target *url.URL, stripPrefix string) http.Handler {
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	orig := proxy.Director
+	proxy.Director = func(r *http.Request) {
+		orig(r)
+		// /ruliu/codex/callback → /ruliu/callback
+		r.URL.Path = "/ruliu" + strings.TrimPrefix(r.URL.Path, stripPrefix)
+		r.URL.RawPath = ""
+		log.Printf("proxy → %s%s", target.Host, r.URL.Path)
+	}
+	return proxy
+}
+
+func main() {
+	codex, _ := url.Parse("http://localhost:8082")
+	cc, _ := url.Parse("http://localhost:8083")
+
+	mux := http.NewServeMux()
+	mux.Handle("/ruliu/codex/", rewriteProxy(codex, "/ruliu/codex"))
+	mux.Handle("/ruliu/cc/", rewriteProxy(cc, "/ruliu/cc"))
+
+	log.Println("proxy listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}


### PR DESCRIPTION
## Summary

- Add Ruliu (如流) platform adapter (`platform/ruliu/`) supporting HTTP Webhook mode
- Implement AES-128-ECB message decryption and MD5 signature verification
- Support text message sending with automatic truncation (2000 chars max)
- Add `plugin_platform_ruliu.go` following the existing build-tag plugin pattern
- Add Ruliu config example to `config.example.toml`
- Add detailed integration docs at `docs/ruliu.md`

## Platform Details

- **Connection**: HTTP Webhook (requires public URL or enterprise gateway)
- **Auth**: MD5 signature (`md5(rn+timestamp+token)`) + AES-128-ECB body decryption
- **Features**: `@bot` message routing, group session sharing (`share_session_in_group`)

## Test Plan

- [ ] Tests pass: `go test ./...`
- [ ] Build succeeds: `make build`
- [ ] Configure a Ruliu bot and verify webhook handshake and message routing