### PR TITLE
feat(claudecode): support /effort command for reasoning effort

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -36,6 +36,7 @@ func init() {
 type Agent struct {
 	workDir          string
 	model            string
+	reasoningEffort  string // "low" | "medium" | "high" | "max"
 	mode             string // "default" | "acceptEdits" | "plan" | "auto" | "bypassPermissions" | "dontAsk"
 	allowedTools     []string
 	disallowedTools  []string
@@ -63,6 +64,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		workDir = "."
 	}
 	model, _ := opts["model"].(string)
+	reasoningEffort, _ := opts["reasoning_effort"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizePermissionMode(mode)
 
@@ -130,6 +132,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	return &Agent{
 		workDir:          workDir,
 		model:            model,
+		reasoningEffort:  normalizeEffort(reasoningEffort),
 		mode:             mode,
 		allowedTools:     allowedTools,
 		disallowedTools:  disallowedTools,
@@ -139,6 +142,24 @@ func New(opts map[string]any) (core.Agent, error) {
 		routerAPIKey:     routerAPIKey,
 		spawnOpts:        spawnOpts,
 	}, nil
+}
+
+// normalizeEffort maps user-friendly aliases to Claude CLI --effort values.
+func normalizeEffort(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return ""
+	case "low":
+		return "low"
+	case "medium", "med":
+		return "medium"
+	case "high":
+		return "high"
+	case "max":
+		return "max"
+	default:
+		return ""
+	}
 }
 
 // normalizePermissionMode maps user-friendly aliases to Claude CLI values.
@@ -188,6 +209,23 @@ func (a *Agent) GetModel() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return core.GetProviderModel(a.providers, a.activeIdx, a.model)
+}
+
+func (a *Agent) SetReasoningEffort(effort string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.reasoningEffort = normalizeEffort(effort)
+	slog.Info("claudecode: reasoning effort changed", "effort", a.reasoningEffort)
+}
+
+func (a *Agent) GetReasoningEffort() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.reasoningEffort
+}
+
+func (a *Agent) AvailableReasoningEfforts() []string {
+	return []string{"low", "medium", "high", "max"}
 }
 
 func (a *Agent) configuredModels() []core.ModelOption {
@@ -289,6 +327,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	copy(disTools, a.disallowedTools)
 	maxTok := a.maxContextTokens
 	model := a.model
+	effort := a.reasoningEffort
 	extraEnv := a.providerEnvLocked()
 	extraEnv = append(extraEnv, a.sessionEnv...)
 
@@ -316,7 +355,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, a.workDir, model, sessionID, a.mode, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
+	return newClaudeSession(ctx, a.workDir, model, effort, sessionID, a.mode, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -51,7 +51,7 @@ type claudeSession struct {
 	gracefulStopTimeout time.Duration
 }
 
-func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
+func newClaudeSession(ctx context.Context, workDir, model, effort, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	args := []string{
@@ -91,6 +91,9 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 		args = append(args, "--append-system-prompt", sysPrompt)
 	}
 
+	if effort != "" {
+		args = append(args, "--effort", effort)
+	}
 	if maxContextTokens > 0 {
 		args = append(args, "--max-context-tokens", strconv.Itoa(maxContextTokens))
 	}

--- a/config.example.toml
+++ b/config.example.toml
@@ -589,6 +589,10 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "auto" | "bypassP
 # When using IM platforms, you can reply "允许"/"allow" to grant permission.
 # 在 IM 平台中，可回复"允许"或"allow"来授权操作。
 
+# Optional: set reasoning effort level (passed to claude --effort)
+# 可选：设置推理强度等级（传递给 claude --effort）
+# reasoning_effort = "high"  # "low" | "medium" | "high" | "max"
+
 # In default/acceptEdits mode, you can pre-approve specific tools:
 # 在 default/acceptEdits 模式下，可预授权特定工具：
 # allowed_tools = ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]


### PR DESCRIPTION
## Summary
- Implements `ReasoningEffortSwitcher` interface on the Claude Code agent, enabling the existing `/reasoning` and `/effort` commands that were previously Codex-only
- Passes `--effort <level>` flag to the Claude CLI when starting sessions (levels: low, medium, high, max)
- Adds `reasoning_effort` config option to `[projects.agent.options]` for static configuration

## Test plan
- [x] `go build ./agent/claudecode/` compiles cleanly
- [x] `go vet` and `golangci-lint` pass with no issues
- [x] All 56 existing claudecode tests pass
- [x] Core `TestCmdReasoning*` tests pass (3/3)
- [ ] CI lint + test pipeline
- [ ] Manual: send `/effort max` via Slack, verify new session starts with `--effort max` in process args
- [ ] Manual: set `reasoning_effort = "high"` in config, restart, verify sessions launch with `--effort high`

🤖 Generated with [Claude Code](https://claude.com/claude-code)