### PR TITLE
fix(feishu): notify user when media download fails

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -892,6 +892,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		imgData, mimeType, err := p.downloadImage(messageID, imgBody.ImageKey)
 		if err != nil {
 			slog.Error(p.tag()+": download image failed", "error", err)
+			if sendErr := p.Send(ctx, rctx, "⚠️ Image download failed (network error). Please resend."); sendErr != nil {
+				slog.Error(p.tag()+": failed to notify user about image download failure", "error", sendErr)
+			}
 			return
 		}
 		p.handler(p.dispatchPlatform(), &core.Message{
@@ -915,6 +918,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		audioData, err := p.downloadResource(messageID, audioBody.FileKey, "file")
 		if err != nil {
 			slog.Error(p.tag()+": download audio failed", "error", err)
+			if sendErr := p.Send(ctx, rctx, "⚠️ Voice message download failed (network error). Please resend."); sendErr != nil {
+				slog.Error(p.tag()+": failed to notify user about audio download failure", "error", sendErr)
+			}
 			return
 		}
 		p.handler(p.dispatchPlatform(), &core.Message{
@@ -957,6 +963,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		fileData, err := p.downloadResource(messageID, fileBody.FileKey, "file")
 		if err != nil {
 			slog.Error(p.tag()+": download file failed", "error", err)
+			if sendErr := p.Send(ctx, rctx, "⚠️ File download failed (network error). Please resend."); sendErr != nil {
+				slog.Error(p.tag()+": failed to notify user about file download failure", "error", sendErr)
+			}
 			return
 		}
 		slog.Debug(p.tag()+": file downloaded", "file_name", fileBody.FileName, "size", len(fileData))


### PR DESCRIPTION
## Summary
- When image, audio, or file downloads fail due to network errors (e.g. `connection reset by peer`), the message was **silently dropped** with only a server-side log entry
- Users had no indication their message wasn't received and would wait indefinitely for a response
- Now sends a notification back to the user (via `p.Send`) so they know to resend

## Changes
Three locations in `platform/feishu/feishu.go` where `downloadImage` / `downloadResource` errors caused silent `return`:
- **Image download failure** (line ~894) — now notifies user
- **Audio/voice download failure** (line ~918) — now notifies user  
- **File download failure** (line ~963) — now notifies user

## Context
Encountered this in production: a Feishu voice message download failed due to a TCP connection reset. The bot went silent for 25 minutes with no feedback to the user. The error was only visible in server logs.

## Test plan
- [x] Compiles successfully (`go build ./cmd/...`)
- [ ] Trigger media download failure (e.g. network interruption) and verify notification is sent
- [ ] Verify normal media processing still works unchanged