### PR TITLE
feat(discord): 支持通过 bot 给用户发送文件

### DIFF
--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -796,6 +796,62 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 	}
 }
 
+func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachment) error {
+	name := file.FileName
+	if name == "" {
+		name = "attachment"
+	}
+
+	newFile := func() *discordgo.File {
+		return &discordgo.File{
+			Name:        name,
+			ContentType: file.MimeType,
+			Reader:      bytes.NewReader(file.Data),
+		}
+	}
+
+	switch rc := rctx.(type) {
+	case *interactionReplyCtx:
+		rc.mu.Lock()
+		first := !rc.firstDone
+		if first {
+			rc.firstDone = true
+		}
+		rc.mu.Unlock()
+
+		var err error
+		if first {
+			_, err = p.session.InteractionResponseEdit(rc.interaction, &discordgo.WebhookEdit{
+				Files: []*discordgo.File{newFile()},
+			})
+		} else {
+			_, err = p.session.FollowupMessageCreate(rc.interaction, true, &discordgo.WebhookParams{
+				Files: []*discordgo.File{newFile()},
+			})
+		}
+		if err != nil {
+			slog.Warn("discord: interaction file failed, falling back to channel message", "error", err)
+			_, err = p.session.ChannelMessageSendComplex(rc.channelID, &discordgo.MessageSend{
+				Files: []*discordgo.File{newFile()},
+			})
+			if err != nil {
+				return fmt.Errorf("discord: send file fallback: %w", err)
+			}
+		}
+		return nil
+	case replyContext:
+		_, err := p.session.ChannelMessageSendComplex(rc.targetChannelID(), &discordgo.MessageSend{
+			Files: []*discordgo.File{newFile()},
+		})
+		if err != nil {
+			return fmt.Errorf("discord: send file: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("discord: SendFile: invalid reply context type %T", rctx)
+	}
+}
+
 func buildDiscordActionRows(rows [][]core.ButtonOption) []discordgo.MessageComponent {
 	components := make([]discordgo.MessageComponent, 0, len(rows))
 	for _, row := range rows {
@@ -850,6 +906,7 @@ func (p *Platform) SendWithButtons(ctx context.Context, rctx any, content string
 }
 
 var _ core.ImageSender = (*Platform)(nil)
+var _ core.FileSender = (*Platform)(nil)
 var _ core.InlineButtonSender = (*Platform)(nil)
 
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -391,6 +391,92 @@ func TestSendWithButtons_PreservesMultipleRows(t *testing.T) {
 	}
 }
 
+func TestSendFile_SendsChannelAttachment(t *testing.T) {
+	var contentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType = r.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg-file","channel_id":"ch-1"}`)
+	}))
+	defer server.Close()
+
+	oldEndpointDiscord := discordgo.EndpointDiscord
+	oldEndpointAPI := discordgo.EndpointAPI
+	oldEndpointChannels := discordgo.EndpointChannels
+	discordgo.EndpointDiscord = server.URL + "/"
+	discordgo.EndpointAPI = discordgo.EndpointDiscord + "api/v" + discordgo.APIVersion + "/"
+	discordgo.EndpointChannels = discordgo.EndpointAPI + "channels/"
+	defer func() {
+		discordgo.EndpointDiscord = oldEndpointDiscord
+		discordgo.EndpointAPI = oldEndpointAPI
+		discordgo.EndpointChannels = oldEndpointChannels
+	}()
+
+	s, err := discordgo.New("Bot test-token")
+	if err != nil {
+		t.Fatalf("discordgo.New() error = %v", err)
+	}
+	s.Client = server.Client()
+
+	p := &Platform{session: s}
+	err = p.SendFile(context.Background(), replyContext{channelID: "ch-1"}, core.FileAttachment{
+		FileName: "report.pdf",
+		MimeType: "application/pdf",
+		Data:     []byte("pdf-data"),
+	})
+	if err != nil {
+		t.Fatalf("SendFile() error = %v", err)
+	}
+	if !strings.Contains(contentType, "multipart/form-data") {
+		t.Fatalf("content type = %q, want multipart/form-data", contentType)
+	}
+}
+
+func TestSendFile_UsesInteractionEndpoints(t *testing.T) {
+	requests := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg-file","channel_id":"ch-1"}`)
+	}))
+	defer server.Close()
+
+	oldEndpointDiscord := discordgo.EndpointDiscord
+	oldEndpointAPI := discordgo.EndpointAPI
+	oldEndpointChannels := discordgo.EndpointChannels
+	oldEndpointWebhooks := discordgo.EndpointWebhooks
+	discordgo.EndpointDiscord = server.URL + "/"
+	discordgo.EndpointAPI = discordgo.EndpointDiscord + "api/v" + discordgo.APIVersion + "/"
+	discordgo.EndpointChannels = discordgo.EndpointAPI + "channels/"
+	discordgo.EndpointWebhooks = discordgo.EndpointAPI + "webhooks/"
+	defer func() {
+		discordgo.EndpointDiscord = oldEndpointDiscord
+		discordgo.EndpointAPI = oldEndpointAPI
+		discordgo.EndpointChannels = oldEndpointChannels
+		discordgo.EndpointWebhooks = oldEndpointWebhooks
+	}()
+
+	s, err := discordgo.New("Bot test-token")
+	if err != nil {
+		t.Fatalf("discordgo.New() error = %v", err)
+	}
+	s.Client = server.Client()
+
+	p := &Platform{session: s}
+	rc := &interactionReplyCtx{interaction: &discordgo.Interaction{AppID: "app-1", Token: "token-1"}}
+	err = p.SendFile(context.Background(), rc, core.FileAttachment{
+		FileName: "report.pdf",
+		MimeType: "application/pdf",
+		Data:     []byte("pdf-data"),
+	})
+	if err != nil {
+		t.Fatalf("SendFile() error = %v", err)
+	}
+	if len(requests) != 1 || !strings.Contains(requests[0], "/messages/@original") {
+		t.Fatalf("requests = %v, want one original interaction edit", requests)
+	}
+}
+
 // ── Dedup tests ──────────────────────────────────────────────
 
 // simulateHandlerCall mimics the dedup + dispatch logic in the MessageCreate


### PR DESCRIPTION
## 概要
- 为 Discord 平台实现 `core.FileSender`，支持通过 bot 回复向用户发送文件附件
- 覆盖普通频道回复和 slash command / interaction 回复两条发送路径
- 补充 Discord 文件发送回归测试

## 测试计划
- [x] go test ./platform/discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)