### PR TITLE
feat(progress): throttle discord progress updates

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"time"
 )
 
 // Platform abstracts a messaging platform (Feishu, DingTalk, Slack, etc.).
@@ -152,6 +153,12 @@ type ProgressStyleProvider interface {
 // parse and render structured progress-card payloads.
 type ProgressCardPayloadSupport interface {
 	SupportsProgressCardPayload() bool
+}
+
+// ProgressUpdateThrottler is an optional interface for platforms that need
+// rate-limited progress edits (e.g. Discord's ~5 edits / 5s per channel).
+type ProgressUpdateThrottler interface {
+	ProgressUpdateInterval() time.Duration
 }
 
 // ButtonOption represents a clickable inline button.

--- a/core/progress_compact.go
+++ b/core/progress_compact.go
@@ -227,6 +227,10 @@ type compactProgressWriter struct {
 	truncated  bool
 	lastSent   string
 	maxEntries int
+
+	// Throttle message edits to avoid platform rate limits (e.g. Discord ~5 edits/5s).
+	minUpdateInterval time.Duration
+	lastUpdateAt      time.Time
 }
 
 func normalizeProgressStyle(style string) string {
@@ -299,6 +303,9 @@ func newCompactProgressWriter(ctx context.Context, p Platform, replyCtx any, age
 		agentName:  normalizeProgressAgentLabel(agentName),
 		lang:       lang,
 		maxEntries: 10,
+	}
+	if throttler, ok := p.(ProgressUpdateThrottler); ok {
+		w.minUpdateInterval = throttler.ProgressUpdateInterval()
 	}
 	if w.style != progressStyleCompact && w.style != progressStyleCard {
 		slog.Debug("progress writer disabled: unsupported style", "platform", p.Name(), "style", w.style)
@@ -453,6 +460,7 @@ func (w *compactProgressWriter) AppendStructured(item ProgressCardEntry, fallbac
 			}
 			w.handle = handle
 			w.lastSent = w.content
+			w.lastUpdateAt = time.Now()
 			return true
 		}
 		callCtx, cancel := w.withAPITimeout()
@@ -465,6 +473,11 @@ func (w *compactProgressWriter) AppendStructured(item ProgressCardEntry, fallbac
 		}
 		w.handle = w.replyCtx
 		w.lastSent = w.content
+		w.lastUpdateAt = time.Now()
+		return true
+	}
+
+	if w.minUpdateInterval > 0 && time.Since(w.lastUpdateAt) < w.minUpdateInterval {
 		return true
 	}
 
@@ -477,6 +490,7 @@ func (w *compactProgressWriter) AppendStructured(item ProgressCardEntry, fallbac
 		return false
 	}
 	w.lastSent = w.content
+	w.lastUpdateAt = time.Now()
 	return true
 }
 

--- a/core/progress_compact_test.go
+++ b/core/progress_compact_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 type suppressTestPlatform struct {
@@ -220,6 +221,63 @@ func TestCompactProgressWriter_AppliesTransformToCardPayloadEntries(t *testing.T
 	}
 	if got := payload.Items[0].Text; got != "Inspect 📄 `src/app.ts:42`" {
 		t.Fatalf("payload item text = %q, want transformed text", got)
+	}
+}
+
+type stubThrottledProgressPlatform struct {
+	stubCompactProgressPlatform
+	throttle time.Duration
+}
+
+func (p *stubThrottledProgressPlatform) ProgressUpdateInterval() time.Duration {
+	return p.throttle
+}
+
+func TestCompactProgressWriter_ThrottlesRapidUpdates(t *testing.T) {
+	p := &stubThrottledProgressPlatform{
+		stubCompactProgressPlatform: stubCompactProgressPlatform{
+			stubPlatformEngine: stubPlatformEngine{n: "discord"},
+			style:              "card",
+			supportPayload:     true,
+		},
+		throttle: 50 * time.Millisecond,
+	}
+	w := newCompactProgressWriter(context.Background(), p, "ctx", "cc", LangEnglish, nil)
+
+	w.AppendStructured(ProgressCardEntry{Kind: ProgressEntryThinking, Text: "step 1"}, "step 1")
+	if len(p.getPreviewStarts()) != 1 {
+		t.Fatal("first update should create the preview message")
+	}
+
+	w.AppendStructured(ProgressCardEntry{Kind: ProgressEntryToolUse, Tool: "Bash", Text: "pwd"}, "pwd")
+	w.AppendStructured(ProgressCardEntry{Kind: ProgressEntryToolResult, Tool: "Bash", Text: "ok"}, "ok")
+	editsBeforeThrottle := len(p.getPreviewEdits())
+	if editsBeforeThrottle > 0 {
+		t.Fatalf("rapid updates within throttle window should be skipped, got %d edits", editsBeforeThrottle)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	w.AppendStructured(ProgressCardEntry{Kind: ProgressEntryThinking, Text: "step 4"}, "step 4")
+	editsAfterWait := len(p.getPreviewEdits())
+	if editsAfterWait != 1 {
+		t.Fatalf("update after throttle interval should go through, got %d edits", editsAfterWait)
+	}
+
+	ok := w.Finalize(ProgressCardStateCompleted)
+	if !ok {
+		t.Fatal("Finalize should succeed")
+	}
+	finalEdits := p.getPreviewEdits()
+	last := finalEdits[len(finalEdits)-1]
+	payload, parsed := ParseProgressCardPayload(last)
+	if !parsed {
+		t.Fatalf("final edit should be a valid payload, got %q", last)
+	}
+	if payload.State != ProgressCardStateCompleted {
+		t.Fatalf("state = %q, want completed", payload.State)
+	}
+	if len(payload.Items) != 4 {
+		t.Fatalf("items = %d, want 4 (all buffered items)", len(payload.Items))
 	}
 }
 

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -1015,11 +1015,16 @@ func (p *Platform) SendWithButtons(ctx context.Context, rctx any, content string
 	return nil
 }
 
+func (p *progressPlatform) ProgressUpdateInterval() time.Duration {
+	return 2 * time.Second
+}
+
 var _ core.ImageSender = (*Platform)(nil)
 var _ core.FileSender = (*Platform)(nil)
 var _ core.InlineButtonSender = (*Platform)(nil)
 var _ core.ProgressStyleProvider = (*progressPlatform)(nil)
 var _ core.ProgressCardPayloadSupport = (*progressPlatform)(nil)
+var _ core.ProgressUpdateThrottler = (*progressPlatform)(nil)
 
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 	// discord:{channelID}:{userID} or discord:{threadID}


### PR DESCRIPTION
# Problem 
Discord rate-limits message edits to ~5 per 5 seconds per channel. The compact progress writer edits the progress card on every event, which triggers 429s and causes edit failures on Discord.

# Solution
Introduced a ProgressUpdateThrottler interface in core/interfaces.go that platforms can implement to declare a minimum interval between progress edits. The compactProgressWriter checks this interval and skips edits that come too fast, while still buffering all items internally so Finalize() always sends the complete state. Discord implements the interface with a 2-second interval.

# Tests
New TestCompactProgressWriter_ThrottlesRapidUpdates verifies that rapid updates within the window are skipped, updates after the window go through, and Finalize includes all buffered items.
