### PR TITLE
feat(feishu): support runtime domain override

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -653,6 +653,7 @@ type = "feishu"
 [projects.platforms.options]
 app_id = "your-feishu-app-id"
 app_secret = "your-feishu-app-secret"
+# domain = "https://open.feishu.cn"  # Optional runtime API/WebSocket base URL override / 可选：运行时 API/WebSocket 域名覆盖
 # enable_feishu_card = true  # Enable Feishu interactive cards (default: true); set false to force plain-text replies
 #                              # 启用飞书交互式卡片（默认 true）；设为 false 时强制回退纯文本回复
 # allow_from = "*"          # Allowed user open_ids, comma-separated; "*" = all (default). Use /whoami to get your open_id.
@@ -686,6 +687,7 @@ app_secret = "your-feishu-app-secret"
 # [projects.platforms.options]
 # app_id = "your-lark-app-id"
 # app_secret = "your-lark-app-secret"
+# domain = "https://open.larksuite.com"  # Optional runtime API base URL override / 可选：运行时 API 域名覆盖
 # port = "8080"                  # Webhook server port / Webhook 服务器端口
 # callback_path = "/feishu/webhook"  # Webhook callback path / Webhook 回调路径
 # encrypt_key = ""               # Event encrypt key (optional) / 事件加密密钥（可选）

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -107,6 +107,7 @@ type = "feishu"
 [projects.platforms.options]
 app_id = "cli_axxxxxxxxxxxx"
 app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
+# domain = "https://open.feishu.cn" # 可选：覆盖运行时 API/WebSocket 域名
 # enable_feishu_card = true  # 可选：关闭后统一回退纯文本回复
 # thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
 # progress_style = "legacy"  # 可选：legacy | compact | card
@@ -115,6 +116,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
 > 如果开启 `thread_isolation = true`，群聊里每个根消息 / reply thread 会对应一个独立 agent session；私聊行为保持原样。
 > `progress_style = "compact"` 会把思考/工具进度合并到一条可更新消息里，减少刷屏；`legacy` 保持原有逐条发送；`card` 会使用结构化卡片（标题 + 进度块）持续更新同一条消息，观感比纯文本更清晰。
+> `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -288,6 +288,7 @@ Behavior:
 - If project exists but has no `feishu/lark` platform, one is added automatically.
 - The command writes credentials (`app_id`, `app_secret`); in QR onboarding flow, Feishu usually pre-configures permissions and event subscriptions.
 - Still verify app publish status and availability scope in Feishu Open Platform.
+- Runtime platform config also supports an optional `domain` override for Feishu/Lark API endpoints; this does not change setup/onboarding URLs.
 
 ---
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -288,6 +288,7 @@ cc-connect feishu bind --project my-project --app cli_xxx:sec_xxx
 - 项目存在但没有 `feishu/lark` 平台时会自动补一个平台配置。
 - 命令会回填凭证（`app_id` / `app_secret`）；扫码新建场景下飞书通常会预配权限和事件订阅。
 - 建议在飞书开放平台再核验一次发布状态与可用范围。
+- 运行时平台配置还支持可选 `domain` 覆盖 Feishu/Lark API 域名；这不会改变 `setup/new/bind` 的引导地址。
 
 ---
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -153,6 +154,15 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	appSecret, _ := opts["app_secret"].(string)
 	if appID == "" || appSecret == "" {
 		return nil, fmt.Errorf("%s: app_id and app_secret are required", name)
+	}
+	if v, ok := opts["domain"].(string); ok {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			if _, err := url.ParseRequestURI(v); err != nil {
+				return nil, fmt.Errorf("%s: invalid domain %q: %w", name, v, err)
+			}
+			domain = v
+		}
 	}
 	reactionEmoji, _ := opts["reaction_emoji"].(string)
 	if reactionEmoji == "" {

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -474,6 +474,32 @@ func TestNewFeishu_PlatformNameAndDomain(t *testing.T) {
 	}
 }
 
+func TestNewFeishu_CustomDomainOverride(t *testing.T) {
+	customDomain := "https://open.example.invalid"
+	p, err := New(map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "domain": customDomain,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip, ok := p.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("type = %T, want *interactivePlatform", p)
+	}
+	if ip.domain != customDomain {
+		t.Fatalf("domain = %q, want %q", ip.domain, customDomain)
+	}
+}
+
+func TestNewFeishu_InvalidCustomDomain(t *testing.T) {
+	_, err := New(map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "domain": "://bad",
+	})
+	if err == nil {
+		t.Fatal("expected invalid domain error")
+	}
+}
+
 func TestLark_SessionKeyPrefix(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,


### PR DESCRIPTION
## Summary

Add optional runtime `domain` override support for Feishu/Lark platform configuration.

Related to #402.

## What changed

- allow `projects.platforms.options.domain` for `feishu` / `lark`
- use the custom domain for Feishu/Lark runtime SDK clients
- validate custom domain format during platform initialization
- keep default behavior unchanged when `domain` is not set
- document the new option in:
  - `config.example.toml`
  - `docs/feishu.md`
  - `docs/usage.md`
  - `docs/usage.zh-CN.md`
- add regression tests for:
  - custom domain override
  - invalid custom domain rejection

## Scope

This PR only adds **runtime platform domain override** support.

It does **not** change the domain used by Feishu setup/onboarding commands such as:

- `cc-connect feishu setup`
- `cc-connect feishu new`
- `cc-connect feishu bind`

Those flows still use the existing built-in onboarding URLs.

## Why

Current `main` already has internal runtime support for a Feishu/Lark domain concept:

- REST client can use `lark.WithOpenBaseUrl(...)`
- Feishu WebSocket client can use `larkws.WithDomain(...)`

But this capability was not exposed through config, so users could not actually use it.

This PR exposes that existing runtime capability in a minimal and backward-compatible way.

## Validation

- [x] `gofmt -w platform/feishu/feishu.go platform/feishu/platform_test.go`
- [x] `go test ./platform/feishu -v`
- [x] `pnpm install --frozen-lockfile && pnpm build` in `web/`
- [x] `go build ./...`
- [x] `go test ./...`
