### PR TITLE
fix(weixin): send video files as video messages

### DIFF
--- a/platform/weixin/media_outbound.go
+++ b/platform/weixin/media_outbound.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -112,6 +113,24 @@ func (p *Platform) sendSingleItem(ctx context.Context, rc *replyContext, item me
 	return p.sendSingleItemWithRetry(ctx, rc, item)
 }
 
+func mediaFromUploadRef(ref *cdnUploadedRef) *cdnMedia {
+	return &cdnMedia{
+		EncryptQueryParam: ref.downloadParam,
+		AESKey:            formatAesKeyForAPI(ref.aesKey),
+		EncryptType:       1,
+	}
+}
+
+func buildVideoMessageItem(ref *cdnUploadedRef) messageItem {
+	return messageItem{
+		Type: messageItemVideo,
+		VideoItem: &videoItem{
+			Media:     mediaFromUploadRef(ref),
+			VideoSize: ref.cipherSize,
+		},
+	}
+}
+
 // sendSingleItemWithRetry sends a media item with retry mechanism for ret=-2 errors.
 func (p *Platform) sendSingleItemWithRetry(ctx context.Context, rc *replyContext, item messageItem) error {
 	var lastErr error
@@ -196,6 +215,15 @@ func (p *Platform) SendFile(ctx context.Context, replyCtx any, file core.FileAtt
 	if name == "" {
 		name = "file.bin"
 	}
+
+	if isVideoFile(file) {
+		ref, err := p.uploadToWeixinCDN(ctx, rc.peerUserID, file.Data, uploadMediaVideo, "SendFileVideo")
+		if err != nil {
+			return err
+		}
+		return p.sendSingleItem(ctx, rc, buildVideoMessageItem(ref))
+	}
+
 	ref, err := p.uploadToWeixinCDN(ctx, rc.peerUserID, file.Data, uploadMediaFile, "SendFile")
 	if err != nil {
 		return err
@@ -213,6 +241,20 @@ func (p *Platform) SendFile(ctx context.Context, replyCtx any, file core.FileAtt
 		},
 	}
 	return p.sendSingleItem(ctx, rc, item)
+}
+
+func isVideoFile(file core.FileAttachment) bool {
+	mime := strings.ToLower(strings.TrimSpace(file.MimeType))
+	if strings.HasPrefix(mime, "video/") {
+		return true
+	}
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(file.FileName)), ".")
+	switch ext {
+	case "avi", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "webm":
+		return true
+	default:
+		return false
+	}
 }
 
 // SendAudio implements core.AudioSender.

--- a/platform/weixin/media_outbound_test.go
+++ b/platform/weixin/media_outbound_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
 )
 
 func TestFormatAesKeyForAPI(t *testing.T) {
@@ -101,8 +103,12 @@ func TestGetUploadURLResponse_Validation(t *testing.T) {
 			// Replicate the validation logic from client.go:
 			// both fields empty/whitespace-only → error
 			trim := func(s string) string {
-				for len(s) > 0 && s[0] == ' ' { s = s[1:] }
-				for len(s) > 0 && s[len(s)-1] == ' ' { s = s[:len(s)-1] }
+				for len(s) > 0 && s[0] == ' ' {
+					s = s[1:]
+				}
+				for len(s) > 0 && s[len(s)-1] == ' ' {
+					s = s[:len(s)-1]
+				}
 				return s
 			}
 			hasError := trim(tt.resp.UploadParam) == "" && trim(tt.resp.UploadFullURL) == ""
@@ -110,5 +116,79 @@ func TestGetUploadURLResponse_Validation(t *testing.T) {
 				t.Errorf("validation error = %v, wantError %v", hasError, tt.wantError)
 			}
 		})
+	}
+}
+
+func TestIsVideoFile(t *testing.T) {
+	tests := []struct {
+		name string
+		file core.FileAttachment
+		want bool
+	}{
+		{
+			name: "video mime",
+			file: core.FileAttachment{MimeType: "video/mp4", FileName: "reply.bin"},
+			want: true,
+		},
+		{
+			name: "mp4 extension",
+			file: core.FileAttachment{MimeType: "application/octet-stream", FileName: "reply.mp4"},
+			want: true,
+		},
+		{
+			name: "uppercase mov extension",
+			file: core.FileAttachment{FileName: "reply.MOV"},
+			want: true,
+		},
+		{
+			name: "plain file",
+			file: core.FileAttachment{MimeType: "application/pdf", FileName: "reply.pdf"},
+			want: false,
+		},
+		{
+			name: "audio is not video",
+			file: core.FileAttachment{MimeType: "audio/mpeg", FileName: "reply.mp3"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isVideoFile(tt.file); got != tt.want {
+				t.Fatalf("isVideoFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildVideoMessageItemUsesVideoShape(t *testing.T) {
+	ref := &cdnUploadedRef{
+		downloadParam: "encrypted-query",
+		aesKey:        []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		cipherSize:    4096,
+		rawSize:       4000,
+	}
+
+	item := buildVideoMessageItem(ref)
+	if item.Type != messageItemVideo {
+		t.Fatalf("item.Type = %d, want %d", item.Type, messageItemVideo)
+	}
+	if item.VideoItem == nil {
+		t.Fatal("VideoItem is nil")
+	}
+	if item.VideoItem.VideoSize != ref.cipherSize {
+		t.Fatalf("VideoSize = %d, want %d", item.VideoItem.VideoSize, ref.cipherSize)
+	}
+	if item.VideoItem.Media == nil {
+		t.Fatal("VideoItem.Media is nil")
+	}
+	if item.VideoItem.Media.EncryptQueryParam != ref.downloadParam {
+		t.Fatalf("EncryptQueryParam = %q, want %q", item.VideoItem.Media.EncryptQueryParam, ref.downloadParam)
+	}
+	if item.VideoItem.Media.AESKey != formatAesKeyForAPI(ref.aesKey) {
+		t.Fatal("VideoItem.Media.AESKey does not match API format")
+	}
+	if item.VideoItem.Media.EncryptType != 1 {
+		t.Fatalf("EncryptType = %d, want 1", item.VideoItem.Media.EncryptType)
 	}
 }


### PR DESCRIPTION
## Summary
- route outbound Weixin file attachments with video MIME/extension through native video media items
- keep non-video files on the existing file attachment path
- add tests for video detection and video message item shape

## Verification
- gofmt via Go toolchain on Linux VM
- GOTOOLCHAIN=auto go test ./platform/weixin