### PR TITLE
fix(claudecode): repair [ctx: ~N%] using per-sub-call snapshot and per-model window

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -22,6 +22,17 @@ import (
 	"github.com/chenhg5/cc-connect/core"
 )
 
+// modelContextWindow returns the context window size (in tokens) for a given
+// Claude model ID. The "[1m]" suffix signals the 1M-context variant; everything
+// else falls back to the 200k default. Empty/unknown model names also get 200k.
+func modelContextWindow(model string) int {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if strings.Contains(m, "[1m]") || strings.HasSuffix(m, "-1m") {
+		return 1_000_000
+	}
+	return 200_000
+}
+
 // claudeSession manages a long-running Claude Code process using
 // --input-format stream-json and --permission-prompt-tool stdio.
 //
@@ -38,10 +49,20 @@ type claudeSession struct {
 	acceptEditsOnly atomic.Bool
 	dontAsk         atomic.Bool
 	workDir         string
+	model           string
 	ctx             context.Context
 	cancel          context.CancelFunc
 	done            chan struct{}
 	alive           atomic.Bool
+
+	// lastInputTokens is the prompt size of the most recent assistant API
+	// sub-call (input + cache_creation + cache_read). Sourced per-call from
+	// handleAssistant so the ctx % indicator reflects current prompt
+	// occupancy. The result event's usage is a per-turn aggregate that
+	// sums cache_read across every sub-call, which on long agentic turns
+	// inflates the value far beyond the actual context window.
+	usageMu         sync.Mutex
+	lastInputTokens int
 
 	// gracefulStopTimeout is how long Close() waits for a clean exit
 	// (stdin close → Stop hooks → process exit) before escalating to
@@ -97,7 +118,7 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	if maxContextTokens > 0 {
 		innerArgs = append(innerArgs, "--max-context-tokens", strconv.Itoa(maxContextTokens))
 	}
-	
+
 	// outerArgs are understood by both the wrapper and Claude CLI directly.
 	var outerArgs []string
 	if model != "" {
@@ -192,6 +213,7 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		stdin:               stdin,
 		events:              make(chan core.Event, 64),
 		workDir:             workDir,
+		model:               model,
 		ctx:                 sessionCtx,
 		cancel:              cancel,
 		done:                make(chan struct{}),
@@ -346,6 +368,25 @@ func (cs *claudeSession) handleAssistant(raw map[string]any) {
 	if !ok {
 		return
 	}
+
+	if usageRaw, ok := msg["usage"].(map[string]any); ok {
+		var input, cc, cr int
+		if v, ok := usageRaw["input_tokens"].(float64); ok {
+			input = int(v)
+		}
+		if v, ok := usageRaw["cache_creation_input_tokens"].(float64); ok {
+			cc = int(v)
+		}
+		if v, ok := usageRaw["cache_read_input_tokens"].(float64); ok {
+			cr = int(v)
+		}
+		if used := input + cc + cr; used > 0 {
+			cs.usageMu.Lock()
+			cs.lastInputTokens = used
+			cs.usageMu.Unlock()
+		}
+	}
+
 	contentArr, ok := msg["content"].([]any)
 	if !ok {
 		return
@@ -425,23 +466,25 @@ func (cs *claudeSession) handleResult(raw map[string]any) {
 		cs.sessionID.Store(sid)
 	}
 
-	var inputTokens, outputTokens int
+	var outputTokens int
 	if usage, ok := raw["usage"].(map[string]any); ok {
-		if v, ok := usage["input_tokens"].(float64); ok {
-			inputTokens = int(v)
-		}
 		if v, ok := usage["output_tokens"].(float64); ok {
 			outputTokens = int(v)
 		}
 	}
 
+	cs.usageMu.Lock()
+	inputTokens := cs.lastInputTokens
+	cs.usageMu.Unlock()
+
 	evt := core.Event{
-		Type:         core.EventResult,
-		Content:      content,
-		SessionID:    cs.CurrentSessionID(),
-		Done:         true,
-		InputTokens:  inputTokens,
-		OutputTokens: outputTokens,
+		Type:          core.EventResult,
+		Content:       content,
+		SessionID:     cs.CurrentSessionID(),
+		Done:          true,
+		InputTokens:   inputTokens,
+		OutputTokens:  outputTokens,
+		ContextWindow: modelContextWindow(cs.model),
 	}
 	select {
 	case cs.events <- evt:
@@ -740,7 +783,7 @@ func (cs *claudeSession) Close() error {
 // Uses single quotes because some splitters (e.g. my_cli) don't support
 // backslash escapes inside double quotes. For values containing single
 // quotes, we close the single-quoted segment, add an escaped single
-// quote, and reopen: 'it'\''s' → it's
+// quote, and reopen: 'it'\”s' → it's
 func shellJoinArgs(args []string) string {
 	var b strings.Builder
 	for i, a := range args {

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/chenhg5/cc-connect/core"
 )
 
-func TestHandleResultParsesUsage(t *testing.T) {
+func TestHandleResultUsesPerSubCallSnapshot(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -23,24 +23,133 @@ func TestHandleResultParsesUsage(t *testing.T) {
 	cs.sessionID.Store("test-session")
 	cs.alive.Store(true)
 
+	cs.handleAssistant(map[string]any{
+		"message": map[string]any{
+			"usage": map[string]any{
+				"input_tokens": float64(150000),
+			},
+			"content": []any{},
+		},
+	})
+
 	raw := map[string]any{
 		"type":       "result",
 		"result":     "done",
 		"session_id": "test-session",
 		"usage": map[string]any{
-			"input_tokens":  float64(150000),
+			"input_tokens":  float64(99999999),
 			"output_tokens": float64(2000),
 		},
 	}
-
 	cs.handleResult(raw)
 
 	evt := <-cs.events
 	if evt.InputTokens != 150000 {
-		t.Errorf("InputTokens = %d, want 150000", evt.InputTokens)
+		t.Errorf("InputTokens = %d, want 150000 (per-sub-call snapshot, not result.usage)", evt.InputTokens)
 	}
 	if evt.OutputTokens != 2000 {
 		t.Errorf("OutputTokens = %d, want 2000", evt.OutputTokens)
+	}
+}
+
+func TestHandleResultSnapshotSumsCacheAndModel1MWindow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+		model:  "claude-opus-4-7[1m]",
+	}
+	cs.sessionID.Store("test-session")
+	cs.alive.Store(true)
+
+	cs.handleAssistant(map[string]any{
+		"message": map[string]any{
+			"usage": map[string]any{
+				"input_tokens":                float64(500),
+				"cache_read_input_tokens":     float64(98000),
+				"cache_creation_input_tokens": float64(1500),
+			},
+			"content": []any{},
+		},
+	})
+
+	raw := map[string]any{
+		"type":       "result",
+		"result":     "done",
+		"session_id": "test-session",
+		"usage": map[string]any{
+			"input_tokens":                float64(99999999),
+			"cache_read_input_tokens":     float64(99999999),
+			"cache_creation_input_tokens": float64(99999999),
+			"output_tokens":               float64(800),
+		},
+	}
+	cs.handleResult(raw)
+
+	evt := <-cs.events
+	if evt.InputTokens != 100000 {
+		t.Errorf("InputTokens = %d, want 100000 (500 + 98000 + 1500 from snapshot)", evt.InputTokens)
+	}
+	if evt.ContextWindow != 1_000_000 {
+		t.Errorf("ContextWindow = %d, want 1_000_000 for [1m] model", evt.ContextWindow)
+	}
+}
+
+func TestHandleAssistantSnapshotIsLastSubCall(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("test-session")
+	cs.alive.Store(true)
+
+	cs.handleAssistant(map[string]any{
+		"message": map[string]any{
+			"usage":   map[string]any{"input_tokens": float64(10000), "cache_read_input_tokens": float64(40000)},
+			"content": []any{},
+		},
+	})
+	cs.handleAssistant(map[string]any{
+		"message": map[string]any{
+			"usage":   map[string]any{"input_tokens": float64(20000), "cache_read_input_tokens": float64(100000)},
+			"content": []any{},
+		},
+	})
+
+	cs.handleResult(map[string]any{
+		"type":   "result",
+		"result": "done",
+		"usage":  map[string]any{"output_tokens": float64(500)},
+	})
+
+	evt := <-cs.events
+	if evt.InputTokens != 120000 {
+		t.Errorf("InputTokens = %d, want 120000 (last sub-call: 20000 + 100000)", evt.InputTokens)
+	}
+}
+
+func TestModelContextWindow(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int
+	}{
+		{"claude-opus-4-7[1m]", 1_000_000},
+		{"CLAUDE-OPUS-4-7[1M]", 1_000_000},
+		{"claude-sonnet-4-6-1m", 1_000_000},
+		{"claude-opus-4-7", 200_000},
+		{"claude-sonnet-4-6", 200_000},
+		{"claude-haiku-4-5-20251001", 200_000},
+		{"", 200_000},
+	}
+	for _, tt := range tests {
+		if got := modelContextWindow(tt.model); got != tt.want {
+			t.Errorf("modelContextWindow(%q) = %d, want %d", tt.model, got, tt.want)
+		}
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -199,16 +199,16 @@ type Engine struct {
 	userRoles    *UserRoleManager // nil = legacy mode (no per-user policies)
 	userRolesMu  sync.RWMutex     // protects userRoles, disabledCmds, and adminFrom
 
-	rateLimiter      *RateLimiter
-	outgoingRL       *OutgoingRateLimiter
-	streamPreview    StreamPreviewCfg
-	references       ReferenceRenderCfg
-	relayManager     *RelayManager
-	eventIdleTimeout time.Duration
+	rateLimiter       *RateLimiter
+	outgoingRL        *OutgoingRateLimiter
+	streamPreview     StreamPreviewCfg
+	references        ReferenceRenderCfg
+	relayManager      *RelayManager
+	eventIdleTimeout  time.Duration
 	maxQueuedMessages int
-	dirHistory       *DirHistory
-	baseWorkDir      string
-	projectState     *ProjectStateStore
+	dirHistory        *DirHistory
+	baseWorkDir       string
+	projectState      *ProjectStateStore
 
 	// Auto-compress settings
 	autoCompressEnabled   bool
@@ -406,7 +406,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		streamPreview:         DefaultStreamPreviewCfg(),
 		references:            DefaultReferenceRenderCfg(),
 		eventIdleTimeout:      defaultEventIdleTimeout,
-		maxQueuedMessages:    defaultMaxQueuedMessages,
+		maxQueuedMessages:     defaultMaxQueuedMessages,
 		showContextIndicator:  true,
 	}
 
@@ -3025,7 +3025,7 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 
 				if fullResponse != "" {
 					if e.showContextIndicator && event.InputTokens >= 100 {
-						fullResponse += contextIndicator(event.InputTokens)
+						fullResponse += contextIndicator(event.InputTokens, event.ContextWindow)
 					}
 					for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
 						e.send(p, replyCtx, chunk)
@@ -3599,7 +3599,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 			if e.showContextIndicator && !isSilent {
 				if sdkPlausible {
-					cleanResponse += contextIndicator(event.InputTokens)
+					cleanResponse += contextIndicator(event.InputTokens, event.ContextWindow)
 				} else if selfPct > 0 {
 					cleanResponse += fmt.Sprintf("\n[ctx: ~%d%%]", selfPct)
 				}
@@ -12809,14 +12809,21 @@ func gitClone(repoURL, dest string) error {
 
 // ── Context usage indicator ──────────────────────────────────
 
-const modelContextWindow = 200_000 // generic fallback window for heuristic context estimates
+// defaultContextWindow is the fallback window used when the agent event
+// doesn't carry a model-specific size (e.g. older Codex/Claude events).
+const defaultContextWindow = 200_000
 
-// contextIndicator returns a suffix like "\n[ctx: ~42%]" based on SDK-reported input tokens.
-func contextIndicator(inputTokens int) string {
+// contextIndicator returns a suffix like "\n[ctx: ~42%]" based on SDK-reported
+// input tokens. The window comes from the agent event when available, so 1M
+// variants render correctly without a central model table in the engine.
+func contextIndicator(inputTokens, window int) string {
 	if inputTokens <= 0 {
 		return ""
 	}
-	pct := inputTokens * 100 / modelContextWindow
+	if window <= 0 {
+		window = defaultContextWindow
+	}
+	pct := inputTokens * 100 / window
 	if pct > 100 {
 		pct = 100
 	}

--- a/core/message.go
+++ b/core/message.go
@@ -128,32 +128,32 @@ type AudioAttachment struct {
 
 // LocationAttachment represents a geographical location sent by the user.
 type LocationAttachment struct {
-	Latitude            float64 // latitude coordinate
-	Longitude           float64 // longitude coordinate
-	HorizontalAccuracy  float64 // accuracy radius in meters (optional)
-	LivePeriod          int     // time period for live location updates in seconds (optional)
-	Heading             int     // direction of movement in degrees (optional)
-	ProximityAlertRadius int    // maximum distance for proximity alerts in meters (optional)
+	Latitude             float64 // latitude coordinate
+	Longitude            float64 // longitude coordinate
+	HorizontalAccuracy   float64 // accuracy radius in meters (optional)
+	LivePeriod           int     // time period for live location updates in seconds (optional)
+	Heading              int     // direction of movement in degrees (optional)
+	ProximityAlertRadius int     // maximum distance for proximity alerts in meters (optional)
 }
 
 // Message represents a unified incoming message from any platform.
 type Message struct {
-	SessionKey string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
-	Platform   string
-	MessageID  string // platform message ID for tracing
-	UserID     string
-	UserName   string
-	ChatName   string // human-readable chat/group name (optional)
-	Content    string
-	Images     []ImageAttachment // attached images (if any)
-	Files      []FileAttachment  // attached files (if any)
-	Audio        *AudioAttachment // voice message (if any)
+	SessionKey   string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
+	Platform     string
+	MessageID    string // platform message ID for tracing
+	UserID       string
+	UserName     string
+	ChatName     string // human-readable chat/group name (optional)
+	Content      string
+	Images       []ImageAttachment   // attached images (if any)
+	Files        []FileAttachment    // attached files (if any)
+	Audio        *AudioAttachment    // voice message (if any)
 	Location     *LocationAttachment // geographical location (if any)
 	ExtraContent string              // platform-enriched content (e.g. location text, reply quote) prepended for the agent
 	ChannelKey   string              // platform-provided channel identifier for workspace binding (optional)
-	ReplyCtx     any             // platform-specific context needed for replying
-	FromVoice    bool            // true if message originated from voice transcription
-	ModeOverride string          // if set, temporarily override agent permission mode for this message
+	ReplyCtx     any                 // platform-specific context needed for replying
+	FromVoice    bool                // true if message originated from voice transcription
+	ModeOverride string              // if set, temporarily override agent permission mode for this message
 }
 
 // EventType distinguishes different kinds of agent output.
@@ -185,24 +185,25 @@ type UserQuestionOption struct {
 
 // Event represents a single piece of agent output streamed back to the engine.
 type Event struct {
-	Type         EventType
-	Content      string
-	ToolName     string         // populated for EventToolUse, EventPermissionRequest
-	ToolInput    string         // human-readable summary of tool input
-	ToolInputRaw map[string]any // raw tool input (for EventPermissionRequest, used in allow response)
-	ToolResult   string         // populated for EventToolResult
-	ToolStatus   string         // optional status for EventToolResult (e.g. completed/failed)
-	ToolExitCode *int           // optional exit code for EventToolResult
-	ToolSuccess  *bool          // optional success flag for EventToolResult
-	SessionID    string         // agent-managed session ID for conversation continuity
-	RequestID    string         // unique request ID for EventPermissionRequest
-	Questions    []UserQuestion // populated when ToolName == "AskUserQuestion"
-	Done         bool
-	Error        error
-	InputTokens  int // token usage from agent result events
-	OutputTokens int
-	Metadata     map[string]any // optional metadata from agent (e.g. compaction_continue)
-	Synthetic    bool           // true if this is a synthetic/generated message (not from real user)
+	Type          EventType
+	Content       string
+	ToolName      string         // populated for EventToolUse, EventPermissionRequest
+	ToolInput     string         // human-readable summary of tool input
+	ToolInputRaw  map[string]any // raw tool input (for EventPermissionRequest, used in allow response)
+	ToolResult    string         // populated for EventToolResult
+	ToolStatus    string         // optional status for EventToolResult (e.g. completed/failed)
+	ToolExitCode  *int           // optional exit code for EventToolResult
+	ToolSuccess   *bool          // optional success flag for EventToolResult
+	SessionID     string         // agent-managed session ID for conversation continuity
+	RequestID     string         // unique request ID for EventPermissionRequest
+	Questions     []UserQuestion // populated when ToolName == "AskUserQuestion"
+	Done          bool
+	Error         error
+	InputTokens   int // token usage from agent result events
+	OutputTokens  int
+	ContextWindow int            // model's context window size, for context usage percentage
+	Metadata      map[string]any // optional metadata from agent (e.g. compaction_continue)
+	Synthetic     bool           // true if this is a synthetic/generated message (not from real user)
 }
 
 // HistoryEntry is one turn in a conversation.


### PR DESCRIPTION
Re-opens the work originally in #765 with a different algorithm — credit to @Cigarrr (#774) for catching that `result.usage` is a per-turn aggregate, not a per-call snapshot.

## Summary

Two bugs broke the `[ctx: ~N%]` indicator in the claudecode path:

1. `handleResult` sourced the indicator's input from the result event's `usage`. The result event aggregates usage across every sub-call in a tool-using turn, summing `cache_read_input_tokens` — on long agentic turns this is many times the actual context window, so `[ctx: ~N%]` clamps at 100% and stops being useful.

2. `contextIndicator` divided by a hardcoded `200_000`. Users on `claude-opus-4-7[1m]` saw 5× inflated percentages.

## Fix

- Capture per-sub-call usage (`input + cache_creation + cache_read`) from each `assistant` event into `lastInputTokens`. The latest snapshot is the real "context used right now" — what the indicator should show.
- `handleResult` sources `InputTokens` from this snapshot; only `output_tokens` is still read from the result event itself.
- `ContextWindow` is stamped via `modelContextWindow(cs.model)`: `[1m]` / `-1m` suffix → `1_000_000`, otherwise `200_000`.

## Why this is the minimal change (intentional scope)

#774 (@Cigarrr) provides the same algorithmic fix plus a comprehensive structured-footer infrastructure (`StatusFooterSender` / `StatusFooterUpdater` interfaces, per-project toggles, claudecode-specific status line). That rendering work conflicts with the Card 2.0 PR (#657) and other in-flight UI changes.

This PR pulls in **only** the algorithmic fix to the ctx % indicator, leaving the rendering path untouched — so it can land alongside #657 and similar UI PRs without merge conflicts. Once #774 lands, a follow-up can wire its \`StatusFooterSender\` into Card 2.0's \`BuildRichCard\` directly.

## Codex precedent

The codex agent already faces this exact split in \`agent/codex/context_usage.go:290\`, where it picks \`LastTokenUsage\` (per-call snapshot) over \`TotalTokenUsage\` (aggregate) for the same reason.

## Tests

- \`TestHandleResultUsesPerSubCallSnapshot\` — verifies snapshot, not result.usage, drives InputTokens
- \`TestHandleResultSnapshotSumsCacheAndModel1MWindow\` — verifies cache fields summed from snapshot + 1M window for \`[1m]\` model
- \`TestHandleAssistantSnapshotIsLastSubCall\` — verifies multi-sub-call snapshot uses the last value
- Existing \`TestModelContextWindow\` and \`TestHandleResultNoUsage\` continue to pass.

\`go build -tags no_web ./...\` / \`go vet -tags no_web ./...\` / \`go test -count=1 -tags no_web ./agent/claudecode/...\` all green.

## Relation to #765

Supersedes the now-closed #765 (\`include cache tokens and per-model window in [ctx: ~N%]\`). #765 had the right model-window fix and the right idea about cache tokens, but sourced them from the wrong event (\`result.usage\`, which is a per-turn aggregate). That issue is now fixed via the snapshot path.