### PR TITLE
feat: --as-prompt flag and --new-thread session inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,42 @@ start if any gate fails or if the probe detects a cross-user leak.
 
 ---
 
+### 🧵 Thread-Aware Session Routing (Slack)
+
+When users have concurrent conversations in different Slack threads, cc-connect routes each thread to a dedicated session — preventing cross-talk.
+
+**Model: context-switch first, fork on contention**
+
+```
+Message arrives
+  → Thread idle? Resume context, respond. (One session, context-switch.)
+  → Thread mid-turn? Fork new session, lock it to this thread.
+  → max_concurrent reached? Queue in primary session.
+```
+
+- `client_msg_id` deduplication prevents the "also send to channel" double-event from being processed twice.
+- Forked sessions follow the same idle/reset timeouts as the primary session.
+- When a forked session ends, the thread re-routes fresh on the next message.
+
+**Configuration** (all optional — defaults work out of the box):
+
+```toml
+[threads]
+max_concurrent = 3   # Max simultaneous mid-turn sessions per channel (default: 3)
+                     # Set to 1 to disable forking (sequential/queue-only mode)
+```
+
+**Resource sizing:**
+
+| `max_concurrent` | Min RAM per project binding |
+|---|---|
+| 1 (no forking) | ~2 GB |
+| 3 (default)    | ~4 GB |
+| 5              | ~6 GB |
+
+Each additional concurrent session requires ~430 MB (300–360 MB Claude Code + 70 MB Node.js worker).
+
+
 ### 🔐 Permission Modes
 
 ```

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -500,11 +500,12 @@ func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, erro
 			continue
 		}
 
-		summary, msgCount := scanSessionMeta(filepath.Join(projectDir, name))
+		firstSummary, summary, msgCount := scanSessionMeta(filepath.Join(projectDir, name))
 
 		sessions = append(sessions, core.AgentSessionInfo{
 			ID:           sessionID,
 			Summary:      summary,
+			FirstSummary: firstSummary,
 			MessageCount: msgCount,
 			ModifiedAt:   info.ModTime(),
 		})
@@ -537,18 +538,24 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 	return os.Remove(path)
 }
 
-func scanSessionMeta(path string) (string, int) {
+// scanSessionMeta parses a claude JSONL session file and returns
+// (firstUserSummary, lastUserSummary, messageCount). Both summaries are
+// XML-tag stripped and truncated to ~40 runes so they fit cleanly in a
+// Slack list row. firstUserSummary is the opening user message in the
+// file (what the user originally started the session with); lastUserSummary
+// is the most recent user message (what the session is currently about).
+// Used by /list, /switch (which want the "current topic" = Summary) and
+// by /resume (which also wants the original starting point = FirstSummary
+// so long-running drifted sessions remain identifiable).
+func scanSessionMeta(path string) (firstSummary, summary string, count int) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", 0
+		return "", "", 0
 	}
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 256*1024), 256*1024)
-
-	var summary string
-	var count int
 
 	for scanner.Scan() {
 		var entry struct {
@@ -563,16 +570,33 @@ func scanSessionMeta(path string) (string, int) {
 		if entry.Type == "user" || entry.Type == "assistant" {
 			count++
 			if entry.Type == "user" && entry.Message.Content != "" {
+				if firstSummary == "" {
+					firstSummary = entry.Message.Content
+				}
 				summary = entry.Message.Content
 			}
 		}
 	}
-	summary = stripXMLTags(summary)
-	summary = strings.TrimSpace(summary)
-	if utf8.RuneCountInString(summary) > 40 {
-		summary = string([]rune(summary)[:40]) + "..."
+	firstSummary = truncateSummaryForList(stripXMLTags(firstSummary))
+	summary = truncateSummaryForList(stripXMLTags(summary))
+	return firstSummary, summary, count
+}
+
+// truncateSummaryForList trims whitespace, collapses interior newlines to
+// spaces (so a multi-line user message does not blow out the picker row),
+// and truncates to ~40 runes with an ellipsis.
+func truncateSummaryForList(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	// Collapse runs of whitespace.
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
 	}
-	return summary, count
+	if utf8.RuneCountInString(s) > 40 {
+		s = string([]rune(s)[:40]) + "..."
+	}
+	return s
 }
 
 var xmlTagRe = regexp.MustCompile(`<[^>]+>`)

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -161,8 +161,10 @@ func New(opts map[string]any) (core.Agent, error) {
 	// Disallowing them here is the cleanest way to enforce "cc-connect owns
 	// message delivery on every platform it bridges to". Per-project config
 	// can extend this list but cannot override it.
+	// Note: mcp__claude_ai_Slack is NOT blocked here because a PreToolUse hook
+	// (slack-guard.sh) guards write operations while allowing search/read.
+	// This gives agents access to Slack history for context.
 	disallowedTools := []string{
-		"mcp__claude_ai_Slack",
 		"mcp__claude_ai_Gmail",
 		"mcp__claude_ai_Google_Calendar",
 	}

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -137,7 +137,35 @@ func New(opts map[string]any) (core.Agent, error) {
 		}
 	}
 
-	var disallowedTools []string
+	// Hardcoded baseline of disallowed tools that always applies when this
+	// agent runs under cc-connect, regardless of per-project config.
+	//
+	// Cloud-managed claude.ai MCP connectors (Slack, Gmail, Google Calendar,
+	// etc.) are tied to the authenticated claude.ai account's OAuth token
+	// rather than to the cc-connect bot identity. When the agent calls one
+	// of them, the resulting API call happens AS the account owner, so:
+	//
+	//   - Slack messages post with "Sent using @Claude" attributed to the
+	//     human account, not the cc-connect bot — the whole conversation
+	//     attribution is broken for any observer.
+	//   - cc-connect's own delivery path (which knows about thread_ts,
+	//     progress streaming, tool-call suppression, etc.) is bypassed
+	//     entirely, so the message shape is inconsistent with the rest
+	//     of the session.
+	//   - In sandboxed deployments where several Unix users share one
+	//     claude.ai account via file-copied credentials, every sandbox
+	//     user inherits access to every connector that has ever been
+	//     authorised on the shared account — even though the human only
+	//     intended to authorise the connector for their own use.
+	//
+	// Disallowing them here is the cleanest way to enforce "cc-connect owns
+	// message delivery on every platform it bridges to". Per-project config
+	// can extend this list but cannot override it.
+	disallowedTools := []string{
+		"mcp__claude_ai_Slack",
+		"mcp__claude_ai_Gmail",
+		"mcp__claude_ai_Google_Calendar",
+	}
 	if tools, ok := opts["disallowed_tools"].([]any); ok {
 		for _, t := range tools {
 			if s, ok := t.(string); ok {

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -649,8 +649,8 @@ func TestWorkspaceAgentOptions_RoundTripsThroughNew(t *testing.T) {
 	if !reflect.DeepEqual(child.allowedTools, []string{"Edit", "Read"}) {
 		t.Errorf("allowedTools = %v, want [Edit Read]", child.allowedTools)
 	}
-	if !reflect.DeepEqual(child.disallowedTools, []string{"Bash"}) {
-		t.Errorf("disallowedTools = %v, want [Bash]", child.disallowedTools)
+	if !reflect.DeepEqual(child.disallowedTools, []string{"mcp__claude_ai_Gmail", "mcp__claude_ai_Google_Calendar", "Bash"}) {
+		t.Errorf("disallowedTools = %v, want [mcp__claude_ai_Gmail mcp__claude_ai_Google_Calendar Bash]", child.disallowedTools)
 	}
 	if child.maxContextTokens != 200000 {
 		t.Errorf("maxContextTokens = %d, want 200000", child.maxContextTokens)

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -69,9 +69,22 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	if mode != "" && mode != "default" {
 		innerArgs = append(innerArgs, "--permission-mode", mode)
 	}
-	switch sessionID {
-	case "", core.ContinueSession:
-		// Truly fresh session — no resume, no continue.
+	switch {
+	case sessionID == "":
+		// Truly fresh session -- no resume, no continue.
+	case sessionID == core.ContinueSession:
+		// --continue grabs the most recent session in the workspace, which
+		// may belong to an active CLI terminal. Fork it so the platform
+		// conversation gets its own independent context branch.
+		args = append(args, "--continue", "--fork-session")
+	case strings.HasPrefix(sessionID, core.ResumeForkPrefix):
+		// User explicitly picked a prior workspace session via /resume.
+		// Strip the fork prefix and pass --resume <uuid> --fork-session so
+		// the source session (which may still be live in a terminal or
+		// another Slack conversation) is not mutated -- we branch off its
+		// context into our own independent timeline.
+		realID := strings.TrimPrefix(sessionID, core.ResumeForkPrefix)
+		args = append(args, "--resume", realID, "--fork-session")
 	default:
 		// Resuming a known session ID — this is cc-connect's own session
 		// from a previous connection, safe to resume directly.

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -76,7 +76,7 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		// --continue grabs the most recent session in the workspace, which
 		// may belong to an active CLI terminal. Fork it so the platform
 		// conversation gets its own independent context branch.
-		args = append(args, "--continue", "--fork-session")
+		innerArgs = append(innerArgs, "--continue", "--fork-session")
 	case strings.HasPrefix(sessionID, core.ResumeForkPrefix):
 		// User explicitly picked a prior workspace session via /resume.
 		// Strip the fork prefix and pass --resume <uuid> --fork-session so
@@ -84,7 +84,7 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		// another Slack conversation) is not mutated -- we branch off its
 		// context into our own independent timeline.
 		realID := strings.TrimPrefix(sessionID, core.ResumeForkPrefix)
-		args = append(args, "--resume", realID, "--fork-session")
+		innerArgs = append(innerArgs, "--resume", realID, "--fork-session")
 	default:
 		// Resuming a known session ID — this is cc-connect's own session
 		// from a previous connection, safe to resume directly.

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -113,6 +113,11 @@ func main() {
 			return
 		case "web":
 			runWeb(os.Args[2:])
+		case "react":
+			runReact(os.Args[2:])
+			return
+		case "unreact":
+			runUnreact(os.Args[2:])
 			return
 		}
 	}

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -539,6 +539,20 @@ func main() {
 				"project", proj.Name, "default_minutes", defaultResetOnIdleMins)
 		}
 
+		// Wire thread-aware session routing.
+		// Enabled by default (max_concurrent = 3) when the [threads] section is present
+		// or the binary is built with Slack support.  Can be disabled by setting
+		// max_concurrent = 1, which prevents forking but still dedups client_msg_id.
+		{
+			maxConcurrent := 3
+			if cfg.Threads.MaxConcurrent != nil {
+				maxConcurrent = *cfg.Threads.MaxConcurrent
+			}
+			if maxConcurrent > 0 {
+				engine.SetThreadRouter(core.NewThreadRouter(maxConcurrent))
+			}
+		}
+
 		// Wire sender injection
 		if proj.InjectSender != nil {
 			engine.SetInjectSender(*proj.InjectSender)

--- a/cmd/cc-connect/react.go
+++ b/cmd/cc-connect/react.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func runReact(args []string) {
+	runReactionCmd(args, false)
+}
+
+func runUnreact(args []string) {
+	runReactionCmd(args, true)
+}
+
+func runReactionCmd(args []string, remove bool) {
+	req, dataDir, err := parseReactArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		printReactUsage(remove)
+		os.Exit(1)
+	}
+
+	sockPath := resolveSocketPath(dataDir)
+	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		os.Exit(1)
+	}
+
+	endpoint := "/react"
+	if remove {
+		endpoint = "/unreact"
+	}
+
+	payload, _ := json.Marshal(req)
+	resp, err := apiPost(sockPath, endpoint, payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", strings.TrimSpace(string(body)))
+		os.Exit(1)
+	}
+
+	verb := "added"
+	if remove {
+		verb = "removed"
+	}
+	fmt.Printf("Reaction :%s: %s.\n", req.Emoji, verb)
+}
+
+func parseReactArgs(args []string) (core.ReactRequest, string, error) {
+	var req core.ReactRequest
+	var dataDir string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--emoji", "-e":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--emoji requires a value")
+			}
+			i++
+			req.Emoji = strings.Trim(args[i], ":")
+		case "--channel", "-c":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--channel requires a value")
+			}
+			i++
+			req.Channel = args[i]
+		case "--ts", "-t":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--ts requires a value")
+			}
+			i++
+			req.Ts = args[i]
+		case "--project", "-p":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--project requires a value")
+			}
+			i++
+			req.Project = args[i]
+		case "--data-dir":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--data-dir requires a value")
+			}
+			i++
+			dataDir = args[i]
+		case "--help", "-h":
+			return req, "", fmt.Errorf("show usage")
+		default:
+			return req, "", fmt.Errorf("unknown flag: %s", args[i])
+		}
+	}
+
+	if req.Project == "" {
+		req.Project = strings.TrimSpace(os.Getenv("CC_PROJECT"))
+	}
+
+	if req.Channel == "" {
+		return req, "", fmt.Errorf("--channel is required")
+	}
+	if req.Ts == "" {
+		return req, "", fmt.Errorf("--ts is required")
+	}
+	if req.Emoji == "" {
+		return req, "", fmt.Errorf("--emoji is required")
+	}
+
+	return req, dataDir, nil
+}
+
+func printReactUsage(remove bool) {
+	cmd := "react"
+	verb := "Add"
+	if remove {
+		cmd = "unreact"
+		verb = "Remove"
+	}
+	fmt.Printf(`Usage: cc-connect %s --emoji <name> --channel <channel_id> --ts <message_ts>
+
+%s an emoji reaction to a Slack message.
+
+Options:
+  -e, --emoji <name>       Emoji short name without colons (e.g. white_check_mark)
+  -c, --channel <id>       Slack channel ID (e.g. C0AL12WCNBG)
+  -t, --ts <timestamp>     Message timestamp (e.g. 1775870955.961349)
+  -p, --project <name>     Target project (optional if only one project)
+      --data-dir <path>    Data directory (default: ~/.cc-connect)
+  -h, --help               Show this help
+
+Examples:
+  cc-connect %s --emoji white_check_mark --channel C0AL12WCNBG --ts 1775870955.961349
+  cc-connect %s --emoji eyes --channel C0AL12WCNBG --ts 1775870955.961349
+`, cmd, verb, cmd, cmd)
+}

--- a/cmd/cc-connect/relay.go
+++ b/cmd/cc-connect/relay.go
@@ -28,6 +28,7 @@ func runRelay(args []string) {
 
 func runRelaySend(args []string) {
 	var from, to, sessionKey, message, dataDir, channel string
+	var dispatch bool
 
 	var positional []string
 	for i := 0; i < len(args); i++ {
@@ -57,6 +58,8 @@ func runRelaySend(args []string) {
 				i++
 				channel = args[i]
 			}
+		case "--dispatch", "-d":
+			dispatch = true
 		case "--data-dir":
 			if i+1 < len(args) {
 				i++
@@ -101,7 +104,7 @@ func runRelaySend(args []string) {
 		os.Exit(1)
 	}
 
-	relayBody := map[string]string{
+	relayBody := map[string]any{
 		"from":        from,
 		"to":          to,
 		"session_key": sessionKey,
@@ -109,6 +112,9 @@ func runRelaySend(args []string) {
 	}
 	if channel != "" {
 		relayBody["channel"] = channel
+	}
+	if dispatch {
+		relayBody["dispatch"] = true
 	}
 	payload, _ := json.Marshal(relayBody)
 
@@ -156,11 +162,15 @@ Options:
   -m, --message <text>       Message to send
   -c, --channel <channel_id> Target workspace channel (routes multi-workspace agents
                              to the correct repo directory via workspace bindings)
+  -d, --dispatch             Fire-and-forget: inject prompt into the target channel's
+                             interactive session. Agent works and responds in that
+                             channel naturally. Returns immediately. Requires --channel.
       --data-dir <path>      Data directory (default: ~/.cc-connect)
   -h, --help                 Show this help
 
 Examples:
   cc-connect relay send --to claude-bot "What's the weather today?"
   cc-connect relay send claude-bot What is the weather today
-  cc-connect relay send --to claude --channel C0ALZC59C8Z "review the latest PR"`)
+  cc-connect relay send --to claude --channel C0ALZC59C8Z "review the latest PR"
+  cc-connect relay send --to claude --channel C0AL785R0MV --dispatch "implement feature X"`)
 }

--- a/cmd/cc-connect/relay.go
+++ b/cmd/cc-connect/relay.go
@@ -27,7 +27,7 @@ func runRelay(args []string) {
 }
 
 func runRelaySend(args []string) {
-	var from, to, sessionKey, message, dataDir string
+	var from, to, sessionKey, message, dataDir, channel string
 
 	var positional []string
 	for i := 0; i < len(args); i++ {
@@ -51,6 +51,11 @@ func runRelaySend(args []string) {
 			if i+1 < len(args) {
 				i++
 				message = args[i]
+			}
+		case "--channel", "-c":
+			if i+1 < len(args) {
+				i++
+				channel = args[i]
 			}
 		case "--data-dir":
 			if i+1 < len(args) {
@@ -96,12 +101,16 @@ func runRelaySend(args []string) {
 		os.Exit(1)
 	}
 
-	payload, _ := json.Marshal(map[string]string{
+	relayBody := map[string]string{
 		"from":        from,
 		"to":          to,
 		"session_key": sessionKey,
 		"message":     message,
-	})
+	}
+	if channel != "" {
+		relayBody["channel"] = channel
+	}
+	payload, _ := json.Marshal(relayBody)
 
 	resp, err := apiPost(sockPath, "/relay/send", payload)
 	if err != nil {
@@ -145,10 +154,13 @@ Options:
   -t, --to <project>         Target bot project name
   -s, --session-key <key>    Session key (auto-detected from CC_SESSION_KEY env)
   -m, --message <text>       Message to send
+  -c, --channel <channel_id> Target workspace channel (routes multi-workspace agents
+                             to the correct repo directory via workspace bindings)
       --data-dir <path>      Data directory (default: ~/.cc-connect)
   -h, --help                 Show this help
 
 Examples:
   cc-connect relay send --to claude-bot "What's the weather today?"
-  cc-connect relay send claude-bot What is the weather today`)
+  cc-connect relay send claude-bot What is the weather today
+  cc-connect relay send --to claude --channel C0ALZC59C8Z "review the latest PR"`)
 }

--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -107,6 +107,10 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 			}
 			i++
 			filePaths = append(filePaths, args[i])
+		case "--new-thread":
+			req.NewThread = true
+		case "--as-prompt":
+			req.AsPrompt = true
 		case "--stdin":
 			useStdin = true
 		case "--data-dir":
@@ -259,6 +263,12 @@ Options:
       --stdin              Read message from stdin (best for long/special-char messages)
   -p, --project <name>     Target project (optional if only one project)
   -s, --session <key>      Target session key (optional, picks first active)
+      --new-thread         Post as a new top-level channel message; does not require
+                           an active session. Requires a session key (--session or
+                           CC_SESSION_KEY) to identify the target channel.
+      --as-prompt          Inject as an inbound message the agent will process and
+                           respond to, instead of posting as the bot. Use for
+                           external triggers (file watchers, CI hooks).
       --data-dir <path>    Data directory (default: ~/.cc-connect)
   -h, --help               Show this help
 
@@ -267,6 +277,7 @@ Examples:
   cc-connect send -m "Build completed successfully"
   cc-connect send --message "Chart generated" --image /tmp/chart.png
   cc-connect send --file /tmp/report.pdf
+  cc-connect send --new-thread -m "New completion file: STORY-22.3.md"
   cc-connect send --stdin <<'EOF'
     Long message with "special" chars, $variables, and newlines
   EOF`)

--- a/config.example.toml
+++ b/config.example.toml
@@ -248,6 +248,35 @@ level = "info" # debug, info, warn, error
 # channel = "C0AL13PN4BG"           # Slack channel ID to post observations to
 
 # =============================================================================
+# Thread-Aware Session Routing / 多线程会话路由
+# =============================================================================
+# Routes Slack thread messages to dedicated sessions, preventing cross-talk
+# when users have concurrent conversations in different threads.
+# 将 Slack 线程消息路由到专属会话，避免多个线程并发时互相干扰。
+#
+# Model: context-switch first, fork on contention.
+# 策略：优先上下文切换，竞争时新建会话。
+#
+#   • One active thread at a time → the primary session handles it (context-switch).
+#     一次只有一个活跃线程 → 主会话处理（上下文切换）。
+#   • Two threads active simultaneously → second thread gets a forked session.
+#     两个线程同时活跃 → 第二个线程获得新建的子会话。
+#   • max_concurrent reached → excess threads queue in the primary session.
+#     达到 max_concurrent 上限 → 超出线程在主会话中排队。
+#
+# Resource guidance (per additional concurrent session / 每个并发会话资源占用):
+#   ~430 MB RAM = 300–360 MB (Claude Code) + 70 MB (Node.js worker)
+#   Provision ~512 MB headroom per slot above the base session.
+#   每个并发槽位建议预留 ~512 MB 内存余量。
+#
+# [threads]
+# max_concurrent = 3   # Max simultaneous mid-turn sessions per channel (default: 3)
+#                      # 每个频道最多同时处于处理中的会话数（默认 3）
+#                      # 1 = no forking, sequential only / 1 = 禁止分叉，顺序处理
+#                      # 3 → ~4 GB RAM minimum per project binding
+#                      # 5 → ~6 GB RAM minimum per project binding
+
+# =============================================================================
 # Cron Settings / 定时任务设置
 # =============================================================================
 # Controls cron job behavior.

--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,7 @@ type Config struct {
 	Management         ManagementConfig        `toml:"management"`
 	Hooks              []HookConfig            `toml:"hooks"`
 	IdleTimeoutMins    *int                    `toml:"idle_timeout_mins,omitempty"` // max minutes between agent events; 0 = no timeout; default 120
+	Threads            ThreadsConfig           `toml:"threads"`                     // thread-aware session routing
 	// WorkspaceIdleTimeoutMins controls the workspace idle reaper timeout
 	// (multi-workspace mode) for every engine in the process. 0 disables
 	// reaping. Default: 15 minutes. Defined as a top-level (process-global)
@@ -127,6 +128,23 @@ type CronConfig struct {
 // QueueConfig controls the per-session message queue.
 type QueueConfig struct {
 	MaxDepth *int `toml:"max_depth"` // max queued messages per session; default 5
+}
+
+// ThreadsConfig controls thread-aware session routing.
+type ThreadsConfig struct {
+	// MaxConcurrent is the maximum number of simultaneous mid-turn sessions per project
+	// binding. When the limit is reached, new threads fall back to the base session and
+	// their messages are queued. Default: 3.
+	//
+	// Resource guidance: each additional concurrent session requires ~430 MB RAM
+	// (300-360 MB for Claude Code + 70 MB Node.js worker). Provision ~512 MB headroom
+	// per slot above the base session.
+	//
+	// Examples:
+	//   max_concurrent = 3 (default): ~4 GB RAM minimum per project binding
+	//   max_concurrent = 5:           ~6 GB RAM minimum per project binding
+	//   max_concurrent = 1:           ~2 GB RAM (no forking, sequential only)
+	MaxConcurrent *int `toml:"max_concurrent,omitempty"`
 }
 
 // WebhookConfig controls the external HTTP webhook endpoint.

--- a/core/api.go
+++ b/core/api.go
@@ -45,6 +45,14 @@ type ReactRequest struct {
 	Emoji   string `json:"emoji"`
 }
 
+// ReactRequest is the JSON body for POST /react and POST /unreact.
+type ReactRequest struct {
+	Project string `json:"project"`
+	Channel string `json:"channel"`
+	Ts      string `json:"ts"`
+	Emoji   string `json:"emoji"`
+}
+
 // NewAPIServer creates an API server on a Unix socket.
 func NewAPIServer(dataDir string) (*APIServer, error) {
 	sockDir := filepath.Join(dataDir, "run")

--- a/core/api.go
+++ b/core/api.go
@@ -33,6 +33,16 @@ type SendRequest struct {
 	Message    string            `json:"message"`
 	Images     []ImageAttachment `json:"images,omitempty"`
 	Files      []FileAttachment  `json:"files,omitempty"`
+	NewThread  bool              `json:"new_thread,omitempty"`
+	AsPrompt   bool              `json:"as_prompt,omitempty"`
+}
+
+// ReactRequest is the JSON body for POST /react and POST /unreact.
+type ReactRequest struct {
+	Project string `json:"project"`
+	Channel string `json:"channel"`
+	Ts      string `json:"ts"`
+	Emoji   string `json:"emoji"`
 }
 
 // NewAPIServer creates an API server on a Unix socket.
@@ -167,8 +177,24 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := engine.SendToSessionWithAttachments(req.SessionKey, req.Message, req.Images, req.Files); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if req.AsPrompt {
+		sendErr := engine.InjectPrompt(req.SessionKey, req.Message)
+		if sendErr != nil {
+			http.Error(w, sendErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		apiJSON(w, http.StatusOK, map[string]string{"status": "accepted"})
+		return
+	}
+
+	var sendErr error
+	if req.NewThread {
+		sendErr = engine.PostToNewThread(req.SessionKey, req.Message, req.Images, req.Files)
+	} else {
+		sendErr = engine.SendToSessionWithAttachments(req.SessionKey, req.Message, req.Images, req.Files)
+	}
+	if sendErr != nil {
+		http.Error(w, sendErr.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/core/api.go
+++ b/core/api.go
@@ -45,14 +45,6 @@ type ReactRequest struct {
 	Emoji   string `json:"emoji"`
 }
 
-// ReactRequest is the JSON body for POST /react and POST /unreact.
-type ReactRequest struct {
-	Project string `json:"project"`
-	Channel string `json:"channel"`
-	Ts      string `json:"ts"`
-	Emoji   string `json:"emoji"`
-}
-
 // NewAPIServer creates an API server on a Unix socket.
 func NewAPIServer(dataDir string) (*APIServer, error) {
 	sockDir := filepath.Join(dataDir, "run")

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -8,6 +8,102 @@ import (
 	"testing"
 )
 
+func TestHandleSend_NewThread_PostsTopLevel(t *testing.T) {
+	p := &stubCronReplyTargetPlatform{stubPlatformEngine: stubPlatformEngine{n: "slack"}}
+	engine := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+
+	api := &APIServer{engines: map[string]*Engine{"test": engine}}
+	reqBody := SendRequest{
+		Project:    "test",
+		SessionKey: "slack:C123:U456",
+		Message:    "New completion file: STORY-22.3.md",
+		NewThread:  true,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	// Verify the message was sent via p.Send (top-level), not via an interactiveState
+	sent := p.getSent()
+	if len(sent) != 1 || sent[0] != "New completion file: STORY-22.3.md" {
+		t.Fatalf("sent = %v, want one message", sent)
+	}
+	// Verify ReconstructReplyCtx was called with the session key
+	if p.reconstructSessionKey != "slack:C123:U456" {
+		t.Fatalf("reconstructSessionKey = %q, want slack:C123:U456", p.reconstructSessionKey)
+	}
+	// Verify no interactiveState was created
+	engine.interactiveMu.Lock()
+	nStates := len(engine.interactiveStates)
+	engine.interactiveMu.Unlock()
+	if nStates != 0 {
+		t.Fatalf("expected 0 interactiveStates, got %d", nStates)
+	}
+}
+
+func TestHandleSend_NewThread_InfersSessionKeyFromActiveSession(t *testing.T) {
+	p := &stubCronReplyTargetPlatform{stubPlatformEngine: stubPlatformEngine{n: "slack"}}
+	engine := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	engine.interactiveStates["slack:C123:U456"] = &interactiveState{
+		platform: p,
+	}
+
+	api := &APIServer{engines: map[string]*Engine{"test": engine}}
+	reqBody := SendRequest{
+		Project:   "test",
+		Message:   "inferred session",
+		NewThread: true,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	sent := p.getSent()
+	if len(sent) != 1 || sent[0] != "inferred session" {
+		t.Fatalf("sent = %v, want one message", sent)
+	}
+}
+
+func TestHandleSend_NewThread_ErrorsWithNoSessions(t *testing.T) {
+	p := &stubCronReplyTargetPlatform{stubPlatformEngine: stubPlatformEngine{n: "slack"}}
+	engine := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+
+	api := &APIServer{engines: map[string]*Engine{"test": engine}}
+	reqBody := SendRequest{
+		Project:   "test",
+		Message:   "no sessions at all",
+		NewThread: true,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Fatal("expected error when no active sessions and no session_key")
+	}
+}
+
 func TestHandleSend_AllowsAttachmentOnly(t *testing.T) {
 	engine := NewEngine("test", &stubAgent{}, []Platform{&stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}}, "", LangEnglish)
 	engine.interactiveStates["session-1"] = &interactiveState{

--- a/core/engine.go
+++ b/core/engine.go
@@ -274,17 +274,18 @@ type workspaceInitFlow struct {
 // The message is NOT sent to agent stdin at queue time; the event loop
 // sends it after the current turn completes to avoid mid-turn interference.
 type queuedMessage struct {
-	messageID     string
-	platform      Platform
-	replyCtx      any
-	content       string
-	images        []ImageAttachment
-	files         []FileAttachment
-	fromVoice     bool
-	userID        string
-	userName      string // sender's display name for sender injection
-	msgPlatform   string // platform name for sender injection
-	msgSessionKey string // session key for extracting chat ID
+	messageID       string
+	platform        Platform
+	replyCtx        any
+	content         string
+	images          []ImageAttachment
+	files           []FileAttachment
+	fromVoice       bool
+	userID          string
+	userName        string // sender's display name for sender injection
+	msgPlatform     string // platform name for sender injection
+	msgSessionKey   string // session key for extracting chat ID
+	platformContext string // platform-specific context block (e.g. Slack channel/thread metadata)
 }
 
 // interactiveState tracks a running interactive agent session and its permission state.
@@ -2161,17 +2162,18 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 		return true // handled: queue-full reply sent
 	}
 	state.pendingMessages = append(state.pendingMessages, queuedMessage{
-		messageID:     msg.MessageID,
-		platform:      p,
-		replyCtx:      msg.ReplyCtx,
-		content:       msg.Content,
-		images:        msg.Images,
-		files:         msg.Files,
-		fromVoice:     msg.FromVoice,
-		userID:        msg.UserID,
-		userName:      msg.UserName,
-		msgPlatform:   msg.Platform,
-		msgSessionKey: msg.SessionKey,
+		messageID:       msg.MessageID,
+		platform:        p,
+		replyCtx:        msg.ReplyCtx,
+		content:         msg.Content,
+		images:          msg.Images,
+		files:           msg.Files,
+		fromVoice:       msg.FromVoice,
+		userID:          msg.UserID,
+		userName:        msg.UserName,
+		msgPlatform:     msg.Platform,
+		msgSessionKey:   msg.SessionKey,
+		platformContext: msg.PlatformContext,
 	})
 	queueDepth := len(state.pendingMessages)
 	state.mu.Unlock()
@@ -2595,7 +2597,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 		drainEvents(state.agentSession.Events())
 	}
 
-	promptContent := e.buildSenderPrompt(msg.Content, msg.UserID, msg.UserName, msg.Platform, msg.SessionKey)
+	promptContent := e.buildSenderPrompt(msg.Content, msg.UserID, msg.UserName, msg.Platform, msg.SessionKey, msg.PlatformContext)
 
 	sendStart := time.Now()
 	state.mu.Lock()
@@ -4149,7 +4151,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 				}
 
-				queuedPrompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey)
+				queuedPrompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.platformContext)
 
 				nextSend := make(chan error, 1)
 				go func() {
@@ -4403,7 +4405,7 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 		state.mu.Unlock()
 
 		e.i18n.DetectAndSet(queued.content)
-		prompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey)
+		prompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.platformContext)
 
 		if state.agentSession == nil || !state.agentSession.Alive() {
 			e.send(queued.platform, queued.replyCtx, fmt.Sprintf(e.i18n.T(MsgError), "agent session ended"))
@@ -12846,20 +12848,29 @@ func (e *Engine) cmdBindSetup(p Platform, msg *Message) {
 	}
 }
 
-// buildSenderPrompt prepends a sender identity header to content when
-// injectSender is enabled and userID is non-empty. When userName is available
-// it is included as sender_name so the agent can identify who sent the message
-// by display name (useful in shared channel sessions with multiple users).
-func (e *Engine) buildSenderPrompt(content, userID, userName, platform, sessionKey string) string {
-	if !e.injectSender || userID == "" {
+// buildSenderPrompt prepends platform context and/or a sender identity header
+// to content. platformContext (e.g. Slack channel/thread metadata) is always
+// prepended when present. The sender header is only added when injectSender is
+// enabled and userID is non-empty. When userName is available it is included as
+// sender_name so the agent can identify who sent the message by display name.
+func (e *Engine) buildSenderPrompt(content, userID, userName, platform, sessionKey, platformContext string) string {
+	var prefix string
+	if platformContext != "" {
+		prefix = platformContext + "\n"
+	}
+	if e.injectSender && userID != "" {
+		chatID := extractChannelID(sessionKey)
+		if userName != "" {
+			safeName := strings.NewReplacer(`"`, `'`, "\n", " ", "\r", "").Replace(userName)
+			prefix += fmt.Sprintf("[cc-connect sender_id=%s sender_name=\"%s\" platform=%s chat_id=%s]\n", userID, safeName, platform, chatID)
+		} else {
+			prefix += fmt.Sprintf("[cc-connect sender_id=%s platform=%s chat_id=%s]\n", userID, platform, chatID)
+		}
+	}
+	if prefix == "" {
 		return content
 	}
-	chatID := extractChannelID(sessionKey)
-	if userName != "" {
-		safeName := strings.NewReplacer(`"`, `'`, "\n", " ", "\r", "").Replace(userName)
-		return fmt.Sprintf("[cc-connect sender_id=%s sender_name=\"%s\" platform=%s chat_id=%s]\n%s", userID, safeName, platform, chatID, content)
-	}
-	return fmt.Sprintf("[cc-connect sender_id=%s platform=%s chat_id=%s]\n%s", userID, platform, chatID, content)
+	return prefix + content
 }
 
 func extractChannelID(sessionKey string) string {

--- a/core/engine.go
+++ b/core/engine.go
@@ -5139,21 +5139,13 @@ func (e *Engine) cmdResume(p Platform, msg *Message, args []string) {
 		return
 	}
 
-	// Filter out the session the user is currently in — offering "resume
-	// the conversation you are literally having right now" is nonsensical
-	// and wastes a picker slot. We compare against the session-store's
-	// AgentSessionID because the live agentSession's CurrentSessionID may
-	// not be reachable from this synchronous command path.
+	// The session the user is currently in (according to cc-connect's own
+	// session store) stays in the list — filtering it out makes the
+	// chronological "most recent" row mysteriously missing. Instead, we
+	// note its ID so the picker can label that row with "(current)" and
+	// the user still has the option to re-pick it explicitly (e.g. to
+	// branch off their own current thread).
 	currentID := session.GetAgentSessionID()
-	if currentID != "" {
-		filtered := agentSessions[:0]
-		for _, s := range agentSessions {
-			if s.ID != currentID {
-				filtered = append(filtered, s)
-			}
-		}
-		agentSessions = filtered
-	}
 
 	if len(agentSessions) == 0 {
 		session.ClearPendingResumeCandidates()
@@ -5176,9 +5168,12 @@ func (e *Engine) cmdResume(p Platform, msg *Message, args []string) {
 		if first == "" {
 			first = "(no opening user message)"
 		}
-		last := s.Summary
-		fmt.Fprintf(&b, "%2d. %s  — \"%s\"\n", i+1, rel, first)
-		if last != "" && last != s.FirstSummary {
+		marker := ""
+		if currentID != "" && s.ID == currentID {
+			marker = " *(current)*"
+		}
+		fmt.Fprintf(&b, "%2d. %s%s  — \"%s\"\n", i+1, rel, marker, first)
+		if last := s.Summary; last != "" && last != s.FirstSummary {
 			fmt.Fprintf(&b, "     ↳ \"%s\"\n", last)
 		}
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -8914,6 +8914,71 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 	return nil
 }
 
+// InjectPrompt injects a message into an active session as if it came from an
+// external user. The agent will process and respond to it. If sessionKey is
+// empty, the first active session is used. This is intended for external
+// triggers (file watchers, CI hooks) that need the agent to act on a prompt.
+func (e *Engine) InjectPrompt(sessionKey, prompt string) error {
+	if prompt == "" {
+		return fmt.Errorf("prompt is required")
+	}
+
+	if sessionKey == "" {
+		e.interactiveMu.Lock()
+		for key := range e.interactiveStates {
+			sessionKey = key
+			break
+		}
+		e.interactiveMu.Unlock()
+		if sessionKey == "" {
+			return fmt.Errorf("no active session for --as-prompt")
+		}
+	}
+
+	platformName := ""
+	if idx := strings.Index(sessionKey, ":"); idx > 0 {
+		platformName = sessionKey[:idx]
+	}
+
+	var targetPlatform Platform
+	for _, p := range e.platforms {
+		if p.Name() == platformName {
+			targetPlatform = p
+			break
+		}
+	}
+	if targetPlatform == nil {
+		return fmt.Errorf("platform %q not found for session key %q", platformName, sessionKey)
+	}
+
+	rc, ok := targetPlatform.(ReplyContextReconstructor)
+	if !ok {
+		return fmt.Errorf("platform %q does not support reply context reconstruction", platformName)
+	}
+
+	replyCtx, err := rc.ReconstructReplyCtx(sessionKey)
+	if err != nil {
+		return fmt.Errorf("reconstruct reply context: %w", err)
+	}
+
+	msg := &Message{
+		SessionKey: sessionKey,
+		Platform:   platformName,
+		UserID:     "trigger",
+		UserName:   "trigger",
+		Content:    prompt,
+		ReplyCtx:   replyCtx,
+	}
+
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	if !session.TryLock() {
+		return fmt.Errorf("session busy, prompt not delivered")
+	}
+
+	go e.processInteractiveMessage(targetPlatform, msg, session)
+	return nil
+}
+
 // PostToNewThread posts a message directly to a platform channel as a new
 // top-level message, without requiring or using an existing interactive session.
 // This is intended for automated notifications (e.g. file-watcher alerts) that

--- a/core/engine.go
+++ b/core/engine.go
@@ -12897,10 +12897,15 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 		return "", fmt.Errorf("send relay message: %w", err)
 	}
 
+	// sawNewContent tracks whether Claude has started processing our message
+	// (emitted at least one text or tool event). A stale EventResult from
+	// session resume that slips past the drain is skipped when this is false.
+	sawNewContent := false
 	var textParts []string
 	for event := range agentSession.Events() {
 		switch event.Type {
 		case EventText:
+			sawNewContent = true
 			if event.Content != "" {
 				textParts = append(textParts, event.Content)
 			}
@@ -12914,6 +12919,7 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 				}
 			}
 		case EventToolResult:
+			sawNewContent = true
 			out := strings.TrimSpace(event.Content)
 			if out == "" {
 				out = strings.TrimSpace(event.ToolResult)
@@ -12926,6 +12932,22 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 				textParts = append(textParts, fmt.Sprintf(e.i18n.T(MsgToolResult), tn, out)+"\n\n")
 			}
 		case EventResult:
+			if !sawNewContent {
+				// Stale result from session resume -- save the session ID
+				// but don't treat it as this turn's response.
+				if currentID := agentSession.CurrentSessionID(); currentID != "" {
+					if session.CompareAndSetAgentSessionID(currentID, e.agent.Name()) {
+						pendingName := session.GetName()
+						if pendingName != "" && pendingName != "session" && pendingName != "default" {
+							e.sessions.SetSessionName(currentID, pendingName)
+						}
+					}
+					e.sessions.Save()
+				}
+				slog.Debug("relay: skipped stale result event from resumed session",
+					"from", fromProject, "to", e.name, "session_id", event.SessionID)
+				continue
+			}
 			// Use agentSession.CurrentSessionID() for the same reason as above.
 			if currentID := agentSession.CurrentSessionID(); currentID != "" {
 				if session.CompareAndSetAgentSessionID(currentID, e.agent.Name()) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -3057,7 +3057,9 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 // session is started. If no event arrives within the timeout, the session is
 // assumed clean and returned as-is.
 func (e *Engine) drainStaleResumeResult(agentSession AgentSession, agent Agent, session *Session, sessions *SessionManager, sessionKey string) AgentSession {
-	timer := time.NewTimer(3 * time.Second)
+	// Longer conversations take more time to replay on --resume before the
+	// stale EventResult arrives. 10 seconds handles most cases.
+	timer := time.NewTimer(10 * time.Second)
 	defer timer.Stop()
 
 	events := agentSession.Events()

--- a/core/engine.go
+++ b/core/engine.go
@@ -8971,12 +8971,17 @@ func (e *Engine) InjectPrompt(sessionKey, prompt string) error {
 	}
 
 	session := e.sessions.GetOrCreateActive(sessionKey)
-	if !session.TryLock() {
-		return fmt.Errorf("session busy, prompt not delivered")
-	}
 
-	go e.processInteractiveMessage(targetPlatform, msg, session)
-	return nil
+	// Retry with backoff — the session may be mid-turn when the trigger fires.
+	const maxAttempts = 30
+	for i := 0; i < maxAttempts; i++ {
+		if session.TryLock() {
+			go e.processInteractiveMessage(targetPlatform, msg, session)
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("session busy after %d seconds, prompt not delivered", maxAttempts*2)
 }
 
 // PostToNewThread posts a message directly to a platform channel as a new

--- a/core/engine.go
+++ b/core/engine.go
@@ -12880,6 +12880,9 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 		if err != nil {
 			return "", fmt.Errorf("start relay session: %w", err)
 		}
+	agentSession, err := e.startRelaySession(ctx, agent, session, sessions, relaySessionKey, message)
+	if err != nil {
+		return "", err
 	}
 
 	if newID := agentSession.CurrentSessionID(); newID != "" {
@@ -12905,7 +12908,6 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 	for event := range agentSession.Events() {
 		switch event.Type {
 		case EventText:
-			sawNewContent = true
 			if event.Content != "" {
 				textParts = append(textParts, event.Content)
 			}
@@ -12919,7 +12921,6 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 				}
 			}
 		case EventToolResult:
-			sawNewContent = true
 			out := strings.TrimSpace(event.Content)
 			if out == "" {
 				out = strings.TrimSpace(event.ToolResult)
@@ -12957,6 +12958,9 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 					}
 				}
 				e.sessions.Save()
+			if event.SessionID != "" {
+				session.SetAgentSessionID(event.SessionID, agent.Name())
+				sessions.Save()
 			}
 			resp := event.Content
 			if resp == "" && len(textParts) > 0 {
@@ -13001,6 +13005,124 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 		return strings.Join(textParts, ""), nil
 	}
 	return "", fmt.Errorf("relay: agent process exited without response")
+}
+
+// startRelaySession starts a Claude session for relay, handling resume gracefully.
+//
+// When a previous session ID exists, it attempts --resume first. Resumed
+// sessions replay the prior turn's final EventResult; if the process exits
+// after only producing that stale result (no new assistant content), the
+// session is discarded and a fresh one is started with the message injected.
+func (e *Engine) startRelaySession(ctx context.Context, agent Agent, session *Session, sessions *SessionManager, relaySessionKey, message string) (AgentSession, error) {
+	existingID := session.GetAgentSessionID()
+	agentSession, err := agent.StartSession(ctx, existingID)
+	if err != nil && existingID != "" {
+		slog.Warn("relay: resume failed, falling back to fresh session",
+			"session_key", relaySessionKey, "agent_session_id", existingID, "err", err)
+		session.CompareAndSetAgentSessionID("", agent.Name())
+		agentSession, err = agent.StartSession(ctx, "")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("start relay session: %w", err)
+	}
+
+	if session.CompareAndSetAgentSessionID(agentSession.CurrentSessionID(), agent.Name()) {
+		sessions.Save()
+	}
+
+	if err := agentSession.Send(message, nil, nil); err != nil {
+		agentSession.Close()
+		return nil, fmt.Errorf("send relay message: %w", err)
+	}
+
+	// If we resumed an existing session, the Claude process may replay
+	// the prior turn's EventResult and exit before processing our new
+	// message. Wait briefly to see if actual content arrives; if only a
+	// stale result appears, start a fresh session.
+	if existingID != "" {
+		for event := range agentSession.Events() {
+			switch event.Type {
+			case EventText, EventToolResult:
+				// Real content for our turn — push it back and return this session.
+				// We can't un-read from a channel, so wrap in a prefixed session.
+				return newPrefixedAgentSession(agentSession, event), nil
+			case EventResult:
+				// Stale result from the resumed turn. Save the session ID,
+				// close this session, and fall through to start fresh.
+				if event.SessionID != "" {
+					session.SetAgentSessionID(event.SessionID, agent.Name())
+					sessions.Save()
+				}
+				slog.Info("relay: resumed session produced stale result, starting fresh",
+					"session_key", relaySessionKey, "stale_session_id", event.SessionID)
+				agentSession.Close()
+				goto freshSession
+			case EventError:
+				agentSession.Close()
+				if event.Error != nil {
+					return nil, event.Error
+				}
+				return nil, fmt.Errorf("agent error during relay resume")
+			case EventPermissionRequest:
+				_ = agentSession.RespondPermission(event.RequestID, PermissionResult{
+					Behavior:     "allow",
+					UpdatedInput: event.ToolInputRaw,
+				})
+			}
+		}
+		// Events channel closed without content — process exited.
+		agentSession.Close()
+		slog.Info("relay: resumed session exited without content, starting fresh",
+			"session_key", relaySessionKey)
+		goto freshSession
+	}
+
+	return agentSession, nil
+
+freshSession:
+	session.CompareAndSetAgentSessionID("", agent.Name())
+	agentSession, err = agent.StartSession(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("start fresh relay session: %w", err)
+	}
+	if session.CompareAndSetAgentSessionID(agentSession.CurrentSessionID(), agent.Name()) {
+		sessions.Save()
+	}
+	if err := agentSession.Send(message, nil, nil); err != nil {
+		agentSession.Close()
+		return nil, fmt.Errorf("send relay message (fresh): %w", err)
+	}
+	return agentSession, nil
+}
+
+// prefixedAgentSession wraps an AgentSession and prepends a buffered event
+// to the Events channel. Used when we've already consumed an event from
+// the channel during resume detection and need to replay it.
+type prefixedAgentSession struct {
+	AgentSession
+	prefixCh chan Event
+	merged   chan Event
+	once     sync.Once
+}
+
+func newPrefixedAgentSession(inner AgentSession, first Event) *prefixedAgentSession {
+	merged := make(chan Event, 64)
+	p := &prefixedAgentSession{
+		AgentSession: inner,
+		merged:       merged,
+	}
+	go func() {
+		merged <- first
+		for ev := range inner.Events() {
+			merged <- ev
+		}
+		close(merged)
+	}()
+	return p
+}
+
+func (p *prefixedAgentSession) Events() <-chan Event {
+	return p.merged
 }
 
 func relayPartialResponseOrError(ctxErr error, textParts []string, fromProject, toProject string) (string, error) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -8914,6 +8914,86 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 	return nil
 }
 
+// PostToNewThread posts a message directly to a platform channel as a new
+// top-level message, without requiring or using an existing interactive session.
+// This is intended for automated notifications (e.g. file-watcher alerts) that
+// must not be threaded into an existing conversation.
+//
+// The session key is used only to identify the target channel / chat; the
+// platform's ReconstructReplyCtx always returns a channel-only context (no
+// thread timestamp), so the message lands top-level regardless of any active
+// sessions.
+func (e *Engine) PostToNewThread(sessionKey, message string, images []ImageAttachment, files []FileAttachment) error {
+	if message == "" && len(images) == 0 && len(files) == 0 {
+		return fmt.Errorf("message or attachment is required")
+	}
+	if sessionKey == "" {
+		// No session key provided — borrow one from any active session to resolve
+		// the target channel. PostToNewThread only uses the key for channel lookup
+		// (thread timestamps are stripped by ReconstructReplyCtx), so any session
+		// on the right platform works.
+		e.interactiveMu.Lock()
+		for key := range e.interactiveStates {
+			sessionKey = key
+			break
+		}
+		e.interactiveMu.Unlock()
+		if sessionKey == "" {
+			return fmt.Errorf("no active session and no session_key provided for --new-thread")
+		}
+	}
+	if (len(images) > 0 || len(files) > 0) && !e.attachmentSendEnabled {
+		return ErrAttachmentSendDisabled
+	}
+
+	// Find the platform that recognises this session key.
+	var platform Platform
+	var replyCtx any
+	for _, p := range e.platforms {
+		rc, ok := p.(ReplyContextReconstructor)
+		if !ok {
+			continue
+		}
+		rctx, err := rc.ReconstructReplyCtx(sessionKey)
+		if err == nil {
+			platform = p
+			replyCtx = rctx
+			break
+		}
+	}
+	if platform == nil {
+		return fmt.Errorf("no platform found that can handle session key %q", sessionKey)
+	}
+
+	if len(images) > 0 {
+		if _, ok := platform.(ImageSender); !ok {
+			return fmt.Errorf("platform %s: %w", platform.Name(), ErrNotSupported)
+		}
+	}
+	if len(files) > 0 {
+		if _, ok := platform.(FileSender); !ok {
+			return fmt.Errorf("platform %s: %w", platform.Name(), ErrNotSupported)
+		}
+	}
+
+	if message != "" {
+		if err := platform.Send(e.ctx, replyCtx, message); err != nil {
+			return err
+		}
+	}
+	for _, img := range images {
+		if err := platform.(ImageSender).SendImage(e.ctx, replyCtx, img); err != nil {
+			return err
+		}
+	}
+	for _, file := range files {
+		if err := platform.(FileSender).SendFile(e.ctx, replyCtx, file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // sendPermissionPrompt sends a permission prompt with interactive buttons when
 // the platform supports them. Fallback chain: InlineButtonSender → CardSender → plain text.
 func (e *Engine) sendPermissionPrompt(p Platform, replyCtx any, prompt, toolName, toolInput string) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -2976,6 +2976,15 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		}
 	}
 
+	// When resuming, the Claude process replays the prior turn's final
+	// EventResult before accepting new input. Wait briefly to consume it;
+	// if we get a stale result (no preceding content), discard and start
+	// fresh. This prevents processInteractiveEvents from treating the
+	// replayed result as the response to the next message.
+	if isResume {
+		agentSession = e.drainStaleResumeResult(agentSession, agent, session, sessions, sessionKey)
+	}
+
 	newState := &interactiveState{
 		agentSession:     agentSession,
 		platform:         p,
@@ -3000,6 +3009,84 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	})
 
 	return state
+}
+
+// drainStaleResumeResult waits briefly for the stale EventResult that a resumed
+// Claude session replays from the prior turn. If a stale result arrives (no
+// preceding content), it is consumed silently and the same session is returned.
+// If the session exits after the stale result (process closed stdin), a fresh
+// session is started. If no event arrives within the timeout, the session is
+// assumed clean and returned as-is.
+func (e *Engine) drainStaleResumeResult(agentSession AgentSession, agent Agent, session *Session, sessions *SessionManager, sessionKey string) AgentSession {
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+
+	events := agentSession.Events()
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				// Channel closed — process exited after resume. Start fresh.
+				slog.Info("interactive: resumed session exited, starting fresh",
+					"session_key", sessionKey)
+				agentSession.Close()
+				session.CompareAndSetAgentSessionID("", agent.Name())
+				fresh, err := agent.StartSession(e.ctx, "")
+				if err != nil {
+					slog.Error("interactive: failed to start fresh session after stale drain",
+						"session_key", sessionKey, "error", err)
+					return agentSession // return closed session; caller will handle nil check
+				}
+				if newID := fresh.CurrentSessionID(); newID != "" {
+					if session.CompareAndSetAgentSessionID(newID, agent.Name()) {
+						sessions.Save()
+					}
+				}
+				return fresh
+			}
+			switch event.Type {
+			case EventResult:
+				// Stale result consumed. Save session ID and check if process is still alive.
+				if event.SessionID != "" {
+					session.SetAgentSessionID(event.SessionID, agent.Name())
+					sessions.Save()
+				}
+				slog.Info("interactive: drained stale resume result",
+					"session_key", sessionKey, "session_id", event.SessionID)
+				if !agentSession.Alive() {
+					// Process exited after replaying — start fresh.
+					slog.Info("interactive: process exited after stale result, starting fresh",
+						"session_key", sessionKey)
+					agentSession.Close()
+					session.CompareAndSetAgentSessionID("", agent.Name())
+					fresh, err := agent.StartSession(e.ctx, "")
+					if err != nil {
+						slog.Error("interactive: failed to start fresh session",
+							"session_key", sessionKey, "error", err)
+						return agentSession
+					}
+					if newID := fresh.CurrentSessionID(); newID != "" {
+						if session.CompareAndSetAgentSessionID(newID, agent.Name()) {
+							sessions.Save()
+						}
+					}
+					return fresh
+				}
+				return agentSession
+			default:
+				// Unexpected content before we sent anything — shouldn't happen,
+				// but return the session and let the normal flow handle it.
+				slog.Warn("interactive: unexpected event during stale drain",
+					"session_key", sessionKey, "event_type", event.Type)
+				return agentSession
+			}
+		case <-timer.C:
+			// No stale result arrived — session is clean.
+			return agentSession
+		case <-e.ctx.Done():
+			return agentSession
+		}
+	}
 }
 
 // cleanupInteractiveState removes the interactive state for the given session key

--- a/core/engine.go
+++ b/core/engine.go
@@ -2858,6 +2858,21 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	// is unbound, force a fresh start instead of attaching to whichever CLI
 	// conversation happens to be "latest" in this workspace.
 	startSessionID := session.GetAgentSessionID()
+
+	// /resume <n> arms forkOnNextStart with a workspace session ID that the
+	// user explicitly picked. Consume it here and convert to the fork
+	// sentinel so the claudecode agent spawns with --resume <id>
+	// --fork-session. This overrides any AgentSessionID that might already
+	// be on the session (though cmdResume clears it anyway) and is a
+	// one-shot: next spawn falls back to the normal resume path.
+	if forkID := session.ConsumeForkOnNextStart(); forkID != "" {
+		startSessionID = ResumeForkPrefix + forkID
+		slog.Info("session: fork-on-next-start consumed",
+			"session_key", sessionKey,
+			"fork_from_backend_session", forkID,
+		)
+	}
+
 	isResume := startSessionID != ""
 	startAt := time.Now()
 	agentSession, err := agent.StartSession(e.ctx, startSessionID)
@@ -4443,6 +4458,7 @@ var builtinCommands = []struct {
 	id    string
 }{
 	{[]string{"new"}, "new"},
+	{[]string{"resume"}, "resume"},
 	{[]string{"list", "sessions"}, "list"},
 	{[]string{"switch"}, "switch"},
 	{[]string{"name", "rename"}, "name"},
@@ -4611,6 +4627,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 	switch cmdID {
 	case "new":
 		e.cmdNew(p, msg, args)
+	case "resume":
+		e.cmdResume(p, msg, args)
 	case "list":
 		e.cmdList(p, msg, args)
 	case "switch":
@@ -5023,6 +5041,168 @@ func filterOwnedSessions(sessions []AgentSessionInfo, known map[string]struct{})
 		}
 	}
 	return filtered
+
+// resumePickerLimit is the maximum number of prior workspace sessions
+// shown to the user by /resume. Enough to cover a day or two of work
+// without blowing out the mobile screen.
+const resumePickerLimit = 10
+
+// cmdResume implements the /resume slash command.
+//
+// Two modes:
+//
+//   - /resume            — list up to resumePickerLimit of the most recent
+//                          workspace sessions known to the agent backend.
+//                          Each row shows the numbered index, a relative
+//                          timestamp, the session's opening user message,
+//                          and (indented on a second line) the most recent
+//                          user message so the user can identify a drifted
+//                          long-running session by both its origin and its
+//                          current topic. The session IDs are stashed on
+//                          the Session object as pendingResumeCandidates
+//                          for the next invocation to resolve.
+//
+//   - /resume <n>        — pick the Nth candidate from the last list. Starts
+//                          a new cc-connect session with --resume <id>
+//                          --fork-session via the ResumeForkPrefix sentinel
+//                          so the source session is not mutated (it may
+//                          still be live in a terminal or another Slack
+//                          conversation). Cleans up any prior interactive
+//                          state for this session_key first.
+//
+// TODO: i18n. First cut uses hardcoded English strings. Once the feature
+// shape stabilises, promote these to MsgKey constants in core/i18n.go.
+func (e *Engine) cmdResume(p Platform, msg *Message, args []string) {
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	session := sessions.GetOrCreateActive(msg.SessionKey)
+
+	// Pick mode: /resume <n>
+	if len(args) > 0 {
+		n, parseErr := strconv.Atoi(strings.TrimSpace(args[0]))
+		if parseErr != nil || n < 1 {
+			e.reply(p, msg.ReplyCtx,
+				"/resume <n> expects a positive integer picked from the list. Run /resume with no args first to see the options.")
+			return
+		}
+		sessionID, ok := session.TakePendingResumeCandidate(n)
+		if !ok {
+			e.reply(p, msg.ReplyCtx,
+				"No /resume list is pending — run /resume with no args to see the candidates, then pick one.")
+			return
+		}
+
+		// Safe to fork off the picked session: the source session (which may
+		// be a live terminal session) is never mutated because claudecode
+		// strips the ResumeForkPrefix and passes --fork-session to claude.
+		slog.Info("cmdResume: picking candidate",
+			"session_key", msg.SessionKey,
+			"picked_session_id", sessionID,
+			"index", n,
+		)
+
+		e.cleanupInteractiveState(interactiveKey)
+
+		// Arm the next StartSession call on this session to fork off the
+		// picked session. We deliberately do NOT stash the fork sentinel in
+		// AgentSessionID — that field is persisted to disk and a crash in
+		// the window between here and the first message would leave a
+		// stale sentinel on the next startup. forkOnNextStart is a
+		// transient field that survives only in memory; worst case is
+		// cc-connect crashes and the user re-picks from a fresh /resume.
+		//
+		// Clear the existing AgentSessionID so the engine's normal resume
+		// path does not race ahead of the fork. The engine consumes
+		// forkOnNextStart before falling back to AgentSessionID, but
+		// clearing it removes the fallback entirely and makes the logged
+		// state easier to reason about.
+		session.SetAgentInfo("", agent.Name(), "")
+		session.SetForkOnNextStart(sessionID)
+		sessions.Save()
+
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(
+			"Forked from session #%d. Your next message will branch off that session's context — the original is unchanged.",
+			n,
+		))
+		return
+	}
+
+	// List mode: /resume (no args)
+	agentSessions, err := agent.ListSessions(e.ctx)
+	if err != nil {
+		session.ClearPendingResumeCandidates()
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf("/resume: could not list workspace sessions: %v", err))
+		return
+	}
+
+	// Filter out the session the user is currently in — offering "resume
+	// the conversation you are literally having right now" is nonsensical
+	// and wastes a picker slot. We compare against the session-store's
+	// AgentSessionID because the live agentSession's CurrentSessionID may
+	// not be reachable from this synchronous command path.
+	currentID := session.GetAgentSessionID()
+	if currentID != "" {
+		filtered := agentSessions[:0]
+		for _, s := range agentSessions {
+			if s.ID != currentID {
+				filtered = append(filtered, s)
+			}
+		}
+		agentSessions = filtered
+	}
+
+	if len(agentSessions) == 0 {
+		session.ClearPendingResumeCandidates()
+		e.reply(p, msg.ReplyCtx,
+			"/resume: no prior sessions found in this workspace. Start talking and one will be created.")
+		return
+	}
+
+	if len(agentSessions) > resumePickerLimit {
+		agentSessions = agentSessions[:resumePickerLimit]
+	}
+
+	ids := make([]string, 0, len(agentSessions))
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("*Recent sessions in this workspace* (showing %d of the most recent):\n", len(agentSessions)))
+	for i, s := range agentSessions {
+		ids = append(ids, s.ID)
+		rel := formatRelativeAge(time.Since(s.ModifiedAt))
+		first := s.FirstSummary
+		if first == "" {
+			first = "(no opening user message)"
+		}
+		last := s.Summary
+		fmt.Fprintf(&b, "%2d. %s  — \"%s\"\n", i+1, rel, first)
+		if last != "" && last != s.FirstSummary {
+			fmt.Fprintf(&b, "     ↳ \"%s\"\n", last)
+		}
+	}
+	b.WriteString("\nType `/resume <n>` to fork the chosen session into this conversation. The source session will not be modified.")
+
+	session.SetPendingResumeCandidates(ids)
+	e.reply(p, msg.ReplyCtx, b.String())
+}
+
+// formatRelativeAge renders a duration as a compact human-readable string
+// for the /resume picker rows ("2m ago", "1h ago", "3d ago", etc.).
+func formatRelativeAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d/time.Minute))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d/time.Hour))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d/(24*time.Hour)))
+	default:
+		return fmt.Sprintf("%dw ago", int(d/(7*24*time.Hour)))
+	}
 }
 
 const listPageSize = 20
@@ -7030,6 +7210,7 @@ func helpCardGroups() []helpCardGroup {
 			titleKey: MsgHelpSessionSection,
 			items: []helpCardItem{
 				{command: "/new", action: "act:/new"},
+				{command: "/resume", action: "cmd:/resume"},
 				{command: "/list", action: "nav:/list"},
 				{command: "/current", action: "nav:/current"},
 				{command: "/switch", action: "nav:/list"},

--- a/core/engine.go
+++ b/core/engine.go
@@ -13229,6 +13229,7 @@ func (e *Engine) startRelaySession(ctx context.Context, agent Agent, session *Se
 			"session_key", relaySessionKey, "agent_session_id", existingID, "err", err)
 		session.CompareAndSetAgentSessionID("", agent.Name())
 		agentSession, err = agent.StartSession(ctx, "")
+		existingID = "" // skip stale-result detection — we started fresh
 	}
 	if err != nil {
 		return nil, fmt.Errorf("start relay session: %w", err)

--- a/core/engine.go
+++ b/core/engine.go
@@ -2910,6 +2910,45 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		return state
 	}
 
+	// Check for a pending fork — if armed, use the fork prefix so the agent
+	// starts with --resume <base_id> --fork-session instead of a plain resume.
+	if forkID := session.ConsumeForkOnNextStart(); forkID != "" {
+		startSessionID := ResumeForkPrefix + forkID
+		isResume := true
+		startAt := time.Now()
+		agentSession, err := agent.StartSession(e.ctx, startSessionID)
+		startElapsed := time.Since(startAt)
+		if err != nil {
+			slog.Error("fork session failed, falling back to fresh session",
+				"session_key", sessionKey, "fork_source", forkID, "error", err)
+			agentSession, err = agent.StartSession(e.ctx, "")
+			isResume = false
+		}
+		if err != nil {
+			slog.Error("failed to start session after fork failure", "error", err)
+			state = &interactiveState{platform: p, replyCtx: replyCtx, quiet: quietMode}
+			e.interactiveStates[sessionKey] = state
+			return state
+		}
+		if newID := agentSession.CurrentSessionID(); newID != "" {
+			if session.CompareAndSetAgentSessionID(newID, agent.Name()) {
+				sessions.Save()
+			}
+		}
+		if isResume {
+			agentSession = e.drainStaleResumeResult(agentSession, agent, session, sessions, sessionKey)
+		}
+		state = &interactiveState{
+			agentSession: agentSession,
+			platform:     p,
+			replyCtx:     replyCtx,
+			quiet:        quietMode,
+		}
+		e.interactiveStates[sessionKey] = state
+		slog.Info("session spawned (fork)", "session_key", sessionKey, "fork_source", forkID, "elapsed", startElapsed)
+		return state
+	}
+
 	// Resume only when we have a concrete saved agent session ID. If the session
 	// is unbound, force a fresh start instead of attaching to whichever CLI
 	// conversation happens to be "latest" in this workspace.

--- a/core/engine.go
+++ b/core/engine.go
@@ -2926,7 +2926,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		}
 		if err != nil {
 			slog.Error("failed to start session after fork failure", "error", err)
-			state = &interactiveState{platform: p, replyCtx: replyCtx, quiet: quietMode}
+			state = &interactiveState{platform: p, replyCtx: replyCtx}
 			e.interactiveStates[sessionKey] = state
 			return state
 		}
@@ -2942,7 +2942,6 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 			agentSession: agentSession,
 			platform:     p,
 			replyCtx:     replyCtx,
-			quiet:        quietMode,
 		}
 		e.interactiveStates[sessionKey] = state
 		slog.Info("session spawned (fork)", "session_key", sessionKey, "fork_source", forkID, "elapsed", startElapsed)
@@ -5228,6 +5227,7 @@ func filterOwnedSessions(sessions []AgentSessionInfo, known map[string]struct{})
 		}
 	}
 	return filtered
+}
 
 // resumePickerLimit is the maximum number of prior workspace sessions
 // shown to the user by /resume. Enough to cover a day or two of work
@@ -13053,7 +13053,7 @@ func (e *Engine) sendTTSReply(p Platform, replyCtx any, text string) {
 // HandleRelay processes a relay message synchronously: starts or resumes a
 // dedicated relay session, sends the message to the agent, and blocks until
 // the complete response is collected (or the relay context times out).
-func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message string) (string, error) {
+func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, wsChannelKey, message string) (string, error) {
 	relaySessionKey := "relay:" + fromProject + ":" + chatID
 	session := e.sessions.GetOrCreateActive(relaySessionKey)
 
@@ -13074,21 +13074,7 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 	// Use the engine context (not the relay timeout context) so that the
 	// agent process is not killed when the relay deadline fires. The relay
 	// timeout only controls how long we *wait* for the response.
-	agentSession, err := e.agent.StartSession(e.ctx, session.GetAgentSessionID())
-	if err != nil {
-		// Resume failed — fall back to a fresh session so the relay is not
-		// permanently broken by a corrupted/stale session ID.
-		if session.GetAgentSessionID() != "" {
-			slog.Warn("relay: session resume failed, trying fresh session",
-				"relay_key", relaySessionKey, "error", err)
-			session.SetAgentSessionID("", e.agent.Name())
-			e.sessions.Save()
-			agentSession, err = e.agent.StartSession(e.ctx, "")
-		}
-		if err != nil {
-			return "", fmt.Errorf("start relay session: %w", err)
-		}
-	agentSession, err := e.startRelaySession(ctx, agent, session, sessions, relaySessionKey, message)
+	agentSession, err := e.startRelaySession(ctx, e.agent, session, e.sessions, relaySessionKey, message)
 	if err != nil {
 		return "", err
 	}
@@ -13103,15 +13089,10 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 		}
 	}
 
-	if err := agentSession.Send(message, nil, nil); err != nil {
-		agentSession.Close()
-		return "", fmt.Errorf("send relay message: %w", err)
-	}
-
 	// sawNewContent tracks whether Claude has started processing our message
-	// (emitted at least one text or tool event). A stale EventResult from
-	// session resume that slips past the drain is skipped when this is false.
-	sawNewContent := false
+	// (emitted at least one text or tool event). Since startRelaySession
+	// already handles stale EventResult detection for resumed sessions,
+	// any event reaching this loop is genuine.
 	var textParts []string
 	for event := range agentSession.Events() {
 		switch event.Type {
@@ -13141,22 +13122,6 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 				textParts = append(textParts, fmt.Sprintf(e.i18n.T(MsgToolResult), tn, out)+"\n\n")
 			}
 		case EventResult:
-			if !sawNewContent {
-				// Stale result from session resume -- save the session ID
-				// but don't treat it as this turn's response.
-				if currentID := agentSession.CurrentSessionID(); currentID != "" {
-					if session.CompareAndSetAgentSessionID(currentID, e.agent.Name()) {
-						pendingName := session.GetName()
-						if pendingName != "" && pendingName != "session" && pendingName != "default" {
-							e.sessions.SetSessionName(currentID, pendingName)
-						}
-					}
-					e.sessions.Save()
-				}
-				slog.Debug("relay: skipped stale result event from resumed session",
-					"from", fromProject, "to", e.name, "session_id", event.SessionID)
-				continue
-			}
 			// Use agentSession.CurrentSessionID() for the same reason as above.
 			if currentID := agentSession.CurrentSessionID(); currentID != "" {
 				if session.CompareAndSetAgentSessionID(currentID, e.agent.Name()) {
@@ -13166,9 +13131,6 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 					}
 				}
 				e.sessions.Save()
-			if event.SessionID != "" {
-				session.SetAgentSessionID(event.SessionID, agent.Name())
-				sessions.Save()
 			}
 			resp := event.Content
 			if resp == "" && len(textParts) > 0 {

--- a/core/engine.go
+++ b/core/engine.go
@@ -244,8 +244,14 @@ type Engine struct {
 	// Terminal observation (--observe)
 	observeEnabled    bool
 	observeProjectDir string // ~/.claude/projects/{projectKey}
-	observeSessionKey string // e.g. "slack:C123:U456" — target for forwarding
+	observeSessionKey string // e.g. "slack:C123:U456" -- target for forwarding
 	observeCancel     context.CancelFunc
+
+	// Thread-aware session routing (nil = disabled, all messages share one session)
+	threadRouter *ThreadRouter
+	// threadInteractiveKeys maps interactiveKey -> effectiveSessionKey so that
+	// cleanupInteractiveState can release thread router affinity for the correct key.
+	threadInteractiveKeys sync.Map
 
 	// Interactive agent session management
 	interactiveMu     sync.Mutex
@@ -596,6 +602,13 @@ func (e *Engine) SetReplyFooterEnabled(show bool) {
 // Default false = show all sessions from the agent.
 func (e *Engine) SetFilterExternalSessions(v bool) {
 	e.filterExternalSessions = v
+}
+
+// SetThreadRouter enables thread-aware session routing for this engine.
+// When set, incoming messages are routed to per-thread sessions based on
+// their ThreadID field, with context-switch-first, fork-on-contention semantics.
+func (e *Engine) SetThreadRouter(r *ThreadRouter) {
+	e.threadRouter = r
 }
 
 func (e *Engine) SetWebSetupFunc(fn func() (int, string, bool, error)) { e.webSetupFunc = fn }
@@ -2036,8 +2049,46 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		interactiveKey = resolvedWorkspace + ":" + msg.SessionKey
 	}
 
-	session := sessions.GetOrCreateActive(msg.SessionKey)
-	sessions.UpdateUserMeta(msg.SessionKey, msg.UserName, msg.ChatName)
+	// Thread-aware routing: resolve the effective session key for this message.
+	// This runs BEFORE the session lock so that messages route to the correct
+	// session rather than being queued against the wrong one.
+	effectiveSessionKey := msg.SessionKey
+	if e.threadRouter != nil {
+		// Drop "also send to channel" duplicates: Slack fires two events with
+		// the same client_msg_id when the user ticks "also send to #channel".
+		if msg.ClientMsgID != "" && e.threadRouter.IsDuplicateClientMsg(msg.ClientMsgID) {
+			slog.Debug("thread router: dropping duplicate client_msg_id",
+				"client_msg_id", msg.ClientMsgID,
+				"session", msg.SessionKey,
+			)
+			return
+		}
+
+		routeResult := e.threadRouter.Route(msg.SessionKey, msg.ThreadID, sessions)
+		effectiveSessionKey = routeResult.EffectiveKey
+		if routeResult.Forked {
+			slog.Info("thread router: forked new session for thread",
+				"thread_id", msg.ThreadID,
+				"session_key", effectiveSessionKey,
+			)
+			// Warn the user before starting the fork so they see it in their thread.
+			e.reply(p, msg.ReplyCtx, routeResult.ForkWarning)
+		}
+
+		// Update interactiveKey to use the effective session key.
+		if e.multiWorkspace && wsSessions != nil {
+			interactiveKey = resolvedWorkspace + ":" + effectiveSessionKey
+		} else {
+			interactiveKey = effectiveSessionKey
+		}
+
+		// Register the interactiveKey → effectiveSessionKey mapping so that
+		// cleanupInteractiveState can release thread affinity on session expiry.
+		e.threadInteractiveKeys.Store(interactiveKey, effectiveSessionKey)
+	}
+
+	session := sessions.GetOrCreateActive(effectiveSessionKey)
+	sessions.UpdateUserMeta(effectiveSessionKey, msg.UserName, msg.ChatName)
 	if !session.TryLock() {
 		if e.stopCurrentMessageIfRecalled(interactiveKey) {
 			if e.waitForSessionLock(session, recalledStopLockWait) {
@@ -2063,7 +2114,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	}
 
 sessionLocked:
-	if rotated := e.maybeAutoResetSessionOnIdle(p, msg, sessions, interactiveKey, session); rotated != nil {
+	if rotated := e.maybeAutoResetSessionOnIdle(p, msg, sessions, interactiveKey, session, effectiveSessionKey); rotated != nil {
 		session = rotated
 	}
 
@@ -2076,12 +2127,17 @@ sessionLocked:
 		"platform", msg.Platform,
 		"user", msg.UserName,
 		"session", session.ID,
+		"thread_id", msg.ThreadID,
 	)
 
 	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey)
 }
 
-func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session) *Session {
+// maybeAutoResetSessionOnIdle rotates to a fresh session when the current one has
+// been idle for longer than resetOnIdle.  effectiveSessionKey is the (possibly
+// thread-routed) key that the session was looked up under; it defaults to
+// msg.SessionKey when thread routing is not active.
+func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session, effectiveSessionKey string) *Session {
 	if e.resetOnIdle <= 0 || session == nil {
 		return nil
 	}
@@ -2098,7 +2154,7 @@ func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions 
 	}
 
 	slog.Info("auto-resetting idle session",
-		"session_key", msg.SessionKey,
+		"session_key", effectiveSessionKey,
 		"session_id", session.ID,
 		"idle_for", time.Since(lastActive),
 		"threshold", e.resetOnIdle,
@@ -2121,9 +2177,9 @@ func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions 
 	e.cleanupInteractiveState(interactiveKey)
 	session.UnlockWithoutUpdate()
 
-	newSession := sessions.NewSession(msg.SessionKey, "")
+	newSession := sessions.NewSession(effectiveSessionKey, "")
 	if !newSession.TryLock() {
-		slog.Error("failed to lock new session after idle auto-reset", "session_key", msg.SessionKey, "new_session", newSession.ID)
+		slog.Error("failed to lock new session after idle auto-reset", "session_key", effectiveSessionKey, "new_session", newSession.ID)
 		return nil
 	}
 
@@ -3007,12 +3063,20 @@ func (e *Engine) cleanupInteractiveState(sessionKey string, expected ...*interac
 	// Re-check that the state hasn't been replaced during the close
 	currentState, currentOk := e.interactiveStates[sessionKey]
 	if currentOk && len(expected) > 0 && expected[0] != nil && currentState != expected[0] {
-		// Another turn has replaced the state during our close — don't delete it.
+		// Another turn has replaced the state during our close -- don't delete it.
 		e.interactiveMu.Unlock()
 		return
 	}
 	delete(e.interactiveStates, sessionKey)
 	e.interactiveMu.Unlock()
+
+	// Release thread affinity for this session so future messages from the
+	// same thread re-route fresh (context-switch or fork) after session expiry.
+	if e.threadRouter != nil {
+		if effKey, loaded := e.threadInteractiveKeys.LoadAndDelete(sessionKey); loaded {
+			e.threadRouter.ReleaseSession(effKey.(string))
+		}
+	}
 }
 
 func (e *Engine) closeAgentSessionAsync(sessionKey string, agentSession AgentSession) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -8984,6 +8984,91 @@ func (e *Engine) InjectPrompt(sessionKey, prompt string) error {
 	return fmt.Errorf("session busy after %d seconds, prompt not delivered", maxAttempts*2)
 }
 
+// DispatchToChannel injects a prompt into this engine's interactive session
+// for the given channel, with full multi-workspace routing. The agent processes
+// the message and responds in the target channel naturally.
+//
+// This is the fire-and-forget counterpart to HandleRelay: instead of running a
+// synchronous relay session and returning the response, it feeds the message
+// through the same interactive pipeline that handles normal Slack messages.
+func (e *Engine) DispatchToChannel(platformName, channelID, prompt string) error {
+	if prompt == "" {
+		return fmt.Errorf("dispatch: prompt is required")
+	}
+	if channelID == "" {
+		return fmt.Errorf("dispatch: channel is required")
+	}
+
+	// Find the platform
+	var targetPlatform Platform
+	for _, p := range e.platforms {
+		if p.Name() == platformName {
+			targetPlatform = p
+			break
+		}
+	}
+	if targetPlatform == nil {
+		return fmt.Errorf("dispatch: platform %q not found", platformName)
+	}
+
+	// Reconstruct reply context for the target channel
+	rc, ok := targetPlatform.(ReplyContextReconstructor)
+	if !ok {
+		return fmt.Errorf("dispatch: platform %q does not support reply context reconstruction", platformName)
+	}
+	sessionKey := platformName + ":" + channelID + ":dispatch"
+	replyCtx, err := rc.ReconstructReplyCtx(sessionKey)
+	if err != nil {
+		return fmt.Errorf("dispatch: reconstruct reply context: %w", err)
+	}
+
+	msg := &Message{
+		SessionKey: sessionKey,
+		Platform:   platformName,
+		UserID:     "dispatch",
+		UserName:   "dispatch",
+		Content:    prompt,
+		ReplyCtx:   replyCtx,
+	}
+
+	// Resolve workspace agent for multi-workspace mode
+	agent := e.agent
+	sessions := e.sessions
+	interactiveKey := sessionKey
+	resolvedWorkspace := ""
+
+	if e.multiWorkspace {
+		channelKey := workspaceChannelKey(platformName, channelID)
+		if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
+			wsAgent, wsSessions, wsErr := e.getOrCreateWorkspaceAgent(normalizeWorkspacePath(b.Workspace))
+			if wsErr == nil {
+				agent = wsAgent
+				sessions = wsSessions
+				resolvedWorkspace = b.Workspace
+				interactiveKey = resolvedWorkspace + ":" + sessionKey
+			} else {
+				slog.Warn("dispatch: workspace agent creation failed, using default",
+					"channel", channelID, "err", wsErr)
+			}
+		}
+	}
+
+	session := sessions.GetOrCreateActive(sessionKey)
+
+	// Retry with backoff — the session may be mid-turn.
+	const maxAttempts = 30
+	for i := 0; i < maxAttempts; i++ {
+		if session.TryLock() {
+			slog.Info("dispatch: injecting prompt",
+				"channel", channelID, "workspace", resolvedWorkspace)
+			go e.processInteractiveMessageWith(targetPlatform, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, sessionKey)
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("dispatch: session busy after %d seconds", maxAttempts*2)
+}
+
 // PostToNewThread posts a message directly to a platform channel as a new
 // top-level message, without requiring or using an existing interactive session.
 // This is intended for automated notifications (e.g. file-watcher alerts) that

--- a/core/engine.go
+++ b/core/engine.go
@@ -3087,33 +3087,28 @@ func (e *Engine) drainStaleResumeResult(agentSession AgentSession, agent Agent, 
 			}
 			switch event.Type {
 			case EventResult:
-				// Stale result consumed. Save session ID and check if process is still alive.
+				// Stale result consumed. The resumed process may exit shortly after
+				// replaying, so always start a fresh session instead of trying to
+				// reuse it. Save the session ID first for context continuity.
 				if event.SessionID != "" {
 					session.SetAgentSessionID(event.SessionID, agent.Name())
 					sessions.Save()
 				}
-				slog.Info("interactive: drained stale resume result",
+				slog.Info("interactive: drained stale resume result, starting fresh",
 					"session_key", sessionKey, "session_id", event.SessionID)
-				if !agentSession.Alive() {
-					// Process exited after replaying — start fresh.
-					slog.Info("interactive: process exited after stale result, starting fresh",
-						"session_key", sessionKey)
-					agentSession.Close()
-					session.CompareAndSetAgentSessionID("", agent.Name())
-					fresh, err := agent.StartSession(e.ctx, "")
-					if err != nil {
-						slog.Error("interactive: failed to start fresh session",
-							"session_key", sessionKey, "error", err)
-						return agentSession
-					}
-					if newID := fresh.CurrentSessionID(); newID != "" {
-						if session.CompareAndSetAgentSessionID(newID, agent.Name()) {
-							sessions.Save()
-						}
-					}
-					return fresh
+				agentSession.Close()
+				fresh, err := agent.StartSession(e.ctx, "")
+				if err != nil {
+					slog.Error("interactive: failed to start fresh session after stale drain",
+						"session_key", sessionKey, "error", err)
+					return agentSession // return closed session; caller handles nil check
 				}
-				return agentSession
+				if newID := fresh.CurrentSessionID(); newID != "" {
+					if session.CompareAndSetAgentSessionID(newID, agent.Name()) {
+						sessions.Save()
+					}
+				}
+				return fresh
 			default:
 				// Unexpected content before we sent anything — shouldn't happen,
 				// but return the session and let the normal flow handle it.

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -5541,10 +5541,11 @@ func (s *controllableAgentSession) GetContextUsage() *ContextUsage { return s.co
 func (s *controllableAgentSession) Alive() bool                    { return s.alive }
 func (s *controllableAgentSession) Close() error {
 	s.alive = false
-	close(s.events)
 	select {
 	case <-s.closed:
+		// already closed
 	default:
+		close(s.events)
 		close(s.closed)
 	}
 	return nil

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2834,7 +2834,10 @@ func TestHandleMessage_AutoResetOnIdle_DoesNotRotateFreshSession(t *testing.T) {
 	}
 	e.handleMessage(p, msg)
 
-	deadline := time.After(2 * time.Second)
+	// The drain-stale-resume-result mechanism waits up to 10s for a stale
+	// EventResult from the resumed session before proceeding, so allow
+	// enough time for that plus the actual turn processing.
+	deadline := time.After(15 * time.Second)
 	for {
 		if len(session.GetHistory(0)) >= 3 {
 			break
@@ -8212,7 +8215,7 @@ func TestBuildSenderPrompt_Enabled(t *testing.T) {
 	e := newTestEngine()
 	e.SetInjectSender(true)
 
-	result := e.buildSenderPrompt("hello world", "user123", "Alice", "feishu", "feishu:channel42:user123")
+	result := e.buildSenderPrompt("hello world", "user123", "Alice", "feishu", "feishu:channel42:user123", "")
 	expected := "[cc-connect sender_id=user123 sender_name=\"Alice\" platform=feishu chat_id=channel42]\nhello world"
 	if result != expected {
 		t.Fatalf("got %q, want %q", result, expected)
@@ -8223,7 +8226,7 @@ func TestBuildSenderPrompt_Disabled(t *testing.T) {
 	e := newTestEngine()
 	e.SetInjectSender(false)
 
-	result := e.buildSenderPrompt("hello", "user1", "Alice", "feishu", "feishu:ch:user1")
+	result := e.buildSenderPrompt("hello", "user1", "Alice", "feishu", "feishu:ch:user1", "")
 	if result != "hello" {
 		t.Fatalf("expected raw content when disabled, got %q", result)
 	}
@@ -8233,7 +8236,7 @@ func TestBuildSenderPrompt_EmptyUserID(t *testing.T) {
 	e := newTestEngine()
 	e.SetInjectSender(true)
 
-	result := e.buildSenderPrompt("hello", "", "Bob", "telegram", "telegram:ch:user1")
+	result := e.buildSenderPrompt("hello", "", "Bob", "telegram", "telegram:ch:user1", "")
 	if result != "hello" {
 		t.Fatalf("expected raw content when userID is empty, got %q", result)
 	}
@@ -8243,7 +8246,7 @@ func TestBuildSenderPrompt_EmptyUserName(t *testing.T) {
 	e := newTestEngine()
 	e.SetInjectSender(true)
 
-	result := e.buildSenderPrompt("hello", "user1", "", "feishu", "feishu:ch:user1")
+	result := e.buildSenderPrompt("hello", "user1", "", "feishu", "feishu:ch:user1", "")
 	expected := "[cc-connect sender_id=user1 platform=feishu chat_id=ch]\nhello"
 	if result != expected {
 		t.Fatalf("got %q, want %q", result, expected)
@@ -8254,7 +8257,7 @@ func TestBuildSenderPrompt_NameWithSpaces(t *testing.T) {
 	e := newTestEngine()
 	e.SetInjectSender(true)
 
-	result := e.buildSenderPrompt("hi", "U999", "Jim Tang", "slack", "slack:C012:U999")
+	result := e.buildSenderPrompt("hi", "U999", "Jim Tang", "slack", "slack:C012:U999", "")
 	expected := "[cc-connect sender_id=U999 sender_name=\"Jim Tang\" platform=slack chat_id=C012]\nhi"
 	if result != expected {
 		t.Fatalf("got %q, want %q", result, expected)
@@ -8294,7 +8297,7 @@ func TestBuildSenderPrompt_DifferentPlatforms(t *testing.T) {
 		{"slack", "slack:C012345:carol", "C012345"},
 	}
 	for _, tc := range platforms {
-		result := e.buildSenderPrompt("msg", "uid", "TestUser", tc.platform, tc.sessionKey)
+		result := e.buildSenderPrompt("msg", "uid", "TestUser", tc.platform, tc.sessionKey, "")
 		if !strings.Contains(result, "platform="+tc.platform) {
 			t.Errorf("missing platform=%s in %q", tc.platform, result)
 		}
@@ -8308,7 +8311,7 @@ func TestBuildSenderPrompt_SanitizesSpecialChars(t *testing.T) {
 	e := newTestEngine()
 	e.SetInjectSender(true)
 
-	result := e.buildSenderPrompt("hi", "U1", "Evil\"Name\nInject", "slack", "slack:C1:U1")
+	result := e.buildSenderPrompt("hi", "U1", "Evil\"Name\nInject", "slack", "slack:C1:U1", "")
 	if strings.Contains(result, `"Name`) || strings.Contains(result, "\n"+`Inject`) {
 		t.Fatalf("quotes/newlines should be sanitized, got %q", result)
 	}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -144,6 +144,14 @@ the trailing marker before delivery:
   delivered as a normal reply (the marker only suppresses itself, not the
   surrounding text).
 Use this sparingly; when in doubt, send a brief reply instead.
+### Emoji reactions
+To add or remove an emoji reaction on a Slack message, use:
+
+  cc-connect react --emoji white_check_mark --channel C0AL12WCNBG --ts 1775870955.961349
+  cc-connect unreact --emoji white_check_mark --channel C0AL12WCNBG --ts 1775870955.961349
+
+--channel and --ts are required. --emoji is the Slack short name without colons.
+If the Slack message context provides channel_id and thread_ts, those can be used directly.
 `
 }
 
@@ -169,6 +177,11 @@ type TypingIndicator interface {
 // a push notification (e.g. Feishu card edits don't trigger pushes).
 type TypingIndicatorDone interface {
 	AddDoneReaction(replyCtx any)
+// Reactor is an optional interface for platforms that support adding and
+// removing emoji reactions on messages.
+type Reactor interface {
+	AddReaction(ctx context.Context, channel, ts, emoji string) error
+	RemoveReaction(ctx context.Context, channel, ts, emoji string) error
 }
 
 // ImageSender is an optional interface for platforms that support sending images.

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -177,6 +177,8 @@ type TypingIndicator interface {
 // a push notification (e.g. Feishu card edits don't trigger pushes).
 type TypingIndicatorDone interface {
 	AddDoneReaction(replyCtx any)
+}
+
 // Reactor is an optional interface for platforms that support adding and
 // removing emoji reactions on messages.
 type Reactor interface {

--- a/core/message.go
+++ b/core/message.go
@@ -138,23 +138,24 @@ type LocationAttachment struct {
 
 // Message represents a unified incoming message from any platform.
 type Message struct {
-	SessionKey   string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
-	Platform     string
-	MessageID    string // platform message ID for tracing
-	Recalled     bool   // true for platform message recall/delete events targeting MessageID
-	UserID       string
-	UserName     string
-	ChatName     string // human-readable chat/group name (optional)
-	Content      string
-	Images       []ImageAttachment   // attached images (if any)
-	Files        []FileAttachment    // attached files (if any)
-	Audio        *AudioAttachment    // voice message (if any)
-	Location     *LocationAttachment // geographical location (if any)
-	ExtraContent string              // platform-enriched content (e.g. location text, reply quote) prepended for the agent
-	ChannelKey   string              // platform-provided channel identifier for workspace binding (optional)
-	ReplyCtx     any                 // platform-specific context needed for replying
-	FromVoice    bool                // true if message originated from voice transcription
-	ModeOverride string              // if set, temporarily override agent permission mode for this message
+	SessionKey      string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
+	Platform        string
+	MessageID       string // platform message ID for tracing
+	Recalled        bool   // true for platform message recall/delete events targeting MessageID
+	UserID          string
+	UserName        string
+	ChatName        string // human-readable chat/group name (optional)
+	Content         string
+	Images          []ImageAttachment   // attached images (if any)
+	Files           []FileAttachment    // attached files (if any)
+	Audio           *AudioAttachment    // voice message (if any)
+	Location        *LocationAttachment // geographical location (if any)
+	ExtraContent    string              // platform-enriched content (e.g. location text, reply quote) prepended for the agent
+	ChannelKey      string              // platform-provided channel identifier for workspace binding (optional)
+	ReplyCtx        any                 // platform-specific context needed for replying
+	FromVoice       bool                // true if message originated from voice transcription
+	ModeOverride    string              // if set, temporarily override agent permission mode for this message
+	PlatformContext string              // optional platform-specific context block prepended to the agent prompt (e.g. Slack channel/thread metadata)
 }
 
 // EventType distinguishes different kinds of agent output.

--- a/core/message.go
+++ b/core/message.go
@@ -156,6 +156,8 @@ type Message struct {
 	FromVoice       bool                // true if message originated from voice transcription
 	ModeOverride    string              // if set, temporarily override agent permission mode for this message
 	PlatformContext string              // optional platform-specific context block prepended to the agent prompt (e.g. Slack channel/thread metadata)
+	ThreadID        string              // platform thread identifier for thread-aware session routing (e.g. Slack thread_ts)
+	ClientMsgID     string              // client-generated message ID for deduplication (e.g. Slack client_msg_id)
 }
 
 // EventType distinguishes different kinds of agent output.

--- a/core/message.go
+++ b/core/message.go
@@ -215,9 +215,17 @@ type HistoryEntry struct {
 }
 
 // AgentSessionInfo describes one session as reported by the agent backend.
+//
+// Summary historically carries the LAST user message in the session, which
+// is what /list and /switch want (the most recent topic). FirstSummary was
+// added for /resume, which wants the ORIGINAL user message so the user can
+// recognise a session by how it started, not by wherever it happens to be
+// right now — a live terminal session in particular is constantly drifting
+// and its "latest" message is noisy as an identifier.
 type AgentSessionInfo struct {
 	ID           string
-	Summary      string
+	Summary      string // latest user message (≈40 chars, trimmed)
+	FirstSummary string // first user message (≈40 chars, trimmed)
 	MessageCount int
 	ModifiedAt   time.Time
 	GitBranch    string

--- a/core/relay.go
+++ b/core/relay.go
@@ -277,7 +277,6 @@ func (rm *RelayManager) dispatch(ctx context.Context, req RelayRequest) (*RelayR
 	rm.mu.RLock()
 	binding := rm.bindings[chatID]
 	targetEngine := rm.engines[req.To]
-	sourceEngine := rm.engines[req.From]
 	rm.mu.RUnlock()
 
 	if binding == nil {
@@ -290,7 +289,6 @@ func (rm *RelayManager) dispatch(ctx context.Context, req RelayRequest) (*RelayR
 		return nil, fmt.Errorf("relay dispatch: target engine %q not found (is the project running?)", req.To)
 	}
 
-	// Post dispatch notification to the source group chat
 	fromName := req.From
 	if binding.Bots[req.From] != "" {
 		fromName = binding.Bots[req.From]
@@ -299,11 +297,12 @@ func (rm *RelayManager) dispatch(ctx context.Context, req RelayRequest) (*RelayR
 	if binding.Bots[req.To] != "" {
 		toName = binding.Bots[req.To]
 	}
-	if sourceEngine != nil {
-		groupSessionKey := platform + ":" + chatID + ":relay"
-		label := fmt.Sprintf("[%s → %s dispatch] %s", fromName, toName, truncateRelay(req.Message, 500))
-		rm.sendToGroup(ctx, sourceEngine, platform, groupSessionKey, label)
-	}
+
+	// Post the dispatch prompt visibly in the target channel so humans can
+	// see what was asked. Uses the target engine's platform to send.
+	targetChannelSessionKey := platform + ":" + req.Channel
+	label := fmt.Sprintf("[dispatch from %s]\n%s", fromName, req.Message)
+	rm.sendToGroup(ctx, targetEngine, platform, targetChannelSessionKey, label)
 
 	// Inject prompt into the target engine's interactive session for the channel
 	if err := targetEngine.DispatchToChannel(platform, req.Channel, req.Message); err != nil {

--- a/core/relay.go
+++ b/core/relay.go
@@ -173,11 +173,12 @@ func (rm *RelayManager) ListBoundBots(chatID, selfProject string) map[string]str
 
 // RelayRequest is the payload for a relay send.
 type RelayRequest struct {
-	From       string `json:"from"`        // source project name
-	To         string `json:"to"`          // target project name
-	SessionKey string `json:"session_key"` // source session key (contains platform + chatID)
+	From       string `json:"from"`              // source project name
+	To         string `json:"to"`                // target project name
+	SessionKey string `json:"session_key"`       // source session key (contains platform + chatID)
 	Message    string `json:"message"`
 	Channel    string `json:"channel,omitempty"` // target workspace channel key (e.g. "C0ALZC59C8Z")
+	Dispatch   bool   `json:"dispatch,omitempty"` // fire-and-forget: inject into target channel's interactive session
 }
 
 // RelayResponse is the result of a relay send.
@@ -186,7 +187,12 @@ type RelayResponse struct {
 }
 
 // Send delivers a message from one bot to another and returns the response.
+// When req.Dispatch is true, the message is injected into the target engine's
+// interactive session for the specified channel and Send returns immediately.
 func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayResponse, error) {
+	if req.Dispatch {
+		return rm.dispatch(ctx, req)
+	}
 	platform, chatID, err := parseSessionKeyParts(req.SessionKey)
 	if err != nil {
 		return nil, fmt.Errorf("relay: invalid session key: %w", err)
@@ -253,6 +259,61 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 	}
 
 	return &RelayResponse{Response: response}, nil
+}
+
+// dispatch injects a message into the target engine's interactive session for
+// the specified channel. The agent processes the message and responds naturally
+// in that channel. Returns immediately after injection.
+func (rm *RelayManager) dispatch(ctx context.Context, req RelayRequest) (*RelayResponse, error) {
+	if req.Channel == "" {
+		return nil, fmt.Errorf("relay dispatch: --channel is required for dispatch mode")
+	}
+
+	platform, chatID, err := parseSessionKeyParts(req.SessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("relay dispatch: invalid session key: %w", err)
+	}
+
+	rm.mu.RLock()
+	binding := rm.bindings[chatID]
+	targetEngine := rm.engines[req.To]
+	sourceEngine := rm.engines[req.From]
+	rm.mu.RUnlock()
+
+	if binding == nil {
+		return nil, fmt.Errorf("relay dispatch: no binding for this chat. Use /bind <project> first")
+	}
+	if _, ok := binding.Bots[req.To]; !ok {
+		return nil, fmt.Errorf("relay dispatch: project %q is not bound in this chat", req.To)
+	}
+	if targetEngine == nil {
+		return nil, fmt.Errorf("relay dispatch: target engine %q not found (is the project running?)", req.To)
+	}
+
+	// Post dispatch notification to the source group chat
+	fromName := req.From
+	if binding.Bots[req.From] != "" {
+		fromName = binding.Bots[req.From]
+	}
+	toName := req.To
+	if binding.Bots[req.To] != "" {
+		toName = binding.Bots[req.To]
+	}
+	if sourceEngine != nil {
+		groupSessionKey := platform + ":" + chatID + ":relay"
+		label := fmt.Sprintf("[%s → %s dispatch] %s", fromName, toName, truncateRelay(req.Message, 500))
+		rm.sendToGroup(ctx, sourceEngine, platform, groupSessionKey, label)
+	}
+
+	// Inject prompt into the target engine's interactive session for the channel
+	if err := targetEngine.DispatchToChannel(platform, req.Channel, req.Message); err != nil {
+		return nil, fmt.Errorf("relay dispatch: %w", err)
+	}
+
+	slog.Info("relay: dispatched to channel",
+		"from", fromName, "to", toName, "channel", req.Channel)
+
+	return &RelayResponse{Response: "dispatched"}, nil
 }
 
 // sendToGroup sends a message to the group chat for visibility.

--- a/core/relay.go
+++ b/core/relay.go
@@ -177,6 +177,7 @@ type RelayRequest struct {
 	To         string `json:"to"`          // target project name
 	SessionKey string `json:"session_key"` // source session key (contains platform + chatID)
 	Message    string `json:"message"`
+	Channel    string `json:"channel,omitempty"` // target workspace channel key (e.g. "C0ALZC59C8Z")
 }
 
 // RelayResponse is the result of a relay send.
@@ -233,7 +234,14 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 	relayCtx, cancel := rm.relayContext(ctx)
 	defer cancel()
 
-	response, err := targetEngine.HandleRelay(relayCtx, req.From, chatID, "", req.Message)
+	// Build workspace channel key from the --channel flag if provided.
+	// HandleRelay uses this to resolve the correct workspace binding.
+	wsChannelKey := ""
+	if req.Channel != "" {
+		wsChannelKey = platform + ":" + req.Channel
+	}
+
+	response, err := targetEngine.HandleRelay(relayCtx, req.From, chatID, wsChannelKey, req.Message)
 	if err != nil {
 		return nil, fmt.Errorf("relay: %w", err)
 	}

--- a/core/relay.go
+++ b/core/relay.go
@@ -233,7 +233,7 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 	relayCtx, cancel := rm.relayContext(ctx)
 	defer cancel()
 
-	response, err := targetEngine.HandleRelay(relayCtx, req.From, chatID, req.Message)
+	response, err := targetEngine.HandleRelay(relayCtx, req.From, chatID, "", req.Message)
 	if err != nil {
 		return nil, fmt.Errorf("relay: %w", err)
 	}

--- a/core/relay_test.go
+++ b/core/relay_test.go
@@ -62,7 +62,7 @@ func TestHandleRelay_ReturnsPartialOnTimeout(t *testing.T) {
 	}
 	done := make(chan relayResult, 1)
 	go func() {
-		resp, err := e.HandleRelay(ctx, "source", "chat-1", "hello")
+		resp, err := e.HandleRelay(ctx, "source", "chat-1", "", "hello")
 		done <- relayResult{resp: resp, err: err}
 	}()
 
@@ -105,7 +105,7 @@ func TestHandleRelay_TimeoutWithoutTextReturnsContextError(t *testing.T) {
 	}
 	done := make(chan relayResult, 1)
 	go func() {
-		resp, err := e.HandleRelay(ctx, "source", "chat-1", "hello")
+		resp, err := e.HandleRelay(ctx, "source", "chat-1", "", "hello")
 		done <- relayResult{resp: resp, err: err}
 	}()
 
@@ -164,7 +164,7 @@ func TestHandleRelay_ResumeFailureFallsBackToFreshSession(t *testing.T) {
 	ctx := context.Background()
 	done := make(chan string, 1)
 	go func() {
-		resp, err := e.HandleRelay(ctx, "source", "chat-1", "hello")
+		resp, err := e.HandleRelay(ctx, "source", "chat-1", "", "hello")
 		if err != nil {
 			done <- "error: " + err.Error()
 			return

--- a/core/runas.go
+++ b/core/runas.go
@@ -132,10 +132,43 @@ func (o SpawnOptions) mergedAllowlist() []string {
 // Does NOT run the per-spawn re-check — callers should invoke
 // VerifyRunAsUserCheap immediately before Start() so a sudoers edit
 // between startup preflight and spawn is caught.
-func BuildSpawnCommand(ctx context.Context, opts SpawnOptions, name string, args ...string) *exec.Cmd {
+// BuildSpawnCommandInDir is like BuildSpawnCommand but ensures the spawned
+// process starts in workDir even when sudo -i resets to the target user's
+// home directory. When workDir is empty, behaves identically to the non-dir
+// variant.
+func BuildSpawnCommandInDir(ctx context.Context, opts SpawnOptions, workDir, name string, args ...string) *exec.Cmd {
 	if !opts.IsolationMode() {
-		return exec.CommandContext(ctx, name, args...)
+		cmd := exec.CommandContext(ctx, name, args...)
+		if workDir != "" {
+			cmd.Dir = workDir
+		}
+		return cmd
 	}
+
+	// sudo -i resets cwd to the target user's home. Wrap the command in
+	// bash -c "cd <dir> && exec <cmd> <args>" so the agent starts in the
+	// correct workspace directory.
+	if workDir != "" {
+		// Build a single shell command string with proper quoting.
+		var shellCmd strings.Builder
+		shellCmd.WriteString("cd ")
+		shellCmd.WriteString(shellQuote(workDir))
+		shellCmd.WriteString(" && exec ")
+		shellCmd.WriteString(shellQuote(name))
+		for _, a := range args {
+			shellCmd.WriteByte(' ')
+			shellCmd.WriteString(shellQuote(a))
+		}
+		sudoArgs := []string{
+			"-n",
+			"-iu", opts.RunAsUser,
+			"--preserve-env=" + strings.Join(opts.mergedAllowlist(), ","),
+			"--",
+			"bash", "-c", shellCmd.String(),
+		}
+		return exec.CommandContext(ctx, "sudo", sudoArgs...)
+	}
+
 	sudoArgs := []string{
 		"-n",
 		"-iu", opts.RunAsUser,
@@ -146,6 +179,11 @@ func BuildSpawnCommand(ctx context.Context, opts SpawnOptions, name string, args
 	sudoArgs = append(sudoArgs, args...)
 	return exec.CommandContext(ctx, "sudo", sudoArgs...)
 }
+
+func BuildSpawnCommand(ctx context.Context, opts SpawnOptions, name string, args ...string) *exec.Cmd {
+	return BuildSpawnCommandInDir(ctx, opts, "", name, args...)
+}
+
 
 // FilterEnvForSpawn strips env down to the merged allowlist when
 // opts.IsolationMode() is true. Belt-and-braces with sudo's own

--- a/core/session.go
+++ b/core/session.go
@@ -14,6 +14,14 @@ import (
 // to use --continue (resume most recent session) instead of a specific session ID.
 const ContinueSession = "__continue__"
 
+// ResumeForkPrefix marks a session ID that should be resumed with --fork-session
+// instead of plain --resume. Agents that support forking strip this prefix before
+// passing the real UUID to their backend CLI. Used by the /resume slash command
+// to let the user explicitly pick a prior workspace session — terminal-owned or
+// otherwise — and branch off its context into a fresh cc-connect conversation
+// without mutating the source session if it is still live somewhere else.
+const ResumeForkPrefix = "__fork:"
+
 // Session tracks one conversation between a user and the agent.
 type Session struct {
 	ID                  string         `json:"id"`
@@ -24,6 +32,30 @@ type Session struct {
 	History             []HistoryEntry `json:"history"`
 	CreatedAt           time.Time      `json:"created_at"`
 	UpdatedAt           time.Time      `json:"updated_at"`
+
+	// pendingResumeCandidates is the in-memory list of workspace session IDs
+	// shown to the user by the most recent `/resume` (no-arg) invocation. The
+	// next `/resume <n>` call resolves <n> against this slice. Transient — not
+	// persisted across cc-connect restarts (unexported field = invisible to
+	// the session-store snapshot writer). Dropped implicitly on /new, because
+	// /new allocates a brand-new Session object and the old one with its
+	// pending candidates becomes unreachable. Order matches the picker's
+	// numbering: 1-based in the UI (`/resume 1` is the top of the list),
+	// 0-based in this slice.
+	pendingResumeCandidates []string
+
+	// forkOnNextStart, if non-empty, carries a backend session ID that the
+	// next StartSession call should resume with --fork-session instead of
+	// resuming whatever AgentSessionID points at. Populated by /resume <n>;
+	// consumed and cleared by the engine when it next spawns an interactive
+	// state for this session. Transient by design — we do NOT stash the
+	// sentinel inside AgentSessionID because that field is persisted to
+	// disk by the session-store snapshot writer and a crash in the narrow
+	// window between /resume pick and first message would leave a stale
+	// sentinel on disk that replays incorrectly on next startup. Keeping
+	// it in its own unexported field means a crash simply drops the
+	// pending fork and the user can re-pick from a fresh /resume list.
+	forkOnNextStart string
 
 	mu   sync.Mutex `json:"-"`
 	busy bool       `json:"-"`
@@ -184,6 +216,67 @@ func (s *Session) GetHistory(n int) []HistoryEntry {
 	out := make([]HistoryEntry, n)
 	copy(out, s.History[total-n:])
 	return out
+}
+
+// SetPendingResumeCandidates stores the list of workspace session IDs presented
+// to the user by `/resume` (no-arg). The next `/resume <n>` resolves <n> against
+// this list. Passing nil clears the pending state.
+func (s *Session) SetPendingResumeCandidates(ids []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(ids) == 0 {
+		s.pendingResumeCandidates = nil
+		return
+	}
+	cpy := make([]string, len(ids))
+	copy(cpy, ids)
+	s.pendingResumeCandidates = cpy
+}
+
+// ClearPendingResumeCandidates drops any pending /resume picker state. Called
+// from any non-/resume-pick code path so the picker can't be resolved stale
+// after unrelated messages have been exchanged.
+func (s *Session) ClearPendingResumeCandidates() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pendingResumeCandidates = nil
+}
+
+// TakePendingResumeCandidate atomically returns and clears the pending resume
+// candidate at the given 1-based index (matching the picker UI). Returns the
+// session ID and true on success; empty string and false if the index is out
+// of range or no picker is pending.
+func (s *Session) TakePendingResumeCandidate(oneBasedIndex int) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if oneBasedIndex < 1 || oneBasedIndex > len(s.pendingResumeCandidates) {
+		return "", false
+	}
+	id := s.pendingResumeCandidates[oneBasedIndex-1]
+	s.pendingResumeCandidates = nil
+	return id, true
+}
+
+// SetForkOnNextStart arms the next StartSession call on this session to use
+// --resume <id> --fork-session (via the ResumeForkPrefix sentinel passed
+// through to the agent). Transient; not persisted.
+func (s *Session) SetForkOnNextStart(backendSessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.forkOnNextStart = backendSessionID
+}
+
+// ConsumeForkOnNextStart atomically returns the pending fork-resume target,
+// if any, and clears it. Called by the engine just before it decides what
+// session ID to hand to agent.StartSession. Returns empty string if no fork
+// is pending, in which case the caller falls back to the normal
+// AgentSessionID resume path.
+func (s *Session) ConsumeForkOnNextStart() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := s.forkOnNextStart
+	s.forkOnNextStart = ""
+	return id
 }
 
 // UserMeta stores human-readable display info for a session key.

--- a/core/session.go
+++ b/core/session.go
@@ -79,6 +79,9 @@ func (s *Session) Busy() bool {
 	return s.busy
 }
 
+// IsBusy is an alias for Busy, used by thread-aware session routing.
+func (s *Session) IsBusy() bool { return s.Busy() }
+
 func (s *Session) Unlock() {
 	s.unlock(true)
 }
@@ -346,6 +349,17 @@ func (sm *SessionManager) StorePath() string {
 func (sm *SessionManager) nextID() string {
 	sm.counter++
 	return fmt.Sprintf("s%d", sm.counter)
+}
+
+// PeekActive returns the currently active session for userKey without creating one.
+// Returns nil if no active session exists for the key.
+func (sm *SessionManager) PeekActive(userKey string) *Session {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	if sid, ok := sm.activeSession[userKey]; ok {
+		return sm.sessions[sid]
+	}
+	return nil
 }
 
 func (sm *SessionManager) GetOrCreateActive(userKey string) *Session {

--- a/core/thread_router.go
+++ b/core/thread_router.go
@@ -1,0 +1,181 @@
+package core
+
+import (
+	"fmt"
+	"sync"
+)
+
+const defaultMaxConcurrent = 3
+
+// threadKey uniquely identifies a thread within a base session key space.
+// It combines the base session key (e.g. "slack:C123") with the platform
+// thread ID (e.g. Slack thread_ts) to allow independent routing per channel.
+func threadKey(baseKey, threadID string) string {
+	return baseKey + "|" + threadID
+}
+
+// forkedInfo records the provenance of a forked session key so it can be
+// cleaned up when the session expires.
+type forkedInfo struct {
+	baseKey  string
+	threadID string
+}
+
+// ThreadRouter implements thread-aware session routing for a project binding.
+//
+// Design: context-switch first, fork on contention.
+//
+//	Message arrives → check thread affinity
+//	  → Thread has existing session? Route to it.
+//	  → No affinity yet + base session idle? Context-switch: map thread → base, use base.
+//	  → No affinity yet + base session busy + below max_concurrent? Fork new session.
+//	  → At max_concurrent? Fall back to base (message will be queued).
+//
+// A single ThreadRouter handles all channels/users for a project binding.
+// max_concurrent is enforced per base session key (per channel) so that
+// unrelated channels do not compete for the same concurrency budget.
+// Forked sessions are locked to their originating thread; only the base session
+// participates in context-switching between threads.
+type ThreadRouter struct {
+	mu sync.Mutex
+
+	// threadToKey maps threadKey(baseKey, threadID) → effective session key.
+	threadToKey map[string]string
+
+	// forkedKeys maps effective session key → forkedInfo (base key + thread ID).
+	// Only contains entries for forked (non-base) sessions.
+	forkedKeys map[string]forkedInfo
+
+	maxConcurrent int
+
+	// clientMsgDedup prevents double-processing of Slack "also send to channel"
+	// events, which fire two events sharing the same client_msg_id.
+	clientMsgDedup MessageDedup
+}
+
+// NewThreadRouter creates a ThreadRouter for a project binding.
+// maxConcurrent is the ceiling on simultaneous mid-turn sessions per channel
+// (base session key); it defaults to 3 when <= 0.
+func NewThreadRouter(maxConcurrent int) *ThreadRouter {
+	if maxConcurrent <= 0 {
+		maxConcurrent = defaultMaxConcurrent
+	}
+	return &ThreadRouter{
+		threadToKey:   make(map[string]string),
+		forkedKeys:    make(map[string]forkedInfo),
+		maxConcurrent: maxConcurrent,
+	}
+}
+
+// IsDuplicateClientMsg reports whether clientMsgID was already seen within the
+// dedup TTL window. Empty clientMsgID is never considered a duplicate.
+func (r *ThreadRouter) IsDuplicateClientMsg(clientMsgID string) bool {
+	return r.clientMsgDedup.IsDuplicate(clientMsgID)
+}
+
+// RouteResult carries the outcome of a Route call.
+type RouteResult struct {
+	// EffectiveKey is the session key the message should be processed under.
+	EffectiveKey string
+	// Forked is true when a brand-new parallel session was allocated for this thread.
+	// The caller must ensure the session is created via sessions.GetOrCreateActive.
+	Forked bool
+	// ForkWarning is a user-visible message sent to the thread when Forked is true.
+	ForkWarning string
+}
+
+// Route resolves the effective session key for an incoming message.
+//
+//   - baseKey is msg.SessionKey (e.g. "slack:C123" or "slack:C123:U456").
+//   - threadID is msg.ThreadID (Slack thread_ts or message ts for top-level messages).
+//   - sessions is consulted to check whether the base session is mid-turn.
+//
+// When threadID is empty the base key is returned unchanged (backward-compatible
+// with platforms that do not set ThreadID).
+func (r *ThreadRouter) Route(baseKey, threadID string, sessions *SessionManager) RouteResult {
+	if threadID == "" {
+		return RouteResult{EffectiveKey: baseKey}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tk := threadKey(baseKey, threadID)
+
+	// 1. Existing affinity — route to the already-assigned session.
+	if existing, ok := r.threadToKey[tk]; ok {
+		return RouteResult{EffectiveKey: existing}
+	}
+
+	// 2. No affinity yet.  Check whether the base session is currently mid-turn.
+	if base := sessions.PeekActive(baseKey); base == nil || !base.IsBusy() {
+		// Base session is idle (or not yet created): context-switch into it.
+		r.threadToKey[tk] = baseKey
+		return RouteResult{EffectiveKey: baseKey}
+	}
+
+	// 3. Base is busy.  Count how many sessions for this base key are mid-turn.
+	midTurn := 1 // base session counts as one
+	for fk, fi := range r.forkedKeys {
+		if fi.baseKey != baseKey {
+			continue
+		}
+		if s := sessions.PeekActive(fk); s != nil && s.IsBusy() {
+			midTurn++
+		}
+	}
+
+	if midTurn < r.maxConcurrent {
+		// Fork: allocate a new session key for this thread.
+		forkedKey := fmt.Sprintf("%s:t:%s", baseKey, shortThreadID(threadID))
+		r.threadToKey[tk] = forkedKey
+		r.forkedKeys[forkedKey] = forkedInfo{baseKey: baseKey, threadID: threadID}
+		return RouteResult{
+			EffectiveKey: forkedKey,
+			Forked:       true,
+			ForkWarning: "⚠️ A new parallel session was started for this thread. " +
+				"Parallel sessions may have divergent context. " +
+				"If you experience unexpected behaviour, keep conversations to a single thread.",
+		}
+	}
+
+	// 4. At max_concurrent: fall back to base (message will be queued there).
+	r.threadToKey[tk] = baseKey
+	return RouteResult{EffectiveKey: baseKey}
+}
+
+// ReleaseSession removes routing state for effectiveSessionKey when its session
+// is cleaned up (idle timeout, explicit reset, etc.).
+// After this call, the next message on the owning thread will re-route as a new
+// thread — it will context-switch into the base session if idle, or fork again.
+func (r *ThreadRouter) ReleaseSession(effectiveSessionKey string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if fi, ok := r.forkedKeys[effectiveSessionKey]; ok {
+		// Forked session: remove its specific mapping.
+		delete(r.forkedKeys, effectiveSessionKey)
+		delete(r.threadToKey, threadKey(fi.baseKey, fi.threadID))
+		return
+	}
+
+	// Base session cleanup: release all threads that context-switched into it.
+	// We identify which base key this is by finding all threadToKey entries
+	// that point to effectiveSessionKey (the base key).
+	for tk, mapped := range r.threadToKey {
+		if mapped == effectiveSessionKey {
+			delete(r.threadToKey, tk)
+		}
+	}
+}
+
+// shortThreadID returns the last 12 characters of a thread ID string (e.g.
+// a Slack thread_ts like "1234567890.123456" → "567890.123456"), producing a
+// concise suffix that is unique enough for a session key while staying readable
+// in logs.
+func shortThreadID(s string) string {
+	if len(s) > 12 {
+		return s[len(s)-12:]
+	}
+	return s
+}

--- a/core/thread_router_test.go
+++ b/core/thread_router_test.go
@@ -1,0 +1,151 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestSessionManager returns a fresh in-memory SessionManager (no persistence).
+func newTestSessionManager() *SessionManager {
+	return NewSessionManager("")
+}
+
+func TestThreadRouter_NoThreadID(t *testing.T) {
+	r := NewThreadRouter(3)
+	sm := newTestSessionManager()
+
+	result := r.Route("slack:C1", "", sm)
+	assert.Equal(t, "slack:C1", result.EffectiveKey)
+	assert.False(t, result.Forked)
+}
+
+func TestThreadRouter_ContextSwitch_IdleBase(t *testing.T) {
+	r := NewThreadRouter(3)
+	sm := newTestSessionManager()
+
+	// Base session exists but is idle (not busy).
+	base := sm.GetOrCreateActive("slack:C1")
+	_ = base // idle — not locked
+
+	result := r.Route("slack:C1", "thread-ts-1", sm)
+	assert.Equal(t, "slack:C1", result.EffectiveKey, "should context-switch to base when idle")
+	assert.False(t, result.Forked)
+}
+
+func TestThreadRouter_SameThread_RoutesSameKey(t *testing.T) {
+	r := NewThreadRouter(3)
+	sm := newTestSessionManager()
+
+	// First route establishes affinity.
+	r1 := r.Route("slack:C1", "ts-1", sm)
+	// Second route from same thread must return same key.
+	r2 := r.Route("slack:C1", "ts-1", sm)
+	assert.Equal(t, r1.EffectiveKey, r2.EffectiveKey)
+}
+
+func TestThreadRouter_Fork_WhenBaseBusy(t *testing.T) {
+	r := NewThreadRouter(3)
+	sm := newTestSessionManager()
+
+	// Lock the base session to simulate a mid-turn.
+	base := sm.GetOrCreateActive("slack:C1")
+	require.True(t, base.TryLock(), "should be able to lock fresh session")
+	defer base.Unlock()
+
+	result := r.Route("slack:C1", "ts-new", sm)
+	assert.NotEqual(t, "slack:C1", result.EffectiveKey, "should fork when base is busy")
+	assert.True(t, result.Forked)
+	assert.NotEmpty(t, result.ForkWarning)
+}
+
+func TestThreadRouter_Fork_LimitEnforced(t *testing.T) {
+	r := NewThreadRouter(2) // max 2 concurrent
+	sm := newTestSessionManager()
+
+	// Lock the base session.
+	base := sm.GetOrCreateActive("slack:C1")
+	require.True(t, base.TryLock())
+	defer base.Unlock()
+
+	// First new thread forks (midTurn=1 < max=2).
+	r1 := r.Route("slack:C1", "ts-thread-1", sm)
+	require.True(t, r1.Forked)
+
+	// Lock the forked session so it counts as mid-turn.
+	fork1 := sm.GetOrCreateActive(r1.EffectiveKey)
+	require.True(t, fork1.TryLock())
+	defer fork1.Unlock()
+
+	// Second new thread hits max_concurrent → falls back to base.
+	r2 := r.Route("slack:C1", "ts-thread-2", sm)
+	assert.Equal(t, "slack:C1", r2.EffectiveKey, "should fall back to base when at max_concurrent")
+	assert.False(t, r2.Forked)
+}
+
+func TestThreadRouter_ReleaseForked(t *testing.T) {
+	r := NewThreadRouter(3)
+	sm := newTestSessionManager()
+
+	// Lock base, fork a session.
+	base := sm.GetOrCreateActive("slack:C1")
+	require.True(t, base.TryLock())
+
+	r1 := r.Route("slack:C1", "ts-1", sm)
+	require.True(t, r1.Forked)
+	forkedKey := r1.EffectiveKey
+
+	// Release the forked session.
+	r.ReleaseSession(forkedKey)
+
+	// The thread should now re-route (no existing affinity).
+	// Base is still busy, so it would fork again.
+	r2 := r.Route("slack:C1", "ts-1", sm)
+	assert.True(t, r2.Forked, "should fork again after release when base is still busy")
+	base.Unlock()
+}
+
+func TestThreadRouter_ReleaseBase_ClearsAllAffinity(t *testing.T) {
+	r := NewThreadRouter(3)
+	sm := newTestSessionManager()
+
+	// Two threads context-switch into the idle base.
+	r.Route("slack:C1", "ts-A", sm)
+	r.Route("slack:C1", "ts-B", sm)
+
+	// Release the base session.
+	r.ReleaseSession("slack:C1")
+
+	// Now lock the base and route ts-A — it should fork (no existing affinity).
+	base := sm.GetOrCreateActive("slack:C1")
+	require.True(t, base.TryLock())
+	defer base.Unlock()
+
+	result := r.Route("slack:C1", "ts-A", sm)
+	assert.True(t, result.Forked, "thread affinity should have been cleared on base release")
+}
+
+func TestThreadRouter_IndependentChannels(t *testing.T) {
+	r := NewThreadRouter(1) // max 1 = no forking
+	sm := newTestSessionManager()
+
+	// Lock channel C1's base.
+	c1base := sm.GetOrCreateActive("slack:C1")
+	require.True(t, c1base.TryLock())
+	defer c1base.Unlock()
+
+	// Channel C2 is unaffected — its base is idle.
+	result := r.Route("slack:C2", "ts-X", sm)
+	assert.Equal(t, "slack:C2", result.EffectiveKey, "channels are independent")
+	assert.False(t, result.Forked)
+}
+
+func TestThreadRouter_ClientMsgIDDedup(t *testing.T) {
+	r := NewThreadRouter(3)
+
+	assert.False(t, r.IsDuplicateClientMsg(""), "empty id is never a duplicate")
+	assert.False(t, r.IsDuplicateClientMsg("abc-123"), "first time is not a duplicate")
+	assert.True(t, r.IsDuplicateClientMsg("abc-123"), "second time is a duplicate")
+	assert.False(t, r.IsDuplicateClientMsg("def-456"), "different id is not a duplicate")
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# deploy.sh — safe binary deployment for cc-connect
+#
+# Builds the new binary, installs it, health-checks the start, and
+# auto-rolls back to the previous known-good binary if the new one
+# crashes within the grace period.
+#
+# Usage: ./deploy.sh [--skip-build]
+#   --skip-build  skip make build, just deploy whatever ./cc-connect is now
+
+set -euo pipefail
+
+INSTALL_DIR="/home/leigh/workspace/cc-connect"
+BINARY="$INSTALL_DIR/cc-connect"
+BACKUP="$INSTALL_DIR/cc-connect.known-good"
+SERVICE="cc-connect.service"
+HEALTH_GRACE=15  # seconds the new binary must stay alive to be considered healthy
+
+log() { echo "[deploy] $(date '+%H:%M:%S') $*"; }
+
+# --- Build ---
+if [[ "${1:-}" != "--skip-build" ]]; then
+    log "Building new binary..."
+    cd "$INSTALL_DIR"
+    make build
+    log "Build complete."
+else
+    log "Skipping build (--skip-build)."
+fi
+
+# --- Backup current known-good ---
+if [[ -f "$BACKUP" ]]; then
+    log "Existing known-good backup: $(stat -c '%Y %s' "$BACKUP" | awk '{print strftime("%Y-%m-%d %H:%M:%S", $1), int($2/1024)"K"}')"
+fi
+
+# Only back up if the currently running binary is healthy (service is active)
+if systemctl --user is-active "$SERVICE" &>/dev/null; then
+    log "Service is running — backing up current binary as known-good."
+    cp "$BINARY" "$BACKUP"
+else
+    log "Service is not running — skipping backup (current binary may be bad)."
+    if [[ ! -f "$BACKUP" ]]; then
+        log "WARNING: No known-good backup exists. Proceeding without safety net."
+    fi
+fi
+
+# --- Deploy ---
+log "Stopping service..."
+systemctl --user stop "$SERVICE" 2>/dev/null || true
+sleep 1
+
+log "Starting service with new binary..."
+systemctl --user start "$SERVICE"
+
+# --- Health check ---
+log "Health check: waiting ${HEALTH_GRACE}s for new binary to prove stable..."
+sleep "$HEALTH_GRACE"
+
+if systemctl --user is-active "$SERVICE" &>/dev/null; then
+    log "✓ New binary is healthy. Updating known-good backup."
+    cp "$BINARY" "$BACKUP"
+    log "Deploy complete."
+    exit 0
+fi
+
+# --- Rollback ---
+log "✗ New binary crashed within ${HEALTH_GRACE}s."
+
+if [[ -f "$BACKUP" ]]; then
+    log "Rolling back to known-good binary..."
+    cp "$BACKUP" "$BINARY"
+    systemctl --user reset-failed "$SERVICE" 2>/dev/null || true
+    systemctl --user start "$SERVICE"
+    sleep 3
+
+    if systemctl --user is-active "$SERVICE" &>/dev/null; then
+        log "✓ Rollback successful — running known-good binary."
+        exit 1  # non-zero: deploy failed but service is alive
+    else
+        log "✗ CRITICAL: Rollback also failed. Service is down."
+        log "  Manual recovery: check journalctl --user -u $SERVICE"
+        exit 2
+    fi
+else
+    log "✗ CRITICAL: No known-good backup to roll back to. Service is down."
+    log "  Manual recovery: fix the binary, then: systemctl --user start $SERVICE"
+    exit 2
+fi

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -750,6 +750,58 @@ Notes:
 
 ---
 
+## External Triggers (`--as-prompt`)
+
+Inject a message into an active agent session as if it came from an external user. The agent processes it and responds on its platform — ideal for file watchers, CI hooks, and automated pipelines that need to trigger agent work.
+
+### CLI
+
+```bash
+# Basic trigger — agent will process and respond
+cc-connect send --as-prompt -m "New completion file: STORY-42.md. Read and process it."
+
+# Target a specific project
+cc-connect send --as-prompt -p my-project -m "Build succeeded, deploy to staging"
+
+# With explicit session key
+cc-connect send --as-prompt -s "slack:C123:U456" -m "Review PR #87"
+```
+
+### How it works
+
+1. The message is injected into the agent's session as an inbound prompt (not posted as the bot)
+2. If no `--session` is provided, the first active session is used automatically
+3. If the session is busy (mid-turn), the command retries with 2-second backoff for up to 60 seconds
+4. The agent sees the message as coming from user `trigger` and processes it normally
+
+### Example: completion file watcher
+
+A systemd service watches a directory for new `.md` files and triggers the agent:
+
+```bash
+#!/bin/bash
+WATCH_DIR="/path/to/completions/"
+CC_CONNECT="/path/to/cc-connect"
+
+inotifywait -m -e create -e moved_to --format '%f' "$WATCH_DIR" | while read FILE; do
+  [[ "$FILE" == *.md ]] || continue
+  "$CC_CONNECT" send --as-prompt -p my-project --data-dir ~/.cc-connect \
+    -m "New completion file: ${FILE}. Read and process it."
+done
+```
+
+### Difference from `--new-thread`
+
+| Flag | Behavior |
+|------|----------|
+| (default) | Posts a message from the bot into the active thread |
+| `--new-thread` | Posts a message from the bot as a new top-level channel message |
+| `--as-prompt` | Injects as an inbound message the agent will process and respond to |
+
+Use `--as-prompt` when you need the agent to **act**. Use `--new-thread` when you need to **notify** (e.g., post a summary to the channel).
+
+---
+
 ## Scheduled Tasks (Cron)
 
 Create scheduled tasks that run automatically.

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -884,6 +884,26 @@ func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
 	}
 }
 
+// AddReaction adds an emoji reaction to the specified message.
+// Implements core.Reactor.
+func (p *Platform) AddReaction(ctx context.Context, channel, ts, emoji string) error {
+	ref := slack.ItemRef{Channel: channel, Timestamp: ts}
+	if err := p.client.AddReactionContext(ctx, emoji, ref); err != nil {
+		return fmt.Errorf("slack: add reaction %q: %w", emoji, err)
+	}
+	return nil
+}
+
+// RemoveReaction removes an emoji reaction from the specified message.
+// Implements core.Reactor.
+func (p *Platform) RemoveReaction(ctx context.Context, channel, ts, emoji string) error {
+	ref := slack.ItemRef{Channel: channel, Timestamp: ts}
+	if err := p.client.RemoveReactionContext(ctx, emoji, ref); err != nil {
+		return fmt.Errorf("slack: remove reaction %q: %w", emoji, err)
+	}
+	return nil
+}
+
 func (p *Platform) Stop() error {
 	if p.cancel != nil {
 		p.cancel()

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -142,27 +142,37 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 				}
 
 				var shareFiles []slackevents.File
+				var clientMsgID string
 				if cb, ok := data.Data.(*slackevents.EventsAPICallbackEvent); ok {
 					shareFiles = parseSlackInnerEventFiles(cb.InnerEvent)
+					clientMsgID = parseSlackClientMsgID(cb.InnerEvent)
 				}
 				images, audio, docFiles := p.processSlackFileShares(shareFiles)
 				content := stripAppMentionText(ev.Text)
 				if content == "" && len(images) == 0 && audio == nil && len(docFiles) == 0 {
 					return
 				}
+				// threadTS is the thread the mention was posted in, or the message
+				// timestamp itself when posted in the main channel (no thread).
+				threadTS := ev.ThreadTimeStamp
+				if threadTS == "" {
+					threadTS = ev.TimeStamp
+				}
 				userName := p.resolveUserName(ev.User)
 				channelName := p.resolveChannelNameForMsg(ev.Channel)
 				msg := &core.Message{
-					SessionKey: sessionKey, Platform: "slack",
-					UserID: ev.User, UserName: userName,
-					ChatName:  channelName,
-					Content:   content,
-					Images:    images,
-					Files:     docFiles,
-					Audio:     audio,
-					MessageID: ev.TimeStamp,
-					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: ev.TimeStamp},
+					SessionKey:      sessionKey, Platform: "slack",
+					UserID:          ev.User, UserName: userName,
+					ChatName:        channelName,
+					Content:         content,
+					Images:          images,
+					Files:           docFiles,
+					Audio:           audio,
+					MessageID:       ev.TimeStamp,
+					ReplyCtx:        replyContext{channel: ev.Channel, timestamp: ev.TimeStamp},
 					PlatformContext: slackMessageContext(ev.Channel, channelName, ev.User, userName, ev.TimeStamp, ev.ThreadTimeStamp),
+					ThreadID:        threadTS,
+					ClientMsgID:     clientMsgID,
 				}
 				p.handler(p, msg)
 
@@ -217,16 +227,25 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					return
 				}
 
+				// threadTS is the thread the message belongs to. For a top-level
+				// channel message (no thread), treat the message itself as its own
+				// thread so the router can distinguish it from other conversations.
+				threadTS := ev.ThreadTimeStamp
+				if threadTS == "" {
+					threadTS = ts
+				}
 				userName := p.resolveUserName(ev.User)
 				channelName := p.resolveChannelNameForMsg(ev.Channel)
 				msg := &core.Message{
-					SessionKey: sessionKey, Platform: "slack",
-					UserID: ev.User, UserName: userName,
-					ChatName: channelName,
-					Content:  ev.Text, Images: images, Files: docFiles, Audio: audio,
-					MessageID: ts,
+					SessionKey:      sessionKey, Platform: "slack",
+					UserID:          ev.User, UserName: userName,
+					ChatName:        channelName,
+					Content:         ev.Text, Images: images, Files: docFiles, Audio: audio,
+					MessageID:       ts,
 					ReplyCtx:        replyContext{channel: ev.Channel, timestamp: assistantOrThreadTS(ev)},
 					PlatformContext: slackMessageContext(ev.Channel, channelName, ev.User, userName, ts, ev.ThreadTimeStamp),
+					ThreadID:        threadTS,
+					ClientMsgID:     ev.ClientMsgID,
 				}
 				p.handler(p, msg)
 			}
@@ -320,6 +339,23 @@ func parseSlackInnerEventFiles(raw *json.RawMessage) []slackevents.File {
 		return nil
 	}
 	return wrapper.Files
+}
+
+// parseSlackClientMsgID extracts the client_msg_id field from a raw inner event.
+// AppMentionEvent does not expose this field via the Go struct, so we parse the
+// raw JSON directly — the same approach used by parseSlackInnerEventFiles.
+func parseSlackClientMsgID(raw *json.RawMessage) string {
+	if raw == nil || len(*raw) == 0 {
+		return ""
+	}
+	var wrapper struct {
+		ClientMsgID string `json:"client_msg_id"`
+	}
+	if err := json.Unmarshal(*raw, &wrapper); err != nil {
+		slog.Debug("slack: parse client_msg_id", "error", err)
+		return ""
+	}
+	return wrapper.ClientMsgID
 }
 
 // processSlackFileShares downloads Slack file shares and maps them to core

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -439,9 +439,24 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	return nil
 }
 
-// Send sends a new message (or threaded reply if rctx has timestamp).
-// Patched 2026-05-03: use thread_ts when present so replies in Slack Assistant
-// Chat tab land in the right thread (not the History tab feed).
+// Send posts a message into the channel on the reply context, threading it
+// off rc.timestamp when one is present.
+//
+// In cc-connect's normal Slack flow every triggering user message has its
+// ts captured into replyContext.timestamp, so this effectively threads the
+// entire conversation (final reply, streaming progress, tool-use noise,
+// errors, notifications) under the user's original message. That is the
+// desired shape:
+//
+//   - One thread per conversation, keeping the main channel quiet.
+//   - Tool-call noise and progress updates stay contained inside the thread.
+//   - Parallel conversations in the same channel naturally fork into
+//     separate threads without any per-session book-keeping beyond the
+//     session key that already carries the channel + user.
+//
+// For genuinely standalone posts (slash commands with no message ts,
+// bot-initiated notifications with ReconstructReplyCtx) rc.timestamp is
+// empty and Send falls back to a non-threaded post.
 func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 	rc, ok := rctx.(replyContext)
 	if !ok {
@@ -452,8 +467,9 @@ func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 		slack.MsgOptionText(core.MarkdownToSlackMrkdwn(content), false),
 	}
 	if rc.timestamp != "" {
-		opts = append(opts, slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{ThreadTimestamp: rc.timestamp}))
+		opts = append(opts, slack.MsgOptionTS(rc.timestamp))
 	}
+
 	_, _, err := p.client.PostMessageContext(ctx, rc.channel, opts...)
 	if err != nil {
 		return fmt.Errorf("slack: send: %w", err)

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -546,6 +546,118 @@ func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachm
 
 var _ core.FileSender = (*Platform)(nil)
 
+// ──────────────────────────────────────────────────────────────────────────────
+// Progress writer (compact style)
+//
+// cc-connect's core compact progress writer coalesces intermediate events
+// (thinking, tool_use, tool_result) into a SINGLE message that is updated in
+// place via chat.update, rather than posting a fresh Slack message per event
+// (the "legacy" behaviour). For Slack we want the compact style because:
+//
+//   - One progress message per turn instead of N. Main channel stays quiet.
+//   - Slack's native long-text clipping kicks in on both mobile (~1500 chars)
+//     and desktop (~4000 chars), rendering an inline "Show more" / "Show less"
+//     link without any interactive-component wiring on our side. This gives
+//     the "collapsible card" user experience for free.
+//   - The final agent reply is posted as a separate threaded message
+//     underneath the progress bubble, so the thread ends up with exactly
+//     two messages: [progress] + [answer].
+//
+// To opt in we implement three optional interfaces from core/interfaces.go:
+//
+//   - ProgressStyleProvider — returns "compact" so the core writer enables.
+//   - PreviewStarter        — posts the initial progress message and returns
+//                             a handle carrying the new message's channel+ts.
+//   - MessageUpdater        — edits the progress message in place via
+//                             chat.update as new events stream in.
+// ──────────────────────────────────────────────────────────────────────────────
+
+// slackPreviewHandle carries the channel + ts of the progress message we
+// posted via SendPreviewStart, so UpdateMessage knows which Slack message to
+// chat.update as intermediate events accumulate. The handle is threaded
+// through the core progress writer as an opaque `any` and type-asserted on
+// the way in.
+type slackPreviewHandle struct {
+	channel string
+	ts      string
+}
+
+// ProgressStyle opts the Slack platform into the compact in-place progress
+// writer. See core/progress_compact.go for the writer itself and the block
+// comment at the top of this section for the rationale.
+func (p *Platform) ProgressStyle() string {
+	return "compact"
+}
+
+// SendPreviewStart posts the initial progress message and returns a handle
+// carrying its channel + ts, which subsequent UpdateMessage calls use for
+// in-place edits.
+//
+// The progress message is always threaded off the triggering user message
+// when a thread ts is available in the reply context — that keeps the
+// progress bubble, the tool-call noise, and the final agent reply all
+// inside the same thread as the user's original message, matching the
+// auto-thread behaviour of Send for final replies.
+func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content string) (any, error) {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return nil, fmt.Errorf("slack: SendPreviewStart: invalid reply context type %T", rctx)
+	}
+
+	opts := []slack.MsgOption{
+		slack.MsgOptionText(content, false),
+	}
+	if rc.timestamp != "" {
+		opts = append(opts, slack.MsgOptionTS(rc.timestamp))
+	}
+
+	_, ts, err := p.client.PostMessageContext(ctx, rc.channel, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("slack: send preview start: %w", err)
+	}
+	return &slackPreviewHandle{channel: rc.channel, ts: ts}, nil
+}
+
+// UpdateMessage edits the progress message in place via Slack's chat.update
+// API. The handle was returned by SendPreviewStart and holds the channel +
+// ts of the message to edit.
+//
+// Failures here cause the core compact writer to mark itself failed and
+// fall back to legacy per-event posts for the rest of the turn, so the
+// user never loses visibility into what the agent is doing — they just
+// get slightly noisier output for that one turn.
+//
+// Note on Slack API quirks:
+//   - "message_not_updated" / identical-content responses return nil error
+//     from slack-go, so they are implicitly a no-op.
+//   - chat.update has an approximate rate limit of ~1 call per second per
+//     message; if a turn streams faster than that we may get rate-limited
+//     and the writer will fall back mid-turn. That is acceptable for an
+//     initial implementation and can be revisited later if it shows up in
+//     practice.
+func (p *Platform) UpdateMessage(ctx context.Context, handle any, content string) error {
+	h, ok := handle.(*slackPreviewHandle)
+	if !ok {
+		return fmt.Errorf("slack: UpdateMessage: invalid handle type %T", handle)
+	}
+
+	_, _, _, err := p.client.UpdateMessageContext(ctx, h.channel, h.ts,
+		slack.MsgOptionText(content, false),
+	)
+	if err != nil {
+		return fmt.Errorf("slack: update message: %w", err)
+	}
+	return nil
+}
+
+// Compile-time assertions that the Slack platform implements the optional
+// progress-writer interfaces used by core/progress_compact.go.
+var (
+	_ core.ProgressStyleProvider = (*Platform)(nil)
+	_ core.PreviewStarter        = (*Platform)(nil)
+	_ core.MessageUpdater        = (*Platform)(nil)
+)
+
 func (p *Platform) downloadSlackFile(url string) ([]byte, error) {
 	if url == "" {
 		return nil, fmt.Errorf("empty URL")

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -150,16 +150,19 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 				if content == "" && len(images) == 0 && audio == nil && len(docFiles) == 0 {
 					return
 				}
+				userName := p.resolveUserName(ev.User)
+				channelName := p.resolveChannelNameForMsg(ev.Channel)
 				msg := &core.Message{
 					SessionKey: sessionKey, Platform: "slack",
-					UserID: ev.User, UserName: p.resolveUserName(ev.User),
-					ChatName:  p.resolveChannelNameForMsg(ev.Channel),
+					UserID: ev.User, UserName: userName,
+					ChatName:  channelName,
 					Content:   content,
 					Images:    images,
 					Files:     docFiles,
 					Audio:     audio,
 					MessageID: ev.TimeStamp,
 					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: ev.TimeStamp},
+					PlatformContext: slackMessageContext(ev.Channel, channelName, ev.User, userName, ev.TimeStamp, ev.ThreadTimeStamp),
 				}
 				p.handler(p, msg)
 
@@ -214,13 +217,16 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					return
 				}
 
+				userName := p.resolveUserName(ev.User)
+				channelName := p.resolveChannelNameForMsg(ev.Channel)
 				msg := &core.Message{
 					SessionKey: sessionKey, Platform: "slack",
-					UserID: ev.User, UserName: p.resolveUserName(ev.User),
-					ChatName: p.resolveChannelNameForMsg(ev.Channel),
+					UserID: ev.User, UserName: userName,
+					ChatName: channelName,
 					Content:  ev.Text, Images: images, Files: docFiles, Audio: audio,
 					MessageID: ts,
-					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: assistantOrThreadTS(ev)},
+					ReplyCtx:        replyContext{channel: ev.Channel, timestamp: assistantOrThreadTS(ev)},
+					PlatformContext: slackMessageContext(ev.Channel, channelName, ev.User, userName, ts, ev.ThreadTimeStamp),
 				}
 				p.handler(p, msg)
 			}
@@ -259,8 +265,9 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 		msg := &core.Message{
 			SessionKey: sessionKey, Platform: "slack",
 			UserID: cmd.UserID, UserName: cmd.UserName,
-			Content:  content,
-			ReplyCtx: replyContext{channel: cmd.ChannelID},
+			Content:         content,
+			ReplyCtx:        replyContext{channel: cmd.ChannelID},
+			PlatformContext: slackMessageContext(cmd.ChannelID, cmd.ChannelName, cmd.UserID, cmd.UserName, "", ""),
 		}
 		slog.Debug("slack: slash command", "command", cmd.Command, "text", cmd.Text, "user", cmd.UserID)
 		p.handler(p, msg)
@@ -272,6 +279,23 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 	case socketmode.EventTypeConnectionError:
 		slog.Error("slack: connection error")
 	}
+}
+
+// slackMessageContext builds the ## Slack Message Context block that gets
+// prepended to the agent prompt so Claude knows which channel/thread to target
+// when making Slack MCP tool calls and can apply correct reply threading.
+func slackMessageContext(channelID, channelName, userID, userName, messageTS, threadTS string) string {
+	var b strings.Builder
+	b.WriteString("## Slack Message Context\n")
+	b.WriteString("channel_id: " + channelID + "\n")
+	b.WriteString("channel_name: " + channelName + "\n")
+	b.WriteString("user_id: " + userID + "\n")
+	b.WriteString("user_name: " + userName + "\n")
+	b.WriteString("message_ts: " + messageTS + "\n")
+	if threadTS != "" {
+		b.WriteString("thread_ts: " + threadTS + "\n")
+	}
+	return b.String()
 }
 
 func stripAppMentionText(text string) string {

--- a/restart.sh
+++ b/restart.sh
@@ -150,7 +150,7 @@ if systemctl --user is-active "$SERVICE" &>/dev/null; then
     exit 0
 fi
 
-log "New binary crashed within ${HEALTH_GRACE}s. Journal tail:"
+log "New binary crashed within $HEALTH_GRACE seconds. Journal tail:"
 journalctl --user -u "$SERVICE" -n 20 --no-pager || true
 
 if [[ -f "$BACKUP" ]]; then

--- a/restart.sh
+++ b/restart.sh
@@ -134,11 +134,14 @@ systemctl --user reset-failed "$SERVICE" 2>/dev/null || true
 systemctl --user start "$SERVICE"
 
 # Braces deliberately omitted on $HEALTH_GRACE below. systemd-run
-# substitutes ${VAR}-with-braces in ExecStart lines from the unit's own
-# environment, and since HEALTH_GRACE is only set inside the bash -c
-# script — not in systemd's env — the braced form would render to empty
-# before bash ever sees it. The non-braced form is passed through verbatim
-# and expanded by bash at runtime.
+# pre-substitutes brace-form variable references in ExecStart lines from
+# the unit's own environment before exec, and since HEALTH_GRACE is only
+# set inside the bash -c script (not in systemd's env), the brace form
+# would render to empty before bash ever sees it. The unbraced form is
+# passed through verbatim and expanded by bash at runtime.
+# (See systemd.service "Command lines" section for the full substitution
+# rules; note that comments inside the bash script are still scanned by
+# the substitution pass, which is why this comment avoids literal braces.)
 log "Health check: waiting $HEALTH_GRACE seconds..."
 sleep "$HEALTH_GRACE"
 

--- a/restart.sh
+++ b/restart.sh
@@ -51,8 +51,10 @@ if [[ "${1:-}" != "--deploy" ]]; then
     log "Scheduling detached restart via systemd-run..."
     # Sleep 2s to let the calling Claude session finish sending its response,
     # then restart the service. Runs as a transient systemd unit so it survives
-    # cc-connect dying.
-    systemd-run --user --unit=cc-connect-restart --description="cc-connect restart" \
+    # cc-connect dying. --collect makes systemd garbage-collect the transient
+    # unit after it exits so a lingering failed/completed unit never blocks
+    # the next invocation with "Unit already loaded or has a fragment file".
+    systemd-run --user --collect --unit=cc-connect-restart --description="cc-connect restart" \
         bash -c "sleep 2 && systemctl --user reset-failed $SERVICE 2>/dev/null || true; systemctl --user restart $SERVICE"
     log "Restart scheduled. Service will bounce in ~2 seconds."
     log "Check status: systemctl --user status $SERVICE"
@@ -131,7 +133,13 @@ log "Clearing any failed state and starting service..."
 systemctl --user reset-failed "$SERVICE" 2>/dev/null || true
 systemctl --user start "$SERVICE"
 
-log "Health check: waiting ${HEALTH_GRACE}s..."
+# Braces deliberately omitted on $HEALTH_GRACE below. systemd-run
+# substitutes ${VAR}-with-braces in ExecStart lines from the unit's own
+# environment, and since HEALTH_GRACE is only set inside the bash -c
+# script — not in systemd's env — the braced form would render to empty
+# before bash ever sees it. The non-braced form is passed through verbatim
+# and expanded by bash at runtime.
+log "Health check: waiting $HEALTH_GRACE seconds..."
 sleep "$HEALTH_GRACE"
 
 if systemctl --user is-active "$SERVICE" &>/dev/null; then
@@ -164,7 +172,13 @@ DEPLOY_EOF
 )
 
 log "Scheduling detached deploy via systemd-run..."
-systemd-run --user --unit=cc-connect-deploy --description="cc-connect deploy" \
+# --collect is critical: without it, a failed or completed cc-connect-deploy
+# transient unit lingers in systemd's view until an explicit reset-failed,
+# and the next ./restart.sh --deploy invocation then fails with "Unit
+# cc-connect-deploy.service was already loaded or has a fragment file".
+# --collect makes systemd drop the unit after it exits, regardless of
+# exit status.
+systemd-run --user --collect --unit=cc-connect-deploy --description="cc-connect deploy" \
     bash -c "$deploy_script"
 log "Deploy scheduled. It will run in ~2 seconds."
 log "Monitor: journalctl --user -u cc-connect-deploy -f"

--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# restart.sh — Safely restart cc-connect, even when called from within cc-connect.
+#
+# Uses systemd-run to schedule the actual restart as a transient unit, fully
+# detached from the calling process tree. This means cc-connect can die
+# (as expected) and the restart still completes.
+#
+# Usage:
+#   ./restart.sh              # restart only, keeping the current binary
+#   ./restart.sh --deploy     # build, backup current binary, install, restart,
+#                             # health-check, rollback on failure.
+#
+# --deploy contract:
+#   - The script owns the build. Callers do NOT copy a binary into place
+#     themselves — that caused a past incident where `cp broken $BINARY`
+#     then running --deploy backed up the broken file as "known-good" AND
+#     installed the broken file, leaving both the live binary and the
+#     rollback target corrupted at the same time.
+#   - Build happens in the FOREGROUND so compilation errors are surfaced
+#     to the caller immediately. $BINARY is never touched if the build fails.
+#   - The backup step in the detached phase captures $BINARY BEFORE the
+#     new binary replaces it — the backup is the rollback TARGET, not the
+#     thing we are rolling forward TO.
+#   - Install uses `install -m 0755` so mode is explicit every time.
+#     `cp` over an existing file preserves the destination's mode, which
+#     can silently strip the execute bit if the file was ever touched
+#     to 0664. `install` creates a fresh file with the mode we specify.
+#
+# Ownership notes:
+#   - $BINARY and $BACKUP must be writable by the invoking user. If they
+#     end up owned by a non-leigh user (e.g. after a partseeker-coder
+#     session operated in this directory), fix ownership first:
+#       sudo chown leigh:partseeker-dev cc-connect cc-connect.known-good
+#     The script cannot fix this itself — it has no sudo.
+
+set -euo pipefail
+
+SERVICE="cc-connect.service"
+INSTALL_DIR="/home/leigh/workspace/cc-connect"
+BINARY="$INSTALL_DIR/cc-connect"
+STAGED="$INSTALL_DIR/cc-connect.new"
+BACKUP="$INSTALL_DIR/cc-connect.known-good"
+HEALTH_GRACE=15
+
+log() { echo "[restart] $(date '+%H:%M:%S') $*"; }
+
+# ---------------------------------------------------------------------------
+# Mode: simple restart (default)
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" != "--deploy" ]]; then
+    log "Scheduling detached restart via systemd-run..."
+    # Sleep 2s to let the calling Claude session finish sending its response,
+    # then restart the service. Runs as a transient systemd unit so it survives
+    # cc-connect dying.
+    systemd-run --user --unit=cc-connect-restart --description="cc-connect restart" \
+        bash -c "sleep 2 && systemctl --user reset-failed $SERVICE 2>/dev/null || true; systemctl --user restart $SERVICE"
+    log "Restart scheduled. Service will bounce in ~2 seconds."
+    log "Check status: systemctl --user status $SERVICE"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Mode: deploy — build, backup, install, restart, health check, rollback
+# ---------------------------------------------------------------------------
+
+# Step 1–3 run in the foreground so build/verify errors are visible to the
+# caller and the live $BINARY is never touched if they fail.
+
+log "Building staged binary at $STAGED..."
+cd "$INSTALL_DIR"
+if ! go build -o "$STAGED" ./cmd/cc-connect; then
+    log "ERROR: 'go build ./cmd/cc-connect' failed. Not touching $BINARY."
+    rm -f "$STAGED"
+    exit 1
+fi
+
+log "Verifying staged binary is a real ELF executable..."
+if ! file "$STAGED" | grep -q 'ELF.*executable'; then
+    log "ERROR: $STAGED is not an ELF executable. 'file' output:"
+    file "$STAGED" || true
+    rm -f "$STAGED"
+    exit 1
+fi
+if ! [[ -x "$STAGED" ]]; then
+    # Shouldn't happen — go build sets 0755 — but guard anyway.
+    log "ERROR: $STAGED does not have execute bit set."
+    ls -la "$STAGED" || true
+    rm -f "$STAGED"
+    exit 1
+fi
+log "Staged binary OK ($(stat -c %s "$STAGED") bytes, $(stat -c %A "$STAGED"))."
+
+# Step 4+ runs detached via systemd-run so the calling session dying does
+# not interrupt the restart.
+deploy_script=$(cat <<'DEPLOY_EOF'
+set -euo pipefail
+SERVICE="cc-connect.service"
+INSTALL_DIR="/home/leigh/workspace/cc-connect"
+BINARY="$INSTALL_DIR/cc-connect"
+STAGED="$INSTALL_DIR/cc-connect.new"
+BACKUP="$INSTALL_DIR/cc-connect.known-good"
+HEALTH_GRACE=15
+
+log() { echo "[deploy] $(date '+%H:%M:%S') $*"; }
+
+sleep 2  # let the calling session finish sending its "scheduled" message
+
+log "Starting deploy..."
+
+# Snapshot the OLD (currently-running) $BINARY as $BACKUP before anything
+# modifies it. This is the correct backup-order: the backup captures the
+# thing we want to roll BACK TO, not the thing we are rolling FORWARD TO.
+# If this step is skipped, rollback has nothing real to restore from.
+if [[ -f "$BINARY" ]]; then
+    log "Snapshotting current $BINARY to $BACKUP (rollback target)."
+    install -m 0755 "$BINARY" "$BACKUP"
+fi
+
+log "Stopping service..."
+systemctl --user stop "$SERVICE" 2>/dev/null || true
+sleep 1
+
+# Install the staged binary with an explicit mode. `install -m 0755` creates
+# a fresh file with the mode we specify, so it cannot silently inherit 0664
+# from whatever was at $BINARY before.
+log "Installing staged binary -> $BINARY (mode 0755)..."
+install -m 0755 "$STAGED" "$BINARY"
+rm -f "$STAGED"
+
+log "Clearing any failed state and starting service..."
+systemctl --user reset-failed "$SERVICE" 2>/dev/null || true
+systemctl --user start "$SERVICE"
+
+log "Health check: waiting ${HEALTH_GRACE}s..."
+sleep "$HEALTH_GRACE"
+
+if systemctl --user is-active "$SERVICE" &>/dev/null; then
+    log "New binary is healthy. Deploy complete."
+    exit 0
+fi
+
+log "New binary crashed within ${HEALTH_GRACE}s. Journal tail:"
+journalctl --user -u "$SERVICE" -n 20 --no-pager || true
+
+if [[ -f "$BACKUP" ]]; then
+    log "Rolling back to known-good binary..."
+    install -m 0755 "$BACKUP" "$BINARY"
+    systemctl --user reset-failed "$SERVICE" 2>/dev/null || true
+    systemctl --user start "$SERVICE"
+    sleep 3
+    if systemctl --user is-active "$SERVICE" &>/dev/null; then
+        log "Rollback successful."
+        exit 1
+    else
+        log "CRITICAL: Rollback also failed. Journal tail:"
+        journalctl --user -u "$SERVICE" -n 20 --no-pager || true
+        exit 2
+    fi
+else
+    log "CRITICAL: No known-good backup. Service is down."
+    exit 2
+fi
+DEPLOY_EOF
+)
+
+log "Scheduling detached deploy via systemd-run..."
+systemd-run --user --unit=cc-connect-deploy --description="cc-connect deploy" \
+    bash -c "$deploy_script"
+log "Deploy scheduled. It will run in ~2 seconds."
+log "Monitor: journalctl --user -u cc-connect-deploy -f"
+exit 0

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,43 @@
+# cc-connect Skills
+
+Claude Code skills that ship with cc-connect. Install by symlinking or copying into your Claude Code skills directory.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| [file-watcher](file-watcher/SKILL.md) | Install a systemd file watcher that triggers a cc-connect agent via `--as-prompt` |
+
+## Installation
+
+```bash
+# Symlink into Claude Code skills directory
+ln -s /path/to/cc-connect/skills/file-watcher ~/.claude/skills/file-watcher
+
+# Or copy
+cp -r /path/to/cc-connect/skills/file-watcher ~/.claude/skills/
+```
+
+## Custom Chat Command
+
+You can also expose watcher management as a `/watch` chat command by adding this to your cc-connect `config.toml`:
+
+```toml
+[[projects.commands]]
+name = "watch"
+description = "Set up or manage a file watcher for this project"
+prompt = """
+The user wants to set up or manage a file watcher for this project.
+Use the file-watcher skill to guide setup. Key parameters to ask about:
+- Which directory to watch
+- What file pattern to match (e.g. *.md, *.json)
+- What prompt to send when a file arrives
+- What service name to use
+
+If the user says "status", check: systemctl status <service>.service
+If the user says "logs", show: journalctl -u <service>.service --since "1 hour ago"
+If the user says "stop" or "remove", guide uninstallation.
+"""
+```
+
+This lets users type `/watch` in chat to trigger watcher setup or management.

--- a/skills/file-watcher/SKILL.md
+++ b/skills/file-watcher/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: file-watcher
+description: "Install a systemd file watcher that triggers a cc-connect agent when files appear in a directory. Creates the watch script, systemd unit, and starts the service."
+---
+
+# File Watcher Setup
+
+Install a file watcher that monitors a directory and triggers a cc-connect agent session when matching files appear. Uses `inotifywait` + systemd for reliable, persistent watching.
+
+## When to use
+
+- Setting up automated completion processing pipelines
+- Triggering agent work when CI drops artifacts
+- Monitoring directories for new data files, reports, or configs
+
+## Prerequisites
+
+Check before proceeding:
+
+```bash
+which inotifywait    # Must be installed (apt install inotify-tools)
+which cc-connect     # Must be in PATH or use absolute path
+systemctl --version  # systemd required
+```
+
+If `inotifywait` is missing, install it:
+```bash
+sudo apt install -y inotify-tools
+```
+
+## Required Information
+
+Gather these from the user before creating anything:
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `WATCH_DIR` | Directory to monitor | `/home/leigh/workspace/data-worklog/data/completions/` |
+| `FILE_PATTERN` | Glob pattern for matching files | `*.md` |
+| `CC_PROJECT` | cc-connect project name to target | `data-worklog-PM` |
+| `CC_DATA_DIR` | cc-connect data directory | `~/.cc-connect` |
+| `SERVICE_NAME` | systemd unit name | `completion-watcher` |
+| `PROMPT_TEMPLATE` | Message template (`${FILE}` is replaced) | `New completion file: ${FILE}. Read and process it.` |
+
+## Installation Steps
+
+### 1. Create the watch script
+
+Write to `/opt/${SERVICE_NAME}/watch.sh`:
+
+```bash
+#!/bin/bash
+WATCH_DIR="${WATCH_DIR}"
+CC_CONNECT="${CC_CONNECT_PATH}"
+
+inotifywait -m -e create -e moved_to --format '%f' "$WATCH_DIR" | while read FILE; do
+  [[ "$FILE" == ${FILE_PATTERN} ]] || continue
+  "$CC_CONNECT" send --as-prompt -p ${CC_PROJECT} --data-dir ${CC_DATA_DIR} \
+    -m "${PROMPT_TEMPLATE}"
+done
+```
+
+This requires `sudo` to write to `/opt/`. Make the script executable:
+```bash
+sudo mkdir -p /opt/${SERVICE_NAME}
+sudo tee /opt/${SERVICE_NAME}/watch.sh > /dev/null <<'SCRIPT'
+... (script content)
+SCRIPT
+sudo chmod +x /opt/${SERVICE_NAME}/watch.sh
+```
+
+### 2. Create the systemd unit
+
+Write to `/etc/systemd/system/${SERVICE_NAME}.service`:
+
+```ini
+[Unit]
+Description=${SERVICE_NAME} file watcher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/${SERVICE_NAME}/watch.sh
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Install with:
+```bash
+sudo tee /etc/systemd/system/${SERVICE_NAME}.service > /dev/null <<'UNIT'
+... (unit content)
+UNIT
+```
+
+### 3. Enable and start
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable ${SERVICE_NAME}.service
+sudo systemctl start ${SERVICE_NAME}.service
+```
+
+### 4. Verify
+
+```bash
+systemctl status ${SERVICE_NAME}.service   # Should be active (running)
+journalctl -u ${SERVICE_NAME}.service -f   # Follow logs
+```
+
+Drop a test file to confirm:
+```bash
+echo "# Test" > ${WATCH_DIR}/TEST-watcher-verify.md
+# Check journal for send output
+journalctl -u ${SERVICE_NAME}.service --since "10 seconds ago"
+# Clean up
+rm ${WATCH_DIR}/TEST-watcher-verify.md
+```
+
+## Important Notes
+
+- The watch script uses `--as-prompt` so the message is injected as an inbound prompt the agent will process and respond to
+- If no active session exists when a file arrives, the send will fail — the agent must be running
+- If the session is busy, `--as-prompt` retries with 2-second backoff for up to 60 seconds
+- The `inotifywait` events `create` and `moved_to` cover both new files and files moved into the directory
+- The service runs as root by default; add `User=` to the unit if you need it to run as a specific user
+
+## Updating an Existing Watcher
+
+To modify the watch script or prompt template:
+
+```bash
+sudo vim /opt/${SERVICE_NAME}/watch.sh    # or use tee
+sudo systemctl restart ${SERVICE_NAME}.service
+```
+
+## Uninstalling
+
+```bash
+sudo systemctl stop ${SERVICE_NAME}.service
+sudo systemctl disable ${SERVICE_NAME}.service
+sudo rm /etc/systemd/system/${SERVICE_NAME}.service
+sudo rm -rf /opt/${SERVICE_NAME}
+sudo systemctl daemon-reload
+```


### PR DESCRIPTION
## Summary

- `--as-prompt` flag on `cc-connect send` injects messages as inbound prompts the agent processes and responds to (instead of posting as the bot, which gets ignored)
- `--new-thread` now infers session key from active sessions when none is provided
- Retry with 2s backoff (up to 60s) when the target session is busy mid-turn
- Fix missing `wsChannelKey` arg in relay manager's `HandleRelay` call
- Documentation in `docs/usage.md` with file watcher example

## Motivation

External triggers (file watchers, CI hooks) need to make the agent *act*, not just post a notification. `cc-connect send` posts as the bot, which the platform ignores (bot filtering). `--as-prompt` uses the same `processInteractiveMessage` path as webhooks to inject the message as if a user sent it.

## Test plan

- [x] `go build ./cmd/cc-connect/` passes
- [x] `go test ./...` — all tests pass
- [x] E2E: inotifywait file watcher → `--as-prompt` → agent receives and processes completion file
- [x] `--new-thread` works without explicit session key
- [x] Retry backoff handles busy sessions (verified via journal logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)