### PR TITLE
fix(core): filter /list to only show cc-connect owned sessions

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -67,13 +67,8 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 		args = append(args, "--permission-mode", mode)
 	}
 	switch sessionID {
-	case "":
+	case "", core.ContinueSession:
 		// Truly fresh session — no resume, no continue.
-	case core.ContinueSession:
-		// --continue grabs the most recent session in the workspace, which
-		// may belong to an active CLI terminal. Fork it so the platform
-		// conversation gets its own independent context branch.
-		args = append(args, "--continue", "--fork-session")
 	default:
 		// Resuming a known session ID — this is cc-connect's own session
 		// from a previous connection, safe to resume directly.

--- a/core/engine.go
+++ b/core/engine.go
@@ -3504,6 +3504,23 @@ func (e *Engine) cmdNew(p Platform, msg *Message, args []string) {
 	}
 }
 
+// filterOwnedSessions removes agent sessions that are not tracked by cc-connect's
+// session manager. This prevents external CLI sessions in the same work_dir from
+// appearing in /list, /switch, /delete, etc. If the session manager has no tracked
+// agent sessions at all (e.g. first run), all sessions are returned unfiltered.
+func filterOwnedSessions(sessions []AgentSessionInfo, known map[string]struct{}) []AgentSessionInfo {
+	if len(known) == 0 {
+		return sessions
+	}
+	filtered := make([]AgentSessionInfo, 0, len(sessions))
+	for _, s := range sessions {
+		if _, ok := known[s.ID]; ok {
+			filtered = append(filtered, s)
+		}
+	}
+	return filtered
+}
+
 const listPageSize = 20
 
 // dirCardPageSize is the max directory history rows per card page (Feishu / other card UIs).
@@ -3522,6 +3539,7 @@ func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 			e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgListError), err))
 			return
 		}
+		agentSessions = filterOwnedSessions(agentSessions, sessions.KnownAgentSessionIDs())
 		if len(agentSessions) == 0 {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgListEmpty))
 			return
@@ -3618,6 +3636,7 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgError, err))
 		return
 	}
+	agentSessions = filterOwnedSessions(agentSessions, sessions.KnownAgentSessionIDs())
 
 	matched := e.matchSession(agentSessions, sessions, query)
 	if matched == nil {
@@ -4121,6 +4140,7 @@ func (e *Engine) cmdSearch(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgSearchError), err))
 		return
 	}
+	agentSessions = filterOwnedSessions(agentSessions, sessions.KnownAgentSessionIDs())
 
 	type searchResult struct {
 		id           string
@@ -4214,6 +4234,7 @@ func (e *Engine) cmdName(p Platform, msg *Message, args []string) {
 			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgError, err))
 			return
 		}
+		agentSessions = filterOwnedSessions(agentSessions, sessions.KnownAgentSessionIDs())
 		if idx > len(agentSessions) {
 			e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgSwitchNoSession), idx))
 			return
@@ -6866,6 +6887,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		if err != nil || len(agentSessions) == 0 {
 			return
 		}
+		agentSessions = filterOwnedSessions(agentSessions, sessions.KnownAgentSessionIDs())
 		matched := e.matchSession(agentSessions, sessions, args)
 		if matched == nil {
 			return
@@ -7003,6 +7025,7 @@ func (e *Engine) renderDeleteModeCard(sessionKey string) *Card {
 	if err != nil {
 		return e.simpleCard(e.i18n.T(MsgDeleteModeTitle), "red", err.Error())
 	}
+	agentSessions = filterOwnedSessions(agentSessions, sessions.KnownAgentSessionIDs())
 	dm := e.getDeleteModeState(sessionKey)
 	if dm == nil {
 		return e.simpleCard(e.i18n.T(MsgDeleteModeTitle), "red", e.i18n.T(MsgDeleteUsage))
@@ -7214,7 +7237,7 @@ func parseDeleteModeSelectedIDs(args []string) map[string]struct{} {
 }
 
 func (e *Engine) submitDeleteModeSelection(sessionKey string, dm *deleteModeState) []string {
-	agent, _ := e.sessionContextForKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(sessionKey)
 	deleter, ok := agent.(SessionDeleter)
 	if !ok {
 		return []string{e.i18n.T(MsgDeleteNotSupported)}
@@ -7223,6 +7246,7 @@ func (e *Engine) submitDeleteModeSelection(sessionKey string, dm *deleteModeStat
 	if err != nil {
 		return []string{e.i18n.Tf(MsgError, err)}
 	}
+	agentSessions = filterOwnedSessions(agentSessions, sessions.KnownAgentSessionIDs())
 	seen := make(map[string]struct{}, len(agentSessions))
 	lines := make([]string, 0, len(dm.selectedIDs))
 	for i := range agentSessions {
@@ -7408,6 +7432,7 @@ func (e *Engine) renderListCard(sessionKey string, page int) (*Card, error) {
 	if err != nil {
 		return nil, fmt.Errorf(e.i18n.T(MsgListError), err)
 	}
+	agentSessions = filterOwnedSessions(agentSessions, sessions.KnownAgentSessionIDs())
 	if len(agentSessions) == 0 {
 		return e.simpleCard(e.i18n.Tf(MsgCardTitleSessions, agent.Name(), 0), "turquoise", e.i18n.T(MsgListEmpty)), nil
 	}
@@ -9227,7 +9252,7 @@ func (e *Engine) cmdAliasDel(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdDelete(p Platform, msg *Message, args []string) {
-	agent, _, _, err := e.commandContext(p, msg)
+	agent, sessions, _, err := e.commandContext(p, msg)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
 		return
@@ -9257,6 +9282,7 @@ func (e *Engine) cmdDelete(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgError, err))
 		return
 	}
+	agentSessions = filterOwnedSessions(agentSessions, sessions.KnownAgentSessionIDs())
 
 	prefix := strings.TrimSpace(args[0])
 	if isExplicitDeleteBatchArg(prefix) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2756,7 +2756,13 @@ func TestDeleteMode_ActiveSessionMarkedWithArrowAndNotSelectable(t *testing.T) {
 	}}}
 	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
 	msg := &Message{SessionKey: "feishu:user1", ReplyCtx: "ctx"}
-	e.sessions.GetOrCreateActive(msg.SessionKey).SetAgentSessionID("session-1", "test")
+	// Register both sessions so they pass the owned-session filter.
+	s1 := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s1.SetAgentSessionID("session-1", "test")
+	s2 := e.sessions.NewSession(msg.SessionKey, "two")
+	s2.SetAgentSessionID("session-2", "test")
+	// Switch back to s1 as the active session.
+	e.sessions.SwitchSession(msg.SessionKey, s1.ID)
 
 	e.cmdDelete(p, msg, nil)
 	if len(p.repliedCards) != 1 {
@@ -4069,7 +4075,16 @@ func TestRenderListCard_MakesEveryVisibleSessionClickable(t *testing.T) {
 	}
 
 	e := NewEngine("test", &stubListAgent{sessions: sessions}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
-	e.sessions.GetOrCreateActive("test:user1").SetAgentSessionID(sessions[5].ID, "test")
+	// Register all agent sessions with the session manager so they pass the
+	// owned-session filter (simulates cc-connect having created each session).
+	var internalIDs []string
+	for i, s := range sessions {
+		sess := e.sessions.NewSession("test:user1", "session-"+string(rune('A'+i)))
+		sess.SetAgentSessionID(s.ID, "test")
+		internalIDs = append(internalIDs, sess.ID)
+	}
+	// Switch active to the session mapped to sessions[5] (agent-session-F).
+	e.sessions.SwitchSession("test:user1", internalIDs[5])
 
 	card, err := e.renderListCard("test:user1", 1)
 	if err != nil {

--- a/core/session.go
+++ b/core/session.go
@@ -363,6 +363,24 @@ func (sm *SessionManager) AllSessions() []*Session {
 	return out
 }
 
+// KnownAgentSessionIDs returns the set of agent session IDs tracked by cc-connect.
+// This is used to filter agent.ListSessions() output to only sessions owned by
+// cc-connect, excluding sessions created by external CLI usage in the same work_dir.
+func (sm *SessionManager) KnownAgentSessionIDs() map[string]struct{} {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	ids := make(map[string]struct{})
+	for _, s := range sm.sessions {
+		s.mu.Lock()
+		aid := s.AgentSessionID
+		s.mu.Unlock()
+		if aid != "" {
+			ids[aid] = struct{}{}
+		}
+	}
+	return ids
+}
+
 // SessionKeyMap returns a mapping from session ID to the user key (session_key) it belongs to,
 // plus active session IDs for each user key.
 func (sm *SessionManager) SessionKeyMap() (idToKey map[string]string, activeIDs map[string]bool) {

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -502,3 +502,54 @@ func TestSessionManager_StorePath(t *testing.T) {
 		t.Errorf("StorePath() empty = %q, want empty string", got)
 	}
 }
+
+func TestKnownAgentSessionIDs(t *testing.T) {
+	sm := NewSessionManager("")
+	s1 := sm.NewSession("user1", "a")
+	s1.SetAgentSessionID("uuid-aaa", "claude")
+	s2 := sm.NewSession("user1", "b")
+	s2.SetAgentSessionID("uuid-bbb", "claude")
+	sm.NewSession("user1", "c") // no agent session id
+
+	known := sm.KnownAgentSessionIDs()
+	if len(known) != 2 {
+		t.Fatalf("KnownAgentSessionIDs len = %d, want 2", len(known))
+	}
+	if _, ok := known["uuid-aaa"]; !ok {
+		t.Fatal("expected uuid-aaa in known set")
+	}
+	if _, ok := known["uuid-bbb"]; !ok {
+		t.Fatal("expected uuid-bbb in known set")
+	}
+}
+
+func TestFilterOwnedSessions_FiltersUnknown(t *testing.T) {
+	all := []AgentSessionInfo{
+		{ID: "owned-1"},
+		{ID: "external-1"},
+		{ID: "owned-2"},
+		{ID: "external-2"},
+	}
+	known := map[string]struct{}{
+		"owned-1": {},
+		"owned-2": {},
+	}
+	filtered := filterOwnedSessions(all, known)
+	if len(filtered) != 2 {
+		t.Fatalf("filterOwnedSessions len = %d, want 2", len(filtered))
+	}
+	if filtered[0].ID != "owned-1" || filtered[1].ID != "owned-2" {
+		t.Fatalf("filtered = %v, want owned-1 and owned-2", filtered)
+	}
+}
+
+func TestFilterOwnedSessions_EmptyKnownReturnsAll(t *testing.T) {
+	all := []AgentSessionInfo{
+		{ID: "session-1"},
+		{ID: "session-2"},
+	}
+	filtered := filterOwnedSessions(all, map[string]struct{}{})
+	if len(filtered) != 2 {
+		t.Fatalf("filterOwnedSessions with empty known = %d, want 2", len(filtered))
+	}
+}


### PR DESCRIPTION
## Summary
- Filter all session listing operations (/list, /switch, /delete, /search, /name) to only show sessions tracked by cc-connect's session manager, excluding external CLI sessions in the same work_dir
- Add `KnownAgentSessionIDs()` to `SessionManager` and `filterOwnedSessions()` helper to engine
- Remove dead `--continue` code path from `claudecode/session.go` (engine no longer passes `ContinueSession` sentinel)
- Add regression tests for the filtering logic

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing + 3 new tests)
- [ ] Manual smoke test: run Claude CLI directly in same work_dir, verify /list only shows cc-connect sessions

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)