### PR TITLE
fix: prevent /new session race by detaching state before async close

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2204,12 +2204,25 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 // a stale goroutine (still running after /new created a fresh Session object and
 // a new turn started on it) from accidentally destroying the replacement state.
 func (e *Engine) cleanupInteractiveState(sessionKey string, expected ...*interactiveState) {
+	agentSession := e.detachInteractiveState(sessionKey, expected...)
+	if agentSession != nil {
+		e.closeAgentSessionWithTimeout(sessionKey, agentSession)
+	}
+}
+
+// detachInteractiveState removes the interactive state from the routing map,
+// stops its event loop, and returns the agent session for later closing.
+// It does NOT close the agent session — the caller is responsible for calling
+// closeAgentSessionWithTimeout or closeAgentSessionAsync on the returned value.
+// When an expected state is provided, detach is skipped if the map entry has
+// been replaced by a different state.
+func (e *Engine) detachInteractiveState(sessionKey string, expected ...*interactiveState) AgentSession {
 	e.interactiveMu.Lock()
 	state, ok := e.interactiveStates[sessionKey]
 	if len(expected) > 0 && expected[0] != nil && state != expected[0] {
 		// Another turn has already replaced the state — skip cleanup.
 		e.interactiveMu.Unlock()
-		return
+		return nil
 	}
 	delete(e.interactiveStates, sessionKey)
 	e.interactiveMu.Unlock()
@@ -2221,8 +2234,9 @@ func (e *Engine) cleanupInteractiveState(sessionKey string, expected ...*interac
 	}
 
 	if ok && state != nil && state.agentSession != nil {
-		e.closeAgentSessionWithTimeout(sessionKey, state.agentSession)
+		return state.agentSession
 	}
+	return nil
 }
 
 func (e *Engine) closeAgentSessionAsync(sessionKey string, agentSession AgentSession) {
@@ -2245,7 +2259,7 @@ func (e *Engine) closeAgentSessionWithTimeout(sessionKey string, agentSession Ag
 	// exits sooner — this is the ceiling, not the typical duration.
 	const closeTimeout = 130 * time.Second
 
-	slog.Debug("cleanupInteractiveState: closing agent session", "session", sessionKey)
+	slog.Debug("closeAgentSessionWithTimeout: closing agent session", "session", sessionKey)
 	closeStart := time.Now()
 
 	done := make(chan struct{})
@@ -3435,10 +3449,16 @@ func (e *Engine) cmdNew(p Platform, msg *Message, args []string) {
 	}
 
 	slog.Info("cmdNew: cleaning up old session", "session_key", msg.SessionKey)
-	e.cleanupInteractiveState(interactiveKey)
-	slog.Info("cmdNew: cleanup done, creating new session", "session_key", msg.SessionKey)
 
-	// Clear old session's agent session ID so it cannot be resumed
+	// Phase 1: Detach the interactive state from the routing map and stop its
+	// event loop. This is non-blocking — we get the agent session back for
+	// later cleanup.
+	oldAgentSession := e.detachInteractiveState(interactiveKey)
+
+	// Phase 2: Clear old session data BEFORE the async close, so any message
+	// arriving during the close window starts a fresh agent instead of resuming
+	// the old conversation (race fix: session data must be updated while the
+	// interactive state is already detached but the process may still be exiting).
 	old := sessions.GetOrCreateActive(msg.SessionKey)
 	old.SetAgentSessionID("", "")
 	old.ClearHistory()
@@ -3449,6 +3469,15 @@ func (e *Engine) cmdNew(p Platform, msg *Message, args []string) {
 		name = strings.Join(args, " ")
 	}
 	sessions.NewSession(msg.SessionKey, name)
+
+	// Phase 3: Close the old agent process in the background. The state has
+	// already been detached so no events can leak into the new session.
+	if oldAgentSession != nil {
+		e.closeAgentSessionAsync(interactiveKey, oldAgentSession)
+	}
+
+	slog.Debug("cmdNew: detach done, async close started", "session_key", msg.SessionKey, "had_agent", oldAgentSession != nil)
+	slog.Info("cmdNew: new session created", "session_key", msg.SessionKey)
 	if name != "" {
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgNewSessionCreatedName), name))
 	} else {
@@ -3578,13 +3607,21 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 	}
 
 	slog.Info("cmdSwitch: cleaning up old session", "session_key", msg.SessionKey)
-	e.cleanupInteractiveState(interactiveKey)
-	slog.Info("cmdSwitch: cleanup done", "session_key", msg.SessionKey)
+
+	// Detach the interactive state first (non-blocking), then update session
+	// data before closing the old process asynchronously. This prevents a race
+	// where a message arriving during the close window resumes the old agent.
+	oldAgentSession := e.detachInteractiveState(interactiveKey)
 
 	session := sessions.GetOrCreateActive(msg.SessionKey)
 	session.SetAgentInfo(matched.ID, agent.Name(), matched.Summary)
 	session.ClearHistory()
 	sessions.Save()
+
+	if oldAgentSession != nil {
+		e.closeAgentSessionAsync(interactiveKey, oldAgentSession)
+	}
+	slog.Info("cmdSwitch: cleanup done", "session_key", msg.SessionKey)
 
 	shortID := matched.ID
 	if len(shortID) > 12 {
@@ -3898,12 +3935,16 @@ func (e *Engine) dirApply(agent Agent, sessions *SessionManager, interactiveKey,
 			if !e.multiWorkspace {
 				switcher.SetWorkDir(baseDir)
 			}
-			e.cleanupInteractiveState(interactiveKey)
+			oldAgentSession := e.detachInteractiveState(interactiveKey)
 
 			s := sessions.GetOrCreateActive(sessionKey)
 			s.SetAgentSessionID("", "")
 			s.ClearHistory()
 			sessions.Save()
+
+			if oldAgentSession != nil {
+				e.closeAgentSessionAsync(interactiveKey, oldAgentSession)
+			}
 
 			if e.projectState != nil {
 				if e.multiWorkspace {
@@ -3968,12 +4009,16 @@ func (e *Engine) dirApply(agent Agent, sessions *SessionManager, interactiveKey,
 	if !e.multiWorkspace {
 		switcher.SetWorkDir(newDir)
 	}
-	e.cleanupInteractiveState(interactiveKey)
+	oldAgentSession := e.detachInteractiveState(interactiveKey)
 
 	s := sessions.GetOrCreateActive(sessionKey)
 	s.SetAgentSessionID("", "")
 	s.ClearHistory()
 	sessions.Save()
+
+	if oldAgentSession != nil {
+		e.closeAgentSessionAsync(interactiveKey, oldAgentSession)
+	}
 
 	if e.dirHistory != nil {
 		e.dirHistory.Add(e.name, newDir)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -4661,6 +4661,128 @@ func TestCleanupCAS_UnconditionalWithoutExpected(t *testing.T) {
 	}
 }
 
+// TestDetachInteractiveState_ReturnsAgentSession verifies that detachInteractiveState
+// removes the state from the map and returns the agent session without blocking.
+func TestDetachInteractiveState_ReturnsAgentSession(t *testing.T) {
+	e := newTestEngine()
+	key := "test:user1"
+
+	sess := newControllableSession("s1")
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = &interactiveState{agentSession: sess}
+	e.interactiveMu.Unlock()
+
+	got := e.detachInteractiveState(key)
+
+	e.interactiveMu.Lock()
+	_, exists := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+
+	if exists {
+		t.Fatal("expected state to be removed from map")
+	}
+	if got != sess {
+		t.Fatalf("expected returned session = %p, got %p", sess, got)
+	}
+}
+
+// TestDetachInteractiveState_SkipsWhenStateReplaced verifies CAS behavior.
+func TestDetachInteractiveState_SkipsWhenStateReplaced(t *testing.T) {
+	e := newTestEngine()
+	key := "test:user1"
+
+	oldState := &interactiveState{agentSession: newControllableSession("old")}
+	newState := &interactiveState{agentSession: newControllableSession("new")}
+
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = newState
+	e.interactiveMu.Unlock()
+
+	got := e.detachInteractiveState(key, oldState)
+
+	e.interactiveMu.Lock()
+	current := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+
+	if current != newState {
+		t.Fatal("CAS detach deleted the replacement state")
+	}
+	if got != nil {
+		t.Fatal("expected nil return when CAS skips")
+	}
+}
+
+// TestCmdNew_ClearsSessionDataBeforeAsyncClose is a regression test for the race
+// where /new blocks on agent close while the session's AgentSessionID is still set.
+// A message arriving during the close window would resume the old conversation.
+// The fix detaches the state (non-blocking), clears session data, then closes async.
+func TestCmdNew_ClearsSessionDataBeforeAsyncClose(t *testing.T) {
+	// Create a slow-closing session that blocks in Close().
+	slowSess := &slowCloseSession{
+		controllableAgentSession: *newControllableSession("old-agent-id"),
+		closeStarted:            make(chan struct{}),
+		closeRelease:            make(chan struct{}),
+	}
+
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+
+	// Seed the interactive state with the slow-closing session.
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = &interactiveState{agentSession: slowSess}
+	e.interactiveMu.Unlock()
+
+	// Seed the session with an old agent session ID.
+	session := e.sessions.GetOrCreateActive(key)
+	session.SetAgentSessionID("old-agent-id", "stub")
+	e.sessions.Save()
+
+	// Run /new
+	msg := &Message{SessionKey: key, Content: "/new", ReplyCtx: "ctx1"}
+	e.cmdNew(p, msg, nil)
+
+	// After cmdNew returns, the session's AgentSessionID must be cleared,
+	// even though the old agent process close may still be in progress.
+	if id := e.sessions.GetOrCreateActive(key).GetAgentSessionID(); id != "" {
+		t.Fatalf("AgentSessionID should be empty after /new, got %q", id)
+	}
+
+	// The interactive state must be removed from the map.
+	e.interactiveMu.Lock()
+	_, exists := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+	if exists {
+		t.Fatal("interactive state should be removed after /new")
+	}
+
+	// Verify the async close goroutine was actually started.
+	select {
+	case <-slowSess.closeStarted:
+		// OK — Close() has been invoked asynchronously.
+	case <-time.After(5 * time.Second):
+		t.Fatal("async close goroutine did not start within 5s")
+	}
+
+	// Release the slow close so the goroutine finishes.
+	close(slowSess.closeRelease)
+}
+
+// slowCloseSession wraps controllableAgentSession with a Close() that blocks
+// until the test releases it, simulating a slow agent process shutdown.
+type slowCloseSession struct {
+	controllableAgentSession
+	closeStarted chan struct{} // closed when Close() begins
+	closeRelease chan struct{} // Close() blocks until this is closed
+}
+
+func (s *slowCloseSession) Close() error {
+	close(s.closeStarted)
+	<-s.closeRelease
+	return s.controllableAgentSession.Close()
+}
+
 // TestSessionMismatch_RecyclesStaleAgent verifies that getOrCreateInteractiveStateWith
 // detects when the running agent session ID differs from the active Session's
 // AgentSessionID and creates a fresh agent instead of reusing the stale one.


### PR DESCRIPTION
## Problem

A race condition in `/new`, `/switch`, and `/dir` commands causes session confusion. When the user sends `/new` while an agent session is active, `cleanupInteractiveState()` blocks for up to 130 seconds waiting for the old agent process to exit. During this blocking window:

1. The old event loop exits (stopCh closed) → the session lock is released
2. A new message arrives → `TryLock` succeeds on the **old** session (not yet cleared)
3. `getOrCreateInteractiveStateWith` reads the stale `AgentSessionID` → starts `claude --resume <old-id>`
4. The user's message is sent to the **old** conversation context
5. `cmdNew` finally unblocks → clears session data → creates new session → orphans the process from step 3

## Root Cause

`cleanupInteractiveState()` performs two logically independent operations in sequence:
- **Fast**: remove interactive state from routing map + stop event loop
- **Slow**: close the agent process (stdin EOF → wait for exit → SIGTERM → SIGKILL)

Session data (`AgentSessionID`, history) was only cleared **after** both operations completed, leaving a window where stale data could be read by concurrent message handlers.

## Fix

Introduced `detachInteractiveState()` — a non-blocking function that handles only the fast path (map removal + stop signal) and returns the `AgentSession` for later closing.

Command handlers (`cmdNew`, `cmdSwitch`, `dirApply`) now follow a 3-phase pattern:

1. **Detach** — `detachInteractiveState()` removes the state from the routing map and stops the event loop (non-blocking)
2. **Clear session data** — reset `AgentSessionID`, clear history, create new session record — while the state is already detached but the process may still be exiting
3. **Async close** — `closeAgentSessionAsync()` terminates the old process in a background goroutine

This ensures any message arriving during the close window sees a cleared `AgentSessionID` and starts a fresh agent session instead of resuming the old one.

## Additional Changes

- Fixed log prefix in `closeAgentSessionWithTimeout` (`cleanupInteractiveState:` → `closeAgentSessionWithTimeout:`)
- Added nil guards before `closeAgentSessionAsync` calls, consistent with `cleanupInteractiveState` style
- Added `slog.Debug` after detach in `cmdNew` for troubleshooting

## Tests

- `TestDetachInteractiveState_ReturnsAgentSession` — verifies map removal and return value
- `TestDetachInteractiveState_SkipsWhenStateReplaced` — verifies CAS (compare-and-swap) behavior
- `TestCmdNew_ClearsSessionDataBeforeAsyncClose` — regression test using a `slowCloseSession` stub that blocks in `Close()`, verifying that `AgentSessionID` is cleared and the async close goroutine is started before `cmdNew` returns

All existing tests pass (`go test ./...`).

Refs: #509, #510