### PR TITLE
fix(opencode): pass inbound images as files

### DIFF
--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -62,6 +63,10 @@ func (s *opencodeSession) Send(prompt string, images []core.ImageAttachment, fil
 		filePaths := core.SaveFilesToDisk(s.workDir, files)
 		prompt = core.AppendFileRefs(prompt, filePaths)
 	}
+	prompt, imagePaths, err := s.stageImages(prompt, images)
+	if err != nil {
+		return err
+	}
 	if !s.alive.Load() {
 		return fmt.Errorf("session is closed")
 	}
@@ -69,23 +74,7 @@ func (s *opencodeSession) Send(prompt string, images []core.ImageAttachment, fil
 	chatID := s.CurrentSessionID()
 	isResume := chatID != ""
 
-	args := []string{"run", "--format", "json"}
-
-	if isResume {
-		args = append(args, "--session", chatID)
-	}
-	if s.model != "" {
-		args = append(args, "--model", s.model)
-	}
-	if s.workDir != "" {
-		args = append(args, "--dir", s.workDir)
-	}
-
-	// Enable thinking blocks
-	args = append(args, "--thinking")
-
-	// Append prompt as positional arg
-	args = append(args, prompt)
+	args := s.buildRunArgs(prompt, imagePaths, chatID)
 
 	slog.Debug("opencodeSession: launching", "resume", isResume, "args", core.RedactArgs(args))
 
@@ -113,6 +102,75 @@ func (s *opencodeSession) Send(prompt string, images []core.ImageAttachment, fil
 	go s.readLoop(cmd, stdout, &stderrBuf)
 
 	return nil
+}
+
+func (s *opencodeSession) stageImages(prompt string, images []core.ImageAttachment) (string, []string, error) {
+	if len(images) == 0 {
+		return prompt, nil, nil
+	}
+
+	imgDir := filepath.Join(s.workDir, ".cc-connect", "images")
+	if err := os.MkdirAll(imgDir, 0o755); err != nil {
+		return "", nil, fmt.Errorf("opencodeSession: create image dir: %w", err)
+	}
+
+	imagePaths := make([]string, 0, len(images))
+	for i, img := range images {
+		ext := opencodeImageExt(img.MimeType)
+		fname := fmt.Sprintf("img_%d_%d%s", time.Now().UnixMilli(), i, ext)
+		fpath := filepath.Join(imgDir, fname)
+		if err := os.WriteFile(fpath, img.Data, 0o644); err != nil {
+			return "", nil, fmt.Errorf("opencodeSession: save image: %w", err)
+		}
+		imagePaths = append(imagePaths, fpath)
+	}
+
+	if prompt == "" {
+		prompt = "Please analyze the attached image(s)."
+	}
+
+	return prompt, imagePaths, nil
+}
+
+func opencodeImageExt(mimeType string) string {
+	switch mimeType {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	default:
+		return ".png"
+	}
+}
+
+func (s *opencodeSession) buildRunArgs(prompt string, imagePaths []string, chatID string) []string {
+	args := []string{"run", "--format", "json"}
+
+	if chatID != "" {
+		args = append(args, "--session", chatID)
+	}
+	if s.model != "" {
+		args = append(args, "--model", s.model)
+	}
+	if s.workDir != "" {
+		args = append(args, "--dir", s.workDir)
+	}
+
+	// Enable thinking blocks.
+	args = append(args, "--thinking")
+
+	for _, imagePath := range imagePaths {
+		if imagePath == "" {
+			continue
+		}
+		args = append(args, "--file", imagePath)
+	}
+
+	// Append prompt as positional arg.
+	args = append(args, prompt)
+	return args
 }
 
 func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -3,6 +3,9 @@ package opencode
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -64,6 +67,55 @@ func TestNewOpencodeSession_ContinueSessionTreatedAsFresh(t *testing.T) {
 
 	if got := s.CurrentSessionID(); got != "" {
 		t.Errorf("ContinueSession should be treated as fresh: chatID = %q, want empty", got)
+	}
+}
+
+func TestOpencodeSessionStageImages(t *testing.T) {
+	dir := t.TempDir()
+	s := &opencodeSession{workDir: dir}
+
+	prompt, imagePaths, err := s.stageImages("", []core.ImageAttachment{
+		{MimeType: "image/jpeg", Data: []byte{0xff, 0xd8, 0xff}},
+		{MimeType: "image/webp", Data: []byte("webp")},
+	})
+	if err != nil {
+		t.Fatalf("stageImages: %v", err)
+	}
+	if prompt != "Please analyze the attached image(s)." {
+		t.Fatalf("prompt = %q", prompt)
+	}
+	if len(imagePaths) != 2 {
+		t.Fatalf("imagePaths len = %d, want 2", len(imagePaths))
+	}
+	if filepath.Ext(imagePaths[0]) != ".jpg" {
+		t.Fatalf("first ext = %q, want .jpg", filepath.Ext(imagePaths[0]))
+	}
+	if filepath.Ext(imagePaths[1]) != ".webp" {
+		t.Fatalf("second ext = %q, want .webp", filepath.Ext(imagePaths[1]))
+	}
+	for _, path := range imagePaths {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected staged image %s: %v", path, err)
+		}
+	}
+}
+
+func TestOpencodeSessionBuildRunArgsIncludesImagesAsFiles(t *testing.T) {
+	s := &opencodeSession{workDir: "/repo", model: "provider/model"}
+
+	got := s.buildRunArgs("describe these images", []string{"/tmp/a.png", "/tmp/b.jpg"}, "ses_123")
+	want := []string{
+		"run", "--format", "json",
+		"--session", "ses_123",
+		"--model", "provider/model",
+		"--dir", "/repo",
+		"--thinking",
+		"--file", "/tmp/a.png",
+		"--file", "/tmp/b.jpg",
+		"describe these images",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stage inbound image attachments for OpenCode sessions under the workspace .cc-connect/images directory
- pass staged images to opencode run via repeated --file flags so OpenCode can resolve them as file/image parts
- add unit coverage for image staging and generated run args

## Tests
- go test ./agent/opencode
- go test ./... (fails in this environment: web/embed.go requires missing web/dist; agent/iflow PTY test cannot open /dev/ptmx due sandbox permissions)