### PR TITLE
fix(wecom): strip @bot mentions for permission replies (#98)

### DIFF
--- a/platform/wecom/mention_strip.go
+++ b/platform/wecom/mention_strip.go
@@ -1,0 +1,61 @@
+package wecom
+
+import "strings"
+
+// stripWeComAtMentions removes @<botId> / ＠<botId> segments so group replies like
+// "允许 @机器人" still match engine permission keywords (#98). Only affects wecom.
+func stripWeComAtMentions(s string, botIDs ...string) string {
+	s = strings.TrimSpace(s)
+	for _, id := range botIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		s = stripOneWeComAtMention(s, id)
+		s = strings.TrimSpace(s)
+	}
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	return strings.TrimSpace(s)
+}
+
+func stripOneWeComAtMention(s, botID string) string {
+	if s == "" || botID == "" {
+		return s
+	}
+	// Fullwidth commercial at (common on mobile keyboards)
+	s = removeAllEqualFold(s, "＠"+botID)
+	// ASCII @
+	needleLower := "@" + strings.ToLower(botID)
+	for {
+		lower := strings.ToLower(s)
+		idx := strings.Index(lower, needleLower)
+		if idx < 0 {
+			return s
+		}
+		end := idx + len(needleLower)
+		if end > len(s) {
+			return s
+		}
+		s = s[:idx] + s[end:]
+	}
+}
+
+// removeAllEqualFold removes every case-insensitive occurrence of literal sub from s.
+// sub must be UTF-8; indices align because case folding does not change byte length
+// for ASCII letters in sub.
+func removeAllEqualFold(s, sub string) string {
+	if sub == "" {
+		return s
+	}
+	subLower := strings.ToLower(sub)
+	for {
+		lower := strings.ToLower(s)
+		idx := strings.Index(lower, subLower)
+		if idx < 0 {
+			return s
+		}
+		s = s[:idx] + s[idx+len(sub):]
+	}
+}

--- a/platform/wecom/mention_strip_test.go
+++ b/platform/wecom/mention_strip_test.go
@@ -1,0 +1,29 @@
+package wecom
+
+import "testing"
+
+func TestStripWeComAtMentions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		ids  []string
+		want string
+	}{
+		{"empty", "", []string{"x"}, ""},
+		{"no ids", "允许", nil, "允许"},
+		{"suffix mention", "允许 @mybot", []string{"mybot"}, "允许"},
+		{"prefix mention", "@MyBot 允许", []string{"mybot"}, "允许"},
+		{"fullwidth at", "允许 ＠mybot", []string{"mybot"}, "允许"},
+		{"two ids second", "ok @a @b", []string{"a", "b"}, "ok"},
+		{"unrelated at", "email x@y.com", []string{"mybot"}, "email x@y.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripWeComAtMentions(tt.in, tt.ids...)
+			if got != tt.want {
+				t.Fatalf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -15,27 +15,27 @@ import (
 )
 
 const (
-	wsEndpoint     = "wss://openws.work.weixin.qq.com"
-	wsPingInterval = 30 * time.Second
-	wsMaxBackoff   = 30 * time.Second
+	wsEndpoint      = "wss://openws.work.weixin.qq.com"
+	wsPingInterval  = 30 * time.Second
+	wsMaxBackoff    = 30 * time.Second
 	wsMaxMissedPong = 2
 )
 
 // WSPlatform implements core.Platform using the WeChat Work WebSocket long-connection
 // mode (智能机器人长连接). No public URL, no message encryption, no IP allowlist required.
 type WSPlatform struct {
-	botID     string
-	secret    string
-	allowFrom string
-	conn      *websocket.Conn
-	handler   core.MessageHandler
-	ctx       context.Context
-	cancel    context.CancelFunc
-	mu        sync.Mutex // protects conn writes
-	dedup     core.MessageDedup
-	reqSeq    atomic.Int64 // monotonic counter for generating unique req_id
-	missedPong atomic.Int32 // consecutive heartbeat acks not received
-	pendingAcks sync.Map   // req_id -> chan error, for sequential send with ack waiting
+	botID       string
+	secret      string
+	allowFrom   string
+	conn        *websocket.Conn
+	handler     core.MessageHandler
+	ctx         context.Context
+	cancel      context.CancelFunc
+	mu          sync.Mutex // protects conn writes
+	dedup       core.MessageDedup
+	reqSeq      atomic.Int64 // monotonic counter for generating unique req_id
+	missedPong  atomic.Int32 // consecutive heartbeat acks not received
+	pendingAcks sync.Map     // req_id -> chan error, for sequential send with ack waiting
 }
 
 const wsAckTimeout = 5 * time.Second
@@ -54,11 +54,11 @@ type wsReplyContext struct {
 // Format: { cmd, headers: { req_id }, body: {...} }
 // Response frames may omit cmd and include errcode/errmsg instead.
 type wsFrame struct {
-	Cmd     string            `json:"cmd,omitempty"`
-	Headers wsFrameHeaders    `json:"headers"`
-	Body    json.RawMessage   `json:"body,omitempty"`
-	ErrCode *int              `json:"errcode,omitempty"`
-	ErrMsg  string            `json:"errmsg,omitempty"`
+	Cmd     string          `json:"cmd,omitempty"`
+	Headers wsFrameHeaders  `json:"headers"`
+	Body    json.RawMessage `json:"body,omitempty"`
+	ErrCode *int            `json:"errcode,omitempty"`
+	ErrMsg  string          `json:"errmsg,omitempty"`
 }
 
 type wsFrameHeaders struct {
@@ -362,18 +362,19 @@ func (p *WSPlatform) handleMsgCallback(frame wsFrame) {
 
 	switch body.MsgType {
 	case "text":
-		slog.Debug("wecom-ws: text received", "user", body.From.UserID, "len", len(body.Text.Content))
+		text := stripWeComAtMentions(body.Text.Content, p.botID, body.AibotID)
+		slog.Debug("wecom-ws: text received", "user", body.From.UserID, "len", len(text))
 		go p.handler(p, &core.Message{
 			SessionKey: sessionKey, Platform: "wecom",
 			MessageID: body.MsgID,
-			UserID: body.From.UserID, UserName: body.From.UserID,
+			UserID:    body.From.UserID, UserName: body.From.UserID,
 			ChatName: chatName,
-			Content: body.Text.Content, ReplyCtx: rctx,
+			Content:  text, ReplyCtx: rctx,
 		})
 
 	case "voice":
 		// WebSocket mode: voice messages arrive pre-transcribed by the server
-		text := body.Voice.Text
+		text := stripWeComAtMentions(body.Voice.Text, p.botID, body.AibotID)
 		if text == "" {
 			slog.Debug("wecom-ws: voice message with empty transcription, ignoring")
 			return
@@ -382,9 +383,9 @@ func (p *WSPlatform) handleMsgCallback(frame wsFrame) {
 		go p.handler(p, &core.Message{
 			SessionKey: sessionKey, Platform: "wecom",
 			MessageID: body.MsgID,
-			UserID: body.From.UserID, UserName: body.From.UserID,
+			UserID:    body.From.UserID, UserName: body.From.UserID,
 			ChatName: chatName,
-			Content: text, ReplyCtx: rctx, FromVoice: true,
+			Content:  text, ReplyCtx: rctx, FromVoice: true,
 		})
 
 	default:

--- a/platform/wecom/websocket_test.go
+++ b/platform/wecom/websocket_test.go
@@ -177,6 +177,47 @@ func TestHandleMsgCallback_GroupChat_ChatIDPreserved(t *testing.T) {
 	}
 }
 
+func TestHandleMsgCallback_StripsBotMention(t *testing.T) {
+	p := &WSPlatform{
+		allowFrom: "*",
+		botID:     "robot01",
+	}
+
+	captured := make(chan *core.Message, 1)
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		captured <- msg
+	}
+
+	body := wsMsgCallbackBody{
+		MsgID:    "msg_mention",
+		ChatID:   "grp1",
+		ChatType: "group",
+		MsgType:  "text",
+		AibotID:  "robot01",
+	}
+	body.From.UserID = "u1"
+	body.Text.Content = "允许 @Robot01"
+	body.CreateTime = time.Now().Unix()
+
+	bodyBytes, _ := json.Marshal(body)
+	frame := wsFrame{
+		Cmd:     "aibot_msg_callback",
+		Headers: wsFrameHeaders{ReqID: "req_m"},
+		Body:    bodyBytes,
+	}
+
+	p.handleMsgCallback(frame)
+
+	select {
+	case msg := <-captured:
+		if msg.Content != "允许" {
+			t.Fatalf("expected stripped content %q, got %q", "允许", msg.Content)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("handler not called")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // ReconstructReplyCtx
 // ---------------------------------------------------------------------------

--- a/platform/wecom/wecom.go
+++ b/platform/wecom/wecom.go
@@ -303,12 +303,13 @@ func (p *Platform) handleMessage(w http.ResponseWriter, r *http.Request, msgSig,
 
 	switch msg.MsgType {
 	case "text":
-		slog.Debug("wecom: message received", "user", msg.FromUserName, "text_len", len(msg.Content))
+		text := stripWeComAtMentions(msg.Content, p.agentID)
+		slog.Debug("wecom: message received", "user", msg.FromUserName, "text_len", len(text))
 		go p.handler(p, &core.Message{
 			SessionKey: sessionKey, Platform: "wecom",
 			MessageID: strconv.FormatInt(msg.MsgId, 10),
-			UserID: msg.FromUserName, UserName: p.resolveUserName(msg.FromUserName),
-			Content: msg.Content, ReplyCtx: rctx,
+			UserID:    msg.FromUserName, UserName: p.resolveUserName(msg.FromUserName),
+			Content: text, ReplyCtx: rctx,
 		})
 
 	case "image":
@@ -322,8 +323,8 @@ func (p *Platform) handleMessage(w http.ResponseWriter, r *http.Request, msgSig,
 			p.handler(p, &core.Message{
 				SessionKey: sessionKey, Platform: "wecom",
 				MessageID: strconv.FormatInt(msg.MsgId, 10),
-				UserID: msg.FromUserName, UserName: p.resolveUserName(msg.FromUserName),
-				Images:  []core.ImageAttachment{{MimeType: "image/jpeg", Data: imgData}},
+				UserID:    msg.FromUserName, UserName: p.resolveUserName(msg.FromUserName),
+				Images:   []core.ImageAttachment{{MimeType: "image/jpeg", Data: imgData}},
 				ReplyCtx: rctx,
 			})
 		}()
@@ -343,7 +344,7 @@ func (p *Platform) handleMessage(w http.ResponseWriter, r *http.Request, msgSig,
 			p.handler(p, &core.Message{
 				SessionKey: sessionKey, Platform: "wecom",
 				MessageID: strconv.FormatInt(msg.MsgId, 10),
-				UserID: msg.FromUserName, UserName: p.resolveUserName(msg.FromUserName),
+				UserID:    msg.FromUserName, UserName: p.resolveUserName(msg.FromUserName),
 				Audio:    &core.AudioAttachment{MimeType: "audio/" + format, Data: audioData, Format: format},
 				ReplyCtx: rctx,
 			})


### PR DESCRIPTION
## Summary
WeCom 文本里常会带上 `@robot_id` / `＠robot_id`。Core 里权限确认是整句精确匹配，用户回复「允许 @机器人」时无法匹配「允许」。

本 PR **仅在企微平台** 在入站消息进入引擎前剥掉已配置的机器人 id 提及（WebSocket 用 `bot_id` + `aibotid`，HTTP 回调用 `agent_id`），文本与语音转写均处理。

## Scope
- 只改 `platform/wecom/`，不动 core。

## Limitations
- 仅剥 `@` / `＠` + 配置里的 id；若客户端展示的是中文昵称且与 id 不一致，可能需要后续加别名配置。

## Testing
- `go test ./platform/wecom/ -v`
- `go test ./...`

Fixes #98

Made with [Cursor](https://cursor.com)