### PR TITLE
fix(qqbot): nil wsConn on failed reconnect to prevent stale reference

### DIFF
--- a/platform/qqbot/qqbot.go
+++ b/platform/qqbot/qqbot.go
@@ -588,9 +588,21 @@ func (p *Platform) reconnectLoop(ctx context.Context) {
 
 		if err := p.waitForHello(conn); err != nil {
 			slog.Warn("qqbot: hello failed during reconnect", "error", err)
+			p.wsMu.Lock()
+			p.wsConn = nil
+			p.wsMu.Unlock()
 			conn.Close()
 			backoff = min(backoff*2, maxReconnectBackoff)
 			continue
+		}
+
+		// closeAndNil closes the conn and clears p.wsConn so Stop()
+		// and other code paths don't operate on a stale reference.
+		closeAndNil := func() {
+			p.wsMu.Lock()
+			p.wsConn = nil
+			p.wsMu.Unlock()
+			conn.Close()
 		}
 
 		// Try Resume if we have a session_id, otherwise Identify
@@ -599,24 +611,24 @@ func (p *Platform) reconnectLoop(ctx context.Context) {
 				slog.Warn("qqbot: resume failed, falling back to identify", "error", err)
 				p.sessionID = ""
 				if err := p.sendIdentify(conn, token); err != nil {
-					conn.Close()
+					closeAndNil()
 					backoff = min(backoff*2, maxReconnectBackoff)
 					continue
 				}
 				if err := p.waitForReady(conn); err != nil {
-					conn.Close()
+					closeAndNil()
 					backoff = min(backoff*2, maxReconnectBackoff)
 					continue
 				}
 			}
 		} else {
 			if err := p.sendIdentify(conn, token); err != nil {
-				conn.Close()
+				closeAndNil()
 				backoff = min(backoff*2, maxReconnectBackoff)
 				continue
 			}
 			if err := p.waitForReady(conn); err != nil {
-				conn.Close()
+				closeAndNil()
 				backoff = min(backoff*2, maxReconnectBackoff)
 				continue
 			}


### PR DESCRIPTION
## Summary

- When `reconnectLoop` fails at `waitForHello`, `sendIdentify`, or `waitForReady`, the connection is closed via `conn.Close()` but `p.wsConn` still points to the closed connection. This leaves a stale reference.
- Reset `p.wsConn` to nil under the mutex before closing the failed connection.

## Root cause

`reconnectLoop` sets `p.wsConn = conn` at line 586 after a successful dial. If subsequent steps (`waitForHello`, `sendIdentify`, `waitForReady`) fail, `conn.Close()` is called but `p.wsConn` is not reset to nil. This means:

1. `Stop()` may call `p.wsConn.Close()` on the already-closed connection (double close)
2. If a `sendHeartbeat` or `readLoop` goroutine is still running (race with context cancellation), it may try to operate on the closed connection
3. The reconnect loop prologue at lines 545-549 correctly nils `p.wsConn`, but subsequent failure paths within the same loop don't

## Fix

Extract a `closeAndNil` helper that nils `p.wsConn` under the mutex before closing the connection, applied to all 5 error paths in `reconnectLoop`. This is consistent with the cleanup pattern used at the start of the function and in `Stop()`.

## Test plan

- [x] `go build ./platform/qqbot/` — compiles
- [x] `go test ./...` — full suite passes