### PR TITLE
fix(feishu): fall back to post format when markdown has >5 tables

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1302,7 +1302,11 @@ func buildReplyContent(content string) (msgType string, body string) {
 	// 1. Code blocks / tables → card (schema 2.0 markdown)
 	// 2. Many \n\n paragraphs (help, status, etc.) → post rich-text (preserves blank lines)
 	// 3. Other markdown → post md tag (best native rendering)
-	if hasComplexMarkdown(content) {
+	//
+	// Feishu cards support at most 5 tables (API error 11310).
+	// When content exceeds this limit, fall back to post with md tag
+	// which still renders tables without the card table cap.
+	if hasComplexMarkdown(content) && countMarkdownTables(content) <= maxCardTables {
 		return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)))
 	}
 	if strings.Count(content, "\n\n") >= 2 {
@@ -1324,6 +1328,28 @@ func hasComplexMarkdown(s string) bool {
 		}
 	}
 	return false
+}
+
+// maxCardTables is the Feishu interactive card limit for table components.
+// A single card supports at most 5 tables; exceeding this causes API error 11310.
+const maxCardTables = 5
+
+// countMarkdownTables counts the number of distinct markdown tables in s.
+// A table is a group of consecutive lines where each line starts and ends with '|'.
+func countMarkdownTables(s string) int {
+	count := 0
+	inTable := false
+	for _, line := range strings.Split(s, "\n") {
+		trimmed := strings.TrimSpace(line)
+		isTableLine := len(trimmed) > 1 && trimmed[0] == '|' && trimmed[len(trimmed)-1] == '|'
+		if isTableLine && !inTable {
+			count++
+			inTable = true
+		} else if !isTableLine {
+			inTable = false
+		}
+	}
+	return count
 }
 
 // buildPostMdJSON builds a Feishu post message using the md tag,

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -194,6 +194,61 @@ func TestHasComplexMarkdown(t *testing.T) {
 	}
 }
 
+func TestCountMarkdownTables(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"no tables", "hello world", 0},
+		{"one table", "| A | B |\n|---|---|\n| 1 | 2 |", 1},
+		{"two tables separated by text", "| A |\n|---|\n\nsome text\n\n| B |\n|---|", 2},
+		{"consecutive tables no gap", "| A |\n|---|\n| 1 |\n| B |\n|---|", 1},
+		{"six tables", "| A |\n|---|\n\nx\n\n| B |\n|---|\n\nx\n\n| C |\n|---|\n\nx\n\n| D |\n|---|\n\nx\n\n| E |\n|---|\n\nx\n\n| F |\n|---|", 6},
+		{"table inside code block is still counted", "```\n| A |\n```\n\n| B |\n|---|", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countMarkdownTables(tt.input)
+			if got != tt.want {
+				t.Errorf("countMarkdownTables() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildReplyContent_FallbackWhenManyTables(t *testing.T) {
+	// Build content with 6 tables (exceeds the 5-table card limit).
+	var sb strings.Builder
+	for i := 0; i < 6; i++ {
+		if i > 0 {
+			sb.WriteString("\n\nsome text\n\n")
+		}
+		sb.WriteString("| H |\n|---|\n| V |")
+	}
+	content := sb.String()
+
+	msgType, _ := buildReplyContent(content)
+	if msgType == larkim.MsgTypeInteractive {
+		t.Errorf("expected non-card message type for >5 tables, got interactive")
+	}
+
+	// With exactly 5 tables, card should still be used.
+	sb.Reset()
+	for i := 0; i < 5; i++ {
+		if i > 0 {
+			sb.WriteString("\n\nsome text\n\n")
+		}
+		sb.WriteString("| H |\n|---|\n| V |")
+	}
+	content5 := sb.String()
+
+	msgType5, _ := buildReplyContent(content5)
+	if msgType5 != larkim.MsgTypeInteractive {
+		t.Errorf("expected interactive card for 5 tables, got %s", msgType5)
+	}
+}
+
 func TestParseInlineMarkdown_BoldAndCode(t *testing.T) {
 	elements := parseInlineMarkdown("**bold** and `code`")
 	hasBold, hasCode := false, false


### PR DESCRIPTION
## Summary

Feishu interactive cards support at most 5 table components per card. When an agent response contains more than 5 markdown tables, the Feishu API rejects the card with error 11310 (`card table number over limit`), causing the reply to be silently lost.

## Changes

- Add `countMarkdownTables()` helper that counts distinct markdown table blocks (consecutive `|`-delimited lines)
- In `buildReplyContent()`, check the table count before choosing card format; fall back to post with `md` tag when >5 tables
- Add `TestCountMarkdownTables` (table-driven, 6 cases) and `TestBuildReplyContent_FallbackWhenManyTables` (boundary test at 5 and 6 tables)

## Reproduction

1. Send a message to Feishu bot that triggers an agent response containing 6+ markdown tables
2. Observe `failed to send reply` with `ErrCode: 11310; ErrMsg: card table number over limit`

## Fix rationale

Minimal change — one new predicate in the existing `buildReplyContent` branching logic. Post `md` tag still renders markdown tables natively, just without the card wrapper, so no visual regression for the common case (≤5 tables) and graceful degradation for the edge case.