### PR TITLE
fix(core): handle @mention in permission response messages

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1684,6 +1684,7 @@ func buildAskQuestionResponse(originalInput map[string]any, questions []UserQues
 }
 
 func isApproveAllResponse(s string) bool {
+	s = stripMentions(s)
 	for _, w := range []string{
 		"allow all", "allowall", "approve all", "yes all",
 		"允许所有", "允许全部", "全部允许", "所有允许", "都允许", "全部同意",
@@ -1696,6 +1697,7 @@ func isApproveAllResponse(s string) bool {
 }
 
 func isAllowResponse(s string) bool {
+	s = stripMentions(s)
 	for _, w := range []string{"allow", "yes", "y", "ok", "允许", "同意", "可以", "好", "好的", "是", "确认", "approve"} {
 		if s == w {
 			return true
@@ -1705,12 +1707,22 @@ func isAllowResponse(s string) bool {
 }
 
 func isDenyResponse(s string) bool {
+	s = stripMentions(s)
 	for _, w := range []string{"deny", "no", "n", "reject", "拒绝", "不允许", "不行", "不", "否", "取消", "cancel"} {
 		if s == w {
 			return true
 		}
 	}
 	return false
+}
+
+// mentionRe matches @mention patterns like "@群机器人", "@user123", etc.
+var mentionRe = regexp.MustCompile(`@[^\s]+`)
+
+// stripMentions removes @mention patterns from anywhere in the string.
+// This handles both "@群机器人 允许" -> "允许" and "允许 @群机器人" -> "允许".
+func stripMentions(s string) string {
+	return strings.TrimSpace(mentionRe.ReplaceAllString(s, ""))
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -7917,3 +7917,97 @@ func TestExtractSessionKeyParts(t *testing.T) {
 		})
 	}
 }
+
+func TestStripMentions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"允许", "允许"},
+		{"允许 @群机器人", "允许"},
+		{"@群机器人 允许", "允许"},
+		{"允许 @群机器人 @user123", "允许"},
+		{"@bot1 @bot2 同意", "同意"},
+		{"全部允许 @群机器人", "全部允许"},
+		{"拒绝 @群机器人", "拒绝"},
+		{"@群机器人 拒绝", "拒绝"},
+		{"allow", "allow"},
+		{"allow @bot", "allow"},
+		{"@bot allow", "allow"},
+		{"", ""},
+		{"@群机器人", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := stripMentions(tt.input)
+			if got != tt.expected {
+				t.Errorf("stripMentions(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPermissionResponsesWithMentions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		allow    bool
+		deny     bool
+		approve  bool
+	}{
+		// Basic cases without mentions
+		{"allow basic", "allow", true, false, false},
+		{"deny basic", "deny", false, true, false},
+		{"approve all basic", "allow all", false, false, true},
+		{"允许 basic", "允许", true, false, false},
+		{"拒绝 basic", "拒绝", false, true, false},
+		{"全部允许 basic", "全部允许", false, false, true},
+
+		// With @mention suffix (WeChat Work group chat style)
+		{"允许 @群机器人", "允许 @群机器人", true, false, false},
+		{"拒绝 @群机器人", "拒绝 @群机器人", false, true, false},
+		{"全部允许 @群机器人", "全部允许 @群机器人", false, false, true},
+		{"allow @bot", "allow @bot", true, false, false},
+		{"deny @bot", "deny @bot", false, true, false},
+		{"allow all @bot", "allow all @bot", false, false, true},
+
+		// With @mention prefix
+		{"@群机器人 允许", "@群机器人 允许", true, false, false},
+		{"@群机器人 拒绝", "@群机器人 拒绝", false, true, false},
+		{"@群机器人 全部允许", "@群机器人 全部允许", false, false, true},
+		{"@bot allow", "@bot allow", true, false, false},
+		{"@bot deny", "@bot deny", false, true, false},
+		{"@bot allow all", "@bot allow all", false, false, true},
+
+		// Multiple mentions
+		{"允许 @bot1 @bot2", "允许 @bot1 @bot2", true, false, false},
+		{"@bot1 @bot2 拒绝", "@bot1 @bot2 拒绝", false, true, false},
+
+		// Non-matching cases
+		{"hello", "hello", false, false, false},
+		{"@群机器人", "@群机器人", false, false, false},
+		{"", "", false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Apply the same preprocessing as the actual code
+			lower := strings.ToLower(strings.TrimSpace(tt.input))
+
+			gotAllow := isAllowResponse(lower)
+			gotDeny := isDenyResponse(lower)
+			gotApprove := isApproveAllResponse(lower)
+
+			if gotAllow != tt.allow {
+				t.Errorf("isAllowResponse(%q) = %v, want %v", lower, gotAllow, tt.allow)
+			}
+			if gotDeny != tt.deny {
+				t.Errorf("isDenyResponse(%q) = %v, want %v", lower, gotDeny, tt.deny)
+			}
+			if gotApprove != tt.approve {
+				t.Errorf("isApproveAllResponse(%q) = %v, want %v", lower, gotApprove, tt.approve)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `stripMentions()` helper function that removes `@mention` patterns from messages using regex
- Apply `stripMentions()` to `isApproveAllResponse`, `isAllowResponse`, `isDenyResponse` functions
- Add comprehensive tests for mention handling in all positions (prefix, suffix, multiple mentions)

## Problem
In WeChat Work group chats, when users respond to permission requests with messages like "允许 @群机器人", the response was not matched because the @mention was included in the comparison string.

## Solution
The `stripMentions` function uses regex `@[^\s]+` to remove any @mention pattern, handling:
- "@群机器人 允许" → "允许" (mention prefix)
- "允许 @群机器人" → "允许" (mention suffix)
- "@bot1 @bot2 同意" → "同意" (multiple mentions)

## Test plan
- [x] `go build ./core/...` passes
- [x] `go vet ./core/...` passes
- [x] `go test ./core/...` passes
- [x] Unit tests for stripMentions with various mention positions
- [x] Unit tests for permission response matching with mentions

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)