### PR TITLE
fix(core): use engine context for shell command execution

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2520,7 +2520,7 @@ func (e *Engine) cmdShell(p Platform, msg *Message, raw string) {
 	}
 
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		ctx, cancel := context.WithTimeout(e.ctx, 60*time.Second)
 		defer cancel()
 
 		cmd := exec.CommandContext(ctx, "sh", "-c", shellCmd)
@@ -6383,7 +6383,7 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 	}
 
 	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(e.ctx, 60*time.Second)
 	defer cancel()
 
 	// Execute command using shell


### PR DESCRIPTION
## Summary

- `cmdShell` and custom exec commands (`cmdCommandsAddExec`) create contexts from `context.Background()`, so shell processes are not cancelled when the engine shuts down. They continue running until the 60-second timeout expires, preventing graceful shutdown.
- Use `e.ctx` as the parent context so the engine's cancellation signal propagates to running shell commands.

## Root cause

Both `/shell` command execution (line 2523) and custom exec command execution (line 6386) use `context.WithTimeout(context.Background(), 60*time.Second)`. When `e.Stop()` is called during shutdown or restart, it cancels `e.ctx`, but shell processes created with `context.Background()` don't receive this signal. They keep running until the 60-second timeout, delaying graceful shutdown and potentially leaking resources.

This is inconsistent with cron job execution (line 694) which already correctly uses `e.ctx` as the parent.

## Changes

| Location | Before | After |
|----------|--------|-------|
| `cmdShell` (line 2523) | `context.Background()` | `e.ctx` |
| `cmdCommandsAddExec` (line 6386) | `context.Background()` | `e.ctx` |

## Test plan

- [x] `TestEngine_AdminFrom_AdminCanRunShell` — passes
- [x] `TestEngine_CustomCommand_DisabledByRole` — passes
- [x] `go test ./core/` — all tests pass
- [x] `go test ./...` — full suite passes