### PR TITLE
fix(core): route relay through multi-workspace bindings

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -10948,17 +10948,76 @@ func (e *Engine) sendTTSReply(p Platform, replyCtx any, text string) {
 // Bot-to-bot relay
 // ──────────────────────────────────────────────────────────────
 
+type platformNameOnly struct {
+	name string
+}
+
+func (p platformNameOnly) Name() string                           { return p.name }
+func (platformNameOnly) Start(MessageHandler) error               { return nil }
+func (platformNameOnly) Reply(context.Context, any, string) error { return nil }
+func (platformNameOnly) Send(context.Context, any, string) error  { return nil }
+func (platformNameOnly) Stop() error                              { return nil }
+
+func relayConversationKey(fromProject, platformName, chatID string) string {
+	return "relay:" + fromProject + ":" + workspaceChannelKey(platformName, chatID)
+}
+
+func (e *Engine) platformForName(name string) Platform {
+	for _, p := range e.platforms {
+		if strings.EqualFold(p.Name(), name) {
+			return p
+		}
+	}
+	return platformNameOnly{name: name}
+}
+
+func (e *Engine) relayContextForSourceSessionKey(fromProject, sourceSessionKey string) (Agent, *SessionManager, string, error) {
+	platformName, chatID, err := parseSessionKeyParts(sourceSessionKey)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("invalid source session key: %w", err)
+	}
+
+	relaySessionKey := relayConversationKey(fromProject, platformName, chatID)
+	if !e.multiWorkspace || e.workspaceBindings == nil {
+		return e.agent, e.sessions, relaySessionKey, nil
+	}
+
+	channelKey := workspaceChannelKey(platformName, chatID)
+	workspace, _, err := e.resolveWorkspace(e.platformForName(platformName), chatID)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("resolve relay workspace: %w", err)
+	}
+	if workspace == "" {
+		if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); b != nil && !usable {
+			return nil, nil, "", fmt.Errorf("workspace binding unavailable for source channel %q", channelKey)
+		}
+		return nil, nil, "", fmt.Errorf("no workspace binding for source channel %q", channelKey)
+	}
+
+	agent, sessions, err := e.getOrCreateWorkspaceAgent(workspace)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("get relay workspace agent: %w", err)
+	}
+	if ws := e.workspacePool.Get(workspace); ws != nil {
+		ws.Touch()
+	}
+	return agent, sessions, relaySessionKey, nil
+}
+
 // HandleRelay processes a relay message synchronously: starts or resumes a
 // dedicated relay session, sends the message to the agent, and blocks until
 // the complete response is collected (or the relay context times out).
-func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message string) (string, error) {
-	relaySessionKey := "relay:" + fromProject + ":" + chatID
-	session := e.sessions.GetOrCreateActive(relaySessionKey)
+func (e *Engine) HandleRelay(ctx context.Context, fromProject, sourceSessionKey, message string) (string, error) {
+	agent, sessions, relaySessionKey, err := e.relayContextForSourceSessionKey(fromProject, sourceSessionKey)
+	if err != nil {
+		return "", err
+	}
+	session := sessions.GetOrCreateActive(relaySessionKey)
 
-	if inj, ok := e.agent.(SessionEnvInjector); ok {
+	if inj, ok := agent.(SessionEnvInjector); ok {
 		envVars := []string{
 			"CC_PROJECT=" + e.name,
-			"CC_SESSION_KEY=" + relaySessionKey,
+			"CC_SESSION_KEY=" + sourceSessionKey,
 		}
 		if exePath, err := os.Executable(); err == nil {
 			binDir := filepath.Dir(exePath)
@@ -10972,31 +11031,44 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 	// Use the engine context (not the relay timeout context) so that the
 	// agent process is not killed when the relay deadline fires. The relay
 	// timeout only controls how long we *wait* for the response.
-	agentSession, err := e.agent.StartSession(e.ctx, session.GetAgentSessionID())
+	agentSession, err := agent.StartSession(e.ctx, session.GetAgentSessionID())
 	if err != nil {
 		// Resume failed — fall back to a fresh session so the relay is not
 		// permanently broken by a corrupted/stale session ID.
 		if session.GetAgentSessionID() != "" {
 			slog.Warn("relay: session resume failed, trying fresh session",
 				"relay_key", relaySessionKey, "error", err)
-			session.SetAgentSessionID("", e.agent.Name())
-			e.sessions.Save()
-			agentSession, err = e.agent.StartSession(e.ctx, "")
+			session.SetAgentSessionID("", agent.Name())
+			sessions.Save()
+			agentSession, err = agent.StartSession(e.ctx, "")
 		}
 		if err != nil {
 			return "", fmt.Errorf("start relay session: %w", err)
 		}
 	}
 
-	if newID := agentSession.CurrentSessionID(); newID != "" {
-		if session.CompareAndSetAgentSessionID(newID, e.agent.Name()) {
-			pendingName := session.GetName()
-			if pendingName != "" && pendingName != "session" && pendingName != "default" {
-				e.sessions.SetSessionName(newID, pendingName)
-			}
-			e.sessions.Save()
+	saveRelaySessionID := func(id string, force bool) {
+		if id == "" {
+			return
 		}
+		changed := false
+		if force {
+			session.SetAgentSessionID(id, agent.Name())
+			changed = true
+		} else {
+			changed = session.CompareAndSetAgentSessionID(id, agent.Name())
+		}
+		if !changed {
+			return
+		}
+		pendingName := session.GetName()
+		if pendingName != "" && pendingName != "session" && pendingName != "default" {
+			sessions.SetSessionName(id, pendingName)
+		}
+		sessions.Save()
 	}
+
+	saveRelaySessionID(agentSession.CurrentSessionID(), false)
 
 	if err := agentSession.Send(message, nil, nil); err != nil {
 		agentSession.Close()
@@ -11011,13 +11083,7 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 				textParts = append(textParts, event.Content)
 			}
 			if event.SessionID != "" {
-				if session.CompareAndSetAgentSessionID(event.SessionID, e.agent.Name()) {
-					pendingName := session.GetName()
-					if pendingName != "" && pendingName != "session" && pendingName != "default" {
-						e.sessions.SetSessionName(event.SessionID, pendingName)
-					}
-					e.sessions.Save()
-				}
+				saveRelaySessionID(event.SessionID, false)
 			}
 		case EventToolResult:
 			out := strings.TrimSpace(event.Content)
@@ -11034,13 +11100,7 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 		case EventResult:
 			// Use agentSession.CurrentSessionID() for the same reason as above.
 			if currentID := agentSession.CurrentSessionID(); currentID != "" {
-				if session.CompareAndSetAgentSessionID(currentID, e.agent.Name()) {
-					pendingName := session.GetName()
-					if pendingName != "" && pendingName != "session" && pendingName != "default" {
-						e.sessions.SetSessionName(currentID, pendingName)
-					}
-				}
-				e.sessions.Save()
+				saveRelaySessionID(currentID, true)
 			}
 			resp := event.Content
 			if resp == "" && len(textParts) > 0 {
@@ -11069,7 +11129,7 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 			// Relay timed out. Let the agent finish its turn in the
 			// background so the session state is saved cleanly and the
 			// session remains resumable for the next relay call.
-			go e.drainRelaySession(agentSession, session, relaySessionKey)
+			go e.drainRelaySession(agentSession, session, sessions, agent.Name(), relaySessionKey)
 			return relayPartialResponseOrError(ctx.Err(), textParts, fromProject, e.name)
 		}
 	}
@@ -11106,7 +11166,7 @@ func relayPartialResponseOrError(ctxErr error, textParts []string, fromProject, 
 // agent finish its current turn (saving the session ID for future resumption),
 // auto-approves any permission requests, and then closes the session. A 10-minute
 // safety timeout prevents the goroutine from leaking if the agent hangs.
-func (e *Engine) drainRelaySession(agentSession AgentSession, session *Session, relaySessionKey string) {
+func (e *Engine) drainRelaySession(agentSession AgentSession, session *Session, sessions *SessionManager, agentName, relaySessionKey string) {
 	timer := time.NewTimer(10 * time.Minute)
 	defer timer.Stop()
 
@@ -11119,8 +11179,8 @@ func (e *Engine) drainRelaySession(agentSession AgentSession, session *Session, 
 				return
 			}
 			if ev.SessionID != "" {
-				session.SetAgentSessionID(ev.SessionID, e.agent.Name())
-				e.sessions.Save()
+				session.SetAgentSessionID(ev.SessionID, agentName)
+				sessions.Save()
 			}
 			switch ev.Type {
 			case EventResult:

--- a/core/relay.go
+++ b/core/relay.go
@@ -233,7 +233,7 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 	relayCtx, cancel := rm.relayContext(ctx)
 	defer cancel()
 
-	response, err := targetEngine.HandleRelay(relayCtx, req.From, chatID, req.Message)
+	response, err := targetEngine.HandleRelay(relayCtx, req.From, req.SessionKey, req.Message)
 	if err != nil {
 		return nil, fmt.Errorf("relay: %w", err)
 	}

--- a/core/relay_test.go
+++ b/core/relay_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -62,7 +65,7 @@ func TestHandleRelay_ReturnsPartialOnTimeout(t *testing.T) {
 	}
 	done := make(chan relayResult, 1)
 	go func() {
-		resp, err := e.HandleRelay(ctx, "source", "chat-1", "hello")
+		resp, err := e.HandleRelay(ctx, "source", "test:chat-1:user", "hello")
 		done <- relayResult{resp: resp, err: err}
 	}()
 
@@ -105,7 +108,7 @@ func TestHandleRelay_TimeoutWithoutTextReturnsContextError(t *testing.T) {
 	}
 	done := make(chan relayResult, 1)
 	go func() {
-		resp, err := e.HandleRelay(ctx, "source", "chat-1", "hello")
+		resp, err := e.HandleRelay(ctx, "source", "test:chat-1:user", "hello")
 		done <- relayResult{resp: resp, err: err}
 	}()
 
@@ -156,7 +159,8 @@ func TestHandleRelay_ResumeFailureFallsBackToFreshSession(t *testing.T) {
 	e.agent = &relayFallbackAgent{freshSession: freshSession}
 
 	// Pre-set a stale session ID so that the first StartSession tries to resume.
-	relaySessionKey := "relay:source:chat-1"
+	sourceSessionKey := "test:chat-1:user"
+	relaySessionKey := "relay:source:test:chat-1"
 	sess := e.sessions.GetOrCreateActive(relaySessionKey)
 	sess.SetAgentSessionID("stale-id", "fallback")
 	e.sessions.Save()
@@ -164,7 +168,7 @@ func TestHandleRelay_ResumeFailureFallsBackToFreshSession(t *testing.T) {
 	ctx := context.Background()
 	done := make(chan string, 1)
 	go func() {
-		resp, err := e.HandleRelay(ctx, "source", "chat-1", "hello")
+		resp, err := e.HandleRelay(ctx, "source", sourceSessionKey, "hello")
 		if err != nil {
 			done <- "error: " + err.Error()
 			return
@@ -185,5 +189,91 @@ func TestHandleRelay_ResumeFailureFallsBackToFreshSession(t *testing.T) {
 	case <-freshSession.closed:
 	case <-time.After(2 * time.Second):
 		t.Fatal("session was not closed after EventResult")
+	}
+}
+
+func TestHandleRelay_SingleWorkspaceUsesGlobalAgentAndSourceSessionKey(t *testing.T) {
+	e := newTestEngine()
+	agent := &sessionEnvRecordingAgent{session: newResultAgentSession("global")}
+	e.agent = agent
+
+	sourceSessionKey := "discord:C1:U1"
+	resp, err := e.HandleRelay(context.Background(), "source", sourceSessionKey, "hello")
+	if err != nil {
+		t.Fatalf("HandleRelay() error = %v", err)
+	}
+	if resp != "global" {
+		t.Fatalf("HandleRelay() response = %q, want %q", resp, "global")
+	}
+	if got := agent.EnvValue("CC_SESSION_KEY"); got != sourceSessionKey {
+		t.Fatalf("CC_SESSION_KEY = %q, want %q", got, sourceSessionKey)
+	}
+	if got := e.sessions.ActiveSessionID("relay:source:discord:C1"); got == "" {
+		t.Fatal("expected relay session to be stored under platform-qualified relay key")
+	}
+}
+
+func TestHandleRelay_MultiWorkspaceRoutesBySourceSessionKey(t *testing.T) {
+	baseDir := t.TempDir()
+	channelID := "C42"
+	wsDir := filepath.Join(baseDir, "relay-ws")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &mockChannelResolver{name: "mock", names: map[string]string{channelID: "relay-ws"}}
+	globalAgent := &sessionEnvRecordingAgent{session: newResultAgentSession("global")}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+
+	normalizedWsDir := normalizeWorkspacePath(wsDir)
+	workspaceAgent := &sessionEnvRecordingAgent{session: newResultAgentSession("workspace")}
+	ws := e.workspacePool.GetOrCreate(normalizedWsDir)
+	ws.agent = workspaceAgent
+	ws.sessions = NewSessionManager("")
+
+	sourceSessionKey := "mock:" + channelID + ":U1"
+	resp, err := e.HandleRelay(context.Background(), "source", sourceSessionKey, "hello")
+	if err != nil {
+		t.Fatalf("HandleRelay() error = %v", err)
+	}
+	if resp != "workspace" {
+		t.Fatalf("HandleRelay() response = %q, want %q", resp, "workspace")
+	}
+	if got := workspaceAgent.EnvValue("CC_SESSION_KEY"); got != sourceSessionKey {
+		t.Fatalf("workspace CC_SESSION_KEY = %q, want %q", got, sourceSessionKey)
+	}
+	if got := globalAgent.EnvValue("CC_SESSION_KEY"); got != "" {
+		t.Fatalf("global agent should not receive relay env, got %q", got)
+	}
+	if got := e.sessions.ActiveSessionID("relay:source:mock:" + channelID); got != "" {
+		t.Fatalf("expected no global relay session, got %q", got)
+	}
+	if got := ws.sessions.ActiveSessionID("relay:source:mock:" + channelID); got == "" {
+		t.Fatal("expected relay session in workspace session manager")
+	}
+	if b := e.workspaceBindings.Lookup("project:test", workspaceChannelKey("mock", channelID)); b == nil || b.Workspace != normalizedWsDir {
+		t.Fatalf("expected convention binding to be created for %q", normalizedWsDir)
+	}
+}
+
+func TestHandleRelay_MultiWorkspaceRequiresWorkspaceBinding(t *testing.T) {
+	baseDir := t.TempDir()
+	globalAgent := &sessionEnvRecordingAgent{session: newResultAgentSession("global")}
+	e := NewEngine("test", globalAgent, nil, "", LangEnglish)
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+
+	resp, err := e.HandleRelay(context.Background(), "source", "mock:C404:U1", "hello")
+	if err == nil {
+		t.Fatal("expected error for unbound relay workspace")
+	}
+	if resp != "" {
+		t.Fatalf("HandleRelay() response = %q, want empty", resp)
+	}
+	if !strings.Contains(err.Error(), "no workspace binding") {
+		t.Fatalf("HandleRelay() error = %v, want missing workspace binding", err)
+	}
+	if got := e.sessions.ActiveSessionID("relay:source:mock:C404"); got != "" {
+		t.Fatalf("expected no global relay session, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

This fixes bot-to-bot relay in `multi-workspace` mode.

Before this change, relay requests only passed `chatID` into the target engine, so the target side bypassed normal workspace routing and used the global agent/session manager. That caused relayed messages to run in the wrong workspace.

## What changed

- pass the full source `sessionKey` through relay handling
- resolve relay workspace on the target side from the source session context
- route relay turns to the workspace-specific agent and session manager in `multi-workspace` mode
- use a platform-qualified relay session key to avoid cross-platform collisions
- keep `CC_SESSION_KEY` set to the original source session key for agent-side relay/cron context
- add regression tests for:
  - single-workspace relay staying on the global agent
  - multi-workspace relay routing by source session key
  - multi-workspace relay failing cleanly when no workspace binding exists
  - existing relay timeout behavior

## Behavior note

In `multi-workspace` mode, relay from an unbound source channel now fails explicitly instead of silently falling back to the global agent. This is intentional so relay behavior matches workspace-aware routing expectations.

## Validation

```bash
nix shell nixpkgs#go -c go test ./core -run 'TestHandleRelay|TestSessionContextForKey|TestMultiWorkspaceResolution' -count=1
nix shell nixpkgs#go -c go test ./core -count=1
nix shell nixpkgs#go -c go test ./... -run '^$' -count=1
```
