### PR TITLE
fix(core): silent heartbeat should not send empty response message

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -259,6 +259,7 @@ type interactiveState struct {
 	deleteMode             *deleteModeState
 	lastAutoCompressAt     time.Time
 	lastAutoCompressTokens int
+	silentEmpty            bool // true if empty response should be suppressed (heartbeat silent mode)
 }
 
 type deleteModeState struct {
@@ -962,12 +963,13 @@ func (e *Engine) ExecuteHeartbeat(sessionKey, prompt string, silent bool) error 
 	}
 
 	msg := &Message{
-		SessionKey: sessionKey,
-		Platform:   platformName,
-		UserID:     "heartbeat",
-		UserName:   "heartbeat",
-		Content:    prompt,
-		ReplyCtx:   replyCtx,
+		SessionKey:  sessionKey,
+		Platform:    platformName,
+		UserID:      "heartbeat",
+		UserName:    "heartbeat",
+		Content:     prompt,
+		ReplyCtx:    replyCtx,
+		SilentEmpty: silent,
 	}
 
 	session := e.sessions.GetOrCreateActive(sessionKey)
@@ -1770,6 +1772,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	sendStart := time.Now()
 	state.mu.Lock()
 	state.fromVoice = msg.FromVoice
+	state.silentEmpty = msg.SilentEmpty
 	state.sideText = ""
 	state.mu.Unlock()
 
@@ -2385,7 +2388,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			if fullResponse == "" && len(textParts) > 0 {
 				fullResponse = strings.Join(textParts, "")
 			}
-			if fullResponse == "" {
+			// Check silentEmpty flag to suppress empty response for heartbeat silent mode.
+			state.mu.Lock()
+			silentEmpty := state.silentEmpty
+			state.mu.Unlock()
+			if fullResponse == "" && !silentEmpty {
 				fullResponse = e.i18n.T(MsgEmptyResponse)
 			}
 

--- a/core/message.go
+++ b/core/message.go
@@ -140,6 +140,7 @@ type Message struct {
 	Audio      *AudioAttachment  // voice message (if any)
 	ReplyCtx   any               // platform-specific context needed for replying
 	FromVoice  bool              // true if message originated from voice transcription
+	SilentEmpty bool             // true if empty response should be suppressed (heartbeat silent mode)
 }
 
 // EventType distinguishes different kinds of agent output.


### PR DESCRIPTION
## Summary
- Silent heartbeat mode (heartbeat with `silent=true`) should suppress sending the "(空响应)" / "(empty response)" fallback message when the agent produces no output
- Added `SilentEmpty` field to `Message` struct to propagate the flag from heartbeat execution
- Added `silentEmpty` field to `interactiveState` struct to track the flag during message processing
- Modified empty response handling in `processInteractiveEvents` to check `state.silentEmpty` before applying `MsgEmptyResponse` fallback

## Root Cause
When heartbeat runs in silent mode (`ExecuteHeartbeat(silent=true)`), the agent may produce no output (e.g., just keeping awareness without actual work). Previously, the engine would still send "(空响应)" to the chat, causing unnecessary noise.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./...` passes
- [ ] Manual test: heartbeat with `silent=true` should not send any message when agent produces empty response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #355