### PR TITLE
fix(feishu): extract link, hr, and code_block in quoted post messages

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1064,15 +1064,20 @@ func extractPostPlainText(content string) string {
 		var line []string
 		for _, elem := range para {
 			switch elem.Tag {
-			case "text":
+			case "text", "a":
 				if elem.Text != "" {
 					line = append(line, elem.Text)
 				}
 			case "code_block":
 				if elem.Text != "" {
-					lang := elem.Language
-					line = append(line, "```"+lang+"\n"+elem.Text+"\n```")
+					if elem.Language != "" {
+						line = append(line, fmt.Sprintf("```%s\n%s\n```", elem.Language, elem.Text))
+					} else {
+						line = append(line, fmt.Sprintf("```\n%s\n```", elem.Text))
+					}
 				}
+			case "hr":
+				line = append(line, "---")
 			}
 		}
 		if len(line) > 0 {

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -300,19 +300,36 @@ func TestExtractPostPlainText_Empty(t *testing.T) {
 	}
 }
 
-func TestExtractPostPlainText_NonTextTagsIgnored(t *testing.T) {
+func TestExtractPostPlainText_LinkTag(t *testing.T) {
 	content := `{"content":[[{"tag":"text","text":"hello"},{"tag":"a","text":"link","href":"http://x.com"}]]}`
 	got := extractPostPlainText(content)
-	if got != "hello" {
-		t.Errorf("expected 'hello', got %q", got)
+	if got != "hellolink" {
+		t.Errorf("expected 'hellolink', got %q", got)
 	}
 }
 
 func TestExtractPostPlainText_CodeBlock(t *testing.T) {
 	content := `{"content":[[{"tag":"text","text":"see:"},{"tag":"code_block","language":"go","text":"fmt.Println()"}]]}`
 	got := extractPostPlainText(content)
-	// Same paragraph: inline elements are concatenated (no extra newline before the fence).
 	want := "see:```go\nfmt.Println()\n```"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestExtractPostPlainText_CodeBlockNoLang(t *testing.T) {
+	content := `{"content":[[{"tag":"code_block","text":"echo hello"}]]}`
+	got := extractPostPlainText(content)
+	want := "```\necho hello\n```"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestExtractPostPlainText_HrTag(t *testing.T) {
+	content := `{"content":[[{"tag":"code_block","text":"fmt.Println()","language":"go"}],[{"tag":"hr"}]]}`
+	got := extractPostPlainText(content)
+	want := "```go\nfmt.Println()\n```\n---"
 	if got != want {
 		t.Errorf("expected %q, got %q", want, got)
 	}


### PR DESCRIPTION
## Summary
- Extract `"a"` (link) tag text in `extractPostPlainText` so hyperlinks in quoted posts are visible to the agent
- Add `"hr"` tag support, rendered as markdown `---`
- Improve `code_block` formatting: skip empty language prefix when language field is unset

Based on work from PR #472 by @Cigarrr — the main feature (reply-quote context) was already merged into main via earlier PRs; this captures the remaining improvements from #472's second commit.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Added tests: `TestExtractPostPlainText_LinkTag`, `TestExtractPostPlainText_CodeBlockNoLang`, `TestExtractPostPlainText_HrTag`

Related: #472, #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)