### PR TITLE
feat(discord): support card-style progress updates

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -789,6 +789,8 @@ app_secret = "your-feishu-app-secret"
 # share_session_in_channel = false  # If true, all users in a channel share one agent session / 频道共享会话
 # thread_isolation = false  # If true, cc-connect creates/uses Discord threads as session boundaries when the channel supports threads
 #                           # 设为 true 时，cc-connect 会在支持 thread 的 Discord 频道内按 thread 隔离会话
+# progress_style = "legacy"  # Progress rendering: legacy | compact | card / 进度展示方式：legacy | compact | card
+#                            # card = one editable Discord embed progress card / card = 单条可编辑的 Discord 嵌入式进度卡
 # respond_to_at_everyone_and_here = false  # If true, treat @everyone/@here as a direct mention so the bot responds
 #                              # 设为 true 时，将 @everyone/@here 视为直接 @ 机器人，使机器人响应
 # proxy = "http://127.0.0.1:7890"  # Optional HTTP/SOCKS5 proxy for Discord API & Gateway / 可选代理

--- a/docs/discord.md
+++ b/docs/discord.md
@@ -110,10 +110,12 @@ type = "discord"
 [projects.platforms.options]
 token = "MTk4NjIyNDgzNDcOTY3NDUxMg.G8vKqh.xxx..."
 # thread_isolation = true  # Optional: isolate each agent session in its own Discord thread
+# progress_style = "legacy" # Optional: legacy | compact | card
 ```
 
 > cc-connect automatically configures the required Intents (MESSAGE_CONTENT, GUILD_MESSAGES, DIRECT_MESSAGES).
 > With `thread_isolation = true`, cc-connect creates or reuses a Discord thread for each session and routes follow-up messages by thread channel ID.
+> `progress_style = "compact"` merges thinking/tool updates into one editable message; `progress_style = "card"` renders a Discord-native embed progress card and still sends the final answer as a normal message.
 
 ---
 
@@ -207,6 +209,8 @@ cc-connect: 🤔 Thinking...
 cc-connect: 🔧 Tool: Bash(ls -la)
 cc-connect: Here's the project structure...
 ```
+
+If you enable `progress_style = "card"`, Discord shows one editable progress embed during the turn, then the final answer arrives as a separate normal message. This reduces channel noise compared with the legacy multi-message flow.
 
 ---
 

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -40,10 +40,15 @@ type interactionReplyCtx struct {
 	firstDone   bool
 }
 
+type progressPlatform struct {
+	*Platform
+}
+
 type Platform struct {
 	token                      string
 	allowFrom                  string
 	guildID                    string // optional: per-guild registration (instant) vs global (up to 1h propagation)
+	progressStyle              string
 	groupReplyAll              bool
 	shareSessionInChannel      bool
 	threadIsolation            bool
@@ -58,6 +63,7 @@ type Platform struct {
 	readyCh                    chan struct{}
 	seenMsgs                   sync.Map // message ID dedup: prevents duplicate MessageCreate events
 	seenInteractions           sync.Map // interaction ID dedup: prevents duplicate slash/button events
+	self                       core.Platform
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -72,6 +78,17 @@ func New(opts map[string]any) (core.Platform, error) {
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
+	progressStyle := "legacy"
+	if v, ok := opts["progress_style"].(string); ok {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "", "legacy":
+			progressStyle = "legacy"
+		case "compact", "card":
+			progressStyle = strings.ToLower(strings.TrimSpace(v))
+		default:
+			return nil, fmt.Errorf("discord: invalid progress_style %q (want legacy, compact, or card)", v)
+		}
+	}
 
 	var proxyU *url.URL
 	if proxyStr, _ := opts["proxy"].(string); proxyStr != "" {
@@ -86,20 +103,59 @@ func New(opts map[string]any) (core.Platform, error) {
 		proxyU = u
 	}
 
-	return &Platform{
+	base := &Platform{
 		token:                      token,
 		allowFrom:                  allowFrom,
 		guildID:                    guildID,
+		progressStyle:              progressStyle,
 		groupReplyAll:              groupReplyAll,
 		shareSessionInChannel:      shareSessionInChannel,
 		readyCh:                    make(chan struct{}),
 		threadIsolation:            threadIsolation,
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
 		proxyURL:                   proxyU,
-	}, nil
+	}
+	if progressStyle == "compact" || progressStyle == "card" {
+		wrapped := &progressPlatform{Platform: base}
+		base.self = wrapped
+		return wrapped, nil
+	}
+	base.self = base
+	return base, nil
 }
 
 func (p *Platform) Name() string { return "discord" }
+
+func (p *Platform) selfPlatform() core.Platform {
+	if p != nil && p.self != nil {
+		return p.self
+	}
+	return p
+}
+
+func (p *Platform) dispatchMessage(msg *core.Message) {
+	if p == nil || p.handler == nil {
+		return
+	}
+	p.handler(p.selfPlatform(), msg)
+}
+
+func (p *progressPlatform) ProgressStyle() string {
+	switch strings.ToLower(strings.TrimSpace(p.progressStyle)) {
+	case "", "legacy":
+		return "legacy"
+	case "compact":
+		return "compact"
+	case "card":
+		return "card"
+	default:
+		return "legacy"
+	}
+}
+
+func (p *progressPlatform) SupportsProgressCardPayload() bool {
+	return p.ProgressStyle() == "card"
+}
 
 func (p *Platform) makeSessionKey(channelID string, userID string) string {
 	return buildSessionKey(channelID, userID, p.shareSessionInChannel)
@@ -533,7 +589,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			ChatName: p.resolveChannelName(m.ChannelID),
 			Content:  m.Content, Images: images, Audio: audio, ReplyCtx: rctx,
 		}
-		p.handler(p, msg)
+		p.dispatchMessage(msg)
 	})
 
 	session.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
@@ -623,7 +679,7 @@ func (p *Platform) handleInteraction(s *discordgo.Session, i *discordgo.Interact
 		ChatName: p.resolveChannelName(channelID),
 		Content:  cmdText, ReplyCtx: rctx,
 	}
-	p.handler(p, msg)
+	p.dispatchMessage(msg)
 }
 
 // replyContextForDeferredInteractionFallback builds a replyContext for slash commands
@@ -687,7 +743,7 @@ func (p *Platform) handleComponentInteraction(s *discordgo.Session, i *discordgo
 	if i.Message != nil {
 		rc.messageID = i.Message.ID
 	}
-	p.handler(p, &core.Message{
+	p.dispatchMessage(&core.Message{
 		SessionKey: sessionKey,
 		Platform:   "discord",
 		MessageID:  i.ID,
@@ -952,6 +1008,8 @@ func (p *Platform) SendWithButtons(ctx context.Context, rctx any, content string
 var _ core.ImageSender = (*Platform)(nil)
 var _ core.FileSender = (*Platform)(nil)
 var _ core.InlineButtonSender = (*Platform)(nil)
+var _ core.ProgressStyleProvider = (*progressPlatform)(nil)
+var _ core.ProgressCardPayloadSupport = (*progressPlatform)(nil)
 
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 	// discord:{channelID}:{userID} or discord:{threadID}
@@ -995,10 +1053,8 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 		return nil, fmt.Errorf("discord: invalid reply context type %T", rctx)
 	}
 
-	if len(content) > maxDiscordLen {
-		content = content[:maxDiscordLen]
-	}
-	sent, err := p.session.ChannelMessageSend(channelID, content)
+	msg := buildDiscordPreviewMessage(content)
+	sent, err := p.session.ChannelMessageSendComplex(channelID, msg)
 	if err != nil {
 		return nil, fmt.Errorf("discord: send preview: %w", err)
 	}
@@ -1011,10 +1067,7 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 	if !ok {
 		return fmt.Errorf("discord: invalid preview handle type %T", previewHandle)
 	}
-	if len(content) > maxDiscordLen {
-		content = content[:maxDiscordLen]
-	}
-	_, err := p.session.ChannelMessageEdit(h.channelID, h.messageID, content)
+	_, err := p.session.ChannelMessageEditComplex(buildDiscordPreviewEdit(h.channelID, h.messageID, content))
 	if err != nil {
 		return fmt.Errorf("discord: edit message: %w", err)
 	}

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -23,6 +24,32 @@ type fakeThreadOps struct {
 	startThread           func(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error)
 	startStandaloneThread func(channelID, name string, typ discordgo.ChannelType, archiveDuration int) (*discordgo.Channel, error)
 	joinThread            func(threadID string) error
+}
+
+func newTestDiscordSession(t *testing.T, server *httptest.Server) *discordgo.Session {
+	t.Helper()
+
+	oldEndpointDiscord := discordgo.EndpointDiscord
+	oldEndpointAPI := discordgo.EndpointAPI
+	oldEndpointChannels := discordgo.EndpointChannels
+	oldEndpointWebhooks := discordgo.EndpointWebhooks
+	discordgo.EndpointDiscord = server.URL + "/"
+	discordgo.EndpointAPI = discordgo.EndpointDiscord + "api/v" + discordgo.APIVersion + "/"
+	discordgo.EndpointChannels = discordgo.EndpointAPI + "channels/"
+	discordgo.EndpointWebhooks = discordgo.EndpointAPI + "webhooks/"
+	t.Cleanup(func() {
+		discordgo.EndpointDiscord = oldEndpointDiscord
+		discordgo.EndpointAPI = oldEndpointAPI
+		discordgo.EndpointChannels = oldEndpointChannels
+		discordgo.EndpointWebhooks = oldEndpointWebhooks
+	})
+
+	s, err := discordgo.New("Bot test-token")
+	if err != nil {
+		t.Fatalf("discordgo.New() error = %v", err)
+	}
+	s.Client = server.Client()
+	return s
 }
 
 func (f fakeThreadOps) ResolveChannel(channelID string) (*discordgo.Channel, error) {
@@ -473,6 +500,366 @@ func TestSendFile_UsesInteractionEndpoints(t *testing.T) {
 	}
 	if len(requests) != 1 || !strings.Contains(requests[0], "/messages/@original") {
 		t.Fatalf("requests = %v, want one original interaction edit", requests)
+	}
+}
+
+func TestNew_ProgressStyleSupportsCompactAndCard(t *testing.T) {
+	tests := []struct {
+		style       string
+		wantPayload bool
+	}{
+		{style: "compact", wantPayload: false},
+		{style: "card", wantPayload: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.style, func(t *testing.T) {
+			pAny, err := New(map[string]any{
+				"token":          "discord-token",
+				"progress_style": tt.style,
+			})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			sp, ok := pAny.(core.ProgressStyleProvider)
+			if !ok {
+				t.Fatalf("platform type %T does not implement ProgressStyleProvider", pAny)
+			}
+			if got := sp.ProgressStyle(); got != tt.style {
+				t.Fatalf("ProgressStyle() = %q, want %q", got, tt.style)
+			}
+
+			payloadCap, ok := pAny.(core.ProgressCardPayloadSupport)
+			if !ok {
+				t.Fatalf("platform type %T does not implement ProgressCardPayloadSupport", pAny)
+			}
+			if got := payloadCap.SupportsProgressCardPayload(); got != tt.wantPayload {
+				t.Fatalf("SupportsProgressCardPayload() = %v, want %v", got, tt.wantPayload)
+			}
+		})
+	}
+}
+
+func TestNew_ProgressStyleRejectsInvalidValue(t *testing.T) {
+	_, err := New(map[string]any{
+		"token":          "discord-token",
+		"progress_style": "invalid-style",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid progress_style")
+	}
+	if !strings.Contains(err.Error(), "invalid progress_style") {
+		t.Fatalf("error = %q, want invalid progress_style", err.Error())
+	}
+}
+
+func TestNew_LegacyProgressStyleDoesNotEnableProgressInterfaces(t *testing.T) {
+	pAny, err := New(map[string]any{
+		"token": "discord-token",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if _, ok := pAny.(core.ProgressStyleProvider); ok {
+		t.Fatalf("legacy discord platform should not implement ProgressStyleProvider, got %T", pAny)
+	}
+	if _, ok := pAny.(core.ProgressCardPayloadSupport); ok {
+		t.Fatalf("legacy discord platform should not implement ProgressCardPayloadSupport, got %T", pAny)
+	}
+}
+
+func TestDispatchMessage_UsesWrappedProgressPlatformForHandler(t *testing.T) {
+	pAny, err := New(map[string]any{
+		"token":          "discord-token",
+		"progress_style": "card",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	pp, ok := pAny.(*progressPlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *progressPlatform", pAny)
+	}
+
+	var got core.Platform
+	pp.Platform.handler = func(p core.Platform, msg *core.Message) {
+		got = p
+	}
+
+	pp.Platform.dispatchMessage(&core.Message{SessionKey: "discord:ch-1"})
+
+	if got == nil {
+		t.Fatal("handler platform = nil, want wrapped platform")
+	}
+	if got != pp {
+		t.Fatalf("handler platform = %T, want wrapped %T", got, pp)
+	}
+	sp, ok := got.(core.ProgressStyleProvider)
+	if !ok {
+		t.Fatalf("handler platform type %T does not implement ProgressStyleProvider", got)
+	}
+	if gotStyle := sp.ProgressStyle(); gotStyle != "card" {
+		t.Fatalf("ProgressStyle() = %q, want card", gotStyle)
+	}
+}
+
+func TestDispatchMessage_LegacyPlatformFallsBackToBasePlatform(t *testing.T) {
+	pAny, err := New(map[string]any{
+		"token": "discord-token",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	p, ok := pAny.(*Platform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *Platform", pAny)
+	}
+
+	var got core.Platform
+	p.handler = func(platform core.Platform, msg *core.Message) {
+		got = platform
+	}
+
+	p.dispatchMessage(&core.Message{SessionKey: "discord:ch-1"})
+
+	if got != p {
+		t.Fatalf("handler platform = %T, want base %T", got, p)
+	}
+	if _, ok := got.(core.ProgressStyleProvider); ok {
+		t.Fatalf("legacy handler platform should not implement ProgressStyleProvider, got %T", got)
+	}
+}
+
+func TestSendPreviewStart_ProgressPayloadUsesEmbed(t *testing.T) {
+	var (
+		requestPath string
+		rawBody     string
+		payload     map[string]any
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		rawBody = string(body)
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg-preview","channel_id":"ch-1"}`)
+	}))
+	defer server.Close()
+
+	s := newTestDiscordSession(t, server)
+	p := &Platform{session: s, progressStyle: "card"}
+
+	progress := core.BuildProgressCardPayloadV2([]core.ProgressCardEntry{
+		{Kind: core.ProgressEntryThinking, Text: "planning"},
+		{Kind: core.ProgressEntryToolUse, Tool: "Bash", Text: "pwd"},
+	}, false, "Codex", core.LangEnglish, core.ProgressCardStateRunning)
+	if progress == "" {
+		t.Fatal("BuildProgressCardPayloadV2() returned empty payload")
+	}
+
+	handleAny, err := p.SendPreviewStart(context.Background(), replyContext{channelID: "ch-1"}, progress)
+	if err != nil {
+		t.Fatalf("SendPreviewStart() error = %v", err)
+	}
+	handle, ok := handleAny.(*discordPreviewHandle)
+	if !ok {
+		t.Fatalf("preview handle type = %T, want *discordPreviewHandle", handleAny)
+	}
+	if handle.channelID != "ch-1" || handle.messageID != "msg-preview" {
+		t.Fatalf("preview handle = %#v, want channel/message IDs", handle)
+	}
+	if requestPath != "/api/v"+discordgo.APIVersion+"/channels/ch-1/messages" {
+		t.Fatalf("requestPath = %q, want channel message create path", requestPath)
+	}
+	if strings.Contains(rawBody, core.ProgressCardPayloadPrefix) {
+		t.Fatalf("request body should not leak payload prefix, got %q", rawBody)
+	}
+	embeds, ok := payload["embeds"].([]any)
+	if !ok || len(embeds) != 1 {
+		t.Fatalf("embeds = %#v, want one embed", payload["embeds"])
+	}
+	embed, ok := embeds[0].(map[string]any)
+	if !ok {
+		t.Fatalf("embed = %#v, want object", embeds[0])
+	}
+	if embed["title"] != "Codex · Processing" {
+		t.Fatalf("embed title = %#v, want Codex · Processing", embed["title"])
+	}
+	desc, _ := embed["description"].(string)
+	if !strings.Contains(desc, "💭 planning") {
+		t.Fatalf("embed description = %q, want thinking line", desc)
+	}
+	if !strings.Contains(desc, "🔧 Bash — pwd") {
+		t.Fatalf("embed description = %q, want tool line", desc)
+	}
+	if _, exists := payload["content"]; exists {
+		t.Fatalf("content = %#v, want omitted for embed preview send", payload["content"])
+	}
+}
+
+func TestSendPreviewStart_CompactStyleUsesPlainText(t *testing.T) {
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg-preview","channel_id":"ch-1"}`)
+	}))
+	defer server.Close()
+
+	pAny, err := New(map[string]any{
+		"token":          "discord-token",
+		"progress_style": "compact",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	starter, ok := pAny.(core.PreviewStarter)
+	if !ok {
+		t.Fatalf("platform type %T does not implement PreviewStarter", pAny)
+	}
+
+	pp, ok := pAny.(*progressPlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *progressPlatform", pAny)
+	}
+	pp.session = newTestDiscordSession(t, server)
+
+	handleAny, err := starter.SendPreviewStart(context.Background(), replyContext{channelID: "ch-1"}, "compact preview")
+	if err != nil {
+		t.Fatalf("SendPreviewStart() error = %v", err)
+	}
+	if _, ok := handleAny.(*discordPreviewHandle); !ok {
+		t.Fatalf("preview handle type = %T, want *discordPreviewHandle", handleAny)
+	}
+	if got, _ := payload["content"].(string); got != "compact preview" {
+		t.Fatalf("content = %q, want compact preview", got)
+	}
+	if embeds, exists := payload["embeds"]; exists && embeds != nil {
+		t.Fatalf("embeds = %#v, want omitted or null for compact text preview", embeds)
+	}
+}
+
+func TestUpdateMessage_ProgressPayloadUsesEmbed(t *testing.T) {
+	var (
+		requestPath string
+		payload     map[string]any
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg-preview","channel_id":"ch-1"}`)
+	}))
+	defer server.Close()
+
+	s := newTestDiscordSession(t, server)
+	p := &Platform{session: s, progressStyle: "card"}
+
+	exitCode := 0
+	progress := core.BuildProgressCardPayloadV2([]core.ProgressCardEntry{
+		{Kind: core.ProgressEntryToolResult, Tool: "Bash", Text: "hi", Status: "completed", ExitCode: &exitCode},
+	}, false, "Codex", core.LangEnglish, core.ProgressCardStateCompleted)
+	if progress == "" {
+		t.Fatal("BuildProgressCardPayloadV2() returned empty payload")
+	}
+
+	err := p.UpdateMessage(context.Background(), &discordPreviewHandle{channelID: "ch-1", messageID: "msg-preview"}, progress)
+	if err != nil {
+		t.Fatalf("UpdateMessage() error = %v", err)
+	}
+	if requestPath != "/api/v"+discordgo.APIVersion+"/channels/ch-1/messages/msg-preview" {
+		t.Fatalf("requestPath = %q, want channel message edit path", requestPath)
+	}
+	if got, _ := payload["content"].(string); got != "" {
+		t.Fatalf("content = %q, want explicit empty string to clear text content", got)
+	}
+	embeds, ok := payload["embeds"].([]any)
+	if !ok || len(embeds) != 1 {
+		t.Fatalf("embeds = %#v, want one embed", payload["embeds"])
+	}
+	embed, ok := embeds[0].(map[string]any)
+	if !ok {
+		t.Fatalf("embed = %#v, want object", embeds[0])
+	}
+	if embed["title"] != "Codex · Completed" {
+		t.Fatalf("embed title = %#v, want Codex · Completed", embed["title"])
+	}
+	desc, _ := embed["description"].(string)
+	if !strings.Contains(desc, "🧾 Bash — completed · exit 0 · hi") {
+		t.Fatalf("embed description = %q, want completed tool result", desc)
+	}
+	footer, ok := embed["footer"].(map[string]any)
+	if !ok || footer["text"] == nil {
+		t.Fatalf("footer = %#v, want footer text", embed["footer"])
+	}
+	if !strings.Contains(footer["text"].(string), "Full response is in the next message.") {
+		t.Fatalf("footer text = %q, want completion note", footer["text"].(string))
+	}
+}
+
+func TestBuildDiscordProgressEmbed_ShowsTruncatedNotice(t *testing.T) {
+	payload := &core.ProgressCardPayload{
+		Agent:     "Codex",
+		Lang:      string(core.LangEnglish),
+		State:     core.ProgressCardStateRunning,
+		Truncated: true,
+		Items: []core.ProgressCardEntry{
+			{Kind: core.ProgressEntryThinking, Text: "reviewing repository state"},
+		},
+	}
+
+	embed := buildDiscordProgressEmbed(payload)
+	if embed == nil {
+		t.Fatal("buildDiscordProgressEmbed() returned nil")
+	}
+	if !strings.Contains(embed.Description, "Showing latest updates only.") {
+		t.Fatalf("embed description = %q, want truncated notice", embed.Description)
+	}
+	if !strings.Contains(embed.Description, "💭 reviewing repository state") {
+		t.Fatalf("embed description = %q, want progress line", embed.Description)
+	}
+}
+
+func TestUpdateMessage_PlainTextClearsEmbeds(t *testing.T) {
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg-preview","channel_id":"ch-1"}`)
+	}))
+	defer server.Close()
+
+	s := newTestDiscordSession(t, server)
+	p := &Platform{session: s}
+
+	err := p.UpdateMessage(context.Background(), &discordPreviewHandle{channelID: "ch-1", messageID: "msg-preview"}, "plain preview")
+	if err != nil {
+		t.Fatalf("UpdateMessage() error = %v", err)
+	}
+	if got, _ := payload["content"].(string); got != "plain preview" {
+		t.Fatalf("content = %q, want plain preview", got)
+	}
+	embeds, ok := payload["embeds"].([]any)
+	if !ok {
+		t.Fatalf("embeds = %#v, want explicit empty embeds array", payload["embeds"])
+	}
+	if len(embeds) != 0 {
+		t.Fatalf("embeds = %#v, want empty embeds array", embeds)
 	}
 }
 

--- a/platform/discord/progress.go
+++ b/platform/discord/progress.go
@@ -1,0 +1,377 @@
+package discord
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/chenhg5/cc-connect/core"
+)
+
+const (
+	maxDiscordEmbedTitleLen     = 256
+	maxDiscordProgressDescLen   = 3500
+	maxDiscordProgressLineLen   = 220
+	maxDiscordProgressFooterLen = 512
+)
+
+func buildDiscordPreviewMessage(content string) *discordgo.MessageSend {
+	if payload, ok := core.ParseProgressCardPayload(content); ok {
+		return &discordgo.MessageSend{
+			Embeds: []*discordgo.MessageEmbed{buildDiscordProgressEmbed(payload)},
+		}
+	}
+	return &discordgo.MessageSend{
+		Content: trimDiscordRunes(content, maxDiscordLen),
+	}
+}
+
+func buildDiscordPreviewEdit(channelID, messageID, content string) *discordgo.MessageEdit {
+	edit := discordgo.NewMessageEdit(channelID, messageID)
+	if payload, ok := core.ParseProgressCardPayload(content); ok {
+		edit.SetContent("")
+		edit.SetEmbeds([]*discordgo.MessageEmbed{buildDiscordProgressEmbed(payload)})
+		return edit
+	}
+	edit.SetContent(trimDiscordRunes(content, maxDiscordLen))
+	edit.SetEmbeds([]*discordgo.MessageEmbed{})
+	return edit
+}
+
+func buildDiscordProgressEmbed(payload *core.ProgressCardPayload) *discordgo.MessageEmbed {
+	if payload == nil {
+		return &discordgo.MessageEmbed{Description: " "}
+	}
+	agent := discordProgressAgentLabel(payload.Agent)
+	title, color, footer := discordProgressStateMeta(payload.State, payload.Lang, agent)
+	embed := &discordgo.MessageEmbed{
+		Title:       trimDiscordRunes(title, maxDiscordEmbedTitleLen),
+		Description: buildDiscordProgressDescription(payload),
+		Color:       color,
+	}
+	if footer = strings.TrimSpace(footer); footer != "" {
+		embed.Footer = &discordgo.MessageEmbedFooter{
+			Text: trimDiscordRunes(footer, maxDiscordProgressFooterLen),
+		}
+	}
+	return embed
+}
+
+func buildDiscordProgressDescription(payload *core.ProgressCardPayload) string {
+	if payload == nil {
+		return " "
+	}
+	items := discordProgressItems(payload)
+	lines := make([]string, 0, len(items)+1)
+	if payload.Truncated {
+		lines = append(lines, "ℹ️ "+discordProgressLatestOnlyText(payload.Lang))
+	}
+	for _, item := range items {
+		if line := buildDiscordProgressLine(item, payload.Lang); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	desc := strings.Join(lines, "\n")
+	desc = trimDiscordRunes(desc, maxDiscordProgressDescLen)
+	if strings.TrimSpace(desc) == "" {
+		return " "
+	}
+	return desc
+}
+
+func discordProgressItems(payload *core.ProgressCardPayload) []core.ProgressCardEntry {
+	if payload == nil {
+		return nil
+	}
+	if len(payload.Items) > 0 {
+		return payload.Items
+	}
+	out := make([]core.ProgressCardEntry, 0, len(payload.Entries))
+	for _, entry := range payload.Entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		out = append(out, core.ProgressCardEntry{
+			Kind: core.ProgressEntryInfo,
+			Text: entry,
+		})
+	}
+	return out
+}
+
+func buildDiscordProgressLine(item core.ProgressCardEntry, lang string) string {
+	text := compactDiscordProgressText(item.Text)
+	switch item.Kind {
+	case core.ProgressEntryThinking:
+		return "💭 " + trimDiscordRunes(text, maxDiscordProgressLineLen-2)
+	case core.ProgressEntryToolUse:
+		return "🔧 " + trimDiscordRunes(buildDiscordToolUseSummary(item, lang), maxDiscordProgressLineLen-2)
+	case core.ProgressEntryToolResult:
+		return "🧾 " + trimDiscordRunes(buildDiscordToolResultSummary(item, lang), maxDiscordProgressLineLen-2)
+	case core.ProgressEntryError:
+		return "❌ " + trimDiscordRunes(text, maxDiscordProgressLineLen-2)
+	default:
+		return "• " + trimDiscordRunes(text, maxDiscordProgressLineLen-2)
+	}
+}
+
+func buildDiscordToolUseSummary(item core.ProgressCardEntry, lang string) string {
+	toolName := strings.TrimSpace(item.Tool)
+	if toolName == "" {
+		toolName = discordProgressToolLabel(lang)
+	}
+	text := compactDiscordProgressText(item.Text)
+	if text == "" {
+		return toolName
+	}
+	return toolName + " — " + text
+}
+
+func buildDiscordToolResultSummary(item core.ProgressCardEntry, lang string) string {
+	toolName := strings.TrimSpace(item.Tool)
+	text := compactDiscordProgressText(item.Text)
+	meta := make([]string, 0, 3)
+
+	if status := discordProgressStatusText(item, lang); status != "" {
+		meta = append(meta, status)
+	}
+	if item.ExitCode != nil {
+		meta = append(meta, fmt.Sprintf("exit %d", *item.ExitCode))
+	}
+	if text != "" {
+		duplicate := false
+		for _, part := range meta {
+			if strings.EqualFold(part, text) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			meta = append(meta, text)
+		}
+	}
+	if len(meta) == 0 {
+		meta = append(meta, discordProgressNoOutputText(lang))
+	}
+	if toolName == "" {
+		return strings.Join(meta, " · ")
+	}
+	return toolName + " — " + strings.Join(meta, " · ")
+}
+
+func discordProgressStateMeta(state core.ProgressCardState, lang string, agent string) (title string, color int, footer string) {
+	switch state {
+	case core.ProgressCardStateCompleted:
+		return fmt.Sprintf("%s · %s", agent, discordProgressCompletedText(lang)), 0x57F287, discordProgressCompletedFooter(lang)
+	case core.ProgressCardStateFailed:
+		return fmt.Sprintf("%s · %s", agent, discordProgressFailedText(lang)), 0xED4245, discordProgressFailedFooter(lang)
+	default:
+		return fmt.Sprintf("%s · %s", agent, discordProgressRunningText(lang)), 0x5865F2, ""
+	}
+}
+
+func discordProgressAgentLabel(agent string) string {
+	agent = strings.TrimSpace(agent)
+	if agent == "" {
+		return "Agent"
+	}
+	return agent
+}
+
+func discordProgressRunningText(lang string) string {
+	switch normalizeDiscordProgressLang(lang) {
+	case "zh":
+		return "处理中"
+	case "zh-tw":
+		return "處理中"
+	case "ja":
+		return "処理中"
+	case "es":
+		return "Procesando"
+	default:
+		return "Processing"
+	}
+}
+
+func discordProgressCompletedText(lang string) string {
+	switch normalizeDiscordProgressLang(lang) {
+	case "zh":
+		return "已完成"
+	case "zh-tw":
+		return "已完成"
+	case "ja":
+		return "完了"
+	case "es":
+		return "Completado"
+	default:
+		return "Completed"
+	}
+}
+
+func discordProgressFailedText(lang string) string {
+	switch normalizeDiscordProgressLang(lang) {
+	case "zh":
+		return "失败"
+	case "zh-tw":
+		return "失敗"
+	case "ja":
+		return "失敗"
+	case "es":
+		return "Fallido"
+	default:
+		return "Failed"
+	}
+}
+
+func discordProgressCompletedFooter(lang string) string {
+	switch normalizeDiscordProgressLang(lang) {
+	case "zh":
+		return "本进度卡已停止更新，完整答复见下一条消息。"
+	case "zh-tw":
+		return "本進度卡已停止更新，完整答覆見下一條訊息。"
+	case "ja":
+		return "この進捗カードの更新は終了しました。完全な回答は次のメッセージにあります。"
+	case "es":
+		return "Esta tarjeta de progreso ya no se actualiza. La respuesta completa está en el siguiente mensaje."
+	default:
+		return "This progress card is no longer updating. Full response is in the next message."
+	}
+}
+
+func discordProgressFailedFooter(lang string) string {
+	switch normalizeDiscordProgressLang(lang) {
+	case "zh":
+		return "本进度卡已停止更新（失败），请查看下一条消息中的错误详情。"
+	case "zh-tw":
+		return "本進度卡已停止更新（失敗），請查看下一條訊息中的錯誤詳情。"
+	case "ja":
+		return "この進捗カードは失敗で停止しました。詳細は次のメッセージを確認してください。"
+	case "es":
+		return "Esta tarjeta de progreso se detuvo por error. Consulta el siguiente mensaje para ver los detalles."
+	default:
+		return "This progress card has stopped (failed). See the next message for details."
+	}
+}
+
+func discordProgressLatestOnlyText(lang string) string {
+	switch normalizeDiscordProgressLang(lang) {
+	case "zh":
+		return "仅显示最近更新。"
+	case "zh-tw":
+		return "僅顯示最近更新。"
+	case "ja":
+		return "最新の更新のみ表示しています。"
+	case "es":
+		return "Mostrando solo las actualizaciones más recientes."
+	default:
+		return "Showing latest updates only."
+	}
+}
+
+func discordProgressNoOutputText(lang string) string {
+	switch normalizeDiscordProgressLang(lang) {
+	case "zh":
+		return "无输出"
+	case "zh-tw":
+		return "無輸出"
+	case "ja":
+		return "出力なし"
+	case "es":
+		return "Sin salida"
+	default:
+		return "No output"
+	}
+}
+
+func discordProgressToolLabel(lang string) string {
+	switch normalizeDiscordProgressLang(lang) {
+	case "zh":
+		return "工具"
+	case "zh-tw":
+		return "工具"
+	case "ja":
+		return "ツール"
+	case "es":
+		return "Herramienta"
+	default:
+		return "Tool"
+	}
+}
+
+func discordProgressOKText(lang string) string {
+	switch normalizeDiscordProgressLang(lang) {
+	case "zh":
+		return "成功"
+	case "zh-tw":
+		return "成功"
+	case "ja":
+		return "成功"
+	case "es":
+		return "ok"
+	default:
+		return "ok"
+	}
+}
+
+func discordProgressStatusText(item core.ProgressCardEntry, lang string) string {
+	status := strings.ToLower(strings.TrimSpace(item.Status))
+	switch status {
+	case "completed", "complete", "success", "succeeded", "ok":
+		if status == "completed" || status == "complete" {
+			return strings.ToLower(discordProgressCompletedText(lang))
+		}
+		return discordProgressOKText(lang)
+	case "failed", "failure", "error":
+		return strings.ToLower(discordProgressFailedText(lang))
+	}
+	if item.Success != nil {
+		if *item.Success {
+			return discordProgressOKText(lang)
+		}
+		return strings.ToLower(discordProgressFailedText(lang))
+	}
+	return strings.TrimSpace(item.Status)
+}
+
+func normalizeDiscordProgressLang(lang string) string {
+	l := strings.ToLower(strings.TrimSpace(lang))
+	switch {
+	case l == "zh-tw" || l == "zh-hk":
+		return "zh-tw"
+	case strings.HasPrefix(l, "zh"):
+		return "zh"
+	case strings.HasPrefix(l, "ja"):
+		return "ja"
+	case strings.HasPrefix(l, "es"):
+		return "es"
+	default:
+		return "en"
+	}
+}
+
+func compactDiscordProgressText(s string) string {
+	s = strings.ReplaceAll(strings.TrimSpace(s), "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func trimDiscordRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	rs := []rune(s)
+	if maxRunes == 1 {
+		return string(rs[:1])
+	}
+	return string(rs[:maxRunes-1]) + "…"
+}


### PR DESCRIPTION
## Summary

Add Discord progress-style support for `legacy | compact | card`.

This PR introduces Discord-native progress card rendering using editable embeds,
while keeping the final answer as a normal follow-up message.

## Changes

- parse `progress_style` in Discord platform config
- support `compact` and `card` progress modes
- render structured progress payloads as Discord embeds
- use `ChannelMessageSendComplex` / `ChannelMessageEditComplex` for preview send/edit
- fix wrapper identity loss in Discord callbacks so progress capabilities are preserved at runtime
- add regression tests for:
  - progress style parsing
  - payload send/update behavior
  - wrapper dispatch identity
- update docs:
  - `docs/discord.md`
  - `config.example.toml`

## Validation

- `nix shell nixpkgs#go_1_25 -c go test ./platform/discord ./core`
- `nix shell nixpkgs#go_1_25 -c go test ./...`

## Runtime verification

Verified after local install/restart that Discord logs show:

- `progress writer enabled`
- `platform=discord`
- `style=card`
- `use_payload=true`

and the card-style progress flow is active in Discord.
