### PR TITLE
feat(feishu): add custom domain configuration option

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -91,10 +91,18 @@ func (l *sanitizingLogger) Error(ctx context.Context, args ...interface{}) {
 
 func init() {
 	core.RegisterPlatform("feishu", func(opts map[string]any) (core.Platform, error) {
-		return newPlatform("feishu", lark.FeishuBaseUrl, opts)
+		domain := lark.FeishuBaseUrl
+		if customDomain, ok := opts["domain"].(string); ok && strings.TrimSpace(customDomain) != "" {
+			domain = strings.TrimSpace(customDomain)
+		}
+		return newPlatform("feishu", domain, opts)
 	})
 	core.RegisterPlatform("lark", func(opts map[string]any) (core.Platform, error) {
-		return newPlatform("lark", lark.LarkBaseUrl, opts)
+		domain := lark.LarkBaseUrl
+		if customDomain, ok := opts["domain"].(string); ok && strings.TrimSpace(customDomain) != "" {
+			domain = strings.TrimSpace(customDomain)
+		}
+		return newPlatform("lark", domain, opts)
 	})
 }
 
@@ -145,7 +153,11 @@ func (p *Platform) SetCardNavigationHandler(h core.CardNavigationHandler) {
 }
 
 func New(opts map[string]any) (core.Platform, error) {
-	return newPlatform("feishu", lark.FeishuBaseUrl, opts)
+	domain := lark.FeishuBaseUrl
+	if customDomain, ok := opts["domain"].(string); ok && strings.TrimSpace(customDomain) != "" {
+		domain = strings.TrimSpace(customDomain)
+	}
+	return newPlatform("feishu", domain, opts)
 }
 
 func newPlatform(name, domain string, opts map[string]any) (core.Platform, error) {

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -474,6 +474,44 @@ func TestNewFeishu_PlatformNameAndDomain(t *testing.T) {
 	}
 }
 
+func TestNewFeishu_CustomDomain(t *testing.T) {
+	customDomain := "https://custom.feishu.cn"
+	pAny, err := New(map[string]any{
+		"app_id":     "cli_xxx",
+		"app_secret": "secret",
+		"domain":     customDomain,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	p, ok := pAny.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("type = %T, want *interactivePlatform", pAny)
+	}
+	if p.domain != customDomain {
+		t.Fatalf("domain = %q, want %q", p.domain, customDomain)
+	}
+}
+
+func TestNewLark_CustomDomain(t *testing.T) {
+	customDomain := "https://custom.larksuite.com"
+	pAny, err := core.CreatePlatform("lark", map[string]any{
+		"app_id":     "cli_xxx",
+		"app_secret": "secret",
+		"domain":     customDomain,
+	})
+	if err != nil {
+		t.Fatalf("CreatePlatform(lark) error = %v", err)
+	}
+	p, ok := pAny.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("type = %T, want *interactivePlatform", pAny)
+	}
+	if p.domain != customDomain {
+		t.Fatalf("domain = %q, want %q", p.domain, customDomain)
+	}
+}
+
 func TestLark_SessionKeyPrefix(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,


### PR DESCRIPTION
## Summary
- Add optional `domain` parameter for Feishu/Lark platforms
- Support custom Feishu deployments with custom domain URLs
- Default behavior unchanged when domain is not specified

## Usage
```toml
[[projects.platforms]]
type = "feishu"
[projects.platforms.options]
app_id = "cli_xxx"
app_secret = "secret"
domain = "https://custom.feishu.cn"  # optional
```

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./platform/feishu/...` passes (all tests including new custom domain tests)
- [ ] Manual smoke test: configure custom domain and verify API calls use correct endpoint

Closes #402