### PR TITLE
fix(feishu): parse at/markdown in post content and handle sticker/media messages

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -924,6 +924,69 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		p.handler(p.dispatchPlatform(), coreMsg)
 
+	case "sticker":
+		var stickerBody struct {
+			FileKey string `json:"file_key"`
+		}
+		if err := json.Unmarshal([]byte(content), &stickerBody); err != nil {
+			slog.Error(p.tag()+": failed to parse sticker content", "error", err)
+			return
+		}
+		slog.Info(p.tag()+": sticker received", "user", userID, "file_key", stickerBody.FileKey)
+		imgData, mimeType, err := p.downloadImage(messageID, stickerBody.FileKey)
+		if err != nil {
+			slog.Warn(p.tag()+": download sticker failed, falling back to placeholder", "error", err)
+			p.handler(p.dispatchPlatform(), &core.Message{
+				SessionKey: sessionKey, Platform: p.platformName,
+				MessageID: messageID,
+				UserID:    userID, UserName: userName, ChatName: chatName,
+				Content: "[sticker]", ExtraContent: quotedPrefix, ReplyCtx: rctx,
+			})
+			return
+		}
+		p.handler(p.dispatchPlatform(), &core.Message{
+			SessionKey: sessionKey, Platform: p.platformName,
+			MessageID: messageID,
+			UserID:    userID, UserName: userName, ChatName: chatName,
+			Images:   []core.ImageAttachment{{MimeType: mimeType, Data: imgData}},
+			ReplyCtx: rctx,
+		})
+
+	case "media":
+		var mediaBody struct {
+			FileKey  string `json:"file_key"`
+			ImageKey string `json:"image_key"`
+			FileName string `json:"file_name"`
+			Duration int    `json:"duration"`
+		}
+		if err := json.Unmarshal([]byte(content), &mediaBody); err != nil {
+			slog.Error(p.tag()+": failed to parse media content", "error", err)
+			return
+		}
+		slog.Info(p.tag()+": media received", "user", userID, "file_key", mediaBody.FileKey, "file_name", mediaBody.FileName)
+		text := "[video"
+		if mediaBody.FileName != "" {
+			text += ": " + mediaBody.FileName
+		}
+		if mediaBody.Duration > 0 {
+			text += fmt.Sprintf(", %ds", mediaBody.Duration/1000)
+		}
+		text += "]"
+		var images []core.ImageAttachment
+		if mediaBody.ImageKey != "" {
+			if thumbData, thumbMime, err := p.downloadImage(messageID, mediaBody.ImageKey); err == nil {
+				images = append(images, core.ImageAttachment{MimeType: thumbMime, Data: thumbData})
+			} else {
+				slog.Warn(p.tag()+": download media thumbnail failed", "error", err)
+			}
+		}
+		p.handler(p.dispatchPlatform(), &core.Message{
+			SessionKey: sessionKey, Platform: p.platformName,
+			MessageID: messageID,
+			UserID:    userID, UserName: userName, ChatName: chatName,
+			Content: text, ExtraContent: quotedPrefix, Images: images, ReplyCtx: rctx,
+		})
+
 	default:
 		slog.Debug(p.tag()+": ignoring unsupported message type", "type", msgType)
 	}
@@ -1273,6 +1336,8 @@ func extractPostPlainText(content string) string {
 			Tag      string `json:"tag"`
 			Text     string `json:"text"`
 			Language string `json:"language,omitempty"`
+			UserId   string `json:"user_id,omitempty"`
+			UserName string `json:"user_name,omitempty"`
 		} `json:"content"`
 		Title string `json:"title"`
 	}
@@ -1303,6 +1368,25 @@ func extractPostPlainText(content string) string {
 				if elem.Text != "" {
 					line = append(line, elem.Text)
 				}
+			case "a":
+				if elem.Text != "" {
+					line = append(line, elem.Text)
+				}
+			case "markdown":
+				if elem.Text != "" {
+					line = append(line, elem.Text)
+				}
+			case "at":
+				switch {
+				case elem.UserId == "all":
+					line = append(line, "@all")
+				case elem.UserName != "":
+					line = append(line, "@"+elem.UserName)
+				case elem.UserId != "":
+					line = append(line, "@user")
+				}
+			case "img":
+				line = append(line, "[image]")
 			case "code_block":
 				if elem.Text != "" {
 					lang := elem.Language
@@ -3259,6 +3343,8 @@ type postElement struct {
 	Language string `json:"language,omitempty"`
 	ImageKey string `json:"image_key,omitempty"`
 	Href     string `json:"href,omitempty"`
+	UserId   string `json:"user_id,omitempty"`
+	UserName string `json:"user_name,omitempty"`
 }
 
 type postLang struct {
@@ -3307,6 +3393,22 @@ func (p *Platform) extractPostParts(messageID string, post *postLang) ([]string,
 				if elem.Text != "" {
 					lang := elem.Language
 					textParts = append(textParts, "```"+lang+"\n"+elem.Text+"\n```")
+				}
+			case "markdown":
+				if elem.Text != "" {
+					textParts = append(textParts, elem.Text)
+				}
+			case "at":
+				if p.botOpenID != "" && elem.UserId == p.botOpenID {
+					continue
+				}
+				switch {
+				case elem.UserId == "all":
+					textParts = append(textParts, "@all")
+				case elem.UserName != "":
+					textParts = append(textParts, "@"+elem.UserName)
+				case elem.UserId != "":
+					textParts = append(textParts, "@"+p.resolveUserName(elem.UserId))
 				}
 			case "img":
 				if elem.ImageKey != "" {

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -79,6 +79,41 @@ func TestExtractPostParts_NoTitle(t *testing.T) {
 	}
 }
 
+func TestExtractPostParts_AtMention(t *testing.T) {
+	p := &Platform{botOpenID: "ou_bot"}
+	post := &postLang{
+		Content: [][]postElement{
+			{
+				{Tag: "text", Text: "hi "},
+				{Tag: "at", UserId: "ou_alice", UserName: "Alice"},
+				{Tag: "text", Text: " and "},
+				{Tag: "at", UserId: "all"},
+				{Tag: "text", Text: " but not "},
+				{Tag: "at", UserId: "ou_bot", UserName: "Bot"},
+			},
+		},
+	}
+	texts, _ := p.extractPostParts("", post)
+	joined := strings.Join(texts, "")
+	want := "hi @Alice and @all but not "
+	if joined != want {
+		t.Errorf("want %q, got %q", want, joined)
+	}
+}
+
+func TestExtractPostParts_Markdown(t *testing.T) {
+	p := &Platform{}
+	post := &postLang{
+		Content: [][]postElement{
+			{{Tag: "markdown", Text: "**bold**"}},
+		},
+	}
+	texts, _ := p.extractPostParts("", post)
+	if len(texts) != 1 || texts[0] != "**bold**" {
+		t.Errorf("unexpected texts: %v", texts)
+	}
+}
+
 func TestParsePostContent_FlatFormat(t *testing.T) {
 	p := &Platform{}
 	raw := `{"title":"test","content":[[{"tag":"text","text":"hello"}]]}`
@@ -300,11 +335,38 @@ func TestExtractPostPlainText_Empty(t *testing.T) {
 	}
 }
 
-func TestExtractPostPlainText_NonTextTagsIgnored(t *testing.T) {
-	content := `{"content":[[{"tag":"text","text":"hello"},{"tag":"a","text":"link","href":"http://x.com"}]]}`
+func TestExtractPostPlainText_LinkText(t *testing.T) {
+	content := `{"content":[[{"tag":"text","text":"hello "},{"tag":"a","text":"link","href":"http://x.com"}]]}`
 	got := extractPostPlainText(content)
-	if got != "hello" {
-		t.Errorf("expected 'hello', got %q", got)
+	if got != "hello link" {
+		t.Errorf("expected 'hello link', got %q", got)
+	}
+}
+
+func TestExtractPostPlainText_AtMention(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"named", `{"content":[[{"tag":"text","text":"hi "},{"tag":"at","user_id":"ou_x","user_name":"Alice"}]]}`, "hi @Alice"},
+		{"all", `{"content":[[{"tag":"at","user_id":"all"}]]}`, "@all"},
+		{"fallback", `{"content":[[{"tag":"at","user_id":"ou_x"}]]}`, "@user"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractPostPlainText(tc.content); got != tc.want {
+				t.Errorf("want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestExtractPostPlainText_Markdown(t *testing.T) {
+	content := `{"content":[[{"tag":"markdown","text":"**bold** and *italic*"}]]}`
+	got := extractPostPlainText(content)
+	if got != "**bold** and *italic*" {
+		t.Errorf("expected markdown passthrough, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Closes #725.

## Summary

- **post content parser** (`extractPostParts`, `extractPostPlainText`): add `at` and `markdown` cases. `at` resolves the bot's own mention to a no-op, `all` to `@all`, and other users via `user_name` or `resolveUserName(user_id)`; `markdown` passes its text through. Without this, any rich-text message that combines image + text + @mention loses the mention (the `mentions` array carries placeholder keys that never appear in the extracted post text, so `stripMentions` has nothing to replace).
- **quoted-reply path** (`extractPostPlainText`): also add `a` / `img` handling so quoted context preserves link text and an `[image]` marker instead of silently dropping them.
- **sticker / media message types** (`dispatchMessage`): new cases. Stickers are delivered as image attachments (with a `[sticker]` text fallback if download fails). Videos surface as `[video: <name>, Xs]` plus the thumbnail image when `image_key` is present.
- **`postElement` struct**: add `UserId` and `UserName` fields for `at` elements.

## Tests

- `TestExtractPostParts_AtMention` — covers named mention, `@all`, and bot-mention stripping.
- `TestExtractPostParts_Markdown`
- `TestExtractPostPlainText_LinkText` (replaces the old `NonTextTagsIgnored` test, whose assertion is now incorrect)
- `TestExtractPostPlainText_AtMention` (named / `all` / fallback)
- `TestExtractPostPlainText_Markdown`

`go test ./platform/feishu/...` passes locally.

## Notes

- No new dependencies. Bot-mention stripping reuses the existing `botOpenID` field on `Platform`.
- Sticker image download reuses `downloadImage`; media thumbnail download is best-effort with a warn-log on failure.
- Unknown element tags within post content continue to be ignored (existing behavior preserved for `hr`, `emotion`, etc.).