### PR TITLE
fix: require explicit session when sending attachments

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -5092,8 +5092,18 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 	var state *interactiveState
 	if sessionKey != "" {
 		state = e.interactiveStates[sessionKey]
+	} else if len(e.interactiveStates) == 1 {
+		// Single session: use it when no sessionKey is provided (backward compatible)
+		for _, s := range e.interactiveStates {
+			state = s
+			break
+		}
+	} else if len(e.interactiveStates) > 1 && (len(images) > 0 || len(files) > 0) {
+		// Multiple sessions with attachments but no explicit sessionKey: ambiguous
+		e.interactiveMu.Unlock()
+		return fmt.Errorf("multiple active sessions; must specify --session to send attachments")
 	} else {
-		// Pick the first active session
+		// Multiple sessions but text-only: pick the first (legacy behavior)
 		for _, s := range e.interactiveStates {
 			state = s
 			break

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -560,6 +560,7 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 	if name == "" {
 		name = "image"
 	}
+	slog.Debug("telegram: sending image", "chat_id", rc.chatID, "name", name, "size", len(img.Data))
 	msg := tgbotapi.NewPhoto(rc.chatID, tgbotapi.FileBytes{Name: name, Bytes: img.Data})
 	if _, err := p.bot.Send(msg); err != nil {
 		return fmt.Errorf("telegram: send image: %w", err)


### PR DESCRIPTION
## Summary
- When `cc-connect send --image` or `--file` is called without an explicit `--session` flag and multiple active sessions exist, the code would arbitrarily pick the first session (non-deterministic map iteration order), causing attachments to potentially be sent to the wrong chat.
- Now returns an error: "multiple active sessions; must specify --session to send attachments"
- Also adds debug logging to Telegram SendImage to aid diagnosis of image delivery issues

## Root Cause
In `SendToSessionWithAttachments`, when `sessionKey` is empty, the code would iterate over `interactiveStates` map and pick the first entry. Since Go map iteration order is non-deterministic, this could pick any session when multiple exist.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual: verified behavior when single session (backward compatible) vs multiple sessions (error returned)

Closes #242