### PR TITLE
feat(feishu): include replied-to message content in agent context

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -706,6 +706,7 @@ func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
 		content = *msg.Content
 	}
 	mentions := msg.Mentions
+	parentID := stringValue(msg.ParentId)
 
 	sessionKey := p.makeSessionKey(msg, chatID, userID)
 	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
@@ -719,7 +720,7 @@ func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
 	// blocked by IO-heavy operations (image/audio download, handler HTTP calls).
 	// The dedup and old-message checks above remain synchronous to guarantee
 	// correctness before spawning the goroutine.
-	go p.dispatchMessage(msgType, content, mentions, messageID, sessionKey, userID, userName, chatName, rctx)
+	go p.dispatchMessage(msgType, content, mentions, messageID, sessionKey, userID, userName, chatName, rctx, parentID)
 
 	return nil
 }
@@ -727,7 +728,14 @@ func (p *Platform) onMessage(event *larkim.P2MessageReceiveV1) error {
 // dispatchMessage handles the message content parsing, media download, and
 // handler invocation. It runs in its own goroutine so that onMessage returns
 // quickly and does not block the SDK event loop.
-func (p *Platform) dispatchMessage(msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, userName, chatName string, rctx replyContext) {
+func (p *Platform) dispatchMessage(msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, userName, chatName string, rctx replyContext, parentID string) {
+	// If this message is a reply to another message, fetch the quoted content
+	// and prepend it so the agent has full context.
+	quotedPrefix := ""
+	if parentID != "" {
+		quotedPrefix = p.fetchQuotedMessage(parentID)
+	}
+
 	switch msgType {
 	case "text":
 		var textBody struct {
@@ -750,7 +758,7 @@ func (p *Platform) dispatchMessage(msgType, content string, mentions []*larkim.M
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ReplyCtx: rctx,
+			Content: quotedPrefix + text, ReplyCtx: rctx,
 		})
 
 	case "image":
@@ -812,7 +820,7 @@ func (p *Platform) dispatchMessage(msgType, content string, mentions []*larkim.M
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, Images: images,
+			Content: quotedPrefix + text, Images: images,
 			ReplyCtx: rctx,
 		})
 
@@ -925,6 +933,114 @@ func (p *Platform) resolveChatName(chatID string) string {
 	}
 	p.chatNameCache.Store(chatID, name)
 	return name
+}
+
+// fetchQuotedMessage retrieves the content of a parent message that the user
+// is replying to, and returns a formatted prefix string for context injection.
+// Returns empty string on any failure (graceful degradation — the user's own
+// message is still delivered without the quote).
+func (p *Platform) fetchQuotedMessage(parentID string) string {
+	resp, err := p.client.Im.Message.Get(context.Background(),
+		larkim.NewGetMessageReqBuilder().
+			MessageId(parentID).
+			Build())
+	if err != nil {
+		slog.Debug(p.tag()+": fetch quoted message failed", "parent_id", parentID, "error", err)
+		return ""
+	}
+	if !resp.Success() || resp.Data == nil || len(resp.Data.Items) == 0 {
+		slog.Debug(p.tag()+": fetch quoted message: no data", "parent_id", parentID)
+		return ""
+	}
+
+	item := resp.Data.Items[0]
+	msgType := ""
+	if item.MsgType != nil {
+		msgType = *item.MsgType
+	}
+
+	content := ""
+	if item.Body != nil && item.Body.Content != nil {
+		content = *item.Body.Content
+	}
+	if content == "" {
+		return ""
+	}
+
+	// Extract plain text based on message type.
+	var quotedText string
+	switch msgType {
+	case "text":
+		var textBody struct {
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal([]byte(content), &textBody); err == nil {
+			quotedText = replaceMentions(textBody.Text, item.Mentions)
+		}
+	case "post":
+		// Rich text — extract text elements from the post structure.
+		quotedText = extractPostPlainText(content)
+	default:
+		// For non-text types (image, file, audio, etc.), use a type indicator.
+		quotedText = fmt.Sprintf("[%s]", msgType)
+	}
+
+	if quotedText == "" {
+		return ""
+	}
+
+	// Resolve sender name.
+	senderName := ""
+	if item.Sender != nil && item.Sender.Id != nil {
+		senderName = p.resolveUserName(*item.Sender.Id)
+	}
+	if senderName == "" {
+		senderName = "unknown"
+	}
+
+	return fmt.Sprintf("[Quoted message from %s]:\n%s\n\n", senderName, quotedText)
+}
+
+// extractPostPlainText extracts plain text from a Lark post (rich text) JSON content.
+func extractPostPlainText(content string) string {
+	var post struct {
+		Content [][]struct {
+			Tag  string `json:"tag"`
+			Text string `json:"text"`
+		} `json:"content"`
+		Title string `json:"title"`
+	}
+	// Post content may be wrapped in a locale key like {"zh_cn": {...}}.
+	// Try direct parse first, then try extracting from locale wrapper.
+	if err := json.Unmarshal([]byte(content), &post); err != nil || len(post.Content) == 0 {
+		var localeWrapper map[string]json.RawMessage
+		if err2 := json.Unmarshal([]byte(content), &localeWrapper); err2 == nil {
+			for _, v := range localeWrapper {
+				if err3 := json.Unmarshal(v, &post); err3 == nil && len(post.Content) > 0 {
+					break
+				}
+			}
+		}
+	}
+	if len(post.Content) == 0 {
+		return ""
+	}
+	var parts []string
+	if post.Title != "" {
+		parts = append(parts, post.Title)
+	}
+	for _, para := range post.Content {
+		var line []string
+		for _, elem := range para {
+			if elem.Tag == "text" && elem.Text != "" {
+				line = append(line, elem.Text)
+			}
+		}
+		if len(line) > 0 {
+			parts = append(parts, strings.Join(line, ""))
+		}
+	}
+	return strings.Join(parts, "\n")
 }
 
 // parseMergeForward fetches sub-messages of a merge_forward message via the

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1005,8 +1005,9 @@ func (p *Platform) fetchQuotedMessage(parentID string) string {
 func extractPostPlainText(content string) string {
 	var post struct {
 		Content [][]struct {
-			Tag  string `json:"tag"`
-			Text string `json:"text"`
+			Tag      string `json:"tag"`
+			Text     string `json:"text"`
+			Language string `json:"language"`
 		} `json:"content"`
 		Title string `json:"title"`
 	}
@@ -1032,8 +1033,21 @@ func extractPostPlainText(content string) string {
 	for _, para := range post.Content {
 		var line []string
 		for _, elem := range para {
-			if elem.Tag == "text" && elem.Text != "" {
-				line = append(line, elem.Text)
+			switch elem.Tag {
+			case "text", "a":
+				if elem.Text != "" {
+					line = append(line, elem.Text)
+				}
+			case "code_block":
+				if elem.Text != "" {
+					if elem.Language != "" {
+						line = append(line, fmt.Sprintf("```%s\n%s```", elem.Language, elem.Text))
+					} else {
+						line = append(line, fmt.Sprintf("```\n%s```", elem.Text))
+					}
+				}
+			case "hr":
+				line = append(line, "---")
 			}
 		}
 		if len(line) > 0 {

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -269,6 +269,45 @@ func TestParseInlineMarkdown_BoldAndCode(t *testing.T) {
 	}
 }
 
+func TestExtractPostPlainText_FlatFormat(t *testing.T) {
+	content := `{"title":"公告","content":[[{"tag":"text","text":"第一段"}],[{"tag":"text","text":"第二段"}]]}`
+	got := extractPostPlainText(content)
+	if got != "公告\n第一段\n第二段" {
+		t.Errorf("expected '公告\\n第一段\\n第二段', got %q", got)
+	}
+}
+
+func TestExtractPostPlainText_LocaleWrapped(t *testing.T) {
+	content := `{"zh_cn":{"title":"标题","content":[[{"tag":"text","text":"内容"}]]}}`
+	got := extractPostPlainText(content)
+	if got != "标题\n内容" {
+		t.Errorf("expected '标题\\n内容', got %q", got)
+	}
+}
+
+func TestExtractPostPlainText_NoTitle(t *testing.T) {
+	content := `{"content":[[{"tag":"text","text":"仅内容"}]]}`
+	got := extractPostPlainText(content)
+	if got != "仅内容" {
+		t.Errorf("expected '仅内容', got %q", got)
+	}
+}
+
+func TestExtractPostPlainText_Empty(t *testing.T) {
+	got := extractPostPlainText(`{}`)
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestExtractPostPlainText_NonTextTagsIgnored(t *testing.T) {
+	content := `{"content":[[{"tag":"text","text":"hello"},{"tag":"a","text":"link","href":"http://x.com"}]]}`
+	got := extractPostPlainText(content)
+	if got != "hello" {
+		t.Errorf("expected 'hello', got %q", got)
+	}
+}
+
 func strPtr(s string) *string { return &s }
 
 func TestStripMentions(t *testing.T) {

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -300,11 +300,20 @@ func TestExtractPostPlainText_Empty(t *testing.T) {
 	}
 }
 
-func TestExtractPostPlainText_NonTextTagsIgnored(t *testing.T) {
+func TestExtractPostPlainText_LinkTextExtracted(t *testing.T) {
 	content := `{"content":[[{"tag":"text","text":"hello"},{"tag":"a","text":"link","href":"http://x.com"}]]}`
 	got := extractPostPlainText(content)
-	if got != "hello" {
-		t.Errorf("expected 'hello', got %q", got)
+	if got != "hellolink" {
+		t.Errorf("expected 'hellolink', got %q", got)
+	}
+}
+
+func TestExtractPostPlainText_CodeBlockAndHr(t *testing.T) {
+	content := `{"content":[[{"tag":"code_block","text":"fmt.Println()","language":"go"}],[{"tag":"hr"}]]}`
+	got := extractPostPlainText(content)
+	expected := "```go\nfmt.Println()```\n---"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

When a user replies to a specific message in a Lark/Feishu chat, the agent currently has no visibility into the quoted message content — it only sees the user's reply text. This PR fixes that by fetching the parent message via `Im.Message.Get` and prepending a formatted quote block to the agent's input.

Closes #470

## Environment

- **Version**: 1.2.2-beta.5
- **OS**: macOS (Darwin 25.4.0, Apple Silicon)
- **Agent**: Claude Code
- **Platform**: Feishu/Lark (WebSocket mode)

## Changes

- **`fetchQuotedMessage(parentID)`**: New method that retrieves the parent message content and formats it as `[Quoted message from <sender>]:\n<content>\n\n`
- **`extractPostPlainText(content)`**: New helper for parsing Lark rich-text (post) JSON into plain text, supporting both flat and locale-wrapped formats
- **`onMessage`**: Captures `ParentId` from the incoming event and passes it to `dispatchMessage`
- **`dispatchMessage`**: Fetches quoted content when `parentID` is non-empty, prepends it to `text` and `post` message types

## Design decisions

- **Graceful degradation**: Any API failure silently skips the quote — the user's message is always delivered
- **Reuses existing patterns**: Same `Im.Message.Get` call used by `parseMergeForward`, same `resolveUserName` for sender resolution
- **Minimal blast radius**: Only `platform/feishu/feishu.go` modified; no changes to `core.Message` struct or other platforms
- **Scope**: Quote injection applies to `text` and `post` messages only (the most common reply scenarios). Image/audio/file replies still work as before, just without the quote prefix.

## Test plan

- [x] `go test ./...` passes (pre-existing failure in `core` package unrelated to this change)
- [x] New unit tests for `extractPostPlainText`: flat format, locale-wrapped, no title, empty content, non-text tags
- [x] Manual test: reply to a text message in Lark group → agent sees quoted content
- [x] Manual test: reply to a post (rich text) message → agent sees extracted plain text
- [x] Manual test: reply to an image message → agent sees `[image]` placeholder
- [x] Manual test: normal (non-reply) message → no change in behavior