### PR TITLE
fix(daemon): add --force flag to restart command

### DIFF
--- a/cmd/cc-connect/daemon.go
+++ b/cmd/cc-connect/daemon.go
@@ -29,7 +29,7 @@ func runDaemon(args []string) {
 	case "stop":
 		daemonStop()
 	case "restart":
-		daemonRestart()
+		daemonRestart(args[1:])
 	case "status":
 		daemonStatus()
 	case "logs":
@@ -223,9 +223,24 @@ func daemonStop() {
 	fmt.Println("cc-connect daemon stopped.")
 }
 
-func daemonRestart() {
+func daemonRestart(args []string) {
+	force := false
+	for _, a := range args {
+		if a == "--force" {
+			force = true
+		}
+	}
+
 	mgr := mustManager()
 	requireInstalled(mgr)
+
+	if force {
+		if meta, err := daemon.LoadMeta(); err == nil {
+			configPath := meta.WorkDir + "/config.toml"
+			KillExistingInstance(configPath)
+		}
+	}
+
 	if err := mgr.Restart(); err != nil {
 		fmt.Fprintf(os.Stderr, "Restart failed: %v\n", err)
 		os.Exit(1)
@@ -404,6 +419,9 @@ Install flags:
   --log-max-size N      Max log file size in MB (default: 10)
   --work-dir DIR        Directory containing config.toml (default: current dir)
   --force               Overwrite existing installation
+
+Restart flags:
+  --force               Kill existing process before restarting
 
 Logs flags:
   -f, --follow          Follow log output (like tail -f)


### PR DESCRIPTION
## Summary
- Add `--force` flag to `daemon restart` command
- When `--force` is used, kills the existing process via `KillExistingInstance()` before calling `mgr.Restart()`
- Update usage text to document the new flag

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 28 packages)
- [x] Manual: `cc-connect daemon restart --force` kills stuck process then restarts

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)