### PR TITLE
feat: auto-create multi-workspaces from channel names

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -218,6 +218,7 @@ func main() {
 			}
 			bindingStore := filepath.Join(cfg.DataDir, "workspace_bindings.json")
 			engine.SetMultiWorkspace(baseDir, bindingStore)
+			engine.SetMultiWorkspaceAutoCreateFromChannelName(proj.AutoCreateFromChannelName)
 			slog.Info("multi-workspace mode enabled", "project", proj.Name, "base_dir", baseDir)
 		}
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -406,6 +406,7 @@ level = "info" # debug, info, warn, error
 # name = "claude-multi"
 # mode = "multi-workspace"
 # base_dir = "~/workspace"
+# auto_create_from_channel_name = true
 #
 # [projects.agent]
 # type = "claudecode"

--- a/config/config.go
+++ b/config/config.go
@@ -174,13 +174,14 @@ type AutoCompressConfig struct {
 
 // ProjectConfig binds one agent (with a specific work_dir) to one or more platforms.
 type ProjectConfig struct {
-	Name         string             `toml:"name"`
-	Mode         string             `toml:"mode,omitempty"`     // "" or "multi-workspace"
-	BaseDir      string             `toml:"base_dir,omitempty"` // parent dir for workspaces
-	Agent        AgentConfig        `toml:"agent"`
-	Platforms    []PlatformConfig   `toml:"platforms"`
-	Heartbeat    HeartbeatConfig    `toml:"heartbeat"`
-	AutoCompress AutoCompressConfig `toml:"auto_compress"`
+	Name                      string             `toml:"name"`
+	Mode                      string             `toml:"mode,omitempty"`                          // "" or "multi-workspace"
+	BaseDir                   string             `toml:"base_dir,omitempty"`                      // parent dir for workspaces
+	AutoCreateFromChannelName bool               `toml:"auto_create_from_channel_name,omitempty"` // create/bind base_dir/<channel-name> when missing
+	Agent                     AgentConfig        `toml:"agent"`
+	Platforms                 []PlatformConfig   `toml:"platforms"`
+	Heartbeat                 HeartbeatConfig    `toml:"heartbeat"`
+	AutoCompress              AutoCompressConfig `toml:"auto_compress"`
 	// ShowContextIndicator: nil/true = append [ctx: ~N%] to assistant replies; false = hide.
 	ShowContextIndicator *bool        `toml:"show_context_indicator,omitempty"`
 	Quiet                *bool        `toml:"quiet,omitempty"`             // project-level quiet mode; overrides global setting

--- a/core/engine.go
+++ b/core/engine.go
@@ -192,12 +192,13 @@ type Engine struct {
 	showContextIndicator bool
 
 	// Multi-workspace mode
-	multiWorkspace    bool
-	baseDir           string
-	workspaceBindings *WorkspaceBindingManager
-	workspacePool     *workspacePool
-	initFlows         map[string]*workspaceInitFlow // workspace channel key → init state
-	initFlowsMu       sync.Mutex
+	multiWorkspace                 bool
+	baseDir                        string
+	autoCreateWorkspaceFromChannel bool
+	workspaceBindings              *WorkspaceBindingManager
+	workspacePool                  *workspacePool
+	initFlows                      map[string]*workspaceInitFlow // workspace channel key → init state
+	initFlowsMu                    sync.Mutex
 
 	// Interactive agent session management
 	interactiveMu     sync.Mutex
@@ -323,6 +324,12 @@ func (e *Engine) SetMultiWorkspace(baseDir, bindingStorePath string) {
 	e.workspacePool = newWorkspacePool(15 * time.Minute)
 	e.initFlows = make(map[string]*workspaceInitFlow)
 	go e.runIdleReaper()
+}
+
+// SetMultiWorkspaceAutoCreateFromChannelName controls whether an unresolved
+// channel should create and bind a workspace directory derived from its name.
+func (e *Engine) SetMultiWorkspaceAutoCreateFromChannelName(enabled bool) {
+	e.autoCreateWorkspaceFromChannel = enabled
 }
 
 func (e *Engine) runIdleReaper() {
@@ -9254,7 +9261,7 @@ func (e *Engine) resolveWorkspace(p Platform, channelID string) (string, string,
 	}
 
 	// Step 3: Convention match — check if base_dir/<channel-name> exists
-	candidate := filepath.Join(e.baseDir, channelName)
+	candidate := filepath.Join(e.baseDir, workspaceDirNameForChannel(channelID, channelName))
 	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
 		// Auto-bind
 		projectKey := "project:" + e.name
@@ -9263,9 +9270,26 @@ func (e *Engine) resolveWorkspace(p Platform, channelID string) (string, string,
 		slog.Info("workspace auto-bound by convention",
 			"channel", channelName, "workspace", normalized)
 		return normalized, channelName, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", channelName, err
+	} else if err == nil && !info.IsDir() && e.autoCreateWorkspaceFromChannel {
+		return "", channelName, fmt.Errorf("workspace path exists and is not a directory: %s", candidate)
 	}
 
-	return "", channelName, nil
+	if !e.autoCreateWorkspaceFromChannel {
+		return "", channelName, nil
+	}
+
+	if err := os.MkdirAll(candidate, 0o755); err != nil {
+		return "", channelName, fmt.Errorf("create workspace directory %s: %w", candidate, err)
+	}
+
+	projectKey := "project:" + e.name
+	normalized := normalizeWorkspacePath(candidate)
+	e.workspaceBindings.Bind(projectKey, channelKey, channelName, normalized)
+	slog.Info("workspace auto-created from channel name",
+		"channel", channelName, "workspace", normalized)
+	return normalized, channelName, nil
 }
 
 // handleWorkspaceInitFlow manages the conversational workspace setup.

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -119,6 +119,41 @@ func TestMultiWorkspaceResolution_NoMatch(t *testing.T) {
 	}
 }
 
+func TestMultiWorkspaceResolution_AutoCreatesWorkspaceFromChannelName(t *testing.T) {
+	baseDir := t.TempDir()
+	channelID := "C002A"
+	channelName := "研发/项目 A"
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	e.SetMultiWorkspaceAutoCreateFromChannelName(true)
+	p := &mockChannelResolver{names: map[string]string{channelID: channelName}}
+
+	ws, name, err := e.resolveWorkspace(p, channelID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != channelName {
+		t.Fatalf("expected channel name %q, got %q", channelName, name)
+	}
+
+	expectedDir := filepath.Join(baseDir, workspaceDirNameForChannel(channelID, channelName))
+	expectedWS := normalizeWorkspacePath(expectedDir)
+	if ws != expectedWS {
+		t.Fatalf("expected workspace %q, got %q", expectedWS, ws)
+	}
+	if info, err := os.Stat(expectedDir); err != nil || !info.IsDir() {
+		t.Fatalf("expected auto-created workspace directory %q", expectedDir)
+	}
+
+	b := e.workspaceBindings.Lookup("project:test", workspaceChannelKey(p.Name(), channelID))
+	if b == nil {
+		t.Fatal("expected binding to be created by auto-create")
+	}
+	if b.Workspace != expectedWS {
+		t.Fatalf("binding workspace = %q, want %q", b.Workspace, expectedWS)
+	}
+}
+
 func TestMultiWorkspaceResolution_ExistingBinding(t *testing.T) {
 	baseDir := t.TempDir()
 	channelID := "C003"

--- a/core/workspace_naming.go
+++ b/core/workspace_naming.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const maxWorkspaceDirNameBytes = 120
+
+// workspaceDirNameForChannel derives a safe direct-child directory name from a
+// channel/chat name while preserving the original display name as much as
+// possible for human operators.
+func workspaceDirNameForChannel(channelID, channelName string) string {
+	candidate := cleanWorkspaceDirFragment(channelName)
+	if candidate == "" || candidate == "." || candidate == ".." {
+		fallback := cleanWorkspaceDirFragment(channelID)
+		if fallback != "" {
+			candidate = "channel-" + fallback
+		}
+	}
+	if candidate == "" || candidate == "." || candidate == ".." {
+		candidate = "workspace"
+	}
+	return truncateWorkspaceDirName(candidate, maxWorkspaceDirNameBytes)
+}
+
+func cleanWorkspaceDirFragment(s string) string {
+	s = strings.Map(func(r rune) rune {
+		switch {
+		case r == 0:
+			return -1
+		case r == '/', r == '\\', r == ':':
+			return '-'
+		case unicode.IsControl(r):
+			return ' '
+		default:
+			return r
+		}
+	}, s)
+	s = strings.Join(strings.Fields(strings.TrimSpace(s)), " ")
+	s = strings.Trim(s, ". -_")
+	return s
+}
+
+func truncateWorkspaceDirName(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(maxBytes)
+	for _, r := range s {
+		size := utf8.RuneLen(r)
+		if size < 0 || b.Len()+size > maxBytes {
+			break
+		}
+		b.WriteRune(r)
+	}
+	out := strings.TrimSpace(b.String())
+	out = strings.Trim(out, ". ")
+	if out == "" {
+		return "workspace"
+	}
+	return out
+}

--- a/core/workspace_naming_test.go
+++ b/core/workspace_naming_test.go
@@ -1,0 +1,35 @@
+package core
+
+import "testing"
+
+func TestWorkspaceDirNameForChannel_PreservesSimpleNames(t *testing.T) {
+	got := workspaceDirNameForChannel("C001", "project-a")
+	if got != "project-a" {
+		t.Fatalf("workspaceDirNameForChannel() = %q, want %q", got, "project-a")
+	}
+}
+
+func TestWorkspaceDirNameForChannel_SanitizesTraversalAndSeparators(t *testing.T) {
+	got := workspaceDirNameForChannel("C002", "../研发/项目:alpha")
+	if got != "研发-项目-alpha" {
+		t.Fatalf("workspaceDirNameForChannel() = %q, want %q", got, "研发-项目-alpha")
+	}
+}
+
+func TestWorkspaceDirNameForChannel_FallsBackToChannelID(t *testing.T) {
+	got := workspaceDirNameForChannel("oc_123", " / ")
+	if got != "channel-oc_123" {
+		t.Fatalf("workspaceDirNameForChannel() = %q, want %q", got, "channel-oc_123")
+	}
+}
+
+func TestWorkspaceDirNameForChannel_TruncatesWithoutBreakingUTF8(t *testing.T) {
+	input := "项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目项目"
+	got := workspaceDirNameForChannel("C003", input)
+	if len(got) == 0 {
+		t.Fatal("expected non-empty directory name")
+	}
+	if len(got) > maxWorkspaceDirNameBytes {
+		t.Fatalf("expected %d bytes max, got %d", maxWorkspaceDirNameBytes, len(got))
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -571,6 +571,7 @@ One bot serving multiple workspaces per channel.
 name = "my-project"
 mode = "multi-workspace"
 base_dir = "~/workspaces"
+auto_create_from_channel_name = true
 
 [projects.agent]
 type = "claudecode"
@@ -588,7 +589,8 @@ type = "claudecode"
 
 ### How It Works
 
-- Channel name `#project-a` → auto-binds to `base_dir/project-a/`
+- Channel/chat name `project-a` → auto-binds to `base_dir/project-a/`
+- With `auto_create_from_channel_name = true`, an unresolved channel creates and binds a direct child workspace automatically
 - Each channel has isolated sessions and agent state
 
 ---

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -584,6 +584,7 @@ cc-connect daemon uninstall
 name = "my-project"
 mode = "multi-workspace"
 base_dir = "~/workspaces"
+auto_create_from_channel_name = true
 
 [projects.agent]
 type = "claudecode"
@@ -601,7 +602,8 @@ type = "claudecode"
 
 ### 工作原理
 
-- 频道名 `#project-a` → 自动绑定 `base_dir/project-a/`
+- 频道/聊天名 `project-a` → 自动绑定 `base_dir/project-a/`
+- 开启 `auto_create_from_channel_name = true` 后，未绑定频道会自动创建并绑定一个 `base_dir` 下的直接子目录
 - 每个频道有独立的会话和 Agent 状态
 
 ---

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -886,6 +886,15 @@ func (p *Platform) resolveChatName(chatID string) string {
 	return name
 }
 
+// ResolveChannelName implements core.ChannelNameResolver for multi-workspace mode.
+func (p *Platform) ResolveChannelName(channelID string) (string, error) {
+	name := p.resolveChatName(channelID)
+	if name == "" || name == channelID {
+		return "", fmt.Errorf("%s: resolve channel name for %s: no chat name available", p.tag(), channelID)
+	}
+	return name, nil
+}
+
 // parseMergeForward fetches sub-messages of a merge_forward message via the
 // GET /open-apis/im/v1/messages/{message_id} API, then formats them into
 // readable text. Returns combined text, images, and files from the sub-messages.


### PR DESCRIPTION
## Summary
- add a multi-workspace `auto_create_from_channel_name` config flag to create and bind missing channel workspaces automatically
- implement Feishu `ChannelNameResolver` so Feishu chats can use channel-name workspace resolution like Slack/Discord
- derive safe direct-child workspace directory names from channel/chat names and document the new flow

## Testing
- `go test ./config ./platform/feishu ./core -run 'TestMultiWorkspaceResolution_|TestWorkspaceDirNameForChannel'`
- `go build ./cmd/cc-connect`

## Notes
- `go test ./core` still hits the pre-existing macOS path-normalization failure in `TestCmdShell_MultiWorkspaceIgnoresMissingSharedBinding`, which is unrelated to this change.