### PR TITLE
fix(feishu): add transient network retry for message send operations

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -1142,22 +1146,24 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 	}
 
 	var uploadResp *larkim.CreateImageResp
-	if err := p.withFreshTenantAccessTokenRetry(ctx, "upload image", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
-		req := larkim.NewCreateImageReqBuilder().
-			Body(larkim.NewCreateImageReqBodyBuilder().
-				ImageType("message").
-				Image(bytes.NewReader(img.Data)).
-				Build()).
-			Build()
-		var err error
-		uploadResp, err = client.Im.Image.Create(ctx, req, options...)
-		if err != nil {
-			return fmt.Errorf("%s: upload image: %w", p.tag(), err)
-		}
-		if !uploadResp.Success() {
-			return fmt.Errorf("%s: upload image code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
-		}
-		return nil
+	if err := p.withTransientRetry(ctx, "upload image", func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, "upload image", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			req := larkim.NewCreateImageReqBuilder().
+				Body(larkim.NewCreateImageReqBodyBuilder().
+					ImageType("message").
+					Image(bytes.NewReader(img.Data)).
+					Build()).
+				Build()
+			var err error
+			uploadResp, err = client.Im.Image.Create(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: upload image: %w", p.tag(), err)
+			}
+			if !uploadResp.Success() {
+				return fmt.Errorf("%s: upload image code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+			}
+			return nil
+		})
 	}); err != nil {
 		return err
 	}
@@ -1185,23 +1191,25 @@ func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachm
 	}
 	fileType := detectFeishuFileType(file.MimeType, fileName)
 	var uploadResp *larkim.CreateFileResp
-	if err := p.withFreshTenantAccessTokenRetry(ctx, "upload file", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
-		req := larkim.NewCreateFileReqBuilder().
-			Body(larkim.NewCreateFileReqBodyBuilder().
-				FileType(fileType).
-				FileName(fileName).
-				File(bytes.NewReader(file.Data)).
-				Build()).
-			Build()
-		var err error
-		uploadResp, err = client.Im.File.Create(ctx, req, options...)
-		if err != nil {
-			return fmt.Errorf("%s: upload file: %w", p.tag(), err)
-		}
-		if !uploadResp.Success() {
-			return fmt.Errorf("%s: upload file code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
-		}
-		return nil
+	if err := p.withTransientRetry(ctx, "upload file", func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, "upload file", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			req := larkim.NewCreateFileReqBuilder().
+				Body(larkim.NewCreateFileReqBodyBuilder().
+					FileType(fileType).
+					FileName(fileName).
+					File(bytes.NewReader(file.Data)).
+					Build()).
+				Build()
+			var err error
+			uploadResp, err = client.Im.File.Create(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: upload file: %w", p.tag(), err)
+			}
+			if !uploadResp.Success() {
+				return fmt.Errorf("%s: upload file code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+			}
+			return nil
+		})
 	}); err != nil {
 		return err
 	}
@@ -1760,15 +1768,17 @@ func (p *Platform) replyMessage(ctx context.Context, rc replyContext, msgType, c
 		MessageId(rc.messageID).
 		Body(p.buildReplyMessageReqBody(rc, msgType, content)).
 		Build()
-	return p.withFreshTenantAccessTokenRetry(ctx, "reply", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
-		resp, err := client.Im.Message.Reply(ctx, req, options...)
-		if err != nil {
-			return fmt.Errorf("%s: reply api call: %w", p.tag(), err)
-		}
-		if !resp.Success() {
-			return fmt.Errorf("%s: reply failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-		}
-		return nil
+	return p.withTransientRetry(ctx, "reply", func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, "reply", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			resp, err := client.Im.Message.Reply(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: reply api call: %w", p.tag(), err)
+			}
+			if !resp.Success() {
+				return fmt.Errorf("%s: reply failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			}
+			return nil
+		})
 	})
 }
 
@@ -1781,15 +1791,17 @@ func (p *Platform) createMessage(ctx context.Context, chatID, msgType, content, 
 			Content(content).
 			Build()).
 		Build()
-	return p.withFreshTenantAccessTokenRetry(ctx, op, func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
-		resp, err := client.Im.Message.Create(ctx, req, options...)
-		if err != nil {
-			return fmt.Errorf("%s: %s api call: %w", p.tag(), op, err)
-		}
-		if !resp.Success() {
-			return fmt.Errorf("%s: %s failed code=%d msg=%s", p.tag(), op, resp.Code, resp.Msg)
-		}
-		return nil
+	return p.withTransientRetry(ctx, op, func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, op, func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			resp, err := client.Im.Message.Create(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: %s api call: %w", p.tag(), op, err)
+			}
+			if !resp.Success() {
+				return fmt.Errorf("%s: %s failed code=%d msg=%s", p.tag(), op, resp.Code, resp.Msg)
+			}
+			return nil
+		})
 	})
 }
 
@@ -1849,6 +1861,93 @@ func isTenantAccessTokenInvalid(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "99991663") || strings.Contains(msg, "invalid access token")
+}
+
+// Transient retry constants for network-level failures.
+const (
+	maxTransientRetries    = 3
+	transientRetryInitial  = 500 * time.Millisecond
+	transientRetryMaxDelay = 5 * time.Second
+)
+
+// isTransientError returns true if the error is a transient network error
+// that warrants a retry (connection reset, timeout, EOF, etc.).
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Typed syscall checks — more robust than string matching.
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	// net.Error covers timeouts and temporary errors from the stdlib.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	// EOF usually means the server closed the connection mid-response.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	// Unwrapped string checks for common transient symptoms that may
+	// appear in wrapped Feishu SDK errors.
+	msg := err.Error()
+	for _, substr := range []string{
+		"connection reset by peer",
+		"broken pipe",
+		"i/o timeout",
+		"TLS handshake timeout",
+		"server misbehaving",
+		"connection refused",
+	} {
+		if strings.Contains(msg, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// withTransientRetry wraps an operation with exponential-backoff retry on
+// transient network errors. Non-transient errors are returned immediately.
+// Jitter (up to +25% of delay) is added to prevent thundering-herd retries.
+func (p *Platform) withTransientRetry(ctx context.Context, operation string, fn func() error) error {
+	var lastErr error
+	delay := transientRetryInitial
+	for attempt := 0; attempt <= maxTransientRetries; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			if attempt > 0 {
+				slog.Info(p.tag()+": transient retry succeeded",
+					"operation", operation,
+					"attempt", attempt+1,
+				)
+			}
+			return nil
+		}
+		if !isTransientError(lastErr) {
+			return lastErr
+		}
+		if attempt == maxTransientRetries {
+			break
+		}
+		// Add jitter: up to +25% of delay to spread out concurrent retries.
+		jitter := time.Duration(rand.Int64N(int64(delay / 4)))
+		actualDelay := delay + jitter
+		slog.Warn(p.tag()+": transient error, retrying",
+			"operation", operation,
+			"attempt", attempt+1,
+			"max_retries", maxTransientRetries,
+			"delay", actualDelay,
+			"error", lastErr,
+		)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s: %s retry cancelled: %w (last error: %v)", p.tag(), operation, ctx.Err(), lastErr)
+		case <-time.After(actualDelay):
+		}
+		delay = min(delay*2, transientRetryMaxDelay)
+	}
+	return fmt.Errorf("%s failed after %d retries: %w", operation, maxTransientRetries, lastErr)
 }
 
 func stringValue(v *string) string {
@@ -2256,16 +2355,18 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 			Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeInteractive, cardJSON)).
 			Build()
 		var resp *larkim.ReplyMessageResp
-		if err := p.withFreshTenantAccessTokenRetry(ctx, "send preview", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
-			var err error
-			resp, err = client.Im.Message.Reply(ctx, req, options...)
-			if err != nil {
-				return fmt.Errorf("%s: send preview (reply): %w", p.tag(), err)
-			}
-			if !resp.Success() {
-				return fmt.Errorf("%s: send preview (reply) code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-			}
-			return nil
+		if err := p.withTransientRetry(ctx, "send preview", func() error {
+			return p.withFreshTenantAccessTokenRetry(ctx, "send preview", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+				var err error
+				resp, err = client.Im.Message.Reply(ctx, req, options...)
+				if err != nil {
+					return fmt.Errorf("%s: send preview (reply): %w", p.tag(), err)
+				}
+				if !resp.Success() {
+					return fmt.Errorf("%s: send preview (reply) code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+				}
+				return nil
+			})
 		}); err != nil {
 			return nil, err
 		}
@@ -2282,16 +2383,18 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 				Build()).
 			Build()
 		var resp *larkim.CreateMessageResp
-		if err := p.withFreshTenantAccessTokenRetry(ctx, "send preview", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
-			var err error
-			resp, err = client.Im.Message.Create(ctx, req, options...)
-			if err != nil {
-				return fmt.Errorf("%s: send preview: %w", p.tag(), err)
-			}
-			if !resp.Success() {
-				return fmt.Errorf("%s: send preview code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-			}
-			return nil
+		if err := p.withTransientRetry(ctx, "send preview", func() error {
+			return p.withFreshTenantAccessTokenRetry(ctx, "send preview", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+				var err error
+				resp, err = client.Im.Message.Create(ctx, req, options...)
+				if err != nil {
+					return fmt.Errorf("%s: send preview: %w", p.tag(), err)
+				}
+				if !resp.Success() {
+					return fmt.Errorf("%s: send preview code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+				}
+				return nil
+			})
 		}); err != nil {
 			return nil, err
 		}
@@ -2335,15 +2438,17 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 			Content(cardJSON).
 			Build()).
 		Build()
-	return p.withFreshTenantAccessTokenRetry(ctx, "patch message", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
-		resp, err := client.Im.Message.Patch(ctx, req, options...)
-		if err != nil {
-			return fmt.Errorf("%s: patch message: %w", p.tag(), err)
-		}
-		if !resp.Success() {
-			return fmt.Errorf("%s: patch message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-		}
-		return nil
+	return p.withTransientRetry(ctx, "patch message", func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, "patch message", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			resp, err := client.Im.Message.Patch(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: patch message: %w", p.tag(), err)
+			}
+			if !resp.Success() {
+				return fmt.Errorf("%s: patch message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			}
+			return nil
+		})
 	})
 }
 
@@ -2377,15 +2482,17 @@ func (p *Platform) DeletePreviewMessage(ctx context.Context, previewHandle any) 
 	req := larkim.NewDeleteMessageReqBuilder().
 		MessageId(h.messageID).
 		Build()
-	return p.withFreshTenantAccessTokenRetry(ctx, "delete preview message", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
-		resp, err := client.Im.Message.Delete(ctx, req, options...)
-		if err != nil {
-			return fmt.Errorf("%s: delete preview message: %w", p.tag(), err)
-		}
-		if !resp.Success() {
-			return fmt.Errorf("%s: delete preview message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-		}
-		return nil
+	return p.withTransientRetry(ctx, "delete preview message", func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, "delete preview message", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			resp, err := client.Im.Message.Delete(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: delete preview message: %w", p.tag(), err)
+			}
+			if !resp.Success() {
+				return fmt.Errorf("%s: delete preview message code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			}
+			return nil
+		})
 	})
 }
 
@@ -2408,23 +2515,25 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 	}
 
 	var uploadResp *larkim.CreateFileResp
-	if err := p.withFreshTenantAccessTokenRetry(ctx, "upload audio", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
-		req := larkim.NewCreateFileReqBuilder().
-			Body(larkim.NewCreateFileReqBodyBuilder().
-				FileType(larkim.FileTypeOpus).
-				FileName("tts_audio.opus").
-				File(bytes.NewReader(audio)).
-				Build()).
-			Build()
-		var err error
-		uploadResp, err = client.Im.File.Create(ctx, req, options...)
-		if err != nil {
-			return fmt.Errorf("%s: upload audio: %w", p.tag(), err)
-		}
-		if !uploadResp.Success() {
-			return fmt.Errorf("%s: upload audio code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
-		}
-		return nil
+	if err := p.withTransientRetry(ctx, "upload audio", func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, "upload audio", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			req := larkim.NewCreateFileReqBuilder().
+				Body(larkim.NewCreateFileReqBodyBuilder().
+					FileType(larkim.FileTypeOpus).
+					FileName("tts_audio.opus").
+					File(bytes.NewReader(audio)).
+					Build()).
+				Build()
+			var err error
+			uploadResp, err = client.Im.File.Create(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: upload audio: %w", p.tag(), err)
+			}
+			if !uploadResp.Success() {
+				return fmt.Errorf("%s: upload audio code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+			}
+			return nil
+		})
 	}); err != nil {
 		return err
 	}

--- a/platform/feishu/transient_retry_test.go
+++ b/platform/feishu/transient_retry_test.go
@@ -1,0 +1,523 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+)
+
+// ─── isTransientError unit tests ───────────────────────────────────────────
+
+func TestIsTransientError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "connection reset by peer", err: fmt.Errorf("write tcp: connection reset by peer"), want: true},
+		{name: "broken pipe", err: fmt.Errorf("write: broken pipe"), want: true},
+		{name: "i/o timeout", err: fmt.Errorf("dial tcp: i/o timeout"), want: true},
+		{name: "TLS handshake timeout", err: fmt.Errorf("net/http: TLS handshake timeout"), want: true},
+		{name: "connection refused", err: fmt.Errorf("dial tcp 127.0.0.1:443: connection refused"), want: true},
+		{name: "no such host (permanent)", err: fmt.Errorf("dial tcp: lookup example.invalid: no such host"), want: false},
+		{name: "server misbehaving", err: fmt.Errorf("lookup example.com: server misbehaving"), want: true},
+		{name: "EOF", err: io.EOF, want: true},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF, want: true},
+		{name: "wrapped EOF", err: fmt.Errorf("feishu: reply api call: %w", io.EOF), want: true},
+		{name: "syscall ECONNRESET", err: fmt.Errorf("write tcp: %w", syscall.ECONNRESET), want: true},
+		{name: "syscall EPIPE", err: fmt.Errorf("write tcp: %w", syscall.EPIPE), want: true},
+		{name: "rate limited", err: fmt.Errorf("feishu: reply failed code=230001 msg=rate limited"), want: false},
+		{name: "invalid token", err: fmt.Errorf("feishu: reply failed code=99991663"), want: false},
+		{name: "generic error", err: fmt.Errorf("something went wrong"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientError(tt.err); got != tt.want {
+				t.Fatalf("isTransientError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTransientError_NetTimeout(t *testing.T) {
+	err := &net.OpError{Op: "dial", Err: &timeoutError{}}
+	if !isTransientError(err) {
+		t.Fatal("expected net timeout to be transient")
+	}
+}
+
+type timeoutError struct{}
+
+func (e *timeoutError) Error() string   { return "i/o timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }
+
+// ─── withTransientRetry unit tests ─────────────────────────────────────────
+
+func TestWithTransientRetry_SucceedsFirstAttempt(t *testing.T) {
+	p := &Platform{platformName: "feishu"}
+	calls := 0
+	err := p.withTransientRetry(context.Background(), "test", func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+}
+
+func TestWithTransientRetry_RetriesOnTransientThenSucceeds(t *testing.T) {
+	p := &Platform{platformName: "feishu"}
+	calls := 0
+	err := p.withTransientRetry(context.Background(), "test", func() error {
+		calls++
+		if calls <= 2 {
+			return fmt.Errorf("write tcp: connection reset by peer")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3", calls)
+	}
+}
+
+func TestWithTransientRetry_DoesNotRetryNonTransient(t *testing.T) {
+	p := &Platform{platformName: "feishu"}
+	calls := 0
+	err := p.withTransientRetry(context.Background(), "test", func() error {
+		calls++
+		return fmt.Errorf("feishu: reply failed code=230001 msg=rate limited")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (no retry for non-transient errors)", calls)
+	}
+}
+
+func TestWithTransientRetry_GivesUpAfterMaxRetries(t *testing.T) {
+	p := &Platform{platformName: "feishu"}
+	calls := 0
+	err := p.withTransientRetry(context.Background(), "test", func() error {
+		calls++
+		return io.EOF
+	})
+	if err == nil {
+		t.Fatal("expected error after max retries")
+	}
+	// 1 initial + 3 retries = 4 total calls
+	if calls != maxTransientRetries+1 {
+		t.Fatalf("calls = %d, want %d", calls, maxTransientRetries+1)
+	}
+	if !strings.Contains(err.Error(), "failed after") {
+		t.Fatalf("error = %q, want 'failed after' message", err.Error())
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("error should wrap io.EOF, got %v", err)
+	}
+}
+
+func TestWithTransientRetry_RespectsContextCancellation(t *testing.T) {
+	p := &Platform{platformName: "feishu"}
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	// Cancel after first call to trigger cancellation during backoff wait
+	err := p.withTransientRetry(ctx, "test", func() error {
+		calls++
+		if calls == 1 {
+			cancel()
+		}
+		return fmt.Errorf("connection reset by peer")
+	})
+	if err == nil {
+		t.Fatal("expected error on context cancellation")
+	}
+	if !strings.Contains(err.Error(), "retry cancelled") {
+		t.Fatalf("error = %q, want retry cancelled message", err.Error())
+	}
+}
+
+// ─── Integration tests: transient retry with Feishu API ────────────────────
+
+func TestReplyRetriesOnTransientNetworkError(t *testing.T) {
+	const appID = "cli_transient_retry"
+	const appSecret = "secret"
+
+	var replyCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "valid-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/reply"):
+			call := replyCalls.Add(1)
+			if call <= 2 {
+				// Simulate transient error by closing connection abruptly
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					t.Fatalf("response writer does not support hijacking")
+				}
+				conn, _, err := hj.Hijack()
+				if err != nil {
+					t.Fatalf("hijack failed: %v", err)
+				}
+				conn.Close()
+				return
+			}
+			// 3rd call succeeds
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{"message_id": "om_reply_ok"},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		replayClient: lark.NewClient(appID, appSecret,
+			lark.WithEnableTokenCache(false),
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+	}
+
+	err := p.Reply(context.Background(), replyContext{messageID: "om_root", chatID: "oc_chat"}, "hello")
+	if err != nil {
+		t.Fatalf("Reply() error = %v", err)
+	}
+	if got := replyCalls.Load(); got < 3 {
+		t.Fatalf("replyCalls = %d, want >= 3 (initial + retries)", got)
+	}
+}
+
+func TestCreateMessageRetriesOnTransientNetworkError(t *testing.T) {
+	const appID = "cli_transient_create"
+	const appSecret = "secret"
+
+	var createCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "valid-token",
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages":
+			call := createCalls.Add(1)
+			if call == 1 {
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					t.Fatalf("response writer does not support hijacking")
+				}
+				conn, _, err := hj.Hijack()
+				if err != nil {
+					t.Fatalf("hijack failed: %v", err)
+				}
+				conn.Close()
+				return
+			}
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{"message_id": "om_create_ok"},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		replayClient: lark.NewClient(appID, appSecret,
+			lark.WithEnableTokenCache(false),
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+	}
+
+	err := p.sendNewMessageToChat(context.Background(), replyContext{chatID: "oc_chat"}, "text", `{"text":"hello"}`)
+	if err != nil {
+		t.Fatalf("sendNewMessageToChat() error = %v", err)
+	}
+	if got := createCalls.Load(); got < 2 {
+		t.Fatalf("createCalls = %d, want >= 2 (initial + retry)", got)
+	}
+}
+
+func TestReplyDoesNotRetryOnNonTransientAPIError(t *testing.T) {
+	const appID = "cli_no_transient_retry"
+	const appSecret = "secret"
+
+	var replyCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "valid-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/reply"):
+			replyCalls.Add(1)
+			// Return a non-transient API error (rate limit)
+			writeJSON(t, w, map[string]any{
+				"code": 230001,
+				"msg":  "send too fast, please retry later",
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		replayClient: lark.NewClient(appID, appSecret,
+			lark.WithEnableTokenCache(false),
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+	}
+
+	err := p.Reply(context.Background(), replyContext{messageID: "om_root", chatID: "oc_chat"}, "hello")
+	if err == nil {
+		t.Fatal("Reply() error = nil, want failure")
+	}
+	if !strings.Contains(err.Error(), "send too fast") {
+		t.Fatalf("Reply() error = %v, want rate limited error", err)
+	}
+	// Should only make 1 attempt (no retry on API-level errors)
+	if got := replyCalls.Load(); got != 1 {
+		t.Fatalf("replyCalls = %d, want 1 (no retry)", got)
+	}
+}
+
+func TestPatchMessageRetriesOnTransientError(t *testing.T) {
+	const appID = "cli_patch_retry"
+	const appSecret = "secret"
+
+	var patchCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "valid-token",
+			})
+		case strings.Contains(r.URL.Path, "/messages/") && r.Method == http.MethodPatch:
+			call := patchCalls.Add(1)
+			if call == 1 {
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					t.Fatalf("response writer does not support hijacking")
+				}
+				conn, _, err := hj.Hijack()
+				if err != nil {
+					t.Fatalf("hijack failed: %v", err)
+				}
+				conn.Close()
+				return
+			}
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+			})
+		default:
+			// Allow other paths (e.g. token fetch)
+			json.NewEncoder(w).Encode(map[string]any{"code": 0, "msg": "ok"})
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:       "feishu",
+		domain:             srv.URL,
+		appID:              appID,
+		appSecret:          appSecret,
+		useInteractiveCard: true,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		replayClient: lark.NewClient(appID, appSecret,
+			lark.WithEnableTokenCache(false),
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+	}
+
+	err := p.UpdateMessage(context.Background(), &feishuPreviewHandle{messageID: "om_card_1", chatID: "oc_chat"}, "updated content")
+	if err != nil {
+		t.Fatalf("UpdateMessage() error = %v", err)
+	}
+	if got := patchCalls.Load(); got < 2 {
+		t.Fatalf("patchCalls = %d, want >= 2", got)
+	}
+}
+
+// ─── Test: transient retry + token refresh work together ───────────────────
+
+func TestReplyTransientRetryThenTokenRefresh(t *testing.T) {
+	// Scenario: first call gets connection reset (transient), retry gets
+	// invalid token error, which triggers token refresh, then succeeds.
+	const appID = "cli_combined_retry"
+	const appSecret = "secret"
+
+	var authCalls, replyCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			authCalls.Add(1)
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "fresh-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/reply"):
+			call := replyCalls.Add(1)
+			switch call {
+			case 1:
+				// First attempt: transient error
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					t.Fatalf("hijack not supported")
+				}
+				conn, _, _ := hj.Hijack()
+				conn.Close()
+				return
+			case 2:
+				// Second attempt (after transient retry): invalid token
+				writeJSON(t, w, map[string]any{
+					"code": 99991663,
+					"msg":  "Invalid access token for authorization",
+				})
+			case 3:
+				// Third attempt (after token refresh): success
+				writeJSON(t, w, map[string]any{
+					"code": 0,
+					"msg":  "success",
+					"data": map[string]any{"message_id": "om_reply_ok"},
+				})
+			default:
+				t.Fatalf("unexpected reply call %d", call)
+			}
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		replayClient: lark.NewClient(appID, appSecret,
+			lark.WithEnableTokenCache(false),
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+	}
+
+	err := p.Reply(context.Background(), replyContext{messageID: "om_root", chatID: "oc_chat"}, "hello")
+	if err != nil {
+		t.Fatalf("Reply() error = %v", err)
+	}
+	if got := replyCalls.Load(); got != 3 {
+		t.Fatalf("replyCalls = %d, want 3", got)
+	}
+}
+
+// ─── Timing test: verify backoff delay is reasonable ───────────────────────
+
+func TestWithTransientRetry_BackoffTiming(t *testing.T) {
+	p := &Platform{platformName: "feishu"}
+	start := time.Now()
+	calls := 0
+	_ = p.withTransientRetry(context.Background(), "test", func() error {
+		calls++
+		if calls <= 2 {
+			return io.EOF
+		}
+		return nil
+	})
+	elapsed := time.Since(start)
+	// 2 retries: base delays 500ms + 1000ms = ~1500ms, plus up to 25% jitter each.
+	// Allow generous margin for CI environments.
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("elapsed = %v, expected at least 500ms of backoff", elapsed)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("elapsed = %v, backoff took unreasonably long", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `withTransientRetry` wrapper with exponential backoff + jitter (500ms→1s→2s, max 3 retries, +25% jitter) for all Feishu HTTP API calls
- Detect transient network errors via typed syscall checks (`ECONNRESET`, `EPIPE`), `net.Error` timeout, `io.EOF`, and string-matching fallback
- Wrap all 8 Feishu API call sites: reply, create, patch, delete, upload image/file/audio, and preview start

## Problem

When Feishu WebSocket connections experience rapid resets (every 20-40s for ~3 minutes), HTTP API calls for sending messages also fail with transient network errors (`EOF`, `connection reset by peer`, `i/o timeout`). Previously these errors were not retried — only token refresh retry (code 99991663) existed — causing messages to be silently lost with delays of 5-25 minutes.

## Design

- **Layering**: transient retry (outer) wraps token refresh retry (inner), so a transient retry can re-trigger a fresh token acquisition if needed
- **Jitter**: +25% random jitter on each backoff delay to prevent thundering-herd retries from concurrent sessions
- **Non-transient errors** (API error codes, rate limits, validation) are **not** retried — returned immediately

## Test plan

- [x] `TestIsTransientError` — 16 error type subtests including syscall, net.Error, EOF, string matching, and negative cases
- [x] `TestWithTransientRetry_*` — 5 unit tests: success, retry-then-succeed, non-transient passthrough, max retry exhaustion, context cancellation
- [x] `TestReplyRetriesOnTransientNetworkError` — integration test with httptest + connection hijacking
- [x] `TestCreateMessageRetriesOnTransientNetworkError` — integration test
- [x] `TestPatchMessageRetriesOnTransientError` — integration test
- [x] `TestReplyDoesNotRetryOnNonTransientAPIError` — integration test
- [x] `TestReplyTransientRetryThenTokenRefresh` — validates both retry layers working together
- [x] `TestWithTransientRetry_BackoffTiming` — verifies backoff timing is reasonable
- [x] All existing feishu tests still pass
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)