### PR TITLE
fix(core): remove duplicate case EventToolResult in handleStreamEvents

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2267,56 +2267,6 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 				}
 			}
-
-		case EventToolResult:
-			if !quiet {
-				out := strings.TrimSpace(event.Content)
-				if out == "" {
-					out = strings.TrimSpace(event.ToolResult)
-				}
-				if out == "" {
-					break
-				}
-				tn := strings.TrimSpace(event.ToolName)
-				if tn == "" {
-					tn = "tool"
-				}
-				previewActive := sp.canPreview()
-				if len(textParts) > segmentStart {
-					if !previewActive {
-						segment := strings.Join(textParts[segmentStart:], "")
-						if segment != "" {
-							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
-								e.send(p, replyCtx, chunk)
-							}
-						}
-					}
-					segmentStart = len(textParts)
-				}
-				sp.freeze()
-				if previewActive {
-					sp.detachPreview()
-				}
-				var formattedOut string
-				if strings.Contains(out, "```") {
-					formattedOut = out
-				} else if strings.Contains(out, "\n") || utf8.RuneCountInString(out) > 200 {
-					lang := toolCodeLang(tn, out)
-					formattedOut = fmt.Sprintf("```%s\n%s\n```", lang, out)
-				} else {
-					switch tn {
-					case "shell", "run_shell_command", "Bash":
-						formattedOut = fmt.Sprintf("```bash\n%s\n```", out)
-					default:
-						formattedOut = fmt.Sprintf("`%s`", out)
-					}
-				}
-				toolMsg := fmt.Sprintf(e.i18n.T(MsgToolResult), tn, formattedOut)
-				for _, chunk := range SplitMessageCodeFenceAware(toolMsg, maxPlatformMessageLen) {
-					e.send(p, replyCtx, chunk)
-				}
-			}
-
 		case EventText:
 			if event.Content != "" {
 				textParts = append(textParts, event.Content)


### PR DESCRIPTION
## Summary

The structured progress card commit (b56865f) added a new `EventToolResult` handler with `ProgressCardEntry` support but did not remove the previous fallback handler, causing a Go compile error on `main`:

```
# github.com/chenhg5/cc-connect/core
core/engine.go:2271:8: duplicate case EventToolResult (constant "tool_result" of string type EventType) in expression switch
        core/engine.go:2246:8: previous case
```

- Remove the old handler (lines 2271–2319) that is now superseded by the structured version at line 2246

## Test plan

- [x] `go build ./cmd/cc-connect/` passes
- [x] Verified only 3 `case EventToolResult:` remain (in 3 separate switch statements / functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)