### PR TITLE
fix: prevent qoder session hang when no result event is received

### DIFF
--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -111,20 +111,9 @@ func (qs *qoderSession) Send(prompt string, images []core.ImageAttachment, files
 
 func (qs *qoderSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
 	defer qs.wg.Done()
-	defer func() {
-		if err := cmd.Wait(); err != nil {
-			stderrMsg := strings.TrimSpace(stderrBuf.String())
-			if stderrMsg != "" {
-				slog.Error("qoderSession: process failed", "error", err, "stderr", truncStr(stderrMsg, 200))
-				evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
-				select {
-				case qs.events <- evt:
-				case <-qs.ctx.Done():
-					return
-				}
-			}
-		}
-	}()
+
+	var gotResult bool
+	var nonJSONLines []string
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
@@ -138,19 +127,73 @@ func (qs *qoderSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf 
 		var raw streamEvent
 		if err := json.Unmarshal([]byte(line), &raw); err != nil {
 			slog.Debug("qoderSession: non-JSON line", "line", truncStr(line, 100))
+			nonJSONLines = append(nonJSONLines, line)
 			continue
 		}
 
+		if raw.Type == "result" {
+			gotResult = true
+		}
 		qs.handleEvent(&raw)
 	}
 
-	if err := scanner.Err(); err != nil {
-		slog.Error("qoderSession: scanner error", "error", err)
-		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
+	scanErr := scanner.Err()
+	if scanErr != nil {
+		slog.Error("qoderSession: scanner error", "error", scanErr)
+	}
+
+	// Wait for process to exit.
+	exitErr := cmd.Wait()
+
+	// If we already got a result event, the turn completed normally.
+	if gotResult {
+		if exitErr != nil {
+			stderrMsg := strings.TrimSpace(stderrBuf.String())
+			if stderrMsg != "" {
+				slog.Warn("qoderSession: process exited with error after result", "error", exitErr, "stderr", truncStr(stderrMsg, 200))
+			}
+		}
+		return
+	}
+
+	// No result event was received — emit a fallback to prevent the engine
+	// from hanging forever on the events channel.
+	if len(nonJSONLines) > 0 {
+		// qodercli produced plain text instead of stream-json; forward it
+		// as a result so the user at least sees the response.
+		slog.Warn("qoderSession: no result event, falling back to plain-text output", "lines", len(nonJSONLines))
+		text := strings.Join(nonJSONLines, "\n")
+		evt := core.Event{Type: core.EventResult, Content: text, SessionID: qs.CurrentSessionID(), Done: true}
 		select {
 		case qs.events <- evt:
 		case <-qs.ctx.Done():
-			return
+		}
+	} else if exitErr != nil {
+		// Process failed with no usable output.
+		stderrMsg := strings.TrimSpace(stderrBuf.String())
+		if stderrMsg == "" {
+			stderrMsg = exitErr.Error()
+		}
+		slog.Error("qoderSession: process failed with no result", "error", exitErr, "stderr", truncStr(stderrMsg, 200))
+		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
+		select {
+		case qs.events <- evt:
+		case <-qs.ctx.Done():
+		}
+	} else if scanErr != nil {
+		// Scanner error with no output.
+		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", scanErr)}
+		select {
+		case qs.events <- evt:
+		case <-qs.ctx.Done():
+		}
+	} else {
+		// Process exited cleanly but produced nothing at all.
+		slog.Warn("qoderSession: process exited with no output and no result event")
+		evt := core.Event{Type: core.EventResult, Content: "", SessionID: qs.CurrentSessionID(), Done: true}
+		select {
+		case qs.events <- evt:
+		case <-qs.ctx.Done():
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fix a hang in `qoderSession.readLoop` where the engine blocks forever on the events channel when qodercli outputs plain text instead of stream-json format
- When no `result` event is received before the subprocess exits, emit a fallback event (accumulated text as `EventResult`, or `EventError` for failures) to unblock the engine
- Accumulate non-JSON lines instead of silently discarding them, so users still see the response even when stream-json parsing fails

## Problem

On Windows, when qodercli performs tool calls (file reads, directory listings, etc.), its stdout may degrade from JSON stream events to plain text under certain conditions. The current `readLoop` implementation:

1. Silently discards all non-JSON lines (`continue` in the parse loop)
2. Only emits an `EventError` if the process exits with a non-zero exit code
3. If the process exits cleanly (exit code 0) with only non-JSON output, **no event is ever sent**

This causes the engine's `processInteractiveEvents` to wait indefinitely on `<-events` for an `EventResult` that never arrives — the conversation hangs permanently.

### Debug log showing the issue

```
time=20:26:50 level=DEBUG msg="qoderSession: launching" resume=true args_len=9
time=20:27:12 level=DEBUG msg="qoderSession: non-JSON line" line="这是一个项目目录..."
time=20:27:12 level=DEBUG msg="qoderSession: non-JSON line" line="| 文件/目录 | 说明 |"
... (many non-JSON lines, no result event, hangs forever)
```

### Comparison

| Scenario | init event | Output format | turn complete |
|----------|-----------|---------------|---------------|
| Turns without tools | Yes | JSON | Yes |
| Turn with tools (via cc-connect) | **No** | **Plain text** | **No** |
| Direct qodercli call (with tools) | Yes | JSON | Yes |

## Changes

**`agent/qoder/session.go` — `readLoop` function:**

- Added `gotResult` flag to track whether a `result` event was received
- Accumulate `nonJSONLines` instead of discarding them
- Replaced the deferred `cmd.Wait()` error-only handling with comprehensive post-exit fallback logic:
  - **Non-JSON text captured + no result** → forward as `EventResult` (user sees the response)
  - **Process error + no output** → `EventError` with stderr
  - **Scanner error** → `EventError`
  - **Clean exit + no output** → empty `EventResult`
- Normal flow (JSON parsed successfully, `result` event received) is unchanged

## Test plan

- [ ] Verify normal JSON stream-json flow still works (turns without tool calls)
- [ ] Verify turns with tool calls no longer hang — plain text is forwarded as result
- [ ] Verify process failures still emit proper error events
- [ ] Test on Windows with qodercli via WeChat platform

🤖 Generated with [Qoder][https://qoder.com]