### PR TITLE
fix(codex): correct --json flag position in exec resume command

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -141,9 +141,11 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 
 	var args []string
 	if isResume {
-		args = []string{"exec", "resume", "--json", "--skip-git-repo-check"}
+		// For resume: codex exec resume <thread_id> --json [other flags] <prompt>
+		// --json must come AFTER the subcommand but BEFORE positional args
+		args = []string{"exec", "resume", "--skip-git-repo-check"}
 	} else {
-		args = []string{"exec", "--json", "--skip-git-repo-check"}
+		args = []string{"exec", "--skip-git-repo-check"}
 	}
 
 	switch cs.mode {
@@ -160,17 +162,19 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%q", cs.effort))
 	}
 
+	// Add --json flag right before the prompt to ensure correct position
 	if isResume {
 		args = append(args, tid)
 		for _, imagePath := range imagePaths {
 			args = append(args, "--image", imagePath)
 		}
-		args = append(args, prompt)
+		// --json must be after the thread_id positional arg for resume to work
+		args = append(args, "--json", "--cd", cs.workDir, prompt)
 	} else {
 		for _, imagePath := range imagePaths {
 			args = append(args, "--image", imagePath)
 		}
-		args = append(args, "--cd", cs.workDir, prompt)
+		args = append(args, "--json", "--cd", cs.workDir, prompt)
 	}
 	return args
 }

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -45,13 +45,13 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 
 	want := []string{
 		"exec",
-		"--json",
 		"--skip-git-repo-check",
 		"--full-auto",
 		"--model",
 		"o3",
 		"-c",
 		`model_reasoning_effort="high"`,
+		"--json",
 		"--cd",
 		"/tmp/project",
 		"hello",
@@ -102,8 +102,11 @@ func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 	}
 
 	args := waitForArgsFile(t, argsFile)
-	if !containsSequence(args, []string{"exec", "--json", "--skip-git-repo-check"}) {
+	if !containsSequence(args, []string{"exec", "--skip-git-repo-check"}) {
 		t.Fatalf("args missing exec prelude: %v", args)
+	}
+	if !containsSequence(args, []string{"--json", "--cd"}) {
+		t.Fatalf("args missing --json --cd sequence: %v", args)
 	}
 	imagePath := valueAfter(args, "--image")
 	if imagePath == "" {
@@ -154,16 +157,18 @@ func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
 	}
 
 	args := waitForArgsFile(t, argsFile)
-	if !containsSequence(args, []string{"exec", "resume", "--json", "--skip-git-repo-check"}) {
+	if !containsSequence(args, []string{"exec", "resume", "--skip-git-repo-check"}) {
 		t.Fatalf("args missing resume prelude: %v", args)
 	}
 	tidIndex := indexOf(args, "thread-123")
 	imageIndex := indexOf(args, "--image")
+	jsonIndex := indexOf(args, "--json")
 	promptIndex := indexOf(args, "describe this")
-	if tidIndex == -1 || imageIndex == -1 || promptIndex == -1 {
-		t.Fatalf("missing resume/image/prompt args: %v", args)
+	if tidIndex == -1 || imageIndex == -1 || jsonIndex == -1 || promptIndex == -1 {
+		t.Fatalf("missing resume/image/json/prompt args: %v", args)
 	}
-	if !(tidIndex < imageIndex && imageIndex < promptIndex) {
+	// Verify order: thread-id -> --image -> --json -> --cd -> prompt
+	if !(tidIndex < imageIndex && imageIndex < jsonIndex && jsonIndex < promptIndex) {
 		t.Fatalf("unexpected arg order: %v", args)
 	}
 }


### PR DESCRIPTION
## Description

Fixes issue #220 where the second message in a Codex session would fail with `error: unexpected argument '--json' found`.

## The Problem

The `--json` flag was placed before the `thread_id` positional argument in the `codex exec resume` command, which caused Codex CLI to fail on the second message in a session.

## The Solution

Move the `--json` flag to the correct position - after the thread_id and before the prompt:

**Before:**
```
codex exec resume --json --skip-git-repo-check <thread_id> <prompt>
```

**After:**
```
codex exec resume --skip-git-repo-check <thread_id> --json --cd <dir> <prompt>
```

## Testing

All existing tests pass, including updated test cases for the corrected argument order.

## Related

Fixes #220