### PR TITLE
feat(weixin): add typing indicator support via ilink sendtyping API

### DIFF
--- a/platform/weixin/client.go
+++ b/platform/weixin/client.go
@@ -211,6 +211,42 @@ func (c *apiClient) getUploadURL(ctx context.Context, req getUploadURLRequest) (
 	return &out, nil
 }
 
+func (c *apiClient) getConfig(ctx context.Context, userID, contextToken string) (*getConfigResp, error) {
+	req := getConfigReq{
+		UserID:       userID,
+		ContextToken: contextToken,
+		BaseInfo:     baseInfo{ChannelVersion: channelVersion},
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := c.post(ctx, "ilink/bot/getconfig", payload, 0, "getConfig")
+	if err != nil {
+		return nil, err
+	}
+	var out getConfigResp
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("weixin: getConfig json: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *apiClient) sendTyping(ctx context.Context, userID, typingTicket string, status int) error {
+	req := sendTypingReq{
+		IlinkUserID:  userID,
+		TypingTicket: typingTicket,
+		Status:       status,
+		BaseInfo:     baseInfo{ChannelVersion: channelVersion},
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	_, err = c.post(ctx, "ilink/bot/sendtyping", payload, 0, "sendTyping")
+	return err
+}
+
 func (c *apiClient) sendText(ctx context.Context, to, text, contextToken, clientID string) error {
 	if strings.TrimSpace(contextToken) == "" {
 		return fmt.Errorf("weixin: context_token is required for send")

--- a/platform/weixin/types.go
+++ b/platform/weixin/types.go
@@ -19,6 +19,9 @@ const (
 	uploadMediaImage = 1
 	uploadMediaVideo = 2
 	uploadMediaFile  = 3
+
+	typingStatusStart = 1
+	typingStatusStop  = 2
 )
 
 type baseInfo struct {
@@ -132,6 +135,26 @@ type sendMessageResp struct {
 	Ret     int    `json:"ret"`
 	Errcode int    `json:"errcode"`
 	Errmsg  string `json:"errmsg"`
+}
+
+type sendTypingReq struct {
+	IlinkUserID   string   `json:"ilink_user_id"`
+	TypingTicket  string   `json:"typing_ticket"`
+	Status        int      `json:"status"`
+	BaseInfo      baseInfo `json:"base_info"`
+}
+
+type getConfigReq struct {
+	UserID       string   `json:"user_id"`
+	ContextToken string   `json:"context_token,omitempty"`
+	BaseInfo     baseInfo `json:"base_info"`
+}
+
+type getConfigResp struct {
+	Ret          int    `json:"ret"`
+	Errcode      int    `json:"errcode"`
+	Errmsg       string `json:"errmsg"`
+	TypingTicket string `json:"typing_ticket"`
 }
 
 type weixinOutboundMsg struct {

--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -33,6 +33,10 @@ const (
 	weixinSendRetryDelay = 500 * time.Millisecond
 	// weixinChunkSendDelay is the delay between sending message chunks to avoid rate limiting.
 	weixinChunkSendDelay = 100 * time.Millisecond
+	// typingTicketTTL is how long a cached typing ticket remains valid.
+	typingTicketTTL = 10 * time.Minute
+	// typingRepeatInterval is how often to resend the typing status to keep it alive.
+	typingRepeatInterval = 5 * time.Second
 )
 
 type replyContext struct {
@@ -74,6 +78,14 @@ type Platform struct {
 	tokensMu   sync.RWMutex
 	tokens     map[string]string
 	tokensPath string
+
+	typingMu      sync.RWMutex
+	typingTickets map[string]typingTicketEntry // peerUserID → cached ticket
+}
+
+type typingTicketEntry struct {
+	ticket    string
+	fetchedAt time.Time
 }
 
 func sanitizePathSegment(s string) string {
@@ -160,8 +172,9 @@ func New(opts map[string]any) (core.Platform, error) {
 		accountLabel:  accountLabel,
 		httpClient:    httpClient,
 		cdnHttpClient: cdnHttpClient,
-		tokens:       make(map[string]string),
-		dedup:        make(map[string]time.Time),
+		tokens:        make(map[string]string),
+		dedup:         make(map[string]time.Time),
+		typingTickets: make(map[string]typingTicketEntry),
 	}
 	p.api = newAPIClient(baseURL, token, routeTag, httpClient)
 
@@ -421,6 +434,7 @@ func (p *Platform) dispatchInbound(ctx context.Context, m *weixinMessage, h core
 
 	if tok := strings.TrimSpace(m.ContextToken); tok != "" {
 		p.setContextToken(from, tok)
+		p.refreshTypingTicket(ctx, from, tok)
 	}
 
 	body := bodyFromItemList(m.ItemList)
@@ -487,6 +501,93 @@ func (p *Platform) Reply(ctx context.Context, replyCtx any, content string) erro
 
 func (p *Platform) Send(ctx context.Context, replyCtx any, content string) error {
 	return p.sendChunks(ctx, replyCtx, content)
+}
+
+// StartTyping sends a typing indicator to the peer and repeats every few seconds
+// until the returned stop function is called. Implements core.TypingIndicator.
+func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
+	rc, ok := rctx.(*replyContext)
+	if !ok || rc == nil {
+		return func() {}
+	}
+	peerID := rc.peerUserID
+	contextToken := rc.contextToken
+	if strings.TrimSpace(contextToken) == "" {
+		contextToken = p.getContextToken(peerID)
+	}
+
+	ticket := p.getTypingTicket(ctx, peerID, contextToken)
+	if ticket == "" {
+		return func() {}
+	}
+
+	if err := p.api.sendTyping(ctx, peerID, ticket, typingStatusStart); err != nil {
+		slog.Debug("weixin: initial typing start failed", "peer", peerID, "error", err)
+		return func() {}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(typingRepeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				// Best-effort stop; use background context since ctx may already be cancelled.
+				stopCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				if err := p.api.sendTyping(stopCtx, peerID, ticket, typingStatusStop); err != nil {
+					slog.Debug("weixin: typing stop failed", "peer", peerID, "error", err)
+				}
+				cancel()
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := p.api.sendTyping(ctx, peerID, ticket, typingStatusStart); err != nil {
+					slog.Debug("weixin: typing repeat failed", "peer", peerID, "error", err)
+					return
+				}
+			}
+		}
+	}()
+
+	return func() { close(done) }
+}
+
+// getTypingTicket returns a cached typing ticket for the peer, fetching one
+// from the getconfig API if the cache is empty or expired.
+func (p *Platform) getTypingTicket(ctx context.Context, peerID, contextToken string) string {
+	p.typingMu.RLock()
+	entry, ok := p.typingTickets[peerID]
+	p.typingMu.RUnlock()
+	if ok && time.Since(entry.fetchedAt) < typingTicketTTL {
+		return entry.ticket
+	}
+
+	resp, err := p.api.getConfig(ctx, peerID, contextToken)
+	if err != nil {
+		slog.Debug("weixin: getConfig for typing ticket failed", "peer", peerID, "error", err)
+		return ""
+	}
+	ticket := strings.TrimSpace(resp.TypingTicket)
+	if ticket == "" {
+		return ""
+	}
+
+	p.typingMu.Lock()
+	p.typingTickets[peerID] = typingTicketEntry{ticket: ticket, fetchedAt: time.Now()}
+	p.typingMu.Unlock()
+	return ticket
+}
+
+// refreshTypingTicket proactively fetches and caches a typing ticket when a
+// message is received, so that StartTyping can use it without an extra round-trip.
+func (p *Platform) refreshTypingTicket(ctx context.Context, peerID, contextToken string) {
+	go func() {
+		fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		p.getTypingTicket(fetchCtx, peerID, contextToken)
+	}()
 }
 
 func (p *Platform) sendChunks(ctx context.Context, replyCtx any, content string) error {
@@ -598,4 +699,5 @@ var (
 	_ core.FormattingInstructionProvider = (*Platform)(nil)
 	_ core.ImageSender                   = (*Platform)(nil)
 	_ core.FileSender                    = (*Platform)(nil)
+	_ core.TypingIndicator               = (*Platform)(nil)
 )


### PR DESCRIPTION
## Summary

- Implement `core.TypingIndicator` interface for the Weixin (personal WeChat / ilink) platform
- Shows a "typing..." bubble in the WeChat conversation while the agent is processing
- Fetches `typing_ticket` from `ilink/bot/getconfig`, caches per peer with 10-minute TTL
- Proactively refreshes ticket on each inbound message to minimize latency on `StartTyping`
- Repeats typing status every 5 seconds and sends best-effort stop on completion

### Changes

| File | What |
|------|------|
| `platform/weixin/types.go` | Add `typingStatusStart/Stop` constants, `sendTypingReq`, `getConfigReq/Resp` types |
| `platform/weixin/client.go` | Add `getConfig()` and `sendTyping()` API methods |
| `platform/weixin/weixin.go` | Add `StartTyping()`, typing ticket cache, proactive ticket refresh on inbound message |

### Context

The ilink bot HTTP API supports a typing indicator via the `ilink/bot/sendtyping` endpoint (documented in the OpenClaw/hermes-agent weixin adapter). All other major platforms in cc-connect (Telegram, Discord, Slack, Feishu) already implement `core.TypingIndicator`, but Weixin was missing it.

The implementation follows the same pattern as Telegram's `StartTyping`: send an initial status, repeat on a ticker, and stop when the returned function is called. The main difference is that Weixin requires a `typing_ticket` obtained from `getconfig`, so we cache it with a TTL and proactively fetch it when messages arrive.

## Test Plan

- [x] `go build ./platform/weixin/...` — compiles cleanly
- [x] `go test ./platform/weixin/...` — all 17 existing tests pass
- [x] Manual verification with personal WeChat via ilink bot token