### PR TITLE
fix(telegram): adapt command menu registration to Telegram limits

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -23,6 +23,7 @@ import (
 )
 
 const maxPlatformMessageLen = 4000
+const telegramBotCommandLimit = 100
 const maxQueuedMessages = 5 // cap queued messages to bound memory usage
 
 const (
@@ -211,8 +212,8 @@ type Engine struct {
 
 	// Terminal observation (--observe)
 	observeEnabled    bool
-	observeProjectDir string             // ~/.claude/projects/{projectKey}
-	observeSessionKey string             // e.g. "slack:C123:U456" — target for forwarding
+	observeProjectDir string // ~/.claude/projects/{projectKey}
+	observeSessionKey string // e.g. "slack:C123:U456" — target for forwarding
 	observeCancel     context.CancelFunc
 
 	// Interactive agent session management
@@ -1267,7 +1268,10 @@ func (e *Engine) markPlatformUnavailable(p Platform) bool {
 
 func (e *Engine) initPlatformCapabilities(p Platform) {
 	if registrar, ok := p.(CommandRegistrar); ok {
-		commands := e.GetAllCommands()
+		commands, skillsOmitted := e.menuCommandsForPlatform(p.Name())
+		if skillsOmitted && strings.EqualFold(p.Name(), "telegram") {
+			slog.Info("telegram: omitting skill commands from menu due to command limit", "project", e.name)
+		}
 		if err := registrar.RegisterCommands(commands); err != nil {
 			slog.Error("platform command registration failed", "project", e.name, "platform", p.Name(), "error", err)
 		} else {
@@ -5219,10 +5223,75 @@ func (e *Engine) GetAllCommands() []BotCommandInfo {
 		commands = append(commands, BotCommandInfo{
 			Command:     s.Name,
 			Description: desc,
+			IsSkill:     true,
 		})
 	}
 
 	return commands
+}
+
+func (e *Engine) menuCommandsForPlatform(platformName string) ([]BotCommandInfo, bool) {
+	commands := e.GetAllCommands()
+	if !strings.EqualFold(platformName, "telegram") {
+		return commands, false
+	}
+	return telegramMenuCommandsAllOrNone(commands)
+}
+
+func telegramMenuCommandsAllOrNone(commands []BotCommandInfo) ([]BotCommandInfo, bool) {
+	var nonSkill []BotCommandInfo
+	var skill []BotCommandInfo
+	for _, command := range commands {
+		if command.IsSkill {
+			skill = append(skill, command)
+			continue
+		}
+		nonSkill = append(nonSkill, command)
+	}
+
+	if len(telegramMenuEntryNames(append(append([]BotCommandInfo{}, nonSkill...), skill...))) <= telegramBotCommandLimit {
+		return commands, false
+	}
+	return nonSkill, len(skill) > 0
+}
+
+func telegramMenuEntryNames(commands []BotCommandInfo) []string {
+	var names []string
+	seen := make(map[string]bool)
+	for _, command := range commands {
+		name := sanitizeTelegramMenuCommand(command.Command)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}
+
+func sanitizeTelegramMenuCommand(cmd string) string {
+	cmd = strings.ToLower(cmd)
+	var b strings.Builder
+	for _, c := range cmd {
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+			b.WriteRune(c)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	result := b.String()
+	for strings.Contains(result, "__") {
+		result = strings.ReplaceAll(result, "__", "_")
+	}
+	result = strings.Trim(result, "_")
+	if len(result) == 0 || result[0] < 'a' || result[0] > 'z' {
+		return ""
+	}
+	if len(result) > 32 {
+		result = result[:32]
+	}
+	return result
 }
 
 func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
@@ -8834,6 +8903,9 @@ func (e *Engine) cmdSkills(p Platform, msg *Message) {
 		}
 
 		sb.WriteString("\n" + e.i18n.T(MsgSkillsHint))
+		if _, skillsOmitted := e.menuCommandsForPlatform(p.Name()); skillsOmitted && strings.EqualFold(p.Name(), "telegram") {
+			sb.WriteString("\n" + e.i18n.T(MsgSkillsTelegramMenuHint))
+		}
 		e.reply(p, msg.ReplyCtx, sb.String())
 		return
 	}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -174,11 +174,12 @@ func (s *resultAgentSession) Close() error                                      
 
 type stubLifecyclePlatform struct {
 	stubPlatformEngine
-	handler         PlatformLifecycleHandler
-	registerCalls   int
-	cardNavSetCalls int
-	startCalls      int
-	stopCalls       int
+	handler            PlatformLifecycleHandler
+	registerCalls      int
+	registeredCommands []BotCommandInfo
+	cardNavSetCalls    int
+	startCalls         int
+	stopCalls          int
 }
 
 func (p *stubLifecyclePlatform) Start(MessageHandler) error {
@@ -195,8 +196,9 @@ func (p *stubLifecyclePlatform) SetLifecycleHandler(h PlatformLifecycleHandler) 
 	p.handler = h
 }
 
-func (p *stubLifecyclePlatform) RegisterCommands([]BotCommandInfo) error {
+func (p *stubLifecyclePlatform) RegisterCommands(commands []BotCommandInfo) error {
 	p.registerCalls++
+	p.registeredCommands = append([]BotCommandInfo(nil), commands...)
 	return nil
 }
 
@@ -4103,6 +4105,59 @@ func TestCmdSkills_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	}
 	if strings.Contains(p.sent[0], "[← Back]") {
 		t.Fatalf("skills text = %q, should not be card fallback text", p.sent[0])
+	}
+}
+
+func TestMenuCommandsForPlatform_TelegramOmitsAllSkillsWhenMenuWouldOverflow(t *testing.T) {
+	e := NewEngine("test", &stubAgent{}, nil, "", LangEnglish)
+	temp := t.TempDir()
+	for i := 0; i < 80; i++ {
+		name := fmt.Sprintf("skill-%02d", i)
+		skillDir := filepath.Join(temp, name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatalf("mkdir skill dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\ndescription: Demo skill\n---\nDo demo"), 0o644); err != nil {
+			t.Fatalf("write skill file: %v", err)
+		}
+	}
+	e.skills.SetDirs([]string{temp})
+
+	commands, skillsOmitted := e.menuCommandsForPlatform("telegram")
+
+	if !skillsOmitted {
+		t.Fatalf("expected Telegram menu planner to omit skill commands when command menu overflows")
+	}
+	for _, cmd := range commands {
+		if cmd.IsSkill {
+			t.Fatalf("menu commands should omit skills when overflowed, got %+v", cmd)
+		}
+	}
+}
+
+func TestCmdSkills_TelegramShowsManualInvocationHintWhenSkillsAreOmittedFromMenu(t *testing.T) {
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	temp := t.TempDir()
+	for i := 0; i < 80; i++ {
+		name := fmt.Sprintf("skill-%02d", i)
+		skillDir := filepath.Join(temp, name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatalf("mkdir skill dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\ndescription: Demo skill\n---\nDo demo"), 0o644); err != nil {
+			t.Fatalf("write skill file: %v", err)
+		}
+	}
+	e.skills.SetDirs([]string{temp})
+
+	e.cmdSkills(p, &Message{SessionKey: "telegram:user1", ReplyCtx: "ctx"})
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "command menu is full") {
+		t.Fatalf("skills text = %q, want Telegram overflow hint", p.sent[0])
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -353,9 +353,10 @@ const (
 	MsgCommandExecError   MsgKey = "command_exec_error"
 	MsgCommandExecSuccess MsgKey = "command_exec_success"
 
-	MsgSkillsTitle MsgKey = "skills_title"
-	MsgSkillsEmpty MsgKey = "skills_empty"
-	MsgSkillsHint  MsgKey = "skills_hint"
+	MsgSkillsTitle            MsgKey = "skills_title"
+	MsgSkillsEmpty            MsgKey = "skills_empty"
+	MsgSkillsHint             MsgKey = "skills_hint"
+	MsgSkillsTelegramMenuHint MsgKey = "skills_telegram_menu_hint"
 
 	MsgConfigTitle       MsgKey = "config_title"
 	MsgConfigHint        MsgKey = "config_hint"
@@ -392,10 +393,10 @@ const (
 	MsgAliasNotFound   MsgKey = "alias_not_found"
 	MsgAliasUsage      MsgKey = "alias_usage"
 
-	MsgNewSessionCreated     MsgKey = "new_session_created"
-	MsgNewSessionCreatedName MsgKey = "new_session_created_name"
-	MsgSessionAutoResetIdle     MsgKey = "session_auto_reset_idle"
-	MsgSessionClosingGraceful   MsgKey = "session_closing_graceful"
+	MsgNewSessionCreated      MsgKey = "new_session_created"
+	MsgNewSessionCreatedName  MsgKey = "new_session_created_name"
+	MsgSessionAutoResetIdle   MsgKey = "session_auto_reset_idle"
+	MsgSessionClosingGraceful MsgKey = "session_closing_graceful"
 
 	MsgDeleteUsage              MsgKey = "delete_usage"
 	MsgDeleteSuccess            MsgKey = "delete_success"
@@ -492,8 +493,8 @@ const (
 	MsgBuiltinCmdDir       MsgKey = "dir"
 	MsgBuiltinCmdDiff      MsgKey = "diff"
 
-	MsgDiffEmpty           MsgKey = "diff_empty"
-	MsgDiffNoDiff2HTML     MsgKey = "diff_no_diff2html"
+	MsgDiffEmpty       MsgKey = "diff_empty"
+	MsgDiffNoDiff2HTML MsgKey = "diff_no_diff2html"
 
 	MsgDirChanged          MsgKey = "dir_changed"
 	MsgDirCurrent          MsgKey = "dir_current"
@@ -2443,6 +2444,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "用法：/<skill名稱> [參數...] 來調用 Skill。",
 		LangJapanese:           "使い方：/<スキル名> [引数...] でスキルを実行します。",
 		LangSpanish:            "Uso: /<nombre-skill> [args...] para invocar un skill.",
+	},
+	MsgSkillsTelegramMenuHint: {
+		LangEnglish:            "Telegram's command menu is full, so skill commands are not listed there. You can still invoke them by typing /<skill-name> manually.",
+		LangChinese:            "Telegram 的命令菜单已满，因此 Skill 不会显示在那里。你仍然可以手动输入 /<skill名称> 来调用它们。",
+		LangTraditionalChinese: "Telegram 的命令選單已滿，因此 Skill 不會顯示在那裡。你仍然可以手動輸入 /<skill名稱> 來調用它們。",
+		LangJapanese:           "Telegram のコマンドメニューがいっぱいのため、スキルコマンドはそこに表示されません。手動で /<スキル名> と入力すれば実行できます。",
+		LangSpanish:            "El menú de comandos de Telegram está lleno, así que los skills no aparecen allí. Aun así puedes invocarlos escribiendo /<nombre-skill> manualmente.",
 	},
 
 	MsgConfigTitle: {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -411,6 +411,7 @@ type PermissionModeInfo struct {
 type BotCommandInfo struct {
 	Command     string // command name without leading "/"
 	Description string // short description for the menu
+	IsSkill     bool   // whether this entry comes from a skill
 }
 
 // CommandRegistrar is an optional interface for platforms that support

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -1405,16 +1405,20 @@ func truncateForLog(s string, maxLen int) string {
 	return string(r[:maxLen]) + "..."
 }
 
-// truncateTelegramBotDescription enforces Telegram's 256-character limit for
-// BotCommand.Description. Byte slicing breaks UTF-8 for CJK text and triggers
+const telegramBotCommandDescriptionLimit = 40
+
+// truncateTelegramBotDescription keeps Telegram command descriptions within a
+// conservative safety budget. Telegram documents a larger per-field limit, but
+// shorter descriptions avoid command menu registration failures when many
+// commands are installed. Byte slicing breaks UTF-8 for CJK text and triggers
 // "text must be encoded in UTF-8" from the API (#119).
 func truncateTelegramBotDescription(s string) string {
-	const max = 256
+	const max = telegramBotCommandDescriptionLimit
 	if utf8.RuneCountInString(s) <= max {
 		return s
 	}
 	r := []rune(s)
-	return string(r[:253]) + "..."
+	return string(r[:max-3]) + "..."
 }
 
 func (p *Platform) Stop() error {
@@ -1443,7 +1447,8 @@ func (p *Platform) RegisterCommands(commands []core.BotCommandInfo) error {
 		return err
 	}
 
-	// Telegram limits: max 100 commands, description max 256 chars
+	// Telegram limits: max 100 commands; keep descriptions conservatively short
+	// to avoid menu registration failures with larger command sets.
 	var tgCommands []models.BotCommand
 	seen := make(map[string]bool)
 	for _, c := range commands {

--- a/platform/telegram/telegram_test.go
+++ b/platform/telegram/telegram_test.go
@@ -69,19 +69,19 @@ func (t *stubTypingTicker) C() <-chan time.Time {
 func (t *stubTypingTicker) Stop() {}
 
 type stubTelegramBot struct {
-	mu                    sync.Mutex
-	sendMessageCalls      int
-	sendPhotoCalls        int
-	sendDocumentCalls     int
-	sendVoiceCalls        int
-	sendAudioCalls        int
-	sendChatActionCalls   int
-	editMessageTextCalls  int
-	deleteMessageCalls    int
-	answerCallbackCalls   int
-	setMyCommandsCalls    int
-	getFileCalls          int
-	setReactionCalls      int
+	mu                   sync.Mutex
+	sendMessageCalls     int
+	sendPhotoCalls       int
+	sendDocumentCalls    int
+	sendVoiceCalls       int
+	sendAudioCalls       int
+	sendChatActionCalls  int
+	editMessageTextCalls int
+	deleteMessageCalls   int
+	answerCallbackCalls  int
+	setMyCommandsCalls   int
+	getFileCalls         int
+	setReactionCalls     int
 
 	sendErr    error
 	getFileErr error
@@ -229,7 +229,6 @@ func (b *stubTelegramBot) GetFileCallCount() int {
 	defer b.mu.Unlock()
 	return b.getFileCalls
 }
-
 
 func TestPlatformStart_RetriesInBackgroundUntilConnected(t *testing.T) {
 	var attempts atomic.Int32
@@ -593,13 +592,13 @@ func TestTruncateTelegramBotDescription_UTF8Safe(t *testing.T) {
 	if !utf8.ValidString(out) {
 		t.Fatal("invalid UTF-8 from CJK description")
 	}
-	if got, max := utf8.RuneCountInString(out), 256; got > max {
+	if got, max := utf8.RuneCountInString(out), telegramBotCommandDescriptionLimit; got > max {
 		t.Fatalf("rune count %d > %d", got, max)
 	}
 
-	long := strings.Repeat("b", 260)
+	long := strings.Repeat("b", 60)
 	out2 := truncateTelegramBotDescription(long)
-	if want := 256; utf8.RuneCountInString(out2) != want {
+	if want := telegramBotCommandDescriptionLimit; utf8.RuneCountInString(out2) != want {
 		t.Fatalf("ascii truncation: got %d runes want %d", utf8.RuneCountInString(out2), want)
 	}
 	if !utf8.ValidString(out2) {


### PR DESCRIPTION
## Summary

Adapt Telegram bot command registration to Telegram command menu constraints.

## Changes

- add Telegram-specific menu planning before command registration
- keep skill commands all-or-none in the Telegram menu
- keep built-in and non-skill commands registered
- add a /skills hint explaining that skills can still be invoked manually when needed
- clamp Telegram bot command descriptions to a conservative safe length
- align the description clamp with the practical strategy used by Hermes Agent

## Why

Telegram command registration needs to stay within platform limits.

This change handles two practical constraints:

- keep the registered command set within Telegram command menu capacity
- clamp command descriptions to avoid registration failures caused by overly long menu payloads

The description clamp is intentionally conservative and follows the same general direction used by Hermes Agent for Telegram command registration.

The all-or-none skill policy also avoids a confusing partial-menu state where only some skills appear in the Telegram slash-command menu.

## Tests

Added coverage for:

- omitting all skill menu commands when Telegram menu capacity would overflow
- showing the manual invocation hint in /skills
- Telegram description truncation staying UTF-8 safe