### PR TITLE
feat(cli): add version update hint to help output

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -735,12 +735,16 @@ func printUsage() {
 	if v == "" || v == "dev" {
 		v = "dev"
 	}
+
+	// 检查是否有新版本可用并显示提示
+	updateHint := getUpdateHintIfAvailable()
+
 	fmt.Fprintf(os.Stderr, `
                                               _
   ___ ___        ___ ___  _ __  _ __   ___  ___| |_
  / __/ __|_____ / __/ _ \| '_ \| '_ \ / _ \/ __| __|
 | (_| (_|_____|  (_| (_) | | | | | | |  __/ (__| |_
- \___\__|      \___\___/|_| |_|_| |_|\___|\___|\__|  %s
+ \___\__|      \___\___/|_| |_|_| |_|\___|\___|\__|  %s%s
 
   Bridge your messaging platforms to local AI coding agents.
   Supports: Claude Code, Codex, Cursor, Gemini CLI, Qoder CLI, OpenCode
@@ -810,7 +814,7 @@ Examples:
   cc-connect config-example           Print full config.toml example
   cc-connect config-example > c.toml  Save example config to a file
 
-`, v)
+`, v, updateHint)
 }
 
 func setupLogger(level string, w io.Writer) {

--- a/cmd/cc-connect/update.go
+++ b/cmd/cc-connect/update.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -19,12 +20,114 @@ const (
 	githubAPI    = "https://api.github.com/repos/" + githubRepo + "/releases/latest"
 	githubAllAPI = "https://api.github.com/repos/" + githubRepo + "/releases"
 	downloadBase = "https://github.com/" + githubRepo + "/releases/download"
+	giteeAPI     = "https://gitee.com/api/v5/repos/cg33/cc-connect/releases/latest"
 )
+
+// cachedLatestVersion 缓存最新版本信息，避免频繁请求API
+var cachedLatestVersion struct {
+	version   string
+	timestamp time.Time
+	mu        sync.RWMutex
+}
+
+// versionCheckTTL 缓存有效期（1小时）
+const versionCheckTTL = time.Hour
 
 type githubRelease struct {
 	TagName    string `json:"tag_name"`
 	HTMLURL    string `json:"html_url"`
 	Prerelease bool   `json:"prerelease"`
+}
+
+// fetchLatestStableReleaseAsync 异步获取最新稳定版本（非pre-release）
+// 优先使用Gitee，如果失败则回退到GitHub
+func fetchLatestStableReleaseAsync() {
+	go func() {
+		release, err := fetchLatestStableFromGitee()
+		if err != nil || release == nil || release.TagName == "" {
+			// Gitee失败，尝试GitHub
+			release, err = fetchLatestStableRelease()
+			if err != nil || release == nil {
+				return
+			}
+		}
+		// 缓存结果
+		cachedLatestVersion.mu.Lock()
+		cachedLatestVersion.version = release.TagName
+		cachedLatestVersion.timestamp = time.Now()
+		cachedLatestVersion.mu.Unlock()
+	}()
+}
+
+// fetchLatestStableFromGitee 从Gitee获取最新稳定版本
+func fetchLatestStableFromGitee() (*githubRelease, error) {
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, _ := http.NewRequest("GET", giteeAPI, nil)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Gitee API returned HTTP %d", resp.StatusCode)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+	// Gitee的latest通常就是稳定版，但检查Prerelease以防万一
+	if release.Prerelease {
+		return nil, nil
+	}
+	return &release, nil
+}
+
+// checkUpdateAsync 启动异步版本检查（不阻塞）
+func checkUpdateAsync() {
+	// dev版本不检查
+	if version == "dev" || version == "" {
+		return
+	}
+	fetchLatestStableReleaseAsync()
+}
+
+// getUpdateHintIfAvailable 如果有新版本可用，返回更新提示字符串
+func getUpdateHintIfAvailable() string {
+	// dev版本不提示
+	if version == "dev" || version == "" {
+		return ""
+	}
+
+	cachedLatestVersion.mu.RLock()
+	cachedVer := cachedLatestVersion.version
+	cachedTime := cachedLatestVersion.timestamp
+	cachedLatestVersion.mu.RUnlock()
+
+	// 如果缓存过期或为空，尝试同步获取（快速超时）
+	if cachedVer == "" || time.Since(cachedTime) > versionCheckTTL {
+		release, err := fetchLatestStableFromGitee()
+		if err != nil || release == nil || release.TagName == "" {
+			release, err = fetchLatestStableRelease()
+			if err != nil || release == nil {
+				return ""
+			}
+		}
+		cachedVer = release.TagName
+		// 更新缓存
+		cachedLatestVersion.mu.Lock()
+		cachedLatestVersion.version = cachedVer
+		cachedLatestVersion.timestamp = time.Now()
+		cachedLatestVersion.mu.Unlock()
+	}
+
+	if cachedVer != "" && isNewer(cachedVer, version) {
+		return fmt.Sprintf("\n📦 新版本可用: %s → %s  (运行: cc-connect update 升级)\n", version, cachedVer)
+	}
+	return ""
 }
 
 func runUpdate() {


### PR DESCRIPTION
## Summary
- Check for latest stable release when running `cc-connect --help`
- Query Gitee first (faster in China), fallback to GitHub
- Only show hint for stable releases (skip pre-release/beta)
- Skip check for dev builds
- Cache results for 1 hour to avoid frequent API calls

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual test: v0.9.0 shows update hint
- [x] Manual test: v1.2.1 (latest) does not show hint
- [x] Manual test: dev version does not show hint

## Screenshots
```
📦 新版本可用: v0.9.0 → v1.2.1  (运行: cc-connect update 升级)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)