### PR TITLE
feat(telegram): react ⚡ to messages on receipt

### DIFF
--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -49,6 +49,7 @@ type telegramBot interface {
 	SetMyCommands(ctx context.Context, params *tgbot.SetMyCommandsParams) (bool, error)
 	GetFile(ctx context.Context, params *tgbot.GetFileParams) (*models.File, error)
 	FileDownloadLink(f *models.File) string
+	SetMessageReaction(ctx context.Context, params *tgbot.SetMessageReactionParams) (bool, error)
 }
 
 type backoffTimer interface {
@@ -355,6 +356,7 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 	}
 
 	rctx := replyContext{chatID: msg.Chat.ID, threadID: threadID, messageID: msg.ID}
+	go p.reactToMessage(ctx, msg.Chat.ID, msg.ID, "⚡")
 	botName := p.botUsername()
 
 	if len(msg.Photo) > 0 {
@@ -478,6 +480,25 @@ func (p *Platform) messageHandler() core.MessageHandler {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.handler
+}
+
+// reactToMessage sets an emoji reaction on a Telegram message.
+// It is called asynchronously so it never blocks the message dispatch path.
+func (p *Platform) reactToMessage(ctx context.Context, chatID int64, messageID int, emoji string) {
+	bot, err := p.connectedBot("react")
+	if err != nil {
+		return
+	}
+	if _, err := bot.SetMessageReaction(ctx, &tgbot.SetMessageReactionParams{
+		ChatID:    chatID,
+		MessageID: messageID,
+		Reaction: []models.ReactionType{{
+			Type:              models.ReactionTypeTypeEmoji,
+			ReactionTypeEmoji: &models.ReactionTypeEmoji{Emoji: emoji},
+		}},
+	}); err != nil {
+		slog.Debug("telegram: set reaction failed", "error", err)
+	}
 }
 
 func (p *Platform) buildSessionKey(chatID int64, threadID int, userID int64) string {

--- a/platform/telegram/telegram_test.go
+++ b/platform/telegram/telegram_test.go
@@ -81,6 +81,7 @@ type stubTelegramBot struct {
 	answerCallbackCalls   int
 	setMyCommandsCalls    int
 	getFileCalls          int
+	setReactionCalls      int
 
 	sendErr    error
 	getFileErr error
@@ -202,6 +203,13 @@ func (b *stubTelegramBot) GetFile(_ context.Context, _ *tgbot.GetFileParams) (*m
 
 func (b *stubTelegramBot) FileDownloadLink(f *models.File) string {
 	return "https://test.example.com/file/" + f.FilePath
+}
+
+func (b *stubTelegramBot) SetMessageReaction(_ context.Context, _ *tgbot.SetMessageReactionParams) (bool, error) {
+	b.mu.Lock()
+	b.setReactionCalls++
+	b.mu.Unlock()
+	return true, nil
 }
 
 func (b *stubTelegramBot) SendMessageCallCount() int {


### PR DESCRIPTION
## Summary

- Add `SetMessageReaction` to the `telegramBot` interface
- Add `reactToMessage` helper that calls `setMessageReaction` asynchronously (non-blocking)
- Call it in `handleMessage` right after the reply context is built, so the bot reacts with ⚡ the moment a message arrives — giving the user immediate visual feedback that processing has started
- Update `stubTelegramBot` in tests to satisfy the extended interface

## Behavior

```
User sends message
    → bot immediately reacts with ⚡  (non-blocking goroutine)
    → processing continues as normal
    → bot replies when done
```

This matches the pattern shown by other Telegram bots (e.g. Alma in cc-connect) where a reaction signals "received & processing".

## Test plan

- [x] `go build ./platform/telegram/...` passes
- [x] `go test ./platform/telegram/...` passes (all existing tests green)
- [ ] Manual: send a message via Telegram → bot should react ⚡ within ~1s