### PR TITLE
fix(core): avoid reaping active multi-workspace sessions

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -377,24 +377,45 @@ func (e *Engine) runIdleReaper() {
 		case <-e.ctx.Done():
 			return
 		case <-ticker.C:
-			if e.workspacePool == nil {
-				continue
-			}
-			reaped := e.workspacePool.ReapIdle()
-			for _, ws := range reaped {
-				e.interactiveMu.Lock()
-				for key, state := range e.interactiveStates {
-					if state.workspaceDir == ws {
-						if state.agentSession != nil {
-							state.agentSession.Close()
-						}
-						delete(e.interactiveStates, key)
-					}
-				}
-				e.interactiveMu.Unlock()
-				slog.Info("workspace idle-reaped", "workspace", ws)
-			}
+			e.reapIdleWorkspaces()
 		}
+	}
+}
+
+func (e *Engine) reapIdleWorkspaces() {
+	if e.workspacePool == nil {
+		return
+	}
+
+	reaped := e.workspacePool.ReapIdle()
+	if len(reaped) == 0 {
+		return
+	}
+
+	reapedSet := make(map[string]struct{}, len(reaped))
+	for _, ws := range reaped {
+		reapedSet[ws] = struct{}{}
+	}
+
+	type cleanupTarget struct {
+		key   string
+		state *interactiveState
+	}
+
+	var targets []cleanupTarget
+	e.interactiveMu.Lock()
+	for key, state := range e.interactiveStates {
+		if _, ok := reapedSet[state.workspaceDir]; ok {
+			targets = append(targets, cleanupTarget{key: key, state: state})
+		}
+	}
+	e.interactiveMu.Unlock()
+
+	for _, target := range targets {
+		e.cleanupInteractiveState(target.key, target.state)
+	}
+	for _, ws := range reaped {
+		slog.Info("workspace idle-reaped", "workspace", ws)
 	}
 }
 
@@ -1829,6 +1850,12 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	if state.agentSession == nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFailedToStartAgentSession))
 		return
+	}
+
+	if workspaceDir != "" && e.workspacePool != nil {
+		ws := e.workspacePool.GetOrCreate(workspaceDir)
+		ws.BeginTurn()
+		defer ws.EndTurn()
 	}
 
 	// Apply per-message permission mode override (e.g. cron jobs with mode = "bypassPermissions").

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -5236,6 +5236,148 @@ func TestProcessInteractiveEvents_PermissionWhileSendBlocked(t *testing.T) {
 	}
 }
 
+func TestReapIdleWorkspaces_SkipsWorkspaceWithActiveTurn(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newBlockingSendSession("busy-turn")
+	e := NewEngine("test", &controllableAgent{nextSession: sess}, []Platform{p}, "", LangEnglish)
+	e.workspacePool = newWorkspacePool(50 * time.Millisecond)
+
+	workspaceDir := normalizeWorkspacePath(t.TempDir())
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	if !session.TryLock() {
+		t.Fatal("expected session lock")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveMessageWith(p, &Message{
+			SessionKey: sessionKey,
+			UserID:     "user1",
+			Content:    "long running task",
+			ReplyCtx:   "ctx",
+		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey)
+		close(done)
+	}()
+
+	select {
+	case <-sess.sendStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send did not reach blocking wait")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	e.reapIdleWorkspaces()
+
+	if !sess.Alive() {
+		t.Fatal("idle reaper closed a session with an active turn")
+	}
+	e.interactiveMu.Lock()
+	_, exists := e.interactiveStates[sessionKey]
+	e.interactiveMu.Unlock()
+	if !exists {
+		t.Fatal("idle reaper removed interactive state for an active turn")
+	}
+
+	close(sess.unblock)
+	sess.events <- Event{Type: EventResult, Content: "done", Done: true}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("processInteractiveMessageWith did not complete")
+	}
+}
+
+func TestReapIdleWorkspaces_SkipsWorkspaceWaitingForPermission(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newBlockingSendSession("perm-wait")
+	e := NewEngine("test", &controllableAgent{nextSession: sess}, []Platform{p}, "", LangEnglish)
+	e.workspacePool = newWorkspacePool(50 * time.Millisecond)
+
+	workspaceDir := normalizeWorkspacePath(t.TempDir())
+	sessionKey := "test:user2"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	if !session.TryLock() {
+		t.Fatal("expected session lock")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveMessageWith(p, &Message{
+			SessionKey: sessionKey,
+			UserID:     "user2",
+			Content:    "needs approval",
+			ReplyCtx:   "ctx",
+		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey)
+		close(done)
+	}()
+
+	select {
+	case <-sess.sendStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send did not reach blocking wait")
+	}
+
+	sess.events <- Event{
+		Type:         EventPermissionRequest,
+		RequestID:    "req-1",
+		ToolName:     "write_file",
+		ToolInput:    "/tmp/x",
+		ToolInputRaw: map[string]any{"path": "/tmp/x"},
+	}
+
+	var pending *pendingPermission
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		e.interactiveMu.Lock()
+		state := e.interactiveStates[sessionKey]
+		e.interactiveMu.Unlock()
+		if state != nil {
+			state.mu.Lock()
+			pending = state.pending
+			state.mu.Unlock()
+			if pending != nil {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if pending == nil {
+		t.Fatal("expected pending permission while turn is waiting")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	e.reapIdleWorkspaces()
+
+	if !sess.Alive() {
+		t.Fatal("idle reaper closed a session waiting for permission")
+	}
+	e.interactiveMu.Lock()
+	_, exists := e.interactiveStates[sessionKey]
+	e.interactiveMu.Unlock()
+	if !exists {
+		t.Fatal("idle reaper removed interactive state while waiting for permission")
+	}
+
+	if !e.handlePendingPermission(p, &Message{
+		SessionKey: sessionKey,
+		UserID:     "user2",
+		Content:    "allow",
+		ReplyCtx:   "ctx",
+	}, "allow") {
+		t.Fatal("expected pending permission to be handled")
+	}
+	close(sess.unblock)
+	sess.events <- Event{Type: EventResult, Content: "done", Done: true}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("processInteractiveMessageWith did not complete after permission")
+	}
+}
+
 func TestQueueMessageForBusySession_FIFODequeue(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newQueuingSession("qs1")

--- a/core/workspace_state.go
+++ b/core/workspace_state.go
@@ -30,6 +30,7 @@ type workspaceState struct {
 	sessions     *SessionManager
 	agent        Agent
 	lastActivity time.Time
+	activeTurns  int
 }
 
 func newWorkspaceState(workspace string) *workspaceState {
@@ -43,6 +44,28 @@ func (ws *workspaceState) Touch() {
 	ws.mu.Lock()
 	ws.lastActivity = time.Now()
 	ws.mu.Unlock()
+}
+
+func (ws *workspaceState) BeginTurn() {
+	ws.mu.Lock()
+	ws.activeTurns++
+	ws.lastActivity = time.Now()
+	ws.mu.Unlock()
+}
+
+func (ws *workspaceState) EndTurn() {
+	ws.mu.Lock()
+	if ws.activeTurns > 0 {
+		ws.activeTurns--
+	}
+	ws.lastActivity = time.Now()
+	ws.mu.Unlock()
+}
+
+func (ws *workspaceState) HasActiveTurn() bool {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	return ws.activeTurns > 0
 }
 
 func (ws *workspaceState) LastActivity() time.Time {
@@ -119,6 +142,9 @@ func (p *workspacePool) ReapIdle() []string {
 	cutoff := time.Now().Add(-p.idleTimeout)
 	var reaped []string
 	for path, state := range p.states {
+		if state.HasActiveTurn() {
+			continue
+		}
 		if state.LastActivity().Before(cutoff) {
 			reaped = append(reaped, path)
 			delete(p.states, path)

--- a/core/workspace_state_test.go
+++ b/core/workspace_state_test.go
@@ -36,6 +36,30 @@ func TestWorkspacePool_Touch(t *testing.T) {
 	}
 }
 
+func TestWorkspaceState_BeginEndTurn(t *testing.T) {
+	state := newWorkspaceState("/workspace/a")
+
+	before := state.LastActivity()
+	time.Sleep(10 * time.Millisecond)
+	state.BeginTurn()
+	if !state.HasActiveTurn() {
+		t.Fatal("expected workspace to report an active turn after BeginTurn")
+	}
+	if !state.LastActivity().After(before) {
+		t.Fatal("expected lastActivity to advance on BeginTurn")
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	mid := state.LastActivity()
+	state.EndTurn()
+	if state.HasActiveTurn() {
+		t.Fatal("expected workspace to report no active turns after EndTurn")
+	}
+	if !state.LastActivity().After(mid) {
+		t.Fatal("expected lastActivity to advance on EndTurn")
+	}
+}
+
 func TestWorkspacePool_ReapIdle(t *testing.T) {
 	pool := newWorkspacePool(50 * time.Millisecond)
 	pool.GetOrCreate("/workspace/a")
@@ -124,6 +148,28 @@ func TestWorkspacePool_ReapIdle_KeepsActive(t *testing.T) {
 
 	if s := pool.Get("/workspace/active"); s == nil {
 		t.Error("expected active workspace to still exist")
+	}
+}
+
+func TestWorkspacePool_ReapIdle_SkipsBusyWorkspace(t *testing.T) {
+	pool := newWorkspacePool(50 * time.Millisecond)
+	state := pool.GetOrCreate("/workspace/busy")
+	state.BeginTurn()
+
+	time.Sleep(100 * time.Millisecond)
+	reaped := pool.ReapIdle()
+	if len(reaped) != 0 {
+		t.Fatalf("expected busy workspace to be preserved, got %v", reaped)
+	}
+	if got := pool.Get("/workspace/busy"); got == nil {
+		t.Fatal("expected busy workspace to remain in pool")
+	}
+
+	state.EndTurn()
+	time.Sleep(60 * time.Millisecond)
+	reaped = pool.ReapIdle()
+	if len(reaped) != 1 || reaped[0] != "/workspace/busy" {
+		t.Fatalf("expected busy workspace to reap after EndTurn, got %v", reaped)
 	}
 }
 


### PR DESCRIPTION
## Summary

Prevent the multi-workspace idle reaper from closing agent sessions that still have an active turn in progress.

## What changed

- track active turns on each `workspaceState` in addition to `lastActivity`
- skip idle reaping for workspaces that still have an active turn
- mark workspace turns as active for the full `processInteractiveMessageWith(...)` lifecycle, including long-running turns and permission waits
- route reaper cleanup through `cleanupInteractiveState(...)` instead of directly deleting interactive state entries
- add regression tests for active long-running sessions and permission waits, plus workspace-state coverage for begin/end turn semantics

## Why

Before this change:

- `workspacePool` only used `lastActivity` to decide whether a workspace was idle
- `lastActivity` was only refreshed when a new message was routed into the workspace
- a long-running turn or a permission wait in multi-workspace mode could be reaped after 15 minutes even though the agent session was still active

After this change:

- active turns keep the workspace marked as busy until the turn fully exits
- the idle reaper only reaps truly idle workspaces
- long-running turns and permission waits are preserved until they finish normally

## Validation

- [x] `go test ./core -run 'TestWorkspace(State|Pool)_|TestReapIdleWorkspaces_' -count=1`
- [x] `go test ./core -count=1`
- [x] `go test ./... -count=1`

## Related

- Related to multi-workspace idle reaper behavior
- This PR only covers active-session reaping semantics; it does not change the configured idle timeout value or add new config knobs
