### PR TITLE
feat(core): add busy_action inject mode

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -215,6 +215,7 @@ func main() {
 		}
 		engine.SetShowContextIndicator(showCtx)
 		engine.SetAttachmentSendEnabled(cfg.AttachmentSend != "off")
+		engine.SetBusyAction(proj.BusyAction)
 		engine.SetBaseWorkDir(workDir)
 		engine.SetProjectStateStore(projectState)
 
@@ -396,6 +397,7 @@ func main() {
 		if proj.InjectSender != nil {
 			engine.SetInjectSender(*proj.InjectSender)
 		}
+		engine.SetBusyAction(proj.BusyAction)
 
 		// Wire speech-to-text if enabled
 		if cfg.Speech.Enabled {
@@ -1233,6 +1235,7 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 
 	// Reload sender injection
 	engine.SetInjectSender(proj.InjectSender != nil && *proj.InjectSender)
+	engine.SetBusyAction(proj.BusyAction)
 
 	// Reload attachment send-back switch
 	engine.SetAttachmentSendEnabled(cfg.AttachmentSend != "off")

--- a/config.example.toml
+++ b/config.example.toml
@@ -453,6 +453,9 @@ level = "info" # debug, info, warn, error
 name = "my-backend"
 # show_context_indicator = false  # Hide the “[ctx: ~N%]” suffix on assistant replies (default: true / show)
 #                                   # 不在助手回复末尾显示「[ctx: ~N%]」上下文占用提示（默认 true 显示）
+# quiet = true  # Override global quiet for this project / 覆盖全局静默模式
+# busy_action = "inject"  # "queue" (default) | "inject" to auto-send busy messages like /btw
+#                         # "queue"（默认）| "inject" 在会话忙时自动按 /btw 方式注入消息
 # disabled_commands = ["restart", "upgrade", "cron"]  # Disable specific commands for this project
 #                                                     # 禁用该项目的指定命令
 #

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,8 @@ var configMu sync.Mutex
 var ConfigPath string
 
 type Config struct {
-	DataDir           string                  `toml:"data_dir"` // session store directory, default ~/.cc-connect
-	AttachmentSend    string                  `toml:"attachment_send"`
+	DataDir        string `toml:"data_dir"` // session store directory, default ~/.cc-connect
+	AttachmentSend string `toml:"attachment_send"`
 	// Quiet is legacy: when true and [display] does not set thinking_messages / tool_messages,
 	// engines behave as if those flags were false. Per-project quiet overrides when set.
 	Quiet             *bool                   `toml:"quiet,omitempty"`
@@ -208,8 +208,9 @@ type ReferenceConfig struct {
 // ProjectConfig binds one agent (with a specific work_dir) to one or more platforms.
 type ProjectConfig struct {
 	Name         string             `toml:"name"`
-	Mode         string             `toml:"mode,omitempty"`     // "" or "multi-workspace"
-	BaseDir      string             `toml:"base_dir,omitempty"` // parent dir for workspaces
+	Mode         string             `toml:"mode,omitempty"`        // "" or "multi-workspace"
+	BaseDir      string             `toml:"base_dir,omitempty"`    // parent dir for workspaces
+	BusyAction   string             `toml:"busy_action,omitempty"` // "queue" (default) | "inject"
 	Agent        AgentConfig        `toml:"agent"`
 	Platforms    []PlatformConfig   `toml:"platforms"`
 	Heartbeat    HeartbeatConfig    `toml:"heartbeat"`
@@ -219,15 +220,15 @@ type ProjectConfig struct {
 	// 0 or nil disables the behavior.
 	ResetOnIdleMins *int `toml:"reset_on_idle_mins,omitempty"`
 	// ShowContextIndicator: nil/true = append [ctx: ~N%] to assistant replies; false = hide.
-	ShowContextIndicator *bool           `toml:"show_context_indicator,omitempty"`
-	InjectSender         *bool           `toml:"inject_sender,omitempty"`     // prepend sender identity (platform + user ID) to each message sent to the agent
-	DisabledCommands     []string        `toml:"disabled_commands,omitempty"` // commands to disable for this project (e.g. ["restart", "upgrade"])
-	AdminFrom            string          `toml:"admin_from,omitempty"`        // comma-separated user IDs allowed to run privileged commands; "*" = all allowed users
-	Users                *UsersConfig    `toml:"users,omitempty"`             // per-user role config; nil = legacy behavior
+	ShowContextIndicator *bool        `toml:"show_context_indicator,omitempty"`
+	InjectSender         *bool        `toml:"inject_sender,omitempty"`     // prepend sender identity (platform + user ID) to each message sent to the agent
+	DisabledCommands     []string     `toml:"disabled_commands,omitempty"` // commands to disable for this project (e.g. ["restart", "upgrade"])
+	AdminFrom            string       `toml:"admin_from,omitempty"`        // comma-separated user IDs allowed to run privileged commands; "*" = all allowed users
+	Users                *UsersConfig `toml:"users,omitempty"`             // per-user role config; nil = legacy behavior
 	// Quiet is legacy per-project override; see Config.Quiet. When true and global [display]
 	// omits thinking_messages / tool_messages, those default to off for this project.
 	Quiet      *bool           `toml:"quiet,omitempty"`
-	References           ReferenceConfig `toml:"references,omitempty"`
+	References ReferenceConfig `toml:"references,omitempty"`
 }
 
 type AgentConfig struct {
@@ -378,6 +379,11 @@ func (c *Config) validate() error {
 			if p.Type == "" {
 				return fmt.Errorf("config: %s.platforms[%d].type is required", prefix, j)
 			}
+		}
+		switch strings.ToLower(strings.TrimSpace(proj.BusyAction)) {
+		case "", "queue", "inject":
+		default:
+			return fmt.Errorf("config: %s.busy_action must be \"queue\" or \"inject\"", prefix)
 		}
 		if proj.Mode == "multi-workspace" {
 			if proj.BaseDir == "" {
@@ -2067,6 +2073,9 @@ func GetProjectConfigDetails(projectName string) map[string]any {
 		}
 		if p.ShowContextIndicator != nil {
 			result["show_context_indicator"] = *p.ShowContextIndicator
+		}
+		if strings.TrimSpace(p.BusyAction) != "" {
+			result["busy_action"] = p.BusyAction
 		}
 		platConfigs := make([]map[string]any, len(p.Platforms))
 		for j, plat := range p.Platforms {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -97,6 +97,31 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: `project "demo": multi-workspace mode conflicts with agent work_dir`,
 		},
 		{
+			name: "rejects invalid busy action",
+			cfg: Config{
+				Projects: []ProjectConfig{
+					func() ProjectConfig {
+						p := validProject("demo")
+						p.BusyAction = "drop"
+						return p
+					}(),
+				},
+			},
+			wantErr: `projects[0].busy_action must be "queue" or "inject"`,
+		},
+		{
+			name: "accepts inject busy action",
+			cfg: Config{
+				Projects: []ProjectConfig{
+					func() ProjectConfig {
+						p := validProject("demo")
+						p.BusyAction = "inject"
+						return p
+					}(),
+				},
+			},
+		},
+		{
 			name: "accepts valid config",
 			cfg: Config{
 				Projects: []ProjectConfig{validProject("demo")},
@@ -1627,7 +1652,7 @@ func TestSaveProjectSettings_ExtraFields(t *testing.T) {
 }
 
 func TestGetProjectConfigDetails(t *testing.T) {
-	configPath := writeConfigFixture(t, feishuConfigFixture)
+	configPath := writeConfigFixture(t, strings.Replace(feishuConfigFixture, "name = \"alpha\"", "name = \"alpha\"\nbusy_action = \"inject\"", 1))
 	patchConfigPath(t, configPath)
 
 	details := GetProjectConfigDetails("alpha")
@@ -1636,6 +1661,9 @@ func TestGetProjectConfigDetails(t *testing.T) {
 	}
 	if details["work_dir"] != "/tmp/alpha" {
 		t.Fatalf("work_dir = %v", details["work_dir"])
+	}
+	if details["busy_action"] != "inject" {
+		t.Fatalf("busy_action = %v, want inject", details["busy_action"])
 	}
 	pcs, ok := details["platform_configs"].([]map[string]any)
 	if !ok || len(pcs) < 2 {

--- a/core/engine.go
+++ b/core/engine.go
@@ -134,6 +134,11 @@ type RateLimitCfg struct {
 }
 
 // Engine routes messages between platforms and the agent for a single project.
+const (
+	busyActionQueue  = "queue"
+	busyActionInject = "inject"
+)
+
 type Engine struct {
 	name                  string
 	agent                 Agent
@@ -147,6 +152,7 @@ type Engine struct {
 	display               DisplayCfg
 	injectSender          bool
 	attachmentSendEnabled bool
+	busyAction            string
 	startedAt             time.Time
 
 	providerSaveFunc       func(providerName string) error
@@ -332,6 +338,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		cancel:                cancel,
 		i18n:                  NewI18n(lang),
 		attachmentSendEnabled: true,
+		busyAction:            busyActionQueue,
 		display:               DisplayCfg{ThinkingMessages: true, ThinkingMaxLen: defaultThinkingMaxLen, ToolMaxLen: defaultToolMaxLen, ToolMessages: true},
 		commands:              NewCommandRegistry(),
 		skills:                NewSkillRegistry(),
@@ -504,6 +511,22 @@ func (e *Engine) SetWebStatusFunc(fn func() string)                    { e.webSt
 // accordingly (e.g. personal task views, role-based access control).
 func (e *Engine) SetInjectSender(v bool) {
 	e.injectSender = v
+}
+
+func normalizeBusyAction(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case busyActionInject:
+		return busyActionInject
+	default:
+		return busyActionQueue
+	}
+}
+
+// SetBusyAction controls what happens when a new message arrives while the
+// session is already processing a turn. Supported values are queue (default)
+// and inject.
+func (e *Engine) SetBusyAction(v string) {
+	e.busyAction = normalizeBusyAction(v)
 }
 
 // SetAttachmentSendEnabled controls whether side-channel image/file delivery is allowed.
@@ -1437,23 +1460,25 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	session := sessions.GetOrCreateActive(msg.SessionKey)
 	sessions.UpdateUserMeta(msg.SessionKey, msg.UserName, msg.ChatName)
 	if !session.TryLock() {
-		// Check for /btw — inject into the running session mid-turn
 		trimmed := strings.TrimSpace(content)
+		injected := ""
 		if isBtwCommand(trimmed) {
-			btw := strings.TrimSpace(trimmed[len(matchBtwPrefix(trimmed)):])
-			if btw != "" {
-				e.interactiveMu.Lock()
-				state, ok := e.interactiveStates[interactiveKey]
-				e.interactiveMu.Unlock()
-				if ok && state.agentSession != nil && state.agentSession.Alive() {
-					if err := state.agentSession.Send(btw, nil, nil); err != nil {
-						slog.Error("btw: send failed", "error", err)
-						e.reply(p, msg.ReplyCtx, e.i18n.T(MsgBtwSendFailed))
-					} else {
-						e.reply(p, msg.ReplyCtx, e.i18n.T(MsgBtwSent))
-					}
-					return
+			injected = strings.TrimSpace(trimmed[len(matchBtwPrefix(trimmed)):])
+		} else if e.busyAction == busyActionInject && trimmed != "" && len(msg.Images) == 0 && len(msg.Files) == 0 && !msg.FromVoice {
+			injected = trimmed
+		}
+		if injected != "" {
+			e.interactiveMu.Lock()
+			state, ok := e.interactiveStates[interactiveKey]
+			e.interactiveMu.Unlock()
+			if ok && state.agentSession != nil && state.agentSession.Alive() {
+				if err := state.agentSession.Send(injected, nil, nil); err != nil {
+					slog.Error("btw: send failed", "error", err)
+					e.reply(p, msg.ReplyCtx, e.i18n.T(MsgBtwSendFailed))
+				} else {
+					e.reply(p, msg.ReplyCtx, e.i18n.T(MsgBtwSent))
 				}
+				return
 			}
 		}
 		// Session is busy — try to queue the message for the running turn

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -5947,6 +5947,115 @@ func TestQueueMessage_DeadSession_ReturnsFalse(t *testing.T) {
 	}
 }
 
+func TestHandleMessage_BusyActionInject_SendsMidTurnText(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("busy-inject")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetBusyAction("inject")
+
+	key := "test:user1"
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx-running",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	session := e.sessions.GetOrCreateActive(key)
+	if !session.TryLock() {
+		t.Fatal("expected TryLock to succeed")
+	}
+	defer session.Unlock()
+
+	e.handleMessage(p, &Message{SessionKey: key, Content: "follow up", ReplyCtx: "ctx-new", UserName: "u1"})
+
+	sess.sendMu.Lock()
+	defer sess.sendMu.Unlock()
+	if len(sess.sendCalls) != 1 || sess.sendCalls[0] != "follow up" {
+		t.Fatalf("sendCalls = %v, want [follow up]", sess.sendCalls)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.pendingMessages) != 0 {
+		t.Fatalf("pendingMessages len = %d, want 0", len(state.pendingMessages))
+	}
+
+	sent := p.getSent()
+	found := false
+	for _, s := range sent {
+		if strings.Contains(s, e.i18n.T(MsgBtwSent)) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected MsgBtwSent reply, got %v", sent)
+	}
+}
+
+func TestHandleMessage_BusyActionInject_QueuesAttachments(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("busy-queue-attachments")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetBusyAction("inject")
+
+	key := "test:user2"
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx-running",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	session := e.sessions.GetOrCreateActive(key)
+	if !session.TryLock() {
+		t.Fatal("expected TryLock to succeed")
+	}
+	defer session.Unlock()
+
+	e.handleMessage(p, &Message{
+		SessionKey: key,
+		Content:    "with image",
+		ReplyCtx:   "ctx-new",
+		UserName:   "u2",
+		Images:     []ImageAttachment{{MimeType: "image/png", FileName: "a.png"}},
+	})
+
+	sess.sendMu.Lock()
+	defer sess.sendMu.Unlock()
+	if len(sess.sendCalls) != 0 {
+		t.Fatalf("sendCalls = %v, want []", sess.sendCalls)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.pendingMessages) != 1 {
+		t.Fatalf("pendingMessages len = %d, want 1", len(state.pendingMessages))
+	}
+	if state.pendingMessages[0].content != "with image" {
+		t.Fatalf("queued content = %q, want with image", state.pendingMessages[0].content)
+	}
+
+	sent := p.getSent()
+	found := false
+	for _, s := range sent {
+		if strings.Contains(s, e.i18n.T(MsgMessageQueued)) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected MsgMessageQueued reply, got %v", sent)
+	}
+}
+
 // --- 2. /compress flow ---
 
 type stubCompressorAgent struct {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6259,8 +6259,8 @@ func TestHandleMessage_BusyActionInject_QueuesAttachments(t *testing.T) {
 		t.Fatalf("queued content = %q, want with image", state.pendingMessages[0].content)
 	}
 
-	sent = p.getSent()
-	found = false
+	sent := p.getSent()
+	found := false
 	for _, s := range sent {
 		if strings.Contains(s, e.i18n.T(MsgMessageQueued)) {
 			found = true


### PR DESCRIPTION
 ## Summary
  - add project-level `busy_action = "inject"` support
  - auto-forward busy pure-text messages through the existing mid-turn `/btw`
  send path
  - keep images, files, and voice messages on the existing queueing path
  - expose `busy_action` in config details and document it in
  `config.example.toml`
  - add regression tests for config validation, config detail export, and busy-
  session inject behavior

  ## Why
  cc-connect already supports `/btw` for sending a follow-up message into a
  running interactive turn, but the default busy-session behavior still queues
  normal text messages. This adds an opt-in project mode for users who prefer
  busy text messages to behave like `/btw` automatically.

  ## Behavior
  - default: `busy_action = "queue"`
  - opt-in: `busy_action = "inject"`
  - inject mode only applies to plain text while a session is busy
  - attachments and voice still queue to avoid changing side-channel delivery
  behavior

  ## Validation
  - ran `go test ./config`
  - ran `go test ./core`
  - ran `git diff --check`

  Closes #397