### PR TITLE
feat(dingtalk): support richText message type

### DIFF
--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -173,6 +173,31 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel) {
 		return
 	}
 
+	// Handle richText messages — extract plain text from rich content
+	if data.Msgtype == "richText" {
+		text := extractRichText(data.Content)
+		if text == "" {
+			slog.Debug("dingtalk: richText message with no extractable text", "msg_id", data.MsgId)
+			return
+		}
+		msg := &core.Message{
+			SessionKey: sessionKey,
+			Platform:   "dingtalk",
+			UserID:     data.SenderStaffId,
+			UserName:   data.SenderNick,
+			ChatName:   data.ConversationTitle,
+			Content:    text,
+			MessageID:  data.MsgId,
+			ReplyCtx: replyContext{
+				sessionWebhook: data.SessionWebhook,
+				conversationId: data.ConversationId,
+				senderStaffId:  data.SenderStaffId,
+			},
+		}
+		p.handler(p, msg)
+		return
+	}
+
 	// Handle text messages (default)
 	msg := &core.Message{
 		SessionKey: sessionKey,
@@ -190,6 +215,31 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel) {
 	}
 
 	p.handler(p, msg)
+}
+
+// extractRichText extracts plain text from a DingTalk richText content payload.
+// The expected structure is: {"richText": [{"text": "..."}, {"text": "...", "attrs": {...}}, ...]}
+// Non-text elements (e.g. pictureDownloadCode) are skipped.
+func extractRichText(content interface{}) string {
+	m, ok := content.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	parts, ok := m["richText"].([]interface{})
+	if !ok {
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range parts {
+		item, ok := part.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if text, ok := item["text"].(string); ok {
+			b.WriteString(text)
+		}
+	}
+	return strings.TrimSpace(b.String())
 }
 
 func (p *Platform) handleAudioMessage(data *chatbot.BotCallbackDataModel, sessionKey string) {

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -134,3 +134,85 @@ func TestPlatform_AccessTokenFieldsExist(t *testing.T) {
 
 	t.Log("Platform token caching fields exist and are accessible")
 }
+
+func TestExtractRichText(t *testing.T) {
+	tests := []struct {
+		name    string
+		content interface{}
+		want    string
+	}{
+		{
+			name:    "nil content",
+			content: nil,
+			want:    "",
+		},
+		{
+			name:    "non-map content",
+			content: "not a map",
+			want:    "",
+		},
+		{
+			name: "empty richText array",
+			content: map[string]interface{}{
+				"richText": []interface{}{},
+			},
+			want: "",
+		},
+		{
+			name: "single text element",
+			content: map[string]interface{}{
+				"richText": []interface{}{
+					map[string]interface{}{"text": "Hello World"},
+				},
+			},
+			want: "Hello World",
+		},
+		{
+			name: "multiple text elements",
+			content: map[string]interface{}{
+				"richText": []interface{}{
+					map[string]interface{}{"text": "Hello "},
+					map[string]interface{}{"text": "World"},
+				},
+			},
+			want: "Hello World",
+		},
+		{
+			name: "text with attrs (bold etc) — attrs ignored, text extracted",
+			content: map[string]interface{}{
+				"richText": []interface{}{
+					map[string]interface{}{"text": "normal "},
+					map[string]interface{}{"text": "bold", "attrs": map[string]interface{}{"bold": true}},
+				},
+			},
+			want: "normal bold",
+		},
+		{
+			name: "mixed text and picture elements — pictures skipped",
+			content: map[string]interface{}{
+				"richText": []interface{}{
+					map[string]interface{}{"text": "See image: "},
+					map[string]interface{}{"pictureDownloadCode": "abc123"},
+					map[string]interface{}{"text": "done"},
+				},
+			},
+			want: "See image: done",
+		},
+		{
+			name: "missing richText key",
+			content: map[string]interface{}{
+				"other": "data",
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractRichText(tt.content)
+			if got != tt.want {
+				t.Errorf("extractRichText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add explicit handling for DingTalk `richText` message type in `platform/dingtalk/dingtalk.go`
- Add `extractRichText()` helper that parses `data.Content` to extract plain text from the richText array, skipping non-text elements (e.g. pictures)
- Previously, richText messages fell through to the text handler which read `data.Text.Content` (empty for richText), causing silent no-response

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all packages OK)
- [x] `TestExtractRichText` — 8 test cases covering nil, non-map, empty array, single/multiple text, attrs, mixed text+picture, missing key

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)