### PR TITLE
fix(feishu): cron jobs send new chat messages instead of thread replies

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -2356,6 +2356,20 @@ func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 	return rc, nil
 }
 
+// ResolveCronReplyTarget implements CronReplyTargetResolver. For cron jobs,
+// return a replyContext with only chatID (no messageID) so that Send() uses
+// sendNewMessageToChat instead of ReplyInThread. Without this, cron jobs
+// bound to a thread-isolated session key (feishu:chat:root:msgID) would
+// reply inside a thread rather than posting a new message in the group.
+func (p *Platform) ResolveCronReplyTarget(sessionKey string, title string) (string, any, error) {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) < 2 || parts[0] != p.platformName {
+		return "", nil, fmt.Errorf("%s: invalid session key %q", p.tag(), sessionKey)
+	}
+	rc := replyContext{chatID: parts[1], sessionKey: sessionKey}
+	return sessionKey, rc, nil
+}
+
 func parseThreadRootID(sessionTail string) (string, bool) {
 	for _, prefix := range []string{"root:", "thread:"} {
 		if strings.HasPrefix(sessionTail, prefix) {

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -987,3 +987,55 @@ func TestFormatProgressToolInput_OtherTools(t *testing.T) {
 		t.Errorf("TodoWrite with invalid JSON should fall back to text block, got %q", result)
 	}
 }
+
+func TestResolveCronReplyTarget_ReturnsReplyCtxWithoutMessageID(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	// Session key with root: format (the problematic case)
+	sessionKey := "feishu:oc_chat123:root:om_msg456"
+	_, rctx, err := ip.ResolveCronReplyTarget(sessionKey, "Daily report")
+	if err != nil {
+		t.Fatalf("ResolveCronReplyTarget error = %v", err)
+	}
+
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		t.Fatalf("replyCtx type = %T, want replyContext", rctx)
+	}
+	if rc.chatID != "oc_chat123" {
+		t.Fatalf("chatID = %q, want %q", rc.chatID, "oc_chat123")
+	}
+	if rc.messageID != "" {
+		t.Fatalf("messageID = %q, want empty (so Send uses sendNewMessageToChat)", rc.messageID)
+	}
+}
+
+func TestResolveCronReplyTarget_NonThreadSessionKey(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret",
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+
+	// User-scoped session key (no root:)
+	sessionKey := "feishu:oc_chat123:ou_user789"
+	_, rctx, err := p.(*interactivePlatform).ResolveCronReplyTarget(sessionKey, "Check")
+	if err != nil {
+		t.Fatalf("ResolveCronReplyTarget error = %v", err)
+	}
+
+	rc := rctx.(replyContext)
+	if rc.chatID != "oc_chat123" {
+		t.Fatalf("chatID = %q, want %q", rc.chatID, "oc_chat123")
+	}
+	if rc.messageID != "" {
+		t.Fatalf("messageID = %q, want empty", rc.messageID)
+	}
+}


### PR DESCRIPTION
## Summary                                                                       
                                                                                  
  Cron jobs reply inside a thread instead of posting new messages in group chat    
  when `thread_isolation` is enabled.                                             
                                                                                   
  ## Problem                                                                       
                                     
  When `thread_isolation = true`, every standalone group message gets a session key
   in the format `feishu:{chatID}:root:{messageID}` — even messages without an
  actual thread (`root_id` is empty, so `makeSessionKey` falls back to the         
  message's own ID).                         
                                     
  When a cron job fires with this session key, `ReconstructReplyCtx` extracts the  
  message ID from the `root:` prefix and sets it as `replyContext.messageID`. Then
  `shouldReplyInThread` returns true, and the bot calls                            
  `Im.Message.Reply(messageID, ReplyInThread=true)` — creating a thread on the
  original `/cron add` message instead of posting a new message in the group.
                                                                                  
  User sends "/cron add ..." in group                                              
    → session key: feishu:chat:root:{this_message_id}
    → cron job bound to this session key                                           
                                                                                   
  Cron fires:                                                                      
    → ReconstructReplyCtx extracts messageID from "root:{id}"                      
    → replyContext{chatID: "...", messageID: "{id}"}                               
    → shouldReplyInThread → true (messageID is set + session key has "root:")      
    → Reply(messageID, ReplyInThread=true)                                         
    → Creates thread on the "/cron add" message ✗                                  
                                                                                   
  ## Fix                                                                           
                                                                                   
  Implement the `CronReplyTargetResolver` interface for the Feishu platform. This  
  interface already exists in core (`core/interfaces.go:34`) and is used by Discord
   for similar purposes.                                                           
                                             
  The implementation returns a `replyContext` with only `chatID` (no `messageID`), 
  so `Send()` takes the `sendNewMessageToChat` path instead of `ReplyInThread`:   
                                                                                   
  ```go                                      
  func (p *Platform) ResolveCronReplyTarget(sessionKey string, title string)
  (string, any, error) {                                                           
      parts := strings.SplitN(sessionKey, ":", 3)
      if len(parts) < 2 || parts[0] != p.platformName {                            
          return "", nil, fmt.Errorf("%s: invalid session key %q", p.tag(),        
  sessionKey)                                                                      
      }                                                                            
      rc := replyContext{chatID: parts[1], sessionKey: sessionKey}                 
      return sessionKey, rc, nil                                                   
  }                                                                                
                                                                                   
  No changes to core/ — the fix is entirely within platform/feishu/.               
                                             
  Test plan                                                                        
                                                                                  
  - go build ./cmd/cc-connect passes                                               
  - go test ./platform/feishu/ — all tests pass (2 new tests added)               
  - Manual test: create cron job in group chat, verify it posts new messages       
  instead of replying in a thread                                                  
                                                                                   
  🤖 Generated with https://claude.com/claude-code                                 
  ```                                        
                                                                                   