### PR TITLE
fix(qq): return error on malformed session key instead of routing to ID 0

### DIFF
--- a/platform/qq/qq.go
+++ b/platform/qq/qq.go
@@ -474,14 +474,26 @@ func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 	}
 	if len(parts) == 3 {
 		if parts[1] == "g" {
-			gid, _ := strconv.ParseInt(parts[2], 10, 64)
+			gid, err := strconv.ParseInt(parts[2], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("qq: invalid group ID in %q: %w", sessionKey, err)
+			}
 			return &replyContext{messageType: "group", groupID: gid}, nil
 		}
-		gid, _ := strconv.ParseInt(parts[1], 10, 64)
-		uid, _ := strconv.ParseInt(parts[2], 10, 64)
+		gid, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("qq: invalid group ID in %q: %w", sessionKey, err)
+		}
+		uid, err := strconv.ParseInt(parts[2], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("qq: invalid user ID in %q: %w", sessionKey, err)
+		}
 		return &replyContext{messageType: "group", groupID: gid, userID: uid}, nil
 	}
-	uid, _ := strconv.ParseInt(parts[1], 10, 64)
+	uid, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("qq: invalid user ID in %q: %w", sessionKey, err)
+	}
 	return &replyContext{messageType: "private", userID: uid}, nil
 }
 

--- a/platform/qq/qq_test.go
+++ b/platform/qq/qq_test.go
@@ -78,3 +78,97 @@ func TestNew_ShareSessionInChannel(t *testing.T) {
 
 // verify Platform implements core.Platform
 var _ core.Platform = (*Platform)(nil)
+
+func TestReconstructReplyCtx(t *testing.T) {
+	p := &Platform{}
+
+	tests := []struct {
+		name        string
+		sessionKey  string
+		wantErr     bool
+		wantType    string
+		wantUserID  int64
+		wantGroupID int64
+	}{
+		{
+			name:       "private session",
+			sessionKey: "qq:12345",
+			wantType:   "private",
+			wantUserID: 12345,
+		},
+		{
+			name:        "group with shared session",
+			sessionKey:  "qq:g:67890",
+			wantType:    "group",
+			wantGroupID: 67890,
+		},
+		{
+			name:        "group with per-user session",
+			sessionKey:  "qq:67890:12345",
+			wantType:    "group",
+			wantGroupID: 67890,
+			wantUserID:  12345,
+		},
+		{
+			name:       "missing prefix",
+			sessionKey: "telegram:123",
+			wantErr:    true,
+		},
+		{
+			name:       "too few parts",
+			sessionKey: "qq",
+			wantErr:    true,
+		},
+		{
+			name:       "non-numeric private user ID",
+			sessionKey: "qq:notanumber",
+			wantErr:    true,
+		},
+		{
+			name:       "non-numeric shared-group ID",
+			sessionKey: "qq:g:notanumber",
+			wantErr:    true,
+		},
+		{
+			name:       "non-numeric per-user group ID",
+			sessionKey: "qq:abc:12345",
+			wantErr:    true,
+		},
+		{
+			name:       "non-numeric per-user user ID",
+			sessionKey: "qq:67890:xyz",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, err := p.ReconstructReplyCtx(tt.sessionKey)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil (ctx=%+v)", tt.sessionKey, ctx)
+				}
+				if ctx != nil {
+					t.Errorf("expected nil ctx on error, got %+v", ctx)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.sessionKey, err)
+			}
+			rc, ok := ctx.(*replyContext)
+			if !ok {
+				t.Fatalf("ctx type = %T, want *replyContext", ctx)
+			}
+			if rc.messageType != tt.wantType {
+				t.Errorf("messageType = %q, want %q", rc.messageType, tt.wantType)
+			}
+			if rc.userID != tt.wantUserID {
+				t.Errorf("userID = %d, want %d", rc.userID, tt.wantUserID)
+			}
+			if rc.groupID != tt.wantGroupID {
+				t.Errorf("groupID = %d, want %d", rc.groupID, tt.wantGroupID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`ReconstructReplyCtx` in `platform/qq/qq.go` ignores `strconv.ParseInt` errors in all four parsing branches. A non-numeric session key — surfacing from corrupted persisted state, a hand-edited cron config, or a cross-version data migration — silently produces a `replyContext` with `userID`/`groupID` set to `0`, so the platform pushes the reply to QQ user/group `0` with no diagnostic.

## Fix

Match the pattern already used in `platform/telegram/telegram.go`: check the `ParseInt` error and return it. All call sites (`core/webhook.go`, `core/relay.go`, `core/engine.go`) already handle the error branch by logging and skipping, so this only changes behaviour in the malformed-key case.

```go
// before
gid, _ := strconv.ParseInt(parts[2], 10, 64)
return &replyContext{messageType: "group", groupID: gid}, nil

// after
gid, err := strconv.ParseInt(parts[2], 10, 64)
if err != nil {
    return nil, fmt.Errorf("qq: invalid group ID in %q: %w", sessionKey, err)
}
return &replyContext{messageType: "group", groupID: gid}, nil
```

## Tests

Added a table-driven `TestReconstructReplyCtx` covering:
- 3 valid formats: `qq:{userID}`, `qq:g:{groupID}`, `qq:{groupID}:{userID}`
- 5 malformed variants exercising every parse branch (non-numeric private user ID, non-numeric shared-group ID, non-numeric per-user group ID, non-numeric per-user user ID, missing prefix, too few parts)

```
$ go test ./platform/qq/... -v
=== RUN   TestReconstructReplyCtx
--- PASS: TestReconstructReplyCtx (0.00s)
    --- PASS: TestReconstructReplyCtx/private_session
    --- PASS: TestReconstructReplyCtx/group_with_shared_session
    --- PASS: TestReconstructReplyCtx/group_with_per-user_session
    --- PASS: TestReconstructReplyCtx/missing_prefix
    --- PASS: TestReconstructReplyCtx/too_few_parts
    --- PASS: TestReconstructReplyCtx/non-numeric_private_user_ID
    --- PASS: TestReconstructReplyCtx/non-numeric_shared-group_ID
    --- PASS: TestReconstructReplyCtx/non-numeric_per-user_group_ID
    --- PASS: TestReconstructReplyCtx/non-numeric_per-user_user_ID
PASS
ok      github.com/chenhg5/cc-connect/platform/qq
```

## Test plan

- [x] `go build -tags no_web ./...`
- [x] `go test -tags no_web ./platform/qq/...`
- [x] Pre-existing failures on `main` (`TestProcessInteractiveEvents_*`, `TestResolveLocalDirPath_AcceptsSubdir`, `TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable`) reproduce on this branch as well — environment-dependent, unrelated to this change.