### PR TITLE
fix(daemon): macOS launchd do not respawn on clean exit (#153)

### DIFF
--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -171,7 +171,10 @@ func buildPlist(cfg Config) string {
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
-	<true/>
+	<dict>
+		<key>SuccessfulExit</key>
+		<true/>
+	</dict>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>CC_LOG_FILE</key>

--- a/daemon/launchd_test.go
+++ b/daemon/launchd_test.go
@@ -1,0 +1,26 @@
+//go:build darwin
+
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPlist_KeepAliveDoesNotRestartOnCleanExit(t *testing.T) {
+	cfg := Config{
+		BinaryPath: "/opt/cc-connect/cc-connect",
+		WorkDir:    "/tmp/wd",
+		LogFile:    "/tmp/log",
+		LogMaxSize: 10485760,
+		EnvPATH:    "/usr/bin",
+	}
+	xml := buildPlist(cfg)
+	if !strings.Contains(xml, "<key>SuccessfulExit</key>") {
+		t.Fatal("plist should use KeepAlive dict with SuccessfulExit so exit 0 does not respawn")
+	}
+	// Boolean KeepAlive causes launchd to restart after every exit, including SIGTERM shutdown.
+	if strings.Contains(xml, "<key>KeepAlive</key>\n\t<true/>") {
+		t.Fatal("plist must not use boolean KeepAlive true")
+	}
+}


### PR DESCRIPTION
## 问题（#153）
macOS 下 `daemon install` 生成的 LaunchAgent 使用 `KeepAlive` 布尔 `true`。按 launchd 语义，这会在**进程每次退出后都重启**，包括收到 SIGTERM 后正常退出（日志里先 `shutting down...` 很快又 `config loaded`）。若外部逻辑等待 `api.sock` 消失，可能出现「stop 卡住」的现象。

## 修改
将 `KeepAlive` 改为字典形式并设置 `SuccessfulExit` 为 `true`：仅在**非干净退出**（如崩溃、非零退出码）时由 launchd 拉起进程，与 Linux systemd 单元里的 `Restart=on-failure` 语义对齐。

## 已有安装
需重新写入 plist：`cc-connect daemon install --force`（或先 uninstall 再 install）。

## 测试
- `go test ./...`（Linux 上 darwin 单测按 build tag 跳过）
- 新增 `daemon/launchd_test.go`（`//go:build darwin`）在 macOS 上校验 plist 片段

Fixes #153

Made with [Cursor](https://cursor.com)