### PR TITLE
fix(telegram): paginate /skills output

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -8753,6 +8753,8 @@ func (e *Engine) cmdSkills(p Platform, msg *Message, args []string) {
 		}
 
 		if strings.EqualFold(p.Name(), "telegram") {
+			// Telegram rejects oversized text replies, so render /skills as
+			// explicit pages instead of sending one giant skill list.
 			pages := e.renderTelegramSkillsPages(skills)
 			page, ok := parseTelegramSkillsPageArg(args, len(pages))
 			if !ok {
@@ -8793,6 +8795,9 @@ func parseTelegramSkillsPageArg(args []string, totalPages int) (int, bool) {
 }
 
 func (e *Engine) renderTelegramSkillsPages(skills []*Skill) []string {
+	// Keep Telegram-specific pagination local to /skills for now. If other
+	// plain-text platforms need the same treatment later, we can lift this into
+	// a shared long-text pagination helper.
 	title := e.i18n.Tf(MsgSkillsTitle, e.agent.Name(), len(skills))
 	hint := e.i18n.T(MsgSkillsHint)
 	bodyBudget := telegramSkillsPageMaxLen - len(title) - len(hint) - telegramSkillsFooterReserve

--- a/core/engine.go
+++ b/core/engine.go
@@ -23,6 +23,8 @@ import (
 )
 
 const maxPlatformMessageLen = 4000
+const telegramSkillsPageMaxLen = 3500
+const telegramSkillsFooterReserve = 160
 const maxQueuedMessages = 5 // cap queued messages to bound memory usage
 
 const (
@@ -211,8 +213,8 @@ type Engine struct {
 
 	// Terminal observation (--observe)
 	observeEnabled    bool
-	observeProjectDir string             // ~/.claude/projects/{projectKey}
-	observeSessionKey string             // e.g. "slack:C123:U456" — target for forwarding
+	observeProjectDir string // ~/.claude/projects/{projectKey}
+	observeSessionKey string // e.g. "slack:C123:U456" — target for forwarding
 	observeCancel     context.CancelFunc
 
 	// Interactive agent session management
@@ -3183,7 +3185,7 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 	case "commands":
 		e.cmdCommands(p, msg, args)
 	case "skills":
-		e.cmdSkills(p, msg)
+		e.cmdSkills(p, msg, args)
 	case "config":
 		e.cmdConfig(p, msg, args)
 	case "doctor":
@@ -8742,11 +8744,22 @@ func (e *Engine) executeSkill(p Platform, msg *Message, skill *Skill, args []str
 	go e.processInteractiveMessage(p, msg, session)
 }
 
-func (e *Engine) cmdSkills(p Platform, msg *Message) {
+func (e *Engine) cmdSkills(p Platform, msg *Message, args []string) {
 	if !supportsCards(p) {
 		skills := e.skills.ListAll()
 		if len(skills) == 0 {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgSkillsEmpty))
+			return
+		}
+
+		if strings.EqualFold(p.Name(), "telegram") {
+			pages := e.renderTelegramSkillsPages(skills)
+			page, ok := parseTelegramSkillsPageArg(args, len(pages))
+			if !ok {
+				e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgSkillsInvalidPage, len(pages)))
+				return
+			}
+			e.reply(p, msg.ReplyCtx, pages[page-1])
 			return
 		}
 
@@ -8763,6 +8776,74 @@ func (e *Engine) cmdSkills(p Platform, msg *Message) {
 	}
 
 	e.replyWithCard(p, msg.ReplyCtx, e.renderSkillsCard())
+}
+
+func parseTelegramSkillsPageArg(args []string, totalPages int) (int, bool) {
+	if len(args) == 0 {
+		return 1, true
+	}
+	if len(args) != 1 {
+		return 0, false
+	}
+	page, err := strconv.Atoi(args[0])
+	if err != nil || page < 1 || page > totalPages {
+		return 0, false
+	}
+	return page, true
+}
+
+func (e *Engine) renderTelegramSkillsPages(skills []*Skill) []string {
+	title := e.i18n.Tf(MsgSkillsTitle, e.agent.Name(), len(skills))
+	hint := e.i18n.T(MsgSkillsHint)
+	bodyBudget := telegramSkillsPageMaxLen - len(title) - len(hint) - telegramSkillsFooterReserve
+	if bodyBudget < 256 {
+		bodyBudget = 256
+	}
+
+	var pages [][]string
+	var current []string
+	currentLen := 0
+	for _, s := range skills {
+		line := fmt.Sprintf("  /%s — %s\n", s.Name, s.Description)
+		if len(line) > bodyBudget {
+			line = truncateStr(strings.TrimSpace(line), bodyBudget-3) + "...\n"
+		}
+		if currentLen+len(line) > bodyBudget && len(current) > 0 {
+			pages = append(pages, current)
+			current = nil
+			currentLen = 0
+		}
+		current = append(current, line)
+		currentLen += len(line)
+	}
+	if len(current) > 0 {
+		pages = append(pages, current)
+	}
+	if len(pages) == 0 {
+		pages = append(pages, nil)
+	}
+
+	out := make([]string, 0, len(pages))
+	totalPages := len(pages)
+	for i, lines := range pages {
+		var sb strings.Builder
+		sb.WriteString(title)
+		for _, line := range lines {
+			sb.WriteString(line)
+		}
+		sb.WriteString("\n")
+		if totalPages > 1 {
+			if i+1 < totalPages {
+				sb.WriteString(e.i18n.Tf(MsgSkillsPageHintNext, i+1, totalPages, i+2))
+			} else {
+				sb.WriteString(e.i18n.Tf(MsgSkillsPageHintOther, i+1, totalPages))
+			}
+			sb.WriteString("\n")
+		}
+		sb.WriteString(hint)
+		out = append(out, sb.String())
+	}
+	return out
 }
 
 // ── /config command ──────────────────────────────────────────

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -4043,7 +4043,7 @@ func TestCmdSkills_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	}
 	e.skills.SetDirs([]string{temp})
 
-	e.cmdSkills(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"})
+	e.cmdSkills(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, nil)
 
 	if len(p.sent) != 1 {
 		t.Fatalf("sent messages = %d, want 1", len(p.sent))
@@ -4053,6 +4053,73 @@ func TestCmdSkills_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	}
 	if strings.Contains(p.sent[0], "[← Back]") {
 		t.Fatalf("skills text = %q, should not be card fallback text", p.sent[0])
+	}
+}
+
+func TestCmdSkills_TelegramPaginatesLongSkillLists(t *testing.T) {
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	temp := t.TempDir()
+
+	for i := 0; i < 24; i++ {
+		name := fmt.Sprintf("skill-%02d", i)
+		skillDir := filepath.Join(temp, name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatalf("mkdir skill dir: %v", err)
+		}
+		desc := strings.Repeat(fmt.Sprintf("description-%02d ", i), 18)
+		content := fmt.Sprintf("---\ndescription: %s\n---\nDo demo", desc)
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+			t.Fatalf("write skill file: %v", err)
+		}
+	}
+	e.skills.SetDirs([]string{temp})
+
+	e.cmdSkills(p, &Message{SessionKey: "telegram:user1", ReplyCtx: "ctx"}, nil)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if len(p.sent[0]) >= maxPlatformMessageLen {
+		t.Fatalf("skills page len = %d, want less than %d", len(p.sent[0]), maxPlatformMessageLen)
+	}
+	if !strings.Contains(p.sent[0], "Page 1/") {
+		t.Fatalf("skills text = %q, want pagination footer", p.sent[0])
+	}
+	if !strings.Contains(p.sent[0], "/skills 2") {
+		t.Fatalf("skills text = %q, want next-page hint", p.sent[0])
+	}
+
+	p.sent = nil
+	e.cmdSkills(p, &Message{SessionKey: "telegram:user1", ReplyCtx: "ctx"}, []string{"2"})
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages on page 2 = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "Page 2/") {
+		t.Fatalf("skills text = %q, want second page footer", p.sent[0])
+	}
+}
+
+func TestCmdSkills_TelegramRejectsInvalidPage(t *testing.T) {
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	temp := t.TempDir()
+	skillDir := filepath.Join(temp, "demo")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\ndescription: Demo skill\n---\nDo demo"), 0o644); err != nil {
+		t.Fatalf("write skill file: %v", err)
+	}
+	e.skills.SetDirs([]string{temp})
+
+	e.cmdSkills(p, &Message{SessionKey: "telegram:user1", ReplyCtx: "ctx"}, []string{"2"})
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "Invalid page") {
+		t.Fatalf("skills text = %q, want invalid page message", p.sent[0])
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -353,9 +353,12 @@ const (
 	MsgCommandExecError   MsgKey = "command_exec_error"
 	MsgCommandExecSuccess MsgKey = "command_exec_success"
 
-	MsgSkillsTitle MsgKey = "skills_title"
-	MsgSkillsEmpty MsgKey = "skills_empty"
-	MsgSkillsHint  MsgKey = "skills_hint"
+	MsgSkillsTitle         MsgKey = "skills_title"
+	MsgSkillsEmpty         MsgKey = "skills_empty"
+	MsgSkillsHint          MsgKey = "skills_hint"
+	MsgSkillsPageHintNext  MsgKey = "skills_page_hint_next"
+	MsgSkillsPageHintOther MsgKey = "skills_page_hint_other"
+	MsgSkillsInvalidPage   MsgKey = "skills_invalid_page"
 
 	MsgConfigTitle       MsgKey = "config_title"
 	MsgConfigHint        MsgKey = "config_hint"
@@ -392,10 +395,10 @@ const (
 	MsgAliasNotFound   MsgKey = "alias_not_found"
 	MsgAliasUsage      MsgKey = "alias_usage"
 
-	MsgNewSessionCreated     MsgKey = "new_session_created"
-	MsgNewSessionCreatedName MsgKey = "new_session_created_name"
-	MsgSessionAutoResetIdle     MsgKey = "session_auto_reset_idle"
-	MsgSessionClosingGraceful   MsgKey = "session_closing_graceful"
+	MsgNewSessionCreated      MsgKey = "new_session_created"
+	MsgNewSessionCreatedName  MsgKey = "new_session_created_name"
+	MsgSessionAutoResetIdle   MsgKey = "session_auto_reset_idle"
+	MsgSessionClosingGraceful MsgKey = "session_closing_graceful"
 
 	MsgDeleteUsage              MsgKey = "delete_usage"
 	MsgDeleteSuccess            MsgKey = "delete_success"
@@ -492,8 +495,8 @@ const (
 	MsgBuiltinCmdDir       MsgKey = "dir"
 	MsgBuiltinCmdDiff      MsgKey = "diff"
 
-	MsgDiffEmpty           MsgKey = "diff_empty"
-	MsgDiffNoDiff2HTML     MsgKey = "diff_no_diff2html"
+	MsgDiffEmpty       MsgKey = "diff_empty"
+	MsgDiffNoDiff2HTML MsgKey = "diff_no_diff2html"
 
 	MsgDirChanged          MsgKey = "dir_changed"
 	MsgDirCurrent          MsgKey = "dir_current"
@@ -2443,6 +2446,27 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "用法：/<skill名稱> [參數...] 來調用 Skill。",
 		LangJapanese:           "使い方：/<スキル名> [引数...] でスキルを実行します。",
 		LangSpanish:            "Uso: /<nombre-skill> [args...] para invocar un skill.",
+	},
+	MsgSkillsPageHintNext: {
+		LangEnglish:            "Page %d/%d. Use /skills %d to view the next page.",
+		LangChinese:            "第 %d/%d 页。使用 /skills %d 查看下一页。",
+		LangTraditionalChinese: "第 %d/%d 頁。使用 /skills %d 查看下一頁。",
+		LangJapanese:           "%d/%d ページです。次のページを見るには /skills %d を使います。",
+		LangSpanish:            "Página %d/%d. Usa /skills %d para ver la siguiente página.",
+	},
+	MsgSkillsPageHintOther: {
+		LangEnglish:            "Page %d/%d. Use /skills <page> to view another page.",
+		LangChinese:            "第 %d/%d 页。使用 /skills <页码> 查看其他页面。",
+		LangTraditionalChinese: "第 %d/%d 頁。使用 /skills <頁碼> 查看其他頁面。",
+		LangJapanese:           "%d/%d ページです。他のページを見るには /skills <page> を使います。",
+		LangSpanish:            "Página %d/%d. Usa /skills <page> para ver otra página.",
+	},
+	MsgSkillsInvalidPage: {
+		LangEnglish:            "Invalid page. Use /skills <1-%d>.",
+		LangChinese:            "页码无效。请使用 /skills <1-%d>。",
+		LangTraditionalChinese: "頁碼無效。請使用 /skills <1-%d>。",
+		LangJapanese:           "無効なページです。/skills <1-%d> を使ってください。",
+		LangSpanish:            "Página inválida. Usa /skills <1-%d>.",
 	},
 
 	MsgConfigTitle: {


### PR DESCRIPTION
## Summary

This paginates Telegram `/skills` output so long skill lists no longer exceed Telegram's message size limit.

## Why

With enough discovered skills, `/skills` can generate a reply that is longer than Telegram allows in a single text message. In that case the command is received and handled, but Telegram rejects the reply with `Bad Request: message is too long`, so users see no response at all.

## Changes

- add Telegram-specific `/skills <page>` support
- paginate Telegram `/skills` output by message-length budget instead of dumping every skill in one reply
- include page hints such as `/skills 2` when more pages are available
- return a clear invalid-page message when the requested page is out of range
- add regression tests for pagination and invalid page handling

## Validation

- `go test ./core ./platform/telegram`
- manually reproduced the failure with a long Telegram skill list and verified the patched build responds instead of hitting Telegram's message-length error
