### PR TITLE
feat(core): retry agent turns on rate-limit and overloaded errors

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -167,19 +167,24 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 
 func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
 	defer func() {
-		cs.alive.Store(false)
 		if err := cs.cmd.Wait(); err != nil {
 			stderrMsg := strings.TrimSpace(stderrBuf.String())
 			if stderrMsg != "" {
-				slog.Error("claudeSession: process failed", "error", err, "stderr", stderrMsg)
-				evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
+				kind := core.ClassifyAnthropicError(stderrMsg)
+				slog.Error("claudeSession: process failed", "error", err, "stderr", stderrMsg, "kind", kind)
+				evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg), ErrorKind: kind}
 				select {
 				case cs.events <- evt:
 				case <-cs.ctx.Done():
-					return
 				}
 			}
 		}
+		// Mark dead only after the process has fully exited (cmd.Wait
+		// returned). Previously alive was set before Wait, leaving a
+		// window where Alive()==false but the process was still running,
+		// causing getOrCreateInteractiveStateWith to spawn a replacement
+		// without killing the old one → zombie Claude processes.
+		cs.alive.Store(false)
 		close(cs.events)
 		close(cs.done)
 	}()
@@ -324,6 +329,33 @@ func (cs *claudeSession) handleResult(raw map[string]any) {
 	}
 	if sid, ok := raw["session_id"].(string); ok && sid != "" {
 		cs.sessionID.Store(sid)
+	}
+
+	// Claude Code's stream-json schema: result events carry a `subtype` field
+	// (e.g. "success", "error_during_execution", "error_max_turns",
+	// "error_max_budget_usd", "error_max_structured_output_retries") and an
+	// `is_error` boolean. When the turn failed at the API layer, route through
+	// EventError so the engine can decide whether to retry (e.g. on 429).
+	subtype, _ := raw["subtype"].(string)
+	isErr, _ := raw["is_error"].(bool)
+	if isErr || (subtype != "" && subtype != "success") {
+		errMsg := content
+		if errMsg == "" {
+			errMsg = subtype
+		}
+		kind := core.ClassifyAnthropicError(content)
+		slog.Error("claudeSession: result error", "subtype", subtype, "is_error", isErr, "kind", kind, "msg", errMsg)
+		evt := core.Event{
+			Type:      core.EventError,
+			Error:     fmt.Errorf("%s", errMsg),
+			ErrorKind: kind,
+			SessionID: cs.CurrentSessionID(),
+		}
+		select {
+		case cs.events <- evt:
+		case <-cs.ctx.Done():
+		}
+		return
 	}
 
 	var inputTokens, outputTokens int

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -65,3 +65,123 @@ func TestHandleResultNoUsage(t *testing.T) {
 		t.Errorf("OutputTokens = %d, want 0", evt.OutputTokens)
 	}
 }
+
+// TestHandleResultSuccessSubtype ensures a successful result still routes
+// through EventResult, not EventError.
+func TestHandleResultSuccessSubtype(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("s1")
+	cs.alive.Store(true)
+
+	raw := map[string]any{
+		"type":    "result",
+		"subtype": "success",
+		"result":  "all good",
+	}
+	cs.handleResult(raw)
+	evt := <-cs.events
+	if evt.Type != core.EventResult {
+		t.Fatalf("Type = %v, want EventResult", evt.Type)
+	}
+	if evt.ErrorKind != core.ErrorKindUnknown {
+		t.Errorf("ErrorKind = %q, want empty", evt.ErrorKind)
+	}
+}
+
+// TestHandleResultRateLimitClassified verifies a result event carrying an
+// Anthropic rate_limit_error payload is surfaced as EventError with
+// ErrorKindRateLimit so the engine can schedule a retry.
+func TestHandleResultRateLimitClassified(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("s1")
+	cs.alive.Store(true)
+
+	raw := map[string]any{
+		"type":     "result",
+		"subtype":  "error_during_execution",
+		"is_error": true,
+		"result":   `{"error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`,
+	}
+	cs.handleResult(raw)
+	evt := <-cs.events
+	if evt.Type != core.EventError {
+		t.Fatalf("Type = %v, want EventError", evt.Type)
+	}
+	if evt.ErrorKind != core.ErrorKindRateLimit {
+		t.Errorf("ErrorKind = %q, want %q", evt.ErrorKind, core.ErrorKindRateLimit)
+	}
+	if evt.Error == nil {
+		t.Fatal("Error is nil")
+	}
+}
+
+// TestHandleResultOverloadedClassified verifies 529/overloaded_error is
+// classified as ErrorKindOverloaded.
+func TestHandleResultOverloadedClassified(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("s1")
+	cs.alive.Store(true)
+
+	raw := map[string]any{
+		"type":     "result",
+		"subtype":  "error_during_execution",
+		"is_error": true,
+		"result":   `{"error":{"type":"overloaded_error","message":"overloaded"}}`,
+	}
+	cs.handleResult(raw)
+	evt := <-cs.events
+	if evt.Type != core.EventError {
+		t.Fatalf("Type = %v, want EventError", evt.Type)
+	}
+	if evt.ErrorKind != core.ErrorKindOverloaded {
+		t.Errorf("ErrorKind = %q, want %q", evt.ErrorKind, core.ErrorKindOverloaded)
+	}
+}
+
+// TestHandleResultMaxTurnsNotRetriable verifies error_max_turns surfaces as
+// EventError but with ErrorKindUnknown (not retriable) — the engine must
+// fall through to the normal error path, not spin forever.
+func TestHandleResultMaxTurnsNotRetriable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("s1")
+	cs.alive.Store(true)
+
+	raw := map[string]any{
+		"type":     "result",
+		"subtype":  "error_max_turns",
+		"is_error": true,
+		"result":   "Reached max turns",
+	}
+	cs.handleResult(raw)
+	evt := <-cs.events
+	if evt.Type != core.EventError {
+		t.Fatalf("Type = %v, want EventError", evt.Type)
+	}
+	if evt.ErrorKind != core.ErrorKindUnknown {
+		t.Errorf("ErrorKind = %q, want empty/unknown", evt.ErrorKind)
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -2005,32 +2005,100 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 		}
 	}()
 
-	// Drain any stale events left in the channel from a previous turn.
-	// This prevents the next processInteractiveEvents from reading an old
-	// EventResult that was pushed after the previous turn already returned.
-	drainEvents(state.agentSession.Events())
-
 	promptContent := e.buildSenderPrompt(msg.Content, msg.UserID, msg.Platform, msg.SessionKey)
 
-	sendStart := time.Now()
-	state.mu.Lock()
-	state.fromVoice = msg.FromVoice
-	state.sideText = ""
-	state.mu.Unlock()
+	// Retry loop: on retriable backend errors (429 rate limit, 529
+	// overloaded), wait and re-run the turn on a fresh agent session via
+	// --resume. The loop stays inside the same session lock, so queued
+	// messages remain queued across the wait.
+	for attempt := 1; ; attempt++ {
+		if state.agentSession == nil {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFailedToStartAgentSession))
+			return
+		}
 
-	// Run Send concurrently with processInteractiveEvents. Some agents block inside
-	// Send until the prompt turn finishes (e.g. ACP session/prompt); they may emit
-	// EventPermissionRequest while blocked — the event loop must run in parallel.
-	sendDone := make(chan error, 1)
-	go func() {
-		sendDone <- state.agentSession.Send(promptContent, msg.Images, msg.Files)
-	}()
+		// Drain any stale events left in the channel from a previous turn
+		// or failed attempt. This prevents the next processInteractiveEvents
+		// from reading an old EventResult that was pushed after the previous
+		// turn already returned.
+		drainEvents(state.agentSession.Events())
 
-	e.processInteractiveEvents(state, session, sessions, interactiveKey, msg.MessageID, turnStart, stopTyping, sendDone, msg.ReplyCtx)
-	if elapsed := time.Since(sendStart); elapsed >= slowAgentSend {
-		slog.Warn("slow agent send", "elapsed", elapsed, "session", msg.SessionKey, "content_len", len(msg.Content))
+		sendStart := time.Now()
+		state.mu.Lock()
+		state.fromVoice = msg.FromVoice
+		state.sideText = ""
+		state.mu.Unlock()
+
+		// Run Send concurrently with processInteractiveEvents. Some agents block inside
+		// Send until the prompt turn finishes (e.g. ACP session/prompt); they may emit
+		// EventPermissionRequest while blocked — the event loop must run in parallel.
+		sendDone := make(chan error, 1)
+		go func() {
+			sendDone <- state.agentSession.Send(promptContent, msg.Images, msg.Files)
+		}()
+
+		retriable := e.processInteractiveEvents(state, session, sessions, interactiveKey, msg.MessageID, turnStart, stopTyping, sendDone, msg.ReplyCtx)
+		if elapsed := time.Since(sendStart); elapsed >= slowAgentSend {
+			slog.Warn("slow agent send", "elapsed", elapsed, "session", msg.SessionKey, "content_len", len(msg.Content))
+		}
+		stopTyping = nil // ownership transferred; prevent defer from double-stopping
+
+		if !retriable.IsRetriable() {
+			// Success or non-retriable error — done with this turn.
+			break
+		}
+
+		if attempt >= RateLimitMaxAttempts {
+			// Cap reached; tell the user we're giving up.
+			approxMinutes := (RateLimitInitialDelay + time.Duration(RateLimitMaxAttempts-1)*RateLimitRetryDelay) / time.Minute
+			e.send(p, msg.ReplyCtx, e.i18n.Tf(MsgAgentRateLimitedGaveUp, RateLimitMaxAttempts, int(approxMinutes)))
+			slog.Error("agent rate-limit retry exhausted",
+				"kind", retriable, "attempts", RateLimitMaxAttempts, "session_key", interactiveKey)
+			break
+		}
+
+		delay := RateLimitInitialDelay
+		if attempt > 1 {
+			delay = RateLimitRetryDelay
+		}
+		slog.Warn("agent rate-limit retry scheduled",
+			"kind", retriable, "attempt", attempt, "max", RateLimitMaxAttempts,
+			"delay", delay, "session_key", interactiveKey)
+		e.send(p, msg.ReplyCtx, e.i18n.Tf(MsgAgentRateLimitedRetry, attempt, RateLimitMaxAttempts, int(delay.Seconds())))
+
+		// Wait out the delay. /stop (state.stopSignal) and engine shutdown
+		// both interrupt the wait.
+		select {
+		case <-time.After(delay):
+		case <-e.ctx.Done():
+			return
+		case <-state.stopSignal():
+			return
+		}
+
+		// Recycle the dead agent session. getOrCreateInteractiveStateWith
+		// will spawn a new `claude` process with --resume <session-id> when
+		// the stored Session has an agent session ID.
+		e.interactiveMu.Lock()
+		if current, ok := e.interactiveStates[interactiveKey]; ok && current == state {
+			state.markStopped()
+			e.closeAgentSessionWithTimeout(interactiveKey, state.agentSession)
+			delete(e.interactiveStates, interactiveKey)
+		}
+		e.interactiveMu.Unlock()
+
+		state = e.getOrCreateInteractiveStateWith(interactiveKey, p, msg.ReplyCtx, session, sessions, agentOverride, ccSessionKey)
+		if state.agentSession == nil {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFailedToStartAgentSession))
+			return
+		}
+
+		// Fresh typing indicator for the retry attempt. The previous one
+		// was either stopped by the event loop or by the prior iteration.
+		if ti, ok := p.(TypingIndicator); ok {
+			stopTyping = ti.StartTyping(e.ctx, msg.ReplyCtx)
+		}
 	}
-	stopTyping = nil // ownership transferred; prevent defer from double-stopping
 
 	// Guard against a narrow race: a message may have been queued between
 	// processInteractiveEvents observing an empty queue and returning here
@@ -2145,31 +2213,38 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	defer e.interactiveMu.Unlock()
 
 	state, ok := e.interactiveStates[sessionKey]
-	if ok && state.agentSession != nil && state.agentSession.Alive() {
-		// Verify the running agent session matches the current active session.
-		// After /new or /switch the active session changes, but the old agent
-		// process may still be alive. Reusing it would send messages to the
-		// wrong conversation context.
-		wantID := session.GetAgentSessionID()
-		currentID := state.agentSession.CurrentSessionID()
-		// Reuse only when the live process matches what the Session expects:
-		// - IDs match (same Claude session), or
-		// - the process has not reported an ID yet (startup; empty want is OK).
-		// If wantID is empty (/new, cleared session) but the process already has
-		// a concrete ID, reusing would keep --resume context — recycle (#238).
-		needRecycle := currentID != "" && (wantID == "" || wantID != currentID)
-		if !needRecycle {
-			return state
+	if ok && state.agentSession != nil {
+		if state.agentSession.Alive() {
+			// Verify the running agent session matches the current active session.
+			// After /new or /switch the active session changes, but the old agent
+			// process may still be alive. Reusing it would send messages to the
+			// wrong conversation context.
+			wantID := session.GetAgentSessionID()
+			currentID := state.agentSession.CurrentSessionID()
+			// Reuse only when the live process matches what the Session expects:
+			// - IDs match (same Claude session), or
+			// - the process has not reported an ID yet (startup; empty want is OK).
+			// If wantID is empty (/new, cleared session) but the process already has
+			// a concrete ID, reusing would keep --resume context — recycle (#238).
+			needRecycle := currentID != "" && (wantID == "" || wantID != currentID)
+			if !needRecycle {
+				return state
+			}
+			// Tear down the stale agent so we start one that matches the Session below.
+			slog.Info("interactive session mismatch, recycling",
+				"session_key", sessionKey,
+				"want_agent_session", wantID,
+				"have_agent_session", currentID,
+			)
+		} else {
+			slog.Info("closing dead agent session before replacement",
+				"session_key", sessionKey)
 		}
-		// Tear down the stale agent so we start one that matches the Session below.
-		slog.Info("interactive session mismatch, recycling",
-			"session_key", sessionKey,
-			"want_agent_session", wantID,
-			"have_agent_session", currentID,
-		)
 		state.markStopped()
 		// Close synchronously to prevent race condition where old agent
 		// continues outputting while new agent starts (issue #327).
+		// Also ensures dead-but-not-yet-exited processes are killed before
+		// we spawn a replacement, preventing zombie Claude processes.
 		e.closeAgentSessionWithTimeout(sessionKey, state.agentSession)
 		delete(e.interactiveStates, sessionKey)
 		ok = false // prevent reading stale settings below
@@ -2341,7 +2416,12 @@ func (e *Engine) closeAgentSessionWithTimeout(sessionKey string, agentSession Ag
 
 const defaultEventIdleTimeout = 2 * time.Hour
 
-func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, msgID string, turnStart time.Time, stopTypingFn func(), sendDone <-chan error, replyCtx any) {
+// processInteractiveEvents runs the event loop for a single turn. When the
+// turn ends with a retriable backend error (e.g. 429 rate_limit_error), it
+// returns the classified ErrorKind so the caller can decide whether to
+// retry after a delay. All other outcomes return ErrorKindUnknown (zero
+// value), whether success, non-retriable error, or channel close.
+func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, msgID string, turnStart time.Time, stopTypingFn func(), sendDone <-chan error, replyCtx any) (retriable ErrorKind) {
 	var textParts []string
 	var segmentStart int // index into textParts: text before this has been sent/displayed
 	toolCount := 0
@@ -2882,6 +2962,25 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			return
 
 		case EventError:
+			// Retriable backend errors (429 rate limit, 529 overloaded):
+			// bubble the classified ErrorKind up to the caller. The caller
+			// (processInteractiveMessageWith) decides whether to wait and
+			// retry or to surface a "gave up" message. The event loop
+			// itself stays simple — no cross-goroutine state, no timers.
+			if event.Error != nil && event.ErrorKind.IsRetriable() {
+				cp.Finalize(ProgressCardStateFailed)
+				sp.discard()
+				slog.Warn("agent retriable error",
+					"kind", event.ErrorKind, "error", event.Error, "session_key", sessionKey)
+				if pendingSend != nil {
+					if err := <-pendingSend; err != nil {
+						slog.Debug("async send error during retriable failure", "error", err)
+					}
+				}
+				retriable = event.ErrorKind
+				return
+			}
+
 			cp.Finalize(ProgressCardStateFailed)
 			sp.discard()
 			if event.Error != nil {
@@ -2934,6 +3033,7 @@ channelClosed:
 			}
 		}
 	}
+	return
 }
 
 // notifyDroppedQueuedMessages drains pendingMessages from the state and

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -8990,3 +8990,451 @@ type stubPlatformWithObserve struct {
 func (s *stubPlatformWithObserve) SendObservation(_ context.Context, _, _ string) error {
 	return nil
 }
+
+// ---------- Rate-limit retry tests ----------
+
+// withShortRateLimitDelays temporarily overrides the package-level
+// retry delays so tests don't have to wait 30 seconds. Restores on cleanup.
+func withShortRateLimitDelays(t *testing.T, initial, retry time.Duration, maxAttempts int) {
+	t.Helper()
+	oldInitial, oldRetry, oldMax := RateLimitInitialDelay, RateLimitRetryDelay, RateLimitMaxAttempts
+	RateLimitInitialDelay = initial
+	RateLimitRetryDelay = retry
+	RateLimitMaxAttempts = maxAttempts
+	t.Cleanup(func() {
+		RateLimitInitialDelay = oldInitial
+		RateLimitRetryDelay = oldRetry
+		RateLimitMaxAttempts = oldMax
+	})
+}
+
+// TestProcessInteractiveEvents_ReturnsRetriableKind verifies that when the
+// event loop observes an EventError with a retriable ErrorKind, it returns
+// the kind to the caller (so the caller can schedule a retry) instead of
+// surfacing the error to the platform.
+func TestProcessInteractiveEvents_ReturnsRetriableKind(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s1")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[sessionKey] = state
+	e.interactiveMu.Unlock()
+
+	agentSession.events <- Event{
+		Type:      EventError,
+		Error:     errors.New(`{"error":{"type":"rate_limit_error"}}`),
+		ErrorKind: ErrorKindRateLimit,
+	}
+
+	var got ErrorKind
+	done := make(chan struct{})
+	go func() {
+		got = e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, "ctx-1")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("processInteractiveEvents did not return after EventError")
+	}
+
+	if got != ErrorKindRateLimit {
+		t.Errorf("returned kind = %q, want %q", got, ErrorKindRateLimit)
+	}
+
+	// Must NOT have surfaced the error as a user-visible message — the caller
+	// (processInteractiveMessageWith) decides whether to retry or show "gave up".
+	for _, s := range p.getSent() {
+		if strings.Contains(s, "Error:") || strings.Contains(s, "错误") {
+			t.Errorf("event loop surfaced error during retriable failure: %q", s)
+		}
+	}
+}
+
+// TestProcessInteractiveEvents_ReturnsUnknownOnNonRetriable verifies that a
+// non-retriable EventError returns ErrorKindUnknown and IS surfaced to the
+// platform as the existing error message.
+func TestProcessInteractiveEvents_ReturnsUnknownOnNonRetriable(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s1")
+	agentSession.alive = false // non-retriable errors usually mean the session is dead
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[sessionKey] = state
+	e.interactiveMu.Unlock()
+
+	agentSession.events <- Event{
+		Type:      EventError,
+		Error:     errors.New("compilation failed"),
+		ErrorKind: ErrorKindUnknown,
+	}
+
+	var got ErrorKind
+	done := make(chan struct{})
+	go func() {
+		got = e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, "ctx-1")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("processInteractiveEvents did not return")
+	}
+
+	if got != ErrorKindUnknown {
+		t.Errorf("returned kind = %q, want empty", got)
+	}
+	sent := p.getSent()
+	sawError := false
+	for _, s := range sent {
+		if strings.Contains(s, "Error") || strings.Contains(s, "错误") {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Errorf("non-retriable error not surfaced to platform; sent = %#v", sent)
+	}
+}
+
+// TestProcessInteractiveEvents_ReturnsUnknownOnSuccess verifies the zero
+// value is returned on a normal successful turn.
+func TestProcessInteractiveEvents_ReturnsUnknownOnSuccess(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s1")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[sessionKey] = state
+	e.interactiveMu.Unlock()
+
+	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
+
+	var got ErrorKind
+	done := make(chan struct{})
+	go func() {
+		got = e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, "ctx-1")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("processInteractiveEvents did not return")
+	}
+
+	if got != ErrorKindUnknown {
+		t.Errorf("returned kind = %q, want empty", got)
+	}
+}
+
+// ---------- Integration tests for the retry loop in processInteractiveMessageWith ----------
+
+// scriptedAgent returns a different queuingAgentSession on each StartSession
+// call, consuming from a queue. Used to simulate a claude process that dies
+// on 429 and gets replaced by a fresh one on retry. queuingAgentSession
+// tracks Send calls so tests can synchronize event injection with Send.
+type scriptedAgent struct {
+	mu       sync.Mutex
+	sessions []*queuingAgentSession
+	starts   int
+}
+
+func (a *scriptedAgent) Name() string { return "scripted" }
+func (a *scriptedAgent) StartSession(_ context.Context, _ string) (AgentSession, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.starts++
+	if len(a.sessions) == 0 {
+		return nil, fmt.Errorf("scriptedAgent: no more sessions")
+	}
+	s := a.sessions[0]
+	a.sessions = a.sessions[1:]
+	return s, nil
+}
+func (a *scriptedAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) {
+	return nil, nil
+}
+func (a *scriptedAgent) Stop() error { return nil }
+func (a *scriptedAgent) StartCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.starts
+}
+
+// waitForSend blocks until sess.Send has been called at least once, or the
+// deadline elapses.
+func waitForSend(t *testing.T, sess *queuingAgentSession, deadline time.Duration) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		sess.sendMu.Lock()
+		n := len(sess.sendCalls)
+		sess.sendMu.Unlock()
+		if n > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for Send to be called")
+}
+
+// waitForSessionIdle polls until the session lock is released by the
+// background processInteractiveMessageWith goroutine, so test cleanup can
+// safely reassign package-level state (e.g. retry delays) without racing
+// the goroutine that's still reading it. Reacquires the lock on success so
+// no other goroutine can start a new turn on the session before cleanup.
+func waitForSessionIdle(t *testing.T, session *Session, deadline time.Duration) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if session.TryLock() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for session to become idle")
+}
+
+// TestRetryLoop_RetriesOnRateLimitThenSucceeds drives a full processInteractiveMessageWith
+// where the first agent session emits a rate-limit error and the second
+// succeeds. Verifies the user sees a retry notification followed by the
+// successful reply, and that the agent was restarted (StartSession called twice).
+func TestRetryLoop_RetriesOnRateLimitThenSucceeds(t *testing.T) {
+	withShortRateLimitDelays(t, 10*time.Millisecond, 10*time.Millisecond, 30)
+
+	p := &stubPlatformEngine{n: "test"}
+
+	// First session emits a retriable error. Second session emits success.
+	sess1 := newQueuingSession("s1")
+	sess2 := newQueuingSession("s2")
+	agent := &scriptedAgent{sessions: []*queuingAgentSession{sess1, sess2}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	sessionKey := "test:user1"
+
+	// Inject each session's events after we confirm Send was called.
+	// drainEvents runs before Send in processInteractiveMessageWith, so
+	// pre-queued events would be drained away.
+	go func() {
+		waitForSend(t, sess1, 3*time.Second)
+		sess1.events <- Event{
+			Type:      EventError,
+			Error:     errors.New(`{"error":{"type":"rate_limit_error"}}`),
+			ErrorKind: ErrorKindRateLimit,
+		}
+		waitForSend(t, sess2, 3*time.Second)
+		sess2.events <- Event{Type: EventResult, Content: "hello world", Done: true}
+	}()
+
+	msg := &Message{
+		SessionKey: sessionKey,
+		Platform:   "test",
+		UserID:     "u1",
+		UserName:   "user",
+		Content:    "what's up",
+		ReplyCtx:   "ctx",
+	}
+	e.handleMessage(p, msg)
+
+	// Wait for success reply.
+	deadline := time.After(3 * time.Second)
+	for {
+		sent := p.getSent()
+		sawRetry := false
+		sawSuccess := false
+		for _, s := range sent {
+			if strings.Contains(s, "Retry 1/") || strings.Contains(s, "rate limited") {
+				sawRetry = true
+			}
+			if strings.Contains(s, "hello world") {
+				sawSuccess = true
+			}
+		}
+		if sawRetry && sawSuccess {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for retry + success; sent = %#v", sent)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	if got := agent.StartCount(); got != 2 {
+		t.Errorf("agent.StartSession calls = %d, want 2 (original + retry)", got)
+	}
+	// Wait for the background goroutine to release the session lock before
+	// the test's deferred cleanup touches the global delays.
+	waitForSessionIdle(t, e.sessions.GetOrCreateActive(sessionKey), 2*time.Second)
+}
+
+// TestRetryLoop_GivesUpAtCap verifies that after RateLimitMaxAttempts
+// consecutive rate-limit failures, the loop surfaces the "gave up" message
+// and stops retrying.
+func TestRetryLoop_GivesUpAtCap(t *testing.T) {
+	withShortRateLimitDelays(t, 5*time.Millisecond, 5*time.Millisecond, 3) // 3 total attempts
+
+	p := &stubPlatformEngine{n: "test"}
+
+	// Three sessions all return rate-limit errors.
+	sess1 := newQueuingSession("s1")
+	sess2 := newQueuingSession("s2")
+	sess3 := newQueuingSession("s3")
+	agent := &scriptedAgent{sessions: []*queuingAgentSession{sess1, sess2, sess3}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	sessionKey := "test:user1"
+
+	go func() {
+		rateLimitEvt := Event{
+			Type:      EventError,
+			Error:     errors.New(`{"error":{"type":"rate_limit_error"}}`),
+			ErrorKind: ErrorKindRateLimit,
+		}
+		for _, s := range []*queuingAgentSession{sess1, sess2, sess3} {
+			waitForSend(t, s, 3*time.Second)
+			s.events <- rateLimitEvt
+		}
+	}()
+
+	msg := &Message{
+		SessionKey: sessionKey,
+		Platform:   "test",
+		UserID:     "u1",
+		UserName:   "user",
+		Content:    "what's up",
+		ReplyCtx:   "ctx",
+	}
+	e.handleMessage(p, msg)
+
+	deadline := time.After(3 * time.Second)
+	for {
+		sent := p.getSent()
+		for _, s := range sent {
+			if strings.Contains(s, "did not clear") || strings.Contains(s, "gave up") || strings.Contains(s, "未解除") {
+				goto done
+			}
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for 'gave up' message; sent = %#v", sent)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+done:
+	if got := agent.StartCount(); got != 3 {
+		t.Errorf("agent.StartSession calls = %d, want 3 (all attempts)", got)
+	}
+	waitForSessionIdle(t, e.sessions.GetOrCreateActive(sessionKey), 2*time.Second)
+}
+
+// TestRetryLoop_StopCancelsWait verifies that calling state.markStopped()
+// during the retry wait interrupts the loop.
+func TestRetryLoop_StopCancelsWait(t *testing.T) {
+	// Long delay so the test has time to send the stop signal before the
+	// retry fires.
+	withShortRateLimitDelays(t, 5*time.Second, 5*time.Second, 30)
+
+	p := &stubPlatformEngine{n: "test"}
+	sess1 := newQueuingSession("s1")
+	sess2 := newQueuingSession("s2") // won't actually be used
+	agent := &scriptedAgent{sessions: []*queuingAgentSession{sess1, sess2}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	sessionKey := "test:user1"
+
+	go func() {
+		waitForSend(t, sess1, 3*time.Second)
+		sess1.events <- Event{
+			Type:      EventError,
+			Error:     errors.New(`{"error":{"type":"rate_limit_error"}}`),
+			ErrorKind: ErrorKindRateLimit,
+		}
+	}()
+
+	msg := &Message{
+		SessionKey: sessionKey,
+		Platform:   "test",
+		UserID:     "u1",
+		UserName:   "user",
+		Content:    "what's up",
+		ReplyCtx:   "ctx",
+	}
+
+	handleDone := make(chan struct{})
+	go func() {
+		e.handleMessage(p, msg)
+		close(handleDone)
+	}()
+
+	// Wait until the retry notification has been sent so we know we're in the
+	// post-first-attempt wait.
+	deadline := time.After(2 * time.Second)
+	for {
+		sawRetry := false
+		for _, s := range p.getSent() {
+			if strings.Contains(s, "Retry 1/") {
+				sawRetry = true
+				break
+			}
+		}
+		if sawRetry {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for retry notification to arrive")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Now send stop signal.
+	e.interactiveMu.Lock()
+	state := e.interactiveStates[sessionKey]
+	e.interactiveMu.Unlock()
+	if state == nil {
+		t.Fatal("interactive state missing")
+	}
+	state.markStopped()
+
+	// handleMessage should return promptly (not wait out the 5s delay).
+	select {
+	case <-handleDone:
+	case <-time.After(1 * time.Second):
+		t.Fatal("handleMessage did not return after stop signal")
+	}
+
+	// Wait for the background goroutine to release the session lock before
+	// cleanup so the race detector is happy.
+	waitForSessionIdle(t, e.sessions.GetOrCreateActive(sessionKey), 2*time.Second)
+
+	// Agent should have been started once (the second session is untouched).
+	if got := agent.StartCount(); got != 1 {
+		t.Errorf("agent.StartSession calls = %d, want 1 (stop before retry)", got)
+	}
+}

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -424,6 +424,11 @@ const (
 	MsgCommandDisabled   MsgKey = "command_disabled"
 	MsgAdminRequired     MsgKey = "admin_required"
 	MsgRateLimited       MsgKey = "rate_limited"
+
+	// Agent-side rate limiting (HTTP 429 / overloaded from the AI backend).
+	// Distinct from MsgRateLimited which is cc-connect's own inbound throttle.
+	MsgAgentRateLimitedRetry  MsgKey = "agent_rate_limited_retry"
+	MsgAgentRateLimitedGaveUp MsgKey = "agent_rate_limited_gave_up"
 	MsgBtwSent           MsgKey = "btw_sent"
 	MsgBtwSendFailed     MsgKey = "btw_send_failed"
 
@@ -2893,6 +2898,22 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "⏳ 訊息發送過快，請稍後再試。",
 		LangJapanese:           "⏳ メッセージの送信が速すぎます。しばらくお待ちください。",
 		LangSpanish:            "⏳ Estás enviando mensajes demasiado rápido. Espera un momento.",
+	},
+	MsgAgentRateLimitedRetry: {
+		// args: attempt (int), maxAttempts (int), delaySeconds (int)
+		LangEnglish:            "⏳ Claude rate limited. Retry %d/%d in %ds…",
+		LangChinese:            "⏳ Claude 被限流。%d/%d 次重试将在 %d 秒后进行…",
+		LangTraditionalChinese: "⏳ Claude 被限流。%d/%d 次重試將在 %d 秒後進行…",
+		LangJapanese:           "⏳ Claude がレート制限されました。%d/%d 回目の再試行を %d 秒後に実行します…",
+		LangSpanish:            "⏳ Claude con límite de tasa. Reintento %d/%d en %d s…",
+	},
+	MsgAgentRateLimitedGaveUp: {
+		// args: attempts (int), minutes (int)
+		LangEnglish:            "⚠️ Claude rate limit did not clear after %d attempts over ~%d min. Please try again later.",
+		LangChinese:            "⚠️ 经过 %d 次尝试（约 %d 分钟），Claude 限流仍未解除。请稍后再试。",
+		LangTraditionalChinese: "⚠️ 經過 %d 次嘗試（約 %d 分鐘），Claude 限流仍未解除。請稍後再試。",
+		LangJapanese:           "⚠️ %d 回の再試行（約 %d 分）を経ても Claude のレート制限が解除されませんでした。後でもう一度お試しください。",
+		LangSpanish:            "⚠️ El límite de tasa de Claude no se resolvió tras %d intentos (~%d min). Inténtalo más tarde.",
 	},
 	MsgBtwSent: {
 		LangEnglish:            "✅ Message injected into the current session.",

--- a/core/message.go
+++ b/core/message.go
@@ -169,6 +169,19 @@ const (
 	EventThinking          EventType = "thinking"           // thinking/processing status
 )
 
+// ErrorKind is a structured classification of agent errors so the engine can
+// decide how to react (retry, surface, drop queued messages, etc.) without
+// string-matching free-form error text. Agents set this when emitting an
+// EventError; the zero value ErrorKindUnknown means "not classified" and the
+// engine falls back to its default error surface.
+type ErrorKind string
+
+const (
+	ErrorKindUnknown    ErrorKind = ""            // not classified; use default error surface
+	ErrorKindRateLimit  ErrorKind = "rate_limit"  // HTTP 429 / Anthropic rate_limit_error — retriable
+	ErrorKindOverloaded ErrorKind = "overloaded"  // HTTP 529 / Anthropic overloaded_error — retriable
+)
+
 // UserQuestion represents a structured question from AskUserQuestion.
 type UserQuestion struct {
 	Question    string               `json:"question"`
@@ -199,7 +212,8 @@ type Event struct {
 	Questions    []UserQuestion // populated when ToolName == "AskUserQuestion"
 	Done         bool
 	Error        error
-	InputTokens  int // token usage from agent result events
+	ErrorKind    ErrorKind // structured classification for EventError (zero value = unknown)
+	InputTokens  int       // token usage from agent result events
 	OutputTokens int
 }
 

--- a/core/rate_limit.go
+++ b/core/rate_limit.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// Rate-limit retry timing. The product requirement is a literal
+// "30s, then every minute, for up to ~30 minutes". These are `var` rather
+// than `const` so tests can shorten them to keep the suite fast; production
+// code should not reassign them.
+var (
+	RateLimitInitialDelay = 30 * time.Second
+	RateLimitRetryDelay   = 60 * time.Second
+	// RateLimitMaxAttempts is the total number of Send attempts including
+	// the original one. With initial=30s and retry=60s, 30 attempts caps
+	// the retry window at roughly 29.5 minutes.
+	RateLimitMaxAttempts = 30
+)
+
+// ClassifyAnthropicError inspects an Anthropic-style error payload and
+// returns a structured ErrorKind. It accepts three input shapes:
+//
+//  1. A full JSON object like `{"error":{"type":"rate_limit_error",...}}`.
+//  2. A JSON object with a top-level `"type"` field.
+//  3. A wrapper string that embeds (1) or (2) after some prefix text,
+//     e.g. `API Error: {"error":{"type":"rate_limit_error"}}`.
+//
+// Detection targets Anthropic's canonical `error.type` strings
+// ("rate_limit_error", "overloaded_error") — these come from the API's typed
+// error schema, not free-form prose. Returns ErrorKindUnknown when nothing
+// matches, in which case callers should NOT retry.
+func ClassifyAnthropicError(payload string) ErrorKind {
+	if payload == "" {
+		return ErrorKindUnknown
+	}
+
+	// 1. Try parsing the whole payload as JSON.
+	if k := classifyJSON([]byte(payload)); k != ErrorKindUnknown {
+		return k
+	}
+
+	// 2. If the payload has a prefix before an embedded JSON object, slice
+	//    from the first '{' and retry. CLI stderr often looks like
+	//    "Error: {"error":{"type":"rate_limit_error"}}".
+	if i := strings.Index(payload, "{"); i > 0 {
+		if k := classifyJSON([]byte(payload[i:])); k != ErrorKindUnknown {
+			return k
+		}
+	}
+
+	// 3. Last-resort literal fallback: match Anthropic's canonical error-type
+	//    tokens directly. We still require the full token — not partial
+	//    words like "rate limit" — so we don't misclassify ordinary prose.
+	low := strings.ToLower(payload)
+	if strings.Contains(low, "rate_limit_error") {
+		return ErrorKindRateLimit
+	}
+	if strings.Contains(low, "overloaded_error") {
+		return ErrorKindOverloaded
+	}
+	return ErrorKindUnknown
+}
+
+// classifyJSON walks an Anthropic error JSON object and extracts error.type.
+func classifyJSON(b []byte) ErrorKind {
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return ErrorKindUnknown
+	}
+	// Shape A: {"error": {"type": "..."}}
+	if inner, ok := raw["error"].(map[string]any); ok {
+		if t, _ := inner["type"].(string); t != "" {
+			return kindFromAnthropicType(t)
+		}
+	}
+	// Shape B: {"type": "..."}
+	if t, _ := raw["type"].(string); t != "" {
+		return kindFromAnthropicType(t)
+	}
+	return ErrorKindUnknown
+}
+
+// kindFromAnthropicType maps Anthropic's error.type strings to ErrorKind.
+// Unknown types return ErrorKindUnknown so callers don't retry auth or
+// validation failures.
+func kindFromAnthropicType(t string) ErrorKind {
+	switch t {
+	case "rate_limit_error":
+		return ErrorKindRateLimit
+	case "overloaded_error":
+		return ErrorKindOverloaded
+	}
+	return ErrorKindUnknown
+}
+
+// IsRetriable reports whether an ErrorKind should trigger rate-limit retry.
+func (k ErrorKind) IsRetriable() bool {
+	return k == ErrorKindRateLimit || k == ErrorKindOverloaded
+}

--- a/core/rate_limit_test.go
+++ b/core/rate_limit_test.go
@@ -1,0 +1,122 @@
+package core
+
+import "testing"
+
+func TestClassifyAnthropicError(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    ErrorKind
+	}{
+		{
+			name:    "shape A rate limit",
+			payload: `{"error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`,
+			want:    ErrorKindRateLimit,
+		},
+		{
+			name:    "shape A overloaded",
+			payload: `{"error":{"type":"overloaded_error","message":"overloaded"}}`,
+			want:    ErrorKindOverloaded,
+		},
+		{
+			name:    "shape B top-level type",
+			payload: `{"type":"rate_limit_error"}`,
+			want:    ErrorKindRateLimit,
+		},
+		{
+			name:    "embedded JSON with prefix",
+			payload: `API Error: {"error":{"type":"rate_limit_error","message":"slow down"}}`,
+			want:    ErrorKindRateLimit,
+		},
+		{
+			name:    "embedded JSON with shell-style prefix",
+			payload: `claude: error: {"error":{"type":"overloaded_error"}}`,
+			want:    ErrorKindOverloaded,
+		},
+		{
+			name:    "literal fallback rate_limit_error in prose",
+			payload: `Request failed: rate_limit_error: too many requests from this key`,
+			want:    ErrorKindRateLimit,
+		},
+		{
+			name:    "literal fallback overloaded_error in prose",
+			payload: `Upstream returned overloaded_error after 3 retries`,
+			want:    ErrorKindOverloaded,
+		},
+		{
+			name:    "literal fallback case-insensitive",
+			payload: `API RETURNED Rate_Limit_Error STATUS`,
+			want:    ErrorKindRateLimit,
+		},
+		{
+			name:    "invalid_request_error not retried",
+			payload: `{"error":{"type":"invalid_request_error","message":"bad model"}}`,
+			want:    ErrorKindUnknown,
+		},
+		{
+			name:    "authentication_error not retried",
+			payload: `{"error":{"type":"authentication_error","message":"bad key"}}`,
+			want:    ErrorKindUnknown,
+		},
+		{
+			name:    "api_error (500) not retried by this helper",
+			payload: `{"error":{"type":"api_error","message":"server fail"}}`,
+			want:    ErrorKindUnknown,
+		},
+		{
+			name:    "compilation error — unrelated prose",
+			payload: `internal compiler error at line 42`,
+			want:    ErrorKindUnknown,
+		},
+		{
+			name:    "generic rate limit prose without canonical token",
+			payload: `You are being rate limited, please wait`,
+			want:    ErrorKindUnknown, // intentionally NOT matched — requires canonical token
+		},
+		{
+			name:    "HTTP 429 text alone",
+			payload: `HTTP 429 Too Many Requests`,
+			want:    ErrorKindUnknown, // not a canonical Anthropic token
+		},
+		{
+			name:    "empty",
+			payload: "",
+			want:    ErrorKindUnknown,
+		},
+		{
+			name:    "malformed JSON with canonical token",
+			payload: `{not valid json but contains rate_limit_error somewhere}`,
+			want:    ErrorKindRateLimit,
+		},
+		{
+			name:    "nested error object without type",
+			payload: `{"error":{"message":"something went wrong"}}`,
+			want:    ErrorKindUnknown,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyAnthropicError(tc.payload)
+			if got != tc.want {
+				t.Errorf("ClassifyAnthropicError(%q) = %q, want %q", tc.payload, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrorKindIsRetriable(t *testing.T) {
+	cases := []struct {
+		kind ErrorKind
+		want bool
+	}{
+		{ErrorKindUnknown, false},
+		{ErrorKindRateLimit, true},
+		{ErrorKindOverloaded, true},
+	}
+	for _, tc := range cases {
+		if got := tc.kind.IsRetriable(); got != tc.want {
+			t.Errorf("(%q).IsRetriable() = %v, want %v", tc.kind, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

When Claude's API returns `429 rate_limit_error` or `529 overloaded_error`, the engine now automatically waits and re-runs the turn on a fresh agent session (via `--resume`) instead of surfacing the raw error to the user.

- **Structured error detection**: `ClassifyAnthropicError` parses Anthropic's canonical `error.type` field from JSON payloads, top-level type fields, and CLI stderr wrappers. Only `rate_limit_error` and `overloaded_error` trigger retry — auth/validation errors surface immediately.
- **Retry loop**: 30 attempts spaced "30s initial, then 60s each" (~30 min window). The loop holds the session lock so queued messages stay queued. `/stop` and engine shutdown interrupt the wait.
- **Agent-side classification**: Claude Code session emits `EventError` with `ErrorKind` set from both stderr on process exit and stream-json result events with `is_error=true` or non-success `subtype`.
- **Zombie process fix** (related): `cs.alive.Store(false)` now runs *after* `cmd.Wait()` returns, closing a window where the engine could spawn a replacement while the old process was still running.

## Changes

| File | What |
|------|------|
| `core/rate_limit.go` | `ClassifyAnthropicError` + `ErrorKind.IsRetriable` |
| `core/rate_limit_test.go` | 17 classification cases + `IsRetriable` tests |
| `core/message.go` | `ErrorKind` type + `Event.ErrorKind` field |
| `core/engine.go` | Retry loop in `processInteractiveMessageWith`, `ErrorKind` return from `processInteractiveEvents`, dead-session detection in `getOrCreateInteractiveStateWith` |
| `core/engine_test.go` | `TestRetryLoop_RetriesOnRateLimitThenSucceeds`, `_GivesUpAtCap`, `_StopCancelsWait` |
| `core/i18n.go` | `MsgAgentRateLimitedRetry` / `MsgAgentRateLimitedGaveUp` in EN/ZH/ZH-TW/JA/ES |
| `agent/claudecode/session.go` | Classify errors on stderr + result events; zombie fix |
| `agent/claudecode/session_test.go` | `TestHandleResultRateLimitClassified`, `_OverloadedClassified`, `_MaxTurnsNotRetriable` |

## Tunables

```go
var (
    RateLimitInitialDelay = 30 * time.Second
    RateLimitRetryDelay   = 60 * time.Second
    RateLimitMaxAttempts  = 30
)
```

These are `var` (not `const`) so tests can shorten them.

## Test plan

- [x] `go test ./...` passes
- [x] `go test -race ./core/ ./agent/claudecode/` passes
- [ ] Manual: trigger a 429 from Claude API → engine retries with user-facing "⏳ Claude rate limited. Retry 1/30 in 30s…" and eventually succeeds or gives up
- [ ] `/stop` during retry wait cancels the retry loop