### PR TITLE
fix(cron): cleanup interactive state for new_per_run jobs

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2580,6 +2580,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					slog.Debug("async send error after EventResult", "error", err)
 				}
 			}
+			// Cleanup interactive state for new_per_run cron jobs.
+			// Cron sessions have "#cron:" in their interactive key.
+			if strings.Contains(sessionKey, "#cron:") {
+				e.cleanupInteractiveState(sessionKey, state)
+			}
 			return
 
 		case EventError:


### PR DESCRIPTION
## Summary
- Fix memory leak in `new_per_run` cron jobs where Claude CLI processes were not cleaned up after job completion
- Root cause: `ExecuteCronJob()` returns normally but `cleanupInteractiveState()` was never called for cron sessions
- The fix detects cron sessions (by "#cron:" in sessionKey) and calls `cleanupInteractiveState()` after the turn completes in `processInteractiveEvents()`

## Technical details
When `session_mode` is `"new_per_run"`, cron jobs spawn a fresh session each run with an interactive key containing `"#cron:"` (e.g., `sessionKey#cron:sessionID`). After the agent finishes processing (EventResult), the goroutine in `processInteractiveEvents()` returns without cleanup, leaving:
1. The interactive state in `e.interactiveStates` map
2. The agent session (Claude CLI process) still running

This fix adds cleanup logic after the turn completes for cron sessions, ensuring the agent process is properly terminated via `cleanupInteractiveState()`.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./core/...` passes

Fixes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)