### PR TITLE
fix (discord): Discord cron thread retargeting when thread_isolation=true

### DIFF
--- a/core/cron.go
+++ b/core/cron.go
@@ -28,8 +28,8 @@ type CronJob struct {
 	WorkDir     string    `json:"work_dir,omitempty"` // working directory for exec; empty = agent work_dir
 	Description string    `json:"description"`
 	Enabled     bool      `json:"enabled"`
-	Silent      *bool     `json:"silent,omitempty"` // suppress start notification; nil = use global default
-	Mute        bool      `json:"mute,omitempty"`   // suppress ALL messages (start + result); job runs silently
+	Silent      *bool     `json:"silent,omitempty"`       // suppress start notification; nil = use global default
+	Mute        bool      `json:"mute,omitempty"`         // suppress ALL messages (start + result); job runs silently
 	SessionMode string    `json:"session_mode,omitempty"` // "" or "reuse" = share active session; "new_per_run" = fresh session each run
 	TimeoutMins *int      `json:"timeout_mins,omitempty"` // nil = default 30m wait; 0 = no limit; >0 = minutes
 	CreatedAt   time.Time `json:"created_at"`

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -180,7 +180,7 @@ func TestRenderCronCard_WithButtons(t *testing.T) {
 	scheduler := NewCronScheduler(store)
 	e.cronScheduler = scheduler
 
-	card := e.renderCronCard("test:ch1")
+	card := e.renderCronCard("test:ch1", "")
 	if card == nil {
 		t.Fatal("card should not be nil")
 	}
@@ -245,7 +245,7 @@ func TestRenderCronCard_HasHint(t *testing.T) {
 	scheduler := NewCronScheduler(store)
 	e.cronScheduler = scheduler
 
-	card := e.renderCronCard("test:ch1")
+	card := e.renderCronCard("test:ch1", "")
 	text := card.RenderText()
 	if !strings.Contains(text, "/cron add") || !strings.Contains(text, "/cron mute") {
 		t.Errorf("card should contain command hints, got:\n%s", text)

--- a/core/engine.go
+++ b/core/engine.go
@@ -736,9 +736,31 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		return fmt.Errorf("platform %q does not support proactive messaging (cron)", platformName)
 	}
 
-	replyCtx, err := rc.ReconstructReplyCtx(sessionKey)
-	if err != nil {
-		return fmt.Errorf("reconstruct reply context: %w", err)
+	runSessionKey := sessionKey
+	var replyCtx any
+	var err error
+	if !job.Mute {
+		if resolver, ok := targetPlatform.(CronReplyTargetResolver); ok {
+			resolvedSessionKey, resolvedReplyCtx, err := resolver.ResolveCronReplyTarget(sessionKey, cronRunTitle(job))
+			if err != nil {
+				if !errors.Is(err, ErrNotSupported) {
+					return fmt.Errorf("resolve cron reply target: %w", err)
+				}
+			} else {
+				if resolvedSessionKey != "" {
+					runSessionKey = resolvedSessionKey
+				}
+				if resolvedReplyCtx != nil {
+					replyCtx = resolvedReplyCtx
+				}
+			}
+		}
+	}
+	if replyCtx == nil {
+		replyCtx, err = rc.ReconstructReplyCtx(runSessionKey)
+		if err != nil {
+			return fmt.Errorf("reconstruct reply context: %w", err)
+		}
 	}
 
 	// Wrap platform to discard all outgoing messages when muted
@@ -780,12 +802,13 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 	}
 
 	if job.UsesNewSessionPerRun() {
-		session := e.sessions.NewSideSession(sessionKey, "cron-"+job.ID)
+		msg.SessionKey = runSessionKey
+		session := e.sessions.NewSideSession(runSessionKey, "cron-"+job.ID)
 		if !session.TryLock() {
-			return fmt.Errorf("session %q is busy", sessionKey)
+			return fmt.Errorf("session %q is busy", runSessionKey)
 		}
-		iKey := fmt.Sprintf("%s#cron:%s", sessionKey, session.ID)
-		e.processInteractiveMessageWith(effectivePlatform, msg, session, e.agent, e.sessions, iKey, "", sessionKey)
+		iKey := fmt.Sprintf("%s#cron:%s", runSessionKey, session.ID)
+		e.processInteractiveMessageWith(effectivePlatform, msg, session, e.agent, e.sessions, iKey, "", runSessionKey)
 		return nil
 	}
 
@@ -794,8 +817,27 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		return fmt.Errorf("session %q is busy", sessionKey)
 	}
 
-	e.processInteractiveMessage(effectivePlatform, msg, session)
+	e.processInteractiveMessageWith(effectivePlatform, msg, session, e.agent, e.sessions, sessionKey, "", sessionKey)
 	return nil
+}
+
+func cronRunTitle(job *CronJob) string {
+	if job == nil {
+		return "cron"
+	}
+	if desc := strings.TrimSpace(job.Description); desc != "" {
+		return truncateStr(desc, 60)
+	}
+	if job.IsShellJob() {
+		if cmd := strings.TrimSpace(job.Exec); cmd != "" {
+			return truncateStr(cmd, 60)
+		}
+		return "cron"
+	}
+	if prompt := strings.TrimSpace(job.Prompt); prompt != "" {
+		return truncateStr(prompt, 60)
+	}
+	return "cron"
 }
 
 // executeCronShell runs a shell command for a cron job and sends the output.
@@ -3562,8 +3604,7 @@ func (e *Engine) cmdStatus(p Platform, msg *Message) {
 
 		var cronStr string
 		if e.cronScheduler != nil {
-			jobs := e.cronScheduler.Store().ListBySessionKey(msg.SessionKey)
-			if len(jobs) > 0 {
+			if jobs := e.cronScheduler.Store().ListBySessionKey(msg.SessionKey); len(jobs) > 0 {
 				enabledCount := 0
 				for _, j := range jobs {
 					if j.Enabled {
@@ -3959,8 +4000,7 @@ func (e *Engine) renderStatusCard(sessionKey string, userID string) *Card {
 
 	var cronStr string
 	if e.cronScheduler != nil {
-		jobs := e.cronScheduler.Store().ListBySessionKey(sessionKey)
-		if len(jobs) > 0 {
+		if jobs := e.cronScheduler.Store().ListBySessionKey(sessionKey); len(jobs) > 0 {
 			enabledCount := 0
 			for _, j := range jobs {
 				if j.Enabled {
@@ -5643,7 +5683,7 @@ func (e *Engine) handleCardNav(action string, sessionKey string) *Card {
 	case "/provider":
 		return e.renderProviderCard()
 	case "/cron":
-		return e.renderCronCard(sessionKey)
+		return e.renderCronCard(sessionKey, extractUserID(sessionKey))
 	case "/heartbeat":
 		return e.renderHeartbeatCard()
 	case "/commands":
@@ -6541,7 +6581,7 @@ func (e *Engine) renderProviderCard() *Card {
 	return cb.Buttons(e.cardBackButton()).Build()
 }
 
-func (e *Engine) renderCronCard(sessionKey string) *Card {
+func (e *Engine) renderCronCard(sessionKey string, userID string) *Card {
 	if e.cronScheduler == nil {
 		return e.simpleCard(e.i18n.T(MsgCardTitleCron), "orange", e.i18n.T(MsgCronNotAvailable))
 	}
@@ -6896,7 +6936,7 @@ func (e *Engine) cmdCron(p Platform, msg *Message, args []string) {
 			e.cmdCronList(p, msg)
 			return
 		}
-		e.replyWithCard(p, msg.ReplyCtx, e.renderCronCard(msg.SessionKey))
+		e.replyWithCard(p, msg.ReplyCtx, e.renderCronCard(msg.SessionKey, msg.UserID))
 		return
 	}
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -82,6 +82,63 @@ func (p *stubPlatformEngine) clearSent() {
 	p.mu.Unlock()
 }
 
+type stubCronReplyTargetPlatform struct {
+	stubPlatformEngine
+	reconstructSessionKey string
+	resolvedSessionKey    string
+	resolveTitle          string
+}
+
+func (p *stubCronReplyTargetPlatform) ReconstructReplyCtx(sessionKey string) (any, error) {
+	p.reconstructSessionKey = sessionKey
+	return "base-rctx", nil
+}
+
+func (p *stubCronReplyTargetPlatform) ResolveCronReplyTarget(sessionKey string, title string) (string, any, error) {
+	p.resolvedSessionKey = sessionKey
+	p.resolveTitle = title
+	return "discord:thread-fresh", "fresh-rctx", nil
+}
+
+type resultAgent struct {
+	session AgentSession
+}
+
+func (a *resultAgent) Name() string { return "stub" }
+func (a *resultAgent) StartSession(_ context.Context, _ string) (AgentSession, error) {
+	return a.session, nil
+}
+func (a *resultAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) { return nil, nil }
+func (a *resultAgent) Stop() error                                                { return nil }
+
+type resultAgentSession struct {
+	events      chan Event
+	result      string
+	sendOnce    sync.Once
+	sentPrompts []string
+}
+
+func newResultAgentSession(result string) *resultAgentSession {
+	return &resultAgentSession{
+		events: make(chan Event, 1),
+		result: result,
+	}
+}
+
+func (s *resultAgentSession) Send(prompt string, _ []ImageAttachment, _ []FileAttachment) error {
+	s.sentPrompts = append(s.sentPrompts, prompt)
+	s.sendOnce.Do(func() {
+		s.events <- Event{Type: EventResult, Content: s.result, Done: true}
+	})
+	return nil
+}
+
+func (s *resultAgentSession) RespondPermission(_ string, _ PermissionResult) error { return nil }
+func (s *resultAgentSession) Events() <-chan Event                                 { return s.events }
+func (s *resultAgentSession) CurrentSessionID() string                             { return "result-session" }
+func (s *resultAgentSession) Alive() bool                                          { return true }
+func (s *resultAgentSession) Close() error                                         { return nil }
+
 type stubLifecyclePlatform struct {
 	stubPlatformEngine
 	handler         PlatformLifecycleHandler
@@ -6215,6 +6272,74 @@ func TestEngine_AddPlatform_Multiple(t *testing.T) {
 
 	if len(e.platforms) != 3 {
 		t.Fatalf("expected 3 platforms, got %d", len(e.platforms))
+	}
+}
+
+func TestExecuteCronJob_ResolvesCronReplyTarget(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatalf("NewCronStore() error = %v", err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agentSession := newResultAgentSession("cron complete")
+	agent := &resultAgent{session: agentSession}
+
+	e := NewEngine("test", agent, []Platform{platform}, "", LangEnglish)
+	defer e.cancel()
+	e.cronScheduler = scheduler
+
+	job := &CronJob{
+		ID:          "job-1",
+		SessionKey:  "discord:channel-1:user-1",
+		Prompt:      "summarize activity",
+		Description: "Daily summary",
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatalf("store.Add() error = %v", err)
+	}
+
+	if err := e.ExecuteCronJob(job); err != nil {
+		t.Fatalf("ExecuteCronJob() error = %v", err)
+	}
+	if platform.resolvedSessionKey != "discord:channel-1:user-1" {
+		t.Fatalf("ResolveCronReplyTarget sessionKey = %q, want base session key", platform.resolvedSessionKey)
+	}
+	if platform.resolveTitle != "Daily summary" {
+		t.Fatalf("ResolveCronReplyTarget title = %q, want Daily summary", platform.resolveTitle)
+	}
+
+	sent := platform.getSent()
+	if len(sent) != 2 {
+		t.Fatalf("sent messages = %d, want 2", len(sent))
+	}
+	if sent[0] != "⏰ Daily summary" {
+		t.Fatalf("sent[0] = %q, want cron start notice", sent[0])
+	}
+	if sent[1] != "cron complete" {
+		t.Fatalf("sent[1] = %q, want final result", sent[1])
+	}
+
+	if got := len(e.sessions.ListSessions("discord:thread-fresh")); got != 0 {
+		t.Fatalf("fresh session count = %d, want 0 for reuse mode", got)
+	}
+	if got := len(e.sessions.ListSessions("discord:channel-1:user-1")); got != 1 {
+		t.Fatalf("base session count = %d, want 1", got)
+	}
+	if job.SessionKey != "discord:channel-1:user-1" {
+		t.Fatalf("job.SessionKey = %q, want unchanged base session key", job.SessionKey)
+	}
+	stored := store.Get("job-1")
+	if stored == nil || stored.SessionKey != "discord:channel-1:user-1" {
+		t.Fatalf("stored sessionKey = %#v, want unchanged base session key", stored)
+	}
+
+	if len(agentSession.sentPrompts) != 1 || !strings.Contains(agentSession.sentPrompts[0], "summarize activity") {
+		t.Fatalf("agent prompts = %#v, want prompt containing summarize activity", agentSession.sentPrompts)
 	}
 }
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -24,6 +24,17 @@ type ReplyContextReconstructor interface {
 	ReconstructReplyCtx(sessionKey string) (any, error)
 }
 
+// CronReplyTargetResolver is an optional interface for platforms that need to
+// map a logical cron session key to the actual reply target used at execution
+// time. This is useful for platforms where proactive replies may need to create
+// or switch to a thread before the cron run starts.
+//
+// Implementations that do not need special handling should return
+// ErrNotSupported so callers can fall back to ReconstructReplyCtx(sessionKey).
+type CronReplyTargetResolver interface {
+	ResolveCronReplyTarget(sessionKey string, title string) (resolvedSessionKey string, replyCtx any, err error)
+}
+
 // SessionEnvInjector is an optional interface for agents that accept
 // per-session environment variables (e.g. CC_PROJECT, CC_SESSION_KEY).
 type SessionEnvInjector interface {

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -39,21 +39,21 @@ type interactionReplyCtx struct {
 }
 
 type Platform struct {
-	token                 string
-	allowFrom             string
-	guildID               string // optional: per-guild registration (instant) vs global (up to 1h propagation)
-	groupReplyAll         bool
-	shareSessionInChannel bool
-	threadIsolation       bool
-	respondToAtEveryoneAndHere     bool
-	session               *discordgo.Session
-	handler               core.MessageHandler
-	botID                 string
-	appID                 string
-	channelNameCache      sync.Map // channelID -> name
-	botRoleIDs            sync.Map // guildID -> bot managed role ID
-	readyCh               chan struct{}
-	seenMsgs              sync.Map // message ID dedup: prevents duplicate MessageCreate events
+	token                      string
+	allowFrom                  string
+	guildID                    string // optional: per-guild registration (instant) vs global (up to 1h propagation)
+	groupReplyAll              bool
+	shareSessionInChannel      bool
+	threadIsolation            bool
+	respondToAtEveryoneAndHere bool
+	session                    *discordgo.Session
+	handler                    core.MessageHandler
+	botID                      string
+	appID                      string
+	channelNameCache           sync.Map // channelID -> name
+	botRoleIDs                 sync.Map // guildID -> bot managed role ID
+	readyCh                    chan struct{}
+	seenMsgs                   sync.Map // message ID dedup: prevents duplicate MessageCreate events
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -69,14 +69,14 @@ func New(opts map[string]any) (core.Platform, error) {
 	threadIsolation, _ := opts["thread_isolation"].(bool)
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
 	return &Platform{
-		token:                 token,
-		allowFrom:             allowFrom,
-		guildID:               guildID,
-		groupReplyAll:         groupReplyAll,
-		shareSessionInChannel: shareSessionInChannel,
-		readyCh:               make(chan struct{}),
-		threadIsolation:       threadIsolation,
-		respondToAtEveryoneAndHere:     respondToAtEveryoneAndHere,
+		token:                      token,
+		allowFrom:                  allowFrom,
+		guildID:                    guildID,
+		groupReplyAll:              groupReplyAll,
+		shareSessionInChannel:      shareSessionInChannel,
+		readyCh:                    make(chan struct{}),
+		threadIsolation:            threadIsolation,
+		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
 	}, nil
 }
 
@@ -112,6 +112,7 @@ func (rc replyContext) useThreadChannel() bool {
 type discordThreadOps interface {
 	ResolveChannel(channelID string) (*discordgo.Channel, error)
 	StartThread(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error)
+	StartStandaloneThread(channelID, name string, typ discordgo.ChannelType, archiveDuration int) (*discordgo.Channel, error)
 	JoinThread(threadID string) error
 }
 
@@ -134,6 +135,13 @@ func (o sessionThreadOps) StartThread(channelID, messageID, name string, archive
 		return nil, fmt.Errorf("discord: session not initialized")
 	}
 	return o.session.MessageThreadStart(channelID, messageID, name, archiveDuration)
+}
+
+func (o sessionThreadOps) StartStandaloneThread(channelID, name string, typ discordgo.ChannelType, archiveDuration int) (*discordgo.Channel, error) {
+	if o.session == nil {
+		return nil, fmt.Errorf("discord: session not initialized")
+	}
+	return o.session.ThreadStart(channelID, name, typ, archiveDuration)
 }
 
 func (o sessionThreadOps) JoinThread(threadID string) error {
@@ -172,6 +180,33 @@ func threadNameForMessage(m *discordgo.MessageCreate, botID string) string {
 		name = "cc session"
 	}
 	return truncateDiscordThreadName(name, 90)
+}
+
+func freshThreadName(title string) string {
+	name := strings.Join(strings.Fields(strings.ReplaceAll(title, "\n", " ")), " ")
+	if name == "" {
+		name = "cc cron"
+	}
+	return truncateDiscordThreadName(name, 90)
+}
+
+func standaloneThreadType(parentType discordgo.ChannelType) (discordgo.ChannelType, bool) {
+	switch parentType {
+	case discordgo.ChannelTypeGuildText:
+		return discordgo.ChannelTypeGuildPublicThread, true
+	case discordgo.ChannelTypeGuildNews:
+		return discordgo.ChannelTypeGuildNewsThread, true
+	default:
+		return 0, false
+	}
+}
+
+func parseDiscordSessionKeyChannelID(sessionKey string) (string, error) {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) < 2 || parts[0] != "discord" || parts[1] == "" {
+		return "", fmt.Errorf("discord: invalid session key %q", sessionKey)
+	}
+	return parts[1], nil
 }
 
 func resolveSessionKeyForChannel(channelID, userID string, shareSessionInChannel bool, threadIsolation bool, ops discordThreadOps) string {
@@ -226,6 +261,47 @@ func resolveThreadReplyContext(m *discordgo.MessageCreate, botID string, ops dis
 		slog.Debug("discord: join new thread failed", "thread", thread.ID, "error", err)
 	}
 	rc := replyContext{channelID: thread.ID, messageID: m.ID, threadID: thread.ID}
+	return buildThreadSessionKey(thread.ID), rc, nil
+}
+
+func resolveCronReplyTarget(sessionKey, title string, ops discordThreadOps) (string, replyContext, error) {
+	channelID, err := parseDiscordSessionKeyChannelID(sessionKey)
+	if err != nil {
+		return "", replyContext{}, err
+	}
+
+	ch, err := ops.ResolveChannel(channelID)
+	if err != nil {
+		return "", replyContext{}, fmt.Errorf("resolve channel %s: %w", channelID, err)
+	}
+	parentChannelID := channelID
+	parentType := ch.Type
+	if isThreadChannelType(ch.Type) {
+		if ch.ParentID == "" {
+			return "", replyContext{}, core.ErrNotSupported
+		}
+		parent, err := ops.ResolveChannel(ch.ParentID)
+		if err != nil {
+			return "", replyContext{}, fmt.Errorf("resolve parent channel %s: %w", ch.ParentID, err)
+		}
+		parentChannelID = ch.ParentID
+		parentType = parent.Type
+	}
+
+	threadType, ok := standaloneThreadType(parentType)
+	if !ok {
+		return "", replyContext{}, core.ErrNotSupported
+	}
+
+	thread, err := ops.StartStandaloneThread(parentChannelID, freshThreadName(title), threadType, 1440)
+	if err != nil {
+		return "", replyContext{}, fmt.Errorf("start thread in channel %s: %w", parentChannelID, err)
+	}
+	if err := ops.JoinThread(thread.ID); err != nil {
+		slog.Debug("discord: join fresh thread failed", "thread", thread.ID, "error", err)
+	}
+
+	rc := replyContext{channelID: thread.ID, threadID: thread.ID}
 	return buildThreadSessionKey(thread.ID), rc, nil
 }
 
@@ -420,7 +496,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			MessageID: m.ID,
 			UserID:    m.Author.ID, UserName: m.Author.Username,
 			ChatName: p.resolveChannelName(m.ChannelID),
-			Content: m.Content, Images: images, Audio: audio, ReplyCtx: rctx,
+			Content:  m.Content, Images: images, Audio: audio, ReplyCtx: rctx,
 		}
 		p.handler(p, msg)
 	})
@@ -487,7 +563,7 @@ func (p *Platform) handleInteraction(s *discordgo.Session, i *discordgo.Interact
 		MessageID: i.ID,
 		UserID:    userID, UserName: userName,
 		ChatName: p.resolveChannelName(channelID),
-		Content: cmdText, ReplyCtx: ictx,
+		Content:  cmdText, ReplyCtx: ictx,
 	}
 	p.handler(p, msg)
 }
@@ -663,6 +739,17 @@ func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 		rc.threadID = parts[1]
 	}
 	return rc, nil
+}
+
+func (p *Platform) ResolveCronReplyTarget(sessionKey string, title string) (string, any, error) {
+	if !p.threadIsolation {
+		return "", nil, core.ErrNotSupported
+	}
+	resolvedSessionKey, rc, err := resolveCronReplyTarget(sessionKey, title, sessionThreadOps{session: p.session})
+	if err != nil {
+		return "", nil, err
+	}
+	return resolvedSessionKey, rc, nil
 }
 
 // discordPreviewHandle stores the IDs needed to edit or delete a preview message.
@@ -904,4 +991,3 @@ func downloadURL(u string) ([]byte, error) {
 	}
 	return io.ReadAll(resp.Body)
 }
-

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -13,9 +13,10 @@ import (
 // ── Thread tests (upstream) ──────────────────────────────────
 
 type fakeThreadOps struct {
-	resolveChannel func(channelID string) (*discordgo.Channel, error)
-	startThread    func(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error)
-	joinThread     func(threadID string) error
+	resolveChannel        func(channelID string) (*discordgo.Channel, error)
+	startThread           func(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error)
+	startStandaloneThread func(channelID, name string, typ discordgo.ChannelType, archiveDuration int) (*discordgo.Channel, error)
+	joinThread            func(threadID string) error
 }
 
 func (f fakeThreadOps) ResolveChannel(channelID string) (*discordgo.Channel, error) {
@@ -30,6 +31,13 @@ func (f fakeThreadOps) StartThread(channelID, messageID, name string, archiveDur
 		return nil, nil
 	}
 	return f.startThread(channelID, messageID, name, archiveDuration)
+}
+
+func (f fakeThreadOps) StartStandaloneThread(channelID, name string, typ discordgo.ChannelType, archiveDuration int) (*discordgo.Channel, error) {
+	if f.startStandaloneThread == nil {
+		return nil, nil
+	}
+	return f.startStandaloneThread(channelID, name, typ, archiveDuration)
 }
 
 func (f fakeThreadOps) JoinThread(threadID string) error {
@@ -156,6 +164,93 @@ func TestReconstructReplyCtx_ThreadSessionKey(t *testing.T) {
 	rc := rctx.(replyContext)
 	if rc.channelID != "thread-7" || rc.threadID != "thread-7" {
 		t.Fatalf("replyContext = %#v, want thread reply context", rc)
+	}
+}
+
+func TestResolveCronReplyTarget_CreatesStandaloneThread(t *testing.T) {
+	ops := fakeThreadOps{
+		resolveChannel: func(channelID string) (*discordgo.Channel, error) {
+			return &discordgo.Channel{ID: channelID, Type: discordgo.ChannelTypeGuildText}, nil
+		},
+	}
+
+	var (
+		startChannelID string
+		startName      string
+		startType      discordgo.ChannelType
+		joinedThread   string
+	)
+	ops.startStandaloneThread = func(channelID, name string, typ discordgo.ChannelType, archiveDuration int) (*discordgo.Channel, error) {
+		startChannelID = channelID
+		startName = name
+		startType = typ
+		if archiveDuration != 1440 {
+			t.Fatalf("archiveDuration = %d, want 1440", archiveDuration)
+		}
+		return &discordgo.Channel{ID: "thread-fresh", Type: discordgo.ChannelTypeGuildPublicThread}, nil
+	}
+	ops.joinThread = func(threadID string) error {
+		joinedThread = threadID
+		return nil
+	}
+
+	sessionKey, rc, err := resolveCronReplyTarget("discord:channel-1:user-1", "Daily sync", ops)
+	if err != nil {
+		t.Fatalf("resolveCronReplyTarget() error = %v", err)
+	}
+	if sessionKey != "discord:thread-fresh" {
+		t.Fatalf("sessionKey = %q, want discord:thread-fresh", sessionKey)
+	}
+	if rc.channelID != "thread-fresh" || rc.threadID != "thread-fresh" {
+		t.Fatalf("replyContext = %#v, want fresh thread routing", rc)
+	}
+	if startChannelID != "channel-1" {
+		t.Fatalf("startChannelID = %q, want channel-1", startChannelID)
+	}
+	if startName != "Daily sync" {
+		t.Fatalf("thread name = %q, want Daily sync", startName)
+	}
+	if startType != discordgo.ChannelTypeGuildPublicThread {
+		t.Fatalf("thread type = %v, want public thread", startType)
+	}
+	if joinedThread != "thread-fresh" {
+		t.Fatalf("joinedThread = %q, want thread-fresh", joinedThread)
+	}
+}
+
+func TestResolveCronReplyTarget_ReusesExistingThreadKey(t *testing.T) {
+	ops := fakeThreadOps{
+		resolveChannel: func(channelID string) (*discordgo.Channel, error) {
+			switch channelID {
+			case "thread-1":
+				return &discordgo.Channel{ID: "thread-1", Type: discordgo.ChannelTypeGuildPublicThread, ParentID: "channel-1"}, nil
+			case "channel-1":
+				return &discordgo.Channel{ID: "channel-1", Type: discordgo.ChannelTypeGuildText}, nil
+			default:
+				t.Fatalf("unexpected channel lookup %q", channelID)
+				return nil, nil
+			}
+		},
+	}
+
+	startChannelID := ""
+	ops.startStandaloneThread = func(channelID, name string, typ discordgo.ChannelType, archiveDuration int) (*discordgo.Channel, error) {
+		startChannelID = channelID
+		return &discordgo.Channel{ID: "thread-fresh-2", Type: discordgo.ChannelTypeGuildPublicThread}, nil
+	}
+
+	sessionKey, rc, err := resolveCronReplyTarget("discord:thread-1", "cron", ops)
+	if err != nil {
+		t.Fatalf("resolveCronReplyTarget() error = %v", err)
+	}
+	if sessionKey != "discord:thread-fresh-2" {
+		t.Fatalf("sessionKey = %q, want discord:thread-fresh-2", sessionKey)
+	}
+	if rc.threadID != "thread-fresh-2" {
+		t.Fatalf("replyContext = %#v, want thread-fresh-2", rc)
+	}
+	if startChannelID != "channel-1" {
+		t.Fatalf("startChannelID = %q, want channel-1", startChannelID)
 	}
 }
 
@@ -310,10 +405,10 @@ func TestDuplicateMessage_MultipleDuplicateBursts(t *testing.T) {
 
 func TestIsDiscordBotMention_Everyone(t *testing.T) {
 	tests := []struct {
-		name               string
-		respondToAtEveryoneAndHere  bool
-		mentionEveryone    bool
-		want               bool
+		name                       string
+		respondToAtEveryoneAndHere bool
+		mentionEveryone            bool
+		want                       bool
 	}{
 		{"enabled + @everyone", true, true, true},
 		{"disabled + @everyone", false, true, false},


### PR DESCRIPTION
<img width="888" height="340" alt="image" src="https://github.com/user-attachments/assets/6daea619-8291-4a8e-8c8e-4d6b6a2eab3b" />

 ## Summary

  Fix Discord cron replies not staying in threads when `thread_isolation` is enabled.

  This updates cron reply targeting so Discord jobs created from a root channel can resolve to a thread at execution time, and reuse-mode jobs keep using the migrated thread afterward.

  ## Testing

  - `go test ./platform/discord ./core`