### PR TITLE
fix(kimi): capture session UUID from stderr instead of stdout

### DIFF
--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -242,6 +242,19 @@ func (ks *kimiSession) readLoop(ctx context.Context, cmd *exec.Cmd, stdout io.Re
 	// never sees EventError after EventResult from the same turn.
 	waitErr := cmd.Wait()
 
+	// Kimi writes "To resume this session: kimi -r <uuid>" to stderr (not stdout),
+	// so the scanner above never sees it. Extract it from the captured stderr
+	// buffer before emitting EventResult so the next turn can pass --resume.
+	for _, line := range strings.Split(stderrBuf.String(), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "To resume this session:") {
+			if id := extractResumeSessionID(line); id != "" {
+				ks.sessionID.Store(id)
+				slog.Debug("kimiSession: session id from stderr", "session_id", id)
+			}
+			break
+		}
+	}
+
 	if scanErr != nil {
 		slog.Error("kimiSession: scanner error", "error", scanErr)
 		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", scanErr)}


### PR DESCRIPTION
Fixes #758

Kimi CLI writes "To resume this session: kimi -r <uuid>" to stderr, but the scanner in readLoop only reads stdout, so the UUID was never captured. As a result, every turn spawned a fresh kimi process without --resume, and conversation context was lost between messages.

Scan the already-captured stderrBuf after cmd.Wait() to extract the UUID. All downstream plumbing (sessionID.Store, EventResult writeback, engine disk persistence, next-turn --resume arg) is unchanged.

Verified locally (against kimi-cli 1.31.0 on macOS arm64).