### PR TITLE
fix(feishu): guard against nil File in image and resource downloads

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -956,6 +956,9 @@ func (p *Platform) downloadImage(messageID, imageKey string) ([]byte, string, er
 	if !resp.Success() {
 		return nil, "", fmt.Errorf("%s: image API code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
 	}
+	if resp.File == nil {
+		return nil, "", fmt.Errorf("%s: image API returned nil file body", p.tag())
+	}
 	data, err := io.ReadAll(resp.File)
 	if err != nil {
 		return nil, "", fmt.Errorf("%s: read image: %w", p.tag(), err)
@@ -978,6 +981,9 @@ func (p *Platform) downloadResource(messageID, fileKey, resType string) ([]byte,
 	}
 	if !resp.Success() {
 		return nil, fmt.Errorf("%s: resource API code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+	}
+	if resp.File == nil {
+		return nil, fmt.Errorf("%s: resource API returned nil file body", p.tag())
 	}
 	data, err := io.ReadAll(resp.File)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `downloadImage()` and `downloadResource()` call `io.ReadAll(resp.File)` without checking if `resp.File` is nil. The Feishu SDK's `GetMessageResourceResp.File` is typed as `io.Reader` and can be nil even when `resp.Success()` returns true.
- Add nil checks to convert a potential panic into a handled error.

## Root cause

The Feishu SDK's `GetMessageResourceResp` struct defines `File io.Reader` which defaults to nil. The `Success()` method only checks `resp.Code == 0`. In edge cases (e.g., empty file, transient server issue returning success with no body), `File` can be nil while `Success()` is true. `io.ReadAll(nil)` panics with a nil pointer dereference.

Notably, the SDK's own `WriteFile()` method has the same vulnerability — it also calls `ioutil.ReadAll(resp.File)` without a nil check.

## Test plan

- [x] `go test ./platform/feishu/` — passes
- [x] `go test ./...` — full suite passes