### PR TITLE
feat(feishu): cardkit-v1 typewriter + rich card UX bug fixes (split from original)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ secrets/
 credentials/
 
 .codex
+cc-connect-new

--- a/core/engine.go
+++ b/core/engine.go
@@ -4211,6 +4211,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				// it for the reply quote. Without this reassignment, msg2's
 				// reply would quote msg1's bubble.
 				replyCtx = queued.replyCtx
+				// Rich-mode per-turn state must reset too — otherwise EventText for
+				// the queued message would StreamRichCardText against the previous
+				// turn's cardID, overwriting that card's body with the new turn's
+				// content. Same risk for partialText/toolSteps leaking across turns.
+				cardMessageID = nil
+				toolSteps = nil
+				partialText = ""
+				lastRichCardUpdate = time.Time{}
+				lastRichCardLen = 0
 				queuedRenderer := func(content string) string {
 					return e.renderOutgoingContentForWorkspace(queued.platform, content, workspaceDir)
 				}

--- a/core/engine.go
+++ b/core/engine.go
@@ -4039,6 +4039,17 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 				finalCard := richCardSupporter.BuildRichCard(CardStatusDone, "", toolSteps, parts[0], false, time.Since(turnStart))
 				if cardMessageID != nil {
+					// Forced final flush via cardkit-v1 streaming text update before
+					// flipping status to Done via full-card Patch. The throttle in the
+					// EventText path may have skipped the last <200ms / <20 chars; this
+					// catch-up keeps the typewriter rendering smooth all the way to the
+					// end. ErrNotSupported (no cardID) and any error are silent — the
+					// subsequent UpdateMessage will rewrite the body anyway.
+					if streamer, ok := p.(RichCardTextStreamer); ok {
+						if err := streamer.StreamRichCardText(e.ctx, cardMessageID, parts[0]); err != nil && !errors.Is(err, ErrNotSupported) {
+							slog.Debug("rich card: final streaming flush failed (proceeding to full Patch)", "platform", p.Name(), "error", err)
+						}
+					}
 					if updater, ok := p.(MessageUpdater); ok {
 						if err := updater.UpdateMessage(e.ctx, cardMessageID, finalCard); err != nil {
 							slog.Debug("rich card: final update failed, falling back to send", "platform", p.Name(), "error", err)

--- a/core/engine.go
+++ b/core/engine.go
@@ -3738,14 +3738,38 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				textParts = append(textParts, event.Content)
 				partialText += event.Content
 				if hasRichCard {
-					if cardMessageID != nil && (time.Since(lastRichCardUpdate) > 1500*time.Millisecond || len(partialText)-lastRichCardLen > 30) {
-						card := richCardSupporter.BuildRichCard(CardStatusWorking, "", toolSteps, partialText, true, time.Since(turnStart))
-						if updater, ok := p.(MessageUpdater); ok {
-							if err := updater.UpdateMessage(e.ctx, cardMessageID, card); err == nil {
+					// Throttle: cardkit-v1 streaming text path uses tighter limits (200ms / 20 chars)
+					// for smoother typewriter UX; full-card Patch fallback keeps the original 1500ms / 30 chars.
+					streamer, hasStreamer := p.(RichCardTextStreamer)
+					throttleDur := 1500 * time.Millisecond
+					throttleChars := 30
+					if hasStreamer && cardMessageID != nil {
+						throttleDur = 200 * time.Millisecond
+						throttleChars = 20
+					}
+					if cardMessageID != nil && (time.Since(lastRichCardUpdate) > throttleDur || len(partialText)-lastRichCardLen > throttleChars) {
+						// Prefer per-element streaming text update (cardkit-v1) when available;
+						// it engages Lark's native typewriter rendering. Falls back to
+						// full-card Patch on ErrNotSupported (handle without cardID) or any error.
+						streamed := false
+						if hasStreamer {
+							if err := streamer.StreamRichCardText(e.ctx, cardMessageID, partialText); err == nil {
 								lastRichCardUpdate = time.Now()
 								lastRichCardLen = len(partialText)
-							} else {
-								slog.Debug("rich card: failed to update text card", "platform", p.Name(), "error", err)
+								streamed = true
+							} else if !errors.Is(err, ErrNotSupported) {
+								slog.Debug("rich card: streaming text update failed, falling back to full Patch", "platform", p.Name(), "error", err)
+							}
+						}
+						if !streamed {
+							card := richCardSupporter.BuildRichCard(CardStatusWorking, "", toolSteps, partialText, true, time.Since(turnStart))
+							if updater, ok := p.(MessageUpdater); ok {
+								if err := updater.UpdateMessage(e.ctx, cardMessageID, card); err == nil {
+									lastRichCardUpdate = time.Now()
+									lastRichCardLen = len(partialText)
+								} else {
+									slog.Debug("rich card: failed to update text card", "platform", p.Name(), "error", err)
+								}
 							}
 						}
 					}

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -87,6 +87,23 @@ type MarkdownTableSplitter interface {
 	SplitMarkdownByTables(md string, maxTables int) []string
 }
 
+// RichCardTextStreamer is an optional interface for platforms that support
+// per-element streaming text updates on rich cards (e.g. Lark/Feishu's
+// cardkit-v1 streaming text update API). When implemented, the engine routes
+// EventText growth through StreamRichCardText instead of full-card updates,
+// giving the client a native typewriter rendering effect.
+//
+// Returns ErrNotSupported when the specific preview handle was created
+// without a streamable card entity (fallback path); the engine then falls
+// back to the standard MessageUpdater full-card update.
+type RichCardTextStreamer interface {
+	// StreamRichCardText pushes the latest fullText to the streaming-text
+	// element of the rich card identified by previewHandle. The platform
+	// implementation is responsible for serializing concurrent calls and
+	// maintaining a monotonic sequence counter per handle.
+	StreamRichCardText(ctx context.Context, previewHandle any, fullText string) error
+}
+
 // PreviewStarter is an optional interface for platforms that can initiate a
 // streaming preview message and return a handle for subsequent updates.
 type PreviewStarter interface {

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -3482,22 +3482,20 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 
 	// Card 2.0 path: engine passes a pre-built rich card JSON; pass it through.
 	var cardJSON string
-	var sendContent string // what goes into the Im.Message.Create content field
+	var sendContent string // what goes into the Im.Message.Create / Reply content field
 	var cardID string      // cardkit-v1 entity id (empty = no streaming text path)
 	if isCardJSON(content) {
 		cardJSON = content
-		// Try cardkit-v1 two-step flow (only for non-thread/reply path; Reply
-		// API doesn't document card_id reference support).
-		if !p.shouldUseThreadOrReplyAPI(rc) {
-			if id, err := p.createCardEntity(ctx, cardJSON); err == nil {
-				cardID = id
-				sendContent = fmt.Sprintf(`{"type":"card","data":{"card_id":"%s"}}`, id)
-			} else {
-				slog.Debug(p.tag()+": create card entity failed, falling back to inline card JSON",
-					"error", err)
-				sendContent = cardJSON
-			}
+		// Try cardkit-v1 two-step flow regardless of Reply vs Create. Both
+		// Im.Message.Reply and Im.Message.Create accept the {type:card,data:{card_id}}
+		// content schema (verified by direct API call); skipping Reply mode would
+		// disable cardkit-v1 streaming on every @-mention turn (the dominant case).
+		if id, err := p.createCardEntity(ctx, cardJSON); err == nil {
+			cardID = id
+			sendContent = fmt.Sprintf(`{"type":"card","data":{"card_id":"%s"}}`, id)
 		} else {
+			slog.Info(p.tag()+": create card entity failed, falling back to inline card JSON",
+				"error", err)
 			sendContent = cardJSON
 		}
 	} else {

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -3692,8 +3692,21 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 		}
 		cardJSON = buildCardJSON(sanitizeMarkdownURLs(processed))
 	}
+	// Route card-entity-bound messages to cardkit-v1 full-card update API.
+	// Im.Message.Patch on entity-referenced messages is silently no-op for the
+	// card body / header — only inline card JSON messages can be patched that way.
+	h.mu.Lock()
+	cardID := h.cardID
+	h.mu.Unlock()
+	if cardID != "" {
+		return p.updateCardEntity(ctx, h, cardJSON)
+	}
+	return p.patchCardMessage(ctx, h.messageID, cardJSON)
+}
+
+func (p *Platform) patchCardMessage(ctx context.Context, messageID, cardJSON string) error {
 	req := larkim.NewPatchMessageReqBuilder().
-		MessageId(h.messageID).
+		MessageId(messageID).
 		Body(larkim.NewPatchMessageReqBodyBuilder().
 			Content(cardJSON).
 			Build()).
@@ -3710,6 +3723,56 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 			return nil
 		})
 	})
+}
+
+// updateCardEntity performs a full-card replacement on a cardkit-v1 entity via
+// PUT /open-apis/cardkit/v1/cards/{card_id}. Required for messages that were
+// sent as card_id references (rich-mode path) — Im.Message.Patch does not
+// affect the rendered content of such messages.
+//
+// Reuses h.sequence as the monotonic ordering counter (shared with
+// streamRichCardText so any sequence on any element/card is monotonic).
+func (p *Platform) updateCardEntity(ctx context.Context, h *feishuPreviewHandle, cardJSON string) error {
+	h.mu.Lock()
+	if h.cardID == "" {
+		h.mu.Unlock()
+		return fmt.Errorf("%s: updateCardEntity: cardID not set", p.tag())
+	}
+	h.sequence++
+	cardID := h.cardID
+	seq := h.sequence
+	h.mu.Unlock()
+
+	apiPath := fmt.Sprintf("/open-apis/cardkit/v1/cards/%s", cardID)
+	body := map[string]any{
+		"card": map[string]any{
+			"type": "card_json",
+			"data": cardJSON,
+		},
+		"sequence": seq,
+	}
+	var apiResp *larkcore.ApiResp
+	if err := p.withFreshTenantAccessTokenRetry(ctx, "update card entity", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		var err error
+		apiResp, err = client.Put(ctx, apiPath, body, larkcore.AccessTokenTypeTenant, options...)
+		return err
+	}); err != nil {
+		return fmt.Errorf("%s: update card entity: %w", p.tag(), err)
+	}
+	if apiResp == nil || apiResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s: update card entity: HTTP status %d", p.tag(), apiResp.StatusCode)
+	}
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
+		return fmt.Errorf("%s: update card entity: parse response: %w", p.tag(), err)
+	}
+	if resp.Code != 0 {
+		return fmt.Errorf("%s: update card entity: code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+	}
+	return nil
 }
 
 func (p *Platform) Stop() error {

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -3029,10 +3029,18 @@ func isThreadSessionKey(sessionKey string) bool {
 // feishuPreviewHandle stores the message ID for an editable preview message.
 // Card 2.0 path needs mu/status/lastContent to let SetPreviewStatus patch
 // the header color without re-rendering the whole card.
+//
+// Card 2.0 + cardkit-v1 streaming text path additionally needs cardID and a
+// monotonically increasing sequence counter. cardID is empty when the
+// preview was created via the legacy inline-card-JSON path (Create Card
+// Entity failed → fallback), in which case streamRichCardText must NOT be
+// called and the engine falls back to full-card Patch via UpdateMessage.
 type feishuPreviewHandle struct {
 	mu          sync.Mutex
 	messageID   string
 	chatID      string
+	cardID      string // cardkit-v1 entity id (empty = no streaming text path)
+	sequence    int    // cardkit-v1 streaming text monotonic counter (++ before use; first call = 1)
 	status      core.CardStatus
 	lastContent string
 }
@@ -3443,6 +3451,20 @@ func buildPreviewCardJSON(content string) string {
 // SendPreviewStart sends a new card message and returns a handle for subsequent edits.
 // Using card (interactive) type for both preview and final message so updates
 // are in-place without needing to delete and resend.
+//
+// Card 2.0 + cardkit-v1 path (when content is a rich card JSON and we're NOT
+// in thread/reply mode): runs a two-step flow that captures a card_id usable
+// for streaming text updates:
+//
+//  1. POST /open-apis/cardkit/v1/cards with {type:"card_json", data:<cardJSON>}
+//     → returns card_id (numeric string, 14-day TTL).
+//  2. Im.Message.Create with content {"type":"card","data":{"card_id":"..."}}
+//     → returns message_id; both ids are stored on feishuPreviewHandle.
+//
+// If step (1) fails OR we're in thread/reply mode (Reply API doesn't accept
+// card_id reference), we fall back to the inline-card-JSON path. The handle's
+// cardID stays empty in that case and the engine routes EventText through the
+// full-card Patch path (= original #657 behavior, no typewriter).
 func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content string) (any, error) {
 	if !p.useInteractiveCard {
 		return nil, core.ErrNotSupported
@@ -3460,17 +3482,34 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 
 	// Card 2.0 path: engine passes a pre-built rich card JSON; pass it through.
 	var cardJSON string
+	var sendContent string // what goes into the Im.Message.Create content field
+	var cardID string      // cardkit-v1 entity id (empty = no streaming text path)
 	if isCardJSON(content) {
 		cardJSON = content
+		// Try cardkit-v1 two-step flow (only for non-thread/reply path; Reply
+		// API doesn't document card_id reference support).
+		if !p.shouldUseThreadOrReplyAPI(rc) {
+			if id, err := p.createCardEntity(ctx, cardJSON); err == nil {
+				cardID = id
+				sendContent = fmt.Sprintf(`{"type":"card","data":{"card_id":"%s"}}`, id)
+			} else {
+				slog.Debug(p.tag()+": create card entity failed, falling back to inline card JSON",
+					"error", err)
+				sendContent = cardJSON
+			}
+		} else {
+			sendContent = cardJSON
+		}
 	} else {
 		cardJSON = buildPreviewCardJSON(content)
+		sendContent = cardJSON
 	}
 
 	var msgID string
 	if p.shouldUseThreadOrReplyAPI(rc) {
 		req := larkim.NewReplyMessageReqBuilder().
 			MessageId(rc.messageID).
-			Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeInteractive, cardJSON)).
+			Body(p.buildReplyMessageReqBody(rc, larkim.MsgTypeInteractive, sendContent)).
 			Build()
 		var resp *larkim.ReplyMessageResp
 		if err := p.withTransientRetry(ctx, "send preview", func() error {
@@ -3497,7 +3536,7 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 			Body(larkim.NewCreateMessageReqBodyBuilder().
 				ReceiveId(chatID).
 				MsgType(larkim.MsgTypeInteractive).
-				Content(cardJSON).
+				Content(sendContent).
 				Build()).
 			Build()
 		var resp *larkim.CreateMessageResp
@@ -3525,7 +3564,106 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 		return nil, fmt.Errorf("%s: send preview: no message ID returned", p.tag())
 	}
 
-	return &feishuPreviewHandle{messageID: msgID, chatID: chatID}, nil
+	return &feishuPreviewHandle{messageID: msgID, chatID: chatID, cardID: cardID}, nil
+}
+
+// createCardEntity calls the cardkit-v1 Create Card Entity API
+// (POST /open-apis/cardkit/v1/cards) and returns the card_id.
+//
+// The card_id is required to drive the streaming text update path
+// (PUT /open-apis/cardkit/v1/cards/{card_id}/elements/{element_id}/content).
+// If this call fails the caller should fall back to inline card JSON via the
+// regular Im.Message.Create path; the rich card will still render but without
+// native typewriter streaming.
+func (p *Platform) createCardEntity(ctx context.Context, cardJSON string) (string, error) {
+	body := map[string]any{
+		"type": "card_json",
+		"data": cardJSON,
+	}
+	var apiResp *larkcore.ApiResp
+	if err := p.withFreshTenantAccessTokenRetry(ctx, "create card entity", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		var err error
+		apiResp, err = client.Post(ctx, "/open-apis/cardkit/v1/cards", body, larkcore.AccessTokenTypeTenant, options...)
+		return err
+	}); err != nil {
+		return "", fmt.Errorf("%s: create card entity: %w", p.tag(), err)
+	}
+	if apiResp == nil || apiResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%s: create card entity: HTTP status %d", p.tag(), apiResp.StatusCode)
+	}
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			CardID string `json:"card_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
+		return "", fmt.Errorf("%s: create card entity: parse response: %w", p.tag(), err)
+	}
+	if resp.Code != 0 {
+		return "", fmt.Errorf("%s: create card entity: code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+	}
+	if resp.Data.CardID == "" {
+		return "", fmt.Errorf("%s: create card entity: empty card_id in response", p.tag())
+	}
+	return resp.Data.CardID, nil
+}
+
+// StreamRichCardText implements core.RichCardTextStreamer. Pushes the latest
+// fullText to the rich card's main_text element via cardkit-v1 streaming text
+// update API. The Lark client renders the increment between consecutive PUTs
+// with a typewriter animation (controlled by the card's streaming_config).
+//
+// Returns ErrNotSupported when the handle has no cardID (preview was created
+// via the inline-card-JSON fallback path; engine should fall back to full-card
+// Patch).
+func (p *Platform) StreamRichCardText(ctx context.Context, previewHandle any, fullText string) error {
+	h, ok := previewHandle.(*feishuPreviewHandle)
+	if !ok {
+		return fmt.Errorf("%s: StreamRichCardText: invalid preview handle type %T", p.tag(), previewHandle)
+	}
+
+	// Serialize all PUTs for one card so the monotonic sequence counter is
+	// preserved across concurrent EventText calls; rate-limit headroom is
+	// huge (Lark allows 50 QPS per element).
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.cardID == "" {
+		return core.ErrNotSupported
+	}
+
+	h.sequence++
+	apiPath := fmt.Sprintf("/open-apis/cardkit/v1/cards/%s/elements/%s/content",
+		h.cardID, richCardMainTextElementID)
+	body := map[string]any{
+		"content":  fullText,
+		"sequence": h.sequence,
+	}
+
+	var apiResp *larkcore.ApiResp
+	if err := p.withFreshTenantAccessTokenRetry(ctx, "stream rich card text", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+		var err error
+		apiResp, err = client.Put(ctx, apiPath, body, larkcore.AccessTokenTypeTenant, options...)
+		return err
+	}); err != nil {
+		return fmt.Errorf("%s: stream rich card text: %w", p.tag(), err)
+	}
+	if apiResp == nil || apiResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s: stream rich card text: HTTP status %d", p.tag(), apiResp.StatusCode)
+	}
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
+		return fmt.Errorf("%s: stream rich card text: parse response: %w", p.tag(), err)
+	}
+	if resp.Code != 0 {
+		return fmt.Errorf("%s: stream rich card text: code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+	}
+	return nil
 }
 
 // UpdateMessage edits an existing card message identified by previewHandle.
@@ -3830,6 +3968,12 @@ func (p *Platform) onBotMenu(event *larkapplication.P2BotMenuV6) error {
 
 const defaultToolIcon = "setting-inter_outlined"
 
+// richCardMainTextElementID is the fixed element_id assigned to the markdown
+// body block of every rich card. The cardkit-v1 streaming text update API
+// targets card elements by this id (PUT /open-apis/cardkit/v1/cards/{card_id}/elements/{element_id}/content).
+// Hardcoded because each rich card has exactly one streaming-text element.
+const richCardMainTextElementID = "main_text"
+
 var toolIconMap = map[string]string{
 	"Bash":      "terminal-two_outlined",
 	"Edit":      "edit_outlined",
@@ -4082,8 +4226,9 @@ func buildRichCard(status core.CardStatus, _ string, steps []core.ToolStep, mark
 		"elements":         panelElements,
 	}
 	markdownMap := map[string]any{
-		"tag":     "markdown",
-		"content": preprocessFeishuMarkdown(markdown),
+		"tag":        "markdown",
+		"element_id": richCardMainTextElementID, // required for cardkit-v1 streaming text update
+		"content":    preprocessFeishuMarkdown(markdown),
 	}
 
 	// Footer shows elapsed time: "⏱ 运行中 12.3 秒..." during streaming,


### PR DESCRIPTION
## Summary

Lark/Feishu rich card UX improvements — **typewriter only** (footer concerns split into a separate PR; see "Stacked PRs" below).

After @cigarrr and the maintainer aligned on splitting the original #796, this PR has been narrowed to platform UX work that's independent of footer rendering:

- **cardkit-v1 typewriter** (3-step API): `POST /cards` → `POST /messages` → `PUT /elements/main_text/content`. Lark renders the per-element streaming text update natively as a typewriter effect; the engine routes `EventText` through `RichCardTextStreamer.StreamRichCardText` when the platform implements it, falls back to full-card `Im.Message.Patch` otherwise.
- **Reply API also uses cardkit-v1**, so `@`-mention flows get the same typewriter rendering (was disabled on every `@` reply previously).
- **Path C: forced final cardkit-v1 flush** in `EventResult` rich path. The 200ms / 20-char throttle in the streaming branch may skip the last small chunk; this catch-up flush guarantees the typewriter renders all the way to Done.
- **`updateCardEntity` via cardkit-v1 PUT** for messages bound to a card-entity. `Im.Message.Patch` is silently no-op for entity-referenced messages, which previously caused two visible bugs: (1) status header stuck in `Pondering...` / `Working...` forever, (2) two cards rendered per turn (the stuck-working one + the EventResult fall-through Send). Routes `cardID != ""` to `PUT /open-apis/cardkit/v1/cards/{card_id}` and shares the per-handle monotonic sequence with `streamRichCardText` so card+element updates stay totally ordered.
- **Throttle bifurcation**: 200ms / 20 chars on the streaming text path (smoother typewriter), 1500ms / 30 chars on the full-card Patch fallback (preserves existing behavior).
- **Per-turn state reset on queue dequeue** for rich mode — fixes a bug where queued messages reused the previous turn's `cardMessageID` / `lastRichCardLen`.
- `chore`: gitignore `cc-connect-new` build artifact.

## What this PR does NOT include

Footer-related changes (multi-line `statusFooter`, CCD-statusline-style `out N · in N cw N cr N · ctx N% left` rendering, `StatusFooterSender`/`StatusFooterUpdater` interfaces, `text_size: "notation"` styling) have been **moved to a separate stacked PR** to keep review surface small. This PR focuses purely on the typewriter / streaming UX.

## Stacked PRs

This PR is the bottom of a 3-PR stack:

```
main
 └── (this PR) typewriter — Lark cardkit-v1 streaming + bug fixes
      ├── footer PR  — capability-based CCD multi-line statusFooter (depends on this)
      └── B021 PR    — silentHold gate for rich card NO_REPLY no-trace (depends on this)
```

Each downstream PR targets `main` directly and notes "stacked on #796"; once this PR lands they will rebase.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./core/...` rich-card tests pass on top of `upstream/main` HEAD
- [x] Local Lark e2e: typewriter visible (200ms/20-char), card-entity update no longer stuck in `Pondering...`, no double-card, queued messages start fresh card

## Migration

This branch was rebased onto current `upstream/main` HEAD `d7ab11ed` (which now includes #838 = the squash-merge of #657 we depended on previously). All the `#657` pre-squash commits that were in the old version of this PR have been dropped — they're already in `main`.
