### PR TITLE
fix: stabilize codex and management tests

### DIFF
--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -137,10 +138,16 @@ while IFS= read -r line; do
   esac
 done
 `
-	scriptPath := filepath.Join(binDir, "codex")
-	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake codex: %v", err)
-	}
+	powershellScript := `
+while (($line = [Console]::In.ReadLine()) -ne $null) {
+  if ($line -like '*"method":"initialize"*') {
+    [Console]::Out.WriteLine('{"id":1,"result":{"protocolVersion":"2"}}')
+  } elseif ($line -like '*"method":"config/read"*') {
+    [Console]::Out.WriteLine('{"id":2,"result":{"config":{"model":"gpt-5.4","model_reasoning_effort":"xhigh"},"origins":{}}}')
+  }
+}
+`
+	writeFakeCodexScript(t, binDir, script, powershellScript)
 
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
@@ -219,10 +226,12 @@ func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 		"printf '%s\\n' \"$@\" > \"$CODEX_ARGS_FILE\"\n" +
 		"printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"thread-1\"}'\n" +
 		"printf '%s\\n' '{\"type\":\"turn.completed\"}'\n"
-	scriptPath := filepath.Join(binDir, "codex")
-	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake codex: %v", err)
-	}
+	powershellScript := `
+[IO.File]::WriteAllLines($env:CODEX_ARGS_FILE, (fakeCodexArgs))
+[Console]::Out.WriteLine('{"type":"thread.started","thread_id":"thread-1"}')
+[Console]::Out.WriteLine('{"type":"turn.completed"}')
+`
+	writeFakeCodexScript(t, binDir, script, powershellScript)
 
 	t.Setenv("CODEX_ARGS_FILE", argsFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -279,10 +288,11 @@ func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
 	script := "#!/bin/sh\n" +
 		"printf '%s\\n' \"$@\" > \"$CODEX_ARGS_FILE\"\n" +
 		"printf '%s\\n' '{\"type\":\"turn.completed\"}'\n"
-	scriptPath := filepath.Join(binDir, "codex")
-	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake codex: %v", err)
-	}
+	powershellScript := `
+[IO.File]::WriteAllLines($env:CODEX_ARGS_FILE, (fakeCodexArgs))
+[Console]::Out.WriteLine('{"type":"turn.completed"}')
+`
+	writeFakeCodexScript(t, binDir, script, powershellScript)
 
 	t.Setenv("CODEX_ARGS_FILE", argsFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -328,10 +338,13 @@ func TestSend_UsesStdinForMultilinePrompt(t *testing.T) {
 		"cat > \"$CODEX_STDIN_FILE\"\n" +
 		"printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"thread-stdin\"}'\n" +
 		"printf '%s\\n' '{\"type\":\"turn.completed\"}'\n"
-	scriptPath := filepath.Join(binDir, "codex")
-	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake codex: %v", err)
-	}
+	powershellScript := `
+[IO.File]::WriteAllLines($env:CODEX_ARGS_FILE, (fakeCodexArgs))
+[IO.File]::WriteAllText($env:CODEX_STDIN_FILE, [Console]::In.ReadToEnd())
+[Console]::Out.WriteLine('{"type":"thread.started","thread_id":"thread-stdin"}')
+[Console]::Out.WriteLine('{"type":"turn.completed"}')
+`
+	writeFakeCodexScript(t, binDir, script, powershellScript)
 
 	t.Setenv("CODEX_ARGS_FILE", argsFile)
 	t.Setenv("CODEX_STDIN_FILE", stdinFile)
@@ -383,10 +396,9 @@ func TestSend_HandlesLargeJSONLines(t *testing.T) {
 	}
 
 	script := "#!/bin/sh\ncat \"$CODEX_PAYLOAD_FILE\"\n"
-	scriptPath := filepath.Join(binDir, "codex")
-	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake codex: %v", err)
-	}
+	powershellScript := `[Console]::Out.Write([IO.File]::ReadAllText($env:CODEX_PAYLOAD_FILE))
+`
+	writeFakeCodexScript(t, binDir, script, powershellScript)
 
 	t.Setenv("CODEX_PAYLOAD_FILE", payloadFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -446,6 +458,75 @@ func TestWaitForArgsFile_WaitsForNonEmptyContent(t *testing.T) {
 	args := waitForArgsFile(t, argsFile)
 	if !containsSequence(args, []string{"exec", "--json"}) {
 		t.Fatalf("expected non-empty args sequence, got: %v", args)
+	}
+}
+
+func TestWriteFakeCodexScript_PreservesArgsWithSpaces(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	argsFile := filepath.Join(workDir, "args.txt")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$CODEX_ARGS_FILE\"\n"
+	powershellScript := `[IO.File]::WriteAllLines($env:CODEX_ARGS_FILE, (fakeCodexArgs))
+`
+	writeFakeCodexScript(t, binDir, script, powershellScript)
+	t.Setenv("CODEX_ARGS_FILE", argsFile)
+
+	cmd := exec.Command(filepath.Join(binDir, "codex"), "exec", "--cd", filepath.Join(workDir, "dir with spaces"), "-")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("fake codex run: %v", err)
+	}
+
+	args := waitForArgsFile(t, argsFile)
+	wantPath := filepath.Join(workDir, "dir with spaces")
+	if !containsSequence(args, []string{"exec", "--cd", wantPath, "-"}) {
+		t.Fatalf("args = %v, want path with spaces preserved as %q", args, wantPath)
+	}
+}
+
+const fakeCodexPowerShellPrelude = `
+function fakeCodexArgs {
+  if ([string]::IsNullOrWhiteSpace($env:CODEX_FAKE_ARGS_FILE) -or -not (Test-Path -LiteralPath $env:CODEX_FAKE_ARGS_FILE)) {
+    return @()
+  }
+  return @(Get-Content -LiteralPath $env:CODEX_FAKE_ARGS_FILE)
+}
+`
+
+func writeFakeCodexScript(t *testing.T, dir, shellScript, powershellScript string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		psPath := filepath.Join(dir, "codex.ps1")
+		if err := os.WriteFile(psPath, []byte(fakeCodexPowerShellPrelude+powershellScript), 0o644); err != nil {
+			t.Fatalf("write fake codex powershell script: %v", err)
+		}
+		cmdPath := filepath.Join(dir, "codex.cmd")
+		cmdScript := "@echo off\r\n" +
+			"setlocal\r\n" +
+			"set \"CODEX_FAKE_SCRIPT=%~dp0codex.ps1\"\r\n" +
+			"set \"CODEX_FAKE_ARGS_FILE=%TEMP%\\codex-fake-args-%RANDOM%-%RANDOM%.txt\"\r\n" +
+			"type nul > \"%CODEX_FAKE_ARGS_FILE%\"\r\n" +
+			":args\r\n" +
+			"if \"%~1\"==\"\" goto run\r\n" +
+			">> \"%CODEX_FAKE_ARGS_FILE%\" echo(%~1\r\n" +
+			"shift\r\n" +
+			"goto args\r\n" +
+			":run\r\n" +
+			"powershell -NoProfile -ExecutionPolicy Bypass -File \"%CODEX_FAKE_SCRIPT%\"\r\n" +
+			"set \"CODEX_FAKE_EXIT=%ERRORLEVEL%\"\r\n" +
+			"del \"%CODEX_FAKE_ARGS_FILE%\" >nul 2>nul\r\n" +
+			"exit /b %CODEX_FAKE_EXIT%\r\n"
+		if err := os.WriteFile(cmdPath, []byte(cmdScript), 0o755); err != nil {
+			t.Fatalf("write fake codex cmd shim: %v", err)
+		}
+		return
+	}
+	scriptPath := filepath.Join(dir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(shellScript), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
 	}
 }
 

--- a/agent/codex/skilldirs_test.go
+++ b/agent/codex/skilldirs_test.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -13,7 +14,7 @@ func TestSkillDirs_UsesProjectAgentAndCodexHomes(t *testing.T) {
 	repo := filepath.Join(tmp, "repo")
 	workDir := filepath.Join(repo, "nested", "pkg")
 
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	t.Setenv("CODEX_HOME", "")
 
 	for _, dir := range []string{
@@ -61,7 +62,7 @@ func TestSkillDirs_FallsBackToEnvCodexHome(t *testing.T) {
 		t.Fatalf("mkdir workdir: %v", err)
 	}
 
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	t.Setenv("CODEX_HOME", codexHome)
 
 	a := &Agent{workDir: workDir}
@@ -75,5 +76,15 @@ func TestSkillDirs_FallsBackToEnvCodexHome(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("SkillDirs() missing CODEX_HOME skills dir: %v", got)
+	}
+}
+
+func setTestHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+		t.Setenv("HOMEDRIVE", "")
+		t.Setenv("HOMEPATH", "")
 	}
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -768,6 +768,7 @@ func (e *Engine) GetDisabledCommands() []string {
 	for k := range e.disabledCmds {
 		out = append(out, k)
 	}
+	sort.Strings(out)
 	return out
 }
 


### PR DESCRIPTION
## Summary
- make Codex session tests use a Windows `codex.cmd`/PowerShell fake CLI instead of falling through to the real Codex CLI
- make Codex skill-dir tests set Windows home environment variables in addition to `HOME`
- return `disabled_commands` in deterministic order so management tests and API output do not depend on Go map iteration

## Details
- `writeFakeCodexScript` now writes Unix shell fakes on Unix and a `codex.cmd` + `codex.ps1` fake on Windows.
- The Windows shim stores argv entries in a temporary file and the PowerShell fake reads them back, so arguments containing spaces remain intact without handing Codex-style `--flags` to PowerShell `-File` parameter binding.
- Added `TestWriteFakeCodexScript_PreservesArgsWithSpaces` to cover the Windows path-with-spaces regression case.
- `GetDisabledCommands()` now sorts map keys before returning them.

## Validation
- Windows: `go test ./core -run TestMgmt_ProjectPatch_DisabledCommands -count=20`
- Windows: `go test ./agent/codex -count=1`
- WSL/Linux: `go test ./agent/codex -count=1`
- `git diff --check`
