### PR TITLE
fix(core): use native shell for hooks and webhook exec on Windows

### DIFF
--- a/core/hooks.go
+++ b/core/hooks.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -170,7 +171,12 @@ func (hm *HookManager) executeCommand(h *HookConfig, event HookEvent) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", h.Command)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", h.Command)
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", h.Command)
+	}
 	cmd.WaitDelay = 2 * time.Second
 	cmd.Env = append(os.Environ(), eventToEnv(event)...)
 

--- a/core/webhook.go
+++ b/core/webhook.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -305,7 +306,12 @@ func (ws *WebhookServer) executeShell(engine *Engine, req WebhookRequest, event 
 	ctx, cancel := context.WithTimeout(context.Background(), webhookShellTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", req.Exec)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", req.Exec)
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", req.Exec)
+	}
 	cmd.Dir = workDir
 	output, execErr := cmd.CombinedOutput()
 


### PR DESCRIPTION
## Summary

Two shell-exec sites in `core/` still hardcode `exec.CommandContext(ctx, \"sh\", \"-c\", ...)` and were missed when PR #446 (custom commands) and PR #759 (streaming `/shell`) made the rest of the codebase Windows-aware:

| Site | Status before | Status after |
| --- | --- | --- |
| `core/engine.go:1215` (`executeCronShell`) | Windows-aware (PR #446) | unchanged |
| `core/engine.go:5572` (`runShellWithProgress`) | Windows-aware (PR #759) | unchanged |
| `core/hooks.go:173` (`HookManager.executeCommand`) | **`sh -c` only** | now Windows-aware |
| `core/webhook.go:308` (`WebhookServer.executeShell`) | **`sh -c` only** | now Windows-aware |

On a typical Windows host (no POSIX `sh` on `PATH`), both hooks and webhook `exec` requests fail immediately with:

```
exec: \"sh\": executable file not found in %PATH%
```

## Fix

Mirror the exact `runtime.GOOS == \"windows\"` branch already used in `engine.go`:

```go
var cmd *exec.Cmd
if runtime.GOOS == \"windows\" {
    cmd = exec.CommandContext(ctx, \"powershell.exe\", \"-NoProfile\", \"-ExecutionPolicy\", \"Bypass\", \"-Command\", h.Command)
} else {
    cmd = exec.CommandContext(ctx, \"sh\", \"-c\", h.Command)
}
```

Two files touched, +14/-2 total. No behaviour change on POSIX.

Related: closes the missing half of #784 (the issue mentions \`/shell\` v1.3.2; \`/shell\` itself is now covered by PR #759, but hooks/webhook exec were still broken on Windows).

## Test plan

- [x] `go vet -tags=no_web ./core/...` clean
- [x] `go build -tags=no_web ./...` and `GOOS=windows go build ./core/...` both succeed
- [x] `go test -tags=no_web ./core/ -run 'TestHook|TestWebhook'` — all pass
- [x] No new tests added (mirrors PR #446 / PR #759 which similarly skipped Windows-only tests; both existing sites have no platform-specific test coverage either)
- [x] Confirmed the unrelated test failures in the wider `core` suite (`TestProcessInteractiveEvents_…`, `TestResolveLocalDirPath_AcceptsSubdir`) reproduce on `main` without this change