### PR TITLE
fix(cursor): use StdinPipe to prevent agent hang under launchd

### DIFF
--- a/agent/cursor/session.go
+++ b/agent/cursor/session.go
@@ -107,6 +107,14 @@ func (cs *cursorSession) Send(prompt string, images []core.ImageAttachment, file
 	}
 	cmd.Env = env
 
+	// Explicit StdinPipe prevents the child from inheriting the parent's stdin.
+	// Under launchd, the parent stdin is /dev/null which can cause the Cursor
+	// agent CLI (Node.js) to hang on startup in newer versions.
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("cursorSession: stdin pipe: %w", err)
+	}
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("cursorSession: stdout pipe: %w", err)
@@ -120,13 +128,14 @@ func (cs *cursorSession) Send(prompt string, images []core.ImageAttachment, file
 	}
 
 	cs.wg.Add(1)
-	go cs.readLoop(cmd, stdout, &stderrBuf)
+	go cs.readLoop(cmd, stdout, &stderrBuf, stdinPipe)
 
 	return nil
 }
 
-func (cs *cursorSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
+func (cs *cursorSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer, stdinPipe io.WriteCloser) {
 	defer cs.wg.Done()
+	defer stdinPipe.Close()
 	defer func() {
 		if err := cmd.Wait(); err != nil {
 			stderrMsg := strings.TrimSpace(stderrBuf.String())

--- a/agent/cursor/session_test.go
+++ b/agent/cursor/session_test.go
@@ -1,0 +1,131 @@
+package cursor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestSendSetsStdinPipe verifies that Send() provides a pipe for the child
+// process's stdin instead of inheriting the parent's stdin.  Under launchd
+// (daemon mode) the parent stdin is /dev/null; newer Cursor agent CLI
+// versions hang when they inherit /dev/null as stdin.
+//
+// The test uses a tiny helper script that checks whether stdin is a pipe
+// (not /dev/null or a terminal) and emits a JSON result event so the
+// session's readLoop can consume it normally.
+func TestSendSetsStdinPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a bash helper script")
+	}
+
+	helper := t.TempDir() + "/fake-agent.sh"
+	// The helper script uses "file /dev/stdin" which follows the symlink and
+	// reports "fifo (named pipe)" for pipes vs "character special" for /dev/null.
+	script := `#!/bin/bash
+set -e
+ftype=$(file /dev/stdin 2>/dev/null)
+
+if echo "$ftype" | grep -qi "fifo\|pipe"; then
+  echo '{"type":"result","result":"ok","session_id":"test-stdin-pipe"}'
+  exit 0
+else
+  echo '{"type":"result","result":"stdin is not a pipe: '"$ftype"'","session_id":"test-stdin-pipe"}' >&2
+  exit 1
+fi
+`
+	if err := os.WriteFile(helper, []byte(script), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cs, err := newCursorSession(ctx, helper, t.TempDir(), "", "", "", nil)
+	if err != nil {
+		t.Fatalf("newCursorSession: %v", err)
+	}
+	defer cs.Close()
+
+	if err := cs.Send("hello", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	select {
+	case evt := <-cs.Events():
+		if evt.SessionID != "test-stdin-pipe" {
+			t.Errorf("unexpected session_id %q, want %q", evt.SessionID, "test-stdin-pipe")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for event — agent process likely hung (stdin not a pipe?)")
+	}
+}
+
+// TestSendStdinNotInherited ensures the child process does NOT inherit the
+// parent's stdin even when the parent's stdin is /dev/null (simulating
+// launchd).  We temporarily redirect our own stdin to /dev/null and verify
+// the child still gets a pipe.
+func TestSendStdinNotInherited(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a bash helper script")
+	}
+
+	// Verify we have bash available.
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	helper := t.TempDir() + "/fake-agent.sh"
+	script := `#!/bin/bash
+set -e
+ftype=$(file /dev/stdin 2>/dev/null)
+
+if echo "$ftype" | grep -qi "fifo\|pipe"; then
+  echo '{"type":"result","result":"ok","session_id":"test-no-inherit"}'
+  exit 0
+else
+  echo '{"type":"result","result":"stdin is not a pipe: '"$ftype"'","session_id":"test-no-inherit"}' >&2
+  exit 1
+fi
+`
+	if err := os.WriteFile(helper, []byte(script), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+
+	// Temporarily replace our own stdin with /dev/null to simulate launchd.
+	origStdin := os.Stdin
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open /dev/null: %v", err)
+	}
+	os.Stdin = devnull
+	defer func() {
+		os.Stdin = origStdin
+		devnull.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cs, err := newCursorSession(ctx, helper, t.TempDir(), "", "", "", nil)
+	if err != nil {
+		t.Fatalf("newCursorSession: %v", err)
+	}
+	defer cs.Close()
+
+	if err := cs.Send("hello", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	select {
+	case evt := <-cs.Events():
+		if evt.SessionID != "test-no-inherit" {
+			t.Errorf("unexpected session_id %q, want %q", evt.SessionID, "test-no-inherit")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out — child likely inherited /dev/null stdin instead of getting a pipe")
+	}
+}


### PR DESCRIPTION
## Problem

When cc-connect runs as a launchd daemon, the Cursor agent CLI process
hangs on startup — `cursorSession: launching` appears in the log but no
`cursorSession: raw` output follows, and the process never exits.

This started after the Cursor agent CLI updated to version `2026.03.20-44cb435`.

## Root Cause

`session.go` does not set `cmd.Stdin`. Go's `exec.Cmd` inherits the parent's
stdin by default. Under launchd the parent stdin is `/dev/null`, which causes
the newer Node.js-based agent CLI to hang.

## Fix

Add `cmd.StdinPipe()` — the same approach already used in
`agent/claudecode/session.go`. The pipe is kept open for the lifetime of
`readLoop` and closed when the goroutine exits.

## Testing

- Added two regression tests in `agent/cursor/session_test.go`:
  - `TestSendSetsStdinPipe`: verifies child gets a pipe stdin
  - `TestSendStdinNotInherited`: simulates launchd by setting parent stdin to /dev/null
- Verified on macOS with launchd daemon: agent now produces output and
  `turn complete` appears in the log.
- `go test ./...` passes.