### PR TITLE
feat(claudecode): add auto permission mode

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,7 +162,7 @@ work_dir = "/absolute/path/to/your/project"
 mode = "default"
 
 # --- Claude Code mode options ---
-# "default", "acceptEdits" (alias: "edit"), "plan", "bypassPermissions" (alias: "yolo")
+# "default", "acceptEdits" (alias: "edit"), "plan", "auto", "bypassPermissions" (alias: "yolo")
 # allowed_tools = ["Read", "Grep", "Glob"]  # optional: pre-approve specific tools
 
 # --- Codex mode options ---

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -31,11 +31,12 @@ func init() {
 //   - "default":           every tool call requires user approval
 //   - "acceptEdits":       auto-approve file edit tools, ask for others
 //   - "plan":              plan only, no execution until approved
-//   - "bypassPermissions": auto-approve everything (YOLO mode)
+//   - "auto":              Claude's automatic permission classifier
+//   - "bypassPermissions": auto-approve everything (alias: yolo)
 type Agent struct {
 	workDir         string
 	model           string
-	mode            string // "default" | "acceptEdits" | "plan" | "bypassPermissions" | "dontAsk"
+	mode            string // "default" | "acceptEdits" | "plan" | "auto" | "bypassPermissions" | "dontAsk"
 	allowedTools    []string
 	disallowedTools []string
 	providers       []core.ProviderConfig
@@ -105,8 +106,10 @@ func normalizePermissionMode(raw string) string {
 		return "acceptEdits"
 	case "plan":
 		return "plan"
+	case "auto":
+		return "auto"
 	case "bypasspermissions", "bypass-permissions", "bypass_permissions",
-		"yolo", "auto":
+		"yolo":
 		return "bypassPermissions"
 	case "dontask", "dont-ask", "dont_ask":
 		return "dontAsk"
@@ -503,6 +506,7 @@ func (a *Agent) PermissionModes() []core.PermissionModeInfo {
 		{Key: "default", Name: "Default", NameZh: "默认", Desc: "Ask permission for every tool call", DescZh: "每次工具调用都需确认"},
 		{Key: "acceptEdits", Name: "Accept Edits", NameZh: "接受编辑", Desc: "Auto-approve file edits, ask for others", DescZh: "自动允许文件编辑，其他需确认"},
 		{Key: "plan", Name: "Plan Mode", NameZh: "计划模式", Desc: "Plan only, no execution until approved", DescZh: "只做规划不执行，审批后再执行"},
+		{Key: "auto", Name: "Auto", NameZh: "自动模式", Desc: "Claude decides when to ask for permission", DescZh: "由 Claude 自动判断何时需要确认"},
 		{Key: "bypassPermissions", Name: "YOLO", NameZh: "YOLO 模式", Desc: "Auto-approve everything", DescZh: "全部自动通过"},
 		{Key: "dontAsk", Name: "Don't Ask", NameZh: "静默拒绝", Desc: "Auto-deny tools unless pre-approved via allowed_tools or settings.json allow rules", DescZh: "未预授权的工具自动拒绝，不弹确认"},
 	}

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -96,6 +96,8 @@ func TestNormalizePermissionMode(t *testing.T) {
 		{"dontask", "dontAsk"},
 		{"dont-ask", "dontAsk"},
 		{"dont_ask", "dontAsk"},
+		// auto
+		{"auto", "auto"},
 		// bypassPermissions aliases
 		{"bypassPermissions", "bypassPermissions"},
 		{"yolo", "bypassPermissions"},
@@ -130,14 +132,51 @@ func TestClaudeSessionSetLiveMode(t *testing.T) {
 		t.Fatal("acceptEdits flags not set correctly")
 	}
 
-	cs.SetLiveMode("bypassPermissions")
-	if !cs.autoApprove.Load() || cs.acceptEditsOnly.Load() || cs.dontAsk.Load() {
-		t.Fatal("bypassPermissions flags not set correctly")
+	if cs.SetLiveMode("auto") {
+		t.Fatal("SetLiveMode(auto) = true, want false")
 	}
 
 	cs.SetLiveMode("dontAsk")
 	if !cs.dontAsk.Load() || cs.autoApprove.Load() || cs.acceptEditsOnly.Load() {
 		t.Fatal("dontAsk flags not set correctly")
+	}
+
+	cs.SetLiveMode("bypassPermissions")
+	if !cs.autoApprove.Load() || cs.acceptEditsOnly.Load() || cs.dontAsk.Load() {
+		t.Fatal("bypassPermissions alias flags not set correctly")
+	}
+}
+
+func TestClaudeSessionSetLiveMode_AutoSessionRequiresRestart(t *testing.T) {
+	cs := &claudeSession{}
+	cs.setPermissionMode("auto")
+	if cs.SetLiveMode("default") {
+		t.Fatal("SetLiveMode(default) from auto session = true, want false")
+	}
+}
+
+func TestAgent_PermissionModes(t *testing.T) {
+	a := &Agent{}
+	modes := a.PermissionModes()
+	if len(modes) == 0 {
+		t.Fatal("PermissionModes() returned no modes")
+	}
+
+	foundAuto := false
+	foundBypass := false
+	for _, mode := range modes {
+		if mode.Key == "auto" {
+			foundAuto = true
+		}
+		if mode.Key == "bypassPermissions" {
+			foundBypass = true
+		}
+	}
+	if !foundAuto {
+		t.Fatal("PermissionModes() missing auto mode")
+	}
+	if !foundBypass {
+		t.Fatal("PermissionModes() missing bypassPermissions mode")
 	}
 }
 
@@ -220,6 +259,20 @@ func TestAgent_SetPlatformPrompt(t *testing.T) {
 	a.SetPlatformPrompt("You are a helpful assistant on Feishu.")
 	if a.platformPrompt != "You are a helpful assistant on Feishu." {
 		t.Errorf("platformPrompt = %q, want %q", a.platformPrompt, "You are a helpful assistant on Feishu.")
+	}
+}
+
+func TestAgent_SetMode(t *testing.T) {
+	a := &Agent{}
+
+	a.SetMode("auto")
+	if got := a.GetMode(); got != "auto" {
+		t.Fatalf("GetMode() after SetMode(auto) = %q, want auto", got)
+	}
+
+	a.SetMode("yolo")
+	if got := a.GetMode(); got != "bypassPermissions" {
+		t.Fatalf("GetMode() after SetMode(yolo) = %q, want bypassPermissions", got)
 	}
 }
 

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -31,6 +31,7 @@ type claudeSession struct {
 	stdinMu         sync.Mutex
 	events          chan core.Event
 	sessionID       atomic.Value // stores string
+	permissionMode  atomic.Value // stores string
 	autoApprove     atomic.Bool
 	acceptEditsOnly atomic.Bool
 	dontAsk         atomic.Bool
@@ -533,12 +534,17 @@ func isClaudeEditTool(toolName string) bool {
 }
 
 func (cs *claudeSession) setPermissionMode(mode string) {
+	cs.permissionMode.Store(mode)
 	cs.autoApprove.Store(mode == "bypassPermissions")
 	cs.acceptEditsOnly.Store(mode == "acceptEdits")
 	cs.dontAsk.Store(mode == "dontAsk")
 }
 
 func (cs *claudeSession) SetLiveMode(mode string) bool {
+	current, _ := cs.permissionMode.Load().(string)
+	if mode == "auto" || mode == "plan" || current == "auto" || current == "plan" {
+		return false
+	}
 	cs.setPermissionMode(mode)
 	return true
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -503,12 +503,13 @@ type = "claudecode"
 
 [projects.agent.options]
 work_dir = "/path/to/backend"
-mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "bypassPermissions" (yolo)
+mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "auto" | "bypassPermissions" (yolo)
 
 # Mode options / 模式说明:
 # - "default":            Every tool call requires user approval. / 每次工具调用都需要用户确认。
 # - "acceptEdits" (edit): File edit tools auto-approved; other tools still ask. / 文件编辑自动通过，其他仍需确认。
 # - "plan":               Claude only plans — no execution until you approve. / 只做规划不执行，审批后再执行。
+# - "auto": Claude automatically decides when a permission prompt is needed. / Claude 自动判断何时需要确认。
 # - "bypassPermissions" (yolo): All tool calls auto-approved. Use with caution. / 全部自动通过，请谨慎使用。
 # - "dontAsk" (dont-ask): Auto-deny tools unless pre-approved via allowed_tools or settings allow rules. / 未预授权的工具自动拒绝，安全推荐。
 #
@@ -1238,6 +1239,7 @@ app_secret = "your-feishu-app-secret"
 #
 # [projects.agent.options]
 # work_dir = "/path/to/frontend"
+# mode = "auto"
 # mode = "bypassPermissions"
 #
 # [[projects.platforms]]

--- a/core/engine.go
+++ b/core/engine.go
@@ -4933,7 +4933,7 @@ func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
 					sb.WriteString(fmt.Sprintf("**%s**%s — %s\n", m.Name, suffix, m.Desc))
 				}
 			}
-			sb.WriteString(e.i18n.T(MsgModeUsage))
+			sb.WriteString(e.modeUsageText(modes))
 
 			var buttons [][]ButtonOption
 			var row []ButtonOption
@@ -4985,6 +4985,14 @@ func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
 		reply += "\n\n(Current session updated immediately.)"
 	}
 	e.reply(p, msg.ReplyCtx, reply)
+}
+
+func (e *Engine) modeUsageText(modes []PermissionModeInfo) string {
+	keys := make([]string, 0, len(modes))
+	for _, mode := range modes {
+		keys = append(keys, "`"+mode.Key+"`")
+	}
+	return e.i18n.Tf(MsgModeUsage, strings.Join(keys, " / "))
 }
 
 func (e *Engine) applyLiveModeChange(sessionKey, mode string) bool {
@@ -6717,7 +6725,7 @@ func (e *Engine) renderModeCard() *Card {
 		Markdown(sb.String()).
 		Select(e.i18n.T(MsgModeSelectPlaceholder), opts, initVal).
 		Buttons(e.cardBackButton())
-	cb.Note(e.i18n.T(MsgModeUsage))
+	cb.Note(e.modeUsageText(modes))
 	return cb.Build()
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2879,6 +2879,12 @@ func TestCmdMode_UsesInlineButtonsOnButtonOnlyPlatform(t *testing.T) {
 	if got := p.buttonRows[0][0].Data; got != "cmd:/mode default" {
 		t.Fatalf("first /mode button = %q, want %q", got, "cmd:/mode default")
 	}
+	if !strings.Contains(p.buttonContent, "Available: `default` / `yolo`") {
+		t.Fatalf("button content = %q, want dynamic mode list", p.buttonContent)
+	}
+	if strings.Contains(p.buttonContent, "`edit`") {
+		t.Fatalf("button content = %q, want no hardcoded mode list", p.buttonContent)
+	}
 }
 
 func TestCmdMode_AppliesLiveModeWithoutReset(t *testing.T) {

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -2011,11 +2011,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Uso: `/reasoning <número>` o `/reasoning <low|medium|high|xhigh>`",
 	},
 	MsgModeUsage: {
-		LangEnglish:            "\nUse `/mode <name>` to switch.\nAvailable: `default` / `edit` / `plan` / `yolo`",
-		LangChinese:            "\n使用 `/mode <名称>` 切换模式\n可用值: `default` / `edit` / `plan` / `yolo`",
-		LangTraditionalChinese: "\n使用 `/mode <名稱>` 切換模式\n可用值: `default` / `edit` / `plan` / `yolo`",
-		LangJapanese:           "\n`/mode <名前>` で切り替え\n選択肢: `default` / `edit` / `plan` / `yolo`",
-		LangSpanish:            "\nUse `/mode <nombre>` para cambiar.\nDisponibles: `default` / `edit` / `plan` / `yolo`",
+		LangEnglish:            "\nUse `/mode <name>` to switch.\nAvailable: %s",
+		LangChinese:            "\n使用 `/mode <名称>` 切换模式\n可用值: %s",
+		LangTraditionalChinese: "\n使用 `/mode <名稱>` 切換模式\n可用值: %s",
+		LangJapanese:           "\n`/mode <名前>` で切り替え\n選択肢: %s",
+		LangSpanish:            "\nUse `/mode <nombre>` para cambiar.\nDisponibles: %s",
 	},
 	MsgLangSelectPlaceholder: {
 		LangEnglish: "Select language", LangChinese: "选择语言", LangTraditionalChinese: "選擇語言",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,6 +59,7 @@ All agents support permission modes switchable at runtime via `/mode`.
 |------|-------------|----------|
 | Default | `default` | Every tool call requires approval |
 | Accept Edits | `acceptEdits` / `edit` | File edits auto-approved |
+| Auto | `auto` | Claude decides when to ask for permission |
 | Plan Mode | `plan` | Claude only plans, no execution |
 | YOLO | `bypassPermissions` / `yolo` | All tools auto-approved |
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -59,6 +59,7 @@ cc-connect 完整功能使用指南。
 |------|--------|------|
 | 默认 | `default` | 每次工具调用需确认 |
 | 接受编辑 | `acceptEdits` / `edit` | 文件编辑自动通过 |
+| 自动模式 | `auto` | 由 Claude 自动判断何时需要确认 |
 | 计划模式 | `plan` | 只规划不执行 |
 | YOLO | `bypassPermissions` / `yolo` | 全部自动通过 |
 
@@ -107,7 +108,7 @@ mode = "default"
 运行时切换：
 ```
 /mode          # 查看当前和可用模式
-/mode yolo     # 切换到 YOLO
+/mode yolo     # 切换到 YOLO 模式
 /mode default  # 切回默认
 ```
 


### PR DESCRIPTION
## Summary
- add first-class `auto` mode support for the Claude Code agent
- keep `bypassPermissions` as the full-auto mode and preserve `yolo` as its alias
- generate `/mode` usage text from agent-provided modes instead of a hardcoded list

## Background
- Claude Code now exposes `auto` and `bypassPermissions` as distinct permission modes
- cc-connect needed to stop treating `auto` as a synonym for `bypassPermissions`
- `/mode` help text also needed to reflect the actual mode list for the current agent

## Changes
- update Claude Code mode normalization so `auto` remains distinct while `yolo` maps to `bypassPermissions`
- expose both `auto` and `bypassPermissions` in Claude Code mode metadata
- prevent live hot-switching into or out of `auto`/`plan`, requiring a fresh session when needed
- make core `/mode` usage text dynamic based on `PermissionModes()`
- refresh config/docs/examples for the new Claude Code mode semantics

## Test Plan
- `go test ./core -run 'TestCmdMode_|TestCmdMode_UsesInlineButtonsOnButtonOnlyPlatform|TestCmdMode_AppliesLiveModeWithoutReset'`
- `go test ./agent/claudecode -run 'TestNormalizePermissionMode|TestClaudeSessionSetLiveMode|TestClaudeSessionSetLiveMode_AutoSessionRequiresRestart|TestAgent_PermissionModes|TestAgent_SetMode'`

## Risks
- broader `go test ./core` still hits the pre-existing unrelated failure `TestCmdShell_MultiWorkspaceIgnoresMissingSharedBinding`
- Claude CLI behavior for `auto` is delegated to upstream Claude Code semantics, so future CLI changes may require follow-up alignment
