### PR TITLE
feat(claudecode): support Claude-compatible CLI wrappers via cli_path

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -35,6 +35,9 @@ func init() {
 //   - "bypassPermissions": auto-approve everything (alias: yolo)
 type Agent struct {
 	workDir          string
+	cliBin           string   // CLI binary name or path (default: "claude")
+	cliExtraArgs     []string // extra args parsed from cli_path (e.g. ["code", "-t", "foo"])
+	cliArgsFlag      string   // if set, claude args are passed as a single string via this flag (e.g. "-a")
 	model            string
 	reasoningEffort  string // "low" | "medium" | "high" | "max"
 	mode             string // "default" | "acceptEdits" | "plan" | "auto" | "bypassPermissions" | "dontAsk"
@@ -63,6 +66,16 @@ func New(opts map[string]any) (core.Agent, error) {
 	if workDir == "" {
 		workDir = "."
 	}
+	cliBin := "claude"
+	var cliExtraArgs []string
+	if cliPath, _ := opts["cli_path"].(string); cliPath != "" {
+		parts := strings.Fields(cliPath)
+		cliBin = parts[0]
+		if len(parts) > 1 {
+			cliExtraArgs = parts[1:]
+		}
+	}
+	cliArgsFlag, _ := opts["cli_args_flag"].(string)
 	model, _ := opts["model"].(string)
 	reasoningEffort, _ := opts["reasoning_effort"].(string)
 	mode, _ := opts["mode"].(string)
@@ -124,13 +137,16 @@ func New(opts map[string]any) (core.Agent, error) {
 	// skip the supervisor-side LookPath check and let spawn fail loudly
 	// at runtime if the target doesn't have claude installed.
 	if !spawnOpts.IsolationMode() {
-		if _, err := exec.LookPath("claude"); err != nil {
-			return nil, fmt.Errorf("claudecode: 'claude' CLI not found in PATH, please install Claude Code first")
+		if _, err := exec.LookPath(cliBin); err != nil {
+			return nil, fmt.Errorf("claudecode: %q CLI not found in PATH, please install it first", cliBin)
 		}
 	}
 
 	return &Agent{
 		workDir:          workDir,
+		cliBin:           cliBin,
+		cliExtraArgs:     cliExtraArgs,
+		cliArgsFlag:      cliArgsFlag,
 		model:            model,
 		reasoningEffort:  normalizeEffort(reasoningEffort),
 		mode:             mode,
@@ -182,7 +198,7 @@ func normalizePermissionMode(raw string) string {
 }
 
 func (a *Agent) Name() string           { return "claudecode" }
-func (a *Agent) CLIBinaryName() string  { return "claude" }
+func (a *Agent) CLIBinaryName() string  { return a.cliBin }
 func (a *Agent) CLIDisplayName() string { return "Claude" }
 
 func (a *Agent) SetWorkDir(dir string) {
@@ -355,7 +371,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, a.workDir, model, effort, sessionID, a.mode, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
+	return newClaudeSession(ctx, a.workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, a.mode, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -260,9 +260,14 @@ func TestAgent_Name(t *testing.T) {
 }
 
 func TestAgent_CLIBinaryName(t *testing.T) {
-	a := &Agent{}
+	a := &Agent{cliBin: "claude"}
 	if got := a.CLIBinaryName(); got != "claude" {
 		t.Errorf("CLIBinaryName() = %q, want %q", got, "claude")
+	}
+
+	a2 := &Agent{cliBin: "my-cli"}
+	if got := a2.CLIBinaryName(); got != "my-cli" {
+		t.Errorf("CLIBinaryName() = %q, want %q", got, "my-cli")
 	}
 }
 

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -51,20 +51,23 @@ type claudeSession struct {
 	gracefulStopTimeout time.Duration
 }
 
-func newClaudeSession(ctx context.Context, workDir, model, effort, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
+func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
-	args := []string{
+	// innerArgs are Claude Code CLI flags — when a wrapper is used with
+	// cliArgsFlag these get bundled into a single passthrough string.
+	// outerArgs are flags the wrapper itself understands (e.g. --model).
+	innerArgs := []string{
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--permission-prompt-tool", "stdio",
 	}
 	if !disableVerbose {
-		args = append(args, "--verbose")
+		innerArgs = append(innerArgs, "--verbose")
 	}
 
 	if mode != "" && mode != "default" {
-		args = append(args, "--permission-mode", mode)
+		innerArgs = append(innerArgs, "--permission-mode", mode)
 	}
 	switch sessionID {
 	case "", core.ContinueSession:
@@ -72,33 +75,36 @@ func newClaudeSession(ctx context.Context, workDir, model, effort, sessionID, mo
 	default:
 		// Resuming a known session ID — this is cc-connect's own session
 		// from a previous connection, safe to resume directly.
-		args = append(args, "--resume", sessionID)
-	}
-	if model != "" {
-		args = append(args, "--model", model)
+		innerArgs = append(innerArgs, "--resume", sessionID)
 	}
 	if len(allowedTools) > 0 {
-		args = append(args, "--allowedTools", strings.Join(allowedTools, ","))
+		innerArgs = append(innerArgs, "--allowedTools", strings.Join(allowedTools, ","))
 	}
 	if len(disallowedTools) > 0 {
-		args = append(args, "--disallowedTools", strings.Join(disallowedTools, ","))
+		innerArgs = append(innerArgs, "--disallowedTools", strings.Join(disallowedTools, ","))
 	}
 
 	if sysPrompt := core.AgentSystemPrompt(); sysPrompt != "" {
 		if platformPrompt != "" {
 			sysPrompt += "\n## Formatting\n" + platformPrompt + "\n"
 		}
-		args = append(args, "--append-system-prompt", sysPrompt)
+		innerArgs = append(innerArgs, "--append-system-prompt", sysPrompt)
 	}
 
 	if effort != "" {
-		args = append(args, "--effort", effort)
+		innerArgs = append(innerArgs, "--effort", effort)
 	}
 	if maxContextTokens > 0 {
-		args = append(args, "--max-context-tokens", strconv.Itoa(maxContextTokens))
+		innerArgs = append(innerArgs, "--max-context-tokens", strconv.Itoa(maxContextTokens))
+	}
+	
+	// outerArgs are understood by both the wrapper and Claude CLI directly.
+	var outerArgs []string
+	if model != "" {
+		outerArgs = append(outerArgs, "--model", model)
 	}
 
-	slog.Debug("claudeSession: starting", "args", core.RedactArgs(args), "dir", workDir, "mode", mode, "run_as_user", spawnOpts.RunAsUser)
+	slog.Debug("claudeSession: starting", "innerArgs", core.RedactArgs(innerArgs), "outerArgs", core.RedactArgs(outerArgs), "dir", workDir, "mode", mode, "run_as_user", spawnOpts.RunAsUser)
 
 	// Per-spawn defense in depth: if run_as_user is set, re-run the cheap
 	// preflight (sudo still works + target still can't escalate) right
@@ -114,7 +120,24 @@ func newClaudeSession(ctx context.Context, workDir, model, effort, sessionID, mo
 		}
 	}
 
-	cmd := core.BuildSpawnCommand(sessionCtx, spawnOpts, "claude", args...)
+	// Build final argument list.
+	// When cliArgsFlag is set (e.g. "-a"), inner args are bundled into a
+	// single passthrough string via that flag, while outer args (--model etc.)
+	// are appended directly so the wrapper can also interpret them.
+	// Args containing spaces/newlines are quoted so the wrapper's command-line
+	// parser (e.g. splitCommandLine) keeps them as single tokens.
+	// Result: my-cli code -t foo -a "--verbose --append-system-prompt 'long text'" --model x
+	var allArgs []string
+	if cliArgsFlag != "" {
+		allArgs = append(allArgs, cliExtraArgs...)
+		allArgs = append(allArgs, cliArgsFlag, shellJoinArgs(innerArgs))
+		allArgs = append(allArgs, outerArgs...)
+	} else {
+		allArgs = append(allArgs, cliExtraArgs...)
+		allArgs = append(allArgs, innerArgs...)
+		allArgs = append(allArgs, outerArgs...)
+	}
+	cmd := core.BuildSpawnCommand(sessionCtx, spawnOpts, cliBin, allArgs...)
 	cmd.Dir = workDir
 	// Filter out CLAUDECODE env var to prevent "nested session" detection,
 	// since cc-connect is a bridge, not a nested Claude Code session.
@@ -640,6 +663,37 @@ func (cs *claudeSession) Close() error {
 	}
 	<-cs.done
 	return nil
+}
+
+// shellJoinArgs joins args into a single string, quoting any arg that
+// contains whitespace so that a shell-style splitter (like my_cli's
+// splitCommandLine) preserves each arg as one token.
+//
+// Uses single quotes because some splitters (e.g. my_cli) don't support
+// backslash escapes inside double quotes. For values containing single
+// quotes, we close the single-quoted segment, add an escaped single
+// quote, and reopen: 'it'\''s' → it's
+func shellJoinArgs(args []string) string {
+	var b strings.Builder
+	for i, a := range args {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		if !strings.ContainsAny(a, " \t\n\r'\"\\") {
+			b.WriteString(a)
+			continue
+		}
+		b.WriteByte('\'')
+		for _, c := range a {
+			if c == '\'' {
+				b.WriteString("'\\''")
+			} else {
+				b.WriteRune(c)
+			}
+		}
+		b.WriteByte('\'')
+	}
+	return b.String()
 }
 
 // filterEnv returns a copy of env with entries matching the given key removed.


### PR DESCRIPTION
## Summary

- Add `cli_path` option so the claudecode agent can spawn third-party Claude-compatible CLIs (or wrappers) instead of hardcoding `claude`. The value may include extra args (e.g. `my-cli code -t foo`) which are parsed and prepended before Claude flags.
- Add `cli_args_flag` option: when set (e.g. `-a`), the inner Claude flags (`--verbose`, `--append-system-prompt`, …) are bundled into a single passthrough string via that flag, while wrapper-understood flags (`--model`) are still appended directly. Values with whitespace/quotes are safely single-quoted so shell-style splitters keep them as one token.
- Preflight `LookPath` now checks the configured binary and reports it in the error message.
- `CLIBinaryName()` returns the configured binary so `doctor` diagnostics reflect the real target.

## Test plan

- [x] `go test ./...`
- [x] Manual: configure `cli_path = "claude"` — behavior unchanged vs. before
- [x] Manual: configure a wrapper CLI with `cli_args_flag` and verify inner Claude flags arrive as a single quoted arg
- [ ] Manual: `cc-connect doctor` shows the configured binary name

🤖 Generated with [Claude Code](https://claude.com/claude-code)