### PR TITLE
feat(feishu): add done_emoji reaction after streaming preview updates

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -690,6 +690,8 @@ app_secret = "your-feishu-app-secret"
 #                              # 允许的用户 open_id，逗号分隔；"*" 表示所有（默认）。发送 /whoami 获取你的 open_id。
 # reaction_emoji = "OnIt"  # Emoji reaction on incoming messages (default: "OnIt"); set to "none" to disable
 #                           # 收到消息时添加的表情回复（默认 "OnIt"）；设为 "none" 可禁用
+# done_emoji = "none"       # Emoji reaction after agent finishes streaming work in quiet mode (e.g. "Done"); set to "none" to disable
+#                           # Agent 在 quiet 模式下完成流式工作后的表情回复（如 "Done"）；设为 "none" 可禁用
 # group_reply_all = false   # If true, respond to ALL group messages without requiring @mention
 #                           # 设为 true 时，群聊中无需 @机器人 也会响应所有消息（默认 false）
 # share_session_in_channel = false  # If true, all users in a group share one agent session
@@ -724,6 +726,7 @@ app_secret = "your-feishu-app-secret"
 # enable_feishu_card = true
 # allow_from = "*"
 # reaction_emoji = "OnIt"
+# done_emoji = "none"
 # progress_style = "legacy"  # legacy | compact | card
 
 # DingTalk / 钉钉 (uncomment to enable / 取消注释以启用)

--- a/core/engine.go
+++ b/core/engine.go
@@ -2279,9 +2279,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	// stopTyping tracks the current turn's typing indicator so it can be
 	// stopped when a queued message starts a new turn.
 	stopTyping := stopTypingFn
+	// doneReaction stores a function to add a "done" emoji after stopTyping.
+	// Set during EventResult handling for multi-round quiet turns.
+	var doneReaction func()
 	defer func() {
 		if stopTyping != nil {
 			stopTyping()
+		}
+		if doneReaction != nil {
+			doneReaction()
 		}
 	}()
 
@@ -2743,6 +2749,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				if ti, ok := queued.platform.(TypingIndicator); ok {
 					stopTyping = ti.StartTyping(e.ctx, queued.replyCtx)
 				}
+				// Agent continues working — don't add done reaction for this turn.
+				doneReaction = nil
 
 				// Drain stale events before starting the next turn. Between
 				// EventResult and Send(), the only buffered events would be
@@ -2805,6 +2813,18 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					slog.Debug("async send error after EventResult", "error", err)
 				}
 			}
+
+			// When the preview was updated in-place at least once (e.g. Feishu card
+			// streaming), the user only saw a push for the initial send and subsequent
+			// updates were silent. Add a "done" reaction so they know the agent finished.
+			// The reaction is added after stopTyping (deferred) so the doing emoji
+			// is removed first.
+			if sp.needsDoneReaction() {
+				if doneTI, ok := p.(TypingIndicatorDone); ok {
+					doneReaction = func() { doneTI.AddDoneReaction(replyCtx) }
+				}
+			}
+
 			return
 
 		case EventError:

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -126,6 +126,14 @@ type TypingIndicator interface {
 	StartTyping(ctx context.Context, replyCtx any) (stop func())
 }
 
+// TypingIndicatorDone is an optional interface for platforms that can show a
+// "done" reaction after processing completes. The engine calls AddDoneReaction
+// when the agent finishes a multi-round turn in quiet mode, so the user gets
+// a push notification (e.g. Feishu card edits don't trigger pushes).
+type TypingIndicatorDone interface {
+	AddDoneReaction(replyCtx any)
+}
+
 // ImageSender is an optional interface for platforms that support sending images.
 type ImageSender interface {
 	SendImage(ctx context.Context, replyCtx any, img ImageAttachment) error

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -366,3 +366,13 @@ func (sp *streamPreview) detachPreview() {
 	defer sp.mu.Unlock()
 	sp.previewMsgID = nil
 }
+
+// needsDoneReaction returns true if the preview was delivered via in-place
+// UpdateMessage at least once, meaning the user only received a push for the
+// initial SendPreviewStart and subsequent updates were silent. In this case a
+// "done" reaction can notify the user that processing has completed.
+func (sp *streamPreview) needsDoneReaction() bool {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.previewMsgID != nil && sp.lastSentViaUpdate
+}

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -111,12 +111,14 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # enable_feishu_card = true  # 可选：关闭后统一回退纯文本回复
 # thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
 # progress_style = "legacy"  # 可选：legacy | compact | card
+# done_emoji = "none"          # 可选：quiet 模式下 agent 流式工作完成后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 ```
 
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
 > 如果开启 `thread_isolation = true`，群聊里每个根消息 / reply thread 会对应一个独立 agent session；私聊行为保持原样。
 > `progress_style = "compact"` 会把思考/工具进度合并到一条可更新消息里，减少刷屏；`legacy` 保持原有逐条发送；`card` 会使用结构化卡片（标题 + 进度块）持续更新同一条消息，观感比纯文本更清晰。
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
+> `done_emoji` 仅在 quiet 模式下、飞书卡片被流式更新过（通过 UpdateMessage 原地编辑）时生效：先移除 "OnIt" 表情，再添加你指定的 done 表情，这样用户能收到飞书推送通知。飞书卡片原地更新本身不会触发推送，所以 quiet 模式下用户可能不知道 agent 已完成。单轮纯文本回复（只通过 SendPreviewStart 发送）不会触发此行为。设为 `"none"` 或不配置则禁用。
 
 ---
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -118,6 +118,7 @@ type Platform struct {
 	useInteractiveCard         bool
 	self                       core.Platform
 	reactionEmoji              string
+	doneEmoji                  string
 	allowFrom                  string
 	groupReplyAll              bool
 	respondToAtEveryoneAndHere bool
@@ -180,6 +181,10 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	if v, ok := opts["reaction_emoji"].(string); ok && v == "none" {
 		reactionEmoji = ""
 	}
+	doneEmoji, _ := opts["done_emoji"].(string)
+	if doneEmoji == "none" {
+		doneEmoji = ""
+	}
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom(name, allowFrom)
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
@@ -231,6 +236,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		progressStyle:              progressStyle,
 		useInteractiveCard:         useInteractiveCard,
 		reactionEmoji:              reactionEmoji,
+		doneEmoji:                  doneEmoji,
 		allowFrom:                  allowFrom,
 		groupReplyAll:              groupReplyAll,
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
@@ -585,10 +591,13 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 }
 
 func (p *Platform) addReaction(messageID string) string {
-	if p.reactionEmoji == "" {
+	return p.addReactionWithEmoji(messageID, p.reactionEmoji)
+}
+
+func (p *Platform) addReactionWithEmoji(messageID, emojiType string) string {
+	if emojiType == "" {
 		return ""
 	}
-	emojiType := p.reactionEmoji
 	resp, err := p.client.Im.MessageReaction.Create(context.Background(),
 		larkim.NewCreateMessageReactionReqBuilder().
 			MessageId(messageID).
@@ -639,6 +648,19 @@ func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
 	return func() {
 		go p.removeReaction(rc.messageID, reactionID)
 	}
+}
+
+// AddDoneReaction adds a "done" emoji reaction so the user gets a push
+// notification when the agent finishes a multi-round turn in quiet mode.
+func (p *Platform) AddDoneReaction(rctx any) {
+	if p.doneEmoji == "" {
+		return
+	}
+	rc, ok := rctx.(replyContext)
+	if !ok || rc.messageID == "" {
+		return
+	}
+	go p.addReactionWithEmoji(rc.messageID, p.doneEmoji)
 }
 
 func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) error {


### PR DESCRIPTION
## Summary
- Adds a done reaction after the "OnIt" reaction is removed when the agent completes a streaming preview update in quiet mode
- Users receive a push notification from the done reaction, since Feishu card edits don't trigger pushes
- Add configurable `done_emoji` option for Feishu platform (e.g. `done_emoji = "Done"`)
## How it works
- New `TypingIndicatorDone` interface in core (platform-agnostic)
- Engine checks `sp.needsDoneReaction()` at the end of each turn and returns true only when the preview card was updated in-place via `UpdateMessage` (streaming)
- Feishu implements `AddDoneReaction` to add the configured done emoji
- The reaction is added **after** `stopTyping` (doing emoji removed first, then done emoji appears)
## Activation conditions
- Only when the preview card was streamed in-place (via UpdateMessage)
- Single-round responses (only SendPreviewStart) are unaffected — the initial send already triggers a push
- Non-quiet mode is unaffected, intermediate messages (thinking/tool) trigger pushes and cause `sp.freeze()` which prevents `needsDoneReaction` from returning true
- Default disabled (`none`), users opt in by setting `done_emoji`
## Test plan
- [x] `go test ./...` passes (web/ failure is pre-existing, missing frontend dist)
- [x] Manual test: quiet mode + multi-round tool use → done reaction appears
- [x] Manual test: single-round text response → no done reaction
- [x] Manual test: non-quiet mode → no done reaction