### PR TITLE
fix(gemini): pass prompt via stdin to preserve newlines

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,13 @@ npm install -g cc-connect
 After installation, the `cc-connect` binary will be available globally.
 
 
-### Option B: Download binary from GitHub Releases
+### Option B: Homebrew (macOS / Linux)
+
+```bash
+brew install cc-connect
+```
+
+### Option C: Download binary from GitHub Releases
 
 Go to https://github.com/chenhg5/cc-connect/releases and download the binary for your platform.
 
@@ -50,7 +56,7 @@ On macOS, you may need to remove the quarantine attribute:
 xattr -d com.apple.quarantine cc-connect
 ```
 
-### Option C: Build from source
+### Option D: Build from source
 
 Requires Go 1.22+.
 

--- a/README.md
+++ b/README.md
@@ -200,9 +200,13 @@ Follow https://raw.githubusercontent.com/chenhg5/cc-connect/refs/heads/main/INST
 **Via npm:**
 
 ```bash
-# Stable version
 npm install -g cc-connect
+```
 
+**Via Homebrew (macOS / Linux):**
+
+```bash
+brew install cc-connect
 ```
 
 **Download binary from [GitHub Releases](https://github.com/chenhg5/cc-connect/releases):**
@@ -252,6 +256,9 @@ When a user runs `/dir reset`, cc-connect restores the configured `work_dir` and
 ```bash
 # npm
 npm install -g cc-connect
+
+# Homebrew
+brew upgrade cc-connect
 
 # Binary self-update
 cc-connect update           # Stable

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -200,9 +200,13 @@ MiniMax M2.7 是 MiniMax 首个深度参与自我迭代的模型，可自主构�
 **通过 npm：**
 
 ```bash
-# 稳定版
-npm install -g cc-connect
+# npm install -g cc-connect
+```
 
+**通过 Homebrew（macOS / Linux）：**
+
+```bash
+brew install cc-connect
 ```
 
 **从 [GitHub Releases](https://github.com/chenhg5/cc-connect/releases) 下载：**
@@ -252,6 +256,9 @@ vim ~/.cc-connect/config.toml
 ```bash
 # npm
 npm install -g cc-connect
+
+# Homebrew
+brew upgrade cc-connect
 
 # 二进制自更新
 cc-connect update           # 稳定版

--- a/agent/gemini/session.go
+++ b/agent/gemini/session.go
@@ -21,8 +21,9 @@ import (
 )
 
 // geminiSession manages multi-turn conversations with the Gemini CLI.
-// Each Send() launches a new `gemini -p ... --output-format stream-json` process
-// with --resume for conversation continuity.
+// Each Send() launches a new `gemini -p - --output-format stream-json` process
+// with --resume for conversation continuity. The prompt is passed via stdin
+// (using -p - flag) to preserve newlines in multi-line messages.
 type geminiSession struct {
 	cmd      string
 	workDir  string
@@ -146,7 +147,9 @@ func (gs *geminiSession) Send(prompt string, images []core.ImageAttachment, file
 		fullPrompt += "\n\n[Attached files saved at: " + strings.Join(fileRefs, ", ") + "]"
 	}
 
-	args = append(args, "-p", fullPrompt)
+	// Pass prompt via stdin instead of -p flag to preserve newlines.
+	// The -p flag can truncate at newline characters in some Gemini CLI versions.
+	args = append(args, "-p", "-")
 
 	// Add timeout for each turn to prevent hanging processes
 	var cancel context.CancelFunc
@@ -175,6 +178,7 @@ func (gs *geminiSession) Send(prompt string, images []core.ImageAttachment, file
 		env = core.MergeEnv(env, gs.extraEnv)
 	}
 	cmd.Env = env
+	cmd.Stdin = strings.NewReader(fullPrompt)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fix newline truncation when using Gemini CLI with Telegram (or any platform sending multi-line messages)
- Root cause: `-p <prompt>` CLI flag truncates at newline characters in some Gemini CLI versions
- Fix: pass prompt via stdin using `-p -` flag, matching the pattern used by the Codex agent (`cmd.Stdin = strings.NewReader(prompt)`)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 25 packages)
- [ ] Manual: send multi-line message via Telegram to Gemini agent, verify full content is received

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)