### PR TITLE
Fix Issues #629, #635: Set CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST when provider is active

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -766,6 +766,15 @@ func (a *Agent) providerEnvLocked() []string {
 	for k, v := range p.Env {
 		env = append(env, k+"="+v)
 	}
+
+	// Set CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1 to tell Claude CLI
+	// that provider routing is managed by cc-connect, preventing
+	// settings.json env vars from overriding our provider config.
+	// This fixes issues #629 and #635 where settings.json env vars
+	// (ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN) would override
+	// config.toml provider settings.
+	env = append(env, "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1")
+
 	return env
 }
 


### PR DESCRIPTION
## Summary
- Set `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1` when a provider is active
- Prevents settings.json env vars from overriding config.toml provider settings
- Fixes both Issue #629 (DingTalk model config) and Issue #635 (providers base_url/api_key)

## Root Cause
The issue was identified in Issue #635 comments:

1. cc-connect passes provider env vars (ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN) to Claude CLI subprocess
2. Claude CLI then reads ~/.claude/settings.json and applies its `env` section, **overriding** the provider vars
3. Model works because it's passed via `--model` flag, but `base_url` and `api_key` are lost

This explains why:
- User configures provider in config.toml (api_key, base_url, model)
- Model from config.toml is used
- But base_url/api_key from settings.json (via cc switch) are used instead
- Result: API error "Unknown Model" because wrong endpoint doesn't have the model

## Fix
Add `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1` to the env vars when a provider is active. This env var tells Claude CLI that provider routing is managed by the host, preventing settings.json env vars from overriding provider config.

Claude Code source code already has this protection mechanism - we just need to enable it.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all tests)
- [ ] Manual smoke test: configure provider in config.toml, verify it works with conflicting settings.json env

Closes #629
Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)