### PR TITLE
feat(claudecode): add extended context (1M) model options

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -204,9 +204,11 @@ func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
 		return models
 	}
 	return []core.ModelOption{
-		{Name: "sonnet", Desc: "Claude Sonnet 4 (balanced)"},
-		{Name: "opus", Desc: "Claude Opus 4 (most capable)"},
-		{Name: "haiku", Desc: "Claude Haiku 3.5 (fastest)"},
+		{Name: "sonnet", Desc: "Claude Sonnet 4 (balanced, 200K)"},
+		{Name: "opus", Desc: "Claude Opus 4 (most capable, 200K)"},
+		{Name: "haiku", Desc: "Claude Haiku 3.5 (fastest, 200K)"},
+		{Name: "claude-sonnet-4-20250514", Desc: "Claude Sonnet 4 (1M context)"},
+		{Name: "claude-opus-4-20250514", Desc: "Claude Opus 4 (1M context)"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add 1M context model variants (claude-sonnet-4-20250514, claude-opus-4-20250514) to the default model list
- Users can now switch to extended context models via /model command instead of being limited to 200K defaults

Fixes #384

## Test plan
- [ ] Verify /model command lists the new 1M context model options
- [ ] Verify selecting a 1M model starts a session with the correct model

🤖 Generated with [Claude Code](https://claude.com/claude-code)