### PR TITLE
feat(speech): add Gemini as STT provider

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -420,6 +420,14 @@ func main() {
 				} else {
 					slog.Warn("speech: qwen provider enabled but api_key is empty")
 				}
+			case "gemini":
+				apiKey := cfg.Speech.Gemini.APIKey
+				model := cfg.Speech.Gemini.Model
+				if apiKey != "" {
+					speechCfg.STT = core.NewGeminiSTT(apiKey, model)
+				} else {
+					slog.Warn("speech: gemini provider enabled but api_key is empty")
+				}
 			default: // "openai" or unspecified
 				apiKey := cfg.Speech.OpenAI.APIKey
 				baseURL := cfg.Speech.OpenAI.BaseURL

--- a/config/config.go
+++ b/config/config.go
@@ -129,7 +129,7 @@ type RelayConfig struct {
 // SpeechConfig configures speech-to-text for voice messages.
 type SpeechConfig struct {
 	Enabled  bool   `toml:"enabled"`
-	Provider string `toml:"provider"` // "openai" | "groq" | "qwen"
+	Provider string `toml:"provider"` // "openai" | "groq" | "qwen" | "gemini"
 	Language string `toml:"language"` // e.g. "zh", "en"; empty = auto-detect
 	OpenAI   struct {
 		APIKey  string `toml:"api_key"`
@@ -145,6 +145,10 @@ type SpeechConfig struct {
 		BaseURL string `toml:"base_url"`
 		Model   string `toml:"model"`
 	} `toml:"qwen"`
+	Gemini struct {
+		APIKey string `toml:"api_key"`
+		Model  string `toml:"model"`
+	} `toml:"gemini"`
 }
 
 // TTSConfig configures text-to-speech output (mirrors SpeechConfig style).

--- a/core/speech.go
+++ b/core/speech.go
@@ -199,6 +199,101 @@ func (q *QwenASR) Transcribe(ctx context.Context, audio []byte, format string, l
 	return strings.TrimSpace(result.Choices[0].Message.Content), nil
 }
 
+// GeminiSTT implements SpeechToText using the Google Gemini API.
+// Audio is sent as inline_data (base64) in the contents array, using Gemini's
+// generateContent endpoint with query-parameter authentication.
+type GeminiSTT struct {
+	APIKey  string
+	Model   string
+	BaseURL string // internal; defaults to Google API, overridable for testing
+	Client  *http.Client
+}
+
+func NewGeminiSTT(apiKey, model string) *GeminiSTT {
+	if model == "" {
+		model = "gemini-flash-latest"
+	}
+	return &GeminiSTT{
+		APIKey:  apiKey,
+		Model:   model,
+		BaseURL: "https://generativelanguage.googleapis.com/v1beta",
+		Client:  &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (g *GeminiSTT) Transcribe(ctx context.Context, audio []byte, format string, lang string) (string, error) {
+	b64 := base64.StdEncoding.EncodeToString(audio)
+	mime := formatToAudioMIME(format)
+
+	prompt := "Transcribe this audio accurately. Output only the transcribed text, nothing else."
+	if lang != "" {
+		prompt = fmt.Sprintf("Transcribe this audio accurately in %s. Output only the transcribed text, nothing else.", lang)
+	}
+
+	reqBody := map[string]any{
+		"contents": []map[string]any{
+			{
+				"parts": []map[string]any{
+					{
+						"inline_data": map[string]any{
+							"mime_type": mime,
+							"data":      b64,
+						},
+					},
+					{
+						"text": prompt,
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("gemini stt: marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/models/%s:generateContent?key=%s", g.BaseURL, g.Model, g.APIKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("gemini stt: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := g.Client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("gemini stt: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("gemini stt: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("gemini stt API %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+		} `json:"candidates"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("gemini stt: parse response: %w", err)
+	}
+	if len(result.Candidates) == 0 || len(result.Candidates[0].Content.Parts) == 0 {
+		return "", fmt.Errorf("gemini stt: empty response")
+	}
+
+	return strings.TrimSpace(result.Candidates[0].Content.Parts[0].Text), nil
+}
+
 // ConvertAudioToMP3 uses ffmpeg to convert audio from unsupported formats to mp3.
 // Returns the mp3 bytes. If ffmpeg is not installed, returns an error.
 func ConvertAudioToMP3(audio []byte, srcFormat string) ([]byte, error) {

--- a/core/speech_test.go
+++ b/core/speech_test.go
@@ -1,0 +1,161 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewGeminiSTT_DefaultModel(t *testing.T) {
+	g := NewGeminiSTT("test-key", "")
+	if g.Model != "gemini-flash-latest" {
+		t.Errorf("expected default model gemini-flash-latest, got %s", g.Model)
+	}
+	if g.BaseURL != "https://generativelanguage.googleapis.com/v1beta" {
+		t.Errorf("unexpected base URL: %s", g.BaseURL)
+	}
+}
+
+func TestNewGeminiSTT_CustomModel(t *testing.T) {
+	g := NewGeminiSTT("test-key", "gemini-2.5-flash")
+	if g.Model != "gemini-2.5-flash" {
+		t.Errorf("expected gemini-2.5-flash, got %s", g.Model)
+	}
+}
+
+func TestGeminiSTT_Transcribe_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected application/json, got %s", ct)
+		}
+		if r.URL.Query().Get("key") != "test-key" {
+			t.Errorf("expected API key 'test-key', got %q", r.URL.Query().Get("key"))
+		}
+		if !strings.Contains(r.URL.Path, "test-model") {
+			t.Errorf("expected model in path, got %s", r.URL.Path)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		contents, ok := body["contents"].([]any)
+		if !ok || len(contents) == 0 {
+			t.Fatal("missing contents in request")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{
+				{
+					"content": map[string]any{
+						"parts": []map[string]any{
+							{"text": "你好世界"},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	g := &GeminiSTT{
+		APIKey:  "test-key",
+		Model:   "test-model",
+		BaseURL: server.URL,
+		Client:  server.Client(),
+	}
+
+	text, err := g.Transcribe(context.Background(), []byte("fake-audio"), "mp3", "zh")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if text != "你好世界" {
+		t.Errorf("expected '你好世界', got %q", text)
+	}
+}
+
+func TestGeminiSTT_Transcribe_WithLanguage(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{
+				{"content": map[string]any{"parts": []map[string]any{{"text": "hello"}}}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	g := &GeminiSTT{APIKey: "k", Model: "m", BaseURL: server.URL, Client: server.Client()}
+	_, err := g.Transcribe(context.Background(), []byte("audio"), "mp3", "en")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the prompt includes language
+	contents := gotBody["contents"].([]any)
+	parts := contents[0].(map[string]any)["parts"].([]any)
+	textPart := parts[1].(map[string]any)["text"].(string)
+	if !strings.Contains(textPart, "en") {
+		t.Errorf("expected language 'en' in prompt, got %q", textPart)
+	}
+}
+
+func TestGeminiSTT_Transcribe_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":{"message":"API key invalid","code":403}}`))
+	}))
+	defer server.Close()
+
+	g := &GeminiSTT{APIKey: "bad", Model: "m", BaseURL: server.URL, Client: server.Client()}
+	_, err := g.Transcribe(context.Background(), []byte("audio"), "mp3", "")
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected 403 in error, got: %v", err)
+	}
+}
+
+func TestGeminiSTT_Transcribe_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"candidates": []map[string]any{}})
+	}))
+	defer server.Close()
+
+	g := &GeminiSTT{APIKey: "k", Model: "m", BaseURL: server.URL, Client: server.Client()}
+	_, err := g.Transcribe(context.Background(), []byte("audio"), "mp3", "")
+	if err == nil {
+		t.Fatal("expected error for empty candidates")
+	}
+	if !strings.Contains(err.Error(), "empty response") {
+		t.Errorf("expected 'empty response' in error, got: %v", err)
+	}
+}
+
+func TestGeminiSTT_Transcribe_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	g := &GeminiSTT{APIKey: "k", Model: "m", BaseURL: server.URL, Client: server.Client()}
+	_, err := g.Transcribe(context.Background(), []byte("audio"), "mp3", "")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "parse response") {
+		t.Errorf("expected 'parse response' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add Google Gemini as a speech-to-text provider via the `generateContent` multimodal API
- Complements existing OpenAI Whisper, Groq, and Qwen STT providers
- Uses query-parameter authentication (`?key=`) matching Gemini API conventions

## Environment

- **Version**: 1.2.2-beta.5
- **OS**: macOS (Darwin 25.4.0, Apple Silicon)
- **Agent**: Claude Code
- **Platform**: Feishu/Lark (WebSocket mode)

## Motivation

Users with a Google AI Studio API key (free tier available) can now use Gemini for voice transcription without needing separate OpenAI/Groq/Qwen accounts. Gemini's multimodal capabilities handle audio natively via base64 inline data.

## Changes

- `core/speech.go`: `GeminiSTT` struct implementing `SpeechToText` interface
- `config/config.go`: `[speech.gemini]` config section (`api_key`, `model`)
- `cmd/cc-connect/main.go`: `"gemini"` case in STT provider switch
- `core/speech_test.go`: 6 unit tests (success, language param, API error, empty response, invalid JSON, defaults)

## Config example

```toml
[speech]
  enabled = true
  provider = "gemini"
  language = "zh"

[speech.gemini]
  api_key = "AIza..."
  model = "gemini-flash-latest"  # default
```

## Test plan

- [x] `go test ./...` passes (pre-existing failure in `core` package unrelated to this change)
- [x] Unit tests pass (`go test ./core/ -run TestGeminiSTT`)
- [x] Tested locally with real Gemini API key — voice messages transcribed correctly on Lark
- [x] Verified graceful degradation on API errors (403, empty response, invalid JSON)
- [x] No changes to existing STT providers