### PR TITLE
fix(feishu): skip quote injection in thread-isolated topics

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -851,8 +851,11 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 
 	// If this message is a reply to another message, fetch the quoted content
 	// and prepend it so the agent has full context.
+	// Skip quote injection when thread_isolation is enabled and the message is
+	// inside a thread — the thread already provides conversational context, and
+	// long quoted prefixes can drown out the user's actual text (issue #764).
 	quotedPrefix := ""
-	if parentID != "" {
+	if parentID != "" && !(p.threadIsolation && isThreadSessionKey(sessionKey)) {
 		quotedPrefix = p.fetchQuotedMessage(ctx, parentID)
 	}
 


### PR DESCRIPTION
## Summary
- When `thread_isolation=true` and a message is inside a thread (session key contains `root:` or `thread:`), skip `fetchQuotedMessage()`
- The thread already provides conversational context; the long quoted prefix from bot replies was drowning out the user's actual text
- Users reported the agent only seeing `[Quoted message from ...]` instead of their message

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 28 packages)
- [x] Non-thread replies still get quoted prefix (behavior unchanged)
- [x] Thread replies with `thread_isolation=false` still get quoted prefix (behavior unchanged)

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)