### PR TITLE
fix(core): route queued message responses to origin thread

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2432,6 +2432,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 				state.mu.Lock()
 				p := state.platform
+				replyCtx := state.replyCtx // use current state, not initial parameter (fixes #591)
 				state.mu.Unlock()
 				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), err))
 				return
@@ -2444,6 +2445,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			sp.discard()
 			state.mu.Lock()
 			p := state.platform
+			replyCtx := state.replyCtx // use current state, not initial parameter (fixes #591)
 			state.mu.Unlock()
 			e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), "agent session timed out (no response)"))
 			e.cleanupInteractiveState(sessionKey, state)
@@ -2477,6 +2479,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		state.mu.Lock()
 		p := state.platform
+		replyCtx = state.replyCtx // use current state, not initial parameter (fixes #591)
 		state.mu.Unlock()
 
 		switch event.Type {
@@ -2927,6 +2930,7 @@ channelClosed:
 	if len(textParts) > 0 {
 		state.mu.Lock()
 		p := state.platform
+		replyCtx = state.replyCtx // use current state, not initial parameter (fixes #591)
 		state.mu.Unlock()
 
 		fullResponse := strings.Join(textParts, "")

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -5845,6 +5845,105 @@ func TestProcessInteractiveEvents_DrainsQueuedMessages(t *testing.T) {
 	}
 }
 
+// stubReplyCtxTrackingPlatform tracks which replyCtx was used for each Send call.
+type stubReplyCtxTrackingPlatform struct {
+	stubPlatformEngine
+	replyCtxCalls []any
+	replyCtxMu    sync.Mutex
+}
+
+func (p *stubReplyCtxTrackingPlatform) Send(_ context.Context, replyCtx any, _ string) error {
+	p.replyCtxMu.Lock()
+	p.replyCtxCalls = append(p.replyCtxCalls, replyCtx)
+	p.replyCtxMu.Unlock()
+	return nil
+}
+
+func (p *stubReplyCtxTrackingPlatform) getReplyCtxCalls() []any {
+	p.replyCtxMu.Lock()
+	defer p.replyCtxMu.Unlock()
+	cp := make([]any, len(p.replyCtxCalls))
+	copy(cp, p.replyCtxCalls)
+	return cp
+}
+
+// TestProcessInteractiveEvents_QueuedMessageRoutesToOriginThread verifies that
+// when a queued message is processed, the response (including errors) goes to
+// the queued message's thread (replyCtx) rather than the initial turn's thread.
+// This is the fix for issue #591.
+func TestProcessInteractiveEvents_QueuedMessageRoutesToOriginThread(t *testing.T) {
+	p := &stubReplyCtxTrackingPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
+	sess := newQueuingSession("qs-thread-routing")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+
+	// Pre-populate the interactive state with a queued message from Thread B.
+	// Initial turn is on Thread A (replyCtx: "thread-A"), queued message is from Thread B.
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "thread-A",
+		pendingMessages: []queuedMessage{
+			{platform: p, replyCtx: "thread-B", content: "queued-msg-from-thread-B"},
+		},
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	// Simulate turn 1 completing on Thread A, then turn 2 (queued message) with an error.
+	go func() {
+		// Turn 1 result (Thread A)
+		sess.events <- Event{Type: EventText, Content: "response1"}
+		sess.events <- Event{Type: EventResult, Content: "response1", Done: true}
+
+		// Wait for the queued message's Send() call before pushing turn 2 events.
+		sess.sendMu.Lock()
+		for len(sess.sendCalls) == 0 {
+			sess.sendMu.Unlock()
+			time.Sleep(5 * time.Millisecond)
+			sess.sendMu.Lock()
+		}
+		sess.sendMu.Unlock()
+
+		// Turn 2: Queued message from Thread B gets an error
+		sess.events <- Event{Type: EventError, Error: fmt.Errorf("turn2 error")}
+	}()
+
+	session.AddHistory("user", "initial-msg")
+
+	sendDone := make(chan error, 1)
+	sendDone <- nil
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), nil, sendDone, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(5 * time.Second):
+		t.Fatal("processInteractiveEvents did not complete in time")
+	}
+
+	// Verify the error was sent to Thread B's replyCtx, not Thread A's.
+	replyCtxCalls := p.getReplyCtxCalls()
+	if len(replyCtxCalls) < 1 {
+		t.Fatalf("replyCtxCalls = %d, want >= 1", len(replyCtxCalls))
+	}
+
+	// The last Send call (for the error) should use "thread-B" as replyCtx.
+	lastReplyCtx := replyCtxCalls[len(replyCtxCalls)-1]
+	if lastReplyCtx != "thread-B" {
+		t.Fatalf("last replyCtx = %v, want thread-B (queued message's thread)", lastReplyCtx)
+	}
+}
+
 // TestDrainOrphanedQueue_UsesWorkspaceSessionManager verifies that
 // drainOrphanedQueue saves session history through the passed sessions
 // manager (workspace-specific) rather than e.sessions (global).


### PR DESCRIPTION
## Summary
- Fixed thread routing for queued message responses
- When a queued message is processed, the response now goes to the queued message's origin thread, not the initial turn's thread

## Root Cause
Issue #591: When a message was queued while the agent was busy on Thread A, the response (including errors) was sent to Thread A instead of the queued message's origin thread (Thread B).

The `replyCtx` parameter in `processInteractiveEvents` was passed once and never updated when processing queued messages. While `state.replyCtx` was correctly updated, the local variable remained the original value.

## Fix
Re-read `replyCtx` from `state.replyCtx` at each iteration where `p` is read from `state.platform`:
- Main event loop (line 2481)
- Timeout case (line 2435)
- Idle timeout case (line 2448)
- Channel closed case (line 2932)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] New test `TestProcessInteractiveEvents_QueuedMessageRoutesToOriginThread` verifies queued message error is sent to correct thread

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)