### PR TITLE
fix(codex): pass base URL via -c flag for provider switching

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -322,10 +322,12 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	codexHome := a.codexHome
 	extraEnv := a.providerEnvLocked()
 	extraEnv = append(extraEnv, a.sessionEnv...)
+	var baseURL string
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
 			model = m
 		}
+		baseURL = a.providers[a.activeIdx].BaseURL
 	}
 	a.mu.Unlock()
 
@@ -333,7 +335,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 		return newAppServerSession(ctx, appServerURL, a.workDir, model, reasoningEffort, mode, sessionID, extraEnv, codexHome)
 	}
 
-	return newCodexSession(ctx, a.workDir, model, reasoningEffort, mode, sessionID, extraEnv)
+	return newCodexSession(ctx, a.workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -28,6 +28,7 @@ type codexSession struct {
 	model     string
 	effort    string
 	mode      string
+	baseURL   string   // provider base URL; passed as -c openai_base_url=<url>
 	extraEnv  []string
 	events    chan core.Event
 	threadID  atomic.Value // stores string — Codex thread_id
@@ -45,7 +46,7 @@ type codexSession struct {
 var codexSessionCloseTimeout = 8 * time.Second
 var codexSessionForceKillWait = 2 * time.Second
 
-func newCodexSession(ctx context.Context, workDir, model, effort, mode, resumeID string, extraEnv []string) (*codexSession, error) {
+func newCodexSession(ctx context.Context, workDir, model, effort, mode, resumeID, baseURL string, extraEnv []string) (*codexSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	cs := &codexSession{
@@ -53,6 +54,7 @@ func newCodexSession(ctx context.Context, workDir, model, effort, mode, resumeID
 		model:    model,
 		effort:   effort,
 		mode:     mode,
+		baseURL:  baseURL,
 		extraEnv: extraEnv,
 		events:   make(chan core.Event, 64),
 		ctx:      sessionCtx,
@@ -167,6 +169,9 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 
 	if cs.model != "" {
 		args = append(args, "--model", cs.model)
+	}
+	if cs.baseURL != "" {
+		args = append(args, "-c", fmt.Sprintf("openai_base_url=%q", cs.baseURL))
 	}
 	if cs.effort != "" {
 		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%q", cs.effort))

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -37,7 +37,7 @@ func TestAvailableReasoningEfforts_ExcludesMinimal(t *testing.T) {
 }
 
 func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
-	cs, err := newCodexSession(context.Background(), "/tmp/project", "o3", "high", "full-auto", "", nil)
+	cs, err := newCodexSession(context.Background(), "/tmp/project", "o3", "high", "full-auto", "", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -67,8 +67,21 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestBuildExecArgs_IncludesBaseURL(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "/tmp/project", "o3", "high", "full-auto", "", "https://custom.api.example.com", nil)
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+
+	args := cs.buildExecArgs("hello", nil)
+
+	if !containsSequence(args, []string{"-c", `openai_base_url="https://custom.api.example.com"`}) {
+		t.Fatalf("args missing openai_base_url config flag: %v", args)
+	}
+}
+
 func TestBuildExecArgs_ResumeOmitsCdFlag(t *testing.T) {
-	cs, err := newCodexSession(context.Background(), "/tmp/project", "", "", "full-auto", "thread-abc", nil)
+	cs, err := newCodexSession(context.Background(), "/tmp/project", "", "", "full-auto", "thread-abc", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -108,7 +121,7 @@ func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 	t.Setenv("CODEX_ARGS_FILE", argsFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -168,7 +181,7 @@ func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
 	t.Setenv("CODEX_ARGS_FILE", argsFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "thread-123", nil)
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "thread-123", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -218,7 +231,7 @@ func TestSend_UsesStdinForMultilinePrompt(t *testing.T) {
 	t.Setenv("CODEX_STDIN_FILE", stdinFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "thread-stdin", nil)
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "thread-stdin", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -272,7 +285,7 @@ func TestSend_HandlesLargeJSONLines(t *testing.T) {
 	t.Setenv("CODEX_PAYLOAD_FILE", payloadFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -409,7 +422,7 @@ func indexOf(args []string, target string) int {
 }
 
 func TestCodexSession_ContinueSessionTreatedAsFresh(t *testing.T) {
-	s, err := newCodexSession(context.Background(), "/tmp", "", "", "full-auto", core.ContinueSession, nil)
+	s, err := newCodexSession(context.Background(), "/tmp", "", "", "full-auto", core.ContinueSession, "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -451,7 +464,7 @@ func TestClose_ForceKillsProcessGroupAfterGracefulTimeout(t *testing.T) {
 		codexSessionForceKillWait = oldForceKillWait
 	})
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -518,7 +531,7 @@ func TestClose_ForceKillsAllTrackedProcessesAfterCmdOverwrite(t *testing.T) {
 		codexSessionForceKillWait = oldForceKillWait
 	})
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Codex CLI 0.118.0 deprecated `OPENAI_BASE_URL` env var; provider switching via `/provider` set it as env var but CLI ignored it
- Now passes base URL as `-c openai_base_url=<url>` CLI flag on each subprocess invocation
- Extracts `BaseURL` from active provider in `StartSession()` and threads it through to `buildExecArgs()`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 22 codex tests pass including new `TestBuildExecArgs_IncludesBaseURL`)

Closes #554