### PR TITLE
fix(engine): guard getOrCreateWorkspaceAgent against nil workspacePool

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2209,6 +2209,13 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 // getOrCreateWorkspaceAgent returns (or creates) a per-workspace agent and session manager.
 // workspace must be a normalized path (from resolveWorkspace or normalizeWorkspacePath).
 func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionManager, error) {
+	if e == nil || e.workspacePool == nil {
+		// Cron executor path could invoke this on an Engine whose
+		// workspacePool was not initialized; the subsequent
+		// p.mu.Lock() on a nil pool crashed the process with
+		// 'invalid memory address or nil pointer dereference'.
+		return nil, nil, fmt.Errorf("workspace agent unavailable: engine workspace pool is not initialized")
+	}
 	ws := e.workspacePool.GetOrCreate(workspace)
 	ws.mu.Lock()
 	defer ws.mu.Unlock()


### PR DESCRIPTION
Fixes chenhg5/cc-connect#748.

The cron executor path can reach `Engine.getOrCreateWorkspaceAgent` on an `Engine` whose `workspacePool` field is not initialized (observed on Windows WSL for scheduled jobs). `p.mu.Lock()` on a nil pool crashes the goroutine with:

```
panic: runtime error: invalid memory address or nil pointer dereference
core.(*workspacePool).GetOrCreate workspace_state.go:112 +0x4a
core.(*Engine).getOrCreateWorkspaceAgent engine.go:2200 +0x6e
core.(*Engine).ExecuteCronJob engine.go:1075 +0xd07
core.(*CronScheduler).executeJob.func1
```

Every scheduled cron tick takes the whole cc-connect daemon down.

## Fix

Return a clear error when the pool is nil so the cron scheduler logs a failure and continues instead of crashing the process. Other callers (line 2134) already check `e.workspacePool != nil`; this mirrors that guard.

`go build ./core/...` and `go vet ./core/...` clean.