### PR TITLE
fix(core): resolve workspace for cron prompt-mode jobs in multi-workspace mode

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -926,6 +926,36 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		ModeOverride: job.Mode,
 	}
 
+	// Resolve workspace-specific agent and sessions for multi-workspace mode.
+	// Priority: job.WorkDir (explicit) > workspace binding > global agent fallback.
+	agent := e.agent
+	sessions := e.sessions
+	workspaceDir := ""
+
+	if e.multiWorkspace {
+		channelID := extractChannelID(sessionKey)
+		if channelID != "" {
+			workspace, _, err := e.resolveWorkspace(targetPlatform, channelID)
+			if err == nil && workspace != "" {
+				wsAgent, wsSessions, _, effectiveDir, err := e.workspaceContext(workspace, sessionKey)
+				if err == nil {
+					agent = wsAgent
+					sessions = wsSessions
+					workspaceDir = effectiveDir
+				}
+			}
+		}
+	}
+
+	if job.WorkDir != "" {
+		wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(job.WorkDir)
+		if err == nil {
+			agent = wsAgent
+			sessions = wsSessions
+			workspaceDir = job.WorkDir
+		}
+	}
+
 	useNewSession := false
 	if e.cronScheduler != nil {
 		useNewSession = e.cronScheduler.UsesNewSession(job)
@@ -935,22 +965,29 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 
 	if useNewSession {
 		msg.SessionKey = runSessionKey
-		session := e.sessions.NewSideSession(runSessionKey, "cron-"+job.ID)
+		session := sessions.NewSideSession(runSessionKey, "cron-"+job.ID)
 		if !session.TryLock() {
 			return fmt.Errorf("session %q is busy", runSessionKey)
 		}
 		iKey := fmt.Sprintf("%s#cron:%s", runSessionKey, session.ID)
-		e.processInteractiveMessageWith(effectivePlatform, msg, session, e.agent, e.sessions, iKey, "", runSessionKey)
+		if workspaceDir != "" {
+			iKey = workspaceDir + ":" + iKey
+		}
+		e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, runSessionKey)
 		e.cleanupInteractiveState(iKey)
 		return nil
 	}
 
-	session := e.sessions.GetOrCreateActive(sessionKey)
+	session := sessions.GetOrCreateActive(sessionKey)
 	if !session.TryLock() {
 		return fmt.Errorf("session %q is busy", sessionKey)
 	}
 
-	e.processInteractiveMessageWith(effectivePlatform, msg, session, e.agent, e.sessions, sessionKey, "", sessionKey)
+	iKey := sessionKey
+	if workspaceDir != "" {
+		iKey = workspaceDir + ":" + sessionKey
+	}
+	e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, sessionKey)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

In multi-workspace mode, `ExecuteCronJob()` for prompt (non-shell) jobs always used the global `e.agent` and passed an empty `workspaceDir` to `processInteractiveMessageWith()`. This caused the Claude Code agent to start with the wrong working directory (typically `~/.cc-connect`) instead of the workspace bound to the cron job's channel.

The fix mirrors `handleMessage()`'s workspace resolution logic:

1. Extract `channelID` from the cron job's `sessionKey`
2. Resolve the workspace binding via `resolveWorkspace()`
3. Get a workspace-specific agent/sessions via `workspaceContext()`
4. Pass the resolved agent and `workspaceDir` to `processInteractiveMessageWith()`

`job.WorkDir`, when explicitly set, takes highest priority as an override.

**Priority chain**: `job.WorkDir` (explicit) → workspace binding resolution → global agent fallback

Closes #555

## Related

- #474 — fixed workspace-prefixed session key parsing in `ExecuteCronJob()`, but did not add workspace agent resolution
- #505 — introduced `resolveChannelWorkDir()` and `workspaceContext()` which provide the infrastructure this fix wires into

## Test plan

- [x] `go test ./core/ -count=1` — all tests pass
- [x] `go build ./...` — clean build
- [x] Manually verified: cron prompt jobs now execute in the correct workspace directory (confirmed via `gitStatus` in agent context)
- [x] Verified `job.WorkDir` override takes precedence when explicitly set
- [x] Verified non-multi-workspace mode is unaffected (falls through to global agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)