### PR TITLE
fix(core): suppress reply footer when only workdir is known

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -4101,21 +4101,26 @@ func (e *Engine) buildReplyFooter(agent Agent, session AgentSession, workspaceDi
 	}
 
 	var parts []string
+	hasStatus := false
 	if model := replyFooterModel(session, agent); model != "" {
 		parts = append(parts, model)
+		hasStatus = true
 	}
 	if effort := replyFooterReasoningEffort(session, agent); effort != "" {
 		parts = append(parts, effort)
+		hasStatus = true
 	}
 	if left := strings.TrimSpace(contextLeft); left != "" {
 		parts = append(parts, left)
+		hasStatus = true
 	} else if usage := e.replyFooterUsageText(session, agent); usage != "" {
 		parts = append(parts, usage)
+		hasStatus = true
 	}
 	if dir := replyFooterWorkDir(session, agent, workspaceDir); dir != "" {
 		parts = append(parts, dir)
 	}
-	if len(parts) == 0 {
+	if !hasStatus {
 		return ""
 	}
 	return strings.Join(parts, " · ")

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1156,6 +1156,42 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 	}
 }
 
+// Regression: an agent that only exposes a workdir (no model/effort/usage)
+// must not emit a footer at all. Previously this produced a footer like
+// "*~*" when the agent was running in the user's home directory, which
+// rendered as a bare "~" on Feishu/Weixin.
+func TestProcessInteractiveEvents_SuppressesReplyFooterWhenOnlyWorkDir(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	agent := &stubWorkDirAgent{workDir: homeDir}
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetReplyFooterEnabled(true)
+
+	sessionKey := "telegram:user-footer-workdir-only"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-footer-workdir-only")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-footer-workdir-only",
+		agent:        agent,
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "answer", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-workdir-only", time.Now(), nil, nil, state.replyCtx)
+
+	sent := p.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent = %#v, want one final reply", sent)
+	}
+	if sent[0] != "answer" {
+		t.Fatalf("final reply = %q, want plain answer without footer", sent[0])
+	}
+}
+
 func TestProcessInteractiveEvents_HiddenToolProgressKeepsPreviewOnFinalize(t *testing.T) {
 	p := &mockKeepPreviewPlatform{}
 	p.n = "feishu"


### PR DESCRIPTION
## Summary

Fixes a regression introduced in v1.3.0 where assistant replies end with a bare `~` on Feishu and Weixin (personal WeChat).

## Root cause

`buildReplyFooter` assembles up to four parts: model, reasoning effort, context remaining / usage, and workdir.

The `claudecode` agent does not implement the optional `GetModel`, `GetReasoningEffort`, or `UsageReporter` interfaces, so those three parts are always empty for it. When the workdir also happens to equal `\$HOME`, `compactReplyFooterPath` compacts it to `"~"`, leaving `parts = ["~"]` and producing the footer string `"~"`.

`appendReplyFooter` then wraps it in Markdown italics: `content + "\n\n*~*"`. On Feishu this is rendered via the rich-text post builder (which strips the italic markers and keeps the content), and on Weixin ilink the `*...*` pair is stripped by the client. In both cases the user sees a lone `~` on its own line below every reply.

## Fix

Only emit the footer when at least one status-carrying part (model, reasoning effort, context remaining, or usage) is populated. A bare workdir is not useful status information, and when combined with the `$HOME`-compaction above it actively creates a visible rendering bug.

## Repro

1. Configure a project that uses the `claudecode` agent and `work_dir = "$HOME"`.
2. Connect the project to a Feishu or Weixin platform.
3. Send any message to the bot.
4. Observe that every reply ends with a standalone `~` on a new line.

After this fix, no footer is emitted in that scenario (the user still sees the plain reply).

## Testing

- Added `TestProcessInteractiveEvents_SuppressesReplyFooterWhenOnlyWorkDir` in `core/engine_test.go` covering an agent that only exposes `GetWorkDir()` and runs in `$HOME`.
- Existing reply-footer tests (`…_AppendsReplyFooterWhenEnabled`, `…_DoesNotAppendReplyFooterWhenDisabled`, `…_ReplyFooterPrefersSessionRuntimeState`) still exercise the full-footer path.
- `go vet ./core/` clean; `gofmt` clean.

Note: two pre-existing reply-footer tests and `TestResolveLocalDirPath_AcceptsSubdir` fail on `main` on macOS due to `/private/var` vs `/var` symlink handling in `t.TempDir()` — unrelated to this change (verified by running the same tests on `main` before applying the fix).