### PR TITLE
fix(cursor): discover skills under native .cursor/skills layout

### DIFF
--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -232,9 +232,15 @@ func (a *Agent) SkillDirs() []string {
 	if err != nil {
 		absDir = a.workDir
 	}
-	dirs := []string{filepath.Join(absDir, ".claude", "skills")}
+	dirs := []string{
+		filepath.Join(absDir, ".cursor", "skills"),
+		filepath.Join(absDir, ".claude", "skills"),
+	}
 	if home, err := os.UserHomeDir(); err == nil {
-		dirs = append(dirs, filepath.Join(home, ".claude", "skills"))
+		dirs = append(dirs,
+			filepath.Join(home, ".cursor", "skills"),
+			filepath.Join(home, ".claude", "skills"),
+		)
 	}
 	return dirs
 }

--- a/agent/cursor/skilldirs_test.go
+++ b/agent/cursor/skilldirs_test.go
@@ -1,0 +1,60 @@
+package cursor
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSkillDirs_IncludesCursorAndClaudePaths(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	workDir := filepath.Join(tmp, "workspace")
+
+	t.Setenv("HOME", home)
+
+	a := &Agent{workDir: workDir}
+	got := a.SkillDirs()
+	want := []string{
+		filepath.Join(workDir, ".cursor", "skills"),
+		filepath.Join(workDir, ".claude", "skills"),
+		filepath.Join(home, ".cursor", "skills"),
+		filepath.Join(home, ".claude", "skills"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len(SkillDirs()) = %d, want %d\n got=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("SkillDirs()[%d] = %q, want %q\nfull=%v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSkillDirs_CursorBeforeClaude(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	workDir := filepath.Join(tmp, "workspace")
+
+	t.Setenv("HOME", home)
+
+	a := &Agent{workDir: workDir}
+	got := a.SkillDirs()
+
+	cursorWork := filepath.Join(workDir, ".cursor", "skills")
+	claudeWork := filepath.Join(workDir, ".claude", "skills")
+	cursorIdx, claudeIdx := -1, -1
+	for i, d := range got {
+		if d == cursorWork {
+			cursorIdx = i
+		}
+		if d == claudeWork {
+			claudeIdx = i
+		}
+	}
+	if cursorIdx == -1 || claudeIdx == -1 {
+		t.Fatalf("expected both cursor and claude work-dir skill paths, got %v", got)
+	}
+	if cursorIdx > claudeIdx {
+		t.Fatalf("cursor skills should be searched before claude skills, got cursor at %d, claude at %d (%v)", cursorIdx, claudeIdx, got)
+	}
+}


### PR DESCRIPTION
## Summary

- Cursor agent's `SkillDirs()` only scanned `.claude/skills`, so a skill stored at `<work_dir>/.cursor/skills/<name>/SKILL.md` (Cursor's documented native layout) never appeared in `/skills` unless the user renamed the directory tree.
- Add `.cursor/skills` to the search list for both the project work directory and the user home directory, ahead of the existing `.claude/skills` entries so the cursor-native location wins when both exist.
- Keep `.claude/skills` in the list to avoid breaking setups that already relied on the old behavior.

Fixes #786

## Behavior

Before — Cursor agent search order:
1. `<work_dir>/.claude/skills`
2. `<home>/.claude/skills`

After — Cursor agent search order:
1. `<work_dir>/.cursor/skills`
2. `<work_dir>/.claude/skills`
3. `<home>/.cursor/skills`
4. `<home>/.claude/skills`

## Test plan

- [x] `go test ./agent/cursor/...` (new `skilldirs_test.go` covers presence and ordering, plus existing tests still pass)
- [x] `go test -race ./agent/...` (all agent packages green)
- [x] `go vet -tags=no_web ./...` clean