### PR TITLE
fix(runas): use /usr/bin/true for sudo probes (macOS Tahoe compatibility)

### DIFF
--- a/core/runas.go
+++ b/core/runas.go
@@ -208,11 +208,11 @@ func VerifyRunAsUserCheap(ctx context.Context, runner SudoRunner, runAsUser stri
 	if verifyCacheHit(runAsUser) {
 		return nil
 	}
-	if out, err := runner.Run(ctx, "-n", "-iu", runAsUser, "--", "/bin/true"); err != nil {
+	if out, err := runner.Run(ctx, "-n", "-iu", runAsUser, "--", "/usr/bin/true"); err != nil {
 		verifyCacheEvict(runAsUser)
 		return fmt.Errorf("passwordless sudo to user %q failed (check that your sudoers rule is present and scoped to this user): %w: %s", runAsUser, err, strings.TrimSpace(string(out)))
 	}
-	out, err := runner.Run(ctx, "-n", "-iu", runAsUser, "--", "sudo", "-n", "/bin/true")
+	out, err := runner.Run(ctx, "-n", "-iu", runAsUser, "--", "sudo", "-n", "/usr/bin/true")
 	if err == nil {
 		verifyCacheEvict(runAsUser)
 		return fmt.Errorf("target user %q can run passwordless sudo; isolation is meaningless. Remove NOPASSWD sudo for this user. Output: %s", runAsUser, strings.TrimSpace(string(out)))

--- a/core/runas_check.go
+++ b/core/runas_check.go
@@ -92,14 +92,14 @@ func PreflightRunAsUser(ctx context.Context, cfg PreflightConfig) PreflightResul
 		cfg.ScanConfig = DefaultDescendantScanConfig
 	}
 
-	if _, err := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "/bin/true"); err != nil {
+	if _, err := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "/usr/bin/true"); err != nil {
 		result.Fatal = append(result.Fatal, fmt.Errorf(
 			"project %q: passwordless sudo to user %q is not configured. Add a sudoers rule such as:\n  %s ALL=(%s) NOPASSWD: ALL\nthen restart cc-connect. Underlying error: %w",
 			cfg.Project, cfg.RunAsUser, currentUsernameOr("<supervisor>"), cfg.RunAsUser, err))
 		return result // subsequent checks are pointless
 	}
 
-	if _, err := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "sudo", "-n", "/bin/true"); err == nil {
+	if _, err := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "sudo", "-n", "/usr/bin/true"); err == nil {
 		// Escalation succeeded — collect sudo -l from the target's
 		// context to help the operator find the offending rule.
 		if out, listErr := cfg.Runner.Run(ctx, "-n", "-iu", cfg.RunAsUser, "--", "sudo", "-n", "-l"); listErr == nil {


### PR DESCRIPTION
## Summary

`/bin/true` was removed from macOS in Tahoe (26.x). The sudo probes used to verify the `run_as_user` setup fail with `no such file or directory` on fresh installs, blocking the entire startup safety check sequence.

## Symptom

```
ERROR run_as_user: preflight FATAL  project=demo
  error="project \"demo\": passwordless sudo to user \"agent\" is not configured.
  Add a sudoers rule such as:
    ivan ALL=(agent) NOPASSWD: ALL
  then restart cc-connect. Underlying error: exit status 127:
  zsh:1: no such file or directory: /bin/true"
```

…even though the sudoers rule is correct (`sudo -n -iu agent whoami` works).

## Root cause

- `/bin` on macOS Tahoe is part of the sealed System Volume — only a small set of shells (`bash`, `sh`, `zsh`, etc.) live there now. `/bin/true` is gone.
- SIP prevents `ln -s /usr/bin/true /bin/true` even with sudo.
- `/usr/bin/true` still exists on every POSIX system (Linux, macOS, BSD, etc.).

## Fix

Replace the two `/bin/true` literals with `/usr/bin/true`:

- `core/runas_check.go` — preflight passwordless-sudo probe + escalation probe (lines 95, 102)
- `core/runas.go` — runtime `VerifyRunAsUserCheap` before each agent spawn (lines 211, 215)

No behavior change on Linux or older macOS — same binary, same exit semantics.

## Test plan

- [x] On macOS Tahoe 26.4.1: `cc-connect` starts cleanly with `run_as_user = "..."`
- [x] On macOS Sequoia: still works (both `/bin/true` and `/usr/bin/true` exist)
- [x] On Linux: still works (both exist)

## Future work (not in this PR)

`scanDescendants` in `core/runas_check.go` uses GNU find flags (`-readable`, `-writable`, `-executable`) which BSD find on macOS does not support. Currently emits a warning `find: -readable: unknown primary or operator` but doesn't fail. Could be addressed by feature-detecting find or using a portable equivalent.