### PR TITLE
fix(claudecode): propagate cli_path and other options to per-workspace agents

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -671,6 +671,80 @@ func (a *Agent) GetRunAsEnv() []string {
 	return out
 }
 
+// WorkspaceAgentOptions returns a snapshot of user-configured options that
+// must propagate to per-workspace agent instances created lazily by
+// core.Engine.getOrCreateWorkspaceAgent. Without this snapshot, the engine
+// constructs workspace agents from a fresh opts map and silently drops
+// every claudecode field except mode/model — so cli_path, allowed_tools,
+// and friends would only take effect on the project-level agent.
+//
+// Runtime-only state (providers, sessionEnv, providerProxy, platformPrompt)
+// is intentionally omitted: providers are rewired separately by the engine
+// after construction; the rest is per-session and recomputed.
+//
+// run_as_user / run_as_env are also omitted because the engine has its own
+// dedicated propagation path via GetRunAsUser/GetRunAsEnv (see cc-connect#496).
+func (a *Agent) WorkspaceAgentOptions() map[string]any {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	opts := map[string]any{
+		"mode": a.mode,
+	}
+	if cliPath := snapshotCLIPath(a.cliBin, a.cliExtraArgs); cliPath != "" {
+		opts["cli_path"] = cliPath
+	}
+	if a.cliArgsFlag != "" {
+		opts["cli_args_flag"] = a.cliArgsFlag
+	}
+	if a.model != "" {
+		opts["model"] = a.model
+	}
+	if a.reasoningEffort != "" {
+		opts["reasoning_effort"] = a.reasoningEffort
+	}
+	if len(a.allowedTools) > 0 {
+		opts["allowed_tools"] = stringsToAny(a.allowedTools)
+	}
+	if len(a.disallowedTools) > 0 {
+		opts["disallowed_tools"] = stringsToAny(a.disallowedTools)
+	}
+	if a.maxContextTokens > 0 {
+		opts["max_context_tokens"] = a.maxContextTokens
+	}
+	if a.routerURL != "" {
+		opts["router_url"] = a.routerURL
+	}
+	if a.routerAPIKey != "" {
+		opts["router_api_key"] = a.routerAPIKey
+	}
+	return opts
+}
+
+// snapshotCLIPath rebuilds the cli_path opts string from cliBin and the
+// extra-args tail captured at construction. Returns "" when only the
+// default "claude" binary is in use, so we don't pollute the workspace
+// opts with a redundant default.
+func snapshotCLIPath(cliBin string, cliExtraArgs []string) string {
+	if cliBin == "" || (cliBin == "claude" && len(cliExtraArgs) == 0) {
+		return ""
+	}
+	if len(cliExtraArgs) == 0 {
+		return cliBin
+	}
+	return cliBin + " " + strings.Join(cliExtraArgs, " ")
+}
+
+// stringsToAny copies a []string into a fresh []any so it round-trips
+// through New()'s opts["..."].([]any) type assertion.
+func stringsToAny(in []string) []any {
+	out := make([]any, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}
+
 // PermissionModes returns all supported permission modes.
 func (a *Agent) PermissionModes() []core.PermissionModeInfo {
 	return []core.PermissionModeInfo{

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -3,6 +3,8 @@ package claudecode
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -495,5 +497,168 @@ func TestFindProjectDir_ICloudPath(t *testing.T) {
 	found := findProjectDir(homeDir, iCloudWorkDir)
 	if found != mockProjectDir {
 		t.Errorf("findProjectDir(%q, %q) = %q, want %q", homeDir, iCloudWorkDir, found, mockProjectDir)
+	}
+}
+
+func TestSnapshotCLIPath(t *testing.T) {
+	cases := []struct {
+		name      string
+		cliBin    string
+		extraArgs []string
+		want      string
+	}{
+		{"default-claude-skipped", "claude", nil, ""},
+		{"empty-binary-skipped", "", nil, ""},
+		{"custom-binary-only", "/usr/local/bin/claude", nil, "/usr/local/bin/claude"},
+		{"wrapper-with-args", "my-cli", []string{"code", "-t", "foo"}, "my-cli code -t foo"},
+		{"claude-with-add-dir", "claude", []string{"--add-dir", "/parent"}, "claude --add-dir /parent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := snapshotCLIPath(tc.cliBin, tc.extraArgs)
+			if got != tc.want {
+				t.Errorf("snapshotCLIPath(%q, %v) = %q, want %q", tc.cliBin, tc.extraArgs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceAgentOptions_FullSnapshot(t *testing.T) {
+	// Construct an Agent directly so we don't depend on `claude` being on
+	// PATH. WorkspaceAgentOptions only reads fields that the production
+	// New() also writes; this just verifies the snapshot shape.
+	a := &Agent{
+		cliBin:           "my-cli",
+		cliExtraArgs:     []string{"--add-dir", "/parent"},
+		cliArgsFlag:      "-a",
+		model:            "claude-opus-4-7",
+		reasoningEffort:  "high",
+		mode:             "acceptEdits",
+		allowedTools:     []string{"Edit", "Read"},
+		disallowedTools:  []string{"Bash"},
+		maxContextTokens: 200000,
+		routerURL:        "http://127.0.0.1:3456",
+		routerAPIKey:     "secret",
+	}
+	got := a.WorkspaceAgentOptions()
+
+	want := map[string]any{
+		"mode":               "acceptEdits",
+		"cli_path":           "my-cli --add-dir /parent",
+		"cli_args_flag":      "-a",
+		"model":              "claude-opus-4-7",
+		"reasoning_effort":   "high",
+		"allowed_tools":      []any{"Edit", "Read"},
+		"disallowed_tools":   []any{"Bash"},
+		"max_context_tokens": 200000,
+		"router_url":         "http://127.0.0.1:3456",
+		"router_api_key":     "secret",
+	}
+	if len(got) != len(want) {
+		t.Errorf("snapshot len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for k, wv := range want {
+		gv, ok := got[k]
+		if !ok {
+			t.Errorf("snapshot missing key %q", k)
+			continue
+		}
+		if !reflect.DeepEqual(gv, wv) {
+			t.Errorf("snapshot[%q] = %v (%T), want %v (%T)", k, gv, gv, wv, wv)
+		}
+	}
+}
+
+func TestWorkspaceAgentOptions_OmitsZeroValues(t *testing.T) {
+	// Default agent (only mode is always emitted, plus default cliBin
+	// "claude" should be skipped by snapshotCLIPath).
+	a := &Agent{cliBin: "claude", mode: "default"}
+	got := a.WorkspaceAgentOptions()
+
+	if len(got) != 1 {
+		t.Errorf("snapshot len = %d, want 1 (got=%v)", len(got), got)
+	}
+	if got["mode"] != "default" {
+		t.Errorf("snapshot[mode] = %v, want %q", got["mode"], "default")
+	}
+	for _, k := range []string{
+		"cli_path", "cli_args_flag", "model", "reasoning_effort",
+		"allowed_tools", "disallowed_tools", "max_context_tokens",
+		"router_url", "router_api_key",
+	} {
+		if _, ok := got[k]; ok {
+			t.Errorf("snapshot unexpectedly includes %q = %v", k, got[k])
+		}
+	}
+}
+
+func TestWorkspaceAgentOptions_RoundTripsThroughNew(t *testing.T) {
+	// End-to-end: snapshot → New() should reproduce every field. Use
+	// run_as_user to skip the supervisor-side LookPath check, since the
+	// fake "my-cli" binary doesn't exist on the test host's PATH.
+	//
+	// run_as_user only short-circuits LookPath on platforms where
+	// SpawnOptions.IsolationMode() can be true — i.e. Unix. On Windows
+	// it always returns false (see core/runas_windows.go), so the fake
+	// CLI would fail LookPath and New() would error out before the
+	// round-trip assertions run.
+	if runtime.GOOS == "windows" {
+		t.Skip("run_as_user-based LookPath bypass is Unix-only")
+	}
+	parent := &Agent{
+		cliBin:           "my-cli",
+		cliExtraArgs:     []string{"code", "--add-dir", "/parent"},
+		cliArgsFlag:      "-a",
+		model:            "claude-opus-4-7",
+		reasoningEffort:  "high",
+		mode:             "acceptEdits",
+		allowedTools:     []string{"Edit", "Read"},
+		disallowedTools:  []string{"Bash"},
+		maxContextTokens: 200000,
+		routerURL:        "http://127.0.0.1:3456",
+		routerAPIKey:     "secret",
+	}
+	opts := parent.WorkspaceAgentOptions()
+	opts["work_dir"] = "/tmp/claudecode-test"
+	opts["run_as_user"] = "skip-lookpath"
+
+	a, err := New(opts)
+	if err != nil {
+		t.Fatalf("New(snapshot) returned error: %v", err)
+	}
+	child := a.(*Agent)
+
+	if child.cliBin != "my-cli" {
+		t.Errorf("cliBin = %q, want %q", child.cliBin, "my-cli")
+	}
+	if !reflect.DeepEqual(child.cliExtraArgs, []string{"code", "--add-dir", "/parent"}) {
+		t.Errorf("cliExtraArgs = %v, want [code --add-dir /parent]", child.cliExtraArgs)
+	}
+	if child.cliArgsFlag != "-a" {
+		t.Errorf("cliArgsFlag = %q, want -a", child.cliArgsFlag)
+	}
+	if child.model != "claude-opus-4-7" {
+		t.Errorf("model = %q, want claude-opus-4-7", child.model)
+	}
+	if child.reasoningEffort != "high" {
+		t.Errorf("reasoningEffort = %q, want high", child.reasoningEffort)
+	}
+	if child.mode != "acceptEdits" {
+		t.Errorf("mode = %q, want acceptEdits", child.mode)
+	}
+	if !reflect.DeepEqual(child.allowedTools, []string{"Edit", "Read"}) {
+		t.Errorf("allowedTools = %v, want [Edit Read]", child.allowedTools)
+	}
+	if !reflect.DeepEqual(child.disallowedTools, []string{"Bash"}) {
+		t.Errorf("disallowedTools = %v, want [Bash]", child.disallowedTools)
+	}
+	if child.maxContextTokens != 200000 {
+		t.Errorf("maxContextTokens = %d, want 200000", child.maxContextTokens)
+	}
+	if child.routerURL != "http://127.0.0.1:3456" {
+		t.Errorf("routerURL = %q, want http://127.0.0.1:3456", child.routerURL)
+	}
+	if child.routerAPIKey != "secret" {
+		t.Errorf("routerAPIKey = %q, want secret", child.routerAPIKey)
 	}
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -7230,7 +7230,9 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 	if sessionKey != "" {
 		state = e.interactiveStates[sessionKey]
 		if state == nil && e.multiWorkspace {
-			if iKey := e.interactiveKeyForSessionKey(sessionKey); iKey != sessionKey {
+			// We already hold interactiveMu, so call the *Locked variant
+			// to avoid a self-deadlock on the non-reentrant mutex.
+			if iKey := e.interactiveKeyForSessionKeyLocked(sessionKey); iKey != sessionKey {
 				state = e.interactiveStates[iKey]
 			}
 		}
@@ -11654,32 +11656,139 @@ func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager
 	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return e.agent, e.sessions
 	}
-	channelKey := extractWorkspaceChannelKey(sessionKey)
-	if channelKey == "" {
-		return e.agent, e.sessions
+	if channelKey := extractWorkspaceChannelKey(sessionKey); channelKey != "" {
+		if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
+			if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(normalizeWorkspacePath(b.Workspace)); err == nil {
+				return wsAgent, wsSessions
+			}
+		}
 	}
-	if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
-		if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(normalizeWorkspacePath(b.Workspace)); err == nil {
+	// Live-state fallback: when channel-derived binding misses (Discord
+	// thread_isolation case where binding is keyed by parent channel but
+	// sessionKey is the thread ID), recover the workspace from any live
+	// interactive state keyed as "<workspace>:<sessionKey>". Without this,
+	// callers would route to the global agent while interactiveKeyForSessionKey
+	// returns the workspace-prefixed key, allowing concurrent unlocked sends
+	// to the same agent session.
+	if workspace := e.workspaceFromLiveState(sessionKey); workspace != "" {
+		if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(workspace); err == nil {
 			return wsAgent, wsSessions
 		}
 	}
 	return e.agent, e.sessions
 }
 
+// workspaceFromLiveState extracts the workspace path embedded in a live
+// interactive state key for sessionKey, or "" if no live state references
+// this sessionKey. Used as a recovery path when channel-binding-derived
+// workspace resolution misses.
+func (e *Engine) workspaceFromLiveState(sessionKey string) string {
+	if sessionKey == "" {
+		return ""
+	}
+	e.interactiveMu.Lock()
+	defer e.interactiveMu.Unlock()
+	suffix := ":" + sessionKey
+	for k := range e.interactiveStates {
+		if strings.HasSuffix(k, suffix) {
+			return strings.TrimSuffix(k, suffix)
+		}
+	}
+	return ""
+}
+
 // interactiveKeyForSessionKey returns the interactive state key for a sessionKey.
 // In multi-workspace mode, it prefixes with the bound workspace path when available.
 func (e *Engine) interactiveKeyForSessionKey(sessionKey string) string {
+	// Single-workspace fast path: no scan, no binding lookup, no lock.
 	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return sessionKey
 	}
-	channelKey := extractWorkspaceChannelKey(sessionKey)
-	if channelKey == "" {
+	e.interactiveMu.Lock()
+	defer e.interactiveMu.Unlock()
+	return e.interactiveKeyForSessionKeyLocked(sessionKey)
+}
+
+// interactiveKeyForSessionKeyLocked is the lock-free variant of
+// interactiveKeyForSessionKey. It assumes the caller already holds
+// e.interactiveMu (e.g. SendToSessionWithAttachments which scans
+// interactiveStates under the lock and then needs to resolve the
+// canonical key for a session).
+//
+// Resolution precedence:
+//
+//  1. Exact match — if state already exists under raw sessionKey, prefer it
+//     so a single-workspace placeholder isn't shadowed by a workspace-
+//     prefixed state created later.
+//  2. Channel-binding-derived — if the channel resolves to a workspace,
+//     return "<workspace>:<sessionKey>". This is deterministic even when
+//     multiple workspace-prefixed states for the same sessionKey coexist
+//     (e.g. a channel rebound to a new workspace while the old workspace's
+//     state hasn't been cleaned up yet) — the *current* binding wins, and
+//     any stale workspace state becomes unreachable through this lookup,
+//     which is exactly what we want.
+//  3. Live-state suffix scan — only fires when channel-binding lookup
+//     fails. This is the recovery path for Discord thread_isolation: the
+//     binding is keyed by the parent channel, but sessionKey is the thread
+//     ID, so step 2 misses. The state map was keyed correctly at processing
+//     time, so we recover the workspace prefix from there.
+func (e *Engine) interactiveKeyForSessionKeyLocked(sessionKey string) string {
+	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return sessionKey
 	}
-	if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
-		return normalizeWorkspacePath(b.Workspace) + ":" + sessionKey
+	if _, ok := e.interactiveStates[sessionKey]; ok {
+		return sessionKey
+	}
+	if channelKey := extractWorkspaceChannelKey(sessionKey); channelKey != "" {
+		if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
+			return normalizeWorkspacePath(b.Workspace) + ":" + sessionKey
+		}
+	}
+	if found := findInteractiveKeyInStatesLocked(e.interactiveStates, sessionKey); found != "" {
+		return found
 	}
 	return sessionKey
+}
+
+// findInteractiveKeyForSession scans the live interactiveStates map for an
+// interactive key that matches sessionKey, either as the key itself or as
+// the trailing "<workspace>:<sessionKey>" segment. Returns "" when no live
+// state references this sessionKey. Acquires e.interactiveMu internally;
+// callers that already hold the lock must use findInteractiveKeyInStatesLocked.
+//
+// The scan is bounded by the number of in-flight interactive sessions
+// (typically <10), so the linear cost is negligible compared to even one
+// binding lookup. Avoiding a parallel sessionKey→interactiveKey map keeps
+// the engine's state surface single-source-of-truth.
+func (e *Engine) findInteractiveKeyForSession(sessionKey string) string {
+	e.interactiveMu.Lock()
+	defer e.interactiveMu.Unlock()
+	return findInteractiveKeyInStatesLocked(e.interactiveStates, sessionKey)
+}
+
+// findInteractiveKeyInStatesLocked is the lock-free body of the scan; it
+// assumes the caller holds e.interactiveMu.
+//
+// Precedence is exact match first, then suffix scan. The exact path matters
+// because Go map iteration order is randomized: if both `sessionKey` and
+// `<workspace>:<sessionKey>` are live (e.g. a raw placeholder created before
+// multi-workspace was enabled coexisting with a workspace-prefixed turn),
+// a pure scan could non-deterministically return either, sending /stop or
+// pending-permission handling at the wrong state.
+func findInteractiveKeyInStatesLocked(states map[string]*interactiveState, sessionKey string) string {
+	if sessionKey == "" {
+		return ""
+	}
+	if _, ok := states[sessionKey]; ok {
+		return sessionKey
+	}
+	suffix := ":" + sessionKey
+	for k := range states {
+		if strings.HasSuffix(k, suffix) {
+			return k
+		}
+	}
+	return ""
 }
 
 // lookupEffectiveWorkspaceBinding returns the effective binding for a channel

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2297,6 +2297,139 @@ func TestHandlePendingPermission_MultiWorkspaceLookup(t *testing.T) {
 	}
 }
 
+// Regression for the Discord thread_isolation + multi-workspace auto-bind
+// path: workspace binding is keyed by the *parent* channel ID, but the
+// sessionKey driving follow-up lookups is the *thread* ID.
+//
+// sessionContextForKey must follow the same fallback as
+// interactiveKeyForSessionKey, otherwise commands like /compress would
+// resolve the workspace state correctly via interactiveKeyForSessionKey
+// (live-state scan finds it) but lock the *global* session manager via
+// sessionContextForKey (channel-binding misses, falls through to
+// e.agent/e.sessions). That mismatch lets a normal thread message run
+// concurrently against the same workspace agent session — the exact
+// race we just fixed in interactiveKeyForSessionKey.
+func TestSessionContextForKey_RecoversWorkspaceFromLiveState(t *testing.T) {
+	baseDir := t.TempDir()
+	e := newTestEngineWithMultiWorkspaceAgent(t, baseDir)
+
+	// Workspace dir must exist so getOrCreateWorkspaceAgent can build under it.
+	wsDir := filepath.Join(baseDir, "ws-thread")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	threadSessionKey := "discord:T-thread"
+	storedKey := normalizeWorkspacePath(wsDir) + ":" + threadSessionKey
+
+	// Live state is keyed under the workspace prefix but no binding exists
+	// for the thread channel — exactly the Discord thread_isolation shape.
+	e.interactiveMu.Lock()
+	e.interactiveStates[storedKey] = &interactiveState{}
+	e.interactiveMu.Unlock()
+
+	agent, sessions := e.sessionContextForKey(threadSessionKey)
+	if agent == e.agent {
+		t.Fatal("sessionContextForKey returned the global agent; live-state recovery did not engage")
+	}
+	if sessions == e.sessions {
+		t.Fatal("sessionContextForKey returned the global session manager; live-state recovery did not engage")
+	}
+}
+
+// Same shape as the case above, but exercising interactiveKeyForSessionKey.
+func TestInteractiveKeyForSessionKey_RecoversByLiveStateScan(t *testing.T) {
+	e := newTestEngine()
+	wsDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(t.TempDir(), bindingPath)
+
+	parentChannel := "C-parent"
+	threadID := "T-thread"
+	// Bind the workspace under the *parent* channel — mirrors what the
+	// Discord platform does when thread_isolation is on.
+	e.workspaceBindings.Bind("project:test", "discord:"+parentChannel, "chan", wsDir)
+
+	// Live interactive state is stored under the workspace-prefixed thread
+	// session key, exactly how processInteractiveMessageWith would key it.
+	threadSessionKey := "discord:" + threadID
+	storedInteractiveKey := normalizeWorkspacePath(wsDir) + ":" + threadSessionKey
+	e.interactiveMu.Lock()
+	e.interactiveStates[storedInteractiveKey] = &interactiveState{}
+	e.interactiveMu.Unlock()
+
+	got := e.interactiveKeyForSessionKey(threadSessionKey)
+	if got != storedInteractiveKey {
+		t.Errorf("interactiveKeyForSessionKey(%q) = %q, want %q (suffix-scan fallback failed)",
+			threadSessionKey, got, storedInteractiveKey)
+	}
+}
+
+func TestInteractiveKeyForSessionKey_PrefersCurrentBindingOverStaleState(t *testing.T) {
+	// When a channel is rebound to a new workspace while old workspace state
+	// hasn't been cleaned up, the *current* binding must win. Otherwise the
+	// rebinding silently strands sessions on the old workspace, and a map-
+	// iteration race could send /stop or pending replies to the wrong state.
+	e := newTestEngine()
+	wsBound := t.TempDir()
+	wsStale := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(t.TempDir(), bindingPath)
+
+	channelID := "C1"
+	sessionKey := "slack:" + channelID + ":U1"
+	e.workspaceBindings.Bind("project:test", "slack:"+channelID, "chan", wsBound)
+
+	// Stale state from before rebinding is still in the map.
+	staleKey := normalizeWorkspacePath(wsStale) + ":" + sessionKey
+	e.interactiveMu.Lock()
+	e.interactiveStates[staleKey] = &interactiveState{}
+	e.interactiveMu.Unlock()
+
+	want := normalizeWorkspacePath(wsBound) + ":" + sessionKey
+	if got := e.interactiveKeyForSessionKey(sessionKey); got != want {
+		t.Errorf("interactiveKeyForSessionKey = %q, want current-binding key %q", got, want)
+	}
+}
+
+func TestFindInteractiveKeyForSession(t *testing.T) {
+	e := newTestEngine()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(t.TempDir(), bindingPath)
+
+	cases := []struct {
+		name     string
+		stored   []string
+		query    string
+		expected string
+	}{
+		{"empty-query", []string{}, "", ""},
+		{"no-matches", []string{"/ws:slack:C1:U1"}, "discord:T1", ""},
+		{"exact-match", []string{"slack:C1:U1"}, "slack:C1:U1", "slack:C1:U1"},
+		{"suffix-match", []string{"/ws:discord:T1"}, "discord:T1", "/ws:discord:T1"},
+		{"first-of-multiple", []string{"/wsA:discord:T1", "/wsB:slack:C1:U1"}, "slack:C1:U1", "/wsB:slack:C1:U1"},
+		// Precedence: exact key beats suffix-matched workspace-prefixed key.
+		// Without this, map iteration order would be visible to callers, making
+		// /stop and pending-permission routing non-deterministic when both
+		// raw and workspace-prefixed states coexist.
+		{"exact-beats-prefixed", []string{"slack:C1:U1", "/ws:slack:C1:U1"}, "slack:C1:U1", "slack:C1:U1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e.interactiveMu.Lock()
+			e.interactiveStates = make(map[string]*interactiveState)
+			for _, k := range tc.stored {
+				e.interactiveStates[k] = &interactiveState{}
+			}
+			e.interactiveMu.Unlock()
+
+			if got := e.findInteractiveKeyForSession(tc.query); got != tc.expected {
+				t.Errorf("findInteractiveKeyForSession(%q) = %q, want %q", tc.query, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestHandleMessage_MultiWorkspacePreservesCCSessionKey(t *testing.T) {
 	p := &stubPlatformEngine{n: "discord"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -310,17 +310,54 @@ func resolveSessionKeyForChannel(channelID, userID string, shareSessionInChannel
 	return buildSessionKey(channelID, userID, shareSessionInChannel)
 }
 
-func resolveThreadReplyContext(m *discordgo.MessageCreate, botID string, ops discordThreadOps) (string, replyContext, error) {
+// resolveParentChannelID returns the ID of the parent guild channel a message
+// or interaction belongs to, looking through threads. Returns channelID
+// unchanged when it isn't a thread or when ParentID is unavailable.
+//
+// This is the workspace-binding identity for thread-isolation mode: we want
+// `<base_dir>/<parent-channel-name>` to drive auto-bind, not `<thread-name>`.
+func resolveParentChannelID(channelID string, ops discordThreadOps) string {
+	ch, err := ops.ResolveChannel(channelID)
+	if err != nil {
+		slog.Debug("discord: resolve channel for parent lookup failed", "channel", channelID, "error", err)
+		return channelID
+	}
+	if isThreadChannelType(ch.Type) && ch.ParentID != "" {
+		return ch.ParentID
+	}
+	return channelID
+}
+
+// resolveThreadReplyContext routes a guild message into a Discord thread for
+// thread_isolation mode and returns the per-thread session key, the reply
+// context, and the parent channel ID.
+//
+// parentChannelID is the channel the thread lives under (or, for messages
+// posted directly into an existing thread, the thread's ParentID). It is
+// distinct from the thread itself: it's what callers should stamp onto
+// Message.ChannelKey so multi-workspace auto-bind keys by channel name
+// rather than thread name. Without this distinction, threads break the
+// "channel name → workspace folder" convention because Discord threads
+// have their own names that rarely match a workspace directory.
+func resolveThreadReplyContext(m *discordgo.MessageCreate, botID string, ops discordThreadOps) (string, replyContext, string, error) {
 	ch, err := ops.ResolveChannel(m.ChannelID)
 	if err != nil {
-		return "", replyContext{}, fmt.Errorf("resolve channel %s: %w", m.ChannelID, err)
+		return "", replyContext{}, "", fmt.Errorf("resolve channel %s: %w", m.ChannelID, err)
 	}
 	if isThreadChannelType(ch.Type) {
+		// Message posted directly inside an existing thread. The parent
+		// channel comes from ch.ParentID; fall back to m.ChannelID only
+		// if Discord didn't populate it (defensive — discordgo always
+		// sets ParentID for thread channels).
+		parentChannelID := ch.ParentID
+		if parentChannelID == "" {
+			parentChannelID = m.ChannelID
+		}
 		if err := ops.JoinThread(m.ChannelID); err != nil {
 			slog.Debug("discord: join existing thread failed", "thread", m.ChannelID, "error", err)
 		}
 		rc := replyContext{channelID: m.ChannelID, messageID: m.ID, threadID: m.ChannelID}
-		return buildThreadSessionKey(m.ChannelID), rc, nil
+		return buildThreadSessionKey(m.ChannelID), rc, parentChannelID, nil
 	}
 	if m.Message != nil && m.Message.Thread != nil && m.Message.Thread.ID != "" {
 		threadID := m.Message.Thread.ID
@@ -328,7 +365,7 @@ func resolveThreadReplyContext(m *discordgo.MessageCreate, botID string, ops dis
 			slog.Debug("discord: join attached thread failed", "thread", threadID, "error", err)
 		}
 		rc := replyContext{channelID: threadID, messageID: m.ID, threadID: threadID}
-		return buildThreadSessionKey(threadID), rc, nil
+		return buildThreadSessionKey(threadID), rc, m.ChannelID, nil
 	}
 	if m.Flags&discordgo.MessageFlagsHasThread != 0 {
 		threadID := m.ID
@@ -336,18 +373,18 @@ func resolveThreadReplyContext(m *discordgo.MessageCreate, botID string, ops dis
 			slog.Debug("discord: join message thread failed", "thread", threadID, "error", err)
 		}
 		rc := replyContext{channelID: threadID, messageID: m.ID, threadID: threadID}
-		return buildThreadSessionKey(threadID), rc, nil
+		return buildThreadSessionKey(threadID), rc, m.ChannelID, nil
 	}
 
 	thread, err := ops.StartThread(m.ChannelID, m.ID, threadNameForMessage(m, botID), 1440)
 	if err != nil {
-		return "", replyContext{}, fmt.Errorf("start thread for message %s: %w", m.ID, err)
+		return "", replyContext{}, "", fmt.Errorf("start thread for message %s: %w", m.ID, err)
 	}
 	if err := ops.JoinThread(thread.ID); err != nil {
 		slog.Debug("discord: join new thread failed", "thread", thread.ID, "error", err)
 	}
 	rc := replyContext{channelID: thread.ID, messageID: m.ID, threadID: thread.ID}
-	return buildThreadSessionKey(thread.ID), rc, nil
+	return buildThreadSessionKey(thread.ID), rc, m.ChannelID, nil
 }
 
 func resolveCronReplyTarget(sessionKey, title string, ops discordThreadOps) (string, replyContext, error) {
@@ -539,13 +576,21 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 
 		sessionKey := p.makeSessionKey(m.ChannelID, m.Author.ID)
 		rctx := replyContext{channelID: m.ChannelID, messageID: m.ID}
+		// channelKey pins workspace binding to the parent channel even when
+		// thread_isolation rewrites SessionKey to a thread ID. Without it,
+		// effectiveChannelID() would extract the thread ID from SessionKey
+		// and multi-workspace auto-bind would try to match `<base_dir>/<thread-name>`,
+		// which never exists. Empty value falls back to SessionKey extraction
+		// (the historical, non-isolated behavior).
+		channelKey := ""
 		if p.threadIsolation && m.GuildID != "" {
-			threadSessionKey, threadCtx, err := resolveThreadReplyContext(m, p.botID, sessionThreadOps{session: p.session})
+			threadSessionKey, threadCtx, parentChannelID, err := resolveThreadReplyContext(m, p.botID, sessionThreadOps{session: p.session})
 			if err != nil {
 				slog.Warn("discord: thread isolation setup failed, falling back", "message", m.ID, "channel", m.ChannelID, "error", err)
 			} else {
 				sessionKey = threadSessionKey
 				rctx = threadCtx
+				channelKey = parentChannelID
 			}
 		}
 
@@ -556,7 +601,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 		}
 
 		msg := &core.Message{
-			SessionKey: sessionKey, Platform: "discord",
+			SessionKey: sessionKey, ChannelKey: channelKey, Platform: "discord",
 			MessageID: m.ID,
 			UserID:    m.Author.ID, UserName: m.Author.Username,
 			ChatName: p.resolveChannelName(m.ChannelID),
@@ -643,10 +688,15 @@ func (p *Platform) handleInteraction(s *discordgo.Session, i *discordgo.Interact
 
 	slog.Debug("discord: slash command", "user", userName, "command", cmdText, "channel", channelID)
 
-	sessionKey := resolveSessionKeyForChannel(channelID, userID, p.shareSessionInChannel, p.threadIsolation, sessionThreadOps{session: p.session})
+	ops := sessionThreadOps{session: p.session}
+	sessionKey := resolveSessionKeyForChannel(channelID, userID, p.shareSessionInChannel, p.threadIsolation, ops)
+	channelKey := ""
+	if p.threadIsolation {
+		channelKey = resolveParentChannelID(channelID, ops)
+	}
 
 	msg := &core.Message{
-		SessionKey: sessionKey, Platform: "discord",
+		SessionKey: sessionKey, ChannelKey: channelKey, Platform: "discord",
 		MessageID: i.ID,
 		UserID:    userID, UserName: userName,
 		ChatName: p.resolveChannelName(channelID),
@@ -711,13 +761,19 @@ func (p *Platform) handleComponentInteraction(s *discordgo.Session, i *discordgo
 	}
 
 	channelID := i.ChannelID
-	sessionKey := resolveSessionKeyForChannel(channelID, userID, p.shareSessionInChannel, p.threadIsolation, sessionThreadOps{session: p.session})
+	ops := sessionThreadOps{session: p.session}
+	sessionKey := resolveSessionKeyForChannel(channelID, userID, p.shareSessionInChannel, p.threadIsolation, ops)
+	channelKey := ""
+	if p.threadIsolation {
+		channelKey = resolveParentChannelID(channelID, ops)
+	}
 	rc := replyContext{channelID: channelID}
 	if i.Message != nil {
 		rc.messageID = i.Message.ID
 	}
 	p.dispatchMessage(&core.Message{
 		SessionKey: sessionKey,
+		ChannelKey: channelKey,
 		Platform:   "discord",
 		MessageID:  i.ID,
 		UserID:     userID,

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -93,6 +93,16 @@ func TestResolveThreadReplyContext_UsesExistingThreadChannel(t *testing.T) {
 		return nil
 	}
 
+	// Override resolveChannel to return a thread with a populated ParentID,
+	// so the helper can surface the parent channel for workspace binding.
+	ops.resolveChannel = func(channelID string) (*discordgo.Channel, error) {
+		return &discordgo.Channel{
+			ID:       channelID,
+			Type:     discordgo.ChannelTypeGuildPublicThread,
+			ParentID: "channel-parent",
+		}, nil
+	}
+
 	msg := &discordgo.MessageCreate{
 		Message: &discordgo.Message{
 			ID:        "m1",
@@ -102,7 +112,7 @@ func TestResolveThreadReplyContext_UsesExistingThreadChannel(t *testing.T) {
 		},
 	}
 
-	sessionKey, rc, err := resolveThreadReplyContext(msg, "bot-1", ops)
+	sessionKey, rc, parentChannelID, err := resolveThreadReplyContext(msg, "bot-1", ops)
 	if err != nil {
 		t.Fatalf("resolveThreadReplyContext() error = %v", err)
 	}
@@ -112,8 +122,40 @@ func TestResolveThreadReplyContext_UsesExistingThreadChannel(t *testing.T) {
 	if rc.channelID != "thread-1" || rc.threadID != "thread-1" {
 		t.Fatalf("replyContext = %#v, want thread channel routing", rc)
 	}
+	if parentChannelID != "channel-parent" {
+		t.Fatalf("parentChannelID = %q, want channel-parent", parentChannelID)
+	}
 	if joinedThread != "thread-1" {
 		t.Fatalf("joinedThread = %q, want thread-1", joinedThread)
+	}
+}
+
+func TestResolveThreadReplyContext_FallsBackToMessageChannelWhenParentMissing(t *testing.T) {
+	// Defensive path: if discordgo (or a future API change) ever leaves
+	// ParentID empty on a thread channel, the helper must still return
+	// *some* parent channel ID — best fallback is the thread ID itself,
+	// matching m.ChannelID. Auto-bind will then key off the thread name,
+	// which is no worse than the pre-fix behavior.
+	ops := fakeThreadOps{
+		resolveChannel: func(channelID string) (*discordgo.Channel, error) {
+			return &discordgo.Channel{ID: channelID, Type: discordgo.ChannelTypeGuildPublicThread}, nil
+		},
+		joinThread: func(string) error { return nil },
+	}
+	msg := &discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID:        "m1",
+			ChannelID: "thread-orphan",
+			GuildID:   "guild-1",
+			Author:    &discordgo.User{ID: "u1"},
+		},
+	}
+	_, _, parentChannelID, err := resolveThreadReplyContext(msg, "bot-1", ops)
+	if err != nil {
+		t.Fatalf("resolveThreadReplyContext() error = %v", err)
+	}
+	if parentChannelID != "thread-orphan" {
+		t.Fatalf("parentChannelID = %q, want thread-orphan (fallback)", parentChannelID)
 	}
 }
 
@@ -154,7 +196,7 @@ func TestResolveThreadReplyContext_CreatesThreadForGuildMessage(t *testing.T) {
 		},
 	}
 
-	sessionKey, rc, err := resolveThreadReplyContext(msg, "bot-1", ops)
+	sessionKey, rc, parentChannelID, err := resolveThreadReplyContext(msg, "bot-1", ops)
 	if err != nil {
 		t.Fatalf("resolveThreadReplyContext() error = %v", err)
 	}
@@ -163,6 +205,9 @@ func TestResolveThreadReplyContext_CreatesThreadForGuildMessage(t *testing.T) {
 	}
 	if rc.channelID != "thread-99" || rc.threadID != "thread-99" {
 		t.Fatalf("replyContext = %#v, want thread channel routing", rc)
+	}
+	if parentChannelID != "channel-1" {
+		t.Fatalf("parentChannelID = %q, want channel-1", parentChannelID)
 	}
 	if startChannelID != "channel-1" || startMessageID != "msg-42" {
 		t.Fatalf("thread start args = (%q, %q), want (channel-1, msg-42)", startChannelID, startMessageID)
@@ -184,6 +229,55 @@ func TestSessionKeyForChannel_UsesThreadKeyWhenChannelIsThread(t *testing.T) {
 
 	if got := resolveSessionKeyForChannel("thread-7", "user-1", false, true, ops); got != "discord:thread-7" {
 		t.Fatalf("resolveSessionKeyForChannel() = %q, want discord:thread-7", got)
+	}
+}
+
+func TestResolveParentChannelID(t *testing.T) {
+	cases := []struct {
+		name      string
+		channelID string
+		channel   *discordgo.Channel
+		resolve   func(string) (*discordgo.Channel, error)
+		want      string
+	}{
+		{
+			name:      "thread-with-parent",
+			channelID: "thread-1",
+			channel:   &discordgo.Channel{ID: "thread-1", Type: discordgo.ChannelTypeGuildPublicThread, ParentID: "channel-parent"},
+			want:      "channel-parent",
+		},
+		{
+			name:      "regular-channel-passes-through",
+			channelID: "channel-1",
+			channel:   &discordgo.Channel{ID: "channel-1", Type: discordgo.ChannelTypeGuildText},
+			want:      "channel-1",
+		},
+		{
+			name:      "thread-without-parent-falls-back",
+			channelID: "thread-orphan",
+			channel:   &discordgo.Channel{ID: "thread-orphan", Type: discordgo.ChannelTypeGuildPublicThread},
+			want:      "thread-orphan",
+		},
+		{
+			name:      "resolve-error-falls-back",
+			channelID: "channel-x",
+			resolve:   func(string) (*discordgo.Channel, error) { return nil, fmt.Errorf("not found") },
+			want:      "channel-x",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ops := fakeThreadOps{}
+			if tc.resolve != nil {
+				ops.resolveChannel = tc.resolve
+			} else {
+				ch := tc.channel
+				ops.resolveChannel = func(string) (*discordgo.Channel, error) { return ch, nil }
+			}
+			if got := resolveParentChannelID(tc.channelID, ops); got != tc.want {
+				t.Errorf("resolveParentChannelID(%q) = %q, want %q", tc.channelID, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related multi-workspace fixes for the claudecode + Discord stack.

### 1. claudecode: propagate options to per-workspace agents

claudecode agent didn't implement `core.WorkspaceAgentOptionSnapshotter`, so when multi-workspace mode lazily spawned per-workspace agents via `core.Engine.getOrCreateWorkspaceAgent`, every claudecode-specific opts field — `cli_path`, `cli_args_flag`, `allowed_tools`, `disallowed_tools`, `reasoning_effort`, `max_context_tokens`, `router_url`, `router_api_key` — was silently dropped. Only `model` / `mode` / `run_as_user` / `run_as_env` survived (each via a dedicated accessor path).

Concrete user-visible symptom: `cli_path = "claude --add-dir /shared"` worked on the project-level agent but workspace agents reverted to bare `claude` with none of the extra args.

`WorkspaceAgentOptions()` now snapshots all of these. `cli_path` is rebuilt from `cliBin + cliExtraArgs`. `run_as_user` / `run_as_env` stay out of the snapshot because the engine has dedicated `GetRunAsUser` / `GetRunAsEnv` propagation paths (cc-connect#496).

### 2. Discord: make `thread_isolation` compatible with multi-workspace auto-bind

When `thread_isolation = true`, Discord rewrites a guild message's `SessionKey` from `discord:<channelID>:<userID>` to `discord:<threadID>` so each thread carries its own conversation. The platform never set `Message.ChannelKey`, so `engine.effectiveChannelID(msg)` extracted the **thread** ID from `SessionKey`. Multi-workspace auto-bind by convention (`<base_dir>/<channel-name>` → workspace) then matched the **thread name** — which never matches a workspace folder. Auto-bind silently broke for every thread-isolated channel.

`Message.ChannelKey` is now set to the parent channel ID in all three Discord message paths (regular messages, slash commands, component callbacks). `resolveThreadReplyContext` returns the parent channel alongside the thread session key.

The workspace binding is now stored under the parent channel, but the interactive state is still keyed under the thread-keyed sessionKey. `interactiveKeyForSessionKey` and `sessionContextForKey` now use a unified precedence:

1. **Exact** sessionKey match in `interactiveStates` (raw placeholders win).
2. **Channel-binding-derived** workspace — deterministic; the current binding wins over stale state from a re-bound channel.
3. **Live-state suffix scan** as the final recovery path — only fires for the Discord thread case where channel-binding lookup misses.

`interactiveKeyForSessionKeyLocked` (the lock-free variant) fixes a self-deadlock at `SendToSessionWithAttachments`, which already holds `interactiveMu` when it needs to resolve the canonical key.

## Test plan

- [x] `go build -tags 'no_web' ./...`
- [x] `go test -tags 'no_web' -count=1 ./agent/claudecode/...` — all pass, including 4 claudecode snapshot tests
- [x] `go test -tags 'no_web' -count=1 ./platform/discord/...` — all pass, including new `resolveThreadReplyContext` parent-channel return tests and `resolveParentChannelID` table test
- [x] `go test -tags 'no_web' -count=1 ./core/...` — passes apart from 3 pre-existing failures unrelated to this PR (`TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled`, `TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState`, `TestResolveLocalDirPath_AcceptsSubdir` — verified failing on `origin/main` HEAD too)
- [x] New core tests:
  - `TestSnapshotCLIPath` (5 sub-cases)
  - `TestWorkspaceAgentOptions_FullSnapshot` / `OmitsZeroValues` / `RoundTripsThroughNew`
  - `TestInteractiveKeyForSessionKey_RecoversByLiveStateScan` — Discord thread fallback
  - `TestInteractiveKeyForSessionKey_PrefersCurrentBindingOverStaleState` — re-binding determinism
  - `TestSessionContextForKey_RecoversWorkspaceFromLiveState` — alignment with state lookup
  - `TestFindInteractiveKeyForSession` (6 sub-cases including `exact-beats-prefixed` precedence)
- [x] Codex review (`codex exec review --uncommitted`) iterated 4 rounds:
  - v1 → P2 on Windows portability of round-trip test → fixed via `runtime.GOOS == "windows"` skip
  - v2 → P1 on broken interactive state lookup for thread-isolated sessions → fixed via live-state recovery scan
  - v3 → P2 on non-deterministic exact-vs-prefixed scan + alignment with `sessionContextForKey` → fixed via unified precedence
  - v4 → clean, no actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)