### PR TITLE
fix(gemini): improve session parsing and add history sync on /switch

### DIFF
--- a/agent/gemini/gemini.go
+++ b/agent/gemini/gemini.go
@@ -475,6 +475,10 @@ type sessionMessage struct {
 }
 
 // textContent extracts text from the flexible content field.
+// Gemini CLI can serialize content as:
+// - a plain string
+// - an array of {text: "..."} parts
+// - an array of objects with nested structures
 func (m *sessionMessage) textContent() string {
 	if len(m.RawContent) == 0 {
 		return ""
@@ -484,7 +488,20 @@ func (m *sessionMessage) textContent() string {
 	if json.Unmarshal(m.RawContent, &s) == nil {
 		return s
 	}
-	// Try as array of {text: "..."} parts
+	// Try as array of objects with "text" field
+	var rawParts []map[string]any
+	if json.Unmarshal(m.RawContent, &rawParts) == nil {
+		var texts []string
+		for _, p := range rawParts {
+			if txt, ok := p["text"].(string); ok && txt != "" {
+				texts = append(texts, txt)
+			}
+		}
+		if len(texts) > 0 {
+			return strings.Join(texts, "\n")
+		}
+	}
+	// Fallback: try as array of struct{Text string}
 	var parts []struct {
 		Text string `json:"text"`
 	}
@@ -601,4 +618,74 @@ func extractSessionSummary(sf *sessionFile) string {
 		return sf.SessionID[:12] + "..."
 	}
 	return sf.SessionID
+}
+
+// GetSessionHistory implements core.HistoryProvider to retrieve conversation history
+// from a Gemini CLI session file.
+func (a *Agent) GetSessionHistory(ctx context.Context, sessionID string, limit int) ([]core.HistoryEntry, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("gemini: cannot determine home dir: %w", err)
+	}
+
+	slug := geminiProjectSlug(a.workDir)
+	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", slug, "chats")
+
+	entries, err := os.ReadDir(chatsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("gemini: read chats dir: %w", err)
+	}
+
+	// Find the session file matching sessionID
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(chatsDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+
+		var sf sessionFile
+		if json.Unmarshal(data, &sf) != nil || sf.SessionID != sessionID {
+			continue
+		}
+
+		// Skip subagent sessions
+		if sf.Kind == "subagent" {
+			continue
+		}
+
+		// Extract history entries from messages
+		var history []core.HistoryEntry
+		for _, msg := range sf.Messages {
+			text := strings.TrimSpace(msg.textContent())
+			if text == "" {
+				continue
+			}
+
+			role := "assistant"
+			if msg.Type == "user" {
+				role = "user"
+			}
+
+			history = append(history, core.HistoryEntry{
+				Role:    role,
+				Content: text,
+			})
+		}
+
+		// Apply limit (return most recent entries)
+		if limit > 0 && len(history) > limit {
+			history = history[len(history)-limit:]
+		}
+
+		return history, nil
+	}
+
+	return nil, fmt.Errorf("gemini: session not found: %s", sessionID)
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -3455,6 +3455,17 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 	session := sessions.GetOrCreateActive(msg.SessionKey)
 	session.SetAgentInfo(matched.ID, agent.Name(), matched.Summary)
 	session.ClearHistory()
+
+	// Sync recent history from agent if supported
+	if hp, ok := agent.(HistoryProvider); ok {
+		if history, err := hp.GetSessionHistory(e.ctx, matched.ID, 10); err == nil && len(history) > 0 {
+			for _, h := range history {
+				session.AddHistory(h.Role, h.Content)
+			}
+			slog.Debug("cmdSwitch: synced history from agent", "session_key", msg.SessionKey, "entries", len(history))
+		}
+	}
+
 	sessions.Save()
 
 	shortID := matched.ID


### PR DESCRIPTION
## Summary
- Update textContent() to support multiple JSON formats for Gemini CLI content field
- Implement HistoryProvider interface for Gemini agent
- Optimize cmdSwitch to auto-sync history after switching sessions

## Problem
1. `/list` or `/sessions` shows blank even when valid session files exist
2. After `/switch`, `/current` shows message count as 0, needs manual `/history`

Root causes:
1. Gemini CLI new version uses `[{"text": "..."}]` nested array format, but textContent() only supported specific struct format
2. cmdSwitch clears history but doesn't reload from agent

## Solution
1. Updated textContent() to try multiple JSON formats:
   - Plain string
   - Array of `{text: "..."}` objects  
   - Array of `map[string]any` for flexibility

2. Implemented GetSessionHistory() for Gemini agent to retrieve history from session files

3. Added history sync in cmdSwitch when agent implements HistoryProvider

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./agent/gemini/...` passes
- [ ] Manual test with Gemini CLI sessions

Fixes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)