### PR TITLE
fix(core): persist agent_session_id using CurrentSessionID()

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2700,8 +2700,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		case EventResult:
 			cp.Finalize(ProgressCardStateCompleted)
-			if event.SessionID != "" {
-				session.SetAgentSessionID(event.SessionID, e.agent.Name())
+			// Use state.agentSession.CurrentSessionID() instead of event.SessionID.
+			// event.SessionID may be empty in some cases, causing the agent_session_id
+			// to not be persisted to disk, breaking session resume on next startup.
+			if state != nil && state.agentSession != nil {
+				if currentID := state.agentSession.CurrentSessionID(); currentID != "" {
+					session.SetAgentSessionID(currentID, e.agent.Name())
+					sessions.Save()
+				}
 			}
 
 			fullResponse := event.Content
@@ -9734,8 +9740,9 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 				textParts = append(textParts, fmt.Sprintf(e.i18n.T(MsgToolResult), tn, out)+"\n\n")
 			}
 		case EventResult:
-			if event.SessionID != "" {
-				session.SetAgentSessionID(event.SessionID, e.agent.Name())
+			// Use agentSession.CurrentSessionID() for the same reason as above.
+			if currentID := agentSession.CurrentSessionID(); currentID != "" {
+				session.SetAgentSessionID(currentID, e.agent.Name())
 				e.sessions.Save()
 			}
 			resp := event.Content


### PR DESCRIPTION
## Summary
- Fix `agent_session_id` not being persisted to disk in both interactive and relay modes
- `event.SessionID` can be empty in some cases, causing the session ID to never be written
- When cc-connect restarts, sessions resume without `agent_session_id`, and Claude Code treats them as new conversations, losing all context

## Root Cause
In the `EventResult` handler, the code used `event.SessionID` to set the `agent_session_id`. However, `event.SessionID` is populated by the event emitter and can be empty depending on the execution path. The agent actually tracks its session ID internally via `agentSession.CurrentSessionID()`, which always returns a value.

## Fix
- **Interactive mode**: use `state.agentSession.CurrentSessionID()` + call `sessions.Save()` after `SetAgentSessionID()`
- **Relay mode**: use `agentSession.CurrentSessionID()` + call `e.sessions.Save()`

## Test plan
- [ ] Send a message via Feishu bot, verify session is created with `agent_session_id` in the session file
- [ ] Restart cc-connect, verify the conversation resumes with full context
- [ ] Verify both interactive (web) and relay (Feishu) modes work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)