### PR TITLE
fix(claudecode): encode dots in project key to match Claude Code CLI behavior

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -1211,9 +1211,10 @@ func boolVal(m map[string]any, key string) bool {
 //  1. Replacing path separators (/ or \) with "-"
 //  2. Replacing colons (:) with "-" (Windows drive letters)
 //  3. Replacing underscores (_) with "-"
-//  4. Replacing spaces and tildes (~) with "-" (common in macOS iCloud paths like
+//  4. Replacing dots (.) with "-"
+//  5. Replacing spaces and tildes (~) with "-" (common in macOS iCloud paths like
 //     "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/...")
-//  5. Replacing all non-ASCII characters with "-"
+//  6. Replacing all non-ASCII characters with "-"
 func encodeClaudeProjectKey(absPath string) string {
 	// First, normalize to forward slashes for consistent processing
 	normalized := strings.ReplaceAll(absPath, "\\", "/")
@@ -1221,7 +1222,7 @@ func encodeClaudeProjectKey(absPath string) string {
 	// Build the encoded key character by character
 	var result strings.Builder
 	for _, r := range normalized {
-		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' {
+		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' || r == '.' {
 			result.WriteRune('-')
 		} else if r < 128 { // ASCII range (0-127)
 			result.WriteRune(r)

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -403,6 +403,11 @@ func TestEncodeClaudeProjectKey(t *testing.T) {
 			expected: "-Users-username-Library-Mobile-Documents-com-apple-CloudDocs-my-project",
 		},
 		{
+			name:     "path with dots (e.g. username in home dir)",
+			input:    "/home/user.name/project",
+			expected: "-home-user-name-project",
+		},
+		{
 			name:     "mixed ASCII and non-ASCII",
 			input:    "/Users/username/中文folder/english文件夹",
 			expected: "-Users-username---folder-english---", // "/中文" = 3 hyphens, "/文件夹" = 4 hyphens
@@ -497,6 +502,27 @@ func TestFindProjectDir_ICloudPath(t *testing.T) {
 	found := findProjectDir(homeDir, iCloudWorkDir)
 	if found != mockProjectDir {
 		t.Errorf("findProjectDir(%q, %q) = %q, want %q", homeDir, iCloudWorkDir, found, mockProjectDir)
+	}
+}
+
+func TestFindProjectDir_DotInPath(t *testing.T) {
+	// Regression for issue #500: paths containing dots (e.g. /home/user.name/)
+	// must match the on-disk project key that Claude Code CLI generates, which
+	// collapses dots to "-" alongside other special characters.
+	homeDir := t.TempDir()
+	projectsBase := filepath.Join(homeDir, ".claude", "projects")
+
+	workDir := "/home/user.name/project"
+	expectedKey := "-home-user-name-project"
+
+	mockProjectDir := filepath.Join(projectsBase, expectedKey)
+	if err := os.MkdirAll(mockProjectDir, 0755); err != nil {
+		t.Fatalf("failed to create mock project dir: %v", err)
+	}
+
+	found := findProjectDir(homeDir, workDir)
+	if found != mockProjectDir {
+		t.Errorf("findProjectDir(%q, %q) = %q, want %q", homeDir, workDir, found, mockProjectDir)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `encodeClaudeProjectKey` function currently collapses `/`, `:`, `_`, space, `~`, and non-ASCII to `-`, but the Claude Code CLI also collapses **dots (`.`)** to `-` when creating on-disk project keys under `~/.claude/projects/`. This causes a mismatch for home directory paths containing dotted usernames like:

`/home/user.name/project`

The encoded candidate key becomes:

`-home-user.name-project`

while the actual on-disk directory is:

`-home-user-name-project`

The primary lookup, all legacy candidates, and the fallback scan all miss because they all derive from the same `encodeClaudeProjectKey` output. As a result, `findProjectDir` returns `""`, `ListSessions` returns `nil`, and `/list` and `/switch` show "No sessions found".

## Fix

Extend the replacement set in `encodeClaudeProjectKey` to also collapse `'.'` to `'-'`. The function is the single source of truth for path encoding, so this one edit fixes both the primary candidate and the fallback scan. The docstring has been updated to reflect the new step (dot handling is inserted as step 4, renumbering the others).

This complements PR #706 (which fixed the space and `~` variants of issue #500) by covering the remaining dot character case.

## Test plan

- [x] `go test ./agent/claudecode/ -run 'TestEncodeClaudeProjectKey|TestFindProjectDir' -v` — all pass
- [x] One new `TestEncodeClaudeProjectKey` case: "path with dots (e.g. username in home dir)"
- [x] New `TestFindProjectDir_DotInPath` regression test — creates a mock `~/.claude/projects/-home-user-name-project/` directory and asserts `findProjectDir` resolves the dotted work dir
- [x] All pre-existing test cases still pass unchanged
- [x] Full suite: `go test ./...` passes
- [x] Manual confirmation on Linux with a dotted-username home dir: before the fix `/list` returned "No sessions found"; after the fix sessions are visible



Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)