### PR TITLE
fix(feishu): avoid model card callback timeouts

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -106,19 +106,19 @@ type replyContext struct {
 }
 
 type Platform struct {
-	platformName          string
-	domain                string
-	appID                 string
-	appSecret             string
-	progressStyle         string
-	useInteractiveCard    bool
-	self                  core.Platform
-	reactionEmoji         string
-	allowFrom             string
+	platformName               string
+	domain                     string
+	appID                      string
+	appSecret                  string
+	progressStyle              string
+	useInteractiveCard         bool
+	self                       core.Platform
+	reactionEmoji              string
+	allowFrom                  string
 	groupReplyAll              bool
 	respondToAtEveryoneAndHere bool
-	shareSessionInChannel bool
-	threadIsolation       bool
+	shareSessionInChannel      bool
+	threadIsolation            bool
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
 	noReplyToTrigger bool
 	client           *lark.Client
@@ -220,24 +220,24 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	}
 
 	base := &Platform{
-		platformName:          name,
-		domain:                domain,
-		appID:                 appID,
-		appSecret:             appSecret,
-		progressStyle:         progressStyle,
-		useInteractiveCard:    useInteractiveCard,
-		reactionEmoji:         reactionEmoji,
-		allowFrom:             allowFrom,
+		platformName:               name,
+		domain:                     domain,
+		appID:                      appID,
+		appSecret:                  appSecret,
+		progressStyle:              progressStyle,
+		useInteractiveCard:         useInteractiveCard,
+		reactionEmoji:              reactionEmoji,
+		allowFrom:                  allowFrom,
 		groupReplyAll:              groupReplyAll,
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
-		shareSessionInChannel: shareSessionInChannel,
-		threadIsolation:       threadIsolation,
-		noReplyToTrigger:      noReplyToTrigger,
-		client:                lark.NewClient(appID, appSecret, clientOpts...),
-		replayClient:          newFeishuReplayClient(appID, appSecret, domain),
-		port:                  port,
-		callbackPath:          callbackPath,
-		encryptKey:            encryptKey,
+		shareSessionInChannel:      shareSessionInChannel,
+		threadIsolation:            threadIsolation,
+		noReplyToTrigger:           noReplyToTrigger,
+		client:                     lark.NewClient(appID, appSecret, clientOpts...),
+		replayClient:               newFeishuReplayClient(appID, appSecret, domain),
+		port:                       port,
+		callbackPath:               callbackPath,
+		encryptKey:                 encryptKey,
 	}
 	if !useInteractiveCard {
 		base.self = base
@@ -444,6 +444,25 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 				Toast: &callback.Toast{
 					Type:    "info",
 					Content: "已记录选择（Selection recorded）",
+				},
+			}, nil
+		}
+		if strings.HasPrefix(actionVal, "act:/model ") {
+			cmdText := strings.TrimPrefix(actionVal, "act:")
+			rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+			go p.handler(p.dispatchPlatform(), &core.Message{
+				SessionKey: sessionKey,
+				Platform:   p.platformName,
+				UserID:     userID,
+				UserName:   p.resolveUserName(userID),
+				ChatName:   p.resolveChatName(chatID),
+				Content:    cmdText,
+				ReplyCtx:   rctx,
+			})
+			return &callback.CardActionTriggerResponse{
+				Toast: &callback.Toast{
+					Type:    "info",
+					Content: "正在切换模型（Switching model...）",
 				},
 			}, nil
 		}

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -443,6 +443,57 @@ func TestInteractivePlatform_CardActionUsesCallbackSessionKey(t *testing.T) {
 	}
 }
 
+func TestInteractivePlatform_ModelCardActionDispatchesCommandAsync(t *testing.T) {
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip, ok := platformAny.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *interactivePlatform", platformAny)
+	}
+
+	cardNavCalled := make(chan struct{}, 1)
+	ip.cardNavHandler = func(action string, sessionKey string) *core.Card {
+		cardNavCalled <- struct{}{}
+		return core.NewCard().Markdown("unexpected").Build()
+	}
+
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		msgCh <- msg
+	}
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_test_user"},
+			Action:   &callback.CallBackAction{Value: map[string]any{"action": "act:/model switch 1"}},
+			Context:  &callback.Context{OpenChatID: "oc_test_chat", OpenMessageID: "om_test_message"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp == nil || resp.Toast == nil {
+		t.Fatalf("expected toast response, got %#v", resp)
+	}
+
+	select {
+	case <-cardNavCalled:
+		t.Fatal("expected model card action to skip synchronous card nav")
+	default:
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "/model switch 1" {
+			t.Fatalf("message content = %q, want /model switch 1", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected model card action message")
+	}
+}
+
 func TestNewLark_PlatformNameAndDomain(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret",


### PR DESCRIPTION
## Summary
- route Feishu `/model` card actions through async command dispatch instead of synchronous card navigation
- return a quick toast response so OpenCode model switching no longer blocks the Feishu callback window
- add a regression test covering async `/model switch` card behavior

## Test Plan
- [x] `go test ./platform/feishu -run TestInteractivePlatform_ModelCardActionDispatchesCommandAsync -count=1`
- [x] `go test ./platform/feishu -count=1`
- [x] `go test ./core -run 'TestHandleCardNav|TestRenderModelCard|TestResolveModelAlias|TestParseModelSwitchArgs' -count=1`
- [ ] `go test ./...` currently fails on unrelated existing test `TestCmdShell_MultiWorkspaceIgnoresMissingSharedBinding`