### PR TITLE
fix(claudecode): handle mid-turn compaction events in readLoop

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -188,6 +188,11 @@ func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer)
 		case "control_cancel_request":
 			requestID, _ := raw["request_id"].(string)
 			slog.Debug("claudeSession: permission cancelled", "request_id", requestID)
+		default:
+			// Log unknown event types for diagnostic purposes.
+			// Claude Code may emit new event types (e.g., during context compaction)
+			// that we don't yet handle. Logging helps identify and fix issues.
+			slog.Debug("claudeSession: unknown event type", "type", eventType, "event", raw)
 		}
 	}
 
@@ -308,11 +313,20 @@ func (cs *claudeSession) handleResult(raw map[string]any) {
 		}
 	}
 
+	// Check for subtype to distinguish real turn completion from intermediate events.
+	// Claude Code may emit result events during context compaction that should not
+	// be treated as turn completion.
+	subtype, _ := raw["subtype"].(string)
+	isCompaction := subtype == "compact" || subtype == "compaction"
+	if subtype != "" {
+		slog.Debug("claudeSession: result subtype", "subtype", subtype, "is_compaction", isCompaction)
+	}
+
 	evt := core.Event{
 		Type:         core.EventResult,
 		Content:      content,
 		SessionID:    cs.CurrentSessionID(),
-		Done:         true,
+		Done:         !isCompaction, // Only mark as done if not a compaction event
 		InputTokens:  inputTokens,
 		OutputTokens: outputTokens,
 	}

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -65,3 +65,79 @@ func TestHandleResultNoUsage(t *testing.T) {
 		t.Errorf("OutputTokens = %d, want 0", evt.OutputTokens)
 	}
 }
+
+func TestHandleResult_DoneTrueForNormalResult(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("test-session")
+	cs.alive.Store(true)
+
+	raw := map[string]any{
+		"type":   "result",
+		"result": "Task completed successfully",
+	}
+
+	cs.handleResult(raw)
+
+	evt := <-cs.events
+	if !evt.Done {
+		t.Error("Done = false for normal result, want true")
+	}
+}
+
+func TestHandleResult_DoneFalseForCompactionSubtype(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("test-session")
+	cs.alive.Store(true)
+
+	// Test "compact" subtype
+	raw := map[string]any{
+		"type":    "result",
+		"result":  "Context compressed",
+		"subtype": "compact",
+	}
+
+	cs.handleResult(raw)
+
+	evt := <-cs.events
+	if evt.Done {
+		t.Error("Done = true for compact subtype, want false")
+	}
+}
+
+func TestHandleResult_DoneFalseForCompactionAltSubtype(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("test-session")
+	cs.alive.Store(true)
+
+	// Test "compaction" subtype
+	raw := map[string]any{
+		"type":    "result",
+		"result":  "Context compressed",
+		"subtype": "compaction",
+	}
+
+	cs.handleResult(raw)
+
+	evt := <-cs.events
+	if evt.Done {
+		t.Error("Done = true for compaction subtype, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- Add default case in event switch to log unknown event types for diagnostic purposes
- Handle compaction result events by checking `subtype` field (`compact` or `compaction`)
- Set `Done=false` for compaction result events so the event loop continues processing

## Problem
When Claude Code performs automatic context compaction mid-turn, cc-connect could misinterpret compaction-related events as turn completion, causing the task to be interrupted prematurely. Unknown event types were silently dropped, making diagnosis difficult.

## Solution
1. **Diagnostic logging**: Unknown event types are now logged with their full content, helping identify new event types Claude Code may emit
2. **Compaction detection**: Result events with `subtype: "compact"` or `subtype: "compaction"` are treated as intermediate events (Done=false), not turn completion

## Test plan
- [x] `go build ./agent/claudecode/...` passes
- [x] `go vet ./agent/claudecode/...` passes
- [x] `go test ./agent/claudecode/...` passes
- [x] Unit tests for Done=true on normal result
- [x] Unit tests for Done=false on compaction subtypes

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)