### PR TITLE
feat(discord): add route allowlists for channels and threads

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -771,6 +771,8 @@ app_secret = "your-feishu-app-secret"
 # allow_from = "*"  # Allowed Discord user IDs / 允许的 Discord 用户 ID
 # guild_id = ""     # Optional: set for instant slash command registration (per-guild)
 #                   # 可选：设置后 slash 命令秒级生效（仅该服务器）
+# channel_allow = "" # Optional comma-separated channel IDs routed to this project / 可选：逗号分隔的频道 ID 白名单
+# thread_allow = ""  # Optional comma-separated thread IDs routed to this project / 可选：逗号分隔的 thread ID 白名单
 # group_reply_all = false  # If true, respond to ALL guild messages without @mention / 设为 true 群聊无需 @ 也响应
 # share_session_in_channel = false  # If true, all users in a channel share one agent session / 频道共享会话
 # thread_isolation = false  # If true, cc-connect creates/uses Discord threads as session boundaries when the channel supports threads

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -42,6 +42,8 @@ type Platform struct {
 	token                      string
 	allowFrom                  string
 	guildID                    string // optional: per-guild registration (instant) vs global (up to 1h propagation)
+	channelAllow               map[string]struct{}
+	threadAllow                map[string]struct{}
 	groupReplyAll              bool
 	shareSessionInChannel      bool
 	threadIsolation            bool
@@ -65,6 +67,8 @@ func New(opts map[string]any) (core.Platform, error) {
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom("discord", allowFrom)
 	guildID, _ := opts["guild_id"].(string)
+	channelAllow := parseDiscordIDSet(opts["channel_allow"])
+	threadAllow := parseDiscordIDSet(opts["thread_allow"])
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
@@ -73,6 +77,8 @@ func New(opts map[string]any) (core.Platform, error) {
 		token:                      token,
 		allowFrom:                  allowFrom,
 		guildID:                    guildID,
+		channelAllow:               channelAllow,
+		threadAllow:                threadAllow,
 		groupReplyAll:              groupReplyAll,
 		shareSessionInChannel:      shareSessionInChannel,
 		readyCh:                    make(chan struct{}),
@@ -103,6 +109,53 @@ func buildSessionKey(channelID string, userID string, shareSessionInChannel bool
 		return fmt.Sprintf("discord:%s", channelID)
 	}
 	return fmt.Sprintf("discord:%s:%s", channelID, userID)
+}
+
+func parseDiscordIDSet(v any) map[string]struct{} {
+	var items []string
+	switch vals := v.(type) {
+	case []string:
+		items = append(items, vals...)
+	case []any:
+		for _, item := range vals {
+			s, ok := item.(string)
+			if !ok {
+				continue
+			}
+			items = append(items, s)
+		}
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(items))
+	for _, id := range items {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		out[id] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (p *Platform) routeAllowed(guildID, channelID string) bool {
+	if p.guildID != "" && guildID != p.guildID {
+		return false
+	}
+	if len(p.threadAllow) == 0 && len(p.channelAllow) == 0 {
+		return true
+	}
+	if _, ok := p.threadAllow[channelID]; ok {
+		return true
+	}
+	if _, ok := p.channelAllow[channelID]; ok {
+		return true
+	}
+	return false
 }
 
 // TODO: thread_isolation currently keys each Discord thread as one shared session, so share_session_in_channel=false does not further isolate users within the same thread.
@@ -435,6 +488,10 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			slog.Debug("discord: message from unauthorized user", "user", m.Author.ID)
 			return
 		}
+		if !p.routeAllowed(m.GuildID, m.ChannelID) {
+			slog.Debug("discord: message blocked by route filter", "guild", m.GuildID, "channel", m.ChannelID)
+			return
+		}
 
 		// In guild channels, only respond when the bot is @mentioned (unless group_reply_all).
 		// Check both user mentions and role mentions (Discord auto-creates a managed role
@@ -545,6 +602,17 @@ func (p *Platform) handleInteraction(s *discordgo.Session, i *discordgo.Interact
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Content: "You are not authorized to use this bot.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+	if !p.routeAllowed(i.GuildID, i.ChannelID) {
+		slog.Debug("discord: interaction blocked by route filter", "guild", i.GuildID, "channel", i.ChannelID)
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "This channel is not routed to the current project.",
 				Flags:   discordgo.MessageFlagsEphemeral,
 			},
 		})

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -818,3 +818,83 @@ func TestReplyContextForDeferredInteractionFallback(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDiscordIDSet(t *testing.T) {
+	got := parseDiscordIDSet([]any{" channel-1 ", "", "thread-2"})
+	if len(got) != 2 {
+		t.Fatalf("len(parseDiscordIDSet) = %d, want 2", len(got))
+	}
+	if _, ok := got["channel-1"]; !ok {
+		t.Fatal("missing channel-1")
+	}
+	if _, ok := got["thread-2"]; !ok {
+		t.Fatal("missing thread-2")
+	}
+}
+
+func TestRouteAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		platform  *Platform
+		guildID   string
+		channelID string
+		want      bool
+	}{
+		{
+			name:      "default allows all",
+			platform:  &Platform{},
+			guildID:   "guild-1",
+			channelID: "channel-1",
+			want:      true,
+		},
+		{
+			name:      "guild mismatch denied",
+			platform:  &Platform{guildID: "guild-1"},
+			guildID:   "guild-2",
+			channelID: "channel-1",
+			want:      false,
+		},
+		{
+			name:      "guild match allowed without narrower filters",
+			platform:  &Platform{guildID: "guild-1"},
+			guildID:   "guild-1",
+			channelID: "channel-1",
+			want:      true,
+		},
+		{
+			name: "channel allow narrows within guild",
+			platform: &Platform{
+				guildID:      "guild-1",
+				channelAllow: map[string]struct{}{"channel-1": {}},
+			},
+			guildID:   "guild-1",
+			channelID: "channel-2",
+			want:      false,
+		},
+		{
+			name: "channel allow exact match",
+			platform: &Platform{
+				channelAllow: map[string]struct{}{"channel-1": {}},
+			},
+			guildID:   "guild-1",
+			channelID: "channel-1",
+			want:      true,
+		},
+		{
+			name: "thread allow exact match",
+			platform: &Platform{
+				threadAllow: map[string]struct{}{"thread-9": {}},
+			},
+			guildID:   "guild-1",
+			channelID: "thread-9",
+			want:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.platform.routeAllowed(tt.guildID, tt.channelID); got != tt.want {
+				t.Fatalf("routeAllowed(%q, %q) = %v, want %v", tt.guildID, tt.channelID, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

  Add Discord-side route allowlists so a project can be restricted to specific channels or threads instead of only relying on coarse guild-level routing.

  This makes it easier to run multiple projects in the same Discord server without messages or interactions leaking into the wrong project.

  Fixes #20

  ## What changed

  - add optional `channel_allow` and `thread_allow` config for Discord projects
  - apply route filtering to both normal message events and interaction events
  - keep existing behavior unchanged when no allowlist is configured
  - add parsing and route-decision regression tests
  - document the new config in `config.example.toml`

  ## Why

  Today Discord routing is not fine-grained enough for servers that use multiple channels or threads with the same bot.

  With this change, a project can explicitly allow only the Discord channels and/or thread channels that should be routed into that project, while leaving all other Discord traffic untouched.

  ## Validation

  - [x] `go build ./...`
  - [x] `go test ./... -v -race`
  - [x] `go test ./... -coverprofile=coverage.out -covermode=atomic`
  - [x] `go test -v -tags=smoke ./tests/e2e/...`
  - [x] `go test -v -tags=regression ./tests/e2e/...`
  - [x] `go test -bench=. -benchmem -tags=performance ./tests/performance/...`
  - [x] `$(go env GOPATH)/bin/staticcheck ./platform/discord/...`
