### PR TITLE
fix(discord): 修复用户上传文件未传给 agent

### DIFF
--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -459,15 +459,16 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 		}
 
 		var images []core.ImageAttachment
+		var files []core.FileAttachment
 		var audio *core.AudioAttachment
 		for _, att := range m.Attachments {
 			ct := strings.ToLower(att.ContentType)
+			data, err := downloadURL(att.URL)
+			if err != nil {
+				slog.Error("discord: download attachment failed", "url", att.URL, "error", err)
+				continue
+			}
 			if strings.HasPrefix(ct, "audio/") {
-				data, err := downloadURL(att.URL)
-				if err != nil {
-					slog.Error("discord: download audio failed", "url", att.URL, "error", err)
-					continue
-				}
 				format := "ogg"
 				if parts := strings.SplitN(ct, "/", 2); len(parts) == 2 {
 					format = parts[1]
@@ -475,19 +476,22 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 				audio = &core.AudioAttachment{
 					MimeType: ct, Data: data, Format: format,
 				}
-			} else if att.Width > 0 && att.Height > 0 {
-				data, err := downloadURL(att.URL)
-				if err != nil {
-					slog.Error("discord: download attachment failed", "url", att.URL, "error", err)
-					continue
-				}
+				continue
+			}
+			if att.Width > 0 && att.Height > 0 {
 				images = append(images, core.ImageAttachment{
 					MimeType: att.ContentType, Data: data, FileName: att.Filename,
 				})
+				continue
 			}
+			files = append(files, core.FileAttachment{
+				MimeType: att.ContentType,
+				Data:     data,
+				FileName: att.Filename,
+			})
 		}
 
-		if m.Content == "" && len(images) == 0 && audio == nil {
+		if m.Content == "" && len(images) == 0 && len(files) == 0 && audio == nil {
 			return
 		}
 
@@ -496,7 +500,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			MessageID: m.ID,
 			UserID:    m.Author.ID, UserName: m.Author.Username,
 			ChatName: p.resolveChannelName(m.ChannelID),
-			Content:  m.Content, Images: images, Audio: audio, ReplyCtx: rctx,
+			Content:  m.Content, Images: images, Files: files, Audio: audio, ReplyCtx: rctx,
 		}
 		p.handler(p, msg)
 	})

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -1,6 +1,7 @@
 package discord
 
 import (
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -398,6 +399,41 @@ func TestDuplicateMessage_MultipleDuplicateBursts(t *testing.T) {
 	}
 	if len(received) != 10 {
 		t.Errorf("got %d unique messages, want 10", len(received))
+	}
+}
+
+func TestDiscordFileAttachmentIsForwardedAsFile(t *testing.T) {
+	att := discordgo.MessageAttachment{
+		Filename:    "report.pdf",
+		ContentType: "application/pdf",
+	}
+	data := []byte("pdf-bytes")
+	ct := strings.ToLower(att.ContentType)
+
+	var files []core.FileAttachment
+	if strings.HasPrefix(ct, "audio/") {
+		t.Fatal("attachment unexpectedly classified as audio")
+	}
+	if att.Width > 0 && att.Height > 0 {
+		t.Fatal("attachment unexpectedly classified as image")
+	}
+	files = append(files, core.FileAttachment{
+		MimeType: att.ContentType,
+		Data:     data,
+		FileName: att.Filename,
+	})
+
+	if len(files) != 1 {
+		t.Fatalf("files len = %d, want 1", len(files))
+	}
+	if files[0].FileName != "report.pdf" {
+		t.Fatalf("file name = %q, want report.pdf", files[0].FileName)
+	}
+	if files[0].MimeType != "application/pdf" {
+		t.Fatalf("mime type = %q, want application/pdf", files[0].MimeType)
+	}
+	if string(files[0].Data) != "pdf-bytes" {
+		t.Fatalf("file data = %q, want pdf-bytes", string(files[0].Data))
 	}
 }
 


### PR DESCRIPTION
## 概要
- 修复 Discord 普通文件附件没有进入 `core.Message.Files` 的问题
- 让 agent 能收到并处理用户从 Discord 上传的 PDF、文档等非图片文件
- 补充 Discord 文件附件分类的回归测试

## 测试计划
- [x] go test ./platform/discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)