### PR TITLE
docs(cron): expose 'cron edit' to agents in system prompt and templates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -529,9 +529,19 @@ Examples:
   cc-connect cron add --cron "0 6 * * *" --prompt "Collect GitHub trending repos and send a summary" --desc "Daily GitHub Trending"
   cc-connect cron add --cron "0 9 * * 1" --prompt "Generate a weekly project status report" --desc "Weekly Report"
 
-To list or delete cron jobs:
+To list, edit, or delete cron jobs:
   cc-connect cron list
+  cc-connect cron edit <job-id> <field> <value>
   cc-connect cron del <job-id>
+
+Use `cron edit` to modify a single field instead of delete-and-recreate.
+Common editable fields: cron_expr, prompt, exec, description, enabled (true/false), mute (true/false), timeout_mins (int).
+Run `cc-connect cron edit --help` for the full field list.
+
+Examples:
+  cc-connect cron edit abc123 cron_expr "0 9 * * *"
+  cc-connect cron edit abc123 enabled false
+  cc-connect cron edit abc123 prompt "Updated daily summary task"
 
 ## Send message to current chat
 To proactively send a message back to the user's chat session (use --stdin heredoc for long/multi-line messages):

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -91,9 +91,25 @@ Examples:
   cc-connect cron add --cron "0 9 * * 1" --prompt "Generate a weekly project status report" --desc "Weekly Report"
   cc-connect cron add --cron "*/2 * * * *" --exec "ipconfig" --session-mode new-per-run --desc "Every 2 min ipconfig"
 
-You can also list or delete cron jobs:
+You can also list, edit, or delete cron jobs:
   cc-connect cron list
+  cc-connect cron edit <job-id> <field> <value>
   cc-connect cron del <job-id>
+
+Use ` + "`cron edit`" + ` instead of delete-and-recreate when only one field changes.
+Common editable fields:
+  cron_expr     new schedule, e.g. "0 9 * * *"
+  prompt        new task prompt (or ` + "`exec`" + ` for shell command)
+  description   short label
+  enabled       true / false  (pause without deleting)
+  mute          true / false  (silence all messages)
+  timeout_mins  integer minutes (0 = unlimited)
+Run ` + "`cc-connect cron edit --help`" + ` for the full field list.
+
+Examples:
+  cc-connect cron edit abc123 cron_expr "0 9 * * *"
+  cc-connect cron edit abc123 enabled false
+  cc-connect cron edit abc123 prompt "Updated daily summary task"
 
 ### Bot-to-bot relay
 When you need to communicate with another bot (e.g. ask another AI agent a question), use:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -770,6 +770,7 @@ Example:
 ```bash
 cc-connect cron add --cron "0 6 * * *" --prompt "Summarize GitHub trending" --desc "Daily Trending"
 cc-connect cron list
+cc-connect cron edit <job-id> <field> <value>   # e.g. cron_expr, prompt, enabled, mute, timeout_mins
 cc-connect cron del <job-id>
 ```
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -686,6 +686,7 @@ cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/ch
 ```bash
 cc-connect cron add --cron "0 6 * * *" --prompt "总结 GitHub trending" --desc "每日趋势"
 cc-connect cron list
+cc-connect cron edit <job-id> <field> <value>   # 可改 cron_expr / prompt / enabled / mute / timeout_mins 等
 cc-connect cron del <job-id>
 ```
 


### PR DESCRIPTION
## Summary

The cron CLI already supports `cc-connect cron edit <id> <field> <value>` (handler in `core/api.go:382`, CLI in `cmd/cc-connect/cron.go:460`), but neither the agent system prompt nor the `INSTALL.md` template for non-Claude-Code agents documents it. Agents see only `add` / `list` / `del`, so they fall back to **delete-and-recreate** even when the user just wants to nudge the schedule, change the prompt, pause, or mute a job.

This PR is **docs/prompt-only** — zero behavior or API change.

## Changes

- `core/interfaces.go` — append `cron edit` usage, common editable fields, and three examples to the cron section injected into every Claude Code agent session via `--append-system-prompt`.
- `INSTALL.md` — mirror the same guidance in the non-Claude-Code template (Codex / Cursor / Gemini CLI / Qoder / OpenCode / iFlow), so when users paste it into `AGENTS.md` / `GEMINI.md` / `.cursorrules` etc. the full command set is covered.
- `docs/usage.md`, `docs/usage.zh-CN.md` — add `cron edit` to the CLI reference block in both languages.

Backtick literals in `core/interfaces.go` use the same raw-string-splice pattern (`` ` + "`...`" + ` ``) already used in this file for `NO_REPLY` at line 115.

## Verification

- `go vet ./core/` — clean
- `go build ./core/` — clean
- Rendered `core.AgentSystemPrompt()` and visually confirmed the new section renders correctly, including the backtick formatting around \`cron edit\`, \`exec\`, and \`cc-connect cron edit --help\`.
- Smoke-tested the underlying CLI against a running instance:
  \`\`\`
  \$ cc-connect cron edit <id> description \"<same value>\"
  Updated job <id>:
  { ... full updated job JSON, all other fields preserved ... }
  \`\`\`

## Test plan

- [x] \`go vet ./core/\` passes
- [x] \`go build ./core/\` passes
- [x] Rendered \`AgentSystemPrompt()\` visually inspected
- [x] CLI \`cron edit\` confirmed end-to-end against a live cc-connect instance (no-op edit returns 200 + complete job JSON, all other fields preserved)

## Out of scope

- Slash command \`/cron edit\` (chat-side parser) — not addressed here; this PR only changes what agents and the install docs advertise.
- \`cmd/cc-connect/cron.go\`'s own \`--help\` text — already documents all 13 editable fields; no change needed.