### PR TITLE
feat(core): sanitize ANSI escape sequences from outgoing content

### DIFF
--- a/core/ansi.go
+++ b/core/ansi.go
@@ -1,0 +1,18 @@
+package core
+
+import "regexp"
+
+var (
+	ansiOSCRegexp    = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
+	ansiCSIRegexp    = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+	ansiSingleRegexp = regexp.MustCompile(`\x1b[@-Z\\-_]`)
+)
+
+// NormalizeOutgoingContent strips ANSI escape sequences from content before it
+// is rendered on chat platforms.
+func NormalizeOutgoingContent(content string) string {
+	content = ansiOSCRegexp.ReplaceAllString(content, "")
+	content = ansiCSIRegexp.ReplaceAllString(content, "")
+	content = ansiSingleRegexp.ReplaceAllString(content, "")
+	return content
+}

--- a/core/ansi_test.go
+++ b/core/ansi_test.go
@@ -1,0 +1,12 @@
+package core
+
+import "testing"
+
+func TestNormalizeOutgoingContent_StripsANSISequences(t *testing.T) {
+	input := "warn: \x1b[31;1mfailed\x1b[0m\nlink \x1b]8;;https://example.com\x07docs\x1b]8;;\x07"
+	got := NormalizeOutgoingContent(input)
+	want := "warn: failed\nlink docs"
+	if got != want {
+		t.Fatalf("NormalizeOutgoingContent() = %q, want %q", got, want)
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -7476,6 +7476,7 @@ func (e *Engine) sendWithError(p Platform, replyCtx any, content string) error {
 }
 
 func (e *Engine) sendAlreadyRenderedWithError(p Platform, replyCtx any, content string) error {
+	content = NormalizeOutgoingContent(content)
 	start := time.Now()
 	if err := p.Send(e.ctx, replyCtx, content); err != nil {
 		slog.Error("platform send failed", "platform", p.Name(), "error", err, "content_len", len(content))
@@ -7527,6 +7528,7 @@ func drainEvents(ch <-chan Event) {
 
 // replyWithError applies outgoing rate limiting and p.Reply.
 func (e *Engine) replyWithError(p Platform, replyCtx any, content string) error {
+	content = NormalizeOutgoingContent(content)
 	if err := e.waitOutgoing(p); err != nil {
 		slog.Warn("outgoing rate limit: context cancelled", "platform", p.Name(), "error", err)
 		return err

--- a/core/engine.go
+++ b/core/engine.go
@@ -11650,6 +11650,7 @@ func (e *Engine) sendWithError(p Platform, replyCtx any, content string) error {
 }
 
 func (e *Engine) sendAlreadyRenderedWithError(p Platform, replyCtx any, content string) error {
+	content = NormalizeOutgoingContent(content)
 	start := time.Now()
 	if err := p.Send(e.ctx, replyCtx, content); err != nil {
 		// Check for context_token missing error (common for Weixin platform)
@@ -11710,6 +11711,7 @@ func drainEvents(ch <-chan Event) {
 
 // replyWithError applies outgoing rate limiting and p.Reply.
 func (e *Engine) replyWithError(p Platform, replyCtx any, content string) error {
+	content = NormalizeOutgoingContent(content)
 	if err := e.waitOutgoing(p); err != nil {
 		slog.Warn("outgoing rate limit: context cancelled", "platform", p.Name(), "error", err)
 		return err

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -7810,6 +7811,38 @@ func TestCmdShell_MultiWorkspaceIgnoresMissingSharedBinding(t *testing.T) {
 			t.Fatal("timed out waiting for shell response")
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestExecuteShellCommand_StripsANSIOutput(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubWorkDirAgent{workDir: t.TempDir()}, []Platform{p}, "", LangEnglish)
+
+	msg := &Message{
+		SessionKey: "test:ch:admin",
+		Platform:   "test",
+		ReplyCtx:   "ctx",
+	}
+
+	execCmd := `printf '\033[32;1mId\033[0m\n'`
+	if runtime.GOOS == "windows" {
+		execCmd = `Write-Output ([string][char]27 + '[32;1mId' + [string][char]27 + '[0m')`
+	}
+
+	e.executeShellCommand(p, msg, &CustomCommand{
+		Name: "ansi",
+		Exec: execCmd,
+	}, nil)
+
+	sent := p.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent = %d messages, want 1", len(sent))
+	}
+	if strings.Contains(sent[0], "\x1b[") {
+		t.Fatalf("expected ANSI escapes to be stripped, got %q", sent[0])
+	}
+	if !strings.Contains(sent[0], "Id") {
+		t.Fatalf("expected sanitized output to contain Id, got %q", sent[0])
 	}
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -11376,6 +11376,45 @@ func TestRunShellWithProgress_NonexistentCommand(t *testing.T) {
 	}
 }
 
+func TestExecuteShellCommand_StripsANSIOutput(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubWorkDirAgent{workDir: t.TempDir()}, []Platform{p}, "", LangEnglish)
+
+	msg := &Message{
+		SessionKey: "test:ch:admin",
+		Platform:   "test",
+		ReplyCtx:   "ctx",
+	}
+
+	execCmd := `printf '\033[32;1mId\033[0m\n'`
+	if runtime.GOOS == "windows" {
+		execCmd = `Write-Output ([string][char]27 + '[32;1mId' + [string][char]27 + '[0m')`
+	}
+
+	e.executeShellCommand(p, msg, &CustomCommand{
+		Name: "ansi",
+		Exec: execCmd,
+	}, nil)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		sent := p.getSent()
+		if len(sent) > 0 {
+			if strings.Contains(sent[0], "\x1b[") {
+				t.Fatalf("expected ANSI escapes to be stripped, got %q", sent[0])
+			}
+			if !strings.Contains(sent[0], "Id") {
+				t.Fatalf("expected sanitized output to contain Id, got %q", sent[0])
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for shell response")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // --- /diff command tests ---
 
 func TestCmdDiff_BlockedWithoutAdmin(t *testing.T) {

--- a/core/progress_compact.go
+++ b/core/progress_compact.go
@@ -385,6 +385,8 @@ func (w *compactProgressWriter) AppendStructured(item ProgressCardEntry, fallbac
 	if fallback == "" {
 		fallback = text
 	}
+	text = NormalizeOutgoingContent(text)
+	fallback = NormalizeOutgoingContent(fallback)
 	switch item.Kind {
 	case ProgressEntryThinking, ProgressEntryError, ProgressEntryInfo:
 		if w.transform != nil {

--- a/core/progress_compact.go
+++ b/core/progress_compact.go
@@ -392,6 +392,8 @@ func (w *compactProgressWriter) AppendStructured(item ProgressCardEntry, fallbac
 	if fallback == "" {
 		fallback = text
 	}
+	text = NormalizeOutgoingContent(text)
+	fallback = NormalizeOutgoingContent(fallback)
 	switch item.Kind {
 	case ProgressEntryThinking, ProgressEntryError, ProgressEntryInfo:
 		if w.transform != nil {

--- a/core/progress_compact_test.go
+++ b/core/progress_compact_test.go
@@ -253,3 +253,34 @@ func TestCompactProgressWriter_DoesNotTransformToolResults(t *testing.T) {
 		t.Fatalf("tool result text = %q, want raw %q", got, raw)
 	}
 }
+
+func TestCompactProgressWriter_StripsANSIToolResult(t *testing.T) {
+	p := &stubCompactProgressPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		style:              "card",
+		supportPayload:     true,
+	}
+	w := newCompactProgressWriter(context.Background(), p, "ctx", "codex", LangEnglish, func(s string) string {
+		return strings.ReplaceAll(s, "/root/code/demo/src/app.ts:42", "📄 `src/app.ts:42`")
+	})
+
+	raw := "\x1b[32;1m   Id\x1b[0m\x1b[32;1m ProcessName\x1b[0m"
+	if ok := w.AppendStructured(ProgressCardEntry{
+		Kind: ProgressEntryToolResult,
+		Text: raw,
+	}, raw); !ok {
+		t.Fatal("AppendStructured() = false, want true")
+	}
+
+	starts := p.getPreviewStarts()
+	if len(starts) != 1 {
+		t.Fatalf("preview starts = %d, want 1", len(starts))
+	}
+	payload, ok := ParseProgressCardPayload(starts[0])
+	if !ok {
+		t.Fatalf("ParseProgressCardPayload(%q) failed", starts[0])
+	}
+	if got := payload.Items[0].Text; got != "Id ProcessName" {
+		t.Fatalf("tool result text = %q, want %q", got, "Id ProcessName")
+	}
+}

--- a/core/progress_compact_test.go
+++ b/core/progress_compact_test.go
@@ -311,3 +311,34 @@ func TestCompactProgressWriter_DoesNotTransformToolResults(t *testing.T) {
 		t.Fatalf("tool result text = %q, want raw %q", got, raw)
 	}
 }
+
+func TestCompactProgressWriter_StripsANSIToolResult(t *testing.T) {
+	p := &stubCompactProgressPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		style:              "card",
+		supportPayload:     true,
+	}
+	w := newCompactProgressWriter(context.Background(), p, "ctx", "codex", LangEnglish, func(s string) string {
+		return strings.ReplaceAll(s, "/root/code/demo/src/app.ts:42", "📄 `src/app.ts:42`")
+	})
+
+	raw := "\x1b[32;1m   Id\x1b[0m\x1b[32;1m ProcessName\x1b[0m"
+	if ok := w.AppendStructured(ProgressCardEntry{
+		Kind: ProgressEntryToolResult,
+		Text: raw,
+	}, raw); !ok {
+		t.Fatal("AppendStructured() = false, want true")
+	}
+
+	starts := p.getPreviewStarts()
+	if len(starts) != 1 {
+		t.Fatalf("preview starts = %d, want 1", len(starts))
+	}
+	payload, ok := ParseProgressCardPayload(starts[0])
+	if !ok {
+		t.Fatalf("ParseProgressCardPayload(%q) failed", starts[0])
+	}
+	if got := payload.Items[0].Text; got != "Id ProcessName" {
+		t.Fatalf("tool result text = %q, want %q", got, "Id ProcessName")
+	}
+}

--- a/core/streaming_test.go
+++ b/core/streaming_test.go
@@ -294,83 +294,6 @@ func TestStreamPreview_FinishKeepsPreviewWhenPlatformPrefersInPlaceFinalize(t *t
 	}
 }
 
-func TestStreamPreview_NeedsDoneReaction_TrueAfterUpdate(t *testing.T) {
-	mp := &mockUpdaterPlatform{}
-	cfg := StreamPreviewCfg{
-		Enabled:       true,
-		IntervalMs:    50,
-		MinDeltaChars: 1,
-		MaxChars:      500,
-	}
-
-	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
-
-	if sp.needsDoneReaction() {
-		t.Error("needsDoneReaction should be false before any send")
-	}
-
-	sp.appendText("Hello World")
-	time.Sleep(100 * time.Millisecond)
-
-	if sp.needsDoneReaction() {
-		t.Error("needsDoneReaction should be false after only SendPreviewStart (no UpdateMessage yet)")
-	}
-
-	sp.appendText(" more text to trigger update")
-	time.Sleep(100 * time.Millisecond)
-
-	msgs := mp.getMessages()
-	hasUpdate := false
-	for _, m := range msgs {
-		if len(m) > 7 && m[:7] == "update:" {
-			hasUpdate = true
-			break
-		}
-	}
-	if !hasUpdate {
-		t.Fatal("expected at least one UpdateMessage call")
-	}
-
-	if !sp.needsDoneReaction() {
-		t.Error("needsDoneReaction should be true after UpdateMessage was used")
-	}
-}
-
-func TestStreamPreview_NeedsDoneReaction_FalseAfterDiscard(t *testing.T) {
-	mp := &mockUpdaterPlatform{}
-	cfg := StreamPreviewCfg{
-		Enabled:       true,
-		IntervalMs:    50,
-		MinDeltaChars: 1,
-		MaxChars:      500,
-	}
-
-	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
-	sp.appendText("Hello World")
-	time.Sleep(100 * time.Millisecond)
-	sp.appendText(" more text")
-	time.Sleep(100 * time.Millisecond)
-
-	sp.discard()
-
-	if sp.needsDoneReaction() {
-		t.Error("needsDoneReaction should be false after discard (previewMsgID cleared)")
-	}
-}
-
-func TestStreamPreview_NeedsDoneReaction_FalseWhenDisabled(t *testing.T) {
-	mp := &mockUpdaterPlatform{}
-	cfg := StreamPreviewCfg{Enabled: false}
-
-	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
-	sp.appendText("Hello")
-	time.Sleep(100 * time.Millisecond)
-
-	if sp.needsDoneReaction() {
-		t.Error("needsDoneReaction should be false when preview is disabled")
-	}
-}
-
 func TestStreamPreview_AppliesTransform(t *testing.T) {
 	mp := &mockUpdaterPlatform{}
 	cfg := StreamPreviewCfg{
@@ -400,5 +323,35 @@ func TestStreamPreview_AppliesTransform(t *testing.T) {
 	}
 	if got := msgs[len(msgs)-1]; got != "update:Final 📄 `src/app.ts:42`" {
 		t.Fatalf("final message = %q, want transformed final preview", got)
+	}
+}
+
+func TestStreamPreview_AppliesANSINormalizationTransform(t *testing.T) {
+	mp := &mockUpdaterPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 1,
+		MaxChars:      500,
+	}
+
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), NormalizeOutgoingContent)
+	sp.appendText("See \x1b[31mwarn\x1b[0m")
+	time.Sleep(100 * time.Millisecond)
+
+	ok := sp.finish("Final \x1b[32mok\x1b[0m")
+	if !ok {
+		t.Fatal("finish should succeed when preview is active")
+	}
+
+	msgs := mp.getMessages()
+	if len(msgs) < 2 {
+		t.Fatalf("messages = %#v, want preview start and final update", msgs)
+	}
+	if got := msgs[0]; got != "start:See warn" {
+		t.Fatalf("start message = %q, want sanitized preview start", got)
+	}
+	if got := msgs[len(msgs)-1]; got != "update:Final ok" {
+		t.Fatalf("final message = %q, want sanitized final preview", got)
 	}
 }

--- a/core/streaming_test.go
+++ b/core/streaming_test.go
@@ -461,6 +461,36 @@ func TestStreamPreview_AppliesTransform(t *testing.T) {
 	}
 }
 
+func TestStreamPreview_AppliesANSINormalizationTransform(t *testing.T) {
+	mp := &mockUpdaterPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 1,
+		MaxChars:      500,
+	}
+
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), NormalizeOutgoingContent)
+	sp.appendText("See \x1b[31mwarn\x1b[0m")
+	time.Sleep(100 * time.Millisecond)
+
+	ok := sp.finish("Final \x1b[32mok\x1b[0m", "")
+	if !ok {
+		t.Fatal("finish should succeed when preview is active")
+	}
+
+	msgs := mp.getMessages()
+	if len(msgs) < 2 {
+		t.Fatalf("messages = %#v, want preview start and final update", msgs)
+	}
+	if got := msgs[0]; got != "start:See warn" {
+		t.Fatalf("start message = %q, want sanitized preview start", got)
+	}
+	if got := msgs[len(msgs)-1]; got != "update:Final ok" {
+		t.Fatalf("final message = %q, want sanitized final preview", got)
+	}
+}
+
 // TestStreamPreview_UnfreezeResumesStreaming is the unit-level regression
 // test for the bug where sp.freeze()+detachPreview() (emitted by the
 // EventPermissionRequest handler in core/engine.go) permanently degraded

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1960,6 +1960,7 @@ func predictMsgType(content string) string {
 }
 
 func buildReplyContent(content string) (msgType string, body string) {
+	content = core.NormalizeOutgoingContent(content)
 	if !containsMarkdown(content) {
 		b, _ := json.Marshal(map[string]string{"text": content})
 		return larkim.MsgTypeText, string(b)

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -2914,6 +2914,7 @@ func detectMimeType(data []byte) string {
 }
 
 func buildReplyContent(content string) (msgType string, body string) {
+	content = core.NormalizeOutgoingContent(content)
 	// Feishu does not generate mention events for <at> tags in card/post
 	// messages sent by bots. Force MsgTypeText when a real mention is present
 	// (resolved to an <at user_id="..."> or <at id=...> tag) so Feishu

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -249,6 +249,28 @@ func TestBuildReplyContent_FallbackWhenManyTables(t *testing.T) {
 	}
 }
 
+func TestBuildReplyContent_StripsANSISequences(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "text", content: "status: \x1b[31mfailed\x1b[0m"},
+		{name: "interactive", content: "```text\n\x1b[31mfailed\x1b[0m\n```"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, body := buildReplyContent(tt.content)
+			if strings.Contains(body, "\u001b") || strings.Contains(body, "[31m") {
+				t.Fatalf("buildReplyContent() leaked ANSI sequence: %q", body)
+			}
+			if !strings.Contains(body, "failed") {
+				t.Fatalf("buildReplyContent() body = %q, want readable text", body)
+			}
+		})
+	}
+}
+
 func TestParseInlineMarkdown_BoldAndCode(t *testing.T) {
 	elements := parseInlineMarkdown("**bold** and `code`")
 	hasBold, hasCode := false, false

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -793,6 +793,28 @@ func TestBuildReplyContent_FallbackWhenManyTables(t *testing.T) {
 	}
 }
 
+func TestBuildReplyContent_StripsANSISequences(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "text", content: "status: \x1b[31mfailed\x1b[0m"},
+		{name: "interactive", content: "```text\n\x1b[31mfailed\x1b[0m\n```"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, body := buildReplyContent(tt.content)
+			if strings.Contains(body, "\u001b") || strings.Contains(body, "[31m") {
+				t.Fatalf("buildReplyContent() leaked ANSI sequence: %q", body)
+			}
+			if !strings.Contains(body, "failed") {
+				t.Fatalf("buildReplyContent() body = %q, want readable text", body)
+			}
+		})
+	}
+}
+
 func TestParseInlineMarkdown_BoldAndCode(t *testing.T) {
 	elements := parseInlineMarkdown("**bold** and `code`")
 	hasBold, hasCode := false, false

--- a/platform/wecom/wecom.go
+++ b/platform/wecom/wecom.go
@@ -454,6 +454,7 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	if !ok {
 		return fmt.Errorf("wecom: invalid reply context type %T", rctx)
 	}
+	content = core.NormalizeOutgoingContent(content)
 	if content == "" {
 		return nil
 	}

--- a/platform/wecom/wecom_test.go
+++ b/platform/wecom/wecom_test.go
@@ -1,8 +1,15 @@
 package wecom
 
 import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestWeComAPIURL_DefaultBase(t *testing.T) {
@@ -68,6 +75,81 @@ func TestNew_CustomAPIBaseURL_TrimTrailingSlash(t *testing.T) {
 	}
 	if p.apiBaseURL != "https://wecom.internal.example.com" {
 		t.Fatalf("apiBaseURL = %q, want %q", p.apiBaseURL, "https://wecom.internal.example.com")
+	}
+}
+
+type recordingRoundTripper struct {
+	mu    sync.Mutex
+	bodys [][]byte
+}
+
+func (rt *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	rt.mu.Lock()
+	rt.bodys = append(rt.bodys, append([]byte(nil), body...))
+	rt.mu.Unlock()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"errcode":0,"errmsg":"ok"}`)),
+	}, nil
+}
+
+func (rt *recordingRoundTripper) LastBody() string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if len(rt.bodys) == 0 {
+		return ""
+	}
+	return string(rt.bodys[len(rt.bodys)-1])
+}
+
+func TestReply_StripsANSISequences(t *testing.T) {
+	tests := []struct {
+		name           string
+		enableMarkdown bool
+		wantMsgType    string
+		wantContent    string
+	}{
+		{name: "markdown", enableMarkdown: true, wantMsgType: `"msgtype":"markdown"`, wantContent: `status **failed**`},
+		{name: "text", enableMarkdown: false, wantMsgType: `"msgtype":"text"`, wantContent: `status failed`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &recordingRoundTripper{}
+			p := &Platform{
+				agentID:        "1000001",
+				enableMarkdown: tt.enableMarkdown,
+				apiClient:      &http.Client{Transport: rt},
+				tokenCache: tokenCache{
+					token:     "token",
+					expiresAt: time.Now().Add(time.Hour),
+				},
+			}
+
+			err := p.Reply(context.Background(), replyContext{userID: "alice"}, "status **\x1b[31mfailed\x1b[0m**")
+			if err != nil {
+				t.Fatalf("Reply() error = %v", err)
+			}
+
+			body := rt.LastBody()
+			if body == "" {
+				t.Fatal("Reply() did not send request body")
+			}
+			if strings.Contains(body, "\u001b") || bytes.Contains([]byte(body), []byte{0x1b}) {
+				t.Fatalf("Reply() leaked ANSI sequence: %q", body)
+			}
+			if !strings.Contains(body, tt.wantMsgType) {
+				t.Fatalf("Reply() body = %q, want msg type %q", body, tt.wantMsgType)
+			}
+			if !strings.Contains(body, tt.wantContent) {
+				t.Fatalf("Reply() body = %q, want content %q", body, tt.wantContent)
+			}
+		})
 	}
 }
 

--- a/platform/wecom/wecom_test.go
+++ b/platform/wecom/wecom_test.go
@@ -1,10 +1,13 @@
 package wecom
 
 import (
+	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -139,3 +142,77 @@ func TestGetAccessToken_NormalExpiresIn_AppliesBuffer(t *testing.T) {
 	}
 }
 
+type recordingRoundTripper struct {
+	mu     sync.Mutex
+	bodies [][]byte
+}
+
+func (rt *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	rt.mu.Lock()
+	rt.bodies = append(rt.bodies, append([]byte(nil), body...))
+	rt.mu.Unlock()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"errcode":0,"errmsg":"ok"}`)),
+	}, nil
+}
+
+func (rt *recordingRoundTripper) LastBody() string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if len(rt.bodies) == 0 {
+		return ""
+	}
+	return string(rt.bodies[len(rt.bodies)-1])
+}
+
+func TestReply_StripsANSISequences(t *testing.T) {
+	tests := []struct {
+		name           string
+		enableMarkdown bool
+		wantMsgType    string
+		wantContent    string
+	}{
+		{name: "markdown", enableMarkdown: true, wantMsgType: `"msgtype":"markdown"`, wantContent: `status **failed**`},
+		{name: "text", enableMarkdown: false, wantMsgType: `"msgtype":"text"`, wantContent: `status failed`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &recordingRoundTripper{}
+			p := &Platform{
+				agentID:        "1000001",
+				enableMarkdown: tt.enableMarkdown,
+				apiClient:      &http.Client{Transport: rt},
+				tokenCache: tokenCache{
+					token:     "token",
+					expiresAt: time.Now().Add(time.Hour),
+				},
+			}
+
+			err := p.Reply(context.Background(), replyContext{userID: "alice"}, "status **\x1b[31mfailed\x1b[0m**")
+			if err != nil {
+				t.Fatalf("Reply() error = %v", err)
+			}
+
+			body := rt.LastBody()
+			if body == "" {
+				t.Fatal("Reply() did not send request body")
+			}
+			if strings.Contains(body, "\u001b") || bytes.Contains([]byte(body), []byte{0x1b}) {
+				t.Fatalf("Reply() leaked ANSI sequence: %q", body)
+			}
+			if !strings.Contains(body, tt.wantMsgType) {
+				t.Fatalf("Reply() body = %q, want msg type %q", body, tt.wantMsgType)
+			}
+			if !strings.Contains(body, tt.wantContent) {
+				t.Fatalf("Reply() body = %q, want content %q", body, tt.wantContent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add `NormalizeOutgoingContent()` in `core/ansi.go` to strip ANSI CSI, OSC, and single-byte escape sequences
- apply sanitization at the engine outbound path and keep defensive calls in Feishu and WeCom reply rendering
- cover structured progress-card `tool_result` payloads so raw tool output does not leak ANSI into compact/card progress UIs
- add regression coverage for shell command output sanitization and compact progress tool-result payload sanitization

## Motivation

Agent and tool output may contain terminal ANSI escape codes. This change strips them before content reaches chat platforms, including structured progress-card payloads.

## Test plan

- [x] `TestNormalizeOutgoingContent_StripsANSISequences`
- [x] `TestStreamPreview_AppliesANSINormalizationTransform`
- [x] `TestBuildReplyContent_StripsANSISequences`
- [x] `TestReply_StripsANSISequences`
- [x] `TestCompactProgressWriter_StripsANSIToolResult`
- [x] `TestExecuteShellCommand_StripsANSIOutput`
