### PR TITLE
fix(telegram): drain pending updates before polling to prevent 409 Conflict

### DIFF
--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -223,7 +223,43 @@ func defaultNewBot(token string, onUpdate func(context.Context, *models.Update),
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("getMe: %w", err)
 	}
+
+	// Drain pending updates before starting polling to avoid 409 Conflict.
+	// This clears any outstanding long-poll request from a previous instance.
+	drainPendingUpdates(token, httpClient)
+
 	return b, me, b.Start, nil
+}
+
+// drainPendingUpdates clears any pending updates on Telegram's side by calling
+// getUpdates with offset=-1. This terminates any outstanding long-poll request
+// from a previous bot instance, preventing 409 Conflict errors on restart.
+func drainPendingUpdates(token string, httpClient *http.Client) {
+	apiURL := "https://api.telegram.org/bot" + token + "/getUpdates?offset=-1&timeout=0"
+	client := httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		slog.Debug("telegram: drain updates request creation failed", "error", err)
+		return
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Debug("telegram: drain updates request failed", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Read and discard response body to ensure connection is properly closed
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	slog.Debug("telegram: drained pending updates", "status", resp.StatusCode)
 }
 
 func (p *Platform) connectLoop(ctx context.Context) {


### PR DESCRIPTION
## Summary
- Added `drainPendingUpdates()` function that calls `getUpdates?offset=-1&timeout=0` before starting the polling loop
- This clears any outstanding long-poll request from a previous bot instance, preventing 409 Conflict errors on restart
- Root cause: migration to go-telegram/bot library (commit 1104739) removed the drain step that was present in the old go-telegram-bot-api/v5 implementation

## Test plan
- [ ] Build passes: `go build ./...`
- [ ] Tests pass: `go test ./...`
- [ ] Manual test: restart cc-connect with Telegram platform multiple times, verify no 409 Conflict errors

Fixes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)