### PR TITLE
feat(session): add cross-project session listing and switching

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -324,6 +324,184 @@ func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, erro
 	return sessions, nil
 }
 
+// ListAllProjectSessions returns sessions from ALL Claude Code project directories,
+// not just the current work_dir. Cross-project sessions have ProjectDir set to the
+// raw directory name (e.g. "C--Users-Mi") so callers can identify their origin.
+func (a *Agent) ListAllProjectSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("claudecode: cannot determine home dir: %w", err)
+	}
+
+	absWorkDir, err := filepath.Abs(a.workDir)
+	if err != nil {
+		return nil, fmt.Errorf("claudecode: resolve work_dir: %w", err)
+	}
+
+	currentProjectDir := findProjectDir(homeDir, absWorkDir)
+	projectsBase := filepath.Join(homeDir, ".claude", "projects")
+
+	projectDirs, err := os.ReadDir(projectsBase)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("claudecode: read projects base: %w", err)
+	}
+
+	var allSessions []core.AgentSessionInfo
+	for _, pDir := range projectDirs {
+		if !pDir.IsDir() {
+			continue
+		}
+		projectPath := filepath.Join(projectsBase, pDir.Name())
+		isCurrent := projectPath == currentProjectDir
+
+		entries, err := os.ReadDir(projectPath)
+		if err != nil {
+			continue
+		}
+
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".jsonl") {
+				continue
+			}
+			sessionID := strings.TrimSuffix(name, ".jsonl")
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			summary, msgCount := scanSessionMeta(filepath.Join(projectPath, name))
+
+			s := core.AgentSessionInfo{
+				ID:           sessionID,
+				Summary:      summary,
+				MessageCount: msgCount,
+				ModifiedAt:   info.ModTime(),
+			}
+			if !isCurrent {
+				s.ProjectDir = pDir.Name()
+			}
+			allSessions = append(allSessions, s)
+		}
+	}
+
+	sort.Slice(allSessions, func(i, j int) bool {
+		return allSessions[i].ModifiedAt.After(allSessions[j].ModifiedAt)
+	})
+
+	return allSessions, nil
+}
+
+// resolveWorkDirFromProjectDir attempts to reconstruct a filesystem path from a
+// Claude Code project directory name. The encoding replaces \, /, :, _ with "-",
+// so reconstruction is done greedily by walking the filesystem.
+//
+// Example: "C--Ai-OrionAI" → "C:\Ai\OrionAI" (Windows)
+func resolveWorkDirFromProjectDir(dirName string) string {
+	if dirName == "" {
+		return ""
+	}
+
+	parts := strings.Split(dirName, "-")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	// Windows path: single letter drive (e.g. "C--Ai-OrionAI")
+	// parts[0]="C", parts[1]="" (from double dash), parts[2:]="Ai","OrionAI"
+	if len(parts[0]) == 1 && parts[0][0] >= 'A' && parts[0][0] <= 'Z' {
+		return resolveWindowsPath(parts)
+	}
+
+	// Unix path: starts with empty string from leading "-" (e.g. "-home-user-proj")
+	// parts[0]="", parts[1:]="home","user","proj"
+	if parts[0] == "" && len(parts) >= 2 {
+		return resolveUnixPath(parts[1:])
+	}
+
+	return ""
+}
+
+// resolveWindowsPath rebuilds a Windows path from split parts.
+// Input: ["C", "", "Ai", "OrionAI"] for "C--Ai-OrionAI"
+func resolveWindowsPath(parts []string) string {
+	drive := parts[0] + ":"
+
+	// Skip the empty part from double-dash after drive letter
+	remaining := parts[1:]
+	if len(remaining) > 0 && remaining[0] == "" {
+		remaining = remaining[1:]
+	}
+	if len(remaining) == 0 {
+		return drive + "\\"
+	}
+
+	return greedyResolve(drive+"\\", remaining)
+}
+
+// resolveUnixPath rebuilds a Unix path from split parts.
+func resolveUnixPath(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	return greedyResolve("/", parts)
+}
+
+// greedyResolve tries to reconstruct a filesystem path by greedily joining
+// segments with the OS path separator, falling back to "-" when a directory
+// doesn't exist.
+func greedyResolve(base string, segments []string) string {
+	if len(segments) == 0 {
+		if _, err := os.Stat(base); err == nil {
+			return base
+		}
+		return ""
+	}
+
+	// Try joining with path separator first (most common case)
+	candidate := filepath.Join(base, segments[0])
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		if result := greedyResolve(candidate, segments[1:]); result != "" {
+			return result
+		}
+	}
+
+	// Try joining with "-" (original path had a literal hyphen)
+	if len(segments) >= 2 {
+		merged := segments[0] + "-" + segments[1]
+		rest := append([]string{merged}, segments[2:]...)
+		if result := greedyResolve(base, rest); result != "" {
+			return result
+		}
+	}
+
+	// Try joining with "_" (underscores also become "-")
+	if len(segments) >= 2 {
+		merged := segments[0] + "_" + segments[1]
+		rest := append([]string{merged}, segments[2:]...)
+		if result := greedyResolve(base, rest); result != "" {
+			return result
+		}
+	}
+
+	// Base case: this is the last segment, check if path exists (as file or dir)
+	if len(segments) == 1 {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+
+	return ""
+}
+
+// ResolveProjectWorkDir reconstructs a filesystem path from a Claude Code project
+// directory name. Returns empty string if the path cannot be resolved.
+func (a *Agent) ResolveProjectWorkDir(projectDir string) string {
+	return resolveWorkDirFromProjectDir(projectDir)
+}
+
 func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/core/engine.go
+++ b/core/engine.go
@@ -200,6 +200,10 @@ type Engine struct {
 	interactiveMu     sync.Mutex
 	interactiveStates map[string]*interactiveState // key = sessionKey
 
+	// Cached /list results so /switch numbers match what the user saw
+	lastListCache map[string][]AgentSessionInfo // sessionKey → last /list results
+	lastListMu    sync.RWMutex
+
 	quietMu sync.RWMutex
 	quiet   bool // when true, suppress thinking and tool progress messages globally
 
@@ -292,6 +296,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		skills:                NewSkillRegistry(),
 		aliases:               make(map[string]string),
 		interactiveStates:     make(map[string]*interactiveState),
+		lastListCache:         make(map[string][]AgentSessionInfo),
 		platformReady:         make(map[Platform]bool),
 		startedAt:             time.Now(),
 		streamPreview:         DefaultStreamPreviewCfg(),
@@ -3030,6 +3035,52 @@ func (e *Engine) cmdNew(p Platform, msg *Message, args []string) {
 
 const listPageSize = 20
 
+// resolveListSessions returns agent sessions, optionally including all projects.
+func (e *Engine) resolveListSessions(agent Agent, listAll bool) ([]AgentSessionInfo, error) {
+	if listAll {
+		if lister, ok := agent.(AllProjectSessionLister); ok {
+			return lister.ListAllProjectSessions(e.ctx)
+		}
+	}
+	return agent.ListSessions(e.ctx)
+}
+
+// cacheListResults stores the last /list output so /switch numbers stay consistent.
+func (e *Engine) cacheListResults(sessionKey string, sessions []AgentSessionInfo) {
+	e.lastListMu.Lock()
+	e.lastListCache[sessionKey] = sessions
+	e.lastListMu.Unlock()
+}
+
+// getCachedListResults returns the cached /list results, or nil if none.
+func (e *Engine) getCachedListResults(sessionKey string) []AgentSessionInfo {
+	e.lastListMu.RLock()
+	defer e.lastListMu.RUnlock()
+	return e.lastListCache[sessionKey]
+}
+
+// switchAgentWorkDir resolves a project directory name to a real path and
+// switches the agent's work directory. Used when switching to a cross-project session.
+// If p is non-nil, a notification is sent to the user.
+func (e *Engine) switchAgentWorkDir(agent Agent, projectDir string, p Platform, replyCtx any) {
+	lister, ok := agent.(AllProjectSessionLister)
+	if !ok {
+		return
+	}
+	resolved := lister.ResolveProjectWorkDir(projectDir)
+	if resolved == "" {
+		slog.Warn("switchAgentWorkDir: cannot resolve project dir", "project_dir", projectDir)
+		return
+	}
+	if switcher, ok := agent.(WorkDirSwitcher); ok {
+		switcher.SetWorkDir(resolved)
+		slog.Info("switchAgentWorkDir: switched", "project_dir", projectDir, "resolved", resolved)
+		if p != nil {
+			e.reply(p, replyCtx, e.i18n.Tf(MsgSwitchProjectChanged, resolved))
+		}
+	}
+}
+
 func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 	agent, sessions, _, err := e.commandContext(p, msg)
 	if err != nil {
@@ -3037,12 +3088,27 @@ func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 		return
 	}
 
-	if !supportsCards(p) {
-		agentSessions, err := agent.ListSessions(e.ctx)
-		if err != nil {
-			e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgListError), err))
-			return
+	// Check for "all" / "-a" flag for cross-project listing
+	listAll := false
+	var filteredArgs []string
+	for _, a := range args {
+		if strings.EqualFold(a, "all") || a == "-a" {
+			listAll = true
+		} else {
+			filteredArgs = append(filteredArgs, a)
 		}
+	}
+
+	agentSessions, err := e.resolveListSessions(agent, listAll)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgListError), err))
+		return
+	}
+
+	// Cache results so /switch numbers match what the user sees
+	e.cacheListResults(msg.SessionKey, agentSessions)
+
+	if !supportsCards(p) {
 		if len(agentSessions) == 0 {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgListEmpty))
 			return
@@ -3052,8 +3118,8 @@ func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 		totalPages := (total + listPageSize - 1) / listPageSize
 
 		page := 1
-		if len(args) > 0 {
-			if n, err := strconv.Atoi(args[0]); err == nil && n > 0 {
+		if len(filteredArgs) > 0 {
+			if n, err := strconv.Atoi(filteredArgs[0]); err == nil && n > 0 {
 				page = n
 			}
 		}
@@ -3096,6 +3162,9 @@ func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 					displayName = string([]rune(displayName)[:40]) + "…"
 				}
 			}
+			if s.ProjectDir != "" {
+				displayName += " " + fmt.Sprintf(e.i18n.T(MsgListProjectLabel), s.ProjectDir)
+			}
 			sb.WriteString(fmt.Sprintf("%s **%d.** %s · **%d** msgs · %s\n",
 				marker, i+1, displayName, s.MessageCount, s.ModifiedAt.Format("01-02 15:04")))
 		}
@@ -3108,12 +3177,12 @@ func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 	}
 
 	page := 1
-	if len(args) > 0 {
-		if n, err := strconv.Atoi(args[0]); err == nil && n > 0 {
+	if len(filteredArgs) > 0 {
+		if n, err := strconv.Atoi(filteredArgs[0]); err == nil && n > 0 {
 			page = n
 		}
 	}
-	card, err := e.renderListCard(msg.SessionKey, page)
+	card, err := e.renderListCardEx(msg.SessionKey, page, agentSessions)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, err.Error())
 		return
@@ -3134,16 +3203,38 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
 		return
 	}
-	agentSessions, err := agent.ListSessions(e.ctx)
-	if err != nil {
-		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgError, err))
-		return
-	}
 
-	matched := e.matchSession(agentSessions, sessions, query)
+	// Use cached /list results first (so numbers match what user saw),
+	// then fall back to current-project, then all-project sessions.
+	var matched *AgentSessionInfo
+	if cached := e.getCachedListResults(msg.SessionKey); len(cached) > 0 {
+		matched = e.matchSession(cached, sessions, query)
+	}
+	if matched == nil {
+		agentSessions, err := agent.ListSessions(e.ctx)
+		if err != nil {
+			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgError, err))
+			return
+		}
+		matched = e.matchSession(agentSessions, sessions, query)
+	}
+	if matched == nil {
+		// Try all-project sessions if available
+		if lister, ok := agent.(AllProjectSessionLister); ok {
+			allSessions, err := lister.ListAllProjectSessions(e.ctx)
+			if err == nil {
+				matched = e.matchSession(allSessions, sessions, query)
+			}
+		}
+	}
 	if matched == nil {
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgSwitchNoMatch), query))
 		return
+	}
+
+	// If cross-project session, switch work directory
+	if matched.ProjectDir != "" {
+		e.switchAgentWorkDir(agent, matched.ProjectDir, p, msg.ReplyCtx)
 	}
 
 	slog.Info("cmdSwitch: cleaning up old session", "session_key", msg.SessionKey)
@@ -3983,8 +4074,16 @@ func (e *Engine) simpleCard(title, color, content string) *Card {
 }
 
 // renderListCardSafe wraps renderListCard and returns an error card on failure.
+// It uses cached /list results when available so card navigation preserves
+// the original listing (e.g. all-project sessions from /list all).
 func (e *Engine) renderListCardSafe(sessionKey string, page int) *Card {
-	card, err := e.renderListCard(sessionKey, page)
+	var card *Card
+	var err error
+	if cached := e.getCachedListResults(sessionKey); len(cached) > 0 {
+		card, err = e.renderListCardEx(sessionKey, page, cached)
+	} else {
+		card, err = e.renderListCard(sessionKey, page)
+	}
 	if err != nil {
 		agent, _ := e.sessionContextForKey(sessionKey)
 		return e.simpleCard(e.i18n.Tf(MsgCardTitleSessions, agent.Name(), 0), "red", err.Error())
@@ -5913,13 +6012,31 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 			return
 		}
 		agent, sessions := e.sessionContextForKey(sessionKey)
-		agentSessions, err := agent.ListSessions(e.ctx)
-		if err != nil || len(agentSessions) == 0 {
-			return
+		// Use cached /list results first so card button numbers match
+		var matched *AgentSessionInfo
+		if cached := e.getCachedListResults(sessionKey); len(cached) > 0 {
+			matched = e.matchSession(cached, sessions, args)
 		}
-		matched := e.matchSession(agentSessions, sessions, args)
+		if matched == nil {
+			agentSessions, err := agent.ListSessions(e.ctx)
+			if err != nil || len(agentSessions) == 0 {
+				return
+			}
+			matched = e.matchSession(agentSessions, sessions, args)
+		}
+		if matched == nil {
+			if lister, ok := agent.(AllProjectSessionLister); ok {
+				allSessions, err := lister.ListAllProjectSessions(e.ctx)
+				if err == nil {
+					matched = e.matchSession(allSessions, sessions, args)
+				}
+			}
+		}
 		if matched == nil {
 			return
+		}
+		if matched.ProjectDir != "" {
+			e.switchAgentWorkDir(agent, matched.ProjectDir, nil, nil)
 		}
 		interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 		e.cleanupInteractiveState(interactiveKey)
@@ -6450,11 +6567,18 @@ func (e *Engine) renderModeCard() *Card {
 }
 
 func (e *Engine) renderListCard(sessionKey string, page int) (*Card, error) {
-	agent, sessions := e.sessionContextForKey(sessionKey)
+	agent, _ := e.sessionContextForKey(sessionKey)
 	agentSessions, err := agent.ListSessions(e.ctx)
 	if err != nil {
 		return nil, fmt.Errorf(e.i18n.T(MsgListError), err)
 	}
+	return e.renderListCardEx(sessionKey, page, agentSessions)
+}
+
+// renderListCardEx renders the session list card with pre-resolved sessions.
+// Cross-project sessions (ProjectDir != "") are annotated with their project path.
+func (e *Engine) renderListCardEx(sessionKey string, page int, agentSessions []AgentSessionInfo) (*Card, error) {
+	agent, sessions := e.sessionContextForKey(sessionKey)
 	if len(agentSessions) == 0 {
 		return e.simpleCard(e.i18n.Tf(MsgCardTitleSessions, agent.Name(), 0), "turquoise", e.i18n.T(MsgListEmpty)), nil
 	}
@@ -6501,6 +6625,9 @@ func (e *Engine) renderListCard(sessionKey string, page int) (*Card, error) {
 			if len([]rune(displayName)) > 40 {
 				displayName = string([]rune(displayName)[:40]) + "…"
 			}
+		}
+		if s.ProjectDir != "" {
+			displayName += " " + fmt.Sprintf(e.i18n.T(MsgListProjectLabel), s.ProjectDir)
 		}
 		btnType := "default"
 		if s.ID == activeAgentID {

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -398,9 +398,11 @@ const (
 	MsgDeleteModeResultTitle    MsgKey = "delete_mode_result_title"
 	MsgDeleteModeMissingSession MsgKey = "delete_mode_missing_session"
 
-	MsgSwitchSuccess   MsgKey = "switch_success"
-	MsgSwitchNoMatch   MsgKey = "switch_no_match"
-	MsgSwitchNoSession MsgKey = "switch_no_session"
+	MsgSwitchSuccess        MsgKey = "switch_success"
+	MsgSwitchNoMatch        MsgKey = "switch_no_match"
+	MsgSwitchNoSession      MsgKey = "switch_no_session"
+	MsgSwitchProjectChanged MsgKey = "switch_project_changed"
+	MsgListProjectLabel     MsgKey = "list_project_label"
 
 	MsgCommandTimeout MsgKey = "command_timeout"
 
@@ -2605,6 +2607,20 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "❌ 沒有第 %d 個會話",
 		LangJapanese:           "❌ セッション #%d が見つかりません",
 		LangSpanish:            "❌ No hay sesión #%d",
+	},
+	MsgSwitchProjectChanged: {
+		LangEnglish:            "📂 Work directory switched to: %s",
+		LangChinese:            "📂 工作目录已切换到：%s",
+		LangTraditionalChinese: "📂 工作目錄已切換到：%s",
+		LangJapanese:           "📂 作業ディレクトリ切替：%s",
+		LangSpanish:            "📂 Directorio cambiado a: %s",
+	},
+	MsgListProjectLabel: {
+		LangEnglish:            "📂 %s",
+		LangChinese:            "📂 %s",
+		LangTraditionalChinese: "📂 %s",
+		LangJapanese:           "📂 %s",
+		LangSpanish:            "📂 %s",
 	},
 	MsgCommandTimeout: {
 		LangEnglish:            "⏰ Command timed out (60s): `%s`",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -364,6 +364,17 @@ type SessionDeleter interface {
 	DeleteSession(ctx context.Context, sessionID string) error
 }
 
+// AllProjectSessionLister is an optional interface for agents that can list
+// sessions across all project directories, not just the current work_dir.
+// This enables cross-project session discovery (e.g. listing terminal sessions
+// started from different directories).
+type AllProjectSessionLister interface {
+	ListAllProjectSessions(ctx context.Context) ([]AgentSessionInfo, error)
+	// ResolveProjectWorkDir reconstructs a filesystem path from a project directory name.
+	// Returns empty string if resolution fails.
+	ResolveProjectWorkDir(projectDir string) string
+}
+
 // WorkDirSwitcher is an optional interface for agents that support runtime
 // work directory switching. The change takes effect on the next session start;
 // the current running session is terminated automatically by the engine.

--- a/core/message.go
+++ b/core/message.go
@@ -200,4 +200,5 @@ type AgentSessionInfo struct {
 	MessageCount int
 	ModifiedAt   time.Time
 	GitBranch    string
+	ProjectDir   string // raw project dir name (e.g. "C--Users-Mi"); empty = current project
 }


### PR DESCRIPTION
- Add ListAllProjectSessions to list sessions from all Claude Code project directories
- Add /list all (or -a) flag to show cross-project sessions
- Automatically switch work directory when switching to cross-project sessions
- Cache /list results so /switch numbers remain consistent
- Add i18n messages for cross-project session labels and work directory switching

Enables switching between sessions created from different working directories, e.g., terminal sessions started in different project folders.