### PR TITLE
feat(cli): expose --silent flag for cron add and edit

### DIFF
--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -42,6 +42,7 @@ func runCron(args []string) {
 func runCronAdd(args []string) {
 	var project, sessionKey, cronExpr, prompt, execCmd, desc, dataDir, sessionMode string
 	var timeoutMins *int
+	var silent bool
 
 	var positional []string
 	for i := 0; i < len(args); i++ {
@@ -96,6 +97,8 @@ func runCronAdd(args []string) {
 				}
 				timeoutMins = &n
 			}
+		case "--silent":
+			silent = true
 		case "--help", "-h":
 			printCronAddUsage()
 			return
@@ -145,6 +148,9 @@ func runCronAdd(args []string) {
 		"prompt":      prompt,
 		"exec":        execCmd,
 		"description": desc,
+	}
+	if silent {
+		body["silent"] = true
 	}
 	if sessionMode != "" {
 		body["session_mode"] = sessionMode
@@ -452,7 +458,7 @@ func runCronEdit(args []string) {
 	// Parse value based on field type
 	var value any
 	switch field {
-	case "enabled", "mute":
+	case "enabled", "mute", "silent":
 		v, err := strconv.ParseBool(valueStr)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %s must be true or false\n", field)
@@ -539,12 +545,14 @@ Options:
       --desc <text>          Short description
       --session-mode <mode>  reuse (default) or new-per-run — fresh agent session each run
       --timeout-mins <n>     Max minutes to wait per run (0 = no limit; default 30 if omitted)
+      --silent               Suppress cron start notification
       --data-dir <path>      Data directory (default: ~/.cc-connect)
   -h, --help                 Show this help
 
 Examples:
   cc-connect cron add --cron "0 6 * * *" --prompt "Collect GitHub trending data" --desc "Daily Trending"
   cc-connect cron add --cron "*/30 * * * *" --exec "df -h" --desc "Disk usage check"
+  cc-connect cron add --cron "0 9 * * *" --prompt "Daily standup reminder" --silent
   cc-connect cron add 0 6 * * * Collect GitHub trending data and send me a summary`)
 }
 


### PR DESCRIPTION
## Summary
- Add `--silent` flag to `cc-connect cron add` to suppress cron start notification
- Add "silent" as a valid boolean field in `cc-connect cron edit`
- Update CLI help documentation

## Root Cause
The cron data model and API already support the `silent` field, but it was not exposed in the CLI.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./cmd/cc-connect/...` passes
- Manual: `cc-connect cron add --silent --cron "*/5 * * * *" --exec "date"` should create a silent cron job
- Manual: `cc-connect cron edit <id> silent true` should update the silent field

Fixes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)