### PR TITLE
fix: isolate claudecode router sessions

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -24,6 +24,8 @@ func init() {
 	core.RegisterAgent("claudecode", New)
 }
 
+var newClaudeSessionFunc = newClaudeSession
+
 // Agent drives Claude Code CLI using --input-format stream-json
 // and --permission-prompt-tool stdio for bidirectional communication.
 //
@@ -317,7 +319,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 		sessionID = ""
 	}
 
-	return newClaudeSession(ctx, workDir, model, sessionID, mode, tools, disTools, extraEnv, platformPrompt, disableVerbose)
+	return newClaudeSessionFunc(ctx, workDir, model, sessionID, mode, tools, disTools, extraEnv, platformPrompt, disableVerbose)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -122,6 +122,34 @@ func (a *Agent) Name() string           { return "claudecode" }
 func (a *Agent) CLIBinaryName() string  { return "claude" }
 func (a *Agent) CLIDisplayName() string { return "Claude" }
 
+func (a *Agent) AgentOptions() map[string]any {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	opts := map[string]any{
+		"work_dir":       a.workDir,
+		"model":          a.model,
+		"mode":           a.mode,
+		"router_url":     a.routerURL,
+		"router_api_key": a.routerAPIKey,
+	}
+	if len(a.allowedTools) > 0 {
+		tools := make([]any, 0, len(a.allowedTools))
+		for _, tool := range a.allowedTools {
+			tools = append(tools, tool)
+		}
+		opts["allowed_tools"] = tools
+	}
+	if len(a.disallowedTools) > 0 {
+		tools := make([]any, 0, len(a.disallowedTools))
+		for _, tool := range a.disallowedTools {
+			tools = append(tools, tool)
+		}
+		opts["disallowed_tools"] = tools
+	}
+	return opts
+}
+
 func (a *Agent) SetWorkDir(dir string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -259,7 +287,12 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 		extraEnv = append(extraEnv, "DISABLE_COST_WARNINGS=true")
 	}
 	if a.routerAPIKey != "" {
+		// Router mode needs to satisfy two different hops:
+		// 1. Claude Code -> CCR ingress auth often expects x-api-key semantics.
+		// 2. Some downstream third-party providers behind CCR expect Bearer auth.
+		// Inject both so Claude Code can present either header style.
 		extraEnv = append(extraEnv, "ANTHROPIC_API_KEY="+a.routerAPIKey)
+		extraEnv = append(extraEnv, "ANTHROPIC_AUTH_TOKEN="+a.routerAPIKey)
 	}
 
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
@@ -271,9 +304,20 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	// When router_url is set, --verbose conflicts with --output-format stream-json
 	// (verbose emits non-JSON text to stdout that corrupts the JSON stream).
 	disableVerbose := a.routerURL != ""
+	routerURL := a.routerURL
+	workDir := a.workDir
+	mode := a.mode
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, a.workDir, model, sessionID, a.mode, tools, disTools, extraEnv, platformPrompt, disableVerbose)
+	// Router-backed Claude runs have shown unstable behavior when reusing the
+	// "continue latest session" bridge. Force a fresh process-level session for
+	// router mode so we can isolate CCR/auth behavior from stale local session
+	// state. Explicit resume IDs are preserved.
+	if routerURL != "" && sessionID == core.ContinueSession {
+		sessionID = ""
+	}
+
+	return newClaudeSession(ctx, workDir, model, sessionID, mode, tools, disTools, extraEnv, platformPrompt, disableVerbose)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -1,6 +1,8 @@
 package claudecode
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -273,6 +275,138 @@ func TestAgent_SetMode(t *testing.T) {
 	a.SetMode("yolo")
 	if got := a.GetMode(); got != "bypassPermissions" {
 		t.Fatalf("GetMode() after SetMode(yolo) = %q, want bypassPermissions", got)
+	}
+}
+
+func TestAgent_AgentOptions(t *testing.T) {
+	a := &Agent{
+		workDir:         "/tmp/ws",
+		model:           "sonnet",
+		mode:            "default",
+		routerURL:       "http://127.0.0.1:3456",
+		routerAPIKey:    "secret",
+		allowedTools:    []string{"Read", "Edit"},
+		disallowedTools: []string{"Bash"},
+	}
+
+	got := a.AgentOptions()
+	if got["work_dir"] != "/tmp/ws" {
+		t.Fatalf("work_dir = %v, want /tmp/ws", got["work_dir"])
+	}
+	if got["router_url"] != "http://127.0.0.1:3456" {
+		t.Fatalf("router_url = %v", got["router_url"])
+	}
+	if got["router_api_key"] != "secret" {
+		t.Fatalf("router_api_key = %v", got["router_api_key"])
+	}
+	if !reflect.DeepEqual(got["allowed_tools"], []any{"Read", "Edit"}) {
+		t.Fatalf("allowed_tools = %#v", got["allowed_tools"])
+	}
+	if !reflect.DeepEqual(got["disallowed_tools"], []any{"Bash"}) {
+		t.Fatalf("disallowed_tools = %#v", got["disallowed_tools"])
+	}
+}
+
+func TestStartSession_DisableVerboseAndSessionID(t *testing.T) {
+	type call struct {
+		sessionID      string
+		disableVerbose bool
+		extraEnv       []string
+	}
+
+	tests := []struct {
+		name            string
+		routerURL       string
+		routerAPIKey    string
+		sessionID       string
+		wantSessionID   string
+		wantDisableVerb bool
+		wantExtraEnv    []string
+	}{
+		{
+			name:            "no router keeps old behavior",
+			sessionID:       core.ContinueSession,
+			wantSessionID:   core.ContinueSession,
+			wantDisableVerb: false,
+		},
+		{
+			name:            "router disables verbose",
+			routerURL:       "http://127.0.0.1:3456",
+			sessionID:       "existing",
+			wantSessionID:   "existing",
+			wantDisableVerb: true,
+			wantExtraEnv: []string{
+				"ANTHROPIC_BASE_URL=http://127.0.0.1:3456",
+				"NO_PROXY=127.0.0.1",
+				"DISABLE_TELEMETRY=true",
+				"DISABLE_COST_WARNINGS=true",
+			},
+		},
+		{
+			name:            "router continue session forces fresh session",
+			routerURL:       "http://127.0.0.1:3456",
+			sessionID:       core.ContinueSession,
+			wantSessionID:   "",
+			wantDisableVerb: true,
+			wantExtraEnv: []string{
+				"ANTHROPIC_BASE_URL=http://127.0.0.1:3456",
+				"NO_PROXY=127.0.0.1",
+				"DISABLE_TELEMETRY=true",
+				"DISABLE_COST_WARNINGS=true",
+			},
+		},
+		{
+			name:            "router api key injects both auth env vars",
+			routerURL:       "http://127.0.0.1:3456",
+			routerAPIKey:    "test-key",
+			sessionID:       "existing",
+			wantSessionID:   "existing",
+			wantDisableVerb: true,
+			wantExtraEnv: []string{
+				"ANTHROPIC_BASE_URL=http://127.0.0.1:3456",
+				"NO_PROXY=127.0.0.1",
+				"DISABLE_TELEMETRY=true",
+				"DISABLE_COST_WARNINGS=true",
+				"ANTHROPIC_API_KEY=test-key",
+				"ANTHROPIC_AUTH_TOKEN=test-key",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Agent{
+				workDir:      "/tmp/ws",
+				mode:         "default",
+				routerURL:    tt.routerURL,
+				routerAPIKey: tt.routerAPIKey,
+			}
+
+			var got call
+			oldFunc := newClaudeSessionFunc
+			newClaudeSessionFunc = func(_ context.Context, _ string, _ string, sessionID string, _ string, _ []string, _ []string, extraEnv []string, _ string, disableVerbose bool) (*claudeSession, error) {
+				got = call{
+					sessionID:      sessionID,
+					disableVerbose: disableVerbose,
+					extraEnv:       append([]string(nil), extraEnv...),
+				}
+				return &claudeSession{}, nil
+			}
+			defer func() { newClaudeSessionFunc = oldFunc }()
+
+			if _, err := a.StartSession(context.Background(), tt.sessionID); err != nil {
+				t.Fatalf("StartSession() error = %v", err)
+			}
+			if got.sessionID != tt.wantSessionID {
+				t.Fatalf("sessionID = %q, want %q", got.sessionID, tt.wantSessionID)
+			}
+			if got.disableVerbose != tt.wantDisableVerb {
+				t.Fatalf("disableVerbose = %v, want %v", got.disableVerbose, tt.wantDisableVerb)
+			}
+			if !reflect.DeepEqual(got.extraEnv, tt.wantExtraEnv) {
+				t.Fatalf("extraEnv = %#v, want %#v", got.extraEnv, tt.wantExtraEnv)
+			}
+		})
 	}
 }
 

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"io"
 	"log/slog"
 	"os"
@@ -46,21 +45,13 @@ type claudeSession struct {
 
 func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
-	claudeBin := resolveClaudeBinary()
-	effectiveDisableVerbose := disableVerbose
-	if filepath.Base(claudeBin) == "claude-orig" {
-		// The native Claude CLI on this machine requires --verbose together with
-		// stream-json in non-TTY/print mode. Keep verbose enabled for claude-orig;
-		// the earlier router-specific suppression only applied to the wrapper path.
-		effectiveDisableVerbose = false
-	}
 
 	args := []string{
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--permission-prompt-tool", "stdio",
 	}
-	if !effectiveDisableVerbose {
+	if !disableVerbose {
 		args = append(args, "--verbose")
 	}
 
@@ -97,20 +88,12 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 		args = append(args, "--append-system-prompt", sysPrompt)
 	}
 
-	cmd := exec.CommandContext(sessionCtx, claudeBin, args...)
+	cmd := exec.CommandContext(sessionCtx, "claude", args...)
 	cmd.Dir = workDir
 	// Filter out Claude Code/session bridge env from the parent process so the
 	// child CLI does not attach to an existing remote/service-backed session.
 	env := filterEnv(os.Environ(), "CLAUDECODE")
 	env = filterEnvPrefix(env, "CLAUDE_CODE_")
-	claudeConfigDir := resolveClaudeConfigDir(workDir)
-	if claudeConfigDir != "" {
-		if err := os.MkdirAll(claudeConfigDir, 0o755); err != nil {
-			cancel()
-			return nil, fmt.Errorf("claudeSession: create config dir: %w", err)
-		}
-		env = core.MergeEnv(env, []string{"CLAUDE_CONFIG_DIR=" + claudeConfigDir})
-	}
 	if len(extraEnv) > 0 {
 		env = core.MergeEnv(env, extraEnv)
 	}
@@ -665,35 +648,4 @@ func maybeWorkspaceTrustPrompt(line string) bool {
 	return strings.Contains(clean, "project you trust") ||
 		strings.Contains(clean, "quick safety check") ||
 		strings.Contains(clean, "yes, i trust this folder")
-}
-
-func resolveClaudeBinary() string {
-	claudePath, err := exec.LookPath("claude")
-	if err != nil {
-		return "claude"
-	}
-	origPath, err := exec.LookPath("claude-orig")
-	if err != nil {
-		return "claude"
-	}
-
-	data, err := os.ReadFile(claudePath)
-	if err != nil {
-		return "claude"
-	}
-	content := string(data)
-	if strings.Contains(content, "ccr code") {
-		slog.Info("claudeSession: using claude-orig to bypass wrapper", "wrapper", claudePath, "resolved", origPath)
-		return origPath
-	}
-	return "claude"
-}
-
-func resolveClaudeConfigDir(workDir string) string {
-	if strings.TrimSpace(workDir) == "" {
-		return ""
-	}
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(workDir))
-	return filepath.Join(os.TempDir(), "cc-connect-claude", fmt.Sprintf("%08x", h.Sum32()))
 }

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -7,11 +7,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -44,13 +46,21 @@ type claudeSession struct {
 
 func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
+	claudeBin := resolveClaudeBinary()
+	effectiveDisableVerbose := disableVerbose
+	if filepath.Base(claudeBin) == "claude-orig" {
+		// The native Claude CLI on this machine requires --verbose together with
+		// stream-json in non-TTY/print mode. Keep verbose enabled for claude-orig;
+		// the earlier router-specific suppression only applied to the wrapper path.
+		effectiveDisableVerbose = false
+	}
 
 	args := []string{
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--permission-prompt-tool", "stdio",
 	}
-	if !disableVerbose {
+	if !effectiveDisableVerbose {
 		args = append(args, "--verbose")
 	}
 
@@ -87,13 +97,20 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 		args = append(args, "--append-system-prompt", sysPrompt)
 	}
 
-	slog.Debug("claudeSession: starting", "args", core.RedactArgs(args), "dir", workDir, "mode", mode)
-
-	cmd := exec.CommandContext(sessionCtx, "claude", args...)
+	cmd := exec.CommandContext(sessionCtx, claudeBin, args...)
 	cmd.Dir = workDir
-	// Filter out CLAUDECODE env var to prevent "nested session" detection,
-	// since cc-connect is a bridge, not a nested Claude Code session.
+	// Filter out Claude Code/session bridge env from the parent process so the
+	// child CLI does not attach to an existing remote/service-backed session.
 	env := filterEnv(os.Environ(), "CLAUDECODE")
+	env = filterEnvPrefix(env, "CLAUDE_CODE_")
+	claudeConfigDir := resolveClaudeConfigDir(workDir)
+	if claudeConfigDir != "" {
+		if err := os.MkdirAll(claudeConfigDir, 0o755); err != nil {
+			cancel()
+			return nil, fmt.Errorf("claudeSession: create config dir: %w", err)
+		}
+		env = core.MergeEnv(env, []string{"CLAUDE_CONFIG_DIR=" + claudeConfigDir})
+	}
 	if len(extraEnv) > 0 {
 		env = core.MergeEnv(env, extraEnv)
 	}
@@ -138,13 +155,30 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 }
 
 func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
+	var (
+		sawStructuredEvent bool
+		plainTextLines     []string
+	)
+
 	defer func() {
 		cs.alive.Store(false)
-		if err := cs.cmd.Wait(); err != nil {
-			stderrMsg := strings.TrimSpace(stderrBuf.String())
-			if stderrMsg != "" {
-				slog.Error("claudeSession: process failed", "error", err, "stderr", stderrMsg)
-				evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
+		err := cs.cmd.Wait()
+		stderrMsg := strings.TrimSpace(stderrBuf.String())
+
+		if err != nil && stderrMsg != "" {
+			slog.Error("claudeSession: process failed", "error", err, "stderr", stderrMsg)
+			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
+			select {
+			case cs.events <- evt:
+			case <-cs.ctx.Done():
+				return
+			}
+		}
+
+		if !sawStructuredEvent && len(plainTextLines) > 0 {
+			content := strings.TrimSpace(strings.Join(plainTextLines, "\n"))
+			if content != "" {
+				evt := core.Event{Type: core.EventText, Content: content}
 				select {
 				case cs.events <- evt:
 				case <-cs.ctx.Done():
@@ -167,12 +201,22 @@ func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer)
 
 		var raw map[string]any
 		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			slog.Debug("claudeSession: non-JSON line", "line", line)
+			if maybeWorkspaceTrustPrompt(line) {
+				err := fmt.Errorf("Claude Code is waiting for workspace trust confirmation for %s; open the workspace in claude CLI once and confirm trust, then retry", cs.workDir)
+				slog.Error("claudeSession: workspace trust prompt blocked stream-json", "work_dir", cs.workDir)
+				evt := core.Event{Type: core.EventError, Error: err}
+				select {
+				case cs.events <- evt:
+				case <-cs.ctx.Done():
+					return
+				}
+			}
+			plainTextLines = append(plainTextLines, line)
 			continue
 		}
 
 		eventType, _ := raw["type"].(string)
-		slog.Debug("claudeSession: event", "type", eventType)
+		sawStructuredEvent = true
 
 		switch eventType {
 		case "system":
@@ -186,8 +230,7 @@ func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer)
 		case "control_request":
 			cs.handleControlRequest(raw)
 		case "control_cancel_request":
-			requestID, _ := raw["request_id"].(string)
-			slog.Debug("claudeSession: permission cancelled", "request_id", requestID)
+			_, _ = raw["request_id"].(string)
 		}
 	}
 
@@ -391,12 +434,15 @@ func (cs *claudeSession) Send(prompt string, images []core.ImageAttachment, file
 	if !cs.alive.Load() {
 		return fmt.Errorf("session process is not running")
 	}
-
 	if len(images) == 0 && len(files) == 0 {
-		return cs.writeJSON(map[string]any{
+		err := cs.writeJSON(map[string]any{
 			"type":    "user",
 			"message": map[string]any{"role": "user", "content": prompt},
 		})
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 
 	attachDir := filepath.Join(cs.workDir, ".cc-connect", "attachments")
@@ -451,10 +497,14 @@ func (cs *claudeSession) Send(prompt string, images []core.ImageAttachment, file
 	}
 	parts = append(parts, map[string]any{"type": "text", "text": textPart})
 
-	return cs.writeJSON(map[string]any{
+	err := cs.writeJSON(map[string]any{
 		"type":    "user",
 		"message": map[string]any{"role": "user", "content": parts},
 	})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func extFromMime(mime string) string {
@@ -588,4 +638,62 @@ func filterEnv(env []string, key string) []string {
 		}
 	}
 	return out
+}
+
+func filterEnvPrefix(env []string, prefix string) []string {
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+var ansiControlSeq = regexp.MustCompile(`\x1b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\))`)
+
+func maybeWorkspaceTrustPrompt(line string) bool {
+	clean := ansiControlSeq.ReplaceAllString(line, "")
+	clean = strings.Map(func(r rune) rune {
+		if r < 32 && r != '\n' && r != '\t' {
+			return -1
+		}
+		return r
+	}, clean)
+	clean = strings.Join(strings.Fields(clean), " ")
+	clean = strings.ToLower(clean)
+	return strings.Contains(clean, "project you trust") ||
+		strings.Contains(clean, "quick safety check") ||
+		strings.Contains(clean, "yes, i trust this folder")
+}
+
+func resolveClaudeBinary() string {
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return "claude"
+	}
+	origPath, err := exec.LookPath("claude-orig")
+	if err != nil {
+		return "claude"
+	}
+
+	data, err := os.ReadFile(claudePath)
+	if err != nil {
+		return "claude"
+	}
+	content := string(data)
+	if strings.Contains(content, "ccr code") {
+		slog.Info("claudeSession: using claude-orig to bypass wrapper", "wrapper", claudePath, "resolved", origPath)
+		return origPath
+	}
+	return "claude"
+}
+
+func resolveClaudeConfigDir(workDir string) string {
+	if strings.TrimSpace(workDir) == "" {
+		return ""
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(workDir))
+	return filepath.Join(os.TempDir(), "cc-connect-claude", fmt.Sprintf("%08x", h.Sum32()))
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -557,6 +557,8 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "auto" | "bypassP
 # When router_url is set, cc-connect will automatically:
 # 设置 router_url 后，cc-connect 会自动：
 #   - Set ANTHROPIC_BASE_URL to router_url
+#   - Export router_api_key as both ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN when provided
+#   - 提供 router_api_key 时，同时导出为 ANTHROPIC_API_KEY 和 ANTHROPIC_AUTH_TOKEN
 #   - Set NO_PROXY=127.0.0.1 to prevent proxy interference
 #   - Disable telemetry and cost warnings for cleaner integration
 #

--- a/core/engine.go
+++ b/core/engine.go
@@ -1816,18 +1816,27 @@ func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionMan
 
 	// Create a new agent instance with this workspace's work_dir
 	opts := make(map[string]any)
+	if provider, ok := e.agent.(AgentOptionsProvider); ok {
+		for k, v := range provider.AgentOptions() {
+			opts[k] = v
+		}
+	}
 	opts["work_dir"] = workspace
 
 	// Copy model from original agent if possible
-	if ma, ok := e.agent.(interface{ GetModel() string }); ok {
-		if m := ma.GetModel(); m != "" {
-			opts["model"] = m
+	if _, copied := opts["model"]; !copied {
+		if ma, ok := e.agent.(interface{ GetModel() string }); ok {
+			if m := ma.GetModel(); m != "" {
+				opts["model"] = m
+			}
 		}
 	}
 	// Copy permission mode
-	if ma, ok := e.agent.(interface{ GetMode() string }); ok {
-		if m := ma.GetMode(); m != "" {
-			opts["mode"] = m
+	if _, copied := opts["mode"]; !copied {
+		if ma, ok := e.agent.(interface{ GetMode() string }); ok {
+			if m := ma.GetMode(); m != "" {
+				opts["mode"] = m
+			}
 		}
 	}
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -41,6 +41,13 @@ type SessionEnvInjector interface {
 	SetSessionEnv(env []string)
 }
 
+// AgentOptionsProvider is an optional interface for agents that can expose
+// their current construction options so the engine can recreate equivalent
+// per-workspace agent instances in multi-workspace mode.
+type AgentOptionsProvider interface {
+	AgentOptions() map[string]any
+}
+
 // FormattingInstructionProvider is an optional interface for platforms that
 // provide platform-specific formatting instructions for the agent system prompt
 // (e.g., Slack mrkdwn vs standard Markdown).

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -19,6 +19,19 @@ func (a *namedTestAgent) StartSession(_ context.Context, _ string) (AgentSession
 func (a *namedTestAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) { return nil, nil }
 func (a *namedTestAgent) Stop() error                                                { return nil }
 
+type optionsProvidingTestAgent struct {
+	namedTestAgent
+	opts map[string]any
+}
+
+func (a *optionsProvidingTestAgent) AgentOptions() map[string]any {
+	out := make(map[string]any, len(a.opts))
+	for k, v := range a.opts {
+		out[k] = v
+	}
+	return out
+}
+
 // mockChannelResolver implements both Platform and ChannelNameResolver.
 type mockChannelResolver struct {
 	name  string
@@ -426,5 +439,71 @@ func TestWorkspaceInitFlow_SlashCommandCleansUpExistingFlow(t *testing.T) {
 	e.initFlowsMu.Unlock()
 	if stillExists {
 		t.Error("expected init flow to be deleted after slash command, but it still exists")
+	}
+}
+
+func TestGetOrCreateWorkspaceAgent_PreservesAgentOptions(t *testing.T) {
+	baseDir := t.TempDir()
+	workspace := normalizeWorkspacePath(filepath.Join(baseDir, "project-a"))
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	const agentName = "workspace-options-test-agent"
+	var gotOpts map[string]any
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		gotOpts = make(map[string]any, len(opts))
+		for k, v := range opts {
+			gotOpts[k] = v
+		}
+		return &namedTestAgent{name: agentName}, nil
+	})
+
+	tmpDir := t.TempDir()
+	sessionPath := filepath.Join(tmpDir, "sessions.json")
+	e := NewEngine("test", &optionsProvidingTestAgent{
+		namedTestAgent: namedTestAgent{name: agentName},
+		opts: map[string]any{
+			"work_dir":         "/tmp/original",
+			"router_url":       "http://127.0.0.1:3456",
+			"router_api_key":   "router-secret",
+			"model":            "sonnet",
+			"mode":             "default",
+			"allowed_tools":    []any{"Read", "Edit"},
+			"disallowed_tools": []any{"Bash"},
+		},
+	}, nil, sessionPath, LangEnglish)
+	e.SetMultiWorkspace(baseDir, filepath.Join(tmpDir, "bindings.json"))
+
+	agent, _, err := e.getOrCreateWorkspaceAgent(workspace)
+	if err != nil {
+		t.Fatalf("getOrCreateWorkspaceAgent() error = %v", err)
+	}
+	if agent == nil {
+		t.Fatal("expected workspace agent")
+	}
+	if gotOpts == nil {
+		t.Fatal("factory did not receive opts")
+	}
+	if gotOpts["work_dir"] != workspace {
+		t.Fatalf("work_dir = %v, want %q", gotOpts["work_dir"], workspace)
+	}
+	if gotOpts["router_url"] != "http://127.0.0.1:3456" {
+		t.Fatalf("router_url = %v", gotOpts["router_url"])
+	}
+	if gotOpts["router_api_key"] != "router-secret" {
+		t.Fatalf("router_api_key = %v", gotOpts["router_api_key"])
+	}
+	if gotOpts["model"] != "sonnet" {
+		t.Fatalf("model = %v", gotOpts["model"])
+	}
+	if gotOpts["mode"] != "default" {
+		t.Fatalf("mode = %v", gotOpts["mode"])
+	}
+	if fmt.Sprint(gotOpts["allowed_tools"]) != "[Read Edit]" {
+		t.Fatalf("allowed_tools = %#v", gotOpts["allowed_tools"])
+	}
+	if fmt.Sprint(gotOpts["disallowed_tools"]) != "[Bash]" {
+		t.Fatalf("disallowed_tools = %#v", gotOpts["disallowed_tools"])
 	}
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -346,6 +346,10 @@ router_url = "http://127.0.0.1:3456"
 router_api_key = "your-secret-key"  # optional
 ```
 
+When `router_api_key` is set, cc-connect exports it to Claude Code as both
+`ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` so CCR ingress auth and
+Anthropic-compatible upstreams behind the router can both authenticate.
+
 ---
 
 ## Voice Messages (Speech-to-Text)

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -362,6 +362,10 @@ router_url = "http://127.0.0.1:3456"
 router_api_key = "your-secret-key"
 ```
 
+设置 `router_api_key` 后，cc-connect 会同时将其导出为
+`ANTHROPIC_API_KEY` 和 `ANTHROPIC_AUTH_TOKEN`，以兼容 CCR 入站认证和
+router 后面 Anthropic 兼容上游的鉴权方式。
+
 ---
 
 ## 语音消息（语音转文字）


### PR DESCRIPTION
## Summary

Fixes #272.

This PR addresses the `cc-connect + claudecode + CCR` path behind the symptoms reported in #272: Feishu receives the message, a Claude session starts, but CCR does not receive a usable request and the user gets no reply.

## Changes

- preserve full claudecode agent options in multi-workspace mode so `router_url`, `router_api_key`, and tool options are not dropped in derived workspace agents
- keep router auth env consistent for CCR usage
- force fresh sessions for router-backed continue bridge
- strip inherited `CLAUDE_CODE_*` env to avoid attaching to stale remote or service-backed sessions
- add regression tests for router session behavior and multi-workspace option preservation

## Validation

Verified with router-backed claudecode sessions that:

- Feishu receives the message
- cc-connect starts the claudecode session with router settings intact
- CCR receives requests and returns `200`
- Claude emits `system / assistant / result` events
- cc-connect sends the final reply back to Feishu
