### PR TITLE
fix(opencode): prevent empty response when agent process crashes

### DIFF
--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -10,7 +10,8 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
+"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -175,20 +176,7 @@ func (s *opencodeSession) buildRunArgs(prompt string, imagePaths []string, chatI
 
 func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
 	defer s.wg.Done()
-	defer func() {
-		if err := cmd.Wait(); err != nil {
-			stderrMsg := stderrBuf.String()
-			if stderrMsg != "" {
-				slog.Error("opencodeSession: process failed", "error", err, "stderr", stderrMsg)
-				evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
-				select {
-				case s.events <- evt:
-				case <-s.ctx.Done():
-					return
-				}
-			}
-		}
-	}()
+	defer func() { _ = cmd.Wait() }()
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
@@ -216,10 +204,26 @@ func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBu
 		case <-s.ctx.Done():
 			return
 		}
+		return
 	}
 
-	// Emit EventResult after all steps are done and the process has finished writing.
+	stderrMsg := stderrBuf.String()
+	if stderrMsg != "" {
+		slog.Error("opencodeSession: process error", "stderr", truncate(stderrMsg, 500))
+		if strings.Contains(stderrMsg, "Session not found") {
+			s.chatID.Store("")
+			slog.Warn("opencodeSession: cleared stale session ID")
+		}
+		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
+		select {
+		case s.events <- evt:
+		case <-s.ctx.Done():
+		}
+		return
+	}
+
 	sid := s.CurrentSessionID()
+	slog.Debug("opencodeSession: readLoop complete, sending fallback EventResult", "session_id", sid)
 	evt := core.Event{Type: core.EventResult, SessionID: sid, Done: true}
 	select {
 	case s.events <- evt:

--- a/core/engine.go
+++ b/core/engine.go
@@ -2600,6 +2600,15 @@ func (e *Engine) closeAgentSessionWithTimeout(sessionKey string, agentSession Ag
 
 const defaultEventIdleTimeout = 2 * time.Hour
 
+type agentErrorHandler struct {
+	contains string
+	msgKey   MsgKey
+}
+
+var agentErrorHandlers = []agentErrorHandler{
+	{"Session not found", MsgSessionNotFound},
+}
+
 func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, msgID string, turnStart time.Time, stopTypingFn func(), sendDone <-chan error, replyCtx any) {
 	var textParts []string
 	var segmentStart int // index into textParts: text before this has been sent/displayed
@@ -3285,6 +3294,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			cp.Finalize(ProgressCardStateFailed)
 			sp.discard()
 			if event.Error != nil {
+				errMsg := event.Error.Error()
 				slog.Error("agent error", "error", event.Error)
 				e.hooks.Emit(HookEvent{
 					Event:      HookEventError,
@@ -3292,7 +3302,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					Platform:   p.Name(),
 					Error:      event.Error.Error(),
 				})
-				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), event.Error))
+				userMsg := fmt.Sprintf(e.i18n.T(MsgError), errMsg)
+				for _, h := range agentErrorHandlers {
+					if strings.Contains(errMsg, h.contains) {
+						userMsg = e.i18n.T(h.msgKey)
+						break
+					}
+				}
+				e.send(p, replyCtx, userMsg)
 			}
 			// Only drop queued messages if the agent session is dead.
 			// Some agents (e.g. Codex) emit EventError for per-turn failures

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -140,6 +140,7 @@ const (
 	MsgToolAllowFailed           MsgKey = "tool_allow_failed"
 	MsgToolAllowedNew            MsgKey = "tool_allowed_new"
 	MsgError                     MsgKey = "error"
+	MsgSessionNotFound           MsgKey = "session_not_found"
 	MsgFailedToStartAgentSession MsgKey = "failed_to_start_agent_session"
 	MsgFailedToDeleteSession     MsgKey = "failed_to_delete_session"
 	MsgEmptyResponse             MsgKey = "empty_response"
@@ -716,6 +717,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "❌ 錯誤: %v",
 		LangJapanese:           "❌ エラー: %v",
 		LangSpanish:            "❌ Error: %v",
+	},
+	MsgSessionNotFound: {
+		LangEnglish:            "⚠️ Session expired. Use /new to start a fresh conversation.",
+		LangChinese:            "⚠️ 会话已过期，请发送 /new 开始新会话",
+		LangTraditionalChinese: "⚠️ 會話已過期，請發送 /new 開始新會話",
+		LangJapanese:           "⚠️ セッションが期限切れです。/new で新しい会話を開始してください。",
+		LangSpanish:            "⚠️ Sesión expirada. Usa /new para iniciar una nueva conversación.",
 	},
 	MsgFailedToStartAgentSession: {
 		LangEnglish:            "❌ Error: failed to start agent session",


### PR DESCRIPTION
## Summary

- Fix empty response when the opencode agent process crashes (e.g. stale session ID causes "Session not found")
- Restructure readLoop termination logic to check stderr before emitting fallback EventResult
- Add `agentErrorHandlers` pattern table for extensible error-to-message mapping with i18n support

## Problem

When the opencode process crashes, `readLoop` sends a fallback `EventResult(Done:true)` before the deferred `cmd.Wait()` can detect the error and emit an `EventError`. The engine receives `EventResult` first, returns from the event loop, and the `EventError` is never consumed. The user sees an empty response with no error information.

## Root Cause

The execution order in `readLoop` is:

1. Scanner loop exits (stdout closed after process crash)
2. Fallback `EventResult` sent (line 182, unconditional)
3. Deferred `cmd.Wait()` detects error and sends `EventError` (but engine already exited)

## Fix

**`agent/opencode/session.go`** - Restructure readLoop:
- Check `stderrBuf` immediately after scanner exits, before sending fallback EventResult
- If stderr has content: emit `EventError` (with "Session not found" detection)
- If stderr is empty: emit fallback `EventResult` as before
- `cmd.Wait()` kept in defer for resource cleanup only

**`core/engine.go`** - Pattern table for error messages:
- `agentErrorHandlers` maps error patterns to localized `MsgKey`
- Matched errors show user-friendly recovery hints (e.g. "Use /new to start a fresh conversation")
- Unmatched errors show raw error message
- Adding new error types requires only one line in the table

**`core/i18n.go`** - Add `MsgSessionNotFound` translations (en/zh/zh-TW/ja/es)

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual testing: stale session ID now shows friendly message instead of empty response
