### PR TITLE
fix(core): use commandContext in cmdModel and cmdReasoning for multi-workspace

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -4085,7 +4085,12 @@ func (e *Engine) GetAllCommands() []BotCommandInfo {
 }
 
 func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
-	switcher, ok := e.agent.(ModelSwitcher)
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+	switcher, ok := agent.(ModelSwitcher)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgModelNotSupported))
 		return
@@ -4163,12 +4168,12 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 	}
 
 	switcher.SetModel(target)
-	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+	e.cleanupInteractiveState(interactiveKey)
 
-	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s := sessions.GetOrCreateActive(msg.SessionKey)
 	s.SetAgentSessionID("", "")
 	s.ClearHistory()
-	e.sessions.Save()
+	sessions.Save()
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChanged, target))
 }
@@ -4186,7 +4191,12 @@ func resolveModelAlias(models []ModelOption, input string) string {
 }
 
 func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
-	switcher, ok := e.agent.(ReasoningEffortSwitcher)
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+	switcher, ok := agent.(ReasoningEffortSwitcher)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgReasoningNotSupported))
 		return
@@ -4256,12 +4266,12 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 	}
 
 	switcher.SetReasoningEffort(target)
-	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+	e.cleanupInteractiveState(interactiveKey)
 
-	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s := sessions.GetOrCreateActive(msg.SessionKey)
 	s.SetAgentSessionID("", "")
 	s.ClearHistory()
-	e.sessions.Save()
+	sessions.Save()
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgReasoningChanged, target))
 }


### PR DESCRIPTION
## Summary

- `cmdModel` and `cmdReasoning` access `e.agent`, `e.sessions`, and `msg.SessionKey` directly instead of using `commandContext()` to resolve workspace-specific resources.
- In multi-workspace mode, this causes model/reasoning changes and session cleanup to target the wrong workspace.

## Root cause

Most workspace-aware commands (e.g., `cmdNew`, `cmdSwitch`, `cmdDir`, `cmdStatus`) use the pattern:
```go
agent, sessions, interactiveKey, err := e.commandContext(p, msg)
```

But `cmdModel` and `cmdReasoning` were implemented before multi-workspace was fully established and use:
```go
e.agent.(ModelSwitcher)           // global agent, not workspace-specific
e.cleanupInteractiveState(msg.SessionKey)  // raw session key, not workspace-prefixed
e.sessions.GetOrCreateActive(...)          // global session manager
```

**Impact in multi-workspace mode:**
1. `e.agent` refers to the global agent — model/reasoning changes affect all workspaces instead of just the bound workspace
2. `cleanupInteractiveState(msg.SessionKey)` tries to clean up a key that doesn't exist in the interactive states map (workspace keys are prefixed with the workspace path)
3. `e.sessions` clears history in the global session manager instead of the workspace-specific one

## Fix

Replace direct access with `commandContext()` calls, using the returned `agent`, `sessions`, and `interactiveKey` throughout both functions.

## Test plan

- [x] `TestCmdModel_*` — all model command tests pass
- [x] `TestCmdReasoning_*` — all reasoning command tests pass
- [x] `TestExecuteCardAction_ModelCleansUpWithInteractiveKey` — passes
- [x] `go test ./core/` — all non-preexisting tests pass
- [x] `go test ./...` — full suite passes (only pre-existing macOS symlink failures)