### PR TITLE
feat(config): per-project [projects.display] override

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -92,6 +92,20 @@ level = "info" # debug, info, warn, error
 # tool_max_len = 500       # Max chars for tool use messages (default: 500) / 工具调用消息最大字符数（默认 500）
 # tool_messages = true     # Show/hide tool progress messages (default: true) / 是否显示工具进度消息（默认 true）
 
+# Per-project override: each [[projects]] entry may have its own [projects.display]
+# block that overrides individual fields of the global [display] block above.
+# Resolution order is per-field — set fields win, unset fields fall back to global,
+# then to built-in defaults. Useful when one project should be quiet while others
+# stay verbose, or vice versa.
+# 每个 [[projects]] 条目可以有自己的 [projects.display] 块，逐字段覆盖全局
+# [display]。已设字段优先，未设字段回落到全局值，再回落到默认值。
+#
+# [[projects]]
+# name = "noisy-project"
+# [projects.display]
+# thinking_messages = false  # Override only this field; others inherit from global
+# tool_messages = false
+
 # Agent idle timeout: max minutes between consecutive agent events before
 # considering the session stuck. Set to 0 to disable the timeout entirely.
 # Agent 空闲超时：两次 agent 事件之间的最大等待分钟数，超时则认为会话卡住。设为 0 禁用。

--- a/config/config.go
+++ b/config/config.go
@@ -334,6 +334,22 @@ type ProjectConfig struct {
 	// Quiet is legacy per-project override; see Config.Quiet. When true and global [display]
 	// omits thinking_messages / tool_messages, those default to off for this project.
 	Quiet      *bool           `toml:"quiet,omitempty"`
+	// Display, when non-nil, overrides individual fields of the global [display]
+	// block for this project. Each sub-field is independently optional; unset
+	// fields fall back to the global [display] value, then to the built-in
+	// defaults. Example: enable verbose display globally but force quiet on a
+	// specific noisy project, or vice versa.
+	//
+	//   [display]
+	//   thinking_messages = true
+	//   tool_messages = true
+	//
+	//   [[projects]]
+	//   name = "noisy-project"
+	//   [projects.display]
+	//   thinking_messages = false
+	//   tool_messages = false
+	Display    *DisplayConfig  `toml:"display,omitempty"`
 	Observe    *ObserveConfig  `toml:"observe,omitempty"`
 	References ReferenceConfig `toml:"references,omitempty"`
 	// FilterExternalSessions: when true, /list only shows sessions created by
@@ -576,31 +592,85 @@ func projectQuietEffective(cfg *Config, proj *ProjectConfig) bool {
 	return false
 }
 
-// EffectiveDisplay resolves global [display] together with legacy quiet (root or per-project).
-// If quiet is in effect and thinking_messages / tool_messages were not explicitly set in [display],
-// they map to false (backward-compatible with pre-display quiet = true).
+// EffectiveDisplay resolves the per-project [projects.display] override on top
+// of the global [display] block, falling back to built-in defaults. Resolution
+// order for each field:
+//  1. project-level [projects.display].<field>  (highest precedence)
+//  2. global [display].<field>
+//  3. built-in default
+//
+// Legacy quiet (root or per-project) is preserved: if quiet is in effect AND
+// neither layer explicitly set thinking_messages / tool_messages, they default
+// to false (backward-compatible with pre-display quiet = true).
 func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (thinkingMessages, toolMessages bool, thinkingMaxLen, toolMaxLen int) {
-	thinkingMessages = true
-	toolMessages = true
-	thinkingMaxLen = 300
-	toolMaxLen = 500
-	if cfg.Display.ThinkingMessages != nil {
-		thinkingMessages = *cfg.Display.ThinkingMessages
+	pickBool := func(projVal, globalVal *bool, dflt bool) bool {
+		if projVal != nil {
+			return *projVal
+		}
+		if globalVal != nil {
+			return *globalVal
+		}
+		return dflt
 	}
-	if cfg.Display.ToolMessages != nil {
-		toolMessages = *cfg.Display.ToolMessages
+	pickInt := func(projVal, globalVal *int, dflt int) int {
+		if projVal != nil {
+			return *projVal
+		}
+		if globalVal != nil {
+			return *globalVal
+		}
+		return dflt
 	}
-	if cfg.Display.ThinkingMaxLen != nil {
-		thinkingMaxLen = *cfg.Display.ThinkingMaxLen
+
+	var projDisp *DisplayConfig
+	if proj != nil {
+		projDisp = proj.Display
 	}
-	if cfg.Display.ToolMaxLen != nil {
-		toolMaxLen = *cfg.Display.ToolMaxLen
+	getProjBool := func(f func(*DisplayConfig) *bool) *bool {
+		if projDisp == nil {
+			return nil
+		}
+		return f(projDisp)
 	}
+	getProjInt := func(f func(*DisplayConfig) *int) *int {
+		if projDisp == nil {
+			return nil
+		}
+		return f(projDisp)
+	}
+
+	thinkingMessages = pickBool(
+		getProjBool(func(d *DisplayConfig) *bool { return d.ThinkingMessages }),
+		cfg.Display.ThinkingMessages,
+		true,
+	)
+	toolMessages = pickBool(
+		getProjBool(func(d *DisplayConfig) *bool { return d.ToolMessages }),
+		cfg.Display.ToolMessages,
+		true,
+	)
+	thinkingMaxLen = pickInt(
+		getProjInt(func(d *DisplayConfig) *int { return d.ThinkingMaxLen }),
+		cfg.Display.ThinkingMaxLen,
+		300,
+	)
+	toolMaxLen = pickInt(
+		getProjInt(func(d *DisplayConfig) *int { return d.ToolMaxLen }),
+		cfg.Display.ToolMaxLen,
+		500,
+	)
+
+	// Legacy quiet behavior preserved: when project-level quiet is on AND
+	// neither layer explicitly set thinking_messages / tool_messages, they
+	// default to off. Per-project [projects.display] takes precedence over
+	// both global display and quiet.
 	if projectQuietEffective(cfg, proj) {
-		if cfg.Display.ThinkingMessages == nil {
+		projThink := getProjBool(func(d *DisplayConfig) *bool { return d.ThinkingMessages })
+		projTool := getProjBool(func(d *DisplayConfig) *bool { return d.ToolMessages })
+		if cfg.Display.ThinkingMessages == nil && projThink == nil {
 			thinkingMessages = false
 		}
-		if cfg.Display.ToolMessages == nil {
+		if cfg.Display.ToolMessages == nil && projTool == nil {
 			toolMessages = false
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -268,6 +268,122 @@ func TestEffectiveDisplayQuiet(t *testing.T) {
 	}
 }
 
+func TestEffectiveDisplay_ProjectOverride(t *testing.T) {
+	tru, fal := true, false
+	maxA, maxB := 100, 200
+
+	tests := []struct {
+		name           string
+		cfg            Config
+		proj           ProjectConfig
+		wantTM         bool
+		wantTool       bool
+		wantThinkLen   int
+		wantToolMaxLen int
+	}{
+		{
+			name: "project overrides global thinking_messages",
+			cfg: Config{
+				Display: DisplayConfig{ThinkingMessages: &tru, ToolMessages: &tru},
+			},
+			proj: ProjectConfig{
+				Display: &DisplayConfig{ThinkingMessages: &fal},
+			},
+			wantTM:         false,
+			wantTool:       true,
+			wantThinkLen:   300,
+			wantToolMaxLen: 500,
+		},
+		{
+			name: "project unset falls back to global",
+			cfg: Config{
+				Display: DisplayConfig{ThinkingMessages: &fal, ToolMessages: &fal},
+			},
+			proj: ProjectConfig{
+				Display: &DisplayConfig{},
+			},
+			wantTM:         false,
+			wantTool:       false,
+			wantThinkLen:   300,
+			wantToolMaxLen: 500,
+		},
+		{
+			name: "both unset falls back to default",
+			cfg:  Config{},
+			proj: ProjectConfig{
+				Display: &DisplayConfig{},
+			},
+			wantTM:         true,
+			wantTool:       true,
+			wantThinkLen:   300,
+			wantToolMaxLen: 500,
+		},
+		{
+			name: "project overrides max-len fields",
+			cfg: Config{
+				Display: DisplayConfig{ThinkingMaxLen: &maxA, ToolMaxLen: &maxA},
+			},
+			proj: ProjectConfig{
+				Display: &DisplayConfig{ThinkingMaxLen: &maxB, ToolMaxLen: &maxB},
+			},
+			wantTM:         true,
+			wantTool:       true,
+			wantThinkLen:   200,
+			wantToolMaxLen: 200,
+		},
+		{
+			name: "project quiet still respected when project display unset",
+			cfg:  Config{Quiet: &tru},
+			proj: ProjectConfig{
+				Display: &DisplayConfig{},
+			},
+			wantTM:         false,
+			wantTool:       false,
+			wantThinkLen:   300,
+			wantToolMaxLen: 500,
+		},
+		{
+			name: "project display.thinking_messages true overrides project quiet",
+			cfg:  Config{Quiet: &tru},
+			proj: ProjectConfig{
+				Display: &DisplayConfig{ThinkingMessages: &tru},
+			},
+			wantTM:         true,
+			wantTool:       false,
+			wantThinkLen:   300,
+			wantToolMaxLen: 500,
+		},
+		{
+			name: "nil project display behaves like before",
+			cfg: Config{
+				Display: DisplayConfig{ThinkingMessages: &fal},
+			},
+			proj:           ProjectConfig{},
+			wantTM:         false,
+			wantTool:       true,
+			wantThinkLen:   300,
+			wantToolMaxLen: 500,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tm, tool, thinkLen, toolMaxLen := EffectiveDisplay(&tt.cfg, &tt.proj)
+			if tm != tt.wantTM {
+				t.Errorf("ThinkingMessages = %v, want %v", tm, tt.wantTM)
+			}
+			if tool != tt.wantTool {
+				t.Errorf("ToolMessages = %v, want %v", tool, tt.wantTool)
+			}
+			if thinkLen != tt.wantThinkLen {
+				t.Errorf("ThinkingMaxLen = %d, want %d", thinkLen, tt.wantThinkLen)
+			}
+			if toolMaxLen != tt.wantToolMaxLen {
+				t.Errorf("ToolMaxLen = %d, want %d", toolMaxLen, tt.wantToolMaxLen)
+			}
+		})
+	}
+}
+
 func TestLoad_DefaultsDataDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)


### PR DESCRIPTION
## Summary

Allow each `[[projects]]` entry to override individual fields of the global `[display]` block, on a per-field basis. Useful when you want one project to run quiet while others stay verbose, or vice versa, without splitting into separate cc-connect instances.

## Schema

```toml
[display]
thinking_messages = true
tool_messages = true

[[projects]]
name = "noisy-project"
[projects.display]
thinking_messages = false  # overrides only this field
tool_messages = false
```

Each sub-field is independently optional; unset fields fall back to the global `[display]` value, then to the built-in default.

## Resolution order (per field)

1. `[projects.display].<field>`  — highest precedence
2. `[display].<field>`
3. built-in default

All four `DisplayConfig` fields participate (`ThinkingMessages`, `ToolMessages`, `ThinkingMaxLen`, `ToolMaxLen`).

## Backward compatibility

- Projects with no `[projects.display]` block see no behavior change.
- Legacy `quiet` (root or per-project) is preserved: if quiet is in effect AND neither layer set `thinking_messages` / `tool_messages`, they default to `false` — same as before, just extended to honor project-level overrides when present.

## Tests

7 new sub-tests in `TestEffectiveDisplay_ProjectOverride` cover:

- project overrides global thinking_messages
- project unset falls back to global
- both unset falls back to default
- project overrides max-len fields
- project quiet still respected when project display unset
- project display.thinking_messages true overrides project quiet
- nil project display behaves like before

`go test ./...` passes (the 4 pre-existing failures on `main` — `TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled`, `TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState`, `TestResolveLocalDirPath_AcceptsSubdir`, `TestGetModelAndReasoningEffort_FromRuntimeConfigWhenUnset` — are unrelated to this change).

## Docs

`config.example.toml` updated with a commented-out `[projects.display]` example next to the global `[display]` section.