### PR TITLE
fix(core): lenient bound_at parsing in workspace bindings

### DIFF
--- a/core/workspace_binding.go
+++ b/core/workspace_binding.go
@@ -11,11 +11,41 @@ import (
 
 const sharedWorkspaceBindingsKey = "shared"
 
+// FlexTime wraps time.Time with lenient JSON unmarshaling.
+type FlexTime struct{ time.Time }
+
+func (ft *FlexTime) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		ft.Time = time.Time{}
+		return nil
+	}
+	if s == "" {
+		ft.Time = time.Time{}
+		return nil
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05",
+	} {
+		if t, err := time.ParseInLocation(layout, s, time.Local); err == nil {
+			ft.Time = t
+			return nil
+		}
+	}
+	slog.Warn("workspace bindings: unparseable bound_at, treating as zero", "value", s)
+	ft.Time = time.Time{}
+	return nil
+}
+
 // WorkspaceBinding maps a channel to a workspace directory.
 type WorkspaceBinding struct {
-	ChannelName string    `json:"channel_name"`
-	Workspace   string    `json:"workspace"`
-	BoundAt     time.Time `json:"bound_at"`
+	ChannelName string   `json:"channel_name"`
+	Workspace   string   `json:"workspace"`
+	BoundAt     FlexTime `json:"bound_at"`
 }
 
 // WorkspaceBindingManager persists channel->workspace mappings.
@@ -80,7 +110,7 @@ func (m *WorkspaceBindingManager) Bind(projectKey, channelKey, channelName, work
 	m.bindings[projectKey][channelKey] = &WorkspaceBinding{
 		ChannelName: channelName,
 		Workspace:   workspace,
-		BoundAt:     time.Now(),
+		BoundAt:     FlexTime{time.Now()},
 	}
 	m.saveLocked()
 }


### PR DESCRIPTION
## Summary

- Introduce `FlexTime` wrapper type with lenient `UnmarshalJSON` for `WorkspaceBinding.BoundAt`
- Tries multiple time formats (RFC3339Nano, RFC3339, common no-timezone variants)
- Falls back to zero value on parse failure instead of returning an error
- Prevents a non-critical metadata field from breaking all workspace bindings

Closes #631

## Problem

When `workspace_bindings.json` is externally edited (e.g. by an AI agent), a `bound_at` value without timezone suffix causes `json.Unmarshal` to fail for the entire file. In multi-workspace mode, this makes all channels return "workspace not found".

## Changes

- `core/workspace_binding.go`: Add `FlexTime` type, change `BoundAt` field from `time.Time` to `FlexTime`

## Test plan

- [x] All existing `TestWorkspaceBinding*` tests pass
- [x] Verified with a real `workspace_bindings.json` containing a timezone-less `bound_at` — bindings load correctly, no error logged