### PR TITLE
feat(progress): improve progress cards and add /progress

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -349,16 +349,7 @@ func main() {
 			engine.SetUserRoles(buildUserRoleManager(proj.Users))
 		}
 
-		// Wire display truncation settings (includes legacy quiet → display mapping)
-		{
-			tm, tool, tmlen, toollen := config.EffectiveDisplay(cfg, &proj)
-			engine.SetDisplayConfig(core.DisplayCfg{
-				ThinkingMessages: tm,
-				ThinkingMaxLen:   tmlen,
-				ToolMaxLen:       toollen,
-				ToolMessages:     tool,
-			})
-		}
+		engine.SetDisplayConfig(buildDisplayCfg(cfg, &proj))
 
 		// Wire local reference normalization / rendering
 		engine.SetReferenceConfig(core.ReferenceRenderCfg{
@@ -435,8 +426,19 @@ func main() {
 			}
 		}
 
-		engine.SetDisplaySaveFunc(func(thinkingMessages *bool, thinkingMaxLen, toolMaxLen *int, toolMessages *bool) error {
-			return config.SaveDisplayConfig(thinkingMessages, thinkingMaxLen, toolMaxLen, toolMessages)
+		engine.SetDisplaySaveFunc(func(update core.DisplayCfgUpdate) error {
+			return config.SaveDisplayConfig(config.DisplayConfigUpdate{
+				ThinkingMessages:     update.ThinkingMessages,
+				ThinkingMaxLen:       update.ThinkingMaxLen,
+				ToolMaxLen:           update.ToolMaxLen,
+				ToolMessages:         update.ToolMessages,
+				ProgressStyle:        update.ProgressStyle,
+				ToolLayout:           update.ToolLayout,
+				ToolShowInput:        update.ToolShowInput,
+				ToolShowResultBody:   update.ToolShowResultBody,
+				ProgressMaxEntries:   update.ProgressMaxEntries,
+				ProgressHistoryTurns: update.ProgressHistoryTurns,
+			})
 		})
 
 		// Wire idle timeout
@@ -860,6 +862,26 @@ func main() {
 				iv := int(v)
 				u.ToolMaxLen = &iv
 			}
+			if v, ok := updates["progress_style"].(string); ok {
+				u.ProgressStyle = &v
+			}
+			if v, ok := updates["tool_layout"].(string); ok {
+				u.ToolLayout = &v
+			}
+			if v, ok := updates["tool_show_input"].(bool); ok {
+				u.ToolShowInput = &v
+			}
+			if v, ok := updates["tool_show_result_body"].(bool); ok {
+				u.ToolShowResultBody = &v
+			}
+			if v, ok := updates["progress_max_entries"].(float64); ok {
+				iv := int(v)
+				u.ProgressMaxEntries = &iv
+			}
+			if v, ok := updates["progress_history_turns"].(float64); ok {
+				iv := int(v)
+				u.ProgressHistoryTurns = &iv
+			}
 			if v, ok := updates["stream_preview_enabled"].(bool); ok {
 				u.StreamPreviewOn = &v
 			}
@@ -1265,6 +1287,34 @@ func setupLogger(level string, w io.Writer) {
 	})))
 }
 
+func buildDisplayCfg(cfg *config.Config, proj *config.ProjectConfig) core.DisplayCfg {
+	dcfg := core.DefaultDisplayCfg()
+	tm, tool, tmlen, toollen := config.EffectiveDisplay(cfg, proj)
+	dcfg.ThinkingMessages = tm
+	dcfg.ToolMessages = tool
+	dcfg.ThinkingMaxLen = tmlen
+	dcfg.ToolMaxLen = toollen
+	if cfg.Display.ProgressStyle != nil {
+		dcfg.ProgressStyle = strings.TrimSpace(*cfg.Display.ProgressStyle)
+	}
+	if cfg.Display.ToolLayout != nil && strings.TrimSpace(*cfg.Display.ToolLayout) != "" {
+		dcfg.ToolLayout = strings.TrimSpace(*cfg.Display.ToolLayout)
+	}
+	if cfg.Display.ToolShowInput != nil {
+		dcfg.ToolShowInput = *cfg.Display.ToolShowInput
+	}
+	if cfg.Display.ToolShowResultBody != nil {
+		dcfg.ToolShowResultBody = *cfg.Display.ToolShowResultBody
+	}
+	if cfg.Display.ProgressMaxEntries != nil {
+		dcfg.ProgressMaxEntries = *cfg.Display.ProgressMaxEntries
+	}
+	if cfg.Display.ProgressHistoryTurns != nil {
+		dcfg.ProgressHistoryTurns = *cfg.Display.ProgressHistoryTurns
+	}
+	return dcfg
+}
+
 // reloadConfig re-reads config.toml and applies hot-reloadable settings
 // (display, providers, commands) to the given engine.
 func reloadConfig(configPath, projName string, engine *core.Engine) (*core.ConfigReloadResult, error) {
@@ -1287,14 +1337,8 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 		return nil, fmt.Errorf("project %q not found in config", projName)
 	}
 
-	// Reload display config (includes legacy quiet → display mapping)
-	tm, tool, tmlen, toollen := config.EffectiveDisplay(cfg, proj)
-	engine.SetDisplayConfig(core.DisplayCfg{
-		ThinkingMessages: tm,
-		ThinkingMaxLen:   tmlen,
-		ToolMaxLen:       toollen,
-		ToolMessages:     tool,
-	})
+	// Reload display config
+	engine.SetDisplayConfig(buildDisplayCfg(cfg, proj))
 	result.DisplayUpdated = true
 
 	// Reload auto-compress settings

--- a/config.example.toml
+++ b/config.example.toml
@@ -49,10 +49,15 @@ level = "info" # debug, info, warn, error
 # 设为 0 表示不截断（显示完整内容）。
 
 # [display]
-# thinking_messages = true # Show/hide thinking messages (default: true) / 是否显示思考消息（默认 true）
-# thinking_max_len = 300   # Max chars for thinking messages (default: 300) / 思考消息最大字符数（默认 300）
-# tool_max_len = 500       # Max chars for tool use messages (default: 500) / 工具调用消息最大字符数（默认 500）
-# tool_messages = true     # Show/hide tool progress messages (default: true) / 是否显示工具进度消息（默认 true）
+# thinking_messages = true   # Show/hide thinking messages (default: true) / 是否显示思考消息（默认 true）
+# thinking_max_len = 300     # Max chars for thinking messages (default: 300) / 思考消息最大字符数（默认 300）
+# tool_max_len = 500         # Max chars for tool input/output bodies when shown (default: 500) / 工具输入或结果正文展示时的最大字符数（默认 500）
+# tool_messages = true       # Show/hide all tool progress messages (default: true) / 是否显示所有工具进度消息（默认 true）
+# tool_layout = "merged"     # Tool block layout: split | merged (default: merged) / 工具块布局：split | merged（默认 merged）
+# tool_show_input = true     # Show tool input body when available (default: true) / 是否展示工具输入正文（默认 true）
+# tool_show_result_body = true # Show tool result body when available (default: true) / 是否展示工具结果正文（默认 true）
+# progress_max_entries = 20  # Max recent progress entries in compact/card view, 0 = unlimited (default: 20) / 紧凑或卡片视图中保留的最近进度条数，0 表示不限制（默认 20）
+# progress_history_turns = 3 # Number of assistant turns whose progress timelines are kept for /progress, 0 = disabled (default: 3) / 为 /progress 保留的最近 assistant 回复轮数，0 表示禁用（默认 3）
 
 # Agent idle timeout: max minutes between consecutive agent events before
 # considering the session stuck. Set to 0 to disable the timeout entirely.
@@ -756,8 +761,8 @@ app_secret = "your-feishu-app-secret"
 #                           # 设为 true 时，群聊按飞书话题/根消息隔离会话（一个 thread/root 对应一个 Agent 会话）
 # reply_to_trigger = true   # Default: bot uses “reply to message” API (quotes the user’s message). Set false to post plain chat messages instead.
 #                           # 默认 true：用「回复消息」API（引用用户消息）。设为 false 则在会话里发普通消息、不引用触发消息。
-# progress_style = "legacy" # Progress rendering style: legacy | compact | card
-#                           # 进度消息展示风格：legacy（逐条消息）| compact（单消息持续更新）| card（结构化卡片）
+# progress_style = "card"   # Progress rendering style: legacy | compact | card (Feishu default: card)
+#                           # 进度消息展示风格：legacy（逐条消息）| compact（单消息持续更新）| card（结构化卡片，飞书默认）
 # resolve_mentions = false  # Auto-resolve @name in outgoing messages to Feishu at tags by matching group member names
 #                           # 自动将发出消息中的 @显示名 替换为飞书 at 标签（通过匹配群成员名称）
 
@@ -785,7 +790,7 @@ app_secret = "your-feishu-app-secret"
 # allow_from = "*"
 # reaction_emoji = "OnIt"
 # done_emoji = "none"
-# progress_style = "legacy"  # legacy | compact | card
+# progress_style = "card"    # legacy | compact | card (Feishu/Lark default: card)
 
 # DingTalk / 钉钉 (uncomment to enable / 取消注释以启用)
 # 1. Create an app at https://open-dev.dingtalk.com / 在钉钉开放平台创建应用

--- a/config/config.go
+++ b/config/config.go
@@ -287,7 +287,6 @@ type ProjectConfig struct {
 	Name         string             `toml:"name"`
 	Mode         string             `toml:"mode,omitempty"`     // "" or "multi-workspace"
 	BaseDir      string             `toml:"base_dir,omitempty"` // parent dir for workspaces
-	Quiet        *bool              `toml:"quiet,omitempty"`    // project-level quiet mode; overrides global setting
 	Agent        AgentConfig        `toml:"agent"`
 	Platforms    []PlatformConfig   `toml:"platforms"`
 	Heartbeat    HeartbeatConfig    `toml:"heartbeat"`
@@ -534,46 +533,6 @@ func resolveEnvPlaceholders(s string) string {
 
 // projectQuietEffective returns whether legacy quiet applies to this project: an explicit
 // per-project quiet overrides; otherwise the global root quiet applies.
-func projectQuietEffective(cfg *Config, proj *ProjectConfig) bool {
-	if proj.Quiet != nil {
-		return *proj.Quiet
-	}
-	if cfg.Quiet != nil {
-		return *cfg.Quiet
-	}
-	return false
-}
-
-// EffectiveDisplay resolves global [display] together with legacy quiet (root or per-project).
-// If quiet is in effect and thinking_messages / tool_messages were not explicitly set in [display],
-// they map to false (backward-compatible with pre-display quiet = true).
-func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (thinkingMessages, toolMessages bool, thinkingMaxLen, toolMaxLen int) {
-	thinkingMessages = true
-	toolMessages = true
-	thinkingMaxLen = 300
-	toolMaxLen = 500
-	if cfg.Display.ThinkingMessages != nil {
-		thinkingMessages = *cfg.Display.ThinkingMessages
-	}
-	if cfg.Display.ToolMessages != nil {
-		toolMessages = *cfg.Display.ToolMessages
-	}
-	if cfg.Display.ThinkingMaxLen != nil {
-		thinkingMaxLen = *cfg.Display.ThinkingMaxLen
-	}
-	if cfg.Display.ToolMaxLen != nil {
-		toolMaxLen = *cfg.Display.ToolMaxLen
-	}
-	if projectQuietEffective(cfg, proj) {
-		if cfg.Display.ThinkingMessages == nil {
-			thinkingMessages = false
-		}
-		if cfg.Display.ToolMessages == nil {
-			toolMessages = false
-		}
-	}
-	return thinkingMessages, toolMessages, thinkingMaxLen, toolMaxLen
-}
 func (c *Config) validate() error {
 	switch strings.ToLower(strings.TrimSpace(c.AttachmentSend)) {
 	case "", "on", "off":

--- a/config/config.go
+++ b/config/config.go
@@ -141,10 +141,16 @@ type ManagementConfig struct {
 
 // DisplayConfig controls how intermediate messages (thinking, tool output) are shown.
 type DisplayConfig struct {
-	ThinkingMessages *bool `toml:"thinking_messages"` // whether thinking messages are shown; default true
-	ThinkingMaxLen   *int  `toml:"thinking_max_len"`  // max chars for thinking messages; 0 = no truncation; default 300
-	ToolMaxLen       *int  `toml:"tool_max_len"`      // max chars for tool use messages; 0 = no truncation; default 500
-	ToolMessages     *bool `toml:"tool_messages"`     // whether tool progress messages are shown; default true
+	ThinkingMessages     *bool   `toml:"thinking_messages"`        // whether thinking messages are shown; default true
+	ThinkingMaxLen       *int    `toml:"thinking_max_len"`         // max chars for thinking messages; 0 = no truncation; default 300
+	ToolMaxLen           *int    `toml:"tool_max_len"`             // max chars for tool bodies; 0 = no truncation; default 500
+	ToolMessages         *bool   `toml:"tool_messages"`            // whether tool progress messages are shown; default true
+	ProgressStyle        *string `toml:"progress_style,omitempty"` // "" = platform default; legacy | compact | card
+	ToolLayout           *string `toml:"tool_layout,omitempty"`    // split | merged; default merged
+	ToolShowInput        *bool   `toml:"tool_show_input"`          // whether tool input is shown; default true
+	ToolShowResultBody   *bool   `toml:"tool_show_result_body"`    // whether tool result body is shown; default true
+	ProgressMaxEntries   *int    `toml:"progress_max_entries"`     // max recent progress entries shown in compact/card; 0 = unlimited; default 20
+	ProgressHistoryTurns *int    `toml:"progress_history_turns"`   // number of assistant turns with persisted event timelines; 0 = disabled; default 3
 }
 
 // StreamPreviewConfig controls real-time streaming preview in IM.
@@ -281,6 +287,7 @@ type ProjectConfig struct {
 	Name         string             `toml:"name"`
 	Mode         string             `toml:"mode,omitempty"`     // "" or "multi-workspace"
 	BaseDir      string             `toml:"base_dir,omitempty"` // parent dir for workspaces
+	Quiet        *bool              `toml:"quiet,omitempty"`    // project-level quiet mode; overrides global setting
 	Agent        AgentConfig        `toml:"agent"`
 	Platforms    []PlatformConfig   `toml:"platforms"`
 	Heartbeat    HeartbeatConfig    `toml:"heartbeat"`
@@ -567,7 +574,6 @@ func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (thinkingMessages, toolM
 	}
 	return thinkingMessages, toolMessages, thinkingMaxLen, toolMaxLen
 }
-
 func (c *Config) validate() error {
 	switch strings.ToLower(strings.TrimSpace(c.AttachmentSend)) {
 	case "", "on", "off":
@@ -1137,8 +1143,64 @@ func RemoveAlias(name string) error {
 	return saveConfig(cfg)
 }
 
+type DisplayConfigUpdate struct {
+	ThinkingMessages     *bool
+	ThinkingMaxLen       *int
+	ToolMaxLen           *int
+	ToolMessages         *bool
+	ProgressStyle        *string
+	ToolLayout           *string
+	ToolShowInput        *bool
+	ToolShowResultBody   *bool
+	ProgressMaxEntries   *int
+	ProgressHistoryTurns *int
+}
+
+// projectQuietEffective returns whether legacy quiet applies to this project: an explicit
+// per-project quiet overrides; otherwise the global root quiet applies.
+func projectQuietEffective(cfg *Config, proj *ProjectConfig) bool {
+	if proj != nil && proj.Quiet != nil {
+		return *proj.Quiet
+	}
+	if cfg.Quiet != nil {
+		return *cfg.Quiet
+	}
+	return false
+}
+
+// EffectiveDisplay resolves global [display] together with legacy quiet (root or per-project).
+// If quiet is in effect and thinking_messages / tool_messages were not explicitly set in [display],
+// they map to false (backward-compatible with pre-display quiet = true).
+func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (thinkingMessages, toolMessages bool, thinkingMaxLen, toolMaxLen int) {
+	thinkingMessages = true
+	toolMessages = true
+	thinkingMaxLen = 300
+	toolMaxLen = 500
+	if cfg.Display.ThinkingMessages != nil {
+		thinkingMessages = *cfg.Display.ThinkingMessages
+	}
+	if cfg.Display.ToolMessages != nil {
+		toolMessages = *cfg.Display.ToolMessages
+	}
+	if cfg.Display.ThinkingMaxLen != nil {
+		thinkingMaxLen = *cfg.Display.ThinkingMaxLen
+	}
+	if cfg.Display.ToolMaxLen != nil {
+		toolMaxLen = *cfg.Display.ToolMaxLen
+	}
+	if projectQuietEffective(cfg, proj) {
+		if cfg.Display.ThinkingMessages == nil {
+			thinkingMessages = false
+		}
+		if cfg.Display.ToolMessages == nil {
+			toolMessages = false
+		}
+	}
+	return thinkingMessages, toolMessages, thinkingMaxLen, toolMaxLen
+}
+
 // SaveDisplayConfig persists the display settings to the config file.
-func SaveDisplayConfig(thinkingMessages *bool, thinkingMaxLen, toolMaxLen *int, toolMessages *bool) error {
+func SaveDisplayConfig(u DisplayConfigUpdate) error {
 	configMu.Lock()
 	defer configMu.Unlock()
 	if ConfigPath == "" {
@@ -1152,17 +1214,40 @@ func SaveDisplayConfig(thinkingMessages *bool, thinkingMaxLen, toolMaxLen *int, 
 	if err := toml.Unmarshal(data, cfg); err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
-	if thinkingMessages != nil {
-		cfg.Display.ThinkingMessages = thinkingMessages
+	if u.ThinkingMessages != nil {
+		cfg.Display.ThinkingMessages = u.ThinkingMessages
 	}
-	if thinkingMaxLen != nil {
-		cfg.Display.ThinkingMaxLen = thinkingMaxLen
+	if u.ThinkingMaxLen != nil {
+		cfg.Display.ThinkingMaxLen = u.ThinkingMaxLen
 	}
-	if toolMaxLen != nil {
-		cfg.Display.ToolMaxLen = toolMaxLen
+	if u.ToolMaxLen != nil {
+		cfg.Display.ToolMaxLen = u.ToolMaxLen
 	}
-	if toolMessages != nil {
-		cfg.Display.ToolMessages = toolMessages
+	if u.ToolMessages != nil {
+		cfg.Display.ToolMessages = u.ToolMessages
+	}
+	if u.ProgressStyle != nil {
+		style := strings.ToLower(strings.TrimSpace(*u.ProgressStyle))
+		if style == "" || style == "auto" {
+			cfg.Display.ProgressStyle = nil
+		} else {
+			cfg.Display.ProgressStyle = &style
+		}
+	}
+	if u.ToolLayout != nil {
+		cfg.Display.ToolLayout = u.ToolLayout
+	}
+	if u.ToolShowInput != nil {
+		cfg.Display.ToolShowInput = u.ToolShowInput
+	}
+	if u.ToolShowResultBody != nil {
+		cfg.Display.ToolShowResultBody = u.ToolShowResultBody
+	}
+	if u.ProgressMaxEntries != nil {
+		cfg.Display.ProgressMaxEntries = u.ProgressMaxEntries
+	}
+	if u.ProgressHistoryTurns != nil {
+		cfg.Display.ProgressHistoryTurns = u.ProgressHistoryTurns
 	}
 	return saveConfig(cfg)
 }
@@ -2492,6 +2577,36 @@ func GetGlobalSettings() map[string]any {
 	} else {
 		result["tool_max_len"] = 500
 	}
+	if cfg.Display.ProgressStyle != nil && strings.TrimSpace(*cfg.Display.ProgressStyle) != "" {
+		result["progress_style"] = strings.TrimSpace(*cfg.Display.ProgressStyle)
+	} else {
+		result["progress_style"] = "auto"
+	}
+	if cfg.Display.ToolLayout != nil && strings.TrimSpace(*cfg.Display.ToolLayout) != "" {
+		result["tool_layout"] = *cfg.Display.ToolLayout
+	} else {
+		result["tool_layout"] = "merged"
+	}
+	if cfg.Display.ToolShowInput != nil {
+		result["tool_show_input"] = *cfg.Display.ToolShowInput
+	} else {
+		result["tool_show_input"] = true
+	}
+	if cfg.Display.ToolShowResultBody != nil {
+		result["tool_show_result_body"] = *cfg.Display.ToolShowResultBody
+	} else {
+		result["tool_show_result_body"] = true
+	}
+	if cfg.Display.ProgressMaxEntries != nil {
+		result["progress_max_entries"] = *cfg.Display.ProgressMaxEntries
+	} else {
+		result["progress_max_entries"] = 20
+	}
+	if cfg.Display.ProgressHistoryTurns != nil {
+		result["progress_history_turns"] = *cfg.Display.ProgressHistoryTurns
+	} else {
+		result["progress_history_turns"] = 3
+	}
 	// Stream preview
 	spEnabled := true
 	if cfg.StreamPreview.Enabled != nil {
@@ -2519,18 +2634,24 @@ func GetGlobalSettings() map[string]any {
 
 // GlobalSettingsUpdate holds fields to update in global config.
 type GlobalSettingsUpdate struct {
-	Language           *string `json:"language"`
-	AttachmentSend     *string `json:"attachment_send"`
-	LogLevel           *string `json:"log_level"`
-	IdleTimeoutMins    *int    `json:"idle_timeout_mins"`
-	ThinkingMessages   *bool   `json:"thinking_messages"`
-	ThinkingMaxLen     *int    `json:"thinking_max_len"`
-	ToolMessages       *bool   `json:"tool_messages"`
-	ToolMaxLen         *int    `json:"tool_max_len"`
-	StreamPreviewOn    *bool   `json:"stream_preview_enabled"`
-	StreamPreviewIntMs *int    `json:"stream_preview_interval_ms"`
-	RateLimitMax       *int    `json:"rate_limit_max_messages"`
-	RateLimitWindow    *int    `json:"rate_limit_window_secs"`
+	Language             *string `json:"language"`
+	AttachmentSend       *string `json:"attachment_send"`
+	LogLevel             *string `json:"log_level"`
+	IdleTimeoutMins      *int    `json:"idle_timeout_mins"`
+	ThinkingMessages     *bool   `json:"thinking_messages"`
+	ThinkingMaxLen       *int    `json:"thinking_max_len"`
+	ToolMaxLen           *int    `json:"tool_max_len"`
+	ToolMessages         *bool   `json:"tool_messages"`
+	ProgressStyle        *string `json:"progress_style"`
+	ToolLayout           *string `json:"tool_layout"`
+	ToolShowInput        *bool   `json:"tool_show_input"`
+	ToolShowResultBody   *bool   `json:"tool_show_result_body"`
+	ProgressMaxEntries   *int    `json:"progress_max_entries"`
+	ProgressHistoryTurns *int    `json:"progress_history_turns"`
+	StreamPreviewOn      *bool   `json:"stream_preview_enabled"`
+	StreamPreviewIntMs   *int    `json:"stream_preview_interval_ms"`
+	RateLimitMax         *int    `json:"rate_limit_max_messages"`
+	RateLimitWindow      *int    `json:"rate_limit_window_secs"`
 }
 
 // SaveGlobalSettings persists global settings to config.toml.
@@ -2571,6 +2692,29 @@ func SaveGlobalSettings(u GlobalSettingsUpdate) error {
 	}
 	if u.ToolMaxLen != nil {
 		cfg.Display.ToolMaxLen = u.ToolMaxLen
+	}
+	if u.ProgressStyle != nil {
+		style := strings.ToLower(strings.TrimSpace(*u.ProgressStyle))
+		if style == "" || style == "auto" {
+			cfg.Display.ProgressStyle = nil
+		} else {
+			cfg.Display.ProgressStyle = &style
+		}
+	}
+	if u.ToolLayout != nil {
+		cfg.Display.ToolLayout = u.ToolLayout
+	}
+	if u.ToolShowInput != nil {
+		cfg.Display.ToolShowInput = u.ToolShowInput
+	}
+	if u.ToolShowResultBody != nil {
+		cfg.Display.ToolShowResultBody = u.ToolShowResultBody
+	}
+	if u.ProgressMaxEntries != nil {
+		cfg.Display.ProgressMaxEntries = u.ProgressMaxEntries
+	}
+	if u.ProgressHistoryTurns != nil {
+		cfg.Display.ProgressHistoryTurns = u.ProgressHistoryTurns
 	}
 	if u.StreamPreviewOn != nil {
 		cfg.StreamPreview.Enabled = u.StreamPreviewOn

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -267,7 +267,6 @@ func TestEffectiveDisplayQuiet(t *testing.T) {
 		})
 	}
 }
-
 func TestLoad_DefaultsDataDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
@@ -566,7 +565,21 @@ func TestDisplayConfig_Save(t *testing.T) {
 	thinking := 120
 	tool := 240
 	showTools := false
-	if err := SaveDisplayConfig(nil, &thinking, &tool, &showTools); err != nil {
+	layout := "merged"
+	showInput := true
+	showResultBody := true
+	maxEntries := 20
+	historyTurns := 3
+	if err := SaveDisplayConfig(DisplayConfigUpdate{
+		ThinkingMaxLen:       &thinking,
+		ToolMaxLen:           &tool,
+		ToolMessages:         &showTools,
+		ToolLayout:           &layout,
+		ToolShowInput:        &showInput,
+		ToolShowResultBody:   &showResultBody,
+		ProgressMaxEntries:   &maxEntries,
+		ProgressHistoryTurns: &historyTurns,
+	}); err != nil {
 		t.Fatalf("SaveDisplayConfig() error: %v", err)
 	}
 
@@ -580,9 +593,24 @@ func TestDisplayConfig_Save(t *testing.T) {
 	if cfg.Display.ToolMessages == nil || *cfg.Display.ToolMessages {
 		t.Fatalf("ToolMessages = %#v, want false", cfg.Display.ToolMessages)
 	}
+	if cfg.Display.ToolLayout == nil || *cfg.Display.ToolLayout != "merged" {
+		t.Fatalf("ToolLayout = %#v, want merged", cfg.Display.ToolLayout)
+	}
+	if cfg.Display.ToolShowInput == nil || !*cfg.Display.ToolShowInput {
+		t.Fatalf("ToolShowInput = %#v, want true", cfg.Display.ToolShowInput)
+	}
+	if cfg.Display.ToolShowResultBody == nil || !*cfg.Display.ToolShowResultBody {
+		t.Fatalf("ToolShowResultBody = %#v, want true", cfg.Display.ToolShowResultBody)
+	}
+	if cfg.Display.ProgressMaxEntries == nil || *cfg.Display.ProgressMaxEntries != 20 {
+		t.Fatalf("ProgressMaxEntries = %#v, want 20", cfg.Display.ProgressMaxEntries)
+	}
+	if cfg.Display.ProgressHistoryTurns == nil || *cfg.Display.ProgressHistoryTurns != 3 {
+		t.Fatalf("ProgressHistoryTurns = %#v, want 3", cfg.Display.ProgressHistoryTurns)
+	}
 
 	thinking = 360
-	if err := SaveDisplayConfig(nil, &thinking, nil, nil); err != nil {
+	if err := SaveDisplayConfig(DisplayConfigUpdate{ThinkingMaxLen: &thinking}); err != nil {
 		t.Fatalf("SaveDisplayConfig() second update error: %v", err)
 	}
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -6251,7 +6251,10 @@ func (e *Engine) cmdQuiet(p Platform, msg *Message, args []string) {
 	if e.displaySaveFunc != nil {
 		tm := e.display.ThinkingMessages
 		tool := e.display.ToolMessages
-		if err := e.displaySaveFunc(&tm, nil, nil, &tool); err != nil {
+		if err := e.displaySaveFunc(DisplayCfgUpdate{
+			ThinkingMessages: &tm,
+			ToolMessages:     &tool,
+		}); err != nil {
 			slog.Error("failed to persist display config after /quiet", "error", err)
 		}
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -6839,25 +6839,41 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 	}
 
 	if p == nil && sessionKey != "" {
+		strippedKey := sessionKey
 		platformName := ""
-		if idx := strings.Index(sessionKey, ":"); idx > 0 {
-			platformName = sessionKey[:idx]
+		if idx := strings.Index(strippedKey, ":"); idx > 0 {
+			platformName = strippedKey[:idx]
 		}
+		var targetPlatform Platform
 		for _, candidate := range e.platforms {
-			if candidate.Name() != platformName {
-				continue
+			if candidate.Name() == platformName {
+				targetPlatform = candidate
+				break
 			}
-			rc, ok := candidate.(ReplyContextReconstructor)
+		}
+		// Fallback: multi-workspace mode may prefix the session key with the
+		// workspace path (same heuristic as ExecuteCronJob / ExecuteHeartbeat).
+		if targetPlatform == nil {
+			for _, candidate := range e.platforms {
+				needle := ":" + candidate.Name() + ":"
+				if idx := strings.Index(strippedKey, needle); idx >= 0 {
+					targetPlatform = candidate
+					strippedKey = strippedKey[idx+1:]
+					break
+				}
+			}
+		}
+		if targetPlatform != nil {
+			rc, ok := targetPlatform.(ReplyContextReconstructor)
 			if !ok {
-				return fmt.Errorf("platform %q does not support proactive messaging", platformName)
+				return fmt.Errorf("platform %q does not support proactive messaging", targetPlatform.Name())
 			}
-			reconstructed, err := rc.ReconstructReplyCtx(sessionKey)
+			reconstructed, err := rc.ReconstructReplyCtx(strippedKey)
 			if err != nil {
 				return fmt.Errorf("reconstruct reply context: %w", err)
 			}
-			p = candidate
+			p = targetPlatform
 			replyCtx = reconstructed
-			break
 		}
 	}
 
@@ -9424,12 +9440,16 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 		"CC_PROJECT=" + e.name,
 		"CC_SESSION_KEY=" + msg.SessionKey,
 	}
-	if exePath, err := os.Executable(); err == nil {
-		binDir := filepath.Dir(exePath)
-		if curPath := os.Getenv("PATH"); curPath != "" {
-			envVars = append(envVars, "PATH="+binDir+string(filepath.ListSeparator)+curPath)
-		} else {
-			envVars = append(envVars, "PATH="+binDir)
+	// Prepend the cc-connect binary dir on Windows only (native shell fix);
+	// on Unix it would change command resolution for user scripts.
+	if runtime.GOOS == "windows" {
+		if exePath, err := os.Executable(); err == nil {
+			binDir := filepath.Dir(exePath)
+			if curPath := os.Getenv("PATH"); curPath != "" {
+				envVars = append(envVars, "PATH="+binDir+string(filepath.ListSeparator)+curPath)
+			} else {
+				envVars = append(envVars, "PATH="+binDir)
+			}
 		}
 	}
 	shellCmd.Env = MergeEnv(os.Environ(), envVars)

--- a/core/engine.go
+++ b/core/engine.go
@@ -28,8 +28,11 @@ const telegramBotCommandLimit = 100
 const maxQueuedMessages = 5 // cap queued messages to bound memory usage
 
 const (
-	defaultThinkingMaxLen = 300
-	defaultToolMaxLen     = 500
+	defaultThinkingMaxLen       = 300
+	defaultToolMaxLen           = 500
+	defaultToolLayout           = toolLayoutMerged
+	defaultProgressMaxEntries   = 20
+	defaultProgressHistoryTurns = 3
 )
 
 // Slow-operation thresholds. Operations exceeding these durations produce a
@@ -133,10 +136,43 @@ var RestartCh = make(chan RestartRequest, 1)
 // DisplayCfg controls how intermediate messages are surfaced.
 // A value of -1 means "use default", 0 means "no truncation".
 type DisplayCfg struct {
-	ThinkingMessages bool
-	ThinkingMaxLen   int // max runes for thinking preview; 0 = no truncation
-	ToolMaxLen       int // max runes for tool use preview; 0 = no truncation
-	ToolMessages     bool
+	ThinkingMessages     bool
+	ThinkingMaxLen       int // max runes for thinking preview; 0 = no truncation
+	ToolMaxLen           int // max runes for tool text preview; 0 = no truncation
+	ToolMessages         bool
+	ProgressStyle        string // "" = platform default; legacy | compact | card
+	ToolLayout           string // split | merged
+	ToolShowInput        bool
+	ToolShowResultBody   bool
+	ProgressMaxEntries   int // max recent progress entries in compact/card; 0 = unlimited
+	ProgressHistoryTurns int // number of assistant turns with persisted event timelines; 0 = disabled
+}
+
+type DisplayCfgUpdate struct {
+	ThinkingMessages     *bool
+	ThinkingMaxLen       *int
+	ToolMaxLen           *int
+	ToolMessages         *bool
+	ProgressStyle        *string
+	ToolLayout           *string
+	ToolShowInput        *bool
+	ToolShowResultBody   *bool
+	ProgressMaxEntries   *int
+	ProgressHistoryTurns *int
+}
+
+func DefaultDisplayCfg() DisplayCfg {
+	return DisplayCfg{
+		ThinkingMessages:     true,
+		ThinkingMaxLen:       defaultThinkingMaxLen,
+		ToolMaxLen:           defaultToolMaxLen,
+		ToolMessages:         true,
+		ToolLayout:           defaultToolLayout,
+		ToolShowInput:        true,
+		ToolShowResultBody:   true,
+		ProgressMaxEntries:   defaultProgressMaxEntries,
+		ProgressHistoryTurns: defaultProgressHistoryTurns,
+	}
 }
 
 // RateLimitCfg controls per-session message rate limiting.
@@ -172,7 +208,7 @@ type Engine struct {
 	commandSaveAddFunc func(name, description, prompt, exec, workDir string) error
 	commandSaveDelFunc func(name string) error
 
-	displaySaveFunc  func(thinkingMessages *bool, thinkingMaxLen, toolMaxLen *int, toolMessages *bool) error
+	displaySaveFunc  func(update DisplayCfgUpdate) error
 	configReloadFunc func() (*ConfigReloadResult, error)
 
 	cronScheduler      *CronScheduler
@@ -362,7 +398,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		cancel:                cancel,
 		i18n:                  NewI18n(lang),
 		attachmentSendEnabled: true,
-		display:               DisplayCfg{ThinkingMessages: true, ThinkingMaxLen: defaultThinkingMaxLen, ToolMaxLen: defaultToolMaxLen, ToolMessages: true},
+		display:               DefaultDisplayCfg(),
 		commands:              NewCommandRegistry(),
 		skills:                NewSkillRegistry(),
 		aliases:               make(map[string]string),
@@ -614,7 +650,7 @@ func (e *Engine) SetCommandSaveDelFunc(fn func(name string) error) {
 	e.commandSaveDelFunc = fn
 }
 
-func (e *Engine) SetDisplaySaveFunc(fn func(thinkingMessages *bool, thinkingMaxLen, toolMaxLen *int, toolMessages *bool) error) {
+func (e *Engine) SetDisplaySaveFunc(fn func(update DisplayCfgUpdate) error) {
 	e.displaySaveFunc = fn
 }
 
@@ -2513,7 +2549,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		return e.sendWithErrorForWorkspace(p, replyCtx, content, workspaceDir)
 	}
 	sp := newStreamPreview(e.streamPreview, state.platform, state.replyCtx, e.ctx, workspaceRenderer)
-	cp := newCompactProgressWriter(e.ctx, state.platform, state.replyCtx, e.agent.Name(), e.i18n.CurrentLang(), workspaceRenderer)
+	cp := newCompactProgressWriter(e.ctx, state.platform, state.replyCtx, e.agent.Name(), e.i18n.CurrentLang(), e.display, workspaceRenderer)
 	state.mu.Unlock()
 
 	// Idle timeout: 0 = disabled
@@ -2526,6 +2562,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	}
 
 	events := state.agentSession.Events()
+	currentTimeline := newEventTimeline(turnStart)
 	stopCh := state.stopSignal()
 	for {
 		var event Event
@@ -2603,6 +2640,10 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		switch event.Type {
 		case EventThinking:
+			currentTimeline.appendEvent(TimelineEvent{
+				Kind: EventThinking,
+				Text: event.Content,
+			})
 			// In quiet mode, still split text segments so they don't merge.
 			if !e.display.ThinkingMessages && len(textParts) > segmentStart {
 				if sp.canPreview() {
@@ -2645,6 +2686,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			}
 
 		case EventToolUse:
+			currentTimeline.appendEvent(TimelineEvent{
+				Kind:      EventToolUse,
+				ToolName:  event.ToolName,
+				ToolInput: event.ToolInput,
+				Text:      event.ToolInput,
+			})
 			toolCount++
 			// When tool messages are hidden, split text segments.
 			if !e.display.ToolMessages && len(textParts) > segmentStart {
@@ -2681,6 +2728,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					sp.detachPreview() // keep frozen preview visible as permanent message
 				}
 				toolInput := event.ToolInput
+				if !e.display.ToolShowInput {
+					toolInput = ""
+				}
 				var formattedInput string
 				if toolInput == "" {
 					formattedInput = ""
@@ -2699,7 +2749,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 				}
 				toolMsg := fmt.Sprintf(e.i18n.T(MsgTool), toolCount, event.ToolName, formattedInput)
-				if !cp.AppendEvent(ProgressEntryToolUse, toolInput, event.ToolName, toolMsg) {
+				entry := ProgressCardEntry{
+					Kind:      ProgressEntryToolUse,
+					Tool:      event.ToolName,
+					ToolInput: toolInput,
+				}
+				if !e.display.ToolShowInput {
+					entry.ToolInput = ""
+				}
+				if !cp.AppendStructured(entry, toolMsg) {
 					for _, chunk := range SplitMessageCodeFenceAware(toolMsg, maxPlatformMessageLen) {
 						sendWorkspace(p, replyCtx, chunk)
 					}
@@ -2707,26 +2765,40 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			}
 
 		case EventToolResult:
+			toolResultText := strings.TrimSpace(event.ToolResult)
+			if toolResultText == "" {
+				toolResultText = strings.TrimSpace(event.Content)
+			}
+			currentTimeline.appendEvent(TimelineEvent{
+				Kind:       EventToolResult,
+				ToolName:   event.ToolName,
+				ToolResult: toolResultText,
+				Status:     event.ToolStatus,
+				ExitCode:   event.ToolExitCode,
+				Success:    event.ToolSuccess,
+			})
 			if e.display.ToolMessages {
 				result := strings.TrimSpace(event.ToolResult)
 				if result == "" {
 					result = strings.TrimSpace(event.Content)
 				}
-				if result != "" {
+				if result != "" && e.display.ToolShowResultBody {
 					result = truncateIf(result, e.display.ToolMaxLen)
+				} else if !e.display.ToolShowResultBody {
+					result = ""
 				}
 				if result != "" || event.ToolStatus != "" || event.ToolExitCode != nil || event.ToolSuccess != nil {
-					resultMsg := e.formatToolResultEventFallback(event.ToolName, result, event.ToolStatus, event.ToolExitCode, event.ToolSuccess)
+					resultMsg := e.formatToolResultEventFallback(event.ToolName, result, event.ToolStatus, event.ToolExitCode, event.ToolSuccess, e.display.ToolShowResultBody)
 					entry := ProgressCardEntry{
-						Kind:     ProgressEntryToolResult,
-						Tool:     event.ToolName,
-						Text:     result,
-						Status:   event.ToolStatus,
-						ExitCode: event.ToolExitCode,
-						Success:  event.ToolSuccess,
+						Kind:       ProgressEntryToolResult,
+						Tool:       event.ToolName,
+						Status:     event.ToolStatus,
+						ExitCode:   event.ToolExitCode,
+						Success:    event.ToolSuccess,
+						ToolResult: result,
 					}
 					if !cp.AppendStructured(entry, resultMsg) {
-						if !SuppressStandaloneToolResultEvent(p) {
+						if !SuppressStandaloneToolResultEvent(p, e.display) {
 							e.sendRaw(p, replyCtx, resultMsg)
 						}
 					}
@@ -2878,7 +2950,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 			}
 
-			session.AddHistory("assistant", baseResponse)
+			historyIdx := session.AddHistoryAndReturnIndex("assistant", baseResponse)
+			if e.display.ProgressHistoryTurns != 0 && currentTimeline != nil && len(currentTimeline.Events) > 0 {
+				currentTimeline.AssistantHistoryIdx = historyIdx
+				currentTimeline.CompletedAt = time.Now()
+				session.AppendEventTimeline(*currentTimeline, e.display.ProgressHistoryTurns)
+			}
 			sessions.Save()
 
 			if e.showContextIndicator {
@@ -2968,30 +3045,27 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 			// Auto-compress after finishing a turn, before sending any queued messages.
 			if triggerAutoCompress {
-				compressor, ok := e.agent.(ContextCompressor)
-				if ok && compressor.CompressCommand() != "" {
-					if pendingSend != nil {
-						if err := <-pendingSend; err != nil {
-							slog.Debug("async send error before compress", "error", err)
-						}
+				if pendingSend != nil {
+					if err := <-pendingSend; err != nil {
+						slog.Debug("async send error before compress", "error", err)
 					}
-					state.mu.Lock()
-					state.lastAutoCompressAt = time.Now()
-					tokenEst := state.lastAutoCompressTokens
-					state.mu.Unlock()
-					slog.Info("auto-compress: triggering", "session", sessionKey)
-
-					// Notify user before compressing so they know the context is about to change.
-					compressNotice := e.i18n.T(MsgCompressing)
-					if tokenEst > 0 {
-						compressNotice = fmt.Sprintf("%s (~%dk tokens)", compressNotice, tokenEst/1000)
-					}
-					e.send(state.platform, state.replyCtx, compressNotice)
-
-					// Run compress inline while the session is still locked.
-					e.runCompress(state, session, sessions, sessionKey, state.platform, state.replyCtx, true)
-					return
 				}
+				state.mu.Lock()
+				state.lastAutoCompressAt = time.Now()
+				tokenEst := state.lastAutoCompressTokens
+				state.mu.Unlock()
+				slog.Info("auto-compress: triggering", "session", sessionKey)
+
+				// Notify user before compressing so they know the context is about to change.
+				compressNotice := e.i18n.T(MsgCompressing)
+				if tokenEst > 0 {
+					compressNotice = fmt.Sprintf("%s (~%dk tokens)", compressNotice, tokenEst/1000)
+				}
+				e.send(state.platform, state.replyCtx, compressNotice)
+
+				// Run compress inline while the session is still locked.
+				e.runCompress(state, session, sessions, sessionKey, state.platform, state.replyCtx, true)
+				return
 			}
 
 			// Check for queued messages — if present, continue the event loop
@@ -3052,7 +3126,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					return e.renderOutgoingContentForWorkspace(queued.platform, content, workspaceDir)
 				}
 				sp = newStreamPreview(e.streamPreview, queued.platform, queued.replyCtx, e.ctx, queuedRenderer)
-				cp = newCompactProgressWriter(e.ctx, queued.platform, queued.replyCtx, e.agent.Name(), e.i18n.CurrentLang(), queuedRenderer)
+				cp = newCompactProgressWriter(e.ctx, queued.platform, queued.replyCtx, e.agent.Name(), e.i18n.CurrentLang(), e.display, queuedRenderer)
+				currentTimeline = newEventTimeline(turnStart)
 
 				session.AddHistory("user", queued.content)
 
@@ -3227,6 +3302,7 @@ var builtinCommands = []struct {
 	{[]string{"status"}, "status"},
 	{[]string{"usage", "quota"}, "usage"},
 	{[]string{"history"}, "history"},
+	{[]string{"progress"}, "progress"},
 	{[]string{"allow"}, "allow"},
 	{[]string{"model"}, "model"},
 	{[]string{"reasoning", "effort"}, "reasoning"},
@@ -3391,6 +3467,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdUsage(p, msg)
 	case "history":
 		e.cmdHistory(p, msg, args)
+	case "progress":
+		e.cmdProgress(p, msg, args)
 	case "allow":
 		e.cmdAllow(p, msg, args)
 	case "model":
@@ -5503,6 +5581,7 @@ func helpCardGroups() []helpCardGroup {
 				{command: "/switch", action: "nav:/list"},
 				{command: "/search", action: "cmd:/search"},
 				{command: "/history", action: "nav:/history"},
+				{command: "/progress", action: "cmd:/progress"},
 				{command: "/delete", action: "cmd:/delete"},
 				{command: "/name", action: "cmd:/name"},
 			},
@@ -6760,41 +6839,25 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 	}
 
 	if p == nil && sessionKey != "" {
-		strippedKey := sessionKey
 		platformName := ""
-		if idx := strings.Index(strippedKey, ":"); idx > 0 {
-			platformName = strippedKey[:idx]
+		if idx := strings.Index(sessionKey, ":"); idx > 0 {
+			platformName = sessionKey[:idx]
 		}
-		var targetPlatform Platform
 		for _, candidate := range e.platforms {
-			if candidate.Name() == platformName {
-				targetPlatform = candidate
-				break
+			if candidate.Name() != platformName {
+				continue
 			}
-		}
-		// Fallback: multi-workspace mode may prefix the session key with the
-		// workspace path (same heuristic as ExecuteCronJob / ExecuteHeartbeat).
-		if targetPlatform == nil {
-			for _, candidate := range e.platforms {
-				needle := ":" + candidate.Name() + ":"
-				if idx := strings.Index(strippedKey, needle); idx >= 0 {
-					targetPlatform = candidate
-					strippedKey = strippedKey[idx+1:]
-					break
-				}
-			}
-		}
-		if targetPlatform != nil {
-			rc, ok := targetPlatform.(ReplyContextReconstructor)
+			rc, ok := candidate.(ReplyContextReconstructor)
 			if !ok {
-				return fmt.Errorf("platform %q does not support proactive messaging", targetPlatform.Name())
+				return fmt.Errorf("platform %q does not support proactive messaging", platformName)
 			}
-			reconstructed, err := rc.ReconstructReplyCtx(strippedKey)
+			reconstructed, err := rc.ReconstructReplyCtx(sessionKey)
 			if err != nil {
 				return fmt.Errorf("reconstruct reply context: %w", err)
 			}
-			p = targetPlatform
+			p = candidate
 			replyCtx = reconstructed
+			break
 		}
 	}
 
@@ -9361,16 +9424,12 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 		"CC_PROJECT=" + e.name,
 		"CC_SESSION_KEY=" + msg.SessionKey,
 	}
-	// Prepend the cc-connect binary dir on Windows only (native shell fix);
-	// on Unix it would change command resolution for user scripts.
-	if runtime.GOOS == "windows" {
-		if exePath, err := os.Executable(); err == nil {
-			binDir := filepath.Dir(exePath)
-			if curPath := os.Getenv("PATH"); curPath != "" {
-				envVars = append(envVars, "PATH="+binDir+string(filepath.ListSeparator)+curPath)
-			} else {
-				envVars = append(envVars, "PATH="+binDir)
-			}
+	if exePath, err := os.Executable(); err == nil {
+		binDir := filepath.Dir(exePath)
+		if curPath := os.Getenv("PATH"); curPath != "" {
+			envVars = append(envVars, "PATH="+binDir+string(filepath.ListSeparator)+curPath)
+		} else {
+			envVars = append(envVars, "PATH="+binDir)
 		}
 	}
 	shellCmd.Env = MergeEnv(os.Environ(), envVars)
@@ -9645,7 +9704,7 @@ func (e *Engine) configItems() []configItem {
 				}
 				e.display.ThinkingMessages = b
 				if e.displaySaveFunc != nil {
-					return e.displaySaveFunc(&b, nil, nil, nil)
+					return e.displaySaveFunc(DisplayCfgUpdate{ThinkingMessages: &b})
 				}
 				return nil
 			},
@@ -9667,7 +9726,7 @@ func (e *Engine) configItems() []configItem {
 				}
 				e.display.ThinkingMaxLen = n
 				if e.displaySaveFunc != nil {
-					return e.displaySaveFunc(nil, &n, nil, nil)
+					return e.displaySaveFunc(DisplayCfgUpdate{ThinkingMaxLen: &n})
 				}
 				return nil
 			},
@@ -9686,7 +9745,7 @@ func (e *Engine) configItems() []configItem {
 				}
 				e.display.ToolMessages = b
 				if e.displaySaveFunc != nil {
-					return e.displaySaveFunc(nil, nil, nil, &b)
+					return e.displaySaveFunc(DisplayCfgUpdate{ToolMessages: &b})
 				}
 				return nil
 			},
@@ -9708,7 +9767,139 @@ func (e *Engine) configItems() []configItem {
 				}
 				e.display.ToolMaxLen = n
 				if e.displaySaveFunc != nil {
-					return e.displaySaveFunc(nil, nil, &n, nil)
+					return e.displaySaveFunc(DisplayCfgUpdate{ToolMaxLen: &n})
+				}
+				return nil
+			},
+		},
+		{
+			key:    "tool_layout",
+			desc:   "Tool progress layout (split|merged)",
+			descZh: "工具进度布局 (split|merged)",
+			getFunc: func() string {
+				return normalizeToolLayout(e.display.ToolLayout)
+			},
+			setFunc: func(v string) error {
+				layout := normalizeToolLayout(v)
+				if strings.TrimSpace(v) != "" && layout != strings.ToLower(strings.TrimSpace(v)) {
+					return fmt.Errorf("invalid layout: %s", v)
+				}
+				e.display.ToolLayout = layout
+				if e.displaySaveFunc != nil {
+					return e.displaySaveFunc(DisplayCfgUpdate{ToolLayout: &layout})
+				}
+				return nil
+			},
+		},
+		{
+			key:    "progress_style",
+			desc:   "Progress rendering style override (auto|legacy|compact|card)",
+			descZh: "进度展示风格覆盖 (auto|legacy|compact|card)",
+			getFunc: func() string {
+				v := strings.ToLower(strings.TrimSpace(e.display.ProgressStyle))
+				if v == "" {
+					return "auto"
+				}
+				return v
+			},
+			setFunc: func(v string) error {
+				style := strings.ToLower(strings.TrimSpace(v))
+				switch style {
+				case "", "auto":
+					style = ""
+				case progressStyleLegacy, progressStyleCompact, progressStyleCard:
+				default:
+					return fmt.Errorf("invalid progress style: %s", v)
+				}
+				e.display.ProgressStyle = style
+				if e.displaySaveFunc != nil {
+					if style == "" {
+						auto := "auto"
+						return e.displaySaveFunc(DisplayCfgUpdate{ProgressStyle: &auto})
+					}
+					return e.displaySaveFunc(DisplayCfgUpdate{ProgressStyle: &style})
+				}
+				return nil
+			},
+		},
+		{
+			key:    "tool_show_input",
+			desc:   "Whether tool input is shown in progress (true/false)",
+			descZh: "是否在进度中显示工具输入 (true/false)",
+			getFunc: func() string {
+				return fmt.Sprintf("%t", e.display.ToolShowInput)
+			},
+			setFunc: func(v string) error {
+				b, err := strconv.ParseBool(v)
+				if err != nil {
+					return fmt.Errorf("invalid boolean: %s", v)
+				}
+				e.display.ToolShowInput = b
+				if e.displaySaveFunc != nil {
+					return e.displaySaveFunc(DisplayCfgUpdate{ToolShowInput: &b})
+				}
+				return nil
+			},
+		},
+		{
+			key:    "tool_show_result_body",
+			desc:   "Whether tool result body is shown in progress (true/false)",
+			descZh: "是否在进度中显示工具结果正文 (true/false)",
+			getFunc: func() string {
+				return fmt.Sprintf("%t", e.display.ToolShowResultBody)
+			},
+			setFunc: func(v string) error {
+				b, err := strconv.ParseBool(v)
+				if err != nil {
+					return fmt.Errorf("invalid boolean: %s", v)
+				}
+				e.display.ToolShowResultBody = b
+				if e.displaySaveFunc != nil {
+					return e.displaySaveFunc(DisplayCfgUpdate{ToolShowResultBody: &b})
+				}
+				return nil
+			},
+		},
+		{
+			key:    "progress_max_entries",
+			desc:   "Max recent progress entries in card/compact (0=no truncation)",
+			descZh: "card/compact 中最近进度条目数上限 (0=不截断)",
+			getFunc: func() string {
+				return fmt.Sprintf("%d", e.display.ProgressMaxEntries)
+			},
+			setFunc: func(v string) error {
+				n, err := strconv.Atoi(v)
+				if err != nil {
+					return fmt.Errorf("invalid integer: %s", v)
+				}
+				if n < 0 {
+					return fmt.Errorf("value must be >= 0")
+				}
+				e.display.ProgressMaxEntries = n
+				if e.displaySaveFunc != nil {
+					return e.displaySaveFunc(DisplayCfgUpdate{ProgressMaxEntries: &n})
+				}
+				return nil
+			},
+		},
+		{
+			key:    "progress_history_turns",
+			desc:   "Number of recent assistant turns with persisted progress history (0=disabled)",
+			descZh: "保留最近多少轮 assistant 过程历史 (0=禁用)",
+			getFunc: func() string {
+				return fmt.Sprintf("%d", e.display.ProgressHistoryTurns)
+			},
+			setFunc: func(v string) error {
+				n, err := strconv.Atoi(v)
+				if err != nil {
+					return fmt.Errorf("invalid integer: %s", v)
+				}
+				if n < 0 {
+					return fmt.Errorf("value must be >= 0")
+				}
+				e.display.ProgressHistoryTurns = n
+				if e.displaySaveFunc != nil {
+					return e.displaySaveFunc(DisplayCfgUpdate{ProgressHistoryTurns: &n})
 				}
 				return nil
 			},
@@ -10283,7 +10474,7 @@ func toolCodeLang(toolName, input string) string {
 	return ""
 }
 
-func (e *Engine) formatToolResultEventFallback(toolName, result, status string, exitCode *int, success *bool) string {
+func (e *Engine) formatToolResultEventFallback(toolName, result, status string, exitCode *int, success *bool, showBody bool) string {
 	statusLabel := e.i18n.T(MsgToolResultFmtStatus)
 	exitLabel := e.i18n.T(MsgToolResultFmtExit)
 	noOutput := e.i18n.T(MsgToolResultFmtNoOutput)
@@ -10315,9 +10506,9 @@ func (e *Engine) formatToolResultEventFallback(toolName, result, status string, 
 	if exitCode != nil {
 		lines = append(lines, fmt.Sprintf("🔢 %s: %d", exitLabel, *exitCode))
 	}
-	if strings.TrimSpace(result) != "" {
+	if showBody && strings.TrimSpace(result) != "" {
 		lines = append(lines, "```text\n"+strings.TrimSpace(result)+"\n```")
-	} else {
+	} else if showBody {
 		lines = append(lines, "_"+noOutput+"_")
 	}
 	return strings.Join(lines, "\n")

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -764,37 +764,6 @@ func TestEngineSendToSessionWithAttachments_MultiWorkspaceRawSessionKey(t *testi
 	}
 }
 
-// stubProactiveSendPlatform implements ReplyContextReconstruct for proactive
-// SendToSessionWithAttachments when there is no interactive session.
-type stubProactiveSendPlatform struct {
-	stubMediaPlatform
-	reconstructKey string
-}
-
-func (p *stubProactiveSendPlatform) ReconstructReplyCtx(sessionKey string) (any, error) {
-	p.reconstructKey = sessionKey
-	return "proactive-rctx", nil
-}
-
-func TestEngineSendToSessionWithAttachments_WorkspacePrefixedSessionKey(t *testing.T) {
-	p := &stubProactiveSendPlatform{
-		stubMediaPlatform: stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "slack"}},
-	}
-	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-
-	prefixed := "/tmp/myproject:slack:C123:U1"
-	err := e.SendToSessionWithAttachments(prefixed, "delivery ready", nil, nil)
-	if err != nil {
-		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
-	}
-	if p.reconstructKey != "slack:C123:U1" {
-		t.Fatalf("ReconstructReplyCtx key = %q, want slack:C123:U1", p.reconstructKey)
-	}
-	if got := p.getSent(); len(got) != 1 || got[0] != "delivery ready" {
-		t.Fatalf("sent text = %#v, want one message", got)
-	}
-}
-
 func TestEngineStart_DefersAsyncPlatformReadyInitialization(t *testing.T) {
 	p := &stubLifecyclePlatform{stubPlatformEngine: stubPlatformEngine{n: "telegram"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
@@ -1473,6 +1442,168 @@ func TestProcessInteractiveEvents_CardProgressUsesStructuredPayloadWhenSupported
 	}
 	if finalPayload.State != ProgressCardStateCompleted {
 		t.Fatalf("final payload state = %q, want %q", finalPayload.State, ProgressCardStateCompleted)
+	}
+}
+
+func TestProcessInteractiveEvents_PersistsEventTimeline(t *testing.T) {
+	p := &stubCompactProgressPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}, style: "card", supportPayload: true}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.display.ProgressHistoryTurns = 3
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	session.AddHistory("user", "hello")
+
+	agentSession := newControllableSession("timeline-session")
+	state := &interactiveState{
+		platform:     p,
+		replyCtx:     "reply",
+		agentSession: agentSession,
+	}
+	agentSession.events <- Event{Type: EventThinking, Content: "think"}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "echo hi"}
+	exitCode := 0
+	ok := true
+	agentSession.events <- Event{Type: EventToolResult, ToolName: "Bash", ToolResult: "hi", ToolExitCode: &exitCode, ToolSuccess: &ok}
+	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
+
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-progress", time.Now(), nil, nil, state.replyCtx)
+
+	timelines := session.GetEventTimelines()
+	if len(timelines) != 1 {
+		t.Fatalf("event timelines = %d, want 1", len(timelines))
+	}
+	tl := timelines[0]
+	if tl.AssistantHistoryIdx != 1 {
+		t.Fatalf("assistant history idx = %d, want 1", tl.AssistantHistoryIdx)
+	}
+	if len(tl.Events) != 3 {
+		t.Fatalf("events = %d, want 3", len(tl.Events))
+	}
+	if tl.Events[0].Kind != EventThinking || tl.Events[0].Text != "think" {
+		t.Fatalf("thinking event = %#v", tl.Events[0])
+	}
+	if tl.Events[1].Kind != EventToolUse || tl.Events[1].ToolInput != "echo hi" {
+		t.Fatalf("tool use event = %#v", tl.Events[1])
+	}
+	if tl.Events[2].Kind != EventToolResult || tl.Events[2].ToolResult != "hi" {
+		t.Fatalf("tool result event = %#v", tl.Events[2])
+	}
+}
+
+func TestCmdProgress_ShowsLatestAndPreviousTimelines(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "test:user1"
+	s := e.sessions.GetOrCreateActive(sessionKey)
+	s.AddHistory("user", "u1")
+	idx1 := s.AddHistoryAndReturnIndex("assistant", "a1")
+	s.AppendEventTimeline(EventTimeline{
+		AssistantHistoryIdx: idx1,
+		StartedAt:           time.Now(),
+		CompletedAt:         time.Now(),
+		Events: []TimelineEvent{
+			{Index: 1, Kind: EventThinking, Text: "plan one"},
+			{Index: 2, Kind: EventToolUse, ToolName: "Bash", ToolInput: "echo one"},
+		},
+	}, 3)
+	s.AddHistory("user", "u2")
+	idx2 := s.AddHistoryAndReturnIndex("assistant", "a2")
+	s.AppendEventTimeline(EventTimeline{
+		AssistantHistoryIdx: idx2,
+		StartedAt:           time.Now(),
+		CompletedAt:         time.Now(),
+		Events: []TimelineEvent{
+			{Index: 1, Kind: EventThinking, Text: "plan two"},
+			{Index: 2, Kind: EventToolResult, ToolName: "Bash", ToolResult: "ok"},
+		},
+	}, 3)
+
+	msg := &Message{SessionKey: sessionKey, ReplyCtx: "reply"}
+	e.cmdProgress(p, msg, nil)
+	sent := p.getSent()
+	if len(sent) == 0 || !strings.Contains(sent[len(sent)-1], "plan two") || !strings.Contains(sent[len(sent)-1], "Tool Result · Bash") {
+		t.Fatalf("latest /progress output = %#v, want text fallback with latest timeline content", sent)
+	}
+
+	p.clearSent()
+	e.cmdProgress(p, msg, []string{"prev", "2"})
+	sent = p.getSent()
+	if len(sent) == 0 || !strings.Contains(sent[len(sent)-1], "echo one") || !strings.Contains(sent[len(sent)-1], "Tool Call · Bash") {
+		t.Fatalf("/progress prev 2 output = %#v, want text fallback with previous timeline event", sent)
+	}
+}
+
+func TestCmdProgress_UsesStructuredPayloadForCardPlatform(t *testing.T) {
+	p := &stubCompactProgressPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}, style: "card", supportPayload: true}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "card:user1"
+	s := e.sessions.GetOrCreateActive(sessionKey)
+	s.AddHistory("user", "u1")
+	idx := s.AddHistoryAndReturnIndex("assistant", "a1")
+	s.AppendEventTimeline(EventTimeline{
+		AssistantHistoryIdx: idx,
+		StartedAt:           time.Now(),
+		CompletedAt:         time.Now(),
+		Events: []TimelineEvent{
+			{Index: 1, Kind: EventThinking, Text: "plan"},
+			{Index: 2, Kind: EventToolResult, ToolName: "Bash", ToolResult: "ok"},
+		},
+	}, 3)
+
+	msg := &Message{SessionKey: sessionKey, ReplyCtx: "reply"}
+	e.cmdProgress(p, msg, nil)
+	sent := p.getSent()
+	if len(sent) == 0 {
+		t.Fatalf("/progress output = %#v, want payload reply", sent)
+	}
+	payload, ok := ParseProgressCardPayload(sent[len(sent)-1])
+	if !ok {
+		t.Fatalf("/progress reply should be structured payload, got %#v", sent[len(sent)-1])
+	}
+	if len(payload.Items) != 2 {
+		t.Fatalf("/progress payload items = %#v, want two items", payload.Items)
+	}
+	if payload.Items[0].Kind != ProgressEntryThinking || payload.Items[1].Kind != ProgressEntryToolResult {
+		t.Fatalf("/progress payload items = %#v, want thinking + tool_result", payload.Items)
+	}
+}
+
+func TestCmdProgress_MergedTimelineUsesSingleToolBlock(t *testing.T) {
+	p := &stubCompactProgressPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}, style: "card", supportPayload: true}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangChinese)
+	e.display.ToolLayout = toolLayoutMerged
+	e.display.ToolShowInput = true
+	e.display.ToolShowResultBody = true
+	sessionKey := "card:merged"
+	s := e.sessions.GetOrCreateActive(sessionKey)
+	s.AddHistory("user", "u1")
+	idx := s.AddHistoryAndReturnIndex("assistant", "a1")
+	s.AppendEventTimeline(EventTimeline{
+		AssistantHistoryIdx: idx,
+		StartedAt:           time.Now(),
+		CompletedAt:         time.Now(),
+		Events: []TimelineEvent{
+			{Index: 1, Kind: EventToolUse, ToolName: "Bash", ToolInput: "echo hi"},
+			{Index: 2, Kind: EventToolResult, ToolName: "Bash", ToolResult: "hi"},
+		},
+	}, 3)
+
+	msg := &Message{SessionKey: sessionKey, ReplyCtx: "reply"}
+	e.cmdProgress(p, msg, nil)
+	sent := p.getSent()
+	if len(sent) == 0 {
+		t.Fatalf("merged /progress output = %#v, want payload reply", sent)
+	}
+	payload, ok := ParseProgressCardPayload(sent[len(sent)-1])
+	if !ok {
+		t.Fatalf("merged /progress should be structured payload, got %#v", sent[len(sent)-1])
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("merged /progress items = %d, want 1", len(payload.Items))
+	}
+	item := payload.Items[0]
+	if item.Kind != ProgressEntryToolResult || item.ToolInput != "echo hi" || item.ToolResult != "hi" {
+		t.Fatalf("merged /progress item = %#v, want merged tool_result with input and output", item)
 	}
 }
 
@@ -9417,7 +9548,7 @@ func TestEngine_SetterMethods(t *testing.T) {
 	})
 
 	// Test SetDisplaySaveFunc
-	e.SetDisplaySaveFunc(func(thinkingMessages *bool, thinkMax, toolMax *int, toolMessages *bool) error {
+	e.SetDisplaySaveFunc(func(update DisplayCfgUpdate) error {
 		return nil
 	})
 

--- a/core/event_timeline.go
+++ b/core/event_timeline.go
@@ -1,0 +1,38 @@
+package core
+
+import "time"
+
+type EventTimeline struct {
+	AssistantHistoryIdx int             `json:"assistant_history_idx,omitempty"`
+	StartedAt           time.Time       `json:"started_at"`
+	CompletedAt         time.Time       `json:"completed_at"`
+	Events              []TimelineEvent `json:"events,omitempty"`
+}
+
+type TimelineEvent struct {
+	Index      int       `json:"index"`
+	Kind       EventType `json:"kind"`
+	Text       string    `json:"text,omitempty"`
+	ToolName   string    `json:"tool_name,omitempty"`
+	ToolInput  string    `json:"tool_input,omitempty"`
+	ToolResult string    `json:"tool_result,omitempty"`
+	Status     string    `json:"status,omitempty"`
+	ExitCode   *int      `json:"exit_code,omitempty"`
+	Success    *bool     `json:"success,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+func newEventTimeline(startedAt time.Time) *EventTimeline {
+	return &EventTimeline{
+		StartedAt: startedAt,
+		Events:    make([]TimelineEvent, 0, 8),
+	}
+}
+
+func (t *EventTimeline) appendEvent(ev TimelineEvent) {
+	ev.Index = len(t.Events) + 1
+	if ev.CreatedAt.IsZero() {
+		ev.CreatedAt = time.Now()
+	}
+	t.Events = append(t.Events, ev)
+}

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -174,6 +174,18 @@ const (
 	MsgListSwitchHint            MsgKey = "list_switch_hint"
 	MsgListError                 MsgKey = "list_error"
 	MsgHistoryEmpty              MsgKey = "history_empty"
+	MsgProgressUsage             MsgKey = "progress_usage"
+	MsgProgressEmpty             MsgKey = "progress_empty"
+	MsgProgressNoPrevious        MsgKey = "progress_no_previous"
+	MsgProgressEventNotFound     MsgKey = "progress_event_not_found"
+	MsgProgressRangeNotFound     MsgKey = "progress_range_not_found"
+	MsgProgressHeaderLatest      MsgKey = "progress_header_latest"
+	MsgProgressHeaderPrevious    MsgKey = "progress_header_previous"
+	MsgProgressEventInfo         MsgKey = "progress_event_info"
+	MsgProgressEventThinking     MsgKey = "progress_event_thinking"
+	MsgProgressEventToolUse      MsgKey = "progress_event_tool_use"
+	MsgProgressEventToolResult   MsgKey = "progress_event_tool_result"
+	MsgProgressEventError        MsgKey = "progress_event_error"
 	MsgNameUsage                 MsgKey = "name_usage"
 	MsgNameSet                   MsgKey = "name_set"
 	MsgNameNoSession             MsgKey = "name_no_session"
@@ -851,6 +863,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  Show current active session\n\n" +
 			"/agentsid\n  Print the agent session ID\n\n" +
 			"/history [n]\n  Show last n messages (default 10)\n\n" +
+			"/progress [prev] [event|start:end]\n  Show progress events for the latest or previous assistant turn\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  Manage API providers\n\n" +
 			"/memory [add|global|global add]\n  View/edit agent memory files\n\n" +
 			"/allow <tool>\n  Pre-allow a tool (next session)\n\n" +
@@ -895,6 +908,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  查看当前活跃会话\n\n" +
 			"/agentsid\n  输出 Agent Session ID\n\n" +
 			"/history [n]\n  查看最近 n 条消息（默认 10）\n\n" +
+			"/progress [prev] [事件号|起始:结束]\n  查看最近一轮或上一轮 assistant 回复的过程事件\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  管理 API Provider\n\n" +
 			"/memory [add|global|global add]\n  查看/编辑 Agent 记忆文件\n\n" +
 			"/allow <工具名>\n  预授权工具（下次会话生效）\n\n" +
@@ -939,6 +953,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  查看當前活躍會話\n\n" +
 			"/agentsid\n  輸出 Agent Session ID\n\n" +
 			"/history [n]\n  查看最近 n 條訊息（預設 10）\n\n" +
+			"/progress [prev] [事件號|起始:結束]\n  查看最近一輪或上一輪 assistant 回覆的過程事件\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  管理 API Provider\n\n" +
 			"/memory [add|global|global add]\n  查看/編輯 Agent 記憶檔案\n\n" +
 			"/allow <工具名>\n  預授權工具（下次會話生效）\n\n" +
@@ -981,6 +996,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  現在のアクティブセッションを表示\n\n" +
 			"/agentsid\n  エージェントのセッションIDを表示\n\n" +
 			"/history [n]\n  直近 n 件のメッセージを表示（デフォルト 10）\n\n" +
+			"/progress [prev] [イベント番号|開始:終了]\n  最新または直前の assistant 応答の進行イベントを表示\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  API プロバイダ管理\n\n" +
 			"/memory [add|global|global add]\n  エージェントメモリの表示/編集\n\n" +
 			"/allow <ツール名>\n  ツールを事前許可（次のセッションで有効）\n\n" +
@@ -1023,6 +1039,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/current\n  Mostrar sesión activa actual\n\n" +
 			"/agentsid\n  Mostrar el ID de sesión del agente\n\n" +
 			"/history [n]\n  Mostrar últimos n mensajes (por defecto 10)\n\n" +
+			"/progress [prev] [evento|inicio:fin]\n  Mostrar eventos de progreso del último o anterior turno del assistant\n\n" +
 			"/provider [list|add|remove|switch|clear]\n  Gestionar proveedores API\n\n" +
 			"/memory [add|global|global add]\n  Ver/editar archivos de memoria del agente\n\n" +
 			"/allow <herramienta>\n  Pre-autorizar herramienta (próxima sesión)\n\n" +
@@ -1073,7 +1090,8 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <number>|1,2,3|3-7|1,3-5,8 — Delete session(s)\n" +
 			"/name [number] <text> — Name a session\n" +
 			"/current — Show active session\n" +
-			"/history [n] — Show last n messages",
+			"/history [n] — Show last n messages\n" +
+			"/progress [prev] [event|start:end] — Show recent progress events",
 		LangChinese: "**会话管理**\n" +
 			"/new [名称] — 创建新会话\n" +
 			"/list — 列出会话列表\n" +
@@ -1082,7 +1100,8 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <序号>|1,2,3|3-7|1,3-5,8 — 删除会话\n" +
 			"/name [序号] <名称> — 命名会话\n" +
 			"/current — 查看当前会话\n" +
-			"/history [n] — 查看最近 n 条消息",
+			"/history [n] — 查看最近 n 条消息\n" +
+			"/progress [prev] [事件号|起始:结束] — 查看最近过程事件",
 		LangTraditionalChinese: "**會話管理**\n" +
 			"/new [名稱] — 建立新會話\n" +
 			"/list — 列出會話列表\n" +
@@ -1091,7 +1110,8 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <序號>|1,2,3|3-7|1,3-5,8 — 刪除會話\n" +
 			"/name [序號] <名稱> — 命名會話\n" +
 			"/current — 查看當前會話\n" +
-			"/history [n] — 查看最近 n 條訊息",
+			"/history [n] — 查看最近 n 條訊息\n" +
+			"/progress [prev] [事件號|起始:結束] — 查看最近過程事件",
 		LangJapanese: "**セッション管理**\n" +
 			"/new [名前] — 新しいセッションを開始\n" +
 			"/list — セッション一覧\n" +
@@ -1100,7 +1120,8 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <番号>|1,2,3|3-7|1,3-5,8 — セッション削除\n" +
 			"/name [番号] <名前> — セッションに名前を付ける\n" +
 			"/current — 現在のセッションを表示\n" +
-			"/history [n] — 直近 n 件のメッセージを表示",
+			"/history [n] — 直近 n 件のメッセージを表示\n" +
+			"/progress [prev] [イベント番号|開始:終了] — 直近の進行イベントを表示",
 		LangSpanish: "**Gestión de sesiones**\n" +
 			"/new [nombre] — Iniciar nueva sesión\n" +
 			"/list — Listar sesiones\n" +
@@ -1109,7 +1130,8 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <número>|1,2,3|3-7|1,3-5,8 — Eliminar sesión(es)\n" +
 			"/name [número] <texto> — Nombrar sesión\n" +
 			"/current — Mostrar sesión activa\n" +
-			"/history [n] — Mostrar últimos n mensajes",
+			"/history [n] — Mostrar últimos n mensajes\n" +
+			"/progress [prev] [evento|inicio:fin] — Mostrar eventos de progreso recientes",
 	},
 	MsgHelpAgentSection: {
 		LangEnglish: "**Agent Configuration**\n" +
@@ -1306,6 +1328,90 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "當前會話暫無歷史訊息。",
 		LangJapanese:           "現在のセッションに履歴がありません。",
 		LangSpanish:            "No hay historial en la sesión actual.",
+	},
+	MsgProgressUsage: {
+		LangEnglish:            "Usage: `/progress`, `/progress 7`, `/progress 3:8`, `/progress prev`, `/progress prev 7`, `/progress prev 3:8`",
+		LangChinese:            "用法：`/progress`、`/progress 7`、`/progress 3:8`、`/progress prev`、`/progress prev 7`、`/progress prev 3:8`",
+		LangTraditionalChinese: "用法：`/progress`、`/progress 7`、`/progress 3:8`、`/progress prev`、`/progress prev 7`、`/progress prev 3:8`",
+		LangJapanese:           "使い方: `/progress`、`/progress 7`、`/progress 3:8`、`/progress prev`、`/progress prev 7`、`/progress prev 3:8`",
+		LangSpanish:            "Uso: `/progress`, `/progress 7`, `/progress 3:8`, `/progress prev`, `/progress prev 7`, `/progress prev 3:8`",
+	},
+	MsgProgressEmpty: {
+		LangEnglish:            "No progress history is available for the current session.",
+		LangChinese:            "当前会话暂无可查看的过程历史。",
+		LangTraditionalChinese: "當前會話暫無可查看的過程歷史。",
+		LangJapanese:           "現在のセッションで参照できる進行履歴はありません。",
+		LangSpanish:            "No hay historial de progreso disponible para la sesión actual.",
+	},
+	MsgProgressNoPrevious: {
+		LangEnglish:            "No previous assistant turn with stored progress events was found.",
+		LangChinese:            "没有找到上一轮带过程事件的 assistant 回复。",
+		LangTraditionalChinese: "沒有找到上一輪帶過程事件的 assistant 回覆。",
+		LangJapanese:           "進行イベント付きの直前 assistant ターンは見つかりませんでした。",
+		LangSpanish:            "No se encontró un turno anterior del assistant con eventos de progreso guardados.",
+	},
+	MsgProgressEventNotFound: {
+		LangEnglish:            "Event `%d` is out of range for the selected progress turn.",
+		LangChinese:            "事件 `%d` 超出当前所选过程轮次范围。",
+		LangTraditionalChinese: "事件 `%d` 超出當前所選過程輪次範圍。",
+		LangJapanese:           "イベント `%d` は選択した進行ターンの範囲外です。",
+		LangSpanish:            "El evento `%d` está fuera del rango del turno de progreso seleccionado.",
+	},
+	MsgProgressRangeNotFound: {
+		LangEnglish:            "Event range `%d:%d` is out of range for the selected progress turn.",
+		LangChinese:            "事件范围 `%d:%d` 超出当前所选过程轮次范围。",
+		LangTraditionalChinese: "事件範圍 `%d:%d` 超出當前所選過程輪次範圍。",
+		LangJapanese:           "イベント範囲 `%d:%d` は選択した進行ターンの範囲外です。",
+		LangSpanish:            "El rango `%d:%d` está fuera del rango del turno de progreso seleccionado.",
+	},
+	MsgProgressHeaderLatest: {
+		LangEnglish:            "🧭 Progress for latest assistant turn (%d/%d event(s))",
+		LangChinese:            "🧭 最近一轮 assistant 回复的过程事件（显示 %d/%d 条）",
+		LangTraditionalChinese: "🧭 最近一輪 assistant 回覆的過程事件（顯示 %d/%d 條）",
+		LangJapanese:           "🧭 最新 assistant ターンの進行イベント（%d/%d 件を表示）",
+		LangSpanish:            "🧭 Progreso del último turno del assistant (%d/%d evento(s))",
+	},
+	MsgProgressHeaderPrevious: {
+		LangEnglish:            "🧭 Progress for previous assistant turn (%d/%d event(s))",
+		LangChinese:            "🧭 上一轮 assistant 回复的过程事件（显示 %d/%d 条）",
+		LangTraditionalChinese: "🧭 上一輪 assistant 回覆的過程事件（顯示 %d/%d 條）",
+		LangJapanese:           "🧭 直前 assistant ターンの進行イベント（%d/%d 件を表示）",
+		LangSpanish:            "🧭 Progreso del turno anterior del assistant (%d/%d evento(s))",
+	},
+	MsgProgressEventInfo: {
+		LangEnglish:            "Info",
+		LangChinese:            "信息",
+		LangTraditionalChinese: "資訊",
+		LangJapanese:           "情報",
+		LangSpanish:            "Info",
+	},
+	MsgProgressEventThinking: {
+		LangEnglish:            "Thinking",
+		LangChinese:            "思考",
+		LangTraditionalChinese: "思考",
+		LangJapanese:           "思考",
+		LangSpanish:            "Thinking",
+	},
+	MsgProgressEventToolUse: {
+		LangEnglish:            "Tool Call",
+		LangChinese:            "工具调用",
+		LangTraditionalChinese: "工具調用",
+		LangJapanese:           "ツール呼び出し",
+		LangSpanish:            "Llamada de herramienta",
+	},
+	MsgProgressEventToolResult: {
+		LangEnglish:            "Tool Result",
+		LangChinese:            "工具结果",
+		LangTraditionalChinese: "工具結果",
+		LangJapanese:           "ツール結果",
+		LangSpanish:            "Resultado de herramienta",
+	},
+	MsgProgressEventError: {
+		LangEnglish:            "Error",
+		LangChinese:            "错误",
+		LangTraditionalChinese: "錯誤",
+		LangJapanese:           "エラー",
+		LangSpanish:            "Error",
 	},
 	MsgNameUsage: {
 		LangEnglish:            "Usage:\n`/name <text>` — name the current session\n`/name <number> <text>` — name a session by list number",

--- a/core/progress_command.go
+++ b/core/progress_command.go
@@ -109,7 +109,7 @@ func (e *Engine) cmdProgress(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProgressEmpty))
 		return
 	}
-	if progressStyleFor(p, e.display) == progressStyleCard {
+	if progressStyleFor(p, msg.ReplyCtx, e.display) == progressStyleCard {
 		if cap, ok := p.(ProgressCardPayloadSupport); ok && cap.SupportsProgressCardPayload() {
 			payload := BuildProgressCardPayloadV2(items, false, normalizeProgressAgentLabel(e.agent.Name()), e.i18n.CurrentLang(), ProgressCardStateCompleted)
 			if payload != "" {

--- a/core/progress_command.go
+++ b/core/progress_command.go
@@ -1,0 +1,207 @@
+package core
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type progressSelection struct {
+	usePrevious bool
+	single      *int
+	rangeStart  int
+	rangeEnd    int
+}
+
+func parseProgressSelection(args []string) (progressSelection, error) {
+	sel := progressSelection{}
+	if len(args) == 0 {
+		return sel, nil
+	}
+	if strings.EqualFold(args[0], "prev") {
+		sel.usePrevious = true
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		return sel, nil
+	}
+	if len(args) > 1 {
+		return sel, fmt.Errorf("usage")
+	}
+	token := strings.TrimSpace(args[0])
+	if token == "" {
+		return sel, nil
+	}
+	if strings.Contains(token, ":") {
+		parts := strings.SplitN(token, ":", 2)
+		start, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+		end, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err1 != nil || err2 != nil || start <= 0 || end <= 0 || start > end {
+			return sel, fmt.Errorf("range")
+		}
+		sel.rangeStart = start
+		sel.rangeEnd = end
+		return sel, nil
+	}
+	n, err := strconv.Atoi(token)
+	if err != nil || n <= 0 {
+		return sel, fmt.Errorf("selector")
+	}
+	sel.single = &n
+	return sel, nil
+}
+
+func (e *Engine) cmdProgress(p Platform, msg *Message, args []string) {
+	_, sessions, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+	selection, err := parseProgressSelection(args)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProgressUsage))
+		return
+	}
+
+	s := sessions.GetOrCreateActive(msg.SessionKey)
+	timelines := s.GetEventTimelines()
+	if len(timelines) == 0 {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProgressEmpty))
+		return
+	}
+
+	timelineIdx := len(timelines) - 1
+	if selection.usePrevious {
+		timelineIdx--
+	}
+	if timelineIdx < 0 || timelineIdx >= len(timelines) {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProgressNoPrevious))
+		return
+	}
+
+	timeline := timelines[timelineIdx]
+	if len(timeline.Events) == 0 {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProgressEmpty))
+		return
+	}
+
+	events := timeline.Events
+	if selection.single != nil {
+		if *selection.single > len(events) {
+			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgProgressEventNotFound, *selection.single))
+			return
+		}
+		events = events[*selection.single-1 : *selection.single]
+	} else if selection.rangeStart > 0 {
+		if selection.rangeStart > len(events) {
+			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgProgressRangeNotFound, selection.rangeStart, selection.rangeEnd))
+			return
+		}
+		end := selection.rangeEnd
+		if end > len(events) {
+			end = len(events)
+		}
+		events = events[selection.rangeStart-1 : end]
+	}
+
+	items := buildProgressItemsFromTimeline(events, e.display)
+	if len(items) == 0 {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProgressEmpty))
+		return
+	}
+	if progressStyleFor(p, e.display) == progressStyleCard {
+		if cap, ok := p.(ProgressCardPayloadSupport); ok && cap.SupportsProgressCardPayload() {
+			payload := BuildProgressCardPayloadV2(items, false, normalizeProgressAgentLabel(e.agent.Name()), e.i18n.CurrentLang(), ProgressCardStateCompleted)
+			if payload != "" {
+				e.reply(p, msg.ReplyCtx, payload)
+				return
+			}
+		}
+	}
+
+	e.reply(p, msg.ReplyCtx, e.renderProgressItemsText(items, selection.usePrevious))
+}
+
+func (e *Engine) renderProgressItemsText(items []ProgressCardEntry, previous bool) string {
+	var sb strings.Builder
+	if previous {
+		sb.WriteString(e.i18n.Tf(MsgProgressHeaderPrevious, len(items), len(items)))
+	} else {
+		sb.WriteString(e.i18n.Tf(MsgProgressHeaderLatest, len(items), len(items)))
+	}
+	sb.WriteString("\n\n")
+	for i, item := range items {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString(e.progressItemHeader(item))
+		if body := e.progressItemBody(item); body != "" {
+			sb.WriteString("\n")
+			sb.WriteString(body)
+		}
+	}
+	return sb.String()
+}
+
+func (e *Engine) progressItemHeader(item ProgressCardEntry) string {
+	switch item.Kind {
+	case ProgressEntryThinking:
+		return e.i18n.T(MsgProgressEventThinking)
+	case ProgressEntryToolUse:
+		head := e.i18n.T(MsgProgressEventToolUse)
+		if strings.TrimSpace(item.Tool) != "" {
+			head += " · " + strings.TrimSpace(item.Tool)
+		}
+		return head
+	case ProgressEntryToolResult:
+		head := e.i18n.T(MsgProgressEventToolResult)
+		if strings.TrimSpace(item.Tool) != "" {
+			head += " · " + strings.TrimSpace(item.Tool)
+		}
+		if item.ExitCode != nil {
+			head += fmt.Sprintf(" · %s %d", e.i18n.T(MsgToolResultFmtExit), *item.ExitCode)
+		}
+		return head
+	case ProgressEntryError:
+		return e.i18n.T(MsgProgressEventError)
+	default:
+		return e.i18n.T(MsgProgressEventInfo)
+	}
+}
+
+func (e *Engine) progressItemBody(item ProgressCardEntry) string {
+	switch item.Kind {
+	case ProgressEntryThinking, ProgressEntryError, ProgressEntryInfo:
+		return strings.TrimSpace(item.Text)
+	case ProgressEntryToolUse:
+		if strings.TrimSpace(item.ToolInput) == "" {
+			return ""
+		}
+		return fencedProgressBody(item.Tool, item.ToolInput)
+	case ProgressEntryToolResult:
+		lines := make([]string, 0, 3)
+		if strings.TrimSpace(item.ToolInput) != "" {
+			lines = append(lines, fencedProgressBody(item.Tool, item.ToolInput))
+		}
+		if strings.TrimSpace(item.ToolResult) != "" {
+			lines = append(lines, fencedProgressBody("", item.ToolResult))
+		} else if strings.TrimSpace(item.Status) != "" {
+			lines = append(lines, fmt.Sprintf("%s: %s", e.i18n.T(MsgToolResultFmtStatus), strings.TrimSpace(item.Status)))
+		}
+		return strings.Join(lines, "\n")
+	default:
+		return strings.TrimSpace(item.Text)
+	}
+}
+
+func fencedProgressBody(toolName, text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	lang := toolCodeLang(toolName, text)
+	if lang != "" {
+		return "```" + lang + "\n" + text + "\n```"
+	}
+	return "```\n" + text + "\n```"
+}

--- a/core/progress_compact.go
+++ b/core/progress_compact.go
@@ -14,6 +14,8 @@ const (
 	progressStyleLegacy  = "legacy"
 	progressStyleCompact = "compact"
 	progressStyleCard    = "card"
+	toolLayoutSplit      = "split"
+	toolLayoutMerged     = "merged"
 
 	// ProgressCardPayloadPrefix marks a structured payload for card-style progress.
 	ProgressCardPayloadPrefix = "__cc_connect_progress_card_v1__:"
@@ -45,12 +47,15 @@ const (
 )
 
 type ProgressCardEntry struct {
-	Kind     ProgressCardEntryKind `json:"kind"`
-	Text     string                `json:"text"`
-	Tool     string                `json:"tool,omitempty"`
-	Status   string                `json:"status,omitempty"`
-	ExitCode *int                  `json:"exit_code,omitempty"`
-	Success  *bool                 `json:"success,omitempty"`
+	Kind       ProgressCardEntryKind `json:"kind"`
+	Text       string                `json:"text,omitempty"`
+	Tool       string                `json:"tool,omitempty"`
+	Status     string                `json:"status,omitempty"`
+	ExitCode   *int                  `json:"exit_code,omitempty"`
+	Success    *bool                 `json:"success,omitempty"`
+	ToolInput  string                `json:"tool_input,omitempty"`
+	ToolResult string                `json:"tool_result,omitempty"`
+	Running    bool                  `json:"running,omitempty"`
 }
 
 // ProgressCardPayload carries structured progress entries for platforms that
@@ -94,7 +99,11 @@ func BuildProgressCardPayloadV2(items []ProgressCardEntry, truncated bool, agent
 	cleaned := make([]ProgressCardEntry, 0, len(items))
 	for _, item := range items {
 		text := strings.TrimSpace(item.Text)
-		if text == "" {
+		input := strings.TrimSpace(item.ToolInput)
+		result := strings.TrimSpace(item.ToolResult)
+		tool := strings.TrimSpace(item.Tool)
+		status := strings.TrimSpace(item.Status)
+		if text == "" && input == "" && result == "" && tool == "" {
 			continue
 		}
 		kind := item.Kind
@@ -102,12 +111,15 @@ func BuildProgressCardPayloadV2(items []ProgressCardEntry, truncated bool, agent
 			kind = ProgressEntryInfo
 		}
 		cleaned = append(cleaned, ProgressCardEntry{
-			Kind:     kind,
-			Text:     text,
-			Tool:     strings.TrimSpace(item.Tool),
-			Status:   strings.TrimSpace(item.Status),
-			ExitCode: item.ExitCode,
-			Success:  item.Success,
+			Kind:       kind,
+			Text:       text,
+			Tool:       tool,
+			Status:     status,
+			ExitCode:   item.ExitCode,
+			Success:    item.Success,
+			ToolInput:  input,
+			ToolResult: result,
+			Running:    item.Running,
 		})
 	}
 	if len(cleaned) == 0 {
@@ -153,7 +165,9 @@ func ParseProgressCardPayload(content string) (*ProgressCardPayload, bool) {
 		item.Text = strings.TrimSpace(item.Text)
 		item.Tool = strings.TrimSpace(item.Tool)
 		item.Status = strings.TrimSpace(item.Status)
-		if item.Text == "" {
+		item.ToolInput = strings.TrimSpace(item.ToolInput)
+		item.ToolResult = strings.TrimSpace(item.ToolResult)
+		if item.Text == "" && item.ToolInput == "" && item.ToolResult == "" && item.Tool == "" {
 			continue
 		}
 		if item.Kind == "" {
@@ -227,6 +241,16 @@ type compactProgressWriter struct {
 	truncated  bool
 	lastSent   string
 	maxEntries int
+	toolLayout string
+	showInput  bool
+	showResult bool
+	pending    []pendingToolBlock
+}
+
+type pendingToolBlock struct {
+	itemIndex int
+	toolName  string
+	resolved  bool
 }
 
 func normalizeProgressStyle(style string) string {
@@ -239,6 +263,17 @@ func normalizeProgressStyle(style string) string {
 		return progressStyleCard
 	default:
 		return progressStyleLegacy
+	}
+}
+
+func normalizeToolLayout(layout string) string {
+	switch strings.ToLower(strings.TrimSpace(layout)) {
+	case "", toolLayoutMerged:
+		return toolLayoutMerged
+	case toolLayoutSplit:
+		return toolLayoutSplit
+	default:
+		return toolLayoutMerged
 	}
 }
 
@@ -258,7 +293,15 @@ type progressCardPayloadHintProvider interface {
 	supportsProgressCardPayloadHint() bool
 }
 
-func progressStyleForTarget(p Platform, replyCtx any) string {
+func progressStyleFor(p Platform, replyCtx any, display DisplayCfg) string {
+	if override := strings.ToLower(strings.TrimSpace(display.ProgressStyle)); override != "" {
+		switch override {
+		case "auto":
+			// Fall through to reply context / platform defaults below.
+		case progressStyleLegacy, progressStyleCompact, progressStyleCard:
+			return override
+		}
+	}
 	if hint, ok := replyCtx.(progressStyleHintProvider); ok {
 		return normalizeProgressStyle(hint.progressStyleHint())
 	}
@@ -274,31 +317,33 @@ func progressCardPayloadForTarget(p Platform, replyCtx any) bool {
 	}
 	return false
 }
-
 // SuppressStandaloneToolResultEvent is true when a platform opts into progress
 // styling (ProgressStyleProvider) but uses legacy mode. In that case tool_use
 // lines are still shown, but a separate chat message for EventToolResult is
 // skipped to avoid duplicate noise (e.g. Codex structured tool results on Feishu).
 // Platforms without ProgressStyleProvider keep showing standalone tool results.
-func SuppressStandaloneToolResultEvent(p Platform) bool {
+func SuppressStandaloneToolResultEvent(p Platform, display DisplayCfg) bool {
 	_, ok := p.(ProgressStyleProvider)
 	if !ok {
 		return false
 	}
-	return progressStyleForPlatform(p) == progressStyleLegacy
+	return progressStyleFor(p, nil, display) == progressStyleLegacy
 }
 
-func newCompactProgressWriter(ctx context.Context, p Platform, replyCtx any, agentName string, lang Language, transform func(string) string) *compactProgressWriter {
+func newCompactProgressWriter(ctx context.Context, p Platform, replyCtx any, agentName string, lang Language, display DisplayCfg, transform func(string) string) *compactProgressWriter {
 	w := &compactProgressWriter{
 		ctx:        ctx,
 		platform:   p,
 		replyCtx:   replyCtx,
 		transform:  transform,
-		style:      progressStyleForTarget(p, replyCtx),
+		style:      progressStyleFor(p, replyCtx, display),
 		state:      ProgressCardStateRunning,
 		agentName:  normalizeProgressAgentLabel(agentName),
 		lang:       lang,
-		maxEntries: 10,
+		maxEntries: display.ProgressMaxEntries,
+		toolLayout: normalizeToolLayout(display.ToolLayout),
+		showInput:  display.ToolShowInput,
+		showResult: display.ToolShowResultBody,
 	}
 	if w.style != progressStyleCompact && w.style != progressStyleCard {
 		slog.Debug("progress writer disabled: unsupported style", "platform", p.Name(), "style", w.style)
@@ -374,68 +419,33 @@ func (w *compactProgressWriter) AppendStructured(item ProgressCardEntry, fallbac
 	if !w.enabled || w.failed {
 		return false
 	}
-	text := strings.TrimSpace(item.Text)
+	item = normalizeProgressItem(item)
 	fallback = strings.TrimSpace(fallback)
-	if text == "" && fallback == "" {
+	if item.Text == "" && item.ToolInput == "" && item.ToolResult == "" && fallback == "" {
 		return true
 	}
-	if text == "" {
-		text = fallback
+	if fallback == "" {
+		fallback = progressFallbackText(item)
 	}
 	if fallback == "" {
-		fallback = text
+		fallback = item.Text
 	}
 	switch item.Kind {
 	case ProgressEntryThinking, ProgressEntryError, ProgressEntryInfo:
 		if w.transform != nil {
-			text = w.transform(text)
+			item.Text = w.transform(item.Text)
 			fallback = w.transform(fallback)
 		}
 	}
-	kind := item.Kind
-	if kind == "" {
-		kind = ProgressEntryInfo
-	}
-	item.Kind = kind
-	item.Text = text
-	item.Tool = strings.TrimSpace(item.Tool)
-	item.Status = strings.TrimSpace(item.Status)
 
-	switch w.style {
-	case progressStyleCard:
+	if w.toolLayout == toolLayoutMerged && (item.Kind == ProgressEntryToolUse || item.Kind == ProgressEntryToolResult) {
+		w.appendMerged(item, fallback)
+	} else {
 		w.items = append(w.items, item)
 		w.entries = append(w.entries, fallback)
-		truncated := false
-		if w.maxEntries > 0 && len(w.items) > w.maxEntries {
-			w.items = w.items[len(w.items)-w.maxEntries:]
-			if len(w.entries) > w.maxEntries {
-				w.entries = w.entries[len(w.entries)-w.maxEntries:]
-			}
-			truncated = true
-		} else if w.maxEntries > 0 && len(w.entries) > w.maxEntries {
-			w.entries = w.entries[len(w.entries)-w.maxEntries:]
-			truncated = true
-		}
-		w.truncated = truncated
-		if w.usePayload {
-			w.content = BuildProgressCardPayloadV2(w.items, w.truncated, w.agentName, w.lang, w.state)
-			if w.content == "" {
-				slog.Warn("progress writer: failed to build structured payload", "platform", w.platform.Name())
-				w.failed = true
-				return false
-			}
-		} else {
-			w.content = renderCardProgressMarkdownFallback(w.entries, truncated)
-			w.content = trimCompactProgressText(w.content, compactProgressMaxChars)
-		}
-	default:
-		if w.content == "" {
-			w.content = fallback
-		} else {
-			w.content += "\n\n" + fallback
-		}
-		w.content = trimCompactProgressText(w.content, compactProgressMaxChars)
 	}
+	w.trimEntries()
+	w.rebuildContent()
 
 	if w.content == w.lastSent {
 		return true
@@ -478,6 +488,282 @@ func (w *compactProgressWriter) AppendStructured(item ProgressCardEntry, fallbac
 	}
 	w.lastSent = w.content
 	return true
+}
+
+func normalizeProgressItem(item ProgressCardEntry) ProgressCardEntry {
+	item.Kind = ProgressCardEntryKind(strings.TrimSpace(string(item.Kind)))
+	if item.Kind == "" {
+		item.Kind = ProgressEntryInfo
+	}
+	item.Text = strings.TrimSpace(item.Text)
+	item.Tool = strings.TrimSpace(item.Tool)
+	item.Status = strings.TrimSpace(item.Status)
+	item.ToolInput = strings.TrimSpace(item.ToolInput)
+	item.ToolResult = strings.TrimSpace(item.ToolResult)
+	if item.Text == "" {
+		switch item.Kind {
+		case ProgressEntryToolUse:
+			item.Text = item.ToolInput
+		case ProgressEntryToolResult:
+			item.Text = item.ToolResult
+		}
+	}
+	return item
+}
+
+func progressFallbackText(item ProgressCardEntry) string {
+	switch item.Kind {
+	case ProgressEntryToolUse:
+		if item.ToolInput != "" {
+			return item.ToolInput
+		}
+		return item.Text
+	case ProgressEntryToolResult:
+		if item.ToolResult != "" {
+			return item.ToolResult
+		}
+		return item.Text
+	default:
+		return item.Text
+	}
+}
+
+func (w *compactProgressWriter) appendMerged(item ProgressCardEntry, fallback string) {
+	switch item.Kind {
+	case ProgressEntryToolUse:
+		merged := ProgressCardEntry{
+			Kind:      ProgressEntryToolUse,
+			Tool:      item.Tool,
+			ToolInput: item.ToolInput,
+			Running:   true,
+		}
+		if merged.ToolInput == "" {
+			merged.ToolInput = item.Text
+		}
+		merged.Text = merged.ToolInput
+		entry := fallback
+		if entry == "" {
+			entry = progressFallbackText(merged)
+		}
+		w.items = append(w.items, merged)
+		w.entries = append(w.entries, entry)
+		w.pending = append(w.pending, pendingToolBlock{
+			itemIndex: len(w.items) - 1,
+			toolName:  merged.Tool,
+		})
+	case ProgressEntryToolResult:
+		idx := w.findPendingToolIndex(item.Tool)
+		if idx < 0 {
+			w.items = append(w.items, item)
+			w.entries = append(w.entries, fallback)
+			return
+		}
+		pending := &w.pending[idx]
+		target := pending.itemIndex
+		if target < 0 || target >= len(w.items) {
+			w.items = append(w.items, item)
+			w.entries = append(w.entries, fallback)
+			pending.resolved = true
+			return
+		}
+		existing := w.items[target]
+		existing.Kind = ProgressEntryToolResult
+		existing.Running = false
+		if existing.Tool == "" {
+			existing.Tool = item.Tool
+		}
+		existing.Status = item.Status
+		existing.ExitCode = item.ExitCode
+		existing.Success = item.Success
+		if item.ToolInput != "" {
+			existing.ToolInput = item.ToolInput
+		}
+		if item.ToolResult != "" {
+			existing.ToolResult = item.ToolResult
+		} else if item.Text != "" {
+			existing.ToolResult = item.Text
+		}
+		if existing.Text == "" {
+			existing.Text = existing.ToolInput
+		}
+		w.items[target] = existing
+		w.entries[target] = mergedFallbackText(existing)
+		pending.resolved = true
+	}
+}
+
+func mergedFallbackText(item ProgressCardEntry) string {
+	parts := make([]string, 0, 2)
+	if item.ToolInput != "" {
+		parts = append(parts, item.ToolInput)
+	}
+	if item.ToolResult != "" {
+		parts = append(parts, item.ToolResult)
+	}
+	if len(parts) == 0 {
+		return item.Text
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func buildProgressItemsFromTimeline(events []TimelineEvent, display DisplayCfg) []ProgressCardEntry {
+	collector := compactProgressWriter{
+		toolLayout: normalizeToolLayout(display.ToolLayout),
+		showInput:  display.ToolShowInput,
+		showResult: display.ToolShowResultBody,
+	}
+	for _, ev := range events {
+		item, fallback, ok := progressEntryFromTimelineEvent(ev, display)
+		if !ok {
+			continue
+		}
+		if collector.toolLayout == toolLayoutMerged && (item.Kind == ProgressEntryToolUse || item.Kind == ProgressEntryToolResult) {
+			collector.appendMerged(item, fallback)
+		} else {
+			collector.items = append(collector.items, item)
+			collector.entries = append(collector.entries, fallback)
+		}
+	}
+	return collector.items
+}
+
+func progressEntryFromTimelineEvent(ev TimelineEvent, display DisplayCfg) (ProgressCardEntry, string, bool) {
+	switch ev.Kind {
+	case EventThinking:
+		text := strings.TrimSpace(truncateIf(ev.Text, display.ThinkingMaxLen))
+		if text == "" {
+			return ProgressCardEntry{}, "", false
+		}
+		item := ProgressCardEntry{
+			Kind: ProgressEntryThinking,
+			Text: text,
+		}
+		return item, text, true
+	case EventToolUse:
+		if !display.ToolMessages {
+			return ProgressCardEntry{}, "", false
+		}
+		input := strings.TrimSpace(ev.ToolInput)
+		item := ProgressCardEntry{
+			Kind: ProgressEntryToolUse,
+			Tool: strings.TrimSpace(ev.ToolName),
+		}
+		if display.ToolShowInput {
+			item.ToolInput = input
+			item.Text = input
+		}
+		return item, progressFallbackText(item), true
+	case EventToolResult:
+		if !display.ToolMessages {
+			return ProgressCardEntry{}, "", false
+		}
+		result := strings.TrimSpace(ev.ToolResult)
+		if result == "" {
+			result = strings.TrimSpace(ev.Text)
+		}
+		if display.ToolShowResultBody {
+			result = strings.TrimSpace(truncateIf(result, display.ToolMaxLen))
+		} else {
+			result = ""
+		}
+		item := ProgressCardEntry{
+			Kind:       ProgressEntryToolResult,
+			Tool:       strings.TrimSpace(ev.ToolName),
+			Status:     strings.TrimSpace(ev.Status),
+			ExitCode:   ev.ExitCode,
+			Success:    ev.Success,
+			ToolResult: result,
+		}
+		return item, progressFallbackText(item), true
+	case EventError:
+		text := strings.TrimSpace(ev.Text)
+		if text == "" {
+			return ProgressCardEntry{}, "", false
+		}
+		item := ProgressCardEntry{
+			Kind: ProgressEntryError,
+			Text: text,
+		}
+		return item, text, true
+	default:
+		text := strings.TrimSpace(ev.Text)
+		if text == "" {
+			return ProgressCardEntry{}, "", false
+		}
+		item := ProgressCardEntry{
+			Kind: ProgressEntryInfo,
+			Text: text,
+		}
+		return item, text, true
+	}
+}
+
+func (w *compactProgressWriter) findPendingToolIndex(toolName string) int {
+	toolName = strings.TrimSpace(toolName)
+	for i, pending := range w.pending {
+		if pending.resolved {
+			continue
+		}
+		if toolName != "" && strings.EqualFold(strings.TrimSpace(pending.toolName), toolName) {
+			return i
+		}
+	}
+	for i, pending := range w.pending {
+		if !pending.resolved {
+			return i
+		}
+	}
+	return -1
+}
+
+func (w *compactProgressWriter) trimEntries() {
+	truncated := false
+	if w.maxEntries > 0 && len(w.items) > w.maxEntries {
+		overflow := len(w.items) - w.maxEntries
+		w.items = w.items[overflow:]
+		if len(w.entries) > overflow {
+			w.entries = w.entries[overflow:]
+		} else {
+			w.entries = nil
+		}
+		if len(w.pending) > 0 {
+			next := make([]pendingToolBlock, 0, len(w.pending))
+			for _, pending := range w.pending {
+				if pending.resolved {
+					continue
+				}
+				pending.itemIndex -= overflow
+				if pending.itemIndex >= 0 && pending.itemIndex < len(w.items) {
+					next = append(next, pending)
+				}
+			}
+			w.pending = next
+		}
+		truncated = true
+	} else if w.maxEntries > 0 && len(w.entries) > w.maxEntries {
+		w.entries = w.entries[len(w.entries)-w.maxEntries:]
+		truncated = true
+	}
+	w.truncated = truncated
+}
+
+func (w *compactProgressWriter) rebuildContent() {
+	switch w.style {
+	case progressStyleCard:
+		if w.usePayload {
+			w.content = BuildProgressCardPayloadV2(w.items, w.truncated, w.agentName, w.lang, w.state)
+		} else {
+			w.content = renderCardProgressMarkdownFallback(w.entries, w.truncated)
+			w.content = trimCompactProgressText(w.content, compactProgressMaxChars)
+		}
+	default:
+		w.content = strings.Join(w.entries, "\n\n")
+		w.content = trimCompactProgressText(w.content, compactProgressMaxChars)
+	}
+	if w.usePayload && w.content == "" {
+		slog.Warn("progress writer: failed to build structured payload", "platform", w.platform.Name())
+		w.failed = true
+	}
 }
 
 // Finalize updates card progress state (running/completed/failed) without

--- a/core/progress_compact_test.go
+++ b/core/progress_compact_test.go
@@ -18,17 +18,22 @@ func (s *suppressTestPlatform) Stop() error                              { retur
 func (s *suppressTestPlatform) ProgressStyle() string                    { return s.style }
 
 func TestSuppressStandaloneToolResultEvent(t *testing.T) {
-	if SuppressStandaloneToolResultEvent(&stubPlatformNoProgress{}) {
+	display := DefaultDisplayCfg()
+	if SuppressStandaloneToolResultEvent(&stubPlatformNoProgress{}, display) {
 		t.Fatal("platform without ProgressStyleProvider should not suppress")
 	}
-	if !SuppressStandaloneToolResultEvent(&suppressTestPlatform{style: "legacy"}) {
+	if !SuppressStandaloneToolResultEvent(&suppressTestPlatform{style: "legacy"}, display) {
 		t.Fatal("legacy ProgressStyleProvider should suppress standalone tool results")
 	}
-	if SuppressStandaloneToolResultEvent(&suppressTestPlatform{style: "compact"}) {
+	if SuppressStandaloneToolResultEvent(&suppressTestPlatform{style: "compact"}, display) {
 		t.Fatal("compact should not suppress (writer absorbs tool results)")
 	}
-	if SuppressStandaloneToolResultEvent(&suppressTestPlatform{style: "card"}) {
+	if SuppressStandaloneToolResultEvent(&suppressTestPlatform{style: "card"}, display) {
 		t.Fatal("card should not suppress")
+	}
+	display.ProgressStyle = progressStyleLegacy
+	if !SuppressStandaloneToolResultEvent(&suppressTestPlatform{style: "card"}, display) {
+		t.Fatal("display override to legacy should suppress even when platform style is card")
 	}
 }
 
@@ -108,7 +113,7 @@ func TestCompactProgressWriter_UsesReplyContextHints(t *testing.T) {
 		payload: true,
 	}
 
-	w := newCompactProgressWriter(context.Background(), p, replyCtx, "codex", LangEnglish, nil)
+	w := newCompactProgressWriter(context.Background(), p, replyCtx, "codex", LangEnglish, DisplayCfg{}, nil)
 	if !w.enabled {
 		t.Fatal("progress writer should be enabled")
 	}
@@ -196,7 +201,8 @@ func TestCompactProgressWriter_AppliesTransformToCardPayloadEntries(t *testing.T
 		style:              "card",
 		supportPayload:     true,
 	}
-	w := newCompactProgressWriter(context.Background(), p, "ctx", "codex", LangEnglish, func(s string) string {
+	display := DefaultDisplayCfg()
+	w := newCompactProgressWriter(context.Background(), p, "ctx", "codex", LangEnglish, display, func(s string) string {
 		return strings.ReplaceAll(s, "/root/code/demo/src/app.ts:42", "📄 `src/app.ts:42`")
 	})
 
@@ -229,7 +235,8 @@ func TestCompactProgressWriter_DoesNotTransformToolResults(t *testing.T) {
 		style:              "card",
 		supportPayload:     true,
 	}
-	w := newCompactProgressWriter(context.Background(), p, "ctx", "codex", LangEnglish, func(s string) string {
+	display := DefaultDisplayCfg()
+	w := newCompactProgressWriter(context.Background(), p, "ctx", "codex", LangEnglish, display, func(s string) string {
 		return strings.ReplaceAll(s, "/root/code/demo/src/app.ts:42", "📄 `src/app.ts:42`")
 	})
 
@@ -251,5 +258,71 @@ func TestCompactProgressWriter_DoesNotTransformToolResults(t *testing.T) {
 	}
 	if got := payload.Items[0].Text; got != raw {
 		t.Fatalf("tool result text = %q, want raw %q", got, raw)
+	}
+}
+type progressWriterTestPlatform struct {
+	suppressTestPlatform
+	starts []string
+	edits  []string
+}
+
+func (p *progressWriterTestPlatform) SendPreviewStart(_ context.Context, _ any, content string) (any, error) {
+	p.starts = append(p.starts, content)
+	return "preview", nil
+}
+
+func (p *progressWriterTestPlatform) UpdateMessage(_ context.Context, _ any, content string) error {
+	p.edits = append(p.edits, content)
+	return nil
+}
+
+func (p *progressWriterTestPlatform) SupportsProgressCardPayload() bool { return true }
+
+func TestCompactProgressWriter_MergedToolUpdatesSingleBlock(t *testing.T) {
+	p := &progressWriterTestPlatform{suppressTestPlatform: suppressTestPlatform{style: "card"}}
+	display := DefaultDisplayCfg()
+	display.ToolLayout = toolLayoutMerged
+	w := newCompactProgressWriter(context.Background(), p, "ctx", "Codex", LangEnglish, display, nil)
+
+	if !w.AppendStructured(ProgressCardEntry{
+		Kind:      ProgressEntryToolUse,
+		Tool:      "Bash",
+		ToolInput: "echo hi",
+	}, "echo hi") {
+		t.Fatal("tool use append should succeed")
+	}
+	ok := true
+	exitCode := 0
+	if !w.AppendStructured(ProgressCardEntry{
+		Kind:       ProgressEntryToolResult,
+		Tool:       "Bash",
+		ToolResult: "hi",
+		ExitCode:   &exitCode,
+		Success:    &ok,
+	}, "hi") {
+		t.Fatal("tool result append should succeed")
+	}
+
+	if len(w.items) != 1 {
+		t.Fatalf("items = %d, want 1 merged item", len(w.items))
+	}
+	item := w.items[0]
+	if item.Kind != ProgressEntryToolResult {
+		t.Fatalf("kind = %q, want tool_result", item.Kind)
+	}
+	if item.Running {
+		t.Fatal("item should not remain running after result")
+	}
+	if item.ToolInput != "echo hi" {
+		t.Fatalf("tool input = %q, want echo hi", item.ToolInput)
+	}
+	if item.ToolResult != "hi" {
+		t.Fatalf("tool result = %q, want hi", item.ToolResult)
+	}
+	if len(p.starts) != 1 {
+		t.Fatalf("preview starts = %d, want 1", len(p.starts))
+	}
+	if len(p.edits) != 1 {
+		t.Fatalf("preview edits = %d, want 1", len(p.edits))
 	}
 }

--- a/core/session.go
+++ b/core/session.go
@@ -16,13 +16,14 @@ const ContinueSession = "__continue__"
 
 // Session tracks one conversation between a user and the agent.
 type Session struct {
-	ID             string         `json:"id"`
-	Name           string         `json:"name"`
-	AgentSessionID string         `json:"agent_session_id"`
-	AgentType      string         `json:"agent_type,omitempty"`
-	History        []HistoryEntry `json:"history"`
-	CreatedAt      time.Time      `json:"created_at"`
-	UpdatedAt      time.Time      `json:"updated_at"`
+	ID             string          `json:"id"`
+	Name           string          `json:"name"`
+	AgentSessionID string          `json:"agent_session_id"`
+	AgentType      string          `json:"agent_type,omitempty"`
+	History        []HistoryEntry  `json:"history"`
+	EventTimelines []EventTimeline `json:"event_timelines,omitempty"`
+	CreatedAt      time.Time       `json:"created_at"`
+	UpdatedAt      time.Time       `json:"updated_at"`
 
 	mu   sync.Mutex `json:"-"`
 	busy bool       `json:"-"`
@@ -63,6 +64,17 @@ func (s *Session) AddHistory(role, content string) {
 		Content:   content,
 		Timestamp: time.Now(),
 	})
+}
+
+func (s *Session) AddHistoryAndReturnIndex(role, content string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.History = append(s.History, HistoryEntry{
+		Role:      role,
+		Content:   content,
+		Timestamp: time.Now(),
+	})
+	return len(s.History) - 1
 }
 
 // SetAgentInfo atomically sets the agent session ID, agent type, and name.
@@ -139,6 +151,7 @@ func (s *Session) ClearHistory() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.History = nil
+	s.EventTimelines = nil
 }
 
 // GetHistory returns the last n entries. If n <= 0, returns all.
@@ -151,6 +164,30 @@ func (s *Session) GetHistory(n int) []HistoryEntry {
 	}
 	out := make([]HistoryEntry, n)
 	copy(out, s.History[total-n:])
+	return out
+}
+
+func (s *Session) AppendEventTimeline(t EventTimeline, maxTurns int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.EventTimelines = append(s.EventTimelines, t)
+	if maxTurns > 0 && len(s.EventTimelines) > maxTurns {
+		s.EventTimelines = s.EventTimelines[len(s.EventTimelines)-maxTurns:]
+	}
+}
+
+func (s *Session) GetEventTimelines() []EventTimeline {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]EventTimeline, len(s.EventTimelines))
+	for i, tl := range s.EventTimelines {
+		out[i] = EventTimeline{
+			AssistantHistoryIdx: tl.AssistantHistoryIdx,
+			StartedAt:           tl.StartedAt,
+			CompletedAt:         tl.CompletedAt,
+			Events:              append([]TimelineEvent(nil), tl.Events...),
+		}
+	}
 	return out
 }
 
@@ -481,12 +518,22 @@ func (sm *SessionManager) saveLocked() {
 			agentSID = ""
 			s.AgentSessionID = ""
 		}
+		timelines := make([]EventTimeline, len(s.EventTimelines))
+		for i, tl := range s.EventTimelines {
+			timelines[i] = EventTimeline{
+				AssistantHistoryIdx: tl.AssistantHistoryIdx,
+				StartedAt:           tl.StartedAt,
+				CompletedAt:         tl.CompletedAt,
+				Events:              append([]TimelineEvent(nil), tl.Events...),
+			}
+		}
 		snapSessions[id] = &Session{
 			ID:             s.ID,
 			Name:           s.Name,
 			AgentSessionID: agentSID,
 			AgentType:      s.AgentType,
 			History:        append([]HistoryEntry(nil), s.History...),
+			EventTimelines: timelines,
 			CreatedAt:      s.CreatedAt,
 			UpdatedAt:      s.UpdatedAt,
 		}

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -214,6 +214,20 @@ func TestSession_History(t *testing.T) {
 	if h := s.GetHistory(0); len(h) != 0 {
 		t.Errorf("expected empty history after clear, got %d", len(h))
 	}
+	if got := len(s.GetEventTimelines()); got != 0 {
+		t.Errorf("expected cleared timelines, got %d", got)
+	}
+}
+
+func TestSession_EventTimelinesTrim(t *testing.T) {
+	s := &Session{}
+	s.AppendEventTimeline(EventTimeline{Events: []TimelineEvent{{Index: 1, Kind: EventThinking}}}, 3)
+	s.AppendEventTimeline(EventTimeline{Events: []TimelineEvent{{Index: 1, Kind: EventThinking}}}, 3)
+	s.AppendEventTimeline(EventTimeline{Events: []TimelineEvent{{Index: 1, Kind: EventThinking}}}, 3)
+	s.AppendEventTimeline(EventTimeline{Events: []TimelineEvent{{Index: 1, Kind: EventThinking}}}, 3)
+	if got := len(s.GetEventTimelines()); got != 3 {
+		t.Fatalf("timeline count = %d, want 3", got)
+	}
 }
 
 func TestSession_ConcurrentHistory(t *testing.T) {

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -110,15 +110,13 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # domain = "https://open.feishu.cn" # 可选：覆盖运行时 API/WebSocket 域名
 # enable_feishu_card = true  # 可选：关闭后统一回退纯文本回复
 # thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
-# progress_style = "legacy"  # 可选：legacy | compact | card
-# done_emoji = "none"          # 可选：quiet 模式下 agent 流式工作完成后添加的表情回复（如 "Done"）；设为 "none" 可禁用
+# progress_style = "card"    # 可选：legacy | compact | card（默认 card）
 ```
 
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
 > 如果开启 `thread_isolation = true`，群聊里每个根消息 / reply thread 会对应一个独立 agent session；私聊行为保持原样。
-> `progress_style = "compact"` 会把思考/工具进度合并到一条可更新消息里，减少刷屏；`legacy` 保持原有逐条发送；`card` 会使用结构化卡片（标题 + 进度块）持续更新同一条消息，观感比纯文本更清晰。
+> `progress_style = "compact"` 会把思考/工具进度合并到一条可更新消息里，减少刷屏；`legacy` 保持原有逐条发送；`card` 会使用结构化卡片（标题 + 进度块）持续更新同一条消息。飞书当前默认就是 `card`。
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
-> `done_emoji` 仅在 quiet 模式下、飞书卡片被流式更新过（通过 UpdateMessage 原地编辑）时生效：先移除 "OnIt" 表情，再添加你指定的 done 表情，这样用户能收到飞书推送通知。飞书卡片原地更新本身不会触发推送，所以 quiet 模式下用户可能不知道 agent 已完成。单轮纯文本回复（只通过 SendPreviewStart 发送）不会触发此行为。设为 `"none"` 或不配置则禁用。
 
 ---
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -16,6 +16,7 @@ cc-connect 完整功能使用指南。
 - [语音消息（语音转文字）](#语音消息语音转文字)
 - [语音回复（文字转语音）](#语音回复文字转语音)
 - [图片与文件回传](#图片与文件回传)
+- [进度展示与回看](#进度展示与回看)
 - [定时任务 (Cron)](#定时任务-cron)
 - [多机器人中继](#多机器人中继)
 - [守护进程模式](#守护进程模式)
@@ -654,6 +655,113 @@ cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/ch
 - 只能发送本机上 Agent 可访问到的文件。
 - 必须存在活跃会话；如果当前项目没有活动聊天上下文，命令会失败。
 - 平台本身仍可能有文件大小或文件类型限制。
+
+---
+
+## 进度展示与回看
+
+cc-connect 可以展示 Agent 的中间过程，包括 thinking、工具调用和工具结果。
+
+### Progress 展示风格
+
+平台可以通过 `progress_style` 控制过程消息展示方式：
+
+```toml
+[[projects.platforms]]
+type = "feishu"
+
+[projects.platforms.options]
+progress_style = "card"  # legacy | compact | card
+```
+
+三种风格分别是：
+
+- `legacy`
+  - 保持逐条消息展示
+- `compact`
+  - 把过程合并到一条可更新消息中
+- `card`
+  - 使用结构化卡片持续更新
+
+当前飞书默认是 `card`。
+
+### Display 配置
+
+在 `config.toml` 的 `[display]` 中可控制过程展示：
+
+```toml
+[display]
+thinking_max_len = 300
+tool_max_len = 500
+tool_messages = true
+tool_layout = "merged"          # split | merged
+tool_show_input = true
+tool_show_result_body = true
+progress_max_entries = 20
+progress_history_turns = 3
+```
+
+字段说明：
+
+- `thinking_max_len`
+  - 单条 thinking 的最大展示长度；设为 `0` 表示不截断
+- `tool_max_len`
+  - 工具输入或结果正文在展示时的长度上限；设为 `0` 表示不截断
+- `tool_messages`
+  - 是否显示所有工具相关 progress
+- `tool_layout`
+  - `split`：工具调用和工具结果分别占两个块
+  - `merged`：同一个工具调用只占一个块，结果回来后原位更新
+- `tool_show_input`
+  - 是否展示工具输入正文，例如 Bash 命令
+- `tool_show_result_body`
+  - 是否展示工具结果正文
+- `progress_max_entries`
+  - `compact/card` 视图中最多保留最近多少条 event；设为 `0` 表示不裁剪
+- `progress_history_turns`
+  - 为 `/progress` 保留最近多少轮 assistant 回复对应的过程；设为 `0` 表示禁用过程历史
+
+### 运行时动态调整
+
+这些配置都可以在聊天中直接修改：
+
+```text
+/config get tool_layout
+/config set tool_layout merged
+/config set tool_show_result_body false
+/config set progress_max_entries 30
+/config set progress_history_turns 5
+```
+
+### `/progress` 命令
+
+`/progress` 用于查看最近一轮或上一轮 assistant 回复对应的过程事件。
+
+支持：
+
+```text
+/progress
+/progress 7
+/progress 3:8
+/progress prev
+/progress prev 7
+/progress prev 3:8
+```
+
+含义：
+
+- `/progress`
+  - 查看最近一轮 assistant 回复的全部过程事件
+- `/progress 7`
+  - 查看最近一轮中的第 7 条 event
+- `/progress 3:8`
+  - 查看最近一轮中的第 3 到第 8 条 event
+- `/progress prev`
+  - 查看上一轮 assistant 回复的全部过程事件
+- `/progress prev 7`
+  - 查看上一轮中的第 7 条 event
+- `/progress prev 3:8`
+  - 查看上一轮中的第 3 到第 8 条 event
 
 ---
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -205,10 +205,12 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		noReplyToTrigger = true
 	}
 
-	progressStyle := "legacy"
+	progressStyle := "card"
 	if v, ok := opts["progress_style"].(string); ok {
 		switch strings.ToLower(strings.TrimSpace(v)) {
-		case "", "legacy":
+		case "":
+			progressStyle = "card"
+		case "legacy":
 			progressStyle = "legacy"
 		case "compact", "card":
 			progressStyle = strings.ToLower(strings.TrimSpace(v))
@@ -1947,6 +1949,9 @@ func predictMsgType(content string) string {
 }
 
 func buildReplyContent(content string) (msgType string, body string) {
+	if payload, ok := core.ParseProgressCardPayload(content); ok {
+		return larkim.MsgTypeInteractive, buildProgressCardJSONFromPayload(payload)
+	}
 	if !containsMarkdown(content) {
 		b, _ := json.Marshal(map[string]string{"text": content})
 		return larkim.MsgTypeText, string(b)
@@ -2835,10 +2840,7 @@ func formatProgressToolInput(toolName, text string) string {
 	if isBashToolName(toolName) {
 		return fmt.Sprintf("```bash\n%s\n```", text)
 	}
-	if strings.Contains(text, "\n") || len(text) > 180 {
-		return fmt.Sprintf("```text\n%s\n```", text)
-	}
-	return fmt.Sprintf("`%s`", inlineCodeText(text))
+	return fmt.Sprintf("```text\n%s\n```", text)
 }
 
 func formatProgressToolResult(text string) string {
@@ -2850,39 +2852,42 @@ func formatProgressToolResult(text string) string {
 	if strings.Contains(text, "```") {
 		return text
 	}
-	if strings.Contains(text, "\n") || len(text) > 220 {
-		return fmt.Sprintf("```\n%s\n```", text)
-	}
-	return text
+	return fmt.Sprintf("```text\n%s\n```", text)
 }
 
-func progressNoOutputText(lang string) string {
-	if isZhLikeProgressLang(lang) {
-		return "无输出"
-	}
-	return "No output"
-}
-
-func progressResultDot(item core.ProgressCardEntry) string {
+func progressResultTagColor(item core.ProgressCardEntry) string {
 	if item.Success != nil {
 		if *item.Success {
-			return "🟢"
+			return "green"
 		}
-		return "🔴"
+		return "red"
 	}
 	if item.ExitCode != nil {
 		if *item.ExitCode == 0 {
-			return "🟢"
+			return "green"
 		}
-		return "🔴"
+		return "red"
 	}
 	if strings.EqualFold(strings.TrimSpace(item.Status), "completed") || strings.EqualFold(strings.TrimSpace(item.Status), "success") || strings.EqualFold(strings.TrimSpace(item.Status), "succeeded") || strings.EqualFold(strings.TrimSpace(item.Status), "ok") {
-		return "🟢"
+		return "green"
 	}
 	if strings.EqualFold(strings.TrimSpace(item.Status), "failed") || strings.EqualFold(strings.TrimSpace(item.Status), "error") {
-		return "🔴"
+		return "red"
 	}
-	return "⚪"
+	return "turquoise"
+}
+
+func progressExitWord(lang string) string {
+	switch {
+	case isZhLikeProgressLang(lang):
+		return "退出"
+	case strings.EqualFold(strings.TrimSpace(lang), string(core.LangJapanese)):
+		return "終了"
+	case strings.EqualFold(strings.TrimSpace(lang), string(core.LangSpanish)):
+		return "salida"
+	default:
+		return "exit"
+	}
 }
 
 func renderProgressEntryElement(item core.ProgressCardEntry, lang string) map[string]any {
@@ -2907,7 +2912,11 @@ func renderProgressEntryElement(item core.ProgressCardEntry, lang string) map[st
 			toolName = "Tool"
 		}
 		content := fmt.Sprintf("<text_tag color='blue'>%s</text_tag> `%s`", progressKindLabel(item.Kind, lang), inlineCodeText(toolName))
-		if body := formatProgressToolInput(toolName, text); body != "" {
+		bodyText := item.ToolInput
+		if strings.TrimSpace(bodyText) == "" {
+			bodyText = text
+		}
+		if body := formatProgressToolInput(toolName, bodyText); body != "" {
 			content += "\n" + body
 		}
 		return map[string]any{
@@ -2916,20 +2925,23 @@ func renderProgressEntryElement(item core.ProgressCardEntry, lang string) map[st
 		}
 	case core.ProgressEntryToolResult:
 		toolName := strings.TrimSpace(item.Tool)
-		content := fmt.Sprintf("<text_tag color='turquoise'>%s</text_tag>", progressKindLabel(item.Kind, lang))
+		content := fmt.Sprintf("<text_tag color='%s'>%s</text_tag>", progressResultTagColor(item), progressKindLabel(item.Kind, lang))
 		if toolName != "" {
 			content += " `" + inlineCodeText(toolName) + "`"
 		}
-		dot := progressResultDot(item)
-		meta := dot
 		if item.ExitCode != nil {
-			meta += fmt.Sprintf(" exit code: `%d`", *item.ExitCode)
+			content += fmt.Sprintf(" %s `%d`", progressExitWord(lang), *item.ExitCode)
 		}
-		content += "\n" + meta
-		if body := formatProgressToolResult(item.Text); body != "" {
+		inputBody := formatProgressToolInput(toolName, item.ToolInput)
+		resultText := item.ToolResult
+		if strings.TrimSpace(resultText) == "" {
+			resultText = item.Text
+		}
+		if inputBody != "" {
+			content += "\n" + inputBody
+		}
+		if body := formatProgressToolResult(resultText); body != "" {
 			content += "\n" + body
-		} else {
-			content += "\n_" + progressNoOutputText(lang) + "_"
 		}
 		return map[string]any{
 			"tag":     "markdown",

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -443,7 +443,7 @@ func TestInteractivePlatform_CardActionUsesCallbackSessionKey(t *testing.T) {
 	}
 }
 
-func TestInteractivePlatform_ModelCardActionDispatchesCommandAsync(t *testing.T) {
+func TestInteractivePlatform_ModelCardActionReturnsCardUpdate(t *testing.T) {
 	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -453,15 +453,11 @@ func TestInteractivePlatform_ModelCardActionDispatchesCommandAsync(t *testing.T)
 		t.Fatalf("platform type = %T, want *interactivePlatform", platformAny)
 	}
 
-	cardNavCalled := make(chan struct{}, 1)
+	var gotAction, gotSessionKey string
 	ip.cardNavHandler = func(action string, sessionKey string) *core.Card {
-		cardNavCalled <- struct{}{}
-		return core.NewCard().Markdown("unexpected").Build()
-	}
-
-	msgCh := make(chan *core.Message, 1)
-	ip.handler = func(_ core.Platform, msg *core.Message) {
-		msgCh <- msg
+		gotAction = action
+		gotSessionKey = sessionKey
+		return core.NewCard().Markdown("switching").Build()
 	}
 
 	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
@@ -474,23 +470,20 @@ func TestInteractivePlatform_ModelCardActionDispatchesCommandAsync(t *testing.T)
 	if err != nil {
 		t.Fatalf("onCardAction() error = %v", err)
 	}
-	if resp == nil || resp.Toast == nil {
-		t.Fatalf("expected toast response, got %#v", resp)
+	if resp == nil || resp.Card == nil {
+		t.Fatalf("expected card response, got %#v", resp)
 	}
-
-	select {
-	case <-cardNavCalled:
-		t.Fatal("expected model card action to skip synchronous card nav")
-	default:
+	if gotAction != "act:/model switch 1" {
+		t.Fatalf("action = %q, want act:/model switch 1", gotAction)
 	}
-
-	select {
-	case msg := <-msgCh:
-		if msg.Content != "/model switch 1" {
-			t.Fatalf("message content = %q, want /model switch 1", msg.Content)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected model card action message")
+	if gotSessionKey == "" {
+		t.Fatal("expected non-empty session key")
+	}
+	ip.cardActionMsgMu.Lock()
+	tracked := ip.cardActionMsgIDs[gotSessionKey]
+	ip.cardActionMsgMu.Unlock()
+	if tracked != "om_test_message" {
+		t.Fatalf("tracked message id = %q, want om_test_message", tracked)
 	}
 }
 

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -57,7 +57,7 @@ func TestNew_DisabledInteractiveCardsDoesNotStartPreviewCard(t *testing.T) {
 	}
 }
 
-func TestNew_ProgressStyleDefaultLegacy(t *testing.T) {
+func TestNew_ProgressStyleDefaultCard(t *testing.T) {
 	p, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -66,8 +66,8 @@ func TestNew_ProgressStyleDefaultLegacy(t *testing.T) {
 	if !ok {
 		t.Fatalf("platform type %T does not implement ProgressStyleProvider", p)
 	}
-	if got := sp.ProgressStyle(); got != "legacy" {
-		t.Fatalf("ProgressStyle() = %q, want legacy", got)
+	if got := sp.ProgressStyle(); got != "card" {
+		t.Fatalf("ProgressStyle() = %q, want card", got)
 	}
 }
 
@@ -443,7 +443,7 @@ func TestInteractivePlatform_CardActionUsesCallbackSessionKey(t *testing.T) {
 	}
 }
 
-func TestInteractivePlatform_ModelCardActionReturnsCardUpdate(t *testing.T) {
+func TestInteractivePlatform_ModelCardActionDispatchesCommandAsync(t *testing.T) {
 	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -453,11 +453,15 @@ func TestInteractivePlatform_ModelCardActionReturnsCardUpdate(t *testing.T) {
 		t.Fatalf("platform type = %T, want *interactivePlatform", platformAny)
 	}
 
-	var gotAction, gotSessionKey string
+	cardNavCalled := make(chan struct{}, 1)
 	ip.cardNavHandler = func(action string, sessionKey string) *core.Card {
-		gotAction = action
-		gotSessionKey = sessionKey
-		return core.NewCard().Markdown("switching").Build()
+		cardNavCalled <- struct{}{}
+		return core.NewCard().Markdown("unexpected").Build()
+	}
+
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		msgCh <- msg
 	}
 
 	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
@@ -470,20 +474,23 @@ func TestInteractivePlatform_ModelCardActionReturnsCardUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("onCardAction() error = %v", err)
 	}
-	if resp == nil || resp.Card == nil {
-		t.Fatalf("expected card response, got %#v", resp)
+	if resp == nil || resp.Toast == nil {
+		t.Fatalf("expected toast response, got %#v", resp)
 	}
-	if gotAction != "act:/model switch 1" {
-		t.Fatalf("action = %q, want act:/model switch 1", gotAction)
+
+	select {
+	case <-cardNavCalled:
+		t.Fatal("expected model card action to skip synchronous card nav")
+	default:
 	}
-	if gotSessionKey == "" {
-		t.Fatal("expected non-empty session key")
-	}
-	ip.cardActionMsgMu.Lock()
-	tracked := ip.cardActionMsgIDs[gotSessionKey]
-	ip.cardActionMsgMu.Unlock()
-	if tracked != "om_test_message" {
-		t.Fatalf("tracked message id = %q, want om_test_message", tracked)
+
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "/model switch 1" {
+			t.Fatalf("message content = %q, want /model switch 1", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected model card action message")
 	}
 }
 
@@ -905,6 +912,57 @@ func TestBuildPreviewCardJSON_ProgressPayloadUsesStructuredCard(t *testing.T) {
 	}
 }
 
+func TestBuildPreviewCardJSON_ProgressPayloadMergedToolResultUsesSingleBlock(t *testing.T) {
+	exitCode := 0
+	ok := true
+	payload := core.BuildProgressCardPayloadV2([]core.ProgressCardEntry{
+		{
+			Kind:       core.ProgressEntryToolResult,
+			Tool:       "Bash",
+			ToolInput:  "echo hi",
+			ToolResult: "hi",
+			ExitCode:   &exitCode,
+			Success:    &ok,
+		},
+	}, false, "Codex", core.LangEnglish, core.ProgressCardStateRunning)
+	cardJSON := buildPreviewCardJSON(payload)
+	if !strings.Contains(cardJSON, "\\u003ctext_tag color='green'\\u003eResult") {
+		t.Fatalf("card JSON should include green result tag, got %q", cardJSON)
+	}
+	if !strings.Contains(cardJSON, "```bash") {
+		t.Fatalf("card JSON should render input as bash code block, got %q", cardJSON)
+	}
+	if !strings.Contains(cardJSON, "```text") {
+		t.Fatalf("card JSON should render output as text code block, got %q", cardJSON)
+	}
+	if !strings.Contains(cardJSON, "exit `0`") {
+		t.Fatalf("card JSON should include compact exit code header, got %q", cardJSON)
+	}
+}
+
+func TestBuildPreviewCardJSON_ProgressPayloadToolResultWithoutBodyShowsNoPlaceholder(t *testing.T) {
+	exitCode := 0
+	ok := true
+	payload := core.BuildProgressCardPayloadV2([]core.ProgressCardEntry{
+		{
+			Kind:     core.ProgressEntryToolResult,
+			Tool:     "Bash",
+			ExitCode: &exitCode,
+			Success:  &ok,
+		},
+	}, false, "Codex", core.LangChinese, core.ProgressCardStateRunning)
+	cardJSON := buildPreviewCardJSON(payload)
+	if strings.Contains(cardJSON, "无输出") {
+		t.Fatalf("card JSON should not inject no-output placeholder, got %q", cardJSON)
+	}
+	if strings.Contains(cardJSON, "No output") {
+		t.Fatalf("card JSON should not inject no-output placeholder, got %q", cardJSON)
+	}
+	if !strings.Contains(cardJSON, "\\u003ctext_tag color='green'\\u003e工具结果") {
+		t.Fatalf("card JSON should still include result header, got %q", cardJSON)
+	}
+}
+
 func TestBuildPreviewCardJSON_NormalTextFallback(t *testing.T) {
 	cardJSON := buildPreviewCardJSON("plain progress text")
 	if strings.Contains(cardJSON, "cc-connect · 进度") {
@@ -912,6 +970,22 @@ func TestBuildPreviewCardJSON_NormalTextFallback(t *testing.T) {
 	}
 	if !strings.Contains(cardJSON, "\"tag\":\"markdown\"") {
 		t.Fatalf("default preview card should contain markdown element, got %q", cardJSON)
+	}
+}
+
+func TestBuildReplyContent_ProgressPayloadUsesInteractiveCard(t *testing.T) {
+	payload := core.BuildProgressCardPayloadV2([]core.ProgressCardEntry{
+		{Kind: core.ProgressEntryThinking, Text: "planning"},
+	}, false, "Codex", core.LangEnglish, core.ProgressCardStateCompleted)
+	msgType, body := buildReplyContent(payload)
+	if msgType != larkim.MsgTypeInteractive {
+		t.Fatalf("msgType = %q, want interactive", msgType)
+	}
+	if strings.Contains(body, core.ProgressCardPayloadPrefix) {
+		t.Fatalf("body should not leak payload prefix, got %q", body)
+	}
+	if !strings.Contains(body, "Codex · Completed") {
+		t.Fatalf("body should contain progress card title, got %q", body)
 	}
 }
 
@@ -929,23 +1003,23 @@ func TestFormatProgressToolInput_TodoWrite(t *testing.T) {
 				{"content": "Task 2", "status": "in_progress", "activeForm": "Working on task 2"},
 				{"content": "Task 3", "status": "pending", "activeForm": "Planning task 3"}
 			]}`,
-			wantContains:    []string{"✅", "🔄", "⏳", "Task 1", "Task 2", "Task 3", "Completing task 1", "Working on task 2"},
+			wantContains: []string{"✅", "🔄", "⏳", "Task 1", "Task 2", "Task 3", "Completing task 1", "Working on task 2"},
 			notWantContains: []string{"```"},
 		},
 		{
-			name:            "todos without activeForm",
-			input:           `{"todos": [{"content": "Simple task", "status": "pending"}]}`,
-			wantContains:    []string{"⏳", "Simple task"},
+			name:  "todos without activeForm",
+			input: `{"todos": [{"content": "Simple task", "status": "pending"}]}`,
+			wantContains: []string{"⏳", "Simple task"},
 			notWantContains: []string{"(", ")"},
 		},
 		{
-			name:         "invalid JSON falls back to default",
-			input:        `not valid json`,
+			name:     "invalid JSON falls back to default",
+			input:    `not valid json`,
 			wantContains: []string{"```text"},
 		},
 		{
-			name:         "empty todos array",
-			input:        `{"todos": []}`,
+			name:     "empty todos array",
+			input:    `{"todos": []}`,
 			wantContains: []string{"```text"},
 		},
 	}
@@ -1058,37 +1132,5 @@ func TestResolveMentions_NoAtSign(t *testing.T) {
 	result := p.resolveMentionsInContent(context.Background(), "oc_chat", input)
 	if result != input {
 		t.Fatalf("no @ should return unchanged, got %q", result)
-	}
-}
-
-func TestResolveMentions_DuplicateNameSkipped(t *testing.T) {
-	p := &Platform{platformName: "feishu", resolveMentions: true}
-	p.chatMemberCache.Store("oc_chat", &chatMemberEntry{
-		members:   map[string]string{"张三": "", "李四": "ou_lisi"},
-		fetchedAt: time.Now(),
-	})
-	input := "请 @张三 和 @李四 看看"
-	result := p.resolveMentionsInContent(context.Background(), "oc_chat", input)
-	if !strings.Contains(result, "@张三") {
-		t.Fatal("ambiguous name should be kept as-is")
-	}
-	if strings.Contains(result, "@李四") {
-		t.Fatal("unique name should be resolved")
-	}
-}
-
-func TestResolveMentions_SpecialCharsEscaped(t *testing.T) {
-	p := &Platform{platformName: "feishu", resolveMentions: true}
-	p.chatMemberCache.Store("oc_chat", &chatMemberEntry{
-		members:   map[string]string{`A<"B">`: "ou_special"},
-		fetchedAt: time.Now(),
-	})
-	input := `@A<"B"> 你好`
-	result := p.resolveMentionsInContent(context.Background(), "oc_chat", input)
-	if strings.Contains(result, `<"B">`) {
-		t.Fatalf("special chars should be escaped, got %q", result)
-	}
-	if !strings.Contains(result, "A&lt;") {
-		t.Fatalf("expected HTML-escaped name, got %q", result)
 	}
 }


### PR DESCRIPTION
# Progress Card Compression, Runtime Style Switching, and `/progress` Timeline Review

## Summary

This PR improves long-running task observability in `cc-connect`, with a focus on the `Feishu + Codex` workflow.

It covers two connected improvements:

1. Better progress rendering for long tasks
2. A new `/progress` command for reviewing recent progress timelines after a reply completes

The main goals are:

- reduce visual noise in long `thinking / tool use / tool result` sequences
- make `Feishu` progress cards practical as the default experience
- allow runtime switching between `legacy / compact / card` without editing config files
- preserve recent assistant-turn progress events so users can inspect them after the final reply

## Motivation

The existing progress experience had two main gaps:

1. Long-running tasks produced too much vertical noise, especially when `tool use` and `tool result` were always split into separate blocks.
2. Once progress content was truncated or rolled out of the live card window, there was no convenient way to inspect the previous events for the latest assistant reply.

This PR addresses both:

- it makes live progress more configurable and more compact
- it adds a timeline model plus `/progress` so recent process events can be reviewed after the fact

## Design

### 1. Progress rendering defaults and runtime controls

This PR keeps the existing display controls:

- `thinking_max_len`
- `tool_max_len`
- `tool_messages`

and adds new progress-oriented controls:

- `progress_style`
- `tool_layout`
- `tool_show_input`
- `tool_show_result_body`
- `progress_max_entries`
- `progress_history_turns`

The intent is:

- `progress_style`
  - runtime-selectable `legacy | compact | card | auto`
  - `auto` follows the platform default
- `tool_layout`
  - `split` keeps separate tool-use and tool-result blocks
  - `merged` keeps a single block per tool invocation and upgrades it when the result arrives
- `tool_show_input`
  - controls whether tool input is shown
- `tool_show_result_body`
  - controls whether tool result output is shown
- `progress_max_entries`
  - limits the live recent-window shown in compact/card progress
- `progress_history_turns`
  - controls how many assistant turns keep persisted progress timelines for `/progress`

### 2. Platform defaults

This PR keeps progress semantics global, but allows platform defaults to remain platform-specific.

Current default behavior after this change:

- `Feishu`
  - default `progress_style = card`
- other platforms
  - continue to use their own platform defaults / existing behavior

### 3. Event timeline persistence

Each assistant reply can now keep a corresponding event timeline:

- `thinking`
- `tool use`
- `tool result`

These are stored per session in a lightweight `EventTimeline` structure and linked back to the corresponding assistant message via `AssistantHistoryIdx`.

This design keeps the existing `History` model intact and adds process history as a parallel structure rather than rewriting message history itself.

### 4. `/progress`

This PR adds `/progress` for reviewing recent progress history.

Supported forms:

- `/progress`
- `/progress prev`
- `/progress 2`
- `/progress prev 2:4`

Behavior:

- default: latest assistant-turn timeline
- `prev`: previous assistant-turn timeline
- single numeric selector: one event
- `a:b`: event range

The command reuses the same layout rules as live progress:

- `merged / split`
- input visibility
- result-body visibility
- card vs text style

So `/progress` and live progress stay aligned.

## Supported User-Facing Behavior

### Runtime configuration

These can now be changed in chat via `/config`:

```text
/config set progress_style legacy
/config set progress_style compact
/config set progress_style card
/config set progress_style auto

/config set tool_layout merged
/config set tool_layout split
/config set tool_show_input true
/config set tool_show_result_body false
/config set progress_max_entries 20
/config set progress_history_turns 3
```

### Live progress

For `Feishu`, the recommended default experience is:

- interactive progress card
- `tool_layout = merged`
- tool input visible
- tool result body visible

This reduces duplication while keeping enough detail to audit what actually ran.

### Historical review

After a reply completes, users can inspect recent process events with `/progress` without rerunning the task.

## Examples

### Example prompt used in live validation

```text
请只做两步，不要修改文件。
1. 读取 docs/usage.zh-CN.md 的前 10 行。
2. 再执行 cat does-not-exist.txt。
```

This single example is useful because it covers:

- a successful read
- a failed command
- mixed progress events
- card rendering
- `/progress` replay behavior

### Screenshot plan

#### 1. `merged`

Use:

```text
/config set tool_layout merged
```

Then run the prompt above and capture the resulting `Feishu` card.

<img width="413" height="640" alt="image" src="https://github.com/user-attachments/assets/69b264ea-e146-4971-a5c1-3ef188984847" />

#### 2. `split`

Use:

```text
/config set tool_layout split
```

Then run the same prompt and capture the resulting `Feishu` card.

<img width="413" height="640" alt="image" src="https://github.com/user-attachments/assets/831d3c35-98ae-48d2-8725-a7e946d0e7a2" />

These two screenshots are enough to demonstrate:

- the new default direction
- the `merged / split` contrast
- successful and failed tool rendering in the same example

## Code Changes

### Configuration and runtime controls

- `config/config.go`
  - extends display config with progress-specific options
  - persists runtime display updates
- `cmd/cc-connect/main.go`
  - wires config values into runtime display state
- `config.example.toml`
  - documents the new progress-related settings

### Engine and event capture

- `core/engine.go`
  - extends runtime `/config` items
  - captures progress events during `processInteractiveEvents(...)`
  - appends timelines when assistant replies complete
  - adds `/progress`
- `core/session.go`
  - adds timeline persistence to session state
- `core/event_timeline.go`
  - defines `EventTimeline` and `TimelineEvent`

### Progress rendering

- `core/progress_compact.go`
  - adds runtime `progress_style` override support
  - adds `merged` tool-block behavior
  - makes recent-window size configurable
  - keeps `/progress` rendering aligned with live progress rules
- `platform/feishu/feishu.go`
  - keeps `Feishu` default progress style as `card`
  - updates progress entry rendering
  - supports progress-payload replies for `/progress`

### `/progress`

- `core/progress_command.go`
  - parses latest/previous/single/range selectors
  - renders either card payloads or text fallback depending on style

### Docs and i18n

- `core/i18n.go`
  - adds help / labels / progress-related command text
- `docs/usage.zh-CN.md`
  - documents config and `/progress`
- `docs/feishu.md`
  - documents `Feishu` defaults and style behavior

## Local Testing

Completed locally:

```bash
go build ./...
go test ./... -count=1
go test -race ./...
```

Additional focused verification was also run during iteration for:

- `core`
- `platform/feishu`
- merged tool-block behavior
- `/progress` rendering and selection
- progress payload handling in Feishu replies

## Live Feishu Validation

Live validation was completed against `Feishu + Codex`.

Validated areas:

- `Feishu` default `progress_style = card`
- runtime switching:
  - `legacy`
  - `compact`
  - `card`
  - `auto`
- `merged / split`
- `tool_show_result_body = false`
- `/progress`
- `/progress prev`
- single-event and range selection
- failed tool result rendering

Important validation result:

- `/progress` now follows the same layout rules as live progress
- when `tool_show_result_body = false`, no extra `"无输出"` / `"No output"` placeholder is inserted