### PR TITLE
fix(core): freeze preview card between text segments in quiet mode

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2542,6 +2542,22 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		switch event.Type {
 		case EventThinking:
+			// In quiet mode, still split text segments so they don't merge.
+			if !e.display.ThinkingMessages && len(textParts) > segmentStart {
+				if sp.canPreview() {
+					sp.freeze()
+					sp.detachPreview()
+				} else {
+					// Preview degraded — send accumulated text directly
+					segment := strings.Join(textParts[segmentStart:], "")
+					if segment != "" {
+						for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+							sendWorkspace(p, replyCtx, chunk)
+						}
+					}
+				}
+				segmentStart = len(textParts)
+			}
 			if e.display.ThinkingMessages && event.Content != "" {
 				// Flush accumulated text segment before thinking display
 				previewActive := sp.canPreview()
@@ -2569,13 +2585,21 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		case EventToolUse:
 			toolCount++
-			// When tool messages are hidden, insert a visual break between text
-			// segments so the accumulated response doesn't run together.
+			// When tool messages are hidden, split text segments.
 			if !e.display.ToolMessages && len(textParts) > segmentStart {
-				textParts = append(textParts, "\n\n")
 				if sp.canPreview() {
-					sp.appendText("\n\n")
+					sp.freeze()
+					sp.detachPreview()
+				} else {
+					// Preview degraded — send accumulated text directly
+					segment := strings.Join(textParts[segmentStart:], "")
+					if segment != "" {
+						for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+							sendWorkspace(p, replyCtx, chunk)
+						}
+					}
 				}
+				segmentStart = len(textParts)
 			}
 			if e.display.ToolMessages {
 				// Flush accumulated text segment before tool display


### PR DESCRIPTION
Summary：

  ## Summary

  When quiet mode is enabled (`/quiet` or `quiet = true`), multiple Claude text outputs merge into a single card instead of being sent as separate messages.

  ## Problem

  The stream preview card is designed to show the latest text output, then get "frozen" (preserved as a permanent message) when a thinking or tool event arrives. This creates natural boundaries between text segments.

  In quiet mode, `ThinkingMessages` and `ToolMessages` are both false, so the thinking/tool event handlers are skipped entirely — including their `sp.freeze()` + `sp.detachPreview()` calls. The preview card is never frozen between text outputs, so all text accumulates
  into a single card.

  Normal mode:
    Text1 → preview card
    Thinking → freeze card (permanent) ✓
    Tool → send tool message
    Text2 → new preview card ✓

  Quiet mode (before fix):
    Text1 → preview card
    Thinking → hidden, no freeze ✗
    Tool → hidden
    Text2 → appends to same card ✗ (all text merged)

  ## Fix

  When thinking/tool events are suppressed in quiet mode, still call `freeze()` + `detachPreview()` if there is accumulated text in the preview. This preserves the text segment as a permanent message before the next text output begins.

  ```go
  // EventThinking — even when hidden, freeze to split text segments
  if !e.display.ThinkingMessages && sp.canPreview() && len(textParts) > segmentStart {
      segmentStart = len(textParts)
      sp.freeze()
      sp.detachPreview()
  }

  // EventToolUse — replace previous "\n\n" separator with proper freeze
  if !e.display.ToolMessages && len(textParts) > segmentStart {
      if sp.canPreview() {
          sp.freeze()
          sp.detachPreview()
      }
      segmentStart = len(textParts)
  }

  Also removes the previous workaround that appended "\n\n" as a visual separator — this only added whitespace without actually splitting the card.

  Test plan

  - go build ./cmd/cc-connect passes
  - go test ./core/ passes
  - Manual: enable quiet mode, trigger multi-step Claude response, verify each text output is a separate message

  🤖 Generated with Claude Code
  ```