### PR TITLE
fix(core): resolve socket path via dataDir and inject CC_CONNECT_SOCK…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ Optional capability interfaces (implement only when needed):
 - `ProviderSwitcher` — multi-model switching
 - `DoctorChecker` — agent-specific health checks
 - `AgentDoctorInfo` — CLI binary metadata for diagnostics
+- `SessionResumer` — reconstruct agent sessions from inherited FDs (zero-downtime restart)
+- `SessionRestartDataExporter` — export agent session pipe FDs before daemon restart
 
 ## Development Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.3.3-beta.2 (2026-05-03)
+
+Beta release with zero-downtime restart support and session persistence.
+
+### New Features
+- **Zero-downtime restart (SIGHUP)**: send `SIGHUP` to the cc-connect process to perform a graceful restart without interrupting active agent sessions. The daemon exports running session pipe FDs, `exec`s the same binary, and reconstructs sessions from inherited file descriptors — no message loss, no reconfiguration needed. (#XXX)
+- **`SessionResumer` / `SessionRestartDataExporter` interfaces**: two new optional capability interfaces in `core/` that enable agents to opt into session preservation across restarts. Claude Code agent ships with full support; other agents can implement `ExportRestartData()` and `ResumeSession()` to participate.
+
+### Fixed
+- **Session close on restart**: engine `Stop()` no longer closes agent sessions during a restart — FDs are dup'd without CLOEXEC and inherited by the new process.
+
 ## v1.3.3-beta.1 (2026-04-25)
 
 Beta release with new agents, new features, and broad platform fixes. No breaking changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Optional capability interfaces (implement only when needed):
 - `ProviderSwitcher` — multi-model switching
 - `DoctorChecker` — agent-specific health checks
 - `AgentDoctorInfo` — CLI binary metadata for diagnostics
+- `SessionResumer` — reconstruct agent sessions from inherited FDs (zero-downtime restart)
+- `SessionRestartDataExporter` — export agent session pipe FDs before daemon restart
 
 ## Development Rules
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -739,6 +739,27 @@ Logs auto-rotate at the configured max size and keep one backup.
 cc-connect daemon uninstall
 ```
 
+### Zero-Downtime Restart
+
+cc-connect supports graceful restart via `SIGHUP` — running agent sessions are preserved across the restart without message loss:
+
+```bash
+# Find the cc-connect PID and send SIGHUP
+kill -HUP $(pidof cc-connect)
+
+# Or if using systemd
+systemctl kill -s HUP --user cc-connect
+```
+
+On `SIGHUP`, cc-connect:
+1. Exports all active agent session pipe FDs (with `CLOEXEC` cleared so they survive `exec`)
+2. Saves restart metadata to `{data_dir}/run/restart_sessions_{project}.json`
+3. `exec`s the same binary with the same arguments
+4. On startup, reads the restart state file, reconstructs sessions from inherited FDs
+5. Resumes normal message processing — user messages seamlessly continue existing sessions
+
+If the agent supports the `SessionResumer` interface (Claude Code ships with full support), agent CLI processes also survive the restart.
+
 ## Additional Features
 
 The following additional features are available:

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -414,6 +414,12 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	return newClaudeSession(ctx, a.workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, a.mode, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
 }
 
+// ResumeSession implements core.SessionResumer. It reconstructs a running
+// Claude Code session from file descriptors inherited after a server restart.
+func (a *Agent) ResumeSession(ctx context.Context, data core.SessionRestartData) (core.AgentSession, error) {
+	return restoreClaudeSessionFromFDs(ctx, data)
+}
+
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -43,6 +43,10 @@ type claudeSession struct {
 	done            chan struct{}
 	alive           atomic.Bool
 
+	// Raw pipe FDs for zero-downtime restart export.
+	stdinFD  int
+	stdoutFD int
+
 	// gracefulStopTimeout is how long Close() waits for a clean exit
 	// (stdin close → Stop hooks → process exit) before escalating to
 	// SIGTERM and then SIGKILL. Default: 120s to match claude-mem's
@@ -197,6 +201,13 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		done:                make(chan struct{}),
 		gracefulStopTimeout: 120 * time.Second,
 	}
+	// Extract raw pipe FDs for zero-downtime restart export.
+	if f, ok := stdin.(interface{ Fd() uintptr }); ok {
+		cs.stdinFD = int(f.Fd())
+	}
+	if f, ok := stdout.(interface{ Fd() uintptr }); ok {
+		cs.stdoutFD = int(f.Fd())
+	}
 	cs.setPermissionMode(mode)
 	cs.sessionID.Store(sessionID)
 	cs.alive.Store(true)
@@ -207,7 +218,15 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 }
 
 func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
-	waitErrCh, waitDone := cs.startReadLoopWait(stdout)
+	var waitErrCh <-chan error
+	var waitDone <-chan struct{}
+	if cs.cmd != nil {
+		waitErrCh, waitDone = cs.startReadLoopWait(stdout)
+	} else {
+		// Restored session (zero-downtime restart): cmd is nil because the
+		// original exec.Cmd was lost. We poll the PID for liveness instead.
+		waitErrCh, waitDone = cs.startRestoredReadLoopWait(stdout)
+	}
 	defer cs.finishReadLoop(waitErrCh, stderrBuf)
 
 	scanner := bufio.NewScanner(stdout)
@@ -245,6 +264,28 @@ func (cs *claudeSession) startReadLoopWait(stdout io.ReadCloser) (<-chan error, 
 			return
 		case <-time.After(50 * time.Millisecond):
 		}
+		_ = stdout.Close()
+	}()
+
+	return waitErrCh, waitDone
+}
+
+// startRestoredReadLoopWait is used when the session was reconstructed from
+// inherited FDs after a zero-downtime restart. We can't call cmd.Wait()
+// because cmd is nil, so we poll the PID for liveness instead.
+func (cs *claudeSession) startRestoredReadLoopWait(stdout io.ReadCloser) (<-chan error, <-chan struct{}) {
+	waitErrCh := make(chan error, 1)
+	waitDone := make(chan struct{})
+
+	// For restored sessions cmd is nil, so we can't call cmd.Wait().
+	// Send nil immediately — finishReadLoop will proceed as soon as the
+	// scanner returns EOF (child closed stdout or was killed).
+	waitErrCh <- nil
+	close(waitDone)
+
+	// Second goroutine: clean up stdout when the session is cancelled.
+	go func() {
+		<-cs.ctx.Done()
 		_ = stdout.Close()
 	}()
 
@@ -774,4 +815,129 @@ func filterEnv(env []string, key string) []string {
 		}
 	}
 	return out
+}
+
+// ExportRestartData implements core.SessionRestartDataExporter.
+// It dups the pipe FDs without CLOEXEC so they survive exec.
+func (cs *claudeSession) ExportRestartData() (*core.SessionRestartData, error) {
+	// Dup stdin FD (write end) without CLOEXEC.
+	stdinDup, err := syscall.Dup(cs.stdinFD)
+	if err != nil {
+		return nil, fmt.Errorf("dup stdin fd %d: %w", cs.stdinFD, err)
+	}
+	// Clear CLOEXEC on the dup'd fd so it survives exec.
+	if err := setFDCloexec(stdinDup, false); err != nil {
+		syscall.Close(stdinDup)
+		return nil, fmt.Errorf("clear CLOEXEC on stdin fd %d: %w", stdinDup, err)
+	}
+
+	// Dup stdout FD (read end) without CLOEXEC.
+	stdoutDup, err := syscall.Dup(cs.stdoutFD)
+	if err != nil {
+		syscall.Close(stdinDup)
+		return nil, fmt.Errorf("dup stdout fd %d: %w", cs.stdoutFD, err)
+	}
+	if err := setFDCloexec(stdoutDup, false); err != nil {
+		syscall.Close(stdinDup)
+		syscall.Close(stdoutDup)
+		return nil, fmt.Errorf("clear CLOEXEC on stdout fd %d: %w", stdoutDup, err)
+	}
+
+	pid := 0
+	if cs.cmd != nil && cs.cmd.Process != nil {
+		pid = cs.cmd.Process.Pid
+	}
+
+	return &core.SessionRestartData{
+		StdinFD:        stdinDup,
+		StdoutFD:       stdoutDup,
+		AgentPID:       pid,
+		WorkDir:        cs.workDir,
+		AgentSessionID: cs.CurrentSessionID(),
+		PermissionMode: cs.getPermissionMode(),
+	}, nil
+}
+
+func (cs *claudeSession) getPermissionMode() string {
+	if v := cs.permissionMode.Load(); v != nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// setFDCloexec sets or clears the CLOEXEC flag on a file descriptor.
+func setFDCloexec(fd int, cloexec bool) error {
+	// Use raw syscall for F_GETFD/F_SETFD since FcntlInt is not available on all platforms.
+	raw := uintptr(fd)
+	flags, _, err := syscall.Syscall(syscall.SYS_FCNTL, raw, syscall.F_GETFD, 0)
+	if err != 0 {
+		return err
+	}
+	if cloexec {
+		flags |= syscall.FD_CLOEXEC
+	} else {
+		flags &^= syscall.FD_CLOEXEC
+	}
+	_, _, err = syscall.Syscall(syscall.SYS_FCNTL, raw, syscall.F_SETFD, flags)
+	if err != 0 {
+		return err
+	}
+	return nil
+}
+
+// restoreClaudeSessionFromFDs reconstructs a claudeSession from dup'd FDs
+// after a zero-downtime server restart. The FDs were dup'd without CLOEXEC
+// and are now owned by this session.
+func restoreClaudeSessionFromFDs(ctx context.Context, data core.SessionRestartData) (*claudeSession, error) {
+	sessionCtx, cancel := context.WithCancel(ctx)
+
+	// Recreate the stdin pipe from the inherited FD.
+	stdinFile := os.NewFile(uintptr(data.StdinFD), "restored-stdin")
+	if stdinFile == nil {
+		cancel()
+		return nil, fmt.Errorf("restore stdin: os.NewFile(%d) failed", data.StdinFD)
+	}
+	// Restore CLOEXEC so the fd is cleaned up on future execs.
+	_ = setFDCloexec(data.StdinFD, true)
+
+	// Recreate the stdout pipe from the inherited FD.
+	stdoutFile := os.NewFile(uintptr(data.StdoutFD), "restored-stdout")
+	if stdoutFile == nil {
+		stdinFile.Close()
+		cancel()
+		return nil, fmt.Errorf("restore stdout: os.NewFile(%d) failed", data.StdoutFD)
+	}
+	_ = setFDCloexec(data.StdoutFD, true)
+
+	alive := true
+	if data.AgentPID > 0 {
+		// Check if process is still alive (signal 0 = test, no actual signal sent).
+		err := syscall.Kill(data.AgentPID, syscall.Signal(0))
+		if err != nil {
+			alive = false
+		}
+	}
+
+	cs := &claudeSession{
+		cmd:                 nil, // cmd is nil — we only have the FDs, not the exec.Cmd
+		stdin:               stdinFile,
+		stdinFD:             data.StdinFD,
+		stdoutFD:            data.StdoutFD,
+		events:              make(chan core.Event, 64),
+		workDir:             data.WorkDir,
+		ctx:                 sessionCtx,
+		cancel:              cancel,
+		done:                make(chan struct{}),
+		gracefulStopTimeout: 120 * time.Second,
+	}
+	cs.sessionID.Store(data.AgentSessionID)
+	cs.setPermissionMode(data.PermissionMode)
+	cs.alive.Store(alive)
+
+	// Start readLoop on the restored stdout FD.
+	go cs.readLoop(stdoutFile, nil)
+
+	return cs, nil
 }

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -3,9 +3,12 @@ package claudecode
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -137,9 +140,6 @@ func TestReadLoop_CtxCancelClosesChannels(t *testing.T) {
 		_ = pw.Close()
 	})
 
-	// "err-then-sleep" emits stderr before sleeping so that ctx cancel
-	// produces a non-empty stderrBuf in readLoop's defer — exercising the
-	// `case <-cs.ctx.Done()` select branch in finishReadLoop.
 	cmd := helperCommand(ctx, "err-then-sleep")
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
@@ -254,6 +254,261 @@ func TestShellJoinArgs(t *testing.T) {
 	}
 }
 
+// -- Zero-downtime restart tests --
+
+// TestExportAndRestoreSession verifies that a session's pipe FDs can be
+// exported and then used to reconstruct a working session connected to the
+// same agent process.
+func TestExportAndRestoreSession(t *testing.T) {
+	// Start agent process WITHOUT context binding so that the parent ctx
+	// can be cancelled without killing the agent.
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", "stdin-eof-exit")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	childPID := cmd.Process.Pid
+	t.Logf("agent pid=%d", childPID)
+
+	// Create session with pipes but DON'T start readLoop (stdin-eof-exit
+	// doesn't write to stdout, so there's nothing to read).
+	done := make(chan struct{})
+	cs := &claudeSession{
+		cmd:    cmd,
+		stdin:  stdin,
+		events: make(chan core.Event, 8),
+		done:   done,
+	}
+	cs.sessionID.Store("test-export-restore")
+	cs.alive.Store(true)
+
+	// Extract original pipe FDs
+	if f, ok := stdin.(interface{ Fd() uintptr }); ok {
+		cs.stdinFD = int(f.Fd())
+	}
+	if f, ok := stdout.(interface{ Fd() uintptr }); ok {
+		cs.stdoutFD = int(f.Fd())
+	}
+	t.Logf("original FDs: stdinFD=%d stdoutFD=%d", cs.stdinFD, cs.stdoutFD)
+
+	// Export: dups FDs and clears CLOEXEC
+	restartData, err := cs.ExportRestartData()
+	if err != nil {
+		t.Fatal("ExportRestartData:", err)
+	}
+	t.Logf("exported: stdinFD=%d stdoutFD=%d agentPID=%d",
+		restartData.StdinFD, restartData.StdoutFD, restartData.AgentPID)
+
+	// Validate dup'd FDs
+	var stat syscall.Stat_t
+	if err := syscall.Fstat(restartData.StdinFD, &stat); err != nil {
+		t.Fatal("exported stdin FD invalid:", err)
+	}
+	if err := syscall.Fstat(restartData.StdoutFD, &stat); err != nil {
+		t.Fatal("exported stdout FD invalid:", err)
+	}
+	for _, fd := range []int{restartData.StdinFD, restartData.StdoutFD} {
+		flags, _, err := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_GETFD, 0)
+		if err != 0 {
+			t.Fatalf("F_GETFD failed for fd %d: %v", fd, err)
+		}
+		if flags&syscall.FD_CLOEXEC != 0 {
+			t.Fatalf("fd %d has CLOEXEC set", fd)
+		}
+	}
+
+	// Close original pipe FDs (simulating exec closing CLOEXEC FDs).
+	// The dup'd FDs remain open and point to the same kernel file descriptions.
+	stdin.Close()
+	stdout.Close()
+
+	// Restore session from exported FDs
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sess, err := restoreClaudeSessionFromFDs(ctx, core.SessionRestartData{
+		StdinFD:        restartData.StdinFD,
+		StdoutFD:       restartData.StdoutFD,
+		AgentPID:       restartData.AgentPID,
+		AgentSessionID: "restored-test-session",
+		PermissionMode: "",
+	})
+	if err != nil {
+		t.Fatal("restoreClaudeSessionFromFDs:", err)
+	}
+	if !sess.Alive() {
+		t.Fatal("restored session not alive")
+	}
+	if sess.CurrentSessionID() != "restored-test-session" {
+		t.Fatalf("session ID mismatch: %q", sess.CurrentSessionID())
+	}
+
+	// Send a message through the restored session
+	if err := sess.Send("hello from restored session", nil, nil); err != nil {
+		t.Fatal("Send failed:", err)
+	}
+	t.Log("Send succeeded on restored session")
+
+	// Close restored session → closes dup'd stdin → agent sees EOF → exits
+	sess.Close()
+	t.Log("Close completed")
+
+	// Wait for agent to fully exit
+	err = cmd.Wait()
+	t.Logf("agent exited: %v", err)
+
+	// Cleanup: kill agent if Wait returned error (e.g. if it's still alive)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		cmd.Wait()
+	}
+}
+
+// TestFullRestartCycle simulates the full zero-downtime daemon restart flow
+// using syscall.ForkExec to ensure dup'd FDs (with CLOEXEC cleared) are
+// properly inherited by the child process.
+//
+//   Phase 1: Start agent, create session
+//   Phase 2: Export restart data (dup FDs, clear CLOEXEC)
+//   Phase 3: ForkExec child with inherited FDs
+//   Phase 4: Child restores session, sends message, reports success
+//   Phase 5: Parent validates child's output and cleans up
+func TestFullRestartCycle(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" {
+		// Skip if running as a helper process
+		t.Skip("not a real test")
+	}
+
+	// Phase 1: Start agent process.
+	agent := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", "stdin-eof-exit")
+	agent.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	stdin, err := agent.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := agent.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent.Stderr = nil
+	if err := agent.Start(); err != nil {
+		t.Fatal(err)
+	}
+	agentPID := agent.Process.Pid
+	t.Logf("Phase 1: agent started, pid=%d", agentPID)
+
+	// Phase 2: Create session and export restart data.
+	done := make(chan struct{})
+	sess := &claudeSession{
+		cmd:    agent,
+		stdin:  stdin,
+		events: make(chan core.Event, 8),
+		done:   done,
+	}
+	sess.sessionID.Store("integration-test-session")
+	sess.alive.Store(true)
+
+	if f, ok := stdin.(interface{ Fd() uintptr }); ok {
+		sess.stdinFD = int(f.Fd())
+	}
+	if f, ok := stdout.(interface{ Fd() uintptr }); ok {
+		sess.stdoutFD = int(f.Fd())
+	}
+
+	restartData, err := sess.ExportRestartData()
+	if err != nil {
+		t.Fatal("ExportRestartData:", err)
+	}
+	t.Logf("Phase 2: exported FDs stdinFD=%d stdoutFD=%d",
+		restartData.StdinFD, restartData.StdoutFD)
+
+	// Phase 3: Use syscall.ForkExec to spawn child process that inherits
+	// the dup'd FDs (CLOEXEC was cleared by ExportRestartData).
+	childEnv := append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		fmt.Sprintf("RESTORE_STDIN_FD=%d", restartData.StdinFD),
+		fmt.Sprintf("RESTORE_STDOUT_FD=%d", restartData.StdoutFD),
+		fmt.Sprintf("RESTORE_AGENT_PID=%d", agentPID),
+		"RESTORE_SESSION_ID=integration-test-session",
+	)
+
+	childArgs := []string{os.Args[0], "-test.run=TestHelperProcess", "--", "restore-test-child"}
+
+	// Create pipes for child's stdout
+	childOutR, childOutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal("child stdout pipe:", err)
+	}
+
+	// Prepare syscall.ProcAttr: child inherits stdin/stdout/stderr from parent,
+	// plus the dup'd FDs (CLOEXEC is cleared), plus our pipe for child's stdout.
+	files := make([]uintptr, restartData.StdinFD+1)
+	// FDs 0,1,2 are stdin, stdout, stderr
+	files[0] = uintptr(syscall.Stdin)
+	files[1] = childOutW.Fd() // child's stdout goes to our pipe
+	files[2] = uintptr(syscall.Stderr)
+	// Ensure the dup'd FDs are present in the child's FD table
+	// They are already open with CLOEXEC cleared, so ForkExec will inherit them.
+	for _, fd := range []int{restartData.StdinFD, restartData.StdoutFD} {
+		if fd >= len(files) {
+			newFiles := make([]uintptr, fd+1)
+			copy(newFiles, files)
+			files = newFiles
+		}
+	}
+
+	childPIDRaw, _, err := syscall.StartProcess(childArgs[0], childArgs, &syscall.ProcAttr{
+		Env:   childEnv,
+		Files: files[:3], // Only pass 0/1/2 — the rest are inherited automatically
+		Dir:   "",
+		Sys:   &syscall.SysProcAttr{},
+	})
+	if err != nil {
+		t.Fatal("ForkExec child:", err)
+	}
+	t.Logf("Phase 3: child (new daemon) started, pid=%d", childPIDRaw)
+
+	// Close parent's write end of child stdout pipe (child owns it now)
+	childOutW.Close()
+
+	// Phase 4: Close original pipe FDs and parent's dup'd FDs.
+	stdin.Close()
+	stdout.Close()
+	syscall.Close(restartData.StdinFD)
+	syscall.Close(restartData.StdoutFD)
+	t.Log("Phase 4: original and dup'd FDs closed in parent")
+
+	// Phase 5: Read child's output and wait
+	childOutput, _ := io.ReadAll(childOutR)
+	childOutR.Close()
+
+	// Wait for child process
+	var ws syscall.WaitStatus
+	waitedPID, err := syscall.Wait4(childPIDRaw, &ws, 0, nil)
+	t.Logf("Phase 5: child pid=%d exited: err=%v status=%v", waitedPID, err, ws.ExitStatus())
+	t.Logf("Child stdout:\n%s", string(childOutput))
+
+	// Cleanup: kill agent if still alive
+	_ = agent.Process.Kill()
+	_ = agent.Wait()
+
+	if err != nil || ws.ExitStatus() != 0 {
+		t.Fatalf("child failed: exit=%d err=%v\nOutput: %s", ws.ExitStatus(), err, string(childOutput))
+	}
+	if !bytes.Contains(childOutput, []byte("Send succeeded on restored session")) {
+		t.Fatal("child did not report successful Send")
+	}
+}
+
 func helperCommand(ctx context.Context, mode string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess", "--", mode)
 	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
@@ -279,7 +534,81 @@ func TestHelperProcess(t *testing.T) {
 	case "stdin-eof-exit":
 		_, _ = io.Copy(io.Discard, os.Stdin)
 		os.Exit(0)
-	default:
-		os.Exit(2)
+	case "restore-test-child":
+		os.Exit(runRestoreIntegrationChild())
 	}
+}
+
+func runRestoreIntegrationChild() int {
+	fmt.Fprintf(os.Stderr, "CHILD: starting\n")
+
+	stdinFD, err := strconv.Atoi(os.Getenv("RESTORE_STDIN_FD"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "CHILD: RESTORE_STDIN_FD: %v\n", err)
+		return 1
+	}
+	stdoutFD, err := strconv.Atoi(os.Getenv("RESTORE_STDOUT_FD"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "CHILD: RESTORE_STDOUT_FD: %v\n", err)
+		return 1
+	}
+	agentPID, err := strconv.Atoi(os.Getenv("RESTORE_AGENT_PID"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "CHILD: RESTORE_AGENT_PID: %v\n", err)
+		return 1
+	}
+	sessionID := os.Getenv("RESTORE_SESSION_ID")
+	fmt.Fprintf(os.Stderr, "CHILD: FDs stdin=%d stdout=%d pid=%d\n", stdinFD, stdoutFD, agentPID)
+
+	fmt.Fprintf(os.Stderr, "CHILD: fstat stdin...\n")
+	var stat syscall.Stat_t
+	if err := syscall.Fstat(stdinFD, &stat); err != nil {
+		fmt.Fprintf(os.Stderr, "CHILD: stdin FD %d invalid: %v\n", stdinFD, err)
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "CHILD: fstat stdout...\n")
+	if err := syscall.Fstat(stdoutFD, &stat); err != nil {
+		fmt.Fprintf(os.Stderr, "CHILD: stdout FD %d invalid: %v\n", stdoutFD, err)
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "CHILD: kill(0) agent...\n")
+	if err := syscall.Kill(agentPID, syscall.Signal(0)); err != nil {
+		fmt.Fprintf(os.Stderr, "CHILD: agent died: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "CHILD: calls restoreClaudeSessionFromFDs...\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sess, err := restoreClaudeSessionFromFDs(ctx, core.SessionRestartData{
+		StdinFD:        stdinFD,
+		StdoutFD:       stdoutFD,
+		AgentPID:       agentPID,
+		AgentSessionID: sessionID,
+		PermissionMode: "",
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "CHILD: restore failed: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "CHILD: alive=%v id=%s\n", sess.Alive(), sess.CurrentSessionID())
+	if !sess.Alive() {
+		fmt.Fprintf(os.Stderr, "CHILD: not alive\n")
+		return 1
+	}
+	if sess.CurrentSessionID() != sessionID {
+		fmt.Fprintf(os.Stderr, "CHILD: session ID mismatch: %q vs %q\n", sess.CurrentSessionID(), sessionID)
+		return 1
+	}
+	fmt.Printf("Session restored: id=%s alive=%v\n", sess.CurrentSessionID(), sess.Alive())
+
+	fmt.Fprintf(os.Stderr, "CHILD: sending message...\n")
+	if err := sess.Send("hello from restored child", nil, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "CHILD: Send failed: %v\n", err)
+		return 1
+	}
+	fmt.Println("Send succeeded on restored session")
+	fmt.Fprintf(os.Stderr, "CHILD: done, exiting\n")
+	return 0
 }

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1019,6 +1019,13 @@ func main() {
 
 	slog.Info("cc-connect is running", "projects", len(engines))
 
+	// After startup, consume any zero-downtime restart state and restore sessions
+	for _, e := range engines {
+		if n := e.ConsumeRestartSessions(); n > 0 {
+			slog.Info("restored sessions from zero-downtime restart", "project", e.ProjectName(), "count", n)
+		}
+	}
+
 	// After startup, check if we were restarted and send success notification
 	if notify := core.ConsumeRestartNotify(cfg.DataDir); notify != nil {
 		slog.Info("post-restart: sending success notification", "platform", notify.Platform, "session", notify.SessionKey)
@@ -1028,17 +1035,34 @@ func main() {
 	}
 
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	var restartReq *core.RestartRequest
+	var sigHup bool
 	select {
-	case <-sigCh:
+	case sig := <-sigCh:
+		if sig == syscall.SIGHUP {
+			sigHup = true
+			restartReq = &core.RestartRequest{} // restart will exec with same binary
+			slog.Info("SIGHUP received, performing zero-downtime restart")
+		}
 	case req := <-core.RestartCh:
 		restartReq = &req
 		slog.Info("restart requested via /restart command", "session", req.SessionKey, "platform", req.Platform)
 	}
 
 	slog.Info("shutting down...")
+
+	// For zero-downtime restart (SIGHUP), export all session FDs before shutdown
+	if sigHup {
+		slog.Info("restart: preparing engines for zero-downtime restart")
+		for _, e := range engines {
+			if err := e.PrepareRestart(); err != nil {
+				slog.Error("restart: PrepareRestart failed", "project", e.ProjectName(), "error", err)
+			}
+		}
+	}
+
 	if mgmtSrv != nil {
 		mgmtSrv.Stop()
 	}
@@ -1066,7 +1090,9 @@ func main() {
 	instanceLock.Release()
 
 	if restartReq != nil {
-		if err := core.SaveRestartNotify(cfg.DataDir, *restartReq); err != nil {
+		if sigHup {
+			slog.Info("restart: SIGHUP restart, skipping per-session notification")
+		} else if err := core.SaveRestartNotify(cfg.DataDir, *restartReq); err != nil {
 			slog.Error("restart: save notify failed", "error", err)
 		}
 		execPath, err := os.Executable()

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -251,6 +251,7 @@ func main() {
 		}
 
 		engine := core.NewEngine(proj.Name, agent, platforms, sessionFile, lang)
+		engine.SetDataDir(cfg.DataDir)
 		showCtx := true
 		if proj.ShowContextIndicator != nil {
 			showCtx = *proj.ShowContextIndicator

--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -233,6 +233,10 @@ func decodeSendPayload(data []byte, req *core.SendRequest) error {
 }
 
 func resolveSocketPath(dataDir string) string {
+	// CC_CONNECT_SOCKET env var overrides everything except --data-dir
+	if envSock := os.Getenv("CC_CONNECT_SOCKET"); envSock != "" {
+		return envSock
+	}
 	if dataDir != "" {
 		return filepath.Join(dataDir, "run", "api.sock")
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -324,7 +324,6 @@ type interactiveState struct {
 type restoredSessionInfo struct {
 	agentSession AgentSession
 	agent        Agent
-	session      *Session
 }
 
 type pendingProviderAddState struct {
@@ -1534,8 +1533,6 @@ func (e *Engine) ConsumeRestartSessions() int {
 		e.restoredSessions[sd.SessionKey] = &restoredSessionInfo{
 			agentSession: as,
 			agent:        e.agent,
-			// session is nil here; it will be associated when
-			// getOrCreateInteractiveStateWith is called with this sessionKey
 		}
 		restored++
 		slog.Info("ConsumeRestartSessions: session restored",

--- a/core/engine.go
+++ b/core/engine.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
+	"syscall"
 )
 
 const maxPlatformMessageLen = 4000
@@ -242,9 +243,16 @@ type Engine struct {
 	interactiveMu     sync.Mutex
 	interactiveStates map[string]*interactiveState // key = sessionKey
 
+	// restoredSessions holds agent sessions reconstructed from inherited FDs
+	// after a zero-downtime restart. Consumed by
+	// getOrCreateInteractiveStateWith on the next user message keyed by
+	// session key.
+	restoredSessions map[string]*restoredSessionInfo
+
 	platformLifecycleMu sync.Mutex
 	platformReady       map[Platform]bool
 	stopping            bool
+	restarting          bool // when true, Stop() skips closing agent sessions
 	replyFooterMu       sync.Mutex
 	replyFooterUsage    replyFooterUsageCache
 
@@ -309,6 +317,14 @@ type interactiveState struct {
 	// the next turn (e.g. after an abnormal exit). Defaults to true (safe);
 	// cleared to false only after a clean EventResult.
 	eventsNeedResync bool
+}
+
+// restoredSessionInfo holds a pre-constructed agent session from a
+// zero-downtime restart, keyed by session key in restoredSessions.
+type restoredSessionInfo struct {
+	agentSession AgentSession
+	agent        Agent
+	session      *Session
 }
 
 type pendingProviderAddState struct {
@@ -1359,12 +1375,24 @@ func (e *Engine) Stop() error {
 	}
 	e.interactiveMu.Unlock()
 
-	for key, state := range states {
-		if state.agentSession != nil {
-			slog.Debug("engine.Stop: closing agent session", "session", key)
-			state.agentSession.Close()
+	if e.restarting {
+		slog.Info("engine.Stop: restarting, preserving agent sessions",
+			"engine", e.name, "sessions", len(states))
+		// During restart we do NOT close agent sessions — the FDs have been
+		// dup'd without CLOEXEC and will be inherited by the new process.
+	} else {
+		for key, state := range states {
+			if state.agentSession != nil {
+				slog.Debug("engine.Stop: closing agent session", "session", key)
+				state.agentSession.Close()
+			}
 		}
 	}
+	// Close any restored sessions that were never claimed by a user message.
+	for _, rs := range e.restoredSessions {
+		rs.agentSession.Close()
+	}
+	e.restoredSessions = nil
 
 	if e.rateLimiter != nil {
 		e.rateLimiter.Stop()
@@ -1382,6 +1410,142 @@ func (e *Engine) Stop() error {
 		return fmt.Errorf("engine stop errors: %v", errs)
 	}
 	return nil
+	}
+
+// PrepareRestart marks the engine as restarting and exports all running
+// agent session FDs to a state file so they can be inherited by the new
+// process. Call this BEFORE the main shutdown sequence.
+func (e *Engine) PrepareRestart() error {
+	e.platformLifecycleMu.Lock()
+	e.restarting = true
+	e.platformLifecycleMu.Unlock()
+
+	e.interactiveMu.Lock()
+	defer e.interactiveMu.Unlock()
+
+	var sessionsData []SessionRestartData
+
+	for sessionKey, state := range e.interactiveStates {
+		if state.agentSession == nil {
+			continue
+		}
+		exporter, ok := state.agentSession.(SessionRestartDataExporter)
+		if !ok {
+			slog.Warn("agent session does not support restart export, skipping",
+				"session_key", sessionKey, "agent", state.agent.Name())
+			continue
+		}
+		data, err := exporter.ExportRestartData()
+		if err != nil {
+			slog.Error("failed to export restart data for session",
+				"session_key", sessionKey, "error", err)
+			continue
+		}
+		data.SessionKey = sessionKey
+		data.AgentType = state.agent.Name()
+		sessionsData = append(sessionsData, *data)
+	}
+
+	if len(sessionsData) == 0 {
+		slog.Info("PrepareRestart: no sessions to preserve", "engine", e.name)
+		return nil
+	}
+
+	slog.Info("PrepareRestart: exporting sessions", "engine", e.name, "count", len(sessionsData))
+
+	stateFile := filepath.Join(e.dataDir, "run", "restart_sessions_"+e.name+".json")
+	dir := filepath.Dir(stateFile)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir restart state dir: %w", err)
+	}
+
+	payload, err := json.Marshal(sessionsData)
+	if err != nil {
+		return fmt.Errorf("marshal restart state: %w", err)
+	}
+	if err := os.WriteFile(stateFile, payload, 0o644); err != nil {
+		return fmt.Errorf("write restart state file: %w", err)
+	}
+
+	slog.Info("PrepareRestart: state saved", "engine", e.name, "file", stateFile)
+	return nil
+}
+
+// closeRestartFDs closes file descriptors from a SessionRestartData entry.
+// FDs <= 0 are skipped (they are either unset or invalid).
+func closeRestartFDs(fds ...int) {
+	for _, fd := range fds {
+		if fd > 0 {
+			syscall.Close(fd)
+		}
+	}
+}
+
+// ConsumeRestartSessions reads the restart state file and reconstructs agent
+// sessions from inherited file descriptors. Call this AFTER engine startup,
+// before any messages are processed. Returns the number of restored sessions.
+func (e *Engine) ConsumeRestartSessions() int {
+	stateFile := filepath.Join(e.dataDir, "run", "restart_sessions_"+e.name+".json")
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		slog.Warn("ConsumeRestartSessions: read failed", "engine", e.name, "error", err)
+		return 0
+	}
+	os.Remove(stateFile)
+
+	var sessionsData []SessionRestartData
+	if err := json.Unmarshal(data, &sessionsData); err != nil {
+		slog.Error("ConsumeRestartSessions: unmarshal failed", "engine", e.name, "error", err)
+		return 0
+	}
+
+	resumer, ok := e.agent.(SessionResumer)
+	if !ok {
+		slog.Warn("ConsumeRestartSessions: agent does not support resume", "engine", e.name, "agent", e.agent.Name())
+		return 0
+	}
+
+	e.interactiveMu.Lock()
+	defer e.interactiveMu.Unlock()
+
+	if e.restoredSessions == nil {
+		e.restoredSessions = make(map[string]*restoredSessionInfo)
+	}
+
+	restored := 0
+	for _, sd := range sessionsData {
+		if sd.SessionKey == "" {
+			slog.Warn("ConsumeRestartSessions: empty session key, skipping")
+			closeRestartFDs(sd.StdinFD, sd.StdoutFD)
+			continue
+		}
+
+		as, err := resumer.ResumeSession(e.ctx, sd)
+		if err != nil {
+			slog.Error("ConsumeRestartSessions: resume failed",
+				"session_key", sd.SessionKey, "error", err)
+			closeRestartFDs(sd.StdinFD, sd.StdoutFD)
+			continue
+		}
+
+		e.restoredSessions[sd.SessionKey] = &restoredSessionInfo{
+			agentSession: as,
+			agent:        e.agent,
+			// session is nil here; it will be associated when
+			// getOrCreateInteractiveStateWith is called with this sessionKey
+		}
+		restored++
+		slog.Info("ConsumeRestartSessions: session restored",
+			"session_key", sd.SessionKey,
+			"agent_session_id", as.CurrentSessionID(),
+			"alive", as.Alive())
+	}
+
+	slog.Info("ConsumeRestartSessions: done", "engine", e.name, "restored", restored, "total", len(sessionsData))
+	return restored
 }
 
 // OnPlatformReady marks an async platform as ready and initializes platform-level
@@ -2407,6 +2571,23 @@ func adoptPendingFromPlaceholder(existing, newState *interactiveState) {
 func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, replyCtx any, session *Session, sessions *SessionManager, agentOverride Agent, ccSessionKey string) *interactiveState {
 	e.interactiveMu.Lock()
 	defer e.interactiveMu.Unlock()
+
+	// Check if this session was restored from a zero-downtime restart.
+	if len(e.restoredSessions) > 0 {
+		if rs, ok := e.restoredSessions[sessionKey]; ok {
+			delete(e.restoredSessions, sessionKey)
+			slog.Info("using restored agent session", "session_key", sessionKey)
+			state := &interactiveState{
+				agentSession: rs.agentSession,
+				platform:     p,
+				replyCtx:     replyCtx,
+				agent:        rs.agent,
+				stopCh:       make(chan struct{}),
+			}
+			e.interactiveStates[sessionKey] = state
+			return state
+		}
+	}
 
 	state, ok := e.interactiveStates[sessionKey]
 	if ok && state.agentSession != nil && state.agentSession.Alive() {

--- a/core/engine.go
+++ b/core/engine.go
@@ -160,6 +160,7 @@ type Engine struct {
 	injectSender          bool
 	attachmentSendEnabled bool
 	startedAt             time.Time
+	dataDir               string
 
 	providerSaveFunc        func(providerName string) error
 	providerAddSaveFunc     func(p ProviderConfig) error
@@ -2455,6 +2456,9 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		envVars := []string{
 			"CC_PROJECT=" + e.name,
 			"CC_SESSION_KEY=" + ccKey,
+		}
+		if sock := e.socketPath(); sock != "" {
+			envVars = append(envVars, "CC_CONNECT_SOCKET="+sock)
 		}
 		if exePath, err := os.Executable(); err == nil {
 			binDir := filepath.Dir(exePath)
@@ -10429,6 +10433,9 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 		"CC_PROJECT=" + e.name,
 		"CC_SESSION_KEY=" + msg.SessionKey,
 	}
+	if sock := e.socketPath(); sock != "" {
+		envVars = append(envVars, "CC_CONNECT_SOCKET="+sock)
+	}
 	// Prepend the cc-connect binary dir on Windows only (native shell fix);
 	// on Unix it would change command resolution for user scripts.
 	if runtime.GOOS == "windows" {
@@ -11521,6 +11528,9 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 			"CC_PROJECT=" + e.name,
 			"CC_SESSION_KEY=" + relaySessionKey,
 		}
+		if sock := e.socketPath(); sock != "" {
+			envVars = append(envVars, "CC_CONNECT_SOCKET="+sock)
+		}
 		if exePath, err := os.Executable(); err == nil {
 			binDir := filepath.Dir(exePath)
 			if curPath := os.Getenv("PATH"); curPath != "" {
@@ -12428,4 +12438,22 @@ func (e *Engine) cmdWebStatus(p Platform, msg *Message) {
 		return
 	}
 	e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgWebStatus), url))
+}
+
+// SetDataDir sets the cc-connect data directory for socket path resolution.
+func (e *Engine) SetDataDir(dataDir string) {
+	e.dataDir = dataDir
+}
+
+// socketPath returns the path to the cc-connect daemon Unix socket.
+// Uses the configured dataDir if available, otherwise falls back to ~/.cc-connect.
+func (e *Engine) socketPath() string {
+	if e.dataDir != "" {
+		return filepath.Join(e.dataDir, "run", "api.sock")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".cc-connect", "run", "api.sock")
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -492,3 +492,28 @@ type CommandRegistrar interface {
 type ChannelNameResolver interface {
 	ResolveChannelName(channelID string) (string, error)
 }
+
+// SessionRestartData carries enough info to reconstruct an agent session
+// from inherited file descriptors after a server restart (zero-downtime).
+type SessionRestartData struct {
+	SessionKey      string `json:"session_key"`
+	AgentType       string `json:"agent_type"`
+	WorkDir         string `json:"work_dir"`
+	StdinFD         int    `json:"stdin_fd"`   // dup'd fd without CLOEXEC
+	StdoutFD        int    `json:"stdout_fd"`  // dup'd fd without CLOEXEC
+	AgentSessionID  string `json:"agent_session_id"`
+	PermissionMode  string `json:"permission_mode"`
+	AgentPID        int    `json:"agent_pid"` // PID for signaling (SIGTERM/SIGKILL fallback)
+}
+
+// SessionResumer is an optional interface for Agents that can reconstruct
+// a running session from restart data after a zero-downtime restart.
+type SessionResumer interface {
+	ResumeSession(ctx context.Context, data SessionRestartData) (AgentSession, error)
+}
+
+// SessionRestartDataExporter is an optional interface for AgentSession
+// that exports restart data (duped FDs + metadata) before a server restart.
+type SessionRestartDataExporter interface {
+	ExportRestartData() (*SessionRestartData, error)
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/slack-go/slack v0.15.0
 	github.com/stretchr/testify v1.9.0
+	modernc.org/sqlite v1.49.1
 	rsc.io/qr v0.2.0
 )
 
@@ -56,5 +57,4 @@ require (
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.49.1 // indirect
 )

--- a/web/package.json
+++ b/web/package.json
@@ -33,5 +33,10 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "vite": "^6.3.2"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
…ET env

Previously socketPath() hardcoded ~/.cc-connect/run/api.sock regardless of the configured dataDir, causing CC_CONNECT_SOCKET injected into agent subprocesses to point at the wrong location when dataDir was customized or resolved as a relative path.

- Add dataDir field + SetDataDir() to Engine, use it in socketPath()
- Inject CC_CONNECT_SOCKET into agent session env, shell commands, and relay
- Support CC_CONNECT_SOCKET env var override in resolveSocketPath()