### PR TITLE
Fix cron prompt expansion and delivery status

### DIFF
--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -42,6 +42,7 @@ func runCron(args []string) {
 func runCronAdd(args []string) {
 	var project, sessionKey, cronExpr, prompt, execCmd, desc, dataDir, sessionMode string
 	var timeoutMins *int
+	var silent bool
 
 	var positional []string
 	for i := 0; i < len(args); i++ {
@@ -96,6 +97,8 @@ func runCronAdd(args []string) {
 				}
 				timeoutMins = &n
 			}
+		case "--silent":
+			silent = true
 		case "--help", "-h":
 			printCronAddUsage()
 			return
@@ -151,6 +154,9 @@ func runCronAdd(args []string) {
 	}
 	if timeoutMins != nil {
 		body["timeout_mins"] = *timeoutMins
+	}
+	if silent {
+		body["silent"] = true
 	}
 	payload, _ := json.Marshal(body)
 
@@ -452,7 +458,7 @@ func runCronEdit(args []string) {
 	// Parse value based on field type
 	var value any
 	switch field {
-	case "enabled", "mute":
+	case "enabled", "mute", "silent":
 		v, err := strconv.ParseBool(valueStr)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %s must be true or false\n", field)

--- a/core/cron.go
+++ b/core/cron.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"reflect"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -396,13 +396,13 @@ func toExportedFieldName(s string) string {
 
 // CronScheduler runs cron jobs by injecting synthetic messages into engines.
 type CronScheduler struct {
-	store         *CronStore
-	cron          *cron.Cron
-	engines       map[string]*Engine // project name → engine
-	mu            sync.RWMutex
-	entries       map[string]cron.EntryID // job ID → cron entry
-	defaultSilent      bool   // global default for suppressing cron start notifications
-	defaultSessionMode string // global default session mode; "" = reuse, "new_per_run" = fresh session each run
+	store              *CronStore
+	cron               *cron.Cron
+	engines            map[string]*Engine // project name → engine
+	mu                 sync.RWMutex
+	entries            map[string]cron.EntryID // job ID → cron entry
+	defaultSilent      bool                    // global default for suppressing cron start notifications
+	defaultSessionMode string                  // global default session mode; "" = reuse, "new_per_run" = fresh session each run
 }
 
 func NewCronScheduler(store *CronStore) *CronScheduler {
@@ -677,6 +677,47 @@ type mutePlatform struct {
 
 func (m *mutePlatform) Reply(_ context.Context, _ any, _ string) error { return nil }
 func (m *mutePlatform) Send(_ context.Context, _ any, _ string) error  { return nil }
+
+type cronDeliveryTracker struct {
+	emptyResponse string
+
+	mu              sync.Mutex
+	delivered       int
+	suppressedEmpty bool
+}
+
+func (t *cronDeliveryTracker) shouldDeliver(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" || trimmed == strings.TrimSpace(t.emptyResponse) {
+		t.markSuppressedEmpty()
+		return false
+	}
+	return true
+}
+
+func (t *cronDeliveryTracker) markSuppressedEmpty() {
+	t.mu.Lock()
+	t.suppressedEmpty = true
+	t.mu.Unlock()
+}
+
+func (t *cronDeliveryTracker) markDelivered() {
+	t.mu.Lock()
+	t.delivered++
+	t.mu.Unlock()
+}
+
+func (t *cronDeliveryTracker) deliveredCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.delivered
+}
+
+func (t *cronDeliveryTracker) suppressedEmptyResponse() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.suppressedEmpty
+}
 
 func GenerateCronID() string {
 	b := make([]byte, 4)

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -121,6 +122,42 @@ func TestCronJob_MuteField(t *testing.T) {
 	job.Mute = true
 	if !job.Mute {
 		t.Error("should be muted after setting")
+	}
+}
+
+func TestEngine_ExpandCronSkillPrompt(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "daily-brief")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("write the daily brief"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
+	e.skills.SetDirs([]string{dir})
+
+	got, ok := e.expandCronSkillPrompt("/daily-brief for today")
+	if !ok {
+		t.Fatal("expected cron skill prompt to expand")
+	}
+	if !strings.Contains(got, "## Skill: daily-brief") {
+		t.Fatalf("expanded prompt missing skill name: %q", got)
+	}
+	if !strings.Contains(got, "write the daily brief") {
+		t.Fatalf("expanded prompt missing skill body: %q", got)
+	}
+	if !strings.Contains(got, "for today") {
+		t.Fatalf("expanded prompt missing args: %q", got)
+	}
+
+	plain, ok := e.expandCronSkillPrompt("daily-brief for today")
+	if ok {
+		t.Fatal("non-slash prompt should not expand")
+	}
+	if plain != "daily-brief for today" {
+		t.Fatalf("plain prompt changed: %q", plain)
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -308,6 +308,7 @@ type interactiveState struct {
 	pendingProviderAdd     *pendingProviderAddState
 	lastAutoCompressAt     time.Time
 	lastAutoCompressTokens int
+	cronDelivery           *cronDeliveryTracker
 
 	// Unsolicited event reader: a background goroutine that consumes agent
 	// events between user-initiated turns (e.g. background task completions).
@@ -1062,8 +1063,13 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 
 	// Wrap platform to discard all outgoing messages when muted
 	effectivePlatform := targetPlatform
+	var deliveryTracker *cronDeliveryTracker
 	if job.Mute {
 		effectivePlatform = &mutePlatform{targetPlatform}
+	} else {
+		deliveryTracker = &cronDeliveryTracker{
+			emptyResponse: e.i18n.T(MsgEmptyResponse),
+		}
 	}
 
 	// Notify user that a cron job is executing (unless silent/muted)
@@ -1089,12 +1095,17 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		return e.executeCronShell(effectivePlatform, replyCtx, job)
 	}
 
+	prompt := job.Prompt
+	if expanded, ok := e.expandCronSkillPrompt(prompt); ok {
+		prompt = expanded
+	}
+
 	msg := &Message{
 		SessionKey:   sessionKey,
 		Platform:     platformName,
 		UserID:       "cron",
 		UserName:     "cron",
-		Content:      job.Prompt,
+		Content:      prompt,
 		ReplyCtx:     replyCtx,
 		ModeOverride: job.Mode,
 	}
@@ -1149,9 +1160,9 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		if workspaceDir != "" {
 			iKey = workspaceDir + ":" + iKey
 		}
-		e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, runSessionKey)
+		e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, runSessionKey, deliveryTracker)
 		e.cleanupInteractiveState(iKey)
-		return nil
+		return e.checkCronDelivery(job, deliveryTracker)
 	}
 
 	session := sessions.GetOrCreateActive(sessionKey)
@@ -1163,8 +1174,42 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 	if workspaceDir != "" {
 		iKey = workspaceDir + ":" + sessionKey
 	}
-	e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, sessionKey)
-	return nil
+	e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, sessionKey, deliveryTracker)
+	return e.checkCronDelivery(job, deliveryTracker)
+}
+
+func (e *Engine) checkCronDelivery(job *CronJob, tracker *cronDeliveryTracker) error {
+	if job == nil || job.Mute || tracker == nil {
+		return nil
+	}
+	if tracker.deliveredCount() > 0 {
+		return nil
+	}
+	if tracker.suppressedEmptyResponse() {
+		return fmt.Errorf("cron produced an empty response")
+	}
+	return fmt.Errorf("cron completed without sending a response")
+}
+
+func (e *Engine) expandCronSkillPrompt(raw string) (string, bool) {
+	content := strings.TrimSpace(raw)
+	if content == "" || !strings.HasPrefix(content, "/") {
+		return raw, false
+	}
+
+	parts := strings.Fields(content)
+	if len(parts) == 0 {
+		return raw, false
+	}
+	cmd := strings.TrimPrefix(parts[0], "/")
+	if cmd == "" {
+		return raw, false
+	}
+	skill := e.skills.Resolve(cmd)
+	if skill == nil {
+		return raw, false
+	}
+	return BuildSkillInvocationPrompt(skill, parts[1:]), true
 }
 
 func cronRunTitle(job *CronJob) string {
@@ -2077,7 +2122,7 @@ sessionLocked:
 		"session", session.ID,
 	)
 
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey)
+	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey, nil)
 }
 
 func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session) *Session {
@@ -2489,14 +2534,14 @@ func isDenyResponse(s string) bool {
 // ──────────────────────────────────────────────────────────────
 
 func (e *Engine) processInteractiveMessage(p Platform, msg *Message, session *Session) {
-	e.processInteractiveMessageWith(p, msg, session, e.agent, e.sessions, msg.SessionKey, "", "")
+	e.processInteractiveMessageWith(p, msg, session, e.agent, e.sessions, msg.SessionKey, "", "", nil)
 }
 
 // processInteractiveMessageWith is the core interactive processing loop.
 // It accepts an explicit agent, interactiveKey (for the interactiveStates map),
 // and workspaceDir so that multi-workspace mode can route to per-workspace agents.
 // ccSessionKey, when non-empty, is used for CC_SESSION_KEY in the agent env; otherwise interactiveKey is used.
-func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session *Session, agent Agent, sessions *SessionManager, interactiveKey string, workspaceDir string, ccSessionKey string) {
+func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session *Session, agent Agent, sessions *SessionManager, interactiveKey string, workspaceDir string, ccSessionKey string, cronDelivery *cronDeliveryTracker) {
 	// session.Unlock() is NOT deferred here — it is called explicitly in
 	// the drain loop below while holding state.mu to close the race window
 	// between "queue is empty" and "session unlocked". A deferred fallback
@@ -2536,7 +2581,15 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	state.platform = p
 	state.replyCtx = msg.ReplyCtx
 	state.currentMessageID = msg.MessageID
+	state.cronDelivery = cronDelivery
 	state.mu.Unlock()
+	defer func() {
+		state.mu.Lock()
+		if state.cronDelivery == cronDelivery {
+			state.cronDelivery = nil
+		}
+		state.mu.Unlock()
+	}()
 	stopRecallMonitor := e.startMessageRecallMonitor(interactiveKey)
 	defer stopRecallMonitor()
 
@@ -3278,23 +3331,23 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 				if autoApprove {
 					result = PermissionResult{Behavior: "allow", UpdatedInput: event.ToolInputRaw}
 				}
-			reqID := event.RequestID
-			respondCtx := ctx // capture current unsolicited reader context
-			go func() {
-				// Run in a goroutine to keep reader iterations fast, but honour
-				// the reader's context so we don't call into a dead session after
-				// stopUnsolicitedReader cancels the context.
-				select {
-				case <-respondCtx.Done():
-					return
-				default:
-				}
-				if err := agentSession.RespondPermission(reqID, result); err != nil {
-					if respondCtx.Err() == nil {
-						slog.Error("unsolicited: failed to respond permission", "error", err)
+				reqID := event.RequestID
+				respondCtx := ctx // capture current unsolicited reader context
+				go func() {
+					// Run in a goroutine to keep reader iterations fast, but honour
+					// the reader's context so we don't call into a dead session after
+					// stopUnsolicitedReader cancels the context.
+					select {
+					case <-respondCtx.Done():
+						return
+					default:
 					}
-				}
-			}()
+					if err := agentSession.RespondPermission(reqID, result); err != nil {
+						if respondCtx.Err() == nil {
+							slog.Error("unsolicited: failed to respond permission", "error", err)
+						}
+					}
+				}()
 				if !autoApprove {
 					toolName := event.ToolName
 					if toolName == "" {
@@ -3372,10 +3425,29 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		return e.renderOutgoingContentForWorkspace(state.platform, content, workspaceDir)
 	}
 	sendWorkspace := func(p Platform, replyCtx any, content string) {
+		state.mu.Lock()
+		tracker := state.cronDelivery
+		state.mu.Unlock()
+		if tracker != nil && !tracker.shouldDeliver(content) {
+			return
+		}
 		e.sendForWorkspace(p, replyCtx, content, workspaceDir)
+		if tracker != nil {
+			tracker.markDelivered()
+		}
 	}
 	sendWorkspaceWithError := func(p Platform, replyCtx any, content string) error {
-		return e.sendWithErrorForWorkspace(p, replyCtx, content, workspaceDir)
+		state.mu.Lock()
+		tracker := state.cronDelivery
+		state.mu.Unlock()
+		if tracker != nil && !tracker.shouldDeliver(content) {
+			return nil
+		}
+		err := e.sendWithErrorForWorkspace(p, replyCtx, content, workspaceDir)
+		if err == nil && tracker != nil {
+			tracker.markDelivered()
+		}
+		return err
 	}
 	sp := newStreamPreview(e.streamPreview, state.platform, state.replyCtx, e.ctx, workspaceRenderer)
 	cp := newCompactProgressWriter(e.ctx, state.platform, state.replyCtx, e.agent.Name(), e.i18n.CurrentLang(), workspaceRenderer)
@@ -3886,6 +3958,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			if fullResponse == "" {
 				fullResponse = e.i18n.T(MsgEmptyResponse)
 			}
+			emptyAgentResponse := strings.TrimSpace(fullResponse) == strings.TrimSpace(e.i18n.T(MsgEmptyResponse))
 
 			// Context usage indicator: prefer SDK tokens, fall back to self-reported.
 			sdkPlausible := event.InputTokens >= 100
@@ -3996,6 +4069,20 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					cardMessageID = nil
 				}
 				slog.Info("silent reply suppressed", "session", session.ID)
+			} else if emptyAgentResponse {
+				sp.discard()
+				state.mu.Lock()
+				tracker := state.cronDelivery
+				state.mu.Unlock()
+				if tracker != nil {
+					tracker.markSuppressedEmpty()
+				} else {
+					for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
+							return
+						}
+					}
+				}
 			} else if hasRichCard {
 				parts := []string{fullResponse}
 				if splitter, ok := p.(MarkdownTableSplitter); ok {
@@ -4024,6 +4111,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 						slog.Error("failed to send overflow rich card", "error", err)
 						return
 					}
+				}
+				state.mu.Lock()
+				tracker := state.cronDelivery
+				state.mu.Unlock()
+				if tracker != nil {
+					tracker.markDelivered()
 				}
 			} else if toolCount > 0 && segmentStart > 0 {
 				// When tool calls happened and prior text was already surfaced in segments,
@@ -4062,6 +4155,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			if elapsed := time.Since(replyStart); elapsed >= slowPlatformSend {
 				slog.Warn("slow final reply send", "platform", p.Name(), "elapsed", elapsed, "response_len", len(fullResponse))
 			}
+			state.mu.Lock()
+			state.cronDelivery = nil
+			state.mu.Unlock()
 
 			// TTS: async voice reply if enabled (skipped for silent replies)
 			if !isSilent && e.tts != nil && e.tts.Enabled && e.tts.TTS != nil {
@@ -11299,7 +11395,7 @@ func (e *Engine) executeCustomCommand(p Platform, msg *Message, cmd *CustomComma
 	)
 
 	msg.Content = prompt
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey)
+	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey, nil)
 }
 
 // executeShellCommand runs a shell command and sends the output to the user.
@@ -11522,7 +11618,7 @@ func (e *Engine) executeSkill(p Platform, msg *Message, skill *Skill, args []str
 	)
 
 	msg.Content = prompt
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey)
+	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey, nil)
 }
 
 func (e *Engine) cmdSkills(p Platform, msg *Message) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -3425,18 +3425,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		return e.renderOutgoingContentForWorkspace(state.platform, content, workspaceDir)
 	}
 	sendWorkspace := func(p Platform, replyCtx any, content string) {
-		state.mu.Lock()
-		tracker := state.cronDelivery
-		state.mu.Unlock()
-		if tracker != nil && !tracker.shouldDeliver(content) {
-			return
-		}
 		e.sendForWorkspace(p, replyCtx, content, workspaceDir)
-		if tracker != nil {
-			tracker.markDelivered()
-		}
 	}
 	sendWorkspaceWithError := func(p Platform, replyCtx any, content string) error {
+		return e.sendWithErrorForWorkspace(p, replyCtx, content, workspaceDir)
+	}
+	sendFinalWorkspaceWithError := func(p Platform, replyCtx any, content string) error {
 		state.mu.Lock()
 		tracker := state.cronDelivery
 		state.mu.Unlock()
@@ -4123,21 +4117,31 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				// only send the unsent remainder. When tool progress is hidden, tool events don't surface
 				// side-channel messages and segmentStart stays 0, so keep normal finalize flow.
 				sp.discard()
+				deliveredFinal := false
 				if segmentStart < len(textParts) {
 					unsent := strings.Join(textParts[segmentStart:], "")
 					if unsent != "" {
 						for _, chunk := range splitMessage(unsent, maxPlatformMessageLen) {
-							if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
+							if err := sendFinalWorkspaceWithError(p, replyCtx, chunk); err != nil {
 								return
 							}
+							deliveredFinal = true
 						}
+					}
+				}
+				if !deliveredFinal {
+					state.mu.Lock()
+					tracker := state.cronDelivery
+					state.mu.Unlock()
+					if tracker != nil {
+						tracker.markSuppressedEmpty()
 					}
 				}
 			} else if suppressDuplicate {
 				sp.discard()
 				if metaOnly := strings.TrimSpace(strings.TrimPrefix(fullResponse, baseResponse)); metaOnly != "" {
 					for _, chunk := range splitMessage(metaOnly, maxPlatformMessageLen) {
-						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
+						if err := sendFinalWorkspaceWithError(p, replyCtx, chunk); err != nil {
 							return
 						}
 					}
@@ -4146,7 +4150,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			} else {
 				slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "chunks", len(splitMessage(fullResponse, maxPlatformMessageLen)))
 				for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
-					if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
+					if err := sendFinalWorkspaceWithError(p, replyCtx, chunk); err != nil {
 						return
 					}
 				}
@@ -4390,19 +4394,29 @@ channelClosed:
 
 		if toolCount > 0 && segmentStart > 0 {
 			sp.discard()
+			deliveredFinal := false
 			if segmentStart < len(textParts) {
 				unsent := strings.Join(textParts[segmentStart:], "")
 				if unsent != "" {
 					for _, chunk := range splitMessage(unsent, maxPlatformMessageLen) {
-						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
+						if err := sendFinalWorkspaceWithError(p, replyCtx, chunk); err != nil {
 							return
 						}
+						deliveredFinal = true
 					}
+				}
+			}
+			if !deliveredFinal {
+				state.mu.Lock()
+				tracker := state.cronDelivery
+				state.mu.Unlock()
+				if tracker != nil {
+					tracker.markSuppressedEmpty()
 				}
 			}
 		} else {
 			for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
-				if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
+				if err := sendFinalWorkspaceWithError(p, replyCtx, chunk); err != nil {
 					return
 				}
 			}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6766,6 +6766,43 @@ func TestProcessInteractiveEvents_CronDeliveryDoesNotSuppressQueuedTurn(t *testi
 	}
 }
 
+func TestProcessInteractiveEvents_CronDeliveryIgnoresProgressBeforeEmptyFinal(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{ThinkingMessages: false, ThinkingMaxLen: 300, ToolMaxLen: 500, ToolMessages: true})
+
+	key := "test:user-cron-progress"
+	session := e.sessions.GetOrCreateActive(key)
+	agentSession := newControllableSession("s-cron-progress")
+	tracker := &cronDeliveryTracker{emptyResponse: e.i18n.T(MsgEmptyResponse)}
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-cron-progress",
+		cronDelivery: tracker,
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	agentSession.events <- Event{Type: EventText, Content: "pre-tool"}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "echo hi"}
+	agentSession.events <- Event{Type: EventResult, Content: "", Done: true}
+
+	e.processInteractiveEvents(state, session, e.sessions, key, "msg-cron-progress", time.Now(), nil, nil, state.replyCtx)
+
+	sent := p.getSent()
+	if len(sent) == 0 {
+		t.Fatal("expected progress/segment messages to be sent")
+	}
+	if tracker.deliveredCount() != 0 {
+		t.Fatalf("cron tracker delivered count = %d, want no final delivery", tracker.deliveredCount())
+	}
+	if !tracker.suppressedEmptyResponse() {
+		t.Fatal("expected empty final response to be tracked as suppressed")
+	}
+}
+
 // replyCtxRecordingPlatform records (replyCtx, content) for each Send/Reply
 // so tests can assert which trigger context was used for which message.
 type replyCtxRecordingPlatform struct {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -170,6 +170,7 @@ func (a *sessionEnvRecordingAgent) EnvValue(key string) string {
 type resultAgentSession struct {
 	events      chan Event
 	result      string
+	inputTokens int
 	sendOnce    sync.Once
 	sentPrompts []string
 }
@@ -184,7 +185,7 @@ func newResultAgentSession(result string) *resultAgentSession {
 func (s *resultAgentSession) Send(prompt string, _ []ImageAttachment, _ []FileAttachment) error {
 	s.sentPrompts = append(s.sentPrompts, prompt)
 	s.sendOnce.Do(func() {
-		s.events <- Event{Type: EventResult, Content: s.result, Done: true}
+		s.events <- Event{Type: EventResult, Content: s.result, Done: true, InputTokens: s.inputTokens}
 	})
 	return nil
 }
@@ -6438,7 +6439,7 @@ func TestReapIdleWorkspaces_SkipsWorkspaceWithActiveTurn(t *testing.T) {
 			UserID:     "user1",
 			Content:    "long running task",
 			ReplyCtx:   "ctx",
-		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey)
+		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey, nil)
 		close(done)
 	}()
 
@@ -6491,7 +6492,7 @@ func TestReapIdleWorkspaces_SkipsWorkspaceWaitingForPermission(t *testing.T) {
 			UserID:     "user2",
 			Content:    "needs approval",
 			ReplyCtx:   "ctx",
-		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey)
+		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey, nil)
 		close(done)
 	}()
 
@@ -6700,6 +6701,68 @@ func TestProcessInteractiveEvents_DrainsQueuedMessages(t *testing.T) {
 	}
 	if len(userMsgs) < 2 {
 		t.Fatalf("user history entries = %d, want >= 2", len(userMsgs))
+	}
+}
+
+func TestProcessInteractiveEvents_CronDeliveryDoesNotSuppressQueuedTurn(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("qs-cron-queue")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	tracker := &cronDeliveryTracker{emptyResponse: e.i18n.T(MsgEmptyResponse)}
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx-turn1",
+		cronDelivery: tracker,
+		pendingMessages: []queuedMessage{
+			{platform: p, replyCtx: "ctx-turn2", content: "queued-msg"},
+		},
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	go func() {
+		sess.events <- Event{Type: EventResult, Content: "response1", Done: true}
+		sess.sendMu.Lock()
+		for len(sess.sendCalls) == 0 {
+			sess.sendMu.Unlock()
+			time.Sleep(5 * time.Millisecond)
+			sess.sendMu.Lock()
+		}
+		sess.sendMu.Unlock()
+		sess.events <- Event{Type: EventResult, Content: "", Done: true}
+	}()
+
+	session.AddHistory("user", "initial-msg")
+	sendDone := make(chan error, 1)
+	sendDone <- nil
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), nil, sendDone, "ctx-turn1")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processInteractiveEvents did not complete in time")
+	}
+
+	sent := p.getSent()
+	if len(sent) != 2 {
+		t.Fatalf("sent messages = %d, want both turns delivered: %#v", len(sent), sent)
+	}
+	if sent[1] != e.i18n.T(MsgEmptyResponse) {
+		t.Fatalf("queued turn response = %q, want empty-response message", sent[1])
+	}
+	if tracker.deliveredCount() != 1 {
+		t.Fatalf("cron tracker delivered count = %d, want only first turn", tracker.deliveredCount())
 	}
 }
 
@@ -10555,6 +10618,88 @@ func TestExecuteCronJob_ResolvesCronReplyTarget(t *testing.T) {
 
 	if len(agentSession.sentPrompts) != 1 || !strings.Contains(agentSession.sentPrompts[0], "summarize activity") {
 		t.Fatalf("agent prompts = %#v, want prompt containing summarize activity", agentSession.sentPrompts)
+	}
+}
+
+func TestExecuteCronJob_EmptyAgentResponseFails(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatalf("NewCronStore() error = %v", err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agentSession := newResultAgentSession("")
+	agent := &resultAgent{session: agentSession}
+
+	e := NewEngine("test", agent, []Platform{platform}, "", LangEnglish)
+	defer e.cancel()
+	e.cronScheduler = scheduler
+
+	job := &CronJob{
+		ID:          "job-empty",
+		SessionKey:  "discord:channel-1:user-1",
+		Prompt:      "summarize activity",
+		Description: "Daily summary",
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatalf("store.Add() error = %v", err)
+	}
+
+	err = e.ExecuteCronJob(job)
+	if err == nil || !strings.Contains(err.Error(), "empty response") {
+		t.Fatalf("ExecuteCronJob() error = %v, want empty response error", err)
+	}
+
+	sent := platform.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent messages = %d, want only start notice: %#v", len(sent), sent)
+	}
+	if sent[0] != "⏰ Daily summary" {
+		t.Fatalf("sent[0] = %q, want cron start notice", sent[0])
+	}
+}
+
+func TestExecuteCronJob_EmptyAgentResponseWithContextIndicatorFails(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatalf("NewCronStore() error = %v", err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agentSession := newResultAgentSession("")
+	agentSession.inputTokens = 1000
+	agent := &resultAgent{session: agentSession}
+
+	e := NewEngine("test", agent, []Platform{platform}, "", LangEnglish)
+	defer e.cancel()
+	e.cronScheduler = scheduler
+
+	job := &CronJob{
+		ID:          "job-empty-ctx",
+		SessionKey:  "discord:channel-1:user-1",
+		Prompt:      "summarize activity",
+		Description: "Daily summary",
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatalf("store.Add() error = %v", err)
+	}
+
+	err = e.ExecuteCronJob(job)
+	if err == nil || !strings.Contains(err.Error(), "empty response") {
+		t.Fatalf("ExecuteCronJob() error = %v, want empty response error", err)
+	}
+
+	sent := platform.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent messages = %d, want only start notice: %#v", len(sent), sent)
 	}
 }
 


### PR DESCRIPTION
## Summary

- expand cron prompt jobs that use slash skill syntax before sending them to the agent
- track non-muted cron delivery so empty/no-output runs fail instead of appearing successful
- expose cron `silent` through `cron add --silent` and `cron edit <id> silent true|false`

Fixes #856.
Fixes #857.
Fixes #858.

## Tests

- `go test ./core -run 'TestEngine_ExpandCronSkillPrompt|TestExecuteCronJob_EmptyAgentResponse|TestProcessInteractiveEvents_CronDeliveryDoesNotSuppressQueuedTurn|TestExecuteCronJob_ResolvesCronReplyTarget|TestExecuteCronJob_WorkspacePrefixedSessionKey'`\n- `go test -tags no_web ./cmd/cc-connect -run 'TestParseCron|TestCron|TestParseSendArgs'`\n\nNote: `go test -tags no_web ./cmd/cc-connect ./core` currently fails in `core.TestBridgeBuildCapabilitiesSnapshotIncludesProjectCatalog` on latest main because Bridge now requires a token and the test dereferences a nil server. The targeted cron/core tests above pass.