### PR TITLE
fix(qqbot): cancel old goroutines on WebSocket reconnect

### DIFF
--- a/platform/qqbot/qqbot.go
+++ b/platform/qqbot/qqbot.go
@@ -80,6 +80,7 @@ type Platform struct {
 	heartbeatMs  int
 	heartbeatOK  atomic.Bool
 	reconnecting atomic.Bool
+	connCancel   context.CancelFunc // cancels per-connection goroutines (heartbeatLoop, readLoop)
 
 	// Message dedup
 	dedup core.MessageDedup
@@ -507,9 +508,12 @@ func (p *Platform) connectGateway(ctx context.Context) error {
 		return err
 	}
 
-	// Start heartbeat and read loop
-	go p.heartbeatLoop(ctx)
-	go p.readLoop(ctx)
+	// Start heartbeat and read loop with a per-connection context
+	// so we can cancel them cleanly on reconnect.
+	connCtx, connCancel := context.WithCancel(ctx)
+	p.connCancel = connCancel
+	go p.heartbeatLoop(connCtx)
+	go p.readLoop(connCtx)
 
 	return nil
 }
@@ -723,6 +727,12 @@ func (p *Platform) triggerReconnect(ctx context.Context) {
 }
 
 func (p *Platform) reconnectLoop(ctx context.Context) {
+	// Cancel old heartbeatLoop/readLoop goroutines before closing the
+	// connection, so they stop promptly instead of racing with the new pair.
+	if p.connCancel != nil {
+		p.connCancel()
+	}
+
 	// Close existing connection
 	p.wsMu.Lock()
 	if p.wsConn != nil {
@@ -817,8 +827,10 @@ func (p *Platform) reconnectLoop(ctx context.Context) {
 		}
 
 		slog.Info("qqbot: reconnected successfully")
-		go p.heartbeatLoop(ctx)
-		go p.readLoop(ctx)
+		connCtx, connCancel := context.WithCancel(ctx)
+		p.connCancel = connCancel
+		go p.heartbeatLoop(connCtx)
+		go p.readLoop(connCtx)
 		return
 	}
 	slog.Error("qqbot: failed to reconnect after max attempts", "attempts", maxReconnectAttempts)


### PR DESCRIPTION
## Summary
- Add per-connection `connCancel` context to the Platform struct
- Cancel old heartbeatLoop/readLoop goroutines before closing the WebSocket during reconnection
- Create a fresh child context for each new pair of goroutines after successful reconnect
- Prevents goroutine leak where stale loops from the previous connection race with the new pair

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `go test ./platform/qqbot/ -v` — all 15 tests pass

Closes #524