### PR TITLE
fix(feishu): skip bot open_id fetch in webhook mode for private deplo…

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -290,11 +290,18 @@ func (p *Platform) KeepPreviewOnFinish() bool {
 func (p *Platform) Start(handler core.MessageHandler) error {
 	p.handler = handler
 
-	if openID, err := p.fetchBotOpenID(); err != nil {
-		slog.Warn(p.platformName+": failed to get bot open_id, group chat filtering disabled", "error", err)
-	} else {
-		p.botOpenID = openID
-		slog.Info(p.platformName+": bot identified", "open_id", openID)
+	// In webhook mode (private/self-hosted Feishu/Lark), startup must not depend
+	// on a successful bot-info API call. Older private deployments may not support
+	// the same auth/bootstrap flow as the public SDK path, but the webhook server
+	// can still receive events and operate correctly. We therefore only attempt
+	// bot open_id discovery eagerly for WebSocket mode.
+	if !p.shouldUseWebhookMode() {
+		if openID, err := p.fetchBotOpenID(); err != nil {
+			slog.Warn(p.platformName+": failed to get bot open_id, group chat filtering disabled", "error", err)
+		} else {
+			p.botOpenID = openID
+			slog.Info(p.platformName+": bot identified", "open_id", openID)
+		}
 	}
 
 	p.eventHandler = dispatcher.NewEventDispatcher("", p.encryptKey).


### PR DESCRIPTION
…yments

In webhook mode with private/self-hosted Feishu deployments, the bot open_id API call may fail due to different auth flows or API support. This failure previously prevented the webhook server from starting.

This change defers bot open_id discovery to WebSocket mode only, allowing webhook mode to start successfully even when the bot info API is unavailable. The webhook server can still receive and process events correctly without the bot open_id (it's only used for group chat filtering).

Fixes compatibility with older private Feishu/Lark deployments that use webhook mode with custom domains.