### PR TITLE
feat(core): make message queue depth configurable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,13 @@ npm install -g cc-connect
 After installation, the `cc-connect` binary will be available globally.
 
 
-### Option B: Download binary from GitHub Releases
+### Option B: Homebrew (macOS / Linux)
+
+```bash
+brew install cc-connect
+```
+
+### Option C: Download binary from GitHub Releases
 
 Go to https://github.com/chenhg5/cc-connect/releases and download the binary for your platform.
 
@@ -50,7 +56,7 @@ On macOS, you may need to remove the quarantine attribute:
 xattr -d com.apple.quarantine cc-connect
 ```
 
-### Option C: Build from source
+### Option D: Build from source
 
 Requires Go 1.22+.
 

--- a/README.md
+++ b/README.md
@@ -200,9 +200,13 @@ Follow https://raw.githubusercontent.com/chenhg5/cc-connect/refs/heads/main/INST
 **Via npm:**
 
 ```bash
-# Stable version
 npm install -g cc-connect
+```
 
+**Via Homebrew (macOS / Linux):**
+
+```bash
+brew install cc-connect
 ```
 
 **Download binary from [GitHub Releases](https://github.com/chenhg5/cc-connect/releases):**
@@ -252,6 +256,9 @@ When a user runs `/dir reset`, cc-connect restores the configured `work_dir` and
 ```bash
 # npm
 npm install -g cc-connect
+
+# Homebrew
+brew upgrade cc-connect
 
 # Binary self-update
 cc-connect update           # Stable

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -200,9 +200,13 @@ MiniMax M2.7 是 MiniMax 首个深度参与自我迭代的模型，可自主构�
 **通过 npm：**
 
 ```bash
-# 稳定版
-npm install -g cc-connect
+# npm install -g cc-connect
+```
 
+**通过 Homebrew（macOS / Linux）：**
+
+```bash
+brew install cc-connect
 ```
 
 **从 [GitHub Releases](https://github.com/chenhg5/cc-connect/releases) 下载：**
@@ -252,6 +256,9 @@ vim ~/.cc-connect/config.toml
 ```bash
 # npm
 npm install -g cc-connect
+
+# Homebrew
+brew upgrade cc-connect
 
 # 二进制自更新
 cc-connect update           # 稳定版

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -468,6 +468,11 @@ func main() {
 			}
 		}
 
+		// Wire queue depth
+		if cfg.Queue.MaxDepth != nil && *cfg.Queue.MaxDepth > 0 {
+			engine.SetMaxQueuedMessages(*cfg.Queue.MaxDepth)
+		}
+
 		// Wire auto-compress settings
 		if proj.AutoCompress.Enabled != nil && *proj.AutoCompress.Enabled {
 			minGap := 30 * time.Minute

--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,7 @@ type Config struct {
 	OutgoingRateLimit OutgoingRateLimitConfig `toml:"outgoing_rate_limit"` // outgoing message throttling
 	Relay             RelayConfig             `toml:"relay"`               // bot-to-bot relay behavior
 	Cron              CronConfig              `toml:"cron"`
+	Queue             QueueConfig             `toml:"queue"`
 	Webhook           WebhookConfig           `toml:"webhook"`
 	Bridge            BridgeConfig            `toml:"bridge"`
 	Management        ManagementConfig        `toml:"management"`
@@ -115,6 +116,11 @@ type Config struct {
 type CronConfig struct {
 	Silent      *bool  `toml:"silent"`       // suppress cron start notification; default false
 	SessionMode string `toml:"session_mode"` // default session mode: "" or "reuse" (default) or "new_per_run"
+}
+
+// QueueConfig controls the per-session message queue.
+type QueueConfig struct {
+	MaxDepth *int `toml:"max_depth"` // max queued messages per session; default 5
 }
 
 // WebhookConfig controls the external HTTP webhook endpoint.
@@ -2837,6 +2843,12 @@ func GetGlobalSettings() map[string]any {
 		rlWindow = *cfg.RateLimit.WindowSecs
 	}
 	result["rate_limit_window_secs"] = rlWindow
+	// Queue
+	queueMax := 5
+	if cfg.Queue.MaxDepth != nil {
+		queueMax = *cfg.Queue.MaxDepth
+	}
+	result["queue_max_depth"] = queueMax
 	return result
 }
 
@@ -2854,6 +2866,7 @@ type GlobalSettingsUpdate struct {
 	StreamPreviewIntMs *int    `json:"stream_preview_interval_ms"`
 	RateLimitMax       *int    `json:"rate_limit_max_messages"`
 	RateLimitWindow    *int    `json:"rate_limit_window_secs"`
+	QueueMaxDepth      *int    `json:"queue_max_depth"`
 }
 
 // SaveGlobalSettings persists global settings to config.toml.
@@ -2906,6 +2919,9 @@ func SaveGlobalSettings(u GlobalSettingsUpdate) error {
 	}
 	if u.RateLimitWindow != nil {
 		cfg.RateLimit.WindowSecs = u.RateLimitWindow
+	}
+	if u.QueueMaxDepth != nil {
+		cfg.Queue.MaxDepth = u.QueueMaxDepth
 	}
 	return saveConfig(cfg)
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -25,7 +25,7 @@ import (
 
 const maxPlatformMessageLen = 4000
 const telegramBotCommandLimit = 100
-const maxQueuedMessages = 5 // cap queued messages to bound memory usage
+const defaultMaxQueuedMessages = 5 // default cap for queued messages per session
 
 const (
 	defaultThinkingMaxLen = 300
@@ -203,6 +203,7 @@ type Engine struct {
 	references       ReferenceRenderCfg
 	relayManager     *RelayManager
 	eventIdleTimeout time.Duration
+	maxQueuedMessages int
 	dirHistory       *DirHistory
 	baseWorkDir      string
 	projectState     *ProjectStateStore
@@ -386,6 +387,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		streamPreview:         DefaultStreamPreviewCfg(),
 		references:            DefaultReferenceRenderCfg(),
 		eventIdleTimeout:      defaultEventIdleTimeout,
+		maxQueuedMessages:    defaultMaxQueuedMessages,
 		showContextIndicator:  true,
 	}
 
@@ -858,6 +860,14 @@ func (e *Engine) SetStreamPreviewCfg(cfg StreamPreviewCfg) {
 // 0 disables the timeout entirely.
 func (e *Engine) SetEventIdleTimeout(d time.Duration) {
 	e.eventIdleTimeout = d
+}
+
+// SetMaxQueuedMessages sets the per-session message queue depth.
+// Values <= 0 are ignored.
+func (e *Engine) SetMaxQueuedMessages(n int) {
+	if n > 0 {
+		e.maxQueuedMessages = n
+	}
 }
 
 func (e *Engine) SetRelayManager(rm *RelayManager) {
@@ -1732,9 +1742,11 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 	// EventResult that never arrives. Instead, the event loop sends the
 	// message after the current turn's EventResult is received.
 	state.mu.Lock()
-	if len(state.pendingMessages) >= maxQueuedMessages {
+	if len(state.pendingMessages) >= e.maxQueuedMessages {
+		depth := len(state.pendingMessages)
 		state.mu.Unlock()
-		return false // fall back to "previous processing" reply
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgQueueFull), depth))
+		return true // handled: queue-full reply sent
 	}
 	state.pendingMessages = append(state.pendingMessages, queuedMessage{
 		platform:      p,

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6594,8 +6594,8 @@ func TestQueueMessageOverflow_DropsOldestAndReturnsfalse(t *testing.T) {
 	e.interactiveStates[key] = state
 	e.interactiveMu.Unlock()
 
-	// Fill the queue to maxQueuedMessages (5).
-	for i := 0; i < maxQueuedMessages; i++ {
+	// Fill the queue to defaultMaxQueuedMessages (5).
+	for i := 0; i < defaultMaxQueuedMessages; i++ {
 		msg := &Message{SessionKey: key, Content: fmt.Sprintf("msg-%d", i), ReplyCtx: fmt.Sprintf("ctx-%d", i)}
 		ok := e.queueMessageForBusySession(p, msg, key)
 		if !ok {
@@ -6604,22 +6604,22 @@ func TestQueueMessageOverflow_DropsOldestAndReturnsfalse(t *testing.T) {
 	}
 
 	state.mu.Lock()
-	if len(state.pendingMessages) != maxQueuedMessages {
-		t.Fatalf("queue depth = %d, want %d", len(state.pendingMessages), maxQueuedMessages)
+	if len(state.pendingMessages) != defaultMaxQueuedMessages {
+		t.Fatalf("queue depth = %d, want %d", len(state.pendingMessages), defaultMaxQueuedMessages)
 	}
 	state.mu.Unlock()
 
-	// The 6th message should be rejected (returns false).
+	// The 6th message should be handled (returns true) but not queued — MsgQueueFull sent.
 	overflow := &Message{SessionKey: key, Content: "msg-overflow", ReplyCtx: "ctx-overflow"}
 	ok := e.queueMessageForBusySession(p, overflow, key)
-	if ok {
-		t.Fatal("expected 6th message to be rejected (queue full)")
+	if !ok {
+		t.Fatal("expected 6th message to be handled (queue-full reply), got false")
 	}
 
-	// Queue should still have exactly maxQueuedMessages items (the original 5).
+	// Queue should still have exactly defaultMaxQueuedMessages items (the original 5).
 	state.mu.Lock()
-	if len(state.pendingMessages) != maxQueuedMessages {
-		t.Fatalf("queue depth after overflow = %d, want %d", len(state.pendingMessages), maxQueuedMessages)
+	if len(state.pendingMessages) != defaultMaxQueuedMessages {
+		t.Fatalf("queue depth after overflow = %d, want %d", len(state.pendingMessages), defaultMaxQueuedMessages)
 	}
 	// First message should still be msg-0 (FIFO preserved, no silent drop).
 	if state.pendingMessages[0].content != "msg-0" {
@@ -6627,10 +6627,10 @@ func TestQueueMessageOverflow_DropsOldestAndReturnsfalse(t *testing.T) {
 	}
 	state.mu.Unlock()
 
-	// Platform should have received the MsgMessageQueued replies for the 5 accepted + nothing for rejected.
+	// Platform should have received MsgMessageQueued for 5 accepted + MsgQueueFull for the overflow.
 	sent := p.getSent()
-	if len(sent) != maxQueuedMessages {
-		t.Fatalf("platform replies = %d, want %d (one per accepted queue)", len(sent), maxQueuedMessages)
+	if len(sent) != defaultMaxQueuedMessages+1 {
+		t.Fatalf("platform replies = %d, want %d (queued + queue-full)", len(sent), defaultMaxQueuedMessages+1)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -131,6 +131,7 @@ const (
 	MsgExecutionStopped          MsgKey = "execution_stopped"
 	MsgNoExecution               MsgKey = "no_execution"
 	MsgPreviousProcessing        MsgKey = "previous_processing"
+	MsgQueueFull                 MsgKey = "queue_full"
 	MsgMessageQueued             MsgKey = "message_queued"
 	MsgNoToolsAllowed            MsgKey = "no_tools_allowed"
 	MsgCurrentTools              MsgKey = "current_tools"
@@ -656,6 +657,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "📬 訊息已收到，將在目前任務完成後處理。",
 		LangJapanese:           "📬 メッセージを受信しました。現在のタスク完了後に処理します。",
 		LangSpanish:            "📬 Mensaje recibido — se procesará después de que termine la tarea actual.",
+	},
+	MsgQueueFull: {
+		LangEnglish:            "📬 Message queue is full (%d pending). Please wait for current tasks to complete.",
+		LangChinese:            "📬 消息队列已满（%d 条待处理）。请等待当前任务完成。",
+		LangTraditionalChinese: "📬 訊息佇列已滿（%d 則待處理）。請等待目前任務完成。",
+		LangJapanese:           "📬 メッセージキューが満杯です（%d 件待ち）。現在のタスク完了をお待ちください。",
+		LangSpanish:            "📬 La cola de mensajes está llena (%d pendientes). Espere a que las tareas actuales se completen.",
 	},
 	MsgNoToolsAllowed: {
 		LangEnglish:            "No tools pre-allowed.\nUsage: `/allow <tool_name>`\nExample: `/allow Bash`",


### PR DESCRIPTION
## Summary
- Add `[queue] max_depth` config option to control per-session message queue depth (default: 5)
- Replace misleading `MsgPreviousProcessing` with new `MsgQueueFull` message when queue is full, showing current pending count
- Add `Engine.SetMaxQueuedMessages()` setter and wire through `cmd/cc-connect/main.go`
- Add `MsgQueueFull` i18n translations for all 5 languages (EN, ZH, ZH-TW, JA, ES)

### Config example
```toml
[queue]
max_depth = 10
```

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Existing queue overflow test updated for new behavior

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)