### PR TITLE
feat(telegram): add reply context and location message support

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1277,8 +1277,18 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	}
 
 	content := strings.TrimSpace(msg.Content)
-	if content == "" && len(msg.Images) == 0 && len(msg.Files) == 0 {
+	if content == "" && len(msg.Images) == 0 && len(msg.Files) == 0 && msg.Location == nil {
 		return
+	}
+
+	// Enrich content with platform-specific context (reply quotes, location text, etc.)
+	if msg.ExtraContent != "" {
+		if content == "" {
+			msg.Content = msg.ExtraContent
+			content = msg.ExtraContent
+		} else {
+			msg.Content = msg.ExtraContent + "\n" + content
+		}
 	}
 
 	// Resolve aliases: check if the first word (or whole content) matches an alias

--- a/core/message.go
+++ b/core/message.go
@@ -126,6 +126,16 @@ type AudioAttachment struct {
 	Duration int    // duration in seconds (if known)
 }
 
+// LocationAttachment represents a geographical location sent by the user.
+type LocationAttachment struct {
+	Latitude            float64 // latitude coordinate
+	Longitude           float64 // longitude coordinate
+	HorizontalAccuracy  float64 // accuracy radius in meters (optional)
+	LivePeriod          int     // time period for live location updates in seconds (optional)
+	Heading             int     // direction of movement in degrees (optional)
+	ProximityAlertRadius int    // maximum distance for proximity alerts in meters (optional)
+}
+
 // Message represents a unified incoming message from any platform.
 type Message struct {
 	SessionKey string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
@@ -138,7 +148,9 @@ type Message struct {
 	Images     []ImageAttachment // attached images (if any)
 	Files      []FileAttachment  // attached files (if any)
 	Audio        *AudioAttachment // voice message (if any)
-	ChannelKey   string          // platform-provided channel identifier for workspace binding (optional)
+	Location     *LocationAttachment // geographical location (if any)
+	ExtraContent string              // platform-enriched content (e.g. location text, reply quote) prepended for the agent
+	ChannelKey   string              // platform-provided channel identifier for workspace binding (optional)
 	ReplyCtx     any             // platform-specific context needed for replying
 	FromVoice    bool            // true if message originated from voice transcription
 	ModeOverride string          // if set, temporarily override agent permission mode for this message

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -375,7 +375,7 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 			ChannelKey: channelKey,
 			Images:     []core.ImageAttachment{{MimeType: "image/jpeg", Data: imgData}},
 			ReplyCtx:   rctx,
-		})
+		}, msg)
 		return
 	}
 
@@ -398,7 +398,7 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 				Duration: msg.Voice.Duration,
 			},
 			ReplyCtx: rctx,
-		})
+		}, msg)
 		return
 	}
 
@@ -428,7 +428,7 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 				Duration: msg.Audio.Duration,
 			},
 			ReplyCtx: rctx,
-		})
+		}, msg)
 		return
 	}
 
@@ -448,10 +448,29 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 			ChannelKey: channelKey,
 			Files:      []core.FileAttachment{{MimeType: msg.Document.MimeType, Data: fileData, FileName: msg.Document.FileName}},
 			ReplyCtx:   rctx,
-		})
+		}, msg)
 		return
 	}
 
+	if msg.Location != nil {
+		slog.Info("telegram: location received", "user", userName, "latitude", msg.Location.Latitude, "longitude", msg.Location.Longitude)
+		p.dispatchMessage(&core.Message{
+			SessionKey: sessionKey, Platform: "telegram",
+			UserID: userID, UserName: userName, ChatName: chatName,
+			MessageID:  strconv.Itoa(msg.ID),
+			ChannelKey: channelKey,
+			Location: &core.LocationAttachment{
+				Latitude:             msg.Location.Latitude,
+				Longitude:            msg.Location.Longitude,
+				HorizontalAccuracy:   msg.Location.HorizontalAccuracy,
+				LivePeriod:           msg.Location.LivePeriod,
+				Heading:              msg.Location.Heading,
+				ProximityAlertRadius: msg.Location.ProximityAlertRadius,
+			},
+			ReplyCtx: rctx,
+		}, msg)
+		return
+	}
 	if msg.Text == "" {
 		return
 	}
@@ -465,10 +484,22 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 		MessageID:  strconv.Itoa(msg.ID),
 		ChannelKey: channelKey,
 		ReplyCtx:   rctx,
-	})
+	}, msg)
 }
 
-func (p *Platform) dispatchMessage(msg *core.Message) {
+func (p *Platform) dispatchMessage(msg *core.Message, tgMsg *models.Message) {
+	// Enrich with platform-specific context (reply quotes, location text, etc.)
+	var extras []string
+	if replyText := enrichReplyContent(tgMsg); replyText != "" {
+		extras = append(extras, replyText)
+	}
+	if locText := enrichLocation(msg); locText != "" {
+		extras = append(extras, locText)
+	}
+	if len(extras) > 0 {
+		msg.ExtraContent = strings.Join(extras, "\n")
+	}
+
 	handler := p.messageHandler()
 	if handler == nil {
 		return

--- a/platform/telegram/telegram_location.go
+++ b/platform/telegram/telegram_location.go
@@ -1,0 +1,17 @@
+package telegram
+
+import (
+	"fmt"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// enrichLocation converts a location attachment into text content that AI agents
+// can understand. Returns the enriched content string, or empty string if nothing to add.
+func enrichLocation(msg *core.Message) string {
+	if msg.Location == nil {
+		return ""
+	}
+	return fmt.Sprintf("[Location] Latitude: %.6f, Longitude: %.6f",
+		msg.Location.Latitude, msg.Location.Longitude)
+}

--- a/platform/telegram/telegram_reply.go
+++ b/platform/telegram/telegram_reply.go
@@ -1,0 +1,66 @@
+package telegram
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-telegram/bot/models"
+)
+
+// enrichReplyContent extracts the quoted/original message from a Telegram reply
+// and formats it so the AI agent can see the context of what the user is replying to.
+// Returns the enriched content string, or empty string if this is not a reply.
+func enrichReplyContent(msg *models.Message) string {
+	if msg.ReplyToMessage == nil {
+		return ""
+	}
+
+	original := msg.ReplyToMessage
+	var parts []string
+
+	// Extract text content from the original message
+	if original.Text != "" {
+		parts = append(parts, original.Text)
+	} else if original.Caption != "" {
+		parts = append(parts, original.Caption)
+	}
+
+	if original.Location != nil {
+		parts = append(parts, fmt.Sprintf("[Location] Latitude: %.6f, Longitude: %.6f",
+			original.Location.Latitude, original.Location.Longitude))
+	}
+
+	if len(original.Photo) > 0 {
+		parts = append(parts, "[Image]")
+	}
+
+	if original.Document != nil {
+		parts = append(parts, fmt.Sprintf("[File: %s]", original.Document.FileName))
+	}
+
+	if original.Voice != nil {
+		parts = append(parts, "[Voice Message]")
+	}
+
+	if original.Audio != nil {
+		parts = append(parts, fmt.Sprintf("[Audio: %s]", original.Audio.FileName))
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	// Identify who wrote the original message
+	fromName := "Unknown"
+	if original.From != nil {
+		fromName = original.From.FirstName
+		if original.From.LastName != "" {
+			fromName += " " + original.From.LastName
+		}
+		if original.From.Username != "" {
+			fromName = "@" + original.From.Username
+		}
+	}
+
+	return fmt.Sprintf("[Reply to %s]: %s", fromName, strings.Join(parts, " "))
+}


### PR DESCRIPTION
- Add reply enrichment: when user replies to a message, the original message content (text, image, voice, file, location) is included as context for the AI agent
- Add location message support: convert Telegram location attachments to text content that AI agents can understand
- Add ExtraContent field to core.Message for platform-enriched context
- Add LocationAttachment type to core.Message
- Refactor dispatchMessage to support platform-specific enrichment