### PR TITLE
fix(claudecode): replace dots in encodeClaudeProjectKey to match Claude Code 2.1.91+

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -1213,7 +1213,9 @@ func boolVal(m map[string]any, key string) bool {
 //  3. Replacing underscores (_) with "-"
 //  4. Replacing spaces and tildes (~) with "-" (common in macOS iCloud paths like
 //     "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/...")
-//  5. Replacing all non-ASCII characters with "-"
+//  5. Replacing dots (.) with "-" (e.g. macOS usernames like "yinglong.li";
+//     matches Claude Code 2.1.91+ behavior)
+//  6. Replacing all non-ASCII characters with "-"
 func encodeClaudeProjectKey(absPath string) string {
 	// First, normalize to forward slashes for consistent processing
 	normalized := strings.ReplaceAll(absPath, "\\", "/")
@@ -1221,7 +1223,7 @@ func encodeClaudeProjectKey(absPath string) string {
 	// Build the encoded key character by character
 	var result strings.Builder
 	for _, r := range normalized {
-		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' {
+		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' || r == '.' {
 			result.WriteRune('-')
 		} else if r < 128 { // ASCII range (0-127)
 			result.WriteRune(r)

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -403,6 +403,16 @@ func TestEncodeClaudeProjectKey(t *testing.T) {
 			expected: "-Users-username-Library-Mobile-Documents-com-apple-CloudDocs-my-project",
 		},
 		{
+			name:     "macOS username with dot",
+			input:    "/Users/yinglong.li/dev/project",
+			expected: "-Users-yinglong-li-dev-project",
+		},
+		{
+			name:     "directory name with dot",
+			input:    "/Users/username/projects/my.project.v2",
+			expected: "-Users-username-projects-my-project-v2",
+		},
+		{
 			name:     "mixed ASCII and non-ASCII",
 			input:    "/Users/username/中文folder/english文件夹",
 			expected: "-Users-username---folder-english---", // "/中文" = 3 hyphens, "/文件夹" = 4 hyphens


### PR DESCRIPTION
## Summary

- `encodeClaudeProjectKey` did not replace `.` with `-`, but Claude Code 2.1.91+ does. This caused `/list` to always return 0 sessions whenever the absolute work-dir path contained a dot — most commonly macOS usernames like `yinglong.li`.
- Add `'.'` to the replacement set so the encoded key matches Claude Code's actual on-disk project directory.
- Add two test cases covering a dotted username and a dotted directory name.

## Root cause

For `/Users/yinglong.li`:

| Source | Encoded key |
| --- | --- |
| cc-connect (before) | `-Users-yinglong.li` |
| Claude Code 2.1.91+ | `-Users-yinglong-li` |

`findProjectDir()` therefore failed every candidate and the fallback scan also missed (every candidate kept the dot), so `ListSessions()` returned nil → `/list` showed 0 sessions.

## Fix

Single-character extension to the replacement set in `agent/claudecode/claudecode.go:1217`:

```go
if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' || r == '.' {
    result.WriteRune('-')
}
```

No existing test inputs contained dots, so no test expectations needed updating. Two new cases pin the new behaviour.

Closes #842

## Test plan

- [x] `go test ./agent/claudecode/...` — all existing tests pass plus the two new cases
- [x] `go vet -tags=no_web ./...` clean
- [x] Confirmed the only test failures in the wider suite (`tests/release_local/engine_matrix` race, `agent/codex` flake) reproduce on `main` without this change and are unrelated to the dot-replacement edit