### PR TITLE
fix(tts): don't send empty language_type to Qwen TTS API

### DIFF
--- a/core/tts.go
+++ b/core/tts.go
@@ -101,12 +101,15 @@ func (q *QwenTTS) Synthesize(ctx context.Context, text string, opts TTSSynthesis
 	}
 	reqBody := map[string]any{
 		"model": q.Model,
-		"input": map[string]any{
-			"text":          text,
-			"voice":         voice,
-			"language_type": opts.LanguageType,
-		},
 	}
+	input := map[string]any{
+		"text":  text,
+		"voice": voice,
+	}
+	if opts.LanguageType != "" {
+		input["language_type"] = opts.LanguageType
+	}
+	reqBody["input"] = input
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, "", fmt.Errorf("qwen tts: marshal request: %w", err)


### PR DESCRIPTION
## Problem

  The Qwen TTS (DashScope) API rejects empty string values for the `language_type` parameter with a 400 InvalidParameter
   error. The field is optional — when omitted, the API auto-detects the language from the input text.

  Previously, `QwenTTS.Synthesize` always included `language_type` in the JSON request body, even when
  `opts.LanguageType` was empty (the default value from `engine.go`'s `sendTTSReply`). This caused all TTS synthesis to
  fail with:

    qwen tts API 400: InvalidParameter: Input should be 'Auto', 'Chinese', 'English', ... : input.language_type

  ## Fix

  Only include `language_type` in the request when it is explicitly set (non-empty). When empty, the field is omitted
  entirely, letting the API auto-detect the language.

  This aligns the implementation with the `TTSSynthesisOpts` struct comment:
    LanguageType string  // e.g. "Chinese", "English"; empty = auto-detect

  ## Testing

  All existing tests pass:
    TestQwenTTS_Success --- PASS
    TestQwenTTS_APIError --- PASS
    TestQwenTTS_BusinessErrorCode --- PASS
    TestQwenTTS_EmptyAudioURL --- PASS

  ## Impact

  - Fixes TTS on Feishu platform with Qwen provider
  - No impact on other TTS providers (OpenAI, MiniMax, etc.)
  - Backward compatible: explicitly set language_type values are still passed through