### PR TITLE
fix(relay): preserve thread/user suffix in relay session key

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -12632,7 +12632,7 @@ func (e *Engine) cmdBind(p Platform, msg *Message, args []string) {
 		return
 	}
 
-	_, chatID, err := parseSessionKeyParts(msg.SessionKey)
+	_, chatID, _, err := parseSessionKeyParts(msg.SessionKey)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgRelayNotAvailable))
 		return

--- a/core/relay.go
+++ b/core/relay.go
@@ -222,8 +222,10 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 		toName = binding.Bots[req.To]
 	}
 
-	// Post the forwarded message to the group chat for visibility
-	groupSessionKey := platform + ":" + chatID + ":relay"
+	// Post the forwarded message to the group chat for visibility.
+	// Use fullChatID so the message routes to the correct thread/topic
+	// when the source platform has per-thread session keys.
+	groupSessionKey := platform + ":" + fullChatID
 	if sourceEngine != nil {
 		label := fmt.Sprintf("[%s → %s] %s", fromName, toName, req.Message)
 		rm.sendToGroup(ctx, sourceEngine, platform, groupSessionKey, label)

--- a/core/relay.go
+++ b/core/relay.go
@@ -186,7 +186,7 @@ type RelayResponse struct {
 
 // Send delivers a message from one bot to another and returns the response.
 func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayResponse, error) {
-	platform, chatID, err := parseSessionKeyParts(req.SessionKey)
+	platform, chatID, fullChatID, err := parseSessionKeyParts(req.SessionKey)
 	if err != nil {
 		return nil, fmt.Errorf("relay: invalid session key: %w", err)
 	}
@@ -233,7 +233,7 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 	relayCtx, cancel := rm.relayContext(ctx)
 	defer cancel()
 
-	response, err := targetEngine.HandleRelay(relayCtx, req.From, chatID, req.Message)
+	response, err := targetEngine.HandleRelay(relayCtx, req.From, fullChatID, req.Message)
 	if err != nil {
 		return nil, fmt.Errorf("relay: %w", err)
 	}
@@ -287,18 +287,34 @@ func (rm *RelayManager) relayContext(ctx context.Context) (context.Context, cont
 	return context.WithTimeout(ctx, timeout)
 }
 
-func parseSessionKeyParts(sessionKey string) (platform, chatID string, err error) {
-	// Format: "platform:chatID:userID"
-	// Relay session format: "relay:sourceProject:chatID"
+// parseSessionKeyParts splits a session key into its components.
+//
+// Format: "platform:chatID[:suffix]" where suffix may be userID, threadID,
+// or "root:threadID" (Feishu thread_isolation).
+//
+// Returns:
+//   - platform: the first segment (e.g., "feishu", "telegram", "relay")
+//   - chatID:   the second segment only — used for binding lookups (chat-level)
+//   - fullChatID: chatID + ":" + suffix when a suffix exists; otherwise equals chatID.
+//     Used for relay session construction so that relay sessions match the
+//     isolation boundary of reply sessions (per-user or per-thread).
+func parseSessionKeyParts(sessionKey string) (platform, chatID, fullChatID string, err error) {
 	parts := strings.SplitN(sessionKey, ":", 3)
 	if len(parts) < 2 {
-		return "", "", fmt.Errorf("invalid session key format: %q", sessionKey)
+		return "", "", "", fmt.Errorf("invalid session key format: %q", sessionKey)
 	}
+	// Relay session format: "relay:sourceProject:chatID" — suffix not applicable.
 	if parts[0] == "relay" && len(parts) == 3 {
 		// For relay sessions, chatID is the third part: "relay:sourceProject:chatID"
-		return parts[0], parts[2], nil
+		return parts[0], parts[2], parts[2], nil
 	}
-	return parts[0], parts[1], nil
+	platform = parts[0]
+	chatID = parts[1]
+	fullChatID = parts[1]
+	if len(parts) == 3 && parts[2] != "" {
+		fullChatID = parts[1] + ":" + parts[2]
+	}
+	return platform, chatID, fullChatID, nil
 }
 
 // ── Persistence ─────────────────────────────────────────────

--- a/core/relay_test.go
+++ b/core/relay_test.go
@@ -8,6 +8,108 @@ import (
 	"time"
 )
 
+func TestParseSessionKeyParts(t *testing.T) {
+	tests := []struct {
+		name             string
+		sessionKey       string
+		wantPlatform     string
+		wantChatID       string
+		wantFullChatID   string
+		wantErr          bool
+	}{
+		{
+			name:           "feishu thread isolation",
+			sessionKey:     "feishu:oc_abc:root:om_xyz",
+			wantPlatform:   "feishu",
+			wantChatID:     "oc_abc",
+			wantFullChatID: "oc_abc:root:om_xyz",
+		},
+		{
+			name:           "feishu share_session_in_channel",
+			sessionKey:     "feishu:oc_abc",
+			wantPlatform:   "feishu",
+			wantChatID:     "oc_abc",
+			wantFullChatID: "oc_abc",
+		},
+		{
+			name:           "telegram shared channel with topic",
+			sessionKey:     "telegram:123:456",
+			wantPlatform:   "telegram",
+			wantChatID:     "123",
+			wantFullChatID: "123:456",
+		},
+		{
+			name:           "telegram per-user with topic",
+			sessionKey:     "telegram:123:456:789",
+			wantPlatform:   "telegram",
+			wantChatID:     "123",
+			wantFullChatID: "123:456:789",
+		},
+		{
+			name:           "telegram shared channel no topic",
+			sessionKey:     "telegram:123",
+			wantPlatform:   "telegram",
+			wantChatID:     "123",
+			wantFullChatID: "123",
+		},
+		{
+			name:           "discord per-user",
+			sessionKey:     "discord:CHAN:USER",
+			wantPlatform:   "discord",
+			wantChatID:     "CHAN",
+			wantFullChatID: "CHAN:USER",
+		},
+		{
+			name:           "discord shared channel",
+			sessionKey:     "discord:CHAN",
+			wantPlatform:   "discord",
+			wantChatID:     "CHAN",
+			wantFullChatID: "CHAN",
+		},
+		{
+			name:           "relay session key",
+			sessionKey:     "relay:source:chatID",
+			wantPlatform:   "relay",
+			wantChatID:     "chatID",
+			wantFullChatID: "chatID",
+		},
+		{
+			name:        "invalid format",
+			sessionKey:  "invalid",
+			wantErr:     true,
+		},
+		{
+			name:        "empty string",
+			sessionKey:  "",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			platform, chatID, fullChatID, err := parseSessionKeyParts(tt.sessionKey)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if platform != tt.wantPlatform {
+				t.Fatalf("platform = %q, want %q", platform, tt.wantPlatform)
+			}
+			if chatID != tt.wantChatID {
+				t.Fatalf("chatID = %q, want %q", chatID, tt.wantChatID)
+			}
+			if fullChatID != tt.wantFullChatID {
+				t.Fatalf("fullChatID = %q, want %q", fullChatID, tt.wantFullChatID)
+			}
+		})
+	}
+}
+
 func TestRelayManager_DefaultTimeout(t *testing.T) {
 	rm := NewRelayManager("")
 


### PR DESCRIPTION
parseSessionKeyParts now returns fullChatID (chatID + suffix) so that HandleRelay constructs per-thread or per-user relay sessions instead of sharing one session across all topics/users in the same chat.

Previously, "feishu:chat:root:threadID" was truncated to chatID="chat", causing relaySessionKey="relay:proj:chat" for all threads. With this fix, fullChatID="chat:root:threadID" produces distinct relay sessions per thread, matching the isolation semantics of reply sessions.

Binding lookup and groupSessionKey still use plain chatID.