### PR TITLE
fix(core/markdown): preserve intra-word underscores in StripMarkdown

### DIFF
--- a/core/markdown.go
+++ b/core/markdown.go
@@ -9,9 +9,12 @@ var (
 	reCodeBlock   = regexp.MustCompile("(?s)```[a-zA-Z]*\n?(.*?)```")
 	reInlineCode  = regexp.MustCompile("`([^`]+)`")
 	reBoldAst     = regexp.MustCompile(`\*\*(.+?)\*\*`)
-	reBoldUnd     = regexp.MustCompile(`__(.+?)__`)
+	// Underscore emphasis requires word boundaries on both sides so that
+	// intra-word underscores (e.g. snake_case identifiers) are preserved.
+	// Per CommonMark, "underscores cannot be used for intra-word emphasis."
+	reBoldUnd     = regexp.MustCompile(`\b__(.+?)__\b`)
 	reItalicAst   = regexp.MustCompile(`\*(.+?)\*`)
-	reItalicUnd   = regexp.MustCompile(`_(.+?)_`)
+	reItalicUnd   = regexp.MustCompile(`\b_(.+?)_\b`)
 	reStrike      = regexp.MustCompile(`~~(.+?)~~`)
 	reLink        = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
 	reHeading     = regexp.MustCompile(`(?m)^#{1,6}\s+`)

--- a/core/markdown_test.go
+++ b/core/markdown_test.go
@@ -1,0 +1,86 @@
+package core
+
+import "testing"
+
+func TestStripMarkdown(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "italic underscore",
+			input: "hello _world_",
+			want:  "hello world",
+		},
+		{
+			name:  "italic asterisk",
+			input: "hello *world*",
+			want:  "hello world",
+		},
+		{
+			name:  "bold underscore",
+			input: "hello __world__",
+			want:  "hello world",
+		},
+		{
+			name:  "bold asterisk",
+			input: "hello **world**",
+			want:  "hello world",
+		},
+		{
+			name:  "intraword underscore preserved",
+			input: "edit my_var_name",
+			want:  "edit my_var_name",
+		},
+		{
+			name:  "intraword double underscore preserved",
+			input: "see my__var__name",
+			want:  "see my__var__name",
+		},
+		{
+			name:  "italic underscore inside sentence",
+			input: "this is _important_ today",
+			want:  "this is important today",
+		},
+		{
+			name:  "italic underscore adjacent to punctuation",
+			input: "(_x_),",
+			want:  "(x),",
+		},
+		{
+			name:  "code block content preserved",
+			input: "```go\nfmt.Println(\"hi\")\n```",
+			want:  "fmt.Println(\"hi\")",
+		},
+		{
+			name:  "inline code content preserved",
+			input: "run `my_func()` now",
+			want:  "run my_func() now",
+		},
+		{
+			name:  "link rendered with url",
+			input: "go to [docs](https://example.com)",
+			want:  "go to docs (https://example.com)",
+		},
+		{
+			name:  "heading hash removed",
+			input: "# Title\n\nbody",
+			want:  "Title\n\nbody",
+		},
+		{
+			name:  "blockquote prefix removed",
+			input: "> a quote\n> another line",
+			want:  "a quote\nanother line",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripMarkdown(tt.input)
+			if got != tt.want {
+				t.Errorf("StripMarkdown(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`StripMarkdown` is used to flatten Markdown to plain text for TTS, LINE, and WeChat (when `enable_markdown=false`). The underscore italic/bold regexes had no word-boundary check, so identifiers and snake_case names were silently mangled:

| Input             | Before                  | After                  |
|-------------------|-------------------------|------------------------|
| `my_var_name`     | `myvarname`             | `my_var_name`          |
| `my__var__name`   | `myvarname`             | `my__var__name`        |
| `pre_word_post`   | `prewordpost`           | `pre_word_post`        |
| `_italic_`        | `italic`                | `italic` (unchanged)   |
| `__bold__`        | `bold`                  | `bold` (unchanged)     |

CommonMark explicitly disallows intra-word emphasis with underscores (\"underscores cannot be used for intra-word emphasis\"), so adding `\b` boundaries to `reItalicUnd` / `reBoldUnd` aligns the behavior with the spec without affecting standalone emphasis spans.

## Why this matters

- **TTS** receives the stripped text — `init_session` would be spoken as a single mashed word `initsession` and the `_` removal also breaks downstream code mentions.
- **LINE / WeChat** users see code identifiers and Python dunders rendered with random characters dropped.

## Changes

- `core/markdown.go`: anchor `reItalicUnd` and `reBoldUnd` with `\b` on each side.
- `core/markdown_test.go`: new table-driven test covering basic emphasis, intra-word preservation, code spans, links, headings, and blockquotes.

## Test plan

- [x] `go test ./core/ -run TestStripMarkdown -v` (13 sub-tests pass)
- [x] `go test ./...` — only pre-existing failures remain (`TestProcessInteractiveEvents_*`, `TestResolveLocalDirPath_AcceptsSubdir`, `TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable`, codex `TestGetModelAndReasoningEffort_FromRuntimeConfigWhenUnset`); all unrelated to this change and reproducible on `main`.
- [x] Confirmed regression tests fail on `main` without the regex change.