### PR TITLE
fix(weixin): add upload_full_url support for CDN upload

### DIFF
--- a/platform/weixin/client.go
+++ b/platform/weixin/client.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -201,6 +202,12 @@ func (c *apiClient) getUploadURL(ctx context.Context, req getUploadURLRequest) (
 	var out getUploadURLResponse
 	if err := json.Unmarshal(raw, &out); err != nil {
 		return nil, fmt.Errorf("weixin: getUploadUrl json: %w", err)
+	}
+	// If upload_param is empty but upload_full_url is provided, extract encrypted_query_param from URL
+	if strings.TrimSpace(out.UploadParam) == "" && strings.TrimSpace(out.UploadFullURL) != "" {
+		if u, err := url.Parse(out.UploadFullURL); err == nil {
+			out.UploadParam = u.Query().Get("encrypted_query_param")
+		}
 	}
 	if strings.TrimSpace(out.UploadParam) == "" {
 		return nil, fmt.Errorf("weixin: getUploadUrl: empty upload_param in %s", truncateForLog(raw, 512))

--- a/platform/weixin/types.go
+++ b/platform/weixin/types.go
@@ -105,6 +105,7 @@ type getUploadURLRequest struct {
 type getUploadURLResponse struct {
 	UploadParam      string `json:"upload_param,omitempty"`
 	ThumbUploadParam string `json:"thumb_upload_param,omitempty"`
+	UploadFullURL    string `json:"upload_full_url,omitempty"` // full CDN URL with encrypted_query_param embedded
 }
 
 type weixinMessage struct {


### PR DESCRIPTION
## Summary
- Add `upload_full_url` field to `getUploadURLResponse` struct
- When ilink API returns `upload_full_url` instead of `upload_param`, extract `encrypted_query_param` from URL query string
- Fixes file upload failures when CDN returns empty `upload_param`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./platform/weixin/...` passes
- [ ] Manual test with ilink API returning `upload_full_url` (requires user validation)

Fixes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)