### PR TITLE
fix(feishu): retry sends with a fresh tenant token

### DIFF
--- a/platform/feishu/card.go
+++ b/platform/feishu/card.go
@@ -27,33 +27,9 @@ func (p *interactivePlatform) ReplyCard(ctx context.Context, rctx any, card *cor
 		if rc.chatID == "" {
 			return fmt.Errorf("%s: chatID is empty, cannot send card", p.tag())
 		}
-		resp, err := p.client.Im.Message.Create(ctx, larkim.NewCreateMessageReqBuilder().
-			ReceiveIdType(larkim.ReceiveIdTypeChatId).
-			Body(larkim.NewCreateMessageReqBodyBuilder().
-				ReceiveId(rc.chatID).
-				MsgType(larkim.MsgTypeInteractive).
-				Content(cardJSON).
-				Build()).
-			Build())
-		if err != nil {
-			return fmt.Errorf("%s: send card api call: %w", p.tag(), err)
-		}
-		if !resp.Success() {
-			return fmt.Errorf("%s: send card failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-		}
-		return nil
+		return p.createMessage(ctx, rc.chatID, larkim.MsgTypeInteractive, cardJSON, "send card")
 	}
-	resp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
-		MessageId(rc.messageID).
-		Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeInteractive, cardJSON)).
-		Build())
-	if err != nil {
-		return fmt.Errorf("%s: reply card api call: %w", p.tag(), err)
-	}
-	if !resp.Success() {
-		return fmt.Errorf("%s: reply card failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-	}
-	return nil
+	return p.replyMessage(ctx, rc, larkim.MsgTypeInteractive, cardJSON)
 }
 
 // SendCard sends a structured card as a new message to the chat.
@@ -71,21 +47,7 @@ func (p *interactivePlatform) SendCard(ctx context.Context, rctx any, card *core
 	}
 
 	cardJSON := renderCard(card, rc.sessionKey)
-	resp, err := p.client.Im.Message.Create(ctx, larkim.NewCreateMessageReqBuilder().
-		ReceiveIdType(larkim.ReceiveIdTypeChatId).
-		Body(larkim.NewCreateMessageReqBodyBuilder().
-			ReceiveId(rc.chatID).
-			MsgType(larkim.MsgTypeInteractive).
-			Content(cardJSON).
-			Build()).
-		Build())
-	if err != nil {
-		return fmt.Errorf("%s: send card api call: %w", p.tag(), err)
-	}
-	if !resp.Success() {
-		return fmt.Errorf("%s: send card failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-	}
-	return nil
+	return p.createMessage(ctx, rc.chatID, larkim.MsgTypeInteractive, cardJSON, "send card")
 }
 
 // renderCardMap converts a core.Card into the Feishu Interactive Card map

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -120,6 +120,8 @@ type Platform struct {
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
 	noReplyToTrigger bool
 	client           *lark.Client
+	replayClient     *lark.Client
+	replayClientMu   sync.Mutex
 	wsClient         *larkws.Client
 	handler          core.MessageHandler
 	cardNavHandler   core.CardNavigationHandler
@@ -139,6 +141,8 @@ type Platform struct {
 type interactivePlatform struct {
 	*Platform
 }
+
+type feishuRequestFunc func(client *lark.Client, options ...larkcore.RequestOptionFunc) error
 
 func (p *Platform) SetCardNavigationHandler(h core.CardNavigationHandler) {
 	p.cardNavHandler = h
@@ -217,6 +221,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		threadIsolation:       threadIsolation,
 		noReplyToTrigger:      noReplyToTrigger,
 		client:                lark.NewClient(appID, appSecret, clientOpts...),
+		replayClient:          newFeishuReplayClient(appID, appSecret, domain),
 		port:                  port,
 		callbackPath:          callbackPath,
 		encryptKey:            encryptKey,
@@ -1092,18 +1097,7 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	if !p.shouldUseThreadOrReplyAPI(rc) {
 		return p.sendNewMessageToChat(ctx, rc, msgType, msgBody)
 	}
-
-	resp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
-		MessageId(rc.messageID).
-		Body(p.buildReplyMessageReqBody(rc, msgType, msgBody)).
-		Build())
-	if err != nil {
-		return fmt.Errorf("%s: reply api call: %w", p.tag(), err)
-	}
-	if !resp.Success() {
-		return fmt.Errorf("%s: reply failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-	}
-	return nil
+	return p.replyMessage(ctx, rc, msgType, msgBody)
 }
 
 // Send sends a message. When the original message ID is available, the message
@@ -1129,18 +1123,25 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 		return fmt.Errorf("%s: SendImage: invalid reply context type %T", p.tag(), rctx)
 	}
 
-	uploadResp, err := p.client.Im.Image.Create(ctx,
-		larkim.NewCreateImageReqBuilder().
+	var uploadResp *larkim.CreateImageResp
+	if err := p.withFreshTenantAccessTokenRetry(ctx, "upload image", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		req := larkim.NewCreateImageReqBuilder().
 			Body(larkim.NewCreateImageReqBodyBuilder().
 				ImageType("message").
 				Image(bytes.NewReader(img.Data)).
 				Build()).
-			Build())
-	if err != nil {
-		return fmt.Errorf("%s: upload image: %w", p.tag(), err)
-	}
-	if !uploadResp.Success() {
-		return fmt.Errorf("%s: upload image code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+			Build()
+		var err error
+		uploadResp, err = client.Im.Image.Create(ctx, req, options...)
+		if err != nil {
+			return fmt.Errorf("%s: upload image: %w", p.tag(), err)
+		}
+		if !uploadResp.Success() {
+			return fmt.Errorf("%s: upload image code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	if uploadResp.Data == nil || uploadResp.Data.ImageKey == nil {
 		return fmt.Errorf("%s: upload image: no image_key returned", p.tag())
@@ -1165,19 +1166,26 @@ func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachm
 		fileName = "attachment"
 	}
 	fileType := detectFeishuFileType(file.MimeType, fileName)
-	uploadResp, err := p.client.Im.File.Create(ctx,
-		larkim.NewCreateFileReqBuilder().
+	var uploadResp *larkim.CreateFileResp
+	if err := p.withFreshTenantAccessTokenRetry(ctx, "upload file", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		req := larkim.NewCreateFileReqBuilder().
 			Body(larkim.NewCreateFileReqBodyBuilder().
 				FileType(fileType).
 				FileName(fileName).
 				File(bytes.NewReader(file.Data)).
 				Build()).
-			Build())
-	if err != nil {
-		return fmt.Errorf("%s: upload file: %w", p.tag(), err)
-	}
-	if !uploadResp.Success() {
-		return fmt.Errorf("%s: upload file code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+			Build()
+		var err error
+		uploadResp, err = client.Im.File.Create(ctx, req, options...)
+		if err != nil {
+			return fmt.Errorf("%s: upload file: %w", p.tag(), err)
+		}
+		if !uploadResp.Success() {
+			return fmt.Errorf("%s: upload file code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	if uploadResp.Data == nil || uploadResp.Data.FileKey == nil {
 		return fmt.Errorf("%s: upload file: no file_key returned", p.tag())
@@ -1193,34 +1201,9 @@ func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachm
 
 func (p *Platform) sendMediaMessage(ctx context.Context, rc replyContext, msgType, content string) error {
 	if p.shouldUseThreadOrReplyAPI(rc) {
-		replyResp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
-			MessageId(rc.messageID).
-			Body(p.buildReplyMessageReqBody(rc, msgType, content)).
-			Build())
-		if err != nil {
-			return fmt.Errorf("%s: send media message: %w", p.tag(), err)
-		}
-		if !replyResp.Success() {
-			return fmt.Errorf("%s: send media message code=%d msg=%s", p.tag(), replyResp.Code, replyResp.Msg)
-		}
-		return nil
+		return p.replyMessage(ctx, rc, msgType, content)
 	}
-
-	sendResp, err := p.client.Im.Message.Create(ctx, larkim.NewCreateMessageReqBuilder().
-		ReceiveIdType(larkim.ReceiveIdTypeChatId).
-		Body(larkim.NewCreateMessageReqBodyBuilder().
-			ReceiveId(rc.chatID).
-			MsgType(msgType).
-			Content(content).
-			Build()).
-		Build())
-	if err != nil {
-		return fmt.Errorf("%s: send media message: %w", p.tag(), err)
-	}
-	if !sendResp.Success() {
-		return fmt.Errorf("%s: send media message code=%d msg=%s", p.tag(), sendResp.Code, sendResp.Msg)
-	}
-	return nil
+	return p.createMessage(ctx, rc.chatID, msgType, content, "send media message")
 }
 
 func detectFeishuFileType(mimeType, fileName string) string {
@@ -1741,21 +1724,7 @@ func (p *Platform) sendNewMessageToChat(ctx context.Context, rc replyContext, ms
 	if rc.chatID == "" {
 		return fmt.Errorf("%s: chatID is empty, cannot send new message", p.tag())
 	}
-	resp, err := p.client.Im.Message.Create(ctx, larkim.NewCreateMessageReqBuilder().
-		ReceiveIdType(larkim.ReceiveIdTypeChatId).
-		Body(larkim.NewCreateMessageReqBodyBuilder().
-			ReceiveId(rc.chatID).
-			MsgType(msgType).
-			Content(content).
-			Build()).
-		Build())
-	if err != nil {
-		return fmt.Errorf("%s: send api call: %w", p.tag(), err)
-	}
-	if !resp.Success() {
-		return fmt.Errorf("%s: send failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-	}
-	return nil
+	return p.createMessage(ctx, rc.chatID, msgType, content, "send")
 }
 
 func (p *Platform) buildReplyMessageReqBody(rc replyContext, msgType, content string) *larkim.ReplyMessageReqBody {
@@ -1766,6 +1735,102 @@ func (p *Platform) buildReplyMessageReqBody(rc replyContext, msgType, content st
 		body.ReplyInThread(true)
 	}
 	return body.Build()
+}
+
+func (p *Platform) replyMessage(ctx context.Context, rc replyContext, msgType, content string) error {
+	req := larkim.NewReplyMessageReqBuilder().
+		MessageId(rc.messageID).
+		Body(p.buildReplyMessageReqBody(rc, msgType, content)).
+		Build()
+	return p.withFreshTenantAccessTokenRetry(ctx, "reply", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		resp, err := client.Im.Message.Reply(ctx, req, options...)
+		if err != nil {
+			return fmt.Errorf("%s: reply api call: %w", p.tag(), err)
+		}
+		if !resp.Success() {
+			return fmt.Errorf("%s: reply failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+		}
+		return nil
+	})
+}
+
+func (p *Platform) createMessage(ctx context.Context, chatID, msgType, content, op string) error {
+	req := larkim.NewCreateMessageReqBuilder().
+		ReceiveIdType(larkim.ReceiveIdTypeChatId).
+		Body(larkim.NewCreateMessageReqBodyBuilder().
+			ReceiveId(chatID).
+			MsgType(msgType).
+			Content(content).
+			Build()).
+		Build()
+	return p.withFreshTenantAccessTokenRetry(ctx, op, func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		resp, err := client.Im.Message.Create(ctx, req, options...)
+		if err != nil {
+			return fmt.Errorf("%s: %s api call: %w", p.tag(), op, err)
+		}
+		if !resp.Success() {
+			return fmt.Errorf("%s: %s failed code=%d msg=%s", p.tag(), op, resp.Code, resp.Msg)
+		}
+		return nil
+	})
+}
+
+func (p *Platform) withFreshTenantAccessTokenRetry(ctx context.Context, operation string, fn feishuRequestFunc) error {
+	err := fn(p.client)
+	if !isTenantAccessTokenInvalid(err) {
+		return err
+	}
+
+	freshToken, refreshErr := p.fetchFreshTenantAccessToken(ctx)
+	if refreshErr != nil {
+		return fmt.Errorf("%s: %s failed after token refresh attempt: %w (original error: %v)", p.tag(), operation, refreshErr, err)
+	}
+
+	slog.Warn(p.tag()+": retrying request with fresh tenant access token", "operation", operation)
+	return fn(p.replayAPIClient(), larkcore.WithTenantAccessToken(freshToken))
+}
+
+func (p *Platform) fetchFreshTenantAccessToken(ctx context.Context) (string, error) {
+	resp, err := p.client.GetTenantAccessTokenBySelfBuiltApp(ctx, &larkcore.SelfBuiltTenantAccessTokenReq{
+		AppID:     p.appID,
+		AppSecret: p.appSecret,
+	})
+	if err != nil {
+		return "", fmt.Errorf("%s: fetch tenant access token: %w", p.tag(), err)
+	}
+	if !resp.Success() {
+		return "", fmt.Errorf("%s: fetch tenant access token code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+	}
+	if strings.TrimSpace(resp.TenantAccessToken) == "" {
+		return "", fmt.Errorf("%s: fetch tenant access token returned empty token", p.tag())
+	}
+	return resp.TenantAccessToken, nil
+}
+
+func (p *Platform) replayAPIClient() *lark.Client {
+	p.replayClientMu.Lock()
+	defer p.replayClientMu.Unlock()
+	if p.replayClient == nil {
+		p.replayClient = newFeishuReplayClient(p.appID, p.appSecret, p.domain)
+	}
+	return p.replayClient
+}
+
+func newFeishuReplayClient(appID, appSecret, domain string) *lark.Client {
+	var opts []lark.ClientOptionFunc
+	opts = append(opts, lark.WithEnableTokenCache(false))
+	if domain != "" && domain != lark.FeishuBaseUrl {
+		opts = append(opts, lark.WithOpenBaseUrl(domain))
+	}
+	return lark.NewClient(appID, appSecret, opts...)
+}
+
+func isTenantAccessTokenInvalid(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "99991663") || strings.Contains(msg, "invalid access token")
 }
 
 func stringValue(v *string) string {
@@ -2168,33 +2233,49 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 
 	var msgID string
 	if p.shouldUseThreadOrReplyAPI(rc) {
-		resp, err := p.client.Im.Message.Reply(ctx, larkim.NewReplyMessageReqBuilder().
+		req := larkim.NewReplyMessageReqBuilder().
 			MessageId(rc.messageID).
 			Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeInteractive, cardJSON)).
-			Build())
-		if err != nil {
-			return nil, fmt.Errorf("%s: send preview (reply): %w", p.tag(), err)
-		}
-		if !resp.Success() {
-			return nil, fmt.Errorf("%s: send preview (reply) code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			Build()
+		var resp *larkim.ReplyMessageResp
+		if err := p.withFreshTenantAccessTokenRetry(ctx, "send preview", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			var err error
+			resp, err = client.Im.Message.Reply(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: send preview (reply): %w", p.tag(), err)
+			}
+			if !resp.Success() {
+				return fmt.Errorf("%s: send preview (reply) code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 		if resp.Data != nil && resp.Data.MessageId != nil {
 			msgID = *resp.Data.MessageId
 		}
 	} else {
-		resp, err := p.client.Im.Message.Create(ctx, larkim.NewCreateMessageReqBuilder().
+		req := larkim.NewCreateMessageReqBuilder().
 			ReceiveIdType(larkim.ReceiveIdTypeChatId).
 			Body(larkim.NewCreateMessageReqBodyBuilder().
 				ReceiveId(chatID).
 				MsgType(larkim.MsgTypeInteractive).
 				Content(cardJSON).
 				Build()).
-			Build())
-		if err != nil {
-			return nil, fmt.Errorf("%s: send preview: %w", p.tag(), err)
-		}
-		if !resp.Success() {
-			return nil, fmt.Errorf("%s: send preview code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			Build()
+		var resp *larkim.CreateMessageResp
+		if err := p.withFreshTenantAccessTokenRetry(ctx, "send preview", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			var err error
+			resp, err = client.Im.Message.Create(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: send preview: %w", p.tag(), err)
+			}
+			if !resp.Success() {
+				return fmt.Errorf("%s: send preview code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
 		if resp.Data != nil && resp.Data.MessageId != nil {
 			msgID = *resp.Data.MessageId
@@ -2230,19 +2311,22 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 		}
 		cardJSON = buildCardJSON(sanitizeMarkdownURLs(processed))
 	}
-	resp, err := p.client.Im.Message.Patch(ctx, larkim.NewPatchMessageReqBuilder().
+	req := larkim.NewPatchMessageReqBuilder().
 		MessageId(h.messageID).
 		Body(larkim.NewPatchMessageReqBodyBuilder().
 			Content(cardJSON).
 			Build()).
-		Build())
-	if err != nil {
-		return fmt.Errorf("%s: patch message: %w", p.tag(), err)
-	}
-	if !resp.Success() {
-		return fmt.Errorf("%s: patch message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-	}
-	return nil
+		Build()
+	return p.withFreshTenantAccessTokenRetry(ctx, "patch message", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		resp, err := client.Im.Message.Patch(ctx, req, options...)
+		if err != nil {
+			return fmt.Errorf("%s: patch message: %w", p.tag(), err)
+		}
+		if !resp.Success() {
+			return fmt.Errorf("%s: patch message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+		}
+		return nil
+	})
 }
 
 func (p *Platform) Stop() error {
@@ -2272,16 +2356,19 @@ func (p *Platform) DeletePreviewMessage(ctx context.Context, previewHandle any) 
 		return fmt.Errorf("%s: invalid preview handle type %T", p.tag(), previewHandle)
 	}
 
-	resp, err := p.client.Im.Message.Delete(ctx, larkim.NewDeleteMessageReqBuilder().
+	req := larkim.NewDeleteMessageReqBuilder().
 		MessageId(h.messageID).
-		Build())
-	if err != nil {
-		return fmt.Errorf("%s: delete preview message: %w", p.tag(), err)
-	}
-	if !resp.Success() {
-		return fmt.Errorf("%s: delete preview message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-	}
-	return nil
+		Build()
+	return p.withFreshTenantAccessTokenRetry(ctx, "delete preview message", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		resp, err := client.Im.Message.Delete(ctx, req, options...)
+		if err != nil {
+			return fmt.Errorf("%s: delete preview message: %w", p.tag(), err)
+		}
+		if !resp.Success() {
+			return fmt.Errorf("%s: delete preview message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+		}
+		return nil
+	})
 }
 
 // SendAudio uploads audio bytes to Feishu and sends a voice message.
@@ -2302,19 +2389,26 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 		format = "opus"
 	}
 
-	uploadResp, err := p.client.Im.File.Create(ctx,
-		larkim.NewCreateFileReqBuilder().
+	var uploadResp *larkim.CreateFileResp
+	if err := p.withFreshTenantAccessTokenRetry(ctx, "upload audio", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		req := larkim.NewCreateFileReqBuilder().
 			Body(larkim.NewCreateFileReqBodyBuilder().
 				FileType(larkim.FileTypeOpus).
 				FileName("tts_audio.opus").
 				File(bytes.NewReader(audio)).
 				Build()).
-			Build())
-	if err != nil {
-		return fmt.Errorf("%s: upload audio: %w", p.tag(), err)
-	}
-	if !uploadResp.Success() {
-		return fmt.Errorf("%s: upload audio code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+			Build()
+		var err error
+		uploadResp, err = client.Im.File.Create(ctx, req, options...)
+		if err != nil {
+			return fmt.Errorf("%s: upload audio: %w", p.tag(), err)
+		}
+		if !uploadResp.Success() {
+			return fmt.Errorf("%s: upload audio code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	if uploadResp.Data == nil || uploadResp.Data.FileKey == nil {
 		return fmt.Errorf("%s: upload audio: no file_key returned", p.tag())

--- a/platform/feishu/token_retry_test.go
+++ b/platform/feishu/token_retry_test.go
@@ -1,0 +1,265 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+)
+
+func TestReplyRefreshesTenantTokenAfterInvalidCachedToken(t *testing.T) {
+	const appID = "cli_reply_retry"
+	const appSecret = "secret-reply-retry"
+
+	authCalls := 0
+	replyCalls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			authCalls++
+			token := "stale-token"
+			if authCalls >= 2 {
+				token = "fresh-token"
+			}
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": token,
+			})
+		case strings.HasSuffix(r.URL.Path, "/reply"):
+			replyCalls++
+			authz := r.Header.Get("Authorization")
+			switch replyCalls {
+			case 1, 2:
+				if authz != "Bearer stale-token" {
+					t.Fatalf("reply call %d Authorization = %q, want stale token", replyCalls, authz)
+				}
+				writeJSON(t, w, map[string]any{
+					"code": 99991663,
+					"msg":  "Invalid access token for authorization",
+				})
+			case 3:
+				if authz != "Bearer fresh-token" {
+					t.Fatalf("reply retry Authorization = %q, want fresh token", authz)
+				}
+				writeJSON(t, w, map[string]any{
+					"code": 0,
+					"msg":  "success",
+					"data": map[string]any{"message_id": "om_reply_ok"},
+				})
+			default:
+				t.Fatalf("unexpected extra reply call %d", replyCalls)
+			}
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		replayClient: lark.NewClient(appID, appSecret,
+			lark.WithEnableTokenCache(false),
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+	}
+
+	err := p.Reply(context.Background(), replyContext{messageID: "om_root", chatID: "oc_chat"}, "hello")
+	if err != nil {
+		t.Fatalf("Reply() error = %v", err)
+	}
+	if authCalls != 2 {
+		t.Fatalf("authCalls = %d, want 2", authCalls)
+	}
+	if replyCalls != 3 {
+		t.Fatalf("replyCalls = %d, want 3", replyCalls)
+	}
+}
+
+func TestSendNewMessageToChatRefreshesTenantTokenAfterInvalidCachedToken(t *testing.T) {
+	const appID = "cli_create_retry"
+	const appSecret = "secret-create-retry"
+
+	authCalls := 0
+	createCalls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			authCalls++
+			token := "stale-token"
+			if authCalls >= 2 {
+				token = "fresh-token"
+			}
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": token,
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages":
+			createCalls++
+			authz := r.Header.Get("Authorization")
+			switch createCalls {
+			case 1, 2:
+				if authz != "Bearer stale-token" {
+					t.Fatalf("create call %d Authorization = %q, want stale token", createCalls, authz)
+				}
+				writeJSON(t, w, map[string]any{
+					"code": 99991663,
+					"msg":  "Invalid access token for authorization",
+				})
+			case 3:
+				if authz != "Bearer fresh-token" {
+					t.Fatalf("create retry Authorization = %q, want fresh token", authz)
+				}
+				writeJSON(t, w, map[string]any{
+					"code": 0,
+					"msg":  "success",
+					"data": map[string]any{"message_id": "om_create_ok"},
+				})
+			default:
+				t.Fatalf("unexpected extra create call %d", createCalls)
+			}
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		replayClient: lark.NewClient(appID, appSecret,
+			lark.WithEnableTokenCache(false),
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+	}
+
+	err := p.sendNewMessageToChat(context.Background(), replyContext{chatID: "oc_chat"}, "text", `{"text":"hello"}`)
+	if err != nil {
+		t.Fatalf("sendNewMessageToChat() error = %v", err)
+	}
+	if authCalls != 2 {
+		t.Fatalf("authCalls = %d, want 2", authCalls)
+	}
+	if createCalls != 3 {
+		t.Fatalf("createCalls = %d, want 3", createCalls)
+	}
+}
+
+func TestReplyDoesNotRefreshTenantTokenOnNonTokenError(t *testing.T) {
+	const appID = "cli_non_token_error"
+	const appSecret = "secret-non-token-error"
+
+	authCalls := 0
+	replyCalls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			authCalls++
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "normal-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/reply"):
+			replyCalls++
+			writeJSON(t, w, map[string]any{
+				"code": 230001,
+				"msg":  "rate limited",
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		replayClient: lark.NewClient(appID, appSecret,
+			lark.WithEnableTokenCache(false),
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+	}
+
+	err := p.Reply(context.Background(), replyContext{messageID: "om_root", chatID: "oc_chat"}, "hello")
+	if err == nil {
+		t.Fatal("Reply() error = nil, want failure")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Fatalf("Reply() error = %v, want rate limited", err)
+	}
+	if authCalls > 1 {
+		t.Fatalf("authCalls = %d, want <= 1", authCalls)
+	}
+	if replyCalls != 1 {
+		t.Fatalf("replyCalls = %d, want 1", replyCalls)
+	}
+}
+
+func TestIsTenantAccessTokenInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "code only", err: testError("feishu: reply failed code=99991663 msg=something"), want: true},
+		{name: "message only", err: testError("feishu: reply api call: Invalid access token for authorization"), want: true},
+		{name: "other error", err: testError("feishu: reply failed code=230001 msg=rate limited"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTenantAccessTokenInvalid(tt.err); got != tt.want {
+				t.Fatalf("isTenantAccessTokenInvalid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type testError string
+
+func (e testError) Error() string { return string(e) }
+
+func writeJSON(t *testing.T, w http.ResponseWriter, body map[string]any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Fatalf("encode json: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

  Fix Feishu/Lark outgoing replies failing with `99991663 Invalid access token` after long uptime.

  Partially addresses #395.

  ## What changed

  - add a Feishu-specific recovery path for outgoing API calls
  - detect tenant token invalid failures (`99991663` / `Invalid access token`)
  - fetch a fresh tenant access token explicitly
  - replay the failed request once with a cache-disabled client and the fresh token
  - apply this recovery consistently to:
    - normal replies
    - new message sends
    - media sends/uploads
    - preview message create/update/delete
    - interactive card sends/replies
  - add regression tests covering:
    - reply retry after stale cached token
    - create/send retry after stale cached token
    - non-token errors do not trigger refresh
    - token-invalid error detection

  ## Why

  The current Lark SDK does retry once on `99991663`, but in practice that is not always enough.

  The root cause is that tenant token cache remains enabled, and on retry the SDK can still reuse the same stale cached token. In addition, request-level tenant token override is not sufficient when token cache is enabled.

  So cc-connect now adds a narrow recovery layer on top of the SDK:

  - normal path still uses the default SDK client and cache
  - only when token-invalid is detected, cc-connect explicitly fetches a fresh token
  - the failed request is replayed once through a cache-disabled client

  This keeps the fix small and targeted while making outgoing Feishu sends much more resilient.

  ## Scope

  This PR only fixes the Feishu/Lark outgoing message failure caused by stale tenant access tokens.

  It does **not** attempt to address the other symptoms mentioned in #395, such as Telegram polling conflicts or unexpected restarts, which may have different root causes.

  ## Validation

  - [x] `pnpm install --frozen-lockfile && pnpm build` in `web/`
  - [x] `go build ./...`
  - [x] `go test ./... -v -race`
  - [x] `go test ./... -coverprofile=coverage.out -covermode=atomic`
  - [x] `$(go env GOPATH)/bin/actionlint -color`
  - [x] `go test -v -tags=smoke,no_web ./tests/e2e/...`
  - [x] `go test -v -tags=regression,no_web ./tests/e2e/...`
  - [x] `go test -bench=. -benchmem -tags=performance,no_web ./tests/performance/...`