### PR TITLE
fix(core): use accumulated text when tool messages hidden

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2661,8 +2661,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			}
 
 			fullResponse := event.Content
-			if fullResponse == "" && len(textParts) > 0 {
-				fullResponse = strings.Join(textParts, "")
+			// When tool messages are hidden (segmentStart stays 0), event.Content
+			// only contains the last assistant turn text. Use accumulated textParts
+			// which hold all assistant text across the entire turn.
+			if len(textParts) > 0 {
+				accumulated := strings.Join(textParts, "")
+				if len(accumulated) > len(fullResponse) {
+					fullResponse = accumulated
+				}
 			}
 			if fullResponse == "" {
 				fullResponse = e.i18n.T(MsgEmptyResponse)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -979,6 +979,48 @@ func TestProcessInteractiveEvents_ToolMessagesDisabledSuppressesToolProgressOnly
 	}
 }
 
+// Regression test for #549: when tool_messages=false, EventResult.Content only
+// contains the last assistant turn text, not the full accumulated response.
+// The engine must use accumulated textParts to build fullResponse.
+func TestProcessInteractiveEvents_HiddenToolMessages_AccumulatesAllText(t *testing.T) {
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{ToolMessages: false})
+	sessionKey := "telegram:user-549"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s549")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-549",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	// Simulate: text → tool → text → tool → text → result
+	// The agent sends three text segments, but EventResult.Content only has the last.
+	agentSession.events <- Event{Type: EventText, Content: "First part. "}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "ls"}
+	agentSession.events <- Event{Type: EventToolResult, ToolName: "Bash", ToolResult: "file.go"}
+	agentSession.events <- Event{Type: EventText, Content: "Second part. "}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Read", ToolInput: "file.go"}
+	agentSession.events <- Event{Type: EventToolResult, ToolName: "Read", ToolResult: "package main"}
+	agentSession.events <- Event{Type: EventText, Content: "Third part."}
+	// EventResult.Content = only the last turn text, NOT the full accumulated text
+	agentSession.events <- Event{Type: EventResult, Content: "Third part.", Done: true}
+
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m549", time.Now(), nil, nil, nil)
+
+	sent := p.getSent()
+	if len(sent) == 0 {
+		t.Fatal("expected at least one sent message")
+	}
+	final := sent[len(sent)-1]
+	wantAll := "First part. Second part. Third part."
+	if final != wantAll {
+		t.Fatalf("final message = %q (len=%d), want %q (len=%d)", final, len(final), wantAll, len(wantAll))
+	}
+}
+
 func TestProcessInteractiveEvents_CompactProgressCoalescesThinkingAndToolUse(t *testing.T) {
 	p := &stubCompactProgressPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)


### PR DESCRIPTION
## Summary
- When `tool_messages=false`, `EventResult.Content` only contains the last assistant turn text (e.g. 198 chars), not the full accumulated response (e.g. 822 chars across multiple turns)
- The engine now compares accumulated `textParts` against `event.Content` and uses whichever is longer
- This ensures the final card/message and history contain the complete multi-turn response

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] New regression test: `TestProcessInteractiveEvents_HiddenToolMessages_AccumulatesAllText`
- [ ] Manual: set `tool_messages=false`, send a message that triggers multiple tool calls, verify final response contains all text segments

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)