### PR TITLE
fix(telegram): preserve private topic session keys

### DIFF
--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -185,6 +185,13 @@ level=INFO msg="cc-connect is running" projects=1
 3. Search and add your bot
 4. Send messages in the group
 
+### 6.3 Topic Sessions
+
+Telegram topics include a `message_thread_id`. cc-connect uses that thread ID
+as part of the Telegram session key, so each topic has its own independent
+conversation context. This applies to forum topics in groups and private chat
+topics when Telegram includes `message_thread_id`.
+
 ---
 
 ## Usage Example

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -333,10 +333,7 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 		userName = strings.TrimSpace(msg.From.FirstName + " " + msg.From.LastName)
 	}
 
-	threadID := 0
-	if msg.Chat.IsForum {
-		threadID = msg.MessageThreadID
-	}
+	threadID := msg.MessageThreadID
 	sessionKey := p.buildSessionKey(msg.Chat.ID, threadID, msg.From.ID)
 	channelKey := buildChannelKey(msg.Chat.ID, threadID)
 
@@ -718,10 +715,7 @@ func (p *Platform) handleCallbackQuery(ctx context.Context, cb *models.CallbackQ
 		userName = strings.TrimSpace(cb.From.FirstName + " " + cb.From.LastName)
 	}
 
-	threadID := 0
-	if msg.Chat.IsForum {
-		threadID = msg.MessageThreadID
-	}
+	threadID := msg.MessageThreadID
 	sessionKey := p.buildSessionKey(chatID, threadID, cb.From.ID)
 	channelKey := buildChannelKey(chatID, threadID)
 

--- a/platform/telegram/telegram_test.go
+++ b/platform/telegram/telegram_test.go
@@ -895,7 +895,7 @@ func TestHandleMessageWithForumTopic(t *testing.T) {
 	}
 }
 
-func TestHandleMessageNonForumIgnoresThreadID(t *testing.T) {
+func TestHandleMessagePrivateTopicUsesThreadID(t *testing.T) {
 	handled := make(chan *core.Message, 1)
 	p := &Platform{
 		token:         "token",
@@ -911,14 +911,13 @@ func TestHandleMessageNonForumIgnoresThreadID(t *testing.T) {
 
 	msg := &models.Message{
 		ID:              10,
-		MessageThreadID: 55, // set but not a forum
+		MessageThreadID: 55,
 		Text:            "hello",
 		Date:            int(time.Now().Unix()),
 		From:            &models.User{ID: 7, Username: "alice"},
 		Chat: models.Chat{
 			ID:      100,
-			Type:    models.ChatTypeGroup,
-			Title:   "Test Group",
+			Type:    models.ChatTypePrivate,
 			IsForum: false,
 		},
 	}
@@ -927,12 +926,12 @@ func TestHandleMessageNonForumIgnoresThreadID(t *testing.T) {
 
 	select {
 	case got := <-handled:
-		if got.SessionKey != "telegram:100:7" {
-			t.Fatalf("SessionKey = %q, want %q (no thread)", got.SessionKey, "telegram:100:7")
+		if got.SessionKey != "telegram:100:55:7" {
+			t.Fatalf("SessionKey = %q, want %q", got.SessionKey, "telegram:100:55:7")
 		}
 		rc := got.ReplyCtx.(replyContext)
-		if rc.threadID != 0 {
-			t.Fatalf("threadID = %d, want 0", rc.threadID)
+		if rc.threadID != 55 {
+			t.Fatalf("threadID = %d, want 55", rc.threadID)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("message not handled")


### PR DESCRIPTION
## Summary

- Preserve Telegram `message_thread_id` whenever Telegram provides it, instead of only when `chat.is_forum` is true.
- This lets private chat topics and group forum topics map to distinct Telegram session keys.
- Update the Telegram regression test and docs for topic-based sessions.

## Related discussion

- Related to #421, which added/covered group forum topic session isolation.
- I searched existing issues and PRs for `Telegram topic message_thread_id session`; I did not find an open duplicate for private chat topics.

## Reproduction

Environment tested locally:

- Version before patch: `cc-connect v1.3.2`
- OS: macOS arm64
- Install method: npm global package
- Agent/platform: Codex + Telegram

Steps:

1. Start cc-connect with a Telegram bot.
2. Open a Telegram private chat topic with that bot.
3. Send messages in different topics.

Before this change, private chat topic messages were handled with the same session key because the code only used `MessageThreadID` when `Chat.IsForum` was true.

## Expected behavior

Messages from different Telegram topics should use different session keys when Telegram includes `message_thread_id`, so each topic has an independent conversation context.

## Actual behavior before this PR

Private chat topics could be collapsed into the base private chat session key, for example:

```text
telegram:680002712
```

After applying this change locally, a private topic message used a topic-aware session key, for example:

```text
telegram:680002712:34923
```

## Breaking changes

None expected. Messages without `message_thread_id` still use the existing non-topic session key formats.

## Validation

Passed:

```bash
pnpm --dir web install --frozen-lockfile
pnpm --dir web build
go test ./platform/telegram
go build -tags 'no_web' ./cmd/cc-connect
```

Also verified against a real local Telegram bot: a private chat topic message created/used `telegram:680002712:34923` instead of the base `telegram:680002712` session.

Attempted full validation as requested by CONTRIBUTING:

```bash
go test ./...
```

On my local macOS machine this still fails in packages unrelated to this patch:

- `agent/codex`: `TestGetModelAndReasoningEffort_FromRuntimeConfigWhenUnset` failed once in the full suite, but passes when run directly.
- `core`: existing macOS path expectation failures involving `/var/...` vs `/private/var/...`, plus reply footer path truncation expectations.

The Telegram package touched by this PR passes.
