### PR TITLE
fix(telegram): make HTML→plain-text fallback observable

### DIFF
--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -955,6 +955,12 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 
 	if _, err := bot.SendMessage(ctx, params); err != nil {
 		if strings.Contains(err.Error(), "can't parse") {
+			slog.Warn("telegram: HTML rejected by Telegram, sending as plain text",
+				"method", "Reply",
+				"error", err.Error(),
+				"html_prefix", truncateForLog(html, 200),
+				"html_len", len(html),
+			)
 			params.Text = content
 			params.ParseMode = ""
 			_, err = bot.SendMessage(ctx, params)
@@ -987,6 +993,12 @@ func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 
 	if _, err := bot.SendMessage(ctx, params); err != nil {
 		if strings.Contains(err.Error(), "can't parse") {
+			slog.Warn("telegram: HTML rejected by Telegram, sending as plain text",
+				"method", "Send",
+				"error", err.Error(),
+				"html_prefix", truncateForLog(html, 200),
+				"html_len", len(html),
+			)
 			params.Text = content
 			params.ParseMode = ""
 			_, err = bot.SendMessage(ctx, params)
@@ -1168,6 +1180,12 @@ func (p *Platform) SendWithButtons(ctx context.Context, rctx any, content string
 
 	if _, err := bot.SendMessage(ctx, params); err != nil {
 		if strings.Contains(err.Error(), "can't parse") {
+			slog.Warn("telegram: HTML rejected by Telegram, sending as plain text",
+				"method", "SendWithButtons",
+				"error", err.Error(),
+				"html_prefix", truncateForLog(html, 200),
+				"html_len", len(html),
+			)
 			params.Text = content
 			params.ParseMode = ""
 			_, err = bot.SendMessage(ctx, params)
@@ -1284,6 +1302,12 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 	sent, err := bot.SendMessage(ctx, params)
 	if err != nil {
 		if strings.Contains(err.Error(), "can't parse") {
+			slog.Warn("telegram: HTML rejected by Telegram, sending preview as plain text",
+				"method", "SendPreviewStart",
+				"error", err.Error(),
+				"html_prefix", truncateForLog(html, 200),
+				"html_len", len(html),
+			)
 			params.Text = content
 			params.ParseMode = ""
 			sent, err = bot.SendMessage(ctx, params)
@@ -1326,7 +1350,12 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 			return nil
 		}
 		if strings.Contains(errMsg, "can't parse") {
-			slog.Debug("telegram: UpdateMessage falling back to plain text", "full_html", html)
+			slog.Warn("telegram: HTML rejected by Telegram, editing as plain text",
+				"method", "UpdateMessage",
+				"error", errMsg,
+				"html_prefix", truncateForLog(html, 200),
+				"html_len", len(html),
+			)
 			params.Text = content
 			params.ParseMode = ""
 			if _, err2 := bot.EditMessageText(ctx, params); err2 != nil {


### PR DESCRIPTION
# fix(telegram): make HTML→plain-text fallback observable

## Symptom

When Telegram rejects a `parse_mode=HTML` message (typically with `Bad Request: can't parse entities: ...`), `platform/telegram` silently retries with `parse_mode=""` and the original Markdown text. The IM user sees literal `**bold**`, `# heading`, etc. with no indication of why or which payload triggered the fallback. There is no operator-visible signal at the default log level.

Real example a user pasted from their Telegram client:

```
本机已安装的 Skills

你共有 8 个 skills，全部来自 GitHub 仓库 tw93/Waza，安装在 ~/.agents/skills/ 目录：
Skill      | 用途
-----------+----------------------------------------------------------------
**hunt**   | 调试错误、崩溃、异常行为。先定位根因再修复
**think**  | 新功能/架构决策前的思考和规划
…
```

The expected rendering would have `<b>hunt</b>` etc. as bold. Local conversion via `core.MarkdownToSimpleHTML` produces clean, valid Telegram-HTML for that exact input, so the rejection comes from somewhere we can't see without enabling debug logging — and even then the existing `slog.Debug("...falling back to plain text")` call doesn't include the actual Telegram error message.

## Change

Five sites in `platform/telegram/telegram.go` had silent fallback. Each now logs at `slog.Warn` with:

- `method`: which exported function originated the call (`Reply`, `Send`, `SendWithButtons`, `SendPreviewStart`, `UpdateMessage`)
- `error`: the full Telegram API error message (this is what carries the parse offset / unsupported-tag clue)
- `html_prefix`: first 200 chars of the rejected HTML so operators can correlate without digging through the message store
- `html_len`: total HTML length so length-based corruption can be spotted at a glance

```go
slog.Warn("telegram: HTML rejected by Telegram, sending as plain text",
    "method", "Reply",
    "error", err.Error(),
    "html_prefix", truncateForLog(html, 200),
    "html_len", len(html),
)
params.Text = content
params.ParseMode = ""
```

`UpdateMessage` already had a `slog.Debug` for this case; it's been upgraded to the same `slog.Warn` shape for consistency.

## What this is NOT

- Not a behavior change. Same fallback, same plain-text output, same retry semantics. Users currently affected by silent fallback will continue to see the same plain text — but operators will see *why*, and can route follow-up fixes (Markdown converter bug? Telegram-side regression? user-content edge case?) appropriately.
- Not a Markdown stripping change. The fallback still posts the original Markdown verbatim. A separate change could route fallback content through `core.StripMarkdown(content)` for nicer UX, but that's out of scope here — this PR is purely about observability.
- No new dependencies, no test additions. The fallback path is reached only on live Telegram API rejections; covering it in unit tests would require mocking the Telegram client at a level the existing test suite doesn't.

## Verification

```
$ go vet ./platform/telegram/...
(clean)

$ go build ./...
(clean)

$ go test ./platform/telegram/... -count=1 -race
ok  	github.com/chenhg5/cc-connect/platform/telegram	1.708s
```

After deploying, an affected user will see entries like:

```
level=WARN msg="telegram: HTML rejected by Telegram, editing as plain text"
  method=UpdateMessage
  error="Bad Request: can't parse entities: Unsupported start tag \"…\" at byte offset 247"
  html_prefix="…HTML preview here…"
  html_len=1834
```

…in their normal log stream, no debug-mode toggle required. From there, the next step is straightforward: feed the offending fragment back into `core.MarkdownToSimpleHTML`'s tests to either patch the converter or the Telegram-side workaround.

## Diff stats

```
 platform/telegram/telegram.go | 31 ++++++++++++++++++++++++++++---
 1 file changed, 30 insertions(+), 1 deletion(-)
```
