### PR TITLE
fix(telegram): render markdown tables in monospace <pre> block

### DIFF
--- a/core/markdown_html.go
+++ b/core/markdown_html.go
@@ -56,32 +56,88 @@ func MarkdownToSimpleHTML(md string) string {
 		inBlockquote = false
 	}
 
-	// flushTable renders buffered table rows as readable text.
+	// flushTable renders buffered table rows inside a <pre> block with aligned columns.
 	flushTable := func() {
 		if len(tblLines) == 0 {
 			return
 		}
-		for j, tl := range tblLines {
-			if j > 0 {
-				b.WriteByte('\n')
-			}
+
+		// Parse all rows into cells, skipping separator rows.
+		type row struct {
+			cells []string
+			isSep bool
+		}
+		var rows []row
+		for _, tl := range tblLines {
 			tl = strings.TrimSpace(tl)
 			if reTableSep.MatchString(tl) {
-				b.WriteString("——————————")
-			} else {
-				tlTrim := strings.TrimSpace(tl)
-				inner := tlTrim
-				if strings.HasPrefix(tlTrim, "|") && strings.HasSuffix(tlTrim, "|") && len(tlTrim) >= 2 {
-					inner = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(tlTrim, "|"), "|"))
-				}
-				cells := strings.Split(inner, "|")
-				for k := range cells {
-					cells[k] = strings.TrimSpace(cells[k])
-				}
-				row := strings.Join(cells, " | ")
-				b.WriteString(convertInlineHTML(row))
+				rows = append(rows, row{isSep: true})
+				continue
+			}
+			inner := tl
+			if strings.HasPrefix(tl, "|") && strings.HasSuffix(tl, "|") && len(tl) >= 2 {
+				inner = strings.TrimSpace(tl[1 : len(tl)-1])
+			}
+			cells := strings.Split(inner, "|")
+			for k := range cells {
+				cells[k] = strings.TrimSpace(cells[k])
+			}
+			rows = append(rows, row{cells: cells})
+		}
+
+		// Compute max width per column.
+		numCols := 0
+		for _, r := range rows {
+			if !r.isSep && len(r.cells) > numCols {
+				numCols = len(r.cells)
 			}
 		}
+		colWidths := make([]int, numCols)
+		for _, r := range rows {
+			if r.isSep {
+				continue
+			}
+			for k, c := range r.cells {
+				if k < numCols && len(c) > colWidths[k] {
+					colWidths[k] = len(c)
+				}
+			}
+		}
+
+		// Render inside <pre>.
+		b.WriteString("<pre>")
+		first := true
+		for _, r := range rows {
+			if !first {
+				b.WriteByte('\n')
+			}
+			first = false
+			if r.isSep {
+				// Draw separator line matching column widths.
+				for k, w := range colWidths {
+					if k > 0 {
+						b.WriteString("-+-")
+					}
+					b.WriteString(strings.Repeat("-", w))
+				}
+			} else {
+				for k := 0; k < numCols; k++ {
+					if k > 0 {
+						b.WriteString(" | ")
+					}
+					cell := ""
+					if k < len(r.cells) {
+						cell = r.cells[k]
+					}
+					b.WriteString(escapeHTML(cell))
+					// Pad to column width.
+					if pad := colWidths[k] - len(cell); pad > 0 {
+						b.WriteString(strings.Repeat(" ", pad))
+					}
+				}
+			}
+		}
+		b.WriteString("</pre>")
 		tblLines = tblLines[:0]
 		inTable = false
 	}

--- a/core/markdown_html_test.go
+++ b/core/markdown_html_test.go
@@ -348,28 +348,33 @@ func TestMarkdownToSimpleHTML_BlockquoteBreaksOnBlankLine(t *testing.T) {
 func TestMarkdownToSimpleHTML_Table(t *testing.T) {
 	md := "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |"
 	out := MarkdownToSimpleHTML(md)
-	if !strings.Contains(out, "Name | Age") {
+	if !strings.Contains(out, "<pre>") {
+		t.Errorf("expected table wrapped in <pre>, got %q", out)
+	}
+	if !strings.Contains(out, "Name") || !strings.Contains(out, "Age") {
 		t.Errorf("expected table header cells, got %q", out)
 	}
-	if !strings.Contains(out, "——————————") {
-		t.Errorf("expected separator as rule, got %q", out)
-	}
-	if !strings.Contains(out, "Alice | 30") {
+	if !strings.Contains(out, "Alice") || !strings.Contains(out, "30") {
 		t.Errorf("expected table data cells, got %q", out)
+	}
+	// Columns should be aligned with padding
+	if !strings.Contains(out, "-----+-") {
+		t.Errorf("expected aligned separator row, got %q", out)
 	}
 }
 
 func TestMarkdownToSimpleHTML_TableWithFormatting(t *testing.T) {
+	// Inline formatting is escaped inside <pre> since HTML tags in <pre> render literally in Telegram
 	md := "| **Header** | `code` |\n|---|---|\n| *italic* | normal |"
 	out := MarkdownToSimpleHTML(md)
-	if !strings.Contains(out, "<b>Header</b>") {
-		t.Errorf("expected bold in table cell, got %q", out)
+	if !strings.Contains(out, "<pre>") {
+		t.Errorf("expected table wrapped in <pre>, got %q", out)
 	}
-	if !strings.Contains(out, "<code>code</code>") {
-		t.Errorf("expected code in table cell, got %q", out)
+	if !strings.Contains(out, "Header") {
+		t.Errorf("expected header text in table, got %q", out)
 	}
-	if err := validateHTMLNesting(out); err != nil {
-		t.Errorf("invalid HTML nesting: %v, got %q", err, out)
+	if !strings.Contains(out, "code") {
+		t.Errorf("expected code text in table, got %q", out)
 	}
 }
 


### PR DESCRIPTION
  ## Summary
  - Tables were rendered as proportional-width plain text, causing misaligned columns in Telegram
  - Wrap tables in `<pre>` with per-column padding for proper monospace alignment
  - Separator rows now use `-` and `+-` aligned to column widths

  ## Related
  - openclaw/openclaw#36323

  ## Test plan
  - [x] Updated table tests in `core/markdown_html_test.go`
  - [x] All `go test ./core/` tests pass