### PR TITLE
fix(acp): add configurable auth timeout to prevent indefinite session blocking

### DIFF
--- a/agent/acp/agent.go
+++ b/agent/acp/agent.go
@@ -8,9 +8,15 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
+
+// defaultAuthTimeout is the maximum time to wait for the authenticate RPC to
+// complete. Device-login flows (e.g. cursor_login) block until the user
+// approves in a browser; without a timeout the session hangs indefinitely.
+const defaultAuthTimeout = 2 * time.Minute
 
 func init() {
 	core.RegisterAgent("acp", New)
@@ -23,14 +29,15 @@ type Agent struct {
 	args        []string
 	extraEnv    []string
 	sessionEnv  []string
-	authMethod  string // optional, e.g. "cursor_login" for Cursor CLI (see authenticate RPC)
-	displayName string // optional, for doctor (default "ACP")
+	authMethod  string        // optional, e.g. "cursor_login" for Cursor CLI (see authenticate RPC)
+	authTimeout time.Duration // max wait for authenticate RPC; 0 = no extra timeout (use session ctx)
+	displayName string        // optional, for doctor (default "ACP")
 	mu          sync.RWMutex
 }
 
 // New builds an acp agent from project options.
 // Required: options["command"] — executable name or path for the ACP agent.
-// Optional: options["args"], options["env"], options["auth_method"], options["display_name"].
+// Optional: options["args"], options["env"], options["auth_method"], options["auth_timeout"], options["display_name"].
 func New(opts map[string]any) (core.Agent, error) {
 	workDir, _ := opts["work_dir"].(string)
 	if workDir == "" {
@@ -49,6 +56,17 @@ func New(opts map[string]any) (core.Agent, error) {
 	extra := envPairsFromOpts(opts)
 	authMethod, _ := opts["auth_method"].(string)
 	authMethod = strings.TrimSpace(authMethod)
+	authTimeout := defaultAuthTimeout
+	if v, ok := opts["auth_timeout"].(string); ok && v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return nil, fmt.Errorf("acp: invalid auth_timeout %q: %w", v, err)
+		}
+		if d < 0 {
+			return nil, fmt.Errorf("acp: auth_timeout must not be negative: %s", v)
+		}
+		authTimeout = d // 0 = no extra timeout (use session context)
+	}
 	displayName, _ := opts["display_name"].(string)
 	displayName = strings.TrimSpace(displayName)
 	if displayName == "" {
@@ -61,6 +79,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		args:        args,
 		extraEnv:    extra,
 		authMethod:  authMethod,
+		authTimeout: authTimeout,
 		displayName: displayName,
 	}, nil
 }
@@ -137,11 +156,12 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	args := a.args
 	workDir := a.workDir
 	authMethod := a.authMethod
+	authTimeout := a.authTimeout
 	extra := append([]string(nil), a.extraEnv...)
 	extra = append(extra, a.sessionEnv...)
 	a.mu.RUnlock()
 
-	return newACPSession(ctx, command, args, extra, workDir, sessionID, authMethod)
+	return newACPSession(ctx, command, args, extra, workDir, sessionID, authMethod, authTimeout)
 }
 
 func (a *Agent) ListSessions(context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/acp/auth_timeout_test.go
+++ b/agent/acp/auth_timeout_test.go
@@ -1,0 +1,378 @@
+package acp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// mockACPServer simulates an ACP agent subprocess over pipes.
+// It reads JSON-RPC requests and writes responses. The authenticate
+// handler can be configured to delay or block.
+type mockACPServer struct {
+	t            *testing.T
+	stdin        io.WriteCloser  // server writes responses here (→ transport reads)
+	stdout       io.ReadCloser   // server reads requests here (← transport writes)
+	authDelay    time.Duration   // how long to delay the authenticate response
+	authErr      bool            // if true, return an error for authenticate
+	initResponse json.RawMessage // custom initialize response
+}
+
+func newMockACPServer(t *testing.T) (
+	serverStdin io.ReadCloser, // transport reads from this
+	serverStdout io.WriteCloser, // transport writes to this
+	srv *mockACPServer,
+) {
+	t.Helper()
+	// Pipe 1: transport writes → server reads
+	trOutR, trOutW := io.Pipe()
+	// Pipe 2: server writes → transport reads
+	srvOutR, srvOutW := io.Pipe()
+
+	srv = &mockACPServer{
+		t:      t,
+		stdin:  srvOutW,
+		stdout: trOutR,
+		initResponse: json.RawMessage(`{
+			"protocolVersion": 1,
+			"agentCapabilities": {"loadSession": false}
+		}`),
+	}
+
+	return srvOutR, trOutW, srv
+}
+
+func (s *mockACPServer) serve(ctx context.Context) {
+	sc := bufio.NewScanner(s.stdout)
+	for sc.Scan() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		var req struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      json.RawMessage `json:"id"`
+			Method  string          `json:"method"`
+			Params  json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(sc.Bytes(), &req); err != nil {
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			s.respond(req.ID, s.initResponse, nil)
+
+		case "authenticate":
+			if s.authDelay > 0 {
+				select {
+				case <-time.After(s.authDelay):
+				case <-ctx.Done():
+					return
+				}
+			}
+			if s.authErr {
+				s.respondErr(req.ID, -32000, "auth failed")
+			} else {
+				s.respond(req.ID, json.RawMessage(`{}`), nil)
+			}
+
+		case "session/new":
+			s.respond(req.ID, json.RawMessage(`{"sessionId":"test-session-1"}`), nil)
+
+		default:
+			s.respond(req.ID, json.RawMessage(`{}`), nil)
+		}
+	}
+}
+
+func (s *mockACPServer) respond(id json.RawMessage, result json.RawMessage, rpcErr *rpcErrPayload) {
+	msg := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+	}
+	if rpcErr != nil {
+		msg["error"] = rpcErr
+	} else {
+		msg["result"] = result
+	}
+	data, _ := json.Marshal(msg)
+	data = append(data, '\n')
+	if _, err := s.stdin.Write(data); err != nil {
+		s.t.Logf("mock server write error: %v", err)
+	}
+}
+
+func (s *mockACPServer) respondErr(id json.RawMessage, code int, message string) {
+	s.respond(id, nil, &rpcErrPayload{Code: code, Message: message})
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+func TestHandshake_AuthenticateSucceedsBeforeTimeout(t *testing.T) {
+	srvIn, trOut, srv := newMockACPServer(t)
+	srv.authDelay = 100 * time.Millisecond // fast auth
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tr := newTransport(srvIn, trOut, nil, nil)
+	go tr.readLoop(ctx)
+	go srv.serve(ctx)
+
+	s := &acpSession{
+		ctx:         ctx,
+		cancel:      cancel,
+		tr:          tr,
+		authTimeout: 5 * time.Second,
+		events:      make(chan core.Event, 128),
+		permByID:    make(map[string]permState),
+	}
+
+	err := s.handshake("", "cursor_login")
+	if err != nil {
+		t.Fatalf("handshake() error = %v, want nil", err)
+	}
+	if s.currentACPSessionID() != "test-session-1" {
+		t.Fatalf("session ID = %q, want test-session-1", s.currentACPSessionID())
+	}
+}
+
+func TestHandshake_AuthenticateTimesOut(t *testing.T) {
+	srvIn, trOut, srv := newMockACPServer(t)
+	srv.authDelay = 10 * time.Second // will exceed timeout
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tr := newTransport(srvIn, trOut, nil, nil)
+	go tr.readLoop(ctx)
+	go srv.serve(ctx)
+
+	s := &acpSession{
+		ctx:         ctx,
+		cancel:      cancel,
+		tr:          tr,
+		authTimeout: 200 * time.Millisecond, // short timeout
+		events:      make(chan core.Event, 128),
+		permByID:    make(map[string]permState),
+	}
+
+	start := time.Now()
+	err := s.handshake("", "cursor_login")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("handshake() error = nil, want timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %q, want 'timed out' message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "cursor_login") {
+		t.Fatalf("error = %q, want auth method in message", err.Error())
+	}
+	// Should fail fast (within ~timeout), not block for 10s
+	if elapsed > 2*time.Second {
+		t.Fatalf("elapsed = %v, handshake should have timed out in ~200ms", elapsed)
+	}
+}
+
+func TestHandshake_NoAuthMethodSkipsAuthenticate(t *testing.T) {
+	srvIn, trOut, srv := newMockACPServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tr := newTransport(srvIn, trOut, nil, nil)
+	go tr.readLoop(ctx)
+	go srv.serve(ctx)
+
+	s := &acpSession{
+		ctx:         ctx,
+		cancel:      cancel,
+		tr:          tr,
+		authTimeout: 5 * time.Second,
+		events:      make(chan core.Event, 128),
+		permByID:    make(map[string]permState),
+	}
+
+	err := s.handshake("", "")
+	if err != nil {
+		t.Fatalf("handshake() error = %v, want nil", err)
+	}
+	if s.currentACPSessionID() != "test-session-1" {
+		t.Fatalf("session ID = %q, want test-session-1", s.currentACPSessionID())
+	}
+}
+
+func TestHandshake_AuthenticateErrorPropagated(t *testing.T) {
+	srvIn, trOut, srv := newMockACPServer(t)
+	srv.authErr = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tr := newTransport(srvIn, trOut, nil, nil)
+	go tr.readLoop(ctx)
+	go srv.serve(ctx)
+
+	s := &acpSession{
+		ctx:         ctx,
+		cancel:      cancel,
+		tr:          tr,
+		authTimeout: 5 * time.Second,
+		events:      make(chan core.Event, 128),
+		permByID:    make(map[string]permState),
+	}
+
+	err := s.handshake("", "cursor_login")
+	if err == nil {
+		t.Fatal("handshake() error = nil, want auth error")
+	}
+	if !strings.Contains(err.Error(), "authenticate") {
+		t.Fatalf("error = %q, want 'authenticate' in message", err.Error())
+	}
+	// Should NOT contain "timed out" — this is a regular auth error
+	if strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %q, should not say timed out for non-timeout errors", err.Error())
+	}
+}
+
+func TestNew_AuthTimeoutDefault(t *testing.T) {
+	a, err := New(map[string]any{
+		"command":     "true",
+		"auth_method": "cursor_login",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent := a.(*Agent)
+	if agent.authTimeout != defaultAuthTimeout {
+		t.Fatalf("authTimeout = %v, want %v", agent.authTimeout, defaultAuthTimeout)
+	}
+}
+
+func TestNew_AuthTimeoutCustom(t *testing.T) {
+	a, err := New(map[string]any{
+		"command":      "true",
+		"auth_method":  "cursor_login",
+		"auth_timeout": "5m",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent := a.(*Agent)
+	if agent.authTimeout != 5*time.Minute {
+		t.Fatalf("authTimeout = %v, want 5m", agent.authTimeout)
+	}
+}
+
+func TestNew_AuthTimeoutInvalid(t *testing.T) {
+	_, err := New(map[string]any{
+		"command":      "true",
+		"auth_timeout": "not-a-duration",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid auth_timeout")
+	}
+	if !strings.Contains(err.Error(), "invalid auth_timeout") {
+		t.Fatalf("error = %q, want 'invalid auth_timeout'", err.Error())
+	}
+}
+
+func TestNew_AuthTimeoutZeroDisablesExtraTimeout(t *testing.T) {
+	a, err := New(map[string]any{
+		"command":      "true",
+		"auth_timeout": "0s",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent := a.(*Agent)
+	if agent.authTimeout != 0 {
+		t.Fatalf("authTimeout = %v, want 0 (no extra timeout)", agent.authTimeout)
+	}
+}
+
+func TestNew_AuthTimeoutNegativeRejected(t *testing.T) {
+	_, err := New(map[string]any{
+		"command":      "true",
+		"auth_timeout": "-5m",
+	})
+	if err == nil {
+		t.Fatal("expected error for negative auth_timeout")
+	}
+	if !strings.Contains(err.Error(), "must not be negative") {
+		t.Fatalf("error = %q, want 'must not be negative'", err.Error())
+	}
+}
+
+func TestHandshake_ZeroAuthTimeoutUsesSessionContext(t *testing.T) {
+	// With authTimeout=0, no additional timeout is applied — uses session ctx directly.
+	srvIn, trOut, srv := newMockACPServer(t)
+	srv.authDelay = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tr := newTransport(srvIn, trOut, nil, nil)
+	go tr.readLoop(ctx)
+	go srv.serve(ctx)
+
+	s := &acpSession{
+		ctx:         ctx,
+		cancel:      cancel,
+		tr:          tr,
+		authTimeout: 0, // no additional timeout
+		events:      make(chan core.Event, 128),
+		permByID:    make(map[string]permState),
+	}
+
+	err := s.handshake("", "cursor_login")
+	if err != nil {
+		t.Fatalf("handshake() error = %v", err)
+	}
+}
+
+// Ensure the timeout error message includes actionable guidance.
+func TestHandshake_TimeoutErrorMessage(t *testing.T) {
+	srvIn, trOut, srv := newMockACPServer(t)
+	srv.authDelay = 10 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tr := newTransport(srvIn, trOut, nil, nil)
+	go tr.readLoop(ctx)
+	go srv.serve(ctx)
+
+	timeout := 100 * time.Millisecond
+	s := &acpSession{
+		ctx:         ctx,
+		cancel:      cancel,
+		tr:          tr,
+		authTimeout: timeout,
+		events:      make(chan core.Event, 128),
+		permByID:    make(map[string]permState),
+	}
+
+	err := s.handshake("", "my_auth")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"my_auth", "timed out", fmt.Sprint(timeout), "authenticate manually"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+}

--- a/agent/acp/cursor_integration_test.go
+++ b/agent/acp/cursor_integration_test.go
@@ -29,7 +29,7 @@ func TestCursorCLI_ACPHandshake(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	s, err := newACPSession(ctx, agentBin, []string{"acp"}, nil, t.TempDir(), "", "cursor_login")
+	s, err := newACPSession(ctx, agentBin, []string{"acp"}, nil, t.TempDir(), "", "cursor_login", defaultAuthTimeout)
 	if err != nil {
 		t.Fatalf("handshake failed (is `agent login` done?): %v", err)
 	}

--- a/agent/acp/session.go
+++ b/agent/acp/session.go
@@ -19,12 +19,13 @@ import (
 )
 
 type acpSession struct {
-	workDir string
-	events  chan core.Event
-	ctx     context.Context
-	cancel  context.CancelFunc
-	wg      sync.WaitGroup
-	alive   atomic.Bool
+	workDir     string
+	authTimeout time.Duration
+	events      chan core.Event
+	ctx         context.Context
+	cancel      context.CancelFunc
+	wg          sync.WaitGroup
+	alive       atomic.Bool
 
 	cmd *exec.Cmd
 	tr  *transport
@@ -51,6 +52,7 @@ func newACPSession(
 	workDir string,
 	resumeSessionID string,
 	authMethod string,
+	authTimeout time.Duration,
 ) (*acpSession, error) {
 	absWorkDir, err := filepath.Abs(workDir)
 	if err != nil {
@@ -59,12 +61,13 @@ func newACPSession(
 
 	sessionCtx, cancel := context.WithCancel(ctx)
 	s := &acpSession{
-		workDir:   absWorkDir,
-		events:    make(chan core.Event, 128),
-		ctx:       sessionCtx,
-		cancel:    cancel,
-		permByID:  make(map[string]permState),
-		acpSessID: resumeSessionID,
+		workDir:     absWorkDir,
+		authTimeout: authTimeout,
+		events:      make(chan core.Event, 128),
+		ctx:         sessionCtx,
+		cancel:      cancel,
+		permByID:    make(map[string]permState),
+		acpSessID:   resumeSessionID,
 	}
 	s.alive.Store(true)
 
@@ -150,12 +153,24 @@ func (s *acpSession) handshake(resumeSessionID string, authMethod string) error 
 	slog.Debug("acp: initialized", "protocol", initOut.ProtocolVersion, "load_session", initOut.AgentCapabilities.LoadSession)
 
 	if strings.TrimSpace(authMethod) != "" {
-		if _, err := s.tr.call(s.ctx, "authenticate", map[string]any{
+		authCtx := s.ctx
+		if s.authTimeout > 0 {
+			var authCancel context.CancelFunc
+			authCtx, authCancel = context.WithTimeout(s.ctx, s.authTimeout)
+			defer authCancel()
+		}
+		slog.Info("acp: authenticating", "method_id", authMethod, "timeout", s.authTimeout)
+		if _, err := s.tr.call(authCtx, "authenticate", map[string]any{
 			"methodId": authMethod,
 		}); err != nil {
+			if authCtx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("acp: authenticate (%s) timed out after %s — "+
+					"the device-login flow did not complete in time; "+
+					"please authenticate manually and retry", authMethod, s.authTimeout)
+			}
 			return fmt.Errorf("acp: authenticate (%s): %w", authMethod, err)
 		}
-		slog.Debug("acp: authenticated", "method_id", authMethod)
+		slog.Info("acp: authenticated", "method_id", authMethod)
 	}
 
 	wantResume := resumeSessionID != "" && resumeSessionID != core.ContinueSession

--- a/config.example.toml
+++ b/config.example.toml
@@ -1184,6 +1184,7 @@ app_secret = "your-feishu-app-secret"
 # command = "agent"
 # args = ["acp"]
 # auth_method = "cursor_login"
+# auth_timeout = "2m"              # max wait for device-login (default: 2m)
 # display_name = "Cursor ACP"
 
 # --- Example: OpenClaw (Gateway-backed ACP bridge) ---


### PR DESCRIPTION
## Summary

- Add configurable `auth_timeout` option to ACP agent (default: 2 minutes)
- Wrap the `authenticate` RPC call with a deadline context to prevent indefinite blocking
- On timeout, return a clear error with actionable guidance instead of hanging forever

## Problem

The ACP `authenticate` RPC call in `handshake()` blocks indefinitely during device-login flows (e.g., `cursor_login`). When the Cursor agent runs `device-login --complete` internally, it waits synchronously for the user to complete browser authorization. In one observed case, this blocked for 11 minutes. The user sees no feedback — the session creation hangs with no events emitted.

## Root Cause

```
06:33 [TOOL:Bash] ahcli ... auth device-login --env dev  (run_in_background: true ✓)
06:33 [BOT]  发送 QHAZ-NCFJ 链接给用户
06:33 [TOOL:Bash] ahcli ... auth device-login --env dev --complete  ← ⚠️ synchronous, blocks 11 min
06:44 [BOT]  No response requested.
```

The `authenticate` RPC in `session.go:handshake()` uses the session context (no timeout), causing `s.tr.call()` to block indefinitely in `select { case out := <-ch: }`.

## Design

- **Timeout context**: When `authTimeout > 0`, wraps the authenticate call with `context.WithTimeout`. On deadline exceeded, returns `"authenticate (cursor_login) timed out after 2m0s — please authenticate manually and retry"`.
- **Configurable**: `auth_timeout = "2m"` (default), `"5m"`, `"30s"`, or `"0s"` (no extra timeout, uses session context).
- **Negative values rejected**: `auth_timeout = "-5m"` returns a config error.
- **Non-timeout errors pass through unchanged**.

## Test plan

- [x] `TestHandshake_AuthenticateSucceedsBeforeTimeout` — auth completes within timeout
- [x] `TestHandshake_AuthenticateTimesOut` — auth exceeds timeout, fails fast (<2s)
- [x] `TestHandshake_NoAuthMethodSkipsAuthenticate` — empty auth method skips auth
- [x] `TestHandshake_AuthenticateErrorPropagated` — non-timeout auth errors preserved
- [x] `TestHandshake_ZeroAuthTimeoutUsesSessionContext` — 0 means no extra timeout
- [x] `TestHandshake_TimeoutErrorMessage` — error includes method, timeout, guidance
- [x] `TestNew_AuthTimeoutDefault` — default is 2 minutes
- [x] `TestNew_AuthTimeoutCustom` — custom "5m" parsed correctly
- [x] `TestNew_AuthTimeoutInvalid` — invalid duration rejected
- [x] `TestNew_AuthTimeoutZeroDisablesExtraTimeout` — "0s" → authTimeout=0
- [x] `TestNew_AuthTimeoutNegativeRejected` — "-5m" → error
- [x] All existing ACP tests still pass (22 total)
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)