### PR TITLE
feat(feishu): default lark to websocket

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -671,14 +671,15 @@ app_secret = "your-feishu-app-secret"
 #                           # 进度消息展示风格：legacy（逐条消息）| compact（单消息持续更新）| card（结构化卡片）
 
 # Lark (International Version) / Lark 国际版
-# Lark uses Webhook mode instead of WebSocket long-connection.
-# Lark 使用 Webhook 模式而非 WebSocket 长连接。
+# Lark now supports WebSocket long-connection too; webhook mode is only needed
+# when you explicitly configure encrypt_key.
+# Lark 国际版现已支持 WebSocket 长连接；只有显式配置 encrypt_key 时才需要 Webhook 模式。
 # 1. Create an app at https://open.larksuite.com / 在 https://open.larksuite.com 创建应用
 # 2. Enable Bot capability / 开启机器人能力
-# 3. Add im.message.receive_v1 event, configure Webhook URL (requires public IP)
-#    添加 im.message.receive_v1 事件，配置 Webhook URL（需要公网 IP）
-# 4. Fill in app_id, app_secret, port, callback_path below
-#    填入下方 app_id、app_secret、port、callback_path
+# 3. Add im.message.receive_v1 event and enable WebSocket long-connection mode (recommended)
+#    添加 im.message.receive_v1 事件，并启用 WebSocket 长连接模式（推荐）
+# 4. Fill in app_id and app_secret below; port/callback_path are only used for webhook mode
+#    填入下方 app_id 和 app_secret；port/callback_path 仅在 Webhook 模式下使用
 
 # [[projects.platforms]]
 # type = "lark"

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -288,16 +288,18 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			return p.onBotMenu(event)
 		})
 
-	// Lark international version uses Webhook mode, not WebSocket long connection
-	// Feishu domestic version supports WebSocket long connection
-	if p.platformName == "lark" {
+	if p.shouldUseWebhookMode() {
 		return p.startWebhookMode()
 	}
 
 	return p.startWebSocketMode()
 }
 
-// startWebSocketMode starts the WebSocket long connection mode (for Feishu domestic version)
+func (p *Platform) shouldUseWebhookMode() bool {
+	return strings.TrimSpace(p.encryptKey) != ""
+}
+
+// startWebSocketMode starts the WebSocket long connection mode.
 func (p *Platform) startWebSocketMode() error {
 	wsOpts := []larkws.ClientOption{
 		larkws.WithEventHandler(p.eventHandler),

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -462,6 +462,29 @@ func TestNewLark_PlatformNameAndDomain(t *testing.T) {
 	}
 }
 
+func TestPlatformShouldUseWebhookMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		platform   string
+		encryptKey string
+		want       bool
+	}{
+		{name: "lark defaults to websocket", platform: "lark", want: false},
+		{name: "lark webhook when encrypt key set", platform: "lark", encryptKey: "enc-key", want: true},
+		{name: "feishu defaults to websocket", platform: "feishu", want: false},
+		{name: "feishu webhook when encrypt key set", platform: "feishu", encryptKey: "enc-key", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Platform{platformName: tt.platform, encryptKey: tt.encryptKey}
+			if got := p.shouldUseWebhookMode(); got != tt.want {
+				t.Fatalf("shouldUseWebhookMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewFeishu_PlatformNameAndDomain(t *testing.T) {
 	p, err := New(map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret",


### PR DESCRIPTION
 ## Summary
  - remove the hardcoded Lark webhook-only startup path
  - default both Feishu and Lark to WebSocket long connection
  - keep webhook mode available when `encrypt_key` is explicitly configured
  - update the Lark example in `config.example.toml`
  - add regression tests covering the webhook vs websocket selection logic

  ## Why
  Lark international now supports WebSocket long connection, but cc-connect still
  forced Lark users into webhook mode. That meant requiring a public callback URL even
  when WebSocket would work.

  ## Behavior
  - default: WebSocket long connection
  - when `encrypt_key` is set: webhook mode

  ## Validation
  - ran `go test ./platform/feishu`

  Closes #449