### PR TITLE
fix(tts): strip Markdown formatting before speech synthesis

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -9067,7 +9067,7 @@ func (e *Engine) sendTTSReply(p Platform, replyCtx any, text string) {
 	}
 	slog.Info("tts: starting synthesis", "voice", e.tts.Voice, "text_len", len(text))
 	opts := TTSSynthesisOpts{Voice: e.tts.Voice}
-	audioData, format, err := e.tts.TTS.Synthesize(e.ctx, text, opts)
+	audioData, format, err := e.tts.TTS.Synthesize(e.ctx, StripMarkdown(text), opts)
 	if err != nil {
 		slog.Error("tts: synthesis failed", "error", err)
 		return


### PR DESCRIPTION
## Summary

- TTS engines read Markdown characters aloud (e.g. `**bold**` → "star star bold star star"), producing poor audio quality
- Call the existing `StripMarkdown()` helper to clean text before passing it to `TTS.Synthesize()`
- One-line fix in `sendTTSReply()` — the `StripMarkdown` function already exists in `core/markdown.go` but was not used in the TTS path

## Environment

- **Version**: 1.2.2-beta.5
- **OS**: macOS (Darwin 25.4.0, Apple Silicon)
- **Agent**: Claude Code
- **Platform**: Feishu/Lark (WebSocket mode)
- **TTS provider**: Edge TTS (`zh-CN-XiaoxiaoNeural`)

## Changes

- `core/engine.go`: wrap `text` with `StripMarkdown()` before calling `TTS.Synthesize()` in `sendTTSReply()`

## Test plan

- [x] `go test ./...` passes (pre-existing failure in `core` package unrelated to this change)
- [x] Tested locally with Edge TTS (`zh-CN-XiaoxiaoNeural`) on Lark — Markdown symbols (`**`, `*`, `` ` ``, `#`, `~~`) no longer read aloud
- [ ] Verify with other TTS providers (OpenAI, Qwen, MiniMax)