### PR TITLE
fix(core): avoid placeholder session in /new command

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3512,11 +3512,14 @@ func (e *Engine) cmdNew(p Platform, msg *Message, args []string) {
 	e.cleanupInteractiveState(interactiveKey)
 	slog.Info("cmdNew: cleanup done, creating new session", "session_key", msg.SessionKey)
 
-	// Clear old session's agent session ID so it cannot be resumed
-	old := sessions.GetOrCreateActive(msg.SessionKey)
-	old.SetAgentSessionID("", "")
-	old.ClearHistory()
-	sessions.Save()
+	// Clear old session's agent session ID so it cannot be resumed.
+	// Only do this if there's an existing session; don't create a placeholder.
+	old := sessions.GetActive(msg.SessionKey)
+	if old != nil {
+		old.SetAgentSessionID("", "")
+		old.ClearHistory()
+		sessions.Save()
+	}
 
 	name := ""
 	if len(args) > 0 {

--- a/core/session.go
+++ b/core/session.go
@@ -222,6 +222,17 @@ func (sm *SessionManager) GetOrCreateActive(userKey string) *Session {
 	return s
 }
 
+// GetActive returns the current active session for userKey, or nil if none exists.
+// Unlike GetOrCreateActive, this does not create a placeholder session.
+func (sm *SessionManager) GetActive(userKey string) *Session {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	if sid, ok := sm.activeSession[userKey]; ok {
+		return sm.sessions[sid]
+	}
+	return nil
+}
+
 func (sm *SessionManager) NewSession(userKey, name string) *Session {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()


### PR DESCRIPTION
## Summary
- `/new <name>` was creating two sessions due to `GetOrCreateActive` creating a placeholder
- Added `GetActive` method to return existing session without creating new one
- Updated `cmdNew` to use `GetActive`, only clearing session if one exists

## Root cause
The flow was:
1. `GetOrCreateActive(msg.SessionKey)` → creates placeholder s44 (name="default", no agent_session_id)
2. Clear placeholder's agent_session_id and history (pointless on placeholder)
3. `NewSession(msg.SessionKey, "example")` → creates s45 (name="example")
4. On first message, agent_session_id set on s45, but sessionNames not synced (placeholder s44 broke the chain)

## Fix
- Only clear existing session if there is one (use `GetActive` → returns nil if none)
- This prevents placeholder creation and ensures single session flow

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./core/...` passes
- [ ] Manual: `/new example` on fresh session key should create exactly one session

Fixes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)