### PR TITLE
fix(daemon): handle macOS launchd gui and background sessions

### DIFF
--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -16,6 +16,12 @@ const (
 	launchdLabel = "com.cc-connect.service"
 )
 
+var runLaunchctl = func(args ...string) (string, error) {
+	cmd := exec.Command("launchctl", args...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
 type launchdManager struct{}
 
 func newPlatformManager() (Manager, error) {
@@ -34,28 +40,28 @@ func (m *launchdManager) Install(cfg Config) error {
 		return fmt.Errorf("create log dir: %w", err)
 	}
 
-	// Unload existing service first (ignore errors)
-	_ = exec.Command("launchctl", "bootout", fmt.Sprintf("gui/%d/%s", os.Getuid(), launchdLabel)).Run()
+	// Unload existing service first (ignore errors) so we do not leave a stale
+	// job behind when switching between GUI and headless sessions.
+	bootoutLaunchdTargets()
 
 	plist := buildPlist(cfg)
 	if err := os.WriteFile(plistPath, []byte(plist), 0644); err != nil {
 		return fmt.Errorf("write plist: %w", err)
 	}
 
-	domain := fmt.Sprintf("gui/%d", os.Getuid())
+	domain := preferredLaunchdDomain()
 	if out, err := runLaunchctl("bootstrap", domain, plistPath); err != nil {
 		return fmt.Errorf("launchctl bootstrap: %s (%w)", out, err)
 	}
 
-	if _, err := runLaunchctl("kickstart", "-kp", fmt.Sprintf("%s/%s", domain, launchdLabel)); err != nil {
+	if _, err := runLaunchctl("kickstart", "-kp", launchdTarget(domain)); err != nil {
 		return fmt.Errorf("launchctl kickstart: %w", err)
 	}
 	return nil
 }
 
 func (m *launchdManager) Uninstall() error {
-	domain := fmt.Sprintf("gui/%d", os.Getuid())
-	_, _ = runLaunchctl("bootout", fmt.Sprintf("%s/%s", domain, launchdLabel))
+	bootoutLaunchdTargets()
 
 	plistPath := launchdPlistPath()
 	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
@@ -65,12 +71,20 @@ func (m *launchdManager) Uninstall() error {
 }
 
 func (*launchdManager) Start() error {
-	domain := fmt.Sprintf("gui/%d", os.Getuid())
+	if _, target, _, ok := loadedLaunchdTarget(); ok {
+		out, err := runLaunchctl("kickstart", "-kp", target)
+		if err != nil {
+			return fmt.Errorf("start: %s (%w)", out, err)
+		}
+		return nil
+	}
+
+	domain := preferredLaunchdDomain()
 	plistPath := launchdPlistPath()
 	var out string
 	if _, err := runLaunchctl("bootstrap", domain, plistPath); err != nil {
 		// already bootstrapped — try kickstart
-		out, err = runLaunchctl("kickstart", "-kp", fmt.Sprintf("%s/%s", domain, launchdLabel))
+		out, err = runLaunchctl("kickstart", "-kp", launchdTarget(domain))
 		if err != nil {
 			return fmt.Errorf("start: %s (%w)", out, err)
 		}
@@ -79,18 +93,29 @@ func (*launchdManager) Start() error {
 }
 
 func (*launchdManager) Stop() error {
-	domain := fmt.Sprintf("gui/%d", os.Getuid())
-	out, err := runLaunchctl("bootout", fmt.Sprintf("%s/%s", domain, launchdLabel))
-	if err != nil {
-		return fmt.Errorf("stop: %s (%w)", out, err)
+	var lastOut string
+	var lastErr error
+	for _, target := range launchdTargets() {
+		out, err := runLaunchctl("bootout", target)
+		if err == nil {
+			return nil
+		}
+		lastOut = out
+		lastErr = err
+	}
+	if lastErr != nil {
+		return fmt.Errorf("stop: %s (%w)", lastOut, lastErr)
 	}
 	return nil
 }
 
 func (*launchdManager) Restart() error {
-	domain := fmt.Sprintf("gui/%d", os.Getuid())
-	target := fmt.Sprintf("%s/%s", domain, launchdLabel)
-	_, _ = runLaunchctl("bootout", target)
+	domain := preferredLaunchdDomain()
+	if loadedDomain, _, _, ok := loadedLaunchdTarget(); ok && domain != launchdGUIDomain() {
+		domain = loadedDomain
+	}
+	target := launchdTarget(domain)
+	bootoutLaunchdTargets()
 
 	plistPath := launchdPlistPath()
 
@@ -125,9 +150,10 @@ func (*launchdManager) Status() (*Status, error) {
 	}
 	st.Installed = true
 
-	domain := fmt.Sprintf("gui/%d", os.Getuid())
-	target := fmt.Sprintf("%s/%s", domain, launchdLabel)
-	out, _ := runLaunchctl("print", target)
+	_, _, out, ok := loadedLaunchdTarget()
+	if !ok {
+		return st, nil
+	}
 
 	for _, line := range strings.Split(out, "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -151,6 +177,62 @@ func launchdPlistPath() string {
 	return filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist")
 }
 
+func launchdUserDomain() string {
+	return fmt.Sprintf("user/%d", os.Getuid())
+}
+
+func launchdGUIDomain() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+func preferredLaunchdDomain() string {
+	guiDomain := launchdGUIDomain()
+	if _, err := runLaunchctl("print", guiDomain); err == nil {
+		return guiDomain
+	}
+	return launchdUserDomain()
+}
+
+func launchdDomains() []string {
+	preferred := preferredLaunchdDomain()
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	if preferred == guiDomain {
+		return []string{guiDomain, userDomain}
+	}
+	return []string{userDomain, guiDomain}
+}
+
+func launchdTarget(domain string) string {
+	return fmt.Sprintf("%s/%s", domain, launchdLabel)
+}
+
+func launchdTargets() []string {
+	domains := launchdDomains()
+	targets := make([]string, 0, len(domains))
+	for _, domain := range domains {
+		targets = append(targets, launchdTarget(domain))
+	}
+	return targets
+}
+
+func loadedLaunchdTarget() (string, string, string, bool) {
+	for _, domain := range launchdDomains() {
+		target := launchdTarget(domain)
+		out, err := runLaunchctl("print", target)
+		if err == nil {
+			return domain, target, out, true
+		}
+	}
+	return "", "", "", false
+}
+
+func bootoutLaunchdTargets() {
+	for _, target := range launchdTargets() {
+		_, _ = runLaunchctl("bootout", target)
+	}
+}
+
 func buildPlist(cfg Config) string {
 	envPATH := cfg.EnvPATH
 	if envPATH == "" {
@@ -170,6 +252,11 @@ func buildPlist(cfg Config) string {
 	<string>%s</string>
 	<key>RunAtLoad</key>
 	<true/>
+	<key>LimitLoadToSessionType</key>
+	<array>
+		<string>Aqua</string>
+		<string>Background</string>
+	</array>
 	<key>KeepAlive</key>
 	<dict>
 		<key>SuccessfulExit</key>
@@ -191,10 +278,4 @@ func buildPlist(cfg Config) string {
 </dict>
 </plist>
 `, launchdLabel, cfg.BinaryPath, cfg.WorkDir, cfg.LogFile, cfg.LogMaxSize, envPATH)
-}
-
-func runLaunchctl(args ...string) (string, error) {
-	cmd := exec.Command("launchctl", args...)
-	out, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(out)), err
 }

--- a/daemon/launchd_test.go
+++ b/daemon/launchd_test.go
@@ -3,6 +3,9 @@
 package daemon
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -23,4 +26,217 @@ func TestBuildPlist_KeepAliveDoesNotRestartOnCleanExit(t *testing.T) {
 	if strings.Contains(xml, "<key>KeepAlive</key>\n\t<true/>") {
 		t.Fatal("plist must not use boolean KeepAlive true")
 	}
+	if !strings.Contains(xml, "<key>LimitLoadToSessionType</key>") ||
+		!strings.Contains(xml, "<string>Aqua</string>") ||
+		!strings.Contains(xml, "<string>Background</string>") {
+		t.Fatal("plist should allow both Aqua and Background sessions")
+	}
+}
+
+func TestPreferredLaunchdDomainFallsBackToUserWhenGUIDomainUnavailable(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	runLaunchctl = func(args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "print" && args[1] == guiDomain {
+			return "Bootstrap failed: 125: Domain does not support specified action", fmt.Errorf("exit status 125")
+		}
+		if len(args) >= 2 && args[0] == "print" && args[1] == userDomain {
+			return "subsystem", nil
+		}
+		return "", nil
+	}
+
+	if got := preferredLaunchdDomain(); got != userDomain {
+		t.Fatalf("preferredLaunchdDomain() = %q, want %q", got, userDomain)
+	}
+}
+
+func TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	guiTarget := launchdTarget(guiDomain)
+	userTarget := launchdTarget(userDomain)
+	runLaunchctl = func(args ...string) (string, error) {
+		if len(args) < 2 || args[0] != "print" {
+			return "", nil
+		}
+		switch args[1] {
+		case guiDomain, guiTarget:
+			return "Bootstrap failed: 125: Domain does not support specified action", fmt.Errorf("exit status 125")
+		case userDomain:
+			return "subsystem", nil
+		case userTarget:
+			return "pid = 4321\nstate = running", nil
+		default:
+			return "", fmt.Errorf("unexpected target %q", args[1])
+		}
+	}
+
+	mgr := &launchdManager{}
+	st, err := mgr.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if !st.Running {
+		t.Fatal("Status().Running = false, want true")
+	}
+	if st.PID != 4321 {
+		t.Fatalf("Status().PID = %d, want 4321", st.PID)
+	}
+}
+
+func TestRestartPrefersGUIDomainWhenAvailable(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	dir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", dir)
+	if origHome != "" {
+		t.Cleanup(func() { _ = os.Setenv("HOME", origHome) })
+	}
+	plistPath := launchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("plist"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	guiTarget := launchdTarget(guiDomain)
+	userTarget := launchdTarget(userDomain)
+
+	var calls []string
+	runLaunchctl = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) < 2 {
+			return "", nil
+		}
+		switch args[0] {
+		case "print":
+			switch args[1] {
+			case guiDomain:
+				return "subsystem", nil
+			case guiTarget:
+				return "Bootstrap failed: 113: Could not find service", fmt.Errorf("exit status 113")
+			case userTarget:
+				return "pid = 4321\nstate = running", nil
+			default:
+				return "", fmt.Errorf("unexpected print target %q", args[1])
+			}
+		case "bootout":
+			return "", nil
+		case "bootstrap":
+			if args[1] != guiDomain {
+				t.Fatalf("bootstrap domain = %q, want %q", args[1], guiDomain)
+			}
+			return "", nil
+		case "kickstart":
+			if args[len(args)-1] != guiTarget {
+				t.Fatalf("kickstart target = %q, want %q", args[len(args)-1], guiTarget)
+			}
+			return "", nil
+		default:
+			return "", nil
+		}
+	}
+
+	mgr := &launchdManager{}
+	if err := mgr.Restart(); err != nil {
+		t.Fatalf("Restart() error = %v", err)
+	}
+
+	if !containsCall(calls, "bootstrap "+guiDomain+" "+plistPath) {
+		t.Fatalf("expected bootstrap to gui domain, calls = %#v", calls)
+	}
+	if !containsCall(calls, "kickstart -kp "+guiTarget) {
+		t.Fatalf("expected kickstart to gui target, calls = %#v", calls)
+	}
+}
+
+func TestRestartKeepsUserDomainWhenGUIDomainUnavailable(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	dir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", dir)
+	if origHome != "" {
+		t.Cleanup(func() { _ = os.Setenv("HOME", origHome) })
+	}
+	plistPath := launchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("plist"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	userTarget := launchdTarget(userDomain)
+
+	var calls []string
+	runLaunchctl = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) < 2 {
+			return "", nil
+		}
+		switch args[0] {
+		case "print":
+			switch args[1] {
+			case guiDomain:
+				return "Bootstrap failed: 125: Domain does not support specified action", fmt.Errorf("exit status 125")
+			case userDomain:
+				return "subsystem", nil
+			case userTarget:
+				return "pid = 4321\nstate = running", nil
+			default:
+				return "", fmt.Errorf("unexpected print target %q", args[1])
+			}
+		case "bootout":
+			return "", nil
+		case "bootstrap":
+			if args[1] != userDomain {
+				t.Fatalf("bootstrap domain = %q, want %q", args[1], userDomain)
+			}
+			return "", nil
+		case "kickstart":
+			if args[len(args)-1] != userTarget {
+				t.Fatalf("kickstart target = %q, want %q", args[len(args)-1], userTarget)
+			}
+			return "", nil
+		default:
+			return "", nil
+		}
+	}
+
+	mgr := &launchdManager{}
+	if err := mgr.Restart(); err != nil {
+		t.Fatalf("Restart() error = %v", err)
+	}
+
+	if !containsCall(calls, "bootstrap "+userDomain+" "+plistPath) {
+		t.Fatalf("expected bootstrap to user domain, calls = %#v", calls)
+	}
+	if !containsCall(calls, "kickstart -kp "+userTarget) {
+		t.Fatalf("expected kickstart to user target, calls = %#v", calls)
+	}
+}
+
+func containsCall(calls []string, want string) bool {
+	for _, call := range calls {
+		if call == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

Fix macOS launchd daemon management for both GUI and headless sessions.

- prefer `gui/<uid>` when available
- fall back to `user/<uid>` when no GUI session exists
- keep `restart` GUI-first so a headless-started service can migrate to `gui/<uid>` later
- allow both `Aqua` and `Background` in `LimitLoadToSessionType`
- add regression tests for domain selection and status handling

## Problem

The current macOS daemon implementation always uses `launchctl` with `gui/<uid>`. This fails in headless or remote environments with errors such as:

```text
Bootstrap failed: 125: Domain does not support specified action
```

## Validation

Verified in macOS GUI and headless usage flows:

- reinstall succeeded
- `cc-connect daemon status` worked
- `cc-connect daemon restart` worked
- actual conversation flow remained normal
