### PR TITLE
fix: cron process leak (#348), codex /compact (#378), auto-compress notify, context limit (#384)

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -87,6 +87,8 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 		args = append(args, "--append-system-prompt", sysPrompt)
 	}
 
+	args = append(args, "--max-context-tokens", "900000")
+
 	slog.Debug("claudeSession: starting", "args", core.RedactArgs(args), "dir", workDir, "mode", mode)
 
 	cmd := exec.CommandContext(sessionCtx, "claude", args...)

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -366,7 +366,10 @@ func (a *Agent) SkillDirs() []string {
 
 // ── ContextCompressor implementation ──────────────────────────
 
-func (a *Agent) CompressCommand() string { return "/compact" }
+// CompressCommand returns "" because Codex native slash commands (/compact, /clear)
+// are not reliably executed in exec/resume mode — they may be treated as plain text.
+// See: https://github.com/chenhg5/cc-connect/issues/378
+func (a *Agent) CompressCommand() string { return "" }
 
 // ── MemoryFileProvider implementation ─────────────────────────
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -904,6 +904,7 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		}
 		iKey := fmt.Sprintf("%s#cron:%s", runSessionKey, session.ID)
 		e.processInteractiveMessageWith(effectivePlatform, msg, session, e.agent, e.sessions, iKey, "", runSessionKey)
+		e.cleanupInteractiveState(iKey)
 		return nil
 	}
 
@@ -2591,8 +2592,16 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 				state.mu.Lock()
 				state.lastAutoCompressAt = time.Now()
+				tokenEst := state.lastAutoCompressTokens
 				state.mu.Unlock()
 				slog.Info("auto-compress: triggering", "session", sessionKey)
+
+				// Notify user before compressing so they know the context is about to change.
+				compressNotice := e.i18n.T(MsgCompressing)
+				if tokenEst > 0 {
+					compressNotice = fmt.Sprintf("%s (~%dk tokens)", compressNotice, tokenEst/1000)
+				}
+				e.send(state.platform, state.replyCtx, compressNotice)
 
 				// Run compress inline while the session is still locked.
 				e.runCompress(state, session, sessions, sessionKey, state.platform, state.replyCtx, true)


### PR DESCRIPTION
## Summary

- **fix #348** — `new_per_run` cron jobs leaked Claude CLI processes on successful completion because `cleanupInteractiveState()` was never called on the happy path. Added the cleanup call after `processInteractiveMessageWith()` returns.

- **fix #378** — Codex `CompressCommand()` returned `"/compact"` but this slash command is not reliably executed in `codex exec/resume --json` mode (may be treated as plain text). Changed to return `""` so cc-connect treats Codex as not supporting native context compression, consistent with how Gemini is handled.

- **feat: auto-compress notification** — When auto-compress triggers, send a platform message (`🗜 正在压缩上下文... (~Xk tokens)`) before compression runs, so users are not surprised by sudden context resets. Token estimate is included for visibility.

- **fix #384** — Pass `--max-context-tokens 900000` to the Claude CLI, raising the effective working limit from ~254K to 900K tokens. Claude Code supports a 1M context window but cc-connect was hitting the old 254K prompt-too-long error.

## Test plan

- [ ] Run a `new_per_run` cron job and verify no orphaned `claude` processes remain after completion (`pgrep -f claude`)
- [ ] Send `/compress` to a Codex session and confirm cc-connect falls back gracefully instead of sending `/compact` as text
- [ ] Trigger auto-compress (set `auto_compress.max_tokens` low) and verify notification appears before compression
- [ ] Start a long Claude Code session (>254K tokens) and confirm no "Prompt is too long" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)