### PR TITLE
fix(discord): correct slash command limit from 200 to 100

### DIFF
--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -369,10 +369,10 @@ func (p *Platform) RegisterCommands(commands []core.BotCommandInfo) error {
 		})
 	}
 
-	// Limit to 200 commands
-	if len(cmds) > 200 {
-		cmds = cmds[:200]
-		slog.Warn("discord: commands > 200, truncate")
+	// Discord allows max 100 commands per bulk overwrite (guild or global).
+	if len(cmds) > 100 {
+		slog.Warn("discord: truncating commands to Discord limit of 100", "total", len(cmds), "dropped", len(cmds)-100)
+		cmds = cmds[:100]
 	}
 
 	if len(cmds) == 0 {


### PR DESCRIPTION
## Summary
- Discord bulk overwrite API allows max 100 application commands (guild or global), but cc-connect was truncating at 200 — causing silent HTTP 400 failures for users with >100 commands
- Changed the limit from 200 to 100 and improved the warning log to include total count and number of dropped commands

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: configure >100 slash commands and verify registration succeeds (truncated to 100) with a warning log

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)