### PR TITLE
feat(wecom): support configurable api_base_url for private deployments

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -389,6 +389,7 @@ callback_token = "your-callback-token"
 callback_aes_key = "your-43-char-encoding-aes-key"
 port = "8081"
 callback_path = "/wecom/callback"
+api_base_url = "https://qyapi.weixin.qq.com"  # optional: override WeChat Work API base URL (for private deployments)
 enable_markdown = false  # true = Markdown messages (WeChat Work app only; personal WeChat shows "unsupported")
 # proxy = "http://your-vps-ip:8888"  # optional: forward proxy if your IP is dynamic
 ```

--- a/config.example.toml
+++ b/config.example.toml
@@ -913,6 +913,7 @@ app_secret = "your-feishu-app-secret"
 # callback_aes_key = "your-43-char-encoding-aes-key"
 # port = "8081"
 # callback_path = "/wecom/callback"
+# api_base_url = "https://qyapi.weixin.qq.com"  # optional: WeCom API base URL override / 可选：企业微信 API 基础地址覆盖
 # enable_markdown = false  # set true to send Markdown (only renders in WeChat Work app, NOT personal WeChat)
 #                          # 设为 true 发送 Markdown（仅企业微信应用内可渲染，个人微信显示"暂不支持"）
 # allow_from = "*"  # Allowed WeChat Work user IDs / 允许的企业微信用户 ID

--- a/docs/wecom.md
+++ b/docs/wecom.md
@@ -262,6 +262,7 @@ callback_token = "你在第三步设置的Token"
 callback_aes_key = "你在第三步获取的EncodingAESKey"
 port = "8081"
 callback_path = "/wecom/callback"
+api_base_url = "https://qyapi.weixin.qq.com"
 enable_markdown = false
 ```
 
@@ -276,6 +277,7 @@ enable_markdown = false
 | `callback_aes_key` | ✅ | 回调 EncodingAESKey（43字符） |
 | `port` | ❌ | Webhook 监听端口（默认 `8081`） |
 | `callback_path` | ❌ | Webhook 路径（默认 `/wecom/callback`） |
+| `api_base_url` | ❌ | 企业微信 API 基础地址（默认 `https://qyapi.weixin.qq.com`） |
 | `enable_markdown` | ❌ | 是否发送 Markdown 消息（默认 `false`） |
 | `proxy` | ❌ | HTTP 正向代理地址（动态 IP 场景使用） |
 

--- a/platform/wecom/wecom.go
+++ b/platform/wecom/wecom.go
@@ -69,6 +69,7 @@ type Platform struct {
 	corpID         string
 	corpSecret     string
 	agentID        string
+	apiBaseURL     string
 	allowFrom      string
 	token          string // callback verification token
 	aesKey         []byte // decoded EncodingAESKey (32 bytes)
@@ -82,6 +83,8 @@ type Platform struct {
 	dedup          msgDedup
 	userNameCache  sync.Map // userID -> display name
 }
+
+const defaultAPIBaseURL = "https://qyapi.weixin.qq.com"
 
 // msgDedup tracks recently processed MsgIds to avoid WeChat Work retry duplicates.
 type msgDedup struct {
@@ -144,6 +147,11 @@ func New(opts map[string]any) (core.Platform, error) {
 	if path == "" {
 		path = "/wecom/callback"
 	}
+	apiBaseURL, _ := opts["api_base_url"].(string)
+	apiBaseURL = strings.TrimRight(strings.TrimSpace(apiBaseURL), "/")
+	if apiBaseURL == "" {
+		apiBaseURL = defaultAPIBaseURL
+	}
 
 	transport := &http.Transport{
 		MaxIdleConns:        2,
@@ -174,6 +182,7 @@ func New(opts map[string]any) (core.Platform, error) {
 		corpID:         corpID,
 		corpSecret:     corpSecret,
 		agentID:        agentID,
+		apiBaseURL:     apiBaseURL,
 		allowFrom:      allowFrom,
 		token:          callbackToken,
 		aesKey:         aesKey,
@@ -185,6 +194,18 @@ func New(opts map[string]any) (core.Platform, error) {
 }
 
 func (p *Platform) Name() string { return "wecom" }
+
+func (p *Platform) wecomAPIURL(path string, query url.Values) string {
+	base := strings.TrimRight(strings.TrimSpace(p.apiBaseURL), "/")
+	if base == "" {
+		base = defaultAPIBaseURL
+	}
+	u := base + path
+	if len(query) == 0 {
+		return u
+	}
+	return u + "?" + query.Encode()
+}
 
 func (p *Platform) Start(handler core.MessageHandler) error {
 	p.handler = handler
@@ -490,7 +511,9 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 	}
 
 	body, _ := json.Marshal(payload)
-	apiURL := "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token=" + accessToken
+	apiURL := p.wecomAPIURL("/cgi-bin/message/send", url.Values{
+		"access_token": []string{accessToken},
+	})
 
 	resp, err := p.apiClient.Post(apiURL, "application/json", strings.NewReader(string(body)))
 	if err != nil {
@@ -532,7 +555,10 @@ func (p *Platform) uploadImageMedia(accessToken string, img core.ImageAttachment
 		return "", fmt.Errorf("wecom: close multipart writer: %w", err)
 	}
 
-	apiURL := "https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token=" + accessToken + "&type=image"
+	apiURL := p.wecomAPIURL("/cgi-bin/media/upload", url.Values{
+		"access_token": []string{accessToken},
+		"type":         []string{"image"},
+	})
 	resp, err := p.apiClient.Post(apiURL, writer.FormDataContentType(), body)
 	if err != nil {
 		return "", fmt.Errorf("wecom: upload image: %w", err)
@@ -567,7 +593,9 @@ func (p *Platform) sendMarkdown(accessToken, toUser, content string) error {
 	}
 
 	body, _ := json.Marshal(payload)
-	apiURL := "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token=" + accessToken
+	apiURL := p.wecomAPIURL("/cgi-bin/message/send", url.Values{
+		"access_token": []string{accessToken},
+	})
 
 	resp, err := p.apiClient.Post(apiURL, "application/json", strings.NewReader(string(body)))
 	if err != nil {
@@ -598,7 +626,9 @@ func (p *Platform) sendText(accessToken, toUser, text string) error {
 	}
 
 	body, _ := json.Marshal(payload)
-	apiURL := "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token=" + accessToken
+	apiURL := p.wecomAPIURL("/cgi-bin/message/send", url.Values{
+		"access_token": []string{accessToken},
+	})
 
 	resp, err := p.apiClient.Post(apiURL, "application/json", strings.NewReader(string(body)))
 	if err != nil {
@@ -627,10 +657,10 @@ func (p *Platform) getAccessToken() (string, error) {
 		return p.tokenCache.token, nil
 	}
 
-	apiURL := fmt.Sprintf(
-		"https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid=%s&corpsecret=%s",
-		p.corpID, p.corpSecret,
-	)
+	apiURL := p.wecomAPIURL("/cgi-bin/gettoken", url.Values{
+		"corpid":     []string{p.corpID},
+		"corpsecret": []string{p.corpSecret},
+	})
 
 	resp, err := p.apiClient.Get(apiURL)
 	if err != nil {
@@ -760,7 +790,10 @@ func (p *Platform) resolveUserName(userID string) string {
 		slog.Debug("wecom: resolve user name: get token failed", "error", err)
 		return userID
 	}
-	apiURL := fmt.Sprintf("https://qyapi.weixin.qq.com/cgi-bin/user/get?access_token=%s&userid=%s", accessToken, url.QueryEscape(userID))
+	apiURL := p.wecomAPIURL("/cgi-bin/user/get", url.Values{
+		"access_token": []string{accessToken},
+		"userid":       []string{userID},
+	})
 	resp, err := p.apiClient.Get(apiURL)
 	if err != nil {
 		slog.Debug("wecom: resolve user name failed", "user", userID, "error", err)
@@ -830,7 +863,10 @@ func (p *Platform) downloadMedia(mediaID string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get token: %w", err)
 	}
-	u := fmt.Sprintf("https://qyapi.weixin.qq.com/cgi-bin/media/get?access_token=%s&media_id=%s", accessToken, mediaID)
+	u := p.wecomAPIURL("/cgi-bin/media/get", url.Values{
+		"access_token": []string{accessToken},
+		"media_id":     []string{mediaID},
+	})
 	resp, err := p.apiClient.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("download: %w", err)

--- a/platform/wecom/wecom_test.go
+++ b/platform/wecom/wecom_test.go
@@ -1,0 +1,73 @@
+package wecom
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestWeComAPIURL_DefaultBase(t *testing.T) {
+	p := &Platform{}
+	got := p.wecomAPIURL("/cgi-bin/gettoken", url.Values{
+		"corpid":     []string{"ww-test"},
+		"corpsecret": []string{"sec-test"},
+	})
+	want := "https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid=ww-test&corpsecret=sec-test"
+	if got != want {
+		t.Fatalf("url = %q, want %q", got, want)
+	}
+}
+
+func TestWeComAPIURL_CustomBase(t *testing.T) {
+	p := &Platform{apiBaseURL: "https://wecom.internal.example.com/"}
+	got := p.wecomAPIURL("/cgi-bin/message/send", url.Values{
+		"access_token": []string{"tok"},
+	})
+	want := "https://wecom.internal.example.com/cgi-bin/message/send?access_token=tok"
+	if got != want {
+		t.Fatalf("url = %q, want %q", got, want)
+	}
+}
+
+func TestNew_DefaultAPIBaseURL(t *testing.T) {
+	pf, err := New(map[string]any{
+		"corp_id":          "ww_test",
+		"corp_secret":      "sec_test",
+		"agent_id":         "1000002",
+		"callback_token":   "cb_token",
+		"callback_aes_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	p, ok := pf.(*Platform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *wecom.Platform", pf)
+	}
+	if p.apiBaseURL != defaultAPIBaseURL {
+		t.Fatalf("apiBaseURL = %q, want %q", p.apiBaseURL, defaultAPIBaseURL)
+	}
+}
+
+func TestNew_CustomAPIBaseURL_TrimTrailingSlash(t *testing.T) {
+	pf, err := New(map[string]any{
+		"corp_id":          "ww_test",
+		"corp_secret":      "sec_test",
+		"agent_id":         "1000002",
+		"callback_token":   "cb_token",
+		"callback_aes_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"api_base_url":     "https://wecom.internal.example.com/",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	p, ok := pf.(*Platform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *wecom.Platform", pf)
+	}
+	if p.apiBaseURL != "https://wecom.internal.example.com" {
+		t.Fatalf("apiBaseURL = %q, want %q", p.apiBaseURL, "https://wecom.internal.example.com")
+	}
+}
+

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -230,6 +230,7 @@
     "callbackAesKey": "Callback AES Key",
     "callbackAesKeyHint": "43 characters",
     "callbackPath": "Callback path",
+    "apiBaseUrl": "API base URL",
     "port": "Port",
     "wsUrl": "WebSocket URL",
     "appId": "App ID",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -230,6 +230,7 @@
     "callbackAesKey": "Clave AES de callback",
     "callbackAesKeyHint": "43 caracteres",
     "callbackPath": "Ruta de callback",
+    "apiBaseUrl": "URL base de API",
     "port": "Puerto",
     "wsUrl": "URL de WebSocket",
     "appId": "App ID",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -230,6 +230,7 @@
     "callbackAesKey": "コールバック AES キー",
     "callbackAesKeyHint": "43文字",
     "callbackPath": "コールバックパス",
+    "apiBaseUrl": "API ベース URL",
     "port": "ポート",
     "wsUrl": "WebSocket URL",
     "appId": "アプリ ID",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -230,6 +230,7 @@
     "callbackAesKey": "回呼 AES Key",
     "callbackAesKeyHint": "43 個字元",
     "callbackPath": "回呼路徑",
+    "apiBaseUrl": "API 基礎網址",
     "port": "連接埠",
     "wsUrl": "WebSocket 網址",
     "appId": "App ID",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -230,6 +230,7 @@
     "callbackAesKey": "回调 AES Key",
     "callbackAesKeyHint": "43 个字符",
     "callbackPath": "回调路径",
+    "apiBaseUrl": "API 基础地址",
     "port": "端口",
     "wsUrl": "WebSocket 地址",
     "appId": "App ID",

--- a/web/src/lib/platformMeta.ts
+++ b/web/src/lib/platformMeta.ts
@@ -62,6 +62,7 @@ export const platformMeta: Record<string, PlatformMeta> = {
       { key: 'callback_aes_key', labelKey: 'fields.callbackAesKey', required: true, hintKey: 'fields.callbackAesKeyHint' },
       { key: 'port', labelKey: 'fields.port', required: true, placeholder: '8081' },
       { key: 'callback_path', labelKey: 'fields.callbackPath', placeholder: '/wecom/callback', group: 'advanced' },
+      { key: 'api_base_url', labelKey: 'fields.apiBaseUrl', placeholder: 'https://qyapi.weixin.qq.com', group: 'advanced' },
       { key: 'allow_from', labelKey: 'fields.allowFrom', placeholder: '* (all)', group: 'advanced' },
     ],
   },


### PR DESCRIPTION
## Summary

This PR adds support for private WeCom deployments by introducing a configurable api_base_url
for the wecom platform (webhook mode), while preserving full backward compatibility with the
default public endpoint.

## What Changed

### 1. WeCom API base URL is now configurable

- Added optional platform option:
    - api_base_url (default: https://qyapi.weixin.qq.com)
- Implemented in platform/wecom/wecom.go:
    - Added apiBaseURL field to Platform
    - Added defaultAPIBaseURL constant
    - Added a centralized URL builder (wecomAPIURL) to construct API URLs consistently
- Replaced hardcoded API URLs with the centralized builder for:
    - gettoken
    - message/send
    - media/upload
    - media/get
    - user/get

### 2. Docs and examples updated

- Updated WeCom config example in:
    - config.example.toml
    - docs/wecom.md
    - INSTALL.md
- Added api_base_url description and usage examples.

### 3. Web admin/manual setup updated

- Added api_base_url field to WeCom platform metadata in:
    - web/src/lib/platformMeta.ts
- Added i18n label fields.apiBaseUrl in:
    - web/src/i18n/locales/en.json
    - web/src/i18n/locales/zh.json
    - web/src/i18n/locales/zh-TW.json
    - web/src/i18n/locales/ja.json
    - web/src/i18n/locales/es.json

### 4. Tests added/organized

- Consolidated WeCom API/new-config tests into:
    - platform/wecom/wecom_test.go
- Added coverage for:
    - default API base URL behavior
    - custom API base URL behavior
    - trailing slash normalization
    - URL construction with query params

## Backward Compatibility

- No breaking changes.
- If api_base_url is not provided, behavior is unchanged and still uses:
    - https://qyapi.weixin.qq.com

## Example Configuration

```
[[projects.platforms]]
type = "wecom"

[projects.platforms.options]
corp_id = "wwxxxxxxxxxxxxxx"
corp_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
agent_id = "1000002"
callback_token = "your-callback-token"
callback_aes_key = "your-43-char-encoding-aes-key"
api_base_url = "https://wecom.internal.example.com:8443" # optional
```
## Validation

- go test ./platform/wecom passes.