### PR TITLE
fix(claudecode): add dot (.) to encodeClaudeProjectKey replacement set

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -1099,7 +1099,8 @@ func boolVal(m map[string]any, key string) bool {
 // 3. Replacing underscores (_) with "-"
 // 4. Replacing spaces and tildes (~) with "-" (common in macOS iCloud paths like
 //    "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/...")
-// 5. Replacing all non-ASCII characters with "-"
+// 5. Replacing dots (.) with "-" (common in macOS usernames like "yinglong.li")
+// 6. Replacing all non-ASCII characters with "-"
 func encodeClaudeProjectKey(absPath string) string {
 	// First, normalize to forward slashes for consistent processing
 	normalized := strings.ReplaceAll(absPath, "\\", "/")
@@ -1107,7 +1108,7 @@ func encodeClaudeProjectKey(absPath string) string {
 	// Build the encoded key character by character
 	var result strings.Builder
 	for _, r := range normalized {
-		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' {
+		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' || r == '.' {
 			result.WriteRune('-')
 		} else if r < 128 { // ASCII range (0-127)
 			result.WriteRune(r)

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -406,6 +406,16 @@ func TestEncodeClaudeProjectKey(t *testing.T) {
 			expected: "-Users-username---folder-english---", // "/中文" = 3 hyphens, "/文件夹" = 4 hyphens
 		},
 		{
+			name:     "macOS username with dot",
+			input:    "/Users/yinglong.li/Documents/project",
+			expected: "-Users-yinglong-li-Documents-project",
+		},
+		{
+			name:     "path with multiple dots",
+			input:    "/Users/test.user.name/my.project",
+			expected: "-Users-test-user-name-my-project",
+		},
+		{
 			name:     "empty path",
 			input:    "",
 			expected: "",


### PR DESCRIPTION
## Summary
- Added `.` to the character replacement set in `encodeClaudeProjectKey()` to match Claude Code 2.1.91's behavior
- Fixes `/list` returning 0 sessions when macOS usernames contain dots (e.g. `yinglong.li`)
- Added test cases for single and multiple dots in paths

## Root Cause
cc-connect encoded `/Users/yinglong.li` → `-Users-yinglong.li`  
Claude Code actual directory: `-Users-yinglong-li`  
This mismatch caused `findProjectDir()` to return empty string.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./agent/claudecode/...` passes
- [ ] Manual: user with dot in username runs `/list` and sees sessions

Closes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)