### PR TITLE
feat(claudecode): add extended context (1M) model options

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -162,9 +162,11 @@ func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
 		return models
 	}
 	return []core.ModelOption{
-		{Name: "sonnet", Desc: "Claude Sonnet 4 (balanced)"},
-		{Name: "opus", Desc: "Claude Opus 4 (most capable)"},
-		{Name: "haiku", Desc: "Claude Haiku 3.5 (fastest)"},
+		{Name: "sonnet", Desc: "Claude Sonnet 4 (balanced, 200K)"},
+		{Name: "opus", Desc: "Claude Opus 4 (most capable, 200K)"},
+		{Name: "haiku", Desc: "Claude Haiku 3.5 (fastest, 200K)"},
+		{Name: "claude-sonnet-4-20250514", Desc: "Claude Sonnet 4 (1M context)"},
+		{Name: "claude-opus-4-20250514", Desc: "Claude Opus 4 (1M context)"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add 1M context model variants to the default model list
- Users can now switch to extended context models via /model command

## Problem
Users reported that /model command only showed haiku, sonnet, opus options without the extended context (1M) versions. This limited users to 200K context models.

## Solution
Added two extended context models to the default fallback list:
- `claude-sonnet-4-20250514` (1M context)
- `claude-opus-4-20250514` (1M context)

Also updated descriptions to show context size for clarity.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual test: /model should show 5 options including 1M context variants

Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)