### PR TITLE
feat(feishu): label bot senders by app_id with configurable aliases

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -138,9 +138,10 @@ type Platform struct {
 	cancel           context.CancelFunc
 	dedup            core.MessageDedup
 	botOpenID        string
-	userNameCache    sync.Map // open_id -> display name
-	chatNameCache    sync.Map // chat_id -> chat name
-	chatMemberCache  sync.Map // chatID -> *chatMemberEntry
+	peerBots         map[string]string // app_id -> friendly alias, for quoted-reply attribution
+	userNameCache    sync.Map          // open_id -> display name
+	chatNameCache    sync.Map          // chat_id -> chat name
+	chatMemberCache  sync.Map          // chatID -> *chatMemberEntry
 	// Webhook mode fields (for Lark international version)
 	server       *http.Server
 	port         string
@@ -205,6 +206,15 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		noReplyToTrigger = true
 	}
 
+	peerBots := map[string]string{}
+	if raw, ok := opts["peer_bots"].(map[string]any); ok {
+		for k, v := range raw {
+			if s, ok := v.(string); ok && s != "" {
+				peerBots[k] = s
+			}
+		}
+	}
+
 	progressStyle := "legacy"
 	if v, ok := opts["progress_style"].(string); ok {
 		switch strings.ToLower(strings.TrimSpace(v)) {
@@ -258,6 +268,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		port:                       port,
 		callbackPath:               callbackPath,
 		encryptKey:                 encryptKey,
+		peerBots:                   peerBots,
 	}
 	if !useInteractiveCard {
 		base.self = base
@@ -1126,6 +1137,21 @@ func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) stri
 	return formatReplyChain(chain)
 }
 
+// resolveBotSenderName returns a display name for a bot sender in a quoted
+// reply chain. Feishu sets sender.id to the bot's app_id (globally stable,
+// not an open_id). We consult the peer_bots config to map app_id → alias;
+// if the app is unknown, we surface the app_id so operators can add it to
+// the config rather than seeing an ambiguous "Bot".
+func (p *Platform) resolveBotSenderName(appID string) string {
+	if appID == "" {
+		return "Bot"
+	}
+	if alias := p.peerBots[appID]; alias != "" {
+		return alias
+	}
+	return "Bot[" + appID + "]"
+}
+
 // fetchSingleMessage retrieves one message by ID from the Feishu API and
 // returns its extracted content as a chainMessage. Returns nil on any failure.
 func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *chainMessage {
@@ -1187,8 +1213,7 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 	// Resolve sender name.
 	senderName := ""
 	if item.Sender.SenderType == "app" {
-		// Bot messages: sender ID is app_id, not a user open_id.
-		senderName = "Bot"
+		senderName = p.resolveBotSenderName(item.Sender.ID)
 	} else if item.Sender.ID != "" {
 		resolved := p.resolveUserName(item.Sender.ID)
 		if resolved != item.Sender.ID {

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -401,3 +401,38 @@ func TestStripMentions(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveBotSenderName(t *testing.T) {
+	p := &Platform{peerBots: map[string]string{
+		"cli_known": "Jeeves",
+		"cli_other": "Ivy",
+	}}
+	tests := []struct {
+		name  string
+		appID string
+		want  string
+	}{
+		{"empty app id falls back to Bot", "", "Bot"},
+		{"known app id resolves to alias", "cli_known", "Jeeves"},
+		{"another known app id", "cli_other", "Ivy"},
+		{"unknown app id surfaces id", "cli_unknown", "Bot[cli_unknown]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.resolveBotSenderName(tt.appID)
+			if got != tt.want {
+				t.Errorf("resolveBotSenderName(%q) = %q, want %q", tt.appID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveBotSenderName_NilMap(t *testing.T) {
+	p := &Platform{}
+	if got := p.resolveBotSenderName("cli_any"); got != "Bot[cli_any]" {
+		t.Errorf("nil peerBots: got %q, want %q", got, "Bot[cli_any]")
+	}
+	if got := p.resolveBotSenderName(""); got != "Bot" {
+		t.Errorf("nil peerBots + empty id: got %q, want %q", got, "Bot")
+	}
+}


### PR DESCRIPTION
Closes #727.

## Problem

In Feishu quoted-reply / reply-chain rendering, every bot sender shows up as a bare `"Bot"`. When multiple bots share a chat (e.g. two cc-connect instances, or a cc-connect bot + a third-party peer), the model can't tell its own prior messages apart from another bot's — issue #727 has the full reproduction.

## Fix

Feishu sets `sender.id` to the **bot's app_id** (globally stable, not an open_id) when `sender.sender_type == "app"`. Use it.

Add a `peer_bots` map in `[platforms.feishu]` config mapping `app_id → friendly alias`, and extract the resolution into a `resolveBotSenderName` helper with a 3-case fallback:

- empty id       → `"Bot"` (preserves current behavior on degenerate payloads)
- known app_id   → configured alias (e.g. `Jeeves`, `Ivy`)
- unknown app_id → `"Bot[<app_id>]"` — surfaces the id so operators can drop it straight into the config rather than guessing which peer posted

### Config example

\`\`\`toml
[platforms.feishu]
peer_bots = { cli_aaaaaaaa = \"Jeeves\", cli_bbbbbbbb = \"Ivy\" }
\`\`\`

## Tests

Table-driven unit tests for `resolveBotSenderName` covering:
- known app_id → alias
- unknown app_id → `Bot[<id>]`
- empty id → `Bot`
- nil `peerBots` map (platform started without the config key)

\`go test -tags 'no_web' -count=1 ./platform/feishu/\` passes locally.

## Back-compat

- Default behavior (no `peer_bots` configured, or unknown app_id) changes from `"Bot"` to `"Bot[<app_id>]"`. This is user-visible text in reply chains, not a schema change — but worth calling out. If strict back-compat is preferred, happy to gate the surfacing behind a config switch.
- Bare `"Bot"` is preserved when `sender.id` is empty (shouldn't happen in practice, but keeps the degenerate path identical).