### PR TITLE
fix(claudecode): replace dots in project key encoding

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -1213,7 +1213,8 @@ func boolVal(m map[string]any, key string) bool {
 //  3. Replacing underscores (_) with "-"
 //  4. Replacing spaces and tildes (~) with "-" (common in macOS iCloud paths like
 //     "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/...")
-//  5. Replacing all non-ASCII characters with "-"
+//  5. Replacing dots (.) with "-"
+//  6. Replacing all non-ASCII characters with "-"
 func encodeClaudeProjectKey(absPath string) string {
 	// First, normalize to forward slashes for consistent processing
 	normalized := strings.ReplaceAll(absPath, "\\", "/")
@@ -1221,7 +1222,7 @@ func encodeClaudeProjectKey(absPath string) string {
 	// Build the encoded key character by character
 	var result strings.Builder
 	for _, r := range normalized {
-		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' {
+		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' || r == '.' {
 			result.WriteRune('-')
 		} else if r < 128 { // ASCII range (0-127)
 			result.WriteRune(r)

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -412,6 +412,16 @@ func TestEncodeClaudeProjectKey(t *testing.T) {
 			input:    "",
 			expected: "",
 		},
+		{
+			name:     "path with dots in username",
+			input:    "/home/john.doe/projects/myapp",
+			expected: "-home-john-doe-projects-myapp",
+		},
+		{
+			name:     "path with multiple dots",
+			input:    "/home/j.doe/src/my.app",
+			expected: "-home-j-doe-src-my-app",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #842

## Environment

- **cc-connect version**: v1.3.2 (19406df9)
- **OS**: macOS Darwin 25.3.0 (arm64)
- **Agent**: Claude Code 2.1.91
- **Platform**: any (bug is in core encoding logic)

## Root Cause

`encodeClaudeProjectKey` in `agent/claudecode/claudecode.go` replaces `/`, `:`, `_`, ` `, `~` with `-` but does **not** replace `.` (dot).

Claude Code 2.1.91 **does** replace dots in its project key encoding. This means any workspace path containing a dot (e.g. `/Users/yinglong.li/projects/myapp`) produces a different key than what Claude Code writes to disk, causing `findProjectDir` to fail and `/list` to return 0 sessions.

## Reproduction

1. Use a macOS account with a dot in the username (e.g. `yinglong.li`)
2. Start cc-connect with Claude Code agent
3. Run `/list` in the messaging platform
4. Expected: shows active sessions. Actual: returns 0 sessions.

## Fix

Added `.` to the replacement set in `encodeClaudeProjectKey`, matching Claude Code 2.1.91 behavior.

## Tests

```bash
go test ./agent/claudecode/ -run TestEncodeClaudeProjectKey -v
```

Added two new test cases:
- `path with dots in username`: `/home/john.doe/projects/myapp` → `-home-john-doe-projects-myapp`
- `path with multiple dots`: `/home/j.doe/src/my.app` → `-home-j-doe-src-my-app`

All 14 tests pass (12 existing + 2 new).