### PR TITLE
Fix Issue #619: Replace /btw with /ps as proper builtin command

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1509,25 +1509,6 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	session := sessions.GetOrCreateActive(msg.SessionKey)
 	sessions.UpdateUserMeta(msg.SessionKey, msg.UserName, msg.ChatName)
 	if !session.TryLock() {
-		// Check for /btw — inject into the running session mid-turn
-		trimmed := strings.TrimSpace(content)
-		if isBtwCommand(trimmed) {
-			btw := strings.TrimSpace(trimmed[len(matchBtwPrefix(trimmed)):])
-			if btw != "" {
-				e.interactiveMu.Lock()
-				state, ok := e.interactiveStates[interactiveKey]
-				e.interactiveMu.Unlock()
-				if ok && state.agentSession != nil && state.agentSession.Alive() {
-					if err := state.agentSession.Send(btw, nil, nil); err != nil {
-						slog.Error("btw: send failed", "error", err)
-						e.reply(p, msg.ReplyCtx, e.i18n.T(MsgBtwSendFailed))
-					} else {
-						e.reply(p, msg.ReplyCtx, e.i18n.T(MsgBtwSent))
-					}
-					return
-				}
-			}
-		}
 		// Session is busy — try to queue the message for the running turn
 		// so the agent processes it immediately after the current turn ends.
 		if e.queueMessageForBusySession(p, msg, interactiveKey) {
@@ -3132,6 +3113,7 @@ var builtinCommands = []struct {
 	{[]string{"heartbeat", "hb"}, "heartbeat"},
 	{[]string{"compress", "compact"}, "compress"},
 	{[]string{"stop"}, "stop"},
+	{[]string{"ps", "postscript"}, "ps"},
 	{[]string{"help"}, "help"},
 	{[]string{"version"}, "version"},
 	{[]string{"commands", "command", "cmd"}, "commands"},
@@ -3152,26 +3134,6 @@ var builtinCommands = []struct {
 	{[]string{"whoami", "myid"}, "whoami"},
 	{[]string{"web"}, "web"},
 	{[]string{"diff"}, "diff"},
-}
-
-// isBtwCommand checks if a trimmed message starts with a /btw command.
-func isBtwCommand(trimmed string) bool {
-	return matchBtwPrefix(trimmed) != ""
-}
-
-// matchBtwPrefix returns the prefix portion (e.g. "/btw ") if the
-// message starts with a btw command, or "" if it doesn't match.
-func matchBtwPrefix(trimmed string) string {
-	lower := strings.ToLower(trimmed)
-	for _, prefix := range []string{"/btw"} {
-		if strings.HasPrefix(lower, prefix) {
-			rest := trimmed[len(prefix):]
-			if rest == "" || rest[0] == ' ' {
-				return trimmed[:len(prefix)]
-			}
-		}
-	}
-	return ""
 }
 
 // matchPrefix finds a unique command matching the given prefix.
@@ -3307,6 +3269,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdCompress(p, msg)
 	case "stop":
 		e.cmdStop(p, msg)
+	case "ps":
+		e.cmdPs(p, msg, args)
 	case "help":
 		e.cmdHelp(p, msg)
 	case "version":
@@ -5148,6 +5112,7 @@ func helpCardGroups() []helpCardGroup {
 				{command: "/skills", action: "nav:/skills"},
 				{command: "/compress", action: "cmd:/compress"},
 				{command: "/stop", action: "act:/stop"},
+				{command: "/ps", action: "cmd:/ps"},
 			},
 		},
 		{
@@ -5767,6 +5732,36 @@ func (e *Engine) cmdStop(p Platform, msg *Message) {
 		return
 	}
 	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgExecutionStopped))
+}
+
+// cmdPs injects a message into the running session mid-turn (postscript).
+// Unlike normal commands, it bypasses TryLock and works even when the session is busy.
+func (e *Engine) cmdPs(p Platform, msg *Message, args []string) {
+	// Join args to get the message content
+	content := strings.Join(args, " ")
+	content = strings.TrimSpace(content)
+
+	if content == "" {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsEmpty))
+		return
+	}
+
+	iKey := e.interactiveKeyForSessionKey(msg.SessionKey)
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[iKey]
+	e.interactiveMu.Unlock()
+
+	if !ok || state == nil || state.agentSession == nil || !state.agentSession.Alive() {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsNoSession))
+		return
+	}
+
+	if err := state.agentSession.Send(content, nil, nil); err != nil {
+		slog.Error("ps: send failed", "error", err)
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsSendFailed))
+	} else {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsSent))
+	}
 }
 
 func (e *Engine) stopInteractiveSession(sessionKey string, quietPlatform Platform, quietReplyCtx any) bool {

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -424,8 +424,10 @@ const (
 	MsgCommandDisabled   MsgKey = "command_disabled"
 	MsgAdminRequired     MsgKey = "admin_required"
 	MsgRateLimited       MsgKey = "rate_limited"
-	MsgBtwSent           MsgKey = "btw_sent"
-	MsgBtwSendFailed     MsgKey = "btw_send_failed"
+	MsgPsSent            MsgKey = "ps_sent"
+	MsgPsSendFailed      MsgKey = "ps_send_failed"
+	MsgPsEmpty           MsgKey = "ps_empty"
+	MsgPsNoSession       MsgKey = "ps_no_session"
 
 	MsgWhoamiTitle     MsgKey = "whoami_title"
 	MsgWhoamiCardTitle MsgKey = "whoami_card_title"
@@ -627,11 +629,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "No hay ejecución en progreso.",
 	},
 	MsgPreviousProcessing: {
-		LangEnglish:            "⏳ Previous request still processing. Use `/btw <message>` to add context to the current turn.",
-		LangChinese:            "⏳ 上一个请求仍在处理中。使用 `/btw <消息>` 可向当前轮次追加上下文。",
-		LangTraditionalChinese: "⏳ 上一個請求仍在處理中。使用 `/btw <訊息>` 可向當前輪次追加上下文。",
-		LangJapanese:           "⏳ 前のリクエストを処理中です。`/btw <メッセージ>` で現在のターンにコンテキストを追加できます。",
-		LangSpanish:            "⏳ La solicitud anterior aún se está procesando. Use `/btw <mensaje>` para agregar contexto al turno actual.",
+		LangEnglish:            "⏳ Previous request still processing. Use `/ps <message>` to add context to the current turn.",
+		LangChinese:            "⏳ 上一个请求仍在处理中。使用 `/ps <消息>` 可向当前轮次追加上下文。",
+		LangTraditionalChinese: "⏳ 上一個請求仍在處理中。使用 `/ps <訊息>` 可向當前輪次追加上下文。",
+		LangJapanese:           "⏳ 前のリクエストを処理中です。`/ps <メッセージ>` で現在のターンにコンテキストを追加できます。",
+		LangSpanish:            "⏳ La solicitud anterior aún se está procesando. Use `/ps <mensaje>` para agregar contexto al turno actual.",
 	},
 	MsgMessageQueued: {
 		LangEnglish:            "📬 Message received — will process after the current task finishes.",
@@ -2894,19 +2896,33 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "⏳ メッセージの送信が速すぎます。しばらくお待ちください。",
 		LangSpanish:            "⏳ Estás enviando mensajes demasiado rápido. Espera un momento.",
 	},
-	MsgBtwSent: {
+	MsgPsSent: {
 		LangEnglish:            "✅ Message injected into the current session.",
 		LangChinese:            "✅ 消息已注入当前会话。",
 		LangTraditionalChinese: "✅ 訊息已注入目前會話。",
 		LangJapanese:           "✅ メッセージを現在のセッションに注入しました。",
 		LangSpanish:            "✅ Mensaje inyectado en la sesión actual.",
 	},
-	MsgBtwSendFailed: {
+	MsgPsSendFailed: {
 		LangEnglish:            "❌ Failed to inject message into the current session.",
 		LangChinese:            "❌ 消息注入当前会话失败。",
 		LangTraditionalChinese: "❌ 訊息注入目前會話失敗。",
 		LangJapanese:           "❌ 現在のセッションへのメッセージ注入に失敗しました。",
 		LangSpanish:            "❌ Error al inyectar el mensaje en la sesión actual.",
+	},
+	MsgPsEmpty: {
+		LangEnglish:            "❌ No message to inject. Usage: `/ps <message>`",
+		LangChinese:            "❌ 没有可注入的消息。用法：`/ps <消息>`",
+		LangTraditionalChinese: "❌ 沒有可注入的訊息。用法：`/ps <訊息>`",
+		LangJapanese:           "❌ 注入するメッセージがありません。使い方：`/ps <メッセージ>`",
+		LangSpanish:            "❌ No hay mensaje para inyectar. Uso: `/ps <mensaje>`",
+	},
+	MsgPsNoSession: {
+		LangEnglish:            "❌ No active session. Start a conversation first.",
+		LangChinese:            "❌ 没有活跃会话。请先开始对话。",
+		LangTraditionalChinese: "❌ 沒有活躍會話。請先開始對話。",
+		LangJapanese:           "❌ アクティブなセッションがありません。まず会話を開始してください。",
+		LangSpanish:            "❌ No hay sesión activa. Inicie una conversación primero.",
 	},
 	MsgWhoamiTitle: {
 		LangEnglish:            "🪪 **Your Identity**",


### PR DESCRIPTION
## Summary
- Replace /btw with /ps (postscript) to avoid collision with Claude Code CLI's /btw command
- Register /ps as proper builtin command to fix double-reply issue
- Bypass TryLock - /ps works whether session is busy or not
- Add i18n messages: ps_sent, ps_send_failed, ps_empty, ps_no_session
- Add /ps to help card under tools group
- Remove isBtwCommand() and matchBtwPrefix() helper functions

## Root Cause
The original /btw command had three problems:
1. **Name collision**: Claude Code CLI's /btw means "ask a side question", different from cc-connect's mid-turn injection
2. **Not registered as builtin**: Triggered MsgUnknownCommand before falling through to btw logic, causing two replies
3. **Missing from help**: Not discoverable in /help output

## Fix Approach
- Create /ps command registered in builtinCommands
- Handle via cmdPs() in switch statement, following cmdStop() pattern
- Use interactiveKeyForSessionKey() for multi-workspace support
- Directly access interactiveStates, bypassing TryLock entirely

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all tests)
- [ ] Manual smoke test: send /ps command during busy session

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)