### PR TITLE
fix(daemon/launchd): forward EnvExtra (proxy vars) into launchd plist

### DIFF
--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -238,6 +239,26 @@ func buildPlist(cfg Config) string {
 	if envPATH == "" {
 		envPATH = "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
 	}
+
+	// Mirror systemd.go / windows.go: forward EnvExtra (proxy variables
+	// captured by manager.go::captureDaemonEnv) into the service environment
+	// so the launchd-managed daemon honours user-configured HTTP proxies.
+	// Proxy values can legitimately contain '&' (query strings) or '<', so
+	// XML-escape both the key and value before embedding in the plist.
+	plistEsc := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+	var extraEnv strings.Builder
+	if len(cfg.EnvExtra) > 0 {
+		keys := make([]string, 0, len(cfg.EnvExtra))
+		for key := range cfg.EnvExtra {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			fmt.Fprintf(&extraEnv, "\t\t<key>%s</key>\n\t\t<string>%s</string>\n",
+				plistEsc.Replace(key), plistEsc.Replace(cfg.EnvExtra[key]))
+		}
+	}
+
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -270,12 +291,12 @@ func buildPlist(cfg Config) string {
 		<string>%d</string>
 		<key>PATH</key>
 		<string>%s</string>
-	</dict>
+%s	</dict>
 	<key>StandardOutPath</key>
 	<string>/dev/null</string>
 	<key>StandardErrorPath</key>
 	<string>/dev/null</string>
 </dict>
 </plist>
-`, launchdLabel, cfg.BinaryPath, cfg.WorkDir, cfg.LogFile, cfg.LogMaxSize, envPATH)
+`, launchdLabel, cfg.BinaryPath, cfg.WorkDir, cfg.LogFile, cfg.LogMaxSize, envPATH, extraEnv.String())
 }

--- a/daemon/launchd_test.go
+++ b/daemon/launchd_test.go
@@ -3,7 +3,9 @@
 package daemon
 
 import (
+	"encoding/xml"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -239,4 +241,94 @@ func containsCall(calls []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestBuildPlist_IncludesEnvExtra(t *testing.T) {
+	cfg := Config{
+		BinaryPath: "/opt/cc-connect/cc-connect",
+		WorkDir:    "/tmp/wd",
+		LogFile:    "/tmp/log",
+		LogMaxSize: 10485760,
+		EnvPATH:    "/usr/bin",
+		EnvExtra: map[string]string{
+			"HTTPS_PROXY": "http://127.0.0.1:7890",
+			// '&' inside a proxy query string must be XML-escaped or the
+			// resulting plist is unparseable.
+			"HTTP_PROXY": "http://1.2.3.4:8080?a=1&b=2",
+			"NO_PROXY":   "localhost,127.0.0.1",
+		},
+	}
+	xml := buildPlist(cfg)
+
+	for _, want := range []string{
+		"<key>HTTPS_PROXY</key>",
+		"<string>http://127.0.0.1:7890</string>",
+		"<key>HTTP_PROXY</key>",
+		"<string>http://1.2.3.4:8080?a=1&amp;b=2</string>",
+		"<key>NO_PROXY</key>",
+		"<string>localhost,127.0.0.1</string>",
+	} {
+		if !strings.Contains(xml, want) {
+			t.Errorf("plist missing %q\nfull plist:\n%s", want, xml)
+		}
+	}
+
+	// Raw '&' would make the plist invalid XML; the only '&' allowed in the
+	// document body is the start of an entity reference like &amp;.
+	if strings.Contains(xml, "a=1&b=2") {
+		t.Errorf("plist contains unescaped '&' from proxy query string:\n%s", xml)
+	}
+
+	// Keys must be emitted in deterministic (sorted) order so reinstalls do
+	// not churn the on-disk plist.
+	idxHTTPS := strings.Index(xml, "<key>HTTPS_PROXY</key>")
+	idxHTTP := strings.Index(xml, "<key>HTTP_PROXY</key>")
+	idxNO := strings.Index(xml, "<key>NO_PROXY</key>")
+	if !(idxHTTPS < idxHTTP && idxHTTP < idxNO) {
+		t.Errorf("EnvExtra keys not sorted: HTTPS=%d HTTP=%d NO=%d", idxHTTPS, idxHTTP, idxNO)
+	}
+}
+
+func TestBuildPlist_NoEnvExtraIsValid(t *testing.T) {
+	cfg := Config{
+		BinaryPath: "/opt/cc-connect/cc-connect",
+		WorkDir:    "/tmp/wd",
+		LogFile:    "/tmp/log",
+		LogMaxSize: 10485760,
+		EnvPATH:    "/usr/bin",
+	}
+	got := buildPlist(cfg)
+	// Missing the EnvironmentVariables dict closing tag would mean the
+	// EnvExtra splice broke the template.
+	if !strings.Contains(got, "<key>PATH</key>\n\t\t<string>/usr/bin</string>\n\t</dict>") {
+		t.Errorf("plist EnvironmentVariables dict not properly closed:\n%s", got)
+	}
+}
+
+// TestBuildPlist_XMLWellFormed walks the generated plist with encoding/xml to
+// catch any future change that emits unescaped XML special characters
+// (notably '&' from proxy query strings), which would silently produce a
+// plist that launchd refuses to bootstrap.
+func TestBuildPlist_XMLWellFormed(t *testing.T) {
+	cfg := Config{
+		BinaryPath: "/opt/cc-connect/cc-connect",
+		WorkDir:    "/tmp/wd",
+		LogFile:    "/tmp/log",
+		LogMaxSize: 10485760,
+		EnvPATH:    "/usr/bin",
+		EnvExtra: map[string]string{
+			"HTTP_PROXY":  "http://1.2.3.4:8080?a=1&b=2",
+			"HTTPS_PROXY": "http://127.0.0.1:7890",
+		},
+	}
+	dec := xml.NewDecoder(strings.NewReader(buildPlist(cfg)))
+	for {
+		_, err := dec.Token()
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			t.Fatalf("plist failed XML parse: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

`manager.Resolve` populates `cfg.EnvExtra` with the user's `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (and lowercase variants) so that the daemon can reach the network through a configured proxy. `systemd.go::buildUnit` and `windows.go::buildPowerShellScript` already forward those into their respective service definitions, but `daemon/launchd.go::buildPlist` only emits `CC_LOG_FILE` / `CC_LOG_MAX_SIZE` / `PATH` and silently drops `EnvExtra`.

**Effect on macOS:** a user who runs `cc-connect daemon install` while behind a proxy gets a launchd-managed daemon that ignores the proxy entirely and fails outbound HTTPS, with no diagnostic in the install path.

## Fix

Match the existing `systemd.go` pattern: walk `EnvExtra` in sorted key order and emit one `<key>` / `<string>` pair per entry inside the plist's `EnvironmentVariables` dict.

```go
plistEsc := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
var extraEnv strings.Builder
if len(cfg.EnvExtra) > 0 {
    keys := make([]string, 0, len(cfg.EnvExtra))
    for key := range cfg.EnvExtra {
        keys = append(keys, key)
    }
    sort.Strings(keys)
    for _, key := range keys {
        fmt.Fprintf(&extraEnv, "\t\t<key>%s</key>\n\t\t<string>%s</string>\n",
            plistEsc.Replace(key), plistEsc.Replace(cfg.EnvExtra[key]))
    }
}
```

Proxy values can legitimately contain `&` (query strings) or `<`, either of which would make the plist unparseable, so the new code XML-escapes both key and value. The other plist string fields (`BinaryPath`, `WorkDir`, `LogFile`) keep their existing raw-interpolation behaviour — tightening those is a separate follow-up.

## Tests

- `TestBuildPlist_IncludesEnvExtra` — three vars including a proxy URL with `&`, asserts presence, `&amp;` escaping, and that keys are emitted in sorted order so reinstalls don't churn the plist.
- `TestBuildPlist_NoEnvExtraIsValid` — empty `EnvExtra` still produces a correctly closed `EnvironmentVariables` dict.
- `TestBuildPlist_XMLWellFormed` — walks the generated plist with `encoding/xml.Decoder`; this is the test that would have caught the original bug had it ever been added, and guards against future regressions that emit unescaped XML special characters.

```
$ go test -tags no_web ./daemon/... -run TestBuildPlist -v
=== RUN   TestBuildPlist_KeepAliveDoesNotRestartOnCleanExit
--- PASS
=== RUN   TestBuildPlist_IncludesEnvExtra
--- PASS
=== RUN   TestBuildPlist_NoEnvExtraIsValid
--- PASS
=== RUN   TestBuildPlist_XMLWellFormed
--- PASS
PASS
ok  	github.com/chenhg5/cc-connect/daemon
```

## Test plan

- [x] `go build -tags no_web ./...`
- [x] `go vet -tags no_web ./daemon/...`
- [x] `go test -tags no_web ./daemon/... -run TestBuildPlist`
- [x] Pre-existing failure `TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable` reproduces on `main` as well — environment-dependent on this machine, unrelated to this change.