### PR TITLE
fix(codex): force kill session process group on stop

### DIFF
--- a/agent/codex/proc_unix.go
+++ b/agent/codex/proc_unix.go
@@ -23,7 +23,7 @@ func forceKillCmd(cmd *exec.Cmd) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil
 	}
-	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) && !errors.Is(err, syscall.ESRCH) {
 		return err
 	}
 	return nil

--- a/agent/codex/proc_unix.go
+++ b/agent/codex/proc_unix.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+package codex
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func prepareCmdForKill(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+func forceKillCmd(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
+}

--- a/agent/codex/proc_windows.go
+++ b/agent/codex/proc_windows.go
@@ -3,9 +3,13 @@
 package codex
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -23,8 +27,28 @@ func forceKillCmd(cmd *exec.Cmd) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil
 	}
-	if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		return err
+	killCmd := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid))
+	output, err := killCmd.CombinedOutput()
+	if err == nil {
+		return nil
 	}
-	return nil
+	if bytes.Contains(bytes.ToLower(output), []byte("there is no running instance")) {
+		return nil
+	}
+	if bytes.Contains(bytes.ToLower(output), []byte("not found")) {
+		return nil
+	}
+	if killErr := cmd.Process.Kill(); killErr == nil || errors.Is(killErr, os.ErrProcessDone) {
+		return nil
+	} else {
+		return fmt.Errorf("taskkill failed: %w: %s; process kill fallback failed: %w", err, processKillOutput(output), killErr)
+	}
+}
+
+func processKillOutput(output []byte) string {
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return "(empty output)"
+	}
+	return trimmed
 }

--- a/agent/codex/proc_windows.go
+++ b/agent/codex/proc_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package codex
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func prepareCmdForKill(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= syscall.CREATE_NEW_PROCESS_GROUP
+}
+
+func forceKillCmd(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
+}

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -37,7 +37,7 @@ type codexSession struct {
 	alive     atomic.Bool
 	closeOnce sync.Once
 	cmdMu     sync.Mutex
-	cmd       *exec.Cmd
+	cmds      map[*exec.Cmd]struct{}
 
 	pendingMsgs []string // buffered agent_message texts awaiting classification
 }
@@ -57,6 +57,7 @@ func newCodexSession(ctx context.Context, workDir, model, effort, mode, resumeID
 		events:   make(chan core.Event, 64),
 		ctx:      sessionCtx,
 		cancel:   cancel,
+		cmds:     make(map[*exec.Cmd]struct{}),
 	}
 	cs.alive.Store(true)
 
@@ -107,7 +108,7 @@ func (cs *codexSession) Send(prompt string, images []core.ImageAttachment, files
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("codexSession: start: %w", err)
 	}
-	cs.setCmd(cmd)
+	cs.addCmd(cmd)
 
 	cs.wg.Add(1)
 	go cs.readLoop(cmd, stdout, &stderrBuf)
@@ -201,8 +202,8 @@ func codexImageExt(mime string) string {
 
 func (cs *codexSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
 	defer cs.wg.Done()
-	defer cs.clearCmd(cmd)
 	defer func() {
+		defer cs.removeCmd(cmd)
 		if err := cmd.Wait(); err != nil {
 			stderrMsg := strings.TrimSpace(stderrBuf.String())
 			if stderrMsg != "" {
@@ -549,9 +550,11 @@ func (cs *codexSession) Close() error {
 		})
 		return nil
 	case <-time.After(codexSessionCloseTimeout):
-		slog.Warn("codexSession: graceful close timed out, killing process group",
-			"wait", codexSessionCloseTimeout)
-		if err := forceKillCmd(cs.currentCmd()); err != nil {
+		cmds := cs.activeCmds()
+		slog.Warn("codexSession: graceful close timed out, killing active process groups",
+			"wait", codexSessionCloseTimeout,
+			"count", len(cmds))
+		if err := forceKillAllCmds(cmds); err != nil {
 			slog.Debug("codexSession: force kill failed", "error", err)
 		}
 		select {
@@ -576,24 +579,36 @@ func (cs *codexSession) Close() error {
 	}
 }
 
-func (cs *codexSession) setCmd(cmd *exec.Cmd) {
+func (cs *codexSession) addCmd(cmd *exec.Cmd) {
 	cs.cmdMu.Lock()
 	defer cs.cmdMu.Unlock()
-	cs.cmd = cmd
+	cs.cmds[cmd] = struct{}{}
 }
 
-func (cs *codexSession) clearCmd(cmd *exec.Cmd) {
+func (cs *codexSession) removeCmd(cmd *exec.Cmd) {
 	cs.cmdMu.Lock()
 	defer cs.cmdMu.Unlock()
-	if cs.cmd == cmd {
-		cs.cmd = nil
+	delete(cs.cmds, cmd)
+}
+
+func (cs *codexSession) activeCmds() []*exec.Cmd {
+	cs.cmdMu.Lock()
+	defer cs.cmdMu.Unlock()
+	cmds := make([]*exec.Cmd, 0, len(cs.cmds))
+	for cmd := range cs.cmds {
+		cmds = append(cmds, cmd)
 	}
+	return cmds
 }
 
-func (cs *codexSession) currentCmd() *exec.Cmd {
-	cs.cmdMu.Lock()
-	defer cs.cmdMu.Unlock()
-	return cs.cmd
+func forceKillAllCmds(cmds []*exec.Cmd) error {
+	var errs []error
+	for _, cmd := range cmds {
+		if err := forceKillCmd(cmd); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // extractItemText extracts text from an item's array field (e.g. "summary" or "content").

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -36,9 +36,14 @@ type codexSession struct {
 	wg        sync.WaitGroup
 	alive     atomic.Bool
 	closeOnce sync.Once
+	cmdMu     sync.Mutex
+	cmd       *exec.Cmd
 
 	pendingMsgs []string // buffered agent_message texts awaiting classification
 }
+
+var codexSessionCloseTimeout = 8 * time.Second
+var codexSessionForceKillWait = 2 * time.Second
 
 func newCodexSession(ctx context.Context, workDir, model, effort, mode, resumeID string, extraEnv []string) (*codexSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
@@ -86,6 +91,7 @@ func (cs *codexSession) Send(prompt string, images []core.ImageAttachment, files
 
 	cmd := exec.CommandContext(cs.ctx, "codex", args...)
 	cmd.Dir = cs.workDir
+	prepareCmdForKill(cmd)
 	if len(cs.extraEnv) > 0 {
 		cmd.Env = core.MergeEnv(os.Environ(), cs.extraEnv)
 	}
@@ -101,6 +107,7 @@ func (cs *codexSession) Send(prompt string, images []core.ImageAttachment, files
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("codexSession: start: %w", err)
 	}
+	cs.setCmd(cmd)
 
 	cs.wg.Add(1)
 	go cs.readLoop(cmd, stdout, &stderrBuf)
@@ -194,6 +201,7 @@ func codexImageExt(mime string) string {
 
 func (cs *codexSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
 	defer cs.wg.Done()
+	defer cs.clearCmd(cmd)
 	defer func() {
 		if err := cmd.Wait(); err != nil {
 			stderrMsg := strings.TrimSpace(stderrBuf.String())
@@ -540,20 +548,52 @@ func (cs *codexSession) Close() error {
 			close(cs.events)
 		})
 		return nil
-	case <-time.After(8 * time.Second):
-		// Do not close(cs.events) here: readLoop may still be in handleEvent
-		// (e.g. turn.completed -> flushPendingAsText) and would panic on send.
-		// See https://github.com/chenhg5/cc-connect/issues/281
-		slog.Warn("codexSession: close timed out, deferring events channel close until readLoop exits",
-			"wait", 8*time.Second)
-		go func() {
-			<-done
+	case <-time.After(codexSessionCloseTimeout):
+		slog.Warn("codexSession: graceful close timed out, killing process group",
+			"wait", codexSessionCloseTimeout)
+		if err := forceKillCmd(cs.currentCmd()); err != nil {
+			slog.Debug("codexSession: force kill failed", "error", err)
+		}
+		select {
+		case <-done:
 			cs.closeOnce.Do(func() {
 				close(cs.events)
 			})
-		}()
-		return nil
+			return nil
+		case <-time.After(codexSessionForceKillWait):
+			// Do not close(cs.events) here: readLoop may still be in handleEvent
+			// (e.g. turn.completed -> flushPendingAsText) and would panic on send.
+			slog.Warn("codexSession: force kill wait timed out, deferring events channel close until readLoop exits",
+				"wait", codexSessionForceKillWait)
+			go func() {
+				<-done
+				cs.closeOnce.Do(func() {
+					close(cs.events)
+				})
+			}()
+			return nil
+		}
 	}
+}
+
+func (cs *codexSession) setCmd(cmd *exec.Cmd) {
+	cs.cmdMu.Lock()
+	defer cs.cmdMu.Unlock()
+	cs.cmd = cmd
+}
+
+func (cs *codexSession) clearCmd(cmd *exec.Cmd) {
+	cs.cmdMu.Lock()
+	defer cs.cmdMu.Unlock()
+	if cs.cmd == cmd {
+		cs.cmd = nil
+	}
+}
+
+func (cs *codexSession) currentCmd() *exec.Cmd {
+	cs.cmdMu.Lock()
+	defer cs.cmdMu.Unlock()
+	return cs.cmd
 }
 
 // extractItemText extracts text from an item's array field (e.g. "summary" or "content").

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -422,6 +422,81 @@ func TestClose_ForceKillsProcessGroupAfterGracefulTimeout(t *testing.T) {
 	}
 }
 
+func TestClose_ForceKillsAllTrackedProcessesAfterCmdOverwrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group semantics differ on windows")
+	}
+
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	startsFile := filepath.Join(workDir, "starts.txt")
+	script := "#!/bin/sh\n" +
+		"prompt=''\n" +
+		"for last\n" +
+		"do\n" +
+		"  prompt=\"$last\"\n" +
+		"done\n" +
+		"printf '%s\\n' \"$prompt\" >> \"$CODEX_STARTS_FILE\"\n" +
+		"if [ \"$prompt\" = \"first\" ]; then\n" +
+		"  printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"thread-overlap\"}'\n" +
+		"  printf '%s\\n' '{\"type\":\"turn.completed\"}'\n" +
+		"fi\n" +
+		"sleep 30\n"
+	scriptPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	t.Setenv("CODEX_STARTS_FILE", startsFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	oldCloseTimeout := codexSessionCloseTimeout
+	oldForceKillWait := codexSessionForceKillWait
+	codexSessionCloseTimeout = 50 * time.Millisecond
+	codexSessionForceKillWait = 500 * time.Millisecond
+	t.Cleanup(func() {
+		codexSessionCloseTimeout = oldCloseTimeout
+		codexSessionForceKillWait = oldForceKillWait
+	})
+
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+
+	if err := cs.Send("first", nil, nil); err != nil {
+		t.Fatalf("Send(first): %v", err)
+	}
+	waitForThreadID(t, cs, "thread-overlap")
+	waitForDoneResult(t, cs.Events())
+
+	if err := cs.Send("second", nil, nil); err != nil {
+		t.Fatalf("Send(second): %v", err)
+	}
+	waitForFileLines(t, startsFile, 2)
+
+	closeStarted := time.Now()
+	if err := cs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if elapsed := time.Since(closeStarted); elapsed > time.Second {
+		t.Fatalf("Close took too long after force killing tracked processes: %v", elapsed)
+	}
+
+	select {
+	case evt, ok := <-cs.Events():
+		if ok {
+			t.Fatalf("unexpected event after Close: %#v", evt)
+		}
+	case <-time.After(700 * time.Millisecond):
+		t.Fatal("timed out waiting for events channel to close")
+	}
+}
+
 func waitForThreadID(t *testing.T, cs *codexSession, want string) {
 	t.Helper()
 	timeout := time.After(5 * time.Second)
@@ -435,4 +510,47 @@ func waitForThreadID(t *testing.T, cs *codexSession, want string) {
 			t.Fatalf("timed out waiting for thread id %q", want)
 		}
 	}
+}
+
+func waitForDoneResult(t *testing.T, events <-chan core.Event) {
+	t.Helper()
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				t.Fatal("events channel closed before done result")
+			}
+			if evt.Type == core.EventError {
+				t.Fatalf("unexpected error event: %v", evt.Error)
+			}
+			if evt.Type == core.EventResult && evt.Done {
+				return
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for done result")
+		}
+	}
+}
+
+func waitForFileLines(t *testing.T, path string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+			count := 0
+			for _, line := range lines {
+				if strings.TrimSpace(line) != "" {
+					count++
+				}
+			}
+			if count >= want {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d lines in %s", want, path)
 }

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -358,5 +359,80 @@ func TestCodexSession_ContinueSessionTreatedAsFresh(t *testing.T) {
 
 	if got := s.CurrentSessionID(); got != "" {
 		t.Errorf("ContinueSession should be treated as fresh: threadID = %q, want empty", got)
+	}
+}
+
+func TestClose_ForceKillsProcessGroupAfterGracefulTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group semantics differ on windows")
+	}
+
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"thread-close\"}'\n" +
+		"(sleep 0.12; printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"late child output\"}}'; sleep 30) &\n" +
+		"wait\n"
+	scriptPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	oldCloseTimeout := codexSessionCloseTimeout
+	oldForceKillWait := codexSessionForceKillWait
+	codexSessionCloseTimeout = 50 * time.Millisecond
+	codexSessionForceKillWait = 500 * time.Millisecond
+	t.Cleanup(func() {
+		codexSessionCloseTimeout = oldCloseTimeout
+		codexSessionForceKillWait = oldForceKillWait
+	})
+
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+
+	if err := cs.Send("hello", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	waitForThreadID(t, cs, "thread-close")
+
+	closeStarted := time.Now()
+	if err := cs.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if elapsed := time.Since(closeStarted); elapsed > time.Second {
+		t.Fatalf("Close took too long after force kill: %v", elapsed)
+	}
+
+	select {
+	case evt, ok := <-cs.Events():
+		if ok {
+			t.Fatalf("unexpected event after Close: %#v", evt)
+		}
+	case <-time.After(700 * time.Millisecond):
+		t.Fatal("timed out waiting for events channel to close")
+	}
+}
+
+func waitForThreadID(t *testing.T, cs *codexSession, want string) {
+	t.Helper()
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case <-time.After(10 * time.Millisecond):
+			if cs.CurrentSessionID() == want {
+				return
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for thread id %q", want)
+		}
 	}
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -241,6 +241,8 @@ type interactiveState struct {
 	replyCtx               any
 	workspaceDir           string
 	mu                     sync.Mutex
+	stopCh                 chan struct{}
+	stopped                bool
 	pending                *pendingPermission
 	pendingMessages        []queuedMessage // messages queued while session was busy
 	approveAll             bool            // when true, auto-approve all permission requests for this session
@@ -271,6 +273,37 @@ type pendingPermission struct {
 	CurrentQuestion int            // index of the question currently being asked
 	Resolved        chan struct{}  // closed when user responds
 	resolveOnce     sync.Once
+}
+
+func (s *interactiveState) stopSignal() <-chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopCh == nil {
+		s.stopCh = make(chan struct{})
+		if s.stopped {
+			close(s.stopCh)
+		}
+	}
+	return s.stopCh
+}
+
+func (s *interactiveState) isStopped() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stopped
+}
+
+func (s *interactiveState) markStopped() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped {
+		return
+	}
+	s.stopped = true
+	if s.stopCh == nil {
+		s.stopCh = make(chan struct{})
+	}
+	close(s.stopCh)
 }
 
 // resolve safely closes the Resolved channel exactly once.
@@ -1841,7 +1874,8 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 			"want_agent_session", wantID,
 			"have_agent_session", currentID,
 		)
-		go state.agentSession.Close()
+		state.markStopped()
+		e.closeAgentSessionAsync(sessionKey, state.agentSession)
 		delete(e.interactiveStates, sessionKey)
 		ok = false // prevent reading stale settings below
 	}
@@ -1970,27 +2004,43 @@ func (e *Engine) cleanupInteractiveState(sessionKey string, expected ...*interac
 
 	// Notify senders of any queued messages that will never be processed.
 	if ok && state != nil {
+		state.markStopped()
 		e.notifyDroppedQueuedMessages(state, fmt.Errorf("session reset"))
 	}
 
 	if ok && state != nil && state.agentSession != nil {
-		slog.Debug("cleanupInteractiveState: closing agent session", "session", sessionKey)
-		closeStart := time.Now()
+		e.closeAgentSessionWithTimeout(sessionKey, state.agentSession)
+	}
+}
 
-		done := make(chan struct{})
-		go func() {
-			state.agentSession.Close()
-			close(done)
-		}()
+func (e *Engine) closeAgentSessionAsync(sessionKey string, agentSession AgentSession) {
+	if agentSession == nil {
+		return
+	}
+	go e.closeAgentSessionWithTimeout(sessionKey, agentSession)
+}
 
-		select {
-		case <-done:
-			if elapsed := time.Since(closeStart); elapsed >= slowAgentClose {
-				slog.Warn("slow agent session close", "elapsed", elapsed, "session", sessionKey)
-			}
-		case <-time.After(10 * time.Second):
-			slog.Error("agent session close timed out (10s), abandoning", "session", sessionKey)
+func (e *Engine) closeAgentSessionWithTimeout(sessionKey string, agentSession AgentSession) {
+	if agentSession == nil {
+		return
+	}
+
+	slog.Debug("cleanupInteractiveState: closing agent session", "session", sessionKey)
+	closeStart := time.Now()
+
+	done := make(chan struct{})
+	go func() {
+		agentSession.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(closeStart); elapsed >= slowAgentClose {
+			slog.Warn("slow agent session close", "elapsed", elapsed, "session", sessionKey)
 		}
+	case <-time.After(10 * time.Second):
+		slog.Error("agent session close timed out (10s), abandoning", "session", sessionKey)
 	}
 }
 
@@ -2028,11 +2078,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	}
 
 	events := state.agentSession.Events()
+	stopCh := state.stopSignal()
 	for {
 		var event Event
 		var ok bool
 
 		select {
+		case <-stopCh:
+			sp.discard()
+			return
 		case event, ok = <-events:
 			if !ok {
 				goto channelClosed
@@ -2068,6 +2122,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			e.cleanupInteractiveState(sessionKey, state)
 			return
 		case <-e.ctx.Done():
+			return
+		}
+
+		if state.isStopped() {
+			sp.discard()
 			return
 		}
 
@@ -5076,43 +5135,52 @@ func (e *Engine) cmdTTS(p Platform, msg *Message, args []string) {
 
 func (e *Engine) cmdStop(p Platform, msg *Message) {
 	iKey := e.interactiveKeyForSessionKey(msg.SessionKey)
-	e.interactiveMu.Lock()
-	state, ok := e.interactiveStates[iKey]
-	e.interactiveMu.Unlock()
-
-	if !ok || state == nil {
+	if !e.stopInteractiveSession(iKey, p, msg.ReplyCtx) {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgNoExecution))
 		return
 	}
+	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgExecutionStopped))
+}
 
-	// Cancel pending permission if any
+func (e *Engine) stopInteractiveSession(sessionKey string, quietPlatform Platform, quietReplyCtx any) bool {
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[sessionKey]
+	if !ok || state == nil {
+		e.interactiveMu.Unlock()
+		return false
+	}
+
 	state.mu.Lock()
 	pending := state.pending
+	state.pending = nil
 	quietMode := state.quiet
-	if pending != nil {
-		state.pending = nil
-	}
+	agentSession := state.agentSession
 	state.mu.Unlock()
+
+	state.markStopped()
+	if quietMode {
+		if quietPlatform == nil {
+			quietPlatform = state.platform
+		}
+		if quietReplyCtx == nil {
+			quietReplyCtx = state.replyCtx
+		}
+		e.interactiveStates[sessionKey] = &interactiveState{
+			platform: quietPlatform,
+			replyCtx: quietReplyCtx,
+			quiet:    true,
+		}
+	} else {
+		delete(e.interactiveStates, sessionKey)
+	}
+	e.interactiveMu.Unlock()
+
 	if pending != nil {
 		pending.resolve()
 	}
-
-	e.cleanupInteractiveState(iKey)
-
-	// Preserve quiet preference across stop
-	if quietMode {
-		e.interactiveMu.Lock()
-		if s, ok := e.interactiveStates[iKey]; ok {
-			s.mu.Lock()
-			s.quiet = quietMode
-			s.mu.Unlock()
-		} else {
-			e.interactiveStates[iKey] = &interactiveState{platform: p, replyCtx: msg.ReplyCtx, quiet: quietMode}
-		}
-		e.interactiveMu.Unlock()
-	}
-
-	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgExecutionStopped))
+	e.notifyDroppedQueuedMessages(state, fmt.Errorf("session reset"))
+	e.closeAgentSessionAsync(sessionKey, agentSession)
+	return true
 }
 
 func (e *Engine) cmdCompress(p Platform, msg *Message) {
@@ -5193,6 +5261,7 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 
 	var textParts []string
 	events := state.agentSession.Events()
+	stopCh := state.stopSignal()
 
 	var idleTimer *time.Timer
 	var idleCh <-chan time.Time
@@ -5207,6 +5276,8 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 		var ok bool
 
 		select {
+		case <-stopCh:
+			return
 		case event, ok = <-events:
 			if !ok {
 				e.cleanupInteractiveState(sessionKey, state)
@@ -5228,6 +5299,10 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 			e.notifyDroppedQueuedMessages(state, fmt.Errorf("compress timed out"))
 			return
 		case <-e.ctx.Done():
+			return
+		}
+
+		if state.isStopped() {
 			return
 		}
 
@@ -6208,34 +6283,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 
 	case "/stop":
 		sessionKey = e.interactiveKeyForSessionKey(sessionKey)
-		e.interactiveMu.Lock()
-		state, ok := e.interactiveStates[sessionKey]
-		if !ok || state == nil {
-			e.interactiveMu.Unlock()
-			return
-		}
-		state.mu.Lock()
-		pending := state.pending
-		quietMode := state.quiet
-		agentSession := state.agentSession
-		if pending != nil {
-			state.pending = nil
-		}
-		state.agentSession = nil
-		state.mu.Unlock()
-		if quietMode {
-			e.interactiveStates[sessionKey] = &interactiveState{quiet: true}
-		} else {
-			delete(e.interactiveStates, sessionKey)
-		}
-		e.interactiveMu.Unlock()
-		if pending != nil {
-			pending.resolve()
-		}
-		if agentSession != nil {
-			slog.Debug("cleanupInteractiveState: closing agent session", "session", sessionKey)
-			go agentSession.Close()
-		}
+		e.stopInteractiveSession(sessionKey, nil, nil)
 
 	case "/heartbeat":
 		if e.heartbeatScheduler == nil {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -4557,6 +4557,44 @@ func (s *blockingSendAgentSession) Send(_ string, _ []ImageAttachment, _ []FileA
 	return nil
 }
 
+// blockingCloseAgentSession blocks in Close until releaseClose is closed.
+// It is used to verify that /stop detaches the session and stops forwarding
+// events before the underlying agent process has fully exited.
+type blockingCloseAgentSession struct {
+	controllableAgentSession
+	closeStarted chan struct{}
+	releaseClose chan struct{}
+}
+
+func newBlockingCloseSession(id string) *blockingCloseAgentSession {
+	return &blockingCloseAgentSession{
+		controllableAgentSession: controllableAgentSession{
+			sessionID: id,
+			alive:     true,
+			events:    make(chan Event, 16),
+			closed:    make(chan struct{}),
+		},
+		closeStarted: make(chan struct{}, 1),
+		releaseClose: make(chan struct{}),
+	}
+}
+
+func (s *blockingCloseAgentSession) Close() error {
+	s.alive = false
+	select {
+	case s.closeStarted <- struct{}{}:
+	default:
+	}
+	<-s.releaseClose
+	close(s.events)
+	select {
+	case <-s.closed:
+	default:
+		close(s.closed)
+	}
+	return nil
+}
+
 // permSignalInlinePlatform wraps stubInlineButtonPlatform and signals when a
 // SendWithButtons call includes perm:allow, so tests do not read buttonRows
 // from another goroutine (race with the engine under -race).
@@ -5503,6 +5541,76 @@ func TestExecuteCardAction_StopPreservesQuiet(t *testing.T) {
 	}
 	if state.agentSession != nil {
 		t.Error("expected agentSession to be nil after /stop")
+	}
+}
+
+func TestCmdStop_ReturnsWhileCloseBlockedAndStopsEventLoop(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newBlockingCloseSession("stop-blocked")
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveEvents(state, session, e.sessions, key, "msg-1", time.Now(), nil, nil, "ctx")
+		close(done)
+	}()
+
+	stopDone := make(chan struct{})
+	go func() {
+		e.cmdStop(p, &Message{SessionKey: key, ReplyCtx: "ctx"})
+		close(stopDone)
+	}()
+
+	select {
+	case <-sess.closeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected Close to start after /stop")
+	}
+
+	select {
+	case <-stopDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("cmdStop blocked on Close")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("event loop did not stop after /stop")
+	}
+
+	e.interactiveMu.Lock()
+	_, exists := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+	if exists {
+		t.Fatal("expected interactive state to be removed after /stop")
+	}
+
+	sess.events <- Event{Type: EventText, Content: "stale output"}
+	sess.events <- Event{Type: EventResult, Content: "stale result", Done: true}
+	time.Sleep(50 * time.Millisecond)
+
+	sent := p.getSent()
+	if len(sent) != 1 || sent[0] != e.i18n.T(MsgExecutionStopped) {
+		t.Fatalf("sent messages = %v, want only execution stopped", sent)
+	}
+
+	close(sess.releaseClose)
+	select {
+	case <-sess.closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not finish after release")
 	}
 }
 


### PR DESCRIPTION
## Summary
- track the active Codex exec command and prepare it for process-group termination
- force kill the Codex process group if session close times out instead of only cancelling context
- add a regression test covering late child-process output after `/stop`

## Root Cause
`/stop` in `core` already cleaned up interactive state correctly, but `agent/codex` only cancelled the context and waited 8 seconds. If the Codex child process tree kept stdout open, the read loop stayed alive and the old session continued emitting events after the user saw "Execution stopped".

## Testing
- go test ./agent/codex ./core