### PR TITLE
feat(config): support env var placeholders

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -4,6 +4,10 @@
 # Copy this file to config.toml and fill in your credentials.
 # 复制此文件为 config.toml，填入你的凭证信息。
 #
+# String values support ${VAR_NAME} environment variable substitution.
+# Example: token = "${TELEGRAM_BOT_TOKEN}" / 所有字符串值都支持 ${VAR_NAME} 环境变量替换。
+# 例如：token = "${TELEGRAM_BOT_TOKEN}"
+#
 # Each [[projects]] entry binds one code directory to its own agent + platforms.
 # A single cc-connect process can manage multiple projects simultaneously.
 # 每个 [[projects]] 将一个代码目录绑定到独立的 agent 和平台。

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -372,6 +374,7 @@ func Load(path string) (*Config, error) {
 	if err := toml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
+	resolveEnvInConfig(cfg)
 
 	if cfg.DataDir == "" {
 		if home, err := os.UserHomeDir(); err == nil {
@@ -389,6 +392,128 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 	return cfg, nil
+}
+
+var envPlaceholderPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+func resolveEnvInConfig(cfg *Config) {
+	resolveEnvValue(reflect.ValueOf(cfg))
+}
+
+func resolveEnvValue(v reflect.Value) {
+	if !v.IsValid() {
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.Pointer:
+		if !v.IsNil() {
+			resolveEnvValue(v.Elem())
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			resolveEnvValue(v.Field(i))
+		}
+	case reflect.String:
+		if v.CanSet() {
+			v.SetString(resolveEnvPlaceholders(v.String()))
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			elem := v.Index(i)
+			if elem.CanSet() {
+				elem.Set(resolveEnvClone(elem))
+				continue
+			}
+			resolveEnvValue(elem)
+		}
+	case reflect.Map:
+		if v.IsNil() {
+			return
+		}
+		iter := v.MapRange()
+		for iter.Next() {
+			v.SetMapIndex(iter.Key(), resolveEnvClone(iter.Value()))
+		}
+	case reflect.Interface:
+		if v.IsNil() || !v.CanSet() {
+			return
+		}
+		v.Set(resolveEnvClone(v.Elem()))
+	}
+}
+
+func resolveEnvClone(v reflect.Value) reflect.Value {
+	if !v.IsValid() {
+		return v
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		out := reflect.New(v.Type()).Elem()
+		out.SetString(resolveEnvPlaceholders(v.String()))
+		return out
+	case reflect.Pointer:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		out := reflect.New(v.Type().Elem())
+		out.Elem().Set(v.Elem())
+		resolveEnvValue(out.Elem())
+		return out
+	case reflect.Struct:
+		out := reflect.New(v.Type()).Elem()
+		out.Set(v)
+		resolveEnvValue(out)
+		return out
+	case reflect.Slice:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		out := reflect.MakeSlice(v.Type(), v.Len(), v.Len())
+		for i := 0; i < v.Len(); i++ {
+			out.Index(i).Set(resolveEnvClone(v.Index(i)))
+		}
+		return out
+	case reflect.Array:
+		out := reflect.New(v.Type()).Elem()
+		for i := 0; i < v.Len(); i++ {
+			out.Index(i).Set(resolveEnvClone(v.Index(i)))
+		}
+		return out
+	case reflect.Map:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		out := reflect.MakeMapWithSize(v.Type(), v.Len())
+		iter := v.MapRange()
+		for iter.Next() {
+			out.SetMapIndex(iter.Key(), resolveEnvClone(iter.Value()))
+		}
+		return out
+	case reflect.Interface:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		out := reflect.New(v.Type()).Elem()
+		out.Set(resolveEnvClone(v.Elem()))
+		return out
+	default:
+		return v
+	}
+}
+
+func resolveEnvPlaceholders(s string) string {
+	if !strings.Contains(s, "${") {
+		return s
+	}
+	return envPlaceholderPattern.ReplaceAllStringFunc(s, func(match string) string {
+		parts := envPlaceholderPattern.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			return match
+		}
+		return os.Getenv(parts[1])
+	})
 }
 
 // projectQuietEffective returns whether legacy quiet applies to this project: an explicit

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -288,6 +288,125 @@ func TestLoad_DefaultsDataDir(t *testing.T) {
 	}
 }
 
+func TestLoad_ResolvesEnvPlaceholders(t *testing.T) {
+
+	root := t.TempDir()
+	t.Setenv("CC_ROOT", root)
+	t.Setenv("TG_TOKEN", "tg-secret")
+	t.Setenv("HOOK_TOKEN", "hook-secret")
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:7890")
+
+	configPath := writeConfigFixture(t, `
+ data_dir = "${CC_ROOT}/state"
+
+ [webhook]
+ token = "${HOOK_TOKEN}"
+
+ [[projects]]
+ name = "demo"
+
+ [projects.agent]
+ type = "codex"
+
+ [projects.agent.options]
+ work_dir = "${CC_ROOT}/repo"
+ note = "prefix-${HOOK_TOKEN}-suffix"
+ retries = 3
+
+ [[projects.agent.providers]]
+ name = "relay"
+ api_key = "${OPENAI_API_KEY}"
+ base_url = "https://relay.example/${HOOK_TOKEN}"
+
+ [projects.agent.providers.env]
+ HTTP_PROXY = "${HTTP_PROXY}"
+
+ [[projects.platforms]]
+ type = "telegram"
+
+ [projects.platforms.options]
+ token = "${TG_TOKEN}"
+ chat_id = 12345
+ `)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if got, want := cfg.DataDir, filepath.Join(root, "state"); got != want {
+		t.Fatalf("DataDir = %q, want %q", got, want)
+	}
+	if got := cfg.Webhook.Token; got != "hook-secret" {
+		t.Fatalf("Webhook.Token = %q, want hook-secret", got)
+	}
+	if got := stringMapValue(cfg.Projects[0].Agent.Options, "work_dir"); got != filepath.Join(root, "repo") {
+		t.Fatalf("work_dir = %q, want %q", got, filepath.Join(root, "repo"))
+	}
+	if got := stringMapValue(cfg.Projects[0].Agent.Options, "note"); got != "prefix-hook-secret-suffix" {
+		t.Fatalf("note = %q, want prefix-hook-secret-suffix", got)
+	}
+	if got := cfg.Projects[0].Agent.Providers[0].APIKey; got != "sk-test" {
+		t.Fatalf("provider api_key = %q, want sk-test", got)
+	}
+	if got := cfg.Projects[0].Agent.Providers[0].Env["HTTP_PROXY"]; got != "http://127.0.0.1:7890" {
+		t.Fatalf("provider env HTTP_PROXY = %q, want http://127.0.0.1:7890", got)
+	}
+	if got := stringMapValue(cfg.Projects[0].Platforms[0].Options, "token"); got != "tg-secret" {
+		t.Fatalf("platform token = %q, want tg-secret", got)
+	}
+	if _, ok := cfg.Projects[0].Platforms[0].Options["chat_id"].(int64); !ok {
+		t.Fatalf("chat_id type = %T, want int64", cfg.Projects[0].Platforms[0].Options["chat_id"])
+	}
+}
+
+func TestLoad_MissingEnvPlaceholderBecomesEmptyString(t *testing.T) {
+
+	configPath := writeConfigFixture(t, `
+ [[projects]]
+ name = "demo"
+
+ [projects.agent]
+ type = "codex"
+
+ [projects.agent.options]
+ work_dir = "/tmp/demo"
+ retries = 5
+
+ [[projects.agent.providers]]
+ name = "relay"
+ api_key = "${MISSING_API_KEY}"
+
+ [projects.agent.providers.env]
+ HTTPS_PROXY = "${MISSING_PROXY}"
+
+ [[projects.platforms]]
+ type = "telegram"
+
+ [projects.platforms.options]
+ token = "prefix-${MISSING_TOKEN}-suffix"
+ `)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if got := cfg.Projects[0].Agent.Providers[0].APIKey; got != "" {
+		t.Fatalf("provider api_key = %q, want empty", got)
+	}
+	if got := cfg.Projects[0].Agent.Providers[0].Env["HTTPS_PROXY"]; got != "" {
+		t.Fatalf("provider env HTTPS_PROXY = %q, want empty", got)
+	}
+	if got := stringMapValue(cfg.Projects[0].Platforms[0].Options, "token"); got != "prefix--suffix" {
+		t.Fatalf("platform token = %q, want prefix--suffix", got)
+	}
+	if _, ok := cfg.Projects[0].Agent.Options["retries"].(int64); !ok {
+		t.Fatalf("retries type = %T, want int64", cfg.Projects[0].Agent.Options["retries"])
+	}
+}
+
 func TestListProjects(t *testing.T) {
 	writeTestConfig(t, baseConfigTOML)
 


### PR DESCRIPTION
 ## Summary
  - resolve `${VAR_NAME}` placeholders for string config values after TOML parsing
  - apply substitution recursively across nested structs, `map[string]any`, provider env
  maps, and platform option maps
  - document the feature in `config.example.toml`
  - add regression tests for nested substitution and missing environment variables
  - rebase the change onto current upstream `main` and resolve the `config/config.go`
  conflict with newer quiet/display logic

  ## Why
  Platform tokens and provider credentials are currently stored as plaintext in
  `config.toml`. Supporting `${VAR_NAME}` placeholders lets deployments keep secrets in
  environment variables while preserving the existing config structure.

  ## Example
  ```toml
  [[projects.platforms]]
  type = "telegram"

  [projects.platforms.options]
  token = "${TELEGRAM_BOT_TOKEN}"

  [[projects.agent.providers]]
  name = "relay"
  api_key = "${OPENAI_API_KEY}"

  [projects.agent.providers.env]
  HTTP_PROXY = "${HTTP_PROXY}"

  ## Note

  If an environment variable is unset, its ${VAR_NAME} placeholder is replaced with an
  empty string. Deployments should ensure all referenced variables are set.

  ## Validation

  - resolved conflicts against current upstream main
  - verified the change set still only touches config.example.toml, config/config.go,
    and config/config_test.go
  - could not run go test ./config in this environment because go is not installed

  Closes #486