### PR TITLE
fix(slack): add message deduplication for Socket Mode retransmissions

### DIFF
--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -41,6 +41,7 @@ type Platform struct {
 	channelNameCache      map[string]string
 	channelCacheMu        sync.RWMutex
 	userNameCache         sync.Map // userID -> display name
+	dedup                 core.MessageDedup
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -127,6 +128,11 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					}
 				}
 
+				if p.dedup.IsDuplicate(ev.TimeStamp) {
+					slog.Debug("slack: ignoring duplicate app_mention", "ts", ev.TimeStamp)
+					return
+				}
+
 				slog.Debug("slack: app_mention received", "user", ev.User, "channel", ev.Channel)
 
 				if !core.AllowList(p.allowFrom, ev.User) {
@@ -177,6 +183,11 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 							}
 						}
 					}
+				}
+
+				if p.dedup.IsDuplicate(ev.TimeStamp) {
+					slog.Debug("slack: ignoring duplicate message", "ts", ev.TimeStamp)
+					return
 				}
 
 				slog.Debug("slack: message received", "user", ev.User, "channel", ev.Channel)


### PR DESCRIPTION
## Summary

- Adds `core.MessageDedup` to the Slack platform adapter, matching the pattern used by every other platform (Feishu, DingTalk, QQ, QQBot, WeCom)
- Deduplicates both `AppMentionEvent` and `MessageEvent` using `ev.TimeStamp` as the unique message ID
- Prevents duplicate processing when Slack Socket Mode retransmits events after reconnects or delayed TCP acks

## Problem

Slack Socket Mode retransmits events when acknowledgment is delayed or after connection drops/reconnects. Without dedup, the same message is processed multiple times:

```
09:44:18 msg received (msg_id=1774777453.010829)  ← processed
09:44:32 msg received (msg_id=1774777453.010829)  ← queued as duplicate
09:46:11 msg received (msg_id=1774777453.010829)  ← queued as duplicate
```

This causes "message queued for busy session" spam and can trigger duplicate bot responses after the current turn completes.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./core/` passes (614 tests)
- [x] Manual: verify duplicate messages no longer appear during long agent turns
- [x] Manual: verify normal message flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)