### PR TITLE
fix(claudecode): unblock readLoop when child subprocesses hold stdout pipe

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -193,6 +193,8 @@ func (cs *claudeSession) startReadLoopWait(stdout io.ReadCloser) (<-chan error, 
 	go func() {
 		select {
 		case <-cs.ctx.Done():
+			_ = stdout.Close()
+			return
 		case <-waitDone:
 		}
 

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -228,8 +228,9 @@ func (cs *claudeSession) finishReadLoop(waitErrCh <-chan error, stderrBuf *bytes
 			select {
 			case cs.events <- evt:
 			case <-cs.ctx.Done():
-				// Fall through: events and done must still be closed so
-				// the engine event loop sees the session ending.
+				// INVARIANT: readLoop must close cs.events and cs.done exactly once
+				// on every termination path. Callers (engine event loop) rely on
+				// these closures to observe session end.
 			}
 		}
 	}

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -194,6 +194,16 @@ func (cs *claudeSession) startReadLoopWait(stdout io.ReadCloser) (<-chan error, 
 		case <-cs.ctx.Done():
 		case <-waitDone:
 		}
+		
+		// Grace period: give scanner a brief window to drain any data the
+		// agent wrote to the pipe buffer before exiting. If scanner finishes
+		// on its own (pipe fully closed, no descendants holding it),
+		// cs.done fires first and we skip the force-close entirely
+		select {
+		case<-cs.done:
+				return
+		case<-time.After(500*time.Millisecond):
+		}
 		_ = stdout.Close()
 	}()
 

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -169,72 +169,117 @@ func newClaudeSession(ctx context.Context, workDir, model, effort, sessionID, mo
 }
 
 func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
-	defer func() {
-		cs.alive.Store(false)
-		// Always close stdout to unblock any future reads
-		_ = stdout.Close()
-		// Wait for process to exit (this is needed to release resources)
-		if err := cs.cmd.Wait(); err != nil {
-			stderrMsg := strings.TrimSpace(stderrBuf.String())
-			if stderrMsg != "" {
-				slog.Error("claudeSession: process failed", "error", err, "stderr", stderrMsg)
-				evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
-				// Try to send error event, but don't block if context is cancelled
-				select {
-				case cs.events <- evt:
-				case <-cs.ctx.Done():
-					// Context cancelled, proceed to close channels anyway
-				}
-			}
-		}
-		// Always close channels - no early returns above should skip this
-		close(cs.events)
-		close(cs.done)
-	}()
+	waitErrCh, waitDone := cs.startReadLoopWait(stdout)
+	defer cs.finishReadLoop(waitErrCh, stderrBuf)
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
+	scanner := cs.newReadLoopScanner(stdout)
 	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
-		var raw map[string]any
-		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			slog.Debug("claudeSession: non-JSON line", "line", line)
-			continue
-		}
-
-		eventType, _ := raw["type"].(string)
-		slog.Debug("claudeSession: event", "type", eventType)
-
-		switch eventType {
-		case "system":
-			cs.handleSystem(raw)
-		case "assistant":
-			cs.handleAssistant(raw)
-		case "user":
-			cs.handleUser(raw)
-		case "result":
-			cs.handleResult(raw)
-		case "control_request":
-			cs.handleControlRequest(raw)
-		case "control_cancel_request":
-			requestID, _ := raw["request_id"].(string)
-			slog.Debug("claudeSession: permission cancelled", "request_id", requestID)
-		}
+		cs.handleReadLoopLine(scanner.Text())
 	}
 
-	if err := scanner.Err(); err != nil {
-		slog.Error("claudeSession: scanner error", "error", err)
-		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
+	cs.handleReadLoopScanErr(scanner.Err(), waitDone)
+}
+
+func (cs *claudeSession) startReadLoopWait(stdout io.ReadCloser) (<-chan error, <-chan struct{}) {
+	waitErrCh := make(chan error, 1)
+	waitDone := make(chan struct{})
+
+	go func() {
+		waitErrCh <- cs.cmd.Wait()
+		close(waitDone)
+	}()
+
+	go func() {
 		select {
-		case cs.events <- evt:
 		case <-cs.ctx.Done():
-			return
+		case <-waitDone:
 		}
+		_ = stdout.Close()
+	}()
+
+	return waitErrCh, waitDone
+}
+
+func (cs *claudeSession) finishReadLoop(waitErrCh <-chan error, stderrBuf *bytes.Buffer) {
+	err := <-waitErrCh
+
+	cs.alive.Store(false)
+	if err != nil {
+		stderrMsg := ""
+		if stderrBuf != nil {
+			stderrMsg = strings.TrimSpace(stderrBuf.String())
+		}
+		if stderrMsg != "" {
+			slog.Error("claudeSession: process failed", "error", err, "stderr", stderrMsg)
+			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
+			select {
+			case cs.events <- evt:
+			case <-cs.ctx.Done():
+				// Fall through: events and done must still be closed so
+				// the engine event loop sees the session ending.
+			}
+		}
+	}
+	close(cs.events)
+	close(cs.done)
+}
+
+func (cs *claudeSession) newReadLoopScanner(stdout io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	return scanner
+}
+
+func (cs *claudeSession) handleReadLoopScanErr(err error, waitDone <-chan struct{}) {
+	if err == nil {
+		return
+	}
+
+	select {
+	case <-cs.ctx.Done():
+		return
+	case <-waitDone:
+		return
+	default:
+	}
+
+	slog.Error("claudeSession: scanner error", "error", err)
+	evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
+	select {
+	case cs.events <- evt:
+	case <-cs.ctx.Done():
+		return
+	}
+}
+
+func (cs *claudeSession) handleReadLoopLine(line string) {
+	if line == "" {
+		return
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		slog.Debug("claudeSession: non-JSON line", "line", line)
+		return
+	}
+
+	eventType, _ := raw["type"].(string)
+	slog.Debug("claudeSession: event", "type", eventType)
+
+	switch eventType {
+	case "system":
+		cs.handleSystem(raw)
+	case "assistant":
+		cs.handleAssistant(raw)
+	case "user":
+		cs.handleUser(raw)
+	case "result":
+		cs.handleResult(raw)
+	case "control_request":
+		cs.handleControlRequest(raw)
+	case "control_cancel_request":
+		requestID, _ := raw["request_id"].(string)
+		slog.Debug("claudeSession: permission cancelled", "request_id", requestID)
 	}
 }
 

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -169,48 +169,31 @@ func newClaudeSession(ctx context.Context, workDir, model, effort, sessionID, mo
 }
 
 func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
-	waitErrCh, waitDone := cs.startReadLoopWait(stdout)
-	defer cs.finishReadLoop(waitErrCh, stderrBuf)
+	var waitErr error
+	defer func() {
+		cs.finishReadLoop(waitErr, stderrBuf)
+	}()
 
 	scanner := cs.newReadLoopScanner(stdout)
 	for scanner.Scan() {
 		cs.handleReadLoopLine(scanner.Text())
 	}
 
-	cs.handleReadLoopScanErr(scanner.Err(), waitDone)
+	cs.handleReadLoopScanErr(scanner.Err())
+	waitErr = cs.cmd.Wait()
 }
 
-func (cs *claudeSession) startReadLoopWait(stdout io.ReadCloser) (<-chan error, <-chan struct{}) {
-	waitErrCh := make(chan error, 1)
-	waitDone := make(chan struct{})
-
-	go func() {
-		waitErrCh <- cs.cmd.Wait()
-		close(waitDone)
-	}()
-
-	go func() {
-		select {
-		case <-cs.ctx.Done():
-		case <-waitDone:
-		}
-		_ = stdout.Close()
-	}()
-
-	return waitErrCh, waitDone
-}
-
-func (cs *claudeSession) finishReadLoop(waitErrCh <-chan error, stderrBuf *bytes.Buffer) {
-	err := <-waitErrCh
-
+func (cs *claudeSession) finishReadLoop(waitErr error, stderrBuf *bytes.Buffer) {
 	cs.alive.Store(false)
-	if err != nil {
+
+	if waitErr != nil {
 		stderrMsg := ""
 		if stderrBuf != nil {
 			stderrMsg = strings.TrimSpace(stderrBuf.String())
 		}
+
 		if stderrMsg != "" {
-			slog.Error("claudeSession: process failed", "error", err, "stderr", stderrMsg)
+			slog.Error("claudeSession: process failed", "error", waitErr, "stderr", stderrMsg)
 			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
 			select {
 			case cs.events <- evt:
@@ -230,17 +213,13 @@ func (cs *claudeSession) newReadLoopScanner(stdout io.Reader) *bufio.Scanner {
 	return scanner
 }
 
-func (cs *claudeSession) handleReadLoopScanErr(err error, waitDone <-chan struct{}) {
+func (cs *claudeSession) handleReadLoopScanErr(err error) {
 	if err == nil {
 		return
 	}
 
-	select {
-	case <-cs.ctx.Done():
+	if(cs.ctx.Err() != nil) {
 		return
-	case <-waitDone:
-		return
-	default:
 	}
 
 	slog.Error("claudeSession: scanner error", "error", err)
@@ -248,8 +227,7 @@ func (cs *claudeSession) handleReadLoopScanErr(err error, waitDone <-chan struct
 	select {
 	case cs.events <- evt:
 	case <-cs.ctx.Done():
-		return
-	}
+	} 
 }
 
 func (cs *claudeSession) handleReadLoopLine(line string) {

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -195,15 +195,15 @@ func (cs *claudeSession) startReadLoopWait(stdout io.ReadCloser) (<-chan error, 
 		case <-cs.ctx.Done():
 		case <-waitDone:
 		}
-		
+
 		// Grace period: give scanner a brief window to drain any data the
 		// agent wrote to the pipe buffer before exiting. If scanner finishes
 		// on its own (pipe fully closed, no descendants holding it),
 		// cs.done fires first and we skip the force-close entirely
 		select {
-		case<-cs.done:
+		case <-cs.done:
 			return
-		case<-time.After(50 * time.Millisecond):
+		case <-time.After(50 * time.Millisecond):
 		}
 		_ = stdout.Close()
 	}()

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -172,7 +172,8 @@ func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer)
 	waitErrCh, waitDone := cs.startReadLoopWait(stdout)
 	defer cs.finishReadLoop(waitErrCh, stderrBuf)
 
-	scanner := cs.newReadLoopScanner(stdout)
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	for scanner.Scan() {
 		cs.handleReadLoopLine(scanner.Text())
 	}
@@ -201,8 +202,8 @@ func (cs *claudeSession) startReadLoopWait(stdout io.ReadCloser) (<-chan error, 
 		// cs.done fires first and we skip the force-close entirely
 		select {
 		case<-cs.done:
-				return
-		case<-time.After(500*time.Millisecond):
+			return
+		case<-time.After(50 * time.Millisecond):
 		}
 		_ = stdout.Close()
 	}()
@@ -232,12 +233,6 @@ func (cs *claudeSession) finishReadLoop(waitErrCh <-chan error, stderrBuf *bytes
 	}
 	close(cs.events)
 	close(cs.done)
-}
-
-func (cs *claudeSession) newReadLoopScanner(stdout io.Reader) *bufio.Scanner {
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-	return scanner
 }
 
 func (cs *claudeSession) handleReadLoopScanErr(err error, waitDone <-chan struct{}) {

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -169,31 +169,48 @@ func newClaudeSession(ctx context.Context, workDir, model, effort, sessionID, mo
 }
 
 func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
-	var waitErr error
-	defer func() {
-		cs.finishReadLoop(waitErr, stderrBuf)
-	}()
+	waitErrCh, waitDone := cs.startReadLoopWait(stdout)
+	defer cs.finishReadLoop(waitErrCh, stderrBuf)
 
 	scanner := cs.newReadLoopScanner(stdout)
 	for scanner.Scan() {
 		cs.handleReadLoopLine(scanner.Text())
 	}
 
-	cs.handleReadLoopScanErr(scanner.Err())
-	waitErr = cs.cmd.Wait()
+	cs.handleReadLoopScanErr(scanner.Err(), waitDone)
 }
 
-func (cs *claudeSession) finishReadLoop(waitErr error, stderrBuf *bytes.Buffer) {
-	cs.alive.Store(false)
+func (cs *claudeSession) startReadLoopWait(stdout io.ReadCloser) (<-chan error, <-chan struct{}) {
+	waitErrCh := make(chan error, 1)
+	waitDone := make(chan struct{})
 
-	if waitErr != nil {
+	go func() {
+		waitErrCh <- cs.cmd.Wait()
+		close(waitDone)
+	}()
+
+	go func() {
+		select {
+		case <-cs.ctx.Done():
+		case <-waitDone:
+		}
+		_ = stdout.Close()
+	}()
+
+	return waitErrCh, waitDone
+}
+
+func (cs *claudeSession) finishReadLoop(waitErrCh <-chan error, stderrBuf *bytes.Buffer) {
+	err := <-waitErrCh
+
+	cs.alive.Store(false)
+	if err != nil {
 		stderrMsg := ""
 		if stderrBuf != nil {
 			stderrMsg = strings.TrimSpace(stderrBuf.String())
 		}
-
 		if stderrMsg != "" {
-			slog.Error("claudeSession: process failed", "error", waitErr, "stderr", stderrMsg)
+			slog.Error("claudeSession: process failed", "error", err, "stderr", stderrMsg)
 			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
 			select {
 			case cs.events <- evt:
@@ -213,13 +230,17 @@ func (cs *claudeSession) newReadLoopScanner(stdout io.Reader) *bufio.Scanner {
 	return scanner
 }
 
-func (cs *claudeSession) handleReadLoopScanErr(err error) {
+func (cs *claudeSession) handleReadLoopScanErr(err error, waitDone <-chan struct{}) {
 	if err == nil {
 		return
 	}
 
-	if(cs.ctx.Err() != nil) {
+	select {
+	case <-cs.ctx.Done():
 		return
+	case <-waitDone:
+		return
+	default:
 	}
 
 	slog.Error("claudeSession: scanner error", "error", err)
@@ -227,7 +248,8 @@ func (cs *claudeSession) handleReadLoopScanErr(err error) {
 	select {
 	case cs.events <- evt:
 	case <-cs.ctx.Done():
-	} 
+		return
+	}
 }
 
 func (cs *claudeSession) handleReadLoopLine(line string) {

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -1,8 +1,10 @@
 package claudecode
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -69,11 +71,119 @@ func TestHandleResultNoUsage(t *testing.T) {
 	}
 }
 
+func TestReadLoop_ChildHoldsStdoutPipe(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pw.Close()
+	})
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(pw, `{"type":"system","session_id":"test-pipe"}`+"\n")
+		writeDone <- err
+	}()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^$")
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	cs := &claudeSession{
+		cmd:    cmd,
+		events: make(chan core.Event, 64),
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	cs.alive.Store(true)
+	go cs.readLoop(pr, &stderrBuf)
+
+	timeout := time.After(5 * time.Second)
+	gotEvent := false
+	for {
+		select {
+		case err := <-writeDone:
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeDone = nil
+		case evt, ok := <-cs.events:
+			if !ok {
+				if !gotEvent {
+					t.Fatal("events closed but system event lost")
+				}
+				return
+			}
+			if evt.SessionID == "test-pipe" {
+				gotEvent = true
+			}
+		case <-timeout:
+			t.Fatal("HANG: events not closed within 5s - readLoop stuck in scanner.Scan()")
+		}
+	}
+}
+
+func TestReadLoop_CtxCancelClosesChannels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pw.Close()
+	})
+
+	// "err-then-sleep" emits stderr before sleeping so that ctx cancel
+	// produces a non-empty stderrBuf in readLoop's defer — exercising the
+	// `case <-cs.ctx.Done()` select branch in finishReadLoop.
+	cmd := helperCommand(ctx, "err-then-sleep")
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	cs := &claudeSession{
+		cmd:    cmd,
+		events: make(chan core.Event, 64),
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	cs.alive.Store(true)
+	go cs.readLoop(pr, &stderrBuf)
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case _, ok := <-cs.events:
+			if !ok {
+				goto closed
+			}
+		case <-timeout:
+			t.Fatal("HANG: events not closed within 5s after ctx cancel")
+		}
+	}
+closed:
+	select {
+	case <-cs.done:
+	case <-timeout:
+		t.Fatal("HANG: done not closed within 5s after ctx cancel")
+	}
+}
+
 func TestClaudeSessionClose_IdempotentNoPanic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sleep", "120")
+	cmd := helperCommand(ctx, "stdin-eof-exit")
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		t.Fatal(err)
@@ -111,5 +221,35 @@ func TestClaudeSessionClose_IdempotentNoPanic(t *testing.T) {
 	}
 	if err := cs.Close(); err != nil {
 		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func helperCommand(ctx context.Context, mode string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess", "--", mode)
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	return cmd
+}
+
+// TestHelperProcess lets this test binary act as a tiny external command for
+// cases that need a process with controlled lifetime semantics.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	mode := os.Args[len(os.Args)-1]
+	switch mode {
+	case "sleep":
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
+	case "err-then-sleep":
+		_, _ = os.Stderr.WriteString("helper: starting up\n")
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
+	case "stdin-eof-exit":
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		os.Exit(0)
+	default:
+		os.Exit(2)
 	}
 }


### PR DESCRIPTION
## Problem

A user reported two contradictory bot replies sent within the same minute:

| Time | User action | Bot reply |
|------|-------------|-----------|
| 22:53 | sends `1` | `⏳ Previous request is still processing...` |
| 22:53 | sends `/stop` | `No task currently executing.` |

The two replies are mutually inconsistent — the first says a turn is running, the second says there is nothing to stop. The user has no way to recover short of `/new`. In an earlier observed incident the same bug manifested as a session that silently stopped responding for 13 minutes.

## Summary

- The contradiction occurs inside `cleanupInteractiveState`'s window: the interactive-state map entry is removed before `closeAgentSessionWithTimeout` returns, while the session lock is still held by the turn goroutine. Two handlers observing this transient state — `handleMessage` and `cmdStop` — read the same condition and produce different replies.
- The window can be up to **130 seconds** wide because `claudeSession.Close()` hangs whenever a descendant of the agent inherits its stdout fd (MCP helper, Stop-hook subprocess, any fork that didn't close fd 1). The pipe never reaches EOF, `scanner.Scan()` blocks forever, the defer never runs, and `cs.done` is never closed.
- This PR restructures `readLoop` so `Close()` returns in microseconds in all paths, shrinking the inconsistency window from 130 s to negligible. The reply-policy gap that produces the contradictory text itself is intentionally left for a separate follow-up; with this change the window becomes too short for users to race into.

## Root cause

`Close()` waits on `<-cs.done` at every phase. `cs.done` is closed only by `readLoop`'s defer, which runs only when `scanner.Scan()` returns false. With a descendant holding the pipe write end, scanner blocks indefinitely:

- Phase 1 closes stdin and waits 120 s; the descendant still holds the write end so EOF never arrives.
- Phase 2's SIGTERM goes to the agent (often already dead); the descendant is untouched.
- Phase 3 sends SIGKILL and waits for `cs.done` — still never closes.
- The 130 s outer timeout in `closeAgentSessionWithTimeout` eventually returns control.

A secondary defer leak made things worse: when Phase 3 calls `cs.cancel()`, the error-reporting select inside the defer used to `return` on `<-cs.ctx.Done()`, skipping `close(cs.events)` and `close(cs.done)` and stranding the engine event loop on a channel that never closes.

## Fix

Replace the defer-time `cmd.Wait()` with two cooperating goroutines started before the scanner loop:

- **Reaper** — `waitErrCh <- cs.cmd.Wait(); close(waitDone)`. Single `Wait()`, publishes exit status.
- **Stdout closer** — `select { case <-ctx.Done(): case <-waitDone: }; stdout.Close()`. Unblocks scanner in both the process-exit and cancel paths, without disturbing reads while the agent is alive.

`handleReadLoopScanErr` checks `ctx.Done()` / `waitDone` before reporting, suppressing the expected `ErrClosed` from the reaper-triggered close so no spurious `EventError` reaches the engine. The defer now reads `waitErrCh` and unconditionally closes `events` / `done`. `readLoop` is split into focused helpers per `AGENTS.md` style.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] Regression tests committed **before** the fix so reviewers can verify red→green:

  ```
  git checkout HEAD~1   # test commit
  go test -timeout 30s -run TestReadLoop ./agent/claudecode/   # both tests HANG
  git checkout HEAD     # fix commit
  go test -timeout 30s -run TestReadLoop ./agent/claudecode/   # both PASS
  ```

  - `TestReadLoop_ChildHoldsStdoutPipe` — descendant holds pipe after parent exits. Also asserts the agent's last buffered event is delivered.
  - `TestReadLoop_CtxCancelClosesChannels` — ctx cancel with non-empty stderr exercises the previously leaky defer branch.

- [ ] End-to-end reproduction via the Claude Code Bash tool was not possible in the test environment: the Bash tool redirects subprocess stdout into an internal capture file, so user-spawned processes never inherit the agent's stdout pipe. The unit tests use the `sh -c 'sleep 60 & echo … & exit 0'` pattern that triggers the deadlock in any Go program using `StdoutPipe`.