### PR TITLE
fix(claudecode): encode spaces and "~" in project keys (#500)

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -1096,7 +1096,9 @@ func boolVal(m map[string]any, key string) bool {
 // 1. Replacing path separators (/ or \) with "-"
 // 2. Replacing colons (:) with "-" (Windows drive letters)
 // 3. Replacing underscores (_) with "-"
-// 4. Replacing all non-ASCII characters with "-"
+// 4. Replacing spaces and tildes (~) with "-" (common in macOS iCloud paths like
+//    "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/...")
+// 5. Replacing all non-ASCII characters with "-"
 func encodeClaudeProjectKey(absPath string) string {
 	// First, normalize to forward slashes for consistent processing
 	normalized := strings.ReplaceAll(absPath, "\\", "/")
@@ -1104,7 +1106,7 @@ func encodeClaudeProjectKey(absPath string) string {
 	// Build the encoded key character by character
 	var result strings.Builder
 	for _, r := range normalized {
-		if r == '/' || r == ':' || r == '_' {
+		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' {
 			result.WriteRune('-')
 		} else if r < 128 { // ASCII range (0-127)
 			result.WriteRune(r)

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -386,6 +386,21 @@ func TestEncodeClaudeProjectKey(t *testing.T) {
 			expected: "-Users-username-my-project",
 		},
 		{
+			name:     "path with spaces",
+			input:    "/Users/username/Mobile Documents/my project",
+			expected: "-Users-username-Mobile-Documents-my-project",
+		},
+		{
+			name:     "path with tildes",
+			input:    "/Users/username/com~apple~CloudDocs/project",
+			expected: "-Users-username-com-apple-CloudDocs-project",
+		},
+		{
+			name:     "iCloud path with spaces and tildes",
+			input:    "/Users/username/Library/Mobile Documents/com~apple~CloudDocs/my project",
+			expected: "-Users-username-Library-Mobile-Documents-com-apple-CloudDocs-my-project",
+		},
+		{
 			name:     "mixed ASCII and non-ASCII",
 			input:    "/Users/username/中文folder/english文件夹",
 			expected: "-Users-username---folder-english---", // "/中文" = 3 hyphens, "/文件夹" = 4 hyphens
@@ -457,5 +472,28 @@ func TestFindProjectDir_NotFound(t *testing.T) {
 	found := findProjectDir(homeDir, workDir)
 	if found != "" {
 		t.Errorf("findProjectDir for nonexistent project = %q, want empty string", found)
+	}
+}
+
+func TestFindProjectDir_ICloudPath(t *testing.T) {
+	// Regression for issue #500: paths containing spaces and "~" (common in macOS
+	// iCloud Drive paths like "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/...")
+	// must match the on-disk project key that Claude Code CLI generates, which
+	// collapses both spaces and "~" to "-".
+	homeDir := t.TempDir()
+	projectsBase := filepath.Join(homeDir, ".claude", "projects")
+
+	iCloudWorkDir := "/Users/test/Library/Mobile Documents/com~apple~CloudDocs/my project"
+	// The on-disk key Claude Code CLI actually writes (spaces and "~" → "-").
+	expectedKey := "-Users-test-Library-Mobile-Documents-com-apple-CloudDocs-my-project"
+
+	mockProjectDir := filepath.Join(projectsBase, expectedKey)
+	if err := os.MkdirAll(mockProjectDir, 0755); err != nil {
+		t.Fatalf("failed to create mock project dir: %v", err)
+	}
+
+	found := findProjectDir(homeDir, iCloudWorkDir)
+	if found != mockProjectDir {
+		t.Errorf("findProjectDir(%q, %q) = %q, want %q", homeDir, iCloudWorkDir, found, mockProjectDir)
 	}
 }


### PR DESCRIPTION
## Summary

`encodeClaudeProjectKey` in [agent/claudecode/claudecode.go](https://github.com/chenhg5/cc-connect/blob/main/agent/claudecode/claudecode.go#L1094) only collapses `/`, `:`, `_`, and non-ASCII characters to `-`, but Claude Code CLI's on-disk project keys under `~/.claude/projects/` also collapse **spaces** and **`~`** to `-`. As a result, on macOS any work dir that lives inside iCloud Drive — e.g.

```
/Users/<me>/Library/Mobile Documents/com~apple~CloudDocs/<project>
```

produces the candidate key

```
-Users-<me>-Library-Mobile Documents-com~apple~CloudDocs-<project>
```

while Claude Code actually wrote the directory

```
-Users-<me>-Library-Mobile-Documents-com-apple-CloudDocs-<project>
```

The primary lookup misses; all three legacy candidates in `findProjectDir` use only `/ \ : _` replacements so they also miss; and the fallback `ReadDir` scan compares against `encodeClaudeProjectKey(absWorkDir)` too, so it misses as well. `findProjectDir` returns `""`, `ListSessions` returns `nil`, and Feishu / Telegram `/list` permanently shows `(0) 未找到此项目的会话`.

## Fix

Extend the replacement set in `encodeClaudeProjectKey` to also collapse `' '` and `'~'` to `'-'`. The function is the single source of truth — both the primary candidate and the fallback scan go through it, so one edit fixes both paths.

Docstring updated to list the iCloud-path rationale.

## Tests

`go test ./agent/claudecode/ -run 'TestEncodeClaudeProjectKey|TestFindProjectDir' -v` — all pass, including three new `TestEncodeClaudeProjectKey` cases and a new `TestFindProjectDir_ICloudPath` regression test:

- `path with spaces`
- `path with tildes`
- `iCloud path with spaces and tildes`
- `TestFindProjectDir_ICloudPath` — creates a mock `~/.claude/projects/-Users-test-Library-Mobile-Documents-com-apple-CloudDocs-my-project/` and asserts `findProjectDir` resolves the iCloud-style work dir to it

All pre-existing test cases still pass unchanged.

## Scope note

This PR fixes the macOS iCloud variant of the broader "encoded key doesn't match on-disk dir" problem reported in #500. The reporter there is on Windows 11, so their specific case may involve additional characters (drive letters, backslashes) that this PR does not touch — but the root cause ("encoder diverges from Claude Code CLI's real encoding") is shared, and the macOS iCloud case is likely to be reported identically given how common `com~apple~CloudDocs` paths are. Happy to narrow or broaden the scope based on maintainer preference.

Refs #500

## Test plan

- [x] `go test ./agent/claudecode/ -run 'TestEncodeClaudeProjectKey|TestFindProjectDir' -v` — all pass
- [x] `go test ./agent/claudecode/` — full package passes
- [x] Manual: on macOS with work dir under iCloud Drive, confirmed (before this fix) that `/list` returned empty despite `~/.claude/projects/-Users-...-Mobile-Documents-com-apple-CloudDocs-...` existing with valid `.jsonl` session files