### PR TITLE
fix(core): use NewBridgeServerInsecure in bridge test

### DIFF
--- a/core/bridge_capabilities_snapshot_test.go
+++ b/core/bridge_capabilities_snapshot_test.go
@@ -13,7 +13,7 @@ func TestBridgeBuildCapabilitiesSnapshotIncludesProjectCatalog(t *testing.T) {
 		CurrentBuildTime = prevBuildTime
 	}()
 
-	bs := NewBridgeServer(0, "", "/bridge/ws", nil)
+	bs := NewBridgeServerInsecure(0, "", "/bridge/ws", nil)
 	bp := bs.NewPlatform("test-proj")
 	e := NewEngine("test-proj", &stubAgent{}, []Platform{bp}, "", LangEnglish)
 	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")


### PR DESCRIPTION
## Why

`TestBridgeBuildCapabilitiesSnapshotIncludesProjectCatalog` panics with nil pointer dereference on CI. Commit `24a097b` made `NewBridgeServer` return nil when no token is provided, but this test still calls it with an empty token.

## Summary

Change the test to use `NewBridgeServerInsecure` which allows empty tokens (intended for local/test use).

## Test plan

- [x] `go test ./core/ -run TestBridgeBuildCapabilitiesSnapshotIncludesProjectCatalog` passes