### PR TITLE
feat: pass through codex permission config

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -119,6 +119,7 @@ type appServerSession struct {
 	mode          string
 	baseURL       string
 	modelProvider string
+	permissions   codexPermissionOverrides
 	extraEnv      []string
 	codexHome     string
 
@@ -160,7 +161,7 @@ const (
 	appServerUsageRefreshTimeout = 1500 * time.Millisecond
 )
 
-func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string) (*appServerSession, error) {
+func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string, permissions codexPermissionOverrides) (*appServerSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 	s := &appServerSession{
 		url:              url,
@@ -170,6 +171,7 @@ func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode,
 		mode:             mode,
 		baseURL:          baseURL,
 		modelProvider:    modelProvider,
+		permissions:      permissions,
 		extraEnv:         append([]string(nil), extraEnv...),
 		codexHome:        strings.TrimSpace(codexHome),
 		events:           make(chan core.Event, 128),
@@ -202,22 +204,7 @@ func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode,
 }
 
 func (s *appServerSession) connect() error {
-	args := []string{"app-server"}
-	if strings.TrimSpace(s.url) != "" {
-		args = append(args, "--listen", strings.TrimSpace(s.url))
-	}
-	if model := strings.TrimSpace(s.model); model != "" {
-		args = append(args, "-c", fmt.Sprintf("model=%q", model))
-	}
-	if effort := strings.TrimSpace(s.effort); effort != "" {
-		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%q", effort))
-	}
-	if provider := strings.TrimSpace(s.modelProvider); provider != "" {
-		args = append(args, "-c", fmt.Sprintf("model_provider=%q", provider))
-	}
-	if baseURL := strings.TrimSpace(s.baseURL); baseURL != "" {
-		args = append(args, "-c", fmt.Sprintf("openai_base_url=%q", baseURL))
-	}
+	args := s.appServerCommandArgs()
 	cmd := exec.CommandContext(s.ctx, "codex", args...)
 	cmd.Dir = s.workDir
 	env := append([]string(nil), s.extraEnv...)
@@ -256,6 +243,27 @@ func (s *appServerSession) connect() error {
 	go s.stderrLoop(stderr)
 	go s.waitLoop()
 	return nil
+}
+
+func (s *appServerSession) appServerCommandArgs() []string {
+	args := []string{"app-server"}
+	if strings.TrimSpace(s.url) != "" {
+		args = append(args, "--listen", strings.TrimSpace(s.url))
+	}
+	if model := strings.TrimSpace(s.model); model != "" {
+		args = append(args, "-c", fmt.Sprintf("model=%q", model))
+	}
+	if effort := strings.TrimSpace(s.effort); effort != "" {
+		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%q", effort))
+	}
+	if provider := strings.TrimSpace(s.modelProvider); provider != "" {
+		args = append(args, "-c", fmt.Sprintf("model_provider=%q", provider))
+	}
+	if baseURL := strings.TrimSpace(s.baseURL); baseURL != "" {
+		args = append(args, "-c", fmt.Sprintf("openai_base_url=%q", baseURL))
+	}
+	args = s.permissions.appendConfigArgs(args)
+	return args
 }
 
 func (s *appServerSession) initialize() error {
@@ -328,24 +336,17 @@ func (s *appServerSession) threadRequestParams() map[string]any {
 	if model := s.GetModel(); model != "" {
 		params["model"] = model
 	}
-	if approval, sandbox := appServerModeSettings(s.mode); approval != "" {
-		params["approvalPolicy"] = approval
-		if sandbox != "" {
-			params["sandbox"] = sandbox
-		}
+	permissions := s.permissions.effectiveForMode(s.mode)
+	if permissions.ApprovalPolicy != "" {
+		params["approvalPolicy"] = permissions.ApprovalPolicy
+	}
+	if permissions.ApprovalsReviewer != "" {
+		params["approvalsReviewer"] = permissions.ApprovalsReviewer
+	}
+	if permissions.SandboxMode != "" {
+		params["sandbox"] = permissions.SandboxMode
 	}
 	return params
-}
-
-func appServerModeSettings(mode string) (approval string, sandbox string) {
-	switch normalizeMode(mode) {
-	case "auto-edit", "full-auto":
-		return "never", "workspace-write"
-	case "yolo":
-		return "never", "danger-full-access"
-	default:
-		return "on-request", "read-only"
-	}
 }
 
 func (s *appServerSession) applyThreadRuntimeState(workDir, model string, effort *string) {
@@ -441,18 +442,9 @@ func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, fi
 		})
 	}
 
-	params := map[string]any{
-		"threadId": threadID,
-		"input":    input,
-	}
-	if model := s.GetModel(); model != "" {
-		params["model"] = model
-	}
-	if effort := s.GetReasoningEffort(); effort != "" {
-		params["effort"] = effort
-	}
-	if approval, _ := appServerModeSettings(s.mode); approval != "" {
-		params["approvalPolicy"] = approval
+	params, err := s.turnRequestParams(threadID, input)
+	if err != nil {
+		return err
 	}
 
 	var resp turnStartResponse
@@ -469,6 +461,49 @@ func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, fi
 	s.stateMu.Unlock()
 
 	return nil
+}
+
+func (s *appServerSession) turnRequestParams(threadID string, input []map[string]any) (map[string]any, error) {
+	params := map[string]any{
+		"threadId": threadID,
+		"input":    input,
+	}
+	if model := s.GetModel(); model != "" {
+		params["model"] = model
+	}
+	if effort := s.GetReasoningEffort(); effort != "" {
+		params["effort"] = effort
+	}
+	permissions := s.permissions.effectiveForMode(s.mode)
+	if permissions.ApprovalPolicy != "" {
+		params["approvalPolicy"] = permissions.ApprovalPolicy
+	}
+	if permissions.ApprovalsReviewer != "" {
+		params["approvalsReviewer"] = permissions.ApprovalsReviewer
+	}
+	if s.permissions.SandboxMode != "" {
+		sandboxPolicy, err := appServerSandboxPolicy(permissions.SandboxMode)
+		if err != nil {
+			return nil, err
+		}
+		params["sandboxPolicy"] = sandboxPolicy
+	}
+	return params, nil
+}
+
+func appServerSandboxPolicy(mode string) (map[string]any, error) {
+	// thread/start uses config-style sandbox strings such as "workspace-write".
+	// turn/start sandboxPolicy.type uses app-server's structured spelling, e.g. "workspaceWrite".
+	switch strings.TrimSpace(mode) {
+	case "read-only":
+		return map[string]any{"type": "readOnly"}, nil
+	case "workspace-write":
+		return map[string]any{"type": "workspaceWrite"}, nil
+	case "danger-full-access":
+		return map[string]any{"type": "dangerFullAccess"}, nil
+	default:
+		return nil, fmt.Errorf("unsupported codex sandbox_mode %q: allowed values are read-only, workspace-write, and danger-full-access", mode)
+	}
 }
 
 func (s *appServerSession) stageImages(prompt string, images []core.ImageAttachment) (string, []string, error) {

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -23,6 +24,237 @@ func TestAppServerSession_ApplyThreadRuntimeState(t *testing.T) {
 	if got := s.GetReasoningEffort(); got != "xhigh" {
 		t.Fatalf("GetReasoningEffort() = %q, want xhigh", got)
 	}
+}
+
+func TestAppServerCommandArgs_IncludesNativePermissionOverrides(t *testing.T) {
+	s := &appServerSession{
+		url: "stdio://",
+		permissions: codexPermissionOverrides{
+			ApprovalPolicy:    "on-request",
+			ApprovalsReviewer: "auto_review",
+			SandboxMode:       "workspace-write",
+		},
+	}
+
+	args := s.appServerCommandArgs()
+
+	for _, want := range [][]string{
+		{"-c", `approval_policy="on-request"`},
+		{"-c", `approvals_reviewer="auto_review"`},
+		{"-c", `sandbox_mode="workspace-write"`},
+	} {
+		if !containsSequence(args, want) {
+			t.Fatalf("args missing %v: %v", want, args)
+		}
+	}
+}
+
+func TestAppServerSession_ThreadRequestParamsNativePermissionOverrides(t *testing.T) {
+	s := &appServerSession{
+		mode: "full-auto",
+		permissions: codexPermissionOverrides{
+			ApprovalPolicy:    "on-request",
+			ApprovalsReviewer: "auto_review",
+			SandboxMode:       "read-only",
+		},
+	}
+
+	params := s.threadRequestParams()
+
+	if got := params["approvalPolicy"]; got != "on-request" {
+		t.Fatalf("approvalPolicy = %#v, want on-request", got)
+	}
+	if got := params["approvalsReviewer"]; got != "auto_review" {
+		t.Fatalf("approvalsReviewer = %#v, want auto_review", got)
+	}
+	if got := params["sandbox"]; got != "read-only" {
+		t.Fatalf("sandbox = %#v, want read-only", got)
+	}
+}
+
+func TestAppServerSession_ThreadRequestParamsPartialNativePermissionOverrides(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        string
+		permissions codexPermissionOverrides
+		want        map[string]any
+		absent      []string
+	}{
+		{
+			name:        "sandbox only preserves full-auto approval",
+			mode:        "full-auto",
+			permissions: codexPermissionOverrides{SandboxMode: "read-only"},
+			want: map[string]any{
+				"approvalPolicy": "never",
+				"sandbox":        "read-only",
+			},
+			absent: []string{"approvalsReviewer"},
+		},
+		{
+			name:        "approval only preserves yolo sandbox",
+			mode:        "yolo",
+			permissions: codexPermissionOverrides{ApprovalPolicy: "on-request"},
+			want: map[string]any{
+				"approvalPolicy": "on-request",
+				"sandbox":        "danger-full-access",
+			},
+			absent: []string{"approvalsReviewer"},
+		},
+		{
+			name:        "reviewer only preserves full-auto mode settings",
+			mode:        "full-auto",
+			permissions: codexPermissionOverrides{ApprovalsReviewer: "guardian_subagent"},
+			want: map[string]any{
+				"approvalPolicy":    "never",
+				"sandbox":           "workspace-write",
+				"approvalsReviewer": "guardian_subagent",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &appServerSession{
+				mode:        tt.mode,
+				permissions: tt.permissions,
+			}
+
+			params := s.threadRequestParams()
+
+			for key, want := range tt.want {
+				if got := params[key]; got != want {
+					t.Fatalf("%s = %#v, want %#v; params=%#v", key, got, want, params)
+				}
+			}
+			for _, key := range tt.absent {
+				if _, ok := params[key]; ok {
+					t.Fatalf("%s present, want absent; params=%#v", key, params)
+				}
+			}
+		})
+	}
+}
+
+func TestAppServerSession_TurnRequestParamsNativePermissionOverrides(t *testing.T) {
+	s := &appServerSession{
+		mode:   "full-auto",
+		effort: "high",
+		permissions: codexPermissionOverrides{
+			ApprovalPolicy:    "on-request",
+			ApprovalsReviewer: "guardian_subagent",
+			SandboxMode:       "workspace-write",
+		},
+	}
+
+	params, err := s.turnRequestParams("thread-1", []map[string]any{{"type": "text", "text": "hello"}})
+	if err != nil {
+		t.Fatalf("turnRequestParams: %v", err)
+	}
+
+	if got := params["approvalPolicy"]; got != "on-request" {
+		t.Fatalf("approvalPolicy = %#v, want on-request", got)
+	}
+	if got := params["approvalsReviewer"]; got != "guardian_subagent" {
+		t.Fatalf("approvalsReviewer = %#v, want guardian_subagent", got)
+	}
+	sandboxPolicy, ok := params["sandboxPolicy"].(map[string]any)
+	if !ok {
+		t.Fatalf("sandboxPolicy = %#v, want map", params["sandboxPolicy"])
+	}
+	if got := sandboxPolicy["type"]; got != "workspaceWrite" {
+		t.Fatalf("sandboxPolicy.type = %#v, want workspaceWrite", got)
+	}
+}
+
+func TestAppServerSession_TurnRequestParamsPartialNativePermissionOverrides(t *testing.T) {
+	tests := []struct {
+		name              string
+		mode              string
+		permissions       codexPermissionOverrides
+		wantApproval      string
+		wantReviewer      string
+		wantSandboxPolicy map[string]any
+	}{
+		{
+			name:              "sandbox only preserves full-auto approval",
+			mode:              "full-auto",
+			permissions:       codexPermissionOverrides{SandboxMode: "read-only"},
+			wantApproval:      "never",
+			wantSandboxPolicy: map[string]any{"type": "readOnly"},
+		},
+		{
+			name:         "approval only leaves yolo sandbox unchanged",
+			mode:         "yolo",
+			permissions:  codexPermissionOverrides{ApprovalPolicy: "on-request"},
+			wantApproval: "on-request",
+		},
+		{
+			name:         "reviewer only preserves full-auto approval",
+			mode:         "full-auto",
+			permissions:  codexPermissionOverrides{ApprovalsReviewer: "guardian_subagent"},
+			wantApproval: "never",
+			wantReviewer: "guardian_subagent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &appServerSession{
+				mode:        tt.mode,
+				permissions: tt.permissions,
+			}
+
+			params, err := s.turnRequestParams("thread-1", []map[string]any{{"type": "text", "text": "hello"}})
+			if err != nil {
+				t.Fatalf("turnRequestParams: %v", err)
+			}
+
+			if got := params["approvalPolicy"]; got != tt.wantApproval {
+				t.Fatalf("approvalPolicy = %#v, want %#v; params=%#v", got, tt.wantApproval, params)
+			}
+			if tt.wantReviewer != "" {
+				if got := params["approvalsReviewer"]; got != tt.wantReviewer {
+					t.Fatalf("approvalsReviewer = %#v, want %#v; params=%#v", got, tt.wantReviewer, params)
+				}
+			} else if _, ok := params["approvalsReviewer"]; ok {
+				t.Fatalf("approvalsReviewer present, want absent; params=%#v", params)
+			}
+			if tt.wantSandboxPolicy != nil {
+				if got := params["sandboxPolicy"]; !mapsEqual(got, tt.wantSandboxPolicy) {
+					t.Fatalf("sandboxPolicy = %#v, want %#v; params=%#v", got, tt.wantSandboxPolicy, params)
+				}
+			} else if _, ok := params["sandboxPolicy"]; ok {
+				t.Fatalf("sandboxPolicy present, want omitted to keep thread sandbox; params=%#v", params)
+			}
+		})
+	}
+}
+
+func TestAppServerSession_TurnRequestParamsRejectsUnknownSandboxMode(t *testing.T) {
+	s := &appServerSession{
+		permissions: codexPermissionOverrides{SandboxMode: "container"},
+	}
+
+	_, err := s.turnRequestParams("thread-1", []map[string]any{{"type": "text", "text": "hello"}})
+	if err == nil {
+		t.Fatal("turnRequestParams() error = nil, want unsupported sandbox_mode error")
+	}
+	if !strings.Contains(err.Error(), "unsupported codex sandbox_mode") {
+		t.Fatalf("turnRequestParams() error = %v, want unsupported sandbox_mode", err)
+	}
+}
+
+func mapsEqual(got any, want map[string]any) bool {
+	gotMap, ok := got.(map[string]any)
+	if !ok || len(gotMap) != len(want) {
+		return false
+	}
+	for key, wantValue := range want {
+		if gotMap[key] != wantValue {
+			return false
+		}
+	}
+	return true
 }
 
 func TestAppServerSession_HandleRateLimitsUpdatedCachesUsage(t *testing.T) {

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -32,6 +32,7 @@ type Agent struct {
 	model           string
 	reasoningEffort string
 	mode            string // "suggest" | "auto-edit" | "full-auto" | "yolo"
+	permissions     codexPermissionOverrides
 	backend         string // "exec" | "app_server"
 	appServerURL    string
 	codexHome       string
@@ -56,6 +57,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	codexHome, _ := opts["codex_home"].(string)
 	mode = normalizeMode(mode)
 	backend = normalizeBackend(backend)
+	permissions := codexPermissionOverridesFromOptions(opts)
 
 	if appServerURL == "" {
 		appServerURL = "ws://127.0.0.1:3845"
@@ -83,6 +85,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		model:           model,
 		reasoningEffort: normalizeReasoningEffort(reasoningEffort),
 		mode:            mode,
+		permissions:     permissions,
 		backend:         backend,
 		appServerURL:    appServerURL,
 		codexHome:       strings.TrimSpace(codexHome),
@@ -90,6 +93,68 @@ func New(opts map[string]any) (core.Agent, error) {
 		cliExtraArgs:    cliExtraArgs,
 		activeIdx:       -1,
 	}, nil
+}
+
+type codexPermissionOverrides struct {
+	ApprovalPolicy    string
+	ApprovalsReviewer string
+	SandboxMode       string
+}
+
+func codexPermissionOverridesFromOptions(opts map[string]any) codexPermissionOverrides {
+	return codexPermissionOverrides{
+		ApprovalPolicy:    codexStringOption(opts["approval_policy"]),
+		ApprovalsReviewer: codexStringOption(opts["approvals_reviewer"]),
+		SandboxMode:       codexStringOption(opts["sandbox_mode"]),
+	}
+}
+
+func codexStringOption(v any) string {
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+func (p codexPermissionOverrides) hasApprovalOrSandboxOverride() bool {
+	return p.ApprovalPolicy != "" || p.SandboxMode != ""
+}
+
+func (p codexPermissionOverrides) effectiveForMode(mode string) codexPermissionOverrides {
+	approval, sandbox := codexModePermissionDefaults(mode)
+	if p.ApprovalPolicy != "" {
+		approval = p.ApprovalPolicy
+	}
+	if p.SandboxMode != "" {
+		sandbox = p.SandboxMode
+	}
+	return codexPermissionOverrides{
+		ApprovalPolicy:    approval,
+		ApprovalsReviewer: p.ApprovalsReviewer,
+		SandboxMode:       sandbox,
+	}
+}
+
+func (p codexPermissionOverrides) appendConfigArgs(args []string) []string {
+	if p.ApprovalPolicy != "" {
+		args = append(args, "-c", fmt.Sprintf("approval_policy=%q", p.ApprovalPolicy))
+	}
+	if p.ApprovalsReviewer != "" {
+		args = append(args, "-c", fmt.Sprintf("approvals_reviewer=%q", p.ApprovalsReviewer))
+	}
+	if p.SandboxMode != "" {
+		args = append(args, "-c", fmt.Sprintf("sandbox_mode=%q", p.SandboxMode))
+	}
+	return args
+}
+
+func codexModePermissionDefaults(mode string) (approval string, sandbox string) {
+	switch normalizeMode(mode) {
+	case "auto-edit", "full-auto":
+		return "never", "workspace-write"
+	case "yolo":
+		return "never", "danger-full-access"
+	default:
+		return "on-request", "read-only"
+	}
 }
 
 func normalizeBackend(raw string) string {
@@ -332,6 +397,7 @@ func (a *Agent) SetSessionEnv(env []string) {
 func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentSession, error) {
 	a.mu.Lock()
 	mode := a.mode
+	permissions := a.permissions
 	model := a.model
 	reasoningEffort := a.reasoningEffort
 	backend := a.backend
@@ -361,13 +427,18 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 
 	if backend == "app_server" {
-		return newAppServerSession(ctx, appServerURL, a.workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome)
+		return newAppServerSession(ctx, appServerURL, a.workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome, permissions)
 	}
 	if codexHome != "" {
 		extraEnv = append(extraEnv, "CODEX_HOME="+codexHome)
 	}
 
-	return newCodexSession(ctx, cliBin, cliExtraArgs, a.workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv, provName)
+	session, err := newCodexSession(ctx, cliBin, cliExtraArgs, a.workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv, provName)
+	if err != nil {
+		return nil, err
+	}
+	session.permissions = permissions
+	return session, nil
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
@@ -431,6 +502,15 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	}
 	if a.codexHome != "" {
 		opts["codex_home"] = a.codexHome
+	}
+	if a.permissions.ApprovalPolicy != "" {
+		opts["approval_policy"] = a.permissions.ApprovalPolicy
+	}
+	if a.permissions.ApprovalsReviewer != "" {
+		opts["approvals_reviewer"] = a.permissions.ApprovalsReviewer
+	}
+	if a.permissions.SandboxMode != "" {
+		opts["sandbox_mode"] = a.permissions.SandboxMode
 	}
 	return opts
 }

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -28,20 +28,21 @@ type codexSession struct {
 	model         string
 	effort        string
 	mode          string
+	permissions   codexPermissionOverrides
 	baseURL       string // provider base URL; passed as -c openai_base_url=<url>
 	modelProvider string // Codex model_provider name; passed as -c model_provider=<name>
 	cliBin        string   // CLI binary, default "codex"
 	cliExtraArgs  []string // extra args from cli_path, prepended before exec args
 	extraEnv      []string
 	events        chan core.Event
-	threadID  atomic.Value // stores string — Codex thread_id
-	ctx       context.Context
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
-	alive     atomic.Bool
-	closeOnce sync.Once
-	cmdMu     sync.Mutex
-	cmds      map[*exec.Cmd]struct{}
+	threadID      atomic.Value // stores string — Codex thread_id
+	ctx           context.Context
+	cancel        context.CancelFunc
+	wg            sync.WaitGroup
+	alive         atomic.Bool
+	closeOnce     sync.Once
+	cmdMu         sync.Mutex
+	cmds          map[*exec.Cmd]struct{}
 
 	pendingMsgs []string // buffered agent_message texts awaiting classification
 
@@ -188,12 +189,7 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 		args = []string{"exec", "--skip-git-repo-check"}
 	}
 
-	switch cs.mode {
-	case "auto-edit", "full-auto":
-		args = append(args, "--full-auto")
-	case "yolo":
-		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
-	}
+	args = cs.appendPermissionArgs(args)
 
 	if cs.model != "" {
 		args = append(args, "--model", cs.model)
@@ -223,6 +219,23 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 		args = append(args, "--json", "--cd", cs.workDir, "-")
 	}
 	return args
+}
+
+func (cs *codexSession) appendPermissionArgs(args []string) []string {
+	if !cs.permissions.hasApprovalOrSandboxOverride() {
+		switch cs.mode {
+		case "auto-edit", "full-auto":
+			args = append(args, "--full-auto")
+		case "yolo":
+			args = append(args, "--dangerously-bypass-approvals-and-sandbox")
+		}
+		if cs.permissions.ApprovalsReviewer != "" {
+			args = append(args, "-c", fmt.Sprintf("approvals_reviewer=%q", cs.permissions.ApprovalsReviewer))
+		}
+		return args
+	}
+
+	return cs.permissions.effectiveForMode(cs.mode).appendConfigArgs(args)
 }
 
 func codexImageExt(mime string) string {

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -37,6 +37,94 @@ func TestAvailableReasoningEfforts_ExcludesMinimal(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAgentOptions_IncludesNativePermissionOverrides(t *testing.T) {
+	agent := &Agent{
+		mode:    "full-auto",
+		backend: "exec",
+		permissions: codexPermissionOverrides{
+			ApprovalPolicy:    "on-request",
+			ApprovalsReviewer: "auto_review",
+			SandboxMode:       "workspace-write",
+		},
+	}
+
+	opts := agent.WorkspaceAgentOptions()
+
+	if got := opts["approval_policy"]; got != "on-request" {
+		t.Fatalf("approval_policy = %#v, want on-request", got)
+	}
+	if got := opts["approvals_reviewer"]; got != "auto_review" {
+		t.Fatalf("approvals_reviewer = %#v, want auto_review", got)
+	}
+	if got := opts["sandbox_mode"]; got != "workspace-write" {
+		t.Fatalf("sandbox_mode = %#v, want workspace-write", got)
+	}
+}
+
+func TestCodexPermissionOverridesFromOptions_TrimsNativePermissionOptions(t *testing.T) {
+	got := codexPermissionOverridesFromOptions(map[string]any{
+		"approval_policy":    " on-request ",
+		"approvals_reviewer": " guardian_subagent ",
+		"sandbox_mode":       " workspace-write ",
+	})
+
+	if got.ApprovalPolicy != "on-request" {
+		t.Fatalf("ApprovalPolicy = %q, want on-request", got.ApprovalPolicy)
+	}
+	if got.ApprovalsReviewer != "guardian_subagent" {
+		t.Fatalf("ApprovalsReviewer = %q, want guardian_subagent", got.ApprovalsReviewer)
+	}
+	if got.SandboxMode != "workspace-write" {
+		t.Fatalf("SandboxMode = %q, want workspace-write", got.SandboxMode)
+	}
+}
+
+func TestCodexNewPreservesNativePermissionOptions(t *testing.T) {
+	binDir := t.TempDir()
+	writeFakeCodexExecutable(t, binDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	agent, err := New(map[string]any{
+		"mode":               "full-auto",
+		"approval_policy":    "on-request",
+		"approvals_reviewer": "auto_review",
+		"sandbox_mode":       "workspace-write",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	codexAgent, ok := agent.(*Agent)
+	if !ok {
+		t.Fatalf("New returned %T, want *Agent", agent)
+	}
+	opts := codexAgent.WorkspaceAgentOptions()
+	if got := opts["approval_policy"]; got != "on-request" {
+		t.Fatalf("approval_policy = %#v, want on-request", got)
+	}
+	if got := opts["approvals_reviewer"]; got != "auto_review" {
+		t.Fatalf("approvals_reviewer = %#v, want auto_review", got)
+	}
+	if got := opts["sandbox_mode"]; got != "workspace-write" {
+		t.Fatalf("sandbox_mode = %#v, want workspace-write", got)
+	}
+}
+
+func writeFakeCodexExecutable(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "codex.cmd")
+		if err := os.WriteFile(path, []byte("@echo off\r\n"), 0o755); err != nil {
+			t.Fatalf("write fake codex: %v", err)
+		}
+		return
+	}
+	path := filepath.Join(dir, "codex")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+}
+
 func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "o3", "high", "full-auto", "", "", nil, "")
 	if err != nil {
@@ -115,6 +203,126 @@ func TestBuildExecArgs_ResumeOmitsCdFlag(t *testing.T) {
 	// --json and stdin marker must still be present.
 	if !containsSequence(args, []string{"--json", "-"}) {
 		t.Fatalf("resume args missing --json + stdin marker: %v", args)
+	}
+}
+
+func TestBuildExecArgs_NativePermissionOverrides(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "full-auto", "", "", nil, "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	cs.permissions = codexPermissionOverrides{
+		ApprovalPolicy:    "on-request",
+		ApprovalsReviewer: "auto_review",
+		SandboxMode:       "workspace-write",
+	}
+
+	args := cs.buildExecArgs("hello", nil)
+
+	for _, flag := range []string{"--full-auto", "--dangerously-bypass-approvals-and-sandbox"} {
+		if indexOf(args, flag) >= 0 {
+			t.Fatalf("args should not contain conflicting %s flag when native overrides are set: %v", flag, args)
+		}
+	}
+	for _, want := range [][]string{
+		{"-c", `approval_policy="on-request"`},
+		{"-c", `approvals_reviewer="auto_review"`},
+		{"-c", `sandbox_mode="workspace-write"`},
+	} {
+		if !containsSequence(args, want) {
+			t.Fatalf("args missing %v: %v", want, args)
+		}
+	}
+}
+
+func TestBuildExecArgs_PartialNativePermissionOverridePreservesModeAxis(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "full-auto", "", "", nil, "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	cs.permissions = codexPermissionOverrides{SandboxMode: "read-only"}
+
+	args := cs.buildExecArgs("hello", nil)
+
+	if indexOf(args, "--full-auto") >= 0 {
+		t.Fatalf("args should not contain --full-auto when sandbox axis is overridden: %v", args)
+	}
+	if !containsSequence(args, []string{"-c", `approval_policy="never"`}) {
+		t.Fatalf("args should preserve full-auto approval axis as native config: %v", args)
+	}
+	if !containsSequence(args, []string{"-c", `sandbox_mode="read-only"`}) {
+		t.Fatalf("args missing explicit sandbox override: %v", args)
+	}
+}
+
+func TestBuildExecArgs_YoloPartialNativePermissionOverridePreservesSandboxAxis(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "yolo", "", "", nil, "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	cs.permissions = codexPermissionOverrides{ApprovalPolicy: "on-request"}
+
+	args := cs.buildExecArgs("hello", nil)
+
+	if indexOf(args, "--dangerously-bypass-approvals-and-sandbox") >= 0 {
+		t.Fatalf("args should not contain bypass flag when approval axis is overridden: %v", args)
+	}
+	if !containsSequence(args, []string{"-c", `approval_policy="on-request"`}) {
+		t.Fatalf("args missing explicit approval override: %v", args)
+	}
+	if !containsSequence(args, []string{"-c", `sandbox_mode="danger-full-access"`}) {
+		t.Fatalf("args should preserve yolo sandbox axis as native config: %v", args)
+	}
+}
+
+func TestBuildExecArgs_SuggestPartialNativePermissionOverridePreservesApprovalAxis(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "suggest", "", "", nil, "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	cs.permissions = codexPermissionOverrides{SandboxMode: "workspace-write"}
+
+	args := cs.buildExecArgs("hello", nil)
+
+	if !containsSequence(args, []string{"-c", `approval_policy="on-request"`}) {
+		t.Fatalf("args should preserve suggest approval axis as native config: %v", args)
+	}
+	if !containsSequence(args, []string{"-c", `sandbox_mode="workspace-write"`}) {
+		t.Fatalf("args missing explicit sandbox override: %v", args)
+	}
+}
+
+func TestBuildExecArgs_SuggestPartialNativePermissionOverridePreservesSandboxAxis(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "suggest", "", "", nil, "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	cs.permissions = codexPermissionOverrides{ApprovalPolicy: "never"}
+
+	args := cs.buildExecArgs("hello", nil)
+
+	if !containsSequence(args, []string{"-c", `approval_policy="never"`}) {
+		t.Fatalf("args missing explicit approval override: %v", args)
+	}
+	if !containsSequence(args, []string{"-c", `sandbox_mode="read-only"`}) {
+		t.Fatalf("args should preserve suggest sandbox axis as native config: %v", args)
+	}
+}
+
+func TestBuildExecArgs_ReviewerOnlyKeepsModeFlag(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "full-auto", "", "", nil, "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	cs.permissions = codexPermissionOverrides{ApprovalsReviewer: "guardian_subagent"}
+
+	args := cs.buildExecArgs("hello", nil)
+
+	if indexOf(args, "--full-auto") < 0 {
+		t.Fatalf("reviewer-only override should keep --full-auto mode flag: %v", args)
+	}
+	if !containsSequence(args, []string{"-c", `approvals_reviewer="guardian_subagent"`}) {
+		t.Fatalf("args missing reviewer config: %v", args)
 	}
 }
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1277,6 +1277,20 @@ app_secret = "your-feishu-app-secret"
 # - "full-auto": auto-approve everything with workspace sandbox / 全部自动通过，工作区沙箱保护
 # - "yolo":      bypass all approvals and sandbox (dangerous) / 跳过所有审批和沙箱（危险）
 #
+# Optional: pass native Codex permission config through to codex exec/app-server.
+# 可选：将 Codex 原生权限配置透传给 codex exec/app-server。
+# If approval_policy or sandbox_mode is set, cc-connect expands mode into native
+# config values first, then applies the explicit override.
+# 如果设置 approval_policy 或 sandbox_mode，cc-connect 会先把 mode 展开为原生配置，
+# 再应用显式覆盖，因此另一条权限轴会保留 mode 的行为。
+# approval_policy = "on-request"       # common: "untrusted" | "on-request" | "never"
+# approvals_reviewer = "auto_review"   # "user" | "auto_review" | "guardian_subagent"
+# sandbox_mode = "workspace-write"     # "read-only" | "workspace-write" | "danger-full-access"
+# approval_policy passes through other Codex-supported values, such as deprecated "on-failure".
+# sandbox_mode is limited to the three values listed above because app-server maps it to structured policy.
+# approval_policy 会透传其他 Codex 支持的值，例如已弃用的 "on-failure"。
+# sandbox_mode 当前仅支持上面列出的三个值，因为 app-server 会把它映射为结构化 policy。
+#
 # Optional: specify a model / 可选：指定模型
 # model = "o3"
 #

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,6 +87,25 @@ All agents support permission modes switchable at runtime via `/mode`.
 | Full Auto | `full-auto` | Auto-approve with sandbox |
 | YOLO | `yolo` | Bypass all approvals and sandbox |
 
+Codex also accepts native permission overrides in `[projects.agent.options]`.
+These keys are passed through to `codex exec -c ...` and `codex app-server -c ...`:
+
+```toml
+approval_policy = "on-request"       # common: "untrusted" | "on-request" | "never"
+approvals_reviewer = "auto_review"   # "user" | "auto_review" | "guardian_subagent"
+sandbox_mode = "workspace-write"     # "read-only" | "workspace-write" | "danger-full-access"
+```
+
+When `approval_policy` or `sandbox_mode` is set, cc-connect expands the selected
+Codex `mode` into native config values and then applies the explicit override,
+so the other permission axis keeps the mode's behavior. `approvals_reviewer`
+only changes who reviews approvals and can be used by itself. `auto_review` is
+the preferred automatic reviewer value; `guardian_subagent` is kept for Codex
+legacy compatibility. `approval_policy` also passes through other
+Codex-supported values, such as the deprecated `on-failure`; `sandbox_mode`
+is currently limited to the three values listed above because the app-server
+RPC path maps it to structured sandbox policy fields.
+
 ### Cursor Agent Modes
 
 | Mode | Config Value | Behavior |

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -89,6 +89,22 @@ reset_on_idle_mins = 60
 | 全自动 | `full-auto` | 自动通过 + 沙箱保护 |
 | YOLO | `yolo` | 跳过所有审批 |
 
+Codex 还可以在 `[projects.agent.options]` 中配置原生权限覆盖项。
+这些键会透传给 `codex exec -c ...` 和 `codex app-server -c ...`：
+
+```toml
+approval_policy = "on-request"       # 常用："untrusted" | "on-request" | "never"
+approvals_reviewer = "auto_review"   # "user" | "auto_review" | "guardian_subagent"
+sandbox_mode = "workspace-write"     # "read-only" | "workspace-write" | "danger-full-access"
+```
+
+当设置 `approval_policy` 或 `sandbox_mode` 时，cc-connect 会先把当前 Codex
+`mode` 展开为原生配置值，再应用显式覆盖，因此另一条权限轴仍保留该 mode
+的行为。`approvals_reviewer` 只改变审批人，可以单独使用。自动审查推荐使用
+`auto_review`；`guardian_subagent` 保留为 Codex legacy 兼容值。`approval_policy`
+还会透传其他 Codex 支持的值，例如已弃用的 `on-failure`；`sandbox_mode`
+当前仅支持上面列出的三个值，因为 app-server RPC 路径会把它映射为结构化 sandbox policy。
+
 ### Cursor Agent 模式
 
 | 模式 | 配置值 | 行为 |


### PR DESCRIPTION
## Summary
- pass Codex native permission options through from `[projects.agent.options]`
- map `approval_policy`, `approvals_reviewer`, and `sandbox_mode` for both `codex exec` and `codex app-server`
- document the new Codex options in the example config and usage docs

## Details
- `exec` keeps existing mode flags unless `approval_policy` or `sandbox_mode` is explicitly set.
- When one permission axis is overridden, cc-connect expands the selected Codex mode into native config values first, then applies the explicit override so the other axis is preserved.
- `approvals_reviewer` can be used by itself and supports both `auto_review` and legacy `guardian_subagent` values.
- app-server sessions pass the same options at process startup and through thread/turn RPC params.
- `approvalPolicy` and thread `sandbox` use the Codex app-server schema values (`on-request`, `untrusted`, `workspace-write`, etc.); turn `sandboxPolicy` is mapped to the structured app-server policy shape.

## Review follow-up
- added hermetic fake `codex` setup for the `New()` options test
- centralized permission override merging through a shared `effectiveForMode` helper used by exec and app-server paths
- added app-server partial override tests for sandbox-only, approval-only, and reviewer-only cases
- documented the app-server `sandbox` vs `sandboxPolicy.type` spelling difference in code
- tightened docs so only `approval_policy` is described as forwarding additional Codex-supported values; `sandbox_mode` is documented as limited to the three mapped values

## Validation
- WSL/Linux: `go test ./agent/codex -count=1`
- WSL/Linux: `go test ./config -run "TestSaveProjectSettings_ExtraFields|TestSaveActiveProvider_PreservesCommentsAndUnknownFields|TestSaveAgentModel_PreservesCommentsAndUnknownFields" -count=1`
- Windows: `go test ./agent/codex -run "Test(WorkspaceAgentOptions|CodexPermission|CodexNewPreservesNativePermissionOptions|BuildExecArgs|AppServer)" -count=1`
- `git diff --check`
- smoke tested `codex app-server -c approval_policy=... -c approvals_reviewer=... -c sandbox_mode=... --listen stdio://` initialize on Windows with Codex CLI `0.125.0-alpha.3`
- smoke tested real `thread/start` with `approvalPolicy="untrusted"` and `sandbox="workspace-write"`; app-server accepted the params and returned `approvalPolicy="untrusted"` plus a `workspaceWrite` sandbox policy
