### PR TITLE
fix(feishu): support multi-select in AskUserQuestion cards

### DIFF
--- a/core/card.go
+++ b/core/card.go
@@ -68,12 +68,24 @@ type CardSelectOption struct {
 	Value string
 }
 
-func (CardMarkdown) cardElement() {}
-func (CardDivider) cardElement()  {}
-func (CardActions) cardElement()  {}
-func (CardNote) cardElement()     {}
-func (CardListItem) cardElement() {}
-func (CardSelect) cardElement()   {}
+// CardAskQuestionMultiSelect renders a multi-select form for AskUserQuestion.
+// On Feishu this maps to a form with checker elements; on other platforms it
+// degrades to numbered text instructions.
+type CardAskQuestionMultiSelect struct {
+	Question     string              // the question text
+	Options      []CardSelectOption  // available options
+	QuestionIdx  int                 // question index (for callback routing)
+	SubmitText   string              // submit button text
+	CancelText   string              // cancel button text (optional)
+}
+
+func (CardMarkdown) cardElement()                {}
+func (CardDivider) cardElement()                 {}
+func (CardActions) cardElement()                 {}
+func (CardNote) cardElement()                    {}
+func (CardListItem) cardElement()                {}
+func (CardSelect) cardElement()                  {}
+func (CardAskQuestionMultiSelect) cardElement()  {}
 
 // CardButton represents a clickable button inside a CardActions element.
 type CardButton struct {
@@ -200,6 +212,21 @@ func (b *CardBuilder) Select(placeholder string, options []CardSelectOption, ini
 	return b
 }
 
+// AskQuestionMultiSelect appends a multi-select form element for AskUserQuestion.
+// This is rendered as a form with checkboxes on Feishu, and as numbered text on other platforms.
+func (b *CardBuilder) AskQuestionMultiSelect(question string, options []CardSelectOption, qIdx int, submitText, cancelText string) *CardBuilder {
+	if len(options) > 0 {
+		b.card.Elements = append(b.card.Elements, CardAskQuestionMultiSelect{
+			Question:     question,
+			Options:      options,
+			QuestionIdx:  qIdx,
+			SubmitText:   submitText,
+			CancelText:   cancelText,
+		})
+	}
+	return b
+}
+
 // Note appends a footnote element.
 func (b *CardBuilder) Note(text string) *CardBuilder {
 	if text != "" {
@@ -267,6 +294,13 @@ func (c *Card) RenderText() string {
 				sb.WriteString(opt.Text)
 			}
 			sb.WriteString("\n\n")
+		case CardAskQuestionMultiSelect:
+			sb.WriteString(e.Question)
+			sb.WriteString("\n")
+			for i, opt := range e.Options {
+				sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, opt.Text))
+			}
+			sb.WriteString("\n")
 		case CardNote:
 			sb.WriteString(e.Text)
 			sb.WriteString("\n")
@@ -280,7 +314,7 @@ func (c *Card) RenderText() string {
 func (c *Card) HasButtons() bool {
 	for _, elem := range c.Elements {
 		switch elem.(type) {
-		case CardActions, CardListItem, CardSelect:
+		case CardActions, CardListItem, CardSelect, CardAskQuestionMultiSelect:
 			return true
 		}
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -8714,21 +8714,34 @@ func (e *Engine) sendAskQuestionPrompt(p Platform, replyCtx any, questions []Use
 	// Try card (Feishu/Lark)
 	if supportsCards(p) {
 		cb := NewCard().Title(e.i18n.T(MsgAskQuestionTitle)+titleSuffix, "blue")
-		body := "**" + q.Question + "**"
 		if q.MultiSelect {
-			body += e.i18n.T(MsgAskQuestionMulti)
-		}
-		cb.Markdown(body)
-		for i, opt := range q.Options {
-			desc := opt.Label
-			if opt.Description != "" {
-				desc += " — " + opt.Description
+			// Use multi-select form element for Feishu
+			// On Feishu, multi-select needs a form with checkers and submit button
+			options := make([]CardSelectOption, len(q.Options))
+			for i, opt := range q.Options {
+				desc := opt.Label
+				if opt.Description != "" {
+					desc += " — " + opt.Description
+				}
+				options[i] = CardSelectOption{Text: desc, Value: fmt.Sprintf("%d", i+1)}
 			}
-			answerData := fmt.Sprintf("askq:%d:%d", qIdx, i+1)
-			cb.ListItemBtnExtra(desc, opt.Label, "default", answerData, map[string]string{
-				"askq_label":    opt.Label,
-				"askq_question": q.Question,
-			})
+			cb.AskQuestionMultiSelect(q.Question, options, qIdx,
+				e.i18n.T(MsgAskQuestionSubmit), e.i18n.T(MsgAskQuestionCancel))
+		} else {
+			// Single-select: use existing button-based approach
+			body := "**" + q.Question + "**"
+			cb.Markdown(body)
+			for i, opt := range q.Options {
+				desc := opt.Label
+				if opt.Description != "" {
+					desc += " — " + opt.Description
+				}
+				answerData := fmt.Sprintf("askq:%d:%d", qIdx, i+1)
+				cb.ListItemBtnExtra(desc, opt.Label, "default", answerData, map[string]string{
+					"askq_label":    opt.Label,
+					"askq_question": q.Question,
+				})
+			}
 		}
 		cb.Note(e.i18n.T(MsgAskQuestionNote))
 		e.sendWithCard(p, replyCtx, cb.Build())

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -351,6 +351,8 @@ const (
 	MsgAskQuestionMulti    MsgKey = "ask_question_multi"
 	MsgAskQuestionPrompt   MsgKey = "ask_question_prompt"
 	MsgAskQuestionAnswered MsgKey = "ask_question_answered"
+	MsgAskQuestionSubmit   MsgKey = "ask_question_submit"
+	MsgAskQuestionCancel   MsgKey = "ask_question_cancel"
 
 	MsgCommandsTitle        MsgKey = "commands_title"
 	MsgCommandsEmpty        MsgKey = "commands_empty"
@@ -2464,6 +2466,20 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "已回答",
 		LangJapanese:           "回答済み",
 		LangSpanish:            "Respondido",
+	},
+	MsgAskQuestionSubmit: {
+		LangEnglish:            "Submit",
+		LangChinese:            "提交",
+		LangTraditionalChinese: "提交",
+		LangJapanese:           "送信",
+		LangSpanish:            "Enviar",
+	},
+	MsgAskQuestionCancel: {
+		LangEnglish:            "Cancel",
+		LangChinese:            "取消",
+		LangTraditionalChinese: "取消",
+		LangJapanese:           "キャンセル",
+		LangSpanish:            "Cancelar",
 	},
 	MsgCommandsTitle: {
 		LangEnglish:            "🔧 **Custom Commands** (%d)\n\n",

--- a/platform/feishu/card.go
+++ b/platform/feishu/card.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -243,6 +245,73 @@ func renderCardMap(card *core.Card, sessionKey string) map[string]any {
 				"tag":     "action",
 				"actions": []map[string]any{selectElem},
 			})
+		case core.CardAskQuestionMultiSelect:
+			// Build a form with checker elements for multi-select
+			formElements := make([]map[string]any, 0)
+			// Add question as markdown
+			formElements = append(formElements, map[string]any{
+				"tag":     "markdown",
+				"content": "**" + e.Question + "**",
+			})
+			// Add checker for each option
+			for i, opt := range e.Options {
+				optIdx := i + 1 // 1-based index for callback
+				checkerName := askQuestionCheckerName(e.QuestionIdx, optIdx)
+				formElements = append(formElements, map[string]any{
+					"tag":     "checker",
+					"name":    checkerName,
+					"checked": false,
+					"text": map[string]any{
+						"tag":     "lark_md",
+						"content": opt.Text,
+					},
+				})
+			}
+			// Add submit/cancel buttons
+			buttonColumns := []map[string]any{
+				{
+					"tag":            "column",
+					"width":          "auto",
+					"vertical_align": "center",
+					"elements": []map[string]any{
+						{
+							"tag":              "button",
+							"text":             plainText(e.SubmitText),
+							"type":             "primary",
+							"name":             "askq_multiselect_submit",
+							"form_action_type": "submit",
+							"value":            map[string]string{"action": fmt.Sprintf("askq:%d:multi", e.QuestionIdx)},
+						},
+					},
+				},
+			}
+			if e.CancelText != "" {
+				buttonColumns = append(buttonColumns, map[string]any{
+					"tag":            "column",
+					"width":          "auto",
+					"vertical_align": "center",
+					"elements": []map[string]any{
+						{
+							"tag":   "button",
+							"text":  plainText(e.CancelText),
+							"type":  "default",
+							"name":  "askq_multiselect_cancel",
+							"value": map[string]string{"action": fmt.Sprintf("askq:%d:cancel", e.QuestionIdx)},
+						},
+					},
+				})
+			}
+			formElements = append(formElements, map[string]any{
+				"tag":              "column_set",
+				"horizontal_align": "left",
+				"columns":          buttonColumns,
+			})
+			// Wrap in a form
+			elements = append(elements, map[string]any{
+				"tag":      "form",
+				"name":     fmt.Sprintf("askq_form_%d", e.QuestionIdx),
+				"elements": formElements,
+			})
 		case core.CardNote:
 			elements = append(elements, map[string]any{
 				"tag":      "note",
@@ -461,4 +530,50 @@ func renderCard(card *core.Card, sessionKey string) string {
 		return `{"config":{"wide_screen_mode":true},"elements":[]}`
 	}
 	return string(b)
+}
+
+// askQuestionCheckerNamePrefix is used for multi-select AskUserQuestion form elements.
+const askQuestionCheckerNamePrefix = "askq_sel_"
+
+// askQuestionCheckerName generates a unique checker name for an AskUserQuestion option.
+func askQuestionCheckerName(qIdx, optIdx int) string {
+	// Encode as "askq_sel_<qIdx>_<optIdx>"
+	return fmt.Sprintf("%s%d_%d", askQuestionCheckerNamePrefix, qIdx, optIdx)
+}
+
+// parseAskQuestionCheckerName extracts qIdx and optIdx from a checker name.
+func parseAskQuestionCheckerName(name string) (qIdx, optIdx int, ok bool) {
+	if !strings.HasPrefix(name, askQuestionCheckerNamePrefix) {
+		return 0, 0, false
+	}
+	parts := strings.Split(strings.TrimPrefix(name, askQuestionCheckerNamePrefix), "_")
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	q, err1 := strconv.Atoi(parts[0])
+	o, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return q, o, true
+}
+
+// collectAskQuestionMultiSelectFromFormValue extracts selected option indices from
+// a form submission for multi-select AskUserQuestion.
+func collectAskQuestionMultiSelectFromFormValue(formValue map[string]any, qIdx int) []int {
+	if len(formValue) == 0 {
+		return nil
+	}
+	var selected []int
+	for key, val := range formValue {
+		parsedQIdx, optIdx, ok := parseAskQuestionCheckerName(key)
+		if !ok || parsedQIdx != qIdx {
+			continue
+		}
+		if isTruthyFormValue(val) {
+			selected = append(selected, optIdx)
+		}
+	}
+	sort.Ints(selected)
+	return selected
 }

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -624,6 +624,27 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 
 	// askq: — AskUserQuestion option selected, forward as user message
 	if strings.HasPrefix(actionVal, "askq:") {
+		// Handle multi-select form submission
+		if strings.HasSuffix(actionVal, ":multi") {
+			// Extract question index from actionVal (format: "askq:<qIdx>:multi")
+			parts := strings.Split(actionVal, ":")
+			if len(parts) >= 2 {
+				qIdxStr := parts[1]
+				qIdx, err := strconv.Atoi(qIdxStr)
+				if err == nil {
+					// Collect selected options from form value
+					selected := collectAskQuestionMultiSelectFromFormValue(event.Event.Action.FormValue, qIdx)
+					if len(selected) > 0 {
+						// Build response with selected indices (format: "askq:<qIdx>:<opt1>,<opt2>,...")
+						actionVal = fmt.Sprintf("askq:%d:%s", qIdx, intSliceJoin(selected, ","))
+					} else {
+						// No selection - treat as empty response
+						actionVal = fmt.Sprintf("askq:%d:0", qIdx)
+					}
+				}
+			}
+		}
+
 		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
 		go p.handler(p.dispatchPlatform(), &core.Message{
 			SessionKey: sessionKey,
@@ -672,6 +693,21 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 	}
 
 	return nil, nil
+}
+
+// intSliceJoin joins a slice of ints with a separator.
+func intSliceJoin(ints []int, sep string) string {
+	if len(ints) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, v := range ints {
+		if i > 0 {
+			sb.WriteString(sep)
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	return sb.String()
 }
 
 func (p *Platform) addReaction(messageID string) string {


### PR DESCRIPTION
## Summary

When AskUserQuestion has `multiSelect=true`, Feishu cards now use a form with checker elements instead of individual buttons. This allows users to select multiple options before submitting, instead of each button click immediately triggering a callback.

**Changes:**
- Add `CardAskQuestionMultiSelect` element type in `core/card.go`
- Render multi-select as form with checkers + submit button in `platform/feishu/card.go`
- Handle form submission to collect selected indices in `platform/feishu/feishu.go`
- Add i18n keys for submit/cancel buttons
- Single-select questions keep existing button-based behavior

**User experience:**
- Multi-select: checkboxes for each option + Submit/Cancel buttons
- Single-select: existing button-per-option behavior unchanged

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all tests)
- [ ] Manual smoke test: verify multi-select card allows checking multiple options before submit on Feishu

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)