### PR TITLE
feat(core): discover skills recursively

### DIFF
--- a/core/skill.go
+++ b/core/skill.go
@@ -78,9 +78,7 @@ func (r *SkillRegistry) ListAll() []*Skill {
 	seen := make(map[string]bool)
 
 	for _, dir := range r.dirs {
-		for _, skill := range discoverSkillsInDir(dir, seen) {
-			result = append(result, skill)
-		}
+		result = append(result, discoverSkillsInDir(dir, seen)...)
 	}
 
 	r.cache = result

--- a/core/skill.go
+++ b/core/skill.go
@@ -78,43 +78,63 @@ func (r *SkillRegistry) ListAll() []*Skill {
 	seen := make(map[string]bool)
 
 	for _, dir := range r.dirs {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			continue
-		}
-		for _, entry := range entries {
-			fullPath := filepath.Join(dir, entry.Name())
-			info, err := os.Stat(fullPath)
-			if err != nil {
-				continue
-			}
-			if !info.IsDir() {
-				continue
-			}
-			skillName := entry.Name()
-			if seen[strings.ToLower(skillName)] {
-				continue
-			}
-
-			mdPath := filepath.Join(dir, skillName, "SKILL.md")
-			data, err := os.ReadFile(mdPath)
-			if err != nil {
-				continue
-			}
-
-			skill := parseSkillMD(skillName, string(data), dir)
-			if skill == nil {
-				continue
-			}
-
-			seen[strings.ToLower(skillName)] = true
+		for _, skill := range discoverSkillsInDir(dir, seen) {
 			result = append(result, skill)
-			slog.Debug("skill: discovered", "name", skillName, "dir", dir)
 		}
 	}
 
 	r.cache = result
 	return result
+}
+
+func discoverSkillsInDir(root string, seen map[string]bool) []*Skill {
+	var result []*Skill
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() != "SKILL.md" {
+			return nil
+		}
+
+		skillDir := filepath.Dir(path)
+		if sameFilePath(skillDir, root) {
+			return nil
+		}
+
+		skillName := filepath.Base(skillDir)
+		if seen[strings.ToLower(skillName)] {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+
+		skill := parseSkillMD(skillName, string(data), skillDir)
+		if skill == nil {
+			return nil
+		}
+
+		seen[strings.ToLower(skillName)] = true
+		result = append(result, skill)
+		slog.Debug("skill: discovered", "name", skillName, "dir", skillDir)
+		return nil
+	})
+	if err != nil {
+		return result
+	}
+	return result
+}
+
+func sameFilePath(a, b string) bool {
+	aClean := filepath.Clean(a)
+	bClean := filepath.Clean(b)
+	return aClean == bClean
 }
 
 // Invalidate clears the cache so skills are re-scanned on next access.

--- a/core/skill_test.go
+++ b/core/skill_test.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSkillRegistryListAll_RecursesIntoGroupedDirectories(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "automation", "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
+	writeSkillFile(t, filepath.Join(root, "productivity", "doc", "SKILL.md"), "Doc skill")
+	writeSkillFile(t, filepath.Join(root, ".system", "skill-installer", "SKILL.md"), "System skill")
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 3 {
+		t.Fatalf("skills discovered = %d, want 3", len(skills))
+	}
+	if r.Resolve("telegram-codex-bot") == nil {
+		t.Fatalf("expected grouped skill to resolve")
+	}
+	if r.Resolve("doc") == nil {
+		t.Fatalf("expected nested productivity skill to resolve")
+	}
+	if r.Resolve("skill-installer") == nil {
+		t.Fatalf("expected .system skill to resolve")
+	}
+}
+
+func TestSkillRegistryListAll_DedupesByLeafDirectoryName(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "apple", "helper", "SKILL.md"), "Apple helper")
+	writeSkillFile(t, filepath.Join(root, "automation", "helper", "SKILL.md"), "Automation helper")
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 1 {
+		t.Fatalf("skills discovered = %d, want 1", len(skills))
+	}
+	if skills[0].Name != "helper" {
+		t.Fatalf("skill name = %q, want helper", skills[0].Name)
+	}
+}
+
+func TestSkillRegistryListAll_IgnoresRootSkillFile(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "SKILL.md"), "Root skill should be ignored")
+	writeSkillFile(t, filepath.Join(root, "group", "visible-skill", "SKILL.md"), "Visible skill")
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 1 {
+		t.Fatalf("skills discovered = %d, want 1", len(skills))
+	}
+	if skills[0].Name != "visible-skill" {
+		t.Fatalf("skill name = %q, want visible-skill", skills[0].Name)
+	}
+}
+
+func writeSkillFile(t *testing.T, path, description string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	data := []byte("---\ndescription: " + description + "\n---\nPrompt body")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

This changes skill discovery to scan skill roots recursively instead of only looking one directory deep.

## Why

Codex skills can be organized into grouped directories such as `skills/.system/imagegen/SKILL.md`. The previous `cc-connect` discovery logic only scanned `<root>/<name>/SKILL.md`, so grouped skills were invisible to `/skills` and could not be resolved.

## Changes

- recursively discover `SKILL.md` files under each configured skill root
- keep the skill command name based on the leaf directory name
- continue deduping by leaf directory name to preserve existing conflict behavior
- include nested `.system` skills in discovery as well
- add tests for grouped directories, `.system` discovery, duplicate leaf names, and ignoring a root-level `SKILL.md`

## Validation

- `go test ./core ./platform/telegram`
- manually verified in a real Telegram bot session that `/skills` now lists grouped Codex skills from nested directories
