### PR TITLE
fix(wecom): drain pendingAcks on WebSocket disconnect to prevent leak

### DIFF
--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -169,6 +169,19 @@ func (p *WSPlatform) runConnection() error {
 		p.conn = nil
 		p.mu.Unlock()
 		conn.Close()
+
+		// Drain pending ACK channels so waiting goroutines are unblocked
+		// and stale entries do not accumulate across reconnections.
+		p.pendingAcks.Range(func(key, value any) bool {
+			if ch, ok := value.(chan error); ok {
+				select {
+				case ch <- fmt.Errorf("wecom-ws: connection closed"):
+				default:
+				}
+			}
+			p.pendingAcks.Delete(key)
+			return true
+		})
 	}()
 
 	// Send subscribe (auth) frame


### PR DESCRIPTION
## Summary

- When the WebSocket connection drops, entries in `pendingAcks` from in-flight requests are never cleaned up. Each reconnection cycle accumulates orphaned entries, causing unbounded memory growth.
- Drain all pending ACK channels in the `runConnection` defer block to unblock waiting goroutines and remove stale entries.

## Root cause

`writeAndWaitAck` stores a channel in `pendingAcks` (line 490) and waits for a response. When a response arrives, `handleFrame` removes the entry with `LoadAndDelete` (line 257). However, if the connection drops before the response arrives, the read loop exits and `runConnection` returns — but no code cleans up the remaining `pendingAcks` entries.

The `connectLoop` (line 120-151) then reconnects and starts a new read loop. The old entries from the previous connection remain in the `sync.Map` forever because the new connection will never receive ACKs for those old request IDs. Over time with repeated reconnections, memory steadily grows.

## Fix

In the `runConnection` defer block (after closing the connection), iterate through `pendingAcks`, send errors to all waiting channels to unblock goroutines, and delete the entries.

## Test plan

- [x] `go test ./platform/wecom/` — passes
- [x] `go test ./...` — full suite passes