### PR TITLE
feat(core): add directory history for /dir command

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -600,9 +600,21 @@ func main() {
 			}
 		}
 		apiSrv.SetRelayManager(relayMgr)
+
+		// Create shared DirHistory for all engines
+		dirHistory := core.NewDirHistory(cfg.DataDir)
+
 		for i, e := range engines {
 			apiSrv.RegisterEngine(cfg.Projects[i].Name, e)
 			e.SetRelayManager(relayMgr)
+			e.SetDirHistory(dirHistory)
+
+			// Ensure initial work_dir is in history
+			if initWorkDir, _ := cfg.Projects[i].Agent.Options["work_dir"].(string); initWorkDir != "" {
+				if !dirHistory.Contains(cfg.Projects[i].Name, initWorkDir) {
+					dirHistory.Add(cfg.Projects[i].Name, initWorkDir)
+				}
+			}
 		}
 		if cronSched != nil {
 			apiSrv.SetCronScheduler(cronSched)

--- a/core/dir_history.go
+++ b/core/dir_history.go
@@ -1,0 +1,168 @@
+package core
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	defaultDirHistorySize = 10
+	dirHistoryFileName    = "dir_history.json"
+)
+
+// DirHistory manages directory switch history per project.
+type DirHistory struct {
+	mu        sync.RWMutex
+	storePath string
+	entries   map[string][]string // project name -> dir list (most recent first)
+	maxSize   int
+}
+
+// NewDirHistory creates a new DirHistory with the given data directory.
+func NewDirHistory(dataDir string) *DirHistory {
+	dh := &DirHistory{
+		storePath: filepath.Join(dataDir, dirHistoryFileName),
+		entries:   make(map[string][]string),
+		maxSize:   defaultDirHistorySize,
+	}
+	dh.load()
+	return dh
+}
+
+// Add adds a directory to the history for the given project.
+// If the directory already exists, it's moved to the front.
+func (dh *DirHistory) Add(project, dir string) {
+	if dir == "" {
+		return
+	}
+
+	dh.mu.Lock()
+	defer dh.mu.Unlock()
+
+	entries := dh.entries[project]
+
+	// Remove if exists
+	for i, d := range entries {
+		if d == dir {
+			entries = append(entries[:i], entries[i+1:]...)
+			break
+		}
+	}
+
+	// Add to front
+	entries = append([]string{dir}, entries...)
+
+	// Trim to max size
+	if len(entries) > dh.maxSize {
+		entries = entries[:dh.maxSize]
+	}
+
+	dh.entries[project] = entries
+	dh.saveLocked()
+}
+
+// List returns the history for the given project.
+func (dh *DirHistory) List(project string) []string {
+	dh.mu.RLock()
+	defer dh.mu.RUnlock()
+
+	entries := dh.entries[project]
+	if entries == nil {
+		return nil
+	}
+
+	// Return a copy
+	result := make([]string, len(entries))
+	copy(result, entries)
+	return result
+}
+
+// Get returns the directory at the given index (1-based) for the project.
+// Returns empty string if index is out of range.
+func (dh *DirHistory) Get(project string, index int) string {
+	dh.mu.RLock()
+	defer dh.mu.RUnlock()
+
+	entries := dh.entries[project]
+	if index < 1 || index > len(entries) {
+		return ""
+	}
+	return entries[index-1]
+}
+
+// Previous returns the previous directory (index 2, since index 1 is current).
+func (dh *DirHistory) Previous(project string) string {
+	return dh.Get(project, 2)
+}
+
+// Contains checks if a directory is in the history for the given project.
+func (dh *DirHistory) Contains(project, dir string) bool {
+	dh.mu.RLock()
+	defer dh.mu.RUnlock()
+
+	entries := dh.entries[project]
+	for _, d := range entries {
+		if d == dir {
+			return true
+		}
+	}
+	return false
+}
+
+// SetMaxSize sets the maximum history size.
+func (dh *DirHistory) SetMaxSize(size int) {
+	if size < 1 {
+		size = 1
+	}
+	dh.mu.Lock()
+	defer dh.mu.Unlock()
+	dh.maxSize = size
+}
+
+func (dh *DirHistory) load() {
+	if dh.storePath == "" {
+		return
+	}
+
+	data, err := os.ReadFile(dh.storePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Error("dir_history: failed to read", "path", dh.storePath, "error", err)
+		}
+		return
+	}
+
+	var entries map[string][]string
+	if err := json.Unmarshal(data, &entries); err != nil {
+		slog.Error("dir_history: failed to unmarshal", "path", dh.storePath, "error", err)
+		return
+	}
+
+	if entries != nil {
+		dh.entries = entries
+	}
+}
+
+func (dh *DirHistory) saveLocked() {
+	if dh.storePath == "" {
+		return
+	}
+
+	data, err := json.MarshalIndent(dh.entries, "", "  ")
+	if err != nil {
+		slog.Error("dir_history: failed to marshal", "error", err)
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dh.storePath), 0755); err != nil {
+		slog.Error("dir_history: failed to create dir", "error", err)
+		return
+	}
+
+	if err := AtomicWriteFile(dh.storePath, data, 0644); err != nil {
+		slog.Error("dir_history: failed to write", "path", dh.storePath, "error", err)
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -176,6 +176,7 @@ type Engine struct {
 	streamPreview    StreamPreviewCfg
 	relayManager     *RelayManager
 	eventIdleTimeout time.Duration
+	dirHistory       *DirHistory
 
 	// Multi-workspace mode
 	multiWorkspace    bool
@@ -620,6 +621,10 @@ func (e *Engine) SetRelayManager(rm *RelayManager) {
 
 func (e *Engine) RelayManager() *RelayManager {
 	return e.relayManager
+}
+
+func (e *Engine) SetDirHistory(dh *DirHistory) {
+	e.dirHistory = dh
 }
 
 // RemoveCommand removes a custom command by name. Returns false if not found.
@@ -2983,10 +2988,33 @@ func (e *Engine) cmdDir(p Platform, msg *Message, args []string) {
 		return
 	}
 
+	currentDir := switcher.GetWorkDir()
+
+	// No args: show current dir + history
 	if len(args) == 0 {
-		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgDirCurrent, switcher.GetWorkDir()))
+		var sb strings.Builder
+		sb.WriteString(e.i18n.Tf(MsgDirCurrent, currentDir))
+
+		if e.dirHistory != nil {
+			history := e.dirHistory.List(e.name)
+			if len(history) > 0 {
+				sb.WriteString("\n\n")
+				sb.WriteString(e.i18n.T(MsgDirHistoryTitle))
+				for i, dir := range history {
+					marker := "◻"
+					if dir == currentDir {
+						marker = "▶"
+					}
+					sb.WriteString(fmt.Sprintf("\n  %s %d. %s", marker, i+1, dir))
+				}
+				sb.WriteString("\n\n")
+				sb.WriteString(e.i18n.T(MsgDirHistoryHint))
+			}
+		}
+		e.reply(p, msg.ReplyCtx, sb.String())
 		return
 	}
+
 	if len(args) == 1 {
 		switch strings.ToLower(strings.TrimSpace(args[0])) {
 		case "help", "-h", "--help":
@@ -2995,13 +3023,43 @@ func (e *Engine) cmdDir(p Platform, msg *Message, args []string) {
 		}
 	}
 
-	newDir := filepath.Clean(strings.Join(args, " "))
-	if !filepath.IsAbs(newDir) {
-		baseDir := switcher.GetWorkDir()
-		if baseDir == "" {
-			baseDir, _ = os.Getwd()
+	arg := strings.Join(args, " ")
+	var newDir string
+
+	// Check if argument is a number (history index)
+	if idx, err := strconv.Atoi(strings.TrimSpace(arg)); err == nil && idx > 0 {
+		if e.dirHistory != nil {
+			newDir = e.dirHistory.Get(e.name, idx)
+			if newDir == "" {
+				e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgDirInvalidIndex, idx))
+				return
+			}
+		} else {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgDirNoHistory))
+			return
 		}
-		newDir = filepath.Join(baseDir, newDir)
+	} else if arg == "-" {
+		// Jump to previous directory
+		if e.dirHistory != nil {
+			newDir = e.dirHistory.Previous(e.name)
+			if newDir == "" {
+				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgDirNoPrevious))
+				return
+			}
+		} else {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgDirNoHistory))
+			return
+		}
+	} else {
+		// Normal path
+		newDir = filepath.Clean(arg)
+		if !filepath.IsAbs(newDir) {
+			baseDir := currentDir
+			if baseDir == "" {
+				baseDir, _ = os.Getwd()
+			}
+			newDir = filepath.Join(baseDir, newDir)
+		}
 	}
 
 	info, err := os.Stat(newDir)
@@ -3017,6 +3075,11 @@ func (e *Engine) cmdDir(p Platform, msg *Message, args []string) {
 	s.SetAgentSessionID("", "")
 	s.ClearHistory()
 	sessions.Save()
+
+	// Add to history
+	if e.dirHistory != nil {
+		e.dirHistory.Add(e.name, newDir)
+	}
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgDirChanged, newDir))
 }

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2061,6 +2061,104 @@ func TestCmdDir_HelpShowsUsage(t *testing.T) {
 	}
 }
 
+func TestCmdDir_SwitchesByHistoryIndex(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	tempDir := t.TempDir()
+	dir1 := filepath.Join(tempDir, "dir1")
+	dir2 := filepath.Join(tempDir, "dir2")
+	dir3 := filepath.Join(tempDir, "dir3")
+	for _, d := range []string{dir1, dir2, dir3} {
+		if err := os.Mkdir(d, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	dataDir := t.TempDir() // separate data dir for history
+	agent := &stubWorkDirAgent{workDir: dir1}
+	e := NewEngine("test", agent, []Platform{p}, dataDir, LangEnglish)
+	e.SetDirHistory(NewDirHistory(dataDir))
+
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	// Build history: dir1 -> dir2 -> dir3
+	e.cmdDir(p, msg, []string{dir2})
+	if agent.workDir != dir2 {
+		t.Fatalf("after /dir dir2: workDir = %q, want %q", agent.workDir, dir2)
+	}
+
+	e.cmdDir(p, msg, []string{dir3})
+	if agent.workDir != dir3 {
+		t.Fatalf("after /dir dir3: workDir = %q, want %q", agent.workDir, dir3)
+	}
+
+	// Now history should be: [dir3, dir2, dir1] (dir1 might not be in history since it wasn't added initially)
+	// Current dir is dir3
+	// Index 2 should be dir2
+
+	p.sent = nil
+	e.cmdDir(p, msg, []string{"2"})
+
+	// Should have switched to dir2
+	if agent.workDir != dir2 {
+		t.Fatalf("after /dir 2: workDir = %q, want %q", agent.workDir, dir2)
+	}
+
+	// Check the reply mentions dir2
+	if len(p.sent) != 1 {
+		t.Fatalf("sent = %d messages, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], dir2) {
+		t.Fatalf("sent = %q, want message containing %q", p.sent[0], dir2)
+	}
+}
+
+func TestCmdDir_DisplaysCorrectIndices(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	tempDir := t.TempDir()
+	dir1 := filepath.Join(tempDir, "dir1")
+	dir2 := filepath.Join(tempDir, "dir2")
+	dir3 := filepath.Join(tempDir, "dir3")
+	for _, d := range []string{dir1, dir2, dir3} {
+		if err := os.Mkdir(d, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	dataDir := t.TempDir()
+	agent := &stubWorkDirAgent{workDir: dir1}
+	e := NewEngine("test", agent, []Platform{p}, dataDir, LangEnglish)
+	e.SetDirHistory(NewDirHistory(dataDir))
+
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	// Build history
+	e.cmdDir(p, msg, []string{dir2})
+	e.cmdDir(p, msg, []string{dir3})
+
+	// Now current is dir3, history is [dir3, dir2]
+	p.sent = nil
+	e.cmdDir(p, msg, nil) // show current + history
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent = %d messages, want 1", len(p.sent))
+	}
+
+	// Verify the display shows:
+	// - dir3 with ▶ marker (current)
+	// - dir2 with ◻ marker at index 2
+	output := p.sent[0]
+
+	// Check that dir3 is marked as current
+	if !strings.Contains(output, "▶ 1. "+dir3) {
+		t.Fatalf("output should contain '▶ 1. %s', got: %s", dir3, output)
+	}
+
+	// Check that dir2 is at index 2
+	if !strings.Contains(output, "◻ 2. "+dir2) {
+		t.Fatalf("output should contain '◻ 2. %s', got: %s", dir2, output)
+	}
+}
+
 func TestEngine_AdminFrom_GatesDir(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	tempDir := t.TempDir()

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -480,6 +480,11 @@ const (
 	MsgDirUsage        MsgKey = "dir_usage"
 	MsgDirNotSupported MsgKey = "dir_not_supported"
 	MsgDirInvalidPath  MsgKey = "dir_invalid_path"
+	MsgDirHistoryTitle MsgKey = "dir_history_title"
+	MsgDirHistoryHint  MsgKey = "dir_history_hint"
+	MsgDirInvalidIndex MsgKey = "dir_invalid_index"
+	MsgDirNoHistory    MsgKey = "dir_no_history"
+	MsgDirNoPrevious   MsgKey = "dir_no_previous"
 
 	// Multi-workspace messages
 	MsgWsNotEnabled      MsgKey = "ws_not_enabled"
@@ -3178,6 +3183,41 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "❌ 目錄不存在: `%s`",
 		LangJapanese:           "❌ ディレクトリが存在しません: `%s`",
 		LangSpanish:            "❌ El directorio no existe: `%s`",
+	},
+	MsgDirHistoryTitle: {
+		LangEnglish:            "📋 History:",
+		LangChinese:            "📋 历史记录:",
+		LangTraditionalChinese: "📋 歷史記錄:",
+		LangJapanese:           "📋 履歴:",
+		LangSpanish:            "📋 Historial:",
+	},
+	MsgDirHistoryHint: {
+		LangEnglish:            "💡 Use `/dir <number>` to switch, or `/dir -` for previous.",
+		LangChinese:            "💡 使用 `/dir <序号>` 切换，或 `/dir -` 返回上一个目录。",
+		LangTraditionalChinese: "💡 使用 `/dir <序號>` 切換，或 `/dir -` 返回上一個目錄。",
+		LangJapanese:           "💡 `/dir <番号>` で切り替え、`/dir -` で前のディレクトリに戻ります。",
+		LangSpanish:            "💡 Usa `/dir <número>` para cambiar, o `/dir -` para el anterior.",
+	},
+	MsgDirInvalidIndex: {
+		LangEnglish:            "❌ Invalid history index: %d",
+		LangChinese:            "❌ 无效的历史序号: %d",
+		LangTraditionalChinese: "❌ 無效的歷史序號: %d",
+		LangJapanese:           "❌ 無効な履歴番号: %d",
+		LangSpanish:            "❌ Índice de historial inválido: %d",
+	},
+	MsgDirNoHistory: {
+		LangEnglish:            "❌ No directory history available.",
+		LangChinese:            "❌ 暂无目录历史记录。",
+		LangTraditionalChinese: "❌ 暫無目錄歷史記錄。",
+		LangJapanese:           "❌ ディレクトリの履歴がありません。",
+		LangSpanish:            "❌ No hay historial de directorios.",
+	},
+	MsgDirNoPrevious: {
+		LangEnglish:            "❌ No previous directory in history.",
+		LangChinese:            "❌ 没有上一个目录记录。",
+		LangTraditionalChinese: "❌ 沒有上一個目錄記錄。",
+		LangJapanese:           "❌ 前のディレクトリが履歴にありません。",
+		LangSpanish:            "❌ No hay directorio anterior en el historial.",
 	},
 
 	// Multi-workspace messages


### PR DESCRIPTION
## Summary

- Add directory history tracking for the `/dir` command
- Display history list with visual markers (▶ for current, ◻ for others) matching `/list` style
- Support switching directories by history index (`/dir 2`) or using `-` for previous directory
- Persist history across sessions in `dir_history.json`

## Test plan

- [x] `go test ./core/ -run "TestCmdDir"` - all tests pass
- [x] `go build ./cmd/cc-connect` - compiles successfully