### PR TITLE
fix: normalize symlinked work_dir paths

### DIFF
--- a/agent/codex/list.go
+++ b/agent/codex/list.go
@@ -21,6 +21,7 @@ func listCodexSessions(workDir string) ([]core.AgentSessionInfo, error) {
 	if err != nil {
 		absWorkDir = workDir
 	}
+	absWorkDir = core.NormalizeDirPath(absWorkDir)
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -137,6 +138,10 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 				}
 			}
 		}
+	}
+
+	if sessionCwd != "" {
+		sessionCwd = core.NormalizeDirPath(sessionCwd)
 	}
 
 	// Filter by cwd

--- a/agent/codex/list_test.go
+++ b/agent/codex/list_test.go
@@ -1,0 +1,51 @@
+package codex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestListCodexSessions_MatchesSymlinkedWorkDir(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CODEX_HOME", filepath.Join(tmpHome, ".codex"))
+
+	realDir := filepath.Join(tmpHome, "real-project")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(tmpHome, "link-project")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	sessionsDir := filepath.Join(tmpHome, ".codex", "sessions", "2026", "04", "17")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionFile := filepath.Join(sessionsDir, "rollout-test-thread.jsonl")
+	content := strings.Join([]string{
+		`{"type":"session_meta","payload":{"id":"thread-1","cwd":"` + realDir + `"}}`,
+		`{"type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"hello"}]}}`,
+	}, "\n")
+	if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := New(map[string]any{"work_dir": linkDir})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	sessions, err := a.ListSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "thread-1" {
+		t.Fatalf("sessions = %+v, want thread-1", sessions)
+	}
+}

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -218,6 +218,10 @@ func main() {
 		}
 
 		workDir, _ := proj.Agent.Options["work_dir"].(string)
+		if workDir != "" {
+			workDir = core.NormalizeDirPath(workDir)
+			proj.Agent.Options["work_dir"] = workDir
+		}
 		projectState := core.NewProjectStateStore(projectStatePath(cfg.DataDir, proj.Name))
 		effectiveWorkDir := applyProjectStateOverride(proj.Name, agent, workDir, projectState)
 		startInitialRefreshIfReady(agent, providerWiring)
@@ -996,32 +1000,59 @@ func main() {
 // It checks for legacy session files (without the sessions/ subdirectory) in dataDir
 // for backward compatibility; if found, uses that path. Otherwise uses dataDir/sessions/.
 func sessionStorePath(dataDir, name, workDir string) string {
-	var filename string
+	filenames := sessionStoreFilenames(name, workDir)
+	if len(filenames) == 0 {
+		return filepath.Join(dataDir, "sessions", name+".json")
+	}
+
+	for _, filename := range filenames {
+		preferred := filepath.Join(dataDir, "sessions", filename)
+		if _, err := os.Stat(preferred); err == nil {
+			return preferred
+		}
+
+		for _, legacy := range []string{
+			filepath.Join(dataDir, filename),
+			filepath.Join(dataDir, strings.TrimSuffix(filename, ".json")+".sessions.json"),
+		} {
+			if _, err := os.Stat(legacy); err == nil {
+				slog.Info("session: using legacy file in dataDir", "path", legacy)
+				return legacy
+			}
+		}
+	}
+
+	return filepath.Join(dataDir, "sessions", filenames[0])
+}
+
+func sessionStoreFilenames(name, workDir string) []string {
 	if workDir == "" {
-		filename = name + ".json"
-	} else {
-		abs, err := filepath.Abs(workDir)
-		if err != nil {
-			abs = workDir
-		}
-		h := sha256.Sum256([]byte(abs))
+		return []string{name + ".json"}
+	}
+
+	abs, err := filepath.Abs(workDir)
+	if err != nil {
+		abs = workDir
+	}
+	canonical := core.NormalizeDirPath(abs)
+	candidates := []string{canonical}
+	if canonical != abs {
+		candidates = append(candidates, abs)
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	filenames := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		h := sha256.Sum256([]byte(candidate))
 		short := hex.EncodeToString(h[:4])
-		filename = fmt.Sprintf("%s_%s.json", name, short)
-	}
-
-	// Check legacy path in dataDir (without sessions/ subdirectory) for backward compatibility.
-	// Also check for the older .sessions.json naming convention.
-	for _, legacy := range []string{
-		filepath.Join(dataDir, filename),
-		filepath.Join(dataDir, strings.TrimSuffix(filename, ".json")+".sessions.json"),
-	} {
-		if _, err := os.Stat(legacy); err == nil {
-			slog.Info("session: using legacy file in dataDir", "path", legacy)
-			return legacy
+		filename := fmt.Sprintf("%s_%s.json", name, short)
+		if _, ok := seen[filename]; ok {
+			continue
 		}
+		seen[filename] = struct{}{}
+		filenames = append(filenames, filename)
 	}
-
-	return filepath.Join(dataDir, "sessions", filename)
+	return filenames
 }
 
 func projectStatePath(dataDir, projectName string) string {
@@ -1062,6 +1093,7 @@ func applyProjectStateOverride(projectName string, agent core.Agent, configuredW
 	if abs, err := filepath.Abs(override); err == nil {
 		override = abs
 	}
+	override = core.NormalizeDirPath(override)
 
 	info, err := os.Stat(override)
 	if err != nil || !info.IsDir() {

--- a/cmd/cc-connect/main_test.go
+++ b/cmd/cc-connect/main_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/config"
@@ -73,6 +76,70 @@ func TestApplyProjectStateOverride(t *testing.T) {
 	}
 	if agent.workDir != overrideDir {
 		t.Fatalf("agent workDir = %q, want %q", agent.workDir, overrideDir)
+	}
+}
+
+func TestApplyProjectStateOverride_NormalizesSymlink(t *testing.T) {
+	baseDir := t.TempDir()
+	realDir := filepath.Join(baseDir, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(baseDir, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	resolvedRealDir, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := core.NewProjectStateStore(filepath.Join(t.TempDir(), "projects", "demo.state.json"))
+	store.SetWorkDirOverride(linkDir)
+
+	agent := &stubMainAgent{workDir: baseDir}
+	got := applyProjectStateOverride("demo", agent, baseDir, store)
+
+	if got != resolvedRealDir {
+		t.Fatalf("applyProjectStateOverride() = %q, want %q", got, resolvedRealDir)
+	}
+	if agent.workDir != resolvedRealDir {
+		t.Fatalf("agent workDir = %q, want %q", agent.workDir, resolvedRealDir)
+	}
+}
+
+func TestSessionStorePath_PrefersExistingSymlinkHashFile(t *testing.T) {
+	dataDir := t.TempDir()
+	realDir := filepath.Join(t.TempDir(), "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	absLink, err := filepath.Abs(linkDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := sha256.Sum256([]byte(absLink))
+	legacyName := "demo_" + hex.EncodeToString(h[:4]) + ".json"
+	legacyPath := filepath.Join(dataDir, "sessions", legacyName)
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := sessionStorePath(dataDir, "demo", linkDir)
+	if got != legacyPath {
+		t.Fatalf("sessionStorePath() = %q, want %q", got, legacyPath)
+	}
+	if strings.Contains(filepath.Base(got), "sessions.json") {
+		t.Fatalf("sessionStorePath() = %q, want sessions dir file", got)
 	}
 }
 

--- a/core/dir_history.go
+++ b/core/dir_history.go
@@ -35,6 +35,7 @@ func NewDirHistory(dataDir string) *DirHistory {
 // Add adds a directory to the history for the given project.
 // If the directory already exists, it's moved to the front.
 func (dh *DirHistory) Add(project, dir string) {
+	dir = NormalizeDirPath(dir)
 	if dir == "" {
 		return
 	}
@@ -42,20 +43,7 @@ func (dh *DirHistory) Add(project, dir string) {
 	dh.mu.Lock()
 	defer dh.mu.Unlock()
 
-	entries := dh.entries[project]
-
-	// Remove if exists
-	for i, d := range entries {
-		if d == dir {
-			entries = append(entries[:i], entries[i+1:]...)
-			break
-		}
-	}
-
-	// Add to front
-	entries = append([]string{dir}, entries...)
-
-	// Trim to max size
+	entries := dedupeNormalizedDirs(append([]string{dir}, dh.entries[project]...))
 	if len(entries) > dh.maxSize {
 		entries = entries[:dh.maxSize]
 	}
@@ -142,8 +130,44 @@ func (dh *DirHistory) load() {
 	}
 
 	if entries != nil {
-		dh.entries = entries
+		migrated := make(map[string][]string, len(entries))
+		changed := false
+		for project, dirs := range entries {
+			normalized := dedupeNormalizedDirs(dirs)
+			migrated[project] = normalized
+			if len(normalized) != len(dirs) {
+				changed = true
+				continue
+			}
+			for i := range dirs {
+				if normalized[i] != dirs[i] {
+					changed = true
+					break
+				}
+			}
+		}
+		dh.entries = migrated
+		if changed {
+			dh.saveLocked()
+		}
 	}
+}
+
+func dedupeNormalizedDirs(dirs []string) []string {
+	seen := make(map[string]struct{}, len(dirs))
+	out := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		normalized := NormalizeDirPath(dir)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out
 }
 
 func (dh *DirHistory) saveLocked() {

--- a/core/dir_history_test.go
+++ b/core/dir_history_test.go
@@ -1,0 +1,111 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDirHistoryAdd_DedupsSymlinkAndRealPath(t *testing.T) {
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(tmp, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	resolvedRealDir, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dh := NewDirHistory(t.TempDir())
+	dh.Add("demo", linkDir)
+	dh.Add("demo", realDir)
+
+	got := dh.List("demo")
+	if len(got) != 1 {
+		t.Fatalf("len(history) = %d, want 1; history=%v", len(got), got)
+	}
+	if got[0] != resolvedRealDir {
+		t.Fatalf("history[0] = %q, want %q", got[0], resolvedRealDir)
+	}
+}
+
+func TestDirHistoryLoad_MigratesSymlinkEntries(t *testing.T) {
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(tmp, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	resolvedRealDir, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataDir := t.TempDir()
+	storePath := filepath.Join(dataDir, dirHistoryFileName)
+	payload := []byte("{\n  \"demo\": [\n    \"" + linkDir + "\",\n    \"" + realDir + "\"\n  ]\n}\n")
+	if err := os.WriteFile(storePath, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dh := NewDirHistory(dataDir)
+	got := dh.List("demo")
+	if len(got) != 1 {
+		t.Fatalf("len(history) = %d, want 1; history=%v", len(got), got)
+	}
+	if got[0] != resolvedRealDir {
+		t.Fatalf("history[0] = %q, want %q", got[0], resolvedRealDir)
+	}
+
+	reloaded := NewDirHistory(dataDir)
+	got = reloaded.List("demo")
+	if len(got) != 1 || got[0] != resolvedRealDir {
+		t.Fatalf("reloaded history = %v, want [%q]", got, resolvedRealDir)
+	}
+}
+
+func TestDirHistoryPrevious_UsesCanonicalizedHistory(t *testing.T) {
+	tmp := t.TempDir()
+	realA := filepath.Join(tmp, "real-a")
+	realB := filepath.Join(tmp, "real-b")
+	if err := os.Mkdir(realA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(realB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkA := filepath.Join(tmp, "link-a")
+	if err := os.Symlink(realA, linkA); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	resolvedA, err := filepath.EvalSymlinks(realA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedB, err := filepath.EvalSymlinks(realB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dh := NewDirHistory(t.TempDir())
+	dh.Add("demo", linkA)
+	dh.Add("demo", realB)
+
+	if got := dh.Previous("demo"); got != resolvedA {
+		t.Fatalf("Previous() = %q, want %q", got, resolvedA)
+	}
+	if got := dh.Get("demo", 1); got != resolvedB {
+		t.Fatalf("Get(1) = %q, want %q", got, resolvedB)
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -4459,6 +4459,7 @@ func (e *Engine) dirApply(agent Agent, sessions *SessionManager, interactiveKey,
 			if absDir, err := filepath.Abs(baseDir); err == nil {
 				baseDir = absDir
 			}
+			baseDir = NormalizeDirPath(baseDir)
 
 			if !e.multiWorkspace {
 				switcher.SetWorkDir(baseDir)
@@ -4524,6 +4525,7 @@ func (e *Engine) dirApply(agent Agent, sessions *SessionManager, interactiveKey,
 	if absDir, err := filepath.Abs(newDir); err == nil {
 		newDir = absDir
 	}
+	newDir = NormalizeDirPath(newDir)
 
 	info, err := os.Stat(newDir)
 	if err != nil || !info.IsDir() {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3750,6 +3750,34 @@ func TestCmdDir_PersistsAbsoluteOverride(t *testing.T) {
 	}
 }
 
+func TestCmdDir_SymlinkSwitchStoresCanonicalPath(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "real-project")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(tmp, "link-project")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	resolvedRealDir, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	agent := &stubWorkDirAgent{workDir: tmp}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	e.cmdDir(p, msg, []string{linkDir})
+
+	if agent.workDir != resolvedRealDir {
+		t.Fatalf("workDir = %q, want %q", agent.workDir, resolvedRealDir)
+	}
+}
+
 func TestDirApply_MultiWorkspacePersistsWorkspaceSpecificOverride(t *testing.T) {
 	baseDir := t.TempDir()
 	workspace := normalizeWorkspacePath(t.TempDir())
@@ -3988,9 +4016,10 @@ func TestCmdDir_ExpandsTilde(t *testing.T) {
 		if err := os.MkdirAll(tc.wantDir, 0o755); err != nil {
 			t.Fatalf("MkdirAll %q: %v", tc.wantDir, err)
 		}
+		wantDir := NormalizeDirPath(tc.wantDir)
 		e.cmdDir(p, msg, []string{tc.input})
-		if agent.workDir != tc.wantDir {
-			t.Errorf("input %q: workDir = %q, want %q", tc.input, agent.workDir, tc.wantDir)
+		if agent.workDir != wantDir {
+			t.Errorf("input %q: workDir = %q, want %q", tc.input, agent.workDir, wantDir)
 		}
 	}
 }

--- a/core/path_normalize.go
+++ b/core/path_normalize.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"log/slog"
+	"path/filepath"
+)
+
+// NormalizeDirPath cleans a directory-like path and resolves symlinks when
+// possible. If symlink resolution fails, it falls back to the cleaned path.
+func NormalizeDirPath(path string) string {
+	cleaned := filepath.Clean(path)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return cleaned
+	}
+	if resolved != path {
+		slog.Debug("directory path normalized", "original", path, "normalized", resolved)
+	}
+	return resolved
+}

--- a/core/path_normalize_test.go
+++ b/core/path_normalize_test.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeDirPath(t *testing.T) {
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "real-project")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(tmp, "link-project")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	resolvedRealDir, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"symlink", linkDir, resolvedRealDir},
+		{"clean only", filepath.Join(tmp, "real-project", ".", "..", "real-project"), resolvedRealDir},
+		{"nonexistent", "/nonexistent/path/./foo/../bar", "/nonexistent/path/bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeDirPath(tt.input); got != tt.want {
+				t.Fatalf("NormalizeDirPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/core/workspace_state.go
+++ b/core/workspace_state.go
@@ -1,8 +1,6 @@
 package core
 
 import (
-	"log/slog"
-	"path/filepath"
 	"sync"
 	"time"
 )
@@ -12,15 +10,7 @@ import (
 // If the path cannot be resolved (e.g. doesn't exist yet), falls back to
 // filepath.Clean only.
 func normalizeWorkspacePath(path string) string {
-	cleaned := filepath.Clean(path)
-	resolved, err := filepath.EvalSymlinks(cleaned)
-	if err != nil {
-		return cleaned
-	}
-	if resolved != path {
-		slog.Debug("workspace path normalized", "original", path, "normalized", resolved)
-	}
-	return resolved
+	return NormalizeDirPath(path)
 }
 
 // workspaceState holds the runtime state for a single workspace.


### PR DESCRIPTION
# Symlink Work Directory Normalization

## Background

`cc-connect` uses `work_dir` as an identity boundary for:
- `/dir` runtime switching
- persisted work_dir override restore on startup
- Codex session discovery via transcript `cwd`
- local session-state file naming
- `/dir` history display

This breaks when a user switches to a symlinked directory.

Example:
- symlink path: `/path/to/symbol-link`
- real path: `/path/to/realpath`

Previously these were treated as different strings, so `/list` could miss existing Codex sessions even though `/new` still worked.

## Solution

Normalize directory-like paths to one canonical identity before comparison or persistence:
1. `filepath.Clean(path)`
2. `filepath.Abs(path)` where needed
3. `filepath.EvalSymlinks(path)` if the path exists
4. fall back to the cleaned path if resolution fails

Applied to:
- `/dir` switch and `/dir reset`
- startup restore of persisted `work_dir` overrides
- Codex transcript `cwd` matching in `/list`
- session-store filename derivation
- `/dir` history add/load behavior

For backward compatibility, session-state lookup checks both:
- the new canonical-path-based filename
- the old raw-path-based filename

Directory history also migrates old entries by canonicalizing and deduplicating persisted values on load.

## Result

After the fix:
- switching to `/path/to/symbol-link` is treated the same as `/path/to/realpath`
- Codex `/list` finds sessions recorded under the real `cwd`
- old session-state files created from raw symlink paths are still found after upgrade
- old `/dir` history entries for both symlink and real path collapse into a single canonical entry

The only user-visible change is that some UI/status output may show the resolved real path instead of the symlink alias.