### PR TITLE
fix(discord): use SplitMessageCodeFenceAware in interaction responses

### DIFF
--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -513,19 +513,8 @@ func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 // mechanism. The first call edits the deferred "thinking" response; subsequent
 // calls create followup messages.
 func (p *Platform) sendInteraction(ictx *interactionReplyCtx, content string) error {
-	for len(content) > 0 {
-		chunk := content
-		if len(chunk) > maxDiscordLen {
-			cut := maxDiscordLen
-			if idx := lastIndexBefore(content, '\n', cut); idx > 0 {
-				cut = idx + 1
-			}
-			chunk = content[:cut]
-			content = content[cut:]
-		} else {
-			content = ""
-		}
-
+	chunks := core.SplitMessageCodeFenceAware(content, maxDiscordLen)
+	for _, chunk := range chunks {
 		ictx.mu.Lock()
 		first := !ictx.firstDone
 		if first {
@@ -726,11 +715,3 @@ func downloadURL(u string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
-func lastIndexBefore(s string, b byte, before int) int {
-	for i := before - 1; i >= 0; i-- {
-		if s[i] == b {
-			return i
-		}
-	}
-	return -1
-}


### PR DESCRIPTION
## Summary

- `sendInteraction` splits messages using byte length (`len`) and slices at byte offsets, which can cut multi-byte UTF-8 characters (emoji, CJK) in half, producing invalid strings that cause Discord API errors.
- Replace with `SplitMessageCodeFenceAware`, already used by `sendChannelReply` and `sendChannel`.

## Root cause

`sendInteraction` (line 516) checks `len(chunk) > maxDiscordLen` — this is byte length, not character count. For a 1999-character message containing emoji or CJK characters, the byte length can exceed 2000, triggering a byte-offset slice at line 523 (`content[:cut]`) that splits a multi-byte character mid-sequence.

Meanwhile, the other two send paths (`sendChannelReply` at line 556 and `sendChannel` at line 573) correctly use `core.SplitMessageCodeFenceAware`, which handles character boundaries properly.

## Changes

- Replace inline byte-based splitting in `sendInteraction` with `core.SplitMessageCodeFenceAware`
- Remove the now-unused `lastIndexBefore` helper function

## Test plan

- [x] `go test ./platform/discord/` — all tests pass
- [x] `go test ./...` — full suite passes