### PR TITLE
feat(config): add relay timeout settings

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -569,6 +569,14 @@ func main() {
 		slog.Warn("api server unavailable", "error", err)
 	} else {
 		relayMgr := core.NewRelayManager(cfg.DataDir)
+		if cfg.Relay.TimeoutSecs != nil {
+			secs := *cfg.Relay.TimeoutSecs
+			if secs <= 0 {
+				relayMgr.SetTimeout(0)
+			} else {
+				relayMgr.SetTimeout(time.Duration(secs) * time.Second)
+			}
+		}
 		apiSrv.SetRelayManager(relayMgr)
 		for i, e := range engines {
 			apiSrv.RegisterEngine(cfg.Projects[i].Name, e)

--- a/config.example.toml
+++ b/config.example.toml
@@ -85,6 +85,16 @@ level = "info" # debug, info, warn, error
 # window_secs = 60          # Window size in seconds (default: 60) / 窗口时间秒数（默认 60）
 
 # =============================================================================
+# Relay Settings / Relay 设置
+# =============================================================================
+# Bot-to-bot relay timeout. Controls how long cc-connect waits for the target
+# bot to finish responding during `cc-connect relay send`.
+# Bot 间 relay 超时。控制 `cc-connect relay send` 时等待目标 bot 完成回复的最长时间。
+
+# [relay]
+# timeout_secs = 120        # Max relay wait in seconds; 0 = disabled (default: 120) / relay 最大等待秒数；0 = 禁用（默认 120）
+
+# =============================================================================
 # Cron Settings / 定时任务设置
 # =============================================================================
 # Controls cron job behavior.

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Display         DisplayConfig       `toml:"display"`
 	StreamPreview   StreamPreviewConfig `toml:"stream_preview"`  // real-time streaming preview
 	RateLimit       RateLimitConfig     `toml:"rate_limit"`      // per-session rate limiting
+	Relay           RelayConfig         `toml:"relay"`           // bot-to-bot relay behavior
 	Quiet           *bool               `toml:"quiet,omitempty"` // global default for quiet mode; project-level overrides this
 	Cron            CronConfig          `toml:"cron"`
 	Webhook         WebhookConfig       `toml:"webhook"`
@@ -100,6 +101,11 @@ type RoleConfig struct {
 	UserIDs          []string         `toml:"user_ids"`
 	DisabledCommands []string         `toml:"disabled_commands,omitempty"`
 	RateLimit        *RateLimitConfig `toml:"rate_limit,omitempty"` // nil = inherit global
+}
+
+// RelayConfig controls bot-to-bot relay behavior.
+type RelayConfig struct {
+	TimeoutSecs *int `toml:"timeout_secs"` // max seconds to wait for relay response; 0 = disabled; default 120
 }
 
 // SpeechConfig configures speech-to-text for voice messages.
@@ -248,6 +254,9 @@ func (c *Config) validate() error {
 	case "", "on", "off":
 	default:
 		return fmt.Errorf("config: attachment_send must be \"on\" or \"off\"")
+	}
+	if c.Relay.TimeoutSecs != nil && *c.Relay.TimeoutSecs < 0 {
+		return fmt.Errorf("config: relay.timeout_secs must be >= 0")
 	}
 	if len(c.Projects) == 0 {
 		return fmt.Errorf("config: at least one [[projects]] entry is required")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -316,6 +316,46 @@ type = "telegram"
 bot_token = "token_xxx"
 `
 
+const relayConfigFixture = `
+[relay]
+timeout_secs = 300
+
+[[projects]]
+name = "alpha"
+
+[projects.agent]
+type = "codex"
+
+[projects.agent.options]
+work_dir = "/tmp/alpha"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+bot_token = "token_xxx"
+`
+
+const relayConfigNegativeFixture = `
+[relay]
+timeout_secs = -1
+
+[[projects]]
+name = "alpha"
+
+[projects.agent]
+type = "codex"
+
+[projects.agent.options]
+work_dir = "/tmp/alpha"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+bot_token = "token_xxx"
+`
+
 func TestSaveFeishuPlatformCredentials_UpdateFirstCandidateAndAllowFrom(t *testing.T) {
 	configPath := writeConfigFixture(t, feishuConfigFixture)
 	patchConfigPath(t, configPath)
@@ -595,6 +635,32 @@ func readTestConfig(t *testing.T) Config {
 	return cfg
 }
 
+func TestLoadRelayTimeoutConfig(t *testing.T) {
+	configPath := writeConfigFixture(t, relayConfigFixture)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Relay.TimeoutSecs == nil {
+		t.Fatal("cfg.Relay.TimeoutSecs = nil, want non-nil")
+	}
+	if *cfg.Relay.TimeoutSecs != 300 {
+		t.Fatalf("cfg.Relay.TimeoutSecs = %d, want 300", *cfg.Relay.TimeoutSecs)
+	}
+}
+
+func TestLoadRejectsNegativeRelayTimeout(t *testing.T) {
+	configPath := writeConfigFixture(t, relayConfigNegativeFixture)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("expected error for negative relay timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "relay.timeout_secs must be >= 0") {
+		t.Fatalf("error = %q, want contains %q", err.Error(), "relay.timeout_secs must be >= 0")
+	}
+}
 func writeConfigFixture(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/core/relay.go
+++ b/core/relay.go
@@ -24,15 +24,17 @@ type RelayBinding struct {
 // RelayManager coordinates bot-to-bot message relay across engines.
 type RelayManager struct {
 	mu        sync.RWMutex
-	engines   map[string]*Engine         // project name → engine (runtime only)
-	bindings  map[string]*RelayBinding   // chatID → binding
-	storePath string                     // empty = no persistence
+	engines   map[string]*Engine       // project name → engine (runtime only)
+	bindings  map[string]*RelayBinding // chatID → binding
+	storePath string                   // empty = no persistence
+	timeout   time.Duration
 }
 
 func NewRelayManager(dataDir string) *RelayManager {
 	rm := &RelayManager{
 		engines:  make(map[string]*Engine),
 		bindings: make(map[string]*RelayBinding),
+		timeout:  relayTimeout,
 	}
 	if dataDir != "" {
 		rm.storePath = filepath.Join(dataDir, "relay_bindings.json")
@@ -45,6 +47,16 @@ func (rm *RelayManager) RegisterEngine(name string, e *Engine) {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 	rm.engines[name] = e
+}
+
+// SetTimeout overrides the relay response timeout. Set to 0 to disable it.
+func (rm *RelayManager) SetTimeout(d time.Duration) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	if d < 0 {
+		d = 0
+	}
+	rm.timeout = d
 }
 
 // Bind establishes a relay binding between bots in a group chat.
@@ -218,7 +230,7 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 	}
 
 	// Execute relay: inject message into target engine and collect response
-	relayCtx, cancel := context.WithTimeout(ctx, relayTimeout)
+	relayCtx, cancel := rm.relayContext(ctx)
 	defer cancel()
 
 	response, err := targetEngine.HandleRelay(relayCtx, req.From, chatID, req.Message)
@@ -263,6 +275,16 @@ func truncateRelay(s string, maxLen int) string {
 		return s
 	}
 	return string(runes[:maxLen]) + "…"
+}
+
+func (rm *RelayManager) relayContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	rm.mu.RLock()
+	timeout := rm.timeout
+	rm.mu.RUnlock()
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
 }
 
 func parseSessionKeyParts(sessionKey string) (platform, chatID string, err error) {

--- a/core/relay_test.go
+++ b/core/relay_test.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRelayManager_DefaultTimeout(t *testing.T) {
+	rm := NewRelayManager("")
+
+	if rm.timeout != relayTimeout {
+		t.Fatalf("rm.timeout = %v, want %v", rm.timeout, relayTimeout)
+	}
+}
+
+func TestRelayManager_RelayContextHonorsConfiguredTimeout(t *testing.T) {
+	rm := NewRelayManager("")
+	rm.SetTimeout(3 * time.Second)
+
+	ctx, cancel := rm.relayContext(context.Background())
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected relay context deadline")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > 3*time.Second {
+		t.Fatalf("time until deadline = %v, want within (0, 3s]", remaining)
+	}
+}
+
+func TestRelayManager_RelayContextDisablesTimeoutAtZero(t *testing.T) {
+	rm := NewRelayManager("")
+	rm.SetTimeout(0)
+
+	baseCtx := context.Background()
+	ctx, cancel := rm.relayContext(baseCtx)
+	defer cancel()
+
+	if ctx != baseCtx {
+		t.Fatal("expected relayContext to return the original context when timeout is disabled")
+	}
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("expected no deadline when timeout is disabled")
+	}
+}


### PR DESCRIPTION
## Summary
- add global relay timeout config under `[relay].timeout_secs`
- keep the default relay timeout at 120 seconds
- allow `0` to disable the relay timeout entirely
- add config parsing/validation tests plus relay manager timeout tests

## Why
Relay timeout is currently hardcoded in `core/relay.go`. Some relay targets legitimately need more than 120 seconds, and the existing config style in cc-connect already prefers explicit numeric duration fields such as `window_secs`, `timeout_mins`, and `interval_ms`.

## Config
```toml
[relay]
timeout_secs = 300
```

## Testing
- `go test ./...`

Closes #44