### PR TITLE
fix(core): keep streaming preview as one in-place card under fully-quiet display

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2731,11 +2731,25 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		switch event.Type {
 		case EventThinking:
-			// In quiet mode, still split text segments so they don't merge.
+			// When thinking messages are hidden, this event won't surface a
+			// visible message of its own. To keep the streaming preview
+			// rendering one in-place updated card across the whole turn
+			// (rather than freezing it into a permanent message and
+			// emitting subsequent text as fresh sends), insert a paragraph
+			// separator into the live preview instead of freezing. The
+			// separator is mirrored into textParts so the final response
+			// text includes the same break that appeared on screen.
+			//
+			// When the preview is degraded (platform doesn't support edits,
+			// or a prior visible thinking/tool event already froze it),
+			// fall back to flushing the accumulated text segment as a
+			// standalone message — matches the legacy behavior for those
+			// platforms.
 			if !e.display.ThinkingMessages && len(textParts) > segmentStart {
 				if sp.canPreview() {
-					sp.freeze()
-					sp.detachPreview()
+					if sp.appendSeparator("\n\n") {
+						textParts = append(textParts, "\n\n")
+					}
 				} else {
 					// Preview degraded — send accumulated text directly
 					segment := strings.Join(textParts[segmentStart:], "")
@@ -2744,9 +2758,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 							sendWorkspace(p, replyCtx, chunk)
 						}
 					}
+					segmentStart = len(textParts)
+					silentHold = false
 				}
-				segmentStart = len(textParts)
-				silentHold = false
 			}
 			if e.display.ThinkingMessages && event.Content != "" {
 				// Flush accumulated text segment before thinking display
@@ -2776,11 +2790,17 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		case EventToolUse:
 			toolCount++
-			// When tool messages are hidden, split text segments.
+			// When tool messages are hidden, this event won't surface a
+			// visible message of its own. To keep the streaming preview
+			// rendering one in-place updated card across the whole turn,
+			// insert a paragraph separator into the live preview instead
+			// of freezing it. See the symmetric EventThinking case above
+			// for rationale and the degraded-preview fallback.
 			if !e.display.ToolMessages && len(textParts) > segmentStart {
 				if sp.canPreview() {
-					sp.freeze()
-					sp.detachPreview()
+					if sp.appendSeparator("\n\n") {
+						textParts = append(textParts, "\n\n")
+					}
 				} else {
 					// Preview degraded — send accumulated text directly
 					segment := strings.Join(textParts[segmentStart:], "")
@@ -2789,9 +2809,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 							sendWorkspace(p, replyCtx, chunk)
 						}
 					}
+					segmentStart = len(textParts)
+					silentHold = false
 				}
-				segmentStart = len(textParts)
-				silentHold = false
 			}
 			if e.display.ToolMessages {
 				// Flush accumulated text segment before tool display

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1192,6 +1192,121 @@ func TestProcessInteractiveEvents_SuppressesReplyFooterWhenOnlyWorkDir(t *testin
 	}
 }
 
+// TestProcessInteractiveEvents_FullyQuietKeepsSinglePreviewAcrossToolCalls is
+// the regression test for the bug where stream_preview + progress_style=card
+// + ThinkingMessages=false + ToolMessages=false produced multiple messages
+// (one per tool boundary) instead of a single edit-updated card.
+//
+// Expected behavior: when no event class is visible (fully quiet), the
+// streaming preview must accumulate text across tool calls into a single
+// card and finalize via in-place UpdateMessage — never falling back to
+// freestanding sendWorkspace messages or extra preview-start calls. The
+// final card must also carry paragraph separators between text segments
+// that were bounded by tool calls so they don't visually merge.
+func TestProcessInteractiveEvents_FullyQuietKeepsSinglePreviewAcrossToolCalls(t *testing.T) {
+	p := &mockKeepPreviewPlatform{}
+	p.n = "feishu"
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{ThinkingMessages: false, ThinkingMaxLen: 300, ToolMaxLen: 500, ToolMessages: false})
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s1")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventText, Content: "before "}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "echo 1"}
+	agentSession.events <- Event{Type: EventToolResult, ToolName: "Bash", ToolResult: "1"}
+	agentSession.events <- Event{Type: EventText, Content: "after "}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "echo 2"}
+	agentSession.events <- Event{Type: EventToolResult, ToolName: "Bash", ToolResult: "2"}
+	agentSession.events <- Event{Type: EventText, Content: "tool"}
+	agentSession.events <- Event{Type: EventResult, Content: "before \n\nafter \n\ntool", Done: true}
+
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil)
+
+	if got := p.getSent(); len(got) != 0 {
+		t.Fatalf("sent text fallbacks = %#v, want zero (fully quiet should never fall back to sendWorkspace)", got)
+	}
+
+	p.mu.Lock()
+	deletedCount := len(p.deleted)
+	previewMsgs := append([]string(nil), p.messages...)
+	p.mu.Unlock()
+
+	if deletedCount != 0 {
+		t.Fatalf("deleted previews = %d, want 0 (preview must survive tool boundaries)", deletedCount)
+	}
+	if len(previewMsgs) == 0 {
+		t.Fatalf("no preview messages recorded; expected one start + at least one update")
+	}
+	startCount := 0
+	for _, m := range previewMsgs {
+		if strings.HasPrefix(m, "start:") {
+			startCount++
+		}
+	}
+	if startCount != 1 {
+		t.Fatalf("preview start count = %d, want exactly 1 (single card across whole turn). messages=%#v", startCount, previewMsgs)
+	}
+	last := previewMsgs[len(previewMsgs)-1]
+	if !strings.HasPrefix(last, "update:") {
+		t.Fatalf("last preview op = %q, want a final UpdateMessage", last)
+	}
+	for _, sub := range []string{"before ", "after ", "tool"} {
+		if !strings.Contains(last, sub) {
+			t.Fatalf("final update missing segment %q\nfull: %q", sub, last)
+		}
+	}
+	if !strings.Contains(last, "\n\n") {
+		t.Errorf("final update missing paragraph separator between segments\nfull: %q", last)
+	}
+}
+
+// TestProcessInteractiveEvents_FullyQuietInsertsBlankLinesBetweenSegments is
+// a focused regression for the appendSeparator restoration: a turn with
+// text → tool → text in fully-quiet mode must show the two text fragments
+// separated by a blank line in the final card.
+func TestProcessInteractiveEvents_FullyQuietInsertsBlankLinesBetweenSegments(t *testing.T) {
+	p := &mockKeepPreviewPlatform{}
+	p.n = "feishu"
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{ThinkingMessages: false, ThinkingMaxLen: 300, ToolMaxLen: 500, ToolMessages: false})
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s1")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventText, Content: "first segment"}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "echo"}
+	agentSession.events <- Event{Type: EventToolResult, ToolName: "Bash", ToolResult: "ok"}
+	agentSession.events <- Event{Type: EventText, Content: "second segment"}
+	agentSession.events <- Event{Type: EventResult, Content: "first segment\n\nsecond segment", Done: true}
+
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil)
+
+	p.mu.Lock()
+	previewMsgs := append([]string(nil), p.messages...)
+	p.mu.Unlock()
+
+	if len(previewMsgs) == 0 {
+		t.Fatal("no preview messages recorded")
+	}
+	last := previewMsgs[len(previewMsgs)-1]
+	if !strings.Contains(last, "first segment\n\nsecond segment") {
+		t.Errorf("expected blank-line separated segments in final card, got %q", last)
+	}
+}
+
 func TestProcessInteractiveEvents_HiddenToolProgressKeepsPreviewOnFinalize(t *testing.T) {
 	p := &mockKeepPreviewPlatform{}
 	p.n = "feishu"

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -367,6 +367,28 @@ func (sp *streamPreview) detachPreview() {
 	sp.previewMsgID = nil
 }
 
+// appendSeparator inserts a literal separator string into the accumulated
+// preview text without sending an update. Use it at hidden segment
+// boundaries (e.g. EventThinking / EventToolUse with thinking_messages /
+// tool_messages = false) so the next text segment is visually offset
+// from the previous one within the same in-place updated card.
+//
+// Returns true when the separator was appended, false when it was
+// suppressed because the preview is degraded, disabled, or has no
+// content yet (we don't want a leading separator on an otherwise empty
+// card). Callers should mirror the separator into their own text
+// accumulator (engine.textParts) only when this returns true so the
+// final response text matches what the live preview shows.
+func (sp *streamPreview) appendSeparator(sep string) bool {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	if sp.degraded || !sp.cfg.Enabled || sp.fullText == "" {
+		return false
+	}
+	sp.fullText += sep
+	return true
+}
+
 // needsDoneReaction returns true if the preview was delivered via in-place
 // UpdateMessage at least once, meaning the user only received a push for the
 // initial SendPreviewStart and subsequent updates were silent. In this case a

--- a/core/streaming_test.go
+++ b/core/streaming_test.go
@@ -402,3 +402,89 @@ func TestStreamPreview_AppliesTransform(t *testing.T) {
 		t.Fatalf("final message = %q, want transformed final preview", got)
 	}
 }
+
+func TestStreamPreview_AppendSeparator_AppendsAfterText(t *testing.T) {
+	mp := &mockUpdaterPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 1,
+		MaxChars:      500,
+	}
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+	sp.appendText("Hello")
+	time.Sleep(100 * time.Millisecond)
+
+	if !sp.appendSeparator("\n\n") {
+		t.Fatal("appendSeparator should return true after text exists")
+	}
+	if got := sp.fullText; got != "Hello\n\n" {
+		t.Fatalf("fullText = %q, want %q", got, "Hello\n\n")
+	}
+
+	// Subsequent text concatenates onto the separator.
+	sp.appendText("World")
+	time.Sleep(100 * time.Millisecond)
+	if got := sp.fullText; got != "Hello\n\nWorld" {
+		t.Fatalf("fullText = %q, want %q", got, "Hello\n\nWorld")
+	}
+}
+
+func TestStreamPreview_AppendSeparator_SuppressedOnEmptyPreview(t *testing.T) {
+	mp := &mockUpdaterPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 1,
+		MaxChars:      500,
+	}
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+
+	if sp.appendSeparator("\n\n") {
+		t.Error("appendSeparator should return false when preview has no text yet")
+	}
+	if got := sp.fullText; got != "" {
+		t.Errorf("fullText = %q, want empty", got)
+	}
+}
+
+func TestStreamPreview_AppendSeparator_SuppressedAfterFreeze(t *testing.T) {
+	mp := &mockUpdaterPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 1,
+		MaxChars:      500,
+	}
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+	sp.appendText("Hello")
+	time.Sleep(100 * time.Millisecond)
+	sp.freeze() // simulates a visible thinking/tool event taking over
+
+	if sp.appendSeparator("\n\n") {
+		t.Error("appendSeparator should return false once preview is degraded by freeze")
+	}
+}
+
+func TestStreamPreview_AppendSeparator_DoesNotTriggerFlush(t *testing.T) {
+	mp := &mockUpdaterPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 1,
+		MaxChars:      500,
+	}
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+	sp.appendText("Hello")
+	time.Sleep(100 * time.Millisecond)
+
+	startCount := len(mp.getMessages())
+	sp.appendSeparator("\n\n")
+	// Give any spurious timer a chance to fire.
+	time.Sleep(150 * time.Millisecond)
+
+	endCount := len(mp.getMessages())
+	if endCount != startCount {
+		t.Errorf("appendSeparator triggered an extra send: %d → %d", startCount, endCount)
+	}
+}


### PR DESCRIPTION
Closes #776.

## Problem

With `stream_preview.enabled = true`, `progress_style = "card"`, `display.thinking_messages = false`, and `display.tool_messages = false`, a turn that includes tool calls is rendered as multiple messages instead of a single edit-updated card. Every `EventThinking` and `EventToolUse` boundary triggers `sp.freeze() + sp.detachPreview()`, which commits the current preview as a permanent card and disables further updates. Subsequent text events fall back to fresh `p.Send` messages. Adjacent text segments also visually merge because nothing inserts a separator between them.

## Fix

Restore the "quiet" branch that the earlier three-mode `display.mode` enum used: at hidden segment boundaries, append a paragraph separator into the live preview instead of freezing it.

* `core/streaming.go`: add `streamPreview.appendSeparator(sep) bool`. It appends the separator into `fullText` without sending an update. Returns `false` when the preview is degraded, disabled, or has no content yet so we never produce a leading separator on an otherwise empty card.

* `core/engine.go`: in the `!ThinkingMessages` and `!ToolMessages` branches, replace `sp.freeze() + sp.detachPreview()` with `sp.appendSeparator("\n\n")` when `sp.canPreview()` is true, and mirror the separator into `textParts` so the final response text matches the live preview. The degraded-preview fallback (send the accumulated segment as a standalone message) is unchanged so platforms without message-edit support keep their previous behavior.

This is purely a streaming-preview UX fix; tool/thinking semantics, segmentation logic for visible events, and the other display modes are untouched.

## Compatibility

* `display.thinking_messages = true` or `display.tool_messages = true` (default): no behavior change. The visible-event branches still flush the segment, freeze, and emit the thinking/tool message as before.
* Platforms without `MessageUpdater` (legacy preview-degraded path): no behavior change. The accumulated segment is still flushed via `p.Send` at the boundary.

## Tests

`go test -count=1 -tags no_web ./...` passes (3 pre-existing failures in `core/` are unrelated — they fail on the unmodified `main` branch as well on macOS due to a `/var` ↔ `/private/var` symlink in the path-resolution tests: `TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled`, `_ReplyFooterPrefersSessionRuntimeState`, `TestResolveLocalDirPath_AcceptsSubdir`).

New tests:

* `core/streaming_test.go`:
  * `TestStreamPreview_AppendSeparator_AppendsAfterText`
  * `TestStreamPreview_AppendSeparator_SuppressedOnEmptyPreview`
  * `TestStreamPreview_AppendSeparator_SuppressedAfterFreeze`
  * `TestStreamPreview_AppendSeparator_DoesNotTriggerFlush`
* `core/engine_test.go`:
  * `TestProcessInteractiveEvents_FullyQuietKeepsSinglePreviewAcrossToolCalls` — exercises the engine event loop end-to-end with the bug repro (text → tool → text → tool → text → result) and asserts a single preview start, an in-place final update containing every segment, and a paragraph break between segments.
  * `TestProcessInteractiveEvents_FullyQuietInsertsBlankLinesBetweenSegments` — focused regression for the separator restoration.

## Test plan

- [x] `go build -tags no_web ./...`
- [x] `go vet -tags no_web ./...`
- [x] `go test -count=1 -tags no_web ./...`
- [x] Live testing on Lark / Feishu under the repro config: a multi-tool turn now stays on a single in-place updated card and adjacent text segments are separated by a blank line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)