### PR TITLE
feat(wecom): add streaming preview, typing indicator, and inline tool…

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2526,7 +2526,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	sendWorkspaceWithError := func(p Platform, replyCtx any, content string) error {
 		return e.sendWithErrorForWorkspace(p, replyCtx, content, workspaceDir)
 	}
-	sp := newStreamPreview(e.streamPreview, state.platform, state.replyCtx, e.ctx, workspaceRenderer)
+	spCfg := e.streamPreview
+	if pref, ok := state.platform.(PreviewFinishPreference); ok && pref.KeepPreviewOnFinish() {
+		spCfg.TailTruncate = true // show latest content, scroll off old
+	}
+	sp := newStreamPreview(spCfg, state.platform, state.replyCtx, e.ctx, workspaceRenderer)
 	cp := newCompactProgressWriter(e.ctx, state.platform, state.replyCtx, e.agent.Name(), e.i18n.CurrentLang(), workspaceRenderer)
 	state.mu.Unlock()
 
@@ -2660,27 +2664,19 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		case EventToolUse:
 			toolCount++
-			// When tool messages are hidden, split text segments.
-			if !e.display.ToolMessages && len(textParts) > segmentStart {
-				if sp.canPreview() {
-					sp.freeze()
-					sp.detachPreview()
-				} else {
-					// Preview degraded — send accumulated text directly
-					segment := strings.Join(textParts[segmentStart:], "")
-					if segment != "" {
-						for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
-							sendWorkspace(p, replyCtx, chunk)
-						}
-					}
-				}
-				segmentStart = len(textParts)
+			// Check if the platform keeps preview in-place and can absorb tool
+			// events into the running stream instead of separate messages.
+			inlineTools := false
+			if pref, ok := p.(PreviewFinishPreference); ok && pref.KeepPreviewOnFinish() {
+				inlineTools = sp.canPreview()
 			}
-			if e.display.ToolMessages {
-				// Flush accumulated text segment before tool display
-				previewActive := sp.canPreview()
-				if len(textParts) > segmentStart {
-					if !previewActive {
+
+			if !e.display.ToolMessages && len(textParts) > segmentStart {
+				if !inlineTools {
+					if sp.canPreview() {
+						sp.freeze()
+						sp.detachPreview()
+					} else {
 						segment := strings.Join(textParts[segmentStart:], "")
 						if segment != "" {
 							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
@@ -2690,38 +2686,77 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 					segmentStart = len(textParts)
 				}
-				sp.freeze()
-				if previewActive {
-					sp.detachPreview() // keep frozen preview visible as permanent message
-				}
-				toolInput := event.ToolInput
-				var formattedInput string
-				if toolInput == "" {
-					formattedInput = ""
-				} else if strings.Contains(toolInput, "```") {
-					// Already contains code blocks (pre-formatted by agent) — use as-is
-					formattedInput = toolInput
-				} else if strings.Contains(toolInput, "\n") || utf8.RuneCountInString(toolInput) > 200 {
-					lang := toolCodeLang(event.ToolName, toolInput)
-					formattedInput = fmt.Sprintf("```%s\n%s\n```", lang, toolInput)
-				} else {
-					switch event.ToolName {
-					case "shell", "run_shell_command", "Bash":
-						formattedInput = fmt.Sprintf("```bash\n%s\n```", toolInput)
-					default:
-						formattedInput = fmt.Sprintf("`%s`", toolInput)
+			}
+			if e.display.ToolMessages {
+				if inlineTools {
+					// Append tool info into the streaming preview instead of
+					// freezing and sending a separate message.
+					toolInput := event.ToolInput
+					var inputSummary string
+					if toolInput != "" {
+						// Truncate long inputs for inline display.
+						const maxInlineLen = 200
+						if utf8.RuneCountInString(toolInput) > maxInlineLen {
+							toolInput = string([]rune(toolInput)[:maxInlineLen]) + "…"
+						}
+						// Remove newlines to keep it compact.
+						toolInput = strings.ReplaceAll(toolInput, "\n", " ")
+						inputSummary = fmt.Sprintf(": `%s`", toolInput)
 					}
-				}
-				toolMsg := fmt.Sprintf(e.i18n.T(MsgTool), toolCount, event.ToolName, formattedInput)
-				if !cp.AppendEvent(ProgressEntryToolUse, toolInput, event.ToolName, toolMsg) {
-					for _, chunk := range SplitMessageCodeFenceAware(toolMsg, maxPlatformMessageLen) {
-						sendWorkspace(p, replyCtx, chunk)
+					toolLine := fmt.Sprintf("\n\n🔧 [%d] %s%s", toolCount, event.ToolName, inputSummary)
+					textParts = append(textParts, toolLine)
+					sp.appendText(toolLine)
+				} else {
+					// Flush accumulated text segment before tool display
+					previewActive := sp.canPreview()
+					if len(textParts) > segmentStart {
+						if !previewActive {
+							segment := strings.Join(textParts[segmentStart:], "")
+							if segment != "" {
+								for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+									sendWorkspace(p, replyCtx, chunk)
+								}
+							}
+						}
+						segmentStart = len(textParts)
+					}
+					sp.freeze()
+					if previewActive {
+						sp.detachPreview()
+					}
+					toolInput := event.ToolInput
+					var formattedInput string
+					if toolInput == "" {
+						formattedInput = ""
+					} else if strings.Contains(toolInput, "```") {
+						formattedInput = toolInput
+					} else if strings.Contains(toolInput, "\n") || utf8.RuneCountInString(toolInput) > 200 {
+						lang := toolCodeLang(event.ToolName, toolInput)
+						formattedInput = fmt.Sprintf("```%s\n%s\n```", lang, toolInput)
+					} else {
+						switch event.ToolName {
+						case "shell", "run_shell_command", "Bash":
+							formattedInput = fmt.Sprintf("```bash\n%s\n```", toolInput)
+						default:
+							formattedInput = fmt.Sprintf("`%s`", toolInput)
+						}
+					}
+					toolMsg := fmt.Sprintf(e.i18n.T(MsgTool), toolCount, event.ToolName, formattedInput)
+					if !cp.AppendEvent(ProgressEntryToolUse, toolInput, event.ToolName, toolMsg) {
+						for _, chunk := range SplitMessageCodeFenceAware(toolMsg, maxPlatformMessageLen) {
+							sendWorkspace(p, replyCtx, chunk)
+						}
 					}
 				}
 			}
 
 		case EventToolResult:
 			if e.display.ToolMessages {
+				inlineResult := false
+				if pref, ok := p.(PreviewFinishPreference); ok && pref.KeepPreviewOnFinish() {
+					inlineResult = sp.canPreview()
+				}
+
 				result := strings.TrimSpace(event.ToolResult)
 				if result == "" {
 					result = strings.TrimSpace(event.Content)
@@ -2729,7 +2764,26 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				if result != "" {
 					result = truncateIf(result, e.display.ToolMaxLen)
 				}
-				if result != "" || event.ToolStatus != "" || event.ToolExitCode != nil || event.ToolSuccess != nil {
+
+				if inlineResult {
+					// Append result summary into the stream.
+					status := "✅"
+					if event.ToolSuccess != nil && !*event.ToolSuccess {
+						status = "❌"
+					}
+					resultLine := " " + status
+					if result != "" {
+						// Show a compact snippet of the result.
+						const maxResultInline = 100
+						snippet := strings.ReplaceAll(result, "\n", " ")
+						if utf8.RuneCountInString(snippet) > maxResultInline {
+							snippet = string([]rune(snippet)[:maxResultInline]) + "…"
+						}
+						resultLine += " `" + snippet + "`"
+					}
+					textParts = append(textParts, resultLine)
+					sp.appendText(resultLine)
+				} else if result != "" || event.ToolStatus != "" || event.ToolExitCode != nil || event.ToolSuccess != nil {
 					resultMsg := e.formatToolResultEventFallback(event.ToolName, result, event.ToolStatus, event.ToolExitCode, event.ToolSuccess)
 					entry := ProgressCardEntry{
 						Kind:     ProgressEntryToolResult,
@@ -3065,7 +3119,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				queuedRenderer := func(content string) string {
 					return e.renderOutgoingContentForWorkspace(queued.platform, content, workspaceDir)
 				}
-				sp = newStreamPreview(e.streamPreview, queued.platform, queued.replyCtx, e.ctx, queuedRenderer)
+				qSpCfg := e.streamPreview
+				if pref, ok := queued.platform.(PreviewFinishPreference); ok && pref.KeepPreviewOnFinish() {
+					qSpCfg.TailTruncate = true
+				}
+				sp = newStreamPreview(qSpCfg, queued.platform, queued.replyCtx, e.ctx, queuedRenderer)
 				cp = newCompactProgressWriter(e.ctx, queued.platform, queued.replyCtx, e.agent.Name(), e.i18n.CurrentLang(), queuedRenderer)
 
 				session.AddHistory("user", queued.content)

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -15,6 +15,7 @@ type StreamPreviewCfg struct {
 	IntervalMs        int      // minimum ms between updates (default 1500)
 	MinDeltaChars     int      // minimum new chars before sending an update (default 30)
 	MaxChars          int      // max preview length (default 2000)
+	TailTruncate      bool     // when true, keep the *last* MaxChars (scrolling window) instead of the first
 }
 
 // DefaultStreamPreviewCfg returns sensible defaults.
@@ -103,6 +104,20 @@ func (sp *streamPreview) canPreview() bool {
 	return ok
 }
 
+// truncatePreview applies MaxChars truncation. When TailTruncate is set it
+// keeps the tail (scrolling window); otherwise it keeps the head.
+func (sp *streamPreview) truncatePreview(text string) string {
+	maxChars := sp.cfg.MaxChars
+	if maxChars <= 0 || len([]rune(text)) <= maxChars {
+		return text
+	}
+	if sp.cfg.TailTruncate {
+		runes := []rune(text)
+		return "…" + string(runes[len(runes)-maxChars:])
+	}
+	return string([]rune(text)[:maxChars]) + "…"
+}
+
 // appendText adds new text content and triggers a throttled flush if needed.
 func (sp *streamPreview) appendText(text string) {
 	sp.mu.Lock()
@@ -114,11 +129,7 @@ func (sp *streamPreview) appendText(text string) {
 
 	sp.fullText += text
 
-	displayText := sp.fullText
-	maxChars := sp.cfg.MaxChars
-	if maxChars > 0 && len([]rune(displayText)) > maxChars {
-		displayText = string([]rune(displayText)[:maxChars]) + "…"
-	}
+	displayText := sp.truncatePreview(sp.fullText)
 
 	delta := len([]rune(displayText)) - len([]rune(sp.lastSentText))
 	elapsed := time.Since(sp.lastSentAt)
@@ -150,11 +161,7 @@ func (sp *streamPreview) scheduleFlushLocked(delay time.Duration) {
 		if sp.degraded {
 			return
 		}
-		displayText := sp.fullText
-		maxChars := sp.cfg.MaxChars
-		if maxChars > 0 && len([]rune(displayText)) > maxChars {
-			displayText = string([]rune(displayText)[:maxChars]) + "…"
-		}
+		displayText := sp.truncatePreview(sp.fullText)
 		sp.flushLocked(displayText)
 	})
 }
@@ -231,11 +238,7 @@ func (sp *streamPreview) freeze() {
 
 	if sp.previewMsgID != nil && !sp.degraded {
 		if updater, ok := sp.platform.(MessageUpdater); ok {
-			text := sp.fullText
-			maxChars := sp.cfg.MaxChars
-			if maxChars > 0 && len([]rune(text)) > maxChars {
-				text = string([]rune(text)[:maxChars]) + "…"
-			}
+			text := sp.truncatePreview(sp.fullText)
 			if text != "" {
 				if sp.transform != nil {
 					text = sp.transform(text)

--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -36,6 +36,11 @@ type WSPlatform struct {
 	reqSeq      atomic.Int64 // monotonic counter for generating unique req_id
 	missedPong  atomic.Int32 // consecutive heartbeat acks not received
 	pendingAcks sync.Map     // req_id -> chan error, for sequential send with ack waiting
+
+	// typingPreviews stores preview handles created by StartTyping so that
+	// SendPreviewStart can reuse the same stream instead of creating a new message.
+	// Key: reqID (string), Value: *wsPreviewHandle.
+	typingPreviews sync.Map
 }
 
 const wsAckTimeout = 5 * time.Second
@@ -46,6 +51,12 @@ type wsReplyContext struct {
 	chatID   string // chatid for aibot_send_msg
 	chatType string // chattype: "single" or "group"
 	userID   string // from.userid
+}
+
+// wsPreviewHandle stores the stream ID for in-place message updates via streaming.
+type wsPreviewHandle struct {
+	streamID string
+	reqID    string
 }
 
 // --- WebSocket protocol frame types (matching official SDK) ---
@@ -467,6 +478,158 @@ func (p *WSPlatform) Reply(ctx context.Context, rctx any, content string) error 
 	}
 	slog.Debug("wecom-ws: reply sent", "user", rc.userID, "len", len(content))
 	return nil
+}
+
+// StartTyping sends a "thinking" streaming indicator that progressively adds
+// dots so the user sees the message growing (💭 正在思考. → .. → ... → ....).
+// WeChat Work renders incremental content growth as normal streaming output.
+// The handle is stashed in typingPreviews so SendPreviewStart can reuse it.
+// Implements core.TypingIndicator.
+func (p *WSPlatform) StartTyping(ctx context.Context, rctx any) (stop func()) {
+	rc, ok := rctx.(wsReplyContext)
+	if !ok || rc.reqID == "" {
+		return func() {}
+	}
+	streamID := p.generateReqID("stream")
+	sendFrame := func(content string) error {
+		return p.writeJSON(map[string]any{
+			"cmd":     "aibot_respond_msg",
+			"headers": map[string]string{"req_id": rc.reqID},
+			"body": map[string]any{
+				"msgtype": "stream",
+				"stream": map[string]any{
+					"id":      streamID,
+					"finish":  false,
+					"content": content,
+				},
+			},
+		})
+	}
+	if err := sendFrame("💭 正在思考"); err != nil {
+		slog.Debug("wecom-ws: typing indicator failed", "error", err)
+		return func() {}
+	}
+	handle := &wsPreviewHandle{streamID: streamID, reqID: rc.reqID}
+	p.typingPreviews.Store(rc.reqID, handle)
+	slog.Debug("wecom-ws: typing started", "user", rc.userID, "stream_id", streamID)
+
+	stopCh := make(chan struct{})
+	go func() {
+		const maxDots = 10
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		n := 0
+		growing := true
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if _, ok := p.typingPreviews.Load(rc.reqID); !ok {
+					return
+				}
+				if growing {
+					n++
+					if n >= maxDots {
+						growing = false
+					}
+				} else {
+					n--
+					if n <= 0 {
+						growing = true
+					}
+				}
+				_ = sendFrame("💭 正在思考" + strings.Repeat(".", n))
+			}
+		}
+	}()
+
+	return func() {
+		close(stopCh)
+		p.typingPreviews.Delete(rc.reqID)
+	}
+}
+
+// SendPreviewStart reuses a handle from StartTyping if available, otherwise
+// sends a new streaming frame. Implements core.PreviewStarter.
+func (p *WSPlatform) SendPreviewStart(ctx context.Context, rctx any, content string) (any, error) {
+	rc, ok := rctx.(wsReplyContext)
+	if !ok {
+		return nil, fmt.Errorf("wecom-ws: invalid reply context type %T", rctx)
+	}
+
+	// Reuse the typing indicator's stream if available.
+	if v, ok := p.typingPreviews.LoadAndDelete(rc.reqID); ok {
+		h := v.(*wsPreviewHandle)
+		// Update the existing "thinking" message with real content.
+		frame := map[string]any{
+			"cmd":     "aibot_respond_msg",
+			"headers": map[string]string{"req_id": h.reqID},
+			"body": map[string]any{
+				"msgtype": "stream",
+				"stream": map[string]any{
+					"id":      h.streamID,
+					"finish":  false,
+					"content": content,
+				},
+			},
+		}
+		if err := p.writeJSON(frame); err != nil {
+			return nil, fmt.Errorf("wecom-ws: send preview start (reuse typing): %w", err)
+		}
+		slog.Debug("wecom-ws: preview started (reused typing)", "stream_id", h.streamID, "len", len(content))
+		return h, nil
+	}
+
+	// No typing handle — send a fresh stream.
+	streamID := p.generateReqID("stream")
+	frame := map[string]any{
+		"cmd":     "aibot_respond_msg",
+		"headers": map[string]string{"req_id": rc.reqID},
+		"body": map[string]any{
+			"msgtype": "stream",
+			"stream": map[string]any{
+				"id":      streamID,
+				"finish":  false,
+				"content": content,
+			},
+		},
+	}
+	if err := p.writeJSON(frame); err != nil {
+		return nil, fmt.Errorf("wecom-ws: send preview start: %w", err)
+	}
+	slog.Debug("wecom-ws: preview started", "stream_id", streamID, "len", len(content))
+	return &wsPreviewHandle{streamID: streamID, reqID: rc.reqID}, nil
+}
+
+// UpdateMessage sends an updated streaming frame with the same stream ID.
+// The content is a full replacement (not incremental). Implements core.MessageUpdater.
+func (p *WSPlatform) UpdateMessage(ctx context.Context, previewHandle any, content string) error {
+	h, ok := previewHandle.(*wsPreviewHandle)
+	if !ok {
+		return fmt.Errorf("wecom-ws: invalid preview handle type %T", previewHandle)
+	}
+	frame := map[string]any{
+		"cmd":     "aibot_respond_msg",
+		"headers": map[string]string{"req_id": h.reqID},
+		"body": map[string]any{
+			"msgtype": "stream",
+			"stream": map[string]any{
+				"id":      h.streamID,
+				"finish":  false,
+				"content": content,
+			},
+		},
+	}
+	return p.writeJSON(frame)
+}
+
+// KeepPreviewOnFinish tells the engine to finalize via UpdateMessage instead of
+// deleting the preview and sending a separate Reply. Implements core.PreviewFinishPreference.
+func (p *WSPlatform) KeepPreviewOnFinish() bool {
+	return true
 }
 
 // Send sends a proactive message via aibot_send_msg (markdown format).


### PR DESCRIPTION
- Implement TypingIndicator (StartTyping) with animated dots for immediate user feedback when a message is received
- Implement PreviewStarter (SendPreviewStart) with typing handle reuse for seamless transition from thinking indicator to AI output
- Implement MessageUpdater (UpdateMessage) for in-place stream updates
- Implement PreviewFinishPreference (KeepPreviewOnFinish) to match Feishu's keep-in-place strategy
- Add TailTruncate option to StreamPreviewCfg for scrolling-window display so long outputs keep showing latest content
- When platform supports KeepPreviewOnFinish, tool call events are inlined into the streaming message instead of sent as separate messages