### PR TITLE
fix(config): use dataDir for legacy session path check

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -652,8 +652,8 @@ func main() {
 }
 
 // sessionStorePath builds a unique filename from project name + work_dir.
-// It checks the local .cc-connect/ directory first for backward compatibility;
-// if the file exists there, it is used. Otherwise falls back to dataDir/sessions/.
+// It checks for legacy session files (without the sessions/ subdirectory) in dataDir
+// for backward compatibility; if found, uses that path. Otherwise uses dataDir/sessions/.
 func sessionStorePath(dataDir, name, workDir string) string {
 	var filename string
 	if workDir == "" {
@@ -668,13 +668,14 @@ func sessionStorePath(dataDir, name, workDir string) string {
 		filename = fmt.Sprintf("%s_%s.json", name, short)
 	}
 
-	// Check legacy local path: .cc-connect/<name>.json or .cc-connect/<name>.sessions.json
+	// Check legacy path in dataDir (without sessions/ subdirectory) for backward compatibility.
+	// Also check for the older .sessions.json naming convention.
 	for _, legacy := range []string{
-		filepath.Join(".cc-connect", filename),
-		filepath.Join(".cc-connect", strings.TrimSuffix(filename, ".json")+".sessions.json"),
+		filepath.Join(dataDir, filename),
+		filepath.Join(dataDir, strings.TrimSuffix(filename, ".json")+".sessions.json"),
 	} {
 		if _, err := os.Stat(legacy); err == nil {
-			slog.Info("session: using local file", "path", legacy)
+			slog.Info("session: using legacy file in dataDir", "path", legacy)
 			return legacy
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix the `sessionStorePath` function to use the config's `dataDir` for legacy session file lookup instead of the current working directory
- This ensures that different config files (specified via `--config`) use their own session storage without collisions

## Root Cause
The legacy session path check was looking for `.cc-connect/` relative to the **current working directory**, not relative to the config's `dataDir`. This caused:
- Sessions from the wrong project being loaded when using `--config` with a different config file
- Potential collisions when different configs had the same project name

## Fix
Changed the legacy path check from:
- `.cc-connect/<filename>` (relative to current directory)
- To: `dataDir/<filename>` (relative to the config's data directory)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./...` passes (all tests pass)
- [x] Verified fix with custom test scenarios:
  - Different work_dirs produce different session paths ✅
  - Different data_dirs produce different session paths ✅
  - Legacy files in dataDir are correctly detected ✅
  - Current directory .cc-connect is NOT used (fix working) ✅

Fixes #187