### PR TITLE
fix: codex mode switch not taking effect and --json flag position

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -141,9 +141,11 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 
 	var args []string
 	if isResume {
-		args = []string{"exec", "resume", "--json", "--skip-git-repo-check"}
+		// For resume: codex exec resume <thread_id> --json [other flags] <prompt>
+		// --json must come AFTER the subcommand but BEFORE positional args
+		args = []string{"exec", "resume", "--skip-git-repo-check"}
 	} else {
-		args = []string{"exec", "--json", "--skip-git-repo-check"}
+		args = []string{"exec", "--skip-git-repo-check"}
 	}
 
 	switch cs.mode {
@@ -160,17 +162,19 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%q", cs.effort))
 	}
 
+	// Add --json flag right before the prompt to ensure correct position
 	if isResume {
 		args = append(args, tid)
 		for _, imagePath := range imagePaths {
 			args = append(args, "--image", imagePath)
 		}
-		args = append(args, prompt)
+		// --json must be after the thread_id positional arg for resume to work
+		args = append(args, "--json", "--cd", cs.workDir, prompt)
 	} else {
 		for _, imagePath := range imagePaths {
 			args = append(args, "--image", imagePath)
 		}
-		args = append(args, "--cd", cs.workDir, prompt)
+		args = append(args, "--json", "--cd", cs.workDir, prompt)
 	}
 	return args
 }

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -45,13 +45,13 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 
 	want := []string{
 		"exec",
-		"--json",
 		"--skip-git-repo-check",
 		"--full-auto",
 		"--model",
 		"o3",
 		"-c",
 		`model_reasoning_effort="high"`,
+		"--json",
 		"--cd",
 		"/tmp/project",
 		"hello",
@@ -102,8 +102,11 @@ func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 	}
 
 	args := waitForArgsFile(t, argsFile)
-	if !containsSequence(args, []string{"exec", "--json", "--skip-git-repo-check"}) {
+	if !containsSequence(args, []string{"exec", "--skip-git-repo-check"}) {
 		t.Fatalf("args missing exec prelude: %v", args)
+	}
+	if !containsSequence(args, []string{"--json", "--cd"}) {
+		t.Fatalf("args missing --json --cd sequence: %v", args)
 	}
 	imagePath := valueAfter(args, "--image")
 	if imagePath == "" {
@@ -154,16 +157,18 @@ func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
 	}
 
 	args := waitForArgsFile(t, argsFile)
-	if !containsSequence(args, []string{"exec", "resume", "--json", "--skip-git-repo-check"}) {
+	if !containsSequence(args, []string{"exec", "resume", "--skip-git-repo-check"}) {
 		t.Fatalf("args missing resume prelude: %v", args)
 	}
 	tidIndex := indexOf(args, "thread-123")
 	imageIndex := indexOf(args, "--image")
+	jsonIndex := indexOf(args, "--json")
 	promptIndex := indexOf(args, "describe this")
-	if tidIndex == -1 || imageIndex == -1 || promptIndex == -1 {
-		t.Fatalf("missing resume/image/prompt args: %v", args)
+	if tidIndex == -1 || imageIndex == -1 || jsonIndex == -1 || promptIndex == -1 {
+		t.Fatalf("missing resume/image/json/prompt args: %v", args)
 	}
-	if !(tidIndex < imageIndex && imageIndex < promptIndex) {
+	// Verify order: thread-id -> --image -> --json -> --cd -> prompt
+	if !(tidIndex < imageIndex && imageIndex < jsonIndex && jsonIndex < promptIndex) {
 		t.Fatalf("unexpected arg order: %v", args)
 	}
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -5357,6 +5357,11 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		switcher.SetMode(strings.ToLower(args))
 		interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 		e.cleanupInteractiveState(interactiveKey)
+		// Mode change requires a new session to take effect
+		s := e.sessions.GetOrCreateActive(sessionKey)
+		s.SetAgentSessionID("", "")
+		s.ClearHistory()
+		e.sessions.Save()
 
 	case "/lang":
 		if args == "" {


### PR DESCRIPTION
## Description

Fixes issue #233 and #220.

## Changes

### 1. Fix /mode command not taking effect (Issue #233)

When switching mode via `/mode yolo`, the new mode was saved to the agent but the existing session continued using the old mode. This caused YOLO mode to not work until a new session was manually started.

**Fix:** Reset the session when mode changes, similar to how `/model` works.

**File:** `core/engine.go`

### 2. Fix --json flag position in codex exec resume (Issue #220)

The `--json` flag was placed before the `thread_id` positional argument in `codex exec resume` command, causing `unexpected argument '--json'` error on the second message in a session.

**Fix:** Move `--json` to the correct position after `thread_id` and before `prompt`.

**Before:**
```
codex exec resume --json --skip-git-repo-check <thread_id> <prompt>
```

**After:**
```
codex exec resume --skip-git-repo-check <thread_id> --json --cd <dir> <prompt>
```

**Files:** `agent/codex/session.go`, `agent/codex/session_test.go`

## Testing

All existing tests pass, including updated test cases for the corrected argument order.