### PR TITLE
Use long connection for Lark by default

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -315,12 +315,9 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			return p.onBotMenu(event)
 		})
 
-	// Lark international version uses Webhook mode, not WebSocket long connection
-	// Feishu domestic version supports WebSocket long connection
-	if p.platformName == "lark" {
-		return p.startWebhookMode()
-	}
-
+	// Kernel dedicated build: both Feishu and Lark use the official SDK WebSocket
+	// long-connection path. Keep the webhook implementation available as a helper,
+	// but do not make it the default ingress mode for Lark.
 	return p.startWebSocketMode()
 }
 


### PR DESCRIPTION
## Summary
- route the `lark` platform through the official SDK WebSocket long-connection path
- keep the existing webhook handler implementation available without making it the default ingress mode
- align runtime behavior with the project documentation that treats Feishu and Lark as the same long-connection transport family

## Why
Lark developer apps support long-connection event delivery and do not require a public callback URL for normal bot ingress. The current implementation forces `type = "lark"` into webhook mode, which makes international Lark deployments depend on public webhook infrastructure even when the app is configured for long connection.

This patch removes that forced branch and lets the existing WebSocket startup path handle both Feishu and Lark through the official SDK.

## Validation
- built `cc-connect` from this branch
- started the binary with a Lark app configuration
- confirmed a successful connection to the Lark long-connection endpoint
- confirmed the patched instance started normally without requiring webhook callback configuration
