### PR TITLE
feat(platform/max): add MAX messenger bridge with bidirectional file and voice support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.dylib
 *.test
 *.out
+*.old
 
 # ============================================================================
 # Go workspace & tooling
@@ -36,7 +37,8 @@ vendor/
 # ============================================================================
 # Runtime configuration (contains secrets)
 config.toml
-config.test.toml
+config.*.toml
+!config.example.toml
 .env
 *.local.toml
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PLATFORMS := \
 # ---------------------------------------------------------------------------
 
 ALL_AGENTS    := acp claudecode codex cursor devin gemini iflow kimi opencode pi qoder
-ALL_PLATFORMS := feishu telegram discord slack dingtalk wecom weixin qq qqbot line weibo
+ALL_PLATFORMS := feishu telegram discord slack dingtalk wecom weixin qq qqbot line weibo max
 ALL_EXTRAS    := web
 
 COMMA := ,

--- a/cmd/cc-connect/plugin_platform_max.go
+++ b/cmd/cc-connect/plugin_platform_max.go
@@ -1,0 +1,5 @@
+//go:build !no_max
+
+package main
+
+import _ "github.com/chenhg5/cc-connect/platform/max"

--- a/config.example.toml
+++ b/config.example.toml
@@ -909,6 +909,21 @@ app_secret = "your-feishu-app-secret"
 # share_session_in_channel = false  # If true, all users in a group share one agent session / 群聊共享会话
 # enable_reactions = false  # If true, add ⚡ reaction to incoming messages / 设为 true 收到消息时添加 ⚡ 表情
 
+# MAX messenger (uncomment to enable / 取消注释以启用)
+# 1. Create a bot via @MasterBot in MAX, get the access token
+#    在 MAX 中通过 @MasterBot 创建机器人，获取 access token
+# 2. Paste the token below / 填入下方 token
+# Connection: Long polling via platform-api.max.ru (no public URL needed) / 长轮询，无需公网 IP
+
+# [[projects.platforms]]
+# type = "max"
+#
+# [projects.platforms.options]
+# token = "your-max-bot-token"
+# allow_from = "*"    # Allowed MAX user IDs, e.g. "66624886,12345678"; "*" = all
+#                     # 允许的 MAX 用户 ID，如 "66624886,12345678"；"*" 表示所有
+# api_base = "https://platform-api.max.ru"   # optional override / 可选覆盖默认 API
+
 # Slack (uncomment to enable / 取消注释以启用)
 # 1. Create an app at https://api.slack.com/apps / 创建应用
 # 2. Enable Socket Mode (Settings > Socket Mode) / 开启 Socket Mode

--- a/core/speech.go
+++ b/core/speech.go
@@ -49,7 +49,7 @@ func NewOpenAIWhisper(apiKey, baseURL, model string) *OpenAIWhisper {
 		APIKey:  apiKey,
 		BaseURL: strings.TrimRight(baseURL, "/"),
 		Model:   model,
-		Client:  &http.Client{Timeout: 60 * time.Second},
+		Client:  &http.Client{Timeout: 5 * time.Minute},
 	}
 }
 
@@ -130,7 +130,7 @@ func NewQwenASR(apiKey, baseURL, model string) *QwenASR {
 		APIKey:  apiKey,
 		BaseURL: strings.TrimRight(baseURL, "/"),
 		Model:   model,
-		Client:  &http.Client{Timeout: 60 * time.Second},
+		Client:  &http.Client{Timeout: 5 * time.Minute},
 	}
 }
 

--- a/platform/max/max.go
+++ b/platform/max/max.go
@@ -1,0 +1,1077 @@
+package max
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func init() {
+	core.RegisterPlatform("max", New)
+}
+
+const (
+	defaultAPIBase          = "https://platform-api.max.ru"
+	pollTimeout             = 20 // seconds, long-poll timeout
+	httpTimeout             = 35 * time.Second
+	initialReconnectBackoff = time.Second
+	maxReconnectBackoff     = 30 * time.Second
+	stableConnectionWindow  = 10 * time.Second
+	typingInterval          = 4 * time.Second
+	maxAttachmentBytes      = 25 * 1024 * 1024 // 25 MiB cap per downloaded attachment
+	attachmentDownloadTO    = 60 * time.Second
+	attachmentUploadTO      = 5 * time.Minute
+	// attachmentReadyDelay is the pause between CDN upload and POST /messages.
+	// Without it MAX may reject the message with "attachment.not.ready" while
+	// it is still indexing the freshly uploaded blob.
+	attachmentReadyDelay   = 600 * time.Millisecond
+	attachmentReadyRetries = 4
+)
+
+// replyContext carries the information needed to send a reply.
+type replyContext struct {
+	chatID    string
+	messageID string // populated from incoming message, used only by UpdateMessage
+}
+
+// Platform implements core.Platform for the MAX messenger bot API.
+type Platform struct {
+	token     string
+	apiBase   string
+	allowFrom string
+
+	mu      sync.RWMutex
+	handler core.MessageHandler
+	cancel  context.CancelFunc
+	stopping bool
+	client  *http.Client
+}
+
+// New creates a MAX platform from config options.
+//
+//	[[projects.platforms]]
+//	type = "max"
+//	[projects.platforms.options]
+//	token      = "<bot-token>"
+//	allow_from = "<user_id>,<user_id>"   # optional, "*" or empty = all
+//	api_base   = "https://platform-api.max.ru"  # optional override
+func New(opts map[string]any) (core.Platform, error) {
+	token, _ := opts["token"].(string)
+	if token == "" {
+		return nil, fmt.Errorf("max: token is required")
+	}
+	apiBase, _ := opts["api_base"].(string)
+	if apiBase == "" {
+		apiBase = defaultAPIBase
+	}
+	allowFrom, _ := opts["allow_from"].(string)
+	core.CheckAllowFrom("max", allowFrom)
+
+	return &Platform{
+		token:     token,
+		apiBase:   apiBase,
+		allowFrom: allowFrom,
+		client:    &http.Client{Timeout: httpTimeout},
+	}, nil
+}
+
+func (p *Platform) Name() string { return "max" }
+
+func (p *Platform) Start(handler core.MessageHandler) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.stopping {
+		return fmt.Errorf("max: platform stopped")
+	}
+	p.handler = handler
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.cancel = cancel
+
+	// Verify token at startup
+	if name, id, err := p.getMe(ctx); err != nil {
+		slog.Warn("max: could not verify bot token", "error", err)
+	} else {
+		slog.Info("max: connected", "bot", name, "id", id)
+	}
+
+	go p.pollLoop(ctx)
+	return nil
+}
+
+func (p *Platform) Stop() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.stopping = true
+	if p.cancel != nil {
+		p.cancel()
+	}
+	return nil
+}
+
+// --- Sending ---
+
+func (p *Platform) Reply(ctx context.Context, replyCtx any, content string) error {
+	return p.sendText(ctx, replyCtx, content, nil)
+}
+
+func (p *Platform) Send(ctx context.Context, replyCtx any, content string) error {
+	return p.sendText(ctx, replyCtx, content, nil)
+}
+
+// SendWithButtons implements core.InlineButtonSender — sends message with callback buttons.
+func (p *Platform) SendWithButtons(ctx context.Context, replyCtx any, content string, buttons [][]core.ButtonOption) error {
+	maxButtons := make([][]maxButton, 0, len(buttons))
+	for _, row := range buttons {
+		maxRow := make([]maxButton, 0, len(row))
+		for _, btn := range row {
+			maxRow = append(maxRow, maxButton{
+				Type:    "callback",
+				Text:    btn.Text,
+				Payload: btn.Data,
+			})
+		}
+		maxButtons = append(maxButtons, maxRow)
+	}
+	return p.sendText(ctx, replyCtx, content, maxButtons)
+}
+
+// SendImage implements core.ImageSender.
+func (p *Platform) SendImage(ctx context.Context, replyCtx any, img core.ImageAttachment) error {
+	rctx, ok := replyCtx.(replyContext)
+	if !ok {
+		return fmt.Errorf("max: unexpected replyCtx type %T", replyCtx)
+	}
+	token, err := p.uploadAttachment(ctx, "image", img.Data, img.FileName)
+	if err != nil {
+		return fmt.Errorf("max: upload image: %w", err)
+	}
+	body := &maxSendBody{
+		Attachments: []maxOutAttachment{{
+			Type:    "image",
+			Payload: maxTokenPayload{Token: token},
+		}},
+	}
+	return p.postMessage(ctx, rctx.chatID, body)
+}
+
+// SendFile implements core.FileSender. MAX routes images uploaded via the file
+// endpoint as type="file" in the message, so we honor the declared kind: if the
+// mime says image/*, we upload as image so the recipient sees a proper image
+// preview instead of a generic file card.
+func (p *Platform) SendFile(ctx context.Context, replyCtx any, file core.FileAttachment) error {
+	rctx, ok := replyCtx.(replyContext)
+	if !ok {
+		return fmt.Errorf("max: unexpected replyCtx type %T", replyCtx)
+	}
+	kind := "file"
+	attType := "file"
+	if strings.HasPrefix(file.MimeType, "image/") {
+		kind = "image"
+		attType = "image"
+	} else if strings.HasPrefix(file.MimeType, "video/") {
+		kind = "video"
+		attType = "video"
+	} else if strings.HasPrefix(file.MimeType, "audio/") {
+		kind = "audio"
+		attType = "audio"
+	}
+	token, err := p.uploadAttachment(ctx, kind, file.Data, file.FileName)
+	if err != nil {
+		return fmt.Errorf("max: upload file: %w", err)
+	}
+	body := &maxSendBody{
+		Attachments: []maxOutAttachment{{
+			Type:    attType,
+			Payload: maxTokenPayload{Token: token},
+		}},
+	}
+	return p.postMessage(ctx, rctx.chatID, body)
+}
+
+// SendAudio implements core.AudioSender — uploads a voice/audio blob and sends
+// it as a native MAX audio attachment. Used by the TTS pipeline to reply in
+// voice when [tts] is enabled in config.
+func (p *Platform) SendAudio(ctx context.Context, replyCtx any, audio []byte, format string) error {
+	rctx, ok := replyCtx.(replyContext)
+	if !ok {
+		return fmt.Errorf("max: unexpected replyCtx type %T", replyCtx)
+	}
+	if format == "" {
+		format = "mp3"
+	}
+	token, err := p.uploadAttachment(ctx, "audio", audio, "voice."+format)
+	if err != nil {
+		return fmt.Errorf("max: upload audio: %w", err)
+	}
+	body := &maxSendBody{
+		Attachments: []maxOutAttachment{{
+			Type:    "audio",
+			Payload: maxTokenPayload{Token: token},
+		}},
+	}
+	return p.postMessage(ctx, rctx.chatID, body)
+}
+
+// UpdateMessage implements core.MessageUpdater via PUT /messages?message_id=.
+func (p *Platform) UpdateMessage(ctx context.Context, replyCtx any, content string) error {
+	rctx, ok := replyCtx.(replyContext)
+	if !ok {
+		return fmt.Errorf("max: unexpected replyCtx type %T", replyCtx)
+	}
+	if rctx.messageID == "" {
+		return fmt.Errorf("max: update message: no message id in reply context")
+	}
+	body := maxSendBody{Text: content, Format: "markdown"}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, p.apiBase+"/messages", bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	p.setAuth(req)
+	q := req.URL.Query()
+	q.Set("message_id", rctx.messageID)
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("max: edit message: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("max: edit message: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+	return nil
+}
+
+// uploadAttachment performs the two-step MAX upload: request an upload URL from
+// /uploads?type=<kind>, then POST the binary as multipart/form-data field "data"
+// to that URL. Returns the token to embed in a subsequent /messages attachment.
+func (p *Platform) uploadAttachment(ctx context.Context, kind string, data []byte, filename string) (string, error) {
+	if len(data) == 0 {
+		return "", fmt.Errorf("empty attachment data")
+	}
+	uploadCtx, cancel := context.WithTimeout(ctx, attachmentUploadTO)
+	defer cancel()
+
+	urlReq, err := http.NewRequestWithContext(uploadCtx, http.MethodPost, p.apiBase+"/uploads", nil)
+	if err != nil {
+		return "", err
+	}
+	p.setAuth(urlReq)
+	q := urlReq.URL.Query()
+	q.Set("type", kind)
+	urlReq.URL.RawQuery = q.Encode()
+
+	urlResp, err := p.client.Do(urlReq)
+	if err != nil {
+		return "", fmt.Errorf("request upload url: %w", err)
+	}
+	defer urlResp.Body.Close()
+	if urlResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(urlResp.Body, 512))
+		return "", fmt.Errorf("upload url: HTTP %d: %s", urlResp.StatusCode, body)
+	}
+	var urlInfo struct {
+		URL   string `json:"url"`
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(urlResp.Body).Decode(&urlInfo); err != nil {
+		return "", fmt.Errorf("decode upload url: %w", err)
+	}
+	if urlInfo.URL == "" {
+		return "", fmt.Errorf("upload url: empty url in response")
+	}
+
+	if filename == "" {
+		filename = defaultFilename(kind)
+	}
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("data", filename)
+	if err != nil {
+		return "", err
+	}
+	if _, err := fw.Write(data); err != nil {
+		return "", err
+	}
+	if err := mw.Close(); err != nil {
+		return "", err
+	}
+
+	cdnReq, err := http.NewRequestWithContext(uploadCtx, http.MethodPost, urlInfo.URL, &buf)
+	if err != nil {
+		return "", err
+	}
+	p.setAuth(cdnReq)
+	cdnReq.Header.Set("Content-Type", mw.FormDataContentType())
+
+	cdnResp, err := p.client.Do(cdnReq)
+	if err != nil {
+		return "", fmt.Errorf("cdn upload: %w", err)
+	}
+	defer cdnResp.Body.Close()
+	if cdnResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(cdnResp.Body, 512))
+		return "", fmt.Errorf("cdn upload: HTTP %d: %s", cdnResp.StatusCode, body)
+	}
+	var cdnInfo struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(cdnResp.Body).Decode(&cdnInfo); err != nil {
+		return "", fmt.Errorf("decode cdn response: %w", err)
+	}
+	if cdnInfo.Token == "" {
+		// video/audio sometimes carry the token only in the /uploads response
+		if urlInfo.Token != "" {
+			return urlInfo.Token, nil
+		}
+		return "", fmt.Errorf("cdn upload: empty token")
+	}
+	return cdnInfo.Token, nil
+}
+
+func defaultFilename(kind string) string {
+	switch kind {
+	case "image":
+		return "image.png"
+	case "video":
+		return "video.mp4"
+	case "audio":
+		return "audio.mp3"
+	}
+	return "file.bin"
+}
+
+// StartTyping implements core.TypingIndicator — sends "..." periodically while working.
+func (p *Platform) StartTyping(ctx context.Context, replyCtx any) (stop func()) {
+	rctx, ok := replyCtx.(replyContext)
+	if !ok {
+		return func() {}
+	}
+	// MAX doesn't have a dedicated typing action, so we do nothing here.
+	// The engine already sends a "..." message via Reply before processing.
+	_ = rctx
+	return func() {}
+}
+
+// FormattingInstructions implements core.FormattingInstructionProvider.
+// The engine appends this to the agent system prompt so Claude uses only
+// MAX-supported markdown syntax.
+func (p *Platform) FormattingInstructions() string {
+	return `Formatting rules for MAX messenger:
+- **bold** and _italic_ are supported
+- Inline code: ` + "`code`" + ` and fenced code blocks (` + "```" + `) are supported
+- Bullet lists with - or * are supported as plain text
+- Do NOT use headers (# ## ###)
+- Do NOT use horizontal rules (--- or ***)
+- Do NOT use tables
+- Do NOT use HTML tags
+Keep responses concise and use plain text where possible.`
+}
+
+// ReconstructReplyCtx implements core.ReplyContextReconstructor.
+// Session key format: "max:{chatID}" or "max:{chatID}:{userID}"
+func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
+	// Extract chatID from session key: "max:{chatID}" or "max:{chatID}:{userID}"
+	var chatID string
+	_, err := fmt.Sscanf(sessionKey, "max:%s", &chatID)
+	if err != nil || chatID == "" {
+		return nil, fmt.Errorf("max: cannot reconstruct reply ctx from %q", sessionKey)
+	}
+	// If chatID has trailing ":userID", strip it
+	for i, c := range chatID {
+		if c == ':' {
+			chatID = chatID[:i]
+			break
+		}
+	}
+	return replyContext{chatID: chatID}, nil
+}
+
+// --- MAX API types ---
+
+type maxButton struct {
+	Type    string `json:"type"`
+	Text    string `json:"text"`
+	Payload string `json:"payload"`
+}
+
+// maxOutAttachment is the generic outgoing attachment wrapper used for both
+// inline_keyboard (with maxKbPayload) and image/file/video/audio (with
+// maxTokenPayload).
+type maxOutAttachment struct {
+	Type    string `json:"type"`
+	Payload any    `json:"payload,omitempty"`
+}
+
+type maxKbPayload struct {
+	Buttons [][]maxButton `json:"buttons"`
+}
+
+type maxTokenPayload struct {
+	Token string `json:"token"`
+}
+
+type maxSendBody struct {
+	Text        string             `json:"text"`
+	Format      string             `json:"format,omitempty"`
+	Attachments []maxOutAttachment `json:"attachments,omitempty"`
+}
+
+type maxUpdate struct {
+	UpdateType string `json:"update_type"`
+	Timestamp  int64  `json:"timestamp"`
+
+	// message_created
+	Message *maxMessage `json:"message,omitempty"`
+
+	// message_callback
+	Callback *maxCallback `json:"callback,omitempty"`
+}
+
+type maxMessage struct {
+	Sender    maxUser      `json:"sender"`
+	Recipient maxRecipient `json:"recipient"`
+	Timestamp int64        `json:"timestamp"`
+	Body      maxBody      `json:"body"`
+}
+
+type maxBody struct {
+	Mid         string             `json:"mid"`
+	Text        string             `json:"text"`
+	Attachments []maxAttachmentRaw `json:"attachments,omitempty"`
+}
+
+// maxAttachmentRaw mirrors what MAX API delivers in message_created updates.
+// Known types: "image", "video", "audio", "file", "sticker", "share".
+// "image" carries payload.url directly; "video"/"audio" only carry payload.token
+// and require an extra API round-trip (/videos/{token}, /audios/{token}) to
+// resolve the actual download URL.
+type maxAttachmentRaw struct {
+	Type     string             `json:"type"`
+	Payload  maxAttachmentPayld `json:"payload"`
+	Filename string             `json:"filename,omitempty"`
+}
+
+type maxAttachmentPayld struct {
+	URL   string `json:"url,omitempty"`
+	Token string `json:"token,omitempty"`
+}
+
+type maxUser struct {
+	UserID int64  `json:"user_id"`
+	Name   string `json:"name"`
+}
+
+type maxRecipient struct {
+	ChatID int64 `json:"chat_id"`
+}
+
+type maxCallback struct {
+	CallbackID string     `json:"callback_id"`
+	Payload    string     `json:"payload"`
+	User       maxUser    `json:"user"`
+	Message    maxMessage `json:"message"`
+}
+
+type maxUpdatesResponse struct {
+	Updates []maxUpdate `json:"updates"`
+	Marker  *int64      `json:"marker"`
+}
+
+// --- Long polling ---
+
+func (p *Platform) pollLoop(ctx context.Context) {
+	var marker *int64
+	backoff := initialReconnectBackoff
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		startedAt := time.Now()
+		newMarker, err := p.poll(ctx, marker)
+		if ctx.Err() != nil {
+			return
+		}
+
+		if err != nil {
+			elapsed := time.Since(startedAt)
+			wait := backoff
+			if elapsed >= stableConnectionWindow {
+				wait = initialReconnectBackoff
+				backoff = initialReconnectBackoff
+			} else {
+				backoff *= 2
+				if backoff > maxReconnectBackoff {
+					backoff = maxReconnectBackoff
+				}
+			}
+			slog.Warn("max: poll error, retrying", "error", err, "backoff", wait)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(wait):
+			}
+			continue
+		}
+
+		backoff = initialReconnectBackoff
+		if newMarker != nil {
+			marker = newMarker
+		}
+	}
+}
+
+func (p *Platform) poll(ctx context.Context, marker *int64) (*int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.apiBase+"/updates", nil)
+	if err != nil {
+		return nil, err
+	}
+	p.setAuth(req)
+	q := req.URL.Query()
+	q.Set("timeout", strconv.Itoa(pollTimeout))
+	q.Set("limit", "20")
+	q.Set("types", "message_created,message_callback")
+	if marker != nil {
+		q.Set("marker", strconv.FormatInt(*marker, 10))
+	}
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("poll request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("poll: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var result maxUpdatesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("poll decode: %w", err)
+	}
+
+	for i := range result.Updates {
+		p.handleUpdate(ctx, &result.Updates[i])
+	}
+
+	return result.Marker, nil
+}
+
+func (p *Platform) handleUpdate(ctx context.Context, upd *maxUpdate) {
+	switch upd.UpdateType {
+	case "message_created":
+		if upd.Message != nil {
+			p.handleMessage(ctx, upd.Message)
+		}
+	case "message_callback":
+		if upd.Callback != nil {
+			p.handleCallback(ctx, upd.Callback)
+		}
+	}
+}
+
+func (p *Platform) handleMessage(ctx context.Context, msg *maxMessage) {
+	msgTime := time.UnixMilli(msg.Timestamp)
+	if core.IsOldMessage(msgTime) {
+		slog.Debug("max: ignoring old message after restart", "date", msgTime)
+		return
+	}
+
+	text := msg.Body.Text
+	atts := msg.Body.Attachments
+	if text == "" && len(atts) == 0 {
+		return
+	}
+
+	userID := strconv.FormatInt(msg.Sender.UserID, 10)
+	if !core.AllowList(p.allowFrom, userID) {
+		slog.Debug("max: message from unauthorized user", "user_id", userID)
+		return
+	}
+
+	chatID := strconv.FormatInt(msg.Recipient.ChatID, 10)
+	sessionKey := fmt.Sprintf("max:%s:%s", chatID, userID)
+	rctx := replyContext{chatID: chatID, messageID: msg.Body.Mid}
+
+	images, files, audio := p.fetchAttachments(ctx, atts)
+
+	if text == "" && audio == nil && (len(images) > 0 || len(files) > 0) {
+		switch {
+		case len(images) > 0 && len(files) == 0:
+			text = "Please look at the attached image."
+		case len(files) > 0 && len(images) == 0:
+			text = "Please look at the attached file."
+		default:
+			text = "Please look at the attached files."
+		}
+	}
+
+	slog.Debug("max: message received",
+		"user", msg.Sender.Name, "chat", chatID,
+		"text_len", len(text), "images", len(images), "files", len(files), "has_audio", audio != nil)
+
+	handler := p.getHandler()
+	if handler == nil {
+		return
+	}
+	handler(p, &core.Message{
+		SessionKey: sessionKey,
+		Platform:   "max",
+		MessageID:  msg.Body.Mid,
+		UserID:     userID,
+		UserName:   msg.Sender.Name,
+		Content:    text,
+		Images:     images,
+		Files:      files,
+		Audio:      audio,
+		ReplyCtx:   rctx,
+	})
+}
+
+// fetchAttachments downloads every supported attachment from a MAX message
+// and splits them into images, files, and at most one audio blob. Audio is
+// returned separately so the core engine can route it through the speech
+// transcription pipeline instead of exposing a raw .mp3 to the agent.
+// Unsupported types (sticker, share, contact) are silently dropped.
+func (p *Platform) fetchAttachments(ctx context.Context, atts []maxAttachmentRaw) ([]core.ImageAttachment, []core.FileAttachment, *core.AudioAttachment) {
+	if len(atts) == 0 {
+		return nil, nil, nil
+	}
+	var images []core.ImageAttachment
+	var files []core.FileAttachment
+	var audio *core.AudioAttachment
+	for _, a := range atts {
+		switch a.Type {
+		case "image":
+			data, mime, err := p.downloadAttachment(ctx, a.Payload.URL)
+			if err != nil {
+				slog.Warn("max: image download failed", "error", err)
+				continue
+			}
+			if mime == "" || mime == "application/octet-stream" {
+				mime = sniffImageMime(data)
+			}
+			images = append(images, core.ImageAttachment{
+				MimeType: mime,
+				Data:     data,
+				FileName: a.Filename,
+			})
+		case "file":
+			url := a.Payload.URL
+			if url == "" {
+				slog.Warn("max: file attachment without payload.url, skipping", "filename", a.Filename)
+				continue
+			}
+			data, mime, err := p.downloadAttachment(ctx, url)
+			if err != nil {
+				slog.Warn("max: file download failed", "error", err, "filename", a.Filename)
+				continue
+			}
+			effectiveMime := mime
+			if effectiveMime == "" || effectiveMime == "application/octet-stream" {
+				if sniffed := sniffImageMime(data); sniffed != "application/octet-stream" {
+					effectiveMime = sniffed
+				}
+			}
+			if strings.HasPrefix(effectiveMime, "image/") {
+				images = append(images, core.ImageAttachment{
+					MimeType: effectiveMime,
+					Data:     data,
+					FileName: a.Filename,
+				})
+				continue
+			}
+			if strings.HasPrefix(effectiveMime, "audio/") && audio == nil {
+				audio = &core.AudioAttachment{
+					MimeType: effectiveMime,
+					Data:     data,
+					Format:   audioFormatFromMime(effectiveMime, a.Filename),
+				}
+				continue
+			}
+			if effectiveMime == "" {
+				effectiveMime = "application/octet-stream"
+			}
+			files = append(files, core.FileAttachment{
+				MimeType: effectiveMime,
+				Data:     data,
+				FileName: a.Filename,
+			})
+		case "audio":
+			url, fname, err := p.resolveMediaURL(ctx, a.Type, a.Payload.Token)
+			if err != nil {
+				slog.Warn("max: audio URL resolve failed", "error", err)
+				continue
+			}
+			if url == "" {
+				slog.Warn("max: audio has no resolvable URL")
+				continue
+			}
+			data, mime, err := p.downloadAttachment(ctx, url)
+			if err != nil {
+				slog.Warn("max: audio download failed", "error", err)
+				continue
+			}
+			if a.Filename != "" {
+				fname = a.Filename
+			}
+			if audio == nil {
+				audio = &core.AudioAttachment{
+					MimeType: mime,
+					Data:     data,
+					Format:   audioFormatFromMime(mime, fname),
+				}
+			}
+		case "video":
+			url, fname, err := p.resolveMediaURL(ctx, a.Type, a.Payload.Token)
+			if err != nil {
+				slog.Warn("max: video URL resolve failed", "error", err)
+				continue
+			}
+			if url == "" {
+				slog.Warn("max: video has no resolvable URL")
+				continue
+			}
+			data, mime, err := p.downloadAttachment(ctx, url)
+			if err != nil {
+				slog.Warn("max: video download failed", "error", err)
+				continue
+			}
+			if a.Filename != "" {
+				fname = a.Filename
+			}
+			files = append(files, core.FileAttachment{
+				MimeType: mime,
+				Data:     data,
+				FileName: fname,
+			})
+		default:
+			slog.Debug("max: skipping unsupported attachment type", "type", a.Type)
+		}
+	}
+	return images, files, audio
+}
+
+// audioFormatFromMime derives the short format hint ("ogg", "mp3", "m4a", …)
+// expected by core.AudioAttachment.Format. MAX voice messages are typically
+// ogg/opus; audio files uploaded via paperclip can be anything.
+func audioFormatFromMime(mime, filename string) string {
+	if mime != "" {
+		if i := strings.Index(mime, "/"); i >= 0 {
+			sub := mime[i+1:]
+			switch sub {
+			case "mpeg":
+				return "mp3"
+			case "mp4", "x-m4a":
+				return "m4a"
+			case "ogg", "webm", "wav":
+				return sub
+			}
+			if sub != "" {
+				return sub
+			}
+		}
+	}
+	if filename != "" {
+		if i := strings.LastIndex(filename, "."); i >= 0 && i < len(filename)-1 {
+			return strings.ToLower(filename[i+1:])
+		}
+	}
+	return "ogg"
+}
+
+// downloadAttachment GETs an arbitrary URL (typically a pre-signed CDN link
+// from MAX), capping the response at maxAttachmentBytes. The URLs MAX serves
+// for image/file payloads are already authenticated, so no bot token is
+// attached to the request.
+func (p *Platform) downloadAttachment(ctx context.Context, url string) ([]byte, string, error) {
+	if url == "" {
+		return nil, "", fmt.Errorf("empty url")
+	}
+	dlCtx, cancel := context.WithTimeout(ctx, attachmentDownloadTO)
+	defer cancel()
+	req, err := http.NewRequestWithContext(dlCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAttachmentBytes+1))
+	if err != nil {
+		return nil, "", err
+	}
+	if len(data) > maxAttachmentBytes {
+		return nil, "", fmt.Errorf("attachment exceeds %d bytes", maxAttachmentBytes)
+	}
+	return data, resp.Header.Get("Content-Type"), nil
+}
+
+// resolveMediaURL asks MAX for the playable/downloadable URL of a video or
+// audio attachment. MAX delivers only an opaque token in the message payload
+// and exposes /videos/{token} and /audios/{token} for resolution.
+func (p *Platform) resolveMediaURL(ctx context.Context, kind, token string) (string, string, error) {
+	if token == "" {
+		return "", "", fmt.Errorf("empty token")
+	}
+	endpoint := "/videos/"
+	if kind == "audio" {
+		endpoint = "/audios/"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.apiBase+endpoint+token, nil)
+	if err != nil {
+		return "", "", err
+	}
+	p.setAuth(req)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+	var info struct {
+		URL   string `json:"url"`
+		Files struct {
+			MP4 struct {
+				URL string `json:"url"`
+			} `json:"mp4"`
+		} `json:"files"`
+		Filename string `json:"filename"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return "", "", err
+	}
+	url := info.URL
+	if url == "" {
+		url = info.Files.MP4.URL
+	}
+	return url, info.Filename, nil
+}
+
+// sniffImageMime is a tiny fallback when the CDN returned no Content-Type.
+func sniffImageMime(data []byte) string {
+	if len(data) >= 8 && data[0] == 0x89 && data[1] == 'P' && data[2] == 'N' && data[3] == 'G' {
+		return "image/png"
+	}
+	if len(data) >= 2 && data[0] == 0xFF && data[1] == 0xD8 {
+		return "image/jpeg"
+	}
+	if len(data) >= 4 && string(data[:4]) == "GIF8" {
+		return "image/gif"
+	}
+	if len(data) >= 12 && string(data[:4]) == "RIFF" && string(data[8:12]) == "WEBP" {
+		return "image/webp"
+	}
+	return "application/octet-stream"
+}
+
+func (p *Platform) handleCallback(ctx context.Context, cb *maxCallback) {
+	userID := strconv.FormatInt(cb.User.UserID, 10)
+	if !core.AllowList(p.allowFrom, userID) {
+		slog.Debug("max: callback from unauthorized user", "user_id", userID)
+		return
+	}
+
+	chatID := strconv.FormatInt(cb.Message.Recipient.ChatID, 10)
+	sessionKey := fmt.Sprintf("max:%s:%s", chatID, userID)
+	rctx := replyContext{chatID: chatID, messageID: cb.Message.Body.Mid}
+
+	slog.Debug("max: callback received", "user", cb.User.Name, "payload", cb.Payload)
+
+	handler := p.getHandler()
+	if handler == nil {
+		return
+	}
+	handler(p, &core.Message{
+		SessionKey: sessionKey,
+		Platform:   "max",
+		MessageID:  cb.CallbackID,
+		UserID:     userID,
+		UserName:   cb.User.Name,
+		Content:    cb.Payload,
+		ReplyCtx:   rctx,
+	})
+}
+
+// --- HTTP helpers ---
+
+func (p *Platform) sendText(ctx context.Context, replyCtx any, content string, buttons [][]maxButton) error {
+	rctx, ok := replyCtx.(replyContext)
+	if !ok {
+		return fmt.Errorf("max: unexpected replyCtx type %T", replyCtx)
+	}
+
+	var kbAttachments []maxOutAttachment
+	if len(buttons) > 0 {
+		kbAttachments = []maxOutAttachment{{
+			Type:    "inline_keyboard",
+			Payload: maxKbPayload{Buttons: buttons},
+		}}
+	}
+
+	const maxLen = 4000
+	chunks := splitMessage(content, maxLen)
+	for i, chunk := range chunks {
+		chunkBody := maxSendBody{Text: chunk, Format: "markdown"}
+		if i == len(chunks)-1 && len(kbAttachments) > 0 {
+			chunkBody.Attachments = kbAttachments
+		}
+		if err := p.postMessage(ctx, rctx.chatID, &chunkBody); err != nil {
+			return err
+		}
+		if len(chunks) > 1 && i < len(chunks)-1 {
+			time.Sleep(300 * time.Millisecond)
+		}
+	}
+	return nil
+}
+
+// postMessage sends one /messages request. It is the single HTTP call used by
+// sendText, SendImage, SendFile — kept separate so retry/backoff for
+// "attachment.not.ready" lives in one place.
+func (p *Platform) postMessage(ctx context.Context, chatID string, body *maxSendBody) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	backoff := attachmentReadyDelay
+	for attempt := 0; attempt <= attachmentReadyRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.apiBase+"/messages", bytes.NewReader(data))
+		if err != nil {
+			return err
+		}
+		p.setAuth(req)
+		q := req.URL.Query()
+		q.Set("chat_id", chatID)
+		req.URL.RawQuery = q.Encode()
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := p.client.Do(req)
+		if err != nil {
+			return fmt.Errorf("max: send message: %w", err)
+		}
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			return nil
+		}
+		if isAttachmentNotReady(respBody) && attempt < attachmentReadyRetries {
+			slog.Debug("max: attachment not ready, retrying", "attempt", attempt+1, "backoff", backoff)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+			continue
+		}
+		slog.Warn("max: send message failed", "status", resp.StatusCode, "chat", chatID, "body", string(respBody))
+		return fmt.Errorf("max: send message: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+	return fmt.Errorf("max: send message: attachment not ready after %d retries", attachmentReadyRetries)
+}
+
+func isAttachmentNotReady(body []byte) bool {
+	return bytes.Contains(body, []byte("attachment.not.ready")) ||
+		bytes.Contains(body, []byte("not.ready"))
+}
+
+func (p *Platform) getMe(ctx context.Context) (name string, id int64, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.apiBase+"/me", nil)
+	if err != nil {
+		return "", 0, err
+	}
+	p.setAuth(req)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+
+	var info struct {
+		Name   string `json:"name"`
+		UserID int64  `json:"user_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return "", 0, err
+	}
+	return info.Name, info.UserID, nil
+}
+
+func (p *Platform) getHandler() core.MessageHandler {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.handler
+}
+
+// setAuth adds the Authorization header with the bot token.
+func (p *Platform) setAuth(req *http.Request) {
+	req.Header.Set("Authorization", p.token)
+}
+
+func splitMessage(text string, maxLen int) []string {
+	if len(text) <= maxLen {
+		return []string{text}
+	}
+	var chunks []string
+	for len(text) > 0 {
+		if len(text) <= maxLen {
+			chunks = append(chunks, text)
+			break
+		}
+		cut := maxLen
+		if nl := lastNewline(text[:maxLen]); nl > 100 {
+			cut = nl
+		}
+		chunks = append(chunks, text[:cut])
+		text = text[cut:]
+		// trim leading newlines
+		for len(text) > 0 && text[0] == '\n' {
+			text = text[1:]
+		}
+	}
+	return chunks
+}
+
+func lastNewline(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '\n' {
+			return i
+		}
+	}
+	return -1
+}

--- a/platform/max/max.go
+++ b/platform/max/max.go
@@ -332,20 +332,51 @@ func (p *Platform) uploadAttachment(ctx context.Context, kind string, data []byt
 		body, _ := io.ReadAll(io.LimitReader(cdnResp.Body, 512))
 		return "", fmt.Errorf("cdn upload: HTTP %d: %s", cdnResp.StatusCode, body)
 	}
-	var cdnInfo struct {
-		Token string `json:"token"`
+	cdnBody, err := io.ReadAll(io.LimitReader(cdnResp.Body, 64*1024))
+	if err != nil {
+		return "", fmt.Errorf("read cdn response: %w", err)
 	}
-	if err := json.NewDecoder(cdnResp.Body).Decode(&cdnInfo); err != nil {
-		return "", fmt.Errorf("decode cdn response: %w", err)
+	// MAX CDN uses different response shapes per attachment kind:
+	//   image: {"photos": {"<photo_id>": {"token": "..."}}}
+	//   file:  {"token": "..."}
+	//   video/audio: "<retval>1</retval>" (XML) — the real token is already in urlInfo.Token
+	if token := extractCDNToken(kind, cdnBody); token != "" {
+		return token, nil
 	}
-	if cdnInfo.Token == "" {
-		// video/audio sometimes carry the token only in the /uploads response
-		if urlInfo.Token != "" {
-			return urlInfo.Token, nil
+	if urlInfo.Token != "" {
+		return urlInfo.Token, nil
+	}
+	return "", fmt.Errorf("cdn upload: no token in response: %s", cdnBody)
+}
+
+// extractCDNToken parses the token out of a MAX CDN upload response. Returns
+// "" if not found; the caller is expected to fall back to urlInfo.Token.
+func extractCDNToken(kind string, body []byte) string {
+	switch kind {
+	case "image":
+		var resp struct {
+			Photos map[string]struct {
+				Token string `json:"token"`
+			} `json:"photos"`
 		}
-		return "", fmt.Errorf("cdn upload: empty token")
+		if err := json.Unmarshal(body, &resp); err == nil {
+			for _, ph := range resp.Photos {
+				if ph.Token != "" {
+					return ph.Token
+				}
+			}
+		}
+	case "video", "audio":
+		// CDN returns XML for video/audio; token lives in urlInfo.Token. Nothing to extract here.
+	default: // file
+		var resp struct {
+			Token string `json:"token"`
+		}
+		if err := json.Unmarshal(body, &resp); err == nil && resp.Token != "" {
+			return resp.Token
+		}
 	}
-	return cdnInfo.Token, nil
+	return ""
 }
 
 func defaultFilename(kind string) string {
@@ -721,13 +752,12 @@ func (p *Platform) fetchAttachments(ctx context.Context, atts []maxAttachmentRaw
 				FileName: a.Filename,
 			})
 		case "audio":
-			url, fname, err := p.resolveMediaURL(ctx, a.Type, a.Payload.Token)
-			if err != nil {
-				slog.Warn("max: audio URL resolve failed", "error", err)
-				continue
+			url := a.Payload.URL
+			if url == "" {
+				url, _, _ = p.resolveMediaURL(ctx, a.Type, a.Payload.Token)
 			}
 			if url == "" {
-				slog.Warn("max: audio has no resolvable URL")
+				slog.Warn("max: audio has no download URL")
 				continue
 			}
 			data, mime, err := p.downloadAttachment(ctx, url)
@@ -735,24 +765,20 @@ func (p *Platform) fetchAttachments(ctx context.Context, atts []maxAttachmentRaw
 				slog.Warn("max: audio download failed", "error", err)
 				continue
 			}
-			if a.Filename != "" {
-				fname = a.Filename
-			}
 			if audio == nil {
 				audio = &core.AudioAttachment{
 					MimeType: mime,
 					Data:     data,
-					Format:   audioFormatFromMime(mime, fname),
+					Format:   audioFormatFromMime(mime, a.Filename),
 				}
 			}
 		case "video":
-			url, fname, err := p.resolveMediaURL(ctx, a.Type, a.Payload.Token)
-			if err != nil {
-				slog.Warn("max: video URL resolve failed", "error", err)
-				continue
+			url := a.Payload.URL
+			if url == "" {
+				url, _, _ = p.resolveMediaURL(ctx, a.Type, a.Payload.Token)
 			}
 			if url == "" {
-				slog.Warn("max: video has no resolvable URL")
+				slog.Warn("max: video has no download URL")
 				continue
 			}
 			data, mime, err := p.downloadAttachment(ctx, url)
@@ -760,9 +786,7 @@ func (p *Platform) fetchAttachments(ctx context.Context, atts []maxAttachmentRaw
 				slog.Warn("max: video download failed", "error", err)
 				continue
 			}
-			if a.Filename != "" {
-				fname = a.Filename
-			}
+			fname := a.Filename
 			files = append(files, core.FileAttachment{
 				MimeType: mime,
 				Data:     data,

--- a/platform/max/max.go
+++ b/platform/max/max.go
@@ -51,11 +51,12 @@ type Platform struct {
 	apiBase   string
 	allowFrom string
 
-	mu      sync.RWMutex
-	handler core.MessageHandler
-	cancel  context.CancelFunc
+	mu       sync.RWMutex
+	handler  core.MessageHandler
+	cancel   context.CancelFunc
 	stopping bool
-	client  *http.Client
+	client   *http.Client
+	dedup    core.MessageDedup
 }
 
 // New creates a MAX platform from config options.
@@ -419,20 +420,15 @@ Keep responses concise and use plain text where possible.`
 }
 
 // ReconstructReplyCtx implements core.ReplyContextReconstructor.
-// Session key format: "max:{chatID}" or "max:{chatID}:{userID}"
+// Session key format: "max:{chatID}" or "max:{chatID}:{userID}".
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
-	// Extract chatID from session key: "max:{chatID}" or "max:{chatID}:{userID}"
-	var chatID string
-	_, err := fmt.Sscanf(sessionKey, "max:%s", &chatID)
-	if err != nil || chatID == "" {
+	rest, ok := strings.CutPrefix(sessionKey, "max:")
+	if !ok {
 		return nil, fmt.Errorf("max: cannot reconstruct reply ctx from %q", sessionKey)
 	}
-	// If chatID has trailing ":userID", strip it
-	for i, c := range chatID {
-		if c == ':' {
-			chatID = chatID[:i]
-			break
-		}
+	chatID, _, _ := strings.Cut(rest, ":")
+	if chatID == "" {
+		return nil, fmt.Errorf("max: cannot reconstruct reply ctx from %q", sessionKey)
 	}
 	return replyContext{chatID: chatID}, nil
 }
@@ -628,6 +624,10 @@ func (p *Platform) handleMessage(ctx context.Context, msg *maxMessage) {
 	msgTime := time.UnixMilli(msg.Timestamp)
 	if core.IsOldMessage(msgTime) {
 		slog.Debug("max: ignoring old message after restart", "date", msgTime)
+		return
+	}
+	if p.dedup.IsDuplicate(msg.Body.Mid) {
+		slog.Debug("max: duplicate message ignored", "message_id", msg.Body.Mid)
 		return
 	}
 
@@ -922,6 +922,10 @@ func sniffImageMime(data []byte) string {
 }
 
 func (p *Platform) handleCallback(ctx context.Context, cb *maxCallback) {
+	if p.dedup.IsDuplicate(cb.CallbackID) {
+		slog.Debug("max: duplicate callback ignored", "callback_id", cb.CallbackID)
+		return
+	}
 	userID := strconv.FormatInt(cb.User.UserID, 10)
 	if !core.AllowList(p.allowFrom, userID) {
 		slog.Debug("max: callback from unauthorized user", "user_id", userID)

--- a/platform/max/max_test.go
+++ b/platform/max/max_test.go
@@ -597,6 +597,27 @@ func TestFetchAttachmentsFileWithAudioMimeRoutesToAudio(t *testing.T) {
 	}
 }
 
+func TestHandleMessageDedupsByID(t *testing.T) {
+	p := newTestPlatform(t, "http://unused")
+
+	delivered := 0
+	_ = p.Start(func(_ core.Platform, _ *core.Message) { delivered++ })
+	defer func() { _ = p.Stop() }()
+
+	msg := &maxMessage{
+		Sender:    maxUser{UserID: 1, Name: "u"},
+		Recipient: maxRecipient{ChatID: 42},
+		Timestamp: time.Now().UnixMilli(),
+		Body:      maxBody{Mid: "mid-1", Text: "hi"},
+	}
+	ctx := context.Background()
+	p.handleMessage(ctx, msg)
+	p.handleMessage(ctx, msg) // duplicate mid → should be dropped
+	if delivered != 1 {
+		t.Errorf("handler fired %d times, want 1 (dedup failed)", delivered)
+	}
+}
+
 func TestSendAudio(t *testing.T) {
 	m := newMockAPI(t)
 	defer m.close()

--- a/platform/max/max_test.go
+++ b/platform/max/max_test.go
@@ -241,11 +241,18 @@ func (m *mockAPI) handleUploads(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing type", http.StatusBadRequest)
 		return
 	}
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"url": m.cdnServer.URL + "/upload?kind=" + kind,
-	})
+	resp := map[string]any{"url": m.cdnServer.URL + "/upload?kind=" + kind}
+	// video/audio carry the real token in the /uploads response itself
+	if kind == "video" || kind == "audio" {
+		resp["token"] = "urltok-" + kind
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// handleCDN mimics per-kind MAX CDN response shapes:
+//   image: {"photos": {"<id>": {"token": "..."}}}
+//   file:  {"token": "..."}
+//   video/audio: XML "<retval>1</retval>" (token comes from /uploads instead)
 func (m *mockAPI) handleCDN(w http.ResponseWriter, r *http.Request) {
 	atomic.AddInt32(&m.cdnCalls, 1)
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
@@ -262,7 +269,20 @@ func (m *mockAPI) handleCDN(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	_ = json.NewEncoder(w).Encode(map[string]any{"token": "tok-" + r.URL.Query().Get("kind")})
+	kind := r.URL.Query().Get("kind")
+	switch kind {
+	case "image":
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"photos": map[string]any{
+				"photo-id-1": map[string]any{"token": "cdntok-image"},
+			},
+		})
+	case "video", "audio":
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte("<retval>1</retval>"))
+	default:
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "cdntok-" + kind})
+	}
 }
 
 func newTestPlatform(t *testing.T, apiBase string) *Platform {

--- a/platform/max/max_test.go
+++ b/platform/max/max_test.go
@@ -1,0 +1,602 @@
+package max
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestSplitMessage(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		limit    int
+		chunks   int
+		firstLen int // expected len of first chunk (0 = skip)
+	}{
+		{"short stays whole", "hello", 10, 1, 5},
+		{"exact limit stays whole", "abcdefghij", 10, 1, 10},
+		{"over limit splits", strings.Repeat("a", 25), 10, 3, 10},
+		{"newline aware over threshold", strings.Repeat("a", 150) + "\n" + strings.Repeat("b", 150), 200, 2, 150},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := splitMessage(c.in, c.limit)
+			if len(got) != c.chunks {
+				t.Fatalf("chunks: got %d, want %d (%q)", len(got), c.chunks, got)
+			}
+			if c.firstLen > 0 && len(got[0]) != c.firstLen {
+				t.Errorf("first chunk len: got %d, want %d (%q)", len(got[0]), c.firstLen, got[0])
+			}
+			joined := strings.ReplaceAll(strings.Join(got, ""), "", "")
+			if strings.ReplaceAll(joined, "\n", "") != strings.ReplaceAll(c.in, "\n", "") {
+				t.Errorf("joined chunks lost data: %q vs %q", joined, c.in)
+			}
+		})
+	}
+}
+
+func TestSniffImageMime(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{"png", []byte{0x89, 'P', 'N', 'G', 0, 0, 0, 0}, "image/png"},
+		{"jpeg", []byte{0xFF, 0xD8, 0, 0}, "image/jpeg"},
+		{"gif", []byte("GIF89a"), "image/gif"},
+		{"webp", []byte("RIFF\x00\x00\x00\x00WEBP....."), "image/webp"},
+		{"unknown", []byte{0, 1, 2, 3, 4, 5, 6, 7}, "application/octet-stream"},
+		{"empty", []byte{}, "application/octet-stream"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sniffImageMime(c.in); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsAttachmentNotReady(t *testing.T) {
+	cases := map[string]bool{
+		`{"code":"attachment.not.ready","message":"retry"}`: true,
+		`{"error":"not.ready"}`:                             true,
+		`{"code":"rate.limit"}`:                             false,
+		`{"ok":true}`:                                       false,
+		``:                                                  false,
+	}
+	for body, want := range cases {
+		if got := isAttachmentNotReady([]byte(body)); got != want {
+			t.Errorf("isAttachmentNotReady(%q) = %v, want %v", body, got, want)
+		}
+	}
+}
+
+func TestDefaultFilename(t *testing.T) {
+	cases := map[string]string{
+		"image": "image.png",
+		"video": "video.mp4",
+		"audio": "audio.mp3",
+		"file":  "file.bin",
+		"xyz":   "file.bin",
+	}
+	for in, want := range cases {
+		if got := defaultFilename(in); got != want {
+			t.Errorf("defaultFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestReconstructReplyCtx(t *testing.T) {
+	p := &Platform{}
+	cases := []struct {
+		key     string
+		chatID  string
+		wantErr bool
+	}{
+		{"max:12345", "12345", false},
+		{"max:12345:99", "12345", false},
+		{"telegram:12345", "", true},
+		{"max:", "", true},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.key, func(t *testing.T) {
+			got, err := p.ReconstructReplyCtx(c.key)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, c.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			rc, ok := got.(replyContext)
+			if !ok {
+				t.Fatalf("wrong type %T", got)
+			}
+			if rc.chatID != c.chatID {
+				t.Errorf("chatID=%q, want %q", rc.chatID, c.chatID)
+			}
+		})
+	}
+}
+
+// --- Integration tests against a mock MAX API ---
+
+type mockAPI struct {
+	server       *httptest.Server
+	cdnServer    *httptest.Server
+	messageCalls int32
+	uploadCalls  int32
+	cdnCalls     int32
+	editCalls    int32
+
+	// capture last POST /messages body for inspection
+	mu           sync.Mutex
+	lastMsgBody  maxSendBody
+	lastMsgQuery string
+	lastEditBody maxSendBody
+	lastEditMID  string
+
+	// attachmentReadyAfter: return attachment.not.ready this many times before 200
+	attachmentReadyAfter int32
+}
+
+func newMockAPI(t *testing.T) *mockAPI {
+	t.Helper()
+	m := &mockAPI{}
+	m.cdnServer = httptest.NewServer(http.HandlerFunc(m.handleCDN))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/me", m.handleMe)
+	mux.HandleFunc("/updates", m.handleUpdates)
+	mux.HandleFunc("/messages", m.handleMessages)
+	mux.HandleFunc("/uploads", m.handleUploads)
+	mux.HandleFunc("/audios/", m.handleMediaResolve)
+	mux.HandleFunc("/videos/", m.handleMediaResolve)
+	mux.HandleFunc("/blob/", m.handleBlob)
+	m.server = httptest.NewServer(mux)
+	return m
+}
+
+// handleMediaResolve replies with a JSON pointing to our own /blob/<token>
+// endpoint, letting tests simulate the MAX /audios/{token} → URL → download
+// round-trip without depending on a real CDN.
+func (m *mockAPI) handleMediaResolve(w http.ResponseWriter, r *http.Request) {
+	token := strings.TrimPrefix(r.URL.Path, "/audios/")
+	token = strings.TrimPrefix(token, "/videos/")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"url":      m.server.URL + "/blob/" + token,
+		"filename": "voice.ogg",
+	})
+}
+
+func (m *mockAPI) handleBlob(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "audio/ogg")
+	_, _ = w.Write([]byte("OggS\x00\x00fake-audio-bytes"))
+}
+
+func (m *mockAPI) close() {
+	m.server.Close()
+	m.cdnServer.Close()
+}
+
+func (m *mockAPI) handleMe(w http.ResponseWriter, _ *http.Request) {
+	_ = json.NewEncoder(w).Encode(map[string]any{"name": "test-bot", "user_id": 42})
+}
+
+func (m *mockAPI) handleUpdates(w http.ResponseWriter, r *http.Request) {
+	<-r.Context().Done() // block until caller cancels
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (m *mockAPI) handleMessages(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		atomic.AddInt32(&m.messageCalls, 1)
+		var body maxSendBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// attachment.not.ready simulation
+		remaining := atomic.LoadInt32(&m.attachmentReadyAfter)
+		if remaining > 0 {
+			atomic.AddInt32(&m.attachmentReadyAfter, -1)
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"code":"attachment.not.ready"}`))
+			return
+		}
+		m.mu.Lock()
+		m.lastMsgBody = body
+		m.lastMsgQuery = r.URL.RawQuery
+		m.mu.Unlock()
+		_, _ = w.Write([]byte(`{"message_id":"test-mid"}`))
+	case http.MethodPut:
+		atomic.AddInt32(&m.editCalls, 1)
+		var body maxSendBody
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		m.mu.Lock()
+		m.lastEditBody = body
+		m.lastEditMID = r.URL.Query().Get("message_id")
+		m.mu.Unlock()
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (m *mockAPI) handleUploads(w http.ResponseWriter, r *http.Request) {
+	atomic.AddInt32(&m.uploadCalls, 1)
+	kind := r.URL.Query().Get("type")
+	if kind == "" {
+		http.Error(w, "missing type", http.StatusBadRequest)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"url": m.cdnServer.URL + "/upload?kind=" + kind,
+	})
+}
+
+func (m *mockAPI) handleCDN(w http.ResponseWriter, r *http.Request) {
+	atomic.AddInt32(&m.cdnCalls, 1)
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	f, _, err := r.FormFile("data")
+	if err != nil {
+		http.Error(w, "missing data field: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer f.Close()
+	if _, err := io.Copy(io.Discard, f); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"token": "tok-" + r.URL.Query().Get("kind")})
+}
+
+func newTestPlatform(t *testing.T, apiBase string) *Platform {
+	t.Helper()
+	p, err := New(map[string]any{
+		"token":    "test-token",
+		"api_base": apiBase,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p.(*Platform)
+}
+
+func TestSendText(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := p.Send(ctx, replyContext{chatID: "111"}, "hello world"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if atomic.LoadInt32(&m.messageCalls) != 1 {
+		t.Fatalf("want 1 message call, got %d", m.messageCalls)
+	}
+	m.mu.Lock()
+	body := m.lastMsgBody
+	query := m.lastMsgQuery
+	m.mu.Unlock()
+	if body.Text != "hello world" {
+		t.Errorf("text: got %q", body.Text)
+	}
+	if body.Format != "markdown" {
+		t.Errorf("format: got %q", body.Format)
+	}
+	if !strings.Contains(query, "chat_id=111") {
+		t.Errorf("chat_id missing from query: %q", query)
+	}
+}
+
+func TestSendTextSplitsLong(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	long := strings.Repeat("a", 8500)
+	ctx := context.Background()
+	if err := p.Send(ctx, replyContext{chatID: "111"}, long); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	// 8500 / 4000 = 3 chunks
+	if got := atomic.LoadInt32(&m.messageCalls); got != 3 {
+		t.Errorf("want 3 chunk messages, got %d", got)
+	}
+}
+
+func TestSendWithButtons(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	ctx := context.Background()
+	buttons := [][]core.ButtonOption{{{Text: "OK", Data: "ok"}, {Text: "Cancel", Data: "cancel"}}}
+	if err := p.SendWithButtons(ctx, replyContext{chatID: "111"}, "pick", buttons); err != nil {
+		t.Fatalf("SendWithButtons: %v", err)
+	}
+	m.mu.Lock()
+	body := m.lastMsgBody
+	m.mu.Unlock()
+	if len(body.Attachments) != 1 {
+		t.Fatalf("want 1 attachment, got %d", len(body.Attachments))
+	}
+	if body.Attachments[0].Type != "inline_keyboard" {
+		t.Errorf("attachment type: got %q", body.Attachments[0].Type)
+	}
+}
+
+func TestSendImage(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	ctx := context.Background()
+	img := core.ImageAttachment{MimeType: "image/png", Data: []byte{0x89, 'P', 'N', 'G', 0, 0, 0, 0}, FileName: "chart.png"}
+	if err := p.SendImage(ctx, replyContext{chatID: "111"}, img); err != nil {
+		t.Fatalf("SendImage: %v", err)
+	}
+	if got := atomic.LoadInt32(&m.uploadCalls); got != 1 {
+		t.Errorf("uploads: got %d", got)
+	}
+	if got := atomic.LoadInt32(&m.cdnCalls); got != 1 {
+		t.Errorf("cdn: got %d", got)
+	}
+	m.mu.Lock()
+	body := m.lastMsgBody
+	m.mu.Unlock()
+	if len(body.Attachments) != 1 || body.Attachments[0].Type != "image" {
+		t.Fatalf("want image attachment, got %+v", body.Attachments)
+	}
+}
+
+func TestSendFileRoutesImageByMime(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	ctx := context.Background()
+	file := core.FileAttachment{MimeType: "image/jpeg", Data: []byte{0xFF, 0xD8, 0, 0}, FileName: "photo.jpg"}
+	if err := p.SendFile(ctx, replyContext{chatID: "111"}, file); err != nil {
+		t.Fatalf("SendFile: %v", err)
+	}
+	m.mu.Lock()
+	body := m.lastMsgBody
+	m.mu.Unlock()
+	if len(body.Attachments) != 1 || body.Attachments[0].Type != "image" {
+		t.Fatalf("image/* mime should route to type=image, got %+v", body.Attachments)
+	}
+}
+
+func TestSendFileGeneric(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	ctx := context.Background()
+	file := core.FileAttachment{MimeType: "application/pdf", Data: []byte("%PDF-1.4"), FileName: "report.pdf"}
+	if err := p.SendFile(ctx, replyContext{chatID: "111"}, file); err != nil {
+		t.Fatalf("SendFile: %v", err)
+	}
+	m.mu.Lock()
+	body := m.lastMsgBody
+	m.mu.Unlock()
+	if len(body.Attachments) != 1 || body.Attachments[0].Type != "file" {
+		t.Fatalf("pdf should be type=file, got %+v", body.Attachments)
+	}
+}
+
+func TestAttachmentNotReadyRetry(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	// First two POST /messages return attachment.not.ready, third succeeds
+	atomic.StoreInt32(&m.attachmentReadyAfter, 2)
+
+	p := newTestPlatform(t, m.server.URL)
+
+	ctx := context.Background()
+	img := core.ImageAttachment{MimeType: "image/png", Data: []byte{0x89, 'P', 'N', 'G', 0, 0, 0, 0}}
+	if err := p.SendImage(ctx, replyContext{chatID: "111"}, img); err != nil {
+		t.Fatalf("SendImage: %v", err)
+	}
+	// 1 upload + 1 cdn + 3 message attempts
+	if got := atomic.LoadInt32(&m.messageCalls); got != 3 {
+		t.Errorf("message attempts: got %d, want 3", got)
+	}
+}
+
+func TestUpdateMessage(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	ctx := context.Background()
+	if err := p.UpdateMessage(ctx, replyContext{chatID: "111", messageID: "mid-42"}, "edited"); err != nil {
+		t.Fatalf("UpdateMessage: %v", err)
+	}
+	if got := atomic.LoadInt32(&m.editCalls); got != 1 {
+		t.Errorf("edit calls: got %d, want 1", got)
+	}
+	m.mu.Lock()
+	body := m.lastEditBody
+	mid := m.lastEditMID
+	m.mu.Unlock()
+	if body.Text != "edited" {
+		t.Errorf("edit text: got %q", body.Text)
+	}
+	if mid != "mid-42" {
+		t.Errorf("edit mid: got %q", mid)
+	}
+}
+
+func TestUpdateMessageWithoutMID(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	err := p.UpdateMessage(context.Background(), replyContext{chatID: "111"}, "noop")
+	if err == nil {
+		t.Fatal("expected error when messageID is empty")
+	}
+	if !strings.Contains(err.Error(), "message id") {
+		t.Errorf("error should mention missing message id: %v", err)
+	}
+}
+
+func TestNewRequiresToken(t *testing.T) {
+	_, err := New(map[string]any{})
+	if err == nil {
+		t.Fatal("expected error when token missing")
+	}
+}
+
+func TestPollLoopStopsOnCtxCancel(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	handlerCalled := false
+	err := p.Start(func(_ core.Platform, _ *core.Message) { handlerCalled = true })
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// give the loop a moment to hit /updates
+	time.Sleep(100 * time.Millisecond)
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if handlerCalled {
+		t.Error("handler should not be called for empty /updates")
+	}
+}
+
+// sanity: make sure the /uploads handler sees the expected type query param
+func TestUploadKindPropagation(t *testing.T) {
+	var seenKinds []string
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seenKinds = append(seenKinds, r.URL.Query().Get("type"))
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{"url": r.URL.Scheme + "://" + r.Host + "/invalid"})
+	}))
+	defer server.Close()
+
+	p := newTestPlatform(t, server.URL)
+	// The CDN request will fail, but we only care about the /uploads kind param.
+	_, _ = p.uploadAttachment(context.Background(), "audio", []byte("x"), "a.mp3")
+	mu.Lock()
+	got := append([]string(nil), seenKinds...)
+	mu.Unlock()
+	if len(got) != 1 || got[0] != "audio" {
+		t.Errorf("uploads kinds: got %v", got)
+	}
+}
+
+func TestAudioFormatFromMime(t *testing.T) {
+	cases := []struct{ mime, filename, want string }{
+		{"audio/ogg", "", "ogg"},
+		{"audio/mpeg", "", "mp3"},
+		{"audio/mp4", "", "m4a"},
+		{"audio/x-m4a", "", "m4a"},
+		{"audio/wav", "", "wav"},
+		{"audio/webm", "voice.webm", "webm"},
+		{"", "clip.m4a", "m4a"},
+		{"", "weird_no_ext", "ogg"},
+		{"application/octet-stream", "", "octet-stream"},
+	}
+	for _, c := range cases {
+		if got := audioFormatFromMime(c.mime, c.filename); got != c.want {
+			t.Errorf("audioFormatFromMime(%q,%q) = %q, want %q", c.mime, c.filename, got, c.want)
+		}
+	}
+}
+
+func TestFetchAttachmentsRoutesAudio(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	atts := []maxAttachmentRaw{
+		{Type: "audio", Payload: maxAttachmentPayld{Token: "vm-abc"}},
+	}
+	images, files, audio := p.fetchAttachments(context.Background(), atts)
+	if len(images) != 0 || len(files) != 0 {
+		t.Errorf("audio must not leak into images/files (img=%d, f=%d)", len(images), len(files))
+	}
+	if audio == nil {
+		t.Fatal("audio attachment missing")
+	}
+	if audio.Format != "ogg" {
+		t.Errorf("format: got %q, want ogg", audio.Format)
+	}
+	if len(audio.Data) == 0 {
+		t.Error("audio data is empty")
+	}
+}
+
+func TestFetchAttachmentsFileWithAudioMimeRoutesToAudio(t *testing.T) {
+	// MAX delivers audio files attached via the paperclip menu as type="file"
+	// with audio/* mime. Ensure those also route to Audio so transcription kicks in.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("fake-mp3-data"))
+	}))
+	defer server.Close()
+
+	p := newTestPlatform(t, "http://unused")
+	atts := []maxAttachmentRaw{
+		{Type: "file", Filename: "song.mp3", Payload: maxAttachmentPayld{URL: server.URL + "/song.mp3"}},
+	}
+	_, files, audio := p.fetchAttachments(context.Background(), atts)
+	if len(files) != 0 {
+		t.Errorf("audio/* mime should not be in files, got %+v", files)
+	}
+	if audio == nil {
+		t.Fatal("audio attachment missing")
+	}
+	if audio.Format != "mp3" {
+		t.Errorf("format: got %q, want mp3", audio.Format)
+	}
+}
+
+func TestSendAudio(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	ctx := context.Background()
+	if err := p.SendAudio(ctx, replyContext{chatID: "111"}, []byte("fake-audio"), "mp3"); err != nil {
+		t.Fatalf("SendAudio: %v", err)
+	}
+	if got := atomic.LoadInt32(&m.uploadCalls); got != 1 {
+		t.Errorf("uploads: got %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&m.cdnCalls); got != 1 {
+		t.Errorf("cdn: got %d, want 1", got)
+	}
+	m.mu.Lock()
+	body := m.lastMsgBody
+	m.mu.Unlock()
+	if len(body.Attachments) != 1 || body.Attachments[0].Type != "audio" {
+		t.Fatalf("want audio attachment, got %+v", body.Attachments)
+	}
+}
+


### PR DESCRIPTION
## Summary

Adds support for [MAX](https://max.ru/) messenger — a messaging platform popular in the Russian market, with a documented Bot API at `https://platform-api.max.ru` ([docs](https://dev.max.ru/docs-api)).

## What's included

`core.Platform` plus these capability interfaces:
- `InlineButtonSender` — callback buttons
- `ImageSender` / `FileSender` / `AudioSender` — bidirectional media
- `MessageUpdater` — message editing via `PUT /messages`
- `FormattingInstructionProvider` — MAX-supported markdown subset
- `ReplyContextReconstructor` — cron/proactive replies
- `TypingIndicator` — no-op (MAX has no equivalent action)

Plus:
- `cmd/cc-connect/plugin_platform_max.go` with `//go:build !no_max` tag
- `max` added to `ALL_PLATFORMS` in `Makefile`
- Example block in `config.example.toml` (how to obtain a bot token via @MasterBot)
- 19 unit/integration tests using `httptest`, race-safe (`go test -race`)

## Implementation notes discovered during end-to-end testing

Live testing against the real MAX API surfaced three upstream-facing details worth documenting:

1. **Image CDN response is nested**: `{"photos": {"<photo_id>": {"token": "..."}}}` — not a flat `{"token": "..."}`.
2. **Audio CDN returns XML**, not JSON (`<retval>1</retval>`). The real attachment token lives in the `/uploads` response itself for video/audio, so the code uses `urlInfo.Token` as the source of truth and only scans the CDN body opportunistically.
3. **`/audios/{token}` endpoint does not exist** (returns 404). Incoming voice attachments already carry the download URL directly in `payload.url`, mirroring images/files; the code uses that and falls back to `/videos/{token}` for video where token resolution still applies.

Each of these is handled by `extractCDNToken(kind, body)` + per-kind routing in `fetchAttachments` / `uploadAttachment`.

Also includes retry with exponential backoff on `attachment.not.ready` — MAX occasionally needs a brief moment to index a freshly-uploaded blob before accepting it in a message.

## Minor core tweak

`core/speech.go`: raised the speech HTTP client `Timeout` from 60s to 5m. This covers the first-request cold-start case for local OpenAI-compatible Whisper backends (faster-whisper, whisper.cpp, etc.) that JIT-load their model on first use. Steady-state requests still return in seconds.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `go test -race ./platform/max/` — pass
- [x] `make build PLATFORMS_INCLUDE=max NO_WEB=1` — selective-build works
- [x] Live test with real MAX bot: send/receive text, images, files, voice; TTS reply via Whisper local; cron scheduling; `cc-connect send --image/--file` from agent

## Config example

```toml
[[projects.platforms]]
type = "max"
[projects.platforms.options]
token = "your-max-bot-token"
allow_from = "*"      # or comma-separated user IDs
api_base = "https://platform-api.max.ru"   # optional override
```

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)