### PR TITLE
fix(core): protect degraded field read in streamPreview.canPreview

### DIFF
--- a/core/streaming.go
+++ b/core/streaming.go
@@ -78,7 +78,10 @@ func newStreamPreview(cfg StreamPreviewCfg, p Platform, replyCtx any, ctx contex
 
 // canPreview returns true if the platform supports message updating and is not disabled.
 func (sp *streamPreview) canPreview() bool {
-	if sp.degraded || !sp.cfg.Enabled {
+	sp.mu.Lock()
+	degraded := sp.degraded
+	sp.mu.Unlock()
+	if degraded || !sp.cfg.Enabled {
 		return false
 	}
 	// Check if platform is in disabled list


### PR DESCRIPTION
## Summary

- `canPreview()` reads `sp.degraded` without holding `sp.mu`, but the field is written under the lock by `flushLocked()` (from the timer goroutine) and `freeze()`. This is a data race.
- Acquire `sp.mu` briefly in `canPreview()` to read `sp.degraded` safely.

## Root cause

`streamPreview` uses `sp.mu` to protect its mutable state. The `degraded` field is written under the lock in multiple places (`flushLocked` lines 167/178/185/200, `freeze` line 231). However, `canPreview()` reads `sp.degraded` at line 81 without the lock.

`canPreview()` is called from the main event processing goroutine in `processInteractiveEvents` (engine.go lines 1647, 1671, 1714), while `flushLocked()` runs in the timer callback goroutine via `scheduleFlushLocked()` → `time.AfterFunc()`. These are concurrent goroutines, making this a textbook data race on a boolean field.

## Test plan

- [x] All streaming preview tests pass (`TestStreamPreview_*`)
- [x] `go test ./core/` — all tests pass
- [x] `go test ./...` — full suite passes