### PR TITLE
feat(feishu): support interactive card messages (msg_type=interactive)

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -2397,13 +2397,6 @@ func stringValue(v *string) string {
 	return *v
 }
 
-func truncateString(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
-}
-
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 	// {platformName}:{chatID}:{userID}
 	parts := strings.SplitN(sessionKey, ":", 3)

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -877,8 +877,13 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		})
 
 	case "interactive":
-		cardText := extractInteractiveCardText(content)
-		if cardText == "" || cardText == "[interactive card]" {
+		// The content pushed by Feishu's im.message.receive_v1 event for
+		// interactive cards is a simplified representation (often just an image
+		// key + placeholder text like "请升级至最新版本客户端").
+		// We need to fetch the full card content via the message API with
+		// card_msg_content_type=raw_card_content to get the actual text.
+		cardText := p.fetchInteractiveCardText(ctx, messageID)
+		if cardText == "" {
 			slog.Debug(p.tag()+": interactive card produced no content", "message_id", messageID)
 			return
 		}
@@ -1051,6 +1056,39 @@ func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) stri
 	}
 
 	return fmt.Sprintf("[Quoted message from %s]:\n%s\n\n", senderName, quotedText)
+}
+
+// fetchInteractiveCardText fetches the full card content for an interactive
+// message via the GET /open-apis/im/v1/messages/{message_id} API with
+// card_msg_content_type=raw_card_content. The event-pushed content for
+// interactive cards is a simplified representation; this call retrieves the
+// complete card JSON so we can extract the actual text.
+func (p *Platform) fetchInteractiveCardText(ctx context.Context, messageID string) string {
+	apiPath := fmt.Sprintf("/open-apis/im/v1/messages/%s?card_msg_content_type=raw_card_content", messageID)
+	apiResp, err := p.client.Get(ctx, apiPath, nil, larkcore.AccessTokenTypeTenant)
+	if err != nil {
+		slog.Debug(p.tag()+": fetch interactive card failed", "message_id", messageID, "error", err)
+		return ""
+	}
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			Items []struct {
+				Body struct {
+					Content string `json:"content"`
+				} `json:"body"`
+			} `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil || resp.Code != 0 || len(resp.Data.Items) == 0 {
+		slog.Debug(p.tag()+": fetch interactive card: parse failed or no data", "message_id", messageID, "code", resp.Code)
+		return ""
+	}
+	content := resp.Data.Items[0].Body.Content
+	if content == "" {
+		return ""
+	}
+	return extractInteractiveCardText(content)
 }
 
 // extractPostPlainText extracts plain text from a Lark post (rich text) JSON content.
@@ -2357,6 +2395,13 @@ func stringValue(v *string) string {
 		return ""
 	}
 	return *v
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }
 
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -876,6 +876,24 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			ReplyCtx: rctx,
 		})
 
+	case "interactive":
+		cardText := extractInteractiveCardText(content)
+		if cardText == "" || cardText == "[interactive card]" {
+			slog.Debug(p.tag()+": interactive card produced no content", "message_id", messageID)
+			return
+		}
+		text := stripMentions(cardText, mentions, p.botOpenID)
+		if text == "" {
+			slog.Debug(p.tag()+": interactive card text empty after mention stripping", "message_id", messageID)
+			return
+		}
+		p.handler(p.dispatchPlatform(), &core.Message{
+			SessionKey: sessionKey, Platform: p.platformName,
+			MessageID: messageID,
+			UserID:    userID, UserName: userName, ChatName: chatName,
+			Content: quotedPrefix + text, ReplyCtx: rctx,
+		})
+
 	case "merge_forward":
 		text, images, files := p.parseMergeForward(messageID)
 		if text == "" && len(images) == 0 && len(files) == 0 {

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -1,6 +1,7 @@
 package feishu
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -319,6 +320,53 @@ func TestExtractPostPlainText_CodeBlock(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestExtractInteractiveCardText_LegacyFormat(t *testing.T) {
+	cardJSON := `{"config":{"wide_screen_mode":true},"header":{"title":{"tag":"plain_text","content":"Daily Report"},"template":"blue"},"elements":[{"tag":"div","text":{"tag":"lark_md","content":"**Tasks completed:** 5\n**Pending:** 2"}},{"tag":"action","actions":[{"tag":"button","text":{"tag":"plain_text","content":"View Details"},"type":"primary"}]}]}`
+	got := extractInteractiveCardText(cardJSON)
+	if got == "" || got == "[interactive card]" {
+		t.Fatalf("expected non-empty card text, got %q", got)
+	}
+	// Legacy format extracts header title; div/lark_md content is not extracted
+	// by the legacy path (only tag:"text" elements are handled).
+	if !strings.Contains(got, "Daily Report") {
+		t.Errorf("expected 'Daily Report' in output, got %q", got)
+	}
+}
+
+func TestExtractInteractiveCardText_Schema20(t *testing.T) {
+	cardJSON := `{"schema":"2.0","config":{"wide_screen_mode":true},"body":{"tag":"body","elements":[{"tag":"markdown","content":"**Hello World**\nThis is a test card."}]}}`
+	got := extractInteractiveCardText(cardJSON)
+	if got == "" || got == "[interactive card]" {
+		t.Fatalf("expected non-empty card text, got %q", got)
+	}
+	if !strings.Contains(got, "Hello World") {
+		t.Errorf("expected 'Hello World' in output, got %q", got)
+	}
+}
+
+func TestExtractInteractiveCardText_EmptyCard(t *testing.T) {
+	cardJSON := `{"config":{"wide_screen_mode":true}}`
+	got := extractInteractiveCardText(cardJSON)
+	if got != "[interactive card]" {
+		t.Errorf("expected '[interactive card]' for empty card, got %q", got)
+	}
+}
+
+func TestExtractInteractiveCardText_RawCardContent(t *testing.T) {
+	// When fetched via raw_card_content API, card is wrapped in json_card
+	inner := `{"schema":"2.0","config":{"wide_screen_mode":true},"body":{"tag":"body","elements":[{"tag":"markdown","content":"Server CPU high"}]}}`
+	wrapped := `{"json_card":` + jsonEscape(inner) + `}`
+	got := extractInteractiveCardText(wrapped)
+	if !strings.Contains(got, "CPU") {
+		t.Errorf("expected 'CPU' in output, got %q", got)
+	}
+}
+
+func jsonEscape(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
 
 func TestStripMentions(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Handle `msg_type=interactive` in `dispatchMessage()` instead of ignoring it
- Add `fetchInteractiveCardText()` to fetch full card content via REST API with `card_msg_content_type=raw_card_content`
- Reuse existing `extractInteractiveCardText()` for parsing card JSON
## Problem
When users forward interactive card messages, the WebSocket event only pushes a simplified representation (image_key + placeholder text). The actual card content is not included.
## Solution
Fetch the full card JSON via the REST API, then extract text using the existing card parser.
## Test plan
- [x] Forward interactive card messages and verify text extraction works
- [x] Non-card messages unaffected
- [x] Unit tests pass