### PR TITLE
feat(claudecode): add disallowed_tools config option

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -33,15 +33,16 @@ func init() {
 //   - "plan":              plan only, no execution until approved
 //   - "bypassPermissions": auto-approve everything (YOLO mode)
 type Agent struct {
-	workDir      string
-	model        string
-	mode         string // "default" | "acceptEdits" | "plan" | "bypassPermissions" | "dontAsk"
-	allowedTools []string
-	providers    []core.ProviderConfig
-	activeIdx    int // -1 = no provider set
-	sessionEnv   []string
-	routerURL    string // Claude Code Router URL (e.g., "http://127.0.0.1:3456")
-	routerAPIKey string // Claude Code Router API key (optional)
+	workDir         string
+	model           string
+	mode            string // "default" | "acceptEdits" | "plan" | "bypassPermissions" | "dontAsk"
+	allowedTools    []string
+	disallowedTools []string
+	providers       []core.ProviderConfig
+	activeIdx       int // -1 = no provider set
+	sessionEnv      []string
+	routerURL       string // Claude Code Router URL (e.g., "http://127.0.0.1:3456")
+	routerAPIKey    string // Claude Code Router API key (optional)
 
 	providerProxy  *core.ProviderProxy // local proxy for third-party providers
 	proxyLocalURL  string              // local URL of the proxy
@@ -68,6 +69,15 @@ func New(opts map[string]any) (core.Agent, error) {
 		}
 	}
 
+	var disallowedTools []string
+	if tools, ok := opts["disallowed_tools"].([]any); ok {
+		for _, t := range tools {
+			if s, ok := t.(string); ok {
+				disallowedTools = append(disallowedTools, s)
+			}
+		}
+	}
+
 	// Claude Code Router support
 	routerURL, _ := opts["router_url"].(string)
 	routerAPIKey, _ := opts["router_api_key"].(string)
@@ -77,13 +87,14 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 
 	return &Agent{
-		workDir:      workDir,
-		model:        model,
-		mode:         mode,
-		allowedTools: allowedTools,
-		activeIdx:    -1,
-		routerURL:    routerURL,
-		routerAPIKey: routerAPIKey,
+		workDir:         workDir,
+		model:           model,
+		mode:            mode,
+		allowedTools:    allowedTools,
+		disallowedTools: disallowedTools,
+		activeIdx:       -1,
+		routerURL:       routerURL,
+		routerAPIKey:    routerAPIKey,
 	}, nil
 }
 
@@ -220,6 +231,8 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	a.mu.Lock()
 	tools := make([]string, len(a.allowedTools))
 	copy(tools, a.allowedTools)
+	disTools := make([]string, len(a.disallowedTools))
+	copy(disTools, a.disallowedTools)
 	model := a.model
 	extraEnv := a.providerEnvLocked()
 	extraEnv = append(extraEnv, a.sessionEnv...)
@@ -245,7 +258,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	platformPrompt := a.platformPrompt
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, a.workDir, model, sessionID, a.mode, tools, extraEnv, platformPrompt)
+	return newClaudeSession(ctx, a.workDir, model, sessionID, a.mode, tools, disTools, extraEnv, platformPrompt)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {
@@ -508,6 +521,15 @@ func (a *Agent) GetAllowedTools() []string {
 	defer a.mu.Unlock()
 	result := make([]string, len(a.allowedTools))
 	copy(result, a.allowedTools)
+	return result
+}
+
+// GetDisallowedTools returns the current list of disallowed tools.
+func (a *Agent) GetDisallowedTools() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	result := make([]string, len(a.disallowedTools))
+	copy(result, a.disallowedTools)
 	return result
 }
 

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -39,7 +39,7 @@ type claudeSession struct {
 	alive       atomic.Bool
 }
 
-func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode string, allowedTools []string, extraEnv []string, platformPrompt string) (*claudeSession, error) {
+func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	args := []string{
@@ -60,6 +60,9 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 	}
 	if len(allowedTools) > 0 {
 		args = append(args, "--allowedTools", strings.Join(allowedTools, ","))
+	}
+	if len(disallowedTools) > 0 {
+		args = append(args, "--disallowedTools", strings.Join(disallowedTools, ","))
 	}
 
 	if sysPrompt := core.AgentSystemPrompt(); sysPrompt != "" {

--- a/config.example.toml
+++ b/config.example.toml
@@ -493,6 +493,10 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "bypassPermission
 # 在 default/acceptEdits 模式下，可预授权特定工具：
 # allowed_tools = ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
 
+# You can also disallow specific tools (passed to --disallowedTools):
+# 也可以禁用特定工具（传递给 --disallowedTools）：
+# disallowed_tools = ["WebSearch", "WebFetch"]
+
 # Optional: specify a model / 可选：指定模型
 # model = "claude-sonnet-4-20250514"
 


### PR DESCRIPTION
## Summary

Add support for `--disallowedTools` CLI flag to disable specific built-in tools like WebSearch and WebFetch.

## Why this is needed

Built-in `WebSearch` and `WebFetch` tools often return no results in many regions/countries due to:
- Network restrictions (GFW, corporate firewalls, etc.)
- Service unavailability in certain geographic areas
- Rate limiting or blocking of Anthropic's search endpoints

Users in affected regions waste time waiting for failed searches and get frustrated with poor experience. Disabling these tools allows users to:
1. Rely on alternative methods (e.g., MCP tools with local search providers)
2. Avoid unnecessary delays from failed network requests
3. Have more predictable agent behavior

## Usage

In `config.toml`:

```toml
[projects.agent.options]
work_dir = "/path/to/project"
mode = "default"
# Disable WebSearch and WebFetch tools
disallowed_tools = ["WebSearch", "WebFetch"]
```

This will pass `--disallowedTools WebSearch,WebFetch` to the Claude CLI.

## Changes

- Add `disallowedTools` field to `Agent` struct
- Parse `disallowed_tools` from config options
- Pass `--disallowedTools` flag to Claude CLI session
- Add `GetDisallowedTools()` method for API access
- Update `config.example.toml` with documentation

## Test plan

- [x] Build passes: `make build`
- [x] Config parsing works correctly
- [x] CLI flag is passed to Claude process

🤖 Generated with [Claude Code](https://claude.com/claude-code)