### PR TITLE
feat(discord): support inbound file attachments

### DIFF
--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -551,6 +551,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 
 		var images []core.ImageAttachment
 		var audio *core.AudioAttachment
+		var files []core.FileAttachment
 		for _, att := range m.Attachments {
 			ct := strings.ToLower(att.ContentType)
 			if strings.HasPrefix(ct, "audio/") {
@@ -575,10 +576,19 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 				images = append(images, core.ImageAttachment{
 					MimeType: att.ContentType, Data: data, FileName: att.Filename,
 				})
+			} else {
+				data, err := downloadURL(att.URL)
+				if err != nil {
+					slog.Error("discord: download file attachment failed", "url", att.URL, "error", err)
+					continue
+				}
+				files = append(files, core.FileAttachment{
+					MimeType: att.ContentType, Data: data, FileName: att.Filename,
+				})
 			}
 		}
 
-		if m.Content == "" && len(images) == 0 && audio == nil {
+		if m.Content == "" && len(images) == 0 && audio == nil && len(files) == 0 {
 			return
 		}
 
@@ -587,7 +597,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			MessageID: m.ID,
 			UserID:    m.Author.ID, UserName: m.Author.Username,
 			ChatName: p.resolveChannelName(m.ChannelID),
-			Content:  m.Content, Images: images, Audio: audio, ReplyCtx: rctx,
+			Content:  m.Content, Images: images, Files: files, Audio: audio, ReplyCtx: rctx,
 		}
 		p.dispatchMessage(msg)
 	})


### PR DESCRIPTION
## Summary
- Discord platform previously only handled audio and image attachments from incoming messages
- Non-image, non-audio attachments (PDFs, documents, code files, etc.) were silently dropped
- Added an `else` branch in the attachment loop to capture them as `core.FileAttachment`
- Also updated the empty-message guard to account for file-only messages
- This matches the behavior already present in the Telegram platform (`telegram.go:453`)

## Changes
- `platform/discord/discord.go`: Added `files []core.FileAttachment` collection in the `MessageCreate` handler, with download + error logging for non-image/non-audio attachments

## Test plan
- [x] `go test ./platform/discord/` passes
- [x] `go build ./...` passes
- [x] Manual test: sent PDF via Discord DM, confirmed `has_files=true` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)