### PR TITLE
fix(core): set pending permission before sending prompt

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2332,18 +2332,6 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				"tool", event.ToolName,
 			)
 
-			if isAskQuestion {
-				e.sendAskQuestionPrompt(p, replyCtx, event.Questions, 0)
-			} else {
-				permLimit := e.display.ToolMaxLen
-				if permLimit > 0 {
-					permLimit = permLimit * 8 / 5
-				}
-				toolInput := truncateIf(event.ToolInput, permLimit)
-				prompt := fmt.Sprintf(e.i18n.T(MsgPermissionPrompt), event.ToolName, toolInput)
-				e.sendPermissionPrompt(p, replyCtx, prompt, event.ToolName, toolInput)
-			}
-
 			pending := &pendingPermission{
 				RequestID:    event.RequestID,
 				ToolName:     event.ToolName,
@@ -2355,6 +2343,18 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			state.mu.Lock()
 			state.pending = pending
 			state.mu.Unlock()
+
+			if isAskQuestion {
+				e.sendAskQuestionPrompt(p, replyCtx, event.Questions, 0)
+			} else {
+				permLimit := e.display.ToolMaxLen
+				if permLimit > 0 {
+					permLimit = permLimit * 8 / 5
+				}
+				toolInput := truncateIf(event.ToolInput, permLimit)
+				prompt := fmt.Sprintf(e.i18n.T(MsgPermissionPrompt), event.ToolName, toolInput)
+				e.sendPermissionPrompt(p, replyCtx, prompt, event.ToolName, toolInput)
+			}
 
 			// Stop idle timer while waiting for user permission response;
 			// the user may take a long time to decide, and we don't want

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -268,6 +268,21 @@ func (p *stubInlineButtonPlatform) SendWithButtons(_ context.Context, _ any, con
 	return nil
 }
 
+type callbackInlineButtonPlatform struct {
+	stubInlineButtonPlatform
+	onSend func()
+}
+
+func (p *callbackInlineButtonPlatform) SendWithButtons(ctx context.Context, replyCtx any, content string, buttons [][]ButtonOption) error {
+	if err := p.stubInlineButtonPlatform.SendWithButtons(ctx, replyCtx, content, buttons); err != nil {
+		return err
+	}
+	if p.onSend != nil {
+		p.onSend()
+	}
+	return nil
+}
+
 type stubCardPlatform struct {
 	stubPlatformEngine
 	repliedCards []*Card
@@ -4040,6 +4055,29 @@ func (s *controllableAgentSession) Close() error {
 	return nil
 }
 
+type recordingControllablePermissionSession struct {
+	*controllableAgentSession
+	mu         sync.Mutex
+	lastID     string
+	lastResult PermissionResult
+	calls      int
+}
+
+func newRecordingControllablePermissionSession(id string) *recordingControllablePermissionSession {
+	return &recordingControllablePermissionSession{
+		controllableAgentSession: newControllableSession(id),
+	}
+}
+
+func (s *recordingControllablePermissionSession) RespondPermission(id string, res PermissionResult) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastID = id
+	s.lastResult = res
+	s.calls++
+	return nil
+}
+
 // controllableAgent lets tests control which session is returned by StartSession.
 type controllableAgent struct {
 	nextSession AgentSession
@@ -5002,6 +5040,141 @@ func TestProcessInteractiveEvents_PermissionWhileSendBlocked(t *testing.T) {
 	case <-done:
 	case <-time.After(3 * time.Second):
 		t.Fatal("processInteractiveEvents did not complete")
+	}
+}
+
+func TestProcessInteractiveEvents_PermissionCallbackDuringPromptSend(t *testing.T) {
+	e := NewEngine("test", &stubAgent{}, nil, "", LangEnglish)
+	key := "telegram:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	rec := newRecordingControllablePermissionSession("perm-callback")
+
+	var handled bool
+	p := &callbackInlineButtonPlatform{
+		stubInlineButtonPlatform: stubInlineButtonPlatform{stubPlatformEngine: stubPlatformEngine{n: "telegram"}},
+	}
+	p.onSend = func() {
+		handled = e.handlePendingPermission(p, &Message{
+			SessionKey: key,
+			UserID:     "user1",
+			ReplyCtx:   "ctx",
+		}, "allow")
+	}
+
+	state := &interactiveState{
+		agentSession: rec,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveEvents(state, session, e.sessions, key, "m1", time.Now(), nil, nil, "ctx")
+		close(done)
+	}()
+
+	rec.events <- Event{
+		Type:         EventPermissionRequest,
+		RequestID:    "req-inline",
+		ToolName:     "write_file",
+		ToolInput:    "/tmp/x",
+		ToolInputRaw: map[string]any{"path": "/tmp/x"},
+	}
+	rec.events <- Event{Type: EventResult, Content: "ok", Done: true}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("processInteractiveEvents did not complete; pending permission was likely not set before prompt send")
+	}
+
+	if !handled {
+		t.Fatal("expected inline callback to resolve pending permission during prompt send")
+	}
+	if rec.calls != 1 {
+		t.Fatalf("expected 1 RespondPermission call, got %d", rec.calls)
+	}
+	if rec.lastID != "req-inline" {
+		t.Fatalf("RespondPermission id = %q, want %q", rec.lastID, "req-inline")
+	}
+	if rec.lastResult.Behavior != "allow" {
+		t.Fatalf("RespondPermission behavior = %q, want %q", rec.lastResult.Behavior, "allow")
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.pending != nil {
+		t.Fatal("expected pending permission to be cleared")
+	}
+}
+
+func TestProcessInteractiveEvents_AskQuestionCallbackDuringPromptSend(t *testing.T) {
+	e := NewEngine("test", &stubAgent{}, nil, "", LangEnglish)
+	key := "telegram:user2"
+	session := e.sessions.GetOrCreateActive(key)
+	rec := newRecordingControllablePermissionSession("askq-callback")
+
+	var handled bool
+	p := &callbackInlineButtonPlatform{
+		stubInlineButtonPlatform: stubInlineButtonPlatform{stubPlatformEngine: stubPlatformEngine{n: "telegram"}},
+	}
+	p.onSend = func() {
+		handled = e.handlePendingPermission(p, &Message{
+			SessionKey: key,
+			UserID:     "user2",
+			ReplyCtx:   "ctx",
+		}, "2")
+	}
+
+	state := &interactiveState{
+		agentSession: rec,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveEvents(state, session, e.sessions, key, "m2", time.Now(), nil, nil, "ctx")
+		close(done)
+	}()
+
+	rec.events <- Event{
+		Type:         EventPermissionRequest,
+		RequestID:    "req-ask",
+		ToolName:     "AskUserQuestion",
+		ToolInputRaw: map[string]any{"questions": []any{map[string]any{"question": "Which?"}}},
+		Questions:    testQuestions(),
+	}
+	rec.events <- Event{Type: EventResult, Content: "ok", Done: true}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("processInteractiveEvents did not complete; pending ask-user-question was likely not set before prompt send")
+	}
+
+	if !handled {
+		t.Fatal("expected inline callback to resolve pending ask-user-question during prompt send")
+	}
+	if rec.calls != 1 {
+		t.Fatalf("expected 1 RespondPermission call, got %d", rec.calls)
+	}
+	answers, ok := rec.lastResult.UpdatedInput["answers"].(map[string]any)
+	if !ok {
+		t.Fatal("expected answers in updatedInput")
+	}
+	if answers["0"] != "SQLite" {
+		t.Fatalf("expected answer=SQLite, got %v", answers["0"])
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.pending != nil {
+		t.Fatal("expected pending ask-user-question to be cleared")
 	}
 }
 


### PR DESCRIPTION
  ## Summary

  Fix the permission-handling race reported in #171 by setting `state.pending` before sending the permission or ask-user-question prompt.

  This ensures a very fast platform callback can still resolve the active pending request instead of falling through as if no permission prompt existed.

  ## What changed

  - set `state.pending` before calling `sendPermissionPrompt`
  - set `state.pending` before calling `sendAskQuestionPrompt`
  - add regression coverage for immediate permission callback during prompt send
  - add regression coverage for immediate AskUserQuestion callback during prompt send

  ## Why

  Previously the event flow was:

  1. send permission / ask-question prompt
  2. platform callback arrives immediately
  3. `handlePendingPermission()` sees no pending request yet
  4. response is ignored or falls through to normal busy-session handling

  That could leave the session stuck in a waiting state and produce the “previous request still processing” behavior described in #171.

  By registering the pending request first, the callback can be handled correctly even if it arrives during prompt delivery.

  ## Validation

  - [x] `go test ./core -run 'TestProcessInteractiveEvents_(PermissionCallbackDuringPromptSend|AskQuestionCallbackDuringPromptSend)|
  TestHandlePendingPermission|TestProcessInteractiveEvents_PermissionWhileSendBlocked' -v`
  - [x] `go build ./...`
  - [x] `go test ./... -v -race`
  - [x] `go test ./... -coverprofile=coverage.out -covermode=atomic`
  - [x] `$(go env GOPATH)/bin/staticcheck ./core/...`

  Fixes #171