### PR TITLE
feat(config): support env var substitution for secrets in config.toml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -265,6 +267,9 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
+	// Substitute environment variables in all string fields.
+	substituteEnvVars(cfg)
+
 	if cfg.DataDir == "" {
 		if home, err := os.UserHomeDir(); err == nil {
 			cfg.DataDir = filepath.Join(home, ".cc-connect")
@@ -281,6 +286,114 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 	return cfg, nil
+}
+
+// envVarPattern matches ${VAR_NAME} patterns for environment variable substitution.
+var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+// substituteEnvVars walks through all string fields in the config struct
+// and replaces ${VAR_NAME} patterns with the corresponding environment variable values.
+// Non-existent variables are replaced with empty strings.
+func substituteEnvVars(cfg *Config) {
+	substituteEnvVarsInValue(reflect.ValueOf(cfg).Elem())
+}
+
+// substituteEnvVarsInValue recursively walks a reflect.Value and substitutes env vars in strings.
+func substituteEnvVarsInValue(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.String:
+		if v.CanSet() {
+			original := v.String()
+			replaced := envVarPattern.ReplaceAllStringFunc(original, func(match string) string {
+				// Extract variable name from ${VAR_NAME}
+				varName := envVarPattern.FindStringSubmatch(match)[1]
+				return os.Getenv(varName)
+			})
+			if replaced != original {
+				v.SetString(replaced)
+			}
+		}
+
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			if field.CanAddr() {
+				substituteEnvVarsInValue(field)
+			}
+		}
+
+	case reflect.Ptr:
+		if v.IsNil() {
+			return
+		}
+		substituteEnvVarsInValue(v.Elem())
+
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			elem := v.Index(i)
+			if elem.CanAddr() {
+				substituteEnvVarsInValue(elem)
+			}
+		}
+
+	case reflect.Map:
+		// Only process map[string]string and map[string]any types
+		if v.Type().Key().Kind() != reflect.String {
+			return
+		}
+		iter := v.MapRange()
+		for iter.Next() {
+			key := iter.Key()
+			val := iter.Value()
+			switch val.Kind() {
+			case reflect.String:
+				// Map values are not addressable, so we must use SetMapIndex
+				original := val.String()
+				replaced := envVarPattern.ReplaceAllStringFunc(original, func(match string) string {
+					varName := envVarPattern.FindStringSubmatch(match)[1]
+					return os.Getenv(varName)
+				})
+				if replaced != original {
+					v.SetMapIndex(key, reflect.ValueOf(replaced).Convert(v.Type().Elem()))
+				}
+			case reflect.Interface:
+				// Handle map[string]any where values are stored as interface{}
+				if iface := val.Interface(); iface != nil {
+					switch concrete := iface.(type) {
+					case string:
+						replaced := envVarPattern.ReplaceAllStringFunc(concrete, func(match string) string {
+							varName := envVarPattern.FindStringSubmatch(match)[1]
+							return os.Getenv(varName)
+						})
+						if replaced != concrete {
+							v.SetMapIndex(key, reflect.ValueOf(replaced))
+						}
+					case map[string]any:
+						// Recursively substitute in nested maps
+						substituteEnvVarsInMapAny(concrete)
+					}
+				}
+			}
+		}
+	}
+}
+
+// substituteEnvVarsInMapAny recursively substitutes env vars in a map[string]any.
+func substituteEnvVarsInMapAny(m map[string]any) {
+	for key, val := range m {
+		switch concrete := val.(type) {
+		case string:
+			replaced := envVarPattern.ReplaceAllStringFunc(concrete, func(match string) string {
+				varName := envVarPattern.FindStringSubmatch(match)[1]
+				return os.Getenv(varName)
+			})
+			if replaced != concrete {
+				m[key] = replaced
+			}
+		case map[string]any:
+			substituteEnvVarsInMapAny(concrete)
+		}
+	}
 }
 
 func (c *Config) validate() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1477,3 +1477,194 @@ func TestFormatConfigFile(t *testing.T) {
 		}
 	})
 }
+
+func TestLoadEnvVarSubstitution(t *testing.T) {
+	// Set environment variables for testing
+	t.Setenv("TEST_API_KEY", "secret-api-key-12345")
+	t.Setenv("TEST_BOT_TOKEN", "telegram-bot-token")
+	t.Setenv("TEST_APP_SECRET", "feishu-app-secret")
+
+	envVarConfigTOML := `
+data_dir = "/tmp/test-data"
+
+[[projects]]
+name = "env-test"
+
+[projects.agent]
+type = "claudecode"
+
+[projects.agent.options]
+model = "claude-3-opus"
+api_key = "${TEST_API_KEY}"
+
+[[projects.agent.providers]]
+name = "primary"
+api_key = "${TEST_API_KEY}"
+base_url = "https://api.example.com"
+env = { "MY_VAR" = "${TEST_API_KEY}" }
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+bot_token = "${TEST_BOT_TOKEN}"
+`
+
+	configPath := writeConfigFixture(t, envVarConfigTOML)
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	// Check that env vars were substituted in agent.options.api_key
+	if got := stringMapValue(cfg.Projects[0].Agent.Options, "api_key"); got != "secret-api-key-12345" {
+		t.Fatalf("agent.options.api_key = %q, want %q", got, "secret-api-key-12345")
+	}
+
+	// Check that env vars were substituted in provider.api_key
+	if cfg.Projects[0].Agent.Providers[0].APIKey != "secret-api-key-12345" {
+		t.Fatalf("provider.api_key = %q, want %q", cfg.Projects[0].Agent.Providers[0].APIKey, "secret-api-key-12345")
+	}
+
+	// Check that env vars were substituted in provider.env map
+	if provEnv := cfg.Projects[0].Agent.Providers[0].Env; provEnv != nil {
+		if got := provEnv["MY_VAR"]; got != "secret-api-key-12345" {
+			t.Fatalf("provider.env.MY_VAR = %q, want %q", got, "secret-api-key-12345")
+		}
+	}
+
+	// Check that env vars were substituted in platform.options.bot_token
+	if got := stringMapValue(cfg.Projects[0].Platforms[0].Options, "bot_token"); got != "telegram-bot-token" {
+		t.Fatalf("platform.options.bot_token = %q, want %q", got, "telegram-bot-token")
+	}
+}
+
+func TestLoadEnvVarSubstitutionMissingVariable(t *testing.T) {
+	// Ensure the variable is NOT set (t.Setenv would set it)
+	envVarConfigTOML := `
+[[projects]]
+name = "missing-var-test"
+
+[projects.agent]
+type = "claudecode"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+bot_token = "${MISSING_VAR_NAME}"
+other_value = "static-value"
+`
+
+	configPath := writeConfigFixture(t, envVarConfigTOML)
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	// Missing variable should be replaced with empty string
+	if got := stringMapValue(cfg.Projects[0].Platforms[0].Options, "bot_token"); got != "" {
+		t.Fatalf("platform.options.bot_token = %q, want empty string", got)
+	}
+
+	// Static values should be unchanged
+	if got := stringMapValue(cfg.Projects[0].Platforms[0].Options, "other_value"); got != "static-value" {
+		t.Fatalf("platform.options.other_value = %q, want %q", got, "static-value")
+	}
+}
+
+func TestLoadEnvVarSubstitutionNoEnvVars(t *testing.T) {
+	// Config without any ${...} patterns - should be unchanged
+	noEnvVarConfigTOML := `
+[[projects]]
+name = "no-env-test"
+
+[projects.agent]
+type = "claudecode"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+bot_token = "plain-token-xyz"
+`
+
+	configPath := writeConfigFixture(t, noEnvVarConfigTOML)
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	// Values should remain unchanged
+	if got := stringMapValue(cfg.Projects[0].Platforms[0].Options, "bot_token"); got != "plain-token-xyz" {
+		t.Fatalf("platform.options.bot_token = %q, want %q", got, "plain-token-xyz")
+	}
+}
+
+func TestLoadEnvVarSubstitutionMultipleVarsInOneString(t *testing.T) {
+	t.Setenv("VAR_A", "valueA")
+	t.Setenv("VAR_B", "valueB")
+
+	envVarConfigTOML := `
+[[projects]]
+name = "multi-var-test"
+
+[projects.agent]
+type = "claudecode"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+bot_token = "prefix-${VAR_A}-middle-${VAR_B}-suffix"
+`
+
+	configPath := writeConfigFixture(t, envVarConfigTOML)
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	// Multiple vars in one string should all be substituted
+	expected := "prefix-valueA-middle-valueB-suffix"
+	if got := stringMapValue(cfg.Projects[0].Platforms[0].Options, "bot_token"); got != expected {
+		t.Fatalf("platform.options.bot_token = %q, want %q", got, expected)
+	}
+}
+
+func TestLoadEnvVarSubstitutionInSpeechConfig(t *testing.T) {
+	t.Setenv("SPEECH_API_KEY", "speech-secret-key")
+
+	envVarConfigTOML := `
+[speech]
+enabled = true
+provider = "openai"
+
+[speech.openai]
+api_key = "${SPEECH_API_KEY}"
+base_url = "https://api.openai.com"
+
+[[projects]]
+name = "speech-test"
+
+[projects.agent]
+type = "claudecode"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+bot_token = "test-token"
+`
+
+	configPath := writeConfigFixture(t, envVarConfigTOML)
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	// Check that env vars were substituted in speech.openai.api_key
+	if cfg.Speech.OpenAI.APIKey != "speech-secret-key" {
+		t.Fatalf("speech.openai.api_key = %q, want %q", cfg.Speech.OpenAI.APIKey, "speech-secret-key")
+	}
+}


### PR DESCRIPTION
## Summary
- Add post-processing function to substitute `${VAR_NAME}` patterns with environment variable values after TOML parsing
- This allows users to store secrets (API keys, tokens) securely without exposing them in the config file
- Works with nested structs, slices, and maps (map[string]string, map[string]any)

## Test plan
- [x] `go build ./...` passes (config package)
- [x] `go test ./config/...` passes - all 51 tests including 5 new env var tests
- [x] `go vet ./config/...` passes
- [x] Manual test: `${VAR_NAME}` pattern correctly replaced
- [x] Missing variables replaced with empty string
- [x] Configs without `${...}` unchanged
- [x] Multiple vars in one string handled correctly
- [x] Works in Speech/TTS config sections

## Example usage
```toml
[projects.platforms.options]
token = "${TELEGRAM_BOT_TOKEN}"

[projects.agent.providers]
api_key = "${OPENAI_API_KEY}"
env = { "MY_VAR" = "${OPENAI_API_KEY}" }

[speech.openai]
api_key = "${SPEECH_API_KEY}"
```

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)