### PR TITLE
fix(claudecode): send SIGTERM instead of SIGKILL for graceful session close

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -98,6 +99,13 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 		env = core.MergeEnv(env, extraEnv)
 	}
 	cmd.Env = env
+
+	// Send SIGTERM first to allow Claude Code to run cleanup hooks (SessionEnd, PreCompact).
+	// After WaitDelay, escalate to the default SIGKILL behavior.
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+	cmd.WaitDelay = 8 * time.Second
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary
Set `cmd.Cancel` and `cmd.WaitDelay` to allow Claude Code to run cleanup hooks (SessionEnd, PreCompact) before the process is terminated.

Before this fix, `exec.CommandContext`'s default Cancel behavior sent SIGKILL, which is uncatchable and prevented Claude Code from running any registered hooks on session close (via `/new`, `/switch`, `/clear`, `/delete`, idle timeout, daemon restart, etc.).

## Changes
- `cmd.Cancel` sends SIGTERM instead of SIGKILL
- `cmd.WaitDelay = 8 * time.Second` for graceful shutdown window
- Go runtime automatically escalates to SIGKILL if process doesn't exit within WaitDelay
- Backward compatible: misbehaving processes still get killed after 8 seconds

## Test plan
- [x] `go build ./agent/claudecode/...` passes
- [x] `go vet ./agent/claudecode/...` passes
- [x] `go test ./agent/claudecode/...` passes (all 26 tests)
- [x] Manual verification: SIGTERM sent on session close

## How it works
1. `cs.cancel()` triggers `cmd.Cancel`, which sends SIGTERM
2. Claude Code receives SIGTERM, runs its registered hooks, exits cleanly
3. If Claude Code doesn't exit within `WaitDelay` (8 seconds), Go's runtime escalates to `Process.Kill()` (SIGKILL) automatically
4. The existing `Close()` 8-second timeout fallback is preserved as a safety net

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)