### PR TITLE
feat(core): configurable shell and shell profile for exec

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -417,6 +417,10 @@ func main() {
 			})
 		}
 
+		// Wire shell configuration
+		shell, shellFlag, initCmd := config.EffectiveShell(cfg, &proj)
+		engine.SetShell(shell, shellFlag, initCmd)
+
 		// Wire hooks
 		if len(cfg.Hooks) > 0 {
 			coreHooks := make([]core.HookConfig, len(cfg.Hooks))
@@ -430,7 +434,7 @@ func main() {
 					Async:   h.Async,
 				}
 			}
-			engine.SetHooks(core.NewHookManager(proj.Name, coreHooks))
+			engine.SetHooks(core.NewHookManager(proj.Name, coreHooks, shell, shellFlag, initCmd))
 		}
 
 		// Wire local reference normalization / rendering

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -418,8 +418,8 @@ func main() {
 		}
 
 		// Wire shell configuration
-		shell, shellFlag, initCmd := config.EffectiveShell(cfg, &proj)
-		engine.SetShell(shell, shellFlag, initCmd)
+		shell, shellFlag, shellProfile := config.EffectiveShell(cfg, &proj)
+		engine.SetShell(shell, shellFlag, shellProfile)
 
 		// Wire hooks
 		if len(cfg.Hooks) > 0 {
@@ -434,7 +434,7 @@ func main() {
 					Async:   h.Async,
 				}
 			}
-			engine.SetHooks(core.NewHookManager(proj.Name, coreHooks, shell, shellFlag, initCmd))
+			engine.SetHooks(core.NewHookManager(proj.Name, coreHooks, shell, shellFlag, shellProfile))
 		}
 
 		// Wire local reference normalization / rendering

--- a/config.example.toml
+++ b/config.example.toml
@@ -23,6 +23,17 @@
 # - "" (empty/not set): Auto-detect from user's first message / 留空自动检测
 # language = "en"
 
+# Shell for /shell commands, cron exec, hooks, and webhook exec.
+# /shell 命令、cron exec、hooks 和 webhook exec 使用的 shell。
+# Default / 默认: "sh" (Unix) or "powershell.exe" (Windows)
+# Supported / 支持: sh, bash, zsh, fish, cmd, powershell, pwsh
+# shell = "/bin/zsh"
+
+# Init command prepended to every shell command. Useful for sourcing profiles
+# so user-defined functions and aliases are available.
+# 初始化命令，会添加到每条 shell 命令前面。用于加载 profile，使自定义函数和别名可用。
+# init_command = "source ~/.zshrc"
+
 # Session data storage directory (default: ~/.cc-connect)
 # Stores conversation history and session state as JSON files.
 # 会话数据存储目录（默认 ~/.cc-connect），以 JSON 文件保存对话历史和会话状态。
@@ -668,6 +679,9 @@ name = "my-backend"
 # filter_external_sessions = false
 # filter_external_sessions：为 true 时，/list /switch /delete 仅显示由 cc-connect 创建的会话，
 # 隐藏在相同 work_dir 下通过直接 CLI 创建的会话。默认 false = 显示 agent 的全部会话。
+#
+# shell = "/bin/fish"                        # Per-project shell override / 项目级 shell 覆盖
+# init_command = "source ~/.config/fish/config.fish"  # Per-project init / 项目级初始化命令
 #
 # admin_from controls who can run privileged commands (/dir, /shell, /restart, /upgrade, /commands addexec, /cron addexec).
 # admin_from 控制谁可以执行特权命令（/dir, /shell, /restart, /upgrade, /commands addexec, /cron addexec）。

--- a/config.example.toml
+++ b/config.example.toml
@@ -32,7 +32,7 @@
 # Init command prepended to every shell command. Useful for sourcing profiles
 # so user-defined functions and aliases are available.
 # 初始化命令，会添加到每条 shell 命令前面。用于加载 profile，使自定义函数和别名可用。
-# init_command = "source ~/.zshrc"
+# shell_profile = "source ~/.zshrc"
 
 # Session data storage directory (default: ~/.cc-connect)
 # Stores conversation history and session state as JSON files.
@@ -681,7 +681,7 @@ name = "my-backend"
 # 隐藏在相同 work_dir 下通过直接 CLI 创建的会话。默认 false = 显示 agent 的全部会话。
 #
 # shell = "/bin/fish"                        # Per-project shell override / 项目级 shell 覆盖
-# init_command = "source ~/.config/fish/config.fish"  # Per-project init / 项目级初始化命令
+# shell_profile = "source ~/.config/fish/config.fish"  # Per-project shell profile / 项目级 shell profile
 #
 # admin_from controls who can run privileged commands (/dir, /shell, /restart, /upgrade, /commands addexec, /cron addexec).
 # admin_from 控制谁可以执行特权命令（/dir, /shell, /restart, /upgrade, /commands addexec, /cron addexec）。

--- a/config/config.go
+++ b/config/config.go
@@ -118,6 +118,15 @@ type Config struct {
 	// setting so the reaper policy is consistent across projects; per-project
 	// configuration is intentionally not supported.
 	WorkspaceIdleTimeoutMins *int `toml:"workspace_idle_timeout_mins,omitempty"`
+	// Shell overrides the default shell used for /shell commands, cron exec,
+	// hooks, and webhook exec. On Unix the default is "sh"; on Windows it is
+	// "powershell.exe". Set to an absolute path (e.g. "/bin/zsh") to use a
+	// different shell. Supported: sh, bash, zsh, fish, cmd, powershell, pwsh.
+	Shell string `toml:"shell,omitempty"`
+	// InitCommand is prepended to every shell command before execution. Useful
+	// for sourcing shell profiles so that user-defined functions and aliases are
+	// available. Example: "source ~/.zshrc"
+	InitCommand string `toml:"init_command,omitempty"`
 }
 
 // CronConfig controls cron job behavior.
@@ -407,6 +416,10 @@ type ProjectConfig struct {
 	// cc-connect, hiding sessions created by direct CLI usage in the same work_dir.
 	// Default is false (show all sessions).
 	FilterExternalSessions *bool `toml:"filter_external_sessions,omitempty"`
+	// Shell overrides the global shell for this project. See Config.Shell.
+	Shell string `toml:"shell,omitempty"`
+	// InitCommand overrides the global init_command for this project.
+	InitCommand string `toml:"init_command,omitempty"`
 }
 
 type AgentConfig struct {
@@ -773,6 +786,39 @@ func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMe
 	}
 
 	return
+}
+
+// EffectiveShell returns the shell binary, flag, and init command for the project.
+// Resolution: per-project > global > platform default.
+// The flag is auto-detected: "/C" for cmd, "-Command" for powershell/pwsh, "-c" for everything else.
+func EffectiveShell(cfg *Config, proj *ProjectConfig) (shell, flag, initCmd string) {
+	s := ""
+	p := ""
+	if proj != nil {
+		s = proj.Shell
+		p = proj.InitCommand
+	}
+	if s == "" {
+		s = cfg.Shell
+	}
+	if p == "" {
+		p = cfg.InitCommand
+	}
+	if s == "" {
+		if runtime.GOOS == "windows" {
+			return "powershell.exe", "-Command", p
+		}
+		return "sh", "-c", p
+	}
+	base := strings.ToLower(filepath.Base(s))
+	switch {
+	case base == "cmd" || base == "cmd.exe":
+		return s, "/C", p
+	case strings.HasPrefix(base, "powershell") || strings.HasPrefix(base, "pwsh"):
+		return s, "-Command", p
+	default:
+		return s, "-c", p
+	}
 }
 
 // EffectiveCardMode returns the card rendering mode for the project: "rich" (Feishu Card 2.0)

--- a/config/config.go
+++ b/config/config.go
@@ -123,10 +123,10 @@ type Config struct {
 	// "powershell.exe". Set to an absolute path (e.g. "/bin/zsh") to use a
 	// different shell. Supported: sh, bash, zsh, fish, cmd, powershell, pwsh.
 	Shell string `toml:"shell,omitempty"`
-	// InitCommand is prepended to every shell command before execution. Useful
+	// ShellProfile is prepended to every shell command before execution. Useful
 	// for sourcing shell profiles so that user-defined functions and aliases are
 	// available. Example: "source ~/.zshrc"
-	InitCommand string `toml:"init_command,omitempty"`
+	ShellProfile string `toml:"shell_profile,omitempty"`
 }
 
 // CronConfig controls cron job behavior.
@@ -418,8 +418,8 @@ type ProjectConfig struct {
 	FilterExternalSessions *bool `toml:"filter_external_sessions,omitempty"`
 	// Shell overrides the global shell for this project. See Config.Shell.
 	Shell string `toml:"shell,omitempty"`
-	// InitCommand overrides the global init_command for this project.
-	InitCommand string `toml:"init_command,omitempty"`
+	// ShellProfile overrides the global shell_profile for this project.
+	ShellProfile string `toml:"shell_profile,omitempty"`
 }
 
 type AgentConfig struct {
@@ -791,18 +791,18 @@ func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMe
 // EffectiveShell returns the shell binary, flag, and init command for the project.
 // Resolution: per-project > global > platform default.
 // The flag is auto-detected: "/C" for cmd, "-Command" for powershell/pwsh, "-c" for everything else.
-func EffectiveShell(cfg *Config, proj *ProjectConfig) (shell, flag, initCmd string) {
+func EffectiveShell(cfg *Config, proj *ProjectConfig) (shell, flag, shellProfile string) {
 	s := ""
 	p := ""
 	if proj != nil {
 		s = proj.Shell
-		p = proj.InitCommand
+		p = proj.ShellProfile
 	}
 	if s == "" {
 		s = cfg.Shell
 	}
 	if p == "" {
-		p = cfg.InitCommand
+		p = cfg.ShellProfile
 	}
 	if s == "" {
 		if runtime.GOOS == "windows" {

--- a/core/engine.go
+++ b/core/engine.go
@@ -247,6 +247,11 @@ type Engine struct {
 	// Default false = show all sessions.
 	filterExternalSessions bool
 
+	// Shell configuration for /shell, cron exec, hooks, webhook exec
+	shell       string // shell binary path (e.g. "sh", "/bin/zsh")
+	shellFlag   string // shell flag (e.g. "-c", "-Command", "/C")
+	initCommand string // prepended to every command (e.g. "source ~/.zshrc;")
+
 	// Multi-workspace mode
 	multiWorkspace               bool
 	baseDir                      string
@@ -537,6 +542,8 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		maxQueuedMessages:     defaultMaxQueuedMessages,
 		showContextIndicator:  true,
 		showWorkdirIndicator:  true,
+		shell:                 defaultShell(),
+		shellFlag:             defaultShellFlag(),
 	}
 
 	if ag != nil {
@@ -636,6 +643,13 @@ func (e *Engine) reapIdleWorkspaces() {
 // SetHooks configures the lifecycle event hook manager.
 func (e *Engine) SetHooks(hm *HookManager) {
 	e.hooks = hm
+}
+
+// SetShell configures the shell binary, flag, and init command used for exec.
+func (e *Engine) SetShell(shell, flag, initCmd string) {
+	e.shell = shell
+	e.shellFlag = flag
+	e.initCommand = initCmd
 }
 
 func (e *Engine) SetSpeechConfig(cfg SpeechCfg) {
@@ -1395,12 +1409,7 @@ func (e *Engine) executeCronShell(p Platform, replyCtx any, job *CronJob) error 
 	ctx, cancel := context.WithTimeout(e.ctx, timeout)
 	defer cancel()
 
-	var shellCmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		shellCmd = exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", job.Exec)
-	} else {
-		shellCmd = exec.CommandContext(ctx, "sh", "-c", job.Exec)
-	}
+	shellCmd := shellExecCommand(ctx, e.shell, e.shellFlag, e.initCommand, job.Exec)
 	shellCmd.Dir = workDir
 
 	stdout, err := shellCmd.StdoutPipe()
@@ -6578,6 +6587,35 @@ func (e *Engine) cmdShow(p Platform, msg *Message, args []string) {
 // quickFinishTimeout is how long to wait before assuming the command is long-running.
 const quickFinishTimeout = 500 * time.Millisecond
 
+// shellExecCommand builds an exec.Cmd for running command via the given shell.
+// For PowerShell/pwsh, extra flags (-NoProfile, -ExecutionPolicy Bypass) are
+// added automatically. If initCmd is non-empty, it is prepended to the command
+// with a newline separator (useful for sourcing shell profiles).
+func shellExecCommand(ctx context.Context, shell, flag, initCmd, command string) *exec.Cmd {
+	if initCmd != "" {
+		command = initCmd + "\n" + command
+	}
+	base := strings.ToLower(filepath.Base(shell))
+	if strings.HasPrefix(base, "powershell") || strings.HasPrefix(base, "pwsh") {
+		return exec.CommandContext(ctx, shell, "-NoProfile", "-ExecutionPolicy", "Bypass", flag, command)
+	}
+	return exec.CommandContext(ctx, shell, flag, command)
+}
+
+func defaultShell() string {
+	if runtime.GOOS == "windows" {
+		return "powershell.exe"
+	}
+	return "sh"
+}
+
+func defaultShellFlag() string {
+	if runtime.GOOS == "windows" {
+		return "-Command"
+	}
+	return "-c"
+}
+
 // runShellWithProgress executes a shell command with live progress feedback.
 // Strategy: start the command, wait 500ms. If it finishes within that window,
 // just send the result directly (no intermediate messages). If it's still running,
@@ -6588,12 +6626,7 @@ func (e *Engine) runShellWithProgress(p Platform, replyCtx any, command string, 
 	ctx, cancel := context.WithTimeout(e.ctx, timeout)
 	defer cancel()
 
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command)
-	} else {
-		cmd = exec.CommandContext(ctx, "sh", "-c", command)
-	}
+	cmd := shellExecCommand(ctx, e.shell, e.shellFlag, e.initCommand, command)
 	cmd.Dir = workDir
 
 	stdout, err := cmd.StdoutPipe()

--- a/core/engine.go
+++ b/core/engine.go
@@ -250,7 +250,7 @@ type Engine struct {
 	// Shell configuration for /shell, cron exec, hooks, webhook exec
 	shell       string // shell binary path (e.g. "sh", "/bin/zsh")
 	shellFlag   string // shell flag (e.g. "-c", "-Command", "/C")
-	initCommand string // prepended to every command (e.g. "source ~/.zshrc;")
+	shellProfile string // prepended to every command (e.g. "source ~/.zshrc;")
 
 	// Multi-workspace mode
 	multiWorkspace               bool
@@ -645,11 +645,11 @@ func (e *Engine) SetHooks(hm *HookManager) {
 	e.hooks = hm
 }
 
-// SetShell configures the shell binary, flag, and init command used for exec.
-func (e *Engine) SetShell(shell, flag, initCmd string) {
+// SetShell configures the shell binary, flag, and shell profile used for exec.
+func (e *Engine) SetShell(shell, flag, shellProfile string) {
 	e.shell = shell
 	e.shellFlag = flag
-	e.initCommand = initCmd
+	e.shellProfile = shellProfile
 }
 
 func (e *Engine) SetSpeechConfig(cfg SpeechCfg) {
@@ -1409,7 +1409,7 @@ func (e *Engine) executeCronShell(p Platform, replyCtx any, job *CronJob) error 
 	ctx, cancel := context.WithTimeout(e.ctx, timeout)
 	defer cancel()
 
-	shellCmd := shellExecCommand(ctx, e.shell, e.shellFlag, e.initCommand, job.Exec)
+	shellCmd := shellExecCommand(ctx, e.shell, e.shellFlag, e.shellProfile, job.Exec)
 	shellCmd.Dir = workDir
 
 	stdout, err := shellCmd.StdoutPipe()
@@ -6589,11 +6589,11 @@ const quickFinishTimeout = 500 * time.Millisecond
 
 // shellExecCommand builds an exec.Cmd for running command via the given shell.
 // For PowerShell/pwsh, extra flags (-NoProfile, -ExecutionPolicy Bypass) are
-// added automatically. If initCmd is non-empty, it is prepended to the command
+// added automatically. If shellProfile is non-empty, it is prepended to the command
 // with a newline separator (useful for sourcing shell profiles).
-func shellExecCommand(ctx context.Context, shell, flag, initCmd, command string) *exec.Cmd {
-	if initCmd != "" {
-		command = initCmd + "\n" + command
+func shellExecCommand(ctx context.Context, shell, flag, shellProfile, command string) *exec.Cmd {
+	if shellProfile != "" {
+		command = shellProfile + "\n" + command
 	}
 	base := strings.ToLower(filepath.Base(shell))
 	if strings.HasPrefix(base, "powershell") || strings.HasPrefix(base, "pwsh") {
@@ -6626,7 +6626,7 @@ func (e *Engine) runShellWithProgress(p Platform, replyCtx any, command string, 
 	ctx, cancel := context.WithTimeout(e.ctx, timeout)
 	defer cancel()
 
-	cmd := shellExecCommand(ctx, e.shell, e.shellFlag, e.initCommand, command)
+	cmd := shellExecCommand(ctx, e.shell, e.shellFlag, e.shellProfile, command)
 	cmd.Dir = workDir
 
 	stdout, err := cmd.StdoutPipe()

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -78,13 +78,13 @@ type HookManager struct {
 	project     string
 	shell       string // shell binary (e.g. "sh", "/bin/zsh")
 	shellFlag   string // shell flag (e.g. "-c", "-Command")
-	initCommand string // prepended to every command
+	shellProfile string // prepended to every command
 	mu          sync.RWMutex
 	client      *http.Client
 }
 
 // NewHookManager creates a manager for the given project name.
-func NewHookManager(project string, hooks []HookConfig, shell, shellFlag, initCmd string) *HookManager {
+func NewHookManager(project string, hooks []HookConfig, shell, shellFlag, shellProfile string) *HookManager {
 	valid := make([]HookConfig, 0, len(hooks))
 	for _, h := range hooks {
 		if err := validateHookConfig(h); err != nil {
@@ -98,7 +98,7 @@ func NewHookManager(project string, hooks []HookConfig, shell, shellFlag, initCm
 		project:     project,
 		shell:       shell,
 		shellFlag:   shellFlag,
-		initCommand: initCmd,
+		shellProfile: shellProfile,
 		client:      &http.Client{},
 	}
 }
@@ -175,7 +175,7 @@ func (hm *HookManager) executeCommand(h *HookConfig, event HookEvent) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := shellExecCommand(ctx, hm.shell, hm.shellFlag, hm.initCommand, h.Command)
+	cmd := shellExecCommand(ctx, hm.shell, hm.shellFlag, hm.shellProfile, h.Command)
 	cmd.WaitDelay = 2 * time.Second
 	cmd.Env = append(os.Environ(), eventToEnv(event)...)
 

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -75,14 +74,17 @@ type HookEvent struct {
 
 // HookManager dispatches lifecycle events to configured hook handlers.
 type HookManager struct {
-	hooks   []HookConfig
-	project string
-	mu      sync.RWMutex
-	client  *http.Client
+	hooks       []HookConfig
+	project     string
+	shell       string // shell binary (e.g. "sh", "/bin/zsh")
+	shellFlag   string // shell flag (e.g. "-c", "-Command")
+	initCommand string // prepended to every command
+	mu          sync.RWMutex
+	client      *http.Client
 }
 
 // NewHookManager creates a manager for the given project name.
-func NewHookManager(project string, hooks []HookConfig) *HookManager {
+func NewHookManager(project string, hooks []HookConfig, shell, shellFlag, initCmd string) *HookManager {
 	valid := make([]HookConfig, 0, len(hooks))
 	for _, h := range hooks {
 		if err := validateHookConfig(h); err != nil {
@@ -92,9 +94,12 @@ func NewHookManager(project string, hooks []HookConfig) *HookManager {
 		valid = append(valid, h)
 	}
 	return &HookManager{
-		hooks:   valid,
-		project: project,
-		client:  &http.Client{},
+		hooks:       valid,
+		project:     project,
+		shell:       shell,
+		shellFlag:   shellFlag,
+		initCommand: initCmd,
+		client:      &http.Client{},
 	}
 }
 
@@ -170,7 +175,7 @@ func (hm *HookManager) executeCommand(h *HookConfig, event HookEvent) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", h.Command)
+	cmd := shellExecCommand(ctx, hm.shell, hm.shellFlag, hm.initCommand, h.Command)
 	cmd.WaitDelay = 2 * time.Second
 	cmd.Env = append(os.Environ(), eventToEnv(event)...)
 

--- a/core/hooks_test.go
+++ b/core/hooks_test.go
@@ -27,7 +27,7 @@ func TestNewHookManager_ValidatesConfig(t *testing.T) {
 		{Event: "error", Type: "command", Command: ""},            // missing command
 		{Event: "message.sent", Type: "http", URL: "http://ok.com"},
 	}
-	hm := NewHookManager("test", hooks)
+	hm := NewHookManager("test", hooks, "sh", "-c", "")
 	got := hm.Hooks()
 	if len(got) != 2 {
 		t.Fatalf("expected 2 valid hooks, got %d", len(got))
@@ -121,7 +121,7 @@ func TestEmit_CommandHook(t *testing.T) {
 			Async:   boolPtr(false),
 		},
 	}
-	hm := NewHookManager("test-project", hooks)
+	hm := NewHookManager("test-project", hooks, "sh", "-c", "")
 
 	hm.Emit(HookEvent{
 		Event:      HookEventMessageReceived,
@@ -151,7 +151,7 @@ func TestEmit_CommandHookEnvVars(t *testing.T) {
 			Async:   boolPtr(false),
 		},
 	}
-	hm := NewHookManager("my-proj", hooks)
+	hm := NewHookManager("my-proj", hooks, "sh", "-c", "")
 
 	hm.Emit(HookEvent{
 		Event:      HookEventMessageReceived,
@@ -219,7 +219,7 @@ func TestEmit_HTTPHook(t *testing.T) {
 			Async: boolPtr(false),
 		},
 	}
-	hm := NewHookManager("proj-1", hooks)
+	hm := NewHookManager("proj-1", hooks, "sh", "-c", "")
 
 	hm.Emit(HookEvent{
 		Event:      HookEventError,
@@ -257,7 +257,7 @@ func TestEmit_WildcardMatchesAll(t *testing.T) {
 	hooks := []HookConfig{
 		{Event: "*", Type: "http", URL: srv.URL, Async: boolPtr(false)},
 	}
-	hm := NewHookManager("proj", hooks)
+	hm := NewHookManager("proj", hooks, "sh", "-c", "")
 
 	hm.Emit(HookEvent{Event: HookEventMessageReceived})
 	hm.Emit(HookEvent{Event: HookEventSessionStarted})
@@ -280,7 +280,7 @@ func TestEmit_OnlyMatchingHooksFire(t *testing.T) {
 		{Event: "session.ended", Type: "command", Command: "touch " + matchedFile, Async: boolPtr(false)},
 		{Event: "message.received", Type: "command", Command: "touch " + unmatchedFile, Async: boolPtr(false)},
 	}
-	hm := NewHookManager("proj", hooks)
+	hm := NewHookManager("proj", hooks, "sh", "-c", "")
 
 	hm.Emit(HookEvent{Event: HookEventSessionEnded})
 
@@ -307,7 +307,7 @@ func TestEmit_AsyncDoesNotBlock(t *testing.T) {
 			Async:   boolPtr(true),
 		},
 	}
-	hm := NewHookManager("proj", hooks)
+	hm := NewHookManager("proj", hooks, "sh", "-c", "")
 
 	start := time.Now()
 	hm.Emit(HookEvent{Event: HookEventMessageReceived})
@@ -339,7 +339,7 @@ func TestEmit_SyncBlocks(t *testing.T) {
 			Async:   boolPtr(false),
 		},
 	}
-	hm := NewHookManager("proj", hooks)
+	hm := NewHookManager("proj", hooks, "sh", "-c", "")
 	hm.Emit(HookEvent{Event: HookEventMessageReceived})
 
 	// File should exist immediately after synchronous emit
@@ -352,7 +352,7 @@ func TestEmit_HTTPError_DoesNotPanic(t *testing.T) {
 	hooks := []HookConfig{
 		{Event: "error", Type: "http", URL: "http://127.0.0.1:1", Async: boolPtr(false), Timeout: 1},
 	}
-	hm := NewHookManager("proj", hooks)
+	hm := NewHookManager("proj", hooks, "sh", "-c", "")
 	// Should not panic even with connection refused
 	hm.Emit(HookEvent{Event: HookEventError, Error: "test"})
 }
@@ -367,7 +367,7 @@ func TestEmit_CommandTimeout(t *testing.T) {
 			Timeout: 1,
 		},
 	}
-	hm := NewHookManager("proj", hooks)
+	hm := NewHookManager("proj", hooks, "sh", "-c", "")
 
 	start := time.Now()
 	hm.Emit(HookEvent{Event: HookEventMessageReceived})
@@ -456,7 +456,7 @@ func TestHookManager_ProjectSet(t *testing.T) {
 
 	hm := NewHookManager("special-project", []HookConfig{
 		{Event: "*", Type: "http", URL: srv.URL, Async: boolPtr(false)},
-	})
+	}, "sh", "-c", "")
 
 	hm.Emit(HookEvent{Event: HookEventMessageReceived})
 
@@ -502,7 +502,7 @@ func TestEmit_MultipleHooksSameEvent(t *testing.T) {
 		{Event: "error", Type: "http", URL: srv.URL, Async: boolPtr(false)},
 		{Event: "error", Type: "http", URL: srv.URL, Async: boolPtr(false)},
 	}
-	hm := NewHookManager("proj", hooks)
+	hm := NewHookManager("proj", hooks, "sh", "-c", "")
 	hm.Emit(HookEvent{Event: HookEventError})
 
 	if count.Load() != 3 {
@@ -523,7 +523,7 @@ func TestEmit_TimestampAutoFilled(t *testing.T) {
 
 	hm := NewHookManager("proj", []HookConfig{
 		{Event: "*", Type: "http", URL: srv.URL, Async: boolPtr(false)},
-	})
+	}, "sh", "-c", "")
 
 	before := time.Now()
 	hm.Emit(HookEvent{Event: HookEventMessageReceived})

--- a/core/webhook.go
+++ b/core/webhook.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -305,7 +304,7 @@ func (ws *WebhookServer) executeShell(engine *Engine, req WebhookRequest, event 
 	ctx, cancel := context.WithTimeout(context.Background(), webhookShellTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", req.Exec)
+	cmd := shellExecCommand(ctx, engine.shell, engine.shellFlag, engine.initCommand, req.Exec)
 	cmd.Dir = workDir
 	output, execErr := cmd.CombinedOutput()
 

--- a/core/webhook.go
+++ b/core/webhook.go
@@ -304,7 +304,7 @@ func (ws *WebhookServer) executeShell(engine *Engine, req WebhookRequest, event 
 	ctx, cancel := context.WithTimeout(context.Background(), webhookShellTimeout)
 	defer cancel()
 
-	cmd := shellExecCommand(ctx, engine.shell, engine.shellFlag, engine.initCommand, req.Exec)
+	cmd := shellExecCommand(ctx, engine.shell, engine.shellFlag, engine.shellProfile, req.Exec)
 	cmd.Dir = workDir
 	output, execErr := cmd.CombinedOutput()
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,7 @@ Complete guide to using cc-connect features.
 - [Voice Reply (TTS)](#voice-reply-text-to-speech)
 - [Image and File Send-Back](#image-and-file-send-back)
 - [Scheduled Tasks (Cron)](#scheduled-tasks-cron)
+- [Shell Configuration](#shell-configuration)
 - [Multi-Bot Relay](#multi-bot-relay)
 - [Daemon Mode](#daemon-mode)
 - [Multi-Workspace Mode](#multi-workspace-mode)
@@ -799,6 +800,78 @@ Optional: `--session-mode new-per-run` starts a fresh agent session on each run 
 > "Every day at 6am, summarize GitHub trending"
 
 Claude Code auto-creates the cron job. For other agents that rely on memory files, run `/cron setup` or `/bind setup` once first; both write the same instructions.
+
+---
+
+## Shell Configuration
+
+By default, cc-connect uses `sh` on Unix and `powershell.exe` on Windows for all shell execution (`/shell` commands, cron exec jobs, hooks, and webhook exec). You can override this to use a different shell.
+
+### Supported Shells
+
+| Shell | Config value | Flag |
+|-------|-------------|------|
+| sh (default on Unix) | `sh` | `-c` |
+| bash | `/bin/bash` | `-c` |
+| zsh | `/bin/zsh` | `-c` |
+| fish | `/bin/fish` | `-c` |
+| cmd (Windows) | `cmd` | `/C` |
+| PowerShell (default on Windows) | `powershell.exe` | `-Command` |
+| PowerShell Core | `pwsh` | `-Command` |
+
+The flag is auto-detected from the shell name — no manual configuration needed.
+
+### Global Configuration
+
+Set `shell` at the top level of `config.toml` to change the default for all projects:
+
+```toml
+shell = "/bin/zsh"
+```
+
+### Per-Project Override
+
+Override the shell for a specific project:
+
+```toml
+[[projects]]
+name = "my-project"
+shell = "/bin/fish"
+```
+
+### Init Command
+
+Use `init_command` to prepend a setup script to every shell command. This is useful for sourcing your shell profile so that custom functions, aliases, and environment variables are available:
+
+```toml
+shell = "/bin/zsh"
+init_command = "source ~/.zshrc"
+```
+
+The init command and the user's command are joined with a newline and passed as a single script to the shell, avoiding quoting issues. For example, `/shell echo $MY_VAR` becomes:
+
+```zsh
+source ~/.zshrc
+echo $MY_VAR
+```
+
+`init_command` also supports per-project override:
+
+```toml
+[[projects]]
+name = "my-project"
+shell = "/bin/fish"
+init_command = "source ~/.config/fish/config.fish"
+```
+
+### Affected Execution Paths
+
+The shell configuration applies to all command execution in cc-connect:
+
+- **`/shell` command** — interactive shell commands from chat
+- **Cron exec jobs** — `[[cron]]` entries with `exec` field
+- **Hooks** — `[[hooks]]` entries with `type = "command"`
+- **Webhook exec** — webhook requests with `exec` field
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -839,29 +839,29 @@ name = "my-project"
 shell = "/bin/fish"
 ```
 
-### Init Command
+### Shell Profile
 
-Use `init_command` to prepend a setup script to every shell command. This is useful for sourcing your shell profile so that custom functions, aliases, and environment variables are available:
+Use `shell_profile` to prepend a setup script to every shell command. This is useful for sourcing your shell profile so that custom functions, aliases, and environment variables are available:
 
 ```toml
 shell = "/bin/zsh"
-init_command = "source ~/.zshrc"
+shell_profile = "source ~/.zshrc"
 ```
 
-The init command and the user's command are joined with a newline and passed as a single script to the shell, avoiding quoting issues. For example, `/shell echo $MY_VAR` becomes:
+The shell profile and the user's command are joined with a newline and passed as a single script to the shell, avoiding quoting issues. For example, `/shell echo $MY_VAR` becomes:
 
 ```zsh
 source ~/.zshrc
 echo $MY_VAR
 ```
 
-`init_command` also supports per-project override:
+`shell_profile` also supports per-project override:
 
 ```toml
 [[projects]]
 name = "my-project"
 shell = "/bin/fish"
-init_command = "source ~/.config/fish/config.fish"
+shell_profile = "source ~/.config/fish/config.fish"
 ```
 
 ### Affected Execution Paths

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -17,6 +17,7 @@ cc-connect 完整功能使用指南。
 - [语音回复（文字转语音）](#语音回复文字转语音)
 - [图片与文件回传](#图片与文件回传)
 - [定时任务 (Cron)](#定时任务-cron)
+- [Shell 配置](#shell-配置)
 - [多机器人中继](#多机器人中继)
 - [守护进程模式](#守护进程模式)
 - [多工作区模式](#多工作区模式)
@@ -711,6 +712,78 @@ cc-connect cron del <job-id>
 > "每天早上6点帮我总结 GitHub trending"
 
 Claude Code 会自动创建定时任务。对依赖记忆文件的其他 Agent，先执行一次 `/cron setup` 或 `/bind setup`，效果相同。
+
+---
+
+## Shell 配置
+
+默认情况下，cc-connect 在 Unix 上使用 `sh`，Windows 上使用 `powershell.exe` 来执行所有 shell 命令（`/shell`、cron exec、hooks 和 webhook exec）。你可以配置使用其他 shell。
+
+### 支持的 Shell
+
+| Shell | 配置值 | 参数标志 |
+|-------|--------|---------|
+| sh（Unix 默认） | `sh` | `-c` |
+| bash | `/bin/bash` | `-c` |
+| zsh | `/bin/zsh` | `-c` |
+| fish | `/bin/fish` | `-c` |
+| cmd（Windows） | `cmd` | `/C` |
+| PowerShell（Windows 默认） | `powershell.exe` | `-Command` |
+| PowerShell Core | `pwsh` | `-Command` |
+
+参数标志会根据 shell 名称自动检测，无需手动配置。
+
+### 全局配置
+
+在 `config.toml` 顶层设置 `shell`，更改所有项目的默认 shell：
+
+```toml
+shell = "/bin/zsh"
+```
+
+### 项目级覆盖
+
+为特定项目覆盖 shell：
+
+```toml
+[[projects]]
+name = "my-project"
+shell = "/bin/fish"
+```
+
+### 初始化命令
+
+使用 `init_command` 在每条 shell 命令前添加初始化脚本。适用于加载 shell profile，使自定义函数、别名和环境变量可用：
+
+```toml
+shell = "/bin/zsh"
+init_command = "source ~/.zshrc"
+```
+
+初始化命令和用户命令会用换行符拼接后作为一个整体脚本传给 shell，避免引号转义问题。例如 `/shell echo $MY_VAR` 实际执行的是：
+
+```zsh
+source ~/.zshrc
+echo $MY_VAR
+```
+
+`init_command` 同样支持项目级覆盖：
+
+```toml
+[[projects]]
+name = "my-project"
+shell = "/bin/fish"
+init_command = "source ~/.config/fish/config.fish"
+```
+
+### 影响范围
+
+Shell 配置适用于 cc-connect 中所有命令执行路径：
+
+- **`/shell` 命令** — 聊天中的交互式 shell 命令
+- **Cron exec 任务** — `[[cron]]` 中 `exec` 字段的定时任务
+- **Hooks** — `[[hooks]]` 中 `type = "command"` 的钩子
+- **Webhook exec** — webhook 请求中 `exec` 字段的命令
 
 ---
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -751,29 +751,29 @@ name = "my-project"
 shell = "/bin/fish"
 ```
 
-### 初始化命令
+### Shell Profile
 
-使用 `init_command` 在每条 shell 命令前添加初始化脚本。适用于加载 shell profile，使自定义函数、别名和环境变量可用：
+使用 `shell_profile` 在每条 shell 命令前添加初始化脚本。适用于加载 shell profile，使自定义函数、别名和环境变量可用：
 
 ```toml
 shell = "/bin/zsh"
-init_command = "source ~/.zshrc"
+shell_profile = "source ~/.zshrc"
 ```
 
-初始化命令和用户命令会用换行符拼接后作为一个整体脚本传给 shell，避免引号转义问题。例如 `/shell echo $MY_VAR` 实际执行的是：
+shell profile 和用户命令会用换行符拼接后作为一个整体脚本传给 shell，避免引号转义问题。例如 `/shell echo $MY_VAR` 实际执行的是：
 
 ```zsh
 source ~/.zshrc
 echo $MY_VAR
 ```
 
-`init_command` 同样支持项目级覆盖：
+`shell_profile` 同样支持项目级覆盖：
 
 ```toml
 [[projects]]
 name = "my-project"
 shell = "/bin/fish"
-init_command = "source ~/.config/fish/config.fish"
+shell_profile = "source ~/.config/fish/config.fish"
 ```
 
 ### 影响范围


### PR DESCRIPTION
## Why

cc-connect hardcodes `sh -c` (Unix) / `powershell.exe -Command` (Windows) for all shell execution — `/shell` commands, cron exec, hooks, and webhook exec. Users who prefer zsh, fish, or bash cannot configure this, and Windows users hit `exec: "sh": executable file not found in %PATH%` (#784) when no POSIX sh is on PATH.

## Summary

- Add `shell` config option (global and per-project) to choose which shell binary to use
- Add `init_command` config option to prepend a setup script (e.g. `source ~/.zshrc`) to every shell command, so user-defined functions and aliases are available
- Supported shells: sh, bash, zsh, fish, cmd, powershell, pwsh
- Shell flag (`-c`, `/C`, `-Command`) is auto-detected from the binary name; PowerShell/pwsh automatically gets `-NoProfile -ExecutionPolicy Bypass`
- Extract all shell execution into a single `shellExecCommand()` helper in `core/engine.go`. Previously, `runShellWithProgress` and `executeCronShell` each had their own `if runtime.GOOS == "windows"` branch, while `hooks.go` and `webhook.go` hardcoded `sh -c` with no Windows handling at all. Now all 4 call sites go through one function that reads `e.shell`/`e.shellFlag` from config, so adding a new shell or fixing platform behavior only requires changing one place.
- Add documentation in both `usage.md` and `usage.zh-CN.md`

Supersedes #847 (which only fixed the `/shell` path for Windows by switching to `cmd.exe /C`). This PR covers the same issue more broadly — all 4 shell execution paths now work on Windows out of the box, and users can choose their preferred shell via config.

## Config

```toml
# Global default
shell = "/bin/zsh"
init_command = "source ~/.zshrc"

# Per-project override
[[projects]]
name = "my-project"
shell = "/bin/fish"
init_command = "source ~/.config/fish/config.fish"
```

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — 2237 passed (4 pre-existing failures unrelated to this change)
- [x] Manual: `/shell echo hello` works with default shell
- [x] Manual: configure `shell = "/bin/zsh"` and verify `/shell` uses zsh
- [x] Manual: configure `init_command` and verify environment is loaded

Closes #784
Closes #847