### PR TITLE
fix(telegram): increase HTTP client timeout to prevent long-poll EOF

### DIFF
--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -141,8 +141,10 @@ func New(opts map[string]any) (core.Platform, error) {
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom("telegram", allowFrom)
 
-	// Build HTTP client with optional proxy support
-	httpClient := &http.Client{Timeout: 60 * time.Second}
+	// Build HTTP client with optional proxy support.
+	// Timeout must exceed the server-side long-poll duration (pollTimeout − 1s = 59s)
+	// to avoid the HTTP client racing with Telegram's response. 90s gives 30s headroom.
+	httpClient := &http.Client{Timeout: 90 * time.Second}
 	if proxyURL, _ := opts["proxy"].(string); proxyURL != "" {
 		u, err := url.Parse(proxyURL)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Increase HTTP client timeout from 60s to 90s in `platform/telegram/telegram.go`
- The go-telegram/bot library sends `getUpdates` with `Timeout=59s` (pollTimeout − 1s)
- With HTTP client at 60s, network latency causes the client to timeout before the server responds → `unexpected EOF` every 1-3 minutes
- 90s gives 30s headroom while keeping the Telegram API long-poll at 59s

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 28 packages)

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)