### PR TITLE
fix(core): exact-resume saved session on workspace reconnect

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1926,16 +1926,22 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		return state
 	}
 
-	// On first real-user connection after engine startup (or workspace re-creation
-	// after idle reap), use --continue to pick up the most recent CLI session.
-	// Subsequent connections respect the stored session ID (or "" for fresh).
+	// On first real-user connection after engine startup, use --continue to pick
+	// up the most recent CLI session. For workspace-scoped reconnects after idle
+	// reap, keep that behavior only when we do not already have a concrete saved
+	// agent session ID; otherwise exact resume is more precise than continuing
+	// whatever the CLI considers "latest" in that workspace.
 	startSessionID := session.GetAgentSessionID()
 	once := &e.hasConnectedOnce
 	if connectedOnce != nil {
 		once = connectedOnce
 	}
-	if consumeFirstUserContinueBridge && !once.Swap(true) {
-		startSessionID = ContinueSession
+	if consumeFirstUserContinueBridge {
+		if connectedOnce != nil && startSessionID != "" {
+			once.Store(true)
+		} else if !once.Swap(true) {
+			startSessionID = ContinueSession
+		}
 	}
 
 	isResume := startSessionID != ""

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -4447,6 +4448,47 @@ func TestFreshSessionRespectedAfterFirstConnection(t *testing.T) {
 	// Should be empty string (fresh session), NOT ContinueSession
 	if calls[0] != "" {
 		t.Fatalf("StartSession call = %q, want empty string (fresh session)", calls[0])
+	}
+}
+
+func TestWorkspaceReconnectWithSavedSessionIDSkipsContinueBridge(t *testing.T) {
+	agent := &stubStartSessionAgent{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	e := &Engine{
+		agent:             agent,
+		sessions:          NewSessionManager(""),
+		ctx:               ctx,
+		i18n:              NewI18n("en"),
+		interactiveStates: make(map[string]*interactiveState),
+		display:           DisplayCfg{},
+	}
+
+	session := e.sessions.GetOrCreateActive("test:user3")
+	session.SetAgentSessionID("saved-session-id", "stub")
+
+	var wsConnectedOnce atomic.Bool
+	p := &stubPlatformEngine{n: "test"}
+	state := e.getOrCreateInteractiveStateWith("test:user3", p, "ctx", session, e.sessions, nil, "", true, &wsConnectedOnce)
+
+	if state.agentSession == nil {
+		t.Fatal("expected agentSession to be non-nil")
+	}
+	if !wsConnectedOnce.Load() {
+		t.Fatal("workspace connectedOnce flag should be marked after exact resume")
+	}
+
+	agent.mu.Lock()
+	calls := append([]string{}, agent.calls...)
+	agent.mu.Unlock()
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 StartSession call, got %d: %v", len(calls), calls)
+	}
+	if calls[0] != "saved-session-id" {
+		t.Fatalf("StartSession call = %q, want saved session id", calls[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

- exact-resume a saved `agent_session_id` on workspace-scoped reconnects instead of reusing the one-time `ContinueSession` bridge
- keep the existing first-connect `ContinueSession` behavior for fresh traffic
- prevent Codex from drifting to a new thread after workspace idle-reap or daemon restart in multi-workspace mode

## Problem

When a multi-workspace agent reconnects after idle reaping or restart, the workspace may already have a persisted `agent_session_id`. That case should use the stored id. Instead, the reconnect path could still consume the per-workspace `ContinueSession` bridge. For Codex that may start a different thread, so the bot appears to lose context and `/list` accumulates extra sessions.

## Testing

- `nix shell nixpkgs#go -c go test ./...`
- `nix shell nixpkgs#go -c go build ./...`
- `nix shell nixpkgs#go -c go vet ./...`
- `nix shell nixpkgs#go -c go test -parallel=4 -race ./...`
- `nix shell nixpkgs#go -c go test -parallel=4 -tags=smoke ./tests/e2e/...`
- `nix shell nixpkgs#go -c go test -parallel=2 -tags=regression ./tests/e2e/...`
- manual Discord smoke: after workspace idle-reap, the first message resumed the existing Codex thread
- manual Discord smoke: after daemon restart, the first message again resumed the same Codex thread