### PR TITLE
fix(core): prevent panic when cron job runs without multi-workspace

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2197,6 +2197,9 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 // getOrCreateWorkspaceAgent returns (or creates) a per-workspace agent and session manager.
 // workspace must be a normalized path (from resolveWorkspace or normalizeWorkspacePath).
 func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionManager, error) {
+	if e.workspacePool == nil {
+		return nil, nil, fmt.Errorf("workspace pool not initialized (multi-workspace mode not enabled)")
+	}
 	ws := e.workspacePool.GetOrCreate(workspace)
 	ws.mu.Lock()
 	defer ws.mu.Unlock()


### PR DESCRIPTION
## Summary
- Add nil check for `workspacePool` in `getOrCreateWorkspaceAgent()`
- When a cron job has `WorkDir` set but multi-workspace mode is not enabled, `workspacePool` is nil → panic at `workspace_state.go:112`
- Now returns an error instead, and the cron executor falls back to the global agent gracefully (existing error handling at `engine.go:1080-1083`)

## Root cause
`workspacePool` is only initialized in `SetMultiWorkspace()`, but `ExecuteCronJob()` calls `getOrCreateWorkspaceAgent()` when `job.WorkDir != ""` regardless of multi-workspace mode.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 28 packages)

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)