### PR TITLE
fix(core): reject /ps when no task is currently running

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3511,6 +3511,15 @@ func (e *Engine) cmdPs(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsNoSession))
 		return
 	}
+	// /ps is only meaningful as a supplement to a turn already in flight.
+	// When the session is idle, injecting via agentSession.Send bypasses the
+	// session lock and races with concurrent normal messages on the CLI's
+	// stdin, so reject instead.
+	_, sessions := e.sessionContextForKey(msg.SessionKey)
+	if session := sessions.GetOrCreateActive(msg.SessionKey); !session.Busy() {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsNoSession))
+		return
+	}
 	if err := state.agentSession.Send(text, nil, nil); err != nil {
 		slog.Error("ps: send failed", "error", err)
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsSendFailed))

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -7103,6 +7103,103 @@ func TestCmdCompress_DrainsQueueAfterSuccess(t *testing.T) {
 	}
 }
 
+// --- cmdPs ---
+
+func TestCmdPs_EmptyArgs_RepliesUsage(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+
+	msg := &Message{SessionKey: "test:user1", Content: "/ps", ReplyCtx: "ctx"}
+	e.cmdPs(p, msg, nil)
+
+	sent := p.getSent()
+	if len(sent) == 0 || !strings.Contains(sent[0], e.i18n.T(MsgPsEmpty)) {
+		t.Fatalf("expected MsgPsEmpty, got %v", sent)
+	}
+}
+
+func TestCmdPs_NoAgentSession_RepliesNoSession(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+
+	msg := &Message{SessionKey: "test:user1", Content: "/ps hello", ReplyCtx: "ctx"}
+	e.cmdPs(p, msg, []string{"hello"})
+
+	sent := p.getSent()
+	if len(sent) == 0 || !strings.Contains(sent[0], e.i18n.T(MsgPsNoSession)) {
+		t.Fatalf("expected MsgPsNoSession, got %v", sent)
+	}
+}
+
+func TestCmdPs_IdleSession_RepliesNoSession(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("ps-idle")
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	state := &interactiveState{agentSession: sess, platform: p}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	// Session is alive but idle (not locked by an in-flight turn).
+	msg := &Message{SessionKey: key, Content: "/ps hello", ReplyCtx: "ctx"}
+	e.cmdPs(p, msg, []string{"hello"})
+
+	sent := p.getSent()
+	if len(sent) == 0 || !strings.Contains(sent[0], e.i18n.T(MsgPsNoSession)) {
+		t.Fatalf("expected MsgPsNoSession on idle session, got %v", sent)
+	}
+
+	sess.sendMu.Lock()
+	n := len(sess.sendCalls)
+	sess.sendMu.Unlock()
+	if n != 0 {
+		t.Fatalf("expected no Send on idle session, got %d call(s)", n)
+	}
+}
+
+func TestCmdPs_BusySession_InjectsToAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("ps-busy")
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	state := &interactiveState{agentSession: sess, platform: p}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	// Simulate a turn in flight.
+	session := e.sessions.GetOrCreateActive(key)
+	if !session.TryLock() {
+		t.Fatal("expected TryLock to succeed")
+	}
+	defer session.Unlock()
+
+	msg := &Message{SessionKey: key, Content: "/ps add unit tests", ReplyCtx: "ctx"}
+	e.cmdPs(p, msg, []string{"add", "unit", "tests"})
+
+	sess.sendMu.Lock()
+	calls := append([]string(nil), sess.sendCalls...)
+	sess.sendMu.Unlock()
+	if len(calls) != 1 || calls[0] != "add unit tests" {
+		t.Fatalf("expected Send(\"add unit tests\"), got %v", calls)
+	}
+
+	sent := p.getSent()
+	found := false
+	for _, s := range sent {
+		if strings.Contains(s, e.i18n.T(MsgPsSent)) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected MsgPsSent reply, got %v", sent)
+	}
+}
+
 // --- 3. executeCardAction routing ---
 
 func TestExecuteCardAction_CronEnable(t *testing.T) {

--- a/core/session.go
+++ b/core/session.go
@@ -39,6 +39,14 @@ func (s *Session) TryLock() bool {
 	return true
 }
 
+// Busy reports whether the session is currently locked for an in-flight turn.
+// Used by commands (e.g. /ps) that only make sense while a task is running.
+func (s *Session) Busy() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.busy
+}
+
 func (s *Session) Unlock() {
 	s.unlock(true)
 }

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -191,6 +191,23 @@ func TestSession_TryLockUnlock(t *testing.T) {
 	}
 }
 
+func TestSession_Busy(t *testing.T) {
+	s := &Session{}
+	if s.Busy() {
+		t.Error("fresh session should not be busy")
+	}
+	if !s.TryLock() {
+		t.Fatal("TryLock should succeed")
+	}
+	if !s.Busy() {
+		t.Error("session should be busy after TryLock")
+	}
+	s.Unlock()
+	if s.Busy() {
+		t.Error("session should not be busy after Unlock")
+	}
+}
+
 func TestSession_History(t *testing.T) {
 	s := &Session{}
 	s.AddHistory("user", "hello")


### PR DESCRIPTION
Closes #729.

`/ps` is meant to append a P.S. to a turn already in flight. The idle path used to call `agentSession.Send` directly, which bypassed the session lock and raced with concurrent normal messages on the CLI's stdin (stream-json is strictly one-turn-at-a-time).

### Change

- Add `Session.Busy()` — reads `s.busy` under `s.mu`, same guard as `TryLock`/`Unlock`.
- `cmdPs` checks `Busy()` after the existing alive check. If idle, reply with `MsgPsNoSession` instead of injecting.
- Users who actually want to start a new turn can just send the message without the `/ps` prefix.

### Tests

- `TestSession_Busy` — fresh/locked/unlocked states.
- Four `cmdPs` branches: empty args, no agent session, idle session (new behavior), busy session (unchanged).

`go test ./core/...` passes.

### Note

Stacked on top of #620 (which introduces `/ps` as a builtin). If #620 lands first, this diff becomes just the one fix commit; if this lands first, rebase accordingly.