### PR TITLE
fix(core): 修复多工作区模式下 /mode 未作用到当前 workspace agent 的问题

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -5093,7 +5093,13 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
-	switcher, ok := e.agent.(ModeSwitcher)
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	switcher, ok := agent.(ModeSwitcher)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgModeNotSupported))
 		return
@@ -5141,7 +5147,7 @@ func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
 			e.replyWithButtons(p, msg.ReplyCtx, sb.String(), buttons)
 			return
 		}
-		e.replyWithCard(p, msg.ReplyCtx, e.renderModeCard())
+		e.replyWithCard(p, msg.ReplyCtx, e.renderModeCardForAgent(agent))
 		return
 	}
 
@@ -5151,7 +5157,12 @@ func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
 	appliedLive := e.applyLiveModeChange(msg.SessionKey, newMode)
 
 	if !appliedLive {
-		e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+		e.cleanupInteractiveState(interactiveKey)
+		// Live switch unavailable: recreate the session so the new mode takes effect.
+		s := sessions.GetOrCreateActive(msg.SessionKey)
+		s.SetAgentSessionID("", "")
+		s.ClearHistory()
+		sessions.Save()
 	}
 
 	modes := switcher.PermissionModes()
@@ -6215,7 +6226,8 @@ func (e *Engine) handleCardNav(action string, sessionKey string) *Card {
 	case "/reasoning":
 		return e.renderReasoningCard()
 	case "/mode":
-		return e.renderModeCard()
+		agent, _ := e.sessionContextForKey(sessionKey)
+		return e.renderModeCardForAgent(agent)
 	case "/lang":
 		return e.renderLangCard()
 	case "/status":
@@ -6349,7 +6361,8 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		if args == "" {
 			return
 		}
-		switcher, ok := e.agent.(ModeSwitcher)
+		agent, sessions := e.sessionContextForKey(sessionKey)
+		switcher, ok := agent.(ModeSwitcher)
 		if !ok {
 			return
 		}
@@ -6362,10 +6375,10 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		}
 		e.cleanupInteractiveState(interactiveKey)
 		// Mode change requires a new session to take effect
-		s := e.sessions.GetOrCreateActive(sessionKey)
+		s := sessions.GetOrCreateActive(sessionKey)
 		s.SetAgentSessionID("", "")
 		s.ClearHistory()
-		e.sessions.Save()
+		sessions.Save()
 
 	case "/lang":
 		if args == "" {
@@ -6931,8 +6944,8 @@ func (e *Engine) renderReasoningCard() *Card {
 	return cb.Build()
 }
 
-func (e *Engine) renderModeCard() *Card {
-	switcher, ok := e.agent.(ModeSwitcher)
+func (e *Engine) renderModeCardForAgent(agent Agent) *Card {
+	switcher, ok := agent.(ModeSwitcher)
 	if !ok {
 		return e.simpleCard(e.i18n.T(MsgCardTitleMode), "violet", e.i18n.T(MsgModeNotSupported))
 	}
@@ -6974,6 +6987,10 @@ func (e *Engine) renderModeCard() *Card {
 		Buttons(e.cardBackButton())
 	cb.Note(e.modeUsageText(modes))
 	return cb.Build()
+}
+
+func (e *Engine) renderModeCard() *Card {
+	return e.renderModeCardForAgent(e.agent)
 }
 
 func (e *Engine) renderListCard(sessionKey string, page int) (*Card, error) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -6989,10 +6989,6 @@ func (e *Engine) renderModeCardForAgent(agent Agent) *Card {
 	return cb.Build()
 }
 
-func (e *Engine) renderModeCard() *Card {
-	return e.renderModeCardForAgent(e.agent)
-}
-
 func (e *Engine) renderListCard(sessionKey string, page int) (*Card, error) {
 	agent, sessions := e.sessionContextForKey(sessionKey)
 	agentSessions, err := agent.ListSessions(e.ctx)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3495,6 +3495,39 @@ func TestCmdMode_AppliesLiveModeWithoutReset(t *testing.T) {
 	}
 }
 
+func TestCmdMode_MultiWorkspaceUpdatesWorkspaceAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	globalAgent := &stubModelModeAgent{mode: "default"}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+
+	baseDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindingPath)
+
+	wsDir := filepath.Join(baseDir, "ws1")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	normalizedWsDir := normalizeWorkspacePath(wsDir)
+	channelID := "C123"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", normalizedWsDir)
+
+	wsAgent := &stubModelModeAgent{mode: "default"}
+	ws := e.workspacePool.GetOrCreate(normalizedWsDir)
+	ws.agent = wsAgent
+	ws.sessions = NewSessionManager("")
+
+	msg := &Message{SessionKey: "slack:" + channelID + ":U1", ReplyCtx: "ctx"}
+	e.cmdMode(p, msg, []string{"yolo"})
+
+	if wsAgent.mode != "yolo" {
+		t.Fatalf("workspace agent mode = %q, want yolo", wsAgent.mode)
+	}
+	if globalAgent.mode == "yolo" {
+		t.Fatalf("global agent mode = %q, want unchanged", globalAgent.mode)
+	}
+}
+
 func TestCmdStatus_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
@@ -5602,6 +5635,51 @@ func TestExecuteCardAction_ModeCleansUpWithInteractiveKey(t *testing.T) {
 	e.interactiveMu.Unlock()
 	if exists {
 		t.Error("expected interactive state to be cleaned up after /mode")
+	}
+}
+
+func TestExecuteCardAction_ModeUsesWorkspaceAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	globalAgent := &stubModelModeAgent{mode: "default"}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+
+	baseDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindingPath)
+
+	wsDir := filepath.Join(baseDir, "ws1")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	normalizedWsDir := normalizeWorkspacePath(wsDir)
+	channelID := "channel1"
+	sessionKey := "feishu:" + channelID + ":user1"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", normalizedWsDir)
+
+	wsAgent := &stubModelModeAgent{mode: "default"}
+	ws := e.workspacePool.GetOrCreate(normalizedWsDir)
+	ws.agent = wsAgent
+	ws.sessions = NewSessionManager("")
+
+	interactiveKey := normalizedWsDir + ":" + sessionKey
+	e.interactiveMu.Lock()
+	e.interactiveStates[interactiveKey] = &interactiveState{}
+	e.interactiveMu.Unlock()
+
+	e.executeCardAction("/mode", "yolo", sessionKey)
+
+	if wsAgent.mode != "yolo" {
+		t.Fatalf("workspace agent mode = %q, want yolo", wsAgent.mode)
+	}
+	if globalAgent.mode == "yolo" {
+		t.Fatalf("global agent mode = %q, want unchanged", globalAgent.mode)
+	}
+
+	e.interactiveMu.Lock()
+	_, exists := e.interactiveStates[interactiveKey]
+	e.interactiveMu.Unlock()
+	if exists {
+		t.Error("expected workspace interactive state to be cleaned up after /mode")
 	}
 }
 


### PR DESCRIPTION
关联 issue #233 

## 变更说明

修复多工作区模式下 `/mode` 只更新全局 agent、没有更新当前 workspace agent 的问题。

在 `multi-workspace` 模式下，普通消息会路由到当前工作区对应的 workspace agent。
但原来的 `/mode yolo` 和卡片动作 `act:/mode ...` 实际修改的是全局 `e.agent`，
导致界面上看起来已经切到 YOLO，当前工作区会话却仍然按旧模式运行。

这会表现为：

- `/mode yolo` 后日志显示切换成功
- 但当前 workspace 的实际会话仍然像 `full-auto`
- 一些需要真正无沙箱执行的操作仍然无法按预期生效

## 修改内容

- `cmdMode` 改为通过 `commandContext()` 获取当前会话对应的 agent 和 session manager
- 卡片动作 `/mode` 改为通过 `sessionContextForKey()` 获取当前 workspace agent
- `/mode` 卡片渲染改为显示当前 workspace agent 的真实模式
- 增加多工作区回归测试，覆盖：
  - `/mode` 更新 workspace agent
  - 卡片动作更新 workspace agent

## 为什么 #240 还不够

#240 修复了模式切换后需要重置 session 才能生效的问题，但它仍然操作的是全局
`e.agent` / `e.sessions`。

在多工作区模式下，真正处理消息的是按工作区缓存的 workspace agent，因此仅修复 session
重置还不够，必须把 mode 切换应用到当前 workspace agent 上。

## 测试

已执行：

```bash
go test ./core -run 'TestCmdMode_MultiWorkspaceUpdatesWorkspaceAgent|TestExecuteCardAction_ModeUsesWorkspaceAgent|TestCmdMode_UsesInlineButtonsOnButtonOnlyPlatform|TestExecuteCardAction_ModeCleansUpWithInteractiveKey'