### PR TITLE
feat(bridge): publish command capabilities snapshot to bridge adapters

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -117,6 +117,8 @@ func main() {
 
 	core.VersionInfo = fmt.Sprintf("cc-connect %s\ncommit: %s\nbuilt: %s", version, commit, buildTime)
 	core.CurrentVersion = version
+	core.CurrentCommit = commit
+	core.CurrentBuildTime = buildTime
 
 	configPath := resolveConfigPath(*configFlag)
 

--- a/core/bridge.go
+++ b/core/bridge.go
@@ -45,6 +45,7 @@ type bridgeEngineRef struct {
 type bridgeAdapter struct {
 	platform     string
 	capabilities map[string]bool
+	metadata     map[string]any
 	conn         *websocket.Conn
 	writeMu      sync.Mutex
 	server       *BridgeServer
@@ -584,6 +585,7 @@ func (bs *BridgeServer) handleConnection(conn *websocket.Conn) {
 	adapter := &bridgeAdapter{
 		platform:        reg.Platform,
 		capabilities:    caps,
+		metadata:        reg.Metadata,
 		conn:            conn,
 		server:          bs,
 		previewRequests: make(map[string]chan string),
@@ -601,6 +603,14 @@ func (bs *BridgeServer) handleConnection(conn *websocket.Conn) {
 		slog.Debug("bridge: write register ack failed", "error", err)
 		return
 	}
+
+	if bridgeMetadataStringListContains(reg.Metadata, "control_plane", bridgeCapabilitiesSnapshotProto) {
+		if err := writeJSON(conn, &adapter.writeMu, bs.buildCapabilitiesSnapshot()); err != nil {
+			slog.Debug("bridge: write capabilities snapshot failed", "platform", reg.Platform, "error", err)
+			return
+		}
+	}
+
 	slog.Info("bridge: adapter registered", "platform", reg.Platform, "capabilities", reg.Capabilities)
 
 	defer func() {
@@ -1077,6 +1087,33 @@ func (bs *BridgeServer) sendToAdapter(platform string, msg map[string]any) error
 		return fmt.Errorf("bridge: adapter %q not connected", platform)
 	}
 	return writeJSON(a.conn, &a.writeMu, msg)
+}
+
+func bridgeMetadataStringListContains(metadata map[string]any, key, want string) bool {
+	if metadata == nil || key == "" || want == "" {
+		return false
+	}
+	raw, ok := metadata[key]
+	if !ok {
+		return false
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		if stringsList, ok := raw.([]string); ok {
+			for _, item := range stringsList {
+				if strings.TrimSpace(item) == want {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	for _, item := range items {
+		if s, ok := item.(string); ok && strings.TrimSpace(s) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (bs *BridgeServer) platformFromSessionKey(sessionKey string) string {

--- a/core/bridge_capabilities.go
+++ b/core/bridge_capabilities.go
@@ -1,0 +1,144 @@
+package core
+
+import (
+	"os"
+	"sort"
+	"strings"
+)
+
+const (
+	bridgeCapabilitiesSnapshotType  = "capabilities_snapshot"
+	bridgeCapabilitiesSnapshotProto = "capabilities_snapshot_v1"
+	bridgeCommandArgsModeText       = "text"
+	bridgeCommandSourceBuiltin      = "builtin"
+	bridgeCommandSourceCustom       = "custom"
+)
+
+// CurrentCommit is set by main at startup so bridge clients can inspect the
+// host binary that produced a capability snapshot.
+var CurrentCommit string
+
+// CurrentBuildTime is set by main at startup so bridge clients can compare
+// host snapshots without reverse-engineering git-describe version strings.
+var CurrentBuildTime string
+
+type bridgeCapabilitiesSnapshot struct {
+	Type     string                      `json:"type"`
+	Version  int                         `json:"v"`
+	Host     bridgeCapabilitiesHost      `json:"host"`
+	Projects []bridgeProjectCapabilities `json:"projects"`
+}
+
+type bridgeCapabilitiesHost struct {
+	ID               string `json:"id"`
+	Hostname         string `json:"hostname,omitempty"`
+	CCConnectVersion string `json:"cc_connect_version,omitempty"`
+	Commit           string `json:"commit,omitempty"`
+	BuildTime        string `json:"build_time,omitempty"`
+}
+
+type bridgeProjectCapabilities struct {
+	Project  string                   `json:"project"`
+	Commands []bridgePublishedCommand `json:"commands"`
+}
+
+type bridgePublishedCommand struct {
+	Name              string `json:"name"`
+	Description       string `json:"description"`
+	Source            string `json:"source"`
+	RequiresWorkspace bool   `json:"requires_workspace"`
+	ArgsMode          string `json:"args_mode"`
+}
+
+// GetBridgePublishedCommands returns the subset of commands that a bridge
+// control-plane client can safely expose as slash commands. It intentionally
+// excludes skills and other richer command models until the bridge protocol
+// grows beyond the single free-form "args" text bucket.
+func (e *Engine) GetBridgePublishedCommands() []bridgePublishedCommand {
+	e.userRolesMu.RLock()
+	disabledCmds := e.disabledCmds
+	e.userRolesMu.RUnlock()
+
+	seen := make(map[string]bool)
+	var commands []bridgePublishedCommand
+
+	for _, c := range builtinCommands {
+		if len(c.names) == 0 || disabledCmds[c.id] {
+			continue
+		}
+		if seen[c.id] {
+			continue
+		}
+		seen[c.id] = true
+		commands = append(commands, bridgePublishedCommand{
+			Name:              c.id,
+			Description:       e.i18n.T(MsgKey(c.id)),
+			Source:            bridgeCommandSourceBuiltin,
+			RequiresWorkspace: false,
+			ArgsMode:          bridgeCommandArgsModeText,
+		})
+	}
+
+	customCommands := e.commands.ListAll()
+	sort.Slice(customCommands, func(i, j int) bool {
+		return strings.ToLower(customCommands[i].Name) < strings.ToLower(customCommands[j].Name)
+	})
+	for _, c := range customCommands {
+		lowerName := strings.ToLower(strings.TrimSpace(c.Name))
+		if lowerName == "" || seen[lowerName] || disabledCmds[lowerName] {
+			continue
+		}
+		seen[lowerName] = true
+
+		desc := strings.TrimSpace(c.Description)
+		if desc == "" {
+			desc = "Custom command"
+		}
+
+		commands = append(commands, bridgePublishedCommand{
+			Name:              c.Name,
+			Description:       desc,
+			Source:            bridgeCommandSourceCustom,
+			RequiresWorkspace: false,
+			ArgsMode:          bridgeCommandArgsModeText,
+		})
+	}
+
+	return commands
+}
+
+func (bs *BridgeServer) buildCapabilitiesSnapshot() bridgeCapabilitiesSnapshot {
+	hostName, _ := os.Hostname()
+	projects := make([]bridgeProjectCapabilities, 0, len(bs.engines))
+
+	bs.enginesMu.RLock()
+	projectNames := make([]string, 0, len(bs.engines))
+	for projectName := range bs.engines {
+		projectNames = append(projectNames, projectName)
+	}
+	sort.Strings(projectNames)
+	for _, projectName := range projectNames {
+		ref := bs.engines[projectName]
+		if ref == nil || ref.engine == nil {
+			continue
+		}
+		projects = append(projects, bridgeProjectCapabilities{
+			Project:  projectName,
+			Commands: ref.engine.GetBridgePublishedCommands(),
+		})
+	}
+	bs.enginesMu.RUnlock()
+
+	return bridgeCapabilitiesSnapshot{
+		Type:    bridgeCapabilitiesSnapshotType,
+		Version: 1,
+		Host: bridgeCapabilitiesHost{
+			ID:               hostName,
+			Hostname:         hostName,
+			CCConnectVersion: CurrentVersion,
+			Commit:           CurrentCommit,
+			BuildTime:        CurrentBuildTime,
+		},
+		Projects: projects,
+	}
+}

--- a/core/bridge_capabilities_snapshot_test.go
+++ b/core/bridge_capabilities_snapshot_test.go
@@ -1,0 +1,55 @@
+package core
+
+import "testing"
+
+func TestBridgeBuildCapabilitiesSnapshotIncludesProjectCatalog(t *testing.T) {
+	prevVersion, prevCommit, prevBuildTime := CurrentVersion, CurrentCommit, CurrentBuildTime
+	CurrentVersion = "v9.9.9"
+	CurrentCommit = "abc123"
+	CurrentBuildTime = "2026-04-11T00:00:00Z"
+	defer func() {
+		CurrentVersion = prevVersion
+		CurrentCommit = prevCommit
+		CurrentBuildTime = prevBuildTime
+	}()
+
+	bs := NewBridgeServer(0, "", "/bridge/ws", nil)
+	bp := bs.NewPlatform("test-proj")
+	e := NewEngine("test-proj", &stubAgent{}, []Platform{bp}, "", LangEnglish)
+	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")
+	bs.RegisterEngine("test-proj", e, bp)
+
+	snapshot := bs.buildCapabilitiesSnapshot()
+	if snapshot.Type != bridgeCapabilitiesSnapshotType {
+		t.Fatalf("type = %q, want %q", snapshot.Type, bridgeCapabilitiesSnapshotType)
+	}
+	if snapshot.Version != 1 {
+		t.Fatalf("version = %d, want 1", snapshot.Version)
+	}
+	if snapshot.Host.CCConnectVersion != "v9.9.9" {
+		t.Fatalf("cc_connect_version = %q, want %q", snapshot.Host.CCConnectVersion, "v9.9.9")
+	}
+	if snapshot.Host.Commit != "abc123" {
+		t.Fatalf("commit = %q, want %q", snapshot.Host.Commit, "abc123")
+	}
+	if snapshot.Host.BuildTime != "2026-04-11T00:00:00Z" {
+		t.Fatalf("build_time = %q, want %q", snapshot.Host.BuildTime, "2026-04-11T00:00:00Z")
+	}
+	if len(snapshot.Projects) != 1 {
+		t.Fatalf("projects = %d, want 1", len(snapshot.Projects))
+	}
+	if snapshot.Projects[0].Project != "test-proj" {
+		t.Fatalf("project = %q, want %q", snapshot.Projects[0].Project, "test-proj")
+	}
+
+	foundDeploy := false
+	for _, cmd := range snapshot.Projects[0].Commands {
+		if cmd.Name == "deploy" {
+			foundDeploy = true
+			break
+		}
+	}
+	if !foundDeploy {
+		t.Fatal("expected deploy command in project capabilities snapshot")
+	}
+}

--- a/core/bridge_capabilities_test.go
+++ b/core/bridge_capabilities_test.go
@@ -1,0 +1,54 @@
+package core
+
+import "testing"
+
+func TestEngine_GetBridgePublishedCommands_IncludesBuiltinsAndCustoms(t *testing.T) {
+	e := NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
+	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")
+
+	commands := e.GetBridgePublishedCommands()
+	if len(commands) == 0 {
+		t.Fatal("expected published bridge commands")
+	}
+
+	foundHelp := false
+	foundDeploy := false
+	for _, cmd := range commands {
+		switch cmd.Name {
+		case "help":
+			foundHelp = true
+			if cmd.Source != bridgeCommandSourceBuiltin {
+				t.Fatalf("help source = %q, want %q", cmd.Source, bridgeCommandSourceBuiltin)
+			}
+		case "deploy":
+			foundDeploy = true
+			if cmd.Source != bridgeCommandSourceCustom {
+				t.Fatalf("deploy source = %q, want %q", cmd.Source, bridgeCommandSourceCustom)
+			}
+		}
+		if cmd.ArgsMode != bridgeCommandArgsModeText {
+			t.Fatalf("command %q args_mode = %q, want %q", cmd.Name, cmd.ArgsMode, bridgeCommandArgsModeText)
+		}
+	}
+
+	if !foundHelp {
+		t.Fatal("expected builtin help command in bridge catalog")
+	}
+	if !foundDeploy {
+		t.Fatal("expected custom deploy command in bridge catalog")
+	}
+}
+
+func TestEngine_GetBridgePublishedCommands_SkipsDisabledAndBuiltinCollisions(t *testing.T) {
+	e := NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
+	e.AddCommand("help", "custom help", "override", "", "", "config")
+	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")
+	e.SetDisabledCommands([]string{"help", "deploy"})
+
+	commands := e.GetBridgePublishedCommands()
+	for _, cmd := range commands {
+		if cmd.Name == "help" || cmd.Name == "deploy" {
+			t.Fatalf("unexpected disabled command %q in bridge catalog", cmd.Name)
+		}
+	}
+}

--- a/core/bridge_test.go
+++ b/core/bridge_test.go
@@ -56,6 +56,22 @@ func register(t *testing.T, conn *websocket.Conn, platform string, caps []string
 	}
 }
 
+func registerWithMetadata(t *testing.T, conn *websocket.Conn, platform string, caps []string, metadata map[string]any) {
+	t.Helper()
+	msg := map[string]any{
+		"type":         "register",
+		"platform":     platform,
+		"capabilities": caps,
+		"metadata":     metadata,
+	}
+	mustWriteJSON(t, conn, msg)
+	var ack map[string]any
+	mustReadJSON(t, conn, &ack)
+	if ack["ok"] != true {
+		t.Fatalf("register failed: %v", ack["error"])
+	}
+}
+
 func readMsg(t *testing.T, conn *websocket.Conn) map[string]any {
 	t.Helper()
 	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
@@ -114,6 +130,72 @@ func TestBridge_RegisterAndConnect(t *testing.T) {
 	adapters := bs.ConnectedAdapters()
 	if len(adapters) != 1 || adapters[0] != "test-chat" {
 		t.Fatalf("expected [test-chat], got %v", adapters)
+	}
+}
+
+func TestBridge_RegisterSendsCapabilitiesSnapshotWhenAdapterSupportsIt(t *testing.T) {
+	prevVersion, prevCommit, prevBuildTime := CurrentVersion, CurrentCommit, CurrentBuildTime
+	CurrentVersion = "v2.0.0"
+	CurrentCommit = "deadbeef"
+	CurrentBuildTime = "2026-04-11T00:00:00Z"
+	defer func() {
+		CurrentVersion = prevVersion
+		CurrentCommit = prevCommit
+		CurrentBuildTime = prevBuildTime
+	}()
+
+	bs, wsURL := startTestBridge(t, "")
+	bp := bs.NewPlatform("test-proj")
+	e := NewEngine("test-proj", &stubAgent{}, []Platform{bp}, "", LangEnglish)
+	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")
+	bs.RegisterEngine("test-proj", e, bp)
+
+	conn := dialWS(t, wsURL, nil)
+	registerWithMetadata(t, conn, "bridge", []string{"text"}, map[string]any{
+		"control_plane": []string{bridgeCapabilitiesSnapshotProto},
+	})
+
+	msg := readMsg(t, conn)
+	if msg["type"] != bridgeCapabilitiesSnapshotType {
+		t.Fatalf("type = %v, want %q", msg["type"], bridgeCapabilitiesSnapshotType)
+	}
+	if got := int(msg["v"].(float64)); got != 1 {
+		t.Fatalf("v = %d, want 1", got)
+	}
+	host, ok := msg["host"].(map[string]any)
+	if !ok {
+		t.Fatalf("host = %T, want object", msg["host"])
+	}
+	if host["cc_connect_version"] != "v2.0.0" {
+		t.Fatalf("cc_connect_version = %v, want %q", host["cc_connect_version"], "v2.0.0")
+	}
+	projects, ok := msg["projects"].([]any)
+	if !ok || len(projects) != 1 {
+		t.Fatalf("projects = %T/%d, want 1 project", msg["projects"], len(projects))
+	}
+	project, ok := projects[0].(map[string]any)
+	if !ok {
+		t.Fatalf("project = %T, want object", projects[0])
+	}
+	if project["project"] != "test-proj" {
+		t.Fatalf("project name = %v, want %q", project["project"], "test-proj")
+	}
+	commands, ok := project["commands"].([]any)
+	if !ok || len(commands) == 0 {
+		t.Fatalf("commands = %T/%d, want non-empty list", project["commands"], len(commands))
+	}
+	foundDeploy := false
+	for _, raw := range commands {
+		cmd, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("command = %T, want object", raw)
+		}
+		if cmd["name"] == "deploy" {
+			foundDeploy = true
+		}
+	}
+	if !foundDeploy {
+		t.Fatal("expected deploy command in capabilities snapshot")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an opt-in `capabilities_snapshot_v1` control-plane message for bridge adapters
- publish per-project builtin/custom command metadata after `register_ack`
- include host version, commit, and build time so bridge clients can resolve newer builtins safely

## Details
Bridge adapters that include `metadata.control_plane = ["capabilities_snapshot_v1"]` during register now receive a full command snapshot immediately after `register_ack`.

The snapshot is grouped by project and currently exposes the minimal command fields that are safe to map to slash commands:
- `name`
- `description`
- `source`
- `requires_workspace`
- `args_mode`

Older adapters are unaffected because the server only sends the snapshot when the adapter explicitly opts in.

## Tests
- `go test ./core -run "Bridge|Capabilities"`
- `go test ./cmd/cc-connect ./core -run "TestBridge_RegisterSendsCapabilitiesSnapshotWhenAdapterSupportsIt|TestBridgeBuildCapabilitiesSnapshotIncludesProjectCatalog|TestEngine_GetBridgePublishedCommands"`
