### PR TITLE
feat(discord): 支持按钮式工具权限确认

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2195,7 +2195,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					permLimit = permLimit * 8 / 5
 				}
 				toolInput := truncateIf(event.ToolInput, permLimit)
-				prompt := fmt.Sprintf(e.i18n.T(MsgPermissionPrompt), event.ToolName, toolInput)
+				promptKey := MsgPermissionPrompt
+				if _, ok := p.(PermissionButtonSender); ok {
+					promptKey = MsgPermissionPromptButtons
+				}
+				prompt := fmt.Sprintf(e.i18n.T(promptKey), event.ToolName, toolInput)
 				e.sendPermissionPrompt(p, replyCtx, prompt, event.ToolName, toolInput)
 			}
 
@@ -5352,20 +5356,26 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 }
 
 // sendPermissionPrompt sends a permission prompt with interactive buttons when
-// the platform supports them. Fallback chain: InlineButtonSender → CardSender → plain text.
+// the platform supports them. Fallback chain: PermissionButtonSender → InlineButtonSender → CardSender → plain text.
 func (e *Engine) sendPermissionPrompt(p Platform, replyCtx any, prompt, toolName, toolInput string) {
-	// Try inline buttons first (Telegram)
-	if bs, ok := p.(InlineButtonSender); ok {
-		buttons := [][]ButtonOption{
-			{
-				{Text: e.i18n.T(MsgPermBtnAllow), Data: "perm:allow"},
-				{Text: e.i18n.T(MsgPermBtnDeny), Data: "perm:deny"},
-			},
-			{
-				{Text: e.i18n.T(MsgPermBtnAllowAll), Data: "perm:allow_all"},
-			},
+	buttonAllow := ButtonOption{Text: e.i18n.T(MsgPermBtnAllow), Data: "perm:allow"}
+	buttonDeny := ButtonOption{Text: e.i18n.T(MsgPermBtnDeny), Data: "perm:deny"}
+	buttonAllowAll := ButtonOption{Text: e.i18n.T(MsgPermBtnAllowAll), Data: "perm:allow_all"}
+	permissionButtonAllowAll := ButtonOption{Text: e.i18n.T(MsgPermBtnAllowAllShort), Data: "perm:allow_all"}
+	permissionButtons := [][]ButtonOption{{buttonAllow, buttonDeny, permissionButtonAllowAll}}
+	inlineButtons := [][]ButtonOption{{buttonAllow, buttonDeny}, {buttonAllowAll}}
+
+	// Try dedicated permission buttons first (Discord, etc.)
+	if ps, ok := p.(PermissionButtonSender); ok {
+		if err := ps.SendPermissionButtons(e.ctx, replyCtx, prompt, permissionButtons); err == nil {
+			return
 		}
-		if err := bs.SendWithButtons(e.ctx, replyCtx, prompt, buttons); err == nil {
+		slog.Warn("sendPermissionPrompt: permission buttons failed, falling back")
+	}
+
+	// Try inline buttons next (Telegram)
+	if bs, ok := p.(InlineButtonSender); ok {
+		if err := bs.SendWithButtons(e.ctx, replyCtx, prompt, inlineButtons); err == nil {
 			return
 		}
 		slog.Warn("sendPermissionPrompt: inline buttons failed, falling back")

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -179,6 +179,18 @@ func (p *stubInlineButtonPlatform) SendWithButtons(_ context.Context, _ any, con
 	return nil
 }
 
+type stubPermissionButtonPlatform struct {
+	stubPlatformEngine
+	permissionButtonContent string
+	permissionButtonRows    [][]ButtonOption
+}
+
+func (p *stubPermissionButtonPlatform) SendPermissionButtons(_ context.Context, _ any, content string, buttons [][]ButtonOption) error {
+	p.permissionButtonContent = content
+	p.permissionButtonRows = buttons
+	return nil
+}
+
 type stubCardPlatform struct {
 	stubPlatformEngine
 	repliedCards []*Card
@@ -1310,11 +1322,54 @@ func TestSendPermissionPrompt_InlineButtonPlatform(t *testing.T) {
 	if p.buttonContent != "full prompt text" {
 		t.Errorf("expected button content to be prompt, got %s", p.buttonContent)
 	}
-	if len(p.buttonRows) < 2 {
-		t.Fatalf("expected at least 2 button rows, got %d", len(p.buttonRows))
+	if len(p.buttonRows) != 2 {
+		t.Fatalf("expected 2 button rows, got %d", len(p.buttonRows))
 	}
 	if p.buttonRows[0][0].Data != "perm:allow" {
 		t.Errorf("expected perm:allow, got %s", p.buttonRows[0][0].Data)
+	}
+	if p.buttonRows[0][1].Data != "perm:deny" {
+		t.Errorf("expected perm:deny, got %s", p.buttonRows[0][1].Data)
+	}
+	if p.buttonRows[1][0].Data != "perm:allow_all" {
+		t.Errorf("expected perm:allow_all, got %s", p.buttonRows[1][0].Data)
+	}
+}
+
+func TestSendPermissionPrompt_PermissionButtonPlatform(t *testing.T) {
+	e := newTestEngine()
+	p := &stubPermissionButtonPlatform{stubPlatformEngine: stubPlatformEngine{n: "discord"}}
+
+	e.sendPermissionPrompt(p, "ctx", "full prompt text", "write_file", "/tmp/test.txt")
+
+	if p.permissionButtonContent != "full prompt text" {
+		t.Errorf("expected permission button content to be prompt, got %s", p.permissionButtonContent)
+	}
+	if len(p.permissionButtonRows) != 1 {
+		t.Fatalf("expected 1 permission button row, got %d", len(p.permissionButtonRows))
+	}
+	if len(p.permissionButtonRows[0]) != 3 {
+		t.Fatalf("expected 3 permission buttons in one row, got %d", len(p.permissionButtonRows[0]))
+	}
+	if p.permissionButtonRows[0][0].Data != "perm:allow" {
+		t.Errorf("expected perm:allow, got %s", p.permissionButtonRows[0][0].Data)
+	}
+	if p.permissionButtonRows[0][1].Data != "perm:deny" {
+		t.Errorf("expected perm:deny, got %s", p.permissionButtonRows[0][1].Data)
+	}
+	if p.permissionButtonRows[0][2].Data != "perm:allow_all" {
+		t.Errorf("expected perm:allow_all, got %s", p.permissionButtonRows[0][2].Data)
+	}
+	if p.permissionButtonRows[0][2].Text != e.i18n.T(MsgPermBtnAllowAllShort) {
+		t.Errorf("expected short allow-all label, got %s", p.permissionButtonRows[0][2].Text)
+	}
+}
+
+func TestPermissionPromptButtonsText_UsedForPermissionButtonPlatforms(t *testing.T) {
+	e := newTestEngine()
+	text := fmt.Sprintf(e.i18n.T(MsgPermissionPromptButtons), "write_file", "/tmp/test.txt")
+	if strings.Contains(text, "Reply **allow** / **deny** / **allow all**") {
+		t.Fatalf("button prompt should not include reply hint, got %q", text)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -137,6 +137,7 @@ const (
 	MsgFailedToDeleteSession     MsgKey = "failed_to_delete_session"
 	MsgEmptyResponse             MsgKey = "empty_response"
 	MsgPermissionPrompt          MsgKey = "permission_prompt"
+	MsgPermissionPromptButtons   MsgKey = "permission_prompt_buttons"
 	MsgPermissionAllowed         MsgKey = "permission_allowed"
 	MsgPermissionApproveAll      MsgKey = "permission_approve_all"
 	MsgPermissionDenied          MsgKey = "permission_denied_msg"
@@ -315,10 +316,11 @@ const (
 	MsgCronNextRunLabel  MsgKey = "cron_next_run_label"
 	MsgCronLastRunLabel  MsgKey = "cron_last_run_label"
 
-	MsgPermBtnAllow    MsgKey = "perm_btn_allow"
-	MsgPermBtnDeny     MsgKey = "perm_btn_deny"
-	MsgPermBtnAllowAll MsgKey = "perm_btn_allow_all"
-	MsgPermCardTitle   MsgKey = "perm_card_title"
+	MsgPermBtnAllow          MsgKey = "perm_btn_allow"
+	MsgPermBtnDeny           MsgKey = "perm_btn_deny"
+	MsgPermBtnAllowAll       MsgKey = "perm_btn_allow_all"
+	MsgPermBtnAllowAllShort  MsgKey = "perm_btn_allow_all_short"
+	MsgPermCardTitle         MsgKey = "perm_card_title"
 	MsgPermCardBody    MsgKey = "perm_card_body"
 	MsgPermCardNote    MsgKey = "perm_card_note"
 
@@ -628,6 +630,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "⚠️ **權限請求**\n\nAgent 想要使用 **%s**:\n\n```\n%s\n```\n\n回覆 **允許** / **拒絕** / **允許所有**（本次會話不再提醒）。",
 		LangJapanese:           "⚠️ **権限リクエスト**\n\nエージェントが **%s** を使用しようとしています:\n\n```\n%s\n```\n\n**allow** / **deny** / **allow all**（このセッション中は全て自動許可）で返信してください。",
 		LangSpanish:            "⚠️ **Solicitud de permiso**\n\nEl agente quiere usar **%s**:\n\n```\n%s\n```\n\nResponda **allow** / **deny** / **allow all** (omitir futuras solicitudes en esta sesión).",
+	},
+	MsgPermissionPromptButtons: {
+		LangEnglish:            "⚠️ **Permission Request**\n\nAgent wants to use **%s**:\n\n```\n%s\n```",
+		LangChinese:            "⚠️ **权限请求**\n\nAgent 想要使用 **%s**:\n\n```\n%s\n```",
+		LangTraditionalChinese: "⚠️ **權限請求**\n\nAgent 想要使用 **%s**:\n\n```\n%s\n```",
+		LangJapanese:           "⚠️ **権限リクエスト**\n\nエージェントが **%s** を使用しようとしています:\n\n```\n%s\n```",
+		LangSpanish:            "⚠️ **Solicitud de permiso**\n\nEl agente quiere usar **%s**:\n\n```\n%s\n```",
 	},
 	MsgPermissionAllowed: {
 		LangEnglish:            "✅ Allowed, continuing...",
@@ -2165,6 +2174,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "允許所有 (本次會話)",
 		LangJapanese:           "すべて許可 (このセッション)",
 		LangSpanish:            "Permitir todo (esta sesión)",
+	},
+	MsgPermBtnAllowAllShort: {
+		LangEnglish:            "Allow All",
+		LangChinese:            "允许所有",
+		LangTraditionalChinese: "允許所有",
+		LangJapanese:           "すべて許可",
+		LangSpanish:            "Permitir todo",
 	},
 	MsgPermCardTitle: {
 		LangEnglish:            "Permission Request",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -143,6 +143,13 @@ type InlineButtonSender interface {
 	SendWithButtons(ctx context.Context, replyCtx any, content string, buttons [][]ButtonOption) error
 }
 
+// PermissionButtonSender is an optional interface for platforms that support
+// dedicated permission-request button UIs, which may differ from generic inline
+// button prompts.
+type PermissionButtonSender interface {
+	SendPermissionButtons(ctx context.Context, replyCtx any, content string, buttons [][]ButtonOption) error
+}
+
 // CardSender is an optional interface for platforms that support sending
 // structured rich cards (e.g. Feishu Interactive Card). Platforms that do not
 // implement this interface will receive a plain-text fallback via Card.RenderText().

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -38,6 +38,13 @@ type interactionReplyCtx struct {
 	firstDone   bool
 }
 
+type permissionButtonReplyCtx struct {
+	channelID  string
+	messageID  string
+	replyToID  string
+	sessionKey string
+}
+
 type Platform struct {
 	token                 string
 	allowFrom             string
@@ -438,10 +445,6 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 
 // handleInteraction processes an incoming Discord slash command interaction.
 func (p *Platform) handleInteraction(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	if i.Type != discordgo.InteractionApplicationCommand {
-		return
-	}
-
 	userID, userName := "", ""
 	if i.Member != nil && i.Member.User != nil {
 		userID = i.Member.User.ID
@@ -463,33 +466,40 @@ func (p *Platform) handleInteraction(s *discordgo.Session, i *discordgo.Interact
 		return
 	}
 
-	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
-	}); err != nil {
-		slog.Error("discord: defer interaction failed", "error", err)
+	switch i.Type {
+	case discordgo.InteractionApplicationCommand:
+		if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		}); err != nil {
+			slog.Error("discord: defer interaction failed", "error", err)
+			return
+		}
+
+		data := i.ApplicationCommandData()
+		cmdText := reconstructCommand(data)
+		channelID := i.ChannelID
+
+		slog.Debug("discord: slash command", "user", userName, "command", cmdText, "channel", channelID)
+
+		sessionKey := resolveSessionKeyForChannel(channelID, userID, p.shareSessionInChannel, p.threadIsolation, sessionThreadOps{session: p.session})
+		ictx := &interactionReplyCtx{
+			interaction: i.Interaction,
+			channelID:   channelID,
+		}
+
+		msg := &core.Message{
+			SessionKey: sessionKey, Platform: "discord",
+			MessageID: i.ID,
+			UserID:    userID, UserName: userName,
+			ChatName: p.resolveChannelName(channelID),
+			Content: cmdText, ReplyCtx: ictx,
+		}
+		p.handler(p, msg)
+	case discordgo.InteractionMessageComponent:
+		p.handleComponentInteraction(s, i, userID, userName)
+	default:
 		return
 	}
-
-	data := i.ApplicationCommandData()
-	cmdText := reconstructCommand(data)
-	channelID := i.ChannelID
-
-	slog.Debug("discord: slash command", "user", userName, "command", cmdText, "channel", channelID)
-
-	sessionKey := resolveSessionKeyForChannel(channelID, userID, p.shareSessionInChannel, p.threadIsolation, sessionThreadOps{session: p.session})
-	ictx := &interactionReplyCtx{
-		interaction: i.Interaction,
-		channelID:   channelID,
-	}
-
-	msg := &core.Message{
-		SessionKey: sessionKey, Platform: "discord",
-		MessageID: i.ID,
-		UserID:    userID, UserName: userName,
-		ChatName: p.resolveChannelName(channelID),
-		Content: cmdText, ReplyCtx: ictx,
-	}
-	p.handler(p, msg)
 }
 
 // reconstructCommand converts a Discord interaction back to a text command string
@@ -509,10 +519,72 @@ func reconstructCommand(data discordgo.ApplicationCommandInteractionData) string
 	return strings.Join(parts, " ")
 }
 
+func (p *Platform) handleComponentInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, userID, userName string) {
+	data := i.MessageComponentData()
+	if !strings.HasPrefix(data.CustomID, "perm:") {
+		slog.Debug("discord: unknown component interaction", "custom_id", data.CustomID)
+		return
+	}
+
+	var responseText, choiceLabel string
+	switch data.CustomID {
+	case "perm:allow":
+		responseText = "allow"
+		choiceLabel = "✅ Allowed"
+	case "perm:deny":
+		responseText = "deny"
+		choiceLabel = "❌ Denied"
+	case "perm:allow_all":
+		responseText = "allow all"
+		choiceLabel = "✅ Allow All"
+	default:
+		return
+	}
+
+	origText := "(permission request)"
+	if i.Message != nil && i.Message.Content != "" {
+		origText = i.Message.Content
+	}
+	emptyComponents := []discordgo.MessageComponent{}
+	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Content:    origText + "\n\n" + choiceLabel,
+			Components: emptyComponents,
+		},
+	}); err != nil {
+		slog.Debug("discord: permission component update failed", "error", err)
+	}
+
+	channelID := i.ChannelID
+	messageID := ""
+	if i.Message != nil {
+		messageID = i.Message.ID
+	}
+	rctx := permissionButtonReplyCtx{
+		channelID:  channelID,
+		messageID:  messageID,
+		replyToID:  messageID,
+		sessionKey: resolveSessionKeyForChannel(channelID, userID, p.shareSessionInChannel, p.threadIsolation, sessionThreadOps{session: p.session}),
+	}
+	p.handler(p, &core.Message{
+		SessionKey: rctx.sessionKey,
+		Platform:   "discord",
+		MessageID:  i.ID,
+		UserID:     userID,
+		UserName:   userName,
+		ChatName:   p.resolveChannelName(channelID),
+		Content:    responseText,
+		ReplyCtx:   rctx,
+	})
+}
+
 func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	switch rc := rctx.(type) {
 	case *interactionReplyCtx:
 		return p.sendInteraction(rc, content)
+	case permissionButtonReplyCtx:
+		return p.sendPermissionReply(rc, content)
 	case replyContext:
 		return p.sendChannelReply(rc, content)
 	default:
@@ -525,6 +597,8 @@ func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 	switch rc := rctx.(type) {
 	case *interactionReplyCtx:
 		return p.sendInteraction(rc, content)
+	case permissionButtonReplyCtx:
+		return p.sendPermissionReply(rc, content)
 	case replyContext:
 		return p.sendChannel(rc, content)
 	default:
@@ -592,6 +666,22 @@ func (p *Platform) sendChannel(rc replyContext, content string) error {
 	return nil
 }
 
+func (p *Platform) sendPermissionReply(rc permissionButtonReplyCtx, content string) error {
+	if rc.replyToID == "" {
+		_, err := p.session.ChannelMessageSend(rc.channelID, content)
+		if err != nil {
+			return fmt.Errorf("discord: send permission followup: %w", err)
+		}
+		return nil
+	}
+	ref := &discordgo.MessageReference{MessageID: rc.replyToID}
+	_, err := p.session.ChannelMessageSendReply(rc.channelID, content, ref)
+	if err != nil {
+		return fmt.Errorf("discord: send permission reply: %w", err)
+	}
+	return nil
+}
+
 // SendImage sends an image to the channel or interaction.
 // Implements core.ImageSender.
 func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttachment) error {
@@ -650,7 +740,49 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 	}
 }
 
+func (p *Platform) SendPermissionButtons(ctx context.Context, rctx any, content string, buttons [][]core.ButtonOption) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return core.ErrNotSupported
+	}
+	if len(buttons) == 0 {
+		return fmt.Errorf("discord: no permission buttons provided")
+	}
+	row := make([]discordgo.MessageComponent, 0, len(buttons[0]))
+	for idx, btn := range buttons[0] {
+		style := discordgo.SecondaryButton
+		switch idx {
+		case 0:
+			style = discordgo.SuccessButton
+		case 1:
+			style = discordgo.DangerButton
+		case 2:
+			style = discordgo.PrimaryButton
+		}
+		row = append(row, discordgo.Button{
+			Label:    btn.Text,
+			Style:    style,
+			CustomID: btn.Data,
+		})
+	}
+	msg := &discordgo.MessageSend{
+		Content: content,
+		Components: []discordgo.MessageComponent{
+			discordgo.ActionsRow{Components: row},
+		},
+	}
+	if rc.messageID != "" {
+		msg.Reference = &discordgo.MessageReference{MessageID: rc.messageID}
+	}
+	_, err := p.session.ChannelMessageSendComplex(rc.channelID, msg)
+	if err != nil {
+		return fmt.Errorf("discord: send permission buttons: %w", err)
+	}
+	return nil
+}
+
 var _ core.ImageSender = (*Platform)(nil)
+var _ core.PermissionButtonSender = (*Platform)(nil)
 
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 	// discord:{channelID}:{userID} or discord:{threadID}

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -1,6 +1,11 @@
 package discord
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -156,6 +161,76 @@ func TestReconstructReplyCtx_ThreadSessionKey(t *testing.T) {
 	rc := rctx.(replyContext)
 	if rc.channelID != "thread-7" || rc.threadID != "thread-7" {
 		t.Fatalf("replyContext = %#v, want thread reply context", rc)
+	}
+}
+
+func TestSendPermissionButtons_SendsThreeButtonsInOneRow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload["content"] != "perm prompt" {
+			t.Fatalf("content = %#v, want perm prompt", payload["content"])
+		}
+		components, ok := payload["components"].([]any)
+		if !ok || len(components) != 1 {
+			t.Fatalf("components = %#v, want one row", payload["components"])
+		}
+		row, ok := components[0].(map[string]any)
+		if !ok {
+			t.Fatalf("row = %#v, want object", components[0])
+		}
+		rowComponents, ok := row["components"].([]any)
+		if !ok || len(rowComponents) != 3 {
+			t.Fatalf("row components = %#v, want 3 buttons", row["components"])
+		}
+		if rowComponents[0].(map[string]any)["custom_id"] != "perm:allow" {
+			t.Fatalf("button0 = %#v, want perm:allow", rowComponents[0])
+		}
+		if rowComponents[1].(map[string]any)["custom_id"] != "perm:deny" {
+			t.Fatalf("button1 = %#v, want perm:deny", rowComponents[1])
+		}
+		if rowComponents[2].(map[string]any)["custom_id"] != "perm:allow_all" {
+			t.Fatalf("button2 = %#v, want perm:allow_all", rowComponents[2])
+		}
+		if rowComponents[2].(map[string]any)["style"] != float64(discordgo.PrimaryButton) {
+			t.Fatalf("button2 style = %#v, want %d", rowComponents[2].(map[string]any)["style"], discordgo.PrimaryButton)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg-1","channel_id":"ch-1"}`)
+	}))
+	defer server.Close()
+
+	oldEndpointDiscord := discordgo.EndpointDiscord
+	oldEndpointAPI := discordgo.EndpointAPI
+	oldEndpointChannels := discordgo.EndpointChannels
+	discordgo.EndpointDiscord = server.URL + "/"
+	discordgo.EndpointAPI = discordgo.EndpointDiscord + "api/v" + discordgo.APIVersion + "/"
+	discordgo.EndpointChannels = discordgo.EndpointAPI + "channels/"
+	defer func() {
+		discordgo.EndpointDiscord = oldEndpointDiscord
+		discordgo.EndpointAPI = oldEndpointAPI
+		discordgo.EndpointChannels = oldEndpointChannels
+	}()
+
+	s, err := discordgo.New("Bot test-token")
+	if err != nil {
+		t.Fatalf("discordgo.New() error = %v", err)
+	}
+	s.Client = server.Client()
+
+	p := &Platform{session: s}
+	err = p.SendPermissionButtons(context.Background(), replyContext{channelID: "ch-1", messageID: "orig-1"}, "perm prompt", [][]core.ButtonOption{{
+		{Text: "Allow", Data: "perm:allow"},
+		{Text: "Deny", Data: "perm:deny"},
+		{Text: "Allow All", Data: "perm:allow_all"},
+	}})
+	if err != nil {
+		t.Fatalf("SendPermissionButtons() error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- 在 Discord 的工具权限请求中改为使用按钮交互，无需再通过回复文字进行确认
- 将三个操作按钮放在同一行展示，并将“允许所有”按钮设置为蓝色
- 针对支持专用权限按钮的平台移除“回复 allow / deny / allow all”文案，同时补充相关测试

## Test plan

- [x] `go test ./platform/discord`
- [x] `go test ./core ./platform/discord -run 'TestSendPermissionPrompt_(CardPlatform|InlineButtonPlatform|PermissionButtonPlatform)|TestPermissionPromptButtonsText_UsedForPermissionButtonPlatforms|TestSendPermissionButtons_SendsThreeButtonsInOneRow'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)