### PR TITLE
fix(core): wait for old session to close when recycling

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1888,7 +1888,9 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 			"have_agent_session", currentID,
 		)
 		state.markStopped()
-		e.closeAgentSessionAsync(sessionKey, state.agentSession)
+		// Close synchronously to prevent race condition where old agent
+		// continues outputting while new agent starts (issue #327).
+		e.closeAgentSessionWithTimeout(sessionKey, state.agentSession)
 		delete(e.interactiveStates, sessionKey)
 		ok = false // prevent reading stale settings below
 	}


### PR DESCRIPTION
## Summary
- Fix duplicate response issue when session recycling occurs
- Changed async close to synchronous close in `getOrCreateInteractiveStateWith()`
- Ensures old agent process is fully terminated before starting new one

## Technical details

When a session mismatch was detected (after `/new` or `/switch`), the old agent session was closed asynchronously via `closeAgentSessionAsync()`. The new session started immediately without waiting for the old one to fully terminate.

This caused a race condition where:
1. Old agent's event loop might be mid-processing an event
2. It had already passed the `isStopped()` check
3. It then sent a message to the platform
4. Meanwhile, the new agent also started and produced its own response
5. User received two similar responses from two different agents

The fix changes `closeAgentSessionAsync()` to `closeAgentSessionWithTimeout()` (synchronous) in the recycling path. The function has a 10-second timeout to prevent indefinite blocking.

## Root cause analysis from issue #327

User observed:
- Each message received two similar but different responses
- Log showed different `agent_session` IDs between `session spawned` and `turn complete`
- Two Claude Code processes were created on first message

The different IDs were expected behavior (session update via EventResult), but the duplicate responses were caused by the race condition in session recycling.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./core/...` passes

Fixes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)