### PR TITLE
fix(core): use full accumulated text for stream preview finalization when tool messages hidden

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2414,6 +2414,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		case EventToolUse:
 			toolCount++
+			// When tool messages are hidden, insert a visual break between text
+			// segments so the accumulated response doesn't run together.
+			if !e.display.ToolMessages && len(textParts) > segmentStart {
+				textParts = append(textParts, "\n\n")
+				if sp.canPreview() {
+					sp.appendText("\n\n")
+				}
+			}
 			if e.display.ToolMessages {
 				// Flush accumulated text segment before tool display
 				previewActive := sp.canPreview()
@@ -2587,7 +2595,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			}
 
 			fullResponse := event.Content
-			if fullResponse == "" && len(textParts) > 0 {
+			// When tool progress is hidden, segmentStart stays 0 and textParts
+			// contains ALL text across tool boundaries. Prefer the full accumulated
+			// text over event.Content which only contains the last assistant segment.
+			if len(textParts) > 0 && segmentStart == 0 {
+				fullResponse = strings.Join(textParts, "")
+			} else if fullResponse == "" && len(textParts) > 0 {
 				fullResponse = strings.Join(textParts, "")
 			}
 			if fullResponse == "" {


### PR DESCRIPTION
## Summary

- When tool messages are hidden (`quiet = true` or `[display] tool_messages = false`), `segmentStart` stays 0 and the stream preview card accumulates all text across tool boundaries. However, `EventResult` used `event.Content` (which only contains the last assistant segment) to finalize the preview via `finish()`, overwriting the accumulated content with a truncated version.
- Prefer `strings.Join(textParts, "")` over `event.Content` when `segmentStart == 0`, ensuring the final card contains the complete response.
- Insert a visual line break (`\n\n`) between text segments at tool call boundaries when tool messages are hidden, so consecutive segments don't run together without separation.

Closes #549

## Test plan

- [x] `go test ./...` passes
- [x] Manual verification on Feishu/Lark with `quiet = true`: multi-tool-call responses accumulate in a single card without content loss
- [x] Non-quiet mode behavior unchanged (segmentStart advances normally, original code path taken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)