### PR TITLE
fix(feishu): decouple reply threading from session key and improve thread_isolation behavior

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -754,6 +754,8 @@ app_secret = "your-feishu-app-secret"
 #                                   # 设为 true 时，群聊内所有用户共享同一个 Agent 会话
 # thread_isolation = false  # If true, group messages use Feishu reply threads as session boundaries (one thread/root = one agent session)
 #                           # 设为 true 时，群聊按飞书话题/根消息隔离会话（一个 thread/root 对应一个 Agent 会话）
+# reply_in_thread = false   # If true, bot replies always create/use threads even for non-thread messages
+#                           # 设为 true 时，bot 回复会主动开话题（即使原消息不在话题内）
 # reply_to_trigger = true   # Default: bot uses “reply to message” API (quotes the user’s message). Set false to post plain chat messages instead.
 #                           # 默认 true：用「回复消息」API（引用用户消息）。设为 false 则在会话里发普通消息、不引用触发消息。
 # progress_style = "legacy" # Progress rendering style: legacy | compact | card

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -109,6 +109,7 @@ type replyContext struct {
 	messageID  string
 	chatID     string
 	sessionKey string
+	inThread   bool // true only when the message originates from a real thread (has root_id)
 }
 
 type Platform struct {
@@ -140,6 +141,8 @@ type Platform struct {
 	botOpenID        string
 	userNameCache    sync.Map // open_id -> display name
 	chatNameCache    sync.Map // chat_id -> chat name
+	msgSessionMap    sync.Map // messageID -> sessionKey; tracks which session a message belongs to
+	rootContextSent  sync.Map // sessionKey -> bool; tracks which sessions already received thread root context
 	chatMemberCache  sync.Map // chatID -> *chatMemberEntry
 	// Webhook mode fields (for Lark international version)
 	server       *http.Server
@@ -508,7 +511,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 			return nil, nil
 		}
 
-		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey, inThread: isThreadSessionKey(sessionKey)}
 		go p.handler(p.dispatchPlatform(), &core.Message{
 			SessionKey: sessionKey,
 			Platform:   p.platformName,
@@ -539,7 +542,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 
 	// askq: — AskUserQuestion option selected, forward as user message
 	if strings.HasPrefix(actionVal, "askq:") {
-		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey, inThread: isThreadSessionKey(sessionKey)}
 		go p.handler(p.dispatchPlatform(), &core.Message{
 			SessionKey: sessionKey,
 			Platform:   p.platformName,
@@ -571,7 +574,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 	// cmd: — async command dispatch
 	if strings.HasPrefix(actionVal, "cmd:") {
 		cmdText := strings.TrimPrefix(actionVal, "cmd:")
-		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey, inThread: isThreadSessionKey(sessionKey)}
 
 		slog.Info(p.tag()+": card action dispatched as command", "cmd", cmdText, "user", userID)
 
@@ -748,20 +751,35 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	}
 	mentions := msg.Mentions
 	parentID := stringValue(msg.ParentId)
+	rootID := stringValue(msg.RootId)
 
 	sessionKey := p.makeSessionKey(msg, chatID, userID)
-	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
-	slog.Debug(p.tag()+": routed inbound message",
+	// Record which session this message belongs to, so that if a bot reply
+	// creates a nested thread on this message, subsequent messages in that
+	// thread can be routed back to the same session.
+	if p.threadIsolation {
+		p.msgSessionMap.Store(messageID, sessionKey)
+	}
+	threadID := stringValue(msg.ThreadId)
+	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey, inThread: threadID != ""}
+	mappedFrom := ""
+	if v, ok := p.msgSessionMap.Load(rootID); ok {
+		mappedFrom = v.(string)
+	}
+	slog.Info(p.tag()+": routed inbound message",
 		"message_id", messageID,
+		"root_id", rootID,
+		"parent_id", parentID,
 		"session_key", sessionKey,
-		"reply_in_thread", p.shouldReplyInThread(rctx),
+		"in_thread", rctx.inThread,
+		"msgSessionMap_hit", mappedFrom,
 	)
 
 	// Dispatch message handling asynchronously so the SDK event loop is not
 	// blocked by IO-heavy operations (image/audio download, handler HTTP calls).
 	// The dedup and old-message checks above remain synchronous to guarantee
 	// correctness before spawning the goroutine.
-	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID)
+	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID, rootID)
 
 	return nil
 }
@@ -769,7 +787,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 // dispatchMessage handles the message content parsing, media download, and
 // handler invocation. It runs in its own goroutine so that onMessage returns
 // quickly and does not block the SDK event loop.
-func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, chatID string, rctx replyContext, parentID string) {
+func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, chatID string, rctx replyContext, parentID, rootID string) {
 	// Resolve user and chat names asynchronously so SDK dispatcher is not blocked.
 	userName := ""
 	if userID != "" {
@@ -777,11 +795,21 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	}
 	chatName := p.resolveChatName(chatID)
 
-	// If this message is a reply to another message, fetch the quoted content
-	// and prepend it so the agent has full context.
+	// Determine context prefix based on parent/root relationship:
+	// - parentID == rootID: thread-level reply (Feishu auto-sets parent to root).
+	//   Only inject root message content on the first message of this session.
+	// - parentID != rootID: explicit quote-reply to a specific sub-message.
+	//   Always inject the quoted message content.
 	quotedPrefix := ""
 	if parentID != "" {
-		quotedPrefix = p.fetchQuotedMessage(ctx, parentID)
+		if rootID != "" && parentID == rootID {
+			// Thread root context: only inject once per session.
+			if _, alreadySent := p.rootContextSent.LoadOrStore(sessionKey, true); !alreadySent {
+				quotedPrefix = p.fetchThreadRootMessage(ctx, parentID)
+			}
+		} else {
+			quotedPrefix = p.fetchQuotedMessage(ctx, parentID)
+		}
 	}
 
 	switch msgType {
@@ -1258,6 +1286,35 @@ func formatReplyChain(chain []chainMessage) string {
 	}
 	b.WriteString("---\n\n")
 	return b.String()
+}
+
+const threadRootMaxLen = 2000
+
+// fetchThreadRootMessage retrieves the thread root message and formats it with
+// a distinct prefix. Content is truncated to threadRootMaxLen characters to
+// avoid excessive token usage. Returns empty string on any failure (graceful
+// degradation).
+func (p *Platform) fetchThreadRootMessage(ctx context.Context, rootID string) string {
+	raw := p.fetchQuotedMessage(ctx, rootID)
+	if raw == "" {
+		return ""
+	}
+	const oldPrefix = "[Quoted message from "
+	const newPrefix = "[Thread root message from "
+	result := raw
+	if strings.HasPrefix(raw, oldPrefix) {
+		result = newPrefix + raw[len(oldPrefix):]
+	}
+	if idx := strings.Index(result, "]:\n"); idx >= 0 {
+		header := result[:idx+len("]:\n")]
+		body := result[idx+len("]:\n"):]
+		body = strings.TrimSuffix(body, "\n\n")
+		if len(body) > threadRootMaxLen {
+			body = body[:threadRootMaxLen] + "[...truncated]"
+		}
+		result = header + body + "\n\n"
+	}
+	return result
 }
 
 // extractPostPlainText extracts plain text from a Lark post (rich text) JSON content.
@@ -2329,6 +2386,13 @@ func (p *Platform) makeSessionKey(msg *larkim.EventMessage, chatID, userID strin
 			rootID = stringValue(msg.MessageId)
 		}
 		if rootID != "" {
+			// When a bot reply creates a nested thread on a user's message,
+			// subsequent messages in that thread have root_id = user's messageID.
+			// Look up whether that root was a message in an existing session
+			// and reuse that session key to maintain conversation continuity.
+			if mapped, ok := p.msgSessionMap.Load(rootID); ok {
+				return mapped.(string)
+			}
 			return fmt.Sprintf("%s:%s:root:%s", p.tag(), chatID, rootID)
 		}
 	}
@@ -2354,7 +2418,10 @@ func (p *Platform) shouldReplyInThread(rc replyContext) bool {
 	if rc.messageID == "" {
 		return false
 	}
-	return p.threadIsolation && isThreadSessionKey(rc.sessionKey)
+	// inThread tracks whether the message originates from a real thread.
+	// Also require a thread session key to avoid enabling ReplyInThread
+	// for P2P chats where thread_isolation has no effect on session keys.
+	return p.threadIsolation && rc.inThread && isThreadSessionKey(rc.sessionKey)
 }
 
 // shouldUseThreadOrReplyAPI is true when we should call Im.Message.Reply (optionally with ReplyInThread).
@@ -2395,6 +2462,20 @@ func (p *Platform) replyMessage(ctx context.Context, rc replyContext, msgType, c
 			}
 			if !resp.Success() {
 				return fmt.Errorf("%s: reply failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			}
+			if resp.Data != nil && resp.Data.MessageId != nil {
+				botMsgID := *resp.Data.MessageId
+				slog.Info(p.tag()+": bot reply sent",
+					"bot_reply_id", botMsgID,
+					"reply_to", rc.messageID,
+					"session_key", rc.sessionKey,
+				)
+				// Track bot reply in msgSessionMap so that if a user opens
+				// a thread on this reply, the thread can be traced back to
+				// the same session.
+				if p.threadIsolation && rc.sessionKey != "" {
+					p.msgSessionMap.Store(botMsgID, rc.sessionKey)
+				}
 			}
 			return nil
 		})
@@ -2586,9 +2667,24 @@ func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 	if len(parts) == 3 {
 		if rootID, ok := parseThreadRootID(parts[2]); ok {
 			rc.messageID = rootID
+			rc.inThread = true
 		}
 	}
 	return rc, nil
+}
+
+// ResolveCronReplyTarget implements CronReplyTargetResolver. For cron jobs,
+// return a replyContext with only chatID (no messageID) so that Send() uses
+// sendNewMessageToChat instead of ReplyInThread. Without this, cron jobs
+// bound to a thread-isolated session key (feishu:chat:root:msgID) would
+// reply inside a thread rather than posting a new message in the group.
+func (p *Platform) ResolveCronReplyTarget(sessionKey string, title string) (string, any, error) {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) < 2 || parts[0] != p.platformName {
+		return "", nil, fmt.Errorf("%s: invalid session key %q", p.tag(), sessionKey)
+	}
+	rc := replyContext{chatID: parts[1], sessionKey: sessionKey}
+	return sessionKey, rc, nil
 }
 
 func parseThreadRootID(sessionTail string) (string, bool) {
@@ -3067,6 +3163,10 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 		if resp.Data != nil && resp.Data.MessageId != nil {
 			msgID = *resp.Data.MessageId
 		}
+		// Track preview card message for session continuity
+		if p.threadIsolation && msgID != "" && rc.sessionKey != "" {
+			p.msgSessionMap.Store(msgID, rc.sessionKey)
+		}
 	} else {
 		req := larkim.NewCreateMessageReqBuilder().
 			ReceiveIdType(larkim.ReceiveIdTypeChatId).
@@ -3094,6 +3194,10 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 		}
 		if resp.Data != nil && resp.Data.MessageId != nil {
 			msgID = *resp.Data.MessageId
+		}
+		// Track preview card message for session continuity
+		if p.threadIsolation && msgID != "" && rc.sessionKey != "" {
+			p.msgSessionMap.Store(msgID, rc.sessionKey)
 		}
 	}
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -129,6 +129,7 @@ type Platform struct {
 	threadIsolation            bool
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
 	noReplyToTrigger bool
+	replyInThread    bool // when true, bot replies create threads even for non-thread messages
 	resolveMentions  bool
 	client           *lark.Client
 	replayClient     *lark.Client
@@ -202,6 +203,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
+	replyInThread, _ := opts["reply_in_thread"].(bool)
 	resolveMentionsOpt, _ := opts["resolve_mentions"].(bool)
 	noReplyToTrigger := false
 	if v, ok := opts["reply_to_trigger"].(bool); ok && !v {
@@ -254,6 +256,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
 		shareSessionInChannel:      shareSessionInChannel,
 		threadIsolation:            threadIsolation,
+		replyInThread:              replyInThread,
 		resolveMentions:            resolveMentionsOpt,
 		noReplyToTrigger:           noReplyToTrigger,
 		client:                     lark.NewClient(appID, appSecret, clientOpts...),
@@ -2418,10 +2421,10 @@ func (p *Platform) shouldReplyInThread(rc replyContext) bool {
 	if rc.messageID == "" {
 		return false
 	}
-	// inThread tracks whether the message originates from a real thread.
-	// Also require a thread session key to avoid enabling ReplyInThread
-	// for P2P chats where thread_isolation has no effect on session keys.
-	return p.threadIsolation && rc.inThread && isThreadSessionKey(rc.sessionKey)
+	if rc.inThread {
+		return true // message is in a thread → always reply in thread
+	}
+	return p.replyInThread // not in a thread → reply_in_thread config decides
 }
 
 // shouldUseThreadOrReplyAPI is true when we should call Im.Message.Reply (optionally with ReplyInThread).

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -733,7 +733,7 @@ func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 		{
 			name:          "thread isolation enabled",
 			platform:      &Platform{threadIsolation: true},
-			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:om_root"},
+			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:om_root", inThread: true},
 			wantThreading: true,
 		},
 		{
@@ -1090,5 +1090,397 @@ func TestResolveMentions_SpecialCharsEscaped(t *testing.T) {
 	}
 	if !strings.Contains(result, "A&lt;") {
 		t.Fatalf("expected HTML-escaped name, got %q", result)
+	}
+}
+
+// --- Thread isolation improvements tests ---
+
+func TestThreadIsolation_GroupMessageNoThread_NoReplyInThread(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	messageID := "om_standalone"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	content := `{"text":"@bot run inspection"}`
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	var receivedMsg *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ip.botOpenID = "ou_bot"
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		receivedMsg = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId: &messageID, ChatId: &chatID, ChatType: &chatType,
+				MessageType: &msgType, Content: &content, CreateTime: &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if receivedMsg == nil {
+		t.Fatal("handler not called")
+	}
+	rc := receivedMsg.ReplyCtx.(replyContext)
+	if rc.inThread {
+		t.Fatal("inThread should be false for standalone group message")
+	}
+	if ip.shouldReplyInThread(rc) {
+		t.Fatal("shouldReplyInThread should be false for standalone group message")
+	}
+}
+
+func TestThreadIsolation_ThreadMessage_ReplyInThread(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	messageID := "om_reply"
+	rootID := "om_thread_root"
+	threadID := "omt_thread_123"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	content := `{"text":"@bot check this"}`
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	var receivedMsg *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ip.botOpenID = "ou_bot"
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		receivedMsg = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId: &messageID, RootId: &rootID, ThreadId: &threadID, ChatId: &chatID,
+				ChatType: &chatType, MessageType: &msgType, Content: &content,
+				CreateTime: &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if receivedMsg == nil {
+		t.Fatal("handler not called")
+	}
+	rc := receivedMsg.ReplyCtx.(replyContext)
+	if !rc.inThread {
+		t.Fatal("inThread should be true for thread message")
+	}
+	if !ip.shouldReplyInThread(rc) {
+		t.Fatal("shouldReplyInThread should be true for thread message")
+	}
+}
+
+func TestThreadIsolation_NestedThreadInheritSessionKey(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	originalRoot := "om_original_root"
+	msg1ID := "om_msg1"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	ip.botOpenID = "ou_bot"
+
+	// Step 1: msg1 in thread A (root = originalRoot)
+	content1 := `{"text":"@bot check alert"}`
+	var msg1Received *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		msg1Received = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId: &msg1ID, RootId: &originalRoot, ParentId: &originalRoot,
+				ChatId: &chatID, ChatType: &chatType, MessageType: &msgType,
+				Content: &content1, CreateTime: &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if msg1Received == nil {
+		t.Fatal("msg1 handler not called")
+	}
+	session1Key := msg1Received.SessionKey
+
+	// Step 2: msg2 in nested thread (root = msg1ID)
+	msg2ID := "om_msg2"
+	content2 := `{"text":"@bot continue"}`
+	var msg2Received *core.Message
+	wg.Add(1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		msg2Received = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId: &msg2ID, RootId: &msg1ID, ParentId: &msg1ID,
+				ChatId: &chatID, ChatType: &chatType, MessageType: &msgType,
+				Content: &content2, CreateTime: &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if msg2Received == nil {
+		t.Fatal("msg2 handler not called")
+	}
+	if msg2Received.SessionKey != session1Key {
+		t.Fatalf("msg2 SessionKey = %q, want same as msg1 %q", msg2Received.SessionKey, session1Key)
+	}
+}
+
+func TestThreadRootContext_FirstMessageMarksSession(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	messageID := "om_msg1"
+	rootID := "om_root"
+	parentID := "om_root"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	content := `{"text":"@bot check this"}`
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	var receivedMsg *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ip.botOpenID = "ou_bot"
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		receivedMsg = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId: &messageID, RootId: &rootID, ParentId: &parentID,
+				ChatId: &chatID, ChatType: &chatType, MessageType: &msgType,
+				Content: &content, CreateTime: &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if receivedMsg == nil {
+		t.Fatal("handler not called")
+	}
+	if _, ok := ip.rootContextSent.Load(receivedMsg.SessionKey); !ok {
+		t.Fatal("rootContextSent should be marked after first thread message")
+	}
+}
+
+func TestThreadRootContext_SecondMessageSkipsRootContext(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	rootID := "om_root"
+	parentID := "om_root"
+	chatID := "oc_test"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	ip.botOpenID = "ou_bot"
+
+	sessionKey := "feishu:oc_test:root:om_root"
+	ip.rootContextSent.Store(sessionKey, true)
+
+	msg1ID := "om_msg2"
+	content := `{"text":"@bot second message"}`
+	var receivedMsg *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		defer wg.Done()
+		receivedMsg = msg
+	}
+	_ = ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId: &msg1ID, RootId: &rootID, ParentId: &parentID,
+				ChatId: &chatID, ChatType: &chatType, MessageType: &msgType,
+				Content: &content, CreateTime: &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	})
+	wg.Wait()
+	if receivedMsg == nil {
+		t.Fatal("handler not called")
+	}
+	if strings.Contains(receivedMsg.Content, "[Thread root message") {
+		t.Fatalf("second message should not contain root context, got %q", receivedMsg.Content)
+	}
+}
+
+func TestResolveCronReplyTarget_ReturnsReplyCtxWithoutMessageID(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+
+	sessionKey := "feishu:oc_chat123:root:om_msg456"
+	_, rctx, err := ip.ResolveCronReplyTarget(sessionKey, "Daily report")
+	if err != nil {
+		t.Fatalf("ResolveCronReplyTarget error = %v", err)
+	}
+	rc := rctx.(replyContext)
+	if rc.chatID != "oc_chat123" {
+		t.Fatalf("chatID = %q, want oc_chat123", rc.chatID)
+	}
+	if rc.messageID != "" {
+		t.Fatalf("messageID = %q, want empty", rc.messageID)
+	}
+}
+
+func TestReconstructReplyCtx_ThreadKey_SetsInThread(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret",
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	rctx, err := p.(*interactivePlatform).ReconstructReplyCtx("feishu:oc_chat:root:om_root123")
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	rc := rctx.(replyContext)
+	if !rc.inThread {
+		t.Fatal("inThread should be true for root: session key")
+	}
+}
+
+func TestReconstructReplyCtx_NonThreadKey_NoInThread(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret",
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error = %v", err)
+	}
+	rctx, err := p.(*interactivePlatform).ReconstructReplyCtx("feishu:oc_chat:ou_user123")
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	rc := rctx.(replyContext)
+	if rc.inThread {
+		t.Fatal("inThread should be false for user-scoped key")
+	}
+}
+
+func TestFetchThreadRootMessage_Truncation(t *testing.T) {
+	input := "[Quoted message from AlertBot]:\n" + strings.Repeat("A", 2500) + "\n\n"
+	const oldPrefix = "[Quoted message from "
+	const newPrefix = "[Thread root message from "
+	result := newPrefix + input[len(oldPrefix):]
+	if idx := strings.Index(result, "]:\n"); idx >= 0 {
+		header := result[:idx+len("]:\n")]
+		body := result[idx+len("]:\n"):]
+		body = strings.TrimSuffix(body, "\n\n")
+		if len(body) > threadRootMaxLen {
+			body = body[:threadRootMaxLen] + "[...truncated]"
+		}
+		result = header + body + "\n\n"
+	}
+	if !strings.HasPrefix(result, "[Thread root message from AlertBot]:\n") {
+		t.Fatalf("expected thread root prefix, got %q", result[:60])
+	}
+	bodyStart := strings.Index(result, "]:\n") + len("]:\n")
+	body := result[bodyStart:]
+	body = strings.TrimSuffix(body, "\n\n")
+	if !strings.HasSuffix(body, "[...truncated]") {
+		t.Fatalf("expected truncation suffix, got ...%q", body[len(body)-20:])
+	}
+	bodyWithoutSuffix := strings.TrimSuffix(body, "[...truncated]")
+	if len(bodyWithoutSuffix) != threadRootMaxLen {
+		t.Fatalf("truncated body length = %d, want %d", len(bodyWithoutSuffix), threadRootMaxLen)
 	}
 }

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -748,6 +748,18 @@ func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 			replyCtx:      replyContext{messageID: "om_reply"},
 			wantThreading: false,
 		},
+		{
+			name:          "reply_in_thread config creates thread for non-thread message",
+			platform:      &Platform{replyInThread: true},
+			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:om_reply"},
+			wantThreading: true,
+		},
+		{
+			name:          "reply_in_thread config does not affect already-threaded message",
+			platform:      &Platform{replyInThread: false},
+			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:om_root", inThread: true},
+			wantThreading: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

  Improve `thread_isolation` mode in the Feishu platform: fix reply behavior, session continuity, thread root context injection, cron delivery, and add a new `reply_in_thread` config option.

  All changes are scoped to `platform/feishu/` and `config.example.toml` — no modifications to `core/`.

  ## Problems Solved

  ### 1. Group @bot creates unwanted threads

  When `thread_isolation = true`, `shouldReplyInThread` checked the session key format (`root:` prefix) to decide whether to use `ReplyInThread=true`. Since `makeSessionKey` generates `root:` keys even for standalone group messages (fallback to messageID), every group
  reply created a thread — even when the user just wanted a quick answer in the chat.

  ### 2. Session breaks across threads and bot replies

  When a user opens a thread on a bot reply, the thread's `root_id` points to the bot's message — which wasn't tracked. This produced a different session key and a new agent session, breaking conversation continuity.

  ### 3. Thread root message repeated on every message

  When posting in a thread, Feishu sets `parent_id = root_id`. The existing `fetchQuotedMessage(parentID)` was called on every message, prepending the root content each time — wasting tokens and confusing users when the AI echoed their input with the root message
  attached.

  ### 4. Cron jobs reply in threads instead of posting new messages

  Cron jobs bound to a thread-isolated session key would `ReplyInThread` to the original message instead of posting a new message in the group.

  ## Fixes

  ### Fix 1: Decouple ReplyInThread from session key format

  Add `inThread` field to `replyContext`, set only when the message has a real `thread_id` (not just `root_id`). Quote-replies in the group have `root_id` but no `thread_id`, so they no longer trigger `ReplyInThread`.

  ### Fix 2: Track bot replies for session continuity

  Store bot reply message IDs in `msgSessionMap` (from `replyMessage` and `SendPreviewStart` responses). When a user opens a thread on any tracked message, `makeSessionKey` looks up the map and inherits the original session.

  ### Fix 3: Thread root context — inject once per session

  When `parent_id == root_id`, use `rootContextSent` (`sync.Map`) to inject root message content only on the first message. Uses distinct `[Thread root message from ...]` prefix with 2000 char truncation. Explicit quote-replies (`parent_id != root_id`) preserve existing
  `fetchQuotedMessage` behavior.

  ### Fix 4: Cron sends new messages to group

  Implement `CronReplyTargetResolver` (existing core interface, used by Discord). Returns `replyContext` with only `chatID` and no `messageID`, so `Send()` takes the `sendNewMessageToChat` path.

  ## Enhancement: `reply_in_thread` config

  New independent config option controlling whether bot replies create threads for non-thread messages:

  ```toml
  [projects.platforms.options]
  thread_isolation = true     # session isolation: each thread gets its own session
  reply_in_thread = true      # reply behavior: bot creates threads on every reply

  shouldReplyInThread logic after this change:

  func (p *Platform) shouldReplyInThread(rc replyContext) bool {
      if rc.messageID == "" {
          return false
      }
      if rc.inThread {
          return true           // already in a thread → always reply in thread
      }
      return p.replyInThread    // not in a thread → config decides
  }

  ┌─────────────────┬───────────────────────────┬─────────────────┐
  │ reply_in_thread │        Group @bot         │   Thread @bot   │
  ├─────────────────┼───────────────────────────┼─────────────────┤
  │ false (default) │ Reply in group, no thread │ Reply in thread │
  ├─────────────────┼───────────────────────────┼─────────────────┤
  │ true            │ Create thread on reply    │ Reply in thread │
  └─────────────────┴───────────────────────────┴─────────────────┘

  Session Key Rules (unchanged)

  ┌───────────────────────────────────────────────────────┬─────────────────────────────────────────────┐
  │                       Condition                       │             Session key format              │
  ├───────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ thread_isolation=true, group, has root_id             │ feishu:{chatID}:root:{rootID}               │
  ├───────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ thread_isolation=true, group, no root_id              │ feishu:{chatID}:root:{messageID} (fallback) │
  ├───────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ thread_isolation=true, root_id found in msgSessionMap │ Inherited from parent message               │
  ├───────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ share_session_in_channel=true                         │ feishu:{chatID}                             │
  ├───────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ Default (P2P, no isolation)                           │ feishu:{chatID}:{userID}                    │
  └───────────────────────────────────────────────────────┴─────────────────────────────────────────────┘

  Behavior Matrix

  ┌───────────────────────────────┬───────────┬──────────┬───────────────────────────────────────┬──────────────────────────────────────┬─────────────────────────────┐
  │           Scenario            │ thread_id │ inThread │ ReplyInThread (reply_in_thread=false) │ ReplyInThread (reply_in_thread=true) │           Session           │
  ├───────────────────────────────┼───────────┼──────────┼───────────────────────────────────────┼──────────────────────────────────────┼─────────────────────────────┤
  │ Group @bot (no thread)        │ empty     │ false    │ false                                 │ true                                 │ Per message ID              │
  ├───────────────────────────────┼───────────┼──────────┼───────────────────────────────────────┼──────────────────────────────────────┼─────────────────────────────┤
  │ Quote-reply @bot (no thread)  │ empty     │ false    │ false                                 │ true                                 │ Via root_id chain           │
  ├───────────────────────────────┼───────────┼──────────┼───────────────────────────────────────┼──────────────────────────────────────┼─────────────────────────────┤
  │ Thread @bot                   │ present   │ true     │ true                                  │ true                                 │ Per thread root             │
  ├───────────────────────────────┼───────────┼──────────┼───────────────────────────────────────┼──────────────────────────────────────┼─────────────────────────────┤
  │ Thread on bot reply           │ present   │ true     │ true                                  │ true                                 │ Inherited via msgSessionMap │
  ├───────────────────────────────┼───────────┼──────────┼───────────────────────────────────────┼──────────────────────────────────────┼─────────────────────────────┤
  │ P2P message                   │ empty     │ false    │ false                                 │ false                                │ Per user                    │
  ├───────────────────────────────┼───────────┼──────────┼───────────────────────────────────────┼──────────────────────────────────────┼─────────────────────────────┤
  │ Cron (ResolveCronReplyTarget) │ n/a       │ n/a      │ false                                 │ false                                │ New message in group        │
  └───────────────────────────────┴───────────┴──────────┴───────────────────────────────────────┴──────────────────────────────────────┴─────────────────────────────┘

  Test plan

  - go build ./cmd/cc-connect passes
  - go test ./platform/feishu/ — all tests pass
  - Manual: group @bot → reply in group without creating thread
  - Manual: thread @bot → reply stays in thread
  - Manual: quote-reply bot message → no unwanted thread created
  - Manual: open thread on bot reply → same session (msgSessionMap hit)
  - Manual: thread root message appears only on first message
  - Manual: cron fires → new message in group
  - Manual: reply_in_thread=true → bot creates threads on group replies

  🤖 Generated with Claude Code
  ```