### PR TITLE
fix(core): surface model save failures

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -496,6 +496,9 @@ func main() {
 		engine.SetProviderModelSaveFunc(func(providerName, model string) error {
 			return config.SaveProviderModel(projName, providerName, model)
 		})
+		engine.SetModelSaveFunc(func(model string) error {
+			return config.SaveAgentModel(projName, model)
+		})
 
 		// Wire config reload
 		capturedEngine := engine

--- a/config/config.go
+++ b/config/config.go
@@ -404,6 +404,35 @@ func SaveProviderModel(projectName, providerName, model string) error {
 	return fmt.Errorf("project %q not found in config", projectName)
 }
 
+// SaveAgentModel persists the selected default model for a project's agent.
+func SaveAgentModel(projectName, model string) error {
+	configMu.Lock()
+	defer configMu.Unlock()
+	if ConfigPath == "" {
+		return fmt.Errorf("config path not set")
+	}
+	data, err := os.ReadFile(ConfigPath)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+	cfg := &Config{}
+	if err := toml.Unmarshal(data, cfg); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+
+	for i := range cfg.Projects {
+		if cfg.Projects[i].Name != projectName {
+			continue
+		}
+		if cfg.Projects[i].Agent.Options == nil {
+			cfg.Projects[i].Agent.Options = make(map[string]any)
+		}
+		cfg.Projects[i].Agent.Options["model"] = model
+		return saveConfig(cfg)
+	}
+	return fmt.Errorf("project %q not found in config", projectName)
+}
+
 // AddProviderToConfig adds a provider to a project's agent config and saves.
 func AddProviderToConfig(projectName string, provider ProviderConfig) error {
 	configMu.Lock()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -222,6 +222,28 @@ func TestProviderConfig_SaveProviderModel(t *testing.T) {
 	}
 }
 
+func TestSaveAgentModel(t *testing.T) {
+	writeTestConfig(t, providerConfigTOML)
+
+	if err := SaveAgentModel("demo", "gpt-5.4"); err != nil {
+		t.Fatalf("SaveAgentModel() error: %v", err)
+	}
+
+	cfg := readTestConfig(t)
+	if got, _ := cfg.Projects[0].Agent.Options["model"].(string); got != "gpt-5.4" {
+		t.Fatalf("agent.options.model = %q, want gpt-5.4", got)
+	}
+	if got, _ := cfg.Projects[0].Agent.Options["mode"].(string); got != "default" {
+		t.Fatalf("agent.options.mode = %q, want default", got)
+	}
+	if got, _ := cfg.Projects[0].Agent.Options["provider"].(string); got != "primary" {
+		t.Fatalf("agent.options.provider = %q, want primary", got)
+	}
+	if len(cfg.Projects[0].Agent.Providers) != 2 {
+		t.Fatalf("provider count = %d, want 2", len(cfg.Projects[0].Agent.Providers))
+	}
+}
+
 func TestCommandConfig_AddAndRemove(t *testing.T) {
 	writeTestConfig(t, baseConfigTOML)
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -147,6 +147,7 @@ type Engine struct {
 	providerAddSaveFunc    func(p ProviderConfig) error
 	providerRemoveSaveFunc func(name string) error
 	providerModelSaveFunc  func(providerName, model string) error
+	modelSaveFunc          func(model string) error
 
 	ttsSaveFunc func(mode string) error
 
@@ -443,6 +444,10 @@ func (e *Engine) SetProviderRemoveSaveFunc(fn func(string) error) {
 
 func (e *Engine) SetProviderModelSaveFunc(fn func(providerName, model string) error) {
 	e.providerModelSaveFunc = fn
+}
+
+func (e *Engine) SetModelSaveFunc(fn func(model string) error) {
+	e.modelSaveFunc = fn
 }
 
 // AddPlatform appends a platform to the engine after construction.
@@ -4570,7 +4575,11 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 		target = resolveModelAlias(models, target)
 	}
 
-	target = e.switchModel(target)
+	target, err := e.switchModel(target)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChangeFailed, err))
+		return
+	}
 	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
 
 	s := e.sessions.GetOrCreateActive(msg.SessionKey)
@@ -4611,36 +4620,50 @@ func parseModelSwitchArgs(args []string) (string, bool) {
 
 // switchModel applies a runtime model selection. When an active provider exists,
 // its configured model is updated so new sessions use the selected model instead
-// of the provider's previous fixed model.
-func (e *Engine) switchModel(target string) string {
+// of the provider's previous fixed model. Persistence errors are returned so
+// callers can avoid claiming success when the change would be lost on reload.
+func (e *Engine) switchModel(target string) (string, error) {
 	switcher, ok := e.agent.(ModelSwitcher)
 	if !ok {
-		return target
+		return target, nil
 	}
-	switcher.SetModel(target)
 
 	providerSwitcher, ok := e.agent.(ProviderSwitcher)
 	if !ok {
-		return target
+		if e.modelSaveFunc != nil {
+			if err := e.modelSaveFunc(target); err != nil {
+				return "", fmt.Errorf("save model: %w", err)
+			}
+		}
+		switcher.SetModel(target)
+		return target, nil
 	}
 	active := providerSwitcher.GetActiveProvider()
 	if active == nil {
-		return target
+		if e.modelSaveFunc != nil {
+			if err := e.modelSaveFunc(target); err != nil {
+				return "", fmt.Errorf("save model: %w", err)
+			}
+		}
+		switcher.SetModel(target)
+		return target, nil
 	}
 
 	providers := providerSwitcher.ListProviders()
 	updated, found := SetProviderModel(providers, active.Name, target)
 	if !found {
-		return target
+		switcher.SetModel(target)
+		return target, nil
 	}
-	providerSwitcher.SetProviders(updated)
-	providerSwitcher.SetActiveProvider(active.Name)
 	if e.providerModelSaveFunc != nil {
 		if err := e.providerModelSaveFunc(active.Name, target); err != nil {
-			slog.Error("failed to save provider model", "provider", active.Name, "model", target, "error", err)
+			return "", fmt.Errorf("save provider model %q: %w", active.Name, err)
 		}
 	}
-	return target
+	providerSwitcher.SetProviders(updated)
+	switcher.SetModel(target)
+	providerSwitcher.SetActiveProvider(active.Name)
+	return target, nil
 }
 
 func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
@@ -5793,7 +5816,10 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		} else {
 			target = resolveModelAlias(models, target)
 		}
-		e.switchModel(target)
+		if _, err := e.switchModel(target); err != nil {
+			slog.Error("failed to switch model from card action", "model", target, "error", err)
+			return
+		}
 		interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 		e.cleanupInteractiveState(interactiveKey)
 		s := e.sessions.GetOrCreateActive(sessionKey)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2355,6 +2355,79 @@ func TestCmdModel_LegacySyntaxStillWorks(t *testing.T) {
 	}
 }
 
+func TestCmdModel_SavesModelWhenNoActiveProvider(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubModelModeAgent{
+		model: "gpt-4.1-mini",
+		providers: []ProviderConfig{
+			{
+				Name:   "openai",
+				Model:  "gpt-4.1-mini",
+				Models: []ModelOption{{Name: "gpt-4.1", Alias: "gpt"}, {Name: "gpt-4.1-mini", Alias: "mini"}},
+			},
+		},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	var savedModel string
+	e.SetModelSaveFunc(func(model string) error {
+		savedModel = model
+		return nil
+	})
+
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	e.cmdModel(p, msg, []string{"switch", "gpt"})
+
+	if agent.model != "gpt-4.1" {
+		t.Fatalf("agent model = %q, want gpt-4.1", agent.model)
+	}
+	if savedModel != "gpt-4.1" {
+		t.Fatalf("saved model = %q, want gpt-4.1", savedModel)
+	}
+}
+
+func TestCmdModel_DoesNotClaimSuccessWhenModelSaveFails(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubModelModeAgent{
+		model: "gpt-4.1-mini",
+		providers: []ProviderConfig{
+			{
+				Name:   "openai",
+				Model:  "gpt-4.1-mini",
+				Models: []ModelOption{{Name: "gpt-4.1", Alias: "gpt"}, {Name: "gpt-4.1-mini", Alias: "mini"}},
+			},
+		},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetModelSaveFunc(func(model string) error {
+		return errors.New("disk full")
+	})
+
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s.SetAgentSessionID("existing-session", "test")
+	s.AddHistory("user", "keep me")
+
+	e.cmdModel(p, msg, []string{"switch", "gpt"})
+
+	if agent.model != "gpt-4.1-mini" {
+		t.Fatalf("agent model = %q, want unchanged gpt-4.1-mini", agent.model)
+	}
+	if active := e.sessions.GetOrCreateActive(msg.SessionKey); active.AgentSessionID != "existing-session" {
+		t.Fatalf("session id = %q, want existing-session after failure", active.AgentSessionID)
+	}
+	if active := e.sessions.GetOrCreateActive(msg.SessionKey); len(active.History) != 1 {
+		t.Fatalf("history length = %d, want 1 after failure", len(active.History))
+	}
+	sent := p.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(sent))
+	}
+	if !strings.Contains(sent[0], "Failed to change model") {
+		t.Fatalf("reply = %q, want model change failure message", sent[0])
+	}
+}
+
 func TestCmdDir_ShowsCurrentDirectory(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	agent := &stubWorkDirAgent{workDir: "/tmp/project-a"}

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -237,6 +237,7 @@ const (
 
 	MsgModelCurrent          MsgKey = "model_current"
 	MsgModelChanged          MsgKey = "model_changed"
+	MsgModelChangeFailed     MsgKey = "model_change_failed"
 	MsgModelNotSupported     MsgKey = "model_not_supported"
 	MsgReasoningCurrent      MsgKey = "reasoning_current"
 	MsgReasoningChanged      MsgKey = "reasoning_changed"
@@ -1734,6 +1735,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "模型已切換為 `%s`，新會話將使用此模型。",
 		LangJapanese:           "モデルを `%s` に切り替えました。新しいセッションで使用されます。",
 		LangSpanish:            "Modelo cambiado a `%s`. Las nuevas sesiones usarán este modelo.",
+	},
+	MsgModelChangeFailed: {
+		LangEnglish:            "❌ Failed to change model: %v",
+		LangChinese:            "❌ 切换模型失败: %v",
+		LangTraditionalChinese: "❌ 切換模型失敗: %v",
+		LangJapanese:           "❌ モデルの切り替えに失敗しました: %v",
+		LangSpanish:            "❌ Error al cambiar el modelo: %v",
 	},
 	MsgModelNotSupported: {
 		LangEnglish:            "This agent does not support model switching.",

--- a/core/management.go
+++ b/core/management.go
@@ -854,8 +854,7 @@ func (m *ManagementServer) handleProjectModel(w http.ResponseWriter, r *http.Req
 		mgmtError(w, http.StatusMethodNotAllowed, "POST only")
 		return
 	}
-	ms, ok := e.agent.(ModelSwitcher)
-	if !ok {
+	if _, ok := e.agent.(ModelSwitcher); !ok {
 		mgmtError(w, http.StatusBadRequest, "agent does not support model switching")
 		return
 	}
@@ -870,9 +869,13 @@ func (m *ManagementServer) handleProjectModel(w http.ResponseWriter, r *http.Req
 		mgmtError(w, http.StatusBadRequest, "model is required")
 		return
 	}
-	ms.SetModel(body.Model)
+	model, err := e.switchModel(body.Model)
+	if err != nil {
+		mgmtError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	mgmtJSON(w, http.StatusOK, map[string]any{
-		"model":   body.Model,
+		"model":   model,
 		"message": "model updated",
 	})
 }

--- a/core/management_test.go
+++ b/core/management_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -486,4 +487,128 @@ func TestMgmt_MethodNotAllowed(t *testing.T) {
 		t.Fatalf("decode method not allowed response: %v", err)
 	}
 	resp.Body.Close()
+}
+
+func TestMgmt_ProjectModel_UsesSwitchModelWithActiveProvider(t *testing.T) {
+	agent := &stubModelModeAgent{
+		model: "gpt-4.1-mini",
+		providers: []ProviderConfig{
+			{
+				Name:   "openai",
+				Model:  "gpt-4.1-mini",
+				Models: []ModelOption{{Name: "gpt-4.1", Alias: "gpt"}, {Name: "gpt-4.1-mini", Alias: "mini"}},
+			},
+		},
+		active: "openai",
+	}
+	e := NewEngine("test-project", agent, nil, "", LangEnglish)
+	var savedProvider, savedModel string
+	e.SetProviderModelSaveFunc(func(providerName, model string) error {
+		savedProvider = providerName
+		savedModel = model
+		return nil
+	})
+
+	mgmt := NewManagementServer(0, "tok", nil)
+	mgmt.RegisterEngine("test-project", e)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/projects/", mgmt.wrap(mgmt.handleProjectRoutes))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	r := mgmtPost(t, ts.URL+"/api/v1/projects/test-project/model", "tok", map[string]string{"model": "gpt-4.1"})
+	if !r.OK {
+		t.Fatalf("update model failed: %s", r.Error)
+	}
+
+	if got := agent.GetModel(); got != "gpt-4.1" {
+		t.Fatalf("GetModel() = %q, want gpt-4.1", got)
+	}
+	if got := agent.GetActiveProvider(); got == nil || got.Model != "gpt-4.1" {
+		t.Fatalf("active provider model = %#v, want gpt-4.1", got)
+	}
+	if savedProvider != "openai" || savedModel != "gpt-4.1" {
+		t.Fatalf("saved provider/model = %q/%q, want openai/gpt-4.1", savedProvider, savedModel)
+	}
+}
+
+func TestMgmt_ProjectModel_SavesModelWithoutActiveProvider(t *testing.T) {
+	agent := &stubModelModeAgent{
+		model: "gpt-4.1-mini",
+		providers: []ProviderConfig{
+			{
+				Name:   "openai",
+				Model:  "gpt-4.1-mini",
+				Models: []ModelOption{{Name: "gpt-4.1", Alias: "gpt"}, {Name: "gpt-4.1-mini", Alias: "mini"}},
+			},
+		},
+	}
+	e := NewEngine("test-project", agent, nil, "", LangEnglish)
+	var savedModel string
+	var providerSaveCalled bool
+	e.SetModelSaveFunc(func(model string) error {
+		savedModel = model
+		return nil
+	})
+	e.SetProviderModelSaveFunc(func(providerName, model string) error {
+		providerSaveCalled = true
+		return nil
+	})
+
+	mgmt := NewManagementServer(0, "tok", nil)
+	mgmt.RegisterEngine("test-project", e)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/projects/", mgmt.wrap(mgmt.handleProjectRoutes))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	r := mgmtPost(t, ts.URL+"/api/v1/projects/test-project/model", "tok", map[string]string{"model": "gpt-4.1"})
+	if !r.OK {
+		t.Fatalf("update model failed: %s", r.Error)
+	}
+
+	if got := agent.GetModel(); got != "gpt-4.1" {
+		t.Fatalf("GetModel() = %q, want gpt-4.1", got)
+	}
+	if savedModel != "gpt-4.1" {
+		t.Fatalf("saved model = %q, want gpt-4.1", savedModel)
+	}
+	if providerSaveCalled {
+		t.Fatal("provider save callback should not be called without active provider")
+	}
+}
+
+func TestMgmt_ProjectModel_ReturnsErrorWhenModelSaveFails(t *testing.T) {
+	agent := &stubModelModeAgent{
+		model: "gpt-4.1-mini",
+		providers: []ProviderConfig{
+			{
+				Name:   "openai",
+				Model:  "gpt-4.1-mini",
+				Models: []ModelOption{{Name: "gpt-4.1", Alias: "gpt"}, {Name: "gpt-4.1-mini", Alias: "mini"}},
+			},
+		},
+	}
+	e := NewEngine("test-project", agent, nil, "", LangEnglish)
+	e.SetModelSaveFunc(func(model string) error {
+		return errors.New("disk full")
+	})
+
+	mgmt := NewManagementServer(0, "tok", nil)
+	mgmt.RegisterEngine("test-project", e)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/projects/", mgmt.wrap(mgmt.handleProjectRoutes))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	r := mgmtPost(t, ts.URL+"/api/v1/projects/test-project/model", "tok", map[string]string{"model": "gpt-4.1"})
+	if r.OK {
+		t.Fatal("update model unexpectedly succeeded")
+	}
+	if !strings.Contains(r.Error, "disk full") {
+		t.Fatalf("error = %q, want save failure", r.Error)
+	}
+	if got := agent.GetModel(); got != "gpt-4.1-mini" {
+		t.Fatalf("GetModel() = %q, want unchanged gpt-4.1-mini", got)
+	}
 }


### PR DESCRIPTION
## Summary
- persist agent-level model changes when no provider is active
- return model persistence failures to chat and management API callers
- add regression coverage for successful and failed model save paths

## Background
- switching models without an active provider updated runtime state but did not persist the chosen model
- save callback failures were only logged, so callers still reported success and cleared session state

## Changes
- wire a dedicated agent model save callback from config into the engine
- add SaveAgentModel for updating projects.agent.options.model
- make switchModel persist before mutating runtime state and return errors
- surface model-save failures in /model, card actions, and POST /api/v1/projects/{name}/model
- add i18n for model change failures and tests for both success and failure scenarios

## Test Plan
- go test ./core ./config ./cmd/cc-connect

## Risks
- model switching now fails fast when persistence fails, which changes behavior for callers that previously saw best-effort success
- card-driven model switches now abort without clearing session state if persistence fails
