### PR TITLE
feat(codex): support extra env vars

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -35,6 +35,7 @@ type Agent struct {
 	backend         string // "exec" | "app_server"
 	appServerURL    string
 	codexHome       string
+	extraEnv        []string
 	providers       []core.ProviderConfig
 	activeIdx       int // -1 = no provider set
 	sessionEnv      []string
@@ -58,6 +59,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	if appServerURL == "" {
 		appServerURL = "ws://127.0.0.1:3845"
 	}
+	extraEnv := envPairsFromOpts(opts)
 
 	if _, err := exec.LookPath("codex"); err != nil {
 		return nil, fmt.Errorf("codex: 'codex' CLI not found in PATH, install with: npm install -g @openai/codex")
@@ -71,6 +73,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		backend:         backend,
 		appServerURL:    appServerURL,
 		codexHome:       strings.TrimSpace(codexHome),
+		extraEnv:        extraEnv,
 		activeIdx:       -1,
 	}, nil
 }
@@ -81,6 +84,29 @@ func normalizeBackend(raw string) string {
 		return "app_server"
 	default:
 		return "exec"
+	}
+}
+
+func envPairsFromOpts(opts map[string]any) []string {
+	raw, ok := opts["env"]
+	if !ok || raw == nil {
+		return nil
+	}
+	switch m := raw.(type) {
+	case map[string]string:
+		var out []string
+		for k, v := range m {
+			out = append(out, k+"="+v)
+		}
+		return out
+	case map[string]any:
+		var out []string
+		for k, v := range m {
+			out = append(out, fmt.Sprintf("%s=%v", k, v))
+		}
+		return out
+	default:
+		return nil
 	}
 }
 
@@ -320,7 +346,8 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	backend := a.backend
 	appServerURL := a.appServerURL
 	codexHome := a.codexHome
-	extraEnv := a.providerEnvLocked()
+	extraEnv := append([]string(nil), a.extraEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
@@ -368,7 +395,7 @@ func (a *Agent) GetMode() string {
 	return a.mode
 }
 
-// ── SkillProvider implementation ──────────────────────────────
+// ── SkillProvider implementation ──────────────────────────
 
 func (a *Agent) SkillDirs() []string {
 	absDir, err := filepath.Abs(a.workDir)
@@ -423,7 +450,7 @@ func (a *Agent) GlobalMemoryFile() string {
 	return filepath.Join(codexHome, "AGENTS.md")
 }
 
-// ── ProviderSwitcher implementation ──────────────────────────
+// ── ProviderSwitcher implementation ─────────────────────────
 
 func (a *Agent) SetProviders(providers []core.ProviderConfig) {
 	a.mu.Lock()

--- a/agent/codex/codex_test.go
+++ b/agent/codex/codex_test.go
@@ -1,0 +1,135 @@
+package codex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestNew_ParsesOptionEnv(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	scriptPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	got, err := New(map[string]any{
+		"work_dir": workDir,
+		"env": map[string]any{
+			"HTTP_PROXY": "http://127.0.0.1:7890",
+			"NO_PROXY":   "127.0.0.1,localhost",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	agent, ok := got.(*Agent)
+	if !ok {
+		t.Fatalf("New returned %T, want *Agent", got)
+	}
+	if !containsEnvPair(agent.extraEnv, "HTTP_PROXY=http://127.0.0.1:7890") {
+		t.Fatalf("extraEnv missing HTTP_PROXY: %v", agent.extraEnv)
+	}
+	if !containsEnvPair(agent.extraEnv, "NO_PROXY=127.0.0.1,localhost") {
+		t.Fatalf("extraEnv missing NO_PROXY: %v", agent.extraEnv)
+	}
+}
+
+func TestStartSession_MergesOptionProviderAndSessionEnv(t *testing.T) {
+	agent := &Agent{
+		workDir:  t.TempDir(),
+		extraEnv: []string{"HTTP_PROXY=http://127.0.0.1:7890", "NO_PROXY=127.0.0.1"},
+		providers: []core.ProviderConfig{
+			{
+				Name:    "proxy",
+				APIKey:  "sk-test",
+				BaseURL: "https://relay.example/v1",
+				Env: map[string]string{
+					"HTTPS_PROXY": "http://127.0.0.1:7890",
+				},
+			},
+		},
+		activeIdx:  0,
+		sessionEnv: []string{"CC_SESSION_KEY=session-123"},
+	}
+
+	got, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	cs, ok := got.(*codexSession)
+	if !ok {
+		t.Fatalf("StartSession returned %T, want *codexSession", got)
+	}
+	if !containsEnvPair(cs.extraEnv, "HTTP_PROXY=http://127.0.0.1:7890") {
+		t.Fatalf("extraEnv missing option env: %v", cs.extraEnv)
+	}
+	if !containsEnvPair(cs.extraEnv, "OPENAI_API_KEY=sk-test") {
+		t.Fatalf("extraEnv missing provider API key: %v", cs.extraEnv)
+	}
+	if !containsEnvPair(cs.extraEnv, "OPENAI_BASE_URL=https://relay.example/v1") {
+		t.Fatalf("extraEnv missing provider base URL: %v", cs.extraEnv)
+	}
+	if !containsEnvPair(cs.extraEnv, "HTTPS_PROXY=http://127.0.0.1:7890") {
+		t.Fatalf("extraEnv missing provider env: %v", cs.extraEnv)
+	}
+	if !containsEnvPair(cs.extraEnv, "CC_SESSION_KEY=session-123") {
+		t.Fatalf("extraEnv missing session env: %v", cs.extraEnv)
+	}
+}
+
+func TestSend_PropagatesExtraEnvToProcess(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	envFile := filepath.Join(workDir, "env.txt")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$HTTP_PROXY\" > \"$CODEX_ENV_FILE\"\n" +
+		"printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"thread-env\"}'\n" +
+		"printf '%s\\n' '{\"type\":\"turn.completed\"}'\n"
+	scriptPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	t.Setenv("CODEX_ENV_FILE", envFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", []string{
+		"HTTP_PROXY=http://127.0.0.1:7890",
+	})
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer cs.Close()
+
+	if err := cs.Send("ping", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	waitForFileEquals(t, envFile, "http://127.0.0.1:7890\n")
+}
+
+func containsEnvPair(env []string, want string) bool {
+	for _, item := range env {
+		if strings.EqualFold(item, want) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
  ## Summary
  - add `agent.options.env` support to the Codex agent
  - merge option env, provider env, and session env when starting Codex sessions
  - add regression tests covering env parsing, env merging, and env propagation to the
  `codex` subprocess

  ## Why
  Codex sessions already inherit provider-specific environment variables, but there was
  no direct way to set extra runtime env for users relying on local Codex login instead
  of a configured provider. This is especially useful for proxy variables in `auto-
  edit` / `full-auto` sandboxed workflows.

  ## Example
  ```toml
  [projects.agent]
  type = "codex"

  [projects.agent.options]
  work_dir = "/path/to/project"
  mode = "auto-edit"
  env = { HTTP_PROXY = "http://127.0.0.1:7890", HTTPS_PROXY = "http://127.0.0.1:7890",
  ALL_PROXY = "socks5://127.0.0.1:1080", NO_PROXY = "127.0.0.1,localhost" }

  ## Validation

  - checked the patch with git diff --check
  - ran go test ./agent/codex/...