### PR TITLE
fix(telegram): add HTTP status code validation for file downloads

### DIFF
--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -1075,6 +1075,9 @@ func (p *Platform) downloadFile(bot telegramBot, fileID string) ([]byte, error) 
 	if err != nil {
 		return nil, fmt.Errorf("get file: %w", err)
 	}
+	if file.FilePath == "" {
+		return nil, fmt.Errorf("get file: empty file_path returned for file_id %s", fileID)
+	}
 	link := file.Link(bot.Token())
 
 	resp, err := p.httpClient.Get(link)
@@ -1083,6 +1086,9 @@ func (p *Platform) downloadFile(bot telegramBot, fileID string) ([]byte, error) 
 		return nil, fmt.Errorf("download file %s: %s", fileID, errMsg)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download file %s: status %d", fileID, resp.StatusCode)
+	}
 	return io.ReadAll(resp.Body)
 }
 


### PR DESCRIPTION
- Add file_path validation to catch empty paths
- Add HTTP status code check (resp.StatusCode != 200)
- Prevents silent failures when file downloads fail

Fixes issue where Telegram images were not being delivered to Claude Code due to missing error handling for non-200 HTTP responses.