### PR TITLE
feat(core): make per-session message queue depth configurable

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -426,6 +426,10 @@ func main() {
 				})
 			}
 		}
+		// Wire per-session message queue depth
+		if cfg.Queue.MaxDepth != nil && *cfg.Queue.MaxDepth > 0 {
+			engine.SetMaxQueuedMessages(*cfg.Queue.MaxDepth)
+		}
 		// Wire outgoing rate limiting
 		{
 			var maxPS float64

--- a/config.example.toml
+++ b/config.example.toml
@@ -174,6 +174,18 @@ level = "info" # debug, info, warn, error
 # window_secs = 60          # Window size in seconds (default: 60) / 窗口时间秒数（默认 60）
 
 # =============================================================================
+# Message Queue / 消息队列
+# When the agent is busy with the current turn, additional incoming messages
+# wait in a per-session queue and are replayed after the turn ends. When the
+# queue is full, further senders receive a "queue full" reply instead of being
+# queued. Increase max_depth for chatty users / long-running turns.
+# 当 agent 正在处理当前轮次时，新消息进入每会话队列，本轮结束后依次回放。
+# 队列满时新发送者会收到"队列已满"提示。聊天频繁或单轮较长时可调大 max_depth。
+# =============================================================================
+# [queue]
+# max_depth = 5             # Max queued messages per session (default: 5) / 每会话最大排队消息数（默认 5）
+
+# =============================================================================
 # Outgoing Rate Limit / 出站速率限制
 # Throttle how fast messages are sent TO platforms.
 # Prevents account bans on platforms with strict API rate limits (e.g. WeChat Work).

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,7 @@ type Config struct {
 	StreamPreview     StreamPreviewConfig     `toml:"stream_preview"`      // real-time streaming preview
 	RateLimit         RateLimitConfig         `toml:"rate_limit"`          // per-session rate limiting
 	OutgoingRateLimit OutgoingRateLimitConfig `toml:"outgoing_rate_limit"` // outgoing message throttling
+	Queue             QueueConfig             `toml:"queue"`               // per-session message queue depth
 	Relay             RelayConfig             `toml:"relay"`               // bot-to-bot relay behavior
 	Cron              CronConfig              `toml:"cron"`
 	Webhook           WebhookConfig           `toml:"webhook"`
@@ -173,6 +174,15 @@ type StreamPreviewConfig struct {
 type RateLimitConfig struct {
 	MaxMessages *int `toml:"max_messages"` // max messages per window; 0 = disabled; default 20
 	WindowSecs  *int `toml:"window_secs"`  // window size in seconds; default 60
+}
+
+// QueueConfig controls per-session message queue depth.
+// When the agent is busy with the current turn, additional incoming messages
+// are queued and replayed after the turn ends. MaxDepth caps how many messages
+// can wait; once full, further senders receive MsgQueueFull instead of being
+// queued. nil or non-positive value means use the engine default (5).
+type QueueConfig struct {
+	MaxDepth *int `toml:"max_depth"` // max queued messages per session; default 5
 }
 
 // OutgoingRateLimitConfig controls how fast messages are sent TO platforms.

--- a/core/engine.go
+++ b/core/engine.go
@@ -1637,7 +1637,8 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		}
 		// Session is busy — try to queue the message for the running turn
 		// so the agent processes it immediately after the current turn ends.
-		if e.queueMessageForBusySession(p, msg, interactiveKey) {
+		switch e.queueMessageForBusySession(p, msg, interactiveKey) {
+		case queueResultOK:
 			// Race guard: the drain loop in processInteractiveMessageWith may
 			// have just finished (session unlocked) between our TryLock failure
 			// and the queue append. Re-try TryLock — if it succeeds, no one is
@@ -1645,9 +1646,14 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 			if session.TryLock() {
 				go e.drainOrphanedQueue(session, sessions, interactiveKey, agent, resolvedWorkspace)
 			}
-			return
+		case queueResultFull:
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgQueueFull))
+		default:
+			// queueResultNoState / queueResultSessionDead — the session is
+			// busy but there is no usable queue. Fall back to the generic
+			// "previous request still processing" reply.
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
 		}
-		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgQueueFull))
 		return
 	}
 
@@ -1719,22 +1725,34 @@ func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions 
 	return newSession
 }
 
+// queueResult distinguishes why queueing succeeded or failed so the caller
+// can pick the right user-facing reply.
+type queueResult int
+
+const (
+	queueResultOK            queueResult = iota // message queued for later delivery
+	queueResultNoState                          // no interactiveState for this key
+	queueResultSessionDead                      // agent session existed but is no longer alive
+	queueResultFull                             // pendingMessages already at maxQueuedMessages
+)
+
 // queueMessageForBusySession queues a message for later delivery when the
 // session is busy. The message is NOT sent to agent stdin at queue time;
 // the event loop sends it after the current turn's EventResult is received.
-// Returns true if the message was successfully queued, false otherwise.
-func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiveKey string) bool {
+// Returns queueResultOK on success, or a specific failure reason so the
+// caller can distinguish "queue full" from other rejection paths.
+func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiveKey string) queueResult {
 	e.interactiveMu.Lock()
 	state, hasState := e.interactiveStates[interactiveKey]
 	e.interactiveMu.Unlock()
 
 	if !hasState || state == nil {
-		return false
+		return queueResultNoState
 	}
 	// Allow queueing when agentSession is nil (session is starting up,
 	// issue #565). Only reject if the session was established and died.
 	if state.agentSession != nil && !state.agentSession.Alive() {
-		return false
+		return queueResultSessionDead
 	}
 
 	// Only queue metadata — do NOT send to agent stdin yet.
@@ -1745,7 +1763,7 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 	state.mu.Lock()
 	if len(state.pendingMessages) >= e.maxQueuedMessages {
 		state.mu.Unlock()
-		return false // fall back to "queue full" reply
+		return queueResultFull
 	}
 	state.pendingMessages = append(state.pendingMessages, queuedMessage{
 		platform:      p,
@@ -1768,7 +1786,7 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 		"queue_depth", queueDepth,
 	)
 	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgMessageQueued))
-	return true
+	return queueResultOK
 }
 
 // ensureInteractiveStateForQueueing creates a placeholder interactiveState

--- a/core/engine.go
+++ b/core/engine.go
@@ -25,7 +25,7 @@ import (
 
 const maxPlatformMessageLen = 4000
 const telegramBotCommandLimit = 100
-const maxQueuedMessages = 5 // cap queued messages to bound memory usage
+const defaultMaxQueuedMessages = 5 // default cap on queued messages per session; override via [queue] max_depth
 
 const (
 	defaultThinkingMaxLen = 300
@@ -197,15 +197,16 @@ type Engine struct {
 	userRoles    *UserRoleManager // nil = legacy mode (no per-user policies)
 	userRolesMu  sync.RWMutex     // protects userRoles, disabledCmds, and adminFrom
 
-	rateLimiter      *RateLimiter
-	outgoingRL       *OutgoingRateLimiter
-	streamPreview    StreamPreviewCfg
-	references       ReferenceRenderCfg
-	relayManager     *RelayManager
-	eventIdleTimeout time.Duration
-	dirHistory       *DirHistory
-	baseWorkDir      string
-	projectState     *ProjectStateStore
+	rateLimiter       *RateLimiter
+	outgoingRL        *OutgoingRateLimiter
+	maxQueuedMessages int
+	streamPreview     StreamPreviewCfg
+	references        ReferenceRenderCfg
+	relayManager      *RelayManager
+	eventIdleTimeout  time.Duration
+	dirHistory        *DirHistory
+	baseWorkDir       string
+	projectState      *ProjectStateStore
 
 	// Auto-compress settings
 	autoCompressEnabled   bool
@@ -387,6 +388,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		references:            DefaultReferenceRenderCfg(),
 		eventIdleTimeout:      defaultEventIdleTimeout,
 		showContextIndicator:  true,
+		maxQueuedMessages:     defaultMaxQueuedMessages,
 	}
 
 	if ag != nil {
@@ -797,6 +799,15 @@ func (e *Engine) SetBannedWords(words []string) {
 		lower[i] = strings.ToLower(w)
 	}
 	e.bannedWords = lower
+}
+
+// SetMaxQueuedMessages overrides the per-session message queue depth.
+// Values <= 0 are ignored (default of defaultMaxQueuedMessages is kept).
+func (e *Engine) SetMaxQueuedMessages(n int) {
+	if n <= 0 {
+		return
+	}
+	e.maxQueuedMessages = n
 }
 
 // SetRateLimitCfg configures per-session message rate limiting.
@@ -1636,7 +1647,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 			}
 			return
 		}
-		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgQueueFull))
 		return
 	}
 
@@ -1732,9 +1743,9 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 	// EventResult that never arrives. Instead, the event loop sends the
 	// message after the current turn's EventResult is received.
 	state.mu.Lock()
-	if len(state.pendingMessages) >= maxQueuedMessages {
+	if len(state.pendingMessages) >= e.maxQueuedMessages {
 		state.mu.Unlock()
-		return false // fall back to "previous processing" reply
+		return false // fall back to "queue full" reply
 	}
 	state.pendingMessages = append(state.pendingMessages, queuedMessage{
 		platform:      p,

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6198,11 +6198,11 @@ func TestQueueMessageForBusySession_FIFODequeue(t *testing.T) {
 	msg1 := &Message{SessionKey: key, Content: "msg1", ReplyCtx: "ctx-msg1"}
 	msg2 := &Message{SessionKey: key, Content: "msg2", ReplyCtx: "ctx-msg2"}
 
-	ok1 := e.queueMessageForBusySession(p, msg1, key)
-	ok2 := e.queueMessageForBusySession(p, msg2, key)
+	res1 := e.queueMessageForBusySession(p, msg1, key)
+	res2 := e.queueMessageForBusySession(p, msg2, key)
 
-	if !ok1 || !ok2 {
-		t.Fatal("expected both messages to be queued successfully")
+	if res1 != queueResultOK || res2 != queueResultOK {
+		t.Fatalf("expected both messages queued (OK), got %v / %v", res1, res2)
 	}
 
 	// Since deferred-send, messages are NOT sent to agent stdin at queue
@@ -6597,9 +6597,8 @@ func TestQueueMessageOverflow_DropsOldestAndReturnsfalse(t *testing.T) {
 	// Fill the queue to defaultMaxQueuedMessages (5).
 	for i := 0; i < defaultMaxQueuedMessages; i++ {
 		msg := &Message{SessionKey: key, Content: fmt.Sprintf("msg-%d", i), ReplyCtx: fmt.Sprintf("ctx-%d", i)}
-		ok := e.queueMessageForBusySession(p, msg, key)
-		if !ok {
-			t.Fatalf("expected msg-%d to be queued, got false", i)
+		if res := e.queueMessageForBusySession(p, msg, key); res != queueResultOK {
+			t.Fatalf("expected msg-%d queued OK, got %v", i, res)
 		}
 	}
 
@@ -6609,11 +6608,10 @@ func TestQueueMessageOverflow_DropsOldestAndReturnsfalse(t *testing.T) {
 	}
 	state.mu.Unlock()
 
-	// The 6th message should be rejected (returns false).
+	// The 6th message should be rejected with queueResultFull.
 	overflow := &Message{SessionKey: key, Content: "msg-overflow", ReplyCtx: "ctx-overflow"}
-	ok := e.queueMessageForBusySession(p, overflow, key)
-	if ok {
-		t.Fatal("expected 6th message to be rejected (queue full)")
+	if res := e.queueMessageForBusySession(p, overflow, key); res != queueResultFull {
+		t.Fatalf("expected 6th message rejected with queueResultFull, got %v", res)
 	}
 
 	// Queue should still have exactly defaultMaxQueuedMessages items (the original 5).
@@ -6639,9 +6637,8 @@ func TestQueueMessage_NoState_ReturnsFalse(t *testing.T) {
 	e := newTestEngine()
 
 	msg := &Message{SessionKey: "nonexistent:key", Content: "hello"}
-	ok := e.queueMessageForBusySession(p, msg, "nonexistent:key")
-	if ok {
-		t.Fatal("expected false when no interactive state exists")
+	if res := e.queueMessageForBusySession(p, msg, "nonexistent:key"); res != queueResultNoState {
+		t.Fatalf("expected queueResultNoState when no interactive state exists, got %v", res)
 	}
 }
 
@@ -6662,9 +6659,8 @@ func TestQueueMessage_DeadSession_ReturnsFalse(t *testing.T) {
 	e.interactiveMu.Unlock()
 
 	msg := &Message{SessionKey: key, Content: "hello"}
-	ok := e.queueMessageForBusySession(p, msg, key)
-	if ok {
-		t.Fatal("expected false for dead session")
+	if res := e.queueMessageForBusySession(p, msg, key); res != queueResultSessionDead {
+		t.Fatalf("expected queueResultSessionDead for dead session, got %v", res)
 	}
 }
 
@@ -6687,9 +6683,8 @@ func TestQueueMessage_NilAgentSession_DuringStartup(t *testing.T) {
 	e.interactiveMu.Unlock()
 
 	msg := &Message{SessionKey: key, Content: "queued during startup", ReplyCtx: "ctx-startup"}
-	ok := e.queueMessageForBusySession(p, msg, key)
-	if !ok {
-		t.Fatal("expected true: messages should be queueable during session startup")
+	if res := e.queueMessageForBusySession(p, msg, key); res != queueResultOK {
+		t.Fatalf("expected queueResultOK during session startup, got %v", res)
 	}
 
 	state.mu.Lock()
@@ -6700,6 +6695,64 @@ func TestQueueMessage_NilAgentSession_DuringStartup(t *testing.T) {
 		t.Fatalf("queued content = %q, want %q", state.pendingMessages[0].content, "queued during startup")
 	}
 	state.mu.Unlock()
+}
+
+// TestQueueMessage_SetMaxQueuedMessages_OverridesDefault verifies that
+// SetMaxQueuedMessages changes the per-session queue cap: with depth=n the
+// first n messages are accepted and the (n+1)-th is rejected with
+// queueResultFull.
+func TestQueueMessage_SetMaxQueuedMessages_OverridesDefault(t *testing.T) {
+	const depth = 2 // deliberately != defaultMaxQueuedMessages (5)
+
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("qs-configurable")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetMaxQueuedMessages(depth)
+
+	key := "test:configurable-depth"
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	for i := 0; i < depth; i++ {
+		msg := &Message{SessionKey: key, Content: fmt.Sprintf("msg-%d", i), ReplyCtx: fmt.Sprintf("ctx-%d", i)}
+		if res := e.queueMessageForBusySession(p, msg, key); res != queueResultOK {
+			t.Fatalf("expected msg-%d queued OK under depth=%d, got %v", i, depth, res)
+		}
+	}
+
+	overflow := &Message{SessionKey: key, Content: "msg-overflow", ReplyCtx: "ctx-overflow"}
+	if res := e.queueMessageForBusySession(p, overflow, key); res != queueResultFull {
+		t.Fatalf("expected queueResultFull at depth=%d, got %v", depth, res)
+	}
+
+	state.mu.Lock()
+	if got := len(state.pendingMessages); got != depth {
+		t.Fatalf("queue depth after overflow = %d, want %d", got, depth)
+	}
+	state.mu.Unlock()
+}
+
+// TestSetMaxQueuedMessages_IgnoresNonPositive verifies that SetMaxQueuedMessages
+// is a no-op when n <= 0, preserving the default cap.
+func TestSetMaxQueuedMessages_IgnoresNonPositive(t *testing.T) {
+	e := newTestEngine()
+	e.SetMaxQueuedMessages(0)
+	if e.maxQueuedMessages != defaultMaxQueuedMessages {
+		t.Fatalf("maxQueuedMessages after SetMaxQueuedMessages(0) = %d, want %d (default)",
+			e.maxQueuedMessages, defaultMaxQueuedMessages)
+	}
+	e.SetMaxQueuedMessages(-3)
+	if e.maxQueuedMessages != defaultMaxQueuedMessages {
+		t.Fatalf("maxQueuedMessages after SetMaxQueuedMessages(-3) = %d, want %d (default)",
+			e.maxQueuedMessages, defaultMaxQueuedMessages)
+	}
 }
 
 // --- 2. /compress flow ---

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6594,8 +6594,8 @@ func TestQueueMessageOverflow_DropsOldestAndReturnsfalse(t *testing.T) {
 	e.interactiveStates[key] = state
 	e.interactiveMu.Unlock()
 
-	// Fill the queue to maxQueuedMessages (5).
-	for i := 0; i < maxQueuedMessages; i++ {
+	// Fill the queue to defaultMaxQueuedMessages (5).
+	for i := 0; i < defaultMaxQueuedMessages; i++ {
 		msg := &Message{SessionKey: key, Content: fmt.Sprintf("msg-%d", i), ReplyCtx: fmt.Sprintf("ctx-%d", i)}
 		ok := e.queueMessageForBusySession(p, msg, key)
 		if !ok {
@@ -6604,8 +6604,8 @@ func TestQueueMessageOverflow_DropsOldestAndReturnsfalse(t *testing.T) {
 	}
 
 	state.mu.Lock()
-	if len(state.pendingMessages) != maxQueuedMessages {
-		t.Fatalf("queue depth = %d, want %d", len(state.pendingMessages), maxQueuedMessages)
+	if len(state.pendingMessages) != defaultMaxQueuedMessages {
+		t.Fatalf("queue depth = %d, want %d", len(state.pendingMessages), defaultMaxQueuedMessages)
 	}
 	state.mu.Unlock()
 
@@ -6616,10 +6616,10 @@ func TestQueueMessageOverflow_DropsOldestAndReturnsfalse(t *testing.T) {
 		t.Fatal("expected 6th message to be rejected (queue full)")
 	}
 
-	// Queue should still have exactly maxQueuedMessages items (the original 5).
+	// Queue should still have exactly defaultMaxQueuedMessages items (the original 5).
 	state.mu.Lock()
-	if len(state.pendingMessages) != maxQueuedMessages {
-		t.Fatalf("queue depth after overflow = %d, want %d", len(state.pendingMessages), maxQueuedMessages)
+	if len(state.pendingMessages) != defaultMaxQueuedMessages {
+		t.Fatalf("queue depth after overflow = %d, want %d", len(state.pendingMessages), defaultMaxQueuedMessages)
 	}
 	// First message should still be msg-0 (FIFO preserved, no silent drop).
 	if state.pendingMessages[0].content != "msg-0" {
@@ -6629,8 +6629,8 @@ func TestQueueMessageOverflow_DropsOldestAndReturnsfalse(t *testing.T) {
 
 	// Platform should have received the MsgMessageQueued replies for the 5 accepted + nothing for rejected.
 	sent := p.getSent()
-	if len(sent) != maxQueuedMessages {
-		t.Fatalf("platform replies = %d, want %d (one per accepted queue)", len(sent), maxQueuedMessages)
+	if len(sent) != defaultMaxQueuedMessages {
+		t.Fatalf("platform replies = %d, want %d (one per accepted queue)", len(sent), defaultMaxQueuedMessages)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -132,6 +132,7 @@ const (
 	MsgNoExecution               MsgKey = "no_execution"
 	MsgPreviousProcessing        MsgKey = "previous_processing"
 	MsgMessageQueued             MsgKey = "message_queued"
+	MsgQueueFull                 MsgKey = "queue_full"
 	MsgNoToolsAllowed            MsgKey = "no_tools_allowed"
 	MsgCurrentTools              MsgKey = "current_tools"
 	MsgCurrentSession            MsgKey = "current_session"
@@ -656,6 +657,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "📬 訊息已收到，將在目前任務完成後處理。",
 		LangJapanese:           "📬 メッセージを受信しました。現在のタスク完了後に処理します。",
 		LangSpanish:            "📬 Mensaje recibido — se procesará después de que termine la tarea actual.",
+	},
+	MsgQueueFull: {
+		LangEnglish:            "📭 Message queue is full — please try again shortly.",
+		LangChinese:            "📭 消息队列已满，请稍后再试。",
+		LangTraditionalChinese: "📭 訊息佇列已滿，請稍後再試。",
+		LangJapanese:           "📭 メッセージキューがいっぱいです。しばらくしてからもう一度お試しください。",
+		LangSpanish:            "📭 La cola de mensajes está llena — inténtalo de nuevo en breve.",
 	},
 	MsgNoToolsAllowed: {
 		LangEnglish:            "No tools pre-allowed.\nUsage: `/allow <tool_name>`\nExample: `/allow Bash`",


### PR DESCRIPTION
Closes #688.

## Summary

- Expose the per-session message queue cap as `[queue] max_depth` in `config.toml`. Default remains 5.
- Introduce a distinct `MsgQueueFull` reply so users see "Message queue is full — please try again shortly." when their message is actually rejected due to queue overflow, instead of the misleading "previous request still processing" used for session-busy-with-no-queue paths.

## Changes

| File | Change |
|------|--------|
| `config/config.go` | Add `QueueConfig{ MaxDepth *int }` and wire into `Config` |
| `config.example.toml` | Add commented `[queue]` example |
| `core/engine.go` | Rename `maxQueuedMessages` const → `defaultMaxQueuedMessages`, add `maxQueuedMessages int` field + `SetMaxQueuedMessages(n int)`, swap the overflow reply from `MsgPreviousProcessing` → `MsgQueueFull` |
| `core/i18n.go` | Add `MsgQueueFull` key with EN / ZH / ZH-TW / JA / ES translations |
| `cmd/cc-connect/main.go` | Call `engine.SetMaxQueuedMessages(*cfg.Queue.MaxDepth)` when configured |
| `core/engine_test.go` | Rename references to the renamed const (behavior unchanged) |

`MaxDepth` uses `*int` so `0`/missing is treated as "keep default", and negative values are no-ops (guarded in `SetMaxQueuedMessages`).

## Backward compatibility

No behavior change by default. Existing configs that don't set `[queue]` see the same cap of 5. Only the overflow reply message changes, and only when the queue is actually the bottleneck.

## Test plan

- [x] `go test ./... -tags no_web` — all packages pass (three pre-existing failures in `core` under `TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled`, `TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState`, `TestResolveLocalDirPath_AcceptsSubdir` are unrelated and reproduce on plain `main`).
- [x] Manual verification on Lark: with `[queue] max_depth = 20`, can queue >5 messages during a long-running turn; hitting the cap now replies with `MsgQueueFull`.