### PR TITLE
feat(telegram): handle /start natively instead of forwarding to agent

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3654,6 +3654,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdStop(p, msg)
 	case "help":
 		e.cmdHelp(p, msg)
+	case "start":
+		e.cmdStart(p, msg)
 	case "version":
 		e.reply(p, msg.ReplyCtx, VersionInfo)
 	case "commands":
@@ -5748,6 +5750,22 @@ func (e *Engine) cmdHelp(p Platform, msg *Message) {
 		return
 	}
 	e.replyWithCard(p, msg.ReplyCtx, e.renderHelpCard())
+}
+
+// cmdStart handles the `/start` slash command.
+//
+// On Telegram, `/start` is a protocol convention sent by the client when a
+// user first opens a bot (or taps the Start button). Without a native
+// handler, the message previously fell through to the default branch and
+// got forwarded verbatim to the agent — and Claude Code's CLI interprets a
+// leading "/" as a slash-command request, replying "Unknown command:
+// /start. Did you mean /stats?" instead of greeting the user.
+//
+// Replying with a localized welcome that names the project keeps the
+// behavior consistent with every other Telegram bot framework, and is a
+// no-op improvement on platforms where /start has no special meaning.
+func (e *Engine) cmdStart(p Platform, msg *Message) {
+	e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgWelcome), e.name))
 }
 
 const defaultHelpGroup = "session"

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -161,6 +161,7 @@ const (
 	MsgLangInvalid               MsgKey = "lang_invalid"
 	MsgLangCurrent               MsgKey = "lang_current"
 	MsgUnknownCommand            MsgKey = "unknown_command"
+	MsgWelcome                   MsgKey = "welcome"
 	MsgHelp                      MsgKey = "message_help" // change from "help", which is used now for builtin command help
 	MsgHelpTitle                 MsgKey = "help_title"
 	MsgHelpSessionSection        MsgKey = "help_session_section"
@@ -864,6 +865,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "`%s` 不是 cc-connect 命令，已轉發給 Agent 處理...",
 		LangJapanese:           "`%s` は cc-connect のコマンドではありません。エージェントに転送します...",
 		LangSpanish:            "`%s` no es un comando de cc-connect, reenviando al agente...",
+	},
+	MsgWelcome: {
+		LangEnglish:            "👋 Hi! I'm cc-connect, bridging you to **%s**.\n\nJust send a message to chat with the agent. Type /help to see built-in commands.",
+		LangChinese:            "👋 你好！我是 cc-connect，已为你连接到 **%s**。\n\n直接发送消息即可与 Agent 对话。输入 /help 查看内置命令。",
+		LangTraditionalChinese: "👋 你好！我是 cc-connect，已為你連接到 **%s**。\n\n直接發送訊息即可與 Agent 對話。輸入 /help 查看內建命令。",
+		LangJapanese:           "👋 こんにちは！cc-connect が **%s** に接続しました。\n\nメッセージを送信すればエージェントと会話できます。/help で組み込みコマンド一覧を確認できます。",
+		LangSpanish:            "👋 ¡Hola! Soy cc-connect, conectándote con **%s**.\n\nEnvía un mensaje para chatear con el agente. Usa /help para ver los comandos integrados.",
 	},
 	MsgHelp: {
 		LangEnglish: "📖 Available Commands\n\n" +


### PR DESCRIPTION
Closes #797.

## What

Add a native handler for the `/start` slash command. Previously cc-connect fell through to the agent for any unrecognized slash command, including Telegram's `/start` protocol convention — and Claude Code's CLI then rejected the literal `/start` text with an autocomplete prompt.

## Changes

- `core/i18n.go` — new `MsgWelcome` key + EN/zh/zh-TW/ja/es translations.
- `core/engine.go` — new `cmdStart` method (mirrors `cmdHelp` shape) and a `case "start"` branch in `handleSlashCommand`'s switch.

Total diff: +26 lines, 2 files.

## Behavior before

```
User: /start
cc-connect: /start is not a cc-connect command, forwarding to agent…
Claude Code: Unknown command: /start. Did you mean /stats?
```

## Behavior after

```
User: /start
cc-connect: 👋 Hi! I'm cc-connect, bridging you to **<project>**.

Just send a message to chat with the agent. Type /help to see built-in commands.
```

The welcome names the project (`e.name`) so the user knows which agent they're connected to. Tone matches the existing English copy elsewhere in `core/i18n.go`.

## Why /start specifically

`/start` is a Telegram protocol convention — Telegram clients send it automatically when a user first opens a bot, taps the Start button, or `/start@bot` in a group. Every Telegram bot framework I'm aware of (telegraf, python-telegram-bot, aiogram, etc.) reserves `/start` for a native welcome handler. cc-connect already auto-registers a Telegram bot menu on startup, so this completes the convention.

`/help` is in a similar spot — but cc-connect already had a native `/help`, so it's unaffected. `/start` was the gap.

On platforms where `/start` has no protocol meaning (Slack, Discord, Feishu, etc.) this is a no-op improvement: instead of "Unknown command. Forwarding to agent." → "Unknown command: /start. Did you mean /stats?", the user gets a proper welcome.

## Tests

`go test ./core/... -count=1` — three pre-existing failures (`TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled`, `TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState`, `TestResolveLocalDirPath_AcceptsSubdir`) reproduce on `main` without my changes; everything else passes. Build is clean.

## Repro / verification

1. Configure `[[projects]]` with `[projects.agent].type = "claudecode"` and a `[[projects.platforms]]` of type `telegram`.
2. Open the bot in Telegram and tap Start (or send `/start`).
3. Before this change → "Unknown command: /start. Did you mean /stats?"
4. After this change → welcome message naming the project.

Discovered while testing https://github.com/Automattic/intelligence end-to-end (cc-connect bridges its Claude Code runtime to Telegram).