### PR TITLE
feat(cron): expand skill commands in cron job prompts

### DIFF
--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -110,6 +111,124 @@ func TestMutePlatform_DiscardMessages(t *testing.T) {
 
 	if mp.Name() != "test" {
 		t.Errorf("mutePlatform should delegate Name(), got %q", mp.Name())
+	}
+}
+
+func TestExecuteCronJob_ExpandsSkillCommand(t *testing.T) {
+	// Create a temp skill directory with a test skill
+	skillDir := t.TempDir()
+	skillSubdir := filepath.Join(skillDir, "daily-brief")
+	if err := os.Mkdir(skillSubdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	skillContent := `---
+name: daily-brief
+description: Generate daily briefing
+---
+Summarize today's activity and pending tasks.
+`
+	if err := os.WriteFile(filepath.Join(skillSubdir, "SKILL.md"), []byte(skillContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatalf("NewCronStore() error = %v", err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "slack"},
+	}
+	agentSession := newResultAgentSession("briefing done")
+	agent := &resultAgent{session: agentSession}
+
+	e := NewEngine("test", agent, []Platform{platform}, "", LangEnglish)
+	defer e.cancel()
+	e.cronScheduler = scheduler
+	e.skills.SetDirs([]string{skillDir})
+
+	// Cron job with skill command
+	job := &CronJob{
+		ID:          "job-skill",
+		SessionKey:  "slack:C123:U456",
+		Prompt:      "/daily-brief for today",
+		Description: "Daily briefing",
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatalf("store.Add() error = %v", err)
+	}
+
+	if err := e.ExecuteCronJob(job); err != nil {
+		t.Fatalf("ExecuteCronJob() error = %v", err)
+	}
+
+	// Verify the skill was expanded by checking the prompts sent to the agent
+	// (not the platform messages, which are just notifications + agent responses)
+	prompts := agentSession.sentPrompts
+	if len(prompts) == 0 {
+		t.Fatal("expected prompts to be sent to agent")
+	}
+
+	// The expanded prompt should contain skill instructions
+	found := false
+	for _, prompt := range prompts {
+		if strings.Contains(prompt, "Skill: daily-brief") || strings.Contains(prompt, "Skill Instructions") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected skill expansion in agent prompts, got: %v", prompts)
+	}
+}
+
+func TestExecuteCronJob_UnknownSlashCommandPassthrough(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatalf("NewCronStore() error = %v", err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "telegram"},
+	}
+	agentSession := newResultAgentSession("ok")
+	agent := &resultAgent{session: agentSession}
+
+	e := NewEngine("test", agent, []Platform{platform}, "", LangEnglish)
+	defer e.cancel()
+	e.cronScheduler = scheduler
+	// No skill dirs - so /unknown-command won't be resolved
+
+	// Cron job with unknown slash command
+	job := &CronJob{
+		ID:          "job-unknown",
+		SessionKey:  "telegram:C123:U456",
+		Prompt:      "/unknown-command arg1 arg2",
+		Description: "Unknown cmd",
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatalf("store.Add() error = %v", err)
+	}
+
+	if err := e.ExecuteCronJob(job); err != nil {
+		t.Fatalf("ExecuteCronJob() error = %v", err)
+	}
+
+	// The raw command should be passed through to the agent
+	sent := platform.getSent()
+	if len(sent) == 0 {
+		t.Fatal("expected messages to be sent")
+	}
+
+	// Should NOT contain skill expansion markers
+	for _, msg := range sent {
+		if strings.Contains(msg, "Skill Instructions") {
+			t.Errorf("unknown slash command should not be expanded as skill, got: %s", msg)
+		}
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -1089,12 +1089,31 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		return e.executeCronShell(effectivePlatform, replyCtx, job)
 	}
 
+	// Resolve prompt: expand skill if prompt starts with "/"
+	prompt := job.Prompt
+	if strings.HasPrefix(prompt, "/") {
+		// Parse command and args similar to handleCommand
+		parts := strings.Fields(prompt)
+		cmd := strings.ToLower(strings.TrimPrefix(parts[0], "/"))
+		args := parts[1:]
+
+		// Try to resolve as a skill
+		if skill := e.skills.Resolve(cmd); skill != nil {
+			prompt = BuildSkillInvocationPrompt(skill, args)
+			slog.Info("cron: expanded skill command",
+				"job_id", job.ID,
+				"skill", skill.Name,
+				"args", args)
+		}
+		// If not a known skill, keep the original prompt (fall through to agent)
+	}
+
 	msg := &Message{
 		SessionKey:   sessionKey,
 		Platform:     platformName,
 		UserID:       "cron",
 		UserName:     "cron",
-		Content:      job.Prompt,
+		Content:      prompt,
 		ReplyCtx:     replyCtx,
 		ModeOverride: job.Mode,
 	}


### PR DESCRIPTION
## Summary

- When a cron job's prompt starts with "/", parse it as a slash command
- Resolve through the skill registry to find matching skill
- Use `BuildSkillInvocationPrompt` to expand into full skill instructions
- Unknown slash commands pass through unchanged to the agent

This allows cron jobs to invoke skills like `/daily-brief for today`, which will be expanded into full skill instructions before being sent to the agent.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all tests)
- [x] Added regression test `TestExecuteCronJob_ExpandsSkillCommand`
- [x] Added regression test `TestExecuteCronJob_UnknownSlashCommandPassthrough`

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)