### PR TITLE
feat(cron): add manual exec command for existing jobs

### DIFF
--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -24,6 +24,8 @@ func runCron(args []string) {
 		runCronAdd(args[1:])
 	case "list":
 		runCronList(args[1:])
+	case "exec", "run", "trigger":
+		runCronExec(args[1:])
 	case "edit":
 		runCronEdit(args[1:])
 	case "info":
@@ -407,6 +409,54 @@ func runCronInfo(args []string) {
 	fmt.Println(prettyJSON.String())
 }
 
+func runCronExec(args []string) {
+	var dataDir string
+	var id string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--data-dir":
+			if i+1 < len(args) {
+				i++
+				dataDir = args[i]
+			}
+		case "--help", "-h":
+			printCronExecUsage()
+			return
+		default:
+			id = args[i]
+		}
+	}
+
+	if id == "" {
+		fmt.Fprintln(os.Stderr, "Error: job ID is required")
+		fmt.Fprintln(os.Stderr, "Run 'cc-connect cron exec --help' for usage.")
+		os.Exit(1)
+	}
+
+	sockPath := resolveSocketPath(dataDir)
+	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		os.Exit(1)
+	}
+
+	payload, _ := json.Marshal(map[string]string{"id": id})
+	resp, err := apiPost(sockPath, "/cron/exec", payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", strings.TrimSpace(string(body)))
+		os.Exit(1)
+	}
+
+	fmt.Printf("Cron job %s triggered.\n", id)
+}
+
 func runCronEdit(args []string) {
 	var dataDir string
 	var id, field string
@@ -517,6 +567,7 @@ func printCronUsage() {
 Commands:
   add       Create a new scheduled task
   list      List all scheduled tasks
+  exec <id> Run an existing scheduled task immediately
   edit      Edit a scheduled task field
   info <id> [field]  Show detailed info of a scheduled task
                      (optionally filter to a single field)
@@ -546,6 +597,20 @@ Examples:
   cc-connect cron add --cron "0 6 * * *" --prompt "Collect GitHub trending data" --desc "Daily Trending"
   cc-connect cron add --cron "*/30 * * * *" --exec "df -h" --desc "Disk usage check"
   cc-connect cron add 0 6 * * * Collect GitHub trending data and send me a summary`)
+}
+
+func printCronExecUsage() {
+	fmt.Println(`Usage: cc-connect cron exec <id> [options]
+
+Run an existing scheduled task immediately.
+
+Options:
+      --data-dir <path>  Data directory (default: ~/.cc-connect)
+  -h, --help             Show this help
+
+Examples:
+  cc-connect cron exec abc123
+  cc-connect cron trigger abc123`)
 }
 
 func printCronEditUsage() {

--- a/cmd/cc-connect/cron_test.go
+++ b/cmd/cc-connect/cron_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPrintCronUsage_IncludesExec(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+	})
+
+	printCronUsage()
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if !strings.Contains(buf.String(), "exec <id>") {
+		t.Fatalf("usage = %q, want exec subcommand", buf.String())
+	}
+}

--- a/core/api.go
+++ b/core/api.go
@@ -67,6 +67,7 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 	s.mux.HandleFunc("/cron/list", s.handleCronList)
 	s.mux.HandleFunc("/cron/info", s.handleCronInfo)
 	s.mux.HandleFunc("/cron/edit", s.handleCronEdit)
+	s.mux.HandleFunc("/cron/exec", s.handleCronExec)
 	s.mux.HandleFunc("/cron/del", s.handleCronDel)
 	s.mux.HandleFunc("/relay/send", s.handleRelaySend)
 	s.mux.HandleFunc("/relay/bind", s.handleRelayBind)
@@ -419,6 +420,36 @@ func (s *APIServer) handleCronEdit(w http.ResponseWriter, r *http.Request) {
 	// Return updated job
 	job := s.cron.Store().Get(req.ID)
 	apiJSON(w, http.StatusOK, job)
+}
+
+func (s *APIServer) handleCronExec(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.cron == nil {
+		http.Error(w, "cron scheduler not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.ID == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.cron.TriggerJob(req.ID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	apiJSON(w, http.StatusOK, map[string]string{"status": "ok", "id": req.ID})
 }
 
 // ── Relay API ──────────────────────────────────────────────────

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestHandleSend_AllowsAttachmentOnly(t *testing.T) {
@@ -37,4 +39,51 @@ func TestHandleSend_AllowsAttachmentOnly(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 	}
+}
+
+func TestHandleCronExec_TriggersExistingJob(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job := &CronJob{
+		ID:         "api-exec",
+		Project:    "test",
+		SessionKey: "discord:channel-1:user-1",
+		CronExpr:   "0 6 * * *",
+		Prompt:     "run now",
+		Enabled:    false,
+		CreatedAt:  time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agent := &resultAgent{session: newResultAgentSession("api complete")}
+	engine := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	scheduler := NewCronScheduler(store)
+	scheduler.RegisterEngine("test", engine)
+
+	api := &APIServer{engines: map[string]*Engine{"test": engine}, cron: scheduler}
+	body, err := json.Marshal(map[string]string{"id": "api-exec"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/cron/exec", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleCronExec(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	waitForCron(t, time.Second, func() bool {
+		return strings.Contains(strings.Join(p.getSent(), "\n"), "api complete")
+	})
 }

--- a/core/cron.go
+++ b/core/cron.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"reflect"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -626,8 +626,35 @@ func (cs *CronScheduler) scheduleJob(job *CronJob) error {
 }
 
 func (cs *CronScheduler) executeJob(jobID string) {
+	cs.executeJobInternal(jobID, false)
+}
+
+// TriggerJob runs an existing cron job immediately in the background.
+// Manual execution is allowed even when the job is currently disabled.
+func (cs *CronScheduler) TriggerJob(jobID string) error {
 	job := cs.store.Get(jobID)
-	if job == nil || !job.Enabled {
+	if job == nil {
+		return fmt.Errorf("job %q not found", jobID)
+	}
+
+	cs.mu.RLock()
+	_, ok := cs.engines[job.Project]
+	cs.mu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("project %q not found", job.Project)
+	}
+
+	go cs.executeJobInternal(jobID, true)
+	return nil
+}
+
+func (cs *CronScheduler) executeJobInternal(jobID string, manual bool) {
+	job := cs.store.Get(jobID)
+	if job == nil {
+		return
+	}
+	if !manual && !job.Enabled {
 		return
 	}
 
@@ -636,12 +663,13 @@ func (cs *CronScheduler) executeJob(jobID string) {
 	cs.mu.RUnlock()
 
 	if !ok {
-		slog.Error("cron: project not found", "job", jobID, "project", job.Project)
-		cs.store.MarkRun(jobID, fmt.Errorf("project %q not found", job.Project))
+		err := fmt.Errorf("project %q not found", job.Project)
+		slog.Error("cron: project not found", "job", jobID, "project", job.Project, "manual", manual)
+		cs.store.MarkRun(jobID, err)
 		return
 	}
 
-	slog.Info("cron: executing job", "id", jobID, "project", job.Project, "prompt", truncateStr(job.Prompt, 60))
+	slog.Info("cron: executing job", "id", jobID, "project", job.Project, "manual", manual, "prompt", truncateStr(job.Prompt, 60))
 
 	done := make(chan error, 1)
 	go func() {
@@ -663,9 +691,9 @@ func (cs *CronScheduler) executeJob(jobID string) {
 	cs.store.MarkRun(jobID, err)
 
 	if err != nil {
-		slog.Error("cron: job failed", "id", jobID, "error", err)
+		slog.Error("cron: job failed", "id", jobID, "manual", manual, "error", err)
 	} else {
-		slog.Info("cron: job completed", "id", jobID)
+		slog.Info("cron: job completed", "id", jobID, "manual", manual)
 	}
 }
 

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -9,6 +9,18 @@ import (
 	"time"
 )
 
+func waitForCron(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met before timeout")
+}
+
 func TestCronStore_MuteToggle(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewCronStore(dir)
@@ -260,14 +272,16 @@ func TestExecuteCardAction_CronActions(t *testing.T) {
 	}
 
 	if err := store.Add(&CronJob{
-		ID: "act1", Project: "test", SessionKey: "test:ch1",
+		ID: "act1", Project: "test", SessionKey: "discord:channel-1:user-1",
 		CronExpr: "0 6 * * *", Prompt: "task", Enabled: true,
 		CreatedAt: time.Now(),
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	p := &stubPlatformEngine{n: "test"}
+	p := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
 	scheduler := NewCronScheduler(store)
 	e.cronScheduler = scheduler
@@ -277,34 +291,79 @@ func TestExecuteCardAction_CronActions(t *testing.T) {
 	}
 	defer scheduler.Stop()
 
-	e.executeCardAction("/cron", "disable act1", "test:ch1")
+	e.executeCardAction("/cron", "disable act1", "discord:channel-1:user-1")
 	j := store.Get("act1")
 	if j.Enabled {
 		t.Error("job should be disabled after card action")
 	}
 
-	e.executeCardAction("/cron", "enable act1", "test:ch1")
+	e.executeCardAction("/cron", "enable act1", "discord:channel-1:user-1")
 	j = store.Get("act1")
 	if !j.Enabled {
 		t.Error("job should be re-enabled after card action")
 	}
 
-	e.executeCardAction("/cron", "mute act1", "test:ch1")
+	e.executeCardAction("/cron", "mute act1", "discord:channel-1:user-1")
 	j = store.Get("act1")
 	if !j.Mute {
 		t.Error("job should be muted after card action")
 	}
 
-	e.executeCardAction("/cron", "unmute act1", "test:ch1")
+	e.executeCardAction("/cron", "unmute act1", "discord:channel-1:user-1")
 	j = store.Get("act1")
 	if j.Mute {
 		t.Error("job should be unmuted after card action")
 	}
 
-	e.executeCardAction("/cron", "delete act1", "test:ch1")
+	agentSession := newResultAgentSession("cron run complete")
+	e.agent = &resultAgent{session: agentSession}
+	e.executeCardAction("/cron", "exec act1", "discord:channel-1:user-1")
+	waitForCron(t, time.Second, func() bool {
+		return strings.Contains(strings.Join(p.getSent(), "\n"), "cron run complete")
+	})
+
+	e.executeCardAction("/cron", "delete act1", "discord:channel-1:user-1")
 	if store.Get("act1") != nil {
 		t.Error("job should be deleted after card action")
 	}
+}
+
+func TestCronScheduler_TriggerJob_RunsDisabledJob(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job := &CronJob{
+		ID:         "manual1",
+		Project:    "test",
+		SessionKey: "discord:channel-1:user-1",
+		CronExpr:   "0 6 * * *",
+		Prompt:     "task",
+		Enabled:    false,
+		CreatedAt:  time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agent := &resultAgent{session: newResultAgentSession("manual complete")}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	scheduler := NewCronScheduler(store)
+	scheduler.RegisterEngine("test", e)
+
+	if err := scheduler.TriggerJob("manual1"); err != nil {
+		t.Fatalf("TriggerJob() error = %v", err)
+	}
+
+	waitForCron(t, time.Second, func() bool {
+		j := store.Get("manual1")
+		return j != nil && !j.LastRun.IsZero() && strings.Contains(strings.Join(p.getSent(), "\n"), "manual complete")
+	})
 }
 
 func TestCmdCronMute_TextCommand(t *testing.T) {
@@ -352,6 +411,43 @@ func TestCmdCronMute_TextCommand(t *testing.T) {
 	if len(sent) == 0 || !strings.Contains(sent[len(sent)-1], "not found") {
 		t.Errorf("should reply with not found for bad id, got: %v", sent)
 	}
+}
+
+func TestCmdCronExec_TextCommand(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Add(&CronJob{
+		ID:         "exec1",
+		Project:    "test",
+		SessionKey: "discord:channel-1:user-1",
+		CronExpr:   "0 6 * * *",
+		Prompt:     "task",
+		Enabled:    false,
+		CreatedAt:  time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agent := &resultAgent{session: newResultAgentSession("exec complete")}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	scheduler := NewCronScheduler(store)
+	e.cronScheduler = scheduler
+	scheduler.RegisterEngine("test", e)
+
+	msg := &Message{SessionKey: "discord:channel-1:user-1", UserID: "u1", ReplyCtx: "ctx"}
+	e.cmdCronExec(p, msg, []string{"exec1"})
+
+	waitForCron(t, time.Second, func() bool {
+		sent := p.getSent()
+		return len(sent) >= 2 && strings.Contains(sent[0], "triggered") && strings.Contains(strings.Join(sent, "\n"), "exec complete")
+	})
 }
 
 func TestCronStore_JobsPath(t *testing.T) {

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -361,9 +361,16 @@ func TestCronScheduler_TriggerJob_RunsDisabledJob(t *testing.T) {
 	}
 
 	waitForCron(t, time.Second, func() bool {
-		j := store.Get("manual1")
-		return j != nil && !j.LastRun.IsZero() && strings.Contains(strings.Join(p.getSent(), "\n"), "manual complete")
+		return strings.Contains(strings.Join(p.getSent(), "\n"), "manual complete")
 	})
+
+	j := store.Get("manual1")
+	if j == nil {
+		t.Fatal("job should still exist after manual trigger")
+	}
+	if j.LastRun.IsZero() {
+		t.Fatal("manual trigger should update LastRun")
+	}
 }
 
 func TestCmdCronMute_TextCommand(t *testing.T) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -7087,6 +7087,8 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 			_ = e.cronScheduler.EnableJob(id)
 		case "disable":
 			_ = e.cronScheduler.DisableJob(id)
+		case "exec", "run", "trigger":
+			_ = e.cronScheduler.TriggerJob(id)
 		case "delete":
 			e.cronScheduler.RemoveJob(id)
 		case "mute":
@@ -7884,6 +7886,7 @@ func (e *Engine) renderCronCard(sessionKey string, userID string) *Card {
 		} else {
 			btns = append(btns, PrimaryBtn(e.i18n.T(MsgCronBtnEnable), fmt.Sprintf("act:/cron enable %s", j.ID)))
 		}
+		btns = append(btns, PrimaryBtn(e.i18n.T(MsgCronBtnRun), fmt.Sprintf("act:/cron exec %s", j.ID)))
 		if j.Mute {
 			btns = append(btns, DefaultBtn(e.i18n.T(MsgCronBtnUnmute), fmt.Sprintf("act:/cron unmute %s", j.ID)))
 		} else {
@@ -8183,7 +8186,7 @@ func (e *Engine) cmdCron(p Platform, msg *Message, args []string) {
 	}
 
 	sub := matchSubCommand(strings.ToLower(args[0]), []string{
-		"add", "addexec", "list", "del", "delete", "rm", "remove", "enable", "disable", "mute", "unmute", "setup",
+		"add", "addexec", "list", "del", "delete", "rm", "remove", "enable", "disable", "mute", "unmute", "exec", "run", "trigger", "setup",
 	})
 	switch sub {
 	case "add":
@@ -8202,6 +8205,8 @@ func (e *Engine) cmdCron(p Platform, msg *Message, args []string) {
 		e.cmdCronMute(p, msg, args[1:], true)
 	case "unmute":
 		e.cmdCronMute(p, msg, args[1:], false)
+	case "exec", "run", "trigger":
+		e.cmdCronExec(p, msg, args[1:])
 	case "setup":
 		e.cmdCronSetup(p, msg)
 	default:
@@ -8382,6 +8387,19 @@ func (e *Engine) cmdCronMute(p Platform, msg *Message, args []string, mute bool)
 	} else {
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCronUnmuted), id))
 	}
+}
+
+func (e *Engine) cmdCronExec(p Platform, msg *Message, args []string) {
+	if len(args) == 0 {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgCronExecUsage))
+		return
+	}
+	id := args[0]
+	if err := e.cronScheduler.TriggerJob(id); err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgError, err))
+		return
+	}
+	e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCronTriggered), id))
 }
 
 func (e *Engine) cmdCronSetup(p Platform, msg *Message) {

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -220,6 +220,7 @@ const (
 	MsgCronAdded        MsgKey = "cron_added"
 	MsgCronAddedExec    MsgKey = "cron_added_exec"
 	MsgCronAddExecUsage MsgKey = "cron_addexec_usage"
+	MsgCronExecUsage    MsgKey = "cron_exec_usage"
 	MsgCronEmpty        MsgKey = "cron_empty"
 	MsgCronListTitle    MsgKey = "cron_list_title"
 	MsgCronListFooter   MsgKey = "cron_list_footer"
@@ -228,6 +229,7 @@ const (
 	MsgCronNotFound     MsgKey = "cron_not_found"
 	MsgCronEnabled      MsgKey = "cron_enabled"
 	MsgCronDisabled     MsgKey = "cron_disabled"
+	MsgCronTriggered    MsgKey = "cron_triggered"
 	MsgCronMuted        MsgKey = "cron_muted"
 	MsgCronUnmuted      MsgKey = "cron_unmuted"
 	MsgCronCardHint     MsgKey = "cron_card_hint"
@@ -235,6 +237,7 @@ const (
 	MsgCronLastShort    MsgKey = "cron_last_short"
 	MsgCronBtnEnable    MsgKey = "cron_btn_enable"
 	MsgCronBtnDisable   MsgKey = "cron_btn_disable"
+	MsgCronBtnRun       MsgKey = "cron_btn_run"
 	MsgCronBtnMute      MsgKey = "cron_btn_mute"
 	MsgCronBtnUnmute    MsgKey = "cron_btn_unmute"
 	MsgCronBtnDelete    MsgKey = "cron_btn_delete"
@@ -1606,11 +1609,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "El programador de tareas no está disponible.",
 	},
 	MsgCronUsage: {
-		LangEnglish:            "Usage:\n/cron add <min> <hour> <day> <month> <weekday> <prompt>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — write cc-connect instructions to agent memory file",
-		LangChinese:            "用法：\n/cron add <分> <时> <日> <月> <周> <任务描述>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 静音/取消静音\n/cron setup — 将 cc-connect 指令写入 agent 记忆文件",
-		LangTraditionalChinese: "用法：\n/cron add <分> <時> <日> <月> <週> <任務描述>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 靜音/取消靜音\n/cron setup — 將 cc-connect 指令寫入 agent 記憶檔案",
-		LangJapanese:           "使い方:\n/cron add <分> <時> <日> <月> <曜日> <タスク内容>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> ミュート/解除\n/cron setup — cc-connect の指示をエージェントのメモリファイルに書き込む",
-		LangSpanish:            "Uso:\n/cron add <min> <hora> <día> <mes> <día_semana> <tarea>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — escribir las instrucciones de cc-connect en el archivo de memoria del agente",
+		LangEnglish:            "Usage:\n/cron add <min> <hour> <day> <month> <weekday> <prompt>\n/cron list\n/cron del <id>\n/cron exec <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — write cc-connect instructions to agent memory file",
+		LangChinese:            "用法：\n/cron add <分> <时> <日> <月> <周> <任务描述>\n/cron list\n/cron del <id>\n/cron exec <id> 立即执行\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 静音/取消静音\n/cron setup — 将 cc-connect 指令写入 agent 记忆文件",
+		LangTraditionalChinese: "用法：\n/cron add <分> <時> <日> <月> <週> <任務描述>\n/cron list\n/cron del <id>\n/cron exec <id> 立即執行\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 靜音/取消靜音\n/cron setup — 將 cc-connect 指令寫入 agent 記憶檔案",
+		LangJapanese:           "使い方:\n/cron add <分> <時> <日> <月> <曜日> <タスク内容>\n/cron list\n/cron del <id>\n/cron exec <id> 今すぐ実行\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> ミュート/解除\n/cron setup — cc-connect の指示をエージェントのメモリファイルに書き込む",
+		LangSpanish:            "Uso:\n/cron add <min> <hora> <día> <mes> <día_semana> <tarea>\n/cron list\n/cron del <id>\n/cron exec <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — escribir las instrucciones de cc-connect en el archivo de memoria del agente",
 	},
 	MsgCronAddUsage: {
 		LangEnglish:            "Usage: /cron add <min> <hour> <day> <month> <weekday> <prompt>\nExample: /cron add 0 6 * * * Collect GitHub trending data and send me a summary",
@@ -1639,6 +1642,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "用法：/cron addexec <分> <時> <日> <月> <週> <shell 命令>\n範例：/cron addexec 0 6 * * * df -h",
 		LangJapanese:           "使い方: /cron addexec <分> <時> <日> <月> <曜日> <シェルコマンド>\n例: /cron addexec 0 6 * * * df -h",
 		LangSpanish:            "Uso: /cron addexec <min> <hora> <día> <mes> <día_semana> <comando shell>\nEjemplo: /cron addexec 0 6 * * * df -h",
+	},
+	MsgCronExecUsage: {
+		LangEnglish:            "Usage: /cron exec <id>",
+		LangChinese:            "用法：/cron exec <id>",
+		LangTraditionalChinese: "用法：/cron exec <id>",
+		LangJapanese:           "使い方: /cron exec <id>",
+		LangSpanish:            "Uso: /cron exec <id>",
 	},
 	MsgCronEmpty: {
 		LangEnglish:            "No scheduled tasks.",
@@ -1696,6 +1706,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "⏸ スケジュールタスク `%s` を無効にしました。",
 		LangSpanish:            "⏸ Tarea programada `%s` deshabilitada.",
 	},
+	MsgCronTriggered: {
+		LangEnglish:            "▶️ Cron job `%s` triggered.",
+		LangChinese:            "▶️ 定时任务 `%s` 已触发。",
+		LangTraditionalChinese: "▶️ 定時任務 `%s` 已觸發。",
+		LangJapanese:           "▶️ スケジュールタスク `%s` を実行しました。",
+		LangSpanish:            "▶️ Tarea programada `%s` ejecutada.",
+	},
 	MsgCronMuted: {
 		LangEnglish:            "🔇 Cron job `%s` muted (all messages suppressed).",
 		LangChinese:            "🔇 定时任务 `%s` 已静音（所有消息均不发送）。",
@@ -1711,11 +1728,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "🔔 Tarea programada `%s` reactivada.",
 	},
 	MsgCronCardHint: {
-		LangEnglish:            "💡 `/cron add` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
-		LangChinese:            "💡 `/cron add` 添加 · `/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
-		LangTraditionalChinese: "💡 `/cron add` 新增 · `/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
-		LangJapanese:           "💡 `/cron add` 追加 · `/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
-		LangSpanish:            "💡 `/cron add` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
+		LangEnglish:            "💡 `/cron add` · `/cron exec <id>` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
+		LangChinese:            "💡 `/cron add` 添加 · `/cron exec <id>` 立即执行 · `/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
+		LangTraditionalChinese: "💡 `/cron add` 新增 · `/cron exec <id>` 立即執行 · `/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
+		LangJapanese:           "💡 `/cron add` 追加 · `/cron exec <id>` 今すぐ実行 · `/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
+		LangSpanish:            "💡 `/cron add` · `/cron exec <id>` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
 	},
 	MsgCronBtnEnable: {
 		LangEnglish:            "Enable",
@@ -1730,6 +1747,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "暫停",
 		LangJapanese:           "無効",
 		LangSpanish:            "Desactivar",
+	},
+	MsgCronBtnRun: {
+		LangEnglish:            "Run Now",
+		LangChinese:            "立即执行",
+		LangTraditionalChinese: "立即執行",
+		LangJapanese:           "今すぐ実行",
+		LangSpanish:            "Ejecutar",
 	},
 	MsgCronBtnMute: {
 		LangEnglish:            "Mute",


### PR DESCRIPTION
## Summary
- Add `cron exec <job-id>` command to manually trigger an existing cron job on demand
- Includes API endpoint support for manual triggering
- Adds i18n messages for the new command

## Test plan
- [ ] Verify `cc-connect cron exec <job-id>` triggers the specified job immediately
- [ ] Verify error handling for invalid job IDs
- [ ] Run `go test ./core/... ./cmd/...` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)