### PR TITLE
fix(daemon): escape PATH for systemd unit files

### DIFF
--- a/daemon/systemd.go
+++ b/daemon/systemd.go
@@ -174,7 +174,11 @@ func (m *systemdManager) buildUnit(cfg Config) string {
 	fmt.Fprintf(&sb, "Environment=CC_LOG_FILE=%s\n", cfg.LogFile)
 	fmt.Fprintf(&sb, "Environment=CC_LOG_MAX_SIZE=%d\n", cfg.LogMaxSize)
 	if cfg.EnvPATH != "" {
-		fmt.Fprintf(&sb, "Environment=PATH=%s\n", cfg.EnvPATH)
+		// Escape PATH for systemd: use double quotes and escape special chars.
+		// This handles paths with spaces (common in WSL with Windows paths like
+		// "/mnt/c/Program Files/Git/cmd") that would otherwise break systemd parsing.
+		escapedPATH := escapeSystemdEnvValue(cfg.EnvPATH)
+		fmt.Fprintf(&sb, "Environment=\"PATH=%s\"\n", escapedPATH)
 	}
 	sb.WriteString("\n[Install]\n")
 	if m.system {
@@ -183,6 +187,16 @@ func (m *systemdManager) buildUnit(cfg Config) string {
 		sb.WriteString("WantedBy=default.target\n")
 	}
 	return sb.String()
+}
+
+// escapeSystemdEnvValue escapes a value for use in systemd Environment= directive.
+// The value should be wrapped in double quotes; this function escapes special characters
+// that would break the quoting: backslash and double quote.
+func escapeSystemdEnvValue(s string) string {
+	// Escape backslashes and double quotes
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	return s
 }
 
 func runSystemctl(args ...string) (string, error) {

--- a/daemon/systemd_test.go
+++ b/daemon/systemd_test.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEscapeSystemdEnvValue(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Simple path without special characters
+		{"/usr/bin:/usr/local/bin", "/usr/bin:/usr/local/bin"},
+		// Path with spaces (WSL Windows paths)
+		{"/mnt/c/Program Files/Git/cmd", "/mnt/c/Program Files/Git/cmd"},
+		// Path with backslash
+		{`C:\Windows\System32`, `C:\\Windows\\System32`},
+		// Path with double quote (unlikely but should be escaped)
+		{`/path/with"quote`, `/path/with\"quote`},
+		// Combined: spaces and backslashes
+		{"/mnt/c/Program Files\\Git", "/mnt/c/Program Files\\\\Git"},
+	}
+
+	for _, tt := range tests {
+		got := escapeSystemdEnvValue(tt.input)
+		if got != tt.expected {
+			t.Errorf("escapeSystemdEnvValue(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestBuildUnit_PathWithSpaces(t *testing.T) {
+	cfg := Config{
+		BinaryPath: "/usr/local/bin/cc-connect",
+		WorkDir:    "/home/user",
+		LogFile:    "/tmp/cc-connect.log",
+		LogMaxSize: 10485760,
+		EnvPATH:    "/usr/bin:/mnt/c/Program Files/Git/cmd:/mnt/c/Program Files/nodejs",
+	}
+
+	m := &systemdManager{system: false}
+	unit := m.buildUnit(cfg)
+
+	// PATH should be wrapped in double quotes
+	if !strings.Contains(unit, `Environment="PATH=`) {
+		t.Error("PATH should be wrapped in double quotes")
+	}
+
+	// Should contain the Windows path with spaces
+	if !strings.Contains(unit, "/mnt/c/Program Files/Git/cmd") {
+		t.Error("PATH should contain the Windows path with spaces")
+	}
+
+	// Should NOT have unquoted Environment=PATH= (which breaks systemd parsing)
+	if strings.Contains(unit, "Environment=PATH=") && !strings.Contains(unit, `Environment="PATH=`) {
+		t.Error("PATH should not be unquoted")
+	}
+}
+
+func TestBuildUnit_EscapesSpecialChars(t *testing.T) {
+	cfg := Config{
+		BinaryPath: "/usr/local/bin/cc-connect",
+		WorkDir:    "/home/user",
+		LogFile:    "/tmp/cc-connect.log",
+		LogMaxSize: 10485760,
+		EnvPATH:    `/usr/bin:/path\with\backslash`,
+	}
+
+	m := &systemdManager{system: false}
+	unit := m.buildUnit(cfg)
+
+	// Backslashes should be escaped
+	if !strings.Contains(unit, `PATH=/usr/bin:/path\\with\\backslash"`) {
+		t.Errorf("Backslashes should be escaped in PATH, got:\n%s", unit)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix PATH parsing errors in systemd unit files when PATH contains spaces (common in WSL)
- Wrap PATH value in double quotes: `Environment="PATH=..."`
- Escape backslashes and double quotes inside the PATH value
- Add unit tests for the escaping logic

## Technical details
Under WSL, users often have Windows paths with spaces in their PATH:
```
/mnt/c/Program Files/Git/cmd:/mnt/c/Program Files/nodejs/
```

Systemd unit files cannot handle unquoted environment values with spaces, causing parse errors:
```
Invalid environment assignment, ignoring: Files
Invalid environment assignment, ignoring: Files/Git/cmd:/mnt/c/Program
```

The fix:
1. Wraps PATH in double quotes: `Environment="PATH=/path with spaces"`
2. Escapes backslashes (`\` → `\\`) and double quotes (`"` → `\"`) inside the value
3. Adds helper function `escapeSystemdEnvValue()` and unit tests

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./daemon/...` passes
- [x] New unit tests for PATH escaping

Fixes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)