### PR TITLE
fix(claudecode): fall back to fresh session when resumed jsonl is missing

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -42,6 +42,27 @@ type claudeSession struct {
 	alive           atomic.Bool
 }
 
+// claudeSessionFileExists reports whether Claude's on-disk jsonl for the
+// given workDir + sessionID exists. Claude stores sessions at
+//   ~/.claude/projects/<workDir-with-slashes-and-dots-replaced-by-dashes>/<sessionID>.jsonl
+func claudeSessionFileExists(workDir, sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	abs, err := filepath.Abs(workDir)
+	if err != nil {
+		return false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	flat := strings.NewReplacer("/", "-", ".", "-").Replace(abs)
+	path := filepath.Join(home, ".claude", "projects", flat, sessionID+".jsonl")
+	_, err = os.Stat(path)
+	return err == nil
+}
+
 func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
@@ -66,9 +87,16 @@ func newClaudeSession(ctx context.Context, workDir, model, sessionID, mode strin
 		// conversation gets its own independent context branch.
 		args = append(args, "--continue", "--fork-session")
 	default:
-		// Resuming a known session ID — this is cc-connect's own session
-		// from a previous connection, safe to resume directly.
-		args = append(args, "--resume", sessionID)
+		// Pre-flight: verify the session jsonl still exists. If Claude's
+		// sessions were purged externally (e.g. user cleanup), fall back
+		// to a fresh session instead of failing with "No conversation found".
+		if !claudeSessionFileExists(workDir, sessionID) {
+			slog.Warn("claudeSession: stored session not found on disk, starting fresh",
+				"sessionID", sessionID, "workDir", workDir)
+			sessionID = ""
+		} else {
+			args = append(args, "--resume", sessionID)
+		}
 	}
 	if model != "" {
 		args = append(args, "--model", model)


### PR DESCRIPTION
## Problem

If a user deletes Claude Code's session jsonl files out-of-band (manual `rm`, cleanup scripts, disk space recovery, etc.), cc-connect still has the stale `agent_session_id` persisted in its session.json. On the next platform message it launches `claude --resume <id>` and gets a hard failure:

> Error: No conversation found with session ID: ...

The session is effectively broken until the user manually edits `~/.cc-connect/sessions/*.json` to clear `agent_session_id`.

## Fix

Add a pre-flight check in `newClaudeSession`. If the stored session ID doesn't resolve to an on-disk jsonl under `~/.claude/projects/<flattened-workdir>/<sessionID>.jsonl`, drop the `--resume` argument and start a fresh session. Claude will emit a new `session_id` via the `system` event and normal tracking resumes.

No behavior change when session files are intact.

## Tested

- Deleted a session jsonl externally, sent a Feishu message → cc-connect logged the warning, started fresh session, conversation continued.
- Existing session jsonl still resumes as before.