### PR TITLE
fix(feishu): prefer card over post for markdown rendering

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1242,7 +1242,9 @@ func extractInteractiveCardText(content string) string {
 	if len(parts) == 0 {
 		if raw, ok := card["header"]; ok {
 			var header struct {
-				Title struct{ Content string `json:"content"` } `json:"title"`
+				Title struct {
+					Content string `json:"content"`
+				} `json:"title"`
 			}
 			if json.Unmarshal(raw, &header) == nil && header.Title.Content != "" {
 				parts = append(parts, header.Title.Content)
@@ -1826,7 +1828,7 @@ func predictMsgType(content string) string {
 	if !containsMarkdown(content) {
 		return larkim.MsgTypeText
 	}
-	if hasComplexMarkdown(content) && countMarkdownTables(content) <= maxCardTables {
+	if countMarkdownTables(content) <= maxCardTables {
 		return larkim.MsgTypeInteractive
 	}
 	return larkim.MsgTypePost
@@ -1837,21 +1839,14 @@ func buildReplyContent(content string) (msgType string, body string) {
 		b, _ := json.Marshal(map[string]string{"text": content})
 		return larkim.MsgTypeText, string(b)
 	}
-	// Three-tier rendering strategy:
-	// 1. Code blocks / tables → card (schema 2.0 markdown)
-	// 2. Many \n\n paragraphs (help, status, etc.) → post rich-text (preserves blank lines)
-	// 3. Other markdown → post md tag (best native rendering)
-	//
-	// Feishu cards support at most 5 tables (API error 11310).
-	// When content exceeds this limit, fall back to post with md tag
-	// which still renders tables without the card table cap.
-	if hasComplexMarkdown(content) && countMarkdownTables(content) <= maxCardTables {
-		return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)))
+	// Prefer card for all markdown content — card schema 2.0 has the best
+	// markdown rendering (headings, blockquotes, code blocks, tables, links,
+	// strikethrough, etc.). Only fall back to post md tag when the content
+	// exceeds the card table limit (Feishu API error 11310: max 5 tables).
+	if countMarkdownTables(content) > maxCardTables {
+		return larkim.MsgTypePost, buildPostMdJSON(content)
 	}
-	if strings.Count(content, "\n\n") >= 2 {
-		return larkim.MsgTypePost, buildPostJSON(content)
-	}
-	return larkim.MsgTypePost, buildPostMdJSON(content)
+	return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)))
 }
 
 // hasComplexMarkdown detects code blocks or tables that require card rendering.


### PR DESCRIPTION
## Summary

  Simplify `buildReplyContent` to prefer card rendering for all markdown content, fixing poor rendering of headings, blockquotes, links, and dividers.

  ## Problem

  `buildReplyContent` used a three-tier rendering strategy:

  1. Card — only for "complex" markdown (code blocks, tables)
  2. Post `buildPostJSON` — for content with ≥2 `\n\n` paragraphs
  3. Post `buildPostMdJSON` — for other markdown

  The `hasComplexMarkdown` gate meant most markdown content (no code blocks or tables) was rendered via post format. Feishu post has poor markdown support:

  - `[text](url)` links render but are **not clickable**
  - `> blockquote` not rendered
  - `---` dividers not rendered
  - `# heading` not rendered (buildPostJSON converts to bold as workaround)
  - `<at user_id="...">` at tags require different syntax in post vs card

  This particularly affects AI-generated reports with headings, links, quotes and dividers — all rendered incorrectly.

  ## Fix

  Simplify to two paths:

  ```go
  // Before (three-tier):
  no markdown       → text
  code blocks/tables → card
  ≥2 \n\n           → post (buildPostJSON)   ← poor rendering
  other markdown    → post (buildPostMdJSON)  ← poor rendering

  // After (two-tier):
  no markdown → text
  tables > 5  → post md tag (Feishu card API limit: max 5 tables)
  all other   → card ← best rendering

  Card schema 2.0 markdown supports all common features: headings, blockquotes, code blocks, tables, links, dividers, lists, bold, italic, strikethrough. There is no reason to route markdown content to post format except for the 5-table card limit.

  Changes

  - platform/feishu/feishu.go: rewrite buildReplyContent — remove hasComplexMarkdown gate and buildPostJSON path, default to card for all markdown
  - hasComplexMarkdown and buildPostJSON functions retained (not deleted) for backward compatibility but no longer called by buildReplyContent

  Test plan

  - go build ./cmd/cc-connect passes
  - go test ./platform/feishu/ passes
  - Manual: send AI response with headings + blockquotes + links + dividers → verify card renders correctly
  - Manual: send AI response with >5 markdown tables → verify falls back to post md tag

  🤖 Generated with Claude Code
  ```