### PR TITLE
fix(codex): add panic recovery in readLoop to prevent process crash

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -194,6 +195,17 @@ func codexImageExt(mime string) string {
 
 func (cs *codexSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
 	defer cs.wg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("codexSession: recovered from panic in readLoop",
+				"panic", r, "stack", string(debug.Stack()))
+			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("internal panic: %v", r)}
+			select {
+			case cs.events <- evt:
+			case <-cs.ctx.Done():
+			}
+		}
+	}()
 	defer func() {
 		if err := cmd.Wait(); err != nil {
 			stderrMsg := strings.TrimSpace(stderrBuf.String())

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -360,3 +360,37 @@ func TestCodexSession_ContinueSessionTreatedAsFresh(t *testing.T) {
 		t.Errorf("ContinueSession should be treated as fresh: threadID = %q, want empty", got)
 	}
 }
+
+func TestHandleEvent_RecoverFromPanic(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "/tmp", "", "", "", "", nil)
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer cs.Close()
+
+	// Craft a malformed event that triggers handleItemCompleted with an
+	// item whose "type" matches a known tool name in codexToolNames, but
+	// whose nested structure could cause unexpected panics in downstream
+	// processing. This verifies handleEvent does not crash the process.
+	malformedEvents := []map[string]any{
+		// nil item field
+		{"type": "item.completed", "item": nil},
+		// item with unknown type — should be handled gracefully
+		{"type": "item.completed", "item": map[string]any{"type": "totally_unknown_type_xyz"}},
+		// item matching a known tool name but with unusual nested structure
+		{"type": "item.completed", "item": map[string]any{"type": "web_search", "action": "not-a-map"}},
+	}
+
+	for i, evt := range malformedEvents {
+		// handleEvent should not panic; if it does, the test will catch it.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("handleEvent panicked on malformed event %d: %v", i, r)
+				}
+			}()
+			cs.handleEvent(evt)
+		}()
+	}
+}
+


### PR DESCRIPTION
When handleItemCompleted encounters an unexpected event structure from the Codex CLI (e.g., a new item type or malformed JSON fields), it can panic. Since readLoop runs in a goroutine with no recover(), this crashes the entire cc-connect process.

Add a deferred recover() at the top of readLoop that:
- Catches any panic from handleEvent and its callees
- Logs the panic value and full stack trace via slog.Error
- Emits an EventError to the events channel so the caller is notified
- Allows the process to continue serving other projects/platforms

Also add TestHandleEvent_RecoverFromPanic to verify that malformed item.completed events (nil item, unknown types, unexpected nested structures) do not cause panics.