### PR TITLE
fix(weixin): fix AESKey encoding to match ilink API format

### DIFF
--- a/platform/weixin/media_outbound.go
+++ b/platform/weixin/media_outbound.go
@@ -104,7 +104,7 @@ func (p *Platform) SendImage(ctx context.Context, replyCtx any, img core.ImageAt
 		ImageItem: &imageItem{
 			Media: &cdnMedia{
 				EncryptQueryParam: ref.downloadParam,
-				AESKey:            base64.StdEncoding.EncodeToString(ref.aesKey),
+				AESKey:            base64.StdEncoding.EncodeToString([]byte(hex.EncodeToString(ref.aesKey))),
 				EncryptType:       1,
 			},
 			MidSize: ref.cipherSize,
@@ -135,7 +135,7 @@ func (p *Platform) SendFile(ctx context.Context, replyCtx any, file core.FileAtt
 		FileItem: &fileItem{
 			Media: &cdnMedia{
 				EncryptQueryParam: ref.downloadParam,
-				AESKey:            base64.StdEncoding.EncodeToString(ref.aesKey),
+				AESKey:            base64.StdEncoding.EncodeToString([]byte(hex.EncodeToString(ref.aesKey))),
 				EncryptType:       1,
 			},
 			FileName: name,


### PR DESCRIPTION
## Summary

- In `SendImage` and `SendFile`, `AESKey` was encoded as `base64(raw 16 bytes)`, producing a 24-character string
- The ilink API expects `base64(hex string)`, producing a 44-character string — consistent with how `Aeskey` is already encoded in `getUploadURLRequest`
- Fixed both occurrences (lines 107 and 138 of `platform/weixin/media_outbound.go`)

## Encoding comparison

| | Format | Example (16-byte key) |
|---|---|---|
| Before | `base64(raw bytes)` | `AQIDBAUGBwgJCgsMDQ4PEA==` (24 chars) |
| After | `base64(hex string)` | `MDEwMjAzMDQwNTA2MDcwODA5MGEwYjBjMGQwZTBm` (44 chars) |

No new imports needed — `encoding/hex` was already used in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)