### PR TITLE
feat: upgrade MiniMax default model to M2.7 (1M context)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -566,16 +566,25 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "bypassPermission
 # model = "deepseek-ai/DeepSeek-V3"
 # thinking = "disabled"
 #
-# # MiniMax — OpenAI-compatible provider with 204K context window
-# # MiniMax — 兼容 OpenAI 接口的大模型，支持 204K 超长上下文
-# # Models: MiniMax-M2.5 (flagship), MiniMax-M2.5-highspeed (faster)
+# # MiniMax — OpenAI-compatible provider with 1M context window
+# # MiniMax — 兼容 OpenAI 接口的大模型，支持 1M 超长上下文
+# # Models: MiniMax-M2.7 (flagship, 1M context), MiniMax-M2.5, MiniMax-M2.5-highspeed
 # # Docs: https://platform.minimaxi.com
 # [[projects.agent.providers]]
 # name = "minimax"
 # api_key = "your-minimax-api-key"
 # base_url = "https://api.minimax.io/v1"
-# model = "MiniMax-M2.5"
+# model = "MiniMax-M2.7"
 # thinking = "disabled"
+# [[projects.agent.providers.models]]
+# model = "MiniMax-M2.7"
+# alias = "m27"
+# [[projects.agent.providers.models]]
+# model = "MiniMax-M2.5"
+# alias = "m25"
+# [[projects.agent.providers.models]]
+# model = "MiniMax-M2.5-highspeed"
+# alias = "m25fast"
 #
 # # For special setups (Bedrock, Vertex, etc.), use the env map:
 # # 特殊环境（Bedrock、Vertex 等）使用 env 字段：
@@ -935,7 +944,7 @@ app_secret = "your-feishu-app-secret"
 # name = "minimax"
 # api_key = "your-minimax-api-key"
 # base_url = "https://api.minimax.io/v1"
-# model = "MiniMax-M2.5"
+# model = "MiniMax-M2.7"
 #
 # [[projects.platforms]]
 # type = "telegram"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -143,12 +143,12 @@ alias = "opus"
 model = "claude-haiku-3-5-20241022"
 alias = "haiku"
 
-# MiniMax — OpenAI-compatible, 204K context
+# MiniMax — OpenAI-compatible, 1M context
 [[projects.agent.providers]]
 name = "minimax"
 api_key = "your-minimax-api-key"
 base_url = "https://api.minimax.io/v1"
-model = "MiniMax-M2.5"
+model = "MiniMax-M2.7"
 
 # For Bedrock, Vertex, etc.
 [[projects.agent.providers]]

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -143,12 +143,12 @@ alias = "opus"
 model = "claude-haiku-3-5-20241022"
 alias = "haiku"
 
-# MiniMax — 兼容 OpenAI 接口，204K 超长上下文
+# MiniMax — 兼容 OpenAI 接口，1M 超长上下文
 [[projects.agent.providers]]
 name = "minimax"
 api_key = "your-minimax-api-key"
 base_url = "https://api.minimax.io/v1"
-model = "MiniMax-M2.5"
+model = "MiniMax-M2.7"
 
 # Bedrock、Vertex 等
 [[projects.agent.providers]]


### PR DESCRIPTION
## Summary

Upgrade MiniMax default model from M2.5 to the latest M2.7 flagship model.

- **Default model**: `MiniMax-M2.7` (1M context window, up from 204K)
- **Models list**: Added pre-configured `/model` aliases for M2.7, M2.5, and M2.5-highspeed
- **Documentation**: Updated both English and Chinese docs with new model and context size

## Changes

| File | Change |
|------|--------|
| `config.example.toml` | Default model → M2.7, added `[[models]]` entries, updated context window description |
| `docs/usage.md` | Default model → M2.7, context 204K → 1M |
| `docs/usage.zh-CN.md` | Default model → M2.7, context 204K → 1M |

## About MiniMax-M2.7

MiniMax-M2.7 is the latest flagship model from MiniMax, featuring a 1M token context window. It is fully API-compatible with M2.5 — no code changes are needed, only the model name in config.

## Test plan

- [x] Config syntax validated (TOML comments preserved)
- [x] No code changes — purely config/docs update
- [x] Both English and Chinese docs updated consistently
