### PR TITLE
feat: add MiniMax-M2.7-highspeed model to provider config examples

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -568,7 +568,7 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "bypassPermission
 #
 # # MiniMax — OpenAI-compatible provider with 1M context window
 # # MiniMax — 兼容 OpenAI 接口的大模型，支持 1M 超长上下文
-# # Models: MiniMax-M2.7 (flagship, 1M context), MiniMax-M2.5, MiniMax-M2.5-highspeed
+# # Models: MiniMax-M2.7 (flagship, 1M context), MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
 # # Docs: https://platform.minimaxi.com
 # [[projects.agent.providers]]
 # name = "minimax"
@@ -579,6 +579,9 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "bypassPermission
 # [[projects.agent.providers.models]]
 # model = "MiniMax-M2.7"
 # alias = "m27"
+# [[projects.agent.providers.models]]
+# model = "MiniMax-M2.7-highspeed"
+# alias = "m27fast"
 # [[projects.agent.providers.models]]
 # model = "MiniMax-M2.5"
 # alias = "m25"


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7-highspeed to the model list in config.example.toml
- Add m27fast alias for the new high-speed model variant
- Keep all previous models (M2.5, M2.5-highspeed) as alternatives

## Changes
- Updated model list comment to include MiniMax-M2.7-highspeed
- Added `[[projects.agent.providers.models]]` entry for MiniMax-M2.7-highspeed with alias `m27fast`
- M2.7 models are listed first, followed by M2.5 variants

## Why
MiniMax-M2.7-highspeed is a new high-speed variant of the M2.7 flagship model, optimized for low-latency scenarios. Adding it to the config examples helps users discover and configure it easily.

## Testing
- Existing MiniMax TTS tests pass
- Config change is documentation-only (commented TOML examples)
