### PR TITLE
feat(feishu): Card 2.0 rich cards with collapsible panel and streaming

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2035,6 +2035,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	toolCount := 0
 	waitStart := time.Now()
 	firstEventLogged := false
+	var toolSteps []ToolStep
+	var lastRichCardUpdate time.Time
+	var lastRichCardLen int
+	var cardMessageID any
+	var partialText string
 	triggerAutoCompress := false
 	pendingSend := sendDone
 
@@ -2132,10 +2137,21 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		e.quietMu.RUnlock()
 
 		quiet := globalQuiet || sessionQuiet
+		richCardSupporter, hasRichCard := p.(RichCardSupporter)
 
 		switch event.Type {
 		case EventThinking:
-			if !quiet && event.Content != "" {
+			if hasRichCard && cardMessageID == nil {
+				card := richCardSupporter.BuildRichCard(CardStatusThinking, "", toolSteps, partialText, true)
+				if starter, ok := p.(PreviewStarter); ok {
+					handle, err := starter.SendPreviewStart(e.ctx, replyCtx, card)
+					if err != nil {
+						slog.Debug("rich card: failed to create initial thinking card", "platform", p.Name(), "error", err)
+					} else {
+						cardMessageID = handle
+					}
+				}
+			} else if !quiet && event.Content != "" {
 				// Flush accumulated text segment before thinking display
 				previewActive := sp.canPreview()
 				if len(textParts) > segmentStart {
@@ -2159,7 +2175,28 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		case EventToolUse:
 			toolCount++
-			if !quiet {
+			if hasRichCard {
+				toolSteps = append(toolSteps, ToolStep{
+					Name:    event.ToolName,
+					Summary: truncateIf(event.ToolInput, e.display.ToolMaxLen),
+				})
+				if cardMessageID == nil {
+					card := richCardSupporter.BuildRichCard(CardStatusWorking, "", toolSteps, partialText, true)
+					if starter, ok := p.(PreviewStarter); ok {
+						handle, err := starter.SendPreviewStart(e.ctx, replyCtx, card)
+						if err != nil {
+							slog.Debug("rich card: failed to create initial tool card", "platform", p.Name(), "error", err)
+						} else {
+							cardMessageID = handle
+						}
+					}
+				} else if updater, ok := p.(MessageUpdater); ok {
+					card := richCardSupporter.BuildRichCard(CardStatusWorking, "", toolSteps, partialText, true)
+					if err := updater.UpdateMessage(e.ctx, cardMessageID, card); err != nil {
+						slog.Debug("rich card: failed to update tool card", "platform", p.Name(), "error", err)
+					}
+				}
+			} else if !quiet {
 				// Flush accumulated text segment before tool display
 				previewActive := sp.canPreview()
 				if len(textParts) > segmentStart {
@@ -2182,7 +2219,6 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				if toolInput == "" {
 					formattedInput = ""
 				} else if strings.Contains(toolInput, "```") {
-					// Already contains code blocks (pre-formatted by agent) — use as-is
 					formattedInput = toolInput
 				} else if strings.Contains(toolInput, "\n") || utf8.RuneCountInString(toolInput) > 200 {
 					lang := toolCodeLang(event.ToolName, toolInput)
@@ -2253,10 +2289,37 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		case EventText:
 			if event.Content != "" {
 				if len(textParts) == 0 {
-					sp.setStatus(CardStatusWorking)
+					if hasRichCard {
+						if cardMessageID == nil {
+							card := richCardSupporter.BuildRichCard(CardStatusWorking, "", toolSteps, partialText, true)
+							if starter, ok := p.(PreviewStarter); ok {
+								handle, err := starter.SendPreviewStart(e.ctx, replyCtx, card)
+								if err != nil {
+									slog.Debug("rich card: failed to create initial text card", "platform", p.Name(), "error", err)
+								} else {
+									cardMessageID = handle
+								}
+							}
+						}
+					} else {
+						sp.setStatus(CardStatusWorking)
+					}
 				}
 				textParts = append(textParts, event.Content)
-				if sp.canPreview() {
+				partialText += event.Content
+				if hasRichCard {
+					if cardMessageID != nil && (time.Since(lastRichCardUpdate) > 1500*time.Millisecond || len(partialText)-lastRichCardLen > 30) {
+						card := richCardSupporter.BuildRichCard(CardStatusWorking, "", toolSteps, partialText, true)
+						if updater, ok := p.(MessageUpdater); ok {
+							if err := updater.UpdateMessage(e.ctx, cardMessageID, card); err == nil {
+								lastRichCardUpdate = time.Now()
+								lastRichCardLen = len(partialText)
+							} else {
+								slog.Debug("rich card: failed to update text card", "platform", p.Name(), "error", err)
+							}
+						}
+					}
+				} else if sp.canPreview() {
 					sp.appendText(event.Content)
 				}
 			}
@@ -2414,10 +2477,36 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			state.sideText = ""
 			state.mu.Unlock()
 
-			// When tool calls happened and prior text was already surfaced in segments,
-			// only send the unsent remainder. In quiet mode, tool events don't surface
-			// side-channel messages and segmentStart stays 0, so keep normal finalize flow.
-			if toolCount > 0 && segmentStart > 0 {
+			if hasRichCard {
+				parts := []string{fullResponse}
+				if splitter, ok := p.(MarkdownTableSplitter); ok {
+					parts = splitter.SplitMarkdownByTables(fullResponse, 5)
+				}
+				finalCard := richCardSupporter.BuildRichCard(CardStatusDone, "", toolSteps, parts[0], false)
+				if cardMessageID != nil {
+					if updater, ok := p.(MessageUpdater); ok {
+						if err := updater.UpdateMessage(e.ctx, cardMessageID, finalCard); err != nil {
+							slog.Debug("rich card: final update failed, falling back to send", "platform", p.Name(), "error", err)
+							if err := p.Send(e.ctx, replyCtx, finalCard); err != nil {
+								slog.Error("failed to send rich card reply", "error", err)
+								return
+							}
+						}
+					}
+				} else {
+					if err := p.Send(e.ctx, replyCtx, finalCard); err != nil {
+						slog.Error("failed to send rich card reply", "error", err)
+						return
+					}
+				}
+				for _, overflow := range parts[1:] {
+					overflowCard := richCardSupporter.BuildRichCard(CardStatusDone, "", nil, overflow, false)
+					if err := p.Send(e.ctx, replyCtx, overflowCard); err != nil {
+						slog.Error("failed to send overflow rich card", "error", err)
+						return
+					}
+				}
+			} else if toolCount > 0 && segmentStart > 0 {
 				sp.discard()
 				if segmentStart < len(textParts) {
 					unsent := strings.Join(textParts[segmentStart:], "")

--- a/core/engine.go
+++ b/core/engine.go
@@ -2252,6 +2252,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		case EventText:
 			if event.Content != "" {
+				if len(textParts) == 0 {
+					sp.setStatus(CardStatusWorking)
+				}
 				textParts = append(textParts, event.Content)
 				if sp.canPreview() {
 					sp.appendText(event.Content)
@@ -2430,14 +2433,17 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			} else if suppressDuplicate {
 				sp.discard()
 				slog.Debug("EventResult: suppressed duplicate side-channel text", "response_len", len(fullResponse))
-			} else if sp.finish(fullResponse) {
-				slog.Debug("EventResult: finalized via stream preview", "response_len", len(fullResponse))
 			} else {
-				slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "chunks", len(splitMessage(fullResponse, maxPlatformMessageLen)))
-				for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
-					if err := p.Send(e.ctx, replyCtx, chunk); err != nil {
-						slog.Error("failed to send reply", "error", err, "msg_id", msgID)
-						return
+				sp.setStatus(CardStatusDone)
+				if sp.finish(fullResponse) {
+					slog.Debug("EventResult: finalized via stream preview", "response_len", len(fullResponse))
+				} else {
+					slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "chunks", len(splitMessage(fullResponse, maxPlatformMessageLen)))
+					for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+						if err := p.Send(e.ctx, replyCtx, chunk); err != nil {
+							slog.Error("failed to send reply", "error", err, "msg_id", msgID)
+							return
+						}
 					}
 				}
 			}
@@ -2559,7 +2565,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			return
 
 		case EventError:
-			sp.discard()
+			sp.setStatus(CardStatusError)
+			sp.finish(sp.getFullText())
 			if event.Error != nil {
 				slog.Error("agent error", "error", event.Error)
 				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), event.Error))
@@ -2598,11 +2605,14 @@ channelClosed:
 					}
 				}
 			}
-		} else if sp.finish(fullResponse) {
-			slog.Debug("stream preview: finalized in-place (process exited)")
 		} else {
-			for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
-				e.send(p, replyCtx, chunk)
+			sp.setStatus(CardStatusDone)
+			if sp.finish(fullResponse) {
+				slog.Debug("stream preview: finalized in-place (process exited)")
+			} else {
+				for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+					e.send(p, replyCtx, chunk)
+				}
 			}
 		}
 	}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -411,3 +411,19 @@ type CommandRegistrar interface {
 type ChannelNameResolver interface {
 	ResolveChannelName(channelID string) (string, error)
 }
+
+// CardStatus represents the visual status of a card header.
+type CardStatus string
+
+const (
+	CardStatusThinking CardStatus = "thinking" // grey
+	CardStatusWorking  CardStatus = "working"  // blue
+	CardStatusDone     CardStatus = "done"     // green
+	CardStatusError    CardStatus = "error"    // red
+)
+
+// PreviewStatusUpdater is an optional interface for platforms that support
+// updating the visual status of a preview card header.
+type PreviewStatusUpdater interface {
+	SetPreviewStatus(previewHandle any, status CardStatus)
+}

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -48,6 +48,8 @@ type streamPreview struct {
 
 	timer     *time.Timer
 	timerStop chan struct{} // closed when preview ends
+
+	pendingStatus CardStatus // last status set via setStatus(); applied on recovery
 }
 
 // PreviewStarter is an optional interface for platforms that can initiate a
@@ -343,8 +345,35 @@ func (sp *streamPreview) finish(finalText string) bool {
 		}
 		return false
 	}
+	if sp.pendingStatus != "" {
+		if statusUpdater, ok := sp.platform.(PreviewStatusUpdater); ok {
+			statusUpdater.SetPreviewStatus(sp.previewMsgID, sp.pendingStatus)
+		}
+	}
 	slog.Debug("stream preview finish: success via UpdateMessage")
 	return true
+}
+
+// setStatus updates the card header status of the active preview message.
+// If the preview is not yet active or is degraded, the status is saved and
+// applied when the preview recovers (at finish time).
+func (sp *streamPreview) setStatus(status CardStatus) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.pendingStatus = status
+	if sp.previewMsgID == nil || sp.degraded {
+		return
+	}
+	if updater, ok := sp.platform.(PreviewStatusUpdater); ok {
+		updater.SetPreviewStatus(sp.previewMsgID, status)
+	}
+}
+
+// getFullText returns the accumulated text so far.
+func (sp *streamPreview) getFullText() string {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.fullText
 }
 
 // detachPreview clears the preview message handle so that finish() won't

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -52,6 +52,24 @@ type streamPreview struct {
 	pendingStatus CardStatus // last status set via setStatus(); applied on recovery
 }
 
+// ToolStep is one summarized tool invocation shown in rich progress cards.
+type ToolStep struct {
+	Name    string // tool name (e.g. "Bash", "Edit")
+	Summary string // human-readable summary shown in the card
+}
+
+// RichCardSupporter is an optional interface for platforms that can build
+// native rich cards combining tool steps and markdown content.
+type RichCardSupporter interface {
+	BuildRichCard(status CardStatus, title string, steps []ToolStep, markdown string, streaming bool) string
+}
+
+// MarkdownTableSplitter is an optional interface for platforms that need
+// platform-specific markdown table chunking before final send.
+type MarkdownTableSplitter interface {
+	SplitMarkdownByTables(md string, maxTables int) []string
+}
+
 // PreviewStarter is an optional interface for platforms that can initiate a
 // streaming preview message and return a handle for subsequent updates.
 type PreviewStarter interface {
@@ -286,6 +304,21 @@ func (sp *streamPreview) finish(finalText string) bool {
 
 	if sp.previewMsgID == nil || sp.degraded {
 		if sp.previewMsgID != nil && sp.degraded {
+			// Try to recover degraded preview via UpdateMessage before falling back to delete
+			if finalText != "" {
+				if updater, ok := sp.platform.(MessageUpdater); ok {
+					if err := updater.UpdateMessage(sp.ctx, sp.previewMsgID, finalText); err == nil {
+						if sp.pendingStatus != "" {
+							if statusUpdater, ok := sp.platform.(PreviewStatusUpdater); ok {
+								statusUpdater.SetPreviewStatus(sp.previewMsgID, sp.pendingStatus)
+							}
+						}
+						return true
+					} else {
+						slog.Debug("stream preview finish: degraded UpdateMessage failed, cleaning up", "error", err)
+					}
+				}
+			}
 			if cleaner, ok := sp.platform.(PreviewCleaner); ok {
 				slog.Debug("stream preview finish: deleting stale preview (degraded)")
 				_ = cleaner.DeletePreviewMessage(sp.ctx, sp.previewMsgID)

--- a/core/streaming_test.go
+++ b/core/streaming_test.go
@@ -210,17 +210,12 @@ func TestStreamPreview_FreezeDeletesOnFinish(t *testing.T) {
 	// Simulate a tool/thinking event → freeze
 	sp.freeze()
 
-	// finish should return false (degraded) and delete the stale preview
+	// With degraded recovery, finish attempts UpdateMessage on the degraded
+	// preview. Since mockCleanerPlatform embeds mockUpdaterPlatform,
+	// UpdateMessage succeeds and finish returns true (recovered).
 	ok := sp.finish("Hello World Final")
-	if ok {
-		t.Error("finish should return false when degraded")
-	}
-
-	mp.mu.Lock()
-	deletedCount := len(mp.deleted)
-	mp.mu.Unlock()
-	if deletedCount != 1 {
-		t.Errorf("expected 1 delete call, got %d", deletedCount)
+	if !ok {
+		t.Error("finish should return true when degraded recovery via UpdateMessage succeeds")
 	}
 }
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1303,7 +1303,7 @@ func buildReplyContent(content string) (msgType string, body string) {
 	// 2. Many \n\n paragraphs (help, status, etc.) → post rich-text (preserves blank lines)
 	// 3. Other markdown → post md tag (best native rendering)
 	if hasComplexMarkdown(content) {
-		return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)))
+		return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)), core.CardStatusDone)
 	}
 	if strings.Count(content, "\n\n") >= 2 {
 		return larkim.MsgTypePost, buildPostJSON(content)
@@ -1770,18 +1770,34 @@ func isThreadSessionKey(sessionKey string) bool {
 
 // feishuPreviewHandle stores the message ID for an editable preview message.
 type feishuPreviewHandle struct {
-	messageID string
-	chatID    string
+	mu          sync.Mutex
+	messageID   string
+	chatID      string
+	status      core.CardStatus
+	lastContent string
 }
 
 // buildCardJSON builds a Feishu interactive card JSON string with a markdown element.
 // Uses schema 2.0 which supports code blocks, tables, and inline formatting.
 // Card font is inherently smaller than Post/Text — this is a Feishu platform limitation.
-func buildCardJSON(content string) string {
+func buildCardJSON(content string, status core.CardStatus) string {
+	template := "grey"
+	switch status {
+	case core.CardStatusWorking:
+		template = "blue"
+	case core.CardStatusDone:
+		template = "green"
+	case core.CardStatusError:
+		template = "red"
+	}
 	card := map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
 			"wide_screen_mode": true,
+		},
+		"header": map[string]any{
+			"template": template,
+			"title":    map[string]any{"tag": "plain_text", "content": ""},
 		},
 		"body": map[string]any{
 			"elements": []map[string]any{
@@ -1814,7 +1830,7 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 		return nil, fmt.Errorf("%s: chatID is empty", p.tag())
 	}
 
-	cardJSON := buildCardJSON(sanitizeMarkdownURLs(content))
+	cardJSON := buildCardJSON(sanitizeMarkdownURLs(content), core.CardStatusThinking)
 
 	var msgID string
 	if p.shouldUseThreadOrReplyAPI(rc) {
@@ -1870,11 +1886,16 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 		return fmt.Errorf("%s: invalid preview handle type %T", p.tag(), previewHandle)
 	}
 
+	h.mu.Lock()
+	h.lastContent = content
+	status := h.status
+	h.mu.Unlock()
+
 	processed := content
 	if containsMarkdown(content) {
 		processed = preprocessFeishuMarkdown(content)
 	}
-	cardJSON := buildCardJSON(sanitizeMarkdownURLs(processed))
+	cardJSON := buildCardJSON(sanitizeMarkdownURLs(processed), status)
 	resp, err := p.client.Im.Message.Patch(ctx, larkim.NewPatchMessageReqBuilder().
 		MessageId(h.messageID).
 		Body(larkim.NewPatchMessageReqBodyBuilder().
@@ -1888,6 +1909,41 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 		return fmt.Errorf("%s: patch message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
 	}
 	return nil
+}
+
+// SetPreviewStatus updates the card header color to reflect the agent's current state.
+func (p *Platform) SetPreviewStatus(previewHandle any, status core.CardStatus) {
+	h, ok := previewHandle.(*feishuPreviewHandle)
+	if !ok {
+		return
+	}
+
+	h.mu.Lock()
+	h.status = status
+	lastContent := h.lastContent
+	h.mu.Unlock()
+
+	if lastContent == "" {
+		return
+	}
+	cardJSON := buildCardJSON(lastContent, status)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := p.client.Im.Message.Patch(ctx, larkim.NewPatchMessageReqBuilder().
+		MessageId(h.messageID).
+		Body(larkim.NewPatchMessageReqBodyBuilder().
+			Content(cardJSON).
+			Build()).
+		Build())
+	if err != nil {
+		slog.Debug("feishu: set preview status patch failed", "error", err)
+		return
+	}
+	if !resp.Success() {
+		slog.Debug("feishu: set preview status patch failed", "code", resp.Code, "msg", resp.Msg)
+	}
 }
 
 func (p *Platform) Stop() error {

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1831,6 +1831,16 @@ type feishuPreviewHandle struct {
 // buildCardJSON builds a Feishu interactive card JSON string with a markdown element.
 // Uses schema 2.0 which supports code blocks, tables, and inline formatting.
 // Card font is inherently smaller than Post/Text — this is a Feishu platform limitation.
+
+// isCardJSON returns true if content looks like a complete Feishu card JSON
+// (has "schema" and "body"). Used to avoid double-wrapping rich card output.
+func isCardJSON(content string) bool {
+	if len(content) < 10 || content[0] != '{' {
+		return false
+	}
+	return strings.Contains(content, `"schema"`) && strings.Contains(content, `"body"`)
+}
+
 func buildCardJSON(content string, status core.CardStatus) string {
 	template := "grey"
 	switch status {
@@ -2028,7 +2038,12 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 		return nil, fmt.Errorf("%s: chatID is empty", p.tag())
 	}
 
-	cardJSON := buildCardJSON(sanitizeMarkdownURLs(content), core.CardStatusThinking)
+	var cardJSON string
+	if isCardJSON(content) {
+		cardJSON = content
+	} else {
+		cardJSON = buildCardJSON(sanitizeMarkdownURLs(content), core.CardStatusThinking)
+	}
 
 	var msgID string
 	if p.shouldUseThreadOrReplyAPI(rc) {
@@ -2089,11 +2104,16 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 	status := h.status
 	h.mu.Unlock()
 
-	processed := content
-	if containsMarkdown(content) {
-		processed = preprocessFeishuMarkdown(content)
+	var cardJSON string
+	if isCardJSON(content) {
+		cardJSON = content
+	} else {
+		processed := content
+		if containsMarkdown(content) {
+			processed = preprocessFeishuMarkdown(content)
+		}
+		cardJSON = buildCardJSON(sanitizeMarkdownURLs(processed), status)
 	}
-	cardJSON := buildCardJSON(sanitizeMarkdownURLs(processed), status)
 	resp, err := p.client.Im.Message.Patch(ctx, larkim.NewPatchMessageReqBuilder().
 		MessageId(h.messageID).
 		Body(larkim.NewPatchMessageReqBodyBuilder().

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -98,6 +98,51 @@ func init() {
 	})
 }
 
+var toolIconMap = map[string]string{
+	"Bash":      "terminal-two_outlined",
+	"Edit":      "edit_outlined",
+	"Read":      "file-open_outlined",
+	"Write":     "notes_outlined",
+	"Glob":      "folder-open_outlined",
+	"Grep":      "search_outlined",
+	"WebFetch":  "internet_outlined",
+	"WebSearch": "internet_outlined",
+	"Agent":     "robot_outlined",
+	"Skill":     "code_outlined",
+	"LSP":       "code_outlined",
+}
+
+const defaultToolIcon = "setting-inter_outlined"
+
+var thinkingVerbs = []string{
+	"Churning", "Clauding", "Coalescing", "Cogitating", "Computing",
+	"Combobulating", "Concocting", "Conjuring", "Considering", "Contemplating",
+	"Cooking", "Crafting", "Creating", "Crunching", "Deciphering",
+	"Deliberating", "Divining", "Effecting", "Elucidating", "Enchanting",
+	"Envisioning", "Finagling", "Forging", "Generating", "Germinating",
+	"Hatching", "Ideating", "Imagining", "Incubating", "Inferring",
+	"Manifesting", "Marinating", "Meandering", "Mulling", "Musing",
+	"Noodling", "Percolating", "Perusing", "Pondering", "Processing",
+	"Puzzling", "Reticulating", "Ruminating", "Scheming", "Simmering",
+	"Spelunking", "Spinning", "Stewing", "Sussing", "Synthesizing",
+	"Thinking", "Tinkering", "Transmuting", "Unfurling", "Unravelling",
+	"Vibing", "Wandering", "Whirring", "Wizarding", "Working", "Wrangling",
+}
+
+func pickThinkingVerb() string {
+	idx := time.Now().Unix() % int64(len(thinkingVerbs))
+	return thinkingVerbs[idx] + "..."
+}
+
+var markdownTablePattern = regexp.MustCompile(`(?m)^\|.+\|\s*\n\|[\s:|-]+\|\s*\n(?:\|.+\|\s*\n?)+`)
+
+func getToolIcon(toolName string) string {
+	if icon, ok := toolIconMap[toolName]; ok {
+		return icon
+	}
+	return defaultToolIcon
+}
+
 type replyContext struct {
 	messageID  string
 	chatID     string
@@ -115,7 +160,8 @@ type Platform struct {
 	allowFrom             string
 	groupReplyAll         bool
 	shareSessionInChannel bool
-	threadIsolation       bool
+	threadIsolation    bool
+	alwaysThreadReply  bool // when true, ReplyInThread for all chats including p2p
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
 	noReplyToTrigger bool
 	client           *lark.Client
@@ -165,6 +211,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
+	alwaysThreadReply, _ := opts["always_thread_reply"].(bool)
 	noReplyToTrigger := false
 	if v, ok := opts["reply_to_trigger"].(bool); ok && !v {
 		noReplyToTrigger = true
@@ -201,6 +248,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		groupReplyAll:         groupReplyAll,
 		shareSessionInChannel: shareSessionInChannel,
 		threadIsolation:       threadIsolation,
+		alwaysThreadReply:     alwaysThreadReply,
 		noReplyToTrigger:      noReplyToTrigger,
 		client:                lark.NewClient(appID, appSecret, clientOpts...),
 		port:                  port,
@@ -1682,6 +1730,9 @@ func (p *Platform) shouldReplyInThread(rc replyContext) bool {
 	if rc.messageID == "" {
 		return false
 	}
+	if p.alwaysThreadReply {
+		return true
+	}
 	return p.threadIsolation && isThreadSessionKey(rc.sessionKey)
 }
 
@@ -1810,6 +1861,153 @@ func buildCardJSON(content string, status core.CardStatus) string {
 	}
 	b, _ := json.Marshal(card)
 	return string(b)
+}
+
+func buildRichCard(status core.CardStatus, _ string, steps []core.ToolStep, markdown string, streaming bool) string {
+	panelTitle := "Thinking..."
+	if len(steps) > 0 {
+		if streaming {
+			panelTitle = fmt.Sprintf("Working on it (%d steps)", len(steps))
+		} else {
+			toolCounts := make(map[string]int)
+			var toolOrder []string
+			for _, s := range steps {
+				if toolCounts[s.Name] == 0 {
+					toolOrder = append(toolOrder, s.Name)
+				}
+				toolCounts[s.Name]++
+			}
+			var toolParts []string
+			for _, name := range toolOrder {
+				if toolCounts[name] > 1 {
+					toolParts = append(toolParts, fmt.Sprintf("%s×%d", name, toolCounts[name]))
+				} else {
+					toolParts = append(toolParts, name)
+				}
+			}
+			toolSummary := strings.Join(toolParts, ", ")
+			preview := strings.TrimSpace(markdown)
+			if idx := strings.IndexByte(preview, '\n'); idx > 0 {
+				preview = preview[:idx]
+			}
+			if runes := []rune(preview); len(runes) > 20 {
+				preview = string(runes[:20]) + "..."
+			}
+			if preview != "" {
+				panelTitle = fmt.Sprintf("%s · %s", toolSummary, preview)
+			} else {
+				panelTitle = toolSummary
+			}
+		}
+	}
+
+	panelCap := len(steps)
+	if panelCap < 1 {
+		panelCap = 1
+	}
+	panelElements := make([]map[string]any, 0, panelCap)
+	if len(steps) == 0 {
+		panelElements = append(panelElements, map[string]any{
+			"tag":  "div",
+			"text": map[string]any{"tag": "plain_text", "content": "Thinking..."},
+		})
+	} else {
+		for _, step := range steps {
+			summary := strings.TrimSpace(step.Summary)
+			if summary == "" {
+				summary = step.Name
+			}
+			panelElements = append(panelElements, map[string]any{
+				"tag":  "div",
+				"icon": map[string]any{"tag": "standard_icon", "token": getToolIcon(step.Name)},
+				"text": map[string]any{"tag": "plain_text", "content": summary},
+			})
+		}
+	}
+
+	panelMap := map[string]any{
+		"tag":              "collapsible_panel",
+		"expanded":         streaming,
+		"background_color": "grey",
+		"header": map[string]any{
+			"title": map[string]any{"tag": "plain_text", "content": panelTitle},
+		},
+		"border":           map[string]any{"color": "grey"},
+		"vertical_spacing": "8px",
+		"padding":          "4px 8px",
+		"elements":         panelElements,
+	}
+	markdownMap := map[string]any{
+		"tag":     "markdown",
+		"content": preprocessFeishuMarkdown(markdown),
+	}
+
+	var elements []map[string]any
+	if len(steps) > 0 || streaming {
+		elements = append(elements, panelMap, markdownMap)
+	} else {
+		elements = append(elements, markdownMap)
+	}
+
+	card := map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{
+			"streaming_mode":             streaming,
+			"update_multi":               true,
+			"enable_forward_interaction": true,
+		},
+		"body": map[string]any{"elements": elements},
+	}
+
+	if streaming {
+		card["header"] = map[string]any{
+			"template": "blue",
+			"title":    map[string]any{"tag": "plain_text", "content": pickThinkingVerb()},
+		}
+	}
+
+	b, err := json.Marshal(card)
+	if err != nil {
+		slog.Debug("feishu: build rich card marshal failed, fallback to basic card", "error", err)
+		return buildCardJSON(preprocessFeishuMarkdown(markdown), status)
+	}
+	return string(b)
+}
+
+func splitMarkdownByTables(md string, maxTables int) []string {
+	if maxTables <= 0 {
+		return []string{md}
+	}
+	matches := markdownTablePattern.FindAllStringIndex(md, -1)
+	if len(matches) <= maxTables {
+		return []string{md}
+	}
+	parts := make([]string, 0, len(matches)-maxTables+1)
+	firstEnd := len(md)
+	if len(matches) > maxTables {
+		firstEnd = matches[maxTables][0]
+	}
+	first := strings.TrimSpace(md[:firstEnd])
+	if first != "" {
+		parts = append(parts, first)
+	}
+	for _, match := range matches[maxTables:] {
+		block := strings.TrimSpace(md[match[0]:match[1]])
+		if block != "" {
+			parts = append(parts, block)
+		}
+	}
+	return parts
+}
+
+// BuildRichCard implements core.RichCardSupporter.
+func (p *Platform) BuildRichCard(status core.CardStatus, title string, steps []core.ToolStep, markdown string, streaming bool) string {
+	return buildRichCard(status, title, steps, markdown, streaming)
+}
+
+// SplitMarkdownByTables implements core.MarkdownTableSplitter.
+func (p *Platform) SplitMarkdownByTables(md string, maxTables int) []string {
+	return splitMarkdownByTables(md, maxTables)
 }
 
 // SendPreviewStart sends a new card message and returns a handle for subsequent edits.


### PR DESCRIPTION
## Summary
- Rich Card 2.0 with `collapsible_panel` for tool steps (icons, summaries), `streaming_mode`, thinking verb header
- Throttled streaming card updates (1500ms / 30 chars threshold)
- `splitMarkdownByTables` to split overflow tables into separate messages
- `isCardJSON()` detection to prevent double-wrapping card JSON in `SendPreviewStart`/`UpdateMessage`
- `always_thread_reply` config for thread reply in single chats (p2p)

Depends on #306 (card header status colors).

## Test plan
- [x] Feishu single chat: card renders with collapsible panel, thinking verb header, streaming updates
- [x] Tool steps show correct icons and summaries in collapsible panel
- [x] Card header color transitions: grey (thinking) → blue (working) → green (done) / red (error)
- [x] Thread reply works in both group and single chats with `always_thread_reply = true`
- [x] Large responses with tables split correctly