### PR TITLE
fix(bridge): implement ImageSender and FileSender interfaces

### DIFF
--- a/core/bridge.go
+++ b/core/bridge.go
@@ -292,6 +292,8 @@ var (
 	_ PreviewCleaner            = (*BridgePlatform)(nil)
 	_ TypingIndicator           = (*BridgePlatform)(nil)
 	_ AudioSender               = (*BridgePlatform)(nil)
+	_ ImageSender               = (*BridgePlatform)(nil)
+	_ FileSender                = (*BridgePlatform)(nil)
 	_ CardNavigable             = (*BridgePlatform)(nil)
 	_ ReplyContextReconstructor = (*BridgePlatform)(nil)
 )
@@ -600,6 +602,44 @@ func (bp *BridgePlatform) SendAudio(ctx context.Context, replyCtx any, audio []b
 		"reply_ctx":   rc.ReplyCtx,
 		"data":        base64.StdEncoding.EncodeToString(audio),
 		"format":      format,
+	})
+}
+
+func (bp *BridgePlatform) SendImage(ctx context.Context, replyCtx any, img ImageAttachment) error {
+	rc, ok := replyCtx.(*bridgeReplyCtx)
+	if !ok {
+		return fmt.Errorf("bridge: invalid reply context")
+	}
+	a := bp.server.getAdapter(rc.Platform)
+	if a == nil || !a.capabilities["image"] {
+		return ErrNotSupported
+	}
+	return bp.server.sendToAdapter(rc.Platform, map[string]any{
+		"type":        "image",
+		"session_key": rc.SessionKey,
+		"reply_ctx":   rc.ReplyCtx,
+		"data":        base64.StdEncoding.EncodeToString(img.Data),
+		"mime_type":   img.MimeType,
+		"file_name":   img.FileName,
+	})
+}
+
+func (bp *BridgePlatform) SendFile(ctx context.Context, replyCtx any, file FileAttachment) error {
+	rc, ok := replyCtx.(*bridgeReplyCtx)
+	if !ok {
+		return fmt.Errorf("bridge: invalid reply context")
+	}
+	a := bp.server.getAdapter(rc.Platform)
+	if a == nil || !a.capabilities["file"] {
+		return ErrNotSupported
+	}
+	return bp.server.sendToAdapter(rc.Platform, map[string]any{
+		"type":        "file",
+		"session_key": rc.SessionKey,
+		"reply_ctx":   rc.ReplyCtx,
+		"data":        base64.StdEncoding.EncodeToString(file.Data),
+		"mime_type":   file.MimeType,
+		"file_name":   file.FileName,
 	})
 }
 

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -405,6 +405,36 @@ Send a voice/audio message. Only sent if the adapter declared `"audio"` capabili
 }
 ```
 
+#### `image`
+
+Send an image to the user. Only sent if the adapter declared `"image"` capability.
+
+```json
+{
+  "type": "image",
+  "session_key": "wechat:user123:user123",
+  "reply_ctx": "conv-abc-123",
+  "data": "<base64-encoded-image>",
+  "mime_type": "image/png",
+  "file_name": "screenshot.png"
+}
+```
+
+#### `file`
+
+Send a file to the user. Only sent if the adapter declared `"file"` capability.
+
+```json
+{
+  "type": "file",
+  "session_key": "wechat:user123:user123",
+  "reply_ctx": "conv-abc-123",
+  "data": "<base64-encoded-file>",
+  "mime_type": "application/pdf",
+  "file_name": "report.pdf"
+}
+```
+
 #### `pong`
 
 Response to `ping`.
@@ -437,8 +467,8 @@ Notify the adapter of a server-side error.
 | Capability | Description | Enables |
 |------------|-------------|---------|
 | `text` | Basic text messaging (required) | `message`, `reply` |
-| `image` | Receiving images from users | `message.images` |
-| `file` | Receiving files from users | `message.files` |
+| `image` | Sending/receiving images | `message.images`, `image` reply |
+| `file` | Sending/receiving files | `message.files`, `file` reply |
 | `audio` | Sending/receiving voice messages | `message.audio`, `audio` reply |
 | `card` | Structured rich card rendering | `card` reply |
 | `buttons` | Inline clickable buttons | `buttons` reply, `card_action` |

--- a/docs/bridge-protocol.zh-CN.md
+++ b/docs/bridge-protocol.zh-CN.md
@@ -405,6 +405,36 @@ token = "your-secret"     # 认证密钥，必填
 }
 ```
 
+#### `image`
+
+发送图片给用户。仅在适配器声明了 `"image"` 能力时发送。
+
+```json
+{
+  "type": "image",
+  "session_key": "wechat:user123:user123",
+  "reply_ctx": "conv-abc-123",
+  "data": "<base64 编码的图片数据>",
+  "mime_type": "image/png",
+  "file_name": "screenshot.png"
+}
+```
+
+#### `file`
+
+发送文件给用户。仅在适配器声明了 `"file"` 能力时发送。
+
+```json
+{
+  "type": "file",
+  "session_key": "wechat:user123:user123",
+  "reply_ctx": "conv-abc-123",
+  "data": "<base64 编码的文件数据>",
+  "mime_type": "application/pdf",
+  "file_name": "report.pdf"
+}
+```
+
 #### `pong`
 
 对 `ping` 的回应。
@@ -437,8 +467,8 @@ token = "your-secret"     # 认证密钥，必填
 | 能力 | 说明 | 启用的消息类型 |
 |------|------|--------------|
 | `text` | 基础文本消息（必须） | `message`、`reply` |
-| `image` | 接收用户发送的图片 | `message.images` |
-| `file` | 接收用户发送的文件 | `message.files` |
+| `image` | 收发图片 | `message.images`、`image` 回复 |
+| `file` | 收发文件 | `message.files`、`file` 回复 |
 | `audio` | 收发语音消息 | `message.audio`、`audio` 回复 |
 | `card` | 结构化富卡片渲染 | `card` 回复 |
 | `buttons` | 可点击的内联按钮 | `buttons` 回复、`card_action` |


### PR DESCRIPTION
## Summary
- Add `SendImage` and `SendFile` methods to `BridgePlatform`, following the existing `SendAudio` pattern
- Add compile-time interface checks for `ImageSender` and `FileSender`
- Update bridge protocol docs (EN + ZH-CN) with `image` and `file` outgoing message types
- Update capabilities table to reflect that `image`/`file` now support both sending and receiving

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 25 packages OK)
- [ ] Manual: bridge adapter declaring `"image"` capability receives image messages
- [ ] Manual: bridge adapter declaring `"file"` capability receives file messages

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)