### PR TITLE
feat(feishu): card header status colors

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2252,6 +2252,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		case EventText:
 			if event.Content != "" {
+				if len(textParts) == 0 {
+					sp.setStatus(CardStatusWorking)
+				}
 				textParts = append(textParts, event.Content)
 				if sp.canPreview() {
 					sp.appendText(event.Content)
@@ -2430,14 +2433,17 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			} else if suppressDuplicate {
 				sp.discard()
 				slog.Debug("EventResult: suppressed duplicate side-channel text", "response_len", len(fullResponse))
-			} else if sp.finish(fullResponse) {
-				slog.Debug("EventResult: finalized via stream preview", "response_len", len(fullResponse))
 			} else {
-				slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "chunks", len(splitMessage(fullResponse, maxPlatformMessageLen)))
-				for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
-					if err := p.Send(e.ctx, replyCtx, chunk); err != nil {
-						slog.Error("failed to send reply", "error", err, "msg_id", msgID)
-						return
+				sp.setStatus(CardStatusDone)
+				if sp.finish(fullResponse) {
+					slog.Debug("EventResult: finalized via stream preview", "response_len", len(fullResponse))
+				} else {
+					slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "chunks", len(splitMessage(fullResponse, maxPlatformMessageLen)))
+					for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+						if err := p.Send(e.ctx, replyCtx, chunk); err != nil {
+							slog.Error("failed to send reply", "error", err, "msg_id", msgID)
+							return
+						}
 					}
 				}
 			}
@@ -2559,7 +2565,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			return
 
 		case EventError:
-			sp.discard()
+			sp.setStatus(CardStatusError)
+			sp.finish(sp.getFullText())
 			if event.Error != nil {
 				slog.Error("agent error", "error", event.Error)
 				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), event.Error))
@@ -2598,11 +2605,14 @@ channelClosed:
 					}
 				}
 			}
-		} else if sp.finish(fullResponse) {
-			slog.Debug("stream preview: finalized in-place (process exited)")
 		} else {
-			for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
-				e.send(p, replyCtx, chunk)
+			sp.setStatus(CardStatusDone)
+			if sp.finish(fullResponse) {
+				slog.Debug("stream preview: finalized in-place (process exited)")
+			} else {
+				for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+					e.send(p, replyCtx, chunk)
+				}
 			}
 		}
 	}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -411,3 +411,19 @@ type CommandRegistrar interface {
 type ChannelNameResolver interface {
 	ResolveChannelName(channelID string) (string, error)
 }
+
+// CardStatus represents the visual status of a card header.
+type CardStatus string
+
+const (
+	CardStatusThinking CardStatus = "thinking" // grey
+	CardStatusWorking  CardStatus = "working"  // blue
+	CardStatusDone     CardStatus = "done"     // green
+	CardStatusError    CardStatus = "error"    // red
+)
+
+// PreviewStatusUpdater is an optional interface for platforms that support
+// updating the visual status of a preview card header.
+type PreviewStatusUpdater interface {
+	SetPreviewStatus(previewHandle any, status CardStatus)
+}

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -48,6 +48,8 @@ type streamPreview struct {
 
 	timer     *time.Timer
 	timerStop chan struct{} // closed when preview ends
+
+	pendingStatus CardStatus // last status set via setStatus(); applied on recovery
 }
 
 // PreviewStarter is an optional interface for platforms that can initiate a
@@ -343,8 +345,35 @@ func (sp *streamPreview) finish(finalText string) bool {
 		}
 		return false
 	}
+	if sp.pendingStatus != "" {
+		if statusUpdater, ok := sp.platform.(PreviewStatusUpdater); ok {
+			statusUpdater.SetPreviewStatus(sp.previewMsgID, sp.pendingStatus)
+		}
+	}
 	slog.Debug("stream preview finish: success via UpdateMessage")
 	return true
+}
+
+// setStatus updates the card header status of the active preview message.
+// If the preview is not yet active or is degraded, the status is saved and
+// applied when the preview recovers (at finish time).
+func (sp *streamPreview) setStatus(status CardStatus) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.pendingStatus = status
+	if sp.previewMsgID == nil || sp.degraded {
+		return
+	}
+	if updater, ok := sp.platform.(PreviewStatusUpdater); ok {
+		updater.SetPreviewStatus(sp.previewMsgID, status)
+	}
+}
+
+// getFullText returns the accumulated text so far.
+func (sp *streamPreview) getFullText() string {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.fullText
 }
 
 // detachPreview clears the preview message handle so that finish() won't

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1303,7 +1303,7 @@ func buildReplyContent(content string) (msgType string, body string) {
 	// 2. Many \n\n paragraphs (help, status, etc.) → post rich-text (preserves blank lines)
 	// 3. Other markdown → post md tag (best native rendering)
 	if hasComplexMarkdown(content) {
-		return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)))
+		return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)), core.CardStatusDone)
 	}
 	if strings.Count(content, "\n\n") >= 2 {
 		return larkim.MsgTypePost, buildPostJSON(content)
@@ -1770,18 +1770,34 @@ func isThreadSessionKey(sessionKey string) bool {
 
 // feishuPreviewHandle stores the message ID for an editable preview message.
 type feishuPreviewHandle struct {
-	messageID string
-	chatID    string
+	mu          sync.Mutex
+	messageID   string
+	chatID      string
+	status      core.CardStatus
+	lastContent string
 }
 
 // buildCardJSON builds a Feishu interactive card JSON string with a markdown element.
 // Uses schema 2.0 which supports code blocks, tables, and inline formatting.
 // Card font is inherently smaller than Post/Text — this is a Feishu platform limitation.
-func buildCardJSON(content string) string {
+func buildCardJSON(content string, status core.CardStatus) string {
+	template := "grey"
+	switch status {
+	case core.CardStatusWorking:
+		template = "blue"
+	case core.CardStatusDone:
+		template = "green"
+	case core.CardStatusError:
+		template = "red"
+	}
 	card := map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
 			"wide_screen_mode": true,
+		},
+		"header": map[string]any{
+			"template": template,
+			"title":    map[string]any{"tag": "plain_text", "content": ""},
 		},
 		"body": map[string]any{
 			"elements": []map[string]any{
@@ -1814,7 +1830,7 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 		return nil, fmt.Errorf("%s: chatID is empty", p.tag())
 	}
 
-	cardJSON := buildCardJSON(sanitizeMarkdownURLs(content))
+	cardJSON := buildCardJSON(sanitizeMarkdownURLs(content), core.CardStatusThinking)
 
 	var msgID string
 	if p.shouldUseThreadOrReplyAPI(rc) {
@@ -1870,11 +1886,16 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 		return fmt.Errorf("%s: invalid preview handle type %T", p.tag(), previewHandle)
 	}
 
+	h.mu.Lock()
+	h.lastContent = content
+	status := h.status
+	h.mu.Unlock()
+
 	processed := content
 	if containsMarkdown(content) {
 		processed = preprocessFeishuMarkdown(content)
 	}
-	cardJSON := buildCardJSON(sanitizeMarkdownURLs(processed))
+	cardJSON := buildCardJSON(sanitizeMarkdownURLs(processed), status)
 	resp, err := p.client.Im.Message.Patch(ctx, larkim.NewPatchMessageReqBuilder().
 		MessageId(h.messageID).
 		Body(larkim.NewPatchMessageReqBodyBuilder().
@@ -1888,6 +1909,41 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 		return fmt.Errorf("%s: patch message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
 	}
 	return nil
+}
+
+// SetPreviewStatus updates the card header color to reflect the agent's current state.
+func (p *Platform) SetPreviewStatus(previewHandle any, status core.CardStatus) {
+	h, ok := previewHandle.(*feishuPreviewHandle)
+	if !ok {
+		return
+	}
+
+	h.mu.Lock()
+	h.status = status
+	lastContent := h.lastContent
+	h.mu.Unlock()
+
+	if lastContent == "" {
+		return
+	}
+	cardJSON := buildCardJSON(lastContent, status)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := p.client.Im.Message.Patch(ctx, larkim.NewPatchMessageReqBuilder().
+		MessageId(h.messageID).
+		Body(larkim.NewPatchMessageReqBodyBuilder().
+			Content(cardJSON).
+			Build()).
+		Build())
+	if err != nil {
+		slog.Debug("feishu: set preview status patch failed", "error", err)
+		return
+	}
+	if !resp.Success() {
+		slog.Debug("feishu: set preview status patch failed", "code", resp.Code, "msg", resp.Msg)
+	}
 }
 
 func (p *Platform) Stop() error {


### PR DESCRIPTION
## Summary

- Add dynamic card header color to visually indicate agent processing state
- **Blue** (working): first text output received — agent is generating
- **Green** (done): response complete
- **Red** (error): agent error occurred
- Grey (thinking): initial preview before any output

## Changes

- `core/interfaces.go`: `CardStatus` enum + `PreviewStatusUpdater` optional interface
- `core/streaming.go`: `setStatus()`/`getFullText()` methods on `streamPreview`, `pendingStatus` recovery at finish time
- `core/engine.go`: wire status transitions at `EventText` (first chunk → Working), `EventResult` (→ Done), `EventError` (→ Error + finish with accumulated text)
- `platform/feishu/feishu.go`: `buildCardJSON` now accepts status and renders a colored header; `feishuPreviewHandle` gains mutex-protected `status`/`lastContent` fields; new `SetPreviewStatus` method

## Design

Follows the existing optional-interface pattern (`PreviewStatusUpdater` alongside `PreviewStarter`/`PreviewCleaner`). Other platforms are unaffected — they simply don't implement the interface.

## Test plan

- [x] `go build ./cmd/cc-connect/` passes
- [x] `go test ./platform/feishu/...` passes
- [x] `go test ./core/...` — one pre-existing failure (`TestCmdShell_MultiWorkspaceIgnoresMissingSharedBinding`) unrelated to this PR
- [x] Manual verification: send message in Feishu, observe grey → blue → green header transition