### PR TITLE
fix(feishu): valid icon tokens + width_mode for Card 2.0 rich mode (follow-up to #657)

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -3797,11 +3797,11 @@ func (p *Platform) onBotMenu(event *larkapplication.P2BotMenuV6) error {
 const defaultToolIcon = "setting-inter_outlined"
 
 var toolIconMap = map[string]string{
-	"Bash":      "terminal-two_outlined",
+	"Bash":      "code_outlined",          // was: terminal-two_outlined (not in official Lark icon library)
 	"Edit":      "edit_outlined",
-	"Read":      "file-open_outlined",
-	"Write":     "notes_outlined",
-	"Glob":      "folder-open_outlined",
+	"Read":      "file-link-text_outlined", // was: file-open_outlined (not in official Lark icon library)
+	"Write":     "richtext_outlined",      // was: notes_outlined (not in official Lark icon library)
+	"Glob":      "creat-folder_outlined",  // was: folder-open_outlined (not in official Lark icon library; "creat" is the official spelling)
 	"Grep":      "search_outlined",
 	"WebFetch":  "internet_outlined",
 	"WebSearch": "internet_outlined",
@@ -3908,7 +3908,7 @@ func buildCardJSONWithStatus(content string, status core.CardStatus) string {
 	card := map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
-			"wide_screen_mode": true,
+			"width_mode": "default", // schema 2.0 field; was wide_screen_mode (schema 1.0)
 		},
 		"header": map[string]any{
 			"template": template,


### PR DESCRIPTION
## Summary

Two small fixes on top of @AaronZ345's excellent Card 2.0 rich mode work in [#657](https://github.com/chenhg5/cc-connect/pull/657):

1. **Replace 4 invalid `standard_icon` tokens** in `toolIconMap` that aren't in Lark's official enumeration
2. **Use `width_mode: "default"` instead of `wide_screen_mode: true`** in the rich-card fallback config (the schema 2.0 field name)

## Why this is a follow-up to #657

This PR is **based on the `pr-657-base` branch** (i.e. all 5 commits from #657 are visible in the diff below mine), because the code being patched is introduced by #657 — `toolIconMap` and the rich-card fallback config don't exist on `main` yet.

**Massive thanks to @AaronZ345** for the rich card foundation. After dogfooding #657 in production for a week, the only friction we hit was these two cosmetic issues. Filing them as a separate PR rather than asking @AaronZ345 to amend, so #657 can proceed on its own timeline.

**Recommended merge order**: merge #657 first → rebase this PR onto `main` (will become a clean 5-line diff) → merge.

## Detail 1: invalid icon tokens

Per [Lark official icon library enumeration](https://open.feishu.cn/document/feishu-cards/enumerations-for-icons), 4 of the tokens currently in `toolIconMap` are not in the official list and render as the generic fallback icon when used in Lark cards:

| Old (invalid) | New (valid) | Used for |
|---|---|---|
| `terminal-two_outlined` | `code_outlined` | Bash / shell tool |
| `file-open_outlined` | `file-link-text_outlined` | Read tool |
| `notes_outlined` | `richtext_outlined` | Edit / Write tool |
| `folder-open_outlined` | `creat-folder_outlined` | Glob / directory tool |

Verified by sending parallel test cards via `lark-cli` with the original vs the replacement tokens — the originals showed the generic fallback, the replacements rendered correctly.

## Detail 2: width_mode

The fallback path's card config in `buildCardJSONWithStatus` was using:

```go
"wide_screen_mode": true
```

which is the Card 1.0 / message-card field. For Card 2.0 the equivalent field is:

```go
"width_mode": "default"
```

This is a no-op for the Card 2.0 schema since the field is just unrecognized, but using the right name keeps the config self-consistent across the file.

## Tests

`go test ./...` passes (the same 4 pre-existing failures on `pr-657-base` carry through; none related to this change).