### PR TITLE
fix(core): ExtraContent lost after alias resolution

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1343,8 +1343,9 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		}
 	}
 
-	// Resolve aliases: check if the first word (or whole content) matches an alias
-	content = e.resolveAlias(content)
+	// Resolve aliases: check if the first word (or whole content) matches an alias.
+	// Use msg.Content which includes ExtraContent prefix (reply quotes, etc.).
+	content = e.resolveAlias(msg.Content)
 	msg.Content = content
 
 	// Rate limit check (per-user role-based, then global fallback)


### PR DESCRIPTION
## Summary
- `ExtraContent` (reply quotes, location text, etc.) was silently discarded during message processing
- Root cause: `handleMessage` correctly prepends `ExtraContent` to `msg.Content`, but the subsequent alias resolution uses the original `content` variable (without `ExtraContent`) and overwrites `msg.Content`
- Fix: pass `msg.Content` (which includes `ExtraContent`) to `resolveAlias` instead of the original `content` variable

## Bug reproduction
1. User replies to a message in Discord (or any platform that sets `ExtraContent`)
2. `enrichReplyContent` correctly returns `[Reply to user]: original message`
3. Line 1342 correctly sets `msg.Content = ExtraContent + "\n" + content`
4. **Bug**: Line 1347 `content = e.resolveAlias(content)` uses the original `content` without `ExtraContent`
5. Line 1348 `msg.Content = content` overwrites the enriched content — reply context is lost
6. Agent never sees what the user was replying to

## Changes
- `core/engine.go`: Changed `resolveAlias(content)` → `resolveAlias(msg.Content)` (1 line)

## Test plan
- [x] `go test ./core/ -run Alias` passes
- [x] `go build ./...` passes
- [x] Manual test: Discord reply now correctly delivers quoted context to the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)