### PR TITLE
fix(feishu): preserve session continuity across nested threads and deduplicate root context

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -136,6 +136,8 @@ type Platform struct {
 	botOpenID        string
 	userNameCache    sync.Map // open_id -> display name
 	chatNameCache    sync.Map // chat_id -> chat name
+	msgSessionMap    sync.Map // messageID -> sessionKey; tracks which session a message belongs to
+	rootContextSent  sync.Map // sessionKey -> bool; tracks which sessions already received thread root context
 	// Webhook mode fields (for Lark international version)
 	server       *http.Server
 	port         string
@@ -730,8 +732,15 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	}
 	mentions := msg.Mentions
 	parentID := stringValue(msg.ParentId)
+	rootID := stringValue(msg.RootId)
 
 	sessionKey := p.makeSessionKey(msg, chatID, userID)
+	// Record which session this message belongs to, so that if a bot reply
+	// creates a nested thread on this message, subsequent messages in that
+	// thread can be routed back to the same session.
+	if p.threadIsolation {
+		p.msgSessionMap.Store(messageID, sessionKey)
+	}
 	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
 	slog.Debug(p.tag()+": routed inbound message",
 		"message_id", messageID,
@@ -743,7 +752,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	// blocked by IO-heavy operations (image/audio download, handler HTTP calls).
 	// The dedup and old-message checks above remain synchronous to guarantee
 	// correctness before spawning the goroutine.
-	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, userName, chatName, rctx, parentID)
+	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, userName, chatName, rctx, parentID, rootID)
 
 	return nil
 }
@@ -751,12 +760,22 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 // dispatchMessage handles the message content parsing, media download, and
 // handler invocation. It runs in its own goroutine so that onMessage returns
 // quickly and does not block the SDK event loop.
-func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, userName, chatName string, rctx replyContext, parentID string) {
-	// If this message is a reply to another message, fetch the quoted content
-	// and prepend it so the agent has full context.
+func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, userName, chatName string, rctx replyContext, parentID, rootID string) {
+	// Determine context prefix based on parent/root relationship:
+	// - parentID == rootID: thread-level reply (Feishu auto-sets parent to root).
+	//   Only inject root message content on the first message of this session.
+	// - parentID != rootID: explicit quote-reply to a specific sub-message.
+	//   Always inject the quoted message content.
 	quotedPrefix := ""
 	if parentID != "" {
-		quotedPrefix = p.fetchQuotedMessage(ctx, parentID)
+		if rootID != "" && parentID == rootID {
+			// Thread root context: only inject once per session.
+			if _, alreadySent := p.rootContextSent.LoadOrStore(sessionKey, true); !alreadySent {
+				quotedPrefix = p.fetchThreadRootMessage(ctx, parentID)
+			}
+		} else {
+			quotedPrefix = p.fetchQuotedMessage(ctx, parentID)
+		}
 	}
 
 	switch msgType {
@@ -1035,6 +1054,35 @@ func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) stri
 	return fmt.Sprintf("[Quoted message from %s]:\n%s\n\n", senderName, quotedText)
 }
 
+const threadRootMaxLen = 2000
+
+// fetchThreadRootMessage retrieves the thread root message and formats it with
+// a distinct prefix. Content is truncated to threadRootMaxLen characters to
+// avoid excessive token usage. Returns empty string on any failure (graceful
+// degradation).
+func (p *Platform) fetchThreadRootMessage(ctx context.Context, rootID string) string {
+	raw := p.fetchQuotedMessage(ctx, rootID)
+	if raw == "" {
+		return ""
+	}
+	const oldPrefix = "[Quoted message from "
+	const newPrefix = "[Thread root message from "
+	result := raw
+	if strings.HasPrefix(raw, oldPrefix) {
+		result = newPrefix + raw[len(oldPrefix):]
+	}
+	if idx := strings.Index(result, "]:\n"); idx >= 0 {
+		header := result[:idx+len("]:\n")]
+		body := result[idx+len("]:\n"):]
+		body = strings.TrimSuffix(body, "\n\n")
+		if len(body) > threadRootMaxLen {
+			body = body[:threadRootMaxLen] + "[...truncated]"
+		}
+		result = header + body + "\n\n"
+	}
+	return result
+}
+
 // extractPostPlainText extracts plain text from a Lark post (rich text) JSON content.
 func extractPostPlainText(content string) string {
 	var post struct {
@@ -1129,7 +1177,9 @@ func extractInteractiveCardText(content string) string {
 	if len(parts) == 0 {
 		if raw, ok := card["header"]; ok {
 			var header struct {
-				Title struct{ Content string `json:"content"` } `json:"title"`
+				Title struct {
+					Content string `json:"content"`
+				} `json:"title"`
 			}
 			if json.Unmarshal(raw, &header) == nil && header.Title.Content != "" {
 				parts = append(parts, header.Title.Content)
@@ -2094,6 +2144,13 @@ func (p *Platform) makeSessionKey(msg *larkim.EventMessage, chatID, userID strin
 			rootID = stringValue(msg.MessageId)
 		}
 		if rootID != "" {
+			// When a bot reply creates a nested thread on a user's message,
+			// subsequent messages in that thread have root_id = user's messageID.
+			// Look up whether that root was a message in an existing session
+			// and reuse that session key to maintain conversation continuity.
+			if mapped, ok := p.msgSessionMap.Load(rootID); ok {
+				return mapped.(string)
+			}
 			return fmt.Sprintf("%s:%s:root:%s", p.tag(), chatID, rootID)
 		}
 	}

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -912,6 +912,246 @@ func TestBuildPreviewCardJSON_ProgressPayloadUsesStructuredCard(t *testing.T) {
 	}
 }
 
+func TestThreadIsolation_NestedThreadInheritSessionKey(t *testing.T) {
+	// Simulates: user sends msg1 in thread A (root=X), bot replies with
+	// ReplyInThread creating a nested thread on msg1. User then posts msg2
+	// in the nested thread (root=msg1). msg2 should get the same session key
+	// as msg1 via msgSessionMap lookup.
+	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	originalRoot := "om_original_root"
+	msg1ID := "om_msg1"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	ip.botOpenID = "ou_bot"
+
+	// Step 1: msg1 in thread A (root = originalRoot).
+	content1 := `{"text":"@bot check alert"}`
+	var msg1Received *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		msg1Received = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   &msg1ID,
+				RootId:      &originalRoot,
+				ParentId:    &originalRoot,
+				ChatId:      &chatID,
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     &content1,
+				CreateTime:  &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if msg1Received == nil {
+		t.Fatal("msg1 handler not called")
+	}
+	session1Key := msg1Received.SessionKey
+
+	// Step 2: msg2 in nested thread (root = msg1ID), simulating what happens
+	// after bot's ReplyInThread created a topic on msg1.
+	msg2ID := "om_msg2"
+	content2 := `{"text":"@bot continue"}`
+	var msg2Received *core.Message
+	wg.Add(1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		msg2Received = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   &msg2ID,
+				RootId:      &msg1ID, // nested thread root = msg1
+				ParentId:    &msg1ID,
+				ChatId:      &chatID,
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     &content2,
+				CreateTime:  &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if msg2Received == nil {
+		t.Fatal("msg2 handler not called")
+	}
+
+	// msg2 should inherit msg1's session key, not get a new one based on msg1ID.
+	if msg2Received.SessionKey != session1Key {
+		t.Fatalf("msg2 SessionKey = %q, want same as msg1 %q", msg2Received.SessionKey, session1Key)
+	}
+}
+
+func TestThreadRootContext_FirstMessageMarksSession(t *testing.T) {
+	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	messageID := "om_msg1"
+	rootID := "om_root"
+	parentID := "om_root"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	content := `{"text":"@bot check this"}`
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	var receivedMsg *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ip.botOpenID = "ou_bot"
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		receivedMsg = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId: &messageID, RootId: &rootID, ParentId: &parentID,
+				ChatId: &chatID, ChatType: &chatType, MessageType: &msgType,
+				Content: &content, CreateTime: &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if receivedMsg == nil {
+		t.Fatal("handler not called")
+	}
+	if _, ok := ip.rootContextSent.Load(receivedMsg.SessionKey); !ok {
+		t.Fatal("rootContextSent should be marked after first thread message")
+	}
+}
+
+func TestThreadRootContext_SecondMessageSkipsRootContext(t *testing.T) {
+	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	rootID := "om_root"
+	parentID := "om_root"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	ip.botOpenID = "ou_bot"
+
+	sessionKey := "lark:oc_test:root:om_root"
+	ip.rootContextSent.Store(sessionKey, true)
+
+	msg1ID := "om_msg2"
+	content := `{"text":"@bot second message"}`
+	var receivedMsg *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		receivedMsg = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId: &msg1ID, RootId: &rootID, ParentId: &parentID,
+				ChatId: &chatID, ChatType: &chatType, MessageType: &msgType,
+				Content: &content, CreateTime: &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if receivedMsg == nil {
+		t.Fatal("handler not called")
+	}
+	if strings.Contains(receivedMsg.Content, "[Thread root message") {
+		t.Fatalf("second message should not contain root context, got %q", receivedMsg.Content)
+	}
+}
+
+func TestFetchThreadRootMessage_Truncation(t *testing.T) {
+	input := "[Quoted message from AlertBot]:\n" + strings.Repeat("A", 2500) + "\n\n"
+	const oldPrefix = "[Quoted message from "
+	const newPrefix = "[Thread root message from "
+	result := newPrefix + input[len(oldPrefix):]
+	if idx := strings.Index(result, "]:\n"); idx >= 0 {
+		header := result[:idx+len("]:\n")]
+		body := result[idx+len("]:\n"):]
+		body = strings.TrimSuffix(body, "\n\n")
+		if len(body) > threadRootMaxLen {
+			body = body[:threadRootMaxLen] + "[...truncated]"
+		}
+		result = header + body + "\n\n"
+	}
+	if !strings.HasPrefix(result, "[Thread root message from AlertBot]:\n") {
+		t.Fatalf("expected thread root prefix, got %q", result[:60])
+	}
+	bodyStart := strings.Index(result, "]:\n") + len("]:\n")
+	body := result[bodyStart:]
+	body = strings.TrimSuffix(body, "\n\n")
+	if !strings.HasSuffix(body, "[...truncated]") {
+		t.Fatalf("expected truncation suffix, got ...%q", body[len(body)-20:])
+	}
+	bodyWithoutSuffix := strings.TrimSuffix(body, "[...truncated]")
+	if len(bodyWithoutSuffix) != threadRootMaxLen {
+		t.Fatalf("truncated body length = %d, want %d", len(bodyWithoutSuffix), threadRootMaxLen)
+	}
+}
+
 func TestBuildPreviewCardJSON_NormalTextFallback(t *testing.T) {
 	cardJSON := buildPreviewCardJSON("plain progress text")
 	if strings.Contains(cardJSON, "cc-connect · 进度") {


### PR DESCRIPTION
 ## Summary                                                                                    
                                                                                               
  Fixes two related issues with `thread_isolation` mode in the Feishu platform.                 
                                                                                               
  ### Bug 1: Session breaks when bot reply creates nested thread                                
                                             
  **Problem:** When a user @mentions the bot inside a Feishu thread, the bot calls              
  `Im.Message.Reply(userMessageID, ReplyInThread=true)`. Feishu interprets this as creating a  
  **new nested thread** on the user's message, rather than replying within the existing thread. 
  Subsequent messages in that nested thread have a different `root_id` (the user's message ID  
  instead of the original thread root), which produces a different session key — causing
  cc-connect to start a **new agent session** and lose conversation continuity.                

  **Example from real logs:**                                                                   
  Message 1 (user @bots in thread A):
    message_id = ...3c1b                                                                        
    root_id    = ...0913  ← thread A root    
    → session key: feishu:chat:root:...0913
    → session: s92                                                                              
   
  Message 2 (user continues in nested thread created by bot):                                   
    message_id = ...a37                      
    root_id    = ...3c1b  ← changed to message 1's ID!                                          
    → session key: feishu:chat:root:...3c1b  ← different!                                       
    → session: s93  ← new session, conversation context lost                                    
                                                                                                
  **Fix:** Add a `msgSessionMap` (`sync.Map`) on the Platform struct that records `messageID →  
  sessionKey` for every processed message. In `makeSessionKey()`, when computing the session key
   from `root_id`, first check if that root ID exists in the map. If so, reuse the mapped      
  session key instead of generating a new one. This lets nested threads inherit their parent    
  message's session.                                                                           
                                         
  ### Bug 2: Thread root message content repeated on every message                             

  **Problem:** When a user posts directly in a Feishu thread (not quote-replying a specific     
  sub-message), Feishu sets `parent_id = root_id`. The existing `fetchQuotedMessage(parentID)`
  was called on **every message**, prepending the root message content each time. This caused:  
  1. Wasted tokens sending redundant context to the agent
  2. Confusing UX when the AI echoes user input (e.g., during permission prompts) — the root    
  message content is visible to the user in every response                                      
                                                                                                
  **Fix:** Distinguish between "thread context" (`parent_id == root_id`) and "explicit          
  quote-reply" (`parent_id != root_id`):     
  - **Thread context:** Use `rootContextSent` (`sync.Map`) with `LoadOrStore` to inject root    
  message content only on the **first message** of a session. Uses a distinct `[Thread root     
  message from ...]` prefix and truncates at 2000 characters.
  - **Explicit quote-reply:** Preserve existing `fetchQuotedMessage` behavior unchanged (always 
  fetch).                                    
                                         
  ## Changes                                                                                   

  - `platform/feishu/feishu.go`:
    - Add `msgSessionMap sync.Map` and `rootContextSent sync.Map` to Platform struct
    - `makeSessionKey()`: look up `rootID` in `msgSessionMap` to inherit parent session         
    - `onMessage()`: record `messageID → sessionKey` mapping; extract and pass `rootID` to      
  `dispatchMessage()`                                                                           
    - `dispatchMessage()`: branch on `parentID == rootID` for dedup vs always-fetch             
    - New `fetchThreadRootMessage()`: wraps `fetchQuotedMessage` with prefix replacement and    
  truncation                                                                                    
  - `platform/feishu/platform_test.go`:                                                         
    - `TestThreadIsolation_NestedThreadInheritSessionKey`: verifies nested thread inherits      
  parent session key                                                                            
    - `TestThreadRootContext_FirstMessageMarksSession`: verifies first message marks           
  rootContextSent                                                                               
    - `TestThreadRootContext_SecondMessageSkipsRootContext`: verifies subsequent messages skip
  root context                                                                                  
    - `TestFetchThreadRootMessage_Truncation`: verifies 2000 char truncation with suffix       
                                                                                                
  ## Test plan                                                                                 
                                                                                                
  - [x] `go build ./cmd/cc-connect` passes                                                      
  - [x] `go test ./platform/feishu/` — all tests pass (including 4 new tests)
  - [x] Manual test: @bot in Feishu thread → bot replies → continue in same thread → verify same
   session                                                                                      
  - [x] Manual test: verify root message content appears only on first message of thread session
  - [x] Manual test: explicit quote-reply of a sub-message still fetches quoted content every   
  time