### PR TITLE
fix(acp): improve vendor compatibility for session/update parsing

### DIFF
--- a/agent/acp/mapping.go
+++ b/agent/acp/mapping.go
@@ -2,6 +2,7 @@ package acp
 
 import (
 	"encoding/json"
+	"log/slog"
 	"strings"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -14,6 +15,7 @@ func mapSessionUpdate(sessionID string, params json.RawMessage) []core.Event {
 		Update    json.RawMessage `json:"update"`
 	}
 	if err := json.Unmarshal(params, &wrap); err != nil || len(wrap.Update) == 0 {
+		slog.Debug("acp: mapSessionUpdate: failed to parse wrap", "error", err, "params", string(params))
 		return nil
 	}
 	sid := wrap.SessionID
@@ -25,6 +27,7 @@ func mapSessionUpdate(sessionID string, params json.RawMessage) []core.Event {
 		SessionUpdate string `json:"sessionUpdate"`
 	}
 	if err := json.Unmarshal(wrap.Update, &head); err != nil {
+		slog.Debug("acp: mapSessionUpdate: failed to parse head", "error", err, "update", string(wrap.Update))
 		return nil
 	}
 
@@ -46,24 +49,69 @@ func mapSessionUpdate(sessionID string, params json.RawMessage) []core.Event {
 	}
 }
 
+// mapAgentMessageChunk handles agent_message_chunk and user_message_chunk updates.
+// It supports multiple JSON formats for broader vendor compatibility:
+// - Standard ACP: {"content": {"type": "text", "text": "..."}}
+// - Alternative: {"content": {"text": "..."}} (type omitted)
+// - Alternative: {"text": "..."} (top-level text field)
+// - Alternative: {"content": "..."} (content as string)
 func mapAgentMessageChunk(sessionID string, update json.RawMessage) []core.Event {
+	// Try standard ACP format first
 	var u struct {
 		Content struct {
 			Type string `json:"type"`
 			Text string `json:"text"`
 		} `json:"content"`
 	}
-	if err := json.Unmarshal(update, &u); err != nil {
-		return nil
+	if err := json.Unmarshal(update, &u); err == nil && u.Content.Text != "" {
+		return []core.Event{{
+			Type:      core.EventText,
+			Content:   u.Content.Text,
+			SessionID: sessionID,
+		}}
 	}
-	if u.Content.Text == "" {
-		return nil
+
+	// Try alternative format: content.text without type field
+	var alt1 struct {
+		Content struct {
+			Text string `json:"text"`
+		} `json:"content"`
 	}
-	return []core.Event{{
-		Type:      core.EventText,
-		Content:   u.Content.Text,
-		SessionID: sessionID,
-	}}
+	if err := json.Unmarshal(update, &alt1); err == nil && alt1.Content.Text != "" {
+		return []core.Event{{
+			Type:      core.EventText,
+			Content:   alt1.Content.Text,
+			SessionID: sessionID,
+		}}
+	}
+
+	// Try alternative format: top-level text field
+	var alt2 struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(update, &alt2); err == nil && alt2.Text != "" {
+		return []core.Event{{
+			Type:      core.EventText,
+			Content:   alt2.Text,
+			SessionID: sessionID,
+		}}
+	}
+
+	// Try alternative format: content as string
+	var alt3 struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(update, &alt3); err == nil && alt3.Content != "" {
+		return []core.Event{{
+			Type:      core.EventText,
+			Content:   alt3.Content,
+			SessionID: sessionID,
+		}}
+	}
+
+	// Log unknown format for debugging
+	slog.Debug("acp: mapAgentMessageChunk: unknown format", "update", string(update))
+	return nil
 }
 
 func mapToolCall(sessionID string, update json.RawMessage) []core.Event {
@@ -202,7 +250,62 @@ func mapSessionUpdateFallback(sessionID string, kind string, update json.RawMess
 			Content:   t,
 			SessionID: sessionID,
 		}}
+	case "message", "message_chunk", "text", "response":
+		// Common vendor extensions for text output
+		var u struct {
+			Content struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			Text    string `json:"text"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(update, &u) != nil {
+			return nil
+		}
+		t := u.Content.Text
+		if t == "" {
+			t = u.Text
+		}
+		if t == "" {
+			t = u.Message
+		}
+		if t == "" {
+			return nil
+		}
+		return []core.Event{{
+			Type:      core.EventText,
+			Content:   t,
+			SessionID: sessionID,
+		}}
+	default:
+		// Last resort: try to extract any text-like field from the JSON
+		var generic struct {
+			Content struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			Text    string `json:"text"`
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(update, &generic); err != nil {
+			return nil
+		}
+		t := generic.Content.Text
+		if t == "" {
+			t = generic.Text
+		}
+		if t == "" {
+			t = generic.Message
+		}
+		if t != "" {
+			slog.Debug("acp: mapSessionUpdateFallback: extracted text from unknown format", "kind", kind, "text_len", len(t))
+			return []core.Event{{
+				Type:      core.EventText,
+				Content:   t,
+				SessionID: sessionID,
+			}}
+		}
 	}
+	slog.Debug("acp: mapSessionUpdateFallback: unrecognized format", "kind", kind, "update", string(update))
 	return nil
 }
 

--- a/agent/acp/mapping_test.go
+++ b/agent/acp/mapping_test.go
@@ -21,6 +21,131 @@ func TestMapSessionUpdate_agentMessageChunk(t *testing.T) {
 	}
 }
 
+func TestMapSessionUpdate_agentMessageChunk_AlternativeFormats(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		want   string
+	}{
+		{
+			name: "standard format with type",
+			params: `{
+				"sessionId": "s1",
+				"update": {
+					"sessionUpdate": "agent_message_chunk",
+					"content": {"type": "text", "text": "hello world"}
+				}
+			}`,
+			want: "hello world",
+		},
+		{
+			name: "content.text without type",
+			params: `{
+				"sessionId": "s1",
+				"update": {
+					"sessionUpdate": "agent_message_chunk",
+					"content": {"text": "alt format 1"}
+				}
+			}`,
+			want: "alt format 1",
+		},
+		{
+			name: "top-level text field",
+			params: `{
+				"sessionId": "s1",
+				"update": {
+					"sessionUpdate": "agent_message_chunk",
+					"text": "alt format 2"
+				}
+			}`,
+			want: "alt format 2",
+		},
+		{
+			name: "content as string",
+			params: `{
+				"sessionId": "s1",
+				"update": {
+					"sessionUpdate": "agent_message_chunk",
+					"content": "alt format 3"
+				}
+			}`,
+			want: "alt format 3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evs := mapSessionUpdate("", json.RawMessage(tt.params))
+			if len(evs) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(evs))
+			}
+			if evs[0].Type != core.EventText {
+				t.Fatalf("expected EventText, got %v", evs[0].Type)
+			}
+			if evs[0].Content != tt.want {
+				t.Fatalf("content = %q, want %q", evs[0].Content, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapSessionUpdate_FallbackTextExtraction(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		want   string
+	}{
+		{
+			name: "message_chunk vendor extension",
+			params: `{
+				"sessionId": "s1",
+				"update": {
+					"sessionUpdate": "message_chunk",
+					"text": "vendor text"
+				}
+			}`,
+			want: "vendor text",
+		},
+		{
+			name: "response vendor extension",
+			params: `{
+				"sessionId": "s1",
+				"update": {
+					"sessionUpdate": "response",
+					"message": "vendor message"
+				}
+			}`,
+			want: "vendor message",
+		},
+		{
+			name: "unknown kind with content.text",
+			params: `{
+				"sessionId": "s1",
+				"update": {
+					"sessionUpdate": "custom_output",
+					"content": {"text": "fallback text"}
+				}
+			}`,
+			want: "fallback text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evs := mapSessionUpdate("", json.RawMessage(tt.params))
+			if len(evs) != 1 {
+				t.Fatalf("expected 1 event, got %d", len(evs))
+			}
+			if evs[0].Type != core.EventText {
+				t.Fatalf("expected EventText, got %v", evs[0].Type)
+			}
+			if evs[0].Content != tt.want {
+				t.Fatalf("content = %q, want %q", evs[0].Content, tt.want)
+			}
+		})
+	}
+}
+
 func TestMapSessionUpdate_toolCallUpdate_inProgress(t *testing.T) {
 	params := json.RawMessage(`{
 		"sessionId": "s1",

--- a/agent/acp/session.go
+++ b/agent/acp/session.go
@@ -218,6 +218,8 @@ func (s *acpSession) onNotification(method string, params json.RawMessage) {
 		return
 	}
 	sid := s.currentACPSessionID()
+	// Debug log to capture raw session/update JSON for troubleshooting vendor compatibility
+	slog.Debug("acp: session/update", "session_id", sid, "params", string(params))
 	for _, ev := range mapSessionUpdate(sid, params) {
 		s.emit(ev)
 	}
@@ -324,11 +326,13 @@ func (s *acpSession) Send(prompt string, images []core.ImageAttachment, files []
 		"prompt":    promptBlocks,
 	}
 
-	_, err := s.tr.call(s.ctx, "session/prompt", params)
+	slog.Debug("acp: sending session/prompt", "session_id", sid, "prompt_len", len(prompt))
+	res, err := s.tr.call(s.ctx, "session/prompt", params)
 	if err != nil {
 		s.emit(core.Event{Type: core.EventError, Error: err})
 		return fmt.Errorf("acp: session/prompt: %w", err)
 	}
+	slog.Debug("acp: session/prompt response", "session_id", sid, "response_len", len(res), "response", string(res))
 
 	// Text was streamed via session/update; engine aggregates EventText.
 	s.emit(core.Event{

--- a/config.example.toml
+++ b/config.example.toml
@@ -1189,6 +1189,18 @@ app_secret = "your-feishu-app-secret"
 # --- Example: OpenClaw (Gateway-backed ACP bridge) ---
 # Docs: https://docs.openclaw.ai/cli/acp
 # Install the OpenClaw CLI, run a Gateway, then point cc-connect at `openclaw acp`.
+#
+# IMPORTANT: Remote OpenClaw requires pairing authorization before use!
+#
+# For remote gateways, you MUST complete the pairing process:
+#   1. Start OpenClaw gateway: openclaw acp --url wss://your-gateway:18789
+#   2. In another terminal, run: openclaw pair
+#   3. Approve the pairing request in the OpenClaw UI
+#   4. Now cc-connect can communicate with the authorized gateway
+#
+# Without pairing, OpenClaw will return empty responses ("pairing required" error).
+# Reference: https://zhuanlan.zhihu.com/p/2005687480976970296
+#
 # [[projects]]
 # name = "openclaw-acp"
 #


### PR DESCRIPTION
## Summary
- Added debug logging to capture raw session/update JSON for troubleshooting vendor compatibility issues
- Enhanced `mapAgentMessageChunk()` to support multiple JSON formats:
  - Standard ACP: `{"content": {"type": "text", "text": "..."}}`
  - Alternative: `{"content": {"text": "..."}}` (type omitted)
  - Alternative: `{"text": "..."}` (top-level text field)
  - Alternative: `{"content": "..."}` (content as string)
- Improved `mapSessionUpdateFallback()` to extract text from common vendor extensions (`message`, `message_chunk`, `response`, `text`)
- Added comprehensive tests for all alternative formats

## Root Cause
Issue #432 reported "(empty response)" when using OpenClaw/OpenCode with cc-connect. The ACP agent was only parsing the standard `content.text` format. If a vendor sends text in a different JSON structure, the mapping function returned `nil`, resulting in no `EventText` events and eventually "(empty response)" in the UI.

## Test plan
- [ ] Build passes: `go build ./...`
- [ ] Tests pass: `go test ./...`
- [ ] Manual test: use OpenClaw/OpenCode with Feishu and verify responses are displayed correctly

Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)