### PR TITLE
feat(dingtalk): add native emotion reactions

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -960,8 +960,8 @@ app_secret = "your-feishu-app-secret"
 # client_secret = "your-dingtalk-client-secret"
 # allow_from = "*"  # Allowed staff IDs / 允许的员工 ID
 # share_session_in_channel = false  # If true, all users in a group share one agent session / 群聊共享会话
-# reaction_emoji = "🤔思考中"  # Native DingTalk emotion while processing (default: "🤔思考中"); set to "none" to disable
-# done_emoji = "✅完成"        # Optional native DingTalk emotion when the agent finishes (default: "none")
+# reaction_emoji = "🤔思考中"  # Native DingTalk emotion on incoming messages (default: "🤔思考中"); set to "none" to disable
+# done_emoji = "none"          # Native DingTalk emotion when agent finishes a reply (e.g. "✅完成"); set to "none" to disable
 
 # Telegram (uncomment to enable / 取消注释以启用)
 # 1. Message @BotFather on Telegram, send /newbot to create a bot

--- a/config.example.toml
+++ b/config.example.toml
@@ -960,6 +960,8 @@ app_secret = "your-feishu-app-secret"
 # client_secret = "your-dingtalk-client-secret"
 # allow_from = "*"  # Allowed staff IDs / 允许的员工 ID
 # share_session_in_channel = false  # If true, all users in a group share one agent session / 群聊共享会话
+# reaction_emoji = "🤔思考中"  # Native DingTalk emotion while processing (default: "🤔思考中"); set to "none" to disable
+# done_emoji = "✅完成"        # Optional native DingTalk emotion when the agent finishes (default: "none")
 
 # Telegram (uncomment to enable / 取消注释以启用)
 # 1. Message @BotFather on Telegram, send /newbot to create a bot

--- a/docs/dingtalk.md
+++ b/docs/dingtalk.md
@@ -77,7 +77,7 @@ client_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 # 可选：原生钉钉表情反馈
 reaction_emoji = "🤔思考中"
-done_emoji = "✅完成"
+done_emoji = "none"
 ```
 
 ---
@@ -274,10 +274,12 @@ cc-connect: ✅ 这是一个 Node.js 项目，包含以下目录...
 client_id = "dingxxxxxxxxxxxxxxx"
 client_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 reaction_emoji = "🤔思考中"
-done_emoji = "✅完成"
+done_emoji = "none"
 ```
 
-该功能使用钉钉机器人 emotion 接口，需要应用具备对应 API 权限。若钉钉拒绝某个表情文本，或接口调用失败，cc-connect 只会记录调试日志并继续正常回复，不会中断本轮对话。
+如需处理完成时也添加表情，可将 `done_emoji` 设置为钉钉兼容的文本表情，例如 `"✅完成"`。
+
+该功能使用钉钉机器人 emotion 接口，需要应用具备对应 API 权限。若钉钉拒绝某个表情文本，或接口调用失败，cc-connect 只会记录日志并继续正常回复，不会中断本轮对话。
 
 ---
 

--- a/docs/dingtalk.md
+++ b/docs/dingtalk.md
@@ -74,6 +74,10 @@ type = "dingtalk"
 [projects.platforms.options]
 client_id = "dingxxxxxxxxxxxxxxx"
 client_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# 可选：原生钉钉表情反馈
+reaction_emoji = "🤔思考中"
+done_emoji = "✅完成"
 ```
 
 ---
@@ -253,6 +257,27 @@ cc-connect: ✅ 这是一个 Node.js 项目，包含以下目录...
 | 配置复杂度 | 简单 | 较复杂 |
 | 连接方式 | WebSocket | HTTP 回调 |
 | 适用场景 | 本地开发、内网 | 生产环境 |
+
+---
+
+## 原生表情反馈（可选）
+
+钉钉平台支持可选的原生表情反馈：
+
+- `reaction_emoji`：cc-connect 开始处理收到的消息时，给原消息添加一个钉钉原生表情。默认值为 `"🤔思考中"`，设置为 `"none"` 可关闭。
+- `done_emoji`：处理完成后可添加一个完成表情。默认关闭，设置为空或 `"none"` 表示关闭。
+
+示例：
+
+```toml
+[projects.platforms.options]
+client_id = "dingxxxxxxxxxxxxxxx"
+client_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+reaction_emoji = "🤔思考中"
+done_emoji = "✅完成"
+```
+
+该功能使用钉钉机器人 emotion 接口，需要应用具备对应 API 权限。若钉钉拒绝某个表情文本，或接口调用失败，cc-connect 只会记录调试日志并继续正常回复，不会中断本轮对话。
 
 ---
 

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -27,11 +27,12 @@ func init() {
 }
 
 type replyContext struct {
-	sessionWebhook  string
-	conversationId  string
-	senderStaffId   string
-	isGroup         bool
-	proactive       bool // true when constructed by ReconstructReplyCtx (no sessionWebhook)
+	sessionWebhook string
+	conversationId string
+	senderStaffId  string
+	messageId      string
+	isGroup        bool
+	proactive      bool // true when constructed by ReconstructReplyCtx (no sessionWebhook)
 }
 
 // richTextContent mirrors the full structure of the DingTalk "text" JSON field,
@@ -60,7 +61,7 @@ type Platform struct {
 	clientID              string
 	clientSecret          string
 	robotCode             string
-	agentID               int64    // Agent ID for work notifications API (numeric)
+	agentID               int64 // Agent ID for work notifications API (numeric)
 	allowFrom             string
 	shareSessionInChannel bool
 	streamClient          *dingtalkClient.StreamClient
@@ -71,6 +72,8 @@ type Platform struct {
 	tokenMu               sync.Mutex
 	accessToken           string
 	tokenExpiry           time.Time
+	reactionEmoji         string
+	doneEmoji             string
 	// AI Card configuration
 	cardTemplateID  string
 	cardTemplateKey string
@@ -86,6 +89,11 @@ func New(opts map[string]any) (core.Platform, error) {
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom("dingtalk", allowFrom)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
+	reactionEmoji, _ := opts["reaction_emoji"].(string)
+	if reactionEmoji == "" {
+		reactionEmoji = "🤔思考中"
+	}
+	doneEmoji, _ := opts["done_emoji"].(string)
 	if clientID == "" || clientSecret == "" {
 		return nil, fmt.Errorf("dingtalk: client_id and client_secret are required")
 	}
@@ -132,6 +140,8 @@ func New(opts map[string]any) (core.Platform, error) {
 		allowFrom:             allowFrom,
 		shareSessionInChannel: shareSessionInChannel,
 		httpClient:            &http.Client{Timeout: 30 * time.Second},
+		reactionEmoji:         normalizeDingTalkReactionEmoji(reactionEmoji),
+		doneEmoji:             normalizeDingTalkReactionEmoji(doneEmoji),
 		cardTemplateID:        cardTemplateID,
 		cardTemplateKey:       cardTemplateKey,
 		cardThrottleMs:        cardThrottleMs,
@@ -139,6 +149,14 @@ func New(opts map[string]any) (core.Platform, error) {
 }
 
 func (p *Platform) Name() string { return "dingtalk" }
+
+func normalizeDingTalkReactionEmoji(v string) string {
+	v = strings.TrimSpace(v)
+	if strings.EqualFold(v, "none") {
+		return ""
+	}
+	return v
+}
 
 func (p *Platform) Start(handler core.MessageHandler) error {
 	p.handler = handler
@@ -270,6 +288,8 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 				sessionWebhook: data.SessionWebhook,
 				conversationId: data.ConversationId,
 				senderStaffId:  data.SenderStaffId,
+				messageId:      data.MsgId,
+				isGroup:        data.ConversationType == "2",
 			},
 		}
 		p.handler(p, msg)
@@ -300,10 +320,11 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 		MessageID:  data.MsgId,
 		ChannelKey: data.ConversationId,
 		ReplyCtx: replyContext{
-			sessionWebhook:  data.SessionWebhook,
-			conversationId:  data.ConversationId,
-			senderStaffId:   data.SenderStaffId,
-			isGroup:         data.ConversationType == "2",
+			sessionWebhook: data.SessionWebhook,
+			conversationId: data.ConversationId,
+			senderStaffId:  data.SenderStaffId,
+			messageId:      data.MsgId,
+			isGroup:        data.ConversationType == "2",
 		},
 	}
 
@@ -368,12 +389,13 @@ func (p *Platform) handleAudioMessage(data *chatbot.BotCallbackDataModel, sessio
 				MessageID:  data.MsgId,
 				ChannelKey: data.ConversationId,
 				ReplyCtx: replyContext{
-					sessionWebhook:  data.SessionWebhook,
-					conversationId:  data.ConversationId,
-					senderStaffId:   data.SenderStaffId,
-					isGroup:         data.ConversationType == "2",
+					sessionWebhook: data.SessionWebhook,
+					conversationId: data.ConversationId,
+					senderStaffId:  data.SenderStaffId,
+					messageId:      data.MsgId,
+					isGroup:        data.ConversationType == "2",
 				},
-				FromVoice:  true,
+				FromVoice: true,
 			}
 			p.handler(p, msg)
 		}
@@ -392,12 +414,13 @@ func (p *Platform) handleAudioMessage(data *chatbot.BotCallbackDataModel, sessio
 		MessageID:  data.MsgId,
 		ChannelKey: data.ConversationId,
 		ReplyCtx: replyContext{
-			sessionWebhook:  data.SessionWebhook,
-			conversationId:  data.ConversationId,
-			senderStaffId:   data.SenderStaffId,
-			isGroup:         data.ConversationType == "2",
+			sessionWebhook: data.SessionWebhook,
+			conversationId: data.ConversationId,
+			senderStaffId:  data.SenderStaffId,
+			messageId:      data.MsgId,
+			isGroup:        data.ConversationType == "2",
 		},
-		FromVoice:  true,
+		FromVoice: true,
 		Audio: &core.AudioAttachment{
 			MimeType: mimeType,
 			Data:     audioBytes,
@@ -468,9 +491,11 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 		UserName:   data.SenderNick,
 		MessageID:  data.MsgId,
 		ReplyCtx: replyContext{
-			sessionWebhook:  data.SessionWebhook,
-			conversationId:  data.ConversationId,
-			senderStaffId:   data.SenderStaffId,
+			sessionWebhook: data.SessionWebhook,
+			conversationId: data.ConversationId,
+			senderStaffId:  data.SenderStaffId,
+			messageId:      data.MsgId,
+			isGroup:        data.ConversationType == "2",
 		},
 		Images: []core.ImageAttachment{{
 			MimeType: mimeType,
@@ -625,6 +650,112 @@ func (p *Platform) getAccessToken() (string, error) {
 
 	slog.Debug("dingtalk: access token refreshed", "expires_at", p.tokenExpiry)
 	return p.accessToken, nil
+}
+
+const (
+	dingTalkEmotionReplyEndpoint  = "https://api.dingtalk.com/v1.0/robot/emotion/reply"
+	dingTalkEmotionRecallEndpoint = "https://api.dingtalk.com/v1.0/robot/emotion/recall"
+	dingTalkEmotionTimeout        = 5 * time.Second
+)
+
+// StartTyping adds a native DingTalk emotion reply to the inbound message and
+// returns a stop function that recalls it when processing completes.
+func (p *Platform) StartTyping(ctx context.Context, rctx any) func() {
+	if p.reactionEmoji == "" {
+		return func() {}
+	}
+	rc, ok := rctx.(replyContext)
+	if !ok || rc.messageId == "" || rc.conversationId == "" {
+		return func() {}
+	}
+	emotionCtx, cancel := context.WithTimeout(ctx, dingTalkEmotionTimeout)
+	p.replyEmotion(emotionCtx, rc, p.reactionEmoji)
+	cancel()
+	return func() {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), dingTalkEmotionTimeout)
+			defer cancel()
+			p.recallEmotion(ctx, rc, p.reactionEmoji)
+		}()
+	}
+}
+
+// AddDoneReaction adds a final native DingTalk emotion reply when configured.
+func (p *Platform) AddDoneReaction(rctx any) {
+	if p.doneEmoji == "" {
+		return
+	}
+	rc, ok := rctx.(replyContext)
+	if !ok || rc.messageId == "" || rc.conversationId == "" {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), dingTalkEmotionTimeout)
+		defer cancel()
+		p.replyEmotion(ctx, rc, p.doneEmoji)
+	}()
+}
+
+func (p *Platform) replyEmotion(ctx context.Context, rc replyContext, emoji string) bool {
+	return p.callEmotionAPI(ctx, dingTalkEmotionReplyEndpoint, rc, emoji)
+}
+
+func (p *Platform) recallEmotion(ctx context.Context, rc replyContext, emoji string) {
+	p.callEmotionAPI(ctx, dingTalkEmotionRecallEndpoint, rc, emoji)
+}
+
+func (p *Platform) callEmotionAPI(ctx context.Context, endpoint string, rc replyContext, emoji string) bool {
+	if rc.messageId == "" || rc.conversationId == "" || emoji == "" {
+		return false
+	}
+
+	token, err := p.getAccessToken()
+	if err != nil {
+		slog.Warn("dingtalk: emotion access token failed", "error", err)
+		return false
+	}
+
+	payload := map[string]any{
+		"robotCode":          p.robotCode,
+		"openMsgId":          rc.messageId,
+		"openConversationId": rc.conversationId,
+		"emotionType":        2,
+		"emotionName":        emoji,
+		"textEmotion": map[string]string{
+			"emotionId":    "2659900",
+			"emotionName":  emoji,
+			"text":         emoji,
+			"backgroundId": "im_bg_1",
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		slog.Warn("dingtalk: marshal emotion request failed", "error", err)
+		return false
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		slog.Warn("dingtalk: create emotion request failed", "error", err)
+		return false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-acs-dingtalk-access-token", token)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		slog.Warn("dingtalk: emotion request failed", "endpoint", endpoint, "error", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		slog.Warn("dingtalk: emotion request returned status", "endpoint", endpoint, "status", resp.StatusCode, "body", string(respBody))
+		return false
+	}
+
+	return true
 }
 
 func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
@@ -984,8 +1115,8 @@ func (p *Platform) compressAudioWithFFmpeg(ctx context.Context, audio []byte, fo
 	args := []string{
 		"-i", "pipe:0",
 		"-ar", "16000", // 16kHz sample rate for voice
-		"-ac", "1",     // mono
-		"-b:a", "64k",  // 64 kbps bitrate (voice quality)
+		"-ac", "1", // mono
+		"-b:a", "64k", // 64 kbps bitrate (voice quality)
 		"-f", "mp3",
 		"-y",
 		"pipe:1",

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -1,16 +1,297 @@
 package dingtalk
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/chenhg5/cc-connect/core"
 )
 
 // ──────────────────────────────────────────────────────────────
 // Thread safety tests for token caching
 // ──────────────────────────────────────────────────────────────
+
+type dingtalkEmotionRequest struct {
+	method string
+	path   string
+	token  string
+	body   map[string]any
+}
+
+type rewriteDingTalkTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (rt rewriteDingTalkTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = rt.target.Scheme
+	clone.URL.Host = rt.target.Host
+	clone.Host = rt.target.Host
+	return rt.base.RoundTrip(clone)
+}
+
+type failRoundTripper struct {
+	t *testing.T
+}
+
+func (rt failRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.t.Fatalf("unexpected HTTP call to %s", req.URL.String())
+	return nil, nil
+}
+
+func newEmotionTestPlatform(t *testing.T, reactionEmoji, doneEmoji string) (*Platform, <-chan dingtalkEmotionRequest) {
+	t.Helper()
+
+	requests := make(chan dingtalkEmotionRequest, 10)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var body map[string]any
+		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+			t.Errorf("decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		requests <- dingtalkEmotionRequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			token:  r.Header.Get("x-acs-dingtalk-access-token"),
+			body:   body,
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	targetURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+
+	return &Platform{
+		clientID:      "test_client",
+		clientSecret:  "test_secret",
+		robotCode:     "test_robot",
+		httpClient:    &http.Client{Transport: rewriteDingTalkTransport{target: targetURL, base: http.DefaultTransport}},
+		accessToken:   "test_token",
+		tokenExpiry:   time.Now().Add(time.Hour),
+		reactionEmoji: reactionEmoji,
+		doneEmoji:     doneEmoji,
+	}, requests
+}
+
+func waitEmotionRequest(t *testing.T, requests <-chan dingtalkEmotionRequest) dingtalkEmotionRequest {
+	t.Helper()
+	select {
+	case req := <-requests:
+		return req
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for emotion request")
+		return dingtalkEmotionRequest{}
+	}
+}
+
+func assertEmotionRequest(t *testing.T, req dingtalkEmotionRequest, path, emoji string) {
+	t.Helper()
+	if req.method != http.MethodPost {
+		t.Fatalf("method = %q, want %q", req.method, http.MethodPost)
+	}
+	if req.path != path {
+		t.Fatalf("path = %q, want %q", req.path, path)
+	}
+	if req.token != "test_token" {
+		t.Fatalf("access token header = %q, want test_token", req.token)
+	}
+	if req.body["robotCode"] != "test_robot" {
+		t.Fatalf("robotCode = %v, want test_robot", req.body["robotCode"])
+	}
+	if req.body["openMsgId"] != "msg_123" {
+		t.Fatalf("openMsgId = %v, want msg_123", req.body["openMsgId"])
+	}
+	if req.body["openConversationId"] != "conv_123" {
+		t.Fatalf("openConversationId = %v, want conv_123", req.body["openConversationId"])
+	}
+	if req.body["emotionName"] != emoji {
+		t.Fatalf("emotionName = %v, want %q", req.body["emotionName"], emoji)
+	}
+	if req.body["emotionType"] != float64(2) {
+		t.Fatalf("emotionType = %v, want 2", req.body["emotionType"])
+	}
+	textEmotion, ok := req.body["textEmotion"].(map[string]any)
+	if !ok {
+		t.Fatalf("textEmotion should be an object, got %T", req.body["textEmotion"])
+	}
+	if textEmotion["emotionId"] != "2659900" {
+		t.Fatalf("textEmotion.emotionId = %v, want 2659900", textEmotion["emotionId"])
+	}
+	if textEmotion["backgroundId"] != "im_bg_1" {
+		t.Fatalf("textEmotion.backgroundId = %v, want im_bg_1", textEmotion["backgroundId"])
+	}
+	if textEmotion["emotionName"] != emoji || textEmotion["text"] != emoji {
+		t.Fatalf("textEmotion emoji fields = %#v, want %q", textEmotion, emoji)
+	}
+}
+
+func validEmotionReplyContext() replyContext {
+	return replyContext{
+		sessionWebhook: "https://example.test/webhook",
+		conversationId: "conv_123",
+		senderStaffId:  "staff_123",
+		messageId:      "msg_123",
+	}
+}
+
+func TestNewReactionOptions(t *testing.T) {
+	baseOpts := map[string]any{
+		"client_id":     "test_client",
+		"client_secret": "test_secret",
+		"robot_code":    "test_robot",
+	}
+
+	t.Run("reaction enabled by default", func(t *testing.T) {
+		p, err := New(baseOpts)
+		if err != nil {
+			t.Fatalf("New returned error: %v", err)
+		}
+		got := p.(*Platform)
+		if got.reactionEmoji != "🤔思考中" {
+			t.Fatalf("reactionEmoji = %q, want default value", got.reactionEmoji)
+		}
+		if got.doneEmoji != "" {
+			t.Fatalf("doneEmoji = %q, want empty", got.doneEmoji)
+		}
+	})
+
+	t.Run("configured", func(t *testing.T) {
+		opts := map[string]any{
+			"client_id":      "test_client",
+			"client_secret":  "test_secret",
+			"robot_code":     "test_robot",
+			"reaction_emoji": "🤔思考中",
+			"done_emoji":     "✅完成",
+		}
+		p, err := New(opts)
+		if err != nil {
+			t.Fatalf("New returned error: %v", err)
+		}
+		got := p.(*Platform)
+		if got.reactionEmoji != "🤔思考中" {
+			t.Fatalf("reactionEmoji = %q, want configured value", got.reactionEmoji)
+		}
+		if got.doneEmoji != "✅完成" {
+			t.Fatalf("doneEmoji = %q, want configured value", got.doneEmoji)
+		}
+	})
+
+	t.Run("none disables", func(t *testing.T) {
+		opts := map[string]any{
+			"client_id":      "test_client",
+			"client_secret":  "test_secret",
+			"robot_code":     "test_robot",
+			"reaction_emoji": "none",
+			"done_emoji":     "NONE",
+		}
+		p, err := New(opts)
+		if err != nil {
+			t.Fatalf("New returned error: %v", err)
+		}
+		got := p.(*Platform)
+		if got.reactionEmoji != "" {
+			t.Fatalf("reactionEmoji = %q, want empty", got.reactionEmoji)
+		}
+		if got.doneEmoji != "" {
+			t.Fatalf("doneEmoji = %q, want empty", got.doneEmoji)
+		}
+	})
+}
+
+func TestStartTypingDisabledDoesNotCallHTTP(t *testing.T) {
+	p := &Platform{
+		httpClient:  &http.Client{Transport: failRoundTripper{t: t}},
+		accessToken: "test_token",
+		tokenExpiry: time.Now().Add(time.Hour),
+	}
+
+	stop := p.StartTyping(context.Background(), validEmotionReplyContext())
+	stop()
+}
+
+func TestStartTypingSendsAndRecallsEmotion(t *testing.T) {
+	p, requests := newEmotionTestPlatform(t, "🤔思考中", "")
+
+	stop := p.StartTyping(context.Background(), validEmotionReplyContext())
+	assertEmotionRequest(t, waitEmotionRequest(t, requests), "/v1.0/robot/emotion/reply", "🤔思考中")
+
+	stop()
+	assertEmotionRequest(t, waitEmotionRequest(t, requests), "/v1.0/robot/emotion/recall", "🤔思考中")
+}
+
+func TestAddDoneReactionSendsEmotionWhenConfigured(t *testing.T) {
+	p, requests := newEmotionTestPlatform(t, "", "✅完成")
+
+	p.AddDoneReaction(validEmotionReplyContext())
+	assertEmotionRequest(t, waitEmotionRequest(t, requests), "/v1.0/robot/emotion/reply", "✅完成")
+}
+
+func TestAddDoneReactionDisabledDoesNotCallHTTP(t *testing.T) {
+	p := &Platform{
+		httpClient:  &http.Client{Transport: failRoundTripper{t: t}},
+		accessToken: "test_token",
+		tokenExpiry: time.Now().Add(time.Hour),
+	}
+
+	p.AddDoneReaction(validEmotionReplyContext())
+}
+
+func TestReactionInvalidReplyContextDoesNotCallHTTP(t *testing.T) {
+	p := &Platform{
+		httpClient:    &http.Client{Transport: failRoundTripper{t: t}},
+		accessToken:   "test_token",
+		tokenExpiry:   time.Now().Add(time.Hour),
+		reactionEmoji: "🤔思考中",
+		doneEmoji:     "✅完成",
+	}
+
+	stop := p.StartTyping(context.Background(), "not a reply context")
+	stop()
+	p.AddDoneReaction("not a reply context")
+}
+
+func TestReactionMissingMessageOrConversationDoesNotCallHTTP(t *testing.T) {
+	p := &Platform{
+		httpClient:    &http.Client{Transport: failRoundTripper{t: t}},
+		accessToken:   "test_token",
+		tokenExpiry:   time.Now().Add(time.Hour),
+		reactionEmoji: "🤔思考中",
+		doneEmoji:     "✅完成",
+	}
+
+	missingMessageID := validEmotionReplyContext()
+	missingMessageID.messageId = ""
+	stop := p.StartTyping(context.Background(), missingMessageID)
+	stop()
+	p.AddDoneReaction(missingMessageID)
+
+	missingConversationID := validEmotionReplyContext()
+	missingConversationID.conversationId = ""
+	stop = p.StartTyping(context.Background(), missingConversationID)
+	stop()
+	p.AddDoneReaction(missingConversationID)
+}
+
+var _ core.TypingIndicator = (*Platform)(nil)
+var _ core.TypingIndicatorDone = (*Platform)(nil)
 
 func TestGetAccessToken_ConcurrentAccess(t *testing.T) {
 	// This test verifies that concurrent calls to getAccessToken
@@ -56,7 +337,7 @@ func TestGetAccessToken_ConcurrentAccess(t *testing.T) {
 func TestGetAccessToken_MutexExists(t *testing.T) {
 	// Verify that the tokenMu mutex field exists and works
 	p := &Platform{
-		clientID:    "test_client",
+		clientID:     "test_client",
 		clientSecret: "test_secret",
 	}
 


### PR DESCRIPTION
## Summary
- add DingTalk native emotion reactions through the existing typing indicator interfaces
- enable the processing reaction by default with a DingTalk-compatible text emotion, while supporting reaction_emoji = "none" to disable it
- align DingTalk reaction option examples with Feishu-style defaults: done_emoji defaults to "none" with an example completion emotion in the comment

## Validation
- PASS: go test ./platform/dingtalk
- PASS: go test -race ./tests/release_local/engine_matrix -count=1
- FAIL: go test ./... (unrelated current repo/environment failures observed locally: missing web dist embed files, agent/codex TestGetModelAndReasoningEffort_FromRuntimeConfigWhenUnset, core footer/path expectation tests, core TestResolveLocalDirPath_AcceptsSubdir, daemon TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable)

## Breaking Changes
None.