### PR TITLE
[codex] support request_user_input app-server events

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -111,6 +111,35 @@ type appServerCreditsSnapshot struct {
 	Unlimited  bool    `json:"unlimited"`
 }
 
+type appServerRequestUserInputParams struct {
+	ThreadID  string                              `json:"threadId"`
+	TurnID    string                              `json:"turnId"`
+	ItemID    string                              `json:"itemId"`
+	Questions []appServerRequestUserInputQuestion `json:"questions"`
+}
+
+type appServerRequestUserInputQuestion struct {
+	ID       string                            `json:"id"`
+	Header   string                            `json:"header"`
+	Question string                            `json:"question"`
+	IsOther  bool                              `json:"isOther"`
+	IsSecret bool                              `json:"isSecret"`
+	Options  []appServerRequestUserInputOption `json:"options"`
+}
+
+type appServerRequestUserInputOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+type appServerRequestUserInputResponse struct {
+	Answers map[string]appServerRequestUserInputAnswer `json:"answers"`
+}
+
+type appServerRequestUserInputAnswer struct {
+	Answers []string `json:"answers"`
+}
+
 type appServerSession struct {
 	url           string
 	workDir       string
@@ -526,6 +555,8 @@ func (s *appServerSession) handleServerRequest(probe map[string]json.RawMessage)
 		s.handleApprovalRequest(rawID, method, params)
 	case "item/permissions/requestApproval":
 		s.handlePermissionsApproval(rawID, params)
+	case "item/tool/requestUserInput":
+		s.handleRequestUserInput(rawID, params)
 	case "item/tool/call":
 		s.handleDynamicToolCall(rawID, params)
 	default:
@@ -654,6 +685,65 @@ func (s *appServerSession) handlePermissionsApproval(rawID json.RawMessage, para
 	}()
 }
 
+func (s *appServerSession) handleRequestUserInput(rawID json.RawMessage, paramsRaw json.RawMessage) {
+	requestID := string(rawID)
+	var params appServerRequestUserInputParams
+	if err := json.Unmarshal(paramsRaw, &params); err != nil {
+		_ = s.writeJSON(map[string]any{
+			"jsonrpc": "2.0", "id": rawID,
+			"error": map[string]any{"code": -32602, "message": "invalid params"},
+		})
+		return
+	}
+
+	questions := appServerRequestUserInputQuestions(params.Questions)
+	if len(questions) == 0 {
+		_ = s.writeJSON(map[string]any{
+			"jsonrpc": "2.0", "id": rawID,
+			"result": appServerRequestUserInputResponse{Answers: map[string]appServerRequestUserInputAnswer{}},
+		})
+		return
+	}
+
+	rawInput := appServerRequestUserInputRawInput(params)
+	ch := make(chan core.PermissionResult, 1)
+	s.approvalsMu.Lock()
+	s.pendingApprovals[requestID] = ch
+	s.approvalsMu.Unlock()
+
+	s.flushPendingAsThinking()
+	s.emit(core.Event{
+		Type:         core.EventPermissionRequest,
+		RequestID:    requestID,
+		ToolName:     "AskUserQuestion",
+		ToolInput:    appServerJSON(rawInput),
+		ToolInputRaw: rawInput,
+		Questions:    questions,
+	})
+
+	go func() {
+		timer := time.NewTimer(5 * time.Minute)
+		defer timer.Stop()
+		var result core.PermissionResult
+		select {
+		case result = <-ch:
+		case <-s.ctx.Done():
+			result = core.PermissionResult{Behavior: "deny"}
+		case <-timer.C:
+			result = core.PermissionResult{Behavior: "deny"}
+		}
+		s.approvalsMu.Lock()
+		delete(s.pendingApprovals, requestID)
+		s.approvalsMu.Unlock()
+
+		response := appServerRequestUserInputResponseFromResult(params.Questions, result)
+		_ = s.writeJSON(map[string]any{
+			"jsonrpc": "2.0", "id": rawID,
+			"result": response,
+		})
+	}()
+}
+
 func (s *appServerSession) handleDynamicToolCall(rawID json.RawMessage, paramsRaw json.RawMessage) {
 	_ = s.writeJSON(map[string]any{
 		"jsonrpc": "2.0", "id": rawID,
@@ -662,6 +752,118 @@ func (s *appServerSession) handleDynamicToolCall(rawID json.RawMessage, paramsRa
 			"contentItems": []map[string]any{{"type": "inputText", "text": "tool not available on this client"}},
 		},
 	})
+}
+
+func appServerRequestUserInputQuestions(input []appServerRequestUserInputQuestion) []core.UserQuestion {
+	questions := make([]core.UserQuestion, 0, len(input))
+	for _, in := range input {
+		questionText := strings.TrimSpace(in.Question)
+		if questionText == "" {
+			continue
+		}
+		q := core.UserQuestion{
+			Question: questionText,
+			Header:   strings.TrimSpace(in.Header),
+		}
+		for _, opt := range in.Options {
+			q.Options = append(q.Options, core.UserQuestionOption{
+				Label:       strings.TrimSpace(opt.Label),
+				Description: strings.TrimSpace(opt.Description),
+			})
+		}
+		questions = append(questions, q)
+	}
+	return questions
+}
+
+func appServerRequestUserInputRawInput(params appServerRequestUserInputParams) map[string]any {
+	questions := make([]any, 0, len(params.Questions))
+	for _, in := range params.Questions {
+		q := map[string]any{
+			"id":       in.ID,
+			"header":   in.Header,
+			"question": in.Question,
+			"isOther":  in.IsOther,
+			"isSecret": in.IsSecret,
+			"options":  appServerRequestUserInputRawOptions(in.Options),
+		}
+		questions = append(questions, q)
+	}
+	return map[string]any{
+		"threadId":  params.ThreadID,
+		"turnId":    params.TurnID,
+		"itemId":    params.ItemID,
+		"questions": questions,
+	}
+}
+
+func appServerRequestUserInputRawOptions(options []appServerRequestUserInputOption) []any {
+	out := make([]any, 0, len(options))
+	for _, opt := range options {
+		out = append(out, map[string]any{
+			"label":       opt.Label,
+			"description": opt.Description,
+		})
+	}
+	return out
+}
+
+func appServerRequestUserInputResponseFromResult(questions []appServerRequestUserInputQuestion, result core.PermissionResult) appServerRequestUserInputResponse {
+	response := appServerRequestUserInputResponse{Answers: map[string]appServerRequestUserInputAnswer{}}
+	if !strings.EqualFold(result.Behavior, "allow") {
+		return response
+	}
+
+	answersRaw, _ := result.UpdatedInput["answers"].(map[string]any)
+	if len(answersRaw) == 0 {
+		return response
+	}
+
+	for _, q := range questions {
+		id := strings.TrimSpace(q.ID)
+		text := strings.TrimSpace(q.Question)
+		if id == "" || text == "" {
+			continue
+		}
+		values := appServerRequestUserInputAnswerValues(answersRaw[text])
+		if len(values) == 0 {
+			continue
+		}
+		response.Answers[id] = appServerRequestUserInputAnswer{Answers: values}
+	}
+	return response
+}
+
+func appServerRequestUserInputAnswerValues(raw any) []string {
+	switch v := raw.(type) {
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return nil
+		}
+		return []string{v}
+	case []string:
+		values := make([]string, 0, len(v))
+		for _, s := range v {
+			if strings.TrimSpace(s) != "" {
+				values = append(values, s)
+			}
+		}
+		return values
+	case []any:
+		values := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+				values = append(values, s)
+			}
+		}
+		return values
+	case map[string]any:
+		return appServerRequestUserInputAnswerValues(v["answers"])
+	case appServerRequestUserInputAnswer:
+		return appServerRequestUserInputAnswerValues(v.Answers)
+	default:
+		return nil
+	}
 }
 
 func (s *appServerSession) rejectPendingApprovals(err error) {

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -1,9 +1,14 @@
 package codex
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -162,6 +167,135 @@ func TestMapAppServerRateLimits_PrefersMultiBucketView(t *testing.T) {
 	}
 }
 
+func TestAppServerSession_HandleRequestUserInputEmitsAskQuestion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stdin := &lockedWriteCloser{}
+	s := &appServerSession{
+		events:           make(chan core.Event, 4),
+		ctx:              ctx,
+		pendingApprovals: make(map[string]chan core.PermissionResult),
+		stdin:            stdin,
+	}
+
+	s.handleServerRequest(serverRequestProbe(t, `"rui-1"`, "item/tool/requestUserInput", map[string]any{
+		"threadId": "thread-1",
+		"turnId":   "turn-1",
+		"itemId":   "call-1",
+		"questions": []any{
+			map[string]any{
+				"id":       "database",
+				"header":   "Database",
+				"question": "Which database should we use?",
+				"isOther":  true,
+				"isSecret": false,
+				"options": []any{
+					map[string]any{"label": "Postgres", "description": "Use the existing relational database"},
+					map[string]any{"label": "SQLite", "description": "Keep it embedded"},
+				},
+			},
+		},
+	}))
+
+	var event core.Event
+	select {
+	case event = <-s.events:
+	case <-time.After(time.Second):
+		t.Fatal("expected AskUserQuestion event")
+	}
+	if event.Type != core.EventPermissionRequest {
+		t.Fatalf("event type = %s, want %s", event.Type, core.EventPermissionRequest)
+	}
+	if event.ToolName != "AskUserQuestion" {
+		t.Fatalf("tool name = %q, want AskUserQuestion", event.ToolName)
+	}
+	if event.RequestID != `"rui-1"` {
+		t.Fatalf("request id = %q, want raw JSON id", event.RequestID)
+	}
+	if len(event.Questions) != 1 {
+		t.Fatalf("questions = %d, want 1", len(event.Questions))
+	}
+	q := event.Questions[0]
+	if q.Question != "Which database should we use?" || q.Header != "Database" {
+		t.Fatalf("question = %#v", q)
+	}
+	if len(q.Options) != 2 || q.Options[0].Label != "Postgres" || q.Options[1].Description != "Keep it embedded" {
+		t.Fatalf("options = %#v", q.Options)
+	}
+	if stdin.String() != "" {
+		t.Fatalf("request_user_input should not write before the answer, got %q", stdin.String())
+	}
+}
+
+func TestAppServerSession_HandleRequestUserInputWritesCodexResponse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stdin := &lockedWriteCloser{}
+	s := &appServerSession{
+		events:           make(chan core.Event, 4),
+		ctx:              ctx,
+		pendingApprovals: make(map[string]chan core.PermissionResult),
+		stdin:            stdin,
+	}
+
+	s.handleServerRequest(serverRequestProbe(t, `"rui-2"`, "item/tool/requestUserInput", map[string]any{
+		"threadId": "thread-1",
+		"turnId":   "turn-1",
+		"itemId":   "call-2",
+		"questions": []any{
+			map[string]any{
+				"id":       "database",
+				"header":   "Database",
+				"question": "Which database should we use?",
+				"options": []any{
+					map[string]any{"label": "Postgres", "description": "Use the existing relational database"},
+					map[string]any{"label": "SQLite", "description": "Keep it embedded"},
+				},
+			},
+		},
+	}))
+
+	var event core.Event
+	select {
+	case event = <-s.events:
+	case <-time.After(time.Second):
+		t.Fatal("expected AskUserQuestion event")
+	}
+	if err := s.RespondPermission(event.RequestID, core.PermissionResult{
+		Behavior: "allow",
+		UpdatedInput: map[string]any{
+			"answers": map[string]any{
+				"Which database should we use?": "Postgres",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("RespondPermission() error = %v", err)
+	}
+
+	line := waitForWrittenJSONLine(t, stdin)
+	var envelope struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      string `json:"id"`
+		Result  struct {
+			Answers map[string]struct {
+				Answers []string `json:"answers"`
+			} `json:"answers"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+		t.Fatalf("decode response %q: %v", line, err)
+	}
+	if envelope.JSONRPC != "2.0" || envelope.ID != "rui-2" {
+		t.Fatalf("envelope = %#v", envelope)
+	}
+	got := envelope.Result.Answers["database"].Answers
+	if len(got) != 1 || got[0] != "Postgres" {
+		t.Fatalf("answers[database] = %#v, want [Postgres]", got)
+	}
+}
+
 var _ interface {
 	GetUsage(context.Context) (*core.UsageReport, error)
 } = (*appServerSession)(nil)
@@ -169,3 +303,61 @@ var _ interface {
 var _ interface {
 	GetContextUsage() *core.ContextUsage
 } = (*appServerSession)(nil)
+
+type lockedWriteCloser struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *lockedWriteCloser) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *lockedWriteCloser) Close() error { return nil }
+
+func (w *lockedWriteCloser) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+var _ io.WriteCloser = (*lockedWriteCloser)(nil)
+
+func serverRequestProbe(t *testing.T, idJSON, method string, params any) map[string]json.RawMessage {
+	t.Helper()
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	methodJSON, err := json.Marshal(method)
+	if err != nil {
+		t.Fatalf("marshal method: %v", err)
+	}
+	return map[string]json.RawMessage{
+		"id":     json.RawMessage(idJSON),
+		"method": methodJSON,
+		"params": paramsJSON,
+	}
+}
+
+func waitForWrittenJSONLine(t *testing.T, w *lockedWriteCloser) string {
+	t.Helper()
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for JSON response, buffer=%q", w.String())
+		case <-ticker.C:
+			for _, line := range strings.Split(w.String(), "\n") {
+				line = strings.TrimSpace(line)
+				if line != "" {
+					return line
+				}
+			}
+		}
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -630,7 +630,6 @@ func (e *Engine) SetSkipGit(skipGit bool) {
 	e.skipGit = skipGit
 }
 
-
 // SetInjectSender controls whether sender identity (platform and user ID) is
 // prepended to each message before forwarding it to the agent. When enabled,
 // the agent receives a preamble line like:
@@ -5764,35 +5763,40 @@ func compactReplyFooterPath(path string) string {
 	if path == "" {
 		return ""
 	}
-	path = normalizeWorkspacePath(path)
+	cleaned := filepath.Clean(path)
+	normalized := normalizeWorkspacePath(cleaned)
 	if home, err := os.UserHomeDir(); err == nil {
-		home = normalizeWorkspacePath(home)
-		if path == home {
-			return "~"
-		}
-		prefix := home + string(os.PathSeparator)
-		if strings.HasPrefix(path, prefix) {
-			return "~" + filepath.ToSlash(strings.TrimPrefix(path, home))
+		homeCleaned := filepath.Clean(home)
+		homeNormalized := normalizeWorkspacePath(homeCleaned)
+		for _, candidate := range []struct {
+			path string
+			home string
+		}{
+			{cleaned, homeCleaned},
+			{normalized, homeNormalized},
+			{cleaned, homeNormalized},
+			{normalized, homeCleaned},
+		} {
+			if display, ok := replyFooterHomeRelativePath(candidate.path, candidate.home); ok {
+				return display
+			}
 		}
 	}
+	return filepath.ToSlash(normalized)
+}
 
-	slash := filepath.ToSlash(path)
-	if filepath.IsAbs(path) {
-		trimmed := strings.Trim(slash, "/")
-		if trimmed == "" {
-			return "/"
-		}
-		parts := strings.Split(trimmed, "/")
-		if len(parts) == 1 {
-			return parts[0]
-		}
-		start := len(parts) - 2
-		if start < 0 {
-			start = 0
-		}
-		return "…/" + strings.Join(parts[start:], "/")
+func replyFooterHomeRelativePath(path, home string) (string, bool) {
+	if path == "" || home == "" {
+		return "", false
 	}
-	return slash
+	if path == home {
+		return "~", true
+	}
+	prefix := home + string(os.PathSeparator)
+	if strings.HasPrefix(path, prefix) {
+		return "~" + filepath.ToSlash(strings.TrimPrefix(path, home)), true
+	}
+	return "", false
 }
 
 func appendReplyFooter(content, footer string) string {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -408,6 +408,14 @@ func (p *stubCompactProgressPlatform) getPreviewEdits() []string {
 	return out
 }
 
+type stubAskQuestionRichCardPlatform struct {
+	stubCardPlatform
+}
+
+func (p *stubAskQuestionRichCardPlatform) BuildRichCard(status CardStatus, title string, steps []ToolStep, markdown string, streaming bool, statusFooter string) string {
+	return "rich card"
+}
+
 type stubModelModeAgent struct {
 	stubAgent
 	model           string
@@ -1063,12 +1071,13 @@ func TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
 
+	workDir := filepath.Join(homeDir, "codes", "cc-connect")
 	agent := &stubReplyFooterAgent{
 		stubModelModeAgent: stubModelModeAgent{
 			model:           "gpt-5.4",
 			reasoningEffort: "xhigh",
 		},
-		workDir: filepath.Join(homeDir, "codes", "cc-connect"),
+		workDir: workDir,
 		report: &UsageReport{
 			Buckets: []UsageBucket{{
 				Name: "Rate limit",
@@ -1101,7 +1110,7 @@ func TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled(t *testing.T) {
 	if len(sent) != 1 {
 		t.Fatalf("sent = %#v, want one final reply", sent)
 	}
-	want := "answer\n\n*gpt-5.4 · xhigh · 100% left · ~/codes/cc-connect*"
+	want := "answer\n\n*gpt-5.4 · xhigh · 100% left · " + compactReplyFooterPath(workDir) + "*"
 	if sent[0] != want {
 		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}
@@ -1112,9 +1121,10 @@ func TestProcessInteractiveEvents_AppendsContextIndicatorInsideReplyFooter(t *te
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
 
+	workDir := filepath.Join(homeDir, "code", "TechStudio", "projects", "core", "agents", "ceo")
 	agent := &stubReplyFooterAgent{
 		stubModelModeAgent: stubModelModeAgent{model: "glm-5.1"},
-		workDir:            filepath.Join(homeDir, "code", "TechStudio", "projects", "core", "agents", "ceo"),
+		workDir:            workDir,
 	}
 	p := &stubPlatformEngine{n: "telegram"}
 	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
@@ -1138,7 +1148,7 @@ func TestProcessInteractiveEvents_AppendsContextIndicatorInsideReplyFooter(t *te
 	if len(sent) != 1 {
 		t.Fatalf("sent = %#v, want one final reply", sent)
 	}
-	want := "answer\n\n*[ctx: ~14%] · glm-5.1 · ~/code/TechStudio/projects/core/agents/ceo*"
+	want := "answer\n\n*[ctx: ~14%] · glm-5.1 · " + compactReplyFooterPath(workDir) + "*"
 	if sent[0] != want {
 		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}
@@ -1149,9 +1159,10 @@ func TestProcessInteractiveEvents_ToolSegmentsKeepFinalFooter(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir)
 
+	workDir := filepath.Join(homeDir, "code", "TechStudio", "projects", "core", "agents", "ceo")
 	agent := &stubReplyFooterAgent{
 		stubModelModeAgent: stubModelModeAgent{model: "glm-5.1"},
-		workDir:            filepath.Join(homeDir, "code", "TechStudio", "projects", "core", "agents", "ceo"),
+		workDir:            workDir,
 	}
 	p := &stubPlatformEngine{n: "telegram"}
 	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
@@ -1180,7 +1191,7 @@ func TestProcessInteractiveEvents_ToolSegmentsKeepFinalFooter(t *testing.T) {
 		t.Fatal("sent = nil, want final reply")
 	}
 	final := sent[len(sent)-1]
-	want := "已处理完成。\n\n*[ctx: ~14%] · glm-5.1 · ~/code/TechStudio/projects/core/agents/ceo*"
+	want := "已处理完成。\n\n*[ctx: ~14%] · glm-5.1 · " + compactReplyFooterPath(workDir) + "*"
 	if final != want {
 		t.Fatalf("final reply = %q, want %q\nall sent = %#v", final, want, sent)
 	}
@@ -1290,7 +1301,8 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 	agentSession := newControllableSession("s-footer-runtime")
 	agentSession.model = "gpt-5.4"
 	agentSession.reasoningEffort = "xhigh"
-	agentSession.workDir = filepath.Join(homeDir, "codes", "cc-connect")
+	sessionWorkDir := filepath.Join(homeDir, "codes", "cc-connect")
+	agentSession.workDir = sessionWorkDir
 	agentSession.report = &UsageReport{
 		Buckets: []UsageBucket{{
 			Name: "Rate limit",
@@ -1322,7 +1334,7 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 	if len(sent) != 1 {
 		t.Fatalf("sent = %#v, want one final reply", sent)
 	}
-	want := "answer\n\n*gpt-5.4 · xhigh · 31% left · ~/codes/cc-connect*"
+	want := "answer\n\n*gpt-5.4 · xhigh · 31% left · " + compactReplyFooterPath(sessionWorkDir) + "*"
 	if sent[0] != want {
 		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}
@@ -1798,6 +1810,50 @@ func countCardActionValues(card *Card, prefix string) int {
 		}
 	}
 	return count
+}
+
+func waitForSentCard(t *testing.T, p *stubCardPlatform) *Card {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			p.mu.Lock()
+			count := len(p.sentCards)
+			p.mu.Unlock()
+			t.Fatalf("timed out waiting for sent card, sentCards=%d", count)
+		case <-ticker.C:
+			p.mu.Lock()
+			var card *Card
+			if len(p.sentCards) > 0 {
+				card = p.sentCards[0]
+			}
+			p.mu.Unlock()
+			if card != nil {
+				return card
+			}
+		}
+	}
+}
+
+func waitForSentText(t *testing.T, p *stubPlatformEngine) string {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for sent text, sent=%#v", p.getSent())
+		case <-ticker.C:
+			sent := p.getSent()
+			if len(sent) > 0 {
+				return sent[0]
+			}
+		}
+	}
 }
 
 func findCardAction(card *Card, value string) (CardButton, bool) {
@@ -5663,6 +5719,151 @@ func TestSendAskQuestionPrompt_PlainPlatform(t *testing.T) {
 	}
 }
 
+func TestProcessInteractiveEvents_AskUserQuestionFromAgent_RendersRichCardPrompt(t *testing.T) {
+	p := &stubAskQuestionRichCardPlatform{
+		stubCardPlatform: stubCardPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}},
+	}
+	sess := newBlockingSendSession("codex-ask-card")
+	e := NewEngine("test", &controllableAgent{nextSession: sess}, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{
+		Mode:             "full",
+		CardMode:         "rich",
+		ThinkingMessages: true,
+		ThinkingMaxLen:   defaultThinkingMaxLen,
+		ToolMaxLen:       defaultToolMaxLen,
+		ToolMessages:     true,
+	})
+
+	key := "test:chat:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- sess.Send("prompt", nil, nil)
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveEvents(state, session, e.sessions, key, "m-codex-ask-card", time.Now(), nil, sendDone, nil)
+		close(done)
+	}()
+
+	select {
+	case <-sess.sendStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send did not reach blocking wait")
+	}
+
+	sess.events <- Event{
+		Type:         EventPermissionRequest,
+		RequestID:    `"rui-card"`,
+		ToolName:     "AskUserQuestion",
+		ToolInput:    `{"questions":[{"id":"database","question":"Which database?"}]}`,
+		ToolInputRaw: map[string]any{"questions": []any{map[string]any{"id": "database", "question": "Which database?"}}},
+		Questions:    testQuestions(),
+	}
+
+	card := waitForSentCard(t, &p.stubCardPlatform)
+	if card.Header == nil || card.Header.Color != "blue" {
+		t.Fatalf("card header = %#v, want blue AskUserQuestion card", card.Header)
+	}
+	if countCardActionValues(card, "askq:") != 3 {
+		t.Fatalf("askq button count = %d, want 3", countCardActionValues(card, "askq:"))
+	}
+
+	if !e.handlePendingPermission(p, &Message{
+		SessionKey: key,
+		UserID:     "user1",
+		Content:    "askq:0:2",
+		ReplyCtx:   "ctx",
+	}, "askq:0:2", key) {
+		t.Fatal("expected AskUserQuestion answer to resolve pending request")
+	}
+
+	close(sess.unblock)
+	sess.events <- Event{Type: EventResult, Content: "ok", Done: true}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("processInteractiveEvents did not complete")
+	}
+}
+
+func TestProcessInteractiveEvents_AskUserQuestionFromAgent_RendersLegacyPrompt(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	sess := newBlockingSendSession("codex-ask-legacy")
+	e := NewEngine("test", &controllableAgent{nextSession: sess}, []Platform{p}, "", LangEnglish)
+
+	key := "test:chat:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	sendDone := make(chan error, 1)
+	go func() {
+		sendDone <- sess.Send("prompt", nil, nil)
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveEvents(state, session, e.sessions, key, "m-codex-ask-legacy", time.Now(), nil, sendDone, nil)
+		close(done)
+	}()
+
+	select {
+	case <-sess.sendStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send did not reach blocking wait")
+	}
+
+	sess.events <- Event{
+		Type:         EventPermissionRequest,
+		RequestID:    `"rui-legacy"`,
+		ToolName:     "AskUserQuestion",
+		ToolInput:    `{"questions":[{"id":"database","question":"Which database?"}]}`,
+		ToolInputRaw: map[string]any{"questions": []any{map[string]any{"id": "database", "question": "Which database?"}}},
+		Questions:    testQuestions(),
+	}
+
+	msg := waitForSentText(t, p)
+	if !strings.Contains(msg, "Which database?") || !strings.Contains(msg, "1. **PostgreSQL**") {
+		t.Fatalf("legacy AskUserQuestion prompt = %q, want question and numbered options", msg)
+	}
+
+	if !e.handlePendingPermission(p, &Message{
+		SessionKey: key,
+		UserID:     "user1",
+		Content:    "2",
+		ReplyCtx:   "ctx",
+	}, "2", key) {
+		t.Fatal("expected AskUserQuestion answer to resolve pending request")
+	}
+
+	close(sess.unblock)
+	sess.events <- Event{Type: EventResult, Content: "ok", Done: true}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("processInteractiveEvents did not complete")
+	}
+}
+
 func TestHandlePendingPermission_AskUserQuestion_SingleQuestion(t *testing.T) {
 	e := newTestEngine()
 	p := &stubPlatformEngine{n: "test"}
@@ -8779,8 +8980,12 @@ func TestResolveLocalDirPath_AcceptsSubdir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got != sub {
-		t.Fatalf("expected %q, got %q", sub, got)
+	want, err := filepath.EvalSymlinks(sub)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
 	}
 }
 

--- a/tests/release_local/turn_contract/turn_contract_test.go
+++ b/tests/release_local/turn_contract/turn_contract_test.go
@@ -688,13 +688,13 @@ func TestReplyMetadataConfigurationMatrix(t *testing.T) {
 			name:       "context_and_footer_on_share_one_line",
 			showCtx:    true,
 			showFooter: true,
-			want:       []string{"answer", "[ctx: ~14%] · glm-5.1 · …/tmp/release-agent"},
+			want:       []string{"answer", "[ctx: ~14%] · glm-5.1 · /tmp/release-agent"},
 		},
 		{
 			name:       "context_off_footer_on_keeps_model_footer",
 			showCtx:    false,
 			showFooter: true,
-			want:       []string{"answer", "glm-5.1 · …/tmp/release-agent"},
+			want:       []string{"answer", "glm-5.1 · /tmp/release-agent"},
 			forbid:     []string{"[ctx:"},
 		},
 		{

--- a/tests/release_local/turn_contract/turn_contract_test.go
+++ b/tests/release_local/turn_contract/turn_contract_test.go
@@ -688,13 +688,13 @@ func TestReplyMetadataConfigurationMatrix(t *testing.T) {
 			name:       "context_and_footer_on_share_one_line",
 			showCtx:    true,
 			showFooter: true,
-			want:       []string{"answer", "*[ctx: ~14%] · glm-5.1 · …/tmp/release-agent*"},
+			want:       []string{"answer", "[ctx: ~14%] · glm-5.1 · …/tmp/release-agent"},
 		},
 		{
 			name:       "context_off_footer_on_keeps_model_footer",
 			showCtx:    false,
 			showFooter: true,
-			want:       []string{"answer", "*glm-5.1 · …/tmp/release-agent*"},
+			want:       []string{"answer", "glm-5.1 · …/tmp/release-agent"},
 			forbid:     []string{"[ctx:"},
 		},
 		{


### PR DESCRIPTION
## Summary

- Handle Codex app-server `item/tool/requestUserInput` server requests.
- Convert Codex question payloads into the existing core `AskUserQuestion` permission flow.
- Return user answers using Codex's expected `answers[question_id].answers` response shape.
- Add regression tests for the Codex adapter and the shared rich-card / legacy-text AskUserQuestion rendering path.

## Why

Codex app-server exposes a user-input request method, but cc-connect currently treats it as an unknown server request. This lets Codex ask interactive questions through the same platform UI path already used by `AskUserQuestion`, without changing Claude Code behavior.

## Validation

Passed:

- `go test ./agent/codex -run 'TestAppServerSession_HandleRequestUserInput' -count=1`
- `go test ./core -run 'TestProcessInteractiveEvents_AskUserQuestionFromAgent|TestSendAskQuestionPrompt|TestHandlePendingPermission_AskUserQuestion|TestResolveAskQuestionAnswer|TestBuildAskQuestionResponse' -count=1`
- `go test ./agent/claudecode -run 'TestParseUserQuestions|TestSummarizeInput_AskUserQuestion' -count=1`
- `go test ./agent/codex -count=1`
- `go test ./agent/claudecode -count=1`
- `go test ./platform/feishu -count=1`
- `git diff --check`

Also ran `go test ./... -count=1`; local full-suite did not pass for issues outside this PR's scope:

- `cmd/cc-connect` and `web` setup fail because `web/dist` is not generated locally.
- Existing full-suite-only failures appeared in `core` path expectation tests under macOS `/private/var`, `daemon` launchd status, and one Codex runtime-config timing test. The Codex timing test passes when run directly with the new Codex tests.
