### PR TITLE
fix(core): use cmd.exe on Windows for /shell command

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -4926,7 +4926,13 @@ func (e *Engine) cmdShell(p Platform, msg *Message, raw string) {
 		ctx, cancel := context.WithTimeout(e.ctx, timeout)
 		defer cancel()
 
-		cmd := exec.CommandContext(ctx, "sh", "-c", shellCmd)
+		// Use native shell on Windows (cmd.exe), sh on Unix.
+		var cmd *exec.Cmd
+		if runtime.GOOS == "windows" {
+			cmd = exec.CommandContext(ctx, "cmd.exe", "/C", shellCmd)
+		} else {
+			cmd = exec.CommandContext(ctx, "sh", "-c", shellCmd)
+		}
 		cmd.Dir = workDir
 		output, err := cmd.CombinedOutput()
 


### PR DESCRIPTION
## Summary
- Fixed `/shell` command to use `cmd.exe /C` on Windows instead of hardcoded `sh -c`
- Uses the same pattern as `[[commands]]` exec (PR #446)
- Unix platforms continue to use `sh -c`

## Root Cause
`core/engine.go:4929` was hardcoded to use `sh -c`, which doesn't exist on Windows.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./core/...` passes
- [ ] Manual: Windows user runs `/shell dir` and sees output

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)