### PR TITLE
fix(feishu): handle code_block elements in post message parsing

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -2447,6 +2447,7 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 type postElement struct {
 	Tag      string `json:"tag"`
 	Text     string `json:"text,omitempty"`
+	Language string `json:"language,omitempty"`
 	ImageKey string `json:"image_key,omitempty"`
 	Href     string `json:"href,omitempty"`
 }
@@ -2492,6 +2493,11 @@ func (p *Platform) extractPostParts(messageID string, post *postLang) ([]string,
 			case "a":
 				if elem.Text != "" {
 					textParts = append(textParts, elem.Text)
+				}
+			case "code_block":
+				if elem.Text != "" {
+					lang := elem.Language
+					textParts = append(textParts, "```"+lang+"\n"+elem.Text+"\n```")
 				}
 			case "img":
 				if elem.ImageKey != "" {


### PR DESCRIPTION
1. ## Summary
2. - code_block elements in Feishu post messages are silently dropped in extractPostParts()
3. - Only text, a, and img tags are handled; code_block is missing
4. - This causes code snippets sent from Feishu to be lost before reaching the agent
5. 
6. ## Fix
7. - Add Language field to postElement struct
8. - Add code_block case in extractPostParts() switch, reconstructing as markdown fenced code block
9. 
10. ## Note
11. The outbound path already supports code_block (lines 1439, 1473), so this is an inbound-only gap.