### PR TITLE
fix(core): /cron list shows all project cron jobs instead of session-…

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -8067,7 +8067,7 @@ func (e *Engine) cmdCronAddExec(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdCronList(p Platform, msg *Message) {
-	jobs := e.cronScheduler.Store().ListBySessionKey(msg.SessionKey)
+	jobs := e.cronScheduler.Store().ListByProject(e.name)
 	if len(jobs) == 0 {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgCronEmpty))
 		return


### PR DESCRIPTION
## Summary

  `/cron list` returns empty results when used in group chat with
  `thread_isolation` enabled.

  ## Problem

  When `thread_isolation = true`, every standalone group message gets a unique
  session key in the format `feishu:{chatID}:root:{messageID}`. Since each message
  has a different ID, the session key is different every time.

  `/cron list` filters jobs by the current message's session key:

  ```go
  jobs := e.cronScheduler.Store().ListBySessionKey(msg.SessionKey)

  This means /cron list only returns results when sent from the exact same session
  (thread) where the cron job was created. In group chat, the session key changes
  with every message, so users can never find their cron jobs via /cron list — they
   have to use the CLI (cc-connect cron list) instead.

  Fix

  Replace ListBySessionKey with ListByProject so /cron list shows all cron jobs for
   the current project, regardless of which session the command is sent from.

  // Before
  jobs := e.cronScheduler.Store().ListBySessionKey(msg.SessionKey)

  // After
  jobs := e.cronScheduler.Store().ListByProject(e.name)

  This is a one-line change. ListByProject already exists and is used by the CLI's
  cron list command.

  Test plan

  - go build ./cmd/cc-connect passes
  - go test ./core/ -run TestCron — all tests pass
  - Manual test: create a cron job, then send /cron list from a different thread or
   group chat — verify it shows the job

  🤖 Generated with https://claude.com/claude-code