### PR TITLE
fix: use question text as answers key for AskUserQuestion

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2049,7 +2049,9 @@ func buildAskQuestionResponse(originalInput map[string]any, questions []UserQues
 	}
 	answers := make(map[string]any)
 	for idx, ans := range collected {
-		answers[strconv.Itoa(idx)] = ans
+		if idx >= 0 && idx < len(questions) {
+			answers[questions[idx].Question] = ans
+		}
 	}
 	result["answers"] = answers
 	return result

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -4815,16 +4815,16 @@ func TestBuildAskQuestionResponse(t *testing.T) {
 		"questions": []any{map[string]any{"question": "Which?"}},
 	}
 	collected := map[int]string{0: "PostgreSQL", 1: "Gin"}
-	result := buildAskQuestionResponse(input, testQuestions(), collected)
+	result := buildAskQuestionResponse(input, testMultiQuestions(), collected)
 	answers, ok := result["answers"].(map[string]any)
 	if !ok {
 		t.Fatal("expected answers map")
 	}
-	if answers["0"] != "PostgreSQL" {
-		t.Errorf("expected answer[0]=PostgreSQL, got %v", answers["0"])
+	if answers["Which database?"] != "PostgreSQL" {
+		t.Errorf("expected answer[Which database?]=PostgreSQL, got %v", answers["Which database?"])
 	}
-	if answers["1"] != "Gin" {
-		t.Errorf("expected answer[1]=Gin, got %v", answers["1"])
+	if answers["Which framework?"] != "Gin" {
+		t.Errorf("expected answer[Which framework?]=Gin, got %v", answers["Which framework?"])
 	}
 	if _, ok := result["questions"]; !ok {
 		t.Error("expected original questions to be preserved")
@@ -4934,8 +4934,8 @@ func TestHandlePendingPermission_AskUserQuestion_SingleQuestion(t *testing.T) {
 	if !ok {
 		t.Fatal("expected answers in updatedInput")
 	}
-	if answers["0"] != "SQLite" {
-		t.Errorf("expected answer=SQLite, got %v", answers["0"])
+	if answers["Which database?"] != "SQLite" {
+		t.Errorf("expected answer=SQLite, got %v", answers["Which database?"])
 	}
 
 	state.mu.Lock()
@@ -5006,11 +5006,11 @@ func TestHandlePendingPermission_AskUserQuestion_MultiQuestion_Sequential(t *tes
 	if !ok {
 		t.Fatal("expected answers in updatedInput")
 	}
-	if answers["0"] != "PostgreSQL" {
-		t.Errorf("expected answer[0]=PostgreSQL, got %v", answers["0"])
+	if answers["Which database?"] != "PostgreSQL" {
+		t.Errorf("expected answer[Which database?]=PostgreSQL, got %v", answers["Which database?"])
 	}
-	if answers["1"] != "Echo" {
-		t.Errorf("expected answer[1]=Echo, got %v", answers["1"])
+	if answers["Which framework?"] != "Echo" {
+		t.Errorf("expected answer[Which framework?]=Echo, got %v", answers["Which framework?"])
 	}
 
 	state.mu.Lock()
@@ -5058,8 +5058,8 @@ func TestHandlePendingPermission_AskUserQuestion_SkipsPermFlow(t *testing.T) {
 	if !ok {
 		t.Fatal("expected answers in updatedInput")
 	}
-	if answers["0"] != "allow" {
-		t.Errorf("expected free text 'allow' as answer, got %v", answers["0"])
+	if answers["Which database?"] != "allow" {
+		t.Errorf("expected free text 'allow' as answer, got %v", answers["Which database?"])
 	}
 }
 


### PR DESCRIPTION
## Problem

`AskUserQuestion` tool results show empty answers when used through cc-connect.

The `buildAskQuestionResponse` function uses numeric string indices as keys in the `answers` map, but Claude Code appears to expect question text as key.

**Evidence (binary analysis, not official docs):** Used `strings` on Claude Code 2.1.112 and 2.1.123 binaries. Both show:

```
answers: E.record(E.string(), E.string())
  .describe("The answers provided by the user (question text -> answer string)")
```

And the rendering function uses `Object.entries(answers)` to iterate, displaying each entry as `key → value`.

> **Note for reviewers:** This analysis is based on reverse-engineering the Claude Code binary, not official protocol documentation. I could not find public docs for the `--permission-prompt-tool stdio` protocol. If you have access to internal protocol specs or can confirm the expected format, please verify before merging.

## Fix

Change `buildAskQuestionResponse` to use `questions[idx].Question` as the answers key instead of `strconv.Itoa(idx)`:

```go
// Before
answers[strconv.Itoa(idx)] = ans

// After
answers[questions[idx].Question] = ans
```

## Backward Compatibility

Observed the same `E.record(E.string(), E.string())` schema in both 2.1.112 and 2.1.123 binaries, suggesting the format has not changed between versions. However, this is also based on binary analysis — please verify if you have access to version-specific protocol documentation.