### PR TITLE
fix(core): use /usr/bin/true for macOS compatibility

### DIFF
--- a/core/runas.go
+++ b/core/runas.go
@@ -188,9 +188,9 @@ func (ExecSudoRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
 // VerifyRunAsUserCheap runs the two cheap preflight checks that must pass
 // before every spawn, not just at startup:
 //
-//  1. `sudo -n -iu <user> -- /bin/true` must succeed — the supervisor still
+//  1. `sudo -n -iu <user> -- /usr/bin/true` must succeed — the supervisor still
 //     has passwordless sudo to the target user.
-//  2. `sudo -n -iu <user> -- sudo -n /bin/true` must FAIL — the target user
+//  2. `sudo -n -iu <user> -- sudo -n /usr/bin/true` must FAIL — the target user
 //     cannot non-interactively escalate.
 //
 // Returns nil if both checks behave as expected. Results are cached for
@@ -208,11 +208,11 @@ func VerifyRunAsUserCheap(ctx context.Context, runner SudoRunner, runAsUser stri
 	if verifyCacheHit(runAsUser) {
 		return nil
 	}
-	if out, err := runner.Run(ctx, "-n", "-iu", runAsUser, "--", "/bin/true"); err != nil {
+	if out, err := runner.Run(ctx, "-n", "-iu", runAsUser, "--", "/usr/bin/true"); err != nil {
 		verifyCacheEvict(runAsUser)
 		return fmt.Errorf("passwordless sudo to user %q failed (check that your sudoers rule is present and scoped to this user): %w: %s", runAsUser, err, strings.TrimSpace(string(out)))
 	}
-	out, err := runner.Run(ctx, "-n", "-iu", runAsUser, "--", "sudo", "-n", "/bin/true")
+	out, err := runner.Run(ctx, "-n", "-iu", runAsUser, "--", "sudo", "-n", "/usr/bin/true")
 	if err == nil {
 		verifyCacheEvict(runAsUser)
 		return fmt.Errorf("target user %q can run passwordless sudo; isolation is meaningless. Remove NOPASSWD sudo for this user. Output: %s", runAsUser, strings.TrimSpace(string(out)))

--- a/core/runas_check.go
+++ b/core/runas_check.go
@@ -92,14 +92,14 @@ func PreflightRunAsUser(ctx context.Context, cfg PreflightConfig) PreflightResul
 		cfg.ScanConfig = DefaultDescendantScanConfig
 	}
 
-	if _, err := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "/bin/true"); err != nil {
+	if _, err := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "/usr/bin/true"); err != nil {
 		result.Fatal = append(result.Fatal, fmt.Errorf(
 			"project %q: passwordless sudo to user %q is not configured. Add a sudoers rule such as:\n  %s ALL=(%s) NOPASSWD: ALL\nthen restart cc-connect. Underlying error: %w",
 			cfg.Project, cfg.RunAsUser, currentUsernameOr("<supervisor>"), cfg.RunAsUser, err))
 		return result // subsequent checks are pointless
 	}
 
-	if _, err := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "sudo", "-n", "/bin/true"); err == nil {
+	if _, err := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "sudo", "-n", "/usr/bin/true"); err == nil {
 		// Escalation succeeded — collect sudo -l from the target's
 		// context to help the operator find the offending rule.
 		if out, listErr := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "sudo", "-n", "-l"); listErr == nil {

--- a/core/runas_check_test.go
+++ b/core/runas_check_test.go
@@ -14,8 +14,8 @@ import (
 func TestPreflightRunAsUser_AllPass(t *testing.T) {
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"):                          {nil, nil},
-			key("-n", "-iu", "target", "--", "sudo", "-n", "/bin/true"):            {nil, &exec.ExitError{}}, // escalation fails as required
+			key("-n", "-iu", "target", "--", "/usr/bin/true"):                          {nil, nil},
+			key("-n", "-iu", "target", "--", "sudo", "-n", "/usr/bin/true"):            {nil, &exec.ExitError{}}, // escalation fails as required
 			key("-n", "-iu", "target", "--", "test", "-r", "/tmp/wd", "-a", "-w", "/tmp/wd"): {nil, nil},
 		},
 	}
@@ -60,7 +60,7 @@ func TestPreflightRunAsUser_AllPass(t *testing.T) {
 func TestPreflightRunAsUser_NoSudoToTargetIsFatal(t *testing.T) {
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"): {[]byte("a password is required"), &exec.ExitError{}},
+			key("-n", "-iu", "target", "--", "/usr/bin/true"): {[]byte("a password is required"), &exec.ExitError{}},
 		},
 	}
 	cfg := PreflightConfig{Project: "demo", RunAsUser: "target", WorkDir: "/tmp/wd", Runner: runner}
@@ -76,8 +76,8 @@ func TestPreflightRunAsUser_NoSudoToTargetIsFatal(t *testing.T) {
 func TestPreflightRunAsUser_TargetCanEscalateIsFatal(t *testing.T) {
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"):               {nil, nil},
-			key("-n", "-iu", "target", "--", "sudo", "-n", "/bin/true"): {nil, nil}, // BAD
+			key("-n", "-iu", "target", "--", "/usr/bin/true"):               {nil, nil},
+			key("-n", "-iu", "target", "--", "sudo", "-n", "/usr/bin/true"): {nil, nil}, // BAD
 			key("-n", "-iu", "target", "--", "sudo", "-n", "-l"):        {[]byte("(ALL) NOPASSWD: ALL"), nil},
 			key("-n", "-iu", "target", "--", "test", "-r", "/tmp/wd", "-a", "-w", "/tmp/wd"): {nil, nil},
 		},
@@ -117,8 +117,8 @@ func TestPreflightRunAsUser_TargetCanEscalateIsFatal(t *testing.T) {
 func TestPreflightRunAsUser_WorkDirInaccessibleIsFatal(t *testing.T) {
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"):                          {nil, nil},
-			key("-n", "-iu", "target", "--", "sudo", "-n", "/bin/true"):            {nil, &exec.ExitError{}},
+			key("-n", "-iu", "target", "--", "/usr/bin/true"):                          {nil, nil},
+			key("-n", "-iu", "target", "--", "sudo", "-n", "/usr/bin/true"):            {nil, &exec.ExitError{}},
 			key("-n", "-iu", "target", "--", "test", "-r", "/tmp/wd", "-a", "-w", "/tmp/wd"): {[]byte(""), &exec.ExitError{}},
 		},
 	}
@@ -141,8 +141,8 @@ func TestPreflightRunAsUser_WorkDirInaccessibleIsFatal(t *testing.T) {
 func TestPreflightRunAsUser_DescendantWarnings(t *testing.T) {
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"):                          {nil, nil},
-			key("-n", "-iu", "target", "--", "sudo", "-n", "/bin/true"):            {nil, &exec.ExitError{}},
+			key("-n", "-iu", "target", "--", "/usr/bin/true"):                          {nil, nil},
+			key("-n", "-iu", "target", "--", "sudo", "-n", "/usr/bin/true"):            {nil, &exec.ExitError{}},
 			key("-n", "-iu", "target", "--", "test", "-r", "/tmp/wd", "-a", "-w", "/tmp/wd"): {nil, nil},
 		},
 	}
@@ -183,8 +183,8 @@ func TestPreflightRunAsUser_DescendantWarnings(t *testing.T) {
 func TestPreflightRunAsUser_DescendantWarningsCapped(t *testing.T) {
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"):                          {nil, nil},
-			key("-n", "-iu", "target", "--", "sudo", "-n", "/bin/true"):            {nil, &exec.ExitError{}},
+			key("-n", "-iu", "target", "--", "/usr/bin/true"):                          {nil, nil},
+			key("-n", "-iu", "target", "--", "sudo", "-n", "/usr/bin/true"):            {nil, &exec.ExitError{}},
 			key("-n", "-iu", "target", "--", "test", "-r", "/tmp/wd", "-a", "-w", "/tmp/wd"): {nil, nil},
 		},
 	}

--- a/core/runas_test.go
+++ b/core/runas_test.go
@@ -146,8 +146,8 @@ func TestVerifyRunAsUserCheap_Success(t *testing.T) {
 	ResetVerifyCache()
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"):                           {nil, nil},
-			key("-n", "-iu", "target", "--", "sudo", "-n", "/bin/true"):             {[]byte("a password is required"), &exec.ExitError{}},
+			key("-n", "-iu", "target", "--", "/usr/bin/true"):                           {nil, nil},
+			key("-n", "-iu", "target", "--", "sudo", "-n", "/usr/bin/true"):             {[]byte("a password is required"), &exec.ExitError{}},
 		},
 	}
 	if err := VerifyRunAsUserCheap(context.Background(), runner, "target"); err != nil {
@@ -162,7 +162,7 @@ func TestVerifyRunAsUserCheap_NoPasswordlessSudoToTarget(t *testing.T) {
 	ResetVerifyCache()
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"): {[]byte("a password is required"), &exec.ExitError{}},
+			key("-n", "-iu", "target", "--", "/usr/bin/true"): {[]byte("a password is required"), &exec.ExitError{}},
 		},
 	}
 	err := VerifyRunAsUserCheap(context.Background(), runner, "target")
@@ -178,8 +178,8 @@ func TestVerifyRunAsUserCheap_TargetCanEscalate(t *testing.T) {
 	ResetVerifyCache()
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"):               {nil, nil},
-			key("-n", "-iu", "target", "--", "sudo", "-n", "/bin/true"): {nil, nil}, // BAD — escalation succeeded
+			key("-n", "-iu", "target", "--", "/usr/bin/true"):               {nil, nil},
+			key("-n", "-iu", "target", "--", "sudo", "-n", "/usr/bin/true"): {nil, nil}, // BAD — escalation succeeded
 		},
 	}
 	err := VerifyRunAsUserCheap(context.Background(), runner, "target")
@@ -203,8 +203,8 @@ func TestVerifyRunAsUserCheap_CacheHit(t *testing.T) {
 	ResetVerifyCache()
 	runner := &stubSudoRunner{
 		script: map[string]stubResponse{
-			key("-n", "-iu", "target", "--", "/bin/true"):               {nil, nil},
-			key("-n", "-iu", "target", "--", "sudo", "-n", "/bin/true"): {nil, &exec.ExitError{}},
+			key("-n", "-iu", "target", "--", "/usr/bin/true"):               {nil, nil},
+			key("-n", "-iu", "target", "--", "sudo", "-n", "/usr/bin/true"): {nil, &exec.ExitError{}},
 		},
 	}
 	// First call populates the cache with 2 runner calls.


### PR DESCRIPTION
## Summary
- Replace `/bin/true` with `/usr/bin/true` in runas_check.go and runas.go
- macOS has `true` at `/usr/bin/true` only; Linux has both `/bin/true` and `/usr/bin/true`
- Fixes `doctor user-isolation` FATAL on macOS

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 28 packages)
- [x] `/usr/bin/true` exists on both Linux and macOS

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)