### PR TITLE
Add dedicated /agent switching for Feishu cards

### DIFF
--- a/agent/codex/binary_test.go
+++ b/agent/codex/binary_test.go
@@ -1,0 +1,31 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveCodexBinary_FallsBackToHomeBin(t *testing.T) {
+	tmpHome := t.TempDir()
+	binDir := filepath.Join(tmpHome, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	fakeCodex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(fakeCodex, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write codex stub: %v", err)
+	}
+
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	got, err := resolveCodexBinary()
+	if err != nil {
+		t.Fatalf("resolveCodexBinary: %v", err)
+	}
+	if got != fakeCodex {
+		t.Fatalf("resolveCodexBinary() = %q, want %q", got, fakeCodex)
+	}
+}

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -32,6 +33,8 @@ type Agent struct {
 	model           string
 	reasoningEffort string
 	mode            string // "suggest" | "auto-edit" | "full-auto" | "yolo"
+	binaryPath      string
+	extraEnv        []string
 	providers       []core.ProviderConfig
 	activeIdx       int // -1 = no provider set
 	sessionEnv      []string
@@ -47,9 +50,11 @@ func New(opts map[string]any) (core.Agent, error) {
 	reasoningEffort, _ := opts["reasoning_effort"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
+	extraEnv := parseExtraEnv(opts["env"])
 
-	if _, err := exec.LookPath("codex"); err != nil {
-		return nil, fmt.Errorf("codex: 'codex' CLI not found in PATH, install with: npm install -g @openai/codex")
+	binaryPath, err := resolveCodexBinary()
+	if err != nil {
+		return nil, err
 	}
 
 	return &Agent{
@@ -57,8 +62,49 @@ func New(opts map[string]any) (core.Agent, error) {
 		model:           model,
 		reasoningEffort: normalizeReasoningEffort(reasoningEffort),
 		mode:            mode,
+		binaryPath:      binaryPath,
+		extraEnv:        extraEnv,
 		activeIdx:       -1,
 	}, nil
+}
+
+func resolveCodexBinary() (string, error) {
+	if path, err := exec.LookPath("codex"); err == nil {
+		if isExecutableFile(path) {
+			return path, nil
+		}
+	}
+
+	var candidates []string
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, "bin", "codex"),
+			filepath.Join(home, ".local", "bin", "codex"),
+		)
+	}
+	candidates = append(candidates,
+		"/usr/local/bin/codex",
+		"/usr/bin/codex",
+	)
+
+	for _, candidate := range candidates {
+		if isExecutableFile(candidate) {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("codex: 'codex' CLI not found in PATH or common install locations (try: npm install -g @openai/codex, or add your codex install directory to PATH)")
+}
+
+func isExecutableFile(path string) bool {
+	st, err := os.Stat(path)
+	if err != nil || st.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return st.Mode().Perm()&0o111 != 0
 }
 
 func normalizeMode(raw string) string {
@@ -89,6 +135,27 @@ func normalizeReasoningEffort(raw string) string {
 	default:
 		return ""
 	}
+}
+
+func parseExtraEnv(raw any) []string {
+	envMap, ok := raw.(map[string]any)
+	if !ok || len(envMap) == 0 {
+		return nil
+	}
+	env := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			continue
+		}
+		val := strings.TrimSpace(fmt.Sprint(v))
+		if val == "" {
+			continue
+		}
+		env = append(env, key+"="+val)
+	}
+	sort.Strings(env)
+	return env
 }
 
 func (a *Agent) Name() string { return "codex" }
@@ -294,7 +361,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	mode := a.mode
 	model := a.model
 	reasoningEffort := a.reasoningEffort
+	binaryPath := a.binaryPath
 	extraEnv := a.providerEnvLocked()
+	extraEnv = append(extraEnv, a.extraEnv...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
@@ -303,7 +372,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
-	return newCodexSession(ctx, a.workDir, model, reasoningEffort, mode, sessionID, extraEnv)
+	return newCodexSession(ctx, binaryPath, a.workDir, model, reasoningEffort, mode, sessionID, extraEnv)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/codex/env_test.go
+++ b/agent/codex/env_test.go
@@ -1,0 +1,26 @@
+package codex
+
+import "testing"
+
+func TestParseExtraEnv(t *testing.T) {
+	got := parseExtraEnv(map[string]any{
+		"CODEX_HOME": "/tmp/codex-home",
+		"ZETA":       "last",
+		"ALPHA":      123,
+	})
+
+	want := []string{
+		"ALPHA=123",
+		"CODEX_HOME=/tmp/codex-home",
+		"ZETA=last",
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("len(parseExtraEnv) = %d, want %d, got=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseExtraEnv[%d] = %q, want %q, got=%v", i, got[i], want[i], got)
+		}
+	}
+}

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -24,34 +24,36 @@ import (
 // codexSession manages a multi-turn Codex conversation.
 // First Send() uses `codex exec`, subsequent ones use `codex exec resume <threadID>`.
 type codexSession struct {
-	workDir   string
-	model     string
-	effort    string
-	mode      string
-	extraEnv  []string
-	events    chan core.Event
-	threadID  atomic.Value // stores string — Codex thread_id
-	ctx       context.Context
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
-	alive     atomic.Bool
-	closeOnce sync.Once
+	binaryPath string
+	workDir    string
+	model      string
+	effort     string
+	mode       string
+	extraEnv   []string
+	events     chan core.Event
+	threadID   atomic.Value // stores string — Codex thread_id
+	ctx        context.Context
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+	alive      atomic.Bool
+	closeOnce  sync.Once
 
 	pendingMsgs []string // buffered agent_message texts awaiting classification
 }
 
-func newCodexSession(ctx context.Context, workDir, model, effort, mode, resumeID string, extraEnv []string) (*codexSession, error) {
+func newCodexSession(ctx context.Context, binaryPath, workDir, model, effort, mode, resumeID string, extraEnv []string) (*codexSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	cs := &codexSession{
-		workDir:  workDir,
-		model:    model,
-		effort:   effort,
-		mode:     mode,
-		extraEnv: extraEnv,
-		events:   make(chan core.Event, 64),
-		ctx:      sessionCtx,
-		cancel:   cancel,
+		binaryPath: binaryPath,
+		workDir:    workDir,
+		model:      model,
+		effort:     effort,
+		mode:       mode,
+		extraEnv:   extraEnv,
+		events:     make(chan core.Event, 64),
+		ctx:        sessionCtx,
+		cancel:     cancel,
 	}
 	cs.alive.Store(true)
 
@@ -78,13 +80,20 @@ func (cs *codexSession) Send(prompt string, images []core.ImageAttachment, files
 	if err != nil {
 		return err
 	}
+	binaryPath := cs.binaryPath
+	if strings.TrimSpace(binaryPath) == "" {
+		binaryPath, err = resolveCodexBinary()
+		if err != nil {
+			return err
+		}
+	}
 
 	isResume := cs.CurrentSessionID() != ""
 	args := cs.buildExecArgs(prompt, imagePaths)
 
 	slog.Debug("codexSession: launching", "resume", isResume, "args", core.RedactArgs(args))
 
-	cmd := exec.CommandContext(cs.ctx, "codex", args...)
+	cmd := exec.CommandContext(cs.ctx, binaryPath, args...)
 	cmd.Dir = cs.workDir
 	if len(cs.extraEnv) > 0 {
 		cmd.Env = core.MergeEnv(os.Environ(), cs.extraEnv)

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -36,7 +36,7 @@ func TestAvailableReasoningEfforts_ExcludesMinimal(t *testing.T) {
 }
 
 func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
-	cs, err := newCodexSession(context.Background(), "/tmp/project", "o3", "high", "full-auto", "", nil)
+	cs, err := newCodexSession(context.Background(), "", "/tmp/project", "o3", "high", "full-auto", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 }
 
 func TestBuildExecArgs_ResumeOmitsCdFlag(t *testing.T) {
-	cs, err := newCodexSession(context.Background(), "/tmp/project", "", "", "full-auto", "thread-abc", nil)
+	cs, err := newCodexSession(context.Background(), "", "/tmp/project", "", "", "full-auto", "thread-abc", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 	t.Setenv("CODEX_ARGS_FILE", argsFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	cs, err := newCodexSession(context.Background(), "", workDir, "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
 	t.Setenv("CODEX_ARGS_FILE", argsFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "thread-123", nil)
+	cs, err := newCodexSession(context.Background(), "", workDir, "", "", "", "thread-123", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestSend_HandlesLargeJSONLines(t *testing.T) {
 	t.Setenv("CODEX_PAYLOAD_FILE", payloadFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	cs, err := newCodexSession(context.Background(), "", workDir, "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -350,7 +350,7 @@ func indexOf(args []string, target string) int {
 }
 
 func TestCodexSession_ContinueSessionTreatedAsFresh(t *testing.T) {
-	s, err := newCodexSession(context.Background(), "/tmp", "", "", "full-auto", core.ContinueSession, nil)
+	s, err := newCodexSession(context.Background(), "", "/tmp", "", "", "full-auto", core.ContinueSession, nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}

--- a/agent/switcher/switcher.go
+++ b/agent/switcher/switcher.go
@@ -1,0 +1,768 @@
+package switcher
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func init() {
+	core.RegisterAgent("switcher", New)
+	core.RegisterAgentModelConfigSaver("switcher", saveModelConfig)
+}
+
+type backendSpec struct {
+	name  string
+	typ   string
+	opts  map[string]any
+	agent core.Agent
+}
+
+// Agent multiplexes multiple agent backends behind a single cc-connect project.
+// /agent switches the active backend (e.g. Claude Code vs Codex), while /model
+// delegates to the active backend's own model switcher.
+type Agent struct {
+	workDir         string
+	mode            string
+	currentAgent    string
+	reasoningEffort string
+
+	backends map[string]*backendSpec
+	order    []string
+
+	sessionEnv     []string
+	platformPrompt string
+	mu             sync.RWMutex
+}
+
+func New(opts map[string]any) (core.Agent, error) {
+	workDir := stringOpt(opts, "work_dir", ".")
+	mode := normalizeMode(stringOpt(opts, "mode", "default"))
+	defaultBackend := strings.TrimSpace(stringOpt(opts, "agent", ""))
+	reasoningEffort := strings.TrimSpace(stringOpt(opts, "reasoning_effort", ""))
+
+	backendsRaw, ok := opts["backends"]
+	if !ok {
+		return nil, fmt.Errorf("switcher: [projects.agent.options.backends] is required")
+	}
+
+	backends, order, err := parseBackendSpecs(backendsRaw)
+	if err != nil {
+		return nil, err
+	}
+	if len(backends) == 0 {
+		return nil, fmt.Errorf("switcher: at least one backend is required")
+	}
+
+	if defaultBackend == "" {
+		defaultBackend = order[0]
+	}
+	if _, ok := backends[defaultBackend]; !ok {
+		return nil, fmt.Errorf("switcher: default backend %q not found in backends", defaultBackend)
+	}
+
+	return &Agent{
+		workDir:         workDir,
+		mode:            mode,
+		currentAgent:    defaultBackend,
+		reasoningEffort: reasoningEffort,
+		backends:        backends,
+		order:           order,
+	}, nil
+}
+
+func normalizeMode(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "auto-edit", "autoedit", "auto_edit", "edit":
+		return "auto-edit"
+	case "full-auto", "fullauto", "full_auto", "auto":
+		return "full-auto"
+	case "yolo", "bypass", "dangerously-bypass":
+		return "yolo"
+	default:
+		return "suggest"
+	}
+}
+
+func stringOpt(opts map[string]any, key, fallback string) string {
+	if v, ok := opts[key].(string); ok {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			return v
+		}
+	}
+	return fallback
+}
+
+func parseBackendSpecs(raw any) (map[string]*backendSpec, []string, error) {
+	var items []any
+	switch v := raw.(type) {
+	case []any:
+		items = v
+	case []map[string]any:
+		items = make([]any, len(v))
+		for i := range v {
+			items[i] = v[i]
+		}
+	default:
+		return nil, nil, fmt.Errorf("switcher: backends must be an array of tables")
+	}
+
+	backends := make(map[string]*backendSpec, len(items))
+	order := make([]string, 0, len(items))
+	for i, item := range items {
+		specMap, ok := item.(map[string]any)
+		if !ok {
+			return nil, nil, fmt.Errorf("switcher: backends[%d] must be a table", i)
+		}
+		spec := cloneOptions(specMap)
+		name := strings.TrimSpace(stringFromMap(spec, "name"))
+		if name == "" {
+			return nil, nil, fmt.Errorf("switcher: backends[%d].name is required", i)
+		}
+		typ := strings.TrimSpace(stringFromMap(spec, "type"))
+		if typ == "" {
+			return nil, nil, fmt.Errorf("switcher: backends[%d].type is required", i)
+		}
+		if _, exists := backends[name]; exists {
+			return nil, nil, fmt.Errorf("switcher: duplicate backend name %q", name)
+		}
+		backends[name] = &backendSpec{name: name, typ: typ, opts: spec}
+		order = append(order, name)
+	}
+	return backends, order, nil
+}
+
+func saveModelConfig(options map[string]any, model string) error {
+	if options == nil {
+		return fmt.Errorf("switcher agent has no options")
+	}
+	backendName, _ := options["agent"].(string)
+	backendName = strings.TrimSpace(backendName)
+	if backendName == "" {
+		return fmt.Errorf("switcher agent has no active backend")
+	}
+	rawBackends, ok := options["backends"]
+	if !ok {
+		return fmt.Errorf("switcher agent has no backends")
+	}
+
+	matchBackend := func(m map[string]any) bool {
+		if m == nil {
+			return false
+		}
+		name, _ := m["name"].(string)
+		return strings.EqualFold(strings.TrimSpace(name), backendName)
+	}
+
+	switch backends := rawBackends.(type) {
+	case []any:
+		for i := range backends {
+			spec, ok := backends[i].(map[string]any)
+			if !ok || !matchBackend(spec) {
+				continue
+			}
+			spec["model"] = model
+			options["backends"] = backends
+			return nil
+		}
+	case []map[string]any:
+		for i := range backends {
+			if !matchBackend(backends[i]) {
+				continue
+			}
+			backends[i]["model"] = model
+			options["backends"] = backends
+			return nil
+		}
+	default:
+		return fmt.Errorf("switcher agent backends have unexpected type %T", rawBackends)
+	}
+
+	return fmt.Errorf("backend %q not found in switcher config", backendName)
+}
+
+func stringFromMap(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func cloneOptions(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = cloneValue(v)
+	}
+	return out
+}
+
+func cloneValue(v any) any {
+	switch vv := v.(type) {
+	case map[string]any:
+		return cloneOptions(vv)
+	case []any:
+		out := make([]any, len(vv))
+		for i := range vv {
+			out[i] = cloneValue(vv[i])
+		}
+		return out
+	case []map[string]any:
+		out := make([]any, len(vv))
+		for i := range vv {
+			out[i] = cloneOptions(vv[i])
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func (a *Agent) Name() string { return "switcher" }
+
+func (a *Agent) SnapshotOptions() map[string]any {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	backends := make([]any, 0, len(a.order))
+	for _, name := range a.order {
+		if spec := a.backends[name]; spec != nil {
+			opts := cloneOptions(spec.opts)
+			if spec.agent != nil {
+				if snapshotter, ok := spec.agent.(core.OptionSnapshotter); ok {
+					for k, v := range snapshotter.SnapshotOptions() {
+						if opts == nil {
+							opts = make(map[string]any)
+						}
+						opts[k] = v
+					}
+				}
+			}
+			backends = append(backends, opts)
+		}
+	}
+
+	snapshot := map[string]any{
+		"work_dir":         a.workDir,
+		"mode":             a.mode,
+		"agent":            a.currentAgent,
+		"reasoning_effort": a.reasoningEffort,
+		"backends":         backends,
+	}
+	return snapshot
+}
+
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	for _, spec := range a.backends {
+		if spec.agent != nil {
+			if sw, ok := spec.agent.(interface{ SetWorkDir(string) }); ok {
+				sw.SetWorkDir(dir)
+			}
+		}
+	}
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.workDir
+}
+
+func (a *Agent) SetSessionEnv(env []string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sessionEnv = append([]string(nil), env...)
+	for _, spec := range a.backends {
+		if spec.agent != nil {
+			if inj, ok := spec.agent.(core.SessionEnvInjector); ok {
+				inj.SetSessionEnv(env)
+			}
+		}
+	}
+}
+
+func (a *Agent) SetPlatformPrompt(prompt string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.platformPrompt = prompt
+	for _, spec := range a.backends {
+		if spec.agent != nil {
+			if inj, ok := spec.agent.(core.PlatformPromptInjector); ok {
+				inj.SetPlatformPrompt(prompt)
+			}
+		}
+	}
+}
+
+func (a *Agent) SetModel(model string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	spec := a.activeSpecLocked()
+	if spec == nil {
+		slog.Warn("switcher: no active backend to set model on", "model", model)
+		return
+	}
+	if spec.agent == nil {
+		if _, err := a.ensureBackendLocked(spec.name); err != nil {
+			slog.Warn("switcher: failed to create active backend for model switch", "backend", spec.name, "error", err)
+			return
+		}
+	}
+	agent := spec.agent
+	if agent == nil {
+		slog.Warn("switcher: active backend unavailable after creation", "backend", spec.name, "model", model)
+		return
+	}
+	sw, ok := agent.(core.ModelSwitcher)
+	if !ok {
+		slog.Warn("switcher: active backend does not support model switching", "backend", spec.name, "model", model)
+		return
+	}
+	sw.SetModel(model)
+}
+
+func (a *Agent) GetModel() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	spec := a.activeSpecLocked()
+	if spec == nil {
+		return ""
+	}
+	if spec.agent == nil {
+		if _, err := a.ensureBackendLocked(spec.name); err != nil {
+			return ""
+		}
+	}
+	agent := spec.agent
+	if agent == nil {
+		return ""
+	}
+	sw, ok := agent.(core.ModelSwitcher)
+	if !ok {
+		return ""
+	}
+	return sw.GetModel()
+}
+
+func (a *Agent) AvailableModels(_ context.Context) []core.ModelOption {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	spec := a.activeSpecLocked()
+	if spec == nil {
+		return nil
+	}
+	if spec.agent == nil {
+		if _, err := a.ensureBackendLocked(spec.name); err != nil {
+			return nil
+		}
+	}
+	agent := spec.agent
+	if agent == nil {
+		return nil
+	}
+	sw, ok := agent.(core.ModelSwitcher)
+	if !ok {
+		return nil
+	}
+	return sw.AvailableModels(context.Background())
+}
+
+func (a *Agent) SetActiveAgent(name string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if _, ok := a.backends[name]; !ok {
+		for backendName := range a.backends {
+			if strings.EqualFold(backendName, name) {
+				name = backendName
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	a.currentAgent = name
+	return true
+}
+
+func (a *Agent) GetActiveAgent() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.currentAgent != "" {
+		return a.currentAgent
+	}
+	if len(a.order) > 0 {
+		return a.order[0]
+	}
+	return ""
+}
+
+func (a *Agent) ListAgents() []core.AgentOption {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	agents := make([]core.AgentOption, 0, len(a.order))
+	for _, name := range a.order {
+		spec := a.backends[name]
+		if spec == nil {
+			continue
+		}
+		agents = append(agents, core.AgentOption{
+			Name: name,
+			Desc: a.backendDescLocked(spec),
+		})
+	}
+	return agents
+}
+
+func (a *Agent) backendDescLocked(spec *backendSpec) string {
+	if spec == nil {
+		return ""
+	}
+	descParts := []string{spec.typ}
+	if spec.agent != nil {
+		if sw, ok := spec.agent.(core.ModelSwitcher); ok {
+			if m := strings.TrimSpace(sw.GetModel()); m != "" {
+				descParts = append(descParts, m)
+			}
+		}
+	}
+	if len(descParts) == 1 {
+		if m, _ := spec.opts["model"].(string); strings.TrimSpace(m) != "" {
+			descParts = append(descParts, strings.TrimSpace(m))
+		}
+	}
+	return strings.Join(descParts, " / ")
+}
+
+func (a *Agent) activeSpecLocked() *backendSpec {
+	if spec := a.backends[a.currentAgent]; spec != nil {
+		return spec
+	}
+	if len(a.order) > 0 {
+		return a.backends[a.order[0]]
+	}
+	return nil
+}
+
+func (a *Agent) ensureBackendLocked(name string) (*backendSpec, error) {
+	spec, ok := a.backends[name]
+	if !ok {
+		return nil, fmt.Errorf("switcher: unknown backend %q", name)
+	}
+	if spec.agent != nil {
+		return spec, nil
+	}
+
+	opts := cloneOptions(spec.opts)
+	if opts == nil {
+		opts = make(map[string]any)
+	}
+	if _, ok := opts["work_dir"]; !ok && a.workDir != "" {
+		opts["work_dir"] = a.workDir
+	}
+	if _, ok := opts["mode"]; !ok && a.mode != "" {
+		opts["mode"] = a.mode
+	}
+
+	agent, err := core.CreateAgent(spec.typ, opts)
+	if err != nil {
+		return nil, fmt.Errorf("switcher: create backend %q (%s): %w", name, spec.typ, err)
+	}
+	spec.agent = agent
+	a.applyCommonSettingsLocked(agent)
+	return spec, nil
+}
+
+func (a *Agent) applyCommonSettingsLocked(agent core.Agent) {
+	if sw, ok := agent.(interface{ SetWorkDir(string) }); ok {
+		sw.SetWorkDir(a.workDir)
+	}
+	if ms, ok := agent.(interface{ SetMode(string) }); ok {
+		ms.SetMode(a.mode)
+	}
+	if rs, ok := agent.(interface{ SetReasoningEffort(string) }); ok {
+		rs.SetReasoningEffort(a.reasoningEffort)
+	}
+	if inj, ok := agent.(core.SessionEnvInjector); ok {
+		inj.SetSessionEnv(a.sessionEnv)
+	}
+	if ppi, ok := agent.(core.PlatformPromptInjector); ok {
+		ppi.SetPlatformPrompt(a.platformPrompt)
+	}
+}
+
+func (a *Agent) activeAgent(ctx context.Context) (core.Agent, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	spec, err := a.ensureBackendLocked(a.currentAgent)
+	if err != nil {
+		return nil, err
+	}
+	if spec.agent == nil {
+		return nil, fmt.Errorf("switcher: backend %q is unavailable", a.currentAgent)
+	}
+	return spec.agent, nil
+}
+
+func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentSession, error) {
+	agent, err := a.activeAgent(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return agent.StartSession(ctx, sessionID)
+}
+
+func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {
+	agent, err := a.activeAgent(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return agent.ListSessions(ctx)
+}
+
+func (a *Agent) GetSessionHistory(ctx context.Context, sessionID string, limit int) ([]core.HistoryEntry, error) {
+	agent, err := a.activeAgent(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if hp, ok := agent.(interface {
+		GetSessionHistory(context.Context, string, int) ([]core.HistoryEntry, error)
+	}); ok {
+		return hp.GetSessionHistory(ctx, sessionID, limit)
+	}
+	return nil, fmt.Errorf("switcher: active backend does not support session history")
+}
+
+func (a *Agent) DeleteSession(ctx context.Context, sessionID string) error {
+	agent, err := a.activeAgent(ctx)
+	if err != nil {
+		return err
+	}
+	if deleter, ok := agent.(interface {
+		DeleteSession(context.Context, string) error
+	}); ok {
+		return deleter.DeleteSession(ctx, sessionID)
+	}
+	return fmt.Errorf("switcher: active backend does not support session deletion")
+}
+
+func (a *Agent) Stop() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var errs []string
+	for _, name := range a.order {
+		spec := a.backends[name]
+		if spec == nil || spec.agent == nil {
+			continue
+		}
+		if err := spec.agent.Stop(); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("switcher: stop backend(s): %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func (a *Agent) SetMode(mode string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.mode = normalizeMode(mode)
+	for _, spec := range a.backends {
+		if spec.agent != nil {
+			if ms, ok := spec.agent.(interface{ SetMode(string) }); ok {
+				ms.SetMode(a.mode)
+			}
+		}
+	}
+}
+
+func (a *Agent) GetMode() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.mode
+}
+
+func (a *Agent) SetReasoningEffort(effort string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.reasoningEffort = strings.TrimSpace(effort)
+	for _, spec := range a.backends {
+		if spec.agent != nil {
+			if rs, ok := spec.agent.(interface{ SetReasoningEffort(string) }); ok {
+				rs.SetReasoningEffort(a.reasoningEffort)
+			}
+		}
+	}
+}
+
+func (a *Agent) GetReasoningEffort() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.reasoningEffort
+}
+
+func (a *Agent) AvailableReasoningEfforts() []string {
+	a.mu.RLock()
+	spec := a.activeSpecLocked()
+	a.mu.RUnlock()
+	if spec == nil {
+		return nil
+	}
+	if agent, err := a.activeAgent(context.Background()); err == nil {
+		if rs, ok := agent.(interface{ AvailableReasoningEfforts() []string }); ok {
+			return rs.AvailableReasoningEfforts()
+		}
+	}
+	return nil
+}
+
+func (a *Agent) PermissionModes() []core.PermissionModeInfo {
+	a.mu.RLock()
+	spec := a.activeSpecLocked()
+	a.mu.RUnlock()
+	if spec == nil {
+		return nil
+	}
+	if agent, err := a.activeAgent(context.Background()); err == nil {
+		if ms, ok := agent.(interface {
+			PermissionModes() []core.PermissionModeInfo
+		}); ok {
+			return ms.PermissionModes()
+		}
+	}
+	return nil
+}
+
+func (a *Agent) SetSessionEnvAndPrompt(env []string, prompt string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sessionEnv = append([]string(nil), env...)
+	a.platformPrompt = prompt
+}
+
+func (a *Agent) CommandDirs() []string {
+	return a.dualDirs("commands")
+}
+
+func (a *Agent) SkillDirs() []string {
+	return a.dualDirs("skills")
+}
+
+func (a *Agent) dualDirs(kind string) []string {
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+
+	absDir, err := filepath.Abs(workDir)
+	if err != nil {
+		absDir = workDir
+	}
+
+	dirs := []string{
+		filepath.Join(absDir, ".claude", kind),
+		filepath.Join(absDir, ".codex", kind),
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs,
+			filepath.Join(home, ".claude", kind),
+			filepath.Join(home, ".codex", kind),
+		)
+	}
+
+	return dedupeDirs(dirs)
+}
+
+func dedupeDirs(dirs []string) []string {
+	seen := make(map[string]struct{}, len(dirs))
+	out := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		d = filepath.Clean(d)
+		if d == "." || d == "" {
+			continue
+		}
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (a *Agent) CompressCommand() string { return "/compact" }
+
+func (a *Agent) ProjectMemoryFile() string {
+	a.mu.RLock()
+	spec := a.activeSpecLocked()
+	workDir := a.workDir
+	a.mu.RUnlock()
+
+	if spec != nil {
+		switch spec.typ {
+		case "codex":
+			absDir, err := filepath.Abs(workDir)
+			if err != nil {
+				absDir = workDir
+			}
+			return filepath.Join(absDir, "AGENTS.md")
+		default:
+			absDir, err := filepath.Abs(workDir)
+			if err != nil {
+				absDir = workDir
+			}
+			return filepath.Join(absDir, "CLAUDE.md")
+		}
+	}
+
+	absDir, err := filepath.Abs(workDir)
+	if err != nil {
+		absDir = workDir
+	}
+	return filepath.Join(absDir, "CLAUDE.md")
+}
+
+func (a *Agent) GlobalMemoryFile() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	a.mu.RLock()
+	spec := a.activeSpecLocked()
+	a.mu.RUnlock()
+	if spec != nil && spec.typ == "codex" {
+		codexHome := os.Getenv("CODEX_HOME")
+		if codexHome == "" {
+			codexHome = filepath.Join(homeDir, ".codex")
+		}
+		return filepath.Join(codexHome, "AGENTS.md")
+	}
+	return filepath.Join(homeDir, ".claude", "CLAUDE.md")
+}
+
+func (a *Agent) HasSystemPromptSupport() bool {
+	a.mu.RLock()
+	spec := a.activeSpecLocked()
+	a.mu.RUnlock()
+	if spec == nil {
+		return false
+	}
+	return spec.typ == "claudecode"
+}

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -501,6 +501,9 @@ func main() {
 		engine.SetProviderModelSaveFunc(func(providerName, model string) error {
 			return config.SaveProviderModel(projName, providerName, model)
 		})
+		engine.SetAgentSaveFunc(func(agent string) error {
+			return config.SaveActiveAgent(projName, agent)
+		})
 		engine.SetModelSaveFunc(func(model string) error {
 			return config.SaveAgentModel(projName, model)
 		})

--- a/cmd/cc-connect/plugin_agent_switcher.go
+++ b/cmd/cc-connect/plugin_agent_switcher.go
@@ -1,0 +1,5 @@
+//go:build !no_switcher
+
+package main
+
+import _ "github.com/chenhg5/cc-connect/agent/switcher"

--- a/config.example.toml
+++ b/config.example.toml
@@ -547,6 +547,32 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "bypassPermission
 # 当前激活的 provider（对应下方 providers 中的 name）
 # provider = "anthropic"
 
+# Switcher backend: keep one bot and switch between Claude Code / Codex
+# 通过 switcher 保持一个 bot，在 Claude Code / Codex 之间切换
+#
+# [projects.agent]
+# type = "switcher"
+#
+# [projects.agent.options]
+# work_dir = "/path/to/project"
+# mode = "default"
+# agent = "claude"   # /agent 切换的后端
+#
+# Verify model strings against the provider's official docs before committing.
+# 提交前请先根据官方文档确认模型字符串。
+#
+# [[projects.agent.options.backends]]
+# name = "claude"
+# type = "claudecode"
+# model = "claude-sonnet-4-20250514"
+#
+# [[projects.agent.options.backends]]
+# name = "codex"
+# type = "codex"
+# model = "gpt-4.1"
+# [projects.agent.options.backends.env]
+# CODEX_HOME = "/path/to/isolated/codex-home"
+
 # API Providers — switch between them via /provider command in chat
 # or via CLI: cc-connect provider add --project my-backend --name relay --api-key sk-xxx
 # API Provider 管理 — 可通过聊天命令 /provider 或 CLI 命令切换

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/BurntSushi/toml"
+	"github.com/chenhg5/cc-connect/core"
 )
 
 // configMu serializes read-modify-write cycles to prevent lost updates.
@@ -406,6 +407,35 @@ func SaveProviderModel(projectName, providerName, model string) error {
 	return fmt.Errorf("project %q not found in config", projectName)
 }
 
+// SaveActiveAgent persists the selected active backend agent for a project.
+func SaveActiveAgent(projectName, agentName string) error {
+	configMu.Lock()
+	defer configMu.Unlock()
+	if ConfigPath == "" {
+		return fmt.Errorf("config path not set")
+	}
+	data, err := os.ReadFile(ConfigPath)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+	cfg := &Config{}
+	if err := toml.Unmarshal(data, cfg); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+	for i := range cfg.Projects {
+		if cfg.Projects[i].Name != projectName {
+			continue
+		}
+		if cfg.Projects[i].Agent.Options == nil {
+			cfg.Projects[i].Agent.Options = make(map[string]any)
+		}
+		cfg.Projects[i].Agent.Options["agent"] = agentName
+		delete(cfg.Projects[i].Agent.Options, "model")
+		return saveConfig(cfg)
+	}
+	return fmt.Errorf("project %q not found in config", projectName)
+}
+
 // SaveAgentModel persists the selected default model for a project's agent.
 func SaveAgentModel(projectName, model string) error {
 	configMu.Lock()
@@ -425,6 +455,12 @@ func SaveAgentModel(projectName, model string) error {
 	for i := range cfg.Projects {
 		if cfg.Projects[i].Name != projectName {
 			continue
+		}
+		if saver, ok := core.LookupAgentModelConfigSaver(cfg.Projects[i].Agent.Type); ok {
+			if err := saver(cfg.Projects[i].Agent.Options, model); err != nil {
+				return err
+			}
+			return saveConfig(cfg)
 		}
 		if cfg.Projects[i].Agent.Options == nil {
 			cfg.Projects[i].Agent.Options = make(map[string]any)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
+	_ "github.com/chenhg5/cc-connect/agent/switcher"
 )
 
 func TestConfigValidate(t *testing.T) {
@@ -241,6 +242,52 @@ func TestSaveAgentModel(t *testing.T) {
 	}
 	if len(cfg.Projects[0].Agent.Providers) != 2 {
 		t.Fatalf("provider count = %d, want 2", len(cfg.Projects[0].Agent.Providers))
+	}
+}
+
+func TestSaveActiveAgent(t *testing.T) {
+	writeTestConfig(t, switcherConfigTOML)
+
+	if err := SaveActiveAgent("demo", "codex"); err != nil {
+		t.Fatalf("SaveActiveAgent() error: %v", err)
+	}
+
+	cfg := readTestConfig(t)
+	if got, _ := cfg.Projects[0].Agent.Options["agent"].(string); got != "codex" {
+		t.Fatalf("agent.options.agent = %q, want codex", got)
+	}
+	if _, ok := cfg.Projects[0].Agent.Options["model"]; ok {
+		t.Fatalf("agent.options.model should not be written for switcher projects")
+	}
+}
+
+func TestSaveAgentModel_SwitcherBackend(t *testing.T) {
+	writeTestConfig(t, switcherConfigTOML)
+
+	if err := SaveAgentModel("demo", "claude-sonnet-4-5"); err != nil {
+		t.Fatalf("SaveAgentModel() error: %v", err)
+	}
+
+	cfg := readTestConfig(t)
+	var backends []map[string]any
+	switch v := cfg.Projects[0].Agent.Options["backends"].(type) {
+	case []map[string]any:
+		backends = v
+	case []any:
+		backends = make([]map[string]any, 0, len(v))
+		for _, item := range v {
+			backends = append(backends, item.(map[string]any))
+		}
+	default:
+		t.Fatalf("backends has unexpected type %T", v)
+	}
+	claude := backends[0]
+	if got, _ := claude["model"].(string); got != "claude-sonnet-4-5" {
+		t.Fatalf("switcher backend model = %q, want claude-sonnet-4-5", got)
+	}
+	codex := backends[1]
+	if got, _ := codex["model"].(string); got != "gpt-5.4-mini" {
+		t.Fatalf("other backend model = %q, want unchanged gpt-5.4-mini", got)
 	}
 }
 
@@ -799,6 +846,33 @@ type = "telegram"
 token = "test-token"
 `
 
+const switcherConfigTOML = `
+[[projects]]
+name = "demo"
+
+[projects.agent]
+type = "switcher"
+
+[projects.agent.options]
+agent = "claude"
+
+[[projects.agent.options.backends]]
+name = "claude"
+type = "claudecode"
+model = "claude-sonnet-4-6"
+
+[[projects.agent.options.backends]]
+name = "codex"
+type = "codex"
+model = "gpt-5.4-mini"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+token = "test-token"
+`
+
 const feishuConfigFixture = `
 [[projects]]
 name = "alpha"
@@ -899,10 +973,10 @@ func TestValidateUsersConfig(t *testing.T) {
 			name: "nil users is valid",
 			cfg: Config{
 				Projects: []ProjectConfig{{
-					Name: "p1",
-					Agent: AgentConfig{Type: "codex"},
+					Name:      "p1",
+					Agent:     AgentConfig{Type: "codex"},
 					Platforms: []PlatformConfig{{Type: "telegram", Options: map[string]any{"token": "x"}}},
-					Users: nil,
+					Users:     nil,
 				}},
 			},
 			wantErr: "",
@@ -911,10 +985,10 @@ func TestValidateUsersConfig(t *testing.T) {
 			name: "empty roles",
 			cfg: Config{
 				Projects: []ProjectConfig{{
-					Name: "p1",
-					Agent: AgentConfig{Type: "codex"},
+					Name:      "p1",
+					Agent:     AgentConfig{Type: "codex"},
 					Platforms: []PlatformConfig{{Type: "telegram", Options: map[string]any{"token": "x"}}},
-					Users: &UsersConfig{Roles: map[string]RoleConfig{}},
+					Users:     &UsersConfig{Roles: map[string]RoleConfig{}},
 				}},
 			},
 			wantErr: `no roles defined`,
@@ -923,8 +997,8 @@ func TestValidateUsersConfig(t *testing.T) {
 			name: "empty user_ids in role",
 			cfg: Config{
 				Projects: []ProjectConfig{{
-					Name: "p1",
-					Agent: AgentConfig{Type: "codex"},
+					Name:      "p1",
+					Agent:     AgentConfig{Type: "codex"},
 					Platforms: []PlatformConfig{{Type: "telegram", Options: map[string]any{"token": "x"}}},
 					Users: &UsersConfig{
 						Roles: map[string]RoleConfig{
@@ -939,13 +1013,13 @@ func TestValidateUsersConfig(t *testing.T) {
 			name: "duplicate user in different roles",
 			cfg: Config{
 				Projects: []ProjectConfig{{
-					Name: "p1",
-					Agent: AgentConfig{Type: "codex"},
+					Name:      "p1",
+					Agent:     AgentConfig{Type: "codex"},
 					Platforms: []PlatformConfig{{Type: "telegram", Options: map[string]any{"token": "x"}}},
 					Users: &UsersConfig{
 						Roles: map[string]RoleConfig{
-							"admin":   {UserIDs: []string{"user1"}},
-							"member":  {UserIDs: []string{"user1"}},
+							"admin":  {UserIDs: []string{"user1"}},
+							"member": {UserIDs: []string{"user1"}},
 						},
 					},
 				}},
@@ -956,8 +1030,8 @@ func TestValidateUsersConfig(t *testing.T) {
 			name: "wildcard in multiple roles",
 			cfg: Config{
 				Projects: []ProjectConfig{{
-					Name: "p1",
-					Agent: AgentConfig{Type: "codex"},
+					Name:      "p1",
+					Agent:     AgentConfig{Type: "codex"},
 					Platforms: []PlatformConfig{{Type: "telegram", Options: map[string]any{"token": "x"}}},
 					Users: &UsersConfig{
 						Roles: map[string]RoleConfig{
@@ -973,8 +1047,8 @@ func TestValidateUsersConfig(t *testing.T) {
 			name: "default_role not matching any role",
 			cfg: Config{
 				Projects: []ProjectConfig{{
-					Name: "p1",
-					Agent: AgentConfig{Type: "codex"},
+					Name:      "p1",
+					Agent:     AgentConfig{Type: "codex"},
 					Platforms: []PlatformConfig{{Type: "telegram", Options: map[string]any{"token": "x"}}},
 					Users: &UsersConfig{
 						DefaultRole: "superadmin",
@@ -990,8 +1064,8 @@ func TestValidateUsersConfig(t *testing.T) {
 			name: "valid users config",
 			cfg: Config{
 				Projects: []ProjectConfig{{
-					Name: "p1",
-					Agent: AgentConfig{Type: "codex"},
+					Name:      "p1",
+					Agent:     AgentConfig{Type: "codex"},
 					Platforms: []PlatformConfig{{Type: "telegram", Options: map[string]any{"token": "x"}}},
 					Users: &UsersConfig{
 						DefaultRole: "member",
@@ -1008,8 +1082,8 @@ func TestValidateUsersConfig(t *testing.T) {
 			name: "valid with wildcard in one role only",
 			cfg: Config{
 				Projects: []ProjectConfig{{
-					Name: "p1",
-					Agent: AgentConfig{Type: "codex"},
+					Name:      "p1",
+					Agent:     AgentConfig{Type: "codex"},
 					Platforms: []PlatformConfig{{Type: "telegram", Options: map[string]any{"token": "x"}}},
 					Users: &UsersConfig{
 						Roles: map[string]RoleConfig{
@@ -1173,7 +1247,7 @@ func TestCloneAgentConfig(t *testing.T) {
 			t.Fatalf("Providers length = %d, want 1", len(got.Providers))
 		}
 		p := got.Providers[0]
-		if p.Name != "openai" || p.APIKey != "sk-test" || p.BaseURL != "https://api.openai.com" || p.Model != "gpt-4"  {
+		if p.Name != "openai" || p.APIKey != "sk-test" || p.BaseURL != "https://api.openai.com" || p.Model != "gpt-4" {
 			t.Errorf("Provider fields not cloned correctly: %+v", p)
 		}
 		if p.Env["DEBUG"] != "1" {

--- a/core/engine.go
+++ b/core/engine.go
@@ -146,6 +146,7 @@ type Engine struct {
 	providerAddSaveFunc    func(p ProviderConfig) error
 	providerRemoveSaveFunc func(name string) error
 	providerModelSaveFunc  func(providerName, model string) error
+	agentSaveFunc          func(agent string) error
 	modelSaveFunc          func(model string) error
 
 	ttsSaveFunc func(mode string) error
@@ -451,6 +452,10 @@ func (e *Engine) SetProviderRemoveSaveFunc(fn func(string) error) {
 
 func (e *Engine) SetProviderModelSaveFunc(fn func(providerName, model string) error) {
 	e.providerModelSaveFunc = fn
+}
+
+func (e *Engine) SetAgentSaveFunc(fn func(agent string) error) {
+	e.agentSaveFunc = fn
 }
 
 func (e *Engine) SetModelSaveFunc(fn func(model string) error) {
@@ -1775,8 +1780,22 @@ func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionMan
 	opts := make(map[string]any)
 	opts["work_dir"] = workspace
 
-	// Copy model from original agent if possible
-	if ma, ok := e.agent.(interface{ GetModel() string }); ok {
+	// Preserve any extra agent-specific options when cloning workspace agents.
+	if snapshotter, ok := e.agent.(OptionSnapshotter); ok {
+		for k, v := range snapshotter.SnapshotOptions() {
+			if k == "work_dir" {
+				continue
+			}
+			opts[k] = v
+		}
+	}
+
+	// Copy the active backend selector for backend-multiplexing agents.
+	if as, ok := e.agent.(AgentSwitcher); ok {
+		if backend := as.GetActiveAgent(); backend != "" {
+			opts["agent"] = backend
+		}
+	} else if ma, ok := e.agent.(interface{ GetModel() string }); ok {
 		if m := ma.GetModel(); m != "" {
 			opts["model"] = m
 		}
@@ -2656,6 +2675,7 @@ var builtinCommands = []struct {
 	{[]string{"history"}, "history"},
 	{[]string{"allow"}, "allow"},
 	{[]string{"model"}, "model"},
+	{[]string{"agent"}, "agent"},
 	{[]string{"reasoning", "effort"}, "reasoning"},
 	{[]string{"mode"}, "mode"},
 	{[]string{"lang"}, "lang"},
@@ -2818,6 +2838,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdAllow(p, msg, args)
 	case "model":
 		e.cmdModel(p, msg, args)
+	case "agent":
+		e.cmdAgent(p, msg, args)
 	case "reasoning":
 		e.cmdReasoning(p, msg, args)
 	case "mode":
@@ -4468,6 +4490,7 @@ func helpCardGroups() []helpCardGroup {
 			key:      "agent",
 			titleKey: MsgHelpAgentSection,
 			items: []helpCardItem{
+				{command: "/agent", action: "nav:/agent"},
 				{command: "/model", action: "nav:/model"},
 				{command: "/reasoning", action: "nav:/reasoning"},
 				{command: "/mode", action: "nav:/mode"},
@@ -4748,6 +4771,109 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChanged, target))
 }
 
+func (e *Engine) cmdAgent(p Platform, msg *Message, args []string) {
+	switcher, ok := e.agent.(AgentSwitcher)
+	if !ok {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgAgentNotSupported))
+		return
+	}
+
+	if len(args) == 0 {
+		if !supportsCards(p) {
+			agents := switcher.ListAgents()
+			current := switcher.GetActiveAgent()
+			if current == "" && len(agents) == 0 {
+				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgAgentListEmpty))
+				return
+			}
+
+			var sb strings.Builder
+			if current == "" {
+				sb.WriteString(e.i18n.T(MsgAgentNone))
+			} else {
+				sb.WriteString(e.i18n.Tf(MsgAgentCurrent, current))
+				sb.WriteString("\n")
+			}
+			sb.WriteString("\n")
+			sb.WriteString(e.i18n.T(MsgAgentListTitle))
+			var buttons [][]ButtonOption
+			var row []ButtonOption
+			for i, a := range agents {
+				marker := "  "
+				if a.Name == current {
+					marker = "> "
+				}
+				line := fmt.Sprintf("%s%d. %s", marker, i+1, a.Name)
+				if a.Desc != "" {
+					line += " — " + a.Desc
+				}
+				sb.WriteString(line + "\n")
+
+				label := a.Name
+				if a.Name == current {
+					label = "▶ " + label
+				}
+				row = append(row, ButtonOption{Text: label, Data: fmt.Sprintf("cmd:/agent switch %d", i+1)})
+				if len(row) >= 3 {
+					buttons = append(buttons, row)
+					row = nil
+				}
+			}
+			if len(row) > 0 {
+				buttons = append(buttons, row)
+			}
+			e.replyWithButtons(p, msg.ReplyCtx, sb.String(), buttons)
+			return
+		}
+		e.replyWithCard(p, msg.ReplyCtx, e.renderAgentCard())
+		return
+	}
+
+	targetInput, ok := parseAgentSwitchArgs(args)
+	if !ok {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgAgentUsage))
+		return
+	}
+
+	agents := switcher.ListAgents()
+	target := targetInput
+	if idx, err := strconv.Atoi(target); err == nil && idx >= 1 && idx <= len(agents) {
+		target = agents[idx-1].Name
+	}
+	found := false
+	for _, a := range agents {
+		if strings.EqualFold(a.Name, target) {
+			target = a.Name
+			found = true
+			break
+		}
+	}
+	if !found {
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgAgentNotFound), target))
+		return
+	}
+
+	if e.agentSaveFunc != nil {
+		if err := e.agentSaveFunc(target); err != nil {
+			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgError, err))
+			return
+		}
+	}
+
+	if !switcher.SetActiveAgent(target) {
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgAgentNotFound), target))
+		return
+	}
+	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+
+	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s.SetAgentSessionID("", "")
+	s.ClearHistory()
+	e.sessions.Save()
+
+	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgAgentSwitched, target))
+}
+
 // resolveModelAlias resolves a user-supplied string to a model name.
 // It first checks for an exact alias match, then falls back to the original value
 // (which may be a direct model name).
@@ -4761,6 +4887,13 @@ func resolveModelAlias(models []ModelOption, input string) string {
 }
 
 func parseModelSwitchArgs(args []string) (string, bool) {
+	if len(args) >= 2 && strings.EqualFold(strings.TrimSpace(args[0]), "switch") {
+		return strings.TrimSpace(args[1]), true
+	}
+	return "", false
+}
+
+func parseAgentSwitchArgs(args []string) (string, bool) {
 	if len(args) == 0 {
 		return "", false
 	}
@@ -4768,7 +4901,7 @@ func parseModelSwitchArgs(args []string) (string, bool) {
 		if strings.EqualFold(strings.TrimSpace(args[0]), "switch") {
 			return "", false
 		}
-		return args[0], true
+		return strings.TrimSpace(args[0]), true
 	}
 	if strings.EqualFold(strings.TrimSpace(args[0]), "switch") && len(args) >= 2 {
 		return strings.TrimSpace(args[1]), true
@@ -5934,6 +6067,8 @@ func (e *Engine) handleCardNav(action string, sessionKey string) *Card {
 	switch cmd {
 	case "/help":
 		return e.renderHelpGroupCard(args)
+	case "/agent":
+		return e.renderAgentCard()
 	case "/model":
 		return e.renderModelCard()
 	case "/reasoning":
@@ -6033,6 +6168,50 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		}
 		if _, err := e.switchModel(target); err != nil {
 			slog.Error("failed to switch model from card action", "model", target, "error", err)
+			return
+		}
+		interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+		e.cleanupInteractiveState(interactiveKey)
+		s := e.sessions.GetOrCreateActive(sessionKey)
+		s.SetAgentSessionID("", "")
+		s.ClearHistory()
+		e.sessions.Save()
+	case "/agent":
+		if args == "" {
+			return
+		}
+		switcher, ok := e.agent.(AgentSwitcher)
+		if !ok {
+			return
+		}
+		agents := switcher.ListAgents()
+		target, ok := parseAgentSwitchArgs(strings.Fields(args))
+		if !ok {
+			return
+		}
+		if idx, err := strconv.Atoi(target); err == nil && idx >= 1 && idx <= len(agents) {
+			target = agents[idx-1].Name
+		}
+		found := false
+		for _, a := range agents {
+			if strings.EqualFold(a.Name, target) {
+				target = a.Name
+				found = true
+				break
+			}
+		}
+		if !found {
+			slog.Error("failed to switch agent from card action", "agent", target)
+			return
+		}
+		if e.agentSaveFunc != nil {
+			if err := e.agentSaveFunc(target); err != nil {
+				slog.Error("failed to save agent", "error", err)
+				return
+			}
+		}
+		if !switcher.SetActiveAgent(target) {
+			slog.Error("failed to switch agent from card action", "agent", target)
 			return
 		}
 		interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
@@ -6586,9 +6765,9 @@ func (e *Engine) renderLangCard() *Card {
 	var opts []CardSelectOption
 	initVal := ""
 	for _, l := range langs {
-		opts = append(opts, CardSelectOption{Text: l.label, Value: "act:/lang " + l.code})
+		opts = append(opts, CardSelectOption{Text: l.label, Value: "lang:" + l.code})
 		if string(cur) == l.code || (cur == LangAuto && l.code == "auto") {
-			initVal = "act:/lang " + l.code
+			initVal = "lang:" + l.code
 		}
 	}
 
@@ -6620,14 +6799,14 @@ func (e *Engine) renderModelCard() *Card {
 
 	var opts []CardSelectOption
 	initVal := ""
-	for i, m := range models {
+	for _, m := range models {
 		label := m.Name
 		if m.Alias != "" {
 			label = m.Alias + " - " + m.Name
 		} else if m.Desc != "" {
 			label += " — " + m.Desc
 		}
-		val := fmt.Sprintf("act:/model switch %d", i+1)
+		val := "model:" + m.Name
 		opts = append(opts, CardSelectOption{Text: label, Value: val})
 		if m.Name == current {
 			initVal = val
@@ -6639,6 +6818,45 @@ func (e *Engine) renderModelCard() *Card {
 		Select(e.i18n.T(MsgModelSelectPlaceholder), opts, initVal).
 		Buttons(e.cardBackButton())
 	cb.Note(e.i18n.T(MsgModelUsage))
+	return cb.Build()
+}
+
+func (e *Engine) renderAgentCard() *Card {
+	switcher, ok := e.agent.(AgentSwitcher)
+	if !ok {
+		return e.simpleCard(e.i18n.T(MsgCardTitleAgent), "indigo", e.i18n.T(MsgAgentNotSupported))
+	}
+
+	agents := switcher.ListAgents()
+	current := switcher.GetActiveAgent()
+	if current == "" && len(agents) == 0 {
+		return e.simpleCard(e.i18n.T(MsgCardTitleAgent), "indigo", e.i18n.T(MsgAgentListEmpty))
+	}
+
+	var sb strings.Builder
+	if current == "" {
+		sb.WriteString(e.i18n.T(MsgAgentNone))
+	} else {
+		sb.WriteString(e.i18n.Tf(MsgAgentCurrent, current))
+	}
+
+	var opts []CardSelectOption
+	initVal := ""
+	for _, a := range agents {
+		label := a.Name
+		if a.Desc != "" {
+			label += " — " + a.Desc
+		}
+		val := "agent:" + a.Name
+		opts = append(opts, CardSelectOption{Text: label, Value: val})
+		if a.Name == current {
+			initVal = val
+		}
+	}
+
+	cb := NewCard().Title(e.i18n.T(MsgCardTitleAgent), "indigo").
+		Markdown(sb.String()).
+		Select(e.i18n.T(MsgAgentSelectPlaceholder), opts, initVal)
 	return cb.Build()
 }
 
@@ -6661,7 +6879,7 @@ func (e *Engine) renderReasoningCard() *Card {
 	var opts []CardSelectOption
 	initVal := ""
 	for i, effort := range efforts {
-		val := fmt.Sprintf("act:/reasoning %d", i+1)
+		val := fmt.Sprintf("reasoning:%d", i+1)
 		opts = append(opts, CardSelectOption{Text: effort, Value: val})
 		if effort == current {
 			initVal = val
@@ -6706,7 +6924,7 @@ func (e *Engine) renderModeCard() *Card {
 		if zhLike {
 			label = m.NameZh
 		}
-		val := "act:/mode " + m.Key
+		val := "mode:" + m.Key
 		opts = append(opts, CardSelectOption{Text: label, Value: val})
 		if m.Key == current {
 			initVal = val
@@ -6975,7 +7193,7 @@ func (e *Engine) renderProviderCard() *Card {
 			if prov.BaseURL != "" {
 				label += " (" + prov.BaseURL + ")"
 			}
-			val := "act:/provider " + prov.Name
+			val := "provider:" + prov.Name
 			opts = append(opts, CardSelectOption{Text: label, Value: val})
 			if current != nil && prov.Name == current.Name {
 				initVal = val

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -298,6 +298,8 @@ type stubModelModeAgent struct {
 	reasoningEffort string
 	providers       []ProviderConfig
 	active          string
+	agents          []AgentOption
+	activeAgent     string
 }
 
 type stubLiveModeSession struct {
@@ -316,6 +318,36 @@ func (a *stubModelModeAgent) SetModel(model string) {
 
 func (a *stubModelModeAgent) GetModel() string {
 	return a.model
+}
+
+func (a *stubModelModeAgent) SetActiveAgent(name string) bool {
+	if name == "" {
+		a.activeAgent = ""
+		return true
+	}
+	for _, ag := range a.agents {
+		if ag.Name == name {
+			a.activeAgent = name
+			return true
+		}
+	}
+	return false
+}
+
+func (a *stubModelModeAgent) GetActiveAgent() string {
+	if a.activeAgent != "" {
+		return a.activeAgent
+	}
+	if len(a.agents) > 0 {
+		return a.agents[0].Name
+	}
+	return ""
+}
+
+func (a *stubModelModeAgent) ListAgents() []AgentOption {
+	out := make([]AgentOption, len(a.agents))
+	copy(out, a.agents)
+	return out
 }
 
 func (a *stubModelModeAgent) AvailableModels(_ context.Context) []ModelOption {
@@ -2436,7 +2468,7 @@ func TestCmdModel_UpdatesActiveProviderModel(t *testing.T) {
 	}
 }
 
-func TestCmdModel_LegacySyntaxStillWorks(t *testing.T) {
+func TestCmdModel_RequiresSwitchPrefix(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	agent := &stubModelModeAgent{}
 	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
@@ -2444,8 +2476,15 @@ func TestCmdModel_LegacySyntaxStillWorks(t *testing.T) {
 
 	e.cmdModel(p, msg, []string{"gpt"})
 
-	if agent.model != "gpt-4.1" {
-		t.Fatalf("agent model = %q, want gpt-4.1", agent.model)
+	if agent.model != "" {
+		t.Fatalf("agent model = %q, want unchanged empty model", agent.model)
+	}
+	sent := p.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(sent))
+	}
+	if !strings.Contains(sent[0], "Usage:") {
+		t.Fatalf("reply = %q, want usage message", sent[0])
 	}
 }
 
@@ -2519,6 +2558,75 @@ func TestCmdModel_DoesNotClaimSuccessWhenModelSaveFails(t *testing.T) {
 	}
 	if !strings.Contains(sent[0], "Failed to change model") {
 		t.Fatalf("reply = %q, want model change failure message", sent[0])
+	}
+}
+
+func TestCmdAgent_SwitchesBackendWithoutChangingModel(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubModelModeAgent{
+		model: "claude-sonnet-4-6",
+		agents: []AgentOption{
+			{Name: "claude", Desc: "claudecode / claude-sonnet-4-6"},
+			{Name: "codex", Desc: "codex / gpt-5.4-mini"},
+		},
+		activeAgent: "claude",
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	var savedAgent string
+	e.SetAgentSaveFunc(func(name string) error {
+		savedAgent = name
+		return nil
+	})
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s.SetAgentSessionID("existing-session", "test")
+	s.AddHistory("user", "keep me")
+
+	e.cmdAgent(p, msg, []string{"switch", "codex"})
+
+	if got := agent.GetActiveAgent(); got != "codex" {
+		t.Fatalf("active agent = %q, want codex", got)
+	}
+	if got := agent.GetModel(); got != "claude-sonnet-4-6" {
+		t.Fatalf("model = %q, want unchanged claude-sonnet-4-6", got)
+	}
+	if savedAgent != "codex" {
+		t.Fatalf("saved agent = %q, want codex", savedAgent)
+	}
+	if active := e.sessions.GetOrCreateActive(msg.SessionKey); active.AgentSessionID != "" {
+		t.Fatalf("session id = %q, want cleared after agent switch", active.AgentSessionID)
+	}
+}
+
+func TestCmdModel_StillSwitchesCurrentBackendModel(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubModelModeAgent{
+		model: "claude-sonnet-4-6",
+		agents: []AgentOption{
+			{Name: "claude", Desc: "claudecode / claude-sonnet-4-6"},
+			{Name: "codex", Desc: "codex / gpt-5.4-mini"},
+		},
+		activeAgent: "claude",
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	var savedModel string
+	e.SetModelSaveFunc(func(model string) error {
+		savedModel = model
+		return nil
+	})
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	e.cmdModel(p, msg, []string{"switch", "claude-sonnet-4-5"})
+
+	if got := agent.GetActiveAgent(); got != "claude" {
+		t.Fatalf("active agent = %q, want claude", got)
+	}
+	if got := agent.GetModel(); got != "claude-sonnet-4-5" {
+		t.Fatalf("model = %q, want claude-sonnet-4-5", got)
+	}
+	if savedModel != "claude-sonnet-4-5" {
+		t.Fatalf("saved model = %q, want claude-sonnet-4-5", savedModel)
 	}
 }
 
@@ -4870,7 +4978,7 @@ func TestExecuteCardAction_ModelCleansUpWithInteractiveKey(t *testing.T) {
 	e.interactiveStates[sessionKey] = &interactiveState{}
 	e.interactiveMu.Unlock()
 
-	e.executeCardAction("/model", "new-model", sessionKey)
+	e.executeCardAction("/model", "switch new-model", sessionKey)
 
 	if agent.model != "new-model" {
 		t.Errorf("model = %q, want new-model", agent.model)
@@ -4881,6 +4989,34 @@ func TestExecuteCardAction_ModelCleansUpWithInteractiveKey(t *testing.T) {
 	e.interactiveMu.Unlock()
 	if exists {
 		t.Error("expected interactive state to be cleaned up after /model")
+	}
+}
+
+func TestExecuteCardAction_AgentCleansUpWithInteractiveKey(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubModelModeAgent{
+		agents:      []AgentOption{{Name: "claude"}, {Name: "codex"}},
+		activeAgent: "claude",
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	sessionKey := "feishu:channel1:user1"
+
+	e.interactiveMu.Lock()
+	e.interactiveStates[sessionKey] = &interactiveState{}
+	e.interactiveMu.Unlock()
+
+	e.executeCardAction("/agent", "switch codex", sessionKey)
+
+	if got := agent.GetActiveAgent(); got != "codex" {
+		t.Errorf("active agent = %q, want codex", got)
+	}
+
+	e.interactiveMu.Lock()
+	_, exists := e.interactiveStates[sessionKey]
+	e.interactiveMu.Unlock()
+	if exists {
+		t.Error("expected interactive state to be cleaned up after /agent")
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -172,6 +172,15 @@ const (
 	MsgNameUsage                 MsgKey = "name_usage"
 	MsgNameSet                   MsgKey = "name_set"
 	MsgNameNoSession             MsgKey = "name_no_session"
+	MsgAgentNotSupported         MsgKey = "agent_not_supported"
+	MsgAgentNone                 MsgKey = "agent_none"
+	MsgAgentCurrent              MsgKey = "agent_current"
+	MsgAgentListTitle            MsgKey = "agent_list_title"
+	MsgAgentListEmpty            MsgKey = "agent_list_empty"
+	MsgAgentNotFound             MsgKey = "agent_not_found"
+	MsgAgentSwitched             MsgKey = "agent_switched"
+	MsgAgentUsage                MsgKey = "agent_usage"
+	MsgAgentSelectPlaceholder    MsgKey = "agent_select_placeholder"
 	MsgProviderNotSupported      MsgKey = "provider_not_supported"
 	MsgProviderNone              MsgKey = "provider_none"
 	MsgProviderCurrent           MsgKey = "provider_current"
@@ -288,6 +297,7 @@ const (
 	MsgCardTitleStatus           MsgKey = "card_title_status"
 	MsgCardTitleLanguage         MsgKey = "card_title_language"
 	MsgCardTitleModel            MsgKey = "card_title_model"
+	MsgCardTitleAgent            MsgKey = "card_title_agent"
 	MsgCardTitleReasoning        MsgKey = "card_title_reasoning"
 	MsgCardTitleMode             MsgKey = "card_title_mode"
 	MsgCardTitleSessions         MsgKey = "card_title_sessions"
@@ -455,6 +465,7 @@ const (
 	MsgBuiltinCmdMemory    MsgKey = "memory"
 	MsgBuiltinCmdAllow     MsgKey = "allow"
 	MsgBuiltinCmdModel     MsgKey = "model"
+	MsgBuiltinCmdAgent     MsgKey = "agent"
 	MsgBuiltinCmdReasoning MsgKey = "reasoning"
 	MsgBuiltinCmdMode      MsgKey = "mode"
 	MsgBuiltinCmdLang      MsgKey = "lang"
@@ -781,6 +792,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  Show current active session\n\n" +
 			"/history [n]\n  Show last n messages (default 10)\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  Manage API providers\n\n" +
+			"/agent [switch <name>]\n  Switch backend agents\n\n" +
 			"/memory [add|global|global add]\n  View/edit agent memory files\n\n" +
 			"/allow <tool>\n  Pre-allow a tool (next session)\n\n" +
 			"/model [switch <name>]\n  View/switch model\n\n" +
@@ -824,6 +836,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  查看当前活跃会话\n\n" +
 			"/history [n]\n  查看最近 n 条消息（默认 10）\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  管理 API Provider\n\n" +
+			"/agent [switch <名称>]\n  切换后端 Agent\n\n" +
 			"/memory [add|global|global add]\n  查看/编辑 Agent 记忆文件\n\n" +
 			"/allow <工具名>\n  预授权工具（下次会话生效）\n\n" +
 			"/model [switch <名称>]\n  查看/切换模型\n\n" +
@@ -867,6 +880,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  查看當前活躍會話\n\n" +
 			"/history [n]\n  查看最近 n 條訊息（預設 10）\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  管理 API Provider\n\n" +
+			"/agent [switch <名稱>]\n  切換後端 Agent\n\n" +
 			"/memory [add|global|global add]\n  查看/編輯 Agent 記憶檔案\n\n" +
 			"/allow <工具名>\n  預授權工具（下次會話生效）\n\n" +
 			"/model [switch <名稱>]\n  查看/切換模型\n\n" +
@@ -909,6 +923,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  現在のアクティブセッションを表示\n\n" +
 			"/history [n]\n  直近 n 件のメッセージを表示（デフォルト 10）\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  API プロバイダ管理\n\n" +
+			"/agent [switch <名前>]\n  バックエンド Agent の切り替え\n\n" +
 			"/memory [add|global|global add]\n  エージェントメモリの表示/編集\n\n" +
 			"/allow <ツール名>\n  ツールを事前許可（次のセッションで有効）\n\n" +
 			"/model [switch <名前>]\n  モデルの表示/切り替え\n\n" +
@@ -951,6 +966,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  Mostrar sesión activa actual\n\n" +
 			"/history [n]\n  Mostrar últimos n mensajes (por defecto 10)\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  Gestionar proveedores API\n\n" +
+			"/agent [switch <nombre>]\n  Cambiar agentes de backend\n\n" +
 			"/memory [add|global|global add]\n  Ver/editar archivos de memoria del agente\n\n" +
 			"/allow <herramienta>\n  Pre-autorizar herramienta (próxima sesión)\n\n" +
 			"/model [switch <nombre>]\n  Ver/cambiar modelo\n\n" +
@@ -1041,6 +1057,7 @@ var messages = map[MsgKey]map[Language]string{
 	},
 	MsgHelpAgentSection: {
 		LangEnglish: "**Agent Configuration**\n" +
+			"/agent [switch <name>] — Switch backend agent\n" +
 			"/model [switch <name>] — View/switch model\n" +
 			"/mode [name] — View/switch permission mode\n" +
 			"/provider [list|add|...] — Manage API providers\n" +
@@ -1049,6 +1066,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/lang [en|zh|...] — View/switch language\n" +
 			"/quiet [global] — Toggle progress messages",
 		LangChinese: "**Agent 配置**\n" +
+			"/agent [switch <名称>] — 切换后端 Agent\n" +
 			"/model [switch <名称>] — 查看/切换模型\n" +
 			"/mode [名称] — 查看/切换权限模式\n" +
 			"/provider [list|add|...] — 管理 API Provider\n" +
@@ -1057,6 +1075,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/lang [en|zh|...] — 查看/切换语言\n" +
 			"/quiet [global] — 开关进度消息",
 		LangTraditionalChinese: "**Agent 配置**\n" +
+			"/agent [switch <名稱>] — 切換後端 Agent\n" +
 			"/model [switch <名稱>] — 查看/切換模型\n" +
 			"/mode [名稱] — 查看/切換權限模式\n" +
 			"/provider [list|add|...] — 管理 API Provider\n" +
@@ -1065,6 +1084,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/lang [en|zh|...] — 查看/切換語言\n" +
 			"/quiet [global] — 開關進度訊息",
 		LangJapanese: "**エージェント設定**\n" +
+			"/agent [switch <名前>] — バックエンド Agent の切り替え\n" +
 			"/model [switch <名前>] — モデルの表示/切り替え\n" +
 			"/mode [名前] — 権限モードの表示/切り替え\n" +
 			"/provider [list|add|...] — API プロバイダ管理\n" +
@@ -1073,6 +1093,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/lang [en|zh|...] — 言語の表示/切り替え\n" +
 			"/quiet [global] — 進捗メッセージの表示切替",
 		LangSpanish: "**Configuración del agente**\n" +
+			"/agent [switch <nombre>] — Cambiar agente de backend\n" +
 			"/model [switch <nombre>] — Ver/cambiar modelo\n" +
 			"/mode [nombre] — Ver/cambiar modo de permisos\n" +
 			"/provider [list|add|...] — Gestionar proveedores\n" +
@@ -1258,6 +1279,62 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "❌ 沒有活躍會話，請先傳送訊息或切換到一個會話。",
 		LangJapanese:           "❌ アクティブなセッションがありません。メッセージを送信するかセッションに切り替えてください。",
 		LangSpanish:            "❌ No hay sesión activa. Envía un mensaje primero o cambia a una sesión.",
+	},
+	MsgAgentNotSupported: {
+		LangEnglish:            "This agent does not support backend switching.",
+		LangChinese:            "当前 Agent 不支持后端切换。",
+		LangTraditionalChinese: "當前 Agent 不支援後端切換。",
+		LangJapanese:           "このエージェントはバックエンド切り替えをサポートしていません。",
+		LangSpanish:            "Este agente no soporta el cambio de backend.",
+	},
+	MsgAgentNone: {
+		LangEnglish:            "No backend configured.",
+		LangChinese:            "未配置后端。",
+		LangTraditionalChinese: "未配置後端。",
+		LangJapanese:           "バックエンドが設定されていません。",
+		LangSpanish:            "No hay backend configurado.",
+	},
+	MsgAgentCurrent: {
+		LangEnglish:            "📦 Current agent: **%s**",
+		LangChinese:            "📦 当前 agent: **%s**",
+		LangTraditionalChinese: "📦 當前 agent: **%s**",
+		LangJapanese:           "📦 現在の agent: **%s**",
+		LangSpanish:            "📦 Agente actual: **%s**",
+	},
+	MsgAgentListTitle: {
+		LangEnglish:            "Available backends:\n",
+		LangChinese:            "可用后端:\n",
+		LangTraditionalChinese: "可用後端:\n",
+		LangJapanese:           "利用可能なバックエンド:\n",
+		LangSpanish:            "Backends disponibles:\n",
+	},
+	MsgAgentListEmpty: {
+		LangEnglish:            "No backends configured.",
+		LangChinese:            "未配置后端。",
+		LangTraditionalChinese: "未配置後端。",
+		LangJapanese:           "バックエンドが設定されていません。",
+		LangSpanish:            "No hay backends configurados.",
+	},
+	MsgAgentNotFound: {
+		LangEnglish:            "❌ Backend %q not found. Use `/agent` to see available backends.",
+		LangChinese:            "❌ 未找到后端 %q。使用 `/agent` 查看可用列表。",
+		LangTraditionalChinese: "❌ 未找到後端 %q。使用 `/agent` 查看可用列表。",
+		LangJapanese:           "❌ バックエンド %q が見つかりません。`/agent` で一覧を確認してください。",
+		LangSpanish:            "❌ Backend %q no encontrado. Use `/agent` para ver los disponibles.",
+	},
+	MsgAgentSwitched: {
+		LangEnglish:            "✅ Backend switched to **%s**. New sessions will use this backend.",
+		LangChinese:            "✅ 后端已切换为 **%s**，新会话将使用此后端。",
+		LangTraditionalChinese: "✅ 後端已切換為 **%s**，新會話將使用此後端。",
+		LangJapanese:           "✅ バックエンドを **%s** に切り替えました。新しいセッションで使用されます。",
+		LangSpanish:            "✅ Backend cambiado a **%s**. Las nuevas sesiones usarán este backend.",
+	},
+	MsgAgentUsage: {
+		LangEnglish:            "Usage: `/agent switch <number>` or `/agent switch <name>`",
+		LangChinese:            "用法: `/agent switch <序号>` 或 `/agent switch <后端名>`",
+		LangTraditionalChinese: "用法: `/agent switch <序號>` 或 `/agent switch <後端名>`",
+		LangJapanese:           "使い方: `/agent switch <番号>` または `/agent switch <名前>`",
+		LangSpanish:            "Uso: `/agent switch <número>` o `/agent switch <nombre>`",
 	},
 	MsgProviderNotSupported: {
 		LangEnglish:            "This agent does not support provider switching.",
@@ -2025,6 +2102,10 @@ var messages = map[MsgKey]map[Language]string{
 		LangEnglish: "Select model", LangChinese: "选择模型", LangTraditionalChinese: "選擇模型",
 		LangJapanese: "モデルを選択", LangSpanish: "Seleccionar modelo",
 	},
+	MsgAgentSelectPlaceholder: {
+		LangEnglish: "Select agent", LangChinese: "选择 Agent", LangTraditionalChinese: "選擇 Agent",
+		LangJapanese: "エージェントを選択", LangSpanish: "Seleccionar agente",
+	},
 	MsgReasoningSelectPlaceholder: {
 		LangEnglish: "Select reasoning level", LangChinese: "选择推理强度", LangTraditionalChinese: "選擇推理強度",
 		LangJapanese: "推論強度を選択", LangSpanish: "Seleccionar nivel de razonamiento",
@@ -2060,6 +2141,10 @@ var messages = map[MsgKey]map[Language]string{
 	MsgCardTitleModel: {
 		LangEnglish: "Model", LangChinese: "模型", LangTraditionalChinese: "模型",
 		LangJapanese: "モデル", LangSpanish: "Modelo",
+	},
+	MsgCardTitleAgent: {
+		LangEnglish: "Agent", LangChinese: "Agent", LangTraditionalChinese: "Agent",
+		LangJapanese: "エージェント", LangSpanish: "Agente",
 	},
 	MsgCardTitleReasoning: {
 		LangEnglish: "Reasoning", LangChinese: "推理强度", LangTraditionalChinese: "推理強度",
@@ -3038,6 +3123,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "查看/切換模型，參數: [名稱]",
 		LangJapanese:           "モデルの表示/切り替え、引数: [名前]",
 		LangSpanish:            "Ver/cambiar modelo, arg: [nombre]",
+	},
+	MsgBuiltinCmdAgent: {
+		LangEnglish:            "Switch backend agent, arg: [name]",
+		LangChinese:            "切换后端 Agent，参数: [名称]",
+		LangTraditionalChinese: "切換後端 Agent，參數: [名稱]",
+		LangJapanese:           "バックエンド Agent の切り替え、引数: [名前]",
+		LangSpanish:            "Cambiar agente de backend, arg: [nombre]",
 	},
 	MsgBuiltinCmdReasoning: {
 		LangEnglish:            "View/switch reasoning effort, arg: [level]",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -41,6 +41,12 @@ type SessionEnvInjector interface {
 	SetSessionEnv(env []string)
 }
 
+// OptionSnapshotter is an optional interface for agents that need their
+// original config options preserved when the engine clones per-workspace agents.
+type OptionSnapshotter interface {
+	SnapshotOptions() map[string]any
+}
+
 // FormattingInstructionProvider is an optional interface for platforms that
 // provide platform-specific formatting instructions for the agent system prompt
 // (e.g., Slack mrkdwn vs standard Markdown).
@@ -278,6 +284,21 @@ type ModelSwitcher interface {
 	// AvailableModels tries to fetch models from the provider API.
 	// Falls back to a built-in list on failure.
 	AvailableModels(ctx context.Context) []ModelOption
+}
+
+// AgentOption describes a selectable backend agent for /agent switching.
+type AgentOption struct {
+	Name string // backend identifier shown to the user
+	Desc string // short description (e.g. "claudecode / claude-sonnet-4-6")
+}
+
+// AgentSwitcher is an optional interface for agents that multiplex multiple
+// backend implementations behind a single project. /agent uses this to switch
+// between backends without interfering with /model.
+type AgentSwitcher interface {
+	SetActiveAgent(name string) bool
+	GetActiveAgent() string
+	ListAgents() []AgentOption
 }
 
 // ReasoningEffortSwitcher is an optional interface for agents that support

--- a/core/model_alias_test.go
+++ b/core/model_alias_test.go
@@ -27,7 +27,6 @@ func TestParseModelSwitchArgs(t *testing.T) {
 		want string
 		ok   bool
 	}{
-		{name: "legacy syntax", args: []string{"gpt"}, want: "gpt", ok: true},
 		{name: "switch syntax", args: []string{"switch", "gpt"}, want: "gpt", ok: true},
 		{name: "missing switch target", args: []string{"switch"}, ok: false},
 		{name: "unknown subcommand", args: []string{"list", "gpt"}, ok: false},

--- a/core/registry.go
+++ b/core/registry.go
@@ -1,6 +1,9 @@
 package core
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // PlatformFactory creates a Platform from config options.
 type PlatformFactory func(opts map[string]any) (Platform, error)
@@ -8,20 +11,38 @@ type PlatformFactory func(opts map[string]any) (Platform, error)
 // AgentFactory creates an Agent from config options.
 type AgentFactory func(opts map[string]any) (Agent, error)
 
+// AgentModelConfigSaver updates persisted agent config options for a specific
+// agent type when /model changes the active model.
+type AgentModelConfigSaver func(options map[string]any, model string) error
+
 var (
 	platformFactories = make(map[string]PlatformFactory)
 	agentFactories    = make(map[string]AgentFactory)
+	agentModelSavers  = make(map[string]AgentModelConfigSaver)
+	registryMu        sync.RWMutex
 )
 
 func RegisterPlatform(name string, factory PlatformFactory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
 	platformFactories[name] = factory
 }
 
 func RegisterAgent(name string, factory AgentFactory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
 	agentFactories[name] = factory
 }
 
+func RegisterAgentModelConfigSaver(name string, saver AgentModelConfigSaver) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	agentModelSavers[name] = saver
+}
+
 func CreatePlatform(name string, opts map[string]any) (Platform, error) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
 	f, ok := platformFactories[name]
 	if !ok {
 		available := make([]string, 0, len(platformFactories))
@@ -34,6 +55,8 @@ func CreatePlatform(name string, opts map[string]any) (Platform, error) {
 }
 
 func CreateAgent(name string, opts map[string]any) (Agent, error) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
 	f, ok := agentFactories[name]
 	if !ok {
 		available := make([]string, 0, len(agentFactories))
@@ -43,4 +66,11 @@ func CreateAgent(name string, opts map[string]any) (Agent, error) {
 		return nil, fmt.Errorf("unknown agent %q, available: %v", name, available)
 	}
 	return f(opts)
+}
+
+func LookupAgentModelConfigSaver(name string) (AgentModelConfigSaver, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	saver, ok := agentModelSavers[name]
+	return saver, ok
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,6 +7,7 @@ Complete guide to using cc-connect features.
 - [Session Management](#session-management)
 - [Permission Modes](#permission-modes)
 - [API Provider Management](#api-provider-management)
+- [Backend Switching](#backend-switching)
 - [Model Selection](#model-selection)
 - [Work Directory Switching (`/dir`, `/cd`)](#work-directory-switching-dir-cd)
 - [Feishu Setup CLI](#feishu-setup-cli)
@@ -36,7 +37,8 @@ Each user gets an independent session with full conversation context. Manage ses
 | `/history [n]` | Show last n messages (default 10) |
 | `/usage` | Show account/model quota usage (if supported) |
 | `/provider [...]` | Manage API providers |
-| `/model [switch <alias>]` | List available models or switch by alias |
+| `/agent [switch <name>]` | Switch backend agents (Claude Code / Codex) |
+| `/model [switch <name>]` | List available models for the current backend or switch by name |
 | `/dir [path]` | Show or switch the agent work directory |
 | `/allow <tool>` | Pre-allow a tool (next session) |
 | `/reasoning [level]` | View or switch reasoning effort (Codex) |
@@ -191,6 +193,39 @@ cc-connect provider import --project my-backend  # from cc-switch
 
 ---
 
+## Backend Switching
+
+If you want one Feishu bot to switch quickly between Claude Code and Codex, use `switcher` to mount both backends under one project. Use `/agent` to change backend, and `/model` to change the model within the current backend:
+
+```toml
+[projects.agent]
+type = "switcher"
+
+[projects.agent.options]
+work_dir = "/path/to/project"
+mode = "default"
+agent = "claude"
+
+[[projects.agent.options.backends]]
+name = "claude"
+type = "claudecode"
+model = "claude-sonnet-4-20250514"
+
+[[projects.agent.options.backends]]
+name = "codex"
+type = "codex"
+model = "gpt-4.1"
+```
+
+Chat commands:
+
+```text
+/agent switch codex
+/model switch claude-sonnet-4-20250514
+```
+
+---
+
 ## Model Selection
 
 Pre-configure a list of selectable models per provider using `[[providers.models]]`. Each entry has a `model` identifier and an optional `alias` (short name shown in `/model`).
@@ -219,9 +254,7 @@ alias = "spark"
 
 ```
 /model              List available models (format: alias - model)
-/model switch <alias>      Switch to the model matching the alias
 /model switch <name>       Switch to the model by its full name
-/model <alias>             Legacy syntax, still supported
 ```
 
 When `models` is configured, `/model` shows exactly that list without making an API round-trip. When omitted, models are fetched from the provider API or fall back to a built-in list.

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -7,6 +7,7 @@ cc-connect 完整功能使用指南。
 - [会话管理](#会话管理)
 - [权限模式](#权限模式)
 - [API Provider 管理](#api-provider-管理)
+- [后端切换](#后端切换)
 - [模型选择](#模型选择)
 - [工作目录切换（`/dir`、`/cd`）](#工作目录切换dircd)
 - [飞书配置 CLI](#飞书配置-cli)
@@ -36,7 +37,8 @@ cc-connect 完整功能使用指南。
 | `/history [n]` | 查看最近 n 条消息 |
 | `/usage` | 查看账号/模型限额使用情况 |
 | `/provider [...]` | 管理 API Provider |
-| `/model [switch <alias>]` | 列出可用模型或按别名切换 |
+| `/agent [switch <name>]` | 切换后端 Agent（Claude Code / Codex） |
+| `/model [switch <name>]` | 列出当前后端的可用模型或按名称切换 |
 | `/dir [路径]` | 查看或切换 Agent 工作目录 |
 | `/allow <工具名>` | 预授权工具 |
 | `/reasoning [等级]` | 查看或切换推理强度（Codex）|
@@ -191,6 +193,39 @@ cc-connect provider import --project my-backend  # 从 cc-switch 导入
 
 ---
 
+## 后端切换
+
+如果你想在同一个飞书 bot 里快速切换 Claude Code 和 Codex，可以用 `switcher` 把两个后端挂到同一个项目下，然后通过 `/agent` 切换后端，通过 `/model` 切换当前后端里的模型：
+
+```toml
+[projects.agent]
+type = "switcher"
+
+[projects.agent.options]
+work_dir = "/path/to/project"
+mode = "default"
+agent = "claude"
+
+[[projects.agent.options.backends]]
+name = "claude"
+type = "claudecode"
+model = "claude-sonnet-4-20250514"
+
+[[projects.agent.options.backends]]
+name = "codex"
+type = "codex"
+model = "gpt-4.1"
+```
+
+聊天里：
+
+```text
+/agent switch codex
+/model switch claude-sonnet-4-20250514
+```
+
+---
+
 ## 模型选择
 
 通过 `[[providers.models]]` 为每个 Provider 预配置可选模型列表。每个条目包含 `model`（模型标识符）和可选的 `alias`（别名，显示在 `/model` 中）。
@@ -219,9 +254,7 @@ alias = "spark"
 
 ```
 /model              列出可用模型（格式：alias - model）
-/model switch <alias>      按别名切换模型
 /model switch <name>       按完整名称切换模型
-/model <alias>             兼容旧写法，仍然可用
 ```
 
 配置了 `models` 时，`/model` 直接显示该列表，不发起 API 请求。未配置时，自动从 Provider API 获取或使用内置备选列表。
@@ -617,7 +650,7 @@ type = "claudecode"
 name = "my-project"
 
 [projects.agent]
-type = "claudecode"  # 或 codex, cursor, gemini, qoder, opencode, iflow
+type = "claudecode"  # 或 codex, cursor, gemini, qoder, opencode, iflow, switcher
 
 [projects.agent.options]
 work_dir = "/path/to/project"
@@ -630,3 +663,8 @@ type = "feishu"  # 或 dingtalk, telegram, slack, discord, wecom, weixin, line, 
 [projects.platforms.options]
 # 平台特定配置
 ```
+
+如果你想在同一个飞书 bot 里快速切换 Claude Code 和 Codex，可以使用上面的 `switcher` 示例：
+
+- `/agent` 切换 Claude Code / Codex 后端
+- `/model` 只切当前后端里的具体模型

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -364,11 +364,22 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 	}
 
 	actionVal, _ := event.Event.Action.Value["action"].(string)
+	slog.Info(p.tag()+": card action received",
+		"tag", event.Event.Action.Tag,
+		"name", event.Event.Action.Name,
+		"option", event.Event.Action.Option,
+		"action", actionVal,
+		"value", event.Event.Action.Value,
+	)
 
 	// select_static callbacks put the chosen value in event.Event.Action.Option
 	if actionVal == "" && event.Event.Action.Option != "" {
 		actionVal = event.Event.Action.Option
 	}
+	if event.Event.Action.Tag == "select_static" {
+		actionVal = normalizeSelectStaticAction(actionVal)
+	}
+	slog.Info(p.tag()+": card action normalized", "action", actionVal)
 	if actionVal == "" {
 		switch event.Event.Action.Name {
 		case "delete_mode_submit":
@@ -414,12 +425,23 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		if p.cardNavHandler != nil {
 			card := p.cardNavHandler(actionVal, sessionKey)
 			if card != nil {
-				return &callback.CardActionTriggerResponse{
+				if strings.HasPrefix(actionVal, "act:/agent ") {
+					agentName := strings.TrimPrefix(actionVal, "act:/agent ")
+					go func() {
+						_ = p.Reply(context.Background(), replyContext{
+							messageID:  messageID,
+							chatID:     chatID,
+							sessionKey: sessionKey,
+						}, "已切换 agent: "+agentName)
+					}()
+				}
+				resp := &callback.CardActionTriggerResponse{
 					Card: &callback.Card{
 						Type: "raw",
 						Data: renderCardMap(card, sessionKey),
 					},
-				}, nil
+				}
+				return resp, nil
 			}
 		}
 		if strings.HasPrefix(actionVal, "act:") {
@@ -523,6 +545,34 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 	}
 
 	return nil, nil
+}
+
+func normalizeSelectStaticAction(actionVal string) string {
+	if actionVal == "" {
+		return ""
+	}
+	if strings.HasPrefix(actionVal, "nav:") || strings.HasPrefix(actionVal, "act:") || strings.HasPrefix(actionVal, "cmd:") {
+		return actionVal
+	}
+	if strings.HasPrefix(actionVal, "lang:") {
+		return "act:/lang " + strings.TrimPrefix(actionVal, "lang:")
+	}
+	if strings.HasPrefix(actionVal, "model:") {
+		return "act:/model switch " + strings.TrimPrefix(actionVal, "model:")
+	}
+	if strings.HasPrefix(actionVal, "agent:") {
+		return "act:/agent " + strings.TrimPrefix(actionVal, "agent:")
+	}
+	if strings.HasPrefix(actionVal, "reasoning:") {
+		return "act:/reasoning " + strings.TrimPrefix(actionVal, "reasoning:")
+	}
+	if strings.HasPrefix(actionVal, "mode:") {
+		return "act:/mode " + strings.TrimPrefix(actionVal, "mode:")
+	}
+	if strings.HasPrefix(actionVal, "provider:") {
+		return "act:/provider " + strings.TrimPrefix(actionVal, "provider:")
+	}
+	return actionVal
 }
 
 func (p *Platform) addReaction(messageID string) string {

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -174,6 +174,48 @@ func TestInteractivePlatform_CardActionPassesCardSenderToHandler(t *testing.T) {
 	}
 }
 
+func TestInteractivePlatform_SelectStaticAgentOptionNormalizesToActAction(t *testing.T) {
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip, ok := platformAny.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *interactivePlatform", platformAny)
+	}
+
+	actionCh := make(chan string, 1)
+	ip.cardNavHandler = func(action string, sessionKey string) *core.Card {
+		actionCh <- action
+		return core.NewCard().Markdown("ok").Build()
+	}
+
+	_, err = ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_test_user"},
+			Action: &callback.CallBackAction{
+				Tag:    "select_static",
+				Option: "agent:codex",
+				Value:  map[string]any{"session_key": "feishu:oc_test_chat:ou_test_user"},
+			},
+			Context: &callback.Context{OpenChatID: "oc_test_chat", OpenMessageID: "om_test_message"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+
+	select {
+	case got := <-actionCh:
+		want := "act:/agent codex"
+		if got != want {
+			t.Fatalf("action = %q, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected card nav handler invocation")
+	}
+}
+
 func TestInteractivePlatform_CardActionActWithoutCardResponseDoesNotWarn(t *testing.T) {
 	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add a dedicated `/agent` command to switch between Claude Code and Codex backends without changing `/model` semantics.
- Keep `/model` for model selection inside the active backend.
- Improve Feishu card handling and Codex process isolation.

## Validation
- `go test ./...`
- Rebuilt and restarted `cc-connect`
- Manually verified `/agent` and `/model` flows in Feishu

## Notes
- No secrets, auth files, or real API keys were included in this PR.