### PR TITLE
feat(core): align /model switching with provider flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ cc-connect update --pre     # Beta (includes pre-releases)
 
 ```
 /model                      List available models (format: alias - model)
-/model <alias>              Switch to model by alias
+/model switch <alias>       Switch to model by alias
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -245,7 +245,7 @@ cc-connect update --pre     # Beta 版（含 pre-release）
 
 ```
 /model                      列出可用模型（格式：alias - model）
-/model <alias>              按别名切换模型
+/model switch <alias>       按别名切换模型
 ```
 
 ---

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -131,7 +131,7 @@ func (a *Agent) SetModel(model string) {
 func (a *Agent) GetModel() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.model
+	return core.GetProviderModel(a.providers, a.activeIdx, a.model)
 }
 
 func (a *Agent) configuredModels() []core.ModelOption {

--- a/agent/claudecode/claudecode_model_test.go
+++ b/agent/claudecode/claudecode_model_test.go
@@ -41,3 +41,17 @@ func TestConfiguredModels_BoundaryConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestGetModel_PrefersActiveProviderModel(t *testing.T) {
+	a := &Agent{
+		model: "sonnet",
+		providers: []core.ProviderConfig{
+			{Name: "anthropic", Model: "opus"},
+		},
+		activeIdx: 0,
+	}
+
+	if got := a.GetModel(); got != "opus" {
+		t.Fatalf("GetModel() = %q, want opus", got)
+	}
+}

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -116,7 +116,7 @@ func (a *Agent) SetModel(model string) {
 func (a *Agent) GetModel() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.model
+	return core.GetProviderModel(a.providers, a.activeIdx, a.model)
 }
 
 func (a *Agent) SetReasoningEffort(effort string) {

--- a/agent/codex/codex_model_test.go
+++ b/agent/codex/codex_model_test.go
@@ -41,3 +41,17 @@ func TestConfiguredModels_BoundaryConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestGetModel_PrefersActiveProviderModel(t *testing.T) {
+	a := &Agent{
+		model: "gpt-4.1-mini",
+		providers: []core.ProviderConfig{
+			{Name: "openai", Model: "gpt-5.4"},
+		},
+		activeIdx: 0,
+	}
+
+	if got := a.GetModel(); got != "gpt-5.4" {
+		t.Fatalf("GetModel() = %q, want gpt-5.4", got)
+	}
+}

--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -106,7 +106,7 @@ func (a *Agent) SetModel(model string) {
 func (a *Agent) GetModel() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.model
+	return core.GetProviderModel(a.providers, a.activeIdx, a.model)
 }
 
 func (a *Agent) configuredModels() []core.ModelOption {

--- a/agent/gemini/gemini.go
+++ b/agent/gemini/gemini.go
@@ -124,7 +124,7 @@ func (a *Agent) SetModel(model string) {
 func (a *Agent) GetModel() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.model
+	return core.GetProviderModel(a.providers, a.activeIdx, a.model)
 }
 
 func (a *Agent) configuredModels() []core.ModelOption {

--- a/agent/gemini/gemini_model_test.go
+++ b/agent/gemini/gemini_model_test.go
@@ -41,3 +41,17 @@ func TestConfiguredModels_BoundaryConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestGetModel_PrefersActiveProviderModel(t *testing.T) {
+	a := &Agent{
+		model: "gemini-2.5-flash",
+		providers: []core.ProviderConfig{
+			{Name: "google", Model: "gemini-2.5-pro"},
+		},
+		activeIdx: 0,
+	}
+
+	if got := a.GetModel(); got != "gemini-2.5-pro" {
+		t.Fatalf("GetModel() = %q, want gemini-2.5-pro", got)
+	}
+}

--- a/agent/iflow/iflow.go
+++ b/agent/iflow/iflow.go
@@ -117,7 +117,7 @@ func (a *Agent) SetModel(model string) {
 func (a *Agent) GetModel() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.model
+	return core.GetProviderModel(a.providers, a.activeIdx, a.model)
 }
 
 func (a *Agent) configuredModels() []core.ModelOption {

--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -95,7 +95,7 @@ func (a *Agent) SetModel(model string) {
 func (a *Agent) GetModel() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.model
+	return core.GetProviderModel(a.providers, a.activeIdx, a.model)
 }
 
 func (a *Agent) configuredModels() []core.ModelOption {

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -466,6 +466,9 @@ func main() {
 		engine.SetProviderRemoveSaveFunc(func(name string) error {
 			return config.RemoveProviderFromConfig(projName, name)
 		})
+		engine.SetProviderModelSaveFunc(func(providerName, model string) error {
+			return config.SaveProviderModel(projName, providerName, model)
+		})
 
 		// Wire config reload
 		capturedEngine := engine

--- a/config.example.toml
+++ b/config.example.toml
@@ -544,9 +544,9 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "bypassPermission
 # base_url = "https://api.relay-service.com"
 # model = "claude-sonnet-4-20250514"
 # # Optional: pre-configure available models shown by /model command (alias - model)
-# # /model [alias] switches to the model; omit to auto-fetch from the API.
+# # /model switch [alias] switches to the model; omit to auto-fetch from the API.
 # # 可选：预先配置 /model 命令显示的可用模型列表，格式为 alias - model
-# # 使用 /model [alias] 切换模型；留空则自动从 API 获取
+# # 使用 /model switch [alias] 切换模型；留空则自动从 API 获取
 # [[projects.agent.providers.models]]
 # model = "claude-sonnet-4-20250514"
 # alias = "sonnet"

--- a/config/config.go
+++ b/config/config.go
@@ -55,9 +55,9 @@ type WebhookConfig struct {
 
 // BridgeConfig controls the WebSocket bridge for external platform adapters.
 type BridgeConfig struct {
-	Enabled *bool  `toml:"enabled"`         // default false
-	Port    int    `toml:"port,omitempty"`  // listen port; default 9810
-	Token   string `toml:"token,omitempty"` // shared secret for authentication; required
+	Enabled     *bool    `toml:"enabled"`                // default false
+	Port        int      `toml:"port,omitempty"`         // listen port; default 9810
+	Token       string   `toml:"token,omitempty"`        // shared secret for authentication; required
 	Path        string   `toml:"path,omitempty"`         // URL path; default "/bridge/ws"
 	CORSOrigins []string `toml:"cors_origins,omitempty"` // allowed CORS origins; empty = no CORS
 }
@@ -132,12 +132,12 @@ type SpeechConfig struct {
 
 // TTSConfig configures text-to-speech output (mirrors SpeechConfig style).
 type TTSConfig struct {
-	Enabled     bool   `toml:"enabled"`
-	Provider    string `toml:"provider"`     // "qwen" | "openai" | "minimax" | "espeak" | "pico" | "edge"
-	Voice       string `toml:"voice"`        // default voice name (for edge: "zh-CN-XiaoxiaoNeural"; for pico: "zh-CN"; for espeak: "zh")
-	TTSMode     string `toml:"tts_mode"`     // "voice_only" (default) | "always"
-	MaxTextLen  int    `toml:"max_text_len"` // max rune count before skipping TTS; 0 = no limit
-	OpenAI      struct {
+	Enabled    bool   `toml:"enabled"`
+	Provider   string `toml:"provider"`     // "qwen" | "openai" | "minimax" | "espeak" | "pico" | "edge"
+	Voice      string `toml:"voice"`        // default voice name (for edge: "zh-CN-XiaoxiaoNeural"; for pico: "zh-CN"; for espeak: "zh")
+	TTSMode    string `toml:"tts_mode"`     // "voice_only" (default) | "always"
+	MaxTextLen int    `toml:"max_text_len"` // max rune count before skipping TTS; 0 = no limit
+	OpenAI     struct {
 		APIKey  string `toml:"api_key"`
 		BaseURL string `toml:"base_url"`
 		Model   string `toml:"model"`
@@ -363,6 +363,37 @@ func SaveActiveProvider(projectName, providerName string) error {
 		}
 	}
 	return saveConfig(cfg)
+}
+
+// SaveProviderModel persists the selected model for a provider in a project.
+func SaveProviderModel(projectName, providerName, model string) error {
+	configMu.Lock()
+	defer configMu.Unlock()
+	if ConfigPath == "" {
+		return fmt.Errorf("config path not set")
+	}
+	data, err := os.ReadFile(ConfigPath)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+	cfg := &Config{}
+	if err := toml.Unmarshal(data, cfg); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+
+	for i := range cfg.Projects {
+		if cfg.Projects[i].Name != projectName {
+			continue
+		}
+		for j := range cfg.Projects[i].Agent.Providers {
+			if cfg.Projects[i].Agent.Providers[j].Name == providerName {
+				cfg.Projects[i].Agent.Providers[j].Model = model
+				return saveConfig(cfg)
+			}
+		}
+		return fmt.Errorf("provider %q not found in project %q", providerName, projectName)
+	}
+	return fmt.Errorf("project %q not found in config", projectName)
 }
 
 // AddProviderToConfig adds a provider to a project's agent config and saves.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -206,6 +206,22 @@ func TestProviderConfig_AddAndRemove(t *testing.T) {
 	}
 }
 
+func TestProviderConfig_SaveProviderModel(t *testing.T) {
+	writeTestConfig(t, providerConfigTOML)
+
+	if err := SaveProviderModel("demo", "primary", "gpt-5.4"); err != nil {
+		t.Fatalf("SaveProviderModel() error: %v", err)
+	}
+
+	cfg := readTestConfig(t)
+	if got := cfg.Projects[0].Agent.Providers[0].Model; got != "gpt-5.4" {
+		t.Fatalf("provider model = %q, want gpt-5.4", got)
+	}
+	if err := SaveProviderModel("demo", "missing", "gpt-4.1"); err == nil {
+		t.Fatal("SaveProviderModel() missing provider: expected error")
+	}
+}
+
 func TestCommandConfig_AddAndRemove(t *testing.T) {
 	writeTestConfig(t, baseConfigTOML)
 

--- a/core/bridge_test.go
+++ b/core/bridge_test.go
@@ -338,7 +338,7 @@ func TestSerializeCard(t *testing.T) {
 	card := NewCard().
 		Title("Model", "blue").
 		Markdown("Choose:").
-		Buttons(PrimaryBtn("GPT-4", "cmd:/model gpt-4"), DefaultBtn("Claude", "cmd:/model claude")).
+		Buttons(PrimaryBtn("GPT-4", "cmd:/model switch gpt-4"), DefaultBtn("Claude", "cmd:/model switch claude")).
 		Divider().
 		Note("tip").
 		Build()
@@ -371,7 +371,7 @@ func TestSerializeCard(t *testing.T) {
 	if len(btns) != 2 {
 		t.Fatalf("buttons count = %d", len(btns))
 	}
-	if btns[0]["text"] != "GPT-4" || btns[0]["value"] != "cmd:/model gpt-4" {
+	if btns[0]["text"] != "GPT-4" || btns[0]["value"] != "cmd:/model switch gpt-4" {
 		t.Fatalf("button[0] = %v", btns[0])
 	}
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -144,6 +144,7 @@ type Engine struct {
 	providerSaveFunc       func(providerName string) error
 	providerAddSaveFunc    func(p ProviderConfig) error
 	providerRemoveSaveFunc func(name string) error
+	providerModelSaveFunc  func(providerName, model string) error
 
 	ttsSaveFunc func(mode string) error
 
@@ -388,6 +389,10 @@ func (e *Engine) SetProviderAddSaveFunc(fn func(ProviderConfig) error) {
 
 func (e *Engine) SetProviderRemoveSaveFunc(fn func(string) error) {
 	e.providerRemoveSaveFunc = fn
+}
+
+func (e *Engine) SetProviderModelSaveFunc(fn func(providerName, model string) error) {
+	e.providerModelSaveFunc = fn
 }
 
 // AddPlatform appends a platform to the engine after construction.
@@ -4133,7 +4138,7 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 				if m.Name == current {
 					label = "▶ " + label
 				}
-				row = append(row, ButtonOption{Text: label, Data: fmt.Sprintf("cmd:/model %d", i+1)})
+				row = append(row, ButtonOption{Text: label, Data: fmt.Sprintf("cmd:/model switch %d", i+1)})
 				if len(row) >= 3 {
 					buttons = append(buttons, row)
 					row = nil
@@ -4151,18 +4156,24 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 		return
 	}
 
+	targetInput, ok := parseModelSwitchArgs(args)
+	if !ok {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgModelUsage))
+		return
+	}
+
 	fetchCtx, cancel := context.WithTimeout(e.ctx, 10*time.Second)
 	defer cancel()
 	models := switcher.AvailableModels(fetchCtx)
 
-	target := args[0]
+	target := targetInput
 	if idx, err := strconv.Atoi(target); err == nil && idx >= 1 && idx <= len(models) {
 		target = models[idx-1].Name
 	} else {
 		target = resolveModelAlias(models, target)
 	}
 
-	switcher.SetModel(target)
+	target = e.switchModel(target)
 	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
 
 	s := e.sessions.GetOrCreateActive(msg.SessionKey)
@@ -4183,6 +4194,56 @@ func resolveModelAlias(models []ModelOption, input string) string {
 		}
 	}
 	return input
+}
+
+func parseModelSwitchArgs(args []string) (string, bool) {
+	if len(args) == 0 {
+		return "", false
+	}
+	if len(args) == 1 {
+		if strings.EqualFold(strings.TrimSpace(args[0]), "switch") {
+			return "", false
+		}
+		return args[0], true
+	}
+	if strings.EqualFold(strings.TrimSpace(args[0]), "switch") && len(args) >= 2 {
+		return strings.TrimSpace(args[1]), true
+	}
+	return "", false
+}
+
+// switchModel applies a runtime model selection. When an active provider exists,
+// its configured model is updated so new sessions use the selected model instead
+// of the provider's previous fixed model.
+func (e *Engine) switchModel(target string) string {
+	switcher, ok := e.agent.(ModelSwitcher)
+	if !ok {
+		return target
+	}
+	switcher.SetModel(target)
+
+	providerSwitcher, ok := e.agent.(ProviderSwitcher)
+	if !ok {
+		return target
+	}
+	active := providerSwitcher.GetActiveProvider()
+	if active == nil {
+		return target
+	}
+
+	providers := providerSwitcher.ListProviders()
+	updated, found := SetProviderModel(providers, active.Name, target)
+	if !found {
+		return target
+	}
+	providerSwitcher.SetProviders(updated)
+	providerSwitcher.SetActiveProvider(active.Name)
+	if e.providerModelSaveFunc != nil {
+		if err := e.providerModelSaveFunc(active.Name, target); err != nil {
+			slog.Error("failed to save provider model", "provider", active.Name, "model", target, "error", err)
+		}
+	}
+	return target
 }
 
 func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
@@ -5306,13 +5367,16 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		fetchCtx, cancel := context.WithTimeout(e.ctx, 3*time.Second)
 		defer cancel()
 		models := switcher.AvailableModels(fetchCtx)
-		target := args
+		target, ok := parseModelSwitchArgs(strings.Fields(args))
+		if !ok {
+			return
+		}
 		if idx, err := strconv.Atoi(target); err == nil && idx >= 1 && idx <= len(models) {
 			target = models[idx-1].Name
 		} else {
 			target = resolveModelAlias(models, target)
 		}
-		switcher.SetModel(target)
+		e.switchModel(target)
 		interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 		e.cleanupInteractiveState(interactiveKey)
 		s := e.sessions.GetOrCreateActive(sessionKey)
@@ -5869,7 +5933,7 @@ func (e *Engine) renderModelCard() *Card {
 		} else if m.Desc != "" {
 			label += " — " + m.Desc
 		}
-		val := fmt.Sprintf("act:/model %d", i+1)
+		val := fmt.Sprintf("act:/model switch %d", i+1)
 		opts = append(opts, CardSelectOption{Text: label, Value: val})
 		if m.Name == current {
 			initVal = val

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -138,6 +138,8 @@ type stubModelModeAgent struct {
 	model           string
 	mode            string
 	reasoningEffort string
+	providers       []ProviderConfig
+	active          string
 }
 
 func (a *stubModelModeAgent) SetModel(model string) {
@@ -150,9 +152,42 @@ func (a *stubModelModeAgent) GetModel() string {
 
 func (a *stubModelModeAgent) AvailableModels(_ context.Context) []ModelOption {
 	return []ModelOption{
-		{Name: "gpt-4.1", Desc: "Balanced"},
+		{Name: "gpt-4.1", Desc: "Balanced", Alias: "gpt"},
 		{Name: "gpt-4.1-mini", Desc: "Fast"},
 	}
+}
+
+func (a *stubModelModeAgent) SetProviders(providers []ProviderConfig) {
+	a.providers = providers
+}
+
+func (a *stubModelModeAgent) GetActiveProvider() *ProviderConfig {
+	for i := range a.providers {
+		if a.providers[i].Name == a.active {
+			return &a.providers[i]
+		}
+	}
+	return nil
+}
+
+func (a *stubModelModeAgent) ListProviders() []ProviderConfig {
+	result := make([]ProviderConfig, len(a.providers))
+	copy(result, a.providers)
+	return result
+}
+
+func (a *stubModelModeAgent) SetActiveProvider(name string) bool {
+	if name == "" {
+		a.active = ""
+		return true
+	}
+	for _, prov := range a.providers {
+		if prov.Name == name {
+			a.active = name
+			return true
+		}
+	}
+	return false
 }
 
 func (a *stubModelModeAgent) SetMode(mode string) {
@@ -1959,8 +1994,65 @@ func TestCmdModel_UsesInlineButtonsOnButtonOnlyPlatform(t *testing.T) {
 	if len(p.buttonRows) == 0 {
 		t.Fatal("expected /model to send inline buttons on button-only platform")
 	}
-	if got := p.buttonRows[0][0].Data; got != "cmd:/model 1" {
-		t.Fatalf("first /model button = %q, want %q", got, "cmd:/model 1")
+	if got := p.buttonRows[0][0].Data; got != "cmd:/model switch 1" {
+		t.Fatalf("first /model button = %q, want %q", got, "cmd:/model switch 1")
+	}
+}
+
+func TestCmdModel_UpdatesActiveProviderModel(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubModelModeAgent{
+		model: "gpt-4.1-mini",
+		providers: []ProviderConfig{
+			{
+				Name:   "openai",
+				Model:  "gpt-4.1-mini",
+				Models: []ModelOption{{Name: "gpt-4.1", Alias: "gpt"}, {Name: "gpt-4.1-mini", Alias: "mini"}},
+			},
+		},
+		active: "openai",
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	var savedProvider, savedModel string
+	e.SetProviderModelSaveFunc(func(providerName, model string) error {
+		savedProvider = providerName
+		savedModel = model
+		return nil
+	})
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s.SetAgentSessionID("existing-session", "test")
+
+	e.cmdModel(p, msg, []string{"switch", "gpt"})
+
+	if agent.model != "gpt-4.1" {
+		t.Fatalf("agent model = %q, want gpt-4.1", agent.model)
+	}
+	if got := agent.GetActiveProvider(); got == nil || got.Model != "gpt-4.1" {
+		t.Fatalf("active provider model = %#v, want gpt-4.1", got)
+	}
+	if got := agent.GetModel(); got != "gpt-4.1" {
+		t.Fatalf("GetModel() = %q, want gpt-4.1", got)
+	}
+	if savedProvider != "openai" || savedModel != "gpt-4.1" {
+		t.Fatalf("saved provider/model = %q/%q, want openai/gpt-4.1", savedProvider, savedModel)
+	}
+	if active := e.sessions.GetOrCreateActive(msg.SessionKey); active.AgentSessionID != "" {
+		t.Fatalf("session id = %q, want cleared after model switch", active.AgentSessionID)
+	}
+}
+
+func TestCmdModel_LegacySyntaxStillWorks(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubModelModeAgent{}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	e.cmdModel(p, msg, []string{"gpt"})
+
+	if agent.model != "gpt-4.1" {
+		t.Fatalf("agent model = %q, want gpt-4.1", agent.model)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -119,80 +119,80 @@ func (i *I18n) SetLang(lang Language) {
 type MsgKey string
 
 const (
-	MsgStarting             MsgKey = "starting"
-	MsgThinking             MsgKey = "thinking"
-	MsgTool                 MsgKey = "tool"
-	MsgExecutionStopped     MsgKey = "execution_stopped"
-	MsgNoExecution          MsgKey = "no_execution"
-	MsgPreviousProcessing   MsgKey = "previous_processing"
-	MsgMessageQueued        MsgKey = "message_queued"
-	MsgNoToolsAllowed       MsgKey = "no_tools_allowed"
-	MsgCurrentTools         MsgKey = "current_tools"
-	MsgCurrentSession       MsgKey = "current_session"
-	MsgToolAuthNotSupported MsgKey = "tool_auth_not_supported"
-	MsgToolAllowFailed      MsgKey = "tool_allow_failed"
-	MsgToolAllowedNew       MsgKey = "tool_allowed_new"
+	MsgStarting                  MsgKey = "starting"
+	MsgThinking                  MsgKey = "thinking"
+	MsgTool                      MsgKey = "tool"
+	MsgExecutionStopped          MsgKey = "execution_stopped"
+	MsgNoExecution               MsgKey = "no_execution"
+	MsgPreviousProcessing        MsgKey = "previous_processing"
+	MsgMessageQueued             MsgKey = "message_queued"
+	MsgNoToolsAllowed            MsgKey = "no_tools_allowed"
+	MsgCurrentTools              MsgKey = "current_tools"
+	MsgCurrentSession            MsgKey = "current_session"
+	MsgToolAuthNotSupported      MsgKey = "tool_auth_not_supported"
+	MsgToolAllowFailed           MsgKey = "tool_allow_failed"
+	MsgToolAllowedNew            MsgKey = "tool_allowed_new"
 	MsgError                     MsgKey = "error"
 	MsgFailedToStartAgentSession MsgKey = "failed_to_start_agent_session"
-	MsgFailedToDeleteSession    MsgKey = "failed_to_delete_session"
-	MsgEmptyResponse           MsgKey = "empty_response"
-	MsgPermissionPrompt     MsgKey = "permission_prompt"
-	MsgPermissionAllowed    MsgKey = "permission_allowed"
-	MsgPermissionApproveAll MsgKey = "permission_approve_all"
-	MsgPermissionDenied     MsgKey = "permission_denied_msg"
-	MsgPermissionHint       MsgKey = "permission_hint"
-	MsgQuietOn              MsgKey = "quiet_on"
-	MsgQuietOff             MsgKey = "quiet_off"
-	MsgQuietGlobalOn        MsgKey = "quiet_global_on"
-	MsgQuietGlobalOff       MsgKey = "quiet_global_off"
-	MsgModeChanged          MsgKey = "mode_changed"
-	MsgModeNotSupported     MsgKey = "mode_not_supported"
-	MsgSessionRestarting    MsgKey = "session_restarting"
-	MsgSessionNotStarted    MsgKey = "session_not_started"
-	MsgLangChanged          MsgKey = "lang_changed"
-	MsgLangInvalid          MsgKey = "lang_invalid"
-	MsgLangCurrent          MsgKey = "lang_current"
-	MsgUnknownCommand       MsgKey = "unknown_command"
-	MsgHelp                 MsgKey = "message_help" // change from "help", which is used now for builtin command help
-	MsgHelpTitle            MsgKey = "help_title"
-	MsgHelpSessionSection   MsgKey = "help_session_section"
-	MsgHelpAgentSection     MsgKey = "help_agent_section"
-	MsgHelpToolsSection     MsgKey = "help_tools_section"
-	MsgHelpSystemSection    MsgKey = "help_system_section"
-	MsgHelpTip              MsgKey = "help_tip"
-	MsgListTitle            MsgKey = "list_title"
-	MsgListTitlePaged       MsgKey = "list_title_paged"
-	MsgListEmpty            MsgKey = "list_empty"
-	MsgListMore             MsgKey = "list_more"
-	MsgListPageHint         MsgKey = "list_page_hint"
-	MsgListSwitchHint       MsgKey = "list_switch_hint"
-	MsgListError            MsgKey = "list_error"
-	MsgHistoryEmpty         MsgKey = "history_empty"
-	MsgNameUsage            MsgKey = "name_usage"
-	MsgNameSet              MsgKey = "name_set"
-	MsgNameNoSession        MsgKey = "name_no_session"
-	MsgProviderNotSupported MsgKey = "provider_not_supported"
-	MsgProviderNone         MsgKey = "provider_none"
-	MsgProviderCurrent      MsgKey = "provider_current"
-	MsgProviderListTitle    MsgKey = "provider_list_title"
-	MsgProviderListEmpty    MsgKey = "provider_list_empty"
-	MsgProviderSwitchHint   MsgKey = "provider_switch_hint"
-	MsgProviderNotFound     MsgKey = "provider_not_found"
-	MsgProviderSwitched     MsgKey = "provider_switched"
-	MsgProviderCleared      MsgKey = "provider_cleared"
-	MsgProviderAdded        MsgKey = "provider_added"
-	MsgProviderAddUsage     MsgKey = "provider_add_usage"
-	MsgProviderAddFailed    MsgKey = "provider_add_failed"
-	MsgProviderRemoved      MsgKey = "provider_removed"
-	MsgProviderRemoveFailed MsgKey = "provider_remove_failed"
+	MsgFailedToDeleteSession     MsgKey = "failed_to_delete_session"
+	MsgEmptyResponse             MsgKey = "empty_response"
+	MsgPermissionPrompt          MsgKey = "permission_prompt"
+	MsgPermissionAllowed         MsgKey = "permission_allowed"
+	MsgPermissionApproveAll      MsgKey = "permission_approve_all"
+	MsgPermissionDenied          MsgKey = "permission_denied_msg"
+	MsgPermissionHint            MsgKey = "permission_hint"
+	MsgQuietOn                   MsgKey = "quiet_on"
+	MsgQuietOff                  MsgKey = "quiet_off"
+	MsgQuietGlobalOn             MsgKey = "quiet_global_on"
+	MsgQuietGlobalOff            MsgKey = "quiet_global_off"
+	MsgModeChanged               MsgKey = "mode_changed"
+	MsgModeNotSupported          MsgKey = "mode_not_supported"
+	MsgSessionRestarting         MsgKey = "session_restarting"
+	MsgSessionNotStarted         MsgKey = "session_not_started"
+	MsgLangChanged               MsgKey = "lang_changed"
+	MsgLangInvalid               MsgKey = "lang_invalid"
+	MsgLangCurrent               MsgKey = "lang_current"
+	MsgUnknownCommand            MsgKey = "unknown_command"
+	MsgHelp                      MsgKey = "message_help" // change from "help", which is used now for builtin command help
+	MsgHelpTitle                 MsgKey = "help_title"
+	MsgHelpSessionSection        MsgKey = "help_session_section"
+	MsgHelpAgentSection          MsgKey = "help_agent_section"
+	MsgHelpToolsSection          MsgKey = "help_tools_section"
+	MsgHelpSystemSection         MsgKey = "help_system_section"
+	MsgHelpTip                   MsgKey = "help_tip"
+	MsgListTitle                 MsgKey = "list_title"
+	MsgListTitlePaged            MsgKey = "list_title_paged"
+	MsgListEmpty                 MsgKey = "list_empty"
+	MsgListMore                  MsgKey = "list_more"
+	MsgListPageHint              MsgKey = "list_page_hint"
+	MsgListSwitchHint            MsgKey = "list_switch_hint"
+	MsgListError                 MsgKey = "list_error"
+	MsgHistoryEmpty              MsgKey = "history_empty"
+	MsgNameUsage                 MsgKey = "name_usage"
+	MsgNameSet                   MsgKey = "name_set"
+	MsgNameNoSession             MsgKey = "name_no_session"
+	MsgProviderNotSupported      MsgKey = "provider_not_supported"
+	MsgProviderNone              MsgKey = "provider_none"
+	MsgProviderCurrent           MsgKey = "provider_current"
+	MsgProviderListTitle         MsgKey = "provider_list_title"
+	MsgProviderListEmpty         MsgKey = "provider_list_empty"
+	MsgProviderSwitchHint        MsgKey = "provider_switch_hint"
+	MsgProviderNotFound          MsgKey = "provider_not_found"
+	MsgProviderSwitched          MsgKey = "provider_switched"
+	MsgProviderCleared           MsgKey = "provider_cleared"
+	MsgProviderAdded             MsgKey = "provider_added"
+	MsgProviderAddUsage          MsgKey = "provider_add_usage"
+	MsgProviderAddFailed         MsgKey = "provider_add_failed"
+	MsgProviderRemoved           MsgKey = "provider_removed"
+	MsgProviderRemoveFailed      MsgKey = "provider_remove_failed"
 
-	MsgVoiceNotEnabled       MsgKey = "voice_not_enabled"
+	MsgVoiceNotEnabled               MsgKey = "voice_not_enabled"
 	MsgVoiceUsingPlatformRecognition MsgKey = "voice_using_platform_recognition"
-	MsgVoiceNoFFmpeg         MsgKey = "voice_no_ffmpeg"
-	MsgVoiceTranscribing     MsgKey = "voice_transcribing"
-	MsgVoiceTranscribed      MsgKey = "voice_transcribed"
-	MsgVoiceTranscribeFailed MsgKey = "voice_transcribe_failed"
-	MsgVoiceEmpty            MsgKey = "voice_empty"
+	MsgVoiceNoFFmpeg                 MsgKey = "voice_no_ffmpeg"
+	MsgVoiceTranscribing             MsgKey = "voice_transcribing"
+	MsgVoiceTranscribed              MsgKey = "voice_transcribed"
+	MsgVoiceTranscribeFailed         MsgKey = "voice_transcribe_failed"
+	MsgVoiceEmpty                    MsgKey = "voice_empty"
 
 	MsgTTSNotEnabled MsgKey = "tts_not_enabled"
 	MsgTTSStatus     MsgKey = "tts_status"
@@ -748,7 +748,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/provider [list|add|remove|switch|clear]\n  Manage API providers\n\n" +
 			"/memory [add|global|global add]\n  View/edit agent memory files\n\n" +
 			"/allow <tool>\n  Pre-allow a tool (next session)\n\n" +
-			"/model [name]\n  View/switch model\n\n" +
+			"/model [switch <name>]\n  View/switch model\n\n" +
 			"/reasoning [level]\n  View/switch reasoning effort\n\n" +
 			"/mode [name]\n  View/switch permission mode\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  View/switch language\n\n" +
@@ -791,7 +791,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/provider [list|add|remove|switch|clear]\n  管理 API Provider\n\n" +
 			"/memory [add|global|global add]\n  查看/编辑 Agent 记忆文件\n\n" +
 			"/allow <工具名>\n  预授权工具（下次会话生效）\n\n" +
-			"/model [名称]\n  查看/切换模型\n\n" +
+			"/model [switch <名称>]\n  查看/切换模型\n\n" +
 			"/reasoning [级别]\n  查看/切换推理强度\n\n" +
 			"/mode [名称]\n  查看/切换权限模式\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  查看/切换语言\n\n" +
@@ -834,7 +834,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/provider [list|add|remove|switch|clear]\n  管理 API Provider\n\n" +
 			"/memory [add|global|global add]\n  查看/編輯 Agent 記憶檔案\n\n" +
 			"/allow <工具名>\n  預授權工具（下次會話生效）\n\n" +
-			"/model [名稱]\n  查看/切換模型\n\n" +
+			"/model [switch <名稱>]\n  查看/切換模型\n\n" +
 			"/reasoning [級別]\n  查看/切換推理強度\n\n" +
 			"/mode [名稱]\n  查看/切換權限模式\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  查看/切換語言\n\n" +
@@ -876,7 +876,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/provider [list|add|remove|switch|clear]\n  API プロバイダ管理\n\n" +
 			"/memory [add|global|global add]\n  エージェントメモリの表示/編集\n\n" +
 			"/allow <ツール名>\n  ツールを事前許可（次のセッションで有効）\n\n" +
-			"/model [名前]\n  モデルの表示/切り替え\n\n" +
+			"/model [switch <名前>]\n  モデルの表示/切り替え\n\n" +
 			"/reasoning [レベル]\n  推論レベルの表示/切り替え\n\n" +
 			"/mode [名前]\n  権限モードの表示/切り替え\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  言語の表示/切り替え\n\n" +
@@ -918,7 +918,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/provider [list|add|remove|switch|clear]\n  Gestionar proveedores API\n\n" +
 			"/memory [add|global|global add]\n  Ver/editar archivos de memoria del agente\n\n" +
 			"/allow <herramienta>\n  Pre-autorizar herramienta (próxima sesión)\n\n" +
-			"/model [nombre]\n  Ver/cambiar modelo\n\n" +
+			"/model [switch <nombre>]\n  Ver/cambiar modelo\n\n" +
 			"/reasoning [nivel]\n  Ver/cambiar nivel de razonamiento\n\n" +
 			"/mode [nombre]\n  Ver/cambiar modo de permisos\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  Ver/cambiar idioma\n\n" +
@@ -1006,7 +1006,7 @@ var messages = map[MsgKey]map[Language]string{
 	},
 	MsgHelpAgentSection: {
 		LangEnglish: "**Agent Configuration**\n" +
-			"/model [name] — View/switch model\n" +
+			"/model [switch <name>] — View/switch model\n" +
 			"/mode [name] — View/switch permission mode\n" +
 			"/provider [list|add|...] — Manage API providers\n" +
 			"/memory [add|global|...] — View/edit memory files\n" +
@@ -1014,7 +1014,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/lang [en|zh|...] — View/switch language\n" +
 			"/quiet [global] — Toggle progress messages",
 		LangChinese: "**Agent 配置**\n" +
-			"/model [名称] — 查看/切换模型\n" +
+			"/model [switch <名称>] — 查看/切换模型\n" +
 			"/mode [名称] — 查看/切换权限模式\n" +
 			"/provider [list|add|...] — 管理 API Provider\n" +
 			"/memory [add|global|...] — 查看/编辑记忆文件\n" +
@@ -1022,7 +1022,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/lang [en|zh|...] — 查看/切换语言\n" +
 			"/quiet [global] — 开关进度消息",
 		LangTraditionalChinese: "**Agent 配置**\n" +
-			"/model [名稱] — 查看/切換模型\n" +
+			"/model [switch <名稱>] — 查看/切換模型\n" +
 			"/mode [名稱] — 查看/切換權限模式\n" +
 			"/provider [list|add|...] — 管理 API Provider\n" +
 			"/memory [add|global|...] — 查看/編輯記憶檔案\n" +
@@ -1030,7 +1030,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/lang [en|zh|...] — 查看/切換語言\n" +
 			"/quiet [global] — 開關進度訊息",
 		LangJapanese: "**エージェント設定**\n" +
-			"/model [名前] — モデルの表示/切り替え\n" +
+			"/model [switch <名前>] — モデルの表示/切り替え\n" +
 			"/mode [名前] — 権限モードの表示/切り替え\n" +
 			"/provider [list|add|...] — API プロバイダ管理\n" +
 			"/memory [add|global|...] — メモリの表示/編集\n" +
@@ -1038,7 +1038,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/lang [en|zh|...] — 言語の表示/切り替え\n" +
 			"/quiet [global] — 進捗メッセージの表示切替",
 		LangSpanish: "**Configuración del agente**\n" +
-			"/model [nombre] — Ver/cambiar modelo\n" +
+			"/model [switch <nombre>] — Ver/cambiar modelo\n" +
 			"/mode [nombre] — Ver/cambiar modo de permisos\n" +
 			"/provider [list|add|...] — Gestionar proveedores\n" +
 			"/memory [add|global|...] — Ver/editar memoria\n" +
@@ -1941,11 +1941,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Modelos disponibles:\n",
 	},
 	MsgModelUsage: {
-		LangEnglish:            "Usage: `/model <number>` or `/model <model_name>`",
-		LangChinese:            "用法: `/model <序号>` 或 `/model <模型名>`",
-		LangTraditionalChinese: "用法: `/model <序號>` 或 `/model <模型名>`",
-		LangJapanese:           "使い方: `/model <番号>` または `/model <モデル名>`",
-		LangSpanish:            "Uso: `/model <número>` o `/model <nombre_modelo>`",
+		LangEnglish:            "Usage: `/model switch <number>` or `/model switch <model_name>`",
+		LangChinese:            "用法: `/model switch <序号>` 或 `/model switch <模型名>`",
+		LangTraditionalChinese: "用法: `/model switch <序號>` 或 `/model switch <模型名>`",
+		LangJapanese:           "使い方: `/model switch <番号>` または `/model switch <モデル名>`",
+		LangSpanish:            "Uso: `/model switch <número>` o `/model switch <nombre_modelo>`",
 	},
 	MsgReasoningDefault: {
 		LangEnglish:            "Current reasoning effort: (not set, using Codex default)\n",

--- a/core/model_alias_test.go
+++ b/core/model_alias_test.go
@@ -19,3 +19,29 @@ func TestResolveModelAlias_NoMatchFallsBackToInput(t *testing.T) {
 		t.Fatalf("resolveModelAlias() = %q, want original input", got)
 	}
 }
+
+func TestParseModelSwitchArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+		ok   bool
+	}{
+		{name: "legacy syntax", args: []string{"gpt"}, want: "gpt", ok: true},
+		{name: "switch syntax", args: []string{"switch", "gpt"}, want: "gpt", ok: true},
+		{name: "missing switch target", args: []string{"switch"}, ok: false},
+		{name: "unknown subcommand", args: []string{"list", "gpt"}, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseModelSwitchArgs(tt.args)
+			if ok != tt.ok {
+				t.Fatalf("parseModelSwitchArgs() ok = %v, want %v", ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("parseModelSwitchArgs() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/provider.go
+++ b/core/provider.go
@@ -7,3 +7,29 @@ func GetProviderModels(providers []ProviderConfig, activeIdx int) []ModelOption 
 	}
 	return providers[activeIdx].Models
 }
+
+// GetProviderModel returns the configured model for the active provider.
+// If the active provider has no explicit model, fallback is returned.
+func GetProviderModel(providers []ProviderConfig, activeIdx int, fallback string) string {
+	if activeIdx < 0 || activeIdx >= len(providers) {
+		return fallback
+	}
+	if model := providers[activeIdx].Model; model != "" {
+		return model
+	}
+	return fallback
+}
+
+// SetProviderModel returns a copy of providers with the named provider's model updated.
+// The second return value indicates whether a provider matched the given name.
+func SetProviderModel(providers []ProviderConfig, name, model string) ([]ProviderConfig, bool) {
+	updated := make([]ProviderConfig, len(providers))
+	copy(updated, providers)
+	for i := range updated {
+		if updated[i].Name == name {
+			updated[i].Model = model
+			return updated, true
+		}
+	}
+	return updated, false
+}

--- a/core/provider_test.go
+++ b/core/provider_test.go
@@ -40,3 +40,57 @@ func TestGetProviderModels(t *testing.T) {
 		})
 	}
 }
+
+func TestGetProviderModel(t *testing.T) {
+	providers := []ProviderConfig{
+		{Model: "gpt-4.1"},
+		{Model: "gpt-5.4"},
+	}
+
+	tests := []struct {
+		name      string
+		activeIdx int
+		fallback  string
+		want      string
+	}{
+		{name: "negative index uses fallback", activeIdx: -1, fallback: "default-model", want: "default-model"},
+		{name: "out of range uses fallback", activeIdx: len(providers), fallback: "default-model", want: "default-model"},
+		{name: "empty provider model uses fallback", activeIdx: 0, fallback: "default-model", want: "gpt-4.1"},
+		{name: "active provider model wins", activeIdx: 1, fallback: "default-model", want: "gpt-5.4"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetProviderModel(providers, tt.activeIdx, tt.fallback)
+			if got != tt.want {
+				t.Fatalf("GetProviderModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetProviderModel(t *testing.T) {
+	providers := []ProviderConfig{
+		{Name: "openai", Model: "gpt-4.1"},
+		{Name: "backup", Model: "gpt-4.1-mini"},
+	}
+
+	updated, ok := SetProviderModel(providers, "openai", "gpt-5.4")
+	if !ok {
+		t.Fatal("SetProviderModel() did not find existing provider")
+	}
+	if updated[0].Model != "gpt-5.4" {
+		t.Fatalf("updated provider model = %q, want gpt-5.4", updated[0].Model)
+	}
+	if providers[0].Model != "gpt-4.1" {
+		t.Fatalf("original providers mutated = %q, want gpt-4.1", providers[0].Model)
+	}
+
+	updated, ok = SetProviderModel(providers, "missing", "gpt-5.4")
+	if ok {
+		t.Fatal("SetProviderModel() unexpectedly found missing provider")
+	}
+	if updated[0].Model != providers[0].Model {
+		t.Fatalf("missing provider should leave copy unchanged, got %q want %q", updated[0].Model, providers[0].Model)
+	}
+}

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -327,8 +327,8 @@ Send a structured card to the user. Only sent if the adapter declared `"card"` c
       {
         "type": "actions",
         "buttons": [
-          {"text": "GPT-4", "btn_type": "primary", "value": "cmd:/model gpt-4"},
-          {"text": "Claude", "btn_type": "default", "value": "cmd:/model claude"}
+          {"text": "GPT-4", "btn_type": "primary", "value": "cmd:/model switch gpt-4"},
+          {"text": "Claude", "btn_type": "default", "value": "cmd:/model switch claude"}
         ],
         "layout": "row"
       },
@@ -534,7 +534,7 @@ A card consists of an optional header and a list of elements:
   "text": "GPT-4 — Most capable model",
   "btn_text": "Select",
   "btn_type": "primary",
-  "btn_value": "cmd:/model gpt-4"
+  "btn_value": "cmd:/model switch gpt-4"
 }
 ```
 
@@ -544,10 +544,10 @@ A card consists of an optional header and a list of elements:
   "type": "select",
   "placeholder": "Choose a model",
   "options": [
-    {"text": "GPT-4", "value": "cmd:/model gpt-4"},
-    {"text": "Claude", "value": "cmd:/model claude"}
+    {"text": "GPT-4", "value": "cmd:/model switch gpt-4"},
+    {"text": "Claude", "value": "cmd:/model switch claude"}
   ],
-  "init_value": "cmd:/model gpt-4"
+  "init_value": "cmd:/model switch gpt-4"
 }
 ```
 

--- a/docs/bridge-protocol.zh-CN.md
+++ b/docs/bridge-protocol.zh-CN.md
@@ -327,8 +327,8 @@ token = "your-secret"     # 认证密钥，必填
       {
         "type": "actions",
         "buttons": [
-          {"text": "GPT-4", "btn_type": "primary", "value": "cmd:/model gpt-4"},
-          {"text": "Claude", "btn_type": "default", "value": "cmd:/model claude"}
+          {"text": "GPT-4", "btn_type": "primary", "value": "cmd:/model switch gpt-4"},
+          {"text": "Claude", "btn_type": "default", "value": "cmd:/model switch claude"}
         ],
         "layout": "row"
       },
@@ -534,7 +534,7 @@ token = "your-secret"     # 认证密钥，必填
   "text": "GPT-4 — 最强模型",
   "btn_text": "选择",
   "btn_type": "primary",
-  "btn_value": "cmd:/model gpt-4"
+  "btn_value": "cmd:/model switch gpt-4"
 }
 ```
 
@@ -544,10 +544,10 @@ token = "your-secret"     # 认证密钥，必填
   "type": "select",
   "placeholder": "选择一个模型",
   "options": [
-    {"text": "GPT-4", "value": "cmd:/model gpt-4"},
-    {"text": "Claude", "value": "cmd:/model claude"}
+    {"text": "GPT-4", "value": "cmd:/model switch gpt-4"},
+    {"text": "Claude", "value": "cmd:/model switch claude"}
   ],
-  "init_value": "cmd:/model gpt-4"
+  "init_value": "cmd:/model switch gpt-4"
 }
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,7 +34,7 @@ Each user gets an independent session with full conversation context. Manage ses
 | `/history [n]` | Show last n messages (default 10) |
 | `/usage` | Show account/model quota usage (if supported) |
 | `/provider [...]` | Manage API providers |
-| `/model [alias]` | List available models or switch by alias |
+| `/model [switch <alias>]` | List available models or switch by alias |
 | `/allow <tool>` | Pre-allow a tool (next session) |
 | `/reasoning [level]` | View or switch reasoning effort (Codex) |
 | `/mode [name]` | View or switch permission mode |
@@ -216,8 +216,9 @@ alias = "spark"
 
 ```
 /model              List available models (format: alias - model)
-/model <alias>      Switch to the model matching the alias
-/model <name>       Switch to the model by its full name
+/model switch <alias>      Switch to the model matching the alias
+/model switch <name>       Switch to the model by its full name
+/model <alias>             Legacy syntax, still supported
 ```
 
 When `models` is configured, `/model` shows exactly that list without making an API round-trip. When omitted, models are fetched from the provider API or fall back to a built-in list.

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -34,7 +34,7 @@ cc-connect 完整功能使用指南。
 | `/history [n]` | 查看最近 n 条消息 |
 | `/usage` | 查看账号/模型限额使用情况 |
 | `/provider [...]` | 管理 API Provider |
-| `/model [alias]` | 列出可用模型或按别名切换 |
+| `/model [switch <alias>]` | 列出可用模型或按别名切换 |
 | `/allow <工具名>` | 预授权工具 |
 | `/reasoning [等级]` | 查看或切换推理强度（Codex）|
 | `/mode [名称]` | 查看或切换权限模式 |
@@ -216,8 +216,9 @@ alias = "spark"
 
 ```
 /model              列出可用模型（格式：alias - model）
-/model <alias>      按别名切换模型
-/model <name>       按完整名称切换模型
+/model switch <alias>      按别名切换模型
+/model switch <name>       按完整名称切换模型
+/model <alias>             兼容旧写法，仍然可用
 ```
 
 配置了 `models` 时，`/model` 直接显示该列表，不发起 API 请求。未配置时，自动从 Provider API 获取或使用内置备选列表。


### PR DESCRIPTION
## Summary
- make `/model` update the active provider's effective model immediately and persist it to config
- add `/model switch <alias|name>` as the preferred syntax while keeping legacy `/model <alias|name>` compatible
- align buttons, cards, i18n copy, docs, and tests with the new model switching behavior

## Background
- `/model <alias>` previously only changed the agent's runtime model field
- when an active provider had a fixed `model`, new sessions still used the old provider model, so the switch looked ineffective
- the command syntax was also inconsistent with `/provider switch`

## Changes
- add provider model helpers plus config persistence for per-provider model updates
- update engine model switching to mutate the active provider and reset the session
- change displayed `/model` actions to prefer `switch` subcommand syntax
- add regression coverage for alias parsing, provider model persistence, and agent model resolution

## Test Plan
- `go test ./core ./config ./agent/codex ./agent/claudecode ./agent/gemini ./agent/cursor ./agent/iflow ./agent/opencode ./cmd/cc-connect`
- `go test ./core`

## Risks
- model switching now persists provider model changes to `config.toml`, so users relying on non-persistent runtime-only model changes will see new behavior
- legacy `/model <alias|name>` remains supported to reduce compatibility risk