### PR TITLE
feat(feishu): enable WebSocket mode for Lark international version

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -306,9 +306,11 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			return p.onBotMenu(event)
 		})
 
-	// Lark international version uses Webhook mode, not WebSocket long connection
-	// Feishu domestic version supports WebSocket long connection
-	if p.platformName == "lark" {
+	// Lark international version now supports WebSocket long connection (since SDK v3.5.3).
+	// Use WebSocket by default for all platforms; only fallback to webhook if explicitly configured.
+	// Users can force webhook mode by setting encrypt_key + port + callback_path together.
+	if p.encryptKey != "" && p.port != "" && p.callbackPath != "" {
+		slog.Info(p.tag()+": using webhook mode (encrypt_key configured)", "port", p.port)
 		return p.startWebhookMode()
 	}
 


### PR DESCRIPTION
## Summary
- Enable WebSocket mode for Lark international version (larksuite.com)
- Remove platform name check that forced Lark to webhook mode
- Default to WebSocket for all platforms; fallback to webhook only when explicitly configured

## Problem
Lark international version was forced to use webhook mode, requiring:
- A public IP address
- Port forwarding/reverse proxy configuration

This created a barrier for users without public IP access.

## Solution
Lark SDK v3.5.3+ supports WebSocket for international version via `larkws.WithDomain()`. The `startWebSocketMode()` already handles this correctly.

Changes:
- Remove the `platformName == "lark"` check
- Use WebSocket by default for all platforms
- Only use webhook if user explicitly configures `encrypt_key`, `port`, and `callback_path`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual test with Lark international account using WebSocket mode

Fixes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)