### PR TITLE
fix: resolve workspace for cron jobs in multi-workspace mode

### DIFF
--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -530,3 +530,73 @@ func TestCronStore_ListByProject(t *testing.T) {
 		t.Errorf("ListByProject(nonexistent) = %d jobs, want 0", len(list3))
 	}
 }
+
+// TestExecuteCronJob_MultiWorkspace_NoBinding verifies that in multi-workspace
+// mode, ExecuteCronJob returns an error when the channel has no workspace binding
+// (regression test for #302: cron responses not delivered because workspace
+// resolution was skipped entirely).
+func TestExecuteCronJob_MultiWorkspace_NoBinding(t *testing.T) {
+	p := &cronTestPlatform{name: "slack"}
+	e := NewEngine("test", &stubCronAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetMultiWorkspace(t.TempDir(), "")
+
+	job := &CronJob{
+		ID:         "j1",
+		Project:    "test",
+		SessionKey: "slack:C123:U456",
+		Prompt:     "hello",
+		Enabled:    true,
+	}
+
+	err := e.ExecuteCronJob(job)
+	if err == nil {
+		t.Fatal("expected error for unbound channel, got nil")
+	}
+	if !strings.Contains(err.Error(), "no workspace bound") {
+		t.Fatalf("expected 'no workspace bound' error, got: %v", err)
+	}
+}
+
+// cronTestPlatform is a minimal platform stub that implements
+// ReplyContextReconstructor for cron tests.
+type cronTestPlatform struct {
+	name string
+	sent []string
+}
+
+func (p *cronTestPlatform) Name() string               { return p.name }
+func (p *cronTestPlatform) Start(MessageHandler) error { return nil }
+func (p *cronTestPlatform) Reply(_ context.Context, _ any, content string) error {
+	p.sent = append(p.sent, content)
+	return nil
+}
+func (p *cronTestPlatform) Send(_ context.Context, _ any, content string) error {
+	p.sent = append(p.sent, content)
+	return nil
+}
+func (p *cronTestPlatform) Stop() error { return nil }
+func (p *cronTestPlatform) ReconstructReplyCtx(sessionKey string) (any, error) {
+	return "reconstructed:" + sessionKey, nil
+}
+
+type stubCronAgent struct{}
+
+func (a *stubCronAgent) Name() string { return "stub" }
+func (a *stubCronAgent) StartSession(_ context.Context, _ string) (AgentSession, error) {
+	return &stubCronAgentSession{}, nil
+}
+func (a *stubCronAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) {
+	return nil, nil
+}
+func (a *stubCronAgent) Stop() error { return nil }
+
+type stubCronAgentSession struct{}
+
+func (s *stubCronAgentSession) Send(_ string, _ []ImageAttachment, _ []FileAttachment) error {
+	return nil
+}
+func (s *stubCronAgentSession) RespondPermission(_ string, _ PermissionResult) error { return nil }
+func (s *stubCronAgentSession) Events() <-chan Event                                 { return make(chan Event) }
+func (s *stubCronAgentSession) CurrentSessionID() string                             { return "cron-session" }
+func (s *stubCronAgentSession) Alive() bool                                          { return true }
+func (s *stubCronAgentSession) Close() error                                         { return nil }

--- a/core/engine.go
+++ b/core/engine.go
@@ -743,7 +743,22 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		}
 	}
 	if targetPlatform == nil {
-		return fmt.Errorf("platform %q not found for session %q", platformName, sessionKey)
+		// In multi-workspace mode, legacy cron jobs may have a workspace-prefixed
+		// session key (e.g. "/home/user/workspace:slack:C123:U456") from before the
+		// fix that passes bare session keys. Strip the prefix and retry.
+		if e.multiWorkspace {
+			for _, p := range e.platforms {
+				if idx := strings.Index(sessionKey, ":"+p.Name()+":"); idx >= 0 {
+					sessionKey = sessionKey[idx+1:]
+					platformName = p.Name()
+					targetPlatform = p
+					break
+				}
+			}
+		}
+		if targetPlatform == nil {
+			return fmt.Errorf("platform %q not found for session %q", platformName, sessionKey)
+		}
 	}
 
 	rc, ok := targetPlatform.(ReplyContextReconstructor)

--- a/core/engine.go
+++ b/core/engine.go
@@ -807,6 +807,38 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		return e.executeCronShell(effectivePlatform, replyCtx, job)
 	}
 
+	// Resolve workspace-specific agent and sessions in multi-workspace mode.
+	// Without this, cron jobs use the engine-level agent (wrong workDir) and
+	// a bare interactiveKey that doesn't match the user's prefixed key,
+	// causing responses to be lost.
+	agent := e.agent
+	sessions := e.sessions
+	interactiveKey := sessionKey
+	workspaceDir := ""
+	if e.multiWorkspace {
+		channelID := extractChannelID(sessionKey)
+		workspace, _, err := e.resolveWorkspace(targetPlatform, channelID)
+		if err != nil {
+			return fmt.Errorf("cron: workspace resolution failed for %q: %w", sessionKey, err)
+		}
+		if workspace == "" {
+			return fmt.Errorf("cron: no workspace bound for channel %q", channelID)
+		}
+		workspaceDir = workspace
+		interactiveKey = workspace + ":" + sessionKey
+
+		if ws := e.workspacePool.Get(workspace); ws != nil {
+			ws.Touch()
+		}
+
+		wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(workspace)
+		if err != nil {
+			return fmt.Errorf("cron: failed to create workspace agent for %q: %w", workspace, err)
+		}
+		agent = wsAgent
+		sessions = wsSessions
+	}
+
 	msg := &Message{
 		SessionKey: sessionKey,
 		Platform:   platformName,
@@ -818,21 +850,21 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 
 	if job.UsesNewSessionPerRun() {
 		msg.SessionKey = runSessionKey
-		session := e.sessions.NewSideSession(runSessionKey, "cron-"+job.ID)
+		session := sessions.NewSideSession(runSessionKey, "cron-"+job.ID)
 		if !session.TryLock() {
 			return fmt.Errorf("session %q is busy", runSessionKey)
 		}
-		iKey := fmt.Sprintf("%s#cron:%s", runSessionKey, session.ID)
-		e.processInteractiveMessageWith(effectivePlatform, msg, session, e.agent, e.sessions, iKey, "", runSessionKey)
+		iKey := fmt.Sprintf("%s#cron:%s", interactiveKey, session.ID)
+		e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, runSessionKey)
 		return nil
 	}
 
-	session := e.sessions.GetOrCreateActive(sessionKey)
+	session := sessions.GetOrCreateActive(sessionKey)
 	if !session.TryLock() {
 		return fmt.Errorf("session %q is busy", sessionKey)
 	}
 
-	e.processInteractiveMessageWith(effectivePlatform, msg, session, e.agent, e.sessions, sessionKey, "", sessionKey)
+	e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, interactiveKey, workspaceDir, sessionKey)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #302 — cron-triggered responses not delivered to messaging platform.

• In multi-workspace mode, `ExecuteCronJob` was using the engine-level agent and session manager instead of the workspace-specific ones
• The `interactiveKey` was bare (`slack:channel:user`) instead of prefixed with the workspace path, creating an orphaned state disconnected from the user's conversation
• Now resolves the workspace binding and uses the correct per-workspace agent, sessions, and `interactiveKey` — mirroring what `handleMessage` already does for user messages

## Root cause

When a cron fires in multi-workspace mode, it needs the same workspace resolution that user messages get. Without it:

1. The agent has no workspace context (wrong `workDir`) — Claude Code can't find the project files
2. The `interactiveKey` doesn't match the user's conversation key — creates a separate orphaned `interactiveState`
3. The session manager is engine-level, not workspace-specific — session tracking is broken

One-shot crons worked intermittently because on a fresh start with no active conversation, the bare key didn't conflict.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./core/ ./agent/claudecode/` passes (636 tests)
- [x] New regression test: `TestExecuteCronJob_MultiWorkspace_NoBinding` — verifies cron returns error for unbound channel instead of silently failing
- [ ] Manual: set up recurring cron in multi-workspace mode, verify responses are delivered to Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)