### PR TITLE
Add Trae CLI ACP and COCO ACP examples to config.example.toml

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1447,6 +1447,32 @@ app_secret = "your-feishu-app-secret"
 # display_name = "OpenClaw ACP"
 # # env = { OPENCLAW_GATEWAY_TOKEN = "..." }
 
+# --- Example: Trae CLI ACP (https://www.trae.ai/) ---
+# [[projects]]
+# name = "trae-acp"
+#
+# [projects.agent]
+# type = "acp"
+#
+# [projects.agent.options]
+# work_dir = "/path/to/project"
+# command = "traecli"
+# args = ["acp", "serve"]
+# display_name = "Trae CLI ACP"
+
+# --- Example: COCO ACP ---
+# [[projects]]
+# name = "coco-acp"
+#
+# [projects.agent]
+# type = "acp"
+#
+# [projects.agent.options]
+# work_dir = "/path/to/project"
+# command = "coco"
+# args = ["acp", "serve"]
+# display_name = "COCO ACP"
+
 # --- Example: GitHub Copilot CLI (public preview) ---
 # Docs: https://docs.github.com/en/copilot/reference/copilot-cli-reference/acp-server
 # Requires Copilot CLI installed and authenticated; no auth_method for ACP subprocess.


### PR DESCRIPTION
## Summary
- Add Trae CLI ACP (`traecli acp serve`) example to the ACP section in `config.example.toml`
- Add COCO ACP (`coco acp serve`) example to the ACP section in `config.example.toml`

## Test plan
- [ ] Verify `config.example.toml` parses correctly
- [ ] Confirm examples follow the same pattern as existing ACP entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)