### PR TITLE
feat(codex): add runtime reply footer aligned with Codex CLI

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -40,13 +41,19 @@ type initResponse struct {
 }
 
 type threadStartResponse struct {
-	Thread struct {
+	Cwd             string  `json:"cwd"`
+	Model           string  `json:"model"`
+	ReasoningEffort *string `json:"reasoningEffort"`
+	Thread          struct {
 		ID string `json:"id"`
 	} `json:"thread"`
 }
 
 type threadResumeResponse struct {
-	Thread struct {
+	Cwd             string  `json:"cwd"`
+	Model           string  `json:"model"`
+	ReasoningEffort *string `json:"reasoningEffort"`
+	Thread          struct {
 		ID string `json:"id"`
 	} `json:"thread"`
 }
@@ -76,6 +83,32 @@ type itemNotification struct {
 
 type errorNotification struct {
 	Message string `json:"message"`
+}
+
+type appServerRateLimitsResponse struct {
+	RateLimits          appServerRateLimitSnapshot            `json:"rateLimits"`
+	RateLimitsByLimitID map[string]appServerRateLimitSnapshot `json:"rateLimitsByLimitId"`
+}
+
+type appServerRateLimitSnapshot struct {
+	LimitID   string                    `json:"limitId"`
+	LimitName string                    `json:"limitName"`
+	PlanType  string                    `json:"planType"`
+	Primary   *appServerRateLimitWindow `json:"primary"`
+	Secondary *appServerRateLimitWindow `json:"secondary"`
+	Credits   *appServerCreditsSnapshot `json:"credits"`
+}
+
+type appServerRateLimitWindow struct {
+	UsedPercent        int   `json:"usedPercent"`
+	WindowDurationMins int   `json:"windowDurationMins"`
+	ResetsAt           int64 `json:"resetsAt"`
+}
+
+type appServerCreditsSnapshot struct {
+	Balance    *string `json:"balance"`
+	HasCredits bool    `json:"hasCredits"`
+	Unlimited  bool    `json:"unlimited"`
 }
 
 type appServerSession struct {
@@ -111,7 +144,15 @@ type appServerSession struct {
 	stateMu     sync.Mutex
 	pendingMsgs []string
 	currentTurn string
+
+	runtimeMu sync.RWMutex
+	usage     *core.UsageReport
 }
+
+const (
+	appServerRequestTimeout      = 120 * time.Second
+	appServerUsageRefreshTimeout = 1500 * time.Millisecond
+)
 
 func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID string, extraEnv []string, codexHome string) (*appServerSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
@@ -143,6 +184,9 @@ func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode,
 	if err := s.ensureThread(resumeID); err != nil {
 		_ = s.Close()
 		return nil, err
+	}
+	if err := s.refreshUsage(context.Background()); err != nil {
+		slog.Debug("codex app-server: initial rate limit fetch failed", "error", err)
 	}
 
 	return s, nil
@@ -236,6 +280,7 @@ func (s *appServerSession) ensureThread(resumeID string) error {
 		if resp.Thread.ID == "" {
 			return fmt.Errorf("codex app-server resume returned empty thread id")
 		}
+		s.applyThreadRuntimeState(resp.Cwd, resp.Model, resp.ReasoningEffort)
 		s.threadID.Store(resp.Thread.ID)
 		slog.Info("codex app-server thread resumed", "thread_id", resp.Thread.ID)
 		return nil
@@ -248,6 +293,7 @@ func (s *appServerSession) ensureThread(resumeID string) error {
 	if resp.Thread.ID == "" {
 		return fmt.Errorf("codex app-server start returned empty thread id")
 	}
+	s.applyThreadRuntimeState(resp.Cwd, resp.Model, resp.ReasoningEffort)
 	s.threadID.Store(resp.Thread.ID)
 	slog.Info("codex app-server thread started", "thread_id", resp.Thread.ID)
 	return nil
@@ -258,8 +304,8 @@ func (s *appServerSession) threadRequestParams() map[string]any {
 		"experimentalRawEvents":  false,
 		"persistExtendedHistory": false,
 	}
-	if s.model != "" {
-		params["model"] = s.model
+	if model := s.GetModel(); model != "" {
+		params["model"] = model
 	}
 	if approval, sandbox := appServerModeSettings(s.mode); approval != "" {
 		params["approvalPolicy"] = approval
@@ -279,6 +325,54 @@ func appServerModeSettings(mode string) (approval string, sandbox string) {
 	default:
 		return "on-request", "read-only"
 	}
+}
+
+func (s *appServerSession) applyThreadRuntimeState(workDir, model string, effort *string) {
+	s.runtimeMu.Lock()
+	defer s.runtimeMu.Unlock()
+	if dir := strings.TrimSpace(workDir); dir != "" {
+		s.workDir = dir
+	}
+	if m := strings.TrimSpace(model); m != "" {
+		s.model = m
+	}
+	s.effort = normalizeRuntimeReasoningEffort(stringValue(effort))
+}
+
+func (s *appServerSession) refreshUsage(ctx context.Context) error {
+	timeout := appServerUsageRefreshTimeout
+	if ctx != nil {
+		if deadline, ok := ctx.Deadline(); ok {
+			if until := time.Until(deadline); until > 0 && until < timeout {
+				timeout = until
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	if timeout <= 0 {
+		return context.DeadlineExceeded
+	}
+
+	var resp appServerRateLimitsResponse
+	if err := s.requestWithTimeout("account/rateLimits/read", map[string]any{}, &resp, timeout); err != nil {
+		return err
+	}
+	s.storeUsage(mapAppServerRateLimits(resp))
+	return nil
+}
+
+func (s *appServerSession) cachedUsage() *core.UsageReport {
+	s.runtimeMu.RLock()
+	defer s.runtimeMu.RUnlock()
+	return cloneUsageReport(s.usage)
+}
+
+func (s *appServerSession) storeUsage(report *core.UsageReport) {
+	s.runtimeMu.Lock()
+	defer s.runtimeMu.Unlock()
+	s.usage = cloneUsageReport(report)
 }
 
 func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, files []core.FileAttachment) error {
@@ -318,11 +412,11 @@ func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, fi
 		"threadId": threadID,
 		"input":    input,
 	}
-	if s.model != "" {
-		params["model"] = s.model
+	if model := s.GetModel(); model != "" {
+		params["model"] = model
 	}
-	if s.effort != "" {
-		params["effort"] = s.effort
+	if effort := s.GetReasoningEffort(); effort != "" {
+		params["effort"] = effort
 	}
 	if approval, _ := appServerModeSettings(s.mode); approval != "" {
 		params["approvalPolicy"] = approval
@@ -383,6 +477,37 @@ func (s *appServerSession) Events() <-chan core.Event {
 func (s *appServerSession) CurrentSessionID() string {
 	v, _ := s.threadID.Load().(string)
 	return v
+}
+
+func (s *appServerSession) GetWorkDir() string {
+	s.runtimeMu.RLock()
+	defer s.runtimeMu.RUnlock()
+	return s.workDir
+}
+
+func (s *appServerSession) GetModel() string {
+	s.runtimeMu.RLock()
+	defer s.runtimeMu.RUnlock()
+	return strings.TrimSpace(s.model)
+}
+
+func (s *appServerSession) GetReasoningEffort() string {
+	s.runtimeMu.RLock()
+	defer s.runtimeMu.RUnlock()
+	return strings.TrimSpace(s.effort)
+}
+
+func (s *appServerSession) GetUsage(ctx context.Context) (*core.UsageReport, error) {
+	if err := s.refreshUsage(ctx); err != nil {
+		if cached := s.cachedUsage(); cached != nil {
+			return cached, nil
+		}
+		return nil, err
+	}
+	if cached := s.cachedUsage(); cached != nil {
+		return cached, nil
+	}
+	return nil, fmt.Errorf("codex app-server usage unavailable")
 }
 
 func (s *appServerSession) Alive() bool {
@@ -573,6 +698,12 @@ func (s *appServerSession) handleNotification(method string, paramsRaw json.RawM
 			})
 		}
 
+	case "account/rateLimits/updated":
+		var notif appServerRateLimitsResponse
+		if err := json.Unmarshal(paramsRaw, &notif); err == nil {
+			s.storeUsage(mapAppServerRateLimits(notif))
+		}
+
 	case "error":
 		var notif errorNotification
 		if err := json.Unmarshal(paramsRaw, &notif); err == nil && strings.TrimSpace(notif.Message) != "" {
@@ -748,6 +879,139 @@ func appServerToolSuccess(status string, exitCode *int) bool {
 	return s == "completed" || s == "success" || s == "succeeded" || s == "ok"
 }
 
+func mapAppServerRateLimits(payload appServerRateLimitsResponse) *core.UsageReport {
+	report := &core.UsageReport{Provider: "codex"}
+
+	var snapshots []appServerRateLimitSnapshot
+	if len(payload.RateLimitsByLimitID) > 0 {
+		keys := make([]string, 0, len(payload.RateLimitsByLimitID))
+		for key := range payload.RateLimitsByLimitID {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			snapshots = append(snapshots, payload.RateLimitsByLimitID[key])
+		}
+	} else if payload.RateLimits.LimitID != "" || payload.RateLimits.Primary != nil || payload.RateLimits.Secondary != nil || payload.RateLimits.Credits != nil {
+		snapshots = append(snapshots, payload.RateLimits)
+	}
+
+	for _, snapshot := range snapshots {
+		if report.Plan == "" && strings.TrimSpace(snapshot.PlanType) != "" {
+			report.Plan = strings.TrimSpace(snapshot.PlanType)
+		}
+		if report.Credits == nil && snapshot.Credits != nil {
+			report.Credits = &core.UsageCredits{
+				HasCredits: snapshot.Credits.HasCredits,
+				Unlimited:  snapshot.Credits.Unlimited,
+			}
+			if snapshot.Credits.Balance != nil {
+				report.Credits.Balance = strings.TrimSpace(*snapshot.Credits.Balance)
+			}
+		}
+
+		windows := appServerUsageWindows(snapshot)
+		if len(windows) == 0 {
+			continue
+		}
+		limitReached := false
+		for _, window := range windows {
+			if window.UsedPercent >= 100 {
+				limitReached = true
+				break
+			}
+		}
+
+		report.Buckets = append(report.Buckets, core.UsageBucket{
+			Name:         appServerBucketName(snapshot),
+			Allowed:      !limitReached,
+			LimitReached: limitReached,
+			Windows:      windows,
+		})
+	}
+
+	return report
+}
+
+func appServerBucketName(snapshot appServerRateLimitSnapshot) string {
+	if name := strings.TrimSpace(snapshot.LimitName); name != "" {
+		return name
+	}
+	if id := strings.TrimSpace(snapshot.LimitID); id != "" {
+		return id
+	}
+	return "Rate limit"
+}
+
+func appServerUsageWindows(snapshot appServerRateLimitSnapshot) []core.UsageWindow {
+	var windows []core.UsageWindow
+	if snapshot.Primary != nil {
+		windows = append(windows, appServerUsageWindow("Primary", snapshot.Primary))
+	}
+	if snapshot.Secondary != nil {
+		windows = append(windows, appServerUsageWindow("Secondary", snapshot.Secondary))
+	}
+	return windows
+}
+
+func appServerUsageWindow(name string, window *appServerRateLimitWindow) core.UsageWindow {
+	resetAfter := 0
+	if window != nil && window.ResetsAt > 0 {
+		resetAfter = int(time.Until(time.Unix(window.ResetsAt, 0)).Seconds())
+		if resetAfter < 0 {
+			resetAfter = 0
+		}
+	}
+	return core.UsageWindow{
+		Name:              name,
+		UsedPercent:       window.UsedPercent,
+		WindowSeconds:     window.WindowDurationMins * 60,
+		ResetAfterSeconds: resetAfter,
+		ResetAtUnix:       window.ResetsAt,
+	}
+}
+
+func cloneUsageReport(report *core.UsageReport) *core.UsageReport {
+	if report == nil {
+		return nil
+	}
+	cloned := *report
+	if len(report.Buckets) > 0 {
+		cloned.Buckets = make([]core.UsageBucket, len(report.Buckets))
+		for i, bucket := range report.Buckets {
+			cloned.Buckets[i] = bucket
+			if len(bucket.Windows) > 0 {
+				cloned.Buckets[i].Windows = append([]core.UsageWindow(nil), bucket.Windows...)
+			}
+		}
+	}
+	if report.Credits != nil {
+		credits := *report.Credits
+		cloned.Credits = &credits
+	}
+	return &cloned
+}
+
+func normalizeRuntimeReasoningEffort(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return ""
+	case "med":
+		return "medium"
+	case "x-high", "very-high":
+		return "xhigh"
+	default:
+		return strings.ToLower(strings.TrimSpace(raw))
+	}
+}
+
+func stringValue(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return strings.TrimSpace(*v)
+}
+
 func appServerJSON(v any) string {
 	if v == nil {
 		return ""
@@ -849,10 +1113,17 @@ func (s *appServerSession) rejectPending(err error) {
 }
 
 func (s *appServerSession) request(method string, params any, out any) error {
+	return s.requestWithTimeout(method, params, out, appServerRequestTimeout)
+}
+
+func (s *appServerSession) requestWithTimeout(method string, params any, out any, timeout time.Duration) error {
 	id := s.nextID.Add(1)
 	ch := make(chan rpcResponseEnvelope, 1)
 
 	s.pendingMu.Lock()
+	if s.pending == nil {
+		s.pending = make(map[int64]chan rpcResponseEnvelope)
+	}
 	s.pending[id] = ch
 	s.pendingMu.Unlock()
 
@@ -883,7 +1154,7 @@ func (s *appServerSession) request(method string, params any, out any) error {
 		return nil
 	case <-s.ctx.Done():
 		return s.ctx.Err()
-	case <-time.After(120 * time.Second):
+	case <-time.After(timeout):
 		s.pendingMu.Lock()
 		delete(s.pending, id)
 		s.pendingMu.Unlock()

--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -147,6 +147,7 @@ type appServerSession struct {
 
 	runtimeMu sync.RWMutex
 	usage     *core.UsageReport
+	context   *core.ContextUsage
 }
 
 const (
@@ -369,10 +370,22 @@ func (s *appServerSession) cachedUsage() *core.UsageReport {
 	return cloneUsageReport(s.usage)
 }
 
+func (s *appServerSession) cachedContextUsage() *core.ContextUsage {
+	s.runtimeMu.RLock()
+	defer s.runtimeMu.RUnlock()
+	return cloneContextUsage(s.context)
+}
+
 func (s *appServerSession) storeUsage(report *core.UsageReport) {
 	s.runtimeMu.Lock()
 	defer s.runtimeMu.Unlock()
 	s.usage = cloneUsageReport(report)
+}
+
+func (s *appServerSession) storeContextUsage(usage *core.ContextUsage) {
+	s.runtimeMu.Lock()
+	defer s.runtimeMu.Unlock()
+	s.context = cloneContextUsage(usage)
 }
 
 func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, files []core.FileAttachment) error {
@@ -508,6 +521,10 @@ func (s *appServerSession) GetUsage(ctx context.Context) (*core.UsageReport, err
 		return cached, nil
 	}
 	return nil, fmt.Errorf("codex app-server usage unavailable")
+}
+
+func (s *appServerSession) GetContextUsage() *core.ContextUsage {
+	return s.cachedContextUsage()
 }
 
 func (s *appServerSession) Alive() bool {
@@ -673,6 +690,7 @@ func (s *appServerSession) handleNotification(method string, paramsRaw json.RawM
 			s.currentTurn = notif.Turn.ID
 			s.pendingMsgs = s.pendingMsgs[:0]
 			s.stateMu.Unlock()
+			s.storeContextUsage(nil)
 		}
 
 	case "item/started":
@@ -702,6 +720,12 @@ func (s *appServerSession) handleNotification(method string, paramsRaw json.RawM
 		var notif appServerRateLimitsResponse
 		if err := json.Unmarshal(paramsRaw, &notif); err == nil {
 			s.storeUsage(mapAppServerRateLimits(notif))
+		}
+
+	case "thread/tokenUsage/updated":
+		var notif appServerThreadTokenUsageNotification
+		if err := json.Unmarshal(paramsRaw, &notif); err == nil {
+			s.storeContextUsage(mapAppServerTokenUsage(notif))
 		}
 
 	case "error":

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -80,18 +80,18 @@ func TestAppServerSession_HandleThreadTokenUsageUpdatedCachesContextUsage(t *tes
 			ModelContextWindow int             `json:"modelContextWindow"`
 		}{
 			Total: codexTokenUsage{
-				TotalTokens:           14840,
-				InputTokens:           14809,
-				CachedInputTokens:     3456,
-				OutputTokens:          31,
-				ReasoningOutputTokens: 24,
+				TotalTokens:           52011395,
+				InputTokens:           51847383,
+				CachedInputTokens:     48187904,
+				OutputTokens:          164012,
+				ReasoningOutputTokens: 78910,
 			},
 			Last: codexTokenUsage{
-				TotalTokens:           14840,
-				InputTokens:           14809,
-				CachedInputTokens:     3456,
-				OutputTokens:          31,
-				ReasoningOutputTokens: 24,
+				TotalTokens:           41061,
+				InputTokens:           40849,
+				CachedInputTokens:     36864,
+				OutputTokens:          212,
+				ReasoningOutputTokens: 32,
 			},
 			ModelContextWindow: 258400,
 		},
@@ -106,14 +106,20 @@ func TestAppServerSession_HandleThreadTokenUsageUpdatedCachesContextUsage(t *tes
 	if usage == nil {
 		t.Fatal("GetContextUsage() = nil, want cached context usage")
 	}
-	if usage.TotalTokens != 14840 {
-		t.Fatalf("total tokens = %d, want 14840", usage.TotalTokens)
+	if usage.UsedTokens != 41061 {
+		t.Fatalf("used tokens = %d, want 41061", usage.UsedTokens)
+	}
+	if usage.TotalTokens != 41061 {
+		t.Fatalf("total tokens = %d, want 41061", usage.TotalTokens)
 	}
 	if usage.ContextWindow != 258400 {
 		t.Fatalf("context window = %d, want 258400", usage.ContextWindow)
 	}
-	if usage.CachedInputTokens != 3456 {
-		t.Fatalf("cached input tokens = %d, want 3456", usage.CachedInputTokens)
+	if usage.CachedInputTokens != 36864 {
+		t.Fatalf("cached input tokens = %d, want 36864", usage.CachedInputTokens)
+	}
+	if usage.InputTokens != 40849 {
+		t.Fatalf("input tokens = %d, want 40849", usage.InputTokens)
 	}
 }
 

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -1,0 +1,110 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestAppServerSession_ApplyThreadRuntimeState(t *testing.T) {
+	s := &appServerSession{}
+	effort := "xhigh"
+
+	s.applyThreadRuntimeState("/tmp/project", "gpt-5.4", &effort)
+
+	if got := s.GetWorkDir(); got != "/tmp/project" {
+		t.Fatalf("GetWorkDir() = %q, want /tmp/project", got)
+	}
+	if got := s.GetModel(); got != "gpt-5.4" {
+		t.Fatalf("GetModel() = %q, want gpt-5.4", got)
+	}
+	if got := s.GetReasoningEffort(); got != "xhigh" {
+		t.Fatalf("GetReasoningEffort() = %q, want xhigh", got)
+	}
+}
+
+func TestAppServerSession_HandleRateLimitsUpdatedCachesUsage(t *testing.T) {
+	s := &appServerSession{}
+	raw, err := json.Marshal(appServerRateLimitsResponse{
+		RateLimits: appServerRateLimitSnapshot{
+			LimitID:   "codex",
+			PlanType:  "pro",
+			Primary:   &appServerRateLimitWindow{UsedPercent: 25, WindowDurationMins: 15, ResetsAt: 1730947200},
+			Secondary: &appServerRateLimitWindow{UsedPercent: 42, WindowDurationMins: 60, ResetsAt: 1730950800},
+			Credits:   &appServerCreditsSnapshot{HasCredits: true, Unlimited: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal notification: %v", err)
+	}
+
+	s.handleNotification("account/rateLimits/updated", raw)
+
+	report, err := s.GetUsage(context.Background())
+	if err != nil {
+		t.Fatalf("GetUsage() returned error: %v", err)
+	}
+	if report.Provider != "codex" {
+		t.Fatalf("provider = %q, want codex", report.Provider)
+	}
+	if report.Plan != "pro" {
+		t.Fatalf("plan = %q, want pro", report.Plan)
+	}
+	if len(report.Buckets) != 1 {
+		t.Fatalf("buckets = %d, want 1", len(report.Buckets))
+	}
+	if got := report.Buckets[0].Name; got != "codex" {
+		t.Fatalf("bucket name = %q, want codex", got)
+	}
+	if got := report.Buckets[0].Windows[0].WindowSeconds; got != 15*60 {
+		t.Fatalf("primary window seconds = %d, want %d", got, 15*60)
+	}
+	if got := report.Buckets[0].Windows[1].UsedPercent; got != 42 {
+		t.Fatalf("secondary used percent = %d, want 42", got)
+	}
+	if report.Credits == nil || !report.Credits.HasCredits {
+		t.Fatalf("credits = %#v, want has credits", report.Credits)
+	}
+}
+
+func TestMapAppServerRateLimits_PrefersMultiBucketView(t *testing.T) {
+	report := mapAppServerRateLimits(appServerRateLimitsResponse{
+		RateLimits: appServerRateLimitSnapshot{
+			LimitID:  "legacy",
+			PlanType: "team",
+			Primary:  &appServerRateLimitWindow{UsedPercent: 99, WindowDurationMins: 15},
+		},
+		RateLimitsByLimitID: map[string]appServerRateLimitSnapshot{
+			"codex": {
+				LimitID:   "codex",
+				LimitName: "Codex",
+				PlanType:  "team",
+				Primary:   &appServerRateLimitWindow{UsedPercent: 10, WindowDurationMins: 15},
+			},
+			"codex_other": {
+				LimitID:  "codex_other",
+				PlanType: "team",
+				Primary:  &appServerRateLimitWindow{UsedPercent: 20, WindowDurationMins: 60},
+			},
+		},
+	})
+
+	if report.Plan != "team" {
+		t.Fatalf("plan = %q, want team", report.Plan)
+	}
+	if len(report.Buckets) != 2 {
+		t.Fatalf("buckets = %d, want 2", len(report.Buckets))
+	}
+	if report.Buckets[0].Name != "Codex" {
+		t.Fatalf("first bucket = %q, want Codex", report.Buckets[0].Name)
+	}
+	if report.Buckets[1].Name != "codex_other" {
+		t.Fatalf("second bucket = %q, want codex_other", report.Buckets[1].Name)
+	}
+}
+
+var _ interface {
+	GetUsage(context.Context) (*core.UsageReport, error)
+} = (*appServerSession)(nil)

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -69,6 +69,54 @@ func TestAppServerSession_HandleRateLimitsUpdatedCachesUsage(t *testing.T) {
 	}
 }
 
+func TestAppServerSession_HandleThreadTokenUsageUpdatedCachesContextUsage(t *testing.T) {
+	s := &appServerSession{}
+	raw, err := json.Marshal(appServerThreadTokenUsageNotification{
+		ThreadID: "thread-1",
+		TurnID:   "turn-1",
+		TokenUsage: struct {
+			Total              codexTokenUsage `json:"total"`
+			Last               codexTokenUsage `json:"last"`
+			ModelContextWindow int             `json:"modelContextWindow"`
+		}{
+			Total: codexTokenUsage{
+				TotalTokens:           14840,
+				InputTokens:           14809,
+				CachedInputTokens:     3456,
+				OutputTokens:          31,
+				ReasoningOutputTokens: 24,
+			},
+			Last: codexTokenUsage{
+				TotalTokens:           14840,
+				InputTokens:           14809,
+				CachedInputTokens:     3456,
+				OutputTokens:          31,
+				ReasoningOutputTokens: 24,
+			},
+			ModelContextWindow: 258400,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal notification: %v", err)
+	}
+
+	s.handleNotification("thread/tokenUsage/updated", raw)
+
+	usage := s.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage() = nil, want cached context usage")
+	}
+	if usage.TotalTokens != 14840 {
+		t.Fatalf("total tokens = %d, want 14840", usage.TotalTokens)
+	}
+	if usage.ContextWindow != 258400 {
+		t.Fatalf("context window = %d, want 258400", usage.ContextWindow)
+	}
+	if usage.CachedInputTokens != 3456 {
+		t.Fatalf("cached input tokens = %d, want 3456", usage.CachedInputTokens)
+	}
+}
+
 func TestMapAppServerRateLimits_PrefersMultiBucketView(t *testing.T) {
 	report := mapAppServerRateLimits(appServerRateLimitsResponse{
 		RateLimits: appServerRateLimitSnapshot{
@@ -107,4 +155,8 @@ func TestMapAppServerRateLimits_PrefersMultiBucketView(t *testing.T) {
 
 var _ interface {
 	GetUsage(context.Context) (*core.UsageReport, error)
+} = (*appServerSession)(nil)
+
+var _ interface {
+	GetContextUsage() *core.ContextUsage
 } = (*appServerSession)(nil)

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -109,6 +109,9 @@ func TestAppServerSession_HandleThreadTokenUsageUpdatedCachesContextUsage(t *tes
 	if usage.UsedTokens != 41061 {
 		t.Fatalf("used tokens = %d, want 41061", usage.UsedTokens)
 	}
+	if usage.BaselineTokens != codexContextBaselineTokens {
+		t.Fatalf("baseline tokens = %d, want %d", usage.BaselineTokens, codexContextBaselineTokens)
+	}
 	if usage.TotalTokens != 41061 {
 		t.Fatalf("total tokens = %d, want 41061", usage.TotalTokens)
 	}

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -334,6 +334,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	if backend == "app_server" {
 		return newAppServerSession(ctx, appServerURL, a.workDir, model, reasoningEffort, mode, sessionID, extraEnv, codexHome)
 	}
+	if codexHome != "" {
+		extraEnv = append(extraEnv, "CODEX_HOME="+codexHome)
+	}
 
 	return newCodexSession(ctx, a.workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv)
 }

--- a/agent/codex/context_usage.go
+++ b/agent/codex/context_usage.go
@@ -43,11 +43,12 @@ type appServerThreadTokenUsageNotification struct {
 }
 
 func mapAppServerTokenUsage(notif appServerThreadTokenUsageNotification) *core.ContextUsage {
-	return contextUsageFromCamel(notif.TokenUsage.Total, notif.TokenUsage.ModelContextWindow)
+	return contextUsageFromCamel(notif.TokenUsage.Last, notif.TokenUsage.ModelContextWindow)
 }
 
 func contextUsageFromCamel(usage codexTokenUsage, contextWindow int) *core.ContextUsage {
 	return contextUsageFromParts(
+		currentContextTokens(usage.TotalTokens, usage.InputTokens, usage.OutputTokens),
 		usage.TotalTokens,
 		usage.InputTokens,
 		usage.CachedInputTokens,
@@ -59,6 +60,7 @@ func contextUsageFromCamel(usage codexTokenUsage, contextWindow int) *core.Conte
 
 func contextUsageFromSnake(usage codexSnakeTokenUsage, contextWindow int) *core.ContextUsage {
 	return contextUsageFromParts(
+		currentContextTokens(usage.TotalTokens, usage.InputTokens, usage.OutputTokens),
 		usage.TotalTokens,
 		usage.InputTokens,
 		usage.CachedInputTokens,
@@ -68,7 +70,17 @@ func contextUsageFromSnake(usage codexSnakeTokenUsage, contextWindow int) *core.
 	)
 }
 
-func contextUsageFromParts(totalTokens, inputTokens, cachedInputTokens, outputTokens, reasoningOutputTokens, contextWindow int) *core.ContextUsage {
+func currentContextTokens(totalTokens, inputTokens, outputTokens int) int {
+	if totalTokens > 0 {
+		return totalTokens
+	}
+	if inputTokens > 0 || outputTokens > 0 {
+		return inputTokens + outputTokens
+	}
+	return 0
+}
+
+func contextUsageFromParts(usedTokens, totalTokens, inputTokens, cachedInputTokens, outputTokens, reasoningOutputTokens, contextWindow int) *core.ContextUsage {
 	if totalTokens <= 0 && inputTokens <= 0 && outputTokens <= 0 {
 		return nil
 	}
@@ -76,6 +88,7 @@ func contextUsageFromParts(totalTokens, inputTokens, cachedInputTokens, outputTo
 		return nil
 	}
 	return &core.ContextUsage{
+		UsedTokens:            usedTokens,
 		TotalTokens:           totalTokens,
 		InputTokens:           inputTokens,
 		CachedInputTokens:     cachedInputTokens,
@@ -272,5 +285,5 @@ func parseContextUsageFromRolloutLine(line []byte) *core.ContextUsage {
 	if payload.Type != "token_count" || payload.Info == nil {
 		return nil
 	}
-	return contextUsageFromSnake(payload.Info.TotalTokenUsage, payload.Info.ModelContextWindow)
+	return contextUsageFromSnake(payload.Info.LastTokenUsage, payload.Info.ModelContextWindow)
 }

--- a/agent/codex/context_usage.go
+++ b/agent/codex/context_usage.go
@@ -1,0 +1,276 @@
+package codex
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+const codexRolloutTailBytes int64 = 1 << 20
+
+type codexTokenUsage struct {
+	TotalTokens           int `json:"totalTokens"`
+	InputTokens           int `json:"inputTokens"`
+	CachedInputTokens     int `json:"cachedInputTokens"`
+	OutputTokens          int `json:"outputTokens"`
+	ReasoningOutputTokens int `json:"reasoningOutputTokens"`
+}
+
+type codexSnakeTokenUsage struct {
+	TotalTokens           int `json:"total_tokens"`
+	InputTokens           int `json:"input_tokens"`
+	CachedInputTokens     int `json:"cached_input_tokens"`
+	OutputTokens          int `json:"output_tokens"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens"`
+}
+
+type appServerThreadTokenUsageNotification struct {
+	ThreadID   string `json:"threadId"`
+	TurnID     string `json:"turnId"`
+	TokenUsage struct {
+		Total              codexTokenUsage `json:"total"`
+		Last               codexTokenUsage `json:"last"`
+		ModelContextWindow int             `json:"modelContextWindow"`
+	} `json:"tokenUsage"`
+}
+
+func mapAppServerTokenUsage(notif appServerThreadTokenUsageNotification) *core.ContextUsage {
+	return contextUsageFromCamel(notif.TokenUsage.Total, notif.TokenUsage.ModelContextWindow)
+}
+
+func contextUsageFromCamel(usage codexTokenUsage, contextWindow int) *core.ContextUsage {
+	return contextUsageFromParts(
+		usage.TotalTokens,
+		usage.InputTokens,
+		usage.CachedInputTokens,
+		usage.OutputTokens,
+		usage.ReasoningOutputTokens,
+		contextWindow,
+	)
+}
+
+func contextUsageFromSnake(usage codexSnakeTokenUsage, contextWindow int) *core.ContextUsage {
+	return contextUsageFromParts(
+		usage.TotalTokens,
+		usage.InputTokens,
+		usage.CachedInputTokens,
+		usage.OutputTokens,
+		usage.ReasoningOutputTokens,
+		contextWindow,
+	)
+}
+
+func contextUsageFromParts(totalTokens, inputTokens, cachedInputTokens, outputTokens, reasoningOutputTokens, contextWindow int) *core.ContextUsage {
+	if totalTokens <= 0 && inputTokens <= 0 && outputTokens <= 0 {
+		return nil
+	}
+	if contextWindow <= 0 {
+		return nil
+	}
+	return &core.ContextUsage{
+		TotalTokens:           totalTokens,
+		InputTokens:           inputTokens,
+		CachedInputTokens:     cachedInputTokens,
+		OutputTokens:          outputTokens,
+		ReasoningOutputTokens: reasoningOutputTokens,
+		ContextWindow:         contextWindow,
+	}
+}
+
+func cloneContextUsage(usage *core.ContextUsage) *core.ContextUsage {
+	if usage == nil {
+		return nil
+	}
+	cloned := *usage
+	return &cloned
+}
+
+func loadContextUsageFromRollout(extraEnv []string, sessionID, cachedPath string) (*core.ContextUsage, string, error) {
+	path := strings.TrimSpace(cachedPath)
+	if path != "" {
+		usage, err := readContextUsageFromRollout(path)
+		if err == nil && usage != nil {
+			return usage, path, nil
+		}
+	}
+
+	codexHome, err := resolveCodexHome(extraEnv)
+	if err != nil {
+		return nil, "", err
+	}
+	path = findSessionFileInCodexHome(codexHome, sessionID)
+	if path == "" {
+		return nil, "", fmt.Errorf("session file not found for %s", sessionID)
+	}
+	usage, err := readContextUsageFromRollout(path)
+	if err != nil {
+		return nil, path, err
+	}
+	if usage == nil {
+		return nil, path, fmt.Errorf("context usage not found in rollout")
+	}
+	return usage, path, nil
+}
+
+func resolveCodexHome(extraEnv []string) (string, error) {
+	if value := getenvFromList(extraEnv, "CODEX_HOME"); value != "" {
+		return strings.TrimSpace(value), nil
+	}
+	if value := strings.TrimSpace(os.Getenv("CODEX_HOME")); value != "" {
+		return value, nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".codex"), nil
+}
+
+func getenvFromList(env []string, key string) string {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		entry := env[i]
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(entry, prefix))
+		}
+	}
+	return ""
+}
+
+func findSessionFileInCodexHome(codexHome, sessionID string) string {
+	if strings.TrimSpace(codexHome) == "" || strings.TrimSpace(sessionID) == "" {
+		return ""
+	}
+
+	pattern := filepath.Join(codexHome, "sessions", "*", "*", "*", "rollout-*"+sessionID+".jsonl")
+	if matches, _ := filepath.Glob(pattern); len(matches) > 0 {
+		sort.Strings(matches)
+		return matches[len(matches)-1]
+	}
+
+	sessionsDir := filepath.Join(codexHome, "sessions")
+	var found string
+	_ = filepath.Walk(sessionsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() || found != "" {
+			return nil
+		}
+		if strings.Contains(filepath.Base(path), sessionID) {
+			found = path
+		}
+		return nil
+	})
+	return found
+}
+
+func readContextUsageFromRollout(path string) (*core.ContextUsage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if usage, err := readContextUsageFromRolloutTail(f); err != nil {
+		return nil, err
+	} else if usage != nil {
+		return usage, nil
+	}
+
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	return scanContextUsageFromRollout(f)
+}
+
+func readContextUsageFromRolloutTail(f *os.File) (*core.ContextUsage, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() <= 0 {
+		return nil, nil
+	}
+
+	start := int64(0)
+	if info.Size() > codexRolloutTailBytes {
+		start = info.Size() - codexRolloutTailBytes
+	}
+	buf := make([]byte, int(info.Size()-start))
+	n, err := f.ReadAt(buf, start)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	buf = buf[:n]
+	if start > 0 {
+		if idx := bytes.IndexByte(buf, '\n'); idx >= 0 {
+			buf = buf[idx+1:]
+		}
+	}
+	return parseContextUsageFromRolloutBytes(buf), nil
+}
+
+func parseContextUsageFromRolloutBytes(data []byte) *core.ContextUsage {
+	lines := bytes.Split(data, []byte{'\n'})
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := bytes.TrimSpace(lines[i])
+		if len(line) == 0 {
+			continue
+		}
+		if usage := parseContextUsageFromRolloutLine(line); usage != nil {
+			return usage
+		}
+	}
+	return nil
+}
+
+func scanContextUsageFromRollout(r io.Reader) (*core.ContextUsage, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+
+	var last *core.ContextUsage
+	for scanner.Scan() {
+		if usage := parseContextUsageFromRolloutLine(scanner.Bytes()); usage != nil {
+			last = usage
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return last, nil
+}
+
+func parseContextUsageFromRolloutLine(line []byte) *core.ContextUsage {
+	var entry struct {
+		Type    string          `json:"type"`
+		Payload json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return nil
+	}
+	if entry.Type != "event_msg" {
+		return nil
+	}
+
+	var payload struct {
+		Type string `json:"type"`
+		Info *struct {
+			TotalTokenUsage    codexSnakeTokenUsage `json:"total_token_usage"`
+			LastTokenUsage     codexSnakeTokenUsage `json:"last_token_usage"`
+			ModelContextWindow int                  `json:"model_context_window"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal(entry.Payload, &payload); err != nil {
+		return nil
+	}
+	if payload.Type != "token_count" || payload.Info == nil {
+		return nil
+	}
+	return contextUsageFromSnake(payload.Info.TotalTokenUsage, payload.Info.ModelContextWindow)
+}

--- a/agent/codex/context_usage.go
+++ b/agent/codex/context_usage.go
@@ -15,6 +15,7 @@ import (
 )
 
 const codexRolloutTailBytes int64 = 1 << 20
+const codexContextBaselineTokens = 12000
 
 type codexTokenUsage struct {
 	TotalTokens           int `json:"totalTokens"`
@@ -89,6 +90,7 @@ func contextUsageFromParts(usedTokens, totalTokens, inputTokens, cachedInputToke
 	}
 	return &core.ContextUsage{
 		UsedTokens:            usedTokens,
+		BaselineTokens:        codexContextBaselineTokens,
 		TotalTokens:           totalTokens,
 		InputTokens:           inputTokens,
 		CachedInputTokens:     cachedInputTokens,

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -573,6 +573,18 @@ func (cs *codexSession) CurrentSessionID() string {
 	return v
 }
 
+func (cs *codexSession) GetWorkDir() string {
+	return cs.workDir
+}
+
+func (cs *codexSession) GetModel() string {
+	return strings.TrimSpace(cs.model)
+}
+
+func (cs *codexSession) GetReasoningEffort() string {
+	return strings.TrimSpace(cs.effort)
+}
+
 func (cs *codexSession) Alive() bool {
 	return cs.alive.Load()
 }

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -41,10 +41,18 @@ type codexSession struct {
 	cmds      map[*exec.Cmd]struct{}
 
 	pendingMsgs []string // buffered agent_message texts awaiting classification
+
+	runtimeCfgMu       sync.Mutex
+	runtimeCfgModel    string
+	runtimeCfgEffort   string
+	runtimeCfgFetched  time.Time
+	runtimeCfgFetchErr error
 }
 
 var codexSessionCloseTimeout = 8 * time.Second
 var codexSessionForceKillWait = 2 * time.Second
+var codexRuntimeConfigCacheTTL = 5 * time.Second
+var codexRuntimeConfigTimeout = 1500 * time.Millisecond
 
 func newCodexSession(ctx context.Context, workDir, model, effort, mode, resumeID, baseURL string, extraEnv []string) (*codexSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
@@ -559,6 +567,134 @@ func codexToolSuccess(status string, exitCode *int) bool {
 	return s == "completed" || s == "success" || s == "succeeded" || s == "ok"
 }
 
+func loadCodexRuntimeConfig(ctx context.Context, workDir string, extraEnv []string) (string, string, error) {
+	cmd := exec.CommandContext(ctx, "codex", "app-server")
+	cmd.Dir = workDir
+	prepareCmdForKill(cmd)
+	if len(extraEnv) > 0 {
+		cmd.Env = core.MergeEnv(os.Environ(), extraEnv)
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return "", "", fmt.Errorf("runtime config stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", "", fmt.Errorf("runtime config stdout pipe: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return "", "", fmt.Errorf("runtime config start app-server: %w", err)
+	}
+	defer func() {
+		_ = stdin.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	}()
+
+	reader := bufio.NewReader(stdout)
+	nextID := int64(1)
+
+	if err := rpcRequestOverIO(stdin, reader, nextID, "initialize", map[string]any{
+		"clientInfo": map[string]any{
+			"name":    "cc-connect-codex-runtime-config",
+			"title":   "CC Connect Codex Runtime Config",
+			"version": "0.1.0",
+		},
+	}, nil); err != nil {
+		return "", "", err
+	}
+	nextID++
+
+	if err := rpcNotifyOverIO(stdin, "initialized", map[string]any{}); err != nil {
+		return "", "", err
+	}
+
+	var resp struct {
+		Config struct {
+			Model                string  `json:"model"`
+			ModelReasoningEffort *string `json:"model_reasoning_effort"`
+		} `json:"config"`
+	}
+	if err := rpcRequestOverIO(stdin, reader, nextID, "config/read", map[string]any{
+		"includeLayers": false,
+	}, &resp); err != nil {
+		return "", "", err
+	}
+
+	return strings.TrimSpace(resp.Config.Model), normalizeRuntimeReasoningEffort(stringValue(resp.Config.ModelReasoningEffort)), nil
+}
+
+func rpcRequestOverIO(stdin io.Writer, reader *bufio.Reader, id int64, method string, params any, out any) error {
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	}
+	if err := writeRPCMessage(stdin, payload); err != nil {
+		return err
+	}
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			return fmt.Errorf("%s read response: %w", method, err)
+		}
+
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal(bytes.TrimSpace(line), &probe); err != nil {
+			continue
+		}
+		if _, ok := probe["id"]; !ok {
+			continue
+		}
+
+		var resp rpcResponseEnvelope
+		if err := json.Unmarshal(bytes.TrimSpace(line), &resp); err != nil {
+			continue
+		}
+		respID, ok := rpcIDToInt64(resp.ID)
+		if !ok || respID != id {
+			continue
+		}
+		if resp.Error != nil {
+			return fmt.Errorf("%s: %s", method, strings.TrimSpace(resp.Error.Message))
+		}
+		if out != nil {
+			if err := json.Unmarshal(resp.Result, out); err != nil {
+				return fmt.Errorf("%s decode response: %w", method, err)
+			}
+		}
+		return nil
+	}
+}
+
+func rpcNotifyOverIO(stdin io.Writer, method string, params any) error {
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"params":  params,
+	}
+	return writeRPCMessage(stdin, payload)
+}
+
+func writeRPCMessage(w io.Writer, payload any) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode rpc message: %w", err)
+	}
+	if _, err := w.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write rpc message: %w", err)
+	}
+	return nil
+}
+
 // RespondPermission is a no-op for Codex — permissions are handled via CLI flags.
 func (cs *codexSession) RespondPermission(_ string, _ core.PermissionResult) error {
 	return nil
@@ -578,15 +714,50 @@ func (cs *codexSession) GetWorkDir() string {
 }
 
 func (cs *codexSession) GetModel() string {
-	return strings.TrimSpace(cs.model)
+	if model := strings.TrimSpace(cs.model); model != "" {
+		return model
+	}
+	model, _ := cs.runtimeConfig()
+	return model
 }
 
 func (cs *codexSession) GetReasoningEffort() string {
-	return strings.TrimSpace(cs.effort)
+	if effort := strings.TrimSpace(cs.effort); effort != "" {
+		return effort
+	}
+	_, effort := cs.runtimeConfig()
+	return effort
 }
 
 func (cs *codexSession) Alive() bool {
 	return cs.alive.Load()
+}
+
+func (cs *codexSession) runtimeConfig() (string, string) {
+	cs.runtimeCfgMu.Lock()
+	defer cs.runtimeCfgMu.Unlock()
+
+	if !cs.runtimeCfgFetched.IsZero() && time.Since(cs.runtimeCfgFetched) < codexRuntimeConfigCacheTTL {
+		return cs.runtimeCfgModel, cs.runtimeCfgEffort
+	}
+
+	ctx, cancel := context.WithTimeout(cs.ctx, codexRuntimeConfigTimeout)
+	defer cancel()
+
+	model, effort, err := loadCodexRuntimeConfig(ctx, cs.workDir, cs.extraEnv)
+	if err == nil {
+		cs.runtimeCfgModel = model
+		cs.runtimeCfgEffort = effort
+		cs.runtimeCfgFetchErr = nil
+		cs.runtimeCfgFetched = time.Now()
+		return model, effort
+	}
+
+	cs.runtimeCfgFetchErr = err
+	if !cs.runtimeCfgFetched.IsZero() {
+		return cs.runtimeCfgModel, cs.runtimeCfgEffort
+	}
+	return "", ""
 }
 
 func (cs *codexSession) Close() error {

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -47,12 +47,18 @@ type codexSession struct {
 	runtimeCfgEffort   string
 	runtimeCfgFetched  time.Time
 	runtimeCfgFetchErr error
+
+	contextMu    sync.RWMutex
+	contextUsage *core.ContextUsage
+	sessionFile  string
 }
 
 var codexSessionCloseTimeout = 8 * time.Second
 var codexSessionForceKillWait = 2 * time.Second
 var codexRuntimeConfigCacheTTL = 5 * time.Second
 var codexRuntimeConfigTimeout = 1500 * time.Millisecond
+var codexContextUsageRetryDelay = 50 * time.Millisecond
+var codexContextUsageRetryCount = 4
 
 func newCodexSession(ctx context.Context, workDir, model, effort, mode, resumeID, baseURL string, extraEnv []string) (*codexSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
@@ -295,11 +301,18 @@ func (cs *codexSession) handleEvent(raw map[string]any) {
 	case "thread.started":
 		if tid, ok := raw["thread_id"].(string); ok {
 			cs.threadID.Store(tid)
+			cs.contextMu.Lock()
+			cs.sessionFile = ""
+			cs.contextUsage = nil
+			cs.contextMu.Unlock()
 			slog.Debug("codexSession: thread started", "thread_id", tid)
 		}
 
 	case "turn.started":
 		cs.pendingMsgs = cs.pendingMsgs[:0]
+		cs.contextMu.Lock()
+		cs.contextUsage = nil
+		cs.contextMu.Unlock()
 		slog.Debug("codexSession: turn started")
 
 	case "item.started":
@@ -309,6 +322,7 @@ func (cs *codexSession) handleEvent(raw map[string]any) {
 		cs.handleItemCompleted(raw)
 
 	case "turn.completed":
+		cs.refreshContextUsageFromRollout()
 		cs.flushPendingAsText()
 		evt := core.Event{Type: core.EventResult, SessionID: cs.CurrentSessionID(), Done: true}
 		select {
@@ -733,6 +747,12 @@ func (cs *codexSession) Alive() bool {
 	return cs.alive.Load()
 }
 
+func (cs *codexSession) GetContextUsage() *core.ContextUsage {
+	cs.contextMu.RLock()
+	defer cs.contextMu.RUnlock()
+	return cloneContextUsage(cs.contextUsage)
+}
+
 func (cs *codexSession) runtimeConfig() (string, string) {
 	cs.runtimeCfgMu.Lock()
 	defer cs.runtimeCfgMu.Unlock()
@@ -758,6 +778,41 @@ func (cs *codexSession) runtimeConfig() (string, string) {
 		return cs.runtimeCfgModel, cs.runtimeCfgEffort
 	}
 	return "", ""
+}
+
+func (cs *codexSession) refreshContextUsageFromRollout() {
+	sessionID := strings.TrimSpace(cs.CurrentSessionID())
+	if sessionID == "" {
+		return
+	}
+
+	for attempt := 0; attempt < codexContextUsageRetryCount; attempt++ {
+		cs.contextMu.RLock()
+		cachedPath := cs.sessionFile
+		cs.contextMu.RUnlock()
+
+		usage, path, err := loadContextUsageFromRollout(cs.extraEnv, sessionID, cachedPath)
+		if err == nil && usage != nil {
+			cs.contextMu.Lock()
+			cs.sessionFile = path
+			cs.contextUsage = cloneContextUsage(usage)
+			cs.contextMu.Unlock()
+			return
+		}
+
+		if attempt == codexContextUsageRetryCount-1 {
+			if err != nil {
+				slog.Debug("codexSession: context usage unavailable", "thread_id", sessionID, "error", err)
+			}
+			return
+		}
+
+		select {
+		case <-time.After(codexContextUsageRetryDelay):
+		case <-cs.ctx.Done():
+			return
+		}
+	}
 }
 
 func (cs *codexSession) Close() error {

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -101,6 +101,47 @@ func TestBuildExecArgs_ResumeOmitsCdFlag(t *testing.T) {
 	}
 }
 
+func TestGetModelAndReasoningEffort_FromRuntimeConfigWhenUnset(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	script := `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"id":%s,"result":{"protocolVersion":"2"}}\n' "$id"
+      ;;
+    *'"method":"config/read"'*)
+      printf '{"id":%s,"result":{"config":{"model":"gpt-5.4","model_reasoning_effort":"xhigh"},"origins":{}}}\n' "$id"
+      ;;
+  esac
+done
+`
+	scriptPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer cs.Close()
+
+	if got := cs.GetModel(); got != "gpt-5.4" {
+		t.Fatalf("GetModel() = %q, want gpt-5.4", got)
+	}
+	if got := cs.GetReasoningEffort(); got != "xhigh" {
+		t.Fatalf("GetReasoningEffort() = %q, want xhigh", got)
+	}
+}
+
 func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 	workDir := t.TempDir()
 	binDir := filepath.Join(workDir, "bin")

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -142,7 +142,7 @@ done
 	}
 }
 
-func TestRefreshContextUsageFromRollout_UsesRealTokenCount(t *testing.T) {
+func TestRefreshContextUsageFromRollout_UsesLastTokenCount(t *testing.T) {
 	workDir := t.TempDir()
 	codexHome := filepath.Join(workDir, ".codex")
 	rolloutDir := filepath.Join(codexHome, "sessions", "2026", "04", "12")
@@ -155,7 +155,7 @@ func TestRefreshContextUsageFromRollout_UsesRealTokenCount(t *testing.T) {
 	rollout := strings.Join([]string{
 		`{"type":"session_meta","payload":{"id":"` + sessionID + `","cwd":"/tmp/project"}}`,
 		`{"type":"event_msg","payload":{"type":"token_count","info":null,"rate_limits":{"limit_id":"codex"}}}`,
-		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":14809,"cached_input_tokens":3456,"output_tokens":31,"reasoning_output_tokens":24,"total_tokens":14840},"last_token_usage":{"input_tokens":14809,"cached_input_tokens":3456,"output_tokens":31,"reasoning_output_tokens":24,"total_tokens":14840},"model_context_window":258400},"rate_limits":{"limit_id":"codex"}}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":50665316,"cached_input_tokens":46971872,"output_tokens":156453,"reasoning_output_tokens":75023,"total_tokens":50821769},"last_token_usage":{"input_tokens":180805,"cached_input_tokens":139776,"output_tokens":619,"reasoning_output_tokens":32,"total_tokens":181424},"model_context_window":258400},"rate_limits":{"limit_id":"codex"}}}`,
 		"",
 	}, "\n")
 	if err := os.WriteFile(rolloutPath, []byte(rollout), 0o644); err != nil {
@@ -174,11 +174,14 @@ func TestRefreshContextUsageFromRollout_UsesRealTokenCount(t *testing.T) {
 	if usage == nil {
 		t.Fatal("GetContextUsage() = nil, want rollout token count")
 	}
-	if usage.TotalTokens != 14840 {
-		t.Fatalf("total tokens = %d, want 14840", usage.TotalTokens)
+	if usage.UsedTokens != 181424 {
+		t.Fatalf("used tokens = %d, want 181424", usage.UsedTokens)
 	}
-	if usage.InputTokens != 14809 {
-		t.Fatalf("input tokens = %d, want 14809", usage.InputTokens)
+	if usage.TotalTokens != 181424 {
+		t.Fatalf("total tokens = %d, want 181424", usage.TotalTokens)
+	}
+	if usage.InputTokens != 180805 {
+		t.Fatalf("input tokens = %d, want 180805", usage.InputTokens)
 	}
 	if usage.ContextWindow != 258400 {
 		t.Fatalf("context window = %d, want 258400", usage.ContextWindow)

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -128,7 +128,7 @@ done
 
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", nil)
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", "", "", nil)
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestRefreshContextUsageFromRollout_UsesLastTokenCount(t *testing.T) {
 		t.Fatalf("write rollout: %v", err)
 	}
 
-	cs, err := newCodexSession(context.Background(), workDir, "", "", "", sessionID, []string{"CODEX_HOME=" + codexHome})
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", sessionID, "", []string{"CODEX_HOME=" + codexHome})
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -177,6 +177,9 @@ func TestRefreshContextUsageFromRollout_UsesLastTokenCount(t *testing.T) {
 	if usage.UsedTokens != 181424 {
 		t.Fatalf("used tokens = %d, want 181424", usage.UsedTokens)
 	}
+	if usage.BaselineTokens != codexContextBaselineTokens {
+		t.Fatalf("baseline tokens = %d, want %d", usage.BaselineTokens, codexContextBaselineTokens)
+	}
 	if usage.TotalTokens != 181424 {
 		t.Fatalf("total tokens = %d, want 181424", usage.TotalTokens)
 	}

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -142,6 +142,49 @@ done
 	}
 }
 
+func TestRefreshContextUsageFromRollout_UsesRealTokenCount(t *testing.T) {
+	workDir := t.TempDir()
+	codexHome := filepath.Join(workDir, ".codex")
+	rolloutDir := filepath.Join(codexHome, "sessions", "2026", "04", "12")
+	if err := os.MkdirAll(rolloutDir, 0o755); err != nil {
+		t.Fatalf("mkdir rollout dir: %v", err)
+	}
+
+	sessionID := "019d8019-d05a-7612-ace2-db549494c0f9"
+	rolloutPath := filepath.Join(rolloutDir, "rollout-2026-04-12T05-11-08-"+sessionID+".jsonl")
+	rollout := strings.Join([]string{
+		`{"type":"session_meta","payload":{"id":"` + sessionID + `","cwd":"/tmp/project"}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":null,"rate_limits":{"limit_id":"codex"}}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":14809,"cached_input_tokens":3456,"output_tokens":31,"reasoning_output_tokens":24,"total_tokens":14840},"last_token_usage":{"input_tokens":14809,"cached_input_tokens":3456,"output_tokens":31,"reasoning_output_tokens":24,"total_tokens":14840},"model_context_window":258400},"rate_limits":{"limit_id":"codex"}}}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(rolloutPath, []byte(rollout), 0o644); err != nil {
+		t.Fatalf("write rollout: %v", err)
+	}
+
+	cs, err := newCodexSession(context.Background(), workDir, "", "", "", sessionID, []string{"CODEX_HOME=" + codexHome})
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer cs.Close()
+
+	cs.refreshContextUsageFromRollout()
+
+	usage := cs.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage() = nil, want rollout token count")
+	}
+	if usage.TotalTokens != 14840 {
+		t.Fatalf("total tokens = %d, want 14840", usage.TotalTokens)
+	}
+	if usage.InputTokens != 14809 {
+		t.Fatalf("input tokens = %d, want 14809", usage.InputTokens)
+	}
+	if usage.ContextWindow != 258400 {
+		t.Fatalf("context window = %d, want 258400", usage.ContextWindow)
+	}
+}
+
 func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 	workDir := t.TempDir()
 	binDir := filepath.Join(workDir, "bin")

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -241,6 +241,7 @@ func main() {
 			showCtx = *proj.ShowContextIndicator
 		}
 		engine.SetShowContextIndicator(showCtx)
+		engine.SetReplyFooterEnabled(proj.ReplyFooter != nil && *proj.ReplyFooter)
 		engine.SetAttachmentSendEnabled(cfg.AttachmentSend != "off")
 		engine.SetBaseWorkDir(workDir)
 		engine.SetProjectStateStore(projectState)
@@ -1310,6 +1311,7 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 		showCtx = *proj.ShowContextIndicator
 	}
 	engine.SetShowContextIndicator(showCtx)
+	engine.SetReplyFooterEnabled(proj.ReplyFooter != nil && *proj.ReplyFooter)
 
 	// Reload sender injection
 	engine.SetInjectSender(proj.InjectSender != nil && *proj.InjectSender)

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -241,7 +241,11 @@ func main() {
 			showCtx = *proj.ShowContextIndicator
 		}
 		engine.SetShowContextIndicator(showCtx)
-		engine.SetReplyFooterEnabled(proj.ReplyFooter != nil && *proj.ReplyFooter)
+		showFooter := true
+		if proj.ReplyFooter != nil {
+			showFooter = *proj.ReplyFooter
+		}
+		engine.SetReplyFooterEnabled(showFooter)
 		engine.SetAttachmentSendEnabled(cfg.AttachmentSend != "off")
 		engine.SetBaseWorkDir(workDir)
 		engine.SetProjectStateStore(projectState)
@@ -1311,7 +1315,11 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 		showCtx = *proj.ShowContextIndicator
 	}
 	engine.SetShowContextIndicator(showCtx)
-	engine.SetReplyFooterEnabled(proj.ReplyFooter != nil && *proj.ReplyFooter)
+	showFooter := true
+	if proj.ReplyFooter != nil {
+		showFooter = *proj.ReplyFooter
+	}
+	engine.SetReplyFooterEnabled(showFooter)
 
 	// Reload sender injection
 	engine.SetInjectSender(proj.InjectSender != nil && *proj.InjectSender)

--- a/config.example.toml
+++ b/config.example.toml
@@ -499,6 +499,8 @@ level = "info" # debug, info, warn, error
 name = "my-backend"
 # show_context_indicator = false  # Hide the “[ctx: ~N%]” suffix on assistant replies (default: true / show)
 #                                   # 不在助手回复末尾显示「[ctx: ~N%]」上下文占用提示（默认 true 显示）
+# reply_footer = true              # Append a Codex-like footer to each assistant reply when data is available
+#                                   # 在每条助手回复底部追加类似 Codex 的状态行（有数据时显示 model / reasoning / usage / cwd）
 # disabled_commands = ["restart", "upgrade", "cron"]  # Disable specific commands for this project
 #                                                     # 禁用该项目的指定命令
 #

--- a/config.example.toml
+++ b/config.example.toml
@@ -499,8 +499,8 @@ level = "info" # debug, info, warn, error
 name = "my-backend"
 # show_context_indicator = false  # Hide the “[ctx: ~N%]” suffix on assistant replies (default: true / show)
 #                                   # 不在助手回复末尾显示「[ctx: ~N%]」上下文占用提示（默认 true 显示）
-# reply_footer = true              # Append a Codex-like footer to each assistant reply when data is available
-#                                   # 在每条助手回复底部追加类似 Codex 的状态行（有数据时显示 model / reasoning / usage / cwd）
+# reply_footer = false             # Hide the Codex-like footer on assistant replies (default: true / show)
+#                                   # 不在助手回复底部显示类似 Codex 的状态行（默认 true 显示）
 # disabled_commands = ["restart", "upgrade", "cron"]  # Disable specific commands for this project
 #                                                     # 禁用该项目的指定命令
 #

--- a/config/config.go
+++ b/config/config.go
@@ -80,8 +80,8 @@ var configMu sync.Mutex
 var ConfigPath string
 
 type Config struct {
-	DataDir           string                  `toml:"data_dir"` // session store directory, default ~/.cc-connect
-	AttachmentSend    string                  `toml:"attachment_send"`
+	DataDir        string `toml:"data_dir"` // session store directory, default ~/.cc-connect
+	AttachmentSend string `toml:"attachment_send"`
 	// Quiet is legacy: when true and [display] does not set thinking_messages / tool_messages,
 	// engines behave as if those flags were false. Per-project quiet overrides when set.
 	Quiet             *bool                   `toml:"quiet,omitempty"`
@@ -301,16 +301,19 @@ type ProjectConfig struct {
 	// Use this only for variables the target user cannot set in their profile.
 	RunAsEnv []string `toml:"run_as_env,omitempty"`
 	// ShowContextIndicator: nil/true = append [ctx: ~N%] to assistant replies; false = hide.
-	ShowContextIndicator *bool           `toml:"show_context_indicator,omitempty"`
-	InjectSender         *bool           `toml:"inject_sender,omitempty"`     // prepend sender identity (platform + user ID) to each message sent to the agent
-	DisabledCommands     []string        `toml:"disabled_commands,omitempty"` // commands to disable for this project (e.g. ["restart", "upgrade"])
-	AdminFrom            string          `toml:"admin_from,omitempty"`        // comma-separated user IDs allowed to run privileged commands; "*" = all allowed users
-	Users                *UsersConfig    `toml:"users,omitempty"`             // per-user role config; nil = legacy behavior
+	ShowContextIndicator *bool `toml:"show_context_indicator,omitempty"`
+	// ReplyFooter: nil/false = disable; true = append a Codex-style footer
+	// (model/reasoning/usage/workdir, when available) to assistant replies.
+	ReplyFooter      *bool        `toml:"reply_footer,omitempty"`
+	InjectSender     *bool        `toml:"inject_sender,omitempty"`     // prepend sender identity (platform + user ID) to each message sent to the agent
+	DisabledCommands []string     `toml:"disabled_commands,omitempty"` // commands to disable for this project (e.g. ["restart", "upgrade"])
+	AdminFrom        string       `toml:"admin_from,omitempty"`        // comma-separated user IDs allowed to run privileged commands; "*" = all allowed users
+	Users            *UsersConfig `toml:"users,omitempty"`             // per-user role config; nil = legacy behavior
 	// Quiet is legacy per-project override; see Config.Quiet. When true and global [display]
 	// omits thinking_messages / tool_messages, those default to off for this project.
 	Quiet      *bool           `toml:"quiet,omitempty"`
-	Observe              *ObserveConfig  `toml:"observe,omitempty"`
-	References           ReferenceConfig `toml:"references,omitempty"`
+	Observe    *ObserveConfig  `toml:"observe,omitempty"`
+	References ReferenceConfig `toml:"references,omitempty"`
 }
 
 type AgentConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -302,7 +302,7 @@ type ProjectConfig struct {
 	RunAsEnv []string `toml:"run_as_env,omitempty"`
 	// ShowContextIndicator: nil/true = append [ctx: ~N%] to assistant replies; false = hide.
 	ShowContextIndicator *bool `toml:"show_context_indicator,omitempty"`
-	// ReplyFooter: nil/false = disable; true = append a Codex-style footer
+	// ReplyFooter: nil/true = append a Codex-style footer; false = disable.
 	// (model/reasoning/usage/workdir, when available) to assistant replies.
 	ReplyFooter      *bool        `toml:"reply_footer,omitempty"`
 	InjectSender     *bool        `toml:"inject_sender,omitempty"`     // prepend sender identity (platform + user ID) to each message sent to the agent

--- a/core/engine.go
+++ b/core/engine.go
@@ -2746,7 +2746,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					cleanResponse += fmt.Sprintf("\n[ctx: ~%d%%]", selfPct)
 				}
 			}
-			if footer := e.buildReplyFooter(replyAgent, workspaceDir); footer != "" {
+			if footer := e.buildReplyFooter(replyAgent, state.agentSession, workspaceDir); footer != "" {
 				cleanResponse = appendReplyFooter(cleanResponse, footer)
 			}
 			fullResponse = cleanResponse
@@ -3826,26 +3826,22 @@ func (e *Engine) commandWorkDir(agent Agent, msg *Message) string {
 	return ""
 }
 
-func (e *Engine) buildReplyFooter(agent Agent, workspaceDir string) string {
+func (e *Engine) buildReplyFooter(agent Agent, session AgentSession, workspaceDir string) string {
 	if !e.replyFooterEnabled || agent == nil {
 		return ""
 	}
 
 	var parts []string
-	if switcher, ok := agent.(ModelSwitcher); ok {
-		if model := strings.TrimSpace(switcher.GetModel()); model != "" {
-			parts = append(parts, model)
-		}
+	if model := replyFooterModel(session, agent); model != "" {
+		parts = append(parts, model)
 	}
-	if switcher, ok := agent.(ReasoningEffortSwitcher); ok {
-		if effort := strings.TrimSpace(switcher.GetReasoningEffort()); effort != "" {
-			parts = append(parts, effort)
-		}
+	if effort := replyFooterReasoningEffort(session, agent); effort != "" {
+		parts = append(parts, effort)
 	}
-	if usage := e.replyFooterUsageText(agent); usage != "" {
+	if usage := e.replyFooterUsageText(session, agent); usage != "" {
 		parts = append(parts, usage)
 	}
-	if dir := replyFooterWorkDir(agent, workspaceDir); dir != "" {
+	if dir := replyFooterWorkDir(session, agent, workspaceDir); dir != "" {
 		parts = append(parts, dir)
 	}
 	if len(parts) == 0 {
@@ -3854,7 +3850,46 @@ func (e *Engine) buildReplyFooter(agent Agent, workspaceDir string) string {
 	return strings.Join(parts, " · ")
 }
 
-func (e *Engine) replyFooterUsageText(agent Agent) string {
+func replyFooterModel(session AgentSession, agent Agent) string {
+	if session != nil {
+		if getter, ok := session.(interface{ GetModel() string }); ok {
+			if model := strings.TrimSpace(getter.GetModel()); model != "" {
+				return model
+			}
+		}
+	}
+	if getter, ok := agent.(interface{ GetModel() string }); ok {
+		return strings.TrimSpace(getter.GetModel())
+	}
+	return ""
+}
+
+func replyFooterReasoningEffort(session AgentSession, agent Agent) string {
+	if session != nil {
+		if getter, ok := session.(interface{ GetReasoningEffort() string }); ok {
+			if effort := strings.TrimSpace(getter.GetReasoningEffort()); effort != "" {
+				return effort
+			}
+		}
+	}
+	if getter, ok := agent.(interface{ GetReasoningEffort() string }); ok {
+		return strings.TrimSpace(getter.GetReasoningEffort())
+	}
+	return ""
+}
+
+func (e *Engine) replyFooterUsageText(session AgentSession, agent Agent) string {
+	ctx, cancel := context.WithTimeout(e.ctx, replyFooterUsageTimeout)
+	defer cancel()
+
+	if session != nil {
+		if reporter, ok := session.(UsageReporter); ok {
+			if report, err := reporter.GetUsage(ctx); err == nil {
+				return formatReplyFooterUsage(report, e.i18n)
+			}
+		}
+	}
+
 	reporter, ok := agent.(UsageReporter)
 	if !ok {
 		return ""
@@ -3866,9 +3901,6 @@ func (e *Engine) replyFooterUsageText(agent Agent) string {
 	if !cached.fetchedAt.IsZero() && time.Since(cached.fetchedAt) < replyFooterUsageCacheTTL {
 		return cached.text
 	}
-
-	ctx, cancel := context.WithTimeout(e.ctx, replyFooterUsageTimeout)
-	defer cancel()
 
 	text := ""
 	if report, err := reporter.GetUsage(ctx); err == nil {
@@ -3901,8 +3933,15 @@ func formatReplyFooterUsage(report *UsageReport, i18n *I18n) string {
 	return i18n.Tf(MsgReplyFooterRemaining, remaining)
 }
 
-func replyFooterWorkDir(agent Agent, workspaceDir string) string {
+func replyFooterWorkDir(session AgentSession, agent Agent, workspaceDir string) string {
 	dir := strings.TrimSpace(workspaceDir)
+	if dir == "" {
+		if session != nil {
+			if wd, ok := session.(interface{ GetWorkDir() string }); ok {
+				dir = strings.TrimSpace(wd.GetWorkDir())
+			}
+		}
+	}
 	if dir == "" {
 		if switcher, ok := agent.(WorkDirSwitcher); ok {
 			dir = strings.TrimSpace(switcher.GetWorkDir())

--- a/core/engine.go
+++ b/core/engine.go
@@ -40,6 +40,11 @@ const (
 	slowAgentFirstEvent = 15 * time.Second // time from send to first agent event
 )
 
+const (
+	replyFooterUsageTimeout  = 1500 * time.Millisecond
+	replyFooterUsageCacheTTL = 30 * time.Second
+)
+
 // VersionInfo is set by main at startup so that /version works.
 var VersionInfo string
 
@@ -53,6 +58,11 @@ var ErrAttachmentSendDisabled = errors.New("attachment send is disabled by confi
 type RestartRequest struct {
 	SessionKey string `json:"session_key"`
 	Platform   string `json:"platform"`
+}
+
+type replyFooterUsageCache struct {
+	text      string
+	fetchedAt time.Time
 }
 
 // SaveRestartNotify persists restart info so the new process can send
@@ -200,6 +210,7 @@ type Engine struct {
 
 	// When true, append [ctx: ~N%] (or model self-report) to assistant replies shown on platforms.
 	showContextIndicator bool
+	replyFooterEnabled   bool
 
 	// Multi-workspace mode
 	multiWorkspace    bool
@@ -222,6 +233,8 @@ type Engine struct {
 	platformLifecycleMu sync.Mutex
 	platformReady       map[Platform]bool
 	stopping            bool
+	replyFooterMu       sync.Mutex
+	replyFooterUsage    replyFooterUsageCache
 
 	// /web command callbacks
 	webSetupFunc  func() (port int, token string, needRestart bool, err error)
@@ -257,6 +270,7 @@ type interactiveState struct {
 	platform               Platform
 	replyCtx               any
 	workspaceDir           string
+	agent                  Agent
 	mu                     sync.Mutex
 	stopCh                 chan struct{}
 	stopped                bool
@@ -495,6 +509,12 @@ func (e *Engine) SetResetOnIdle(d time.Duration) {
 // SetShowContextIndicator controls whether assistant replies include the [ctx: ~N%] suffix.
 func (e *Engine) SetShowContextIndicator(show bool) {
 	e.showContextIndicator = show
+}
+
+// SetReplyFooterEnabled controls whether assistant replies include a Codex-like
+// footer line with model / reasoning / usage / workdir metadata when available.
+func (e *Engine) SetReplyFooterEnabled(show bool) {
+	e.replyFooterEnabled = show
 }
 
 func (e *Engine) SetWebSetupFunc(fn func() (int, string, bool, error)) { e.webSetupFunc = fn }
@@ -2231,7 +2251,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	// Check if context is already canceled (e.g. during shutdown/restart)
 	if e.ctx.Err() != nil {
 		slog.Debug("skipping session start: context canceled", "session_key", sessionKey)
-		newState := &interactiveState{platform: p, replyCtx: replyCtx}
+		newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent}
 		adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
 		state = newState
 		e.interactiveStates[sessionKey] = state
@@ -2262,7 +2282,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		}
 		if err != nil {
 			slog.Error("failed to start interactive session", "error", err, "elapsed", startElapsed)
-			newState := &interactiveState{platform: p, replyCtx: replyCtx}
+			newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent}
 			adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
 			state = newState
 			e.interactiveStates[sessionKey] = state
@@ -2283,6 +2303,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		agentSession: agentSession,
 		platform:     p,
 		replyCtx:     replyCtx,
+		agent:        agent,
 	}
 	adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
 	state = newState
@@ -2381,6 +2402,10 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 	state.mu.Lock()
 	workspaceDir := state.workspaceDir
+	replyAgent := state.agent
+	if replyAgent == nil {
+		replyAgent = e.agent
+	}
 	workspaceRenderer := func(content string) string {
 		return e.renderOutgoingContentForWorkspace(state.platform, content, workspaceDir)
 	}
@@ -2693,11 +2718,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			selfPct := parseSelfReportedCtx(fullResponse)
 			cleanResponse := ctxSelfReportRe.ReplaceAllString(fullResponse, "")
 			cleanResponse = strings.TrimRight(cleanResponse, "\n ")
+			baseResponse := cleanResponse
 
 			// Evaluate auto-compress trigger (token estimate on user+assistant text,
 			// including this turn's assistant reply before it is appended to history).
 			if e.autoCompressEnabled && e.autoCompressMaxTokens > 0 {
-				estimate := estimateTokensWithPendingAssistant(session.GetHistory(0), cleanResponse)
+				estimate := estimateTokensWithPendingAssistant(session.GetHistory(0), baseResponse)
 				now := time.Now()
 				state.mu.Lock()
 				last := state.lastAutoCompressAt
@@ -2710,7 +2736,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 			}
 
-			session.AddHistory("assistant", cleanResponse)
+			session.AddHistory("assistant", baseResponse)
 			sessions.Save()
 
 			if e.showContextIndicator {
@@ -2719,6 +2745,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				} else if selfPct > 0 {
 					cleanResponse += fmt.Sprintf("\n[ctx: ~%d%%]", selfPct)
 				}
+			}
+			if footer := e.buildReplyFooter(replyAgent, workspaceDir); footer != "" {
+				cleanResponse = appendReplyFooter(cleanResponse, footer)
 			}
 			fullResponse = cleanResponse
 
@@ -2735,9 +2764,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			)
 
 			replyStart := time.Now()
-			normalizedResponse := strings.TrimSpace(fullResponse)
+			normalizedBaseResponse := strings.TrimSpace(baseResponse)
 			state.mu.Lock()
-			suppressDuplicate := normalizedResponse != "" && normalizedResponse == state.sideText
+			suppressDuplicate := normalizedBaseResponse != "" && normalizedBaseResponse == state.sideText
 			state.sideText = ""
 			state.mu.Unlock()
 
@@ -2758,6 +2787,13 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 			} else if suppressDuplicate {
 				sp.discard()
+				if metaOnly := strings.TrimSpace(strings.TrimPrefix(fullResponse, baseResponse)); metaOnly != "" {
+					for _, chunk := range splitMessage(metaOnly, maxPlatformMessageLen) {
+						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
+							return
+						}
+					}
+				}
 				slog.Debug("EventResult: suppressed duplicate side-channel text", "response_len", len(fullResponse))
 			} else if sp.finish(fullResponse) {
 				slog.Debug("EventResult: finalized via stream preview", "response_len", len(fullResponse))
@@ -3788,6 +3824,146 @@ func (e *Engine) commandWorkDir(agent Agent, msg *Message) string {
 		return normalizeWorkspacePath(cwd)
 	}
 	return ""
+}
+
+func (e *Engine) buildReplyFooter(agent Agent, workspaceDir string) string {
+	if !e.replyFooterEnabled || agent == nil {
+		return ""
+	}
+
+	var parts []string
+	if switcher, ok := agent.(ModelSwitcher); ok {
+		if model := strings.TrimSpace(switcher.GetModel()); model != "" {
+			parts = append(parts, model)
+		}
+	}
+	if switcher, ok := agent.(ReasoningEffortSwitcher); ok {
+		if effort := strings.TrimSpace(switcher.GetReasoningEffort()); effort != "" {
+			parts = append(parts, effort)
+		}
+	}
+	if usage := e.replyFooterUsageText(agent); usage != "" {
+		parts = append(parts, usage)
+	}
+	if dir := replyFooterWorkDir(agent, workspaceDir); dir != "" {
+		parts = append(parts, dir)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " · ")
+}
+
+func (e *Engine) replyFooterUsageText(agent Agent) string {
+	reporter, ok := agent.(UsageReporter)
+	if !ok {
+		return ""
+	}
+
+	e.replyFooterMu.Lock()
+	cached := e.replyFooterUsage
+	e.replyFooterMu.Unlock()
+	if !cached.fetchedAt.IsZero() && time.Since(cached.fetchedAt) < replyFooterUsageCacheTTL {
+		return cached.text
+	}
+
+	ctx, cancel := context.WithTimeout(e.ctx, replyFooterUsageTimeout)
+	defer cancel()
+
+	text := ""
+	if report, err := reporter.GetUsage(ctx); err == nil {
+		text = formatReplyFooterUsage(report, e.i18n)
+	} else if !cached.fetchedAt.IsZero() {
+		text = cached.text
+	}
+
+	e.replyFooterMu.Lock()
+	e.replyFooterUsage = replyFooterUsageCache{text: text, fetchedAt: time.Now()}
+	e.replyFooterMu.Unlock()
+	return text
+}
+
+func formatReplyFooterUsage(report *UsageReport, i18n *I18n) string {
+	if report == nil || i18n == nil {
+		return ""
+	}
+	window, _ := selectUsageWindows(report)
+	if window == nil {
+		return ""
+	}
+	remaining := 100 - window.UsedPercent
+	if remaining < 0 {
+		remaining = 0
+	}
+	if remaining > 100 {
+		remaining = 100
+	}
+	return i18n.Tf(MsgReplyFooterRemaining, remaining)
+}
+
+func replyFooterWorkDir(agent Agent, workspaceDir string) string {
+	dir := strings.TrimSpace(workspaceDir)
+	if dir == "" {
+		if switcher, ok := agent.(WorkDirSwitcher); ok {
+			dir = strings.TrimSpace(switcher.GetWorkDir())
+		}
+	}
+	if dir == "" {
+		if wd, ok := agent.(interface{ GetWorkDir() string }); ok {
+			dir = strings.TrimSpace(wd.GetWorkDir())
+		}
+	}
+	if dir == "" {
+		return ""
+	}
+	return compactReplyFooterPath(dir)
+}
+
+func compactReplyFooterPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = normalizeWorkspacePath(path)
+	if home, err := os.UserHomeDir(); err == nil {
+		home = normalizeWorkspacePath(home)
+		if path == home {
+			return "~"
+		}
+		prefix := home + string(os.PathSeparator)
+		if strings.HasPrefix(path, prefix) {
+			return "~" + filepath.ToSlash(strings.TrimPrefix(path, home))
+		}
+	}
+
+	slash := filepath.ToSlash(path)
+	if filepath.IsAbs(path) {
+		trimmed := strings.Trim(slash, "/")
+		if trimmed == "" {
+			return "/"
+		}
+		parts := strings.Split(trimmed, "/")
+		if len(parts) == 1 {
+			return parts[0]
+		}
+		start := len(parts) - 2
+		if start < 0 {
+			start = 0
+		}
+		return "…/" + strings.Join(parts[start:], "/")
+	}
+	return slash
+}
+
+func appendReplyFooter(content, footer string) string {
+	if footer == "" {
+		return content
+	}
+	content = strings.TrimRight(content, "\n")
+	if content == "" {
+		return "`" + footer + "`"
+	}
+	return content + "\n\n`" + footer + "`"
 }
 
 func (e *Engine) cmdShow(p Platform, msg *Message, args []string) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -3952,10 +3952,23 @@ func replyFooterContextText(usage *ContextUsage, i18n *I18n) string {
 	if usage == nil || i18n == nil {
 		return ""
 	}
-	if usage.ContextWindow <= 0 || usage.TotalTokens < 0 {
+	if usage.ContextWindow <= 0 {
 		return ""
 	}
-	used := usage.TotalTokens * 100 / usage.ContextWindow
+
+	usedTokens := usage.UsedTokens
+	if usedTokens <= 0 {
+		switch {
+		case usage.TotalTokens > 0:
+			usedTokens = usage.TotalTokens
+		case usage.InputTokens > 0 || usage.OutputTokens > 0:
+			usedTokens = usage.InputTokens + usage.OutputTokens
+		default:
+			return ""
+		}
+	}
+
+	used := usedTokens * 100 / usage.ContextWindow
 	if used < 0 {
 		used = 0
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -2720,10 +2720,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			cleanResponse = strings.TrimRight(cleanResponse, "\n ")
 			baseResponse := cleanResponse
 
+			contextEstimate := estimateTokensWithPendingAssistant(session.GetHistory(0), baseResponse)
+
 			// Evaluate auto-compress trigger (token estimate on user+assistant text,
 			// including this turn's assistant reply before it is appended to history).
 			if e.autoCompressEnabled && e.autoCompressMaxTokens > 0 {
-				estimate := estimateTokensWithPendingAssistant(session.GetHistory(0), baseResponse)
+				estimate := contextEstimate
 				now := time.Now()
 				state.mu.Lock()
 				last := state.lastAutoCompressAt
@@ -2746,7 +2748,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					cleanResponse += fmt.Sprintf("\n[ctx: ~%d%%]", selfPct)
 				}
 			}
-			if footer := e.buildReplyFooter(replyAgent, state.agentSession, workspaceDir); footer != "" {
+			if footer := e.buildReplyFooter(replyAgent, state.agentSession, workspaceDir, replyFooterContextText(contextEstimate, e.i18n)); footer != "" {
 				cleanResponse = appendReplyFooter(cleanResponse, footer)
 			}
 			fullResponse = cleanResponse
@@ -3826,7 +3828,7 @@ func (e *Engine) commandWorkDir(agent Agent, msg *Message) string {
 	return ""
 }
 
-func (e *Engine) buildReplyFooter(agent Agent, session AgentSession, workspaceDir string) string {
+func (e *Engine) buildReplyFooter(agent Agent, session AgentSession, workspaceDir string, contextLeft string) string {
 	if !e.replyFooterEnabled || agent == nil {
 		return ""
 	}
@@ -3838,7 +3840,9 @@ func (e *Engine) buildReplyFooter(agent Agent, session AgentSession, workspaceDi
 	if effort := replyFooterReasoningEffort(session, agent); effort != "" {
 		parts = append(parts, effort)
 	}
-	if usage := e.replyFooterUsageText(session, agent); usage != "" {
+	if left := strings.TrimSpace(contextLeft); left != "" {
+		parts = append(parts, left)
+	} else if usage := e.replyFooterUsageText(session, agent); usage != "" {
 		parts = append(parts, usage)
 	}
 	if dir := replyFooterWorkDir(session, agent, workspaceDir); dir != "" {
@@ -3933,6 +3937,20 @@ func formatReplyFooterUsage(report *UsageReport, i18n *I18n) string {
 	return i18n.Tf(MsgReplyFooterRemaining, remaining)
 }
 
+func replyFooterContextText(estimatedTokens int, i18n *I18n) string {
+	if estimatedTokens <= 0 || i18n == nil {
+		return ""
+	}
+	used := estimatedTokens * 100 / modelContextWindow
+	if used < 0 {
+		used = 0
+	}
+	if used > 100 {
+		used = 100
+	}
+	return i18n.Tf(MsgReplyFooterRemaining, 100-used)
+}
+
 func replyFooterWorkDir(session AgentSession, agent Agent, workspaceDir string) string {
 	dir := strings.TrimSpace(workspaceDir)
 	if dir == "" {
@@ -4000,9 +4018,9 @@ func appendReplyFooter(content, footer string) string {
 	}
 	content = strings.TrimRight(content, "\n")
 	if content == "" {
-		return "`" + footer + "`"
+		return "*" + footer + "*"
 	}
-	return content + "\n\n`" + footer + "`"
+	return content + "\n\n*" + footer + "*"
 }
 
 func (e *Engine) cmdShow(p Platform, msg *Message, args []string) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -3968,14 +3969,32 @@ func replyFooterContextText(usage *ContextUsage, i18n *I18n) string {
 		}
 	}
 
-	used := usedTokens * 100 / usage.ContextWindow
-	if used < 0 {
-		used = 0
+	baseline := usage.BaselineTokens
+	if baseline < 0 {
+		baseline = 0
 	}
-	if used > 100 {
-		used = 100
+	if usage.ContextWindow <= baseline {
+		return i18n.Tf(MsgReplyFooterRemaining, 0)
 	}
-	return i18n.Tf(MsgReplyFooterRemaining, 100-used)
+
+	effectiveWindow := usage.ContextWindow - baseline
+	effectiveUsed := usedTokens - baseline
+	if effectiveUsed < 0 {
+		effectiveUsed = 0
+	}
+	remaining := effectiveWindow - effectiveUsed
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	left := int(math.Round(float64(remaining) / float64(effectiveWindow) * 100))
+	if left < 0 {
+		left = 0
+	}
+	if left > 100 {
+		left = 100
+	}
+	return i18n.Tf(MsgReplyFooterRemaining, left)
 }
 
 func replyFooterWorkDir(session AgentSession, agent Agent, workspaceDir string) string {

--- a/core/engine.go
+++ b/core/engine.go
@@ -2748,7 +2748,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					cleanResponse += fmt.Sprintf("\n[ctx: ~%d%%]", selfPct)
 				}
 			}
-			if footer := e.buildReplyFooter(replyAgent, state.agentSession, workspaceDir, replyFooterContextText(contextEstimate, e.i18n)); footer != "" {
+			if footer := e.buildReplyFooter(replyAgent, state.agentSession, workspaceDir, replyFooterContextText(replyFooterSessionContextUsage(state.agentSession), e.i18n)); footer != "" {
 				cleanResponse = appendReplyFooter(cleanResponse, footer)
 			}
 			fullResponse = cleanResponse
@@ -3937,11 +3937,25 @@ func formatReplyFooterUsage(report *UsageReport, i18n *I18n) string {
 	return i18n.Tf(MsgReplyFooterRemaining, remaining)
 }
 
-func replyFooterContextText(estimatedTokens int, i18n *I18n) string {
-	if estimatedTokens <= 0 || i18n == nil {
+func replyFooterSessionContextUsage(session AgentSession) *ContextUsage {
+	if session == nil {
+		return nil
+	}
+	reporter, ok := session.(ContextUsageReporter)
+	if !ok {
+		return nil
+	}
+	return reporter.GetContextUsage()
+}
+
+func replyFooterContextText(usage *ContextUsage, i18n *I18n) string {
+	if usage == nil || i18n == nil {
 		return ""
 	}
-	used := estimatedTokens * 100 / modelContextWindow
+	if usage.ContextWindow <= 0 || usage.TotalTokens < 0 {
+		return ""
+	}
+	used := usage.TotalTokens * 100 / usage.ContextWindow
 	if used < 0 {
 		used = 0
 	}
@@ -10568,7 +10582,7 @@ func gitClone(repoURL, dest string) error {
 
 // ── Context usage indicator ──────────────────────────────────
 
-const modelContextWindow = 200_000 // Claude's context window size in tokens
+const modelContextWindow = 200_000 // generic fallback window for heuristic context estimates
 
 // contextIndicator returns a suffix like "\n[ctx: ~42%]" based on SDK-reported input tokens.
 func contextIndicator(inputTokens int) string {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1016,6 +1016,68 @@ func TestProcessInteractiveEvents_DoesNotAppendReplyFooterWhenDisabled(t *testin
 	}
 }
 
+func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	agent := &stubReplyFooterAgent{
+		stubModelModeAgent: stubModelModeAgent{
+			model:           "agent-model",
+			reasoningEffort: "medium",
+		},
+		workDir: filepath.Join(homeDir, "codes", "agent-default"),
+		report: &UsageReport{
+			Buckets: []UsageBucket{{
+				Name: "Rate limit",
+				Windows: []UsageWindow{{
+					Name:          "Primary",
+					UsedPercent:   80,
+					WindowSeconds: 18000,
+				}},
+			}},
+		},
+	}
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetReplyFooterEnabled(true)
+
+	sessionKey := "telegram:user-footer-runtime"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-footer-runtime")
+	agentSession.model = "gpt-5.4"
+	agentSession.reasoningEffort = "xhigh"
+	agentSession.workDir = filepath.Join(homeDir, "codes", "cc-connect")
+	agentSession.report = &UsageReport{
+		Buckets: []UsageBucket{{
+			Name: "Rate limit",
+			Windows: []UsageWindow{{
+				Name:          "Primary",
+				UsedPercent:   0,
+				WindowSeconds: 18000,
+			}},
+		}},
+	}
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-footer-runtime",
+		agent:        agent,
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "answer", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-runtime", time.Now(), nil, nil, state.replyCtx)
+
+	sent := p.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent = %#v, want one final reply", sent)
+	}
+	want := "answer\n\n`gpt-5.4 · xhigh · 100% left · ~/codes/cc-connect`"
+	if sent[0] != want {
+		t.Fatalf("final reply = %q, want %q", sent[0], want)
+	}
+}
+
 func TestProcessInteractiveEvents_HiddenToolProgressKeepsPreviewOnFinalize(t *testing.T) {
 	p := &mockKeepPreviewPlatform{}
 	p.n = "feishu"
@@ -4708,10 +4770,15 @@ func TestHandlePendingPermission_AskUserQuestion_SkipsPermFlow(t *testing.T) {
 // controllableAgentSession is an AgentSession stub whose session ID, liveness,
 // and events channel can be controlled by the test.
 type controllableAgentSession struct {
-	sessionID string
-	alive     bool
-	events    chan Event
-	closed    chan struct{} // closed when Close() is called
+	sessionID       string
+	alive           bool
+	events          chan Event
+	closed          chan struct{} // closed when Close() is called
+	model           string
+	reasoningEffort string
+	workDir         string
+	report          *UsageReport
+	usageErr        error
 }
 
 func newControllableSession(id string) *controllableAgentSession {
@@ -4729,7 +4796,16 @@ func (s *controllableAgentSession) Send(_ string, _ []ImageAttachment, _ []FileA
 func (s *controllableAgentSession) RespondPermission(_ string, _ PermissionResult) error { return nil }
 func (s *controllableAgentSession) Events() <-chan Event                                 { return s.events }
 func (s *controllableAgentSession) CurrentSessionID() string                             { return s.sessionID }
-func (s *controllableAgentSession) Alive() bool                                          { return s.alive }
+func (s *controllableAgentSession) GetModel() string                                     { return s.model }
+func (s *controllableAgentSession) GetReasoningEffort() string                           { return s.reasoningEffort }
+func (s *controllableAgentSession) GetWorkDir() string                                   { return s.workDir }
+func (s *controllableAgentSession) GetUsage(_ context.Context) (*UsageReport, error) {
+	if s.report == nil && s.usageErr == nil {
+		return nil, fmt.Errorf("usage unavailable")
+	}
+	return s.report, s.usageErr
+}
+func (s *controllableAgentSession) Alive() bool { return s.alive }
 func (s *controllableAgentSession) Close() error {
 	s.alive = false
 	close(s.events)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -557,6 +557,25 @@ func (a *stubUsageAgent) GetUsage(_ context.Context) (*UsageReport, error) {
 	return a.report, a.err
 }
 
+type stubReplyFooterAgent struct {
+	stubModelModeAgent
+	workDir string
+	report  *UsageReport
+	err     error
+}
+
+func (a *stubReplyFooterAgent) SetWorkDir(dir string) {
+	a.workDir = dir
+}
+
+func (a *stubReplyFooterAgent) GetWorkDir() string {
+	return a.workDir
+}
+
+func (a *stubReplyFooterAgent) GetUsage(_ context.Context) (*UsageReport, error) {
+	return a.report, a.err
+}
+
 func newTestEngine() *Engine {
 	return NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
 }
@@ -899,6 +918,54 @@ func TestProcessInteractiveEvents_DoesNotSuppressDifferentFinalText(t *testing.T
 	}
 	if got := p.getSent()[1]; got != finalText {
 		t.Fatalf("final sent text = %q, want %q", got, finalText)
+	}
+}
+
+func TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	agent := &stubReplyFooterAgent{
+		stubModelModeAgent: stubModelModeAgent{
+			model:           "gpt-5.4",
+			reasoningEffort: "xhigh",
+		},
+		workDir: filepath.Join(homeDir, "codes", "cc-connect"),
+		report: &UsageReport{
+			Buckets: []UsageBucket{{
+				Name: "Rate limit",
+				Windows: []UsageWindow{{
+					Name:          "Primary",
+					UsedPercent:   0,
+					WindowSeconds: 18000,
+				}},
+			}},
+		},
+	}
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetReplyFooterEnabled(true)
+
+	sessionKey := "telegram:user-footer"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-footer")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-footer",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "answer", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer", time.Now(), nil, nil, state.replyCtx)
+
+	sent := p.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent = %#v, want one final reply", sent)
+	}
+	want := "answer\n\n`gpt-5.4 · xhigh · 100% left · ~/codes/cc-connect`"
+	if sent[0] != want {
+		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1058,7 +1058,8 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 		}},
 	}
 	agentSession.contextUsage = &ContextUsage{
-		TotalTokens:   14840,
+		UsedTokens:    181424,
+		TotalTokens:   50821769,
 		ContextWindow: 258400,
 	}
 	state := &interactiveState{
@@ -1076,7 +1077,7 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 	if len(sent) != 1 {
 		t.Fatalf("sent = %#v, want one final reply", sent)
 	}
-	want := "answer\n\n*gpt-5.4 · xhigh · 95% left · ~/codes/cc-connect*"
+	want := "answer\n\n*gpt-5.4 · xhigh · 30% left · ~/codes/cc-connect*"
 	if sent[0] != want {
 		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1057,6 +1057,10 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 			}},
 		}},
 	}
+	agentSession.contextUsage = &ContextUsage{
+		TotalTokens:   14840,
+		ContextWindow: 258400,
+	}
 	state := &interactiveState{
 		agentSession: agentSession,
 		platform:     p,
@@ -1072,7 +1076,7 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 	if len(sent) != 1 {
 		t.Fatalf("sent = %#v, want one final reply", sent)
 	}
-	want := "answer\n\n*gpt-5.4 · xhigh · 100% left · ~/codes/cc-connect*"
+	want := "answer\n\n*gpt-5.4 · xhigh · 95% left · ~/codes/cc-connect*"
 	if sent[0] != want {
 		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}
@@ -4778,6 +4782,7 @@ type controllableAgentSession struct {
 	reasoningEffort string
 	workDir         string
 	report          *UsageReport
+	contextUsage    *ContextUsage
 	usageErr        error
 }
 
@@ -4805,7 +4810,8 @@ func (s *controllableAgentSession) GetUsage(_ context.Context) (*UsageReport, er
 	}
 	return s.report, s.usageErr
 }
-func (s *controllableAgentSession) Alive() bool { return s.alive }
+func (s *controllableAgentSession) GetContextUsage() *ContextUsage { return s.contextUsage }
+func (s *controllableAgentSession) Alive() bool                    { return s.alive }
 func (s *controllableAgentSession) Close() error {
 	s.alive = false
 	close(s.events)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1058,9 +1058,10 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 		}},
 	}
 	agentSession.contextUsage = &ContextUsage{
-		UsedTokens:    181424,
-		TotalTokens:   50821769,
-		ContextWindow: 258400,
+		UsedTokens:     181424,
+		BaselineTokens: 12000,
+		TotalTokens:    50821769,
+		ContextWindow:  258400,
 	}
 	state := &interactiveState{
 		agentSession: agentSession,
@@ -1077,7 +1078,7 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 	if len(sent) != 1 {
 		t.Fatalf("sent = %#v, want one final reply", sent)
 	}
-	want := "answer\n\n*gpt-5.4 · xhigh · 30% left · ~/codes/cc-connect*"
+	want := "answer\n\n*gpt-5.4 · xhigh · 31% left · ~/codes/cc-connect*"
 	if sent[0] != want {
 		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -969,6 +969,53 @@ func TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestProcessInteractiveEvents_DoesNotAppendReplyFooterWhenDisabled(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	agent := &stubReplyFooterAgent{
+		stubModelModeAgent: stubModelModeAgent{
+			model:           "gpt-5.4",
+			reasoningEffort: "xhigh",
+		},
+		workDir: filepath.Join(homeDir, "codes", "cc-connect"),
+		report: &UsageReport{
+			Buckets: []UsageBucket{{
+				Name: "Rate limit",
+				Windows: []UsageWindow{{
+					Name:          "Primary",
+					UsedPercent:   0,
+					WindowSeconds: 18000,
+				}},
+			}},
+		},
+	}
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetReplyFooterEnabled(false)
+
+	sessionKey := "telegram:user-footer-off"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-footer-off")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-footer-off",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "answer", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-off", time.Now(), nil, nil, state.replyCtx)
+
+	sent := p.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent = %#v, want one final reply", sent)
+	}
+	if sent[0] != "answer" {
+		t.Fatalf("final reply = %q, want plain answer without footer", sent[0])
+	}
+}
+
 func TestProcessInteractiveEvents_HiddenToolProgressKeepsPreviewOnFinalize(t *testing.T) {
 	p := &mockKeepPreviewPlatform{}
 	p.n = "feishu"

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -963,7 +963,7 @@ func TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled(t *testing.T) {
 	if len(sent) != 1 {
 		t.Fatalf("sent = %#v, want one final reply", sent)
 	}
-	want := "answer\n\n`gpt-5.4 · xhigh · 100% left · ~/codes/cc-connect`"
+	want := "answer\n\n*gpt-5.4 · xhigh · 100% left · ~/codes/cc-connect*"
 	if sent[0] != want {
 		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}
@@ -1072,7 +1072,7 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 	if len(sent) != 1 {
 		t.Fatalf("sent = %#v, want one final reply", sent)
 	}
-	want := "answer\n\n`gpt-5.4 · xhigh · 100% left · ~/codes/cc-connect`"
+	want := "answer\n\n*gpt-5.4 · xhigh · 100% left · ~/codes/cc-connect*"
 	if sent[0] != want {
 		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -239,7 +239,8 @@ const (
 	MsgCronBtnUnmute    MsgKey = "cron_btn_unmute"
 	MsgCronBtnDelete    MsgKey = "cron_btn_delete"
 
-	MsgStatusTitle MsgKey = "status_title"
+	MsgStatusTitle          MsgKey = "status_title"
+	MsgReplyFooterRemaining MsgKey = "reply_footer_remaining"
 
 	MsgModelCurrent          MsgKey = "model_current"
 	MsgModelChanged          MsgKey = "model_changed"
@@ -392,10 +393,10 @@ const (
 	MsgAliasNotFound   MsgKey = "alias_not_found"
 	MsgAliasUsage      MsgKey = "alias_usage"
 
-	MsgNewSessionCreated     MsgKey = "new_session_created"
-	MsgNewSessionCreatedName MsgKey = "new_session_created_name"
-	MsgSessionAutoResetIdle     MsgKey = "session_auto_reset_idle"
-	MsgSessionClosingGraceful   MsgKey = "session_closing_graceful"
+	MsgNewSessionCreated      MsgKey = "new_session_created"
+	MsgNewSessionCreatedName  MsgKey = "new_session_created_name"
+	MsgSessionAutoResetIdle   MsgKey = "session_auto_reset_idle"
+	MsgSessionClosingGraceful MsgKey = "session_closing_graceful"
 
 	MsgDeleteUsage              MsgKey = "delete_usage"
 	MsgDeleteSuccess            MsgKey = "delete_success"
@@ -492,8 +493,8 @@ const (
 	MsgBuiltinCmdDir       MsgKey = "dir"
 	MsgBuiltinCmdDiff      MsgKey = "diff"
 
-	MsgDiffEmpty           MsgKey = "diff_empty"
-	MsgDiffNoDiff2HTML     MsgKey = "diff_no_diff2html"
+	MsgDiffEmpty       MsgKey = "diff_empty"
+	MsgDiffNoDiff2HTML MsgKey = "diff_no_diff2html"
 
 	MsgDirChanged          MsgKey = "dir_changed"
 	MsgDirCurrent          MsgKey = "dir_current"
@@ -1802,6 +1803,13 @@ var messages = map[MsgKey]map[Language]string{
 			"Tiempo activo: %s\n" +
 			"Idioma: %s\n" +
 			"%s" + "%s" + "%s" + "%s" + "%s",
+	},
+	MsgReplyFooterRemaining: {
+		LangEnglish:            "%d%% left",
+		LangChinese:            "剩余 %d%%",
+		LangTraditionalChinese: "剩餘 %d%%",
+		LangJapanese:           "残り %d%%",
+		LangSpanish:            "%d%% restante",
 	},
 	MsgModelCurrent: {
 		LangEnglish:            "Current model: %s",

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -1806,10 +1806,10 @@ var messages = map[MsgKey]map[Language]string{
 	},
 	MsgReplyFooterRemaining: {
 		LangEnglish:            "%d%% left",
-		LangChinese:            "剩余 %d%%",
-		LangTraditionalChinese: "剩餘 %d%%",
-		LangJapanese:           "残り %d%%",
-		LangSpanish:            "%d%% restante",
+		LangChinese:            "%d%% left",
+		LangTraditionalChinese: "%d%% left",
+		LangJapanese:           "%d%% left",
+		LangSpanish:            "%d%% left",
 	},
 	MsgModelCurrent: {
 		LangEnglish:            "Current model: %s",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -357,6 +357,9 @@ type ContextUsageReporter interface {
 
 // ContextUsage describes runtime context consumption for the active session.
 type ContextUsage struct {
+	// UsedTokens is the current token load to compare against ContextWindow when
+	// computing remaining context capacity for the next turn.
+	UsedTokens            int
 	TotalTokens           int
 	InputTokens           int
 	CachedInputTokens     int

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -349,6 +349,22 @@ type UsageCredits struct {
 	Balance    string
 }
 
+// ContextUsageReporter is an optional interface for running agent sessions that
+// can report real runtime context usage for the active conversation.
+type ContextUsageReporter interface {
+	GetContextUsage() *ContextUsage
+}
+
+// ContextUsage describes runtime context consumption for the active session.
+type ContextUsage struct {
+	TotalTokens           int
+	InputTokens           int
+	CachedInputTokens     int
+	OutputTokens          int
+	ReasoningOutputTokens int
+	ContextWindow         int
+}
+
 // ContextCompressor is an optional interface for agents that support
 // compressing/compacting the conversation context within a running session.
 // CompressCommand returns the native slash command (e.g. "/compact", "/compress")

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -359,7 +359,11 @@ type ContextUsageReporter interface {
 type ContextUsage struct {
 	// UsedTokens is the current token load to compare against ContextWindow when
 	// computing remaining context capacity for the next turn.
-	UsedTokens            int
+	UsedTokens int
+	// BaselineTokens is the portion of the context window always occupied by
+	// fixed runtime/system instructions and therefore excluded from user-visible
+	// "left" calculations when the agent provides it.
+	BaselineTokens        int
 	TotalTokens           int
 	InputTokens           int
 	CachedInputTokens     int


### PR DESCRIPTION
## Summary
- add an optional Codex-style reply footer that can show model, reasoning effort, remaining context, and workdir
- enable `reply_footer` by default and source footer metadata from live Codex runtime state instead of config snapshots
- compute context `left` from real `last_token_usage` and match Codex CLI semantics, including the baseline-token adjustment and rounding behavior

## Details
- add footer metadata plumbing in `core` and wire it through config / engine rendering
- teach the Codex app-server session and exec session paths to expose runtime model / effort / workdir / context usage
- use English `"% left"` footer wording and keep the footer visually subdued
- add regression coverage for runtime footer rendering and the Codex context-left calculation

## Testing
- `go test ./core ./agent/codex`
- `go test ./...`
