### PR TITLE
fix(bridge): require token when Bridge is enabled for security

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -627,7 +627,17 @@ func main() {
 		if path == "" {
 			path = "/bridge/ws"
 		}
-		bridgeSrv = core.NewBridgeServer(port, cfg.Bridge.Token, path, cfg.Bridge.CORSOrigins)
+		// Check insecure flag for local development mode
+		insecure := cfg.Bridge.Insecure != nil && *cfg.Bridge.Insecure
+		if insecure {
+			bridgeSrv = core.NewBridgeServerInsecure(port, cfg.Bridge.Token, path, cfg.Bridge.CORSOrigins)
+		} else {
+			bridgeSrv = core.NewBridgeServer(port, cfg.Bridge.Token, path, cfg.Bridge.CORSOrigins)
+		}
+		if bridgeSrv == nil {
+			slog.Error("bridge: failed to create server - token is required (or set insecure=true for local dev)")
+			os.Exit(1)
+		}
 		for i, e := range engines {
 			bp := bridgeSrv.NewPlatform(cfg.Projects[i].Name)
 			bridgeSrv.RegisterEngine(cfg.Projects[i].Name, e, bp)

--- a/config/config.go
+++ b/config/config.go
@@ -58,9 +58,10 @@ type WebhookConfig struct {
 type BridgeConfig struct {
 	Enabled     *bool    `toml:"enabled"`                // default false
 	Port        int      `toml:"port,omitempty"`         // listen port; default 9810
-	Token       string   `toml:"token,omitempty"`        // shared secret for authentication; required
+	Token       string   `toml:"token,omitempty"`        // shared secret for authentication; required unless insecure=true
 	Path        string   `toml:"path,omitempty"`         // URL path; default "/bridge/ws"
 	CORSOrigins []string `toml:"cors_origins,omitempty"` // allowed CORS origins; empty = no CORS
+	Insecure    *bool    `toml:"insecure,omitempty"`     // allow running without token (local dev only); default false
 }
 
 // ManagementConfig controls the HTTP Management API for external tools.

--- a/core/bridge.go
+++ b/core/bridge.go
@@ -28,6 +28,7 @@ type BridgeServer struct {
 	token       string
 	path        string
 	corsOrigins []string
+	insecure    bool // allow running without token (local dev only)
 	server      *http.Server
 
 	mu       sync.RWMutex
@@ -121,11 +122,17 @@ type bridgeAudioData struct {
 	Duration int    `json:"duration,omitempty"`
 }
 
-var wsUpgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+func NewBridgeServer(port int, token, path string, corsOrigins []string) *BridgeServer {
+	return newBridgeServer(port, token, path, corsOrigins, false)
 }
 
-func NewBridgeServer(port int, token, path string, corsOrigins []string) *BridgeServer {
+// NewBridgeServerInsecure creates a BridgeServer that allows running without token.
+// This should only be used for local development.
+func NewBridgeServerInsecure(port int, token, path string, corsOrigins []string) *BridgeServer {
+	return newBridgeServer(port, token, path, corsOrigins, true)
+}
+
+func newBridgeServer(port int, token, path string, corsOrigins []string, insecure bool) *BridgeServer {
 	if port <= 0 {
 		port = 9810
 	}
@@ -135,11 +142,23 @@ func NewBridgeServer(port int, token, path string, corsOrigins []string) *Bridge
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
+
+	// Validate security settings
+	if token == "" && !insecure {
+		slog.Error("bridge: token is required when insecure mode is not enabled",
+			"help", "set bridge.token in config, or use insecure=true for local development only")
+		return nil
+	}
+	if insecure && token == "" {
+		slog.Warn("bridge: running in INSECURE mode without authentication - only use for local development!")
+	}
+
 	return &BridgeServer{
 		port:        port,
 		token:       token,
 		path:        path,
 		corsOrigins: corsOrigins,
+		insecure:    insecure,
 		adapters:    make(map[string]*bridgeAdapter),
 		engines:     make(map[string]*bridgeEngineRef),
 	}
@@ -483,13 +502,60 @@ func (bp *BridgePlatform) SetCardNavigationHandler(h CardNavigationHandler) {
 // WebSocket connection handling (on BridgeServer)
 // ---------------------------------------------------------------------------
 
+// checkOrigin validates the WebSocket origin against CORS origins.
+// In insecure mode, it allows all origins. Otherwise, it checks against CORS origins or same host.
+func (bs *BridgeServer) checkOrigin(r *http.Request) bool {
+	// In insecure mode, allow all origins (for local development)
+	if bs.insecure {
+		return true
+	}
+
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		// No origin header (e.g., non-browser client) - allow only if authenticated
+		// The authentication check happens before this, so we allow
+		return true
+	}
+
+	// If CORS origins are configured, check against them
+	if len(bs.corsOrigins) > 0 {
+		for _, o := range bs.corsOrigins {
+			if o == "*" || o == origin {
+				return true
+			}
+		}
+		slog.Warn("bridge: websocket origin rejected", "origin", origin, "allowed", bs.corsOrigins)
+		return false
+	}
+
+	// No CORS configured - require same-host (origin must match host)
+	host := r.Host
+	if host == "" {
+		host = r.URL.Host
+	}
+	// Parse origin to get host
+	if idx := strings.Index(origin, "://"); idx > 0 {
+		originHost := origin[idx+3:]
+		if originHost == host {
+			return true
+		}
+	}
+	slog.Warn("bridge: websocket origin mismatch", "origin", origin, "host", host)
+	return false
+}
+
 func (bs *BridgeServer) handleWS(w http.ResponseWriter, r *http.Request) {
 	if !bs.authenticate(r) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	conn, err := wsUpgrader.Upgrade(w, r, nil)
+	// Use a custom upgrader with origin checking
+	upgrader := websocket.Upgrader{
+		CheckOrigin: bs.checkOrigin,
+	}
+
+	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		slog.Error("bridge: websocket upgrade failed", "error", err)
 		return
@@ -1003,8 +1069,9 @@ func (bs *BridgeServer) handleSessionSwitch(w http.ResponseWriter, r *http.Reque
 // ---------------------------------------------------------------------------
 
 func (bs *BridgeServer) authenticate(r *http.Request) bool {
+	// If token is not set, only allow in insecure mode
 	if bs.token == "" {
-		return true
+		return bs.insecure
 	}
 	if auth := r.Header.Get("Authorization"); auth != "" {
 		if strings.HasPrefix(auth, "Bearer ") {

--- a/core/bridge_test.go
+++ b/core/bridge_test.go
@@ -20,7 +20,16 @@ import (
 
 func startTestBridge(t *testing.T, token string) (*BridgeServer, string) {
 	t.Helper()
-	bs := NewBridgeServer(0, token, "/bridge/ws", nil)
+	var bs *BridgeServer
+	if token == "" {
+		// Use insecure mode for tests without token
+		bs = NewBridgeServerInsecure(0, token, "/bridge/ws", nil)
+	} else {
+		bs = NewBridgeServer(0, token, "/bridge/ws", nil)
+	}
+	if bs == nil {
+		t.Fatalf("failed to create bridge server")
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/bridge/ws", bs.handleWS)
@@ -427,7 +436,15 @@ func TestSerializeCard(t *testing.T) {
 // startTestBridgeWithREST creates a bridge server with both WS and REST endpoints.
 func startTestBridgeWithREST(t *testing.T, token string) (*BridgeServer, string) {
 	t.Helper()
-	bs := NewBridgeServer(0, token, "/bridge/ws", nil)
+	var bs *BridgeServer
+	if token == "" {
+		bs = NewBridgeServerInsecure(0, token, "/bridge/ws", nil)
+	} else {
+		bs = NewBridgeServer(0, token, "/bridge/ws", nil)
+	}
+	if bs == nil {
+		t.Fatalf("failed to create bridge server")
+	}
 
 	agent := &stubAgent{}
 	sm := NewSessionManager("")


### PR DESCRIPTION
## Summary
- Bridge server now requires token to be set unless `insecure = true` is explicitly configured
- Added `insecure` config option for local development only
- WebSocket origin check now validates against CORS origins or same-host
- Clear error message and exit when token is missing

## Root Cause
Issue #403 identified that when `bridge.token` is not set:
1. `authenticate()` returned `true` for all requests
2. WebSocket `CheckOrigin` always returned `true`
3. Bridge server listened on all interfaces (`:9810`)

This allowed unauthenticated access to the Bridge API.

## Changes
- `config/config.go`: Added `Insecure *bool` field to `BridgeConfig`
- `core/bridge.go`: 
  - Added `insecure` field to `BridgeServer`
  - Added `NewBridgeServerInsecure()` for explicit local-dev mode
  - `authenticate()` now requires token unless `insecure` is true
  - Added `checkOrigin()` that validates against CORS origins or same-host
- `cmd/cc-connect/main.go`: Check insecure flag and exit with error if token is missing
- `core/bridge_test.go`: Updated tests to use insecure mode when testing without token

## Breaking Change
Bridge with empty token now fails to start with error:
```
bridge: token is required when insecure mode is not enabled
```

For local development, add to config:
```toml
[bridge]
enabled = true
insecure = true  # Only for local dev!
```

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./core/...` passes
- [ ] Manual test: Bridge with token works correctly
- [ ] Manual test: Bridge without token fails to start
- [ ] Manual test: Bridge with `insecure = true` starts without token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #403