### PR TITLE
test(opencode): add unit tests for session list JSON parsing

### DIFF
--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -1,0 +1,71 @@
+package opencode
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// TestOpencodeSessionEntry_Unmarshal verifies that OpenCode's
+// `session list --format json` output can be correctly parsed.
+//
+// OpenCode returns `updated` and `created` as Unix timestamps in
+// milliseconds (int64), not strings. This test prevents regression
+// of the unmarshal error:
+//
+//	json: cannot unmarshal number into Go struct field opencodeSessionEntry.updated of type string
+func TestOpencodeSessionEntry_Unmarshal(t *testing.T) {
+	jsonData := `[
+  {
+    "id": "ses_2eb11bb11ffeYwQZOj25mlmGMc",
+    "title": "Test Session",
+    "updated": 1774174646445,
+    "created": 1774172652782,
+    "projectId": "b80385ead03e8b450bdb2016d434aad318f93c16",
+    "directory": "/path/to/project"
+  }
+]`
+
+	var entries []opencodeSessionEntry
+	if err := json.Unmarshal([]byte(jsonData), &entries); err != nil {
+		t.Fatalf("Failed to unmarshal OpenCode session list: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("Expected 1 entry, got %d", len(entries))
+	}
+
+	e := entries[0]
+	if e.ID != "ses_2eb11bb11ffeYwQZOj25mlmGMc" {
+		t.Errorf("ID = %q, want %q", e.ID, "ses_2eb11bb11ffeYwQZOj25mlmGMc")
+	}
+	if e.Title != "Test Session" {
+		t.Errorf("Title = %q, want %q", e.Title, "Test Session")
+	}
+	if e.Updated != 1774174646445 {
+		t.Errorf("Updated = %d, want %d", e.Updated, 1774174646445)
+	}
+	if e.Created != 1774172652782 {
+		t.Errorf("Created = %d, want %d", e.Created, 1774172652782)
+	}
+}
+
+// TestNewOpencodeSession_ContinueSessionTreatedAsFresh verifies that
+// the ContinueSession sentinel (__continue__) is not passed as a literal
+// session ID to the CLI. This was fixed in PR #249.
+func TestNewOpencodeSession_ContinueSessionTreatedAsFresh(t *testing.T) {
+	s, err := newOpencodeSession(context.Background(), "echo", "/tmp", "", "default", core.ContinueSession, nil)
+	if err != nil {
+		t.Fatalf("newOpencodeSession: %v", err)
+	}
+	defer s.Close()
+
+	if got := s.CurrentSessionID(); got != "" {
+		t.Errorf("ContinueSession should be treated as fresh: chatID = %q, want empty", got)
+	}
+}
+
+// verify Agent implements core.Agent
+var _ core.Agent = (*Agent)(nil)


### PR DESCRIPTION
## Summary

Add regression tests to prevent the `int64` vs `string` type mismatch issue in OpenCode session list JSON parsing.

## Background

OpenCode returns `updated` and `created` fields as Unix timestamps in milliseconds (`int64`), but earlier versions of cc-connect defined these as `string` type, causing:

```
json: cannot unmarshal number into Go struct field opencodeSessionEntry.updated of type string
```

While the type was fixed in v1.2.2-beta.x, there were no unit tests to prevent regression.

Additionally, PR #249 fixed the `ContinueSession` sentinel issue for non-Claude agents (pi, gemini, codex, iflow) but did not add tests for opencode. This PR also fills that gap.

## Changes

**New file**: `agent/opencode/session_test.go`

| Test | Purpose |
|------|----------|
| `TestOpencodeSessionEntry_Unmarshal` | Verify int64 timestamp parsing prevents unmarshal errors |
| `TestNewOpencodeSession_ContinueSessionTreatedAsFresh` | Verify `__continue__` sentinel is not passed as literal session ID |

## Test Results

```
go test ./agent/opencode/... -v
PASS ok github.com/chenhg5/cc-connect/agent/opencode
```

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>