### PR TITLE
fix(core): keep preview card on /stop instead of recalling

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3398,7 +3398,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		select {
 		case <-stopCh:
-			sp.discard()
+			sp.finish(strings.Join(textParts, ""))
 			return
 		case event, ok = <-events:
 			if !ok {
@@ -3444,7 +3444,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		}
 
 		if state.isStopped() {
-			sp.discard()
+			sp.finish(strings.Join(textParts, ""))
 			state.mu.Lock()
 			state.eventsNeedResync = true
 			state.mu.Unlock()


### PR DESCRIPTION
## Problem

When sending `/stop` during a streaming response, the preview card (interactive card on Feishu) was deleted via `sp.discard()`. On Feishu, this caused the message to appear as "bot撤回了一条消息", which is a poor UX — the user loses all progress from the agent's partial response.

## Fix

Replace `sp.discard()` with `sp.finish()` in both stop signal paths within `processInteractiveEvents`. This finalizes the preview card in-place (same as normal completion) instead of deleting it.

On platforms that implement `KeepPreviewOnFinish` (Feishu), the card is kept and updated. On platforms that don't (Telegram, Discord), `sp.finish()` still deletes the preview — behavior is unchanged for those platforms.

## Test plan

- [x] Send `/stop` during streaming on Feishu — card stays visible with partial content, no "bot撤回了一条消息"
- [x] Normal completion behavior unchanged (card updates to final state)
- [x] Build passes: `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)