### PR TITLE
feat(core): replace /btw with /ps as builtin command

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1506,25 +1506,6 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	session := sessions.GetOrCreateActive(msg.SessionKey)
 	sessions.UpdateUserMeta(msg.SessionKey, msg.UserName, msg.ChatName)
 	if !session.TryLock() {
-		// Check for /btw — inject into the running session mid-turn
-		trimmed := strings.TrimSpace(content)
-		if isBtwCommand(trimmed) {
-			btw := strings.TrimSpace(trimmed[len(matchBtwPrefix(trimmed)):])
-			if btw != "" {
-				e.interactiveMu.Lock()
-				state, ok := e.interactiveStates[interactiveKey]
-				e.interactiveMu.Unlock()
-				if ok && state.agentSession != nil && state.agentSession.Alive() {
-					if err := state.agentSession.Send(btw, nil, nil); err != nil {
-						slog.Error("btw: send failed", "error", err)
-						e.reply(p, msg.ReplyCtx, e.i18n.T(MsgBtwSendFailed))
-					} else {
-						e.reply(p, msg.ReplyCtx, e.i18n.T(MsgBtwSent))
-					}
-					return
-				}
-			}
-		}
 		// Session is busy — try to queue the message for the running turn
 		// so the agent processes it immediately after the current turn ends.
 		if e.queueMessageForBusySession(p, msg, interactiveKey) {
@@ -3147,26 +3128,29 @@ var builtinCommands = []struct {
 	{[]string{"whoami", "myid"}, "whoami"},
 	{[]string{"web"}, "web"},
 	{[]string{"diff"}, "diff"},
+	{[]string{"ps"}, "ps"},
 }
 
-// isBtwCommand checks if a trimmed message starts with a /btw command.
-func isBtwCommand(trimmed string) bool {
-	return matchBtwPrefix(trimmed) != ""
-}
-
-// matchBtwPrefix returns the prefix portion (e.g. "/btw ") if the
-// message starts with a btw command, or "" if it doesn't match.
-func matchBtwPrefix(trimmed string) string {
-	lower := strings.ToLower(trimmed)
-	for _, prefix := range []string{"/btw"} {
-		if strings.HasPrefix(lower, prefix) {
-			rest := trimmed[len(prefix):]
-			if rest == "" || rest[0] == ' ' {
-				return trimmed[:len(prefix)]
-			}
-		}
+func (e *Engine) cmdPs(p Platform, msg *Message, args []string) {
+	text := strings.TrimSpace(strings.Join(args, " "))
+	if text == "" {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsEmpty))
+		return
 	}
-	return ""
+	iKey := e.interactiveKeyForSessionKey(msg.SessionKey)
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[iKey]
+	e.interactiveMu.Unlock()
+	if !ok || state == nil || state.agentSession == nil || !state.agentSession.Alive() {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsNoSession))
+		return
+	}
+	if err := state.agentSession.Send(text, nil, nil); err != nil {
+		slog.Error("ps: send failed", "error", err)
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsSendFailed))
+		return
+	}
+	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsSent))
 }
 
 // matchPrefix finds a unique command matching the given prefix.
@@ -3347,6 +3331,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdWhoami(p, msg)
 	case "web":
 		e.cmdWeb(p, msg, args)
+	case "ps":
+		e.cmdPs(p, msg, args)
 	default:
 		if custom, ok := e.commands.Resolve(cmd); ok {
 			if disabledCmds[strings.ToLower(custom.Name)] {
@@ -5143,6 +5129,7 @@ func helpCardGroups() []helpCardGroup {
 				{command: "/skills", action: "nav:/skills"},
 				{command: "/compress", action: "cmd:/compress"},
 				{command: "/stop", action: "act:/stop"},
+				{command: "/ps", action: "cmd:/ps"},
 			},
 		},
 		{

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -424,8 +424,10 @@ const (
 	MsgCommandDisabled   MsgKey = "command_disabled"
 	MsgAdminRequired     MsgKey = "admin_required"
 	MsgRateLimited       MsgKey = "rate_limited"
-	MsgBtwSent           MsgKey = "btw_sent"
-	MsgBtwSendFailed     MsgKey = "btw_send_failed"
+	MsgPsSent       MsgKey = "ps_sent"
+	MsgPsSendFailed MsgKey = "ps_send_failed"
+	MsgPsEmpty      MsgKey = "ps_empty"
+	MsgPsNoSession  MsgKey = "ps_no_session"
 
 	MsgWhoamiTitle     MsgKey = "whoami_title"
 	MsgWhoamiCardTitle MsgKey = "whoami_card_title"
@@ -491,6 +493,7 @@ const (
 	MsgBuiltinCmdShell     MsgKey = "shell"
 	MsgBuiltinCmdDir       MsgKey = "dir"
 	MsgBuiltinCmdDiff      MsgKey = "diff"
+	MsgBuiltinCmdPs        MsgKey = "ps"
 
 	MsgDiffEmpty           MsgKey = "diff_empty"
 	MsgDiffNoDiff2HTML     MsgKey = "diff_no_diff2html"
@@ -627,11 +630,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "No hay ejecución en progreso.",
 	},
 	MsgPreviousProcessing: {
-		LangEnglish:            "⏳ Previous request still processing. Use `/btw <message>` to add context to the current turn.",
-		LangChinese:            "⏳ 上一个请求仍在处理中。使用 `/btw <消息>` 可向当前轮次追加上下文。",
-		LangTraditionalChinese: "⏳ 上一個請求仍在處理中。使用 `/btw <訊息>` 可向當前輪次追加上下文。",
-		LangJapanese:           "⏳ 前のリクエストを処理中です。`/btw <メッセージ>` で現在のターンにコンテキストを追加できます。",
-		LangSpanish:            "⏳ La solicitud anterior aún se está procesando. Use `/btw <mensaje>` para agregar contexto al turno actual.",
+		LangEnglish:            "⏳ Previous request still processing. Use `/ps <message>` to send a P.S. to the running task.",
+		LangChinese:            "⏳ 上一个请求仍在处理中。使用 `/ps <消息>` 可向正在执行的任务追加补充信息。",
+		LangTraditionalChinese: "⏳ 上一個請求仍在處理中。使用 `/ps <訊息>` 可向正在執行的任務追加補充資訊。",
+		LangJapanese:           "⏳ 前のリクエストを処理中です。`/ps <メッセージ>` で実行中のタスクに補足情報を送れます。",
+		LangSpanish:            "⏳ La solicitud anterior aún se está procesando. Use `/ps <mensaje>` para enviar un P.S. a la tarea en curso.",
 	},
 	MsgMessageQueued: {
 		LangEnglish:            "📬 Message received — will process after the current task finishes.",
@@ -2894,19 +2897,33 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "⏳ メッセージの送信が速すぎます。しばらくお待ちください。",
 		LangSpanish:            "⏳ Estás enviando mensajes demasiado rápido. Espera un momento.",
 	},
-	MsgBtwSent: {
-		LangEnglish:            "✅ Message injected into the current session.",
-		LangChinese:            "✅ 消息已注入当前会话。",
-		LangTraditionalChinese: "✅ 訊息已注入目前會話。",
-		LangJapanese:           "✅ メッセージを現在のセッションに注入しました。",
-		LangSpanish:            "✅ Mensaje inyectado en la sesión actual.",
+	MsgPsSent: {
+		LangEnglish:            "✅ P.S. delivered.",
+		LangChinese:            "✅ P.S. 已送达。",
+		LangTraditionalChinese: "✅ P.S. 已送達。",
+		LangJapanese:           "✅ P.S. を送信しました。",
+		LangSpanish:            "✅ P.S. entregado.",
 	},
-	MsgBtwSendFailed: {
-		LangEnglish:            "❌ Failed to inject message into the current session.",
-		LangChinese:            "❌ 消息注入当前会话失败。",
-		LangTraditionalChinese: "❌ 訊息注入目前會話失敗。",
-		LangJapanese:           "❌ 現在のセッションへのメッセージ注入に失敗しました。",
-		LangSpanish:            "❌ Error al inyectar el mensaje en la sesión actual.",
+	MsgPsSendFailed: {
+		LangEnglish:            "❌ Failed to deliver P.S.",
+		LangChinese:            "❌ P.S. 发送失败。",
+		LangTraditionalChinese: "❌ P.S. 傳送失敗。",
+		LangJapanese:           "❌ P.S. の送信に失敗しました。",
+		LangSpanish:            "❌ Error al entregar el P.S.",
+	},
+	MsgPsEmpty: {
+		LangEnglish:            "Usage: `/ps <message>`",
+		LangChinese:            "用法：`/ps <消息>`",
+		LangTraditionalChinese: "用法：`/ps <訊息>`",
+		LangJapanese:           "使い方：`/ps <メッセージ>`",
+		LangSpanish:            "Uso: `/ps <mensaje>`",
+	},
+	MsgPsNoSession: {
+		LangEnglish:            "No task is currently running.",
+		LangChinese:            "当前没有正在执行的任务。",
+		LangTraditionalChinese: "目前沒有正在執行的任務。",
+		LangJapanese:           "現在実行中のタスクはありません。",
+		LangSpanish:            "No hay ninguna tarea en ejecución.",
 	},
 	MsgWhoamiTitle: {
 		LangEnglish:            "🪪 **Your Identity**",
@@ -3311,6 +3328,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "產生 git diff 並以 HTML 檔案傳送，參數: [目標]",
 		LangJapanese:           "git diff を HTML ファイルで生成、引数: [ターゲット]",
 		LangSpanish:            "Generar git diff como archivo HTML, arg: [objetivo]",
+	},
+	MsgBuiltinCmdPs: {
+		LangEnglish:            "Send a P.S. to the running task",
+		LangChinese:            "向正在执行的任务追加补充信息",
+		LangTraditionalChinese: "向正在執行的任務追加補充資訊",
+		LangJapanese:           "実行中のタスクに補足情報を送信",
+		LangSpanish:            "Enviar un P.S. a la tarea en curso",
 	},
 	MsgDiffEmpty: {
 		LangEnglish:            "No diff — clean working tree (or no changes vs `%s`).",

--- a/docs/slack-app-manifest.json
+++ b/docs/slack-app-manifest.json
@@ -15,8 +15,8 @@
     },
     "slash_commands": [
       {
-        "command": "/btw",
-        "description": "Send additional context to agent while it's busy",
+        "command": "/ps",
+        "description": "Send a P.S. to the running task",
         "usage_hint": "[message]",
         "should_escape": false
       },


### PR DESCRIPTION
## Summary

- Replace `/btw` with `/ps` (postscript) as a proper builtin command
- Fix the spurious "unknown command" message that `/btw` triggered before injection
- Add `/ps` to the help card so users can discover it

## Motivation

1. **Name collision**: Claude Code CLI already has `/btw` (side question) with different semantics — having cc-connect's `/btw` (mid-turn injection) use the same name confuses users
2. **Routing bug**: `/btw` was not in `builtinCommands`, so `handleCommand()` would first send `MsgUnknownCommand` before falling through to the btw injection logic in the `TryLock` failure branch — producing two replies per invocation
3. **Undiscoverable**: `/btw` was absent from `/help` output; users could only learn about it from `MsgPreviousProcessing`

## Changes

- Register `/ps` in `builtinCommands` and add `case "ps"` to the `handleCommand` switch
- Implement `cmdPs()` following the `cmdStop()` pattern: uses `interactiveKeyForSessionKey()` for multi-workspace support, directly accesses `interactiveStates` — bypasses `TryLock` entirely
- Add 4 new i18n messages (5 languages each): `ps_sent`, `ps_send_failed`, `ps_empty`, `ps_no_session`
- Add builtin command description for help card: `MsgBuiltinCmdPs`
- Add `/ps` to the tools group in `helpCardGroups()`
- Update `MsgPreviousProcessing` to reference `/ps` instead of `/btw`
- Remove `isBtwCommand()` and `matchBtwPrefix()` functions
- Update Slack app manifest slash command registration

## Test plan

- [x] `go test ./...` passes (all packages OK)
- [x] `/ps <message>` while session is busy: injects mid-turn, replies "✅ P.S. delivered."
- [x] `/ps` with no args: replies with usage hint
- [x] `/ps` with no running task: replies "No task is currently running."
- [x] `/help` now shows `/ps` in the tools group
- [x] No remaining references to `btw` in engine.go or i18n.go

Closes #619