### PR TITLE
feat: general improvements - session-id, workspace idle reaper, stop …

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -46,9 +46,9 @@ type Agent struct {
 	routerURL        string // Claude Code Router URL (e.g., "http://127.0.0.1:3456")
 	routerAPIKey     string // Claude Code Router API key (optional)
 
-	providerProxy  *core.ProviderProxy // local proxy for third-party providers
-	proxyLocalURL  string              // local URL of the proxy
-	platformPrompt string              // platform-specific formatting instructions
+	providerProxy    *core.ProviderProxy // local proxy for third-party providers
+	proxyLocalURL    string              // local URL of the proxy
+	platformPrompt   string              // platform-specific formatting instructions
 
 	// spawnOpts controls OS-user isolation via run_as_user. Zero value
 	// means legacy spawn as the supervisor user. See core/runas.go.
@@ -163,6 +163,10 @@ func normalizePermissionMode(raw string) string {
 func (a *Agent) Name() string           { return "claudecode" }
 func (a *Agent) CLIBinaryName() string  { return "claude" }
 func (a *Agent) CLIDisplayName() string { return "Claude" }
+
+func (a *Agent) ResumeCommand(sessionID string) string {
+	return "claude --resume " + sessionID
+}
 
 func (a *Agent) SetWorkDir(dir string) {
 	a.mu.Lock()

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -116,6 +116,10 @@ func normalizeReasoningEffort(raw string) string {
 
 func (a *Agent) Name() string { return "codex" }
 
+func (a *Agent) ResumeCommand(sessionID string) string {
+	return "codex resume " + sessionID
+}
+
 func (a *Agent) SetWorkDir(dir string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -83,6 +83,10 @@ func (a *Agent) Name() string           { return "cursor" }
 func (a *Agent) CLIBinaryName() string  { return "agent" }
 func (a *Agent) CLIDisplayName() string { return "Cursor Agent" }
 
+func (a *Agent) ResumeCommand(sessionID string) string {
+	return "agent --resume " + sessionID
+}
+
 func (a *Agent) SetWorkDir(dir string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/gemini/gemini.go
+++ b/agent/gemini/gemini.go
@@ -101,6 +101,10 @@ func normalizeMode(raw string) string {
 
 func (a *Agent) Name() string { return "gemini" }
 
+func (a *Agent) ResumeCommand(sessionID string) string {
+	return "gemini --resume " + sessionID
+}
+
 func (a *Agent) SetWorkDir(dir string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/iflow/iflow.go
+++ b/agent/iflow/iflow.go
@@ -94,6 +94,10 @@ func normalizeMode(raw string) string {
 
 func (a *Agent) Name() string { return "iflow" }
 
+func (a *Agent) ResumeCommand(sessionID string) string {
+	return "iflow -r " + sessionID
+}
+
 func (a *Agent) SetWorkDir(dir string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -191,6 +191,10 @@ func normalizeMode(raw string) string {
 
 func (a *Agent) Name() string { return "opencode" }
 
+func (a *Agent) ResumeCommand(sessionID string) string {
+	return "opencode -s " + sessionID
+}
+
 func (a *Agent) SetWorkDir(dir string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/qoder/qoder.go
+++ b/agent/qoder/qoder.go
@@ -59,6 +59,10 @@ func (a *Agent) Name() string           { return "qoder" }
 func (a *Agent) CLIBinaryName() string  { return "qodercli" }
 func (a *Agent) CLIDisplayName() string { return "Qoder" }
 
+func (a *Agent) ResumeCommand(sessionID string) string {
+	return "qodercli -r " + sessionID
+}
+
 func (a *Agent) SetWorkDir(dir string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -257,7 +257,11 @@ func main() {
 				continue
 			}
 			bindingStore := filepath.Join(cfg.DataDir, "workspace_bindings.json")
-			engine.SetMultiWorkspace(baseDir, bindingStore)
+			wsIdleTimeout := 2 * time.Hour
+			if proj.WorkspaceIdleTimeoutMins != nil {
+				wsIdleTimeout = time.Duration(*proj.WorkspaceIdleTimeoutMins) * time.Minute
+			}
+			engine.SetMultiWorkspace(baseDir, bindingStore, wsIdleTimeout)
 			slog.Info("multi-workspace mode enabled", "project", proj.Name, "base_dir", baseDir)
 		}
 
@@ -437,6 +441,23 @@ func main() {
 			} else {
 				engine.SetEventIdleTimeout(time.Duration(mins) * time.Minute)
 			}
+		}
+
+		// Wire background-listen timeout
+		if cfg.BgListenTimeoutMins != nil {
+			mins := *cfg.BgListenTimeoutMins
+			if mins <= 0 {
+				engine.SetBgListenTimeout(0)
+			} else {
+				engine.SetBgListenTimeout(time.Duration(mins) * time.Minute)
+			}
+		}
+
+		// Wire default quiet mode: project-level overrides global
+		if proj.Quiet != nil {
+			engine.SetDefaultQuiet(*proj.Quiet)
+		} else if cfg.Quiet != nil {
+			engine.SetDefaultQuiet(*cfg.Quiet)
 		}
 
 		// Wire auto-compress settings

--- a/config/config.go
+++ b/config/config.go
@@ -80,29 +80,30 @@ var configMu sync.Mutex
 var ConfigPath string
 
 type Config struct {
-	DataDir           string                  `toml:"data_dir"` // session store directory, default ~/.cc-connect
-	AttachmentSend    string                  `toml:"attachment_send"`
+	DataDir             string                  `toml:"data_dir"` // session store directory, default ~/.cc-connect
+	AttachmentSend      string                  `toml:"attachment_send"`
 	// Quiet is legacy: when true and [display] does not set thinking_messages / tool_messages,
 	// engines behave as if those flags were false. Per-project quiet overrides when set.
-	Quiet             *bool                   `toml:"quiet,omitempty"`
-	Projects          []ProjectConfig         `toml:"projects"`
-	Commands          []CommandConfig         `toml:"commands"`     // global custom slash commands
-	Aliases           []AliasConfig           `toml:"aliases"`      // global command aliases
-	BannedWords       []string                `toml:"banned_words"` // messages containing any of these words are blocked
-	Log               LogConfig               `toml:"log"`
-	Language          string                  `toml:"language"` // "en" or "zh", default is "en"
-	Speech            SpeechConfig            `toml:"speech"`
-	TTS               TTSConfig               `toml:"tts"`
-	Display           DisplayConfig           `toml:"display"`
-	StreamPreview     StreamPreviewConfig     `toml:"stream_preview"`      // real-time streaming preview
-	RateLimit         RateLimitConfig         `toml:"rate_limit"`          // per-session rate limiting
-	OutgoingRateLimit OutgoingRateLimitConfig `toml:"outgoing_rate_limit"` // outgoing message throttling
-	Relay             RelayConfig             `toml:"relay"`               // bot-to-bot relay behavior
-	Cron              CronConfig              `toml:"cron"`
-	Webhook           WebhookConfig           `toml:"webhook"`
-	Bridge            BridgeConfig            `toml:"bridge"`
-	Management        ManagementConfig        `toml:"management"`
-	IdleTimeoutMins   *int                    `toml:"idle_timeout_mins,omitempty"` // max minutes between agent events; 0 = no timeout; default 120
+	Quiet               *bool                   `toml:"quiet,omitempty"`     // global default for quiet mode; project-level overrides this
+	Projects            []ProjectConfig         `toml:"projects"`
+	Commands            []CommandConfig         `toml:"commands"`     // global custom slash commands
+	Aliases             []AliasConfig           `toml:"aliases"`      // global command aliases
+	BannedWords         []string                `toml:"banned_words"` // messages containing any of these words are blocked
+	Log                 LogConfig               `toml:"log"`
+	Language            string                  `toml:"language"` // "en" or "zh", default is "en"
+	Speech              SpeechConfig            `toml:"speech"`
+	TTS                 TTSConfig               `toml:"tts"`
+	Display             DisplayConfig           `toml:"display"`
+	StreamPreview       StreamPreviewConfig     `toml:"stream_preview"`      // real-time streaming preview
+	RateLimit           RateLimitConfig         `toml:"rate_limit"`          // per-session rate limiting
+	OutgoingRateLimit   OutgoingRateLimitConfig `toml:"outgoing_rate_limit"` // outgoing message throttling
+	Relay               RelayConfig             `toml:"relay"`               // bot-to-bot relay behavior
+	Cron                CronConfig              `toml:"cron"`
+	Webhook             WebhookConfig           `toml:"webhook"`
+	Bridge              BridgeConfig            `toml:"bridge"`
+	Management          ManagementConfig        `toml:"management"`
+	IdleTimeoutMins     *int                    `toml:"idle_timeout_mins,omitempty"`      // max minutes between agent events; 0 = no timeout; default 120
+	BgListenTimeoutMins *int                    `toml:"bg_listen_timeout_mins,omitempty"` // how long to listen for background task events after turn ends; 0 = disabled; default 60
 }
 
 // CronConfig controls cron job behavior.
@@ -301,16 +302,17 @@ type ProjectConfig struct {
 	// Use this only for variables the target user cannot set in their profile.
 	RunAsEnv []string `toml:"run_as_env,omitempty"`
 	// ShowContextIndicator: nil/true = append [ctx: ~N%] to assistant replies; false = hide.
-	ShowContextIndicator *bool           `toml:"show_context_indicator,omitempty"`
-	InjectSender         *bool           `toml:"inject_sender,omitempty"`     // prepend sender identity (platform + user ID) to each message sent to the agent
-	DisabledCommands     []string        `toml:"disabled_commands,omitempty"` // commands to disable for this project (e.g. ["restart", "upgrade"])
-	AdminFrom            string          `toml:"admin_from,omitempty"`        // comma-separated user IDs allowed to run privileged commands; "*" = all allowed users
-	Users                *UsersConfig    `toml:"users,omitempty"`             // per-user role config; nil = legacy behavior
+	ShowContextIndicator     *bool           `toml:"show_context_indicator,omitempty"`
+	InjectSender             *bool           `toml:"inject_sender,omitempty"`                // prepend sender identity (platform + user ID) to each message sent to the agent
+	DisabledCommands         []string        `toml:"disabled_commands,omitempty"`             // commands to disable for this project (e.g. ["restart", "upgrade"])
+	AdminFrom                string          `toml:"admin_from,omitempty"`                   // comma-separated user IDs allowed to run privileged commands; "*" = all allowed users
+	Users                    *UsersConfig    `toml:"users,omitempty"`                        // per-user role config; nil = legacy behavior
 	// Quiet is legacy per-project override; see Config.Quiet. When true and global [display]
 	// omits thinking_messages / tool_messages, those default to off for this project.
-	Quiet      *bool           `toml:"quiet,omitempty"`
-	Observe              *ObserveConfig  `toml:"observe,omitempty"`
-	References           ReferenceConfig `toml:"references,omitempty"`
+	Quiet                    *bool           `toml:"quiet,omitempty"`
+	Observe                  *ObserveConfig  `toml:"observe,omitempty"`
+	References               ReferenceConfig `toml:"references,omitempty"`
+	WorkspaceIdleTimeoutMins *int            `toml:"workspace_idle_timeout_mins,omitempty"` // minutes before idle workspace is reaped; default 120
 }
 
 type AgentConfig struct {

--- a/core/doctor.go
+++ b/core/doctor.go
@@ -52,6 +52,14 @@ type AgentDoctorInfo interface {
 	CLIDisplayName() string // e.g. "Claude", "Codex" (for display in doctor output)
 }
 
+// AgentResumeInfo is an optional interface agents can implement to provide
+// the CLI command for resuming a session from the terminal.
+type AgentResumeInfo interface {
+	// ResumeCommand returns the shell command to resume the given session ID.
+	// e.g. "claude --resume abc123"
+	ResumeCommand(sessionID string) string
+}
+
 // RunDoctorChecks performs all diagnostic checks.
 func RunDoctorChecks(ctx context.Context, agent Agent, platforms []Platform) []DoctorCheckResult {
 	var results []DoctorCheckResult

--- a/core/engine.go
+++ b/core/engine.go
@@ -187,7 +187,8 @@ type Engine struct {
 	streamPreview    StreamPreviewCfg
 	references       ReferenceRenderCfg
 	relayManager     *RelayManager
-	eventIdleTimeout time.Duration
+	eventIdleTimeout  time.Duration
+	bgListenTimeout   time.Duration
 	dirHistory       *DirHistory
 	baseWorkDir      string
 	projectState     *ProjectStateStore
@@ -218,6 +219,17 @@ type Engine struct {
 	// Interactive agent session management
 	interactiveMu     sync.Mutex
 	interactiveStates map[string]*interactiveState // key = sessionKey
+
+	// channelKeys caches the platform-provided ChannelKey for each sessionKey.
+	// Platforms like Telegram set ChannelKey to include composite identifiers
+	// (e.g. "chatID:threadID" for forum topics) that cannot be reliably parsed
+	// from the session key string alone. This cache allows string-only code paths
+	// (card actions, SendToSession, etc.) to resolve the correct channel key.
+	// Protected by interactiveMu.
+	channelKeys map[string]string // sessionKey → channelKey
+
+	quietMu sync.RWMutex
+	quiet   bool // when true, suppress thinking and tool progress messages globally
 
 	platformLifecycleMu sync.Mutex
 	platformReady       map[Platform]bool
@@ -268,6 +280,9 @@ type interactiveState struct {
 	deleteMode             *deleteModeState
 	lastAutoCompressAt     time.Time
 	lastAutoCompressTokens int
+	bgListening            bool           // true while a background-listen goroutine is active
+	bgWakeUp               chan struct{}   // closed to signal background-listen goroutine to exit
+	quiet                  bool           // per-session quiet mode
 }
 
 type deleteModeState struct {
@@ -343,11 +358,13 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		skills:                NewSkillRegistry(),
 		aliases:               make(map[string]string),
 		interactiveStates:     make(map[string]*interactiveState),
+		channelKeys:           make(map[string]string),
 		platformReady:         make(map[Platform]bool),
 		startedAt:             time.Now(),
 		streamPreview:         DefaultStreamPreviewCfg(),
 		references:            DefaultReferenceRenderCfg(),
 		eventIdleTimeout:      defaultEventIdleTimeout,
+		bgListenTimeout:       defaultBgListenTimeout,
 		showContextIndicator:  true,
 	}
 
@@ -366,11 +383,11 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 }
 
 // SetMultiWorkspace enables multi-workspace mode for the engine.
-func (e *Engine) SetMultiWorkspace(baseDir, bindingStorePath string) {
+func (e *Engine) SetMultiWorkspace(baseDir, bindingStorePath string, idleTimeout time.Duration) {
 	e.multiWorkspace = true
 	e.baseDir = baseDir
 	e.workspaceBindings = NewWorkspaceBindingManager(bindingStorePath)
-	e.workspacePool = newWorkspacePool(15 * time.Minute)
+	e.workspacePool = newWorkspacePool(idleTimeout)
 	e.initFlows = make(map[string]*workspaceInitFlow)
 	go e.runIdleReaper()
 }
@@ -802,6 +819,20 @@ func (e *Engine) SetStreamPreviewCfg(cfg StreamPreviewCfg) {
 // 0 disables the timeout entirely.
 func (e *Engine) SetEventIdleTimeout(d time.Duration) {
 	e.eventIdleTimeout = d
+}
+
+// SetBgListenTimeout sets how long the background-listen goroutine waits for
+// post-turn agent events (e.g. background task completion) before exiting.
+// 0 disables background listening entirely.
+func (e *Engine) SetBgListenTimeout(d time.Duration) {
+	e.bgListenTimeout = d
+}
+
+// SetDefaultQuiet sets the default quiet mode for new sessions.
+func (e *Engine) SetDefaultQuiet(q bool) {
+	e.quietMu.Lock()
+	e.quiet = q
+	e.quietMu.Unlock()
 }
 
 func (e *Engine) SetRelayManager(rm *RelayManager) {
@@ -1398,7 +1429,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	// Multi-workspace resolution
 	var wsAgent Agent
 	var wsSessions *SessionManager
-	var resolvedWorkspace string
+	var wsPoolKey string
 	if e.multiWorkspace {
 		channelID := effectiveChannelID(msg)
 		channelKey := effectiveWorkspaceChannelKey(msg)
@@ -1426,21 +1457,20 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 				return
 			}
 		} else {
-			resolvedWorkspace = workspace
+			// Get or create the workspace's agent and session manager.
+			wsPoolKey = workspace
 
 			// Touch for idle tracking
-			if ws := e.workspacePool.Get(workspace); ws != nil {
+			if ws := e.workspacePool.Get(wsPoolKey); ws != nil {
 				ws.Touch()
 			}
 
-			var effectiveWorkspace string
-			wsAgent, wsSessions, _, effectiveWorkspace, err = e.workspaceContext(workspace, msg.SessionKey)
+			wsAgent, wsSessions, _, _, err = e.workspaceContext(workspace, msg.SessionKey)
 			if err != nil {
 				slog.Error("failed to create workspace agent", "workspace", workspace, "err", err)
 				e.reply(p, msg.ReplyCtx, fmt.Sprintf("Failed to initialize workspace: %v", err))
 				return
 			}
-			resolvedWorkspace = effectiveWorkspace
 		}
 	}
 
@@ -1463,7 +1493,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	if e.multiWorkspace && wsSessions != nil {
 		sessions = wsSessions
 		agent = wsAgent
-		interactiveKey = resolvedWorkspace + ":" + msg.SessionKey
+		interactiveKey = wsPoolKey + ":" + msg.SessionKey
 	}
 
 	session := sessions.GetOrCreateActive(msg.SessionKey)
@@ -1496,7 +1526,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 			// and the queue append. Re-try TryLock — if it succeeds, no one is
 			// draining the queue so we must start a processor ourselves.
 			if session.TryLock() {
-				go e.drainOrphanedQueue(session, sessions, interactiveKey, agent, resolvedWorkspace)
+				go e.drainOrphanedQueue(session, sessions, interactiveKey, agent, wsPoolKey)
 			}
 			return
 		}
@@ -1519,7 +1549,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		"session", session.ID,
 	)
 
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey)
+	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, wsPoolKey, msg.SessionKey)
 }
 
 func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session) *Session {
@@ -1715,7 +1745,7 @@ func (e *Engine) handleVoiceMessage(p Platform, msg *Message) {
 // ──────────────────────────────────────────────────────────────
 
 func (e *Engine) handlePendingPermission(p Platform, msg *Message, content string) bool {
-	iKey := e.interactiveKeyForSessionKey(msg.SessionKey)
+	iKey := e.interactiveKeyForMessage(msg)
 	e.interactiveMu.Lock()
 	state, ok := e.interactiveStates[iKey]
 	e.interactiveMu.Unlock()
@@ -1945,7 +1975,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	if agent != e.agent {
 		agentOverride = agent
 	}
-	state := e.getOrCreateInteractiveStateWith(interactiveKey, p, msg.ReplyCtx, session, sessions, agentOverride, ccSessionKey)
+	state := e.getOrCreateInteractiveStateWith(interactiveKey, p, msg, session, sessions, agentOverride, ccSessionKey)
 
 	// Set workspaceDir on the state for idle reaper identification
 	if workspaceDir != "" {
@@ -2004,9 +2034,9 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 		}
 	}()
 
-	// Drain any stale events left in the channel from a previous turn.
-	// This prevents the next processInteractiveEvents from reading an old
-	// EventResult that was pushed after the previous turn already returned.
+	// Stop any background-listen goroutine from the previous turn before
+	// draining, so it does not race with the new turn's event consumption.
+	stopBgListen(state)
 	drainEvents(state.agentSession.Events())
 
 	promptContent := e.buildSenderPrompt(msg.Content, msg.UserID, msg.Platform, msg.SessionKey)
@@ -2043,7 +2073,8 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 // getOrCreateWorkspaceAgent returns (or creates) a per-workspace agent and session manager.
 // workspace must be a normalized path (from resolveWorkspace or normalizeWorkspacePath).
 func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionManager, error) {
-	ws := e.workspacePool.GetOrCreate(workspace)
+	poolKey := workspace
+	ws := e.workspacePool.GetOrCreate(poolKey)
 	ws.mu.Lock()
 	defer ws.mu.Unlock()
 
@@ -2099,8 +2130,8 @@ func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionMan
 		}
 	}
 
-	// Create per-workspace session manager
-	h := sha256.Sum256([]byte(workspace))
+	// Create per-workspace session manager — hash the full poolKey.
+	h := sha256.Sum256([]byte(poolKey))
 	sessionFile := filepath.Join(filepath.Dir(e.sessions.StorePath()),
 		fmt.Sprintf("%s_ws_%s.json", e.name, hex.EncodeToString(h[:4])))
 	sessions := NewSessionManager(sessionFile)
@@ -2154,7 +2185,8 @@ func adoptPendingFromPlaceholder(existing, newState *interactiveState) {
 
 // When agentOverride is non-nil it is used instead of e.agent to start the session.
 // ccSessionKey, when non-empty, is used for CC_SESSION_KEY env injection; otherwise sessionKey is used.
-func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, replyCtx any, session *Session, sessions *SessionManager, agentOverride Agent, ccSessionKey string) *interactiveState {
+func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, msg *Message, session *Session, sessions *SessionManager, agentOverride Agent, ccSessionKey string) *interactiveState {
+	replyCtx := msg.ReplyCtx
 	e.interactiveMu.Lock()
 	defer e.interactiveMu.Unlock()
 
@@ -2360,6 +2392,7 @@ func (e *Engine) closeAgentSessionWithTimeout(sessionKey string, agentSession Ag
 }
 
 const defaultEventIdleTimeout = 2 * time.Hour
+const defaultBgListenTimeout = 1 * time.Hour
 
 func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, msgID string, turnStart time.Time, stopTypingFn func(), sendDone <-chan error, replyCtx any) {
 	var textParts []string
@@ -2411,7 +2444,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		select {
 		case <-stopCh:
-			sp.discard()
+			// User stopped the session — keep existing messages visible
+			// instead of deleting them.
+			sp.freeze()
+			sp.detachPreview()
+			cp.Finalize(ProgressCardStateStopped)
 			return
 		case event, ok = <-events:
 			if !ok {
@@ -2453,7 +2490,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		}
 
 		if state.isStopped() {
-			sp.discard()
+			sp.freeze()
+			sp.detachPreview()
+			cp.Finalize(ProgressCardStateStopped)
 			return
 		}
 
@@ -2466,6 +2505,18 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 			}
 			idleTimer.Reset(e.eventIdleTimeout)
+		}
+
+		// Touch workspace so the idle reaper knows this workspace is still active.
+		if e.workspacePool != nil {
+			state.mu.Lock()
+			wsDir := state.workspaceDir
+			state.mu.Unlock()
+			if wsDir != "" {
+				if ws := e.workspacePool.Get(wsDir); ws != nil {
+					ws.Touch()
+				}
+			}
 		}
 
 		if !firstEventLogged {
@@ -2680,9 +2731,17 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				session.SetAgentSessionID(event.SessionID, e.agent.Name())
 			}
 
-			fullResponse := event.Content
-			if fullResponse == "" && len(textParts) > 0 {
+			// Prefer the accumulated textParts (all EventText chunks from this
+			// turn) over event.Content. Some agents (e.g. Claude Code) set
+			// event.Content to only the *last* text block (after the final tool
+			// call), not the entire turn output. Using textParts ensures we
+			// capture all text including segments emitted before tool calls.
+			fullResponse := ""
+			if len(textParts) > 0 {
 				fullResponse = strings.Join(textParts, "")
+			}
+			if fullResponse == "" {
+				fullResponse = event.Content
 			}
 			if fullResponse == "" {
 				fullResponse = e.i18n.T(MsgEmptyResponse)
@@ -2838,9 +2897,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					stopTyping = ti.StartTyping(e.ctx, queued.replyCtx)
 				}
 
-				// Drain stale events before starting the next turn. Between
-				// EventResult and Send(), the only buffered events would be
-				// stale leftovers (e.g. a deferred EventError from cmd.Wait()).
+				// Stop background listener and drain stale events before starting
+				// the next turn.
+				stopBgListen(state)
 				drainEvents(state.agentSession.Events())
 
 				if pendingSend != nil {
@@ -2899,6 +2958,10 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					slog.Debug("async send error after EventResult", "error", err)
 				}
 			}
+
+			// Start background-listen goroutine to capture post-turn events
+			// (e.g. when Claude Code completes a background task and wakes up).
+			e.startBgListen(state, sessionKey, events)
 			return
 
 		case EventError:
@@ -2998,6 +3061,7 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 			return false
 		}
 
+		stopBgListen(state)
 		drainEvents(state.agentSession.Events())
 
 		session.AddHistory("user", queued.content)
@@ -3064,6 +3128,7 @@ var builtinCommands = []struct {
 	{[]string{"dir", "cd", "chdir", "workdir"}, "dir"},
 	{[]string{"tts"}, "tts"},
 	{[]string{"workspace", "ws"}, "workspace"},
+	{[]string{"session-id", "session_id", "sid"}, "session-id"},
 	{[]string{"whoami", "myid"}, "whoami"},
 	{[]string{"web"}, "web"},
 	{[]string{"diff"}, "diff"},
@@ -3263,6 +3328,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		}
 		e.handleWorkspaceCommand(p, msg, args)
 		return true
+	case "session-id":
+		e.cmdSessionID(p, msg)
 	case "whoami":
 		e.cmdWhoami(p, msg)
 	case "web":
@@ -4337,6 +4404,26 @@ func (e *Engine) cmdCurrent(p Platform, msg *Message) {
 	e.replyWithCard(p, msg.ReplyCtx, e.renderCurrentCard(msg.SessionKey))
 }
 
+func (e *Engine) cmdSessionID(p Platform, msg *Message) {
+	_, sessions, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+	s := sessions.GetOrCreateActive(msg.SessionKey)
+	agentID := s.GetAgentSessionID()
+	if agentID == "" {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgSessionIDNoSession))
+		return
+	}
+
+	if ri, ok := e.agent.(AgentResumeInfo); ok {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgSessionID, agentID, ri.ResumeCommand(agentID)))
+	} else {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgSessionIDOnly, agentID))
+	}
+}
+
 func (e *Engine) cmdStatus(p Platform, msg *Message) {
 	if !supportsCards(p) {
 		agent, sessions, _, err := e.commandContext(p, msg)
@@ -4365,6 +4452,24 @@ func (e *Engine) cmdStatus(p Platform, msg *Message) {
 				modeStr = e.i18n.Tf(MsgStatusMode, mode)
 			}
 		}
+		e.quietMu.RLock()
+		globalQuiet := e.quiet
+		_ = globalQuiet
+		e.quietMu.RUnlock()
+
+		iKey := e.interactiveKeyForMessage(msg)
+		e.interactiveMu.Lock()
+		state, hasState := e.interactiveStates[iKey]
+		e.interactiveMu.Unlock()
+
+		sessionQuiet := false
+		if hasState && state != nil {
+			state.mu.Lock()
+			sessionQuiet = state.quiet
+			_ = sessionQuiet
+			state.mu.Unlock()
+		}
+
 		thinkingStr := e.i18n.T(MsgDisabledShort)
 		if e.display.ThinkingMessages {
 			thinkingStr = e.i18n.T(MsgEnabledShort)
@@ -4769,6 +4874,22 @@ func (e *Engine) renderStatusCard(sessionKey string, userID string) *Card {
 	}
 	modeStr += e.i18n.Tf(MsgStatusThinkingMessages, thinkingStr)
 	modeStr += e.i18n.Tf(MsgStatusToolMessages, toolStr)
+
+	// Add quiet mode status
+	iKey := e.interactiveKeyForSessionKey(sessionKey)
+	e.interactiveMu.Lock()
+	state, hasState := e.interactiveStates[iKey]
+	e.interactiveMu.Unlock()
+	if hasState && state != nil {
+		state.mu.Lock()
+		q := state.quiet
+		state.mu.Unlock()
+		quietStr := e.i18n.T(MsgDisabledShort)
+		if q {
+			quietStr = e.i18n.T(MsgEnabledShort)
+		}
+		modeStr += e.i18n.Tf(MsgStatusQuietMode, quietStr)
+	}
 
 	s := sessions.GetOrCreateActive(sessionKey)
 	sessionDisplayName := sessions.GetSessionName(s.GetAgentSessionID())
@@ -5510,7 +5631,7 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 	}
 
 	switcher.SetReasoningEffort(target)
-	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+	e.cleanupInteractiveState(e.interactiveKeyForMessage(msg))
 
 	s := e.sessions.GetOrCreateActive(msg.SessionKey)
 	s.SetAgentSessionID("", "")
@@ -5579,7 +5700,7 @@ func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
 	appliedLive := e.applyLiveModeChange(msg.SessionKey, newMode)
 
 	if !appliedLive {
-		e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+		e.cleanupInteractiveState(e.interactiveKeyForMessage(msg))
 	}
 
 	modes := switcher.PermissionModes()
@@ -5640,6 +5761,23 @@ func (e *Engine) cmdQuiet(p Platform, msg *Message, args []string) {
 		}
 	}
 
+	// Also toggle per-session quiet
+	iKey := e.interactiveKeyForMessage(msg)
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[iKey]
+	e.interactiveMu.Unlock()
+
+	if !ok || state == nil {
+		state = &interactiveState{platform: p, replyCtx: msg.ReplyCtx, quiet: true}
+		e.interactiveMu.Lock()
+		e.interactiveStates[iKey] = state
+		e.interactiveMu.Unlock()
+	} else {
+		state.mu.Lock()
+		state.quiet = !state.quiet
+		state.mu.Unlock()
+	}
+
 	if isQuiet {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgQuietOn))
 	} else {
@@ -5676,7 +5814,7 @@ func (e *Engine) cmdTTS(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdStop(p Platform, msg *Message) {
-	iKey := e.interactiveKeyForSessionKey(msg.SessionKey)
+	iKey := e.interactiveKeyForMessage(msg)
 	if !e.stopInteractiveSession(iKey, p, msg.ReplyCtx) {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgNoExecution))
 		return
@@ -5717,7 +5855,7 @@ func (e *Engine) cmdCompress(p Platform, msg *Message) {
 		return
 	}
 
-	iKey := e.interactiveKeyForSessionKey(msg.SessionKey)
+	iKey := e.interactiveKeyForMessage(msg)
 	e.interactiveMu.Lock()
 	state, hasState := e.interactiveStates[iKey]
 	e.interactiveMu.Unlock()
@@ -5757,6 +5895,7 @@ func (e *Engine) runCompress(state *interactiveState, session *Session, sessions
 	state.replyCtx = replyCtx
 	state.mu.Unlock()
 
+	stopBgListen(state)
 	drainEvents(state.agentSession.Events())
 
 	compressor, ok := e.agent.(ContextCompressor)
@@ -6035,7 +6174,7 @@ func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
 
 	case "clear", "reset", "none":
 		switcher.SetActiveProvider("")
-		e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+		e.cleanupInteractiveState(e.interactiveKeyForMessage(msg))
 		if e.providerSaveFunc != nil {
 			if err := e.providerSaveFunc(""); err != nil {
 				slog.Error("failed to save provider", "error", err)
@@ -6162,7 +6301,7 @@ func (e *Engine) switchProvider(p Platform, msg *Message, switcher ProviderSwitc
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgProviderNotFound), name))
 		return
 	}
-	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+	e.cleanupInteractiveState(e.interactiveKeyForMessage(msg))
 
 	if e.providerSaveFunc != nil {
 		if err := e.providerSaveFunc(name); err != nil {
@@ -6190,7 +6329,9 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 	if sessionKey != "" {
 		state = e.interactiveStates[sessionKey]
 		if state == nil && e.multiWorkspace {
-			if iKey := e.interactiveKeyForSessionKey(sessionKey); iKey != sessionKey {
+			// Inline the channel key lookup to avoid deadlock (we already hold interactiveMu).
+			cached := e.channelKeys[sessionKey]
+			if iKey := e.interactiveKeyWithChannelKey(sessionKey, cached); iKey != sessionKey {
 				state = e.interactiveStates[iKey]
 			}
 		}
@@ -6610,6 +6751,138 @@ func drainEvents(ch <-chan Event) {
 				slog.Warn("drained stale events from previous turn", "count", drained)
 			}
 			return
+		}
+	}
+}
+
+// startBgListen spawns a goroutine that continues reading agent events after a
+// turn has ended (EventResult received). This captures output from background
+// tasks that wake the agent up after the main turn is complete. The goroutine
+// exits when: (a) a new user message arrives (bgWakeUp is closed), (b) the
+// bgListenTimeout expires, (c) the events channel closes, or (d) the engine
+// context is cancelled.
+func (e *Engine) startBgListen(state *interactiveState, sessionKey string, events <-chan Event) {
+	if e.bgListenTimeout <= 0 {
+		return
+	}
+
+	state.mu.Lock()
+	if state.bgListening {
+		// Already listening (shouldn't happen, but be safe).
+		state.mu.Unlock()
+		return
+	}
+	state.bgListening = true
+	state.bgWakeUp = make(chan struct{})
+	wakeUp := state.bgWakeUp
+	state.mu.Unlock()
+
+	go func() {
+		defer func() {
+			state.mu.Lock()
+			state.bgListening = false
+			state.bgWakeUp = nil
+			state.mu.Unlock()
+		}()
+
+		timer := time.NewTimer(e.bgListenTimeout)
+		defer timer.Stop()
+
+		slog.Info("background listen started", "session", sessionKey, "timeout", e.bgListenTimeout)
+
+		sentText := false // track whether EventText already forwarded content
+		for {
+			select {
+			case event, ok := <-events:
+				if !ok {
+					slog.Info("background listen: channel closed", "session", sessionKey)
+					return
+				}
+				timer.Reset(e.bgListenTimeout)
+
+				state.mu.Lock()
+				p := state.platform
+				rctx := state.replyCtx
+				state.mu.Unlock()
+
+				switch event.Type {
+				case EventText:
+					if event.Content != "" {
+						sentText = true
+						for _, chunk := range splitMessage(event.Content, maxPlatformMessageLen) {
+							e.send(p, rctx, chunk)
+						}
+					}
+				case EventResult:
+					// Only send EventResult content if nothing was already
+					// forwarded via EventText — otherwise it's a duplicate.
+					if !sentText && event.Content != "" {
+						for _, chunk := range splitMessage(event.Content, maxPlatformMessageLen) {
+							e.send(p, rctx, chunk)
+						}
+					}
+					slog.Info("background listen: task completed", "session", sessionKey)
+					// Don't return — Claude Code can emit multiple rounds of
+					// post-turn events (e.g. background Agent completes, then
+					// Claude processes the result and emits more events). Reset
+					// state and keep listening for subsequent rounds.
+					sentText = false
+					timer.Reset(e.bgListenTimeout)
+				case EventError:
+					if event.Error != nil {
+						e.send(p, rctx, fmt.Sprintf(e.i18n.T(MsgError), event.Error))
+					}
+					return
+				}
+
+			case <-wakeUp:
+				slog.Info("background listen: interrupted by new message", "session", sessionKey)
+				return
+
+			case <-timer.C:
+				slog.Info("background listen: timeout", "session", sessionKey, "timeout", e.bgListenTimeout)
+				return
+
+			case <-e.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// stopBgListen signals the background-listen goroutine (if any) to exit and
+// waits briefly for it to clear the bgListening flag. Called before draining
+// events for a new turn so the goroutine does not race with the new turn's
+// event consumption.
+func stopBgListen(state *interactiveState) {
+	state.mu.Lock()
+	if !state.bgListening || state.bgWakeUp == nil {
+		state.mu.Unlock()
+		return
+	}
+	ch := state.bgWakeUp
+	state.mu.Unlock()
+
+	// Signal the goroutine to exit.
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+
+	// Wait for the goroutine to clear bgListening (up to 100ms).
+	deadline := time.After(100 * time.Millisecond)
+	for {
+		select {
+		case <-deadline:
+			return
+		default:
+			state.mu.Lock()
+			done := !state.bgListening
+			state.mu.Unlock()
+			if done {
+				return
+			}
+			time.Sleep(time.Millisecond)
 		}
 	}
 }
@@ -8586,10 +8859,11 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 	var shellCmd *exec.Cmd
 	if runtime.GOOS == "windows" {
 		shellCmd = exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", execCmd)
+		shellCmd.Dir = workDir
 	} else {
 		shellCmd = exec.CommandContext(ctx, "sh", "-c", execCmd)
+		shellCmd.Dir = workDir
 	}
-	shellCmd.Dir = workDir
 	envVars := []string{
 		"CC_PROJECT=" + e.name,
 		"CC_SESSION_KEY=" + msg.SessionKey,
@@ -9714,9 +9988,12 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 				session.SetAgentSessionID(event.SessionID, e.agent.Name())
 				e.sessions.Save()
 			}
-			resp := event.Content
-			if resp == "" && len(textParts) > 0 {
+			resp := ""
+			if len(textParts) > 0 {
 				resp = strings.Join(textParts, "")
+			}
+			if resp == "" {
+				resp = event.Content
 			}
 			if resp == "" {
 				resp = "(empty response)"
@@ -10113,7 +10390,13 @@ func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager
 	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return e.agent, e.sessions
 	}
-	channelKey := extractWorkspaceChannelKey(sessionKey)
+	// Try cached channel key first, then fall back to parsing the session key.
+	e.interactiveMu.Lock()
+	channelKey := e.channelKeys[sessionKey]
+	e.interactiveMu.Unlock()
+	if channelKey == "" {
+		channelKey = extractWorkspaceChannelKey(sessionKey)
+	}
 	if channelKey == "" {
 		return e.agent, e.sessions
 	}
@@ -10127,16 +10410,52 @@ func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager
 
 // interactiveKeyForSessionKey returns the interactive state key for a sessionKey.
 // In multi-workspace mode, it prefixes with the bound workspace path when available.
+//
+// This function first checks the channelKeys cache (populated by interactiveKeyForMessage)
+// for the correct channel key, then falls back to parsing the session key string.
+// The fallback is ambiguous for platforms with composite channel identifiers
+// (e.g. Telegram forum topics: "telegram:chatID:threadID:userID"), so callers
+// with a *Message should prefer interactiveKeyForMessage.
 func (e *Engine) interactiveKeyForSessionKey(sessionKey string) string {
+	// Try cached channel key first (set by interactiveKeyForMessage when a
+	// Message with an explicit ChannelKey was processed).
+	e.interactiveMu.Lock()
+	cached := e.channelKeys[sessionKey]
+	e.interactiveMu.Unlock()
+	return e.interactiveKeyWithChannelKey(sessionKey, cached)
+}
+
+// interactiveKeyForMessage returns the interactive state key for a Message.
+// It uses msg.ChannelKey (set by the platform) when available, which correctly
+// handles composite channel identifiers like Telegram forum topics.
+// It also caches the channel key so that string-only callers (card actions,
+// SendToSession, etc.) can resolve the correct key later.
+func (e *Engine) interactiveKeyForMessage(msg *Message) string {
+	channelKey := effectiveWorkspaceChannelKey(msg)
+	if channelKey != "" && msg.SessionKey != "" {
+		e.interactiveMu.Lock()
+		e.channelKeys[msg.SessionKey] = channelKey
+		e.interactiveMu.Unlock()
+	}
+	return e.interactiveKeyWithChannelKey(msg.SessionKey, channelKey)
+}
+
+// interactiveKeyWithChannelKey is the shared implementation for interactive key resolution.
+// When channelKey is non-empty it is used directly; otherwise the channel is parsed
+// from the sessionKey string (legacy fallback).
+func (e *Engine) interactiveKeyWithChannelKey(sessionKey, channelKey string) string {
 	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return sessionKey
 	}
-	channelKey := extractWorkspaceChannelKey(sessionKey)
+	if channelKey == "" {
+		channelKey = extractWorkspaceChannelKey(sessionKey)
+	}
 	if channelKey == "" {
 		return sessionKey
 	}
 	if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
-		return normalizeWorkspacePath(b.Workspace) + ":" + sessionKey
+		poolKey := normalizeWorkspacePath(b.Workspace)
+		return poolKey + ":" + sessionKey
 	}
 	return sessionKey
 }

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -647,7 +647,7 @@ func TestEngineSendToSessionWithAttachments_MultiWorkspaceRawSessionKey(t *testi
 
 	baseDir := t.TempDir()
 	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindingPath)
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
 
 	wsDir := filepath.Join(baseDir, "ws1")
 	if err := os.MkdirAll(wsDir, 0o755); err != nil {
@@ -1908,7 +1908,7 @@ func TestCmdList_MultiWorkspaceUsesWorkspaceSessions(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindingPath)
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
 
 	wsDir := filepath.Join(baseDir, "ws1")
 	if err := os.MkdirAll(wsDir, 0o755); err != nil {
@@ -1947,7 +1947,7 @@ func TestHandlePendingPermission_MultiWorkspaceLookup(t *testing.T) {
 	// Set up multi-workspace with proper bindings so interactiveKeyForSessionKey works
 	wsDir := t.TempDir()
 	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(t.TempDir(), bindingPath)
+	e.SetMultiWorkspace(t.TempDir(), bindingPath, 15*time.Minute)
 
 	channelID := "C123"
 	e.workspaceBindings.Bind("project:test", channelID, "chan", wsDir)
@@ -2013,7 +2013,7 @@ func TestHandleMessage_MultiWorkspacePreservesCCSessionKey(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindingPath)
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
 
 	wsDir := filepath.Join(baseDir, "ws1")
 	if err := os.MkdirAll(wsDir, 0o755); err != nil {
@@ -2383,6 +2383,69 @@ func TestCmdCurrent_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	}
 	if strings.Contains(p.sent[0], "cc-connect") {
 		t.Fatalf("current text = %q, should not be card fallback title", p.sent[0])
+	}
+}
+
+type stubResumeAgent struct {
+	stubAgent
+}
+
+func (a *stubResumeAgent) ResumeCommand(sessionID string) string {
+	return "mystub --resume " + sessionID
+}
+
+func TestCmdSessionID_ShowsIDAndResumeCommand(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubResumeAgent{}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	session := e.sessions.GetOrCreateActive(msg.SessionKey)
+	session.SetAgentSessionID("abc-123", "stub")
+
+	e.cmdSessionID(p, msg)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "abc-123") {
+		t.Errorf("reply = %q, want to contain session ID", p.sent[0])
+	}
+	if !strings.Contains(p.sent[0], "mystub --resume abc-123") {
+		t.Errorf("reply = %q, want to contain resume command", p.sent[0])
+	}
+}
+
+func TestCmdSessionID_NoResumeSupport(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	session := e.sessions.GetOrCreateActive(msg.SessionKey)
+	session.SetAgentSessionID("abc-123", "stub")
+
+	e.cmdSessionID(p, msg)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "abc-123") {
+		t.Errorf("reply = %q, want to contain session ID", p.sent[0])
+	}
+	if !strings.Contains(p.sent[0], "does not support terminal resume") {
+		t.Errorf("reply = %q, want no-resume message", p.sent[0])
+	}
+}
+
+func TestCmdSessionID_NoSession(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	e.cmdSessionID(p, msg)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "No active agent session") {
+		t.Errorf("reply = %q, want no-session message", p.sent[0])
 	}
 }
 
@@ -3086,7 +3149,7 @@ func TestCmdModel_MultiWorkspaceUsesWorkspaceAgentAndSessions(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindingPath)
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
 
 	wsDir := normalizeWorkspacePath(t.TempDir())
 	channelID := "C-model"
@@ -3127,7 +3190,7 @@ func TestCmdModel_MultiWorkspaceSwitchDoesNotMutateProviderModel(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindingPath)
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
 
 	wsDir := normalizeWorkspacePath(t.TempDir())
 	channelID := "C-model-provider"
@@ -3184,7 +3247,7 @@ func TestGetOrCreateWorkspaceAgent_InheritsActiveProvider(t *testing.T) {
 		},
 	}
 	e := NewEngine("test", globalAgent, []Platform{&stubPlatformEngine{n: "plain"}}, "", LangEnglish)
-	e.SetMultiWorkspace(t.TempDir(), filepath.Join(t.TempDir(), "bindings.json"))
+	e.SetMultiWorkspace(t.TempDir(), filepath.Join(t.TempDir(), "bindings.json"), 15*time.Minute)
 
 	wsAgentRaw, _, err := e.getOrCreateWorkspaceAgent(normalizeWorkspacePath(t.TempDir()))
 	if err != nil {
@@ -3231,7 +3294,7 @@ func TestWorkspaceContext_PerChannelIndependence(t *testing.T) {
 	store.Save()
 
 	e := NewEngine("test", &namedStubWorkDirAgent{name: agentName, stubWorkDirAgent: stubWorkDirAgent{workDir: workspace}}, []Platform{&stubPlatformEngine{n: "plain"}}, "", LangEnglish)
-	e.SetMultiWorkspace(workspace, filepath.Join(t.TempDir(), "bindings.json"))
+	e.SetMultiWorkspace(workspace, filepath.Join(t.TempDir(), "bindings.json"), 15*time.Minute)
 	e.SetProjectStateStore(store)
 
 	agentA, sessionsA, interactiveKeyA, effectiveDirA, err := e.workspaceContext(workspace, "feishu:oc_aaa:ou_111")
@@ -3401,7 +3464,7 @@ func TestDirApply_MultiWorkspacePersistsWorkspaceSpecificOverride(t *testing.T) 
 	store := NewProjectStateStore(statePath)
 	agent := &stubWorkDirAgent{workDir: workspace}
 	e := NewEngine("test", agent, []Platform{&stubPlatformEngine{n: "plain"}}, "", LangEnglish)
-	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"), 15*time.Minute)
 	e.SetProjectStateStore(store)
 
 	sessions := NewSessionManager("")
@@ -3441,7 +3504,7 @@ func TestDirApply_MultiWorkspaceResetClearsWorkspaceSpecificOverride(t *testing.
 	agent := &stubWorkDirAgent{workDir: overrideDir}
 	e := NewEngine("test", agent, []Platform{&stubPlatformEngine{n: "plain"}}, "", LangEnglish)
 	e.SetBaseWorkDir(baseDir)
-	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"), 15*time.Minute)
 	e.SetProjectStateStore(store)
 
 	sessions := NewSessionManager("")
@@ -4744,7 +4807,7 @@ func TestSessionMismatch_RecyclesStaleAgent(t *testing.T) {
 	// The active Session now wants a DIFFERENT agent session ID.
 	session := &Session{AgentSessionID: "new-agent-id"}
 
-	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith(key, p, &Message{ReplyCtx: "ctx"}, session, e.sessions, nil, "")
 
 	if state.agentSession == oldSess {
 		t.Fatal("expected stale agent session to be replaced")
@@ -4781,7 +4844,7 @@ func TestSessionClearedAfterNew_RecyclesAliveAgent(t *testing.T) {
 
 	session := &Session{AgentSessionID: ""}
 
-	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith(key, p, &Message{ReplyCtx: "ctx"}, session, e.sessions, nil, "")
 	if state.agentSession == oldSess {
 		t.Fatal("expected stale agent to be recycled when AgentSessionID was cleared")
 	}
@@ -4792,6 +4855,38 @@ func TestSessionClearedAfterNew_RecyclesAliveAgent(t *testing.T) {
 	case <-oldSess.closed:
 	case <-time.After(2 * time.Second):
 		t.Fatal("old agent session was not closed after /new-style clear")
+	}
+}
+
+// TestSessionMismatch_DoesNotLeakQuiet verifies that after a session mismatch,
+// the new state gets defaultQuiet instead of inheriting quiet from the stale state.
+func TestSessionMismatch_DoesNotLeakQuiet(t *testing.T) {
+	agent := &controllableAgent{nextSession: newControllableSession("new-id")}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+
+	// Seed a stale state with quiet=true.
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = &interactiveState{
+		agentSession: newControllableSession("old-id"),
+		platform:     p,
+		replyCtx:     "ctx",
+		quiet:        true,
+	}
+	e.interactiveMu.Unlock()
+
+	// Active session wants "new-id", which mismatches "old-id".
+	session := &Session{AgentSessionID: "new-id"}
+
+	state := e.getOrCreateInteractiveStateWith(key, p, &Message{ReplyCtx: "ctx"}, session, e.sessions, nil, "")
+
+	state.mu.Lock()
+	q := state.quiet
+	state.mu.Unlock()
+	if q {
+		t.Fatal("quiet leaked from stale state into replacement — ok=false fix not working")
 	}
 }
 
@@ -4816,7 +4911,7 @@ func TestSessionMismatch_ReusesWhenIDsMatch(t *testing.T) {
 
 	session := &Session{AgentSessionID: "matching-id"}
 
-	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith(key, p, &Message{ReplyCtx: "ctx"}, session, e.sessions, nil, "")
 	if state != existingState {
 		t.Fatal("expected existing state to be reused when session IDs match")
 	}
@@ -4834,7 +4929,7 @@ func TestSessionIDWriteback_ImmediateAfterStartSession(t *testing.T) {
 	key := "test:user1"
 	session := &Session{AgentSessionID: ""} // empty — no prior binding
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, &Message{ReplyCtx: "ctx"}, session, e.sessions, nil, "")
 
 	got := session.GetAgentSessionID()
 
@@ -4854,7 +4949,7 @@ func TestSessionIDWriteback_DoesNotOverwriteExisting(t *testing.T) {
 	key := "test:user1"
 	session := &Session{AgentSessionID: "existing-uuid"}
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, &Message{ReplyCtx: "ctx"}, session, e.sessions, nil, "")
 
 	got := session.GetAgentSessionID()
 
@@ -4890,7 +4985,7 @@ func TestStaleGoroutineCleanup_RaceSimulation(t *testing.T) {
 
 	// Step 3: New turn creates Session B and calls getOrCreateInteractiveStateWith.
 	sessionB := &Session{AgentSessionID: ""}
-	newState := e.getOrCreateInteractiveStateWith(key, p, "ctx", sessionB, e.sessions, nil, "")
+	newState := e.getOrCreateInteractiveStateWith(key, p, &Message{ReplyCtx: "ctx"}, sessionB, e.sessions, nil, "")
 
 	// Verify S2 is in the map.
 	e.interactiveMu.Lock()
@@ -5216,7 +5311,7 @@ func TestResumeFailureFallbackToFreshSession(t *testing.T) {
 	session.SetAgentSessionID("old-session-id", "stub")
 
 	p := &stubPlatformEngine{n: "test"}
-	state := e.getOrCreateInteractiveStateWith("test:user1", p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith("test:user1", p, &Message{ReplyCtx: "ctx"}, session, e.sessions, nil, "")
 
 	if state.agentSession == nil {
 		t.Fatal("expected agentSession to be non-nil after fallback")
@@ -5254,7 +5349,7 @@ func TestFreshSessionWithoutSavedSessionIDStartsFresh(t *testing.T) {
 	session := e.sessions.GetOrCreateActive("test:user2")
 
 	p := &stubPlatformEngine{n: "test"}
-	state := e.getOrCreateInteractiveStateWith("test:user2", p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith("test:user2", p, &Message{ReplyCtx: "ctx"}, session, e.sessions, nil, "")
 
 	if state.agentSession == nil {
 		t.Fatal("expected agentSession to be non-nil")
@@ -5291,7 +5386,7 @@ func TestWorkspaceReconnectWithSavedSessionIDUsesExactResume(t *testing.T) {
 	session.SetAgentSessionID("saved-session-id", "stub")
 
 	p := &stubPlatformEngine{n: "test"}
-	state := e.getOrCreateInteractiveStateWith("test:user3", p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith("test:user3", p, &Message{ReplyCtx: "ctx"}, session, e.sessions, nil, "")
 
 	if state.agentSession == nil {
 		t.Fatal("expected agentSession to be non-nil")
@@ -5958,7 +6053,7 @@ func TestExecuteCardAction_ModelUsesWorkspaceContext(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindingPath)
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
 
 	wsDir := normalizeWorkspacePath(t.TempDir())
 	channelID := "channel1"
@@ -6010,7 +6105,7 @@ func TestHandleCardNav_ModelCardUsesWorkspaceAgent(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindingPath)
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
 
 	wsDir := normalizeWorkspacePath(t.TempDir())
 	channelID := "channel-nav"
@@ -6792,6 +6887,38 @@ func TestCmdStatus_UsesInteractiveKeyForMultiWorkspace(t *testing.T) {
 	}
 }
 
+func TestRenderStatusCard_UsesInteractiveKeyForRawSessionKeyInMultiWorkspace(t *testing.T) {
+	agent := &stubModelModeAgent{model: "gpt-4.1", mode: "default"}
+	e := NewEngine("test", agent, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
+
+	baseDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
+
+	wsDir := filepath.Join(baseDir, "ws1")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	normalizedWsDir := normalizeWorkspacePath(wsDir)
+	channelID := "C123"
+	rawKey := "slack:" + channelID + ":U1"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", normalizedWsDir)
+
+	iKey := normalizedWsDir + ":" + rawKey
+	e.interactiveMu.Lock()
+	e.interactiveStates[iKey] = &interactiveState{quiet: true}
+	e.interactiveMu.Unlock()
+
+	card := e.renderStatusCard(rawKey, "U1")
+	if card == nil {
+		t.Fatal("expected status card")
+	}
+	text := card.RenderText()
+	if !strings.Contains(text, "Quiet mode: ON") {
+		t.Fatalf("expected status card to reflect quiet=true from interactiveKey, got %q", text)
+	}
+}
+
 func TestCmdStop_UsesInteractiveKeyForMultiWorkspace(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newControllableSession("ws-stop-test")
@@ -7129,7 +7256,7 @@ func TestCmdShell_MultiWorkspaceUsesSharedBindingWorkDir(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	wsDir := filepath.Join(baseDir, "shared-shell-workspace")
 	if err := os.MkdirAll(wsDir, 0o755); err != nil {
@@ -7168,7 +7295,7 @@ func TestCmdShell_MultiWorkspaceIgnoresMissingSharedBinding(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	missingDir := filepath.Join(baseDir, "missing-shared-workspace")
 	e.workspaceBindings.Bind(sharedWorkspaceBindingsKey, "ch1", "shared-shell", missingDir)
@@ -7468,7 +7595,7 @@ func TestCmdShow_MultiWorkspaceUsesBoundWorkDirForRelativeReference(t *testing.T
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	wsDir := filepath.Join(baseDir, "demo-repo")
 	if err := os.MkdirAll(filepath.Join(wsDir, "svc"), 0o755); err != nil {
@@ -7592,7 +7719,7 @@ func TestWorkspace_Bind_Unbind_List(t *testing.T) {
 		t.Fatal(err)
 	}
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	// Bind
 	msg := &Message{SessionKey: "test:ch1:user1", Content: "/workspace bind my-project", ReplyCtx: "ctx"}
@@ -7664,7 +7791,7 @@ func TestWorkspace_Bind_NonexistentDir(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	msg := &Message{SessionKey: "test:ch1:user1", Content: "/workspace bind nonexistent", ReplyCtx: "ctx"}
 	e.handleCommand(p, msg, msg.Content)
@@ -7687,7 +7814,7 @@ func TestWorkspace_Route_ShowsCurrentAndSupportsSpaces(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	targetDir := filepath.Join(t.TempDir(), "routed project")
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
@@ -7723,7 +7850,7 @@ func TestWorkspace_Route_RejectsRelativePath(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	msg := &Message{SessionKey: "test:ch1:user1", Content: "/workspace route relative/path", ReplyCtx: "ctx"}
 	e.handleCommand(p, msg, msg.Content)
@@ -7743,7 +7870,7 @@ func TestWorkspace_Route_RejectsNonexistentPath(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	missingPath := filepath.Join(t.TempDir(), "missing")
 	msg := &Message{SessionKey: "test:ch1:user1", Content: "/workspace route " + missingPath, ReplyCtx: "ctx"}
@@ -7764,7 +7891,7 @@ func TestWorkspace_Route_RejectsFileTarget(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	fileTarget := filepath.Join(t.TempDir(), "workspace.txt")
 	if err := os.WriteFile(fileTarget, []byte("not a dir"), 0o644); err != nil {
@@ -7789,7 +7916,7 @@ func TestWorkspace_NoArgs_ShowsCurrent(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	// No binding yet — should show "no binding"
 	msg := &Message{SessionKey: "test:ch1:user1", Content: "/workspace", ReplyCtx: "ctx"}
@@ -7807,7 +7934,7 @@ func TestWorkspace_NoArgs_ShowsSharedBinding(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	wsDir := filepath.Join(baseDir, "shared-project")
 	if err := os.MkdirAll(wsDir, 0o755); err != nil {
@@ -7841,7 +7968,7 @@ func TestWorkspace_SharedBind_AllowsRegularUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	msg := &Message{
 		SessionKey: "test:ch1:user1",
@@ -7874,7 +8001,7 @@ func TestWorkspace_SharedBind_Unbind_List(t *testing.T) {
 		t.Fatal(err)
 	}
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	msg := &Message{
 		SessionKey: "test:ch1:user1",
@@ -7924,7 +8051,7 @@ func TestWorkspace_SharedRoute_Unbind_List(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	targetDir := filepath.Join(t.TempDir(), "shared routed workspace")
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
@@ -7983,7 +8110,7 @@ func TestWorkspace_SharedInit_BindsExistingDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	msg := &Message{
 		SessionKey: "test:ch1:user1",
@@ -8005,7 +8132,7 @@ func TestWorkspace_Unbind_SharedBindingShowsHint(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	wsDir := filepath.Join(baseDir, "shared-project")
 	if err := os.MkdirAll(wsDir, 0o755); err != nil {
@@ -8028,7 +8155,7 @@ func TestWorkspace_NoArgs_IgnoresMissingSharedBinding(t *testing.T) {
 
 	baseDir := t.TempDir()
 	bindStore := filepath.Join(t.TempDir(), "bindings.json")
-	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetMultiWorkspace(baseDir, bindStore, 15*time.Minute)
 
 	missingDir := filepath.Join(baseDir, "missing-shared-project")
 	e.workspaceBindings.Bind(sharedWorkspaceBindingsKey, "ch1", "shared-project", missingDir)

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -154,6 +154,9 @@ const (
 	MsgModeChanged               MsgKey = "mode_changed"
 	MsgModeNotSupported          MsgKey = "mode_not_supported"
 	MsgSessionRestarting         MsgKey = "session_restarting"
+	MsgSessionID                 MsgKey = "session_id"
+	MsgSessionIDOnly             MsgKey = "session_id_only"
+	MsgSessionIDNoSession        MsgKey = "session_id_no_session"
 	MsgSessionNotStarted         MsgKey = "session_not_started"
 	MsgLangChanged               MsgKey = "lang_changed"
 	MsgLangInvalid               MsgKey = "lang_invalid"
@@ -270,6 +273,7 @@ const (
 	MsgStatusCron             MsgKey = "status_cron"
 	MsgStatusThinkingMessages MsgKey = "status_thinking_messages"
 	MsgStatusToolMessages     MsgKey = "status_tool_messages"
+	MsgStatusQuietMode        MsgKey = "status_quiet_mode"
 	MsgStatusSessionKey       MsgKey = "status_session_key"
 	MsgStatusUserID           MsgKey = "status_user_id"
 	MsgEnabledShort           MsgKey = "enabled_short"
@@ -491,6 +495,12 @@ const (
 	MsgBuiltinCmdShell     MsgKey = "shell"
 	MsgBuiltinCmdDir       MsgKey = "dir"
 	MsgBuiltinCmdDiff      MsgKey = "diff"
+	MsgBuiltinCmdSessionID MsgKey = "session-id"
+	MsgBuiltinCmdHeartbeat MsgKey = "heartbeat"
+	MsgBuiltinCmdTTS       MsgKey = "tts"
+	MsgBuiltinCmdWorkspace MsgKey = "workspace"
+	MsgBuiltinCmdWhoami    MsgKey = "whoami"
+	MsgBuiltinCmdWeb       MsgKey = "web"
 
 	MsgDiffEmpty           MsgKey = "diff_empty"
 	MsgDiffNoDiff2HTML     MsgKey = "diff_no_diff2html"
@@ -549,6 +559,7 @@ const (
 	MsgWsCloneProgress         MsgKey = "ws_clone_progress"
 	MsgWsCloneSuccess          MsgKey = "ws_clone_success"
 	MsgWsCloneFailed           MsgKey = "ws_clone_failed"
+
 )
 
 var messages = map[MsgKey]map[Language]string{
@@ -793,6 +804,27 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "🔄 會話進程已退出，正在重啟...",
 		LangJapanese:           "🔄 セッションプロセスが終了しました。再起動中...",
 		LangSpanish:            "🔄 El proceso de sesión finalizó, reiniciando...",
+	},
+	MsgSessionID: {
+		LangEnglish:            "Session ID: `%s`\n\nResume in terminal:\n```\n%s\n```",
+		LangChinese:            "会话 ID: `%s`\n\n在终端恢复会话:\n```\n%s\n```",
+		LangTraditionalChinese: "會話 ID: `%s`\n\n在終端恢復會話:\n```\n%s\n```",
+		LangJapanese:           "セッション ID: `%s`\n\nターミナルで再開:\n```\n%s\n```",
+		LangSpanish:            "ID de sesión: `%s`\n\nReanudar en terminal:\n```\n%s\n```",
+	},
+	MsgSessionIDOnly: {
+		LangEnglish:            "Session ID: `%s`\n\nThis agent does not support terminal resume.",
+		LangChinese:            "会话 ID: `%s`\n\n此 agent 不支持终端恢复。",
+		LangTraditionalChinese: "會話 ID: `%s`\n\n此 agent 不支援終端恢復。",
+		LangJapanese:           "セッション ID: `%s`\n\nこのエージェントはターミナル再開に対応していません。",
+		LangSpanish:            "ID de sesión: `%s`\n\nEste agente no soporta reanudación en terminal.",
+	},
+	MsgSessionIDNoSession: {
+		LangEnglish:            "No active agent session. Send a message first to start one.",
+		LangChinese:            "没有活跃的 agent 会话。请先发送消息以启动会话。",
+		LangTraditionalChinese: "沒有活躍的 agent 會話。請先發送訊息以啟動會話。",
+		LangJapanese:           "アクティブなエージェントセッションがありません。まずメッセージを送信してください。",
+		LangSpanish:            "No hay sesión de agente activa. Envía un mensaje primero para iniciar una.",
 	},
 	MsgSessionNotStarted: {
 		LangEnglish:            "(new — not yet started)",
@@ -1057,6 +1089,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <number>|1,2,3|3-7|1,3-5,8 — Delete session(s)\n" +
 			"/name [number] <text> — Name a session\n" +
 			"/current — Show active session\n" +
+			"/session-id — Show session ID with resume command\n" +
 			"/history [n] — Show last n messages",
 		LangChinese: "**会话管理**\n" +
 			"/new [名称] — 创建新会话\n" +
@@ -1066,6 +1099,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <序号>|1,2,3|3-7|1,3-5,8 — 删除会话\n" +
 			"/name [序号] <名称> — 命名会话\n" +
 			"/current — 查看当前会话\n" +
+			"/session-id — 显示会话 ID 和恢复命令\n" +
 			"/history [n] — 查看最近 n 条消息",
 		LangTraditionalChinese: "**會話管理**\n" +
 			"/new [名稱] — 建立新會話\n" +
@@ -1075,6 +1109,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <序號>|1,2,3|3-7|1,3-5,8 — 刪除會話\n" +
 			"/name [序號] <名稱> — 命名會話\n" +
 			"/current — 查看當前會話\n" +
+			"/session-id — 顯示會話 ID 和恢復命令\n" +
 			"/history [n] — 查看最近 n 條訊息",
 		LangJapanese: "**セッション管理**\n" +
 			"/new [名前] — 新しいセッションを開始\n" +
@@ -1084,6 +1119,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <番号>|1,2,3|3-7|1,3-5,8 — セッション削除\n" +
 			"/name [番号] <名前> — セッションに名前を付ける\n" +
 			"/current — 現在のセッションを表示\n" +
+			"/session-id — セッション ID と再開コマンドを表示\n" +
 			"/history [n] — 直近 n 件のメッセージを表示",
 		LangSpanish: "**Gestión de sesiones**\n" +
 			"/new [nombre] — Iniciar nueva sesión\n" +
@@ -1093,6 +1129,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <número>|1,2,3|3-7|1,3-5,8 — Eliminar sesión(es)\n" +
 			"/name [número] <texto> — Nombrar sesión\n" +
 			"/current — Mostrar sesión activa\n" +
+			"/session-id — Mostrar ID de sesión y comando de reanudación\n" +
 			"/history [n] — Mostrar últimos n mensajes",
 	},
 	MsgHelpAgentSection: {
@@ -1999,6 +2036,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "工具進度: %s\n",
 		LangJapanese:           "ツール進捗: %s\n",
 		LangSpanish:            "Progreso de herramientas: %s\n",
+	},
+	MsgStatusQuietMode: {
+		LangEnglish:            "Quiet mode: %s\n",
+		LangChinese:            "静默模式: %s\n",
+		LangTraditionalChinese: "靜默模式: %s\n",
+		LangJapanese:           "静音モード: %s\n",
+		LangSpanish:            "Modo silencioso: %s\n",
 	},
 	MsgStatusSessionKey: {
 		LangEnglish:            "Session Key: `%s`\n",
@@ -3312,6 +3356,48 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "git diff を HTML ファイルで生成、引数: [ターゲット]",
 		LangSpanish:            "Generar git diff como archivo HTML, arg: [objetivo]",
 	},
+	MsgBuiltinCmdSessionID: {
+		LangEnglish:            "Show session ID and terminal resume command",
+		LangChinese:            "显示会话 ID 和终端恢复命令",
+		LangTraditionalChinese: "顯示會話 ID 和終端恢復命令",
+		LangJapanese:           "セッション ID とターミナル再開コマンドを表示",
+		LangSpanish:            "Mostrar ID de sesión y comando de reanudación",
+	},
+	MsgBuiltinCmdHeartbeat: {
+		LangEnglish:            "Configure session heartbeat interval",
+		LangChinese:            "配置会话心跳间隔",
+		LangTraditionalChinese: "配置會話心跳間隔",
+		LangJapanese:           "セッションハートビート間隔を設定",
+		LangSpanish:            "Configurar intervalo de heartbeat de sesión",
+	},
+	MsgBuiltinCmdTTS: {
+		LangEnglish:            "Toggle text-to-speech for responses",
+		LangChinese:            "开关语音合成回复",
+		LangTraditionalChinese: "開關語音合成回覆",
+		LangJapanese:           "テキスト読み上げのオン/オフ",
+		LangSpanish:            "Activar/desactivar texto a voz",
+	},
+	MsgBuiltinCmdWorkspace: {
+		LangEnglish:            "Manage multi-workspace routing",
+		LangChinese:            "管理多工作区路由",
+		LangTraditionalChinese: "管理多工作區路由",
+		LangJapanese:           "マルチワークスペースルーティングを管理",
+		LangSpanish:            "Gestionar enrutamiento multi-workspace",
+	},
+	MsgBuiltinCmdWhoami: {
+		LangEnglish:            "Show your user and platform info",
+		LangChinese:            "显示你的用户和平台信息",
+		LangTraditionalChinese: "顯示你的用戶和平台資訊",
+		LangJapanese:           "ユーザーとプラットフォーム情報を表示",
+		LangSpanish:            "Mostrar tu información de usuario y plataforma",
+	},
+	MsgBuiltinCmdWeb: {
+		LangEnglish:            "Open web management dashboard",
+		LangChinese:            "打开 Web 管理面板",
+		LangTraditionalChinese: "開啟 Web 管理面板",
+		LangJapanese:           "Web 管理ダッシュボードを開く",
+		LangSpanish:            "Abrir panel de gestión web",
+	},
 	MsgDiffEmpty: {
 		LangEnglish:            "No diff — clean working tree (or no changes vs `%s`).",
 		LangChinese:            "无差异 — 工作区干净（或与 `%s` 无变化）。",
@@ -3692,6 +3778,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "❌ リポジトリのクローンに失敗しました: %v",
 		LangSpanish:            "❌ Error al clonar repositorio: %v",
 	},
+
 }
 
 func (i *I18n) T(key MsgKey) string {

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 type namedTestAgent struct {
@@ -47,7 +48,7 @@ func newTestEngineWithMultiWorkspace(t *testing.T, baseDir string) *Engine {
 	tmpDir := t.TempDir()
 	bindingPath := filepath.Join(tmpDir, "bindings.json")
 	e := NewEngine("test", nil, nil, "", LangEnglish)
-	e.SetMultiWorkspace(baseDir, bindingPath)
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
 	return e
 }
 
@@ -61,7 +62,7 @@ func newTestEngineWithMultiWorkspaceAgent(t *testing.T, baseDir string) *Engine 
 		return &namedTestAgent{name: agentName}, nil
 	})
 	e := NewEngine("test", &namedTestAgent{name: agentName}, nil, sessionPath, LangEnglish)
-	e.SetMultiWorkspace(baseDir, bindingPath)
+	e.SetMultiWorkspace(baseDir, bindingPath, 15*time.Minute)
 	return e
 }
 
@@ -502,7 +503,7 @@ func TestMultiWorkspaceAgent_PropagatesRunAsUser(t *testing.T) {
 		runAsEnv:       []string{"CUSTOM_VAR", "ANOTHER_VAR"},
 	}
 	e := NewEngine("test", parent, nil, "", LangEnglish)
-	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"), 15*time.Minute)
 
 	// Trigger per-workspace agent creation via the path the production
 	// code uses when a message arrives for a resolved workspace.
@@ -566,7 +567,7 @@ func TestMultiWorkspaceAgent_NoPropagationWhenParentHasNoRunAs(t *testing.T) {
 	// The interface assertion in getOrCreateWorkspaceAgent must skip silently.
 	parent := &namedTestAgent{name: agentName}
 	e := NewEngine("test", parent, nil, "", LangEnglish)
-	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"), 15*time.Minute)
 
 	_, _, err := e.getOrCreateWorkspaceAgent(workspaceDir)
 	if err != nil {

--- a/core/progress_compact.go
+++ b/core/progress_compact.go
@@ -32,6 +32,7 @@ const (
 	ProgressCardStateRunning   ProgressCardState = "running"
 	ProgressCardStateCompleted ProgressCardState = "completed"
 	ProgressCardStateFailed    ProgressCardState = "failed"
+	ProgressCardStateStopped   ProgressCardState = "stopped"
 )
 
 type ProgressCardEntryKind string

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -2436,6 +2436,11 @@ func progressStateMeta(state core.ProgressCardState, lang string, agent string) 
 			return fmt.Sprintf("%s · 失败", agent), "red", "本过程卡片已停止更新（失败），完整错误说明见下一条消息。"
 		}
 		return fmt.Sprintf("%s · Failed", agent), "red", "This progress card has stopped (failed). See the next message for details."
+	case core.ProgressCardStateStopped:
+		if zh {
+			return fmt.Sprintf("%s · 已停止", agent), "grey", "任务已被用户手动停止。"
+		}
+		return fmt.Sprintf("%s · Stopped", agent), "grey", "Task was stopped by the user."
 	default:
 		if zh {
 			return fmt.Sprintf("%s · 进行中", agent), "blue", ""

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -109,7 +109,7 @@ type Platform struct {
 	allowFrom             string
 	groupReplyAll         bool
 	shareSessionInChannel bool
-	enableReactions       bool
+	reactOnReceive        bool
 	httpClient            *http.Client
 
 	mu                  sync.RWMutex
@@ -159,8 +159,11 @@ func New(opts map[string]any) (core.Platform, error) {
 
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
-	enableReactions, _ := opts["enable_reactions"].(bool)
-	return &Platform{token: token, allowFrom: allowFrom, groupReplyAll: groupReplyAll, shareSessionInChannel: shareSessionInChannel, enableReactions: enableReactions, httpClient: httpClient}, nil
+	reactOnReceive := true
+	if v, ok := opts["react_on_receive"].(bool); ok {
+		reactOnReceive = v
+	}
+	return &Platform{token: token, allowFrom: allowFrom, groupReplyAll: groupReplyAll, shareSessionInChannel: shareSessionInChannel, reactOnReceive: reactOnReceive, httpClient: httpClient}, nil
 }
 
 func (p *Platform) Name() string { return "telegram" }
@@ -325,7 +328,6 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 	if msg.From == nil {
 		return
 	}
-
 	userName := msg.From.Username
 	if userName == "" {
 		userName = strings.TrimSpace(msg.From.FirstName + " " + msg.From.LastName)
@@ -358,7 +360,7 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 	}
 
 	rctx := replyContext{chatID: msg.Chat.ID, threadID: threadID, messageID: msg.ID}
-	if p.enableReactions {
+	if p.reactOnReceive {
 		go p.reactToMessage(ctx, msg.Chat.ID, msg.ID, "⚡")
 	}
 	botName := p.botUsername()
@@ -1056,7 +1058,6 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 	if !ok {
 		return fmt.Errorf("telegram: SendAudio: invalid reply context type %T", rctx)
 	}
-
 	sendData := audio
 	sendFormat := strings.ToLower(strings.TrimSpace(format))
 	if sendFormat == "" {
@@ -1350,7 +1351,6 @@ func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
 	if !ok {
 		return func() {}
 	}
-
 	params := &tgbot.SendChatActionParams{
 		ChatID:          rc.chatID,
 		MessageThreadID: rc.threadID,


### PR DESCRIPTION
…message fix, quiet mode status

- Add /session-id command to show current session ID and resume command
- Add workspace idle reaper with configurable timeout
- Add background listen timeout for agent sessions
- Fix EventResult losing streamed text before tool calls
- Fix stop message deletion: freeze messages instead of discarding on /stop
- Add ProgressCardStateStopped state with platform support
- Add quiet mode status to /status command output
- Fix deadlock in interactiveKeyForSessionKey
- Add ResumeCommand interface for agents
- Update SetMultiWorkspace to accept idle timeout parameter
- Add i18n translations for new commands (session-id, heartbeat, tts, workspace, whoami)