### PR TITLE
feat(claudecode): support custom CLI binary via cmd option

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -34,6 +34,7 @@ func init() {
 //   - "auto":              Claude's automatic permission classifier
 //   - "bypassPermissions": auto-approve everything (alias: yolo)
 type Agent struct {
+	cmd             string // CLI 二进制名称（默认 "claude"）
 	workDir         string
 	model           string
 	mode            string // "default" | "acceptEdits" | "plan" | "auto" | "bypassPermissions" | "dontAsk"
@@ -79,15 +80,21 @@ func New(opts map[string]any) (core.Agent, error) {
 		}
 	}
 
+	cmd, _ := opts["cmd"].(string)
+	if cmd == "" {
+		cmd = "claude"
+	}
+
 	// Claude Code Router support
 	routerURL, _ := opts["router_url"].(string)
 	routerAPIKey, _ := opts["router_api_key"].(string)
 
-	if _, err := exec.LookPath("claude"); err != nil {
-		return nil, fmt.Errorf("claudecode: 'claude' CLI not found in PATH, please install Claude Code first")
+	if _, err := exec.LookPath(cmd); err != nil {
+		return nil, fmt.Errorf("claudecode: %q CLI not found in PATH, please install Claude Code first", cmd)
 	}
 
 	return &Agent{
+		cmd:             cmd,
 		workDir:         workDir,
 		model:           model,
 		mode:            mode,
@@ -119,7 +126,12 @@ func normalizePermissionMode(raw string) string {
 }
 
 func (a *Agent) Name() string           { return "claudecode" }
-func (a *Agent) CLIBinaryName() string  { return "claude" }
+func (a *Agent) CLIBinaryName() string {
+	if a.cmd == "" {
+		return "claude"
+	}
+	return a.cmd
+}
 func (a *Agent) CLIDisplayName() string { return "Claude" }
 
 func (a *Agent) SetWorkDir(dir string) {
@@ -273,7 +285,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, a.workDir, model, sessionID, a.mode, tools, disTools, extraEnv, platformPrompt, disableVerbose)
+	return newClaudeSession(ctx, a.cmd, a.workDir, model, sessionID, a.mode, tools, disTools, extraEnv, platformPrompt, disableVerbose)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -219,7 +219,12 @@ func TestAgent_Name(t *testing.T) {
 func TestAgent_CLIBinaryName(t *testing.T) {
 	a := &Agent{}
 	if got := a.CLIBinaryName(); got != "claude" {
-		t.Errorf("CLIBinaryName() = %q, want %q", got, "claude")
+		t.Errorf("CLIBinaryName() default = %q, want %q", got, "claude")
+	}
+
+	a2 := &Agent{cmd: "claude-sandbox"}
+	if got := a2.CLIBinaryName(); got != "claude-sandbox" {
+		t.Errorf("CLIBinaryName() custom = %q, want %q", got, "claude-sandbox")
 	}
 }
 

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -42,7 +42,7 @@ type claudeSession struct {
 	alive           atomic.Bool
 }
 
-func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool) (*claudeSession, error) {
+func newClaudeSession(ctx context.Context, cmdName, workDir, model, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	args := []string{
@@ -89,7 +89,7 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 
 	slog.Debug("claudeSession: starting", "args", core.RedactArgs(args), "dir", workDir, "mode", mode)
 
-	cmd := exec.CommandContext(sessionCtx, "claude", args...)
+	cmd := exec.CommandContext(sessionCtx, cmdName, args...)
 	cmd.Dir = workDir
 	// Filter out CLAUDECODE env var to prevent "nested session" detection,
 	// since cc-connect is a bridge, not a nested Claude Code session.


### PR DESCRIPTION
## Summary                                                                                                    
            
  - Allow configuring a custom CLI binary name (e.g. `claude-sandbox`) via `agent.options.cmd` in `config.toml`
  - Defaults to `claude` when not specified, maintaining backward compatibility                                                                                                       
  - Updates `CLIBinaryName()` to return the configured cmd, enabling correct `cc-connect doctor` diagnostics
                                                                                                                                                                                      
  ## Changes                                                                                                                                                                          
            
  - `agent/claudecode/claudecode.go`: Add `cmd` field, parse from `opts["cmd"]`, use in `LookPath` and `CLIBinaryName()`                                                              
  - `agent/claudecode/session.go`: Accept `cmdName` parameter instead of hardcoded `"claude"`                           
                                                                                             
  ## Config Example                                                                                                                                                                   
                   
  ```toml                                                                                                                                                                             
[[projects]]
  name = "project-name"
  [projects.agent]
    type = "claudecode"
    [projects.agent.options]
      cmd = "claude-sandbox"  # custom cmd
      work_dir = "work dir"
      mode = "default"
  ``` 