### PR TITLE
Auto-compress context when token threshold exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,7 @@ This is the first stable release of cc-connect 1.2.0, consolidating all beta cha
 
 ### New Features
 - **`/compress` Command**: Compress/compact conversation context by forwarding native commands to agents (Claude Code `/compact`, Codex `/compact`, Gemini `/compress`); keeps long sessions manageable
+- **Auto-Compress**: Added optional automatic context compression when estimated token usage exceeds a configurable threshold (`[projects.auto_compress]`).
 - **Telegram Inline Buttons**: Permission prompts on Telegram now use clickable inline keyboard buttons (Allow / Deny / Allow All) instead of requiring text replies
 - **`/model` Command**: View and switch AI models at runtime; supports numbered quick-select and custom model names. Fetches available models from provider API in real-time (Anthropic, OpenAI, Google), with built-in fallback list
 - **`/memory` Command**: View and edit agent memory files (CLAUDE.md, AGENTS.md, GEMINI.md) directly from chat; supports both project-level and global-level (`/memory global`)

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -318,6 +318,19 @@ func main() {
 			engine.SetDefaultQuiet(*cfg.Quiet)
 		}
 
+		// Wire auto-compress settings
+		if proj.AutoCompress.Enabled != nil && *proj.AutoCompress.Enabled {
+			minGap := 30 * time.Minute
+			if proj.AutoCompress.MinGapMins != nil {
+				minGap = time.Duration(*proj.AutoCompress.MinGapMins) * time.Minute
+			}
+			maxTokens := derefInt(proj.AutoCompress.MaxTokens)
+			if maxTokens <= 0 {
+				maxTokens = 12000
+			}
+			engine.SetAutoCompressConfig(true, maxTokens, minGap)
+		}
+
 		// Wire sender injection
 		if proj.InjectSender != nil {
 			engine.SetInjectSender(*proj.InjectSender)
@@ -918,6 +931,21 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 		engine.SetDefaultQuiet(false)
 	}
 
+	// Reload auto-compress settings
+	if proj.AutoCompress.Enabled != nil && *proj.AutoCompress.Enabled {
+		minGap := 30 * time.Minute
+		if proj.AutoCompress.MinGapMins != nil {
+			minGap = time.Duration(*proj.AutoCompress.MinGapMins) * time.Minute
+		}
+		maxTokens := derefInt(proj.AutoCompress.MaxTokens)
+		if maxTokens <= 0 {
+			maxTokens = 12000
+		}
+		engine.SetAutoCompressConfig(true, maxTokens, minGap)
+	} else {
+		engine.SetAutoCompressConfig(false, 0, 0)
+	}
+
 	// Reload sender injection
 	engine.SetInjectSender(proj.InjectSender != nil && *proj.InjectSender)
 
@@ -1054,4 +1082,11 @@ func buildHeartbeatConfig(hc config.HeartbeatConfig) core.HeartbeatConfig {
 		cfg.TimeoutMins = *hc.TimeoutMins
 	}
 	return cfg
+}
+
+func derefInt(v *int) int {
+	if v == nil {
+		return 0
+	}
+	return *v
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -95,6 +95,17 @@ level = "info" # debug, info, warn, error
 # timeout_secs = 120        # Max relay wait in seconds; 0 = disabled (default: 120) / relay 最大等待秒数；0 = 禁用（默认 120）
 
 # =============================================================================
+# Auto-Compress / 自动压缩
+# =============================================================================
+# Automatically trigger /compress when estimated token usage exceeds threshold.
+# 当估算 token 超过阈值时自动触发 /compress。
+#
+# [projects.auto_compress]
+# enabled = true
+# max_tokens = 12000     # estimated token threshold to trigger compression
+# min_gap_mins = 30      # minimum minutes between auto-compress runs (default 30)
+
+# =============================================================================
 # Cron Settings / 定时任务设置
 # =============================================================================
 # Controls cron job behavior.

--- a/config/config.go
+++ b/config/config.go
@@ -165,19 +165,27 @@ type HeartbeatConfig struct {
 	TimeoutMins  *int   `toml:"timeout_mins,omitempty"`   // max execution time; default 30
 }
 
+// AutoCompressConfig controls automatic context compression for a project.
+type AutoCompressConfig struct {
+	Enabled    *bool `toml:"enabled,omitempty"`      // default false
+	MaxTokens  *int  `toml:"max_tokens,omitempty"`   // estimated token threshold to trigger /compress
+	MinGapMins *int  `toml:"min_gap_mins,omitempty"` // minimum minutes between auto-compress runs (default 30)
+}
+
 // ProjectConfig binds one agent (with a specific work_dir) to one or more platforms.
 type ProjectConfig struct {
-	Name             string           `toml:"name"`
-	Mode             string           `toml:"mode,omitempty"`     // "" or "multi-workspace"
-	BaseDir          string           `toml:"base_dir,omitempty"` // parent dir for workspaces
-	Agent            AgentConfig      `toml:"agent"`
-	Platforms        []PlatformConfig `toml:"platforms"`
-	Heartbeat        HeartbeatConfig  `toml:"heartbeat"`
-	Quiet            *bool            `toml:"quiet,omitempty"`             // project-level quiet mode; overrides global setting
-	InjectSender     *bool            `toml:"inject_sender,omitempty"`     // prepend sender identity (platform + user ID) to each message sent to the agent
-	DisabledCommands []string         `toml:"disabled_commands,omitempty"` // commands to disable for this project (e.g. ["restart", "upgrade"])
-	AdminFrom        string           `toml:"admin_from,omitempty"`        // comma-separated user IDs allowed to run privileged commands; "*" = all allowed users
-	Users            *UsersConfig     `toml:"users,omitempty"`             // per-user role config; nil = legacy behavior
+	Name             string              `toml:"name"`
+	Mode             string              `toml:"mode,omitempty"`     // "" or "multi-workspace"
+	BaseDir          string              `toml:"base_dir,omitempty"` // parent dir for workspaces
+	Agent            AgentConfig         `toml:"agent"`
+	Platforms        []PlatformConfig    `toml:"platforms"`
+	Heartbeat        HeartbeatConfig     `toml:"heartbeat"`
+	AutoCompress     AutoCompressConfig  `toml:"auto_compress"`
+	Quiet            *bool               `toml:"quiet,omitempty"`             // project-level quiet mode; overrides global setting
+	InjectSender     *bool               `toml:"inject_sender,omitempty"`     // prepend sender identity (platform + user ID) to each message sent to the agent
+	DisabledCommands []string            `toml:"disabled_commands,omitempty"` // commands to disable for this project (e.g. ["restart", "upgrade"])
+	AdminFrom        string              `toml:"admin_from,omitempty"`        // comma-separated user IDs allowed to run privileged commands; "*" = all allowed users
+	Users            *UsersConfig        `toml:"users,omitempty"`             // per-user role config; nil = legacy behavior
 }
 
 type AgentConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -568,6 +568,21 @@ func TestLoad_DefaultsAttachmentSendToOn(t *testing.T) {
 	}
 }
 
+func TestLoad_DefaultsAutoCompressDisabled(t *testing.T) {
+	configPath := writeConfigFixture(t, projectWithoutFeishuFixture)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(cfg.Projects) == 0 {
+		t.Fatalf("expected at least one project")
+	}
+	if cfg.Projects[0].AutoCompress.Enabled != nil {
+		t.Fatalf("expected auto_compress.enabled to default to nil")
+	}
+}
+
 func TestLoad_ParsesAttachmentSendOff(t *testing.T) {
 	configPath := writeConfigFixture(t, attachmentSendConfigFixture)
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -177,6 +177,11 @@ type Engine struct {
 	relayManager     *RelayManager
 	eventIdleTimeout time.Duration
 
+	// Auto-compress settings
+	autoCompressEnabled   bool
+	autoCompressMaxTokens int
+	autoCompressMinGap    time.Duration
+
 	// Multi-workspace mode
 	multiWorkspace    bool
 	baseDir           string
@@ -218,18 +223,20 @@ type queuedMessage struct {
 
 // interactiveState tracks a running interactive agent session and its permission state.
 type interactiveState struct {
-	agentSession    AgentSession
-	platform        Platform
-	replyCtx        any
-	workspaceDir    string
-	mu              sync.Mutex
-	pending         *pendingPermission
-	pendingMessages []queuedMessage // messages queued while session was busy
-	approveAll      bool            // when true, auto-approve all permission requests for this session
-	quiet           bool            // when true, suppress thinking and tool progress for this session
-	fromVoice       bool            // true if current turn originated from voice transcription
-	sideText        string
-	deleteMode      *deleteModeState
+	agentSession          AgentSession
+	platform              Platform
+	replyCtx              any
+	workspaceDir          string
+	mu                    sync.Mutex
+	pending               *pendingPermission
+	pendingMessages       []queuedMessage // messages queued while session was busy
+	approveAll            bool            // when true, auto-approve all permission requests for this session
+	quiet                 bool            // when true, suppress thinking and tool progress for this session
+	fromVoice             bool            // true if current turn originated from voice transcription
+	sideText              string
+	deleteMode            *deleteModeState
+	lastAutoCompressAt    time.Time
+	lastAutoCompressTokens int
 }
 
 type deleteModeState struct {
@@ -355,6 +362,29 @@ func (e *Engine) SetDisplayConfig(cfg DisplayCfg) {
 // SetDefaultQuiet sets whether new sessions start in quiet mode.
 func (e *Engine) SetDefaultQuiet(q bool) {
 	e.defaultQuiet = q
+}
+
+// estimateTokens provides a rough token estimate for a set of history entries.
+func estimateTokens(entries []HistoryEntry) int {
+	// Heuristic: ~1 token per 4 characters in mixed English/Chinese.
+	count := 0
+	for _, h := range entries {
+		count += len([]rune(h.Content))
+	}
+	if count == 0 {
+		return 0
+	}
+	return (count + 3) / 4
+}
+
+// SetAutoCompressConfig configures automatic context compression.
+func (e *Engine) SetAutoCompressConfig(enabled bool, maxTokens int, minGap time.Duration) {
+	e.autoCompressEnabled = enabled
+	e.autoCompressMaxTokens = maxTokens
+	if minGap <= 0 {
+		minGap = 30 * time.Minute
+	}
+	e.autoCompressMinGap = minGap
 }
 
 // SetInjectSender controls whether sender identity (platform and user ID) is
@@ -1792,6 +1822,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	toolCount := 0
 	waitStart := time.Now()
 	firstEventLogged := false
+	triggerAutoCompress := false
 
 	// stopTyping tracks the current turn's typing indicator so it can be
 	// stopped when a queued message starts a new turn.
@@ -2046,6 +2077,21 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				fullResponse = e.i18n.T(MsgEmptyResponse)
 			}
 
+			// Evaluate auto-compress trigger (token estimate on user+assistant text)
+			if e.autoCompressEnabled && e.autoCompressMaxTokens > 0 {
+				estimate := estimateTokens(session.GetHistory(0))
+				now := time.Now()
+				state.mu.Lock()
+				last := state.lastAutoCompressAt
+				state.mu.Unlock()
+				if estimate >= e.autoCompressMaxTokens && (last.IsZero() || now.Sub(last) >= e.autoCompressMinGap) {
+					triggerAutoCompress = true
+					state.mu.Lock()
+					state.lastAutoCompressTokens = estimate
+					state.mu.Unlock()
+				}
+			}
+
 			session.AddHistory("assistant", fullResponse)
 			sessions.Save()
 
@@ -2111,6 +2157,18 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 			} else {
 				slog.Debug("tts: not enabled", "tts_nil", e.tts == nil, "enabled", e.tts != nil && e.tts.Enabled, "tts_obj_nil", e.tts == nil || e.tts.TTS == nil)
+			}
+
+			// Auto-compress after finishing a turn, before sending any queued messages.
+			if triggerAutoCompress {
+				state.mu.Lock()
+				state.lastAutoCompressAt = time.Now()
+				state.mu.Unlock()
+				slog.Info("auto-compress: triggering", "session", sessionKey)
+
+				// Run compress inline while the session is still locked.
+				e.runCompress(state, session, sessions, sessionKey, state.platform, state.replyCtx, true)
+				return
 			}
 
 			// Check for queued messages — if present, continue the event loop
@@ -4478,41 +4536,55 @@ func (e *Engine) cmdCompress(p Platform, msg *Message) {
 
 	e.send(p, msg.ReplyCtx, e.i18n.T(MsgCompressing))
 
-	go func() {
-		// session.Unlock() is called inside drainQueuedMessagesAfterCompress
-		// while holding state.mu to close the race window. Deferred fallback
-		// ensures the lock is released on early-return paths.
-		compressUnlocked := false
-		defer func() {
-			if !compressUnlocked {
-				session.Unlock()
-			}
-		}()
+	go e.runCompress(state, session, sessions, iKey, p, msg.ReplyCtx, false)
+}
 
-		state.mu.Lock()
-		state.platform = p
-		state.replyCtx = msg.ReplyCtx
-		state.mu.Unlock()
-
-		drainEvents(state.agentSession.Events())
-
-		cmd := compressor.CompressCommand()
-		if err := state.agentSession.Send(cmd, nil, nil); err != nil {
-			e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgError), err))
-			if !state.agentSession.Alive() {
-				e.cleanupInteractiveState(iKey)
-			}
-			return
+// runCompress sends the agent's compress command and handles results.
+// If autoTriggered is true, suppress user-visible "compressing" and completion messages.
+func (e *Engine) runCompress(state *interactiveState, session *Session, sessions *SessionManager, iKey string, p Platform, replyCtx any, auto bool) {
+	// session.Unlock() is called inside drainQueuedMessagesAfterCompress
+	// while holding state.mu to close the race window. Deferred fallback
+	// ensures the lock is released on early-return paths.
+	compressUnlocked := false
+	defer func() {
+		if !compressUnlocked {
+			session.Unlock()
 		}
-
-		e.processCompressEvents(state, session, sessions, iKey, p, msg.ReplyCtx, &compressUnlocked)
 	}()
+
+	state.mu.Lock()
+	state.platform = p
+	state.replyCtx = replyCtx
+	state.mu.Unlock()
+
+	drainEvents(state.agentSession.Events())
+
+	compressor, ok := e.agent.(ContextCompressor)
+	if !ok || compressor.CompressCommand() == "" {
+		if !auto {
+			e.reply(p, replyCtx, e.i18n.T(MsgCompressNotSupported))
+		}
+		return
+	}
+
+	cmd := compressor.CompressCommand()
+	if err := state.agentSession.Send(cmd, nil, nil); err != nil {
+		if !auto {
+			e.reply(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), err))
+		}
+		if !state.agentSession.Alive() {
+			e.cleanupInteractiveState(iKey)
+		}
+		return
+	}
+
+	e.processCompressEvents(state, session, sessions, iKey, p, replyCtx, &compressUnlocked, auto)
 }
 
 // processCompressEvents drains agent events after a compress command.
 // Unlike processInteractiveEvents it does NOT record history and treats
 // an empty result as success rather than "(empty response)".
-func (e *Engine) processCompressEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, p Platform, replyCtx any, unlocked *bool) {
+func (e *Engine) processCompressEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, p Platform, replyCtx any, unlocked *bool, auto bool) {
 
 	var textParts []string
 	events := state.agentSession.Events()
@@ -4533,16 +4605,20 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 		case event, ok = <-events:
 			if !ok {
 				e.cleanupInteractiveState(sessionKey, state)
-				if len(textParts) > 0 {
-					e.send(p, replyCtx, strings.Join(textParts, ""))
-				} else {
-					e.reply(p, replyCtx, e.i18n.T(MsgCompressDone))
+				if !auto {
+					if len(textParts) > 0 {
+						e.send(p, replyCtx, strings.Join(textParts, ""))
+					} else {
+						e.reply(p, replyCtx, e.i18n.T(MsgCompressDone))
+					}
 				}
 				e.notifyDroppedQueuedMessages(state, fmt.Errorf("agent process exited during compress"))
 				return
 			}
 		case <-idleCh:
-			e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), "compress timed out"))
+			if !auto {
+				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), "compress timed out"))
+			}
 			e.cleanupInteractiveState(sessionKey, state)
 			e.notifyDroppedQueuedMessages(state, fmt.Errorf("compress timed out"))
 			return
@@ -4562,7 +4638,7 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 
 		switch event.Type {
 		case EventText:
-			if event.Content != "" {
+			if !auto && event.Content != "" {
 				textParts = append(textParts, event.Content)
 			}
 		case EventResult:
@@ -4570,17 +4646,19 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 			if result == "" && len(textParts) > 0 {
 				result = strings.Join(textParts, "")
 			}
-			if result != "" {
-				e.send(p, replyCtx, result)
-			} else {
-				e.reply(p, replyCtx, e.i18n.T(MsgCompressDone))
+			if !auto {
+				if result != "" {
+					e.send(p, replyCtx, result)
+				} else {
+					e.reply(p, replyCtx, e.i18n.T(MsgCompressDone))
+				}
 			}
 
 			// After compress succeeds, process any queued messages instead of dropping them.
 			e.drainQueuedMessagesAfterCompress(state, session, sessions, sessionKey, unlocked)
 			return
 		case EventError:
-			if event.Error != nil {
+			if !auto && event.Error != nil {
 				e.reply(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), event.Error))
 			}
 			// Only drop queued messages if the agent is dead; some agents

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3912,6 +3912,57 @@ func TestCmdCompress_NoSession_RepliesNoSession(t *testing.T) {
 	}
 }
 
+func TestAutoCompress_TriggerAfterResult(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("auto-compress")
+	agent := &stubCompressorAgent{cmd: "/compact"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetAutoCompressConfig(true, 4, 0) // tiny threshold
+
+	key := "test:user1"
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	// Seed history so estimate crosses threshold after assistant response.
+	session := e.sessions.GetOrCreateActive(key)
+	session.AddHistory("user", "hello world")
+
+	// Simulate a full turn.
+	go e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), func() {})
+
+	sess.events <- Event{Type: EventResult, Content: "response", Done: true}
+
+	// The auto-compress should send /compact to the agent session.
+	deadline := time.After(2 * time.Second)
+	for {
+		sess.sendMu.Lock()
+		n := len(sess.sendCalls)
+		sess.sendMu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for auto-compress send")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	sess.sendMu.Lock()
+	last := sess.sendCalls[len(sess.sendCalls)-1]
+	sess.sendMu.Unlock()
+	if last != "/compact" {
+		t.Fatalf("expected /compact auto-compress, got %q", last)
+	}
+}
+
 func TestCmdCompress_SessionBusy_RepliesPreviousProcessing(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newQueuingSession("compress-busy")


### PR DESCRIPTION
## Summary
- add project-level auto_compress config
- estimate tokens from session history and auto-trigger /compress
- add min-gap throttling
- document config and update changelog

## Config
```toml
[projects.auto_compress]
enabled = true
max_tokens = 12000
min_gap_mins = 30
```

## Notes
- Uses a simple char-count token heuristic (~1 token / 4 chars)
- Auto-compress reuses existing /compress behavior

## Tests
- go test ./core ./config (fails in repo due to existing macOS path normalization test)
