### PR TITLE
feat(config): add display.show_context_label option

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -199,9 +199,12 @@ func main() {
 		}
 
 		engine := core.NewEngine(proj.Name, agent, platforms, sessionFile, lang)
+		// Context indicator: project-level overrides global display config; default true
 		showCtx := true
 		if proj.ShowContextIndicator != nil {
 			showCtx = *proj.ShowContextIndicator
+		} else if cfg.Display.ShowContextLabel != nil {
+			showCtx = *cfg.Display.ShowContextLabel
 		}
 		engine.SetShowContextIndicator(showCtx)
 		engine.SetAttachmentSendEnabled(cfg.AttachmentSend != "off")
@@ -1225,6 +1228,8 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 	showCtx := true
 	if proj.ShowContextIndicator != nil {
 		showCtx = *proj.ShowContextIndicator
+	} else if cfg.Display.ShowContextLabel != nil {
+		showCtx = *cfg.Display.ShowContextLabel
 	}
 	engine.SetShowContextIndicator(showCtx)
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -53,6 +53,7 @@ level = "info" # debug, info, warn, error
 # thinking_max_len = 300   # Max chars for thinking messages (default: 300) / 思考消息最大字符数（默认 300）
 # tool_max_len = 500       # Max chars for tool use messages (default: 500) / 工具调用消息最大字符数（默认 500）
 # tool_messages = true     # Show/hide tool progress messages (default: true) / 是否显示工具进度消息（默认 true）
+# show_context_label = true # Show/hide [ctx: ~N%] suffix on assistant replies (default: true) / 是否在助手回复显示 [ctx: ~N%] 后缀（默认 true）
 
 # Agent idle timeout: max minutes between consecutive agent events before
 # considering the session stuck. Set to 0 to disable the timeout entirely.

--- a/config/config.go
+++ b/config/config.go
@@ -74,9 +74,10 @@ type ManagementConfig struct {
 
 // DisplayConfig controls how intermediate messages (thinking, tool output) are shown.
 type DisplayConfig struct {
-	ThinkingMaxLen *int  `toml:"thinking_max_len"` // max chars for thinking messages; 0 = no truncation; default 300
-	ToolMaxLen     *int  `toml:"tool_max_len"`     // max chars for tool use messages; 0 = no truncation; default 500
-	ToolMessages   *bool `toml:"tool_messages"`    // whether tool progress messages are shown; default true
+	ThinkingMaxLen    *int  `toml:"thinking_max_len"`    // max chars for thinking messages; 0 = no truncation; default 300
+	ToolMaxLen        *int  `toml:"tool_max_len"`        // max chars for tool use messages; 0 = no truncation; default 500
+	ToolMessages      *bool `toml:"tool_messages"`       // whether tool progress messages are shown; default true
+	ShowContextLabel  *bool `toml:"show_context_label"`  // whether [ctx: ~N%] suffix is shown on assistant replies; default true
 }
 
 // StreamPreviewConfig controls real-time streaming preview in IM.


### PR DESCRIPTION
## Summary
- Add global `display.show_context_label` config option to control `[ctx: ~N%]` suffix visibility
- Project-level `show_context_indicator` still overrides global setting
- Default is `true` (show label) for backward compatibility

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: set `display.show_context_label = false` and verify `[ctx: ~N%]` is hidden

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)