### PR TITLE
[codex] steer busy text by default

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -64,6 +64,10 @@ type turnStartResponse struct {
 	} `json:"turn"`
 }
 
+type turnSteerResponse struct {
+	TurnID string `json:"turnId"`
+}
+
 type turnNotification struct {
 	ThreadID string `json:"threadId"`
 	Turn     struct {
@@ -448,6 +452,40 @@ func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, fi
 	s.pendingMsgs = s.pendingMsgs[:0]
 	s.stateMu.Unlock()
 
+	return nil
+}
+
+func (s *appServerSession) Steer(prompt string) error {
+	if !s.alive.Load() {
+		return fmt.Errorf("session is closed")
+	}
+
+	threadID := s.CurrentSessionID()
+	if threadID == "" {
+		return fmt.Errorf("codex app-server thread id is empty")
+	}
+
+	s.stateMu.Lock()
+	turnID := s.currentTurn
+	s.stateMu.Unlock()
+	if turnID == "" {
+		return fmt.Errorf("codex app-server active turn id is empty")
+	}
+
+	params := map[string]any{
+		"threadId": threadID,
+		"input": []map[string]any{{
+			"type":          "text",
+			"text":          prompt,
+			"text_elements": []any{},
+		}},
+		"expectedTurnId": turnID,
+	}
+
+	var resp turnSteerResponse
+	if err := s.request("turn/steer", params, &resp); err != nil {
+		return fmt.Errorf("codex app-server turn/steer: %w", err)
+	}
 	return nil
 }
 

--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -64,6 +64,10 @@ type turnStartResponse struct {
 	} `json:"turn"`
 }
 
+type turnSteerResponse struct {
+	TurnID string `json:"turnId"`
+}
+
 type turnNotification struct {
 	ThreadID string `json:"threadId"`
 	Turn     struct {
@@ -468,6 +472,40 @@ func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, fi
 	s.pendingMsgs = s.pendingMsgs[:0]
 	s.stateMu.Unlock()
 
+	return nil
+}
+
+func (s *appServerSession) Steer(prompt string) error {
+	if !s.alive.Load() {
+		return fmt.Errorf("session is closed")
+	}
+
+	threadID := s.CurrentSessionID()
+	if threadID == "" {
+		return fmt.Errorf("codex app-server thread id is empty")
+	}
+
+	s.stateMu.Lock()
+	turnID := s.currentTurn
+	s.stateMu.Unlock()
+	if turnID == "" {
+		return fmt.Errorf("codex app-server active turn id is empty")
+	}
+
+	params := map[string]any{
+		"threadId": threadID,
+		"input": []map[string]any{{
+			"type":          "text",
+			"text":          prompt,
+			"text_elements": []any{},
+		}},
+		"expectedTurnId": turnID,
+	}
+
+	var resp turnSteerResponse
+	if err := s.request("turn/steer", params, &resp); err != nil {
+		return fmt.Errorf("codex app-server turn/steer: %w", err)
+	}
 	return nil
 }
 

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -3,6 +3,8 @@ package codex
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"sync"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -126,6 +128,51 @@ func TestAppServerSession_HandleThreadTokenUsageUpdatedCachesContextUsage(t *tes
 	}
 }
 
+func TestAppServerSession_SteerUsesActiveTurn(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &appServerSession{
+		ctx:     ctx,
+		pending: make(map[int64]chan rpcResponseEnvelope),
+	}
+	s.alive.Store(true)
+	s.threadID.Store("thread-1")
+	s.currentTurn = "turn-1"
+	w := &captureRPCWriteCloser{t: t, session: s}
+	s.stdin = w
+
+	if err := s.Steer("adjust course"); err != nil {
+		t.Fatalf("Steer() returned error: %v", err)
+	}
+
+	req := w.request()
+	if got := req["method"]; got != "turn/steer" {
+		t.Fatalf("method = %v, want turn/steer", got)
+	}
+	params, ok := req["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("params = %#v, want object", req["params"])
+	}
+	if got := params["threadId"]; got != "thread-1" {
+		t.Fatalf("threadId = %v, want thread-1", got)
+	}
+	if got := params["expectedTurnId"]; got != "turn-1" {
+		t.Fatalf("expectedTurnId = %v, want turn-1", got)
+	}
+	input, ok := params["input"].([]any)
+	if !ok || len(input) != 1 {
+		t.Fatalf("input = %#v, want one item", params["input"])
+	}
+	first, ok := input[0].(map[string]any)
+	if !ok {
+		t.Fatalf("input[0] = %#v, want object", input[0])
+	}
+	if got := first["text"]; got != "adjust course" {
+		t.Fatalf("input text = %v, want adjust course", got)
+	}
+}
+
 func TestMapAppServerRateLimits_PrefersMultiBucketView(t *testing.T) {
 	report := mapAppServerRateLimits(appServerRateLimitsResponse{
 		RateLimits: appServerRateLimitSnapshot{
@@ -161,6 +208,49 @@ func TestMapAppServerRateLimits_PrefersMultiBucketView(t *testing.T) {
 		t.Fatalf("second bucket = %q, want codex_other", report.Buckets[1].Name)
 	}
 }
+
+type captureRPCWriteCloser struct {
+	t       *testing.T
+	session *appServerSession
+	mu      sync.Mutex
+	req     map[string]any
+}
+
+func (w *captureRPCWriteCloser) Write(p []byte) (int, error) {
+	var req map[string]any
+	if err := json.Unmarshal(p, &req); err != nil {
+		w.t.Fatalf("unmarshal request: %v", err)
+	}
+	w.mu.Lock()
+	w.req = req
+	w.mu.Unlock()
+
+	id, ok := rpcIDToInt64(req["id"])
+	if !ok {
+		w.t.Fatalf("request id = %#v, want numeric id", req["id"])
+	}
+	w.session.pendingMu.Lock()
+	ch := w.session.pending[id]
+	w.session.pendingMu.Unlock()
+	if ch == nil {
+		w.t.Fatalf("pending channel for id %d not found", id)
+	}
+	ch <- rpcResponseEnvelope{ID: id, Result: json.RawMessage(`{"turnId":"turn-1"}`)}
+	return len(p), nil
+}
+
+func (w *captureRPCWriteCloser) Close() error { return nil }
+
+func (w *captureRPCWriteCloser) request() map[string]any {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.req == nil {
+		w.t.Fatal("no request captured")
+	}
+	return w.req
+}
+
+var _ io.WriteCloser = (*captureRPCWriteCloser)(nil)
 
 var _ interface {
 	GetUsage(context.Context) (*core.UsageReport, error)

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -382,6 +382,7 @@ func main() {
 				ThinkingMaxLen:   tmlen,
 				ToolMaxLen:       toollen,
 				ToolMessages:     tool,
+				BusyInputMode:    config.EffectiveBusyInputMode(cfg),
 			})
 		}
 
@@ -1393,6 +1394,7 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 		ThinkingMaxLen:   tmlen,
 		ToolMaxLen:       toollen,
 		ToolMessages:     tool,
+		BusyInputMode:    config.EffectiveBusyInputMode(cfg),
 	})
 	result.DisplayUpdated = true
 

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -407,6 +407,7 @@ func main() {
 				ThinkingMaxLen:   tmlen,
 				ToolMaxLen:       toollen,
 				ToolMessages:     tool,
+				BusyInputMode:    config.EffectiveBusyInputMode(cfg, &proj),
 			})
 		}
 
@@ -1441,6 +1442,7 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 		ThinkingMaxLen:   tmlen,
 		ToolMaxLen:       toollen,
 		ToolMessages:     tool,
+		BusyInputMode:    config.EffectiveBusyInputMode(cfg, proj),
 	})
 	result.DisplayUpdated = true
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -91,6 +91,7 @@ level = "info" # debug, info, warn, error
 # thinking_max_len = 300   # Max chars for thinking messages (default: 300) / 思考消息最大字符数（默认 300）
 # tool_max_len = 500       # Max chars for tool use messages (default: 500) / 工具调用消息最大字符数（默认 500）
 # tool_messages = true     # Show/hide tool progress messages (default: true) / 是否显示工具进度消息（默认 true）
+# busy_input_mode = "steer" # steer busy plain text into the active turn; use "queue" to defer / 会话忙时文本默认注入当前任务；设为 "queue" 则排队
 
 # Agent idle timeout: max minutes between consecutive agent events before
 # considering the session stuck. Set to 0 to disable the timeout entirely.

--- a/config.example.toml
+++ b/config.example.toml
@@ -98,6 +98,7 @@ level = "info" # debug, info, warn, error
 # thinking_max_len = 300    # Max chars for thinking messages (default: 300) / 思考消息最大字符数（默认 300）
 # tool_max_len = 500        # Max chars for tool use messages (default: 500) / 工具调用消息最大字符数（默认 500）
 # tool_messages = true      # Show/hide tool progress messages (default: true) / 是否显示工具进度消息（默认 true）
+# busy_input_mode = "steer" # steer busy plain text into the active turn; use "queue" to defer / 会话忙时文本默认注入当前任务；设为 "queue" 则排队
 
 # Per-project override: each [[projects]] entry may have its own [projects.display]
 # block that overrides individual fields of the global [display] block above.

--- a/config/config.go
+++ b/config/config.go
@@ -166,10 +166,11 @@ type ManagementConfig struct {
 
 // DisplayConfig controls how intermediate messages (thinking, tool output) are shown.
 type DisplayConfig struct {
-	ThinkingMessages *bool `toml:"thinking_messages"` // whether thinking messages are shown; default true
-	ThinkingMaxLen   *int  `toml:"thinking_max_len"`  // max chars for thinking messages; 0 = no truncation; default 300
-	ToolMaxLen       *int  `toml:"tool_max_len"`      // max chars for tool use messages; 0 = no truncation; default 500
-	ToolMessages     *bool `toml:"tool_messages"`     // whether tool progress messages are shown; default true
+	ThinkingMessages *bool  `toml:"thinking_messages"` // whether thinking messages are shown; default true
+	ThinkingMaxLen   *int   `toml:"thinking_max_len"`  // max chars for thinking messages; 0 = no truncation; default 300
+	ToolMaxLen       *int   `toml:"tool_max_len"`      // max chars for tool use messages; 0 = no truncation; default 500
+	ToolMessages     *bool  `toml:"tool_messages"`     // whether tool progress messages are shown; default true
+	BusyInputMode    string `toml:"busy_input_mode"`   // "steer" (default) or "queue" for busy-session messages
 }
 
 // StreamPreviewConfig controls real-time streaming preview in IM.
@@ -617,6 +618,18 @@ func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (thinkingMessages, toolM
 		}
 	}
 	return thinkingMessages, toolMessages, thinkingMaxLen, toolMaxLen
+}
+
+func EffectiveBusyInputMode(cfg *Config) string {
+	if cfg == nil {
+		return "steer"
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Display.BusyInputMode)) {
+	case "queue":
+		return "queue"
+	default:
+		return "steer"
+	}
 }
 
 func (c *Config) validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -181,6 +181,7 @@ type DisplayConfig struct {
 	ThinkingMaxLen   *int    `toml:"thinking_max_len"`  // max chars for thinking messages; 0 = no truncation; default 300
 	ToolMaxLen       *int    `toml:"tool_max_len"`      // max chars for tool use messages; 0 = no truncation; default 500
 	ToolMessages     *bool   `toml:"tool_messages"`     // whether tool progress messages are shown; default true
+	BusyInputMode    string  `toml:"busy_input_mode"`   // "steer" (default) or "queue" for busy-session messages
 }
 
 // StreamPreviewConfig controls real-time streaming preview in IM.
@@ -732,6 +733,25 @@ func EffectiveCardMode(cfg *Config, proj *ProjectConfig) string {
 		}
 	}
 	return "legacy"
+}
+
+func EffectiveBusyInputMode(cfg *Config, proj *ProjectConfig) string {
+	if proj != nil && proj.Display != nil && strings.TrimSpace(proj.Display.BusyInputMode) != "" {
+		return normalizeBusyInputMode(proj.Display.BusyInputMode)
+	}
+	if cfg == nil {
+		return "steer"
+	}
+	return normalizeBusyInputMode(cfg.Display.BusyInputMode)
+}
+
+func normalizeBusyInputMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "queue":
+		return "queue"
+	default:
+		return "steer"
+	}
 }
 
 func (c *Config) validate() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -268,6 +268,27 @@ func TestEffectiveDisplayQuiet(t *testing.T) {
 	}
 }
 
+func TestEffectiveBusyInputMode(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{name: "nil defaults steer", cfg: nil, want: "steer"},
+		{name: "empty defaults steer", cfg: &Config{}, want: "steer"},
+		{name: "explicit steer", cfg: &Config{Display: DisplayConfig{BusyInputMode: "steer"}}, want: "steer"},
+		{name: "explicit queue", cfg: &Config{Display: DisplayConfig{BusyInputMode: "queue"}}, want: "queue"},
+		{name: "unknown defaults steer", cfg: &Config{Display: DisplayConfig{BusyInputMode: "drop"}}, want: "steer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EffectiveBusyInputMode(tt.cfg); got != tt.want {
+				t.Fatalf("EffectiveBusyInputMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoad_DefaultsDataDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -465,6 +465,31 @@ func TestValidateProjectDisplayConfig(t *testing.T) {
 	}
 }
 
+func TestEffectiveBusyInputMode(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		proj *ProjectConfig
+		want string
+	}{
+		{name: "nil defaults steer", cfg: nil, want: "steer"},
+		{name: "empty defaults steer", cfg: &Config{}, want: "steer"},
+		{name: "explicit steer", cfg: &Config{Display: DisplayConfig{BusyInputMode: "steer"}}, want: "steer"},
+		{name: "explicit queue", cfg: &Config{Display: DisplayConfig{BusyInputMode: "queue"}}, want: "queue"},
+		{name: "unknown defaults steer", cfg: &Config{Display: DisplayConfig{BusyInputMode: "drop"}}, want: "steer"},
+		{name: "project queue overrides global steer", cfg: &Config{Display: DisplayConfig{BusyInputMode: "steer"}}, proj: &ProjectConfig{Display: &DisplayConfig{BusyInputMode: "queue"}}, want: "queue"},
+		{name: "project steer overrides global queue", cfg: &Config{Display: DisplayConfig{BusyInputMode: "queue"}}, proj: &ProjectConfig{Display: &DisplayConfig{BusyInputMode: "steer"}}, want: "steer"},
+		{name: "empty project falls back global", cfg: &Config{Display: DisplayConfig{BusyInputMode: "queue"}}, proj: &ProjectConfig{Display: &DisplayConfig{}}, want: "queue"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EffectiveBusyInputMode(tt.cfg, tt.proj); got != tt.want {
+				t.Fatalf("EffectiveBusyInputMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoad_DefaultsDataDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/core/engine.go
+++ b/core/engine.go
@@ -137,6 +137,7 @@ type DisplayCfg struct {
 	ThinkingMaxLen   int // max runes for thinking preview; 0 = no truncation
 	ToolMaxLen       int // max runes for tool use preview; 0 = no truncation
 	ToolMessages     bool
+	BusyInputMode    string // "steer" (default) or "queue"
 }
 
 // RateLimitCfg controls per-session message rate limiting.
@@ -394,7 +395,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		cancel:                cancel,
 		i18n:                  NewI18n(lang),
 		attachmentSendEnabled: true,
-		display:               DisplayCfg{ThinkingMessages: true, ThinkingMaxLen: defaultThinkingMaxLen, ToolMaxLen: defaultToolMaxLen, ToolMessages: true},
+		display:               DisplayCfg{ThinkingMessages: true, ThinkingMaxLen: defaultThinkingMaxLen, ToolMaxLen: defaultToolMaxLen, ToolMessages: true, BusyInputMode: "steer"},
 		commands:              NewCommandRegistry(),
 		skills:                NewSkillRegistry(),
 		aliases:               make(map[string]string),
@@ -517,7 +518,15 @@ func (e *Engine) SetTTSSaveFunc(fn func(mode string) error) {
 
 // SetDisplayConfig overrides the default truncation settings.
 func (e *Engine) SetDisplayConfig(cfg DisplayCfg) {
+	cfg.BusyInputMode = normalizeBusyInputMode(cfg.BusyInputMode)
 	e.display = cfg
+}
+
+func normalizeBusyInputMode(mode string) string {
+	if strings.EqualFold(strings.TrimSpace(mode), "queue") {
+		return "queue"
+	}
+	return "steer"
 }
 
 // SetReferenceConfig configures local reference normalization/rendering.
@@ -1689,8 +1698,13 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	session := sessions.GetOrCreateActive(msg.SessionKey)
 	sessions.UpdateUserMeta(msg.SessionKey, msg.UserName, msg.ChatName)
 	if !session.TryLock() {
-		// Session is busy — try to queue the message for the running turn
-		// so the agent processes it immediately after the current turn ends.
+		// Session is busy. Plain text defaults to same-turn steering; media
+		// still queues because mid-turn attachment delivery is backend-specific.
+		if e.steerBusyMessage(p, msg, interactiveKey) {
+			return
+		}
+		// If steering is disabled or unavailable, queue the message so the
+		// agent processes it immediately after the current turn ends.
 		if e.queueMessageForBusySession(p, msg, interactiveKey) {
 			// Race guard: the drain loop in processInteractiveMessageWith may
 			// have just finished (session unlocked) between our TryLock failure
@@ -1721,6 +1735,41 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	)
 
 	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey)
+}
+
+func (e *Engine) steerBusyMessage(p Platform, msg *Message, interactiveKey string) bool {
+	if normalizeBusyInputMode(e.display.BusyInputMode) != "steer" {
+		return false
+	}
+	if strings.TrimSpace(msg.Content) == "" || len(msg.Images) > 0 || len(msg.Files) > 0 {
+		return false
+	}
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[interactiveKey]
+	e.interactiveMu.Unlock()
+	if !ok || state == nil || state.agentSession == nil || !state.agentSession.Alive() {
+		return false
+	}
+
+	prompt := e.buildSenderPrompt(
+		msg.Content,
+		msg.UserID,
+		msg.UserName,
+		msg.Platform,
+		msg.SessionKey,
+	)
+	var err error
+	if steerer, ok := state.agentSession.(AgentSessionSteerer); ok {
+		err = steerer.Steer(prompt)
+	} else {
+		err = state.agentSession.Send(prompt, nil, nil)
+	}
+	if err != nil {
+		slog.Error("busy steer: send failed", "error", err)
+		return false
+	}
+	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsSent))
+	return true
 }
 
 func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session) *Session {

--- a/core/engine.go
+++ b/core/engine.go
@@ -147,6 +147,7 @@ type DisplayCfg struct {
 	ThinkingMaxLen   int // max runes for thinking preview; 0 = no truncation
 	ToolMaxLen       int // max runes for tool use preview; 0 = no truncation
 	ToolMessages     bool
+	BusyInputMode    string // "steer" (default) or "queue"
 }
 
 // InstantReplyCfg controls the immediate confirmation reply sent when a message
@@ -415,7 +416,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		cancel:                cancel,
 		i18n:                  NewI18n(lang),
 		attachmentSendEnabled: true,
-		display:               DisplayCfg{Mode: "full", ThinkingMessages: true, ThinkingMaxLen: defaultThinkingMaxLen, ToolMaxLen: defaultToolMaxLen, ToolMessages: true, CardMode: "legacy"},
+		display:               DisplayCfg{Mode: "full", CardMode: "legacy", ThinkingMessages: true, ThinkingMaxLen: defaultThinkingMaxLen, ToolMaxLen: defaultToolMaxLen, ToolMessages: true, BusyInputMode: "steer"},
 		commands:              NewCommandRegistry(),
 		skills:                NewSkillRegistry(),
 		aliases:               make(map[string]string),
@@ -538,12 +539,20 @@ func (e *Engine) SetTTSSaveFunc(fn func(mode string) error) {
 
 // SetDisplayConfig overrides the default truncation settings.
 func (e *Engine) SetDisplayConfig(cfg DisplayCfg) {
+	cfg.BusyInputMode = normalizeBusyInputMode(cfg.BusyInputMode)
 	e.display = cfg
 }
 
 // SetInstantReply configures the immediate confirmation reply.
 func (e *Engine) SetInstantReply(cfg InstantReplyCfg) {
 	e.instantReply = cfg
+}
+
+func normalizeBusyInputMode(mode string) string {
+	if strings.EqualFold(strings.TrimSpace(mode), "queue") {
+		return "queue"
+	}
+	return "steer"
 }
 
 // SetReferenceConfig configures local reference normalization/rendering.
@@ -2059,8 +2068,13 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
 			return
 		}
-		// Session is busy — try to queue the message for the running turn
-		// so the agent processes it immediately after the current turn ends.
+		// Session is busy. Plain text defaults to same-turn steering; media
+		// still queues because mid-turn attachment delivery is backend-specific.
+		if e.steerBusyMessage(p, msg, interactiveKey) {
+			return
+		}
+		// If steering is disabled or unavailable, queue the message so the
+		// agent processes it immediately after the current turn ends.
 		if e.queueMessageForBusySession(p, msg, interactiveKey) {
 			// Race guard: the drain loop in processInteractiveMessageWith may
 			// have just finished (session unlocked) between our TryLock failure
@@ -2092,6 +2106,41 @@ sessionLocked:
 	)
 
 	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey)
+}
+
+func (e *Engine) steerBusyMessage(p Platform, msg *Message, interactiveKey string) bool {
+	if normalizeBusyInputMode(e.display.BusyInputMode) != "steer" {
+		return false
+	}
+	if strings.TrimSpace(msg.Content) == "" || len(msg.Images) > 0 || len(msg.Files) > 0 {
+		return false
+	}
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[interactiveKey]
+	e.interactiveMu.Unlock()
+	if !ok || state == nil || state.agentSession == nil || !state.agentSession.Alive() {
+		return false
+	}
+
+	prompt := e.buildSenderPrompt(
+		msg.Content,
+		msg.UserID,
+		msg.UserName,
+		msg.Platform,
+		msg.SessionKey,
+		msg.ChannelKey,
+	)
+	steerer, ok := state.agentSession.(AgentSessionSteerer)
+	if !ok {
+		return false
+	}
+	err := steerer.Steer(prompt)
+	if err != nil {
+		slog.Error("busy steer: send failed", "error", err)
+		return false
+	}
+	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsSent))
+	return true
 }
 
 func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session) *Session {
@@ -3087,7 +3136,6 @@ func buildCardContent(thinking string, tools []cardToolEntry, answer string) str
 	return sb.String()
 }
 
-
 // unsolicitedReaderStopTimeout bounds how long stopUnsolicitedReader waits
 // for the reader goroutine to exit. The reader is structured so its iterations
 // are short (blocking adapter calls like RespondPermission are offloaded), so
@@ -3430,8 +3478,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 	// Streaming card: aggregate entire turn into a single updatable card.
 	var streamCard StreamingCard
-	var cardToolCalls []cardToolEntry // track tool calls for card content
-	var cardThinkingText string       // latest thinking text
+	var cardToolCalls []cardToolEntry  // track tool calls for card content
+	var cardThinkingText string        // latest thinking text
 	var cardAnswerText strings.Builder // accumulated answer text
 
 	if scp, ok := state.platform.(StreamingCardPlatform); ok {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6311,6 +6311,96 @@ func TestQueueMessageForBusySession_FIFODequeue(t *testing.T) {
 	state.mu.Unlock()
 }
 
+func TestHandleMessage_BusyPlainTextDefaultsToSteer(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("busy-steer")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	if !session.TryLock() {
+		t.Fatal("expected to lock session")
+	}
+	defer session.Unlock()
+
+	state := &interactiveState{agentSession: sess, platform: p, replyCtx: "ctx1"}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	e.handleMessage(p, &Message{
+		Platform:   "test",
+		SessionKey: key,
+		Content:    "adjust the current approach",
+		ReplyCtx:   "ctx-followup",
+	})
+
+	sess.sendMu.Lock()
+	sendCalls := append([]string(nil), sess.sendCalls...)
+	sess.sendMu.Unlock()
+	if len(sendCalls) != 1 {
+		t.Fatalf("sendCalls len = %d, want 1 (%v)", len(sendCalls), sendCalls)
+	}
+	if sendCalls[0] != "adjust the current approach" {
+		t.Fatalf("sent prompt = %q", sendCalls[0])
+	}
+
+	state.mu.Lock()
+	pendingLen := len(state.pendingMessages)
+	state.mu.Unlock()
+	if pendingLen != 0 {
+		t.Fatalf("pendingMessages len = %d, want 0", pendingLen)
+	}
+	if sent := p.getSent(); len(sent) != 1 || !strings.Contains(sent[0], e.i18n.T(MsgPsSent)) {
+		t.Fatalf("sent replies = %v, want ps ack", sent)
+	}
+}
+
+func TestHandleMessage_BusyInputModeQueueKeepsQueueing(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("busy-queue")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{ThinkingMessages: true, ToolMessages: true, BusyInputMode: "queue"})
+
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	if !session.TryLock() {
+		t.Fatal("expected to lock session")
+	}
+	defer session.Unlock()
+
+	state := &interactiveState{agentSession: sess, platform: p, replyCtx: "ctx1"}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	e.handleMessage(p, &Message{
+		Platform:   "test",
+		SessionKey: key,
+		Content:    "later",
+		ReplyCtx:   "ctx-followup",
+	})
+
+	sess.sendMu.Lock()
+	sendCalls := append([]string(nil), sess.sendCalls...)
+	sess.sendMu.Unlock()
+	if len(sendCalls) != 0 {
+		t.Fatalf("sendCalls = %v, want none", sendCalls)
+	}
+
+	state.mu.Lock()
+	pendingLen := len(state.pendingMessages)
+	state.mu.Unlock()
+	if pendingLen != 1 {
+		t.Fatalf("pendingMessages len = %d, want 1", pendingLen)
+	}
+	if sent := p.getSent(); len(sent) != 1 || !strings.Contains(sent[0], e.i18n.T(MsgMessageQueued)) {
+		t.Fatalf("sent replies = %v, want queued ack", sent)
+	}
+}
+
 func TestProcessInteractiveEvents_DrainsQueuedMessages(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newQueuingSession("qs2")

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6392,6 +6392,23 @@ func (s *queuingAgentSession) Send(prompt string, _ []ImageAttachment, _ []FileA
 	return nil
 }
 
+type steerableQueuingSession struct {
+	*queuingAgentSession
+	steerCalls []string
+	steerMu    sync.Mutex
+}
+
+func newSteerableQueuingSession(id string) *steerableQueuingSession {
+	return &steerableQueuingSession{queuingAgentSession: newQueuingSession(id)}
+}
+
+func (s *steerableQueuingSession) Steer(prompt string) error {
+	s.steerMu.Lock()
+	s.steerCalls = append(s.steerCalls, prompt)
+	s.steerMu.Unlock()
+	return nil
+}
+
 // blockingSendAgentSession blocks in Send until unblock is closed, mimicking agents
 // whose Send does not return until the prompt turn completes (e.g. ACP session/prompt).
 type blockingSendAgentSession struct {
@@ -6740,6 +6757,146 @@ func TestQueueMessageForBusySession_FIFODequeue(t *testing.T) {
 			state.pendingMessages[0].content, state.pendingMessages[1].content)
 	}
 	state.mu.Unlock()
+}
+
+func TestHandleMessage_BusyPlainTextDefaultsToSteer(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newSteerableQueuingSession("busy-steer")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	if !session.TryLock() {
+		t.Fatal("expected to lock session")
+	}
+	defer session.Unlock()
+
+	state := &interactiveState{agentSession: sess, platform: p, replyCtx: "ctx1"}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	e.handleMessage(p, &Message{
+		Platform:   "test",
+		SessionKey: key,
+		Content:    "adjust the current approach",
+		ReplyCtx:   "ctx-followup",
+	})
+
+	sess.steerMu.Lock()
+	steerCalls := append([]string(nil), sess.steerCalls...)
+	sess.steerMu.Unlock()
+	if len(steerCalls) != 1 {
+		t.Fatalf("steerCalls len = %d, want 1 (%v)", len(steerCalls), steerCalls)
+	}
+	if steerCalls[0] != "adjust the current approach" {
+		t.Fatalf("steered prompt = %q", steerCalls[0])
+	}
+
+	sess.sendMu.Lock()
+	sendCalls := append([]string(nil), sess.sendCalls...)
+	sess.sendMu.Unlock()
+	if len(sendCalls) != 0 {
+		t.Fatalf("sendCalls = %v, want none", sendCalls)
+	}
+
+	state.mu.Lock()
+	pendingLen := len(state.pendingMessages)
+	state.mu.Unlock()
+	if pendingLen != 0 {
+		t.Fatalf("pendingMessages len = %d, want 0", pendingLen)
+	}
+	if sent := p.getSent(); len(sent) != 1 || !strings.Contains(sent[0], e.i18n.T(MsgPsSent)) {
+		t.Fatalf("sent replies = %v, want ps ack", sent)
+	}
+}
+
+func TestHandleMessage_BusyPlainTextQueuesWhenSteerUnsupported(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("busy-no-steer")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	if !session.TryLock() {
+		t.Fatal("expected to lock session")
+	}
+	defer session.Unlock()
+
+	state := &interactiveState{agentSession: sess, platform: p, replyCtx: "ctx1"}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	e.handleMessage(p, &Message{
+		Platform:   "test",
+		SessionKey: key,
+		Content:    "later",
+		ReplyCtx:   "ctx-followup",
+	})
+
+	sess.sendMu.Lock()
+	sendCalls := append([]string(nil), sess.sendCalls...)
+	sess.sendMu.Unlock()
+	if len(sendCalls) != 0 {
+		t.Fatalf("sendCalls = %v, want none", sendCalls)
+	}
+
+	state.mu.Lock()
+	pendingLen := len(state.pendingMessages)
+	state.mu.Unlock()
+	if pendingLen != 1 {
+		t.Fatalf("pendingMessages len = %d, want 1", pendingLen)
+	}
+	if sent := p.getSent(); len(sent) != 1 || !strings.Contains(sent[0], e.i18n.T(MsgMessageQueued)) {
+		t.Fatalf("sent replies = %v, want queued ack", sent)
+	}
+}
+
+func TestHandleMessage_BusyInputModeQueueKeepsQueueing(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("busy-queue")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{ThinkingMessages: true, ToolMessages: true, BusyInputMode: "queue"})
+
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	if !session.TryLock() {
+		t.Fatal("expected to lock session")
+	}
+	defer session.Unlock()
+
+	state := &interactiveState{agentSession: sess, platform: p, replyCtx: "ctx1"}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	e.handleMessage(p, &Message{
+		Platform:   "test",
+		SessionKey: key,
+		Content:    "later",
+		ReplyCtx:   "ctx-followup",
+	})
+
+	sess.sendMu.Lock()
+	sendCalls := append([]string(nil), sess.sendCalls...)
+	sess.sendMu.Unlock()
+	if len(sendCalls) != 0 {
+		t.Fatalf("sendCalls = %v, want none", sendCalls)
+	}
+
+	state.mu.Lock()
+	pendingLen := len(state.pendingMessages)
+	state.mu.Unlock()
+	if pendingLen != 1 {
+		t.Fatalf("pendingMessages len = %d, want 1", pendingLen)
+	}
+	if sent := p.getSent(); len(sent) != 1 || !strings.Contains(sent[0], e.i18n.T(MsgMessageQueued)) {
+		t.Fatalf("sent replies = %v, want queued ack", sent)
+	}
 }
 
 func TestProcessInteractiveEvents_DrainsQueuedMessages(t *testing.T) {
@@ -10871,9 +11028,9 @@ func (p *stubStreamingCardPlatform) CreateStreamingCard(_ context.Context, _ any
 // stubStreamingCard is a minimal StreamingCard for tests.
 type stubStreamingCard struct{}
 
-func (c *stubStreamingCard) Update(_ context.Context, _ string) error { return nil }
+func (c *stubStreamingCard) Update(_ context.Context, _ string) error   { return nil }
 func (c *stubStreamingCard) Finalize(_ context.Context, _ string) error { return nil }
-func (c *stubStreamingCard) Failed() bool                                { return false }
+func (c *stubStreamingCard) Failed() bool                               { return false }
 
 func TestHandleMessage_InstantReply_SendsConfirmationWhenEnabled(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -269,6 +269,12 @@ type AgentSession interface {
 	Close() error
 }
 
+// AgentSessionSteerer injects user input into an active turn without starting
+// a new turn.
+type AgentSessionSteerer interface {
+	Steer(prompt string) error
+}
+
 // PermissionResult represents the user's decision on a permission request.
 type PermissionResult struct {
 	Behavior     string         `json:"behavior"`               // "allow" or "deny"

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -298,6 +298,12 @@ type AgentSession interface {
 	Close() error
 }
 
+// AgentSessionSteerer injects user input into an active turn without starting
+// a new turn.
+type AgentSessionSteerer interface {
+	Steer(prompt string) error
+}
+
 // PermissionResult represents the user's decision on a permission request.
 type PermissionResult struct {
 	Behavior     string         `json:"behavior"`               // "allow" or "deny"


### PR DESCRIPTION
## Summary

- default busy plain-text messages to same-turn steering instead of enqueueing for later
- add `display.busy_input_mode = "queue"` as an opt-out for the previous queue behavior
- wire Codex app-server sessions to native `turn/steer` with the active `expectedTurnId`

## Behavior

Plain text sent while a session is busy now uses the active turn when steering is available. Empty messages, media/file messages, unavailable sessions, failed steering, and explicit `busy_input_mode = "queue"` continue to use the existing busy queue fallback.

Related but not duplicate: #523 adds an opt-in busy action mode, #669 adds an explicit `/steer` command, and #707 handles pre-execution message collection while leaving in-flight continuation unchanged.

## Validation

- `go test ./config ./core ./agent/codex ./cmd/cc-connect`