### PR TITLE
fix(core): follow symlinked skill directories

### DIFF
--- a/core/skill.go
+++ b/core/skill.go
@@ -78,43 +78,84 @@ func (r *SkillRegistry) ListAll() []*Skill {
 	seen := make(map[string]bool)
 
 	for _, dir := range r.dirs {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			continue
-		}
-		for _, entry := range entries {
-			fullPath := filepath.Join(dir, entry.Name())
-			info, err := os.Stat(fullPath)
-			if err != nil {
+		result = append(result, discoverSkillsInDir(dir, dir, seen, make(map[string]bool))...)
+	}
+
+	r.cache = result
+	return result
+}
+
+func discoverSkillsInDir(scanRoot, currentDir string, seen, visited map[string]bool) []*Skill {
+	realDir := realPath(currentDir)
+	if visited[realDir] {
+		return nil
+	}
+	visited[realDir] = true
+
+	entries, err := os.ReadDir(currentDir)
+	if err != nil {
+		return nil
+	}
+
+	var result []*Skill
+	for _, entry := range entries {
+		fullPath := filepath.Join(currentDir, entry.Name())
+
+		if entry.Name() == "SKILL.md" {
+			skillDir := filepath.Dir(fullPath)
+			if sameFilePath(skillDir, scanRoot) {
 				continue
 			}
-			if !info.IsDir() {
-				continue
-			}
-			skillName := entry.Name()
+
+			skillName := filepath.Base(skillDir)
 			if seen[strings.ToLower(skillName)] {
 				continue
 			}
 
-			mdPath := filepath.Join(dir, skillName, "SKILL.md")
-			data, err := os.ReadFile(mdPath)
+			data, err := os.ReadFile(fullPath)
 			if err != nil {
 				continue
 			}
 
-			skill := parseSkillMD(skillName, string(data), dir)
+			skill := parseSkillMD(skillName, string(data), skillDir)
 			if skill == nil {
 				continue
 			}
 
 			seen[strings.ToLower(skillName)] = true
 			result = append(result, skill)
-			slog.Debug("skill: discovered", "name", skillName, "dir", dir)
+			slog.Debug("skill: discovered", "name", skillName, "dir", skillDir)
+			continue
+		}
+
+		if shouldDescendIntoSkillPath(fullPath, entry) {
+			result = append(result, discoverSkillsInDir(scanRoot, fullPath, seen, visited)...)
 		}
 	}
 
-	r.cache = result
 	return result
+}
+
+func shouldDescendIntoSkillPath(path string, entry os.DirEntry) bool {
+	if entry.IsDir() {
+		return true
+	}
+	if entry.Type()&os.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func sameFilePath(a, b string) bool {
+	return realPath(a) == realPath(b)
+}
+
+func realPath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(path)
 }
 
 // Invalidate clears the cache so skills are re-scanned on next access.

--- a/core/skill_test.go
+++ b/core/skill_test.go
@@ -1,0 +1,129 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSkillRegistryListAll_RecursesIntoGroupedDirectories(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "automation", "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
+	writeSkillFile(t, filepath.Join(root, "productivity", "doc", "SKILL.md"), "Doc skill")
+	writeSkillFile(t, filepath.Join(root, ".system", "skill-installer", "SKILL.md"), "System skill")
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 3 {
+		t.Fatalf("skills discovered = %d, want 3", len(skills))
+	}
+	if r.Resolve("telegram-codex-bot") == nil {
+		t.Fatalf("expected grouped skill to resolve")
+	}
+	if r.Resolve("doc") == nil {
+		t.Fatalf("expected nested productivity skill to resolve")
+	}
+	if r.Resolve("skill-installer") == nil {
+		t.Fatalf("expected .system skill to resolve")
+	}
+}
+
+func TestSkillRegistryListAll_FollowsDirectorySymlinks(t *testing.T) {
+	root := t.TempDir()
+	targetRoot := t.TempDir()
+	writeSkillFile(t, filepath.Join(targetRoot, "automation", "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
+	writeSkillFile(t, filepath.Join(targetRoot, "research", "hf-papers", "SKILL.md"), "HF papers skill")
+
+	if err := os.Symlink(filepath.Join(targetRoot, "automation"), filepath.Join(root, "automation")); err != nil {
+		t.Fatalf("symlink automation: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(targetRoot, "research"), filepath.Join(root, "research")); err != nil {
+		t.Fatalf("symlink research: %v", err)
+	}
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 2 {
+		t.Fatalf("skills discovered = %d, want 2", len(skills))
+	}
+	if r.Resolve("telegram-codex-bot") == nil {
+		t.Fatalf("expected symlinked automation skill to resolve")
+	}
+	if r.Resolve("hf-papers") == nil {
+		t.Fatalf("expected symlinked research skill to resolve")
+	}
+}
+
+func TestSkillRegistryListAll_DoesNotLoopOnDirectorySymlinks(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "automation", "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
+
+	if err := os.Symlink(filepath.Join(root, "automation"), filepath.Join(root, "automation", "again")); err != nil {
+		t.Fatalf("symlink loop: %v", err)
+	}
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 1 {
+		t.Fatalf("skills discovered = %d, want 1", len(skills))
+	}
+	if r.Resolve("telegram-codex-bot") == nil {
+		t.Fatalf("expected looping symlink tree to still resolve skill")
+	}
+}
+
+func TestSkillRegistryListAll_DedupesByLeafDirectoryName(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "apple", "helper", "SKILL.md"), "Apple helper")
+	writeSkillFile(t, filepath.Join(root, "automation", "helper", "SKILL.md"), "Automation helper")
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 1 {
+		t.Fatalf("skills discovered = %d, want 1", len(skills))
+	}
+	if skills[0].Name != "helper" {
+		t.Fatalf("skill name = %q, want helper", skills[0].Name)
+	}
+}
+
+func TestSkillRegistryListAll_IgnoresRootSkillFile(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "SKILL.md"), "Root skill should be ignored")
+	writeSkillFile(t, filepath.Join(root, "group", "visible-skill", "SKILL.md"), "Visible skill")
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 1 {
+		t.Fatalf("skills discovered = %d, want 1", len(skills))
+	}
+	if skills[0].Name != "visible-skill" {
+		t.Fatalf("skill name = %q, want visible-skill", skills[0].Name)
+	}
+}
+
+func writeSkillFile(t *testing.T, path, description string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	data := []byte("---\ndescription: " + description + "\n---\nPrompt body")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

Fix skill discovery so cc-connect can recurse into symlinked skill directories.

## Changes

- recurse into directory symlinks during skill discovery
- resolve real paths to avoid symlink loops
- keep deduping by leaf skill directory name

## Why

Some skill layouts use symlinked directories as part of their recursive discovery structure.

Before this change, cc-connect could recurse into real directories but skipped symlinked directory trees, which caused incomplete skill discovery.

## Tests

Added coverage for:

- grouped recursive discovery
- following directory symlinks
- avoiding symlink loops
- deduping same leaf names