### PR TITLE
fix: friendly error when no projects configured

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -169,6 +169,13 @@ func main() {
 	config.ConfigPath = configPath
 	slog.Info("config loaded", "path", configPath)
 
+	if len(cfg.Projects) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: no projects configured in %s\n", configPath)
+		fmt.Fprintln(os.Stderr, "Add at least one [[project]] section to your config.toml, or run:")
+		fmt.Fprintln(os.Stderr, "  cc-connect init")
+		os.Exit(1)
+	}
+
 	setupLogger(cfg.Log.Level, logWriter)
 
 	// run_as_user preflight + isolation audit. MUST run before any engine


### PR DESCRIPTION
## Summary
- Add early validation after config load: if `cfg.Projects` is empty, exit with a clear error message instead of panicking downstream
- Guides user to add a `[[project]]` section or run `cc-connect init`

## Root cause
When the user deletes all projects via web UI, `config.toml` ends up with no `[[project]]` sections. The startup code proceeds with empty slices and panics when accessing indices.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 28 packages)

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)