### PR TITLE
feat(engine): /resume slash command with workspace session picker

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -356,11 +356,12 @@ func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, erro
 			continue
 		}
 
-		summary, msgCount := scanSessionMeta(filepath.Join(projectDir, name))
+		firstSummary, summary, msgCount := scanSessionMeta(filepath.Join(projectDir, name))
 
 		sessions = append(sessions, core.AgentSessionInfo{
 			ID:           sessionID,
 			Summary:      summary,
+			FirstSummary: firstSummary,
 			MessageCount: msgCount,
 			ModifiedAt:   info.ModTime(),
 		})
@@ -393,18 +394,24 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 	return os.Remove(path)
 }
 
-func scanSessionMeta(path string) (string, int) {
+// scanSessionMeta parses a claude JSONL session file and returns
+// (firstUserSummary, lastUserSummary, messageCount). Both summaries are
+// XML-tag stripped and truncated to ~40 runes so they fit cleanly in a
+// Slack list row. firstUserSummary is the opening user message in the
+// file (what the user originally started the session with); lastUserSummary
+// is the most recent user message (what the session is currently about).
+// Used by /list, /switch (which want the "current topic" = Summary) and
+// by /resume (which also wants the original starting point = FirstSummary
+// so long-running drifted sessions remain identifiable).
+func scanSessionMeta(path string) (firstSummary, summary string, count int) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", 0
+		return "", "", 0
 	}
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 256*1024), 256*1024)
-
-	var summary string
-	var count int
 
 	for scanner.Scan() {
 		var entry struct {
@@ -419,16 +426,33 @@ func scanSessionMeta(path string) (string, int) {
 		if entry.Type == "user" || entry.Type == "assistant" {
 			count++
 			if entry.Type == "user" && entry.Message.Content != "" {
+				if firstSummary == "" {
+					firstSummary = entry.Message.Content
+				}
 				summary = entry.Message.Content
 			}
 		}
 	}
-	summary = stripXMLTags(summary)
-	summary = strings.TrimSpace(summary)
-	if utf8.RuneCountInString(summary) > 40 {
-		summary = string([]rune(summary)[:40]) + "..."
+	firstSummary = truncateSummaryForList(stripXMLTags(firstSummary))
+	summary = truncateSummaryForList(stripXMLTags(summary))
+	return firstSummary, summary, count
+}
+
+// truncateSummaryForList trims whitespace, collapses interior newlines to
+// spaces (so a multi-line user message does not blow out the picker row),
+// and truncates to ~40 runes with an ellipsis.
+func truncateSummaryForList(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	// Collapse runs of whitespace.
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
 	}
-	return summary, count
+	if utf8.RuneCountInString(s) > 40 {
+		s = string([]rune(s)[:40]) + "..."
+	}
+	return s
 }
 
 var xmlTagRe = regexp.MustCompile(`<[^>]+>`)

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -66,9 +66,22 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 	if mode != "" && mode != "default" {
 		args = append(args, "--permission-mode", mode)
 	}
-	switch sessionID {
-	case "", core.ContinueSession:
+	switch {
+	case sessionID == "":
 		// Truly fresh session — no resume, no continue.
+	case sessionID == core.ContinueSession:
+		// --continue grabs the most recent session in the workspace, which
+		// may belong to an active CLI terminal. Fork it so the platform
+		// conversation gets its own independent context branch.
+		args = append(args, "--continue", "--fork-session")
+	case strings.HasPrefix(sessionID, core.ResumeForkPrefix):
+		// User explicitly picked a prior workspace session via /resume.
+		// Strip the fork prefix and pass --resume <uuid> --fork-session so
+		// the source session (which may still be live in a terminal or
+		// another Slack conversation) is not mutated — we branch off its
+		// context into our own independent timeline.
+		realID := strings.TrimPrefix(sessionID, core.ResumeForkPrefix)
+		args = append(args, "--resume", realID, "--fork-session")
 	default:
 		// Resuming a known session ID — this is cc-connect's own session
 		// from a previous connection, safe to resume directly.

--- a/core/engine.go
+++ b/core/engine.go
@@ -3682,21 +3682,13 @@ func (e *Engine) cmdResume(p Platform, msg *Message, args []string) {
 		return
 	}
 
-	// Filter out the session the user is currently in — offering "resume
-	// the conversation you are literally having right now" is nonsensical
-	// and wastes a picker slot. We compare against the session-store's
-	// AgentSessionID because the live agentSession's CurrentSessionID may
-	// not be reachable from this synchronous command path.
+	// The session the user is currently in (according to cc-connect's own
+	// session store) stays in the list — filtering it out makes the
+	// chronological "most recent" row mysteriously missing. Instead, we
+	// note its ID so the picker can label that row with "(current)" and
+	// the user still has the option to re-pick it explicitly (e.g. to
+	// branch off their own current thread).
 	currentID := session.GetAgentSessionID()
-	if currentID != "" {
-		filtered := agentSessions[:0]
-		for _, s := range agentSessions {
-			if s.ID != currentID {
-				filtered = append(filtered, s)
-			}
-		}
-		agentSessions = filtered
-	}
 
 	if len(agentSessions) == 0 {
 		session.ClearPendingResumeCandidates()
@@ -3719,9 +3711,12 @@ func (e *Engine) cmdResume(p Platform, msg *Message, args []string) {
 		if first == "" {
 			first = "(no opening user message)"
 		}
-		last := s.Summary
-		fmt.Fprintf(&b, "%2d. %s  — \"%s\"\n", i+1, rel, first)
-		if last != "" && last != s.FirstSummary {
+		marker := ""
+		if currentID != "" && s.ID == currentID {
+			marker = " *(current)*"
+		}
+		fmt.Fprintf(&b, "%2d. %s%s  — \"%s\"\n", i+1, rel, marker, first)
+		if last := s.Summary; last != "" && last != s.FirstSummary {
 			fmt.Fprintf(&b, "     ↳ \"%s\"\n", last)
 		}
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -2242,6 +2242,21 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	// is unbound, force a fresh start instead of attaching to whichever CLI
 	// conversation happens to be "latest" in this workspace.
 	startSessionID := session.GetAgentSessionID()
+
+	// /resume <n> arms forkOnNextStart with a workspace session ID that the
+	// user explicitly picked. Consume it here and convert to the fork
+	// sentinel so the claudecode agent spawns with --resume <id>
+	// --fork-session. This overrides any AgentSessionID that might already
+	// be on the session (though cmdResume clears it anyway) and is a
+	// one-shot: next spawn falls back to the normal resume path.
+	if forkID := session.ConsumeForkOnNextStart(); forkID != "" {
+		startSessionID = ResumeForkPrefix + forkID
+		slog.Info("session: fork-on-next-start consumed",
+			"session_key", sessionKey,
+			"fork_from_backend_session", forkID,
+		)
+	}
+
 	isResume := startSessionID != ""
 	startAt := time.Now()
 	agentSession, err := agent.StartSession(e.ctx, startSessionID)
@@ -3028,6 +3043,7 @@ var builtinCommands = []struct {
 	id    string
 }{
 	{[]string{"new"}, "new"},
+	{[]string{"resume"}, "resume"},
 	{[]string{"list", "sessions"}, "list"},
 	{[]string{"switch"}, "switch"},
 	{[]string{"name", "rename"}, "name"},
@@ -3184,6 +3200,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 	switch cmdID {
 	case "new":
 		e.cmdNew(p, msg, args)
+	case "resume":
+		e.cmdResume(p, msg, args)
 	case "list":
 		e.cmdList(p, msg, args)
 	case "switch":
@@ -3565,6 +3583,169 @@ func filterOwnedSessions(sessions []AgentSessionInfo, known map[string]struct{})
 		}
 	}
 	return filtered
+}
+
+// resumePickerLimit is the maximum number of prior workspace sessions
+// shown to the user by /resume. Enough to cover a day or two of work
+// without blowing out the mobile screen.
+const resumePickerLimit = 10
+
+// cmdResume implements the /resume slash command.
+//
+// Two modes:
+//
+//   - /resume            — list up to resumePickerLimit of the most recent
+//                          workspace sessions known to the agent backend.
+//                          Each row shows the numbered index, a relative
+//                          timestamp, the session's opening user message,
+//                          and (indented on a second line) the most recent
+//                          user message so the user can identify a drifted
+//                          long-running session by both its origin and its
+//                          current topic. The session IDs are stashed on
+//                          the Session object as pendingResumeCandidates
+//                          for the next invocation to resolve.
+//
+//   - /resume <n>        — pick the Nth candidate from the last list. Starts
+//                          a new cc-connect session with --resume <id>
+//                          --fork-session via the ResumeForkPrefix sentinel
+//                          so the source session is not mutated (it may
+//                          still be live in a terminal or another Slack
+//                          conversation). Cleans up any prior interactive
+//                          state for this session_key first.
+//
+// TODO: i18n. First cut uses hardcoded English strings. Once the feature
+// shape stabilises, promote these to MsgKey constants in core/i18n.go.
+func (e *Engine) cmdResume(p Platform, msg *Message, args []string) {
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	session := sessions.GetOrCreateActive(msg.SessionKey)
+
+	// Pick mode: /resume <n>
+	if len(args) > 0 {
+		n, parseErr := strconv.Atoi(strings.TrimSpace(args[0]))
+		if parseErr != nil || n < 1 {
+			e.reply(p, msg.ReplyCtx,
+				"/resume <n> expects a positive integer picked from the list. Run /resume with no args first to see the options.")
+			return
+		}
+		sessionID, ok := session.TakePendingResumeCandidate(n)
+		if !ok {
+			e.reply(p, msg.ReplyCtx,
+				"No /resume list is pending — run /resume with no args to see the candidates, then pick one.")
+			return
+		}
+
+		// Safe to fork off the picked session: the source session (which may
+		// be a live terminal session) is never mutated because claudecode
+		// strips the ResumeForkPrefix and passes --fork-session to claude.
+		slog.Info("cmdResume: picking candidate",
+			"session_key", msg.SessionKey,
+			"picked_session_id", sessionID,
+			"index", n,
+		)
+
+		e.cleanupInteractiveState(interactiveKey)
+
+		// Arm the next StartSession call on this session to fork off the
+		// picked session. We deliberately do NOT stash the fork sentinel in
+		// AgentSessionID — that field is persisted to disk and a crash in
+		// the window between here and the first message would leave a
+		// stale sentinel on the next startup. forkOnNextStart is a
+		// transient field that survives only in memory; worst case is
+		// cc-connect crashes and the user re-picks from a fresh /resume.
+		//
+		// Clear the existing AgentSessionID so the engine's normal resume
+		// path does not race ahead of the fork. The engine consumes
+		// forkOnNextStart before falling back to AgentSessionID, but
+		// clearing it removes the fallback entirely and makes the logged
+		// state easier to reason about.
+		session.SetAgentInfo("", agent.Name(), "")
+		session.SetForkOnNextStart(sessionID)
+		sessions.Save()
+
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(
+			"Forked from session #%d. Your next message will branch off that session's context — the original is unchanged.",
+			n,
+		))
+		return
+	}
+
+	// List mode: /resume (no args)
+	agentSessions, err := agent.ListSessions(e.ctx)
+	if err != nil {
+		session.ClearPendingResumeCandidates()
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf("/resume: could not list workspace sessions: %v", err))
+		return
+	}
+
+	// Filter out the session the user is currently in — offering "resume
+	// the conversation you are literally having right now" is nonsensical
+	// and wastes a picker slot. We compare against the session-store's
+	// AgentSessionID because the live agentSession's CurrentSessionID may
+	// not be reachable from this synchronous command path.
+	currentID := session.GetAgentSessionID()
+	if currentID != "" {
+		filtered := agentSessions[:0]
+		for _, s := range agentSessions {
+			if s.ID != currentID {
+				filtered = append(filtered, s)
+			}
+		}
+		agentSessions = filtered
+	}
+
+	if len(agentSessions) == 0 {
+		session.ClearPendingResumeCandidates()
+		e.reply(p, msg.ReplyCtx,
+			"/resume: no prior sessions found in this workspace. Start talking and one will be created.")
+		return
+	}
+
+	if len(agentSessions) > resumePickerLimit {
+		agentSessions = agentSessions[:resumePickerLimit]
+	}
+
+	ids := make([]string, 0, len(agentSessions))
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("*Recent sessions in this workspace* (showing %d of the most recent):\n", len(agentSessions)))
+	for i, s := range agentSessions {
+		ids = append(ids, s.ID)
+		rel := formatRelativeAge(time.Since(s.ModifiedAt))
+		first := s.FirstSummary
+		if first == "" {
+			first = "(no opening user message)"
+		}
+		last := s.Summary
+		fmt.Fprintf(&b, "%2d. %s  — \"%s\"\n", i+1, rel, first)
+		if last != "" && last != s.FirstSummary {
+			fmt.Fprintf(&b, "     ↳ \"%s\"\n", last)
+		}
+	}
+	b.WriteString("\nType `/resume <n>` to fork the chosen session into this conversation. The source session will not be modified.")
+
+	session.SetPendingResumeCandidates(ids)
+	e.reply(p, msg.ReplyCtx, b.String())
+}
+
+// formatRelativeAge renders a duration as a compact human-readable string
+// for the /resume picker rows ("2m ago", "1h ago", "3d ago", etc.).
+func formatRelativeAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d/time.Minute))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d/time.Hour))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d/(24*time.Hour)))
+	default:
+		return fmt.Sprintf("%dw ago", int(d/(7*24*time.Hour)))
+	}
 }
 
 const listPageSize = 20
@@ -5026,6 +5207,7 @@ func helpCardGroups() []helpCardGroup {
 			titleKey: MsgHelpSessionSection,
 			items: []helpCardItem{
 				{command: "/new", action: "act:/new"},
+				{command: "/resume", action: "cmd:/resume"},
 				{command: "/list", action: "nav:/list"},
 				{command: "/current", action: "nav:/current"},
 				{command: "/switch", action: "nav:/list"},

--- a/core/message.go
+++ b/core/message.go
@@ -211,9 +211,17 @@ type HistoryEntry struct {
 }
 
 // AgentSessionInfo describes one session as reported by the agent backend.
+//
+// Summary historically carries the LAST user message in the session, which
+// is what /list and /switch want (the most recent topic). FirstSummary was
+// added for /resume, which wants the ORIGINAL user message so the user can
+// recognise a session by how it started, not by wherever it happens to be
+// right now — a live terminal session in particular is constantly drifting
+// and its "latest" message is noisy as an identifier.
 type AgentSessionInfo struct {
 	ID           string
-	Summary      string
+	Summary      string // latest user message (≈40 chars, trimmed)
+	FirstSummary string // first user message (≈40 chars, trimmed)
 	MessageCount int
 	ModifiedAt   time.Time
 	GitBranch    string

--- a/core/session.go
+++ b/core/session.go
@@ -14,6 +14,14 @@ import (
 // to use --continue (resume most recent session) instead of a specific session ID.
 const ContinueSession = "__continue__"
 
+// ResumeForkPrefix marks a session ID that should be resumed with --fork-session
+// instead of plain --resume. Agents that support forking strip this prefix before
+// passing the real UUID to their backend CLI. Used by the /resume slash command
+// to let the user explicitly pick a prior workspace session — terminal-owned or
+// otherwise — and branch off its context into a fresh cc-connect conversation
+// without mutating the source session if it is still live somewhere else.
+const ResumeForkPrefix = "__fork:"
+
 // Session tracks one conversation between a user and the agent.
 type Session struct {
 	ID             string         `json:"id"`
@@ -23,6 +31,30 @@ type Session struct {
 	History        []HistoryEntry `json:"history"`
 	CreatedAt      time.Time      `json:"created_at"`
 	UpdatedAt      time.Time      `json:"updated_at"`
+
+	// pendingResumeCandidates is the in-memory list of workspace session IDs
+	// shown to the user by the most recent `/resume` (no-arg) invocation. The
+	// next `/resume <n>` call resolves <n> against this slice. Transient — not
+	// persisted across cc-connect restarts (unexported field = invisible to
+	// the session-store snapshot writer). Dropped implicitly on /new, because
+	// /new allocates a brand-new Session object and the old one with its
+	// pending candidates becomes unreachable. Order matches the picker's
+	// numbering: 1-based in the UI (`/resume 1` is the top of the list),
+	// 0-based in this slice.
+	pendingResumeCandidates []string
+
+	// forkOnNextStart, if non-empty, carries a backend session ID that the
+	// next StartSession call should resume with --fork-session instead of
+	// resuming whatever AgentSessionID points at. Populated by /resume <n>;
+	// consumed and cleared by the engine when it next spawns an interactive
+	// state for this session. Transient by design — we do NOT stash the
+	// sentinel inside AgentSessionID because that field is persisted to
+	// disk by the session-store snapshot writer and a crash in the narrow
+	// window between /resume pick and first message would leave a stale
+	// sentinel on disk that replays incorrectly on next startup. Keeping
+	// it in its own unexported field means a crash simply drops the
+	// pending fork and the user can re-pick from a fresh /resume list.
+	forkOnNextStart string
 
 	mu   sync.Mutex `json:"-"`
 	busy bool       `json:"-"`
@@ -152,6 +184,67 @@ func (s *Session) GetHistory(n int) []HistoryEntry {
 	out := make([]HistoryEntry, n)
 	copy(out, s.History[total-n:])
 	return out
+}
+
+// SetPendingResumeCandidates stores the list of workspace session IDs presented
+// to the user by `/resume` (no-arg). The next `/resume <n>` resolves <n> against
+// this list. Passing nil clears the pending state.
+func (s *Session) SetPendingResumeCandidates(ids []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(ids) == 0 {
+		s.pendingResumeCandidates = nil
+		return
+	}
+	cpy := make([]string, len(ids))
+	copy(cpy, ids)
+	s.pendingResumeCandidates = cpy
+}
+
+// ClearPendingResumeCandidates drops any pending /resume picker state. Called
+// from any non-/resume-pick code path so the picker can't be resolved stale
+// after unrelated messages have been exchanged.
+func (s *Session) ClearPendingResumeCandidates() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pendingResumeCandidates = nil
+}
+
+// TakePendingResumeCandidate atomically returns and clears the pending resume
+// candidate at the given 1-based index (matching the picker UI). Returns the
+// session ID and true on success; empty string and false if the index is out
+// of range or no picker is pending.
+func (s *Session) TakePendingResumeCandidate(oneBasedIndex int) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if oneBasedIndex < 1 || oneBasedIndex > len(s.pendingResumeCandidates) {
+		return "", false
+	}
+	id := s.pendingResumeCandidates[oneBasedIndex-1]
+	s.pendingResumeCandidates = nil
+	return id, true
+}
+
+// SetForkOnNextStart arms the next StartSession call on this session to use
+// --resume <id> --fork-session (via the ResumeForkPrefix sentinel passed
+// through to the agent). Transient; not persisted.
+func (s *Session) SetForkOnNextStart(backendSessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.forkOnNextStart = backendSessionID
+}
+
+// ConsumeForkOnNextStart atomically returns the pending fork-resume target,
+// if any, and clears it. Called by the engine just before it decides what
+// session ID to hand to agent.StartSession. Returns empty string if no fork
+// is pending, in which case the caller falls back to the normal
+// AgentSessionID resume path.
+func (s *Session) ConsumeForkOnNextStart() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := s.forkOnNextStart
+	s.forkOnNextStart = ""
+	return id
 }
 
 // UserMeta stores human-readable display info for a session key.


### PR DESCRIPTION
## Summary

Adds an explicit, two-step \`/resume\` flow that lets a user pick a prior workspace session — including terminal-run sessions on the same Unix user's filesystem — and branch off its context into the current cc-connect conversation. Designed as a deliberate, opt-in alternative to the removed implicit continue-bridge (\`4015259\`, killed by \`6d8bf93\`).

## UX

\`/resume\` (no args) — lists up to 10 recent workspace sessions known to the agent backend, numbered, with a relative timestamp, the opening user message, and (indented) the most recent user message. The current session is shown with a \`*(current)*\` marker so it's not mysteriously missing from the chronological ordering.

\`\`\`
*Recent sessions in this workspace* (showing 5 of the most recent):
 1. 2m ago *(current)*  — \"ok welcome back\"
     ↳ \"por que nos dos?\"
 2. 15m ago  — \"let me check the journal\"
 3. 1h ago  — \"fix restart.sh\"
 4. 3h ago  — \"rebuild cc-connect properly\"
 5. 5h ago  — \"ok I want cc-connect to be aware of sessions\"

Type \`/resume <n>\` to fork the chosen session into this conversation. The source session will not be modified.
\`\`\`

\`/resume <n>\` — picks the Nth candidate from the last list. Arms \`Session.forkOnNextStart\` with the backend session ID. On the next user message the engine consumes that field and spawns claude with \`--resume <id> --fork-session\` via a new \`ResumeForkPrefix\` sentinel, so the source session (which may still be live in a terminal or another conversation) is never mutated — the Slack reply branches off into its own independent timeline.

## Why a picker, not an implicit continue

The previous implicit continue-bridge fired on first-contact-per-engine-lifetime regardless of user intent, and could happily resurrect weeks-old context. \`/resume\` is opt-in: the user sees synopses before picking and the default behaviour is fresh-session-by-default. The picker presents **both the first user message and the most recent user message** per session so a session that has drifted topic is still recognisable by its origin — first-only would lose long-running sessions; last-only would lose just-started ones.

## Key structural decisions

- **Fork sentinel lives in a separate transient field** (\`Session.forkOnNextStart\`, unexported, never serialised) rather than in \`AgentSessionID\`. \`AgentSessionID\` is persisted to disk by the session-store snapshot writer, and stashing a sentinel there would leave stale state on disk if cc-connect crashes in the narrow window between \`/resume\` pick and the first forwarded message. The transient field drops on crash — worst case the user re-picks from a fresh \`/resume\` list.
- **\`ResumeForkPrefix\` (\`__fork:<uuid>\`)** is the cross-package carrier from engine to agent. The claudecode agent strips the prefix and passes \`--resume <uuid> --fork-session\` to claude. Other agents that don't support forking ignore the prefix and fall back to plain \`--resume\`; acceptable because only claudecode supports forked resume today.
- **\`AgentSessionInfo\` gains a \`FirstSummary\` field** alongside the existing \`Summary\` (which is \"latest user message\" — what \`/list\` and \`/switch\` want). \`scanSessionMeta\` now tracks both, and the summary truncation helper was extracted into \`truncateSummaryForList\` so first and last summaries are normalised identically.
- **The engine consumes \`forkOnNextStart\` immediately before** its existing \`startSessionID\` lookup, so the override path and the normal resume path share fallback semantics: if the fork spawn fails, the engine's existing \"try fresh after resume failure\" branch kicks in.

## Scope caveats

- **Sandbox users** (e.g. when cc-connect spawns as a non-supervisor user via \`run_as_user\`) only see their own \`~/.claude/projects\` sessions — they cannot read the supervisor user's terminal session JSONL if the supervisor's home is mode 700. That is by design of any POSIX-isolation setup; full visibility is available in sessions that run as the same user owning the terminal.
- **i18n**: hardcoded English strings for now. Happy to promote to \`MsgKey\` constants in a follow-up once the feature shape stabilises.
- **Unit tests for \`cmdResume\`**: not included in this PR. The existing \`stubListAgent\` fixture can be extended in a follow-up once the UX is settled in real use.

## Help card

\`/resume\` added to the session group so it shows in \`/help\` output.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./core/... ./agent/claudecode/...\` (no regressions)
- [x] Manual: \`/resume\` lists prior workspace sessions; \`/resume <n>\` forks; subsequent message inherits context from the picked session

🤖 Generated with [Claude Code](https://claude.com/claude-code)