### PR TITLE
docs: fix incorrect permission_mode example in multi-workspace config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -439,7 +439,9 @@ level = "info" # debug, info, warn, error
 #
 # [projects.agent]
 # type = "claudecode"
-# permission_mode = "yolo"
+#
+# [projects.agent.options]
+# mode = "yolo"  # "default" | "acceptEdits" (edit) | "plan" | "auto" | "bypassPermissions" (yolo)
 #
 # [[projects.platforms]]
 # type = "slack"


### PR DESCRIPTION
## Summary
- The multi-workspace config example showed `permission_mode = "yolo"` under `[projects.agent]`, but this key doesn't exist in `AgentConfig` and is silently ignored by the TOML parser
- Replace with the correct `[projects.agent.options]` / `mode = "yolo"` that all other agent examples use

## Test plan
- [x] Docs-only change, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)