### PR TITLE
feat(cron): fail when non-muted cron produces empty response

### DIFF
--- a/core/cron.go
+++ b/core/cron.go
@@ -678,6 +678,41 @@ type mutePlatform struct {
 func (m *mutePlatform) Reply(_ context.Context, _ any, _ string) error { return nil }
 func (m *mutePlatform) Send(_ context.Context, _ any, _ string) error  { return nil }
 
+// deliveryTrackingPlatform wraps a Platform and tracks whether any message
+// was successfully delivered via Reply or Send. Used by ExecuteCronJob to
+// detect empty responses.
+type deliveryTrackingPlatform struct {
+	Platform
+	mu       sync.Mutex
+	delivered bool
+}
+
+func (d *deliveryTrackingPlatform) Reply(ctx context.Context, replyCtx any, content string) error {
+	err := d.Platform.Reply(ctx, replyCtx, content)
+	if err == nil {
+		d.mu.Lock()
+		d.delivered = true
+		d.mu.Unlock()
+	}
+	return err
+}
+
+func (d *deliveryTrackingPlatform) Send(ctx context.Context, sessionKey any, content string) error {
+	err := d.Platform.Send(ctx, sessionKey, content)
+	if err == nil {
+		d.mu.Lock()
+		d.delivered = true
+		d.mu.Unlock()
+	}
+	return err
+}
+
+func (d *deliveryTrackingPlatform) wasDelivered() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.delivered
+}
+
 func GenerateCronID() string {
 	b := make([]byte, 4)
 	if _, err := rand.Read(b); err != nil {

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -113,6 +113,41 @@ func TestMutePlatform_DiscardMessages(t *testing.T) {
 	}
 }
 
+func TestDeliveryTrackingPlatform_TracksDelivery(t *testing.T) {
+	inner := &stubPlatformEngine{n: "test"}
+	dp := &deliveryTrackingPlatform{Platform: inner}
+
+	// Initially no delivery
+	if dp.wasDelivered() {
+		t.Error("should not be delivered initially")
+	}
+
+	// Reply triggers delivery tracking
+	if err := dp.Reply(context.Background(), "ctx", "hello"); err != nil {
+		t.Errorf("Reply should return nil, got %v", err)
+	}
+	if !dp.wasDelivered() {
+		t.Error("should be delivered after Reply")
+	}
+
+	// Reset and test Send
+	dp2 := &deliveryTrackingPlatform{Platform: inner}
+	if err := dp2.Send(context.Background(), "key", "world"); err != nil {
+		t.Errorf("Send should return nil, got %v", err)
+	}
+	if !dp2.wasDelivered() {
+		t.Error("should be delivered after Send")
+	}
+}
+
+func TestDeliveryTrackingPlatform_DelegatesName(t *testing.T) {
+	inner := &stubPlatformEngine{n: "myplatform"}
+	dp := &deliveryTrackingPlatform{Platform: inner}
+	if dp.Name() != "myplatform" {
+		t.Errorf("deliveryTrackingPlatform should delegate Name(), got %q", dp.Name())
+	}
+}
+
 func TestCronJob_MuteField(t *testing.T) {
 	job := &CronJob{ID: "m1", Mute: false}
 	if job.Mute {

--- a/core/engine.go
+++ b/core/engine.go
@@ -1067,6 +1067,8 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 	}
 
 	// Notify user that a cron job is executing (unless silent/muted)
+	// Note: this notification uses targetPlatform directly, not the tracking wrapper,
+	// so it won't count as a "meaningful delivery" for empty response detection.
 	if !job.Mute {
 		silent := false
 		if e.cronScheduler != nil {
@@ -1083,6 +1085,15 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 			}
 			e.send(targetPlatform, replyCtx, fmt.Sprintf("⏰ %s", desc))
 		}
+	}
+
+	// For non-muted cron jobs, wrap with delivery tracking to detect empty responses.
+	// This wrapper is created after the "⏰" notification so only actual agent responses
+	// are tracked.
+	var deliveryTracker *deliveryTrackingPlatform
+	if !job.Mute {
+		deliveryTracker = &deliveryTrackingPlatform{Platform: effectivePlatform}
+		effectivePlatform = deliveryTracker
 	}
 
 	if job.IsShellJob() {
@@ -1151,6 +1162,10 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		}
 		e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, runSessionKey)
 		e.cleanupInteractiveState(iKey)
+		// Check if any response was delivered for non-muted cron jobs
+		if deliveryTracker != nil && !deliveryTracker.wasDelivered() {
+			return fmt.Errorf("cron job %q produced an empty response", job.ID)
+		}
 		return nil
 	}
 
@@ -1164,6 +1179,10 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		iKey = workspaceDir + ":" + sessionKey
 	}
 	e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, sessionKey)
+	// Check if any response was delivered for non-muted cron jobs
+	if deliveryTracker != nil && !deliveryTracker.wasDelivered() {
+		return fmt.Errorf("cron job %q produced an empty response", job.ID)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Add `deliveryTrackingPlatform` wrapper that tracks when `Reply`/`Send` is successfully called on the platform
- For non-muted cron jobs, wrap the platform with this tracker after the "⏰" notification is sent
- After `processInteractiveMessageWith` completes, check if any delivery occurred
- If no delivery occurred, return error `"cron job produced an empty response"`

This prevents silent failures where cron jobs appear successful but the agent actually returned nothing meaningful to the user (e.g., when the agent produces only `(empty response)` placeholder).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./...` passes (all 89 test cases)
- [x] New tests for `deliveryTrackingPlatform` added in `cron_test.go`
- [ ] Manual smoke test: verify cron job failure is logged when agent returns empty

Closes #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)