### PR TITLE
feat(discord): preserve table formatting

### DIFF
--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -792,7 +792,7 @@ func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 // mechanism. The first call edits the deferred "thinking" response; subsequent
 // calls create followup messages.
 func (p *Platform) sendInteraction(ictx *interactionReplyCtx, content string) error {
-	chunks := core.SplitMessageCodeFenceAware(content, maxDiscordLen)
+	chunks := core.SplitMessageCodeFenceAware(wrapTablesInCodeBlocks(content), maxDiscordLen)
 	for _, chunk := range chunks {
 		ictx.mu.Lock()
 		first := !ictx.firstDone
@@ -821,7 +821,7 @@ func (p *Platform) sendInteraction(ictx *interactionReplyCtx, content string) er
 }
 
 func (p *Platform) sendChannelReply(rc replyContext, content string) error {
-	chunks := core.SplitMessageCodeFenceAware(content, maxDiscordLen)
+	chunks := core.SplitMessageCodeFenceAware(wrapTablesInCodeBlocks(content), maxDiscordLen)
 	for _, chunk := range chunks {
 		var err error
 		if rc.useThreadChannel() || rc.messageID == "" {
@@ -838,7 +838,7 @@ func (p *Platform) sendChannelReply(rc replyContext, content string) error {
 }
 
 func (p *Platform) sendChannel(rc replyContext, content string) error {
-	chunks := core.SplitMessageCodeFenceAware(content, maxDiscordLen)
+	chunks := core.SplitMessageCodeFenceAware(wrapTablesInCodeBlocks(content), maxDiscordLen)
 	for _, chunk := range chunks {
 		_, err := p.session.ChannelMessageSend(rc.targetChannelID(), chunk)
 		if err != nil {

--- a/platform/discord/format.go
+++ b/platform/discord/format.go
@@ -1,0 +1,52 @@
+package discord
+
+import "strings"
+
+// wrapTablesInCodeBlocks detects markdown tables (contiguous lines starting and
+// ending with "|") that are not already inside a code block, and wraps them
+// with ``` so Discord renders them in monospace with proper alignment.
+func wrapTablesInCodeBlocks(s string) string {
+	lines := strings.Split(s, "\n")
+	var result []string
+	inCodeBlock := false
+	inTable := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "```") {
+			if inTable {
+				result = append(result, "```")
+				inTable = false
+			}
+			inCodeBlock = !inCodeBlock
+			result = append(result, line)
+			continue
+		}
+
+		if inCodeBlock {
+			result = append(result, line)
+			continue
+		}
+
+		isTableLine := len(trimmed) >= 3 &&
+			strings.HasPrefix(trimmed, "|") &&
+			strings.HasSuffix(trimmed, "|")
+
+		if isTableLine && !inTable {
+			result = append(result, "```")
+			inTable = true
+		} else if !isTableLine && inTable {
+			result = append(result, "```")
+			inTable = false
+		}
+
+		result = append(result, line)
+	}
+
+	if inTable {
+		result = append(result, "```")
+	}
+
+	return strings.Join(result, "\n")
+}

--- a/platform/discord/format_test.go
+++ b/platform/discord/format_test.go
@@ -1,0 +1,56 @@
+package discord
+
+import "testing"
+
+func TestWrapTablesInCodeBlocks(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no table",
+			in:   "hello world\nno tables here",
+			want: "hello world\nno tables here",
+		},
+		{
+			name: "simple table",
+			in:   "before\n| a | b |\n| - | - |\n| 1 | 2 |\nafter",
+			want: "before\n```\n| a | b |\n| - | - |\n| 1 | 2 |\n```\nafter",
+		},
+		{
+			name: "table already in code block",
+			in:   "```\n| a | b |\n| 1 | 2 |\n```",
+			want: "```\n| a | b |\n| 1 | 2 |\n```",
+		},
+		{
+			name: "table at end of content",
+			in:   "text\n| x | y |\n| 1 | 2 |",
+			want: "text\n```\n| x | y |\n| 1 | 2 |\n```",
+		},
+		{
+			name: "multiple tables",
+			in:   "| a | b |\n| 1 | 2 |\n\ntext\n| c | d |\n| 3 | 4 |",
+			want: "```\n| a | b |\n| 1 | 2 |\n```\n\ntext\n```\n| c | d |\n| 3 | 4 |\n```",
+		},
+		{
+			name: "pipe in regular text not treated as table",
+			in:   "use | for OR operations",
+			want: "use | for OR operations",
+		},
+		{
+			name: "table with code block after",
+			in:   "| a | b |\n| 1 | 2 |\n```go\nfmt.Println()\n```",
+			want: "```\n| a | b |\n| 1 | 2 |\n```\n```go\nfmt.Println()\n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapTablesInCodeBlocks(tt.in)
+			if got != tt.want {
+				t.Errorf("wrapTablesInCodeBlocks():\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Problem
Discord doesn't render markdown tables — it displays pipe-separated rows as messy plain text with no alignment.

# Solution 
Added a wrapTablesInCodeBlocks() function in platform/discord/format.go that detects markdown table blocks (contiguous |...| lines) not already inside a fenced code block and wraps them with ``` so Discord renders them in monospace with proper column alignment. Applied at all three outbound send paths: sendInteraction, sendChannelReply, and sendChannel.

# Tests 
7 cases covering no-table passthrough, simple tables, tables already in code blocks, tables at EOF, multiple tables, pipes in regular text, and tables adjacent to code blocks.