### PR TITLE
fix(security): harden access controls for issue #60

### DIFF
--- a/core/command_test.go
+++ b/core/command_test.go
@@ -253,8 +253,8 @@ func TestAllowList(t *testing.T) {
 		user   string
 		expect bool
 	}{
-		{"", "anyone", true},
-		{"*", "anyone", true},
+		{"", "anyone", false}, // empty = deny-all (fail-closed)
+		{"*", "anyone", true}, // explicit "*" = allow-all
 		{"user1", "user1", true},
 		{"user1", "USER1", true},
 		{"user1,user2", "user2", true},

--- a/core/engine.go
+++ b/core/engine.go
@@ -449,10 +449,16 @@ func (e *Engine) SetDisabledCommands(cmds []string) {
 }
 
 // SetAdminFrom sets the admin allowlist for privileged commands.
-// "*" means all users who pass allow_from are admins.
 // Empty string means privileged commands are denied for everyone.
+// The "*" wildcard is NOT supported — admins must be explicitly listed.
 func (e *Engine) SetAdminFrom(adminFrom string) {
 	e.adminFrom = strings.TrimSpace(adminFrom)
+	if e.adminFrom == "*" {
+		slog.Warn("admin_from=\"*\" is not allowed for privileged commands. Set explicit user IDs to enable /shell, /restart, /upgrade.",
+			"project", e.name)
+		e.adminFrom = "" // Reset to deny-all
+		return
+	}
 	if e.adminFrom == "" && !e.disabledCmds["shell"] {
 		slog.Warn("admin_from is not set — privileged commands (/shell, /restart, /upgrade) are blocked. "+
 			"Set admin_from in config to enable them, or use disabled_commands to hide them.",
@@ -469,13 +475,16 @@ var privilegedCommands = map[string]bool{
 
 // isAdmin checks whether the given user ID is authorized for privileged commands.
 // Unlike AllowList, empty adminFrom means deny-all (fail-closed).
+// The "*" wildcard is NOT supported for admin_from — admins must be explicitly listed.
 func (e *Engine) isAdmin(userID string) bool {
 	af := strings.TrimSpace(e.adminFrom)
 	if af == "" {
 		return false
 	}
+	// "*" is not allowed for admin_from — require explicit user IDs
 	if af == "*" {
-		return true
+		slog.Warn("admin_from=\"*\" is not allowed for privileged commands. Set explicit user IDs.", "project", e.name)
+		return false
 	}
 	for _, id := range strings.Split(af, ",") {
 		if strings.EqualFold(strings.TrimSpace(id), userID) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -411,11 +411,12 @@ func TestEngine_AdminFrom_Wildcard(t *testing.T) {
 	e := newTestEngine()
 	e.SetAdminFrom("*")
 
-	if !e.isAdmin("anyone") {
-		t.Error("wildcard admin_from should allow any user")
+	// Wildcard "*" is NOT allowed for admin_from - it should deny all
+	if e.isAdmin("anyone") {
+		t.Error("wildcard admin_from should NOT allow any user")
 	}
-	if !e.isAdmin("12345") {
-		t.Error("wildcard admin_from should allow any user ID")
+	if e.isAdmin("12345") {
+		t.Error("wildcard admin_from should NOT allow any user ID")
 	}
 }
 

--- a/core/message.go
+++ b/core/message.go
@@ -30,11 +30,11 @@ func MergeEnv(base, extra []string) []string {
 }
 
 // CheckAllowFrom logs a security warning at startup when allow_from is not
-// configured (defaults to permit-all). Platforms should call this during init.
+// configured (defaults to deny-all). Platforms should call this during init.
 func CheckAllowFrom(platform, allowFrom string) {
 	if strings.TrimSpace(allowFrom) == "" {
-		slog.Warn("allow_from is not set — all users are permitted. "+
-			"Set allow_from in config to restrict access.",
+		slog.Warn("allow_from is not set — all users are DENIED by default. "+
+			"Set allow_from=\"*\" to permit all users, or list specific user IDs.",
 			"platform", platform)
 	}
 }
@@ -49,11 +49,18 @@ func RedactToken(text, token string) string {
 }
 
 // AllowList checks whether a user ID is permitted based on a comma-separated
-// allow_from string. Returns true if allowFrom is empty or "*" (allow all),
-// or if the userID is in the list. Comparison is case-insensitive.
+// allow_from string. Returns true only if:
+//   - allowFrom is "*" (explicit allow-all)
+//   - the userID is in the comma-separated list
+// Empty allowFrom means deny-all (fail-closed for security).
 func AllowList(allowFrom, userID string) bool {
 	allowFrom = strings.TrimSpace(allowFrom)
-	if allowFrom == "" || allowFrom == "*" {
+	// Empty string = deny all (fail-closed)
+	if allowFrom == "" {
+		return false
+	}
+	// Explicit "*" = allow all
+	if allowFrom == "*" {
 		return true
 	}
 	for _, id := range strings.Split(allowFrom, ",") {

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -591,7 +591,7 @@ func (p *Platform) downloadFile(fileID string) ([]byte, error) {
 	fileConfig := tgbotapi.FileConfig{FileID: fileID}
 	file, err := p.bot.GetFile(fileConfig)
 	if err != nil {
-		return nil, fmt.Errorf("get file: %w", err)
+		return nil, fmt.Errorf("get file: %s", core.RedactToken(err.Error(), p.bot.Token))
 	}
 	link := file.Link(p.bot.Token)
 


### PR DESCRIPTION
## Summary

This PR addresses security vulnerabilities reported in issue #60:

1. **admin_from**: Removed `*` wildcard support - admins must be explicitly listed. The wildcard defeats the purpose of admin authorization for privileged commands (`/shell`, `/restart`, `/upgrade`).

2. **allow_from**: Changed default to deny-all (fail-closed). Empty string now denies all users; only explicit `"*"` permits all users. This is a breaking change but necessary for security.

3. **Token redaction**: Fixed bot token leak in Telegram `GetFile` errors. Previously only download errors were redacted.

4. **Unix socket**: Verified already uses `0600` permissions in `core/api.go`.

## Security Impact

Before this fix:
- `allow_from` empty → all users permitted (fail-open)
- `admin_from="*"` → all users can run `/shell` (RCE vulnerability)
- Bot token could leak in Telegram error logs

After this fix:
- `allow_from` empty → all users denied (fail-closed)
- `admin_from="*"` → denied, must use explicit user IDs
- Bot token redacted in all Telegram error messages

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./core/... -run "Admin|AllowList"` passes
- [x] Tests updated for new behavior

Fixes #60