### PR TITLE
fix(claudecode): include cache tokens and per-model window in [ctx: ~N%]

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -22,6 +22,17 @@ import (
 	"github.com/chenhg5/cc-connect/core"
 )
 
+// modelContextWindow returns the context window size (in tokens) for a given
+// Claude model ID. The "[1m]" suffix signals the 1M-context variant; everything
+// else falls back to the 200k default. Empty/unknown model names also get 200k.
+func modelContextWindow(model string) int {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if strings.Contains(m, "[1m]") || strings.HasSuffix(m, "-1m") {
+		return 1_000_000
+	}
+	return 200_000
+}
+
 // claudeSession manages a long-running Claude Code process using
 // --input-format stream-json and --permission-prompt-tool stdio.
 //
@@ -38,6 +49,7 @@ type claudeSession struct {
 	acceptEditsOnly atomic.Bool
 	dontAsk         atomic.Bool
 	workDir         string
+	model           string
 	ctx             context.Context
 	cancel          context.CancelFunc
 	done            chan struct{}
@@ -192,6 +204,7 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		stdin:               stdin,
 		events:              make(chan core.Event, 64),
 		workDir:             workDir,
+		model:               model,
 		ctx:                 sessionCtx,
 		cancel:              cancel,
 		done:                make(chan struct{}),
@@ -430,18 +443,25 @@ func (cs *claudeSession) handleResult(raw map[string]any) {
 		if v, ok := usage["input_tokens"].(float64); ok {
 			inputTokens = int(v)
 		}
+		if v, ok := usage["cache_read_input_tokens"].(float64); ok {
+			inputTokens += int(v)
+		}
+		if v, ok := usage["cache_creation_input_tokens"].(float64); ok {
+			inputTokens += int(v)
+		}
 		if v, ok := usage["output_tokens"].(float64); ok {
 			outputTokens = int(v)
 		}
 	}
 
 	evt := core.Event{
-		Type:         core.EventResult,
-		Content:      content,
-		SessionID:    cs.CurrentSessionID(),
-		Done:         true,
-		InputTokens:  inputTokens,
-		OutputTokens: outputTokens,
+		Type:          core.EventResult,
+		Content:       content,
+		SessionID:     cs.CurrentSessionID(),
+		Done:          true,
+		InputTokens:   inputTokens,
+		OutputTokens:  outputTokens,
+		ContextWindow: modelContextWindow(cs.model),
 	}
 	select {
 	case cs.events <- evt:

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -44,6 +44,61 @@ func TestHandleResultParsesUsage(t *testing.T) {
 	}
 }
 
+func TestHandleResultAggregatesCacheTokensAnd1MWindow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+		model:  "claude-opus-4-7[1m]",
+	}
+	cs.sessionID.Store("test-session")
+	cs.alive.Store(true)
+
+	raw := map[string]any{
+		"type":       "result",
+		"result":     "done",
+		"session_id": "test-session",
+		"usage": map[string]any{
+			"input_tokens":                float64(500),
+			"cache_read_input_tokens":     float64(98000),
+			"cache_creation_input_tokens": float64(1500),
+			"output_tokens":               float64(800),
+		},
+	}
+
+	cs.handleResult(raw)
+
+	evt := <-cs.events
+	if evt.InputTokens != 100000 {
+		t.Errorf("InputTokens = %d, want 100000 (500 + 98000 + 1500)", evt.InputTokens)
+	}
+	if evt.ContextWindow != 1_000_000 {
+		t.Errorf("ContextWindow = %d, want 1_000_000 for [1m] model", evt.ContextWindow)
+	}
+}
+
+func TestModelContextWindow(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int
+	}{
+		{"claude-opus-4-7[1m]", 1_000_000},
+		{"CLAUDE-OPUS-4-7[1M]", 1_000_000},
+		{"claude-sonnet-4-6-1m", 1_000_000},
+		{"claude-opus-4-7", 200_000},
+		{"claude-sonnet-4-6", 200_000},
+		{"claude-haiku-4-5-20251001", 200_000},
+		{"", 200_000},
+	}
+	for _, tt := range tests {
+		if got := modelContextWindow(tt.model); got != tt.want {
+			t.Errorf("modelContextWindow(%q) = %d, want %d", tt.model, got, tt.want)
+		}
+	}
+}
+
 func TestHandleResultNoUsage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/core/engine.go
+++ b/core/engine.go
@@ -3062,7 +3062,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 			if e.showContextIndicator && !isSilent {
 				if sdkPlausible {
-					cleanResponse += contextIndicator(event.InputTokens)
+					cleanResponse += contextIndicator(event.InputTokens, event.ContextWindow)
 				} else if selfPct > 0 {
 					cleanResponse += fmt.Sprintf("\n[ctx: ~%d%%]", selfPct)
 				}
@@ -11923,14 +11923,21 @@ func gitClone(repoURL, dest string) error {
 
 // ── Context usage indicator ──────────────────────────────────
 
-const modelContextWindow = 200_000 // generic fallback window for heuristic context estimates
+// defaultContextWindow is the fallback window used when the agent event
+// doesn't carry a model-specific size (e.g. older Codex/Claude events).
+const defaultContextWindow = 200_000
 
-// contextIndicator returns a suffix like "\n[ctx: ~42%]" based on SDK-reported input tokens.
-func contextIndicator(inputTokens int) string {
+// contextIndicator returns a suffix like "\n[ctx: ~42%]" based on SDK-reported
+// input tokens. The window comes from the agent event when available, so 1M
+// variants render correctly without a central model table in the engine.
+func contextIndicator(inputTokens, window int) string {
 	if inputTokens <= 0 {
 		return ""
 	}
-	pct := inputTokens * 100 / modelContextWindow
+	if window <= 0 {
+		window = defaultContextWindow
+	}
+	pct := inputTokens * 100 / window
 	if pct > 100 {
 		pct = 100
 	}

--- a/core/message.go
+++ b/core/message.go
@@ -199,8 +199,9 @@ type Event struct {
 	Questions    []UserQuestion // populated when ToolName == "AskUserQuestion"
 	Done         bool
 	Error        error
-	InputTokens  int // token usage from agent result events
-	OutputTokens int
+	InputTokens   int // token usage from agent result events
+	OutputTokens  int
+	ContextWindow int // model's context window size, for context usage percentage
 }
 
 // HistoryEntry is one turn in a conversation.


### PR DESCRIPTION
Two bugs broke the `[ctx: ~N%]` indicator in the claudecode path:

1. **Cache tokens missing** — `handleResult` read only `usage.input_tokens` (per-turn delta). In long sessions almost all input is `cache_read_input_tokens`, so the delta stays <100, `sdkPlausible := event.InputTokens >= 100` is false, and the suffix never appears.

2. **Hardcoded 200k window** — `contextIndicator` divided by `const modelContextWindow = 200_000`. Users on `claude-opus-4-7[1m]` saw 5x inflated percentages.

`agent/codex` already does the equivalent (reads `total_token_usage` + `model_context_window` from rollout events). This PR brings claudecode to parity.

### Changes
- `core/message.go`: add `Event.ContextWindow int` (additive).
- `agent/claudecode/session.go`: new `modelContextWindow(model)` maps `[1m]`/`-1m` → 1M, default 200k. `handleResult` sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` and stamps the window on the event.
- `core/engine.go`: remove the constant, rename to `defaultContextWindow` (fallback only). `contextIndicator(inputTokens, window int)` takes window as a parameter.

### Tests
- `TestHandleResultAggregatesCacheTokensAnd1MWindow` — verifies three-field sum + 1M window for `[1m]` model.
- `TestModelContextWindow` — table test across Opus/Sonnet/Haiku variants, empty string, uppercase.
- Existing `TestHandleResultParsesUsage` / `TestHandleResultNoUsage` unchanged and green.
- `go build ./...` clean.

Related: #547