### PR TITLE
feat(opencode): implement SessionDeleter to enable /delete command

### DIFF
--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -190,6 +190,21 @@ func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error)
 
 func (a *Agent) Stop() error { return nil }
 
+// DeleteSession implements core.SessionDeleter via `opencode session delete <id>`.
+func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
+	a.mu.RLock()
+	cmd := a.cmd
+	workDir := a.workDir
+	a.mu.RUnlock()
+
+	c := exec.Command(cmd, "session", "delete", sessionID)
+	c.Dir = workDir
+	if out, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("opencode: delete session %s: %w: %s", sessionID, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 // -- ModeSwitcher --
 
 func (a *Agent) SetMode(mode string) {

--- a/agent/opencode/opencode_model_test.go
+++ b/agent/opencode/opencode_model_test.go
@@ -341,6 +341,68 @@ func TestAvailableModels_CustomCmdUsedForDiscovery(t *testing.T) {
 	}
 }
 
+// ---------- DeleteSession tests ----------
+
+// writeFakeDeleteBin writes a temporary shell script that acts as a fake opencode CLI.
+// When invoked with "session delete <id>", it either succeeds (exitCode=0) or fails.
+// If wantID is non-empty the script validates the session ID matches.
+func writeFakeDeleteBin(t *testing.T, wantID string, exitCode int, stderr string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	name := filepath.Join(tmpDir, "fake-opencode")
+
+	var body strings.Builder
+	body.WriteString("#!/bin/sh\n")
+	body.WriteString("if [ \"$1\" = \"session\" ] && [ \"$2\" = \"delete\" ]; then\n")
+	if wantID != "" {
+		fmt.Fprintf(&body, "  if [ \"$3\" != \"%s\" ]; then\n", wantID)
+		fmt.Fprintf(&body, "    printf 'unexpected session id: %%s\\n' \"$3\" >&2\n")
+		body.WriteString("    exit 1\n")
+		body.WriteString("  fi\n")
+	}
+	if stderr != "" {
+		fmt.Fprintf(&body, "  printf '%s\\n' >&2\n", stderr)
+	}
+	fmt.Fprintf(&body, "  exit %d\n", exitCode)
+	body.WriteString("fi\n")
+	body.WriteString("exit 0\n")
+
+	if err := os.WriteFile(name, []byte(body.String()), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return name
+}
+
+// TestDeleteSession_Success verifies that DeleteSession calls
+// `opencode session delete <id>` and returns nil on success.
+func TestDeleteSession_Success(t *testing.T) {
+	sessionID := "ses_abc123"
+	bin := writeFakeDeleteBin(t, sessionID, 0, "")
+	a := &Agent{cmd: bin, workDir: t.TempDir()}
+
+	if err := a.DeleteSession(context.Background(), sessionID); err != nil {
+		t.Fatalf("DeleteSession() unexpected error: %v", err)
+	}
+}
+
+// TestDeleteSession_CLIError verifies that DeleteSession propagates CLI failures.
+func TestDeleteSession_CLIError(t *testing.T) {
+	bin := writeFakeDeleteBin(t, "", 1, "session not found")
+	a := &Agent{cmd: bin, workDir: t.TempDir()}
+
+	err := a.DeleteSession(context.Background(), "ses_missing")
+	if err == nil {
+		t.Fatal("DeleteSession() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ses_missing") {
+		t.Errorf("error %q should mention the session ID", err.Error())
+	}
+}
+
+// TestDeleteSession_ImplementsInterface is a compile-time check that Agent
+// satisfies core.SessionDeleter.
+var _ core.SessionDeleter = (*Agent)(nil)
+
 // ---------- interface / compile-time checks ----------
 
 // verify Agent implements core.Agent


### PR DESCRIPTION
## Summary

- Add `DeleteSession` method to the opencode `Agent`, implementing `core.SessionDeleter`
- Delegates to `opencode session delete <id>` CLI, the official way to delete sessions
- Enables `/delete 1`, `/delete 1,2,3`, `/delete 1-5`, and interactive card deletion for opencode users on all platforms

## Why this approach

Other agents (claudecode, codex, cursor) delete sessions by directly removing local files. The opencode CLI provides a dedicated `opencode session delete <id>` subcommand, so we call that instead — cleaner and forward-compatible with any storage changes opencode may make.

## Test plan

- [x] `TestDeleteSession_Success` — verifies correct CLI args are passed and nil returned on success
- [x] `TestDeleteSession_CLIError` — verifies CLI failures are propagated with the session ID in the error message
- [x] `var _ core.SessionDeleter = (*Agent)(nil)` — compile-time interface satisfaction check
- [x] All `agent/opencode` tests pass
- [x] Full `go build ./...` passes
- [x] Pre-existing `core` test failure (`TestCmdShell_MultiWorkspaceIgnoresMissingSharedBinding`) confirmed unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)