### PR TITLE
feat(claudecode): add opus[1m] model option and use shorthand descs

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -302,9 +302,10 @@ func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
 		return models
 	}
 	return []core.ModelOption{
-		{Name: "sonnet", Desc: "Claude Sonnet 4 (balanced)"},
-		{Name: "opus", Desc: "Claude Opus 4 (most capable)"},
-		{Name: "haiku", Desc: "Claude Haiku 3.5 (fastest)"},
+		{Name: "sonnet", Desc: "Claude Sonnet (balanced)"},
+		{Name: "opus", Desc: "Claude Opus (most capable)"},
+		{Name: "opus[1m]", Desc: "Claude Opus (1M context)"},
+		{Name: "haiku", Desc: "Claude Haiku (fastest)"},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `opus[1m]` to the default model fallback list so users can switch to Claude Opus 1M context via `/model` without having to configure it manually.
- Drop the model-version numbers from the Sonnet/Opus/Haiku descriptions so the fallback list auto-follows upstream model bumps (4 → 4.6 → 4.7 → future) without code churn. Shorthand names (`sonnet`/`opus`/`haiku`) always resolve to the latest version in the Claude Code CLI, so hard-coding `4`/`3.5` in the description is misleading after a CLI upgrade.

## Why shorthand + `[1m]` instead of full model IDs?

The Claude Code CLI accepts the `<shorthand>[1m]` notation and resolves it to the latest 1M-context variant. This was verified with `claude --model opus[1m] --print` (returns OK on subscriptions that have 1M access). Using shorthand avoids hard-coding model IDs like `claude-opus-4-20250514` which go stale every time Anthropic ships a new model.

`sonnet[1m]` and `haiku[1m]` are intentionally left out:
- `sonnet[1m]` — the CLI accepts the syntax but returns "Extra usage is required for 1M context" on most subscriptions, so exposing it in the default list would produce a dead option for most users.
- `haiku[1m]` — the CLI returns "The long context beta is not yet available for this subscription" regardless of plan.

## Final fallback list

```go
{Name: "sonnet",     Desc: "Claude Sonnet (balanced)"},
{Name: "opus",       Desc: "Claude Opus (most capable)"},
{Name: "opus[1m]",   Desc: "Claude Opus (1M context)"},
{Name: "haiku",      Desc: "Claude Haiku (fastest)"},
```

## Test plan

- [x] `go build ./agent/claudecode/...` passes
- [x] Local `/model` list shows `opus[1m]` alongside the other options
- [x] Selecting `opus[1m]` launches a session with the 1M-context Opus variant