### PR TITLE
codex/telegram: prefer native session names and stop dropping Telegram commands on restart

### DIFF
--- a/agent/codex/list.go
+++ b/agent/codex/list.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -13,6 +14,138 @@ import (
 
 	"github.com/chenhg5/cc-connect/core"
 )
+
+type codexThreadMeta struct {
+	DisplayName string
+	Title       string
+}
+
+func codexHomeDir() string {
+	if codexHome := os.Getenv("CODEX_HOME"); codexHome != "" {
+		return codexHome
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(homeDir, ".codex")
+}
+
+func loadCodexThreadMeta(codexHome, workDir string) map[string]codexThreadMeta {
+	threadMeta := make(map[string]codexThreadMeta)
+	indexPath := filepath.Join(codexHome, "session_index.jsonl")
+	titlesPath := filepath.Join(codexHome, "state_5.sqlite")
+
+	for id, title := range loadCodexThreadTitles(titlesPath, workDir) {
+		meta := threadMeta[id]
+		meta.Title = normalizeCodexSessionLabel(title)
+		threadMeta[id] = meta
+	}
+
+	for id, threadName := range loadCodexThreadNames(indexPath) {
+		meta := threadMeta[id]
+		meta.DisplayName = normalizeCodexSessionLabel(threadName)
+		threadMeta[id] = meta
+	}
+
+	return threadMeta
+}
+
+func loadCodexThreadNames(path string) map[string]string {
+	threadNames := make(map[string]string)
+	if path == "" {
+		return threadNames
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return threadNames
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var entry struct {
+			ID         string `json:"id"`
+			ThreadName string `json:"thread_name"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.ID == "" || strings.TrimSpace(entry.ThreadName) == "" {
+			continue
+		}
+
+		threadNames[entry.ID] = strings.TrimSpace(entry.ThreadName)
+	}
+
+	return threadNames
+}
+
+func loadCodexThreadTitles(dbPath, workDir string) map[string]string {
+	titles := make(map[string]string)
+	if dbPath == "" {
+		return titles
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		return titles
+	}
+
+	sqlite3, err := exec.LookPath("sqlite3")
+	if err != nil {
+		return titles
+	}
+
+	escapedWorkDir := strings.ReplaceAll(workDir, "'", "''")
+	query := fmt.Sprintf(
+		"SELECT id, substr(title, 1, 512) AS title FROM threads WHERE cwd = '%s'",
+		escapedWorkDir,
+	)
+	output, err := exec.Command(sqlite3, dbPath, "-json", query).Output()
+	if err != nil {
+		return titles
+	}
+
+	var rows []struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal(output, &rows); err != nil {
+		return titles
+	}
+
+	for _, row := range rows {
+		if row.ID == "" || strings.TrimSpace(row.Title) == "" {
+			continue
+		}
+		titles[row.ID] = row.Title
+	}
+
+	return titles
+}
+
+func normalizeCodexSessionLabel(text string) string {
+	text = strings.ReplaceAll(text, "\n", " ")
+	text = strings.Join(strings.Fields(text), " ")
+	return strings.TrimSpace(text)
+}
+
+func resolveCodexDisplayName(meta codexThreadMeta) string {
+	displayName := normalizeCodexSessionLabel(meta.DisplayName)
+	if displayName != "" {
+		return displayName
+	}
+	return normalizeCodexSessionLabel(meta.Title)
+}
 
 // listCodexSessions scans ~/.codex/sessions/ for JSONL transcript files
 // whose cwd matches workDir.
@@ -22,16 +155,12 @@ func listCodexSessions(workDir string) ([]core.AgentSessionInfo, error) {
 		absWorkDir = workDir
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-
-	codexHome := os.Getenv("CODEX_HOME")
+	codexHome := codexHomeDir()
 	if codexHome == "" {
-		codexHome = filepath.Join(homeDir, ".codex")
+		return nil, fmt.Errorf("resolve CODEX_HOME: empty path")
 	}
 	sessionsDir := filepath.Join(codexHome, "sessions")
+	threadMeta := loadCodexThreadMeta(codexHome, absWorkDir)
 
 	var files []string
 	_ = filepath.Walk(sessionsDir, func(path string, info os.FileInfo, err error) error {
@@ -50,7 +179,7 @@ func listCodexSessions(workDir string) ([]core.AgentSessionInfo, error) {
 
 	var sessions []core.AgentSessionInfo
 	for _, f := range files {
-		info := parseCodexSessionFile(f, absWorkDir)
+		info := parseCodexSessionFile(f, absWorkDir, threadMeta)
 		if info != nil {
 			patchSessionSource(info.ID)
 			sessions = append(sessions, *info)
@@ -66,7 +195,7 @@ func listCodexSessions(workDir string) ([]core.AgentSessionInfo, error) {
 
 // parseCodexSessionFile reads a Codex JSONL transcript.
 // Returns nil if the session's cwd doesn't match filterCwd.
-func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
+func parseCodexSessionFile(path, filterCwd string, threadMeta map[string]codexThreadMeta) *core.AgentSessionInfo {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil
@@ -82,7 +211,6 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 	var sessionCwd string
 	var summary string
 	var msgCount int
-	userMsgSeen := 0
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 256*1024), 256*1024)
@@ -103,13 +231,17 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 
 		switch entry.Type {
 		case "session_meta":
-			var meta struct {
+			if sessionID != "" {
+				continue
+			}
+
+			var sessionMeta struct {
 				ID  string `json:"id"`
 				Cwd string `json:"cwd"`
 			}
-			if json.Unmarshal(entry.Payload, &meta) == nil {
-				sessionID = meta.ID
-				sessionCwd = meta.Cwd
+			if json.Unmarshal(entry.Payload, &sessionMeta) == nil {
+				sessionID = sessionMeta.ID
+				sessionCwd = sessionMeta.Cwd
 			}
 
 		case "response_item":
@@ -122,7 +254,6 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 			}
 			if json.Unmarshal(entry.Payload, &item) == nil {
 				if item.Role == "user" {
-					userMsgSeen++
 					msgCount++
 					// The actual user prompt is the last user response_item
 					// (earlier ones are system/AGENTS.md instructions).
@@ -152,8 +283,10 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 		summary = string([]rune(summary)[:60]) + "..."
 	}
 
+	meta := threadMeta[sessionID]
 	return &core.AgentSessionInfo{
 		ID:           sessionID,
+		DisplayName:  resolveCodexDisplayName(meta),
 		Summary:      summary,
 		MessageCount: msgCount,
 		ModifiedAt:   stat.ModTime(),
@@ -162,13 +295,9 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 
 // findSessionFile locates the JSONL transcript for a given session ID.
 func findSessionFile(sessionID string) string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	codexHome := os.Getenv("CODEX_HOME")
+	codexHome := codexHomeDir()
 	if codexHome == "" {
-		codexHome = filepath.Join(homeDir, ".codex")
+		return ""
 	}
 	sessionsDir := filepath.Join(codexHome, "sessions")
 

--- a/agent/codex/list_test.go
+++ b/agent/codex/list_test.go
@@ -1,0 +1,150 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func writeTranscript(t *testing.T, path, sessionID, cwd, prompt string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+
+	data := `{"type":"session_meta","payload":{"id":"` + sessionID + `","cwd":"` + cwd + `","source":"cli","originator":"codex_cli_rs"}}` + "\n" +
+		`{"type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"` + prompt + `"}]}}` + "\n" +
+		`{"type":"response_item","payload":{"role":"assistant","content":[{"type":"output_text","text":"ok"}]}}` + "\n"
+
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write transcript %s: %v", path, err)
+	}
+}
+
+func sessionByID(sessions []core.AgentSessionInfo, id string) *core.AgentSessionInfo {
+	for i := range sessions {
+		if sessions[i].ID == id {
+			return &sessions[i]
+		}
+	}
+	return nil
+}
+
+func TestLoadCodexThreadNamesLastEntryWinsAndSkipsInvalid(t *testing.T) {
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+	data := "" +
+		`{"id":"session-1","thread_name":"旧名字"}` + "\n" +
+		`not-json` + "\n" +
+		`{"id":"session-2","thread_name":""}` + "\n" +
+		`{"id":"session-1","thread_name":"服务器运维"}` + "\n"
+
+	if err := os.WriteFile(indexPath, []byte(data), 0o644); err != nil {
+		t.Fatalf("write session index: %v", err)
+	}
+
+	names := loadCodexThreadNames(indexPath)
+	if got := names["session-1"]; got != "服务器运维" {
+		t.Fatalf("names[session-1] = %q, want %q", got, "服务器运维")
+	}
+	if _, ok := names["session-2"]; ok {
+		t.Fatalf("session-2 should be skipped when thread_name is empty: %#v", names)
+	}
+}
+
+func TestListCodexSessionsUsesNativeDisplayNameAndSummaryFallback(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+
+	workDir := filepath.Join(codexHome, "workspace")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	indexData := "" +
+		`{"id":"session-1","thread_name":"服务器运维"}` + "\n" +
+		`{"id":"session-2","thread_name":""}` + "\n"
+	if err := os.WriteFile(filepath.Join(codexHome, "session_index.jsonl"), []byte(indexData), 0o644); err != nil {
+		t.Fatalf("write session index: %v", err)
+	}
+
+	writeTranscript(t, filepath.Join(codexHome, "sessions", "2026", "03", "17", "session-1.jsonl"), "session-1", workDir, "PLEASE IMPLEMENT THIS PLAN")
+	writeTranscript(t, filepath.Join(codexHome, "sessions", "2026", "03", "17", "session-2.jsonl"), "session-2", workDir, "原始摘要")
+	writeTranscript(t, filepath.Join(codexHome, "sessions", "2026", "03", "17", "session-3.jsonl"), "session-3", filepath.Join(codexHome, "other"), "不应匹配")
+
+	sessions, err := listCodexSessions(workDir)
+	if err != nil {
+		t.Fatalf("listCodexSessions: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("session count = %d, want 2", len(sessions))
+	}
+
+	session1 := sessionByID(sessions, "session-1")
+	if session1 == nil {
+		t.Fatalf("missing session-1 in %#v", sessions)
+	}
+	if session1.DisplayName != "服务器运维" {
+		t.Fatalf("session-1 display name = %q, want %q", session1.DisplayName, "服务器运维")
+	}
+	if session1.Summary != "PLEASE IMPLEMENT THIS PLAN" {
+		t.Fatalf("session-1 summary = %q, want original summary", session1.Summary)
+	}
+
+	session2 := sessionByID(sessions, "session-2")
+	if session2 == nil {
+		t.Fatalf("missing session-2 in %#v", sessions)
+	}
+	if session2.DisplayName != "" {
+		t.Fatalf("session-2 display name = %q, want empty fallback", session2.DisplayName)
+	}
+	if session2.Summary != "原始摘要" {
+		t.Fatalf("session-2 summary = %q, want %q", session2.Summary, "原始摘要")
+	}
+}
+
+func TestResolveCodexDisplayNamePrefersNativeThreadNameVerbatim(t *testing.T) {
+	meta := codexThreadMeta{
+		DisplayName: `导出书库笔记到桌面文件夹」}**Wait** The final is:`,
+		Title:       `我要换设备了，刚刚把旧的tab10已经连接到mac，书库和笔记请帮我导出到桌面（新建一个文件夹）`,
+	}
+
+	got := resolveCodexDisplayName(meta)
+	want := `导出书库笔记到桌面文件夹」}**Wait** The final is:`
+	if got != want {
+		t.Fatalf("resolveCodexDisplayName() = %q, want %q", got, want)
+	}
+}
+
+func TestParseCodexSessionFileUsesFirstSessionMetaOnly(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "workspace")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	path := filepath.Join(dir, "session.jsonl")
+	data := "" +
+		`{"type":"session_meta","payload":{"id":"session-first","cwd":"` + workDir + `"}}` + "\n" +
+		`{"type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"首条提示"}]}}` + "\n" +
+		`{"type":"session_meta","payload":{"id":"session-last","cwd":"/tmp/other"}}` + "\n"
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+
+	info := parseCodexSessionFile(path, workDir, map[string]codexThreadMeta{
+		"session-first": {DisplayName: "网络维护"},
+		"session-last":  {DisplayName: "错误命中"},
+	})
+	if info == nil {
+		t.Fatal("parseCodexSessionFile() returned nil")
+	}
+	if info.ID != "session-first" {
+		t.Fatalf("info.ID = %q, want %q", info.ID, "session-first")
+	}
+	if info.DisplayName != "网络维护" {
+		t.Fatalf("info.DisplayName = %q, want %q", info.DisplayName, "网络维护")
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -160,9 +160,9 @@ type Engine struct {
 	bannedMu    sync.RWMutex
 
 	disabledCmds map[string]bool
-	adminFrom    string // comma-separated user IDs for privileged commands; "*" = all allowed users; "" = deny
+	adminFrom    string           // comma-separated user IDs for privileged commands; "*" = all allowed users; "" = deny
 	userRoles    *UserRoleManager // nil = legacy mode (no per-user policies)
-	userRolesMu  sync.RWMutex    // protects userRoles, disabledCmds, and adminFrom
+	userRolesMu  sync.RWMutex     // protects userRoles, disabledCmds, and adminFrom
 
 	rateLimiter      *RateLimiter
 	streamPreview    StreamPreviewCfg
@@ -1933,7 +1933,7 @@ var builtinCommands = []struct {
 }{
 	{[]string{"new"}, "new"},
 	{[]string{"list", "sessions"}, "list"},
-	{[]string{"switch"}, "switch"},
+	{[]string{"switch", "swich"}, "switch"},
 	{[]string{"name", "rename"}, "name"},
 	{[]string{"current"}, "current"},
 	{[]string{"status"}, "status"},
@@ -1967,6 +1967,14 @@ var builtinCommands = []struct {
 	{[]string{"dir", "cd", "chdir", "workdir"}, "dir"},
 	{[]string{"tts"}, "tts"},
 	{[]string{"workspace", "ws"}, "workspace"},
+}
+
+var attachedArgCommands = map[string]bool{
+	"delete": true,
+	"list":   true,
+	"name":   true,
+	"search": true,
+	"switch": true,
 }
 
 // matchPrefix finds a unique command matching the given prefix.
@@ -2021,10 +2029,52 @@ func matchSubCommand(input string, candidates []string) string {
 	return input
 }
 
-func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
+func splitCommandAndArgs(raw string) (string, []string) {
 	parts := strings.Fields(raw)
+	if len(parts) == 0 {
+		return "", nil
+	}
+
 	cmd := strings.ToLower(strings.TrimPrefix(parts[0], "/"))
 	args := parts[1:]
+	if len(args) > 0 || !strings.HasPrefix(parts[0], "/") {
+		return cmd, args
+	}
+
+	body := strings.TrimPrefix(parts[0], "/")
+	var matchedID string
+	var matchedRest string
+	var matchedLen int
+
+	for _, candidate := range builtinCommands {
+		if !attachedArgCommands[candidate.id] {
+			continue
+		}
+		for _, name := range candidate.names {
+			if !strings.HasPrefix(body, name) || len(body) <= len(name) {
+				continue
+			}
+			if len(name) <= matchedLen {
+				continue
+			}
+			matchedID = candidate.id
+			matchedRest = strings.TrimSpace(body[len(name):])
+			matchedLen = len(name)
+		}
+	}
+
+	if matchedID != "" && matchedRest != "" {
+		return matchedID, []string{matchedRest}
+	}
+
+	return cmd, args
+}
+
+func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
+	cmd, args := splitCommandAndArgs(raw)
+	if cmd == "" {
+		return false
+	}
 
 	cmdID := matchPrefix(cmd, builtinCommands)
 
@@ -2297,6 +2347,97 @@ func (e *Engine) cmdNew(p Platform, msg *Message, args []string) {
 
 const listPageSize = 20
 
+func normalizeSessionLabel(text string) string {
+	text = strings.ReplaceAll(text, "\n", " ")
+	text = strings.Join(strings.Fields(text), " ")
+	return strings.TrimSpace(text)
+}
+
+func truncateSessionLabel(text string, limit int) string {
+	if limit <= 0 || utf8.RuneCountInString(text) <= limit {
+		return text
+	}
+
+	runes := []rune(text)
+	return string(runes[:limit]) + "…"
+}
+
+func customSessionName(manager *SessionManager, sessionID string) string {
+	if manager == nil || sessionID == "" {
+		return ""
+	}
+	return normalizeSessionLabel(manager.GetSessionName(sessionID))
+}
+
+func nativeSessionDisplayName(info AgentSessionInfo) string {
+	return normalizeSessionLabel(info.DisplayName)
+}
+
+func (e *Engine) resolveAgentSessionDisplayName(manager *SessionManager, info AgentSessionInfo) string {
+	if name := customSessionName(manager, info.ID); name != "" {
+		return name
+	}
+	if name := nativeSessionDisplayName(info); name != "" {
+		return name
+	}
+	return normalizeSessionLabel(info.Summary)
+}
+
+func (e *Engine) resolveAgentSessionListLabel(manager *SessionManager, info AgentSessionInfo, emptyLabel string) string {
+	if name := customSessionName(manager, info.ID); name != "" {
+		return "📌 " + truncateSessionLabel(name, 40)
+	}
+	if name := nativeSessionDisplayName(info); name != "" {
+		return truncateSessionLabel(name, 40)
+	}
+
+	label := normalizeSessionLabel(info.Summary)
+	if label == "" {
+		label = emptyLabel
+	}
+	return truncateSessionLabel(label, 40)
+}
+
+func (e *Engine) findAgentSessionInfo(agent Agent, sessionID string) *AgentSessionInfo {
+	if agent == nil || sessionID == "" {
+		return nil
+	}
+
+	agentSessions, err := agent.ListSessions(e.ctx)
+	if err != nil {
+		return nil
+	}
+
+	for i := range agentSessions {
+		if agentSessions[i].ID == sessionID {
+			return &agentSessions[i]
+		}
+	}
+
+	return nil
+}
+
+func (e *Engine) resolveSessionDisplayNameByID(agent Agent, manager *SessionManager, sessionID, fallback string) string {
+	if name := customSessionName(manager, sessionID); name != "" {
+		return name
+	}
+	if info := e.findAgentSessionInfo(agent, sessionID); info != nil {
+		if name := e.resolveAgentSessionDisplayName(manager, *info); name != "" {
+			return name
+		}
+	}
+
+	fallback = normalizeSessionLabel(fallback)
+	if fallback != "" {
+		return fallback
+	}
+
+	if len(sessionID) > 12 {
+		return sessionID[:12]
+	}
+	return sessionID
+}
+
 func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 	agent, sessions, _, err := e.commandContext(p, msg)
 	if err != nil {
@@ -2350,19 +2491,7 @@ func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 			if s.ID == activeAgentID {
 				marker = "▶"
 			}
-			displayName := sessions.GetSessionName(s.ID)
-			if displayName != "" {
-				displayName = "📌 " + displayName
-			} else {
-				displayName = strings.ReplaceAll(s.Summary, "\n", " ")
-				displayName = strings.Join(strings.Fields(displayName), " ")
-				if displayName == "" {
-					displayName = "(empty)"
-				}
-				if len([]rune(displayName)) > 40 {
-					displayName = string([]rune(displayName)[:40]) + "…"
-				}
-			}
+			displayName := e.resolveAgentSessionListLabel(sessions, s, "(empty)")
 			sb.WriteString(fmt.Sprintf("%s **%d.** %s · **%d** msgs · %s\n",
 				marker, i+1, displayName, s.MessageCount, s.ModifiedAt.Format("01-02 15:04")))
 		}
@@ -2395,7 +2524,6 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 	}
 	query := strings.TrimSpace(strings.Join(args, " "))
 
-	slog.Info("cmdSwitch: listing agent sessions", "session_key", msg.SessionKey)
 	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
@@ -2413,12 +2541,11 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 		return
 	}
 
-	slog.Info("cmdSwitch: cleaning up old session", "session_key", msg.SessionKey)
 	e.cleanupInteractiveState(interactiveKey)
-	slog.Info("cmdSwitch: cleanup done", "session_key", msg.SessionKey)
 
+	displayName := e.resolveAgentSessionDisplayName(sessions, *matched)
 	session := sessions.GetOrCreateActive(msg.SessionKey)
-	session.SetAgentInfo(matched.ID, agent.Name(), matched.Summary)
+	session.SetAgentInfo(matched.ID, agent.Name(), displayName)
 	session.ClearHistory()
 	sessions.Save()
 
@@ -2426,9 +2553,8 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 	if len(shortID) > 12 {
 		shortID = shortID[:12]
 	}
-	displayName := sessions.GetSessionName(matched.ID)
 	if displayName == "" {
-		displayName = matched.Summary
+		displayName = shortID
 	}
 	e.reply(p, msg.ReplyCtx,
 		e.i18n.Tf(MsgSwitchSuccess, displayName, shortID, matched.MessageCount))
@@ -2439,7 +2565,10 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 //  2. Exact custom name match (case-insensitive)
 //  3. Session ID prefix match
 //  4. Custom name prefix match (case-insensitive)
-//  5. Summary substring match (case-insensitive)
+//  5. Exact native display name match (case-insensitive)
+//  6. Native display name prefix match (case-insensitive)
+//  7. Native display name substring match (case-insensitive)
+//  8. Summary substring match (case-insensitive)
 func (e *Engine) matchSession(sessions []AgentSessionInfo, manager *SessionManager, query string) *AgentSessionInfo {
 	if len(sessions) == 0 {
 		return nil
@@ -2454,8 +2583,8 @@ func (e *Engine) matchSession(sessions []AgentSessionInfo, manager *SessionManag
 
 	// 2. Exact custom name match
 	for i := range sessions {
-		name := manager.GetSessionName(sessions[i].ID)
-		if name != "" && strings.ToLower(name) == queryLower {
+		name := customSessionName(manager, sessions[i].ID)
+		if name != "" && strings.EqualFold(name, query) {
 			return &sessions[i]
 		}
 	}
@@ -2469,15 +2598,39 @@ func (e *Engine) matchSession(sessions []AgentSessionInfo, manager *SessionManag
 
 	// 4. Custom name prefix match
 	for i := range sessions {
-		name := manager.GetSessionName(sessions[i].ID)
+		name := customSessionName(manager, sessions[i].ID)
 		if name != "" && strings.HasPrefix(strings.ToLower(name), queryLower) {
 			return &sessions[i]
 		}
 	}
 
-	// 5. Summary substring match
+	// 5. Exact native display name match
 	for i := range sessions {
-		if sessions[i].Summary != "" && strings.Contains(strings.ToLower(sessions[i].Summary), queryLower) {
+		name := nativeSessionDisplayName(sessions[i])
+		if name != "" && strings.EqualFold(name, query) {
+			return &sessions[i]
+		}
+	}
+
+	// 6. Native display name prefix match
+	for i := range sessions {
+		name := nativeSessionDisplayName(sessions[i])
+		if name != "" && strings.HasPrefix(strings.ToLower(name), queryLower) {
+			return &sessions[i]
+		}
+	}
+
+	// 7. Native display name substring match
+	for i := range sessions {
+		name := nativeSessionDisplayName(sessions[i])
+		if name != "" && strings.Contains(strings.ToLower(name), queryLower) {
+			return &sessions[i]
+		}
+	}
+
+	// 8. Summary substring match
+	for i := range sessions {
+		if summary := normalizeSessionLabel(sessions[i].Summary); summary != "" && strings.Contains(strings.ToLower(summary), queryLower) {
 			return &sessions[i]
 		}
 	}
@@ -2630,20 +2783,27 @@ func (e *Engine) cmdSearch(p Platform, msg *Message, args []string) {
 	var results []searchResult
 
 	for _, s := range agentSessions {
-		// Check session name (custom name or summary)
-		customName := sessions.GetSessionName(s.ID)
-		displayName := customName
-		if displayName == "" {
-			displayName = s.Summary
-		}
+		displayName := e.resolveAgentSessionDisplayName(sessions, s)
 
-		// Match by name/summary
+		// Match by display name
 		if strings.Contains(strings.ToLower(displayName), keyword) {
 			results = append(results, searchResult{
 				id:           s.ID,
 				name:         displayName,
 				summary:      s.Summary,
 				matchType:    "name",
+				messageCount: s.MessageCount,
+			})
+			continue
+		}
+
+		// Match by summary even if a custom/native name exists.
+		if summary := normalizeSessionLabel(s.Summary); summary != "" && strings.Contains(strings.ToLower(summary), keyword) {
+			results = append(results, searchResult{
+				id:           s.ID,
+				name:         displayName,
+				summary:      s.Summary,
+				matchType:    "message",
 				messageCount: s.MessageCount,
 			})
 			continue
@@ -2745,7 +2905,7 @@ func (e *Engine) cmdName(p Platform, msg *Message, args []string) {
 
 func (e *Engine) cmdCurrent(p Platform, msg *Message) {
 	if !supportsCards(p) {
-		_, sessions, _, err := e.commandContext(p, msg)
+		agent, sessions, _, err := e.commandContext(p, msg)
 		if err != nil {
 			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
 			return
@@ -2755,7 +2915,8 @@ func (e *Engine) cmdCurrent(p Platform, msg *Message) {
 		if agentID == "" {
 			agentID = e.i18n.T(MsgSessionNotStarted)
 		}
-		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCurrentSession), s.Name, agentID, len(s.History)))
+		displayName := e.resolveSessionDisplayNameByID(agent, sessions, s.GetAgentSessionID(), s.GetName())
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCurrentSession), displayName, agentID, len(s.History)))
 		return
 	}
 
@@ -2813,10 +2974,7 @@ func (e *Engine) cmdStatus(p Platform, msg *Message) {
 		modeStr += e.i18n.Tf(MsgStatusQuiet, quietStr)
 
 		s := sessions.GetOrCreateActive(msg.SessionKey)
-		sessionDisplayName := sessions.GetSessionName(s.GetAgentSessionID())
-		if sessionDisplayName == "" {
-			sessionDisplayName = s.Name
-		}
+		sessionDisplayName := e.resolveSessionDisplayNameByID(agent, sessions, s.GetAgentSessionID(), s.GetName())
 		sessionStr := e.i18n.Tf(MsgStatusSession, sessionDisplayName, len(s.History))
 
 		var cronStr string
@@ -3204,10 +3362,7 @@ func (e *Engine) renderStatusCard(sessionKey string) *Card {
 	modeStr += e.i18n.Tf(MsgStatusQuiet, quietStr)
 
 	s := sessions.GetOrCreateActive(sessionKey)
-	sessionDisplayName := sessions.GetSessionName(s.GetAgentSessionID())
-	if sessionDisplayName == "" {
-		sessionDisplayName = s.GetName()
-	}
+	sessionDisplayName := e.resolveSessionDisplayNameByID(agent, sessions, s.GetAgentSessionID(), s.GetName())
 	sessionStr := e.i18n.Tf(MsgStatusSession, sessionDisplayName, len(s.History))
 
 	var cronStr string
@@ -4898,7 +5053,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 		e.cleanupInteractiveState(interactiveKey)
 		session := sessions.GetOrCreateActive(sessionKey)
-		session.SetAgentInfo(matched.ID, agent.Name(), matched.Summary)
+		session.SetAgentInfo(matched.ID, agent.Name(), e.resolveAgentSessionDisplayName(sessions, *matched))
 		session.ClearHistory()
 		sessions.Save()
 
@@ -5452,19 +5607,7 @@ func (e *Engine) renderListCard(sessionKey string, page int) (*Card, error) {
 		if s.ID == activeAgentID {
 			marker = "▶"
 		}
-		displayName := sessions.GetSessionName(s.ID)
-		if displayName != "" {
-			displayName = "📌 " + displayName
-		} else {
-			displayName = strings.ReplaceAll(s.Summary, "\n", " ")
-			displayName = strings.Join(strings.Fields(displayName), " ")
-			if displayName == "" {
-				displayName = e.i18n.T(MsgListEmptySummary)
-			}
-			if len([]rune(displayName)) > 40 {
-				displayName = string([]rune(displayName)[:40]) + "…"
-			}
-		}
+		displayName := e.resolveAgentSessionListLabel(sessions, s, e.i18n.T(MsgListEmptySummary))
 		btnType := "default"
 		if s.ID == activeAgentID {
 			btnType = "primary"
@@ -5499,13 +5642,14 @@ func (e *Engine) renderListCard(sessionKey string, page int) (*Card, error) {
 // ──────────────────────────────────────────────────────────────
 
 func (e *Engine) renderCurrentCard(sessionKey string) *Card {
-	_, sessions := e.sessionContextForKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(sessionKey)
 	s := sessions.GetOrCreateActive(sessionKey)
 	agentID := s.GetAgentSessionID()
 	if agentID == "" {
 		agentID = e.i18n.T(MsgSessionNotStarted)
 	}
-	content := fmt.Sprintf(e.i18n.T(MsgCurrentSession), s.Name, agentID, len(s.History))
+	displayName := e.resolveSessionDisplayNameByID(agent, sessions, s.GetAgentSessionID(), s.GetName())
+	content := fmt.Sprintf(e.i18n.T(MsgCurrentSession), displayName, agentID, len(s.History))
 	return NewCard().
 		Title(e.i18n.T(MsgCardTitleCurrentSession), "turquoise").
 		Markdown(content).
@@ -7158,10 +7302,7 @@ func (e *Engine) deleteSingleSessionReply(msg *Message, deleter SessionDeleter, 
 }
 
 func (e *Engine) deleteSessionDisplayName(sessions *SessionManager, matched *AgentSessionInfo) string {
-	displayName := sessions.GetSessionName(matched.ID)
-	if displayName == "" {
-		displayName = matched.Summary
-	}
+	displayName := e.resolveAgentSessionDisplayName(sessions, *matched)
 	if displayName == "" {
 		shortID := matched.ID
 		if len(shortID) > 12 {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -249,6 +249,10 @@ func newTestEngine() *Engine {
 	return NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
 }
 
+func newTestEngineWithAgent(agent Agent) *Engine {
+	return NewEngine("test", agent, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
+}
+
 func countCardActionValues(card *Card, prefix string) int {
 	count := 0
 	for _, elem := range card.Elements {
@@ -3256,5 +3260,189 @@ func TestExecuteCardAction_ModeCleansUpWithInteractiveKey(t *testing.T) {
 	e.interactiveMu.Unlock()
 	if exists {
 		t.Error("expected interactive state to be cleaned up after /mode")
+	}
+}
+
+func TestEngine_ListUsesNativeDisplayName(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubListAgent{sessions: []AgentSessionInfo{
+		{
+			ID:           "session-1",
+			DisplayName:  "服务器运维",
+			Summary:      "PLEASE IMPLEMENT THIS PLAN",
+			MessageCount: 118,
+			ModifiedAt:   time.Date(2026, 3, 17, 9, 45, 0, 0, time.UTC),
+		},
+	}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	msg := &Message{SessionKey: "telegram:1", ReplyCtx: "ctx"}
+	e.cmdList(p, msg, nil)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "服务器运维") {
+		t.Fatalf("list text = %q, want native display name", p.sent[0])
+	}
+	if strings.Contains(p.sent[0], "PLEASE IMPLEMENT THIS PLAN") {
+		t.Fatalf("list text = %q, should not fall back to summary when native display name exists", p.sent[0])
+	}
+}
+
+func TestEngine_ListCustomNameOverridesNativeDisplayName(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubListAgent{sessions: []AgentSessionInfo{
+		{
+			ID:           "session-1",
+			DisplayName:  "服务器运维",
+			Summary:      "PLEASE IMPLEMENT THIS PLAN",
+			MessageCount: 118,
+			ModifiedAt:   time.Date(2026, 3, 17, 9, 45, 0, 0, time.UTC),
+		},
+	}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.sessions.SetSessionName("session-1", "外部命名")
+
+	msg := &Message{SessionKey: "telegram:1", ReplyCtx: "ctx"}
+	e.cmdList(p, msg, nil)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "📌 外部命名") {
+		t.Fatalf("list text = %q, want pinned custom name", p.sent[0])
+	}
+	if strings.Contains(p.sent[0], "服务器运维") {
+		t.Fatalf("list text = %q, should prefer custom name over native display name", p.sent[0])
+	}
+}
+
+func TestEngine_SearchMatchesNativeDisplayName(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubListAgent{sessions: []AgentSessionInfo{
+		{
+			ID:           "session-1",
+			DisplayName:  "服务器运维",
+			Summary:      "PLEASE IMPLEMENT THIS PLAN",
+			MessageCount: 118,
+			ModifiedAt:   time.Date(2026, 3, 17, 9, 45, 0, 0, time.UTC),
+		},
+	}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	msg := &Message{SessionKey: "telegram:1", ReplyCtx: "ctx"}
+	e.cmdSearch(p, msg, []string{"服务器运维"})
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "服务器运维") {
+		t.Fatalf("search text = %q, want native display name", p.sent[0])
+	}
+}
+
+func TestEngine_SwitchByNativeDisplayNameKeepsCurrentAndStatusConsistent(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubListAgent{sessions: []AgentSessionInfo{
+		{
+			ID:           "session-1",
+			DisplayName:  "服务器运维",
+			Summary:      "PLEASE IMPLEMENT THIS PLAN",
+			MessageCount: 118,
+			ModifiedAt:   time.Date(2026, 3, 17, 9, 45, 0, 0, time.UTC),
+		},
+	}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "telegram:1", ReplyCtx: "ctx"}
+
+	e.cmdSwitch(p, msg, []string{"服务器运维"})
+	if len(p.sent) != 1 {
+		t.Fatalf("switch sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "服务器运维") {
+		t.Fatalf("switch text = %q, want native display name", p.sent[0])
+	}
+
+	p.sent = nil
+	e.cmdCurrent(p, msg)
+	if len(p.sent) != 1 {
+		t.Fatalf("current sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "服务器运维") {
+		t.Fatalf("current text = %q, want native display name", p.sent[0])
+	}
+
+	p.sent = nil
+	e.cmdStatus(p, msg)
+	if len(p.sent) != 1 {
+		t.Fatalf("status sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "服务器运维") {
+		t.Fatalf("status text = %q, want native display name", p.sent[0])
+	}
+	if strings.Contains(p.sent[0], "PLEASE IMPLEMENT THIS PLAN") {
+		t.Fatalf("status text = %q, should not fall back to summary", p.sent[0])
+	}
+}
+
+func TestEngine_HandleCommandSwitchWithoutSpaceUsesAttachedArg(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubListAgent{sessions: []AgentSessionInfo{
+		{
+			ID:           "session-1",
+			DisplayName:  "服务器运维",
+			Summary:      "PLEASE IMPLEMENT THIS PLAN",
+			MessageCount: 118,
+			ModifiedAt:   time.Date(2026, 3, 17, 9, 45, 0, 0, time.UTC),
+		},
+	}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "telegram:1", ReplyCtx: "ctx", UserID: "u1", Platform: "telegram"}
+
+	if !e.handleCommand(p, msg, "/switch服务器运维") {
+		t.Fatal("handleCommand should recognize /switch without an explicit space")
+	}
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "服务器运维") {
+		t.Fatalf("switch text = %q, want native display name", p.sent[0])
+	}
+}
+
+func TestEngine_HandleCommandSwichAliasMapsToSwitch(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubListAgent{sessions: []AgentSessionInfo{
+		{
+			ID:           "session-1",
+			DisplayName:  "服务器运维",
+			Summary:      "PLEASE IMPLEMENT THIS PLAN",
+			MessageCount: 118,
+			ModifiedAt:   time.Date(2026, 3, 17, 9, 45, 0, 0, time.UTC),
+		},
+	}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "telegram:1", ReplyCtx: "ctx", UserID: "u1", Platform: "telegram"}
+
+	if !e.handleCommand(p, msg, "/swich 服务器运维") {
+		t.Fatal("handleCommand should recognize /swich as switch")
+	}
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "服务器运维") {
+		t.Fatalf("switch text = %q, want native display name", p.sent[0])
+	}
+}
+
+func TestSplitCommandAndArgsDoesNotAttachUnsupportedCurrentCommand(t *testing.T) {
+	cmd, args := splitCommandAndArgs("/current服务器运维")
+
+	if cmd != "current服务器运维" {
+		t.Fatalf("cmd = %q, want raw merged command", cmd)
+	}
+	if len(args) != 0 {
+		t.Fatalf("args = %#v, want empty", args)
 	}
 }

--- a/core/message.go
+++ b/core/message.go
@@ -155,10 +155,10 @@ const (
 
 // UserQuestion represents a structured question from AskUserQuestion.
 type UserQuestion struct {
-	Question    string             `json:"question"`
-	Header      string             `json:"header"`
+	Question    string               `json:"question"`
+	Header      string               `json:"header"`
 	Options     []UserQuestionOption `json:"options"`
-	MultiSelect bool               `json:"multiSelect"`
+	MultiSelect bool                 `json:"multiSelect"`
 }
 
 // UserQuestionOption is one choice in a UserQuestion.
@@ -192,6 +192,7 @@ type HistoryEntry struct {
 // AgentSessionInfo describes one session as reported by the agent backend.
 type AgentSessionInfo struct {
 	ID           string
+	DisplayName  string
 	Summary      string
 	MessageCount int
 	ModifiedAt   time.Time

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -79,14 +79,6 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 
 	slog.Info("telegram: connected", "bot", bot.Self.UserName)
 
-	// Drain pending updates from previous session to avoid re-processing old messages.
-	// offset -1 tells Telegram to mark all pending updates as confirmed, returning only the latest one.
-	drain := tgbotapi.NewUpdate(-1)
-	drain.Timeout = 0
-	if _, err := bot.GetUpdates(drain); err != nil {
-		slog.Warn("telegram: failed to drain old updates", "error", err)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
 


### PR DESCRIPTION
## Summary

This PR improves the Codex session experience in chat platforms and fixes a Telegram delivery issue found during local verification.

It does three things:

1. Prefer Codex native session names (`thread_name`, then `title`) over transcript summaries
2. Reuse that same naming priority consistently across session UI and matching
3. Stop dropping pending Telegram updates during service restarts

## Changes

### Codex native session names

- load Codex-native session metadata from:
  - `session_index.jsonl` for `thread_name`
  - `state_5.sqlite` for `title` fallback
- add `DisplayName` to `core.AgentSessionInfo`
- keep transcript summary as the final fallback only

### Unified session display and matching

Use the same priority everywhere:

1. cc-connect custom name from `/name`
2. Codex native display name
3. transcript summary

This now applies to:

- `/list`
- `/search`
- `/switch`
- `/current`
- `/status`

Session matching also now supports:

- numeric `/switch <number>`
- custom name match
- session ID prefix match
- native display name exact / prefix / substring match

### More forgiving slash-command parsing

- accept `swich` as an alias for `switch`
- accept attached arguments for selected commands such as:
  - `/switchfoo`
  - `/searchbar`
  - `/list2`

This was added after reproducing chat-side command parsing issues during Telegram testing.

### Telegram restart behavior

Remove the startup drain that acknowledged and discarded pending Telegram updates.

`cc-connect` already filters stale messages with `IsOldMessage`, so draining pending updates at startup could drop valid commands sent during a restart window.

With this change, commands sent while the service is restarting are no longer silently lost.

## Validation

Passed:

- `go test ./platform/telegram ./core ./agent/codex`

Also verified locally with a real Telegram bot session:

- `/list`
- `/search server`
- `/switch server`
- `/switch 5`
- `/current`
- `/status`

Full test suite result:

- `go test ./...`

Known unrelated failure:

- `agent/cursor: TestFetchModelsFromAgentCLI`

That test depends on local `agent models` output and appears to be environment-sensitive. It is unrelated to this PR.

## Notes

- custom `/name` labels still take precedence over Codex-native names
- if native metadata is unavailable, behavior falls back gracefully to the existing summary-based display
- Telegram platform/config format is unchanged
