### PR TITLE
fix(codex): align permission modes with Codex presets

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -154,7 +154,8 @@ mode = "default"
 # allowed_tools = ["Read", "Grep", "Glob"]  # optional: pre-approve specific tools
 
 # --- Codex mode options ---
-# "suggest" (default), "auto-edit", "full-auto", "yolo"
+# "default", "auto-review", "full-access"
+# Legacy aliases: "suggest", "auto-edit", "full-auto" -> "default"; "yolo", "bypassPermissions" -> "full-access"
 # model = "o3"  # optional: specify model
 
 # --- Qoder CLI mode options ---
@@ -590,7 +591,7 @@ type = "codex"
 
 [projects.agent.options]
 work_dir = "/path/to/frontend"
-mode = "full-auto"
+mode = "default"
 
 [[projects.platforms]]
 type = "telegram"

--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -167,7 +167,7 @@ func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode,
 		workDir:          workDir,
 		model:            model,
 		effort:           effort,
-		mode:             mode,
+		mode:             normalizeMode(mode),
 		baseURL:          baseURL,
 		modelProvider:    modelProvider,
 		extraEnv:         append([]string(nil), extraEnv...),
@@ -328,23 +328,53 @@ func (s *appServerSession) threadRequestParams() map[string]any {
 	if model := s.GetModel(); model != "" {
 		params["model"] = model
 	}
-	if approval, sandbox := appServerModeSettings(s.mode); approval != "" {
-		params["approvalPolicy"] = approval
-		if sandbox != "" {
-			params["sandbox"] = sandbox
-		}
+	settings := appServerModeSettings(s.mode)
+	if settings.approvalPolicy != "" {
+		params["approvalPolicy"] = settings.approvalPolicy
+	}
+	if settings.sandbox != "" {
+		params["sandbox"] = settings.sandbox
+	}
+	if settings.approvalsReviewer != "" {
+		params["approvalsReviewer"] = settings.approvalsReviewer
 	}
 	return params
 }
 
-func appServerModeSettings(mode string) (approval string, sandbox string) {
+type appServerModeConfig struct {
+	approvalPolicy    string
+	sandbox           string
+	sandboxPolicy     map[string]any
+	approvalsReviewer string
+}
+
+func appServerModeSettings(mode string) appServerModeConfig {
 	switch normalizeMode(mode) {
-	case "auto-edit", "full-auto":
-		return "never", "workspace-write"
-	case "yolo":
-		return "never", "danger-full-access"
+	case "default":
+		return appServerModeConfig{
+			approvalPolicy: "on-request",
+			sandbox:        "workspace-write",
+			sandboxPolicy:  map[string]any{"type": "workspaceWrite"},
+		}
+	case "auto-review":
+		return appServerModeConfig{
+			approvalPolicy:    "on-request",
+			sandbox:           "workspace-write",
+			sandboxPolicy:     map[string]any{"type": "workspaceWrite"},
+			approvalsReviewer: "auto_review",
+		}
+	case "full-access":
+		return appServerModeConfig{
+			approvalPolicy: "never",
+			sandbox:        "danger-full-access",
+			sandboxPolicy:  map[string]any{"type": "dangerFullAccess"},
+		}
 	default:
-		return "on-request", "read-only"
+		return appServerModeConfig{
+			approvalPolicy: "on-request",
+			sandbox:        "workspace-write",
+			sandboxPolicy:  map[string]any{"type": "workspaceWrite"},
+		}
 	}
 }
 
@@ -451,8 +481,15 @@ func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, fi
 	if effort := s.GetReasoningEffort(); effort != "" {
 		params["effort"] = effort
 	}
-	if approval, _ := appServerModeSettings(s.mode); approval != "" {
-		params["approvalPolicy"] = approval
+	settings := appServerModeSettings(s.mode)
+	if settings.approvalPolicy != "" {
+		params["approvalPolicy"] = settings.approvalPolicy
+	}
+	if settings.sandboxPolicy != nil {
+		params["sandboxPolicy"] = settings.sandboxPolicy
+	}
+	if settings.approvalsReviewer != "" {
+		params["approvalsReviewer"] = settings.approvalsReviewer
 	}
 
 	var resp turnStartResponse

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -126,6 +126,84 @@ func TestAppServerSession_HandleThreadTokenUsageUpdatedCachesContextUsage(t *tes
 	}
 }
 
+func TestAppServerModeSettings_CodexPermissionPresets(t *testing.T) {
+	tests := []struct {
+		name              string
+		mode              string
+		approvalPolicy    string
+		sandbox           string
+		sandboxPolicyType string
+		approvalsReviewer string
+	}{
+		{
+			name:              "default",
+			mode:              "default",
+			approvalPolicy:    "on-request",
+			sandbox:           "workspace-write",
+			sandboxPolicyType: "workspaceWrite",
+		},
+		{
+			name:              "auto review",
+			mode:              "auto-review",
+			approvalPolicy:    "on-request",
+			sandbox:           "workspace-write",
+			sandboxPolicyType: "workspaceWrite",
+			approvalsReviewer: "auto_review",
+		},
+		{
+			name:              "full access",
+			mode:              "full-access",
+			approvalPolicy:    "never",
+			sandbox:           "danger-full-access",
+			sandboxPolicyType: "dangerFullAccess",
+		},
+		{
+			name:              "bypassPermissions legacy alias",
+			mode:              "bypassPermissions",
+			approvalPolicy:    "never",
+			sandbox:           "danger-full-access",
+			sandboxPolicyType: "dangerFullAccess",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := appServerModeSettings(tt.mode)
+			if settings.approvalPolicy != tt.approvalPolicy {
+				t.Fatalf("approvalPolicy = %q, want %q", settings.approvalPolicy, tt.approvalPolicy)
+			}
+			if settings.sandbox != tt.sandbox {
+				t.Fatalf("sandbox = %q, want %q", settings.sandbox, tt.sandbox)
+			}
+			if settings.approvalsReviewer != tt.approvalsReviewer {
+				t.Fatalf("approvalsReviewer = %q, want %q", settings.approvalsReviewer, tt.approvalsReviewer)
+			}
+			if settings.sandboxPolicy == nil {
+				t.Fatal("sandboxPolicy = nil, want policy")
+			}
+			if got, _ := settings.sandboxPolicy["type"].(string); got != tt.sandboxPolicyType {
+				t.Fatalf("sandboxPolicy.type = %q, want %q", got, tt.sandboxPolicyType)
+			}
+		})
+	}
+}
+
+func TestAppServerSession_ThreadRequestParamsIncludesModeSettings(t *testing.T) {
+	s := &appServerSession{mode: "auto-review"}
+
+	params := s.threadRequestParams()
+
+	if got := params["approvalPolicy"]; got != "on-request" {
+		t.Fatalf("approvalPolicy = %v, want on-request", got)
+	}
+	if got := params["sandbox"]; got != "workspace-write" {
+		t.Fatalf("sandbox = %v, want workspace-write", got)
+	}
+	if got := params["approvalsReviewer"]; got != "auto_review" {
+		t.Fatalf("approvalsReviewer = %v, want auto_review", got)
+	}
+}
+
 func TestMapAppServerRateLimits_PrefersMultiBucketView(t *testing.T) {
 	report := mapAppServerRateLimits(appServerRateLimitsResponse{
 		RateLimits: appServerRateLimitSnapshot{

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -22,16 +22,15 @@ func init() {
 
 // Agent drives OpenAI Codex CLI using `codex exec --json`.
 //
-// Modes (maps to codex exec flags):
-//   - "suggest":   default, no special flags (safe commands only)
-//   - "auto-edit": --full-auto (sandbox-protected auto execution)
-//   - "full-auto": --full-auto (sandbox-protected auto execution)
-//   - "yolo":      --dangerously-bypass-approvals-and-sandbox
+// Modes (maps to Codex permission presets):
+//   - "default":     Codex default sandbox and approval behavior
+//   - "auto-review": Codex auto-reviewer handles approval requests
+//   - "full-access": bypass approvals and sandbox
 type Agent struct {
 	workDir         string
 	model           string
 	reasoningEffort string
-	mode            string // "suggest" | "auto-edit" | "full-auto" | "yolo"
+	mode            string // "default" | "auto-review" | "full-access"
 	backend         string // "exec" | "app_server"
 	appServerURL    string
 	codexHome       string
@@ -103,14 +102,19 @@ func normalizeBackend(raw string) string {
 
 func normalizeMode(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "auto-edit", "autoedit", "auto_edit", "edit":
-		return "auto-edit"
-	case "full-auto", "fullauto", "full_auto", "auto":
-		return "full-auto"
-	case "yolo", "bypass", "dangerously-bypass":
-		return "yolo"
+	case "", "default", "suggest":
+		return "default"
+	case "auto-review", "autoreview", "auto_review":
+		return "auto-review"
+	case "full-access", "fullaccess", "full_access", "danger-full-access",
+		"dangerously-bypass", "dangerously-bypass-approvals-and-sandbox",
+		"bypass", "bypasspermissions", "bypass-permissions", "bypass_permissions", "yolo":
+		return "full-access"
+	case "auto-edit", "autoedit", "auto_edit", "edit",
+		"full-auto", "fullauto", "full_auto", "auto":
+		return "default"
 	default:
-		return "suggest"
+		return "default"
 	}
 }
 
@@ -641,9 +645,8 @@ func (a *Agent) activeProviderCodexConfig() (name string, apiKey string, wireAPI
 
 func (a *Agent) PermissionModes() []core.PermissionModeInfo {
 	return []core.PermissionModeInfo{
-		{Key: "suggest", Name: "Suggest", NameZh: "建议", Desc: "Ask permission for every tool call", DescZh: "每次工具调用都需确认"},
-		{Key: "auto-edit", Name: "Auto Edit", NameZh: "自动编辑", Desc: "Auto-approve file edits, ask for shell commands", DescZh: "自动允许文件编辑，Shell 命令需确认"},
-		{Key: "full-auto", Name: "Full Auto", NameZh: "全自动", Desc: "Auto-approve with workspace sandbox", DescZh: "自动通过（工作区沙箱）"},
-		{Key: "yolo", Name: "YOLO", NameZh: "YOLO 模式", Desc: "Bypass all approvals and sandbox", DescZh: "跳过所有审批和沙箱"},
+		{Key: "default", Name: "Default", NameZh: "默认", Desc: "Use Codex default sandbox and approval behavior", DescZh: "使用 Codex 默认沙箱和审批行为"},
+		{Key: "auto-review", Name: "Auto Review", NameZh: "自动审查", Desc: "Use Codex auto-reviewer for approval requests", DescZh: "使用 Codex 自动审查器处理审批请求"},
+		{Key: "full-access", Name: "Full Access", NameZh: "完全访问", Desc: "Bypass approvals and sandbox", DescZh: "跳过审批和沙箱"},
 	}
 }

--- a/agent/codex/integration_test.go
+++ b/agent/codex/integration_test.go
@@ -88,7 +88,8 @@ func TestIntegration_CodexProviderFlow(t *testing.T) {
 		"--model", "openai/gpt-5.3-codex",
 		"-c", `model_provider="shengsuanyun-codex"`,
 		"-c", `openai_base_url="https://router.shengsuanyun.com/api/v1"`,
-		"--full-auto",
+		"-c", `approval_policy="on-request"`,
+		"-c", `sandbox_mode="workspace-write"`,
 	)
 	cmd.Dir = workDir
 	cmd.Env = append(os.Environ(),

--- a/agent/codex/provider_switch_test.go
+++ b/agent/codex/provider_switch_test.go
@@ -163,7 +163,7 @@ func TestIntegration_Codex_ProviderSwitch_SessionArgs(t *testing.T) {
 				activeIdx: -1,
 				workDir:   workDir,
 				codexHome: codexHome,
-				mode:      "suggest",
+				mode:      "default",
 				backend:   "exec",
 			}
 			a.SetActiveProvider(prov.Name)
@@ -296,7 +296,7 @@ func TestIntegration_Codex_ProviderSwitch_SendMessage(t *testing.T) {
 				activeIdx: -1,
 				workDir:   workDir,
 				codexHome: codexHome,
-				mode:      "full-auto",
+				mode:      "default",
 				backend:   "exec",
 			}
 			a.SetActiveProvider(prov.Name)

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -28,20 +28,20 @@ type codexSession struct {
 	model         string
 	effort        string
 	mode          string
-	baseURL       string // provider base URL; passed as -c openai_base_url=<url>
-	modelProvider string // Codex model_provider name; passed as -c model_provider=<name>
+	baseURL       string   // provider base URL; passed as -c openai_base_url=<url>
+	modelProvider string   // Codex model_provider name; passed as -c model_provider=<name>
 	cliBin        string   // CLI binary, default "codex"
 	cliExtraArgs  []string // extra args from cli_path, prepended before exec args
 	extraEnv      []string
 	events        chan core.Event
-	threadID  atomic.Value // stores string — Codex thread_id
-	ctx       context.Context
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
-	alive     atomic.Bool
-	closeOnce sync.Once
-	cmdMu     sync.Mutex
-	cmds      map[*exec.Cmd]struct{}
+	threadID      atomic.Value // stores string — Codex thread_id
+	ctx           context.Context
+	cancel        context.CancelFunc
+	wg            sync.WaitGroup
+	alive         atomic.Bool
+	closeOnce     sync.Once
+	cmdMu         sync.Mutex
+	cmds          map[*exec.Cmd]struct{}
 
 	pendingMsgs []string // buffered agent_message texts awaiting classification
 
@@ -70,7 +70,7 @@ func newCodexSession(ctx context.Context, cliBin string, cliExtraArgs []string, 
 		workDir:       workDir,
 		model:         model,
 		effort:        effort,
-		mode:          mode,
+		mode:          normalizeMode(mode),
 		baseURL:       baseURL,
 		modelProvider: modelProvider,
 		cliBin:        cliBin,
@@ -189,9 +189,18 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 	}
 
 	switch cs.mode {
-	case "auto-edit", "full-auto":
-		args = append(args, "--full-auto")
-	case "yolo":
+	case "default":
+		args = append(args,
+			"-c", `approval_policy="on-request"`,
+			"-c", `sandbox_mode="workspace-write"`,
+		)
+	case "auto-review":
+		args = append(args,
+			"-c", `approval_policy="on-request"`,
+			"-c", `sandbox_mode="workspace-write"`,
+			"-c", `approvals_reviewer="auto_review"`,
+		)
+	case "full-access":
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 	}
 

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -37,8 +37,51 @@ func TestAvailableReasoningEfforts_ExcludesMinimal(t *testing.T) {
 	}
 }
 
+func TestNormalizeMode_CodexPermissionPresetsAndAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty defaults to default", raw: "", want: "default"},
+		{name: "suggest legacy alias", raw: "suggest", want: "default"},
+		{name: "default", raw: "default", want: "default"},
+		{name: "auto review", raw: "auto-review", want: "auto-review"},
+		{name: "auto review underscore", raw: "auto_review", want: "auto-review"},
+		{name: "full access", raw: "full-access", want: "full-access"},
+		{name: "danger full access", raw: "danger-full-access", want: "full-access"},
+		{name: "bypassPermissions legacy alias", raw: "bypassPermissions", want: "full-access"},
+		{name: "yolo legacy alias", raw: "yolo", want: "full-access"},
+		{name: "full auto legacy alias", raw: "full-auto", want: "default"},
+		{name: "auto edit legacy alias", raw: "auto-edit", want: "default"},
+		{name: "unknown falls back to default", raw: "unknown", want: "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeMode(tt.raw); got != tt.want {
+				t.Fatalf("normalizeMode(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPermissionModes_CodexShowsCurrentPresets(t *testing.T) {
+	agent := &Agent{}
+	got := agent.PermissionModes()
+	want := []string{"default", "auto-review", "full-access"}
+	if len(got) != len(want) {
+		t.Fatalf("PermissionModes len = %d, want %d, got=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Key != want[i] {
+			t.Fatalf("PermissionModes[%d].Key = %q, want %q, got=%v", i, got[i].Key, want[i], got)
+		}
+	}
+}
+
 func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
-	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "o3", "high", "full-auto", "", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "o3", "high", "default", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -48,7 +91,10 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 	want := []string{
 		"exec",
 		"--skip-git-repo-check",
-		"--full-auto",
+		"-c",
+		`approval_policy="on-request"`,
+		"-c",
+		`sandbox_mode="workspace-write"`,
 		"--model",
 		"o3",
 		"-c",
@@ -65,6 +111,69 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 		if args[i] != want[i] {
 			t.Fatalf("args[%d] = %q, want %q, args=%v", i, args[i], want[i], args)
 		}
+	}
+}
+
+func TestBuildExecArgs_CodexPermissionModes(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      string
+		wantSeqs  [][]string
+		absentArg string
+	}{
+		{
+			name: "default uses Codex default preset",
+			mode: "default",
+			wantSeqs: [][]string{
+				{"-c", `approval_policy="on-request"`},
+				{"-c", `sandbox_mode="workspace-write"`},
+			},
+			absentArg: "--dangerously-bypass-approvals-and-sandbox",
+		},
+		{
+			name: "auto review routes approvals to reviewer",
+			mode: "auto-review",
+			wantSeqs: [][]string{
+				{"-c", `approval_policy="on-request"`},
+				{"-c", `sandbox_mode="workspace-write"`},
+				{"-c", `approvals_reviewer="auto_review"`},
+			},
+			absentArg: "--dangerously-bypass-approvals-and-sandbox",
+		},
+		{
+			name: "full access bypasses sandbox and approvals",
+			mode: "full-access",
+			wantSeqs: [][]string{
+				{"--dangerously-bypass-approvals-and-sandbox"},
+			},
+			absentArg: `approvals_reviewer="auto_review"`,
+		},
+		{
+			name: "bypassPermissions legacy alias is full access",
+			mode: "bypassPermissions",
+			wantSeqs: [][]string{
+				{"--dangerously-bypass-approvals-and-sandbox"},
+			},
+			absentArg: `sandbox_mode="workspace-write"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", tt.mode, "", "", nil, "")
+			if err != nil {
+				t.Fatalf("newCodexSession: %v", err)
+			}
+			args := cs.buildExecArgs("hello", nil)
+			for _, want := range tt.wantSeqs {
+				if !containsSequence(args, want) {
+					t.Fatalf("args missing %v: %v", want, args)
+				}
+			}
+			if tt.absentArg != "" && containsArg(args, tt.absentArg) {
+				t.Fatalf("args unexpectedly contain %q: %v", tt.absentArg, args)
+			}
+		})
 	}
 }
 
@@ -584,6 +693,15 @@ func containsSequence(args, want []string) bool {
 			}
 		}
 		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
 			return true
 		}
 	}

--- a/config.example.toml
+++ b/config.example.toml
@@ -1281,13 +1281,16 @@ app_secret = "your-feishu-app-secret"
 #
 # [projects.agent.options]
 # work_dir = "/path/to/project"
-# mode = "suggest"  # "suggest" | "auto-edit" | "full-auto" | "yolo"
+# mode = "default"  # "default" | "auto-review" | "full-access"
 #
 # Mode options / 模式说明:
-# - "suggest":   ask permission for every tool call (default, safest) / 每次调用都需确认（默认，最安全）
-# - "auto-edit": auto-approve file edits, ask for shell commands / 文件编辑自动通过，Shell 命令仍需确认
-# - "full-auto": auto-approve everything with workspace sandbox / 全部自动通过，工作区沙箱保护
-# - "yolo":      bypass all approvals and sandbox (dangerous) / 跳过所有审批和沙箱（危险）
+# - "default":     Codex default preset: workspace-write sandbox with approvals on request / Codex 默认权限：工作区可写沙箱，按需审批
+# - "auto-review": Codex auto-reviewer handles approval requests / 由 Codex 自动审查器处理审批请求
+# - "full-access": bypass approvals and sandbox (dangerous) / 跳过审批和沙箱（危险）
+# Legacy aliases are accepted for compatibility:
+# 兼容旧别名：
+# - "suggest", "auto-edit", "full-auto" -> "default"
+# - "yolo", "bypassPermissions" -> "full-access"
 #
 # Optional: specify a model / 可选：指定模型
 # model = "o3"

--- a/core/cron.go
+++ b/core/cron.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"reflect"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -80,17 +80,29 @@ func NormalizeCronSessionMode(s string) string {
 	}
 }
 
+func isValidCronMode(mode string) bool {
+	switch mode {
+	case "", "default",
+		"acceptEdits", "plan", "auto", "bypassPermissions", "dontAsk",
+		"auto-review", "autoreview", "auto_review",
+		"full-access", "fullaccess", "full_access", "danger-full-access",
+		"dangerously-bypass", "dangerously-bypass-approvals-and-sandbox",
+		"bypass", "bypasspermissions", "bypass-permissions", "bypass_permissions", "yolo",
+		"suggest", "auto-edit", "autoedit", "auto_edit", "edit",
+		"full-auto", "fullauto", "full_auto":
+		return true
+	default:
+		return false
+	}
+}
+
 func validateCronJob(j *CronJob) error {
 	mode := NormalizeCronSessionMode(j.SessionMode)
 	if mode != "" && mode != "new_per_run" {
 		return fmt.Errorf("invalid session_mode %q (want reuse, new_per_run, or new-per-run)", j.SessionMode)
 	}
-	if j.Mode != "" {
-		switch j.Mode {
-		case "default", "bypassPermissions", "acceptEdits", "plan", "auto", "dontAsk":
-		default:
-			return fmt.Errorf("invalid mode %q (want default, bypassPermissions, acceptEdits, plan, auto, or dontAsk)", j.Mode)
-		}
+	if !isValidCronMode(j.Mode) {
+		return fmt.Errorf("invalid mode %q (want a supported agent permission mode)", j.Mode)
 	}
 	if j.TimeoutMins != nil && *j.TimeoutMins < 0 {
 		return fmt.Errorf("timeout_mins must be >= 0")
@@ -396,13 +408,13 @@ func toExportedFieldName(s string) string {
 
 // CronScheduler runs cron jobs by injecting synthetic messages into engines.
 type CronScheduler struct {
-	store         *CronStore
-	cron          *cron.Cron
-	engines       map[string]*Engine // project name → engine
-	mu            sync.RWMutex
-	entries       map[string]cron.EntryID // job ID → cron entry
-	defaultSilent      bool   // global default for suppressing cron start notifications
-	defaultSessionMode string // global default session mode; "" = reuse, "new_per_run" = fresh session each run
+	store              *CronStore
+	cron               *cron.Cron
+	engines            map[string]*Engine // project name → engine
+	mu                 sync.RWMutex
+	entries            map[string]cron.EntryID // job ID → cron entry
+	defaultSilent      bool                    // global default for suppressing cron start notifications
+	defaultSessionMode string                  // global default session mode; "" = reuse, "new_per_run" = fresh session each run
 }
 
 func NewCronScheduler(store *CronStore) *CronScheduler {
@@ -535,12 +547,8 @@ func (cs *CronScheduler) UpdateJob(id string, field string, value any) error {
 
 	// Validate mode if updating mode field
 	if field == "mode" {
-		if v, ok := value.(string); ok && v != "" {
-			switch v {
-			case "default", "bypassPermissions", "acceptEdits", "plan", "auto", "dontAsk":
-			default:
-				return fmt.Errorf("invalid mode %q (want default, bypassPermissions, acceptEdits, plan, auto, or dontAsk)", v)
-			}
+		if v, ok := value.(string); ok && !isValidCronMode(v) {
+			return fmt.Errorf("invalid mode %q (want a supported agent permission mode)", v)
 		}
 	}
 

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -399,6 +399,41 @@ func TestCronScheduler_AddJob_InvalidSessionMode(t *testing.T) {
 	}
 }
 
+func TestCronScheduler_AddJob_AllowsCodexPermissionModes(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := NewCronScheduler(store)
+
+	for _, mode := range []string{
+		"default",
+		"auto-review",
+		"auto_review",
+		"full-access",
+		"full_access",
+		"bypassPermissions",
+		"bypass",
+		"yolo",
+		"full-auto",
+	} {
+		t.Run(mode, func(t *testing.T) {
+			err := cs.AddJob(&CronJob{
+				ID:         "job-" + strings.ReplaceAll(mode, "-", "_"),
+				Project:    "p",
+				SessionKey: "test:1:1",
+				CronExpr:   "0 6 * * *",
+				Prompt:     "hi",
+				Mode:       mode,
+			})
+			if err != nil {
+				t.Fatalf("AddJob mode %q: %v", mode, err)
+			}
+		})
+	}
+}
+
 func TestCronJob_UsesNewSessionPerRun(t *testing.T) {
 	for _, mode := range []string{"new_per_run", "new-per-run", "NEW_PER_RUN"} {
 		j := &CronJob{SessionMode: mode}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,10 +86,11 @@ All agents support permission modes switchable at runtime via `/mode`.
 
 | Mode | Config Value | Behavior |
 |------|-------------|----------|
-| Suggest | `suggest` | Only trusted commands run without approval |
-| Auto Edit | `auto-edit` | Model decides when to ask |
-| Full Auto | `full-auto` | Auto-approve with sandbox |
-| YOLO | `yolo` | Bypass all approvals and sandbox |
+| Default | `default` | Workspace-write sandbox with approvals on request |
+| Auto Review | `auto-review` | Route approval requests to Codex auto-reviewer |
+| Full Access | `full-access` | Bypass approvals and sandbox |
+
+Legacy aliases are still accepted: `suggest`, `auto-edit`, and `full-auto` map to `default`; `yolo` and `bypassPermissions` map to `full-access`.
 
 ### Cursor Agent Modes
 
@@ -127,7 +128,7 @@ mode = "default"
 Switch at runtime:
 ```
 /mode          # show current and available modes
-/mode yolo     # switch to YOLO mode
+/mode full-access # switch to full access mode
 /mode default  # switch back
 ```
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -84,10 +84,11 @@ reset_on_idle_mins = 60
 
 | 模式 | 配置值 | 行为 |
 |------|--------|------|
-| 建议 | `suggest` | 仅受信命令自动执行 |
-| 自动编辑 | `auto-edit` | 模型自行决定 |
-| 全自动 | `full-auto` | 自动通过 + 沙箱保护 |
-| YOLO | `yolo` | 跳过所有审批 |
+| 默认 | `default` | 工作区可写沙箱，按需审批 |
+| 自动审查 | `auto-review` | 由 Codex 自动审查器处理审批请求 |
+| 完全访问 | `full-access` | 跳过审批和沙箱 |
+
+仍兼容旧别名：`suggest`、`auto-edit`、`full-auto` 会映射到 `default`；`yolo`、`bypassPermissions` 会映射到 `full-access`。
 
 ### Cursor Agent 模式
 
@@ -125,7 +126,7 @@ mode = "default"
 运行时切换：
 ```
 /mode          # 查看当前和可用模式
-/mode yolo     # 切换到 YOLO 模式
+/mode full-access # 切换到完全访问模式
 /mode default  # 切回默认
 ```
 

--- a/web/src/pages/Cron/CronList.tsx
+++ b/web/src/pages/Cron/CronList.tsx
@@ -10,7 +10,8 @@ import { listProjects, type ProjectSummary } from '@/api/projects';
 import { listSessions, type Session } from '@/api/sessions';
 import { formatTime, cn } from '@/lib/utils';
 
-const MODE_OPTIONS = ['bypassPermissions', 'acceptEdits', 'auto', 'plan', 'dontAsk'] as const;
+const DEFAULT_MODE_OPTIONS = ['default', 'bypassPermissions', 'acceptEdits', 'auto', 'plan', 'dontAsk'];
+const CODEX_MODE_OPTIONS = ['default', 'auto-review', 'full-access'];
 
 /* ── Cron presets ── */
 interface CronPreset {
@@ -194,6 +195,15 @@ export default function CronList() {
     () => projects.map(p => ({ value: p.name, label: p.name })),
     [projects],
   );
+
+  const modeOptions = useMemo(() => {
+    const agentType = projects.find(p => p.name === form.project)?.agent_type;
+    const base = agentType === 'codex' ? [...CODEX_MODE_OPTIONS] : [...DEFAULT_MODE_OPTIONS];
+    if (form.mode && !base.includes(form.mode)) {
+      base.push(form.mode);
+    }
+    return base;
+  }, [form.mode, form.project, projects]);
 
   useEffect(() => {
     if (!form.project) { setSessionKeys([]); return; }
@@ -501,7 +511,7 @@ export default function CronList() {
             label={t('cron.mode')}
             value={form.mode}
             onChange={v => setForm({ ...form, mode: v })}
-            options={MODE_OPTIONS.map(m => ({ value: m, label: m }))}
+            options={modeOptions.map(m => ({ value: m, label: m }))}
             placeholder={t('cron.modeDefault')}
           />
 

--- a/web/src/pages/Projects/ProjectDetail.tsx
+++ b/web/src/pages/Projects/ProjectDetail.tsx
@@ -29,6 +29,9 @@ const PLATFORM_OPTIONS: { key: string; label: string; color: string; abbr: strin
   { key: 'weibo', label: 'Weibo (微博)', abbr: 'WB', color: 'bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400' },
 ];
 
+const DEFAULT_MODE_OPTIONS = ['default', 'acceptEdits', 'plan', 'auto', 'bypassPermissions', 'dontAsk'];
+const CODEX_MODE_OPTIONS = ['default', 'auto-review', 'full-access'];
+
 const isQRPlatform = (type: string) => type === 'feishu' || type === 'lark' || type === 'weixin';
 
 type Tab = 'overview' | 'providers' | 'heartbeat' | 'settings';
@@ -82,6 +85,8 @@ export default function ProjectDetail() {
   const navigate = useNavigate();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  const agentModeOptions = selectedAgentType === 'codex' ? CODEX_MODE_OPTIONS : DEFAULT_MODE_OPTIONS;
 
   const handleDeleteProject = async () => {
     if (!name) return;
@@ -516,11 +521,12 @@ export default function ProjectDetail() {
                 onChange={(e) => setAgentMode(e.target.value)}
                 className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-accent/50"
               >
-                <option value="default">default</option>
-                <option value="acceptEdits">acceptEdits (edit)</option>
-                <option value="plan">plan</option>
-                <option value="bypassPermissions">bypassPermissions (yolo)</option>
-                <option value="dontAsk">dontAsk</option>
+                {agentModeOptions.map(mode => (
+                  <option key={mode} value={mode}>{mode}</option>
+                ))}
+                {agentMode && !agentModeOptions.includes(agentMode) && (
+                  <option value={agentMode}>{agentMode}</option>
+                )}
               </select>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Align Codex agent modes with current Codex permission presets: default, auto-review, and full-access.
- Preserve legacy aliases such as suggest, full-auto, yolo, and bypassPermissions for existing configs.
- Keep exec and app-server Codex backends consistent, including approvalsReviewer and sandboxPolicy overrides.
- Allow Codex permission modes in cron overrides and show Codex-specific mode options in the web UI.
- Update Codex docs and example config to describe current modes and compatibility aliases.

## Tests
- go test ./agent/codex ./core
- go test -tags no_web ./...
- pnpm install --frozen-lockfile
- pnpm run build
- go test ./...
- git diff --check