### PR TITLE
fix(telegram): unbound large file uploads from the long-poll timeout

### DIFF
--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -101,8 +101,28 @@ type stdlibTypingTicker struct {
 
 func (t *stdlibTypingTicker) C() <-chan time.Time { return t.Ticker.C }
 
+// telegramHTTPClient routes Telegram Bot API requests to one of two underlying
+// http.Clients depending on the API method. The long-poll (getUpdates) keeps a
+// 90s ceiling so a hung connection self-recovers; everything else (sendMessage,
+// sendDocument, sendPhoto, …) honours only the caller's context, so large file
+// uploads — up to cc-connect's 50 MB attachment cap — can outlast the poll
+// window on slow uplinks. Without this split, the 90s Client.Timeout applies to
+// SendDocument as well and aborts uploads with `context deadline exceeded`
+// (see issue #539).
+type telegramHTTPClient struct {
+	poll *http.Client
+	send *http.Client
+}
+
+func (c *telegramHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if strings.HasSuffix(req.URL.Path, "/getUpdates") {
+		return c.poll.Do(req)
+	}
+	return c.send.Do(req)
+}
+
 // botFactory creates a bot, returns it plus self user info and a blocking poll function.
-type botFactory func(token string, onUpdate func(context.Context, *models.Update), httpClient *http.Client) (telegramBot, *models.User, func(context.Context), error)
+type botFactory func(token string, onUpdate func(context.Context, *models.Update), httpClient tgbot.HttpClient) (telegramBot, *models.User, func(context.Context), error)
 
 type Platform struct {
 	token                 string
@@ -110,7 +130,10 @@ type Platform struct {
 	groupReplyAll         bool
 	shareSessionInChannel bool
 	enableReactions       bool
-	httpClient            *http.Client
+	// httpClient is used for direct attachment downloads (no fixed timeout).
+	httpClient *http.Client
+	// pollHTTPClient bounds the SDK long-poll request (90s); see telegramHTTPClient.
+	pollHTTPClient *http.Client
 
 	mu                  sync.RWMutex
 	bot                 telegramBot
@@ -141,10 +164,20 @@ func New(opts map[string]any) (core.Platform, error) {
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom("telegram", allowFrom)
 
-	// Build HTTP client with optional proxy support.
-	// Timeout must exceed the server-side long-poll duration (pollTimeout − 1s = 59s)
-	// to avoid the HTTP client racing with Telegram's response. 90s gives 30s headroom.
-	httpClient := &http.Client{Timeout: 90 * time.Second}
+	// Build HTTP clients with optional proxy support.
+	//
+	// pollHTTPClient is used by the SDK long-poll loop (getUpdates). Its timeout
+	// must exceed the server-side long-poll duration (pollTimeout − 1s = 59s)
+	// to avoid the HTTP client racing with Telegram's response; 90s gives 30s
+	// headroom and lets a hung poll self-recover.
+	//
+	// sendHTTPClient has no fixed timeout. It is used for every non-poll Bot
+	// API call (sendDocument/sendPhoto/sendMessage/...) and for direct
+	// attachment downloads. File uploads up to cc-connect's 50 MB cap can
+	// legitimately exceed 90s on slow uplinks (issue #539), so they rely on
+	// the caller's context instead of a one-size-fits-all client timeout.
+	pollHTTPClient := &http.Client{Timeout: 90 * time.Second}
+	sendHTTPClient := &http.Client{}
 	if proxyURL, _ := opts["proxy"].(string); proxyURL != "" {
 		u, err := url.Parse(proxyURL)
 		if err != nil {
@@ -155,14 +188,24 @@ func New(opts map[string]any) (core.Platform, error) {
 		if proxyUser != "" {
 			u.User = url.UserPassword(proxyUser, proxyPass)
 		}
-		httpClient.Transport = &http.Transport{Proxy: http.ProxyURL(u)}
+		transport := &http.Transport{Proxy: http.ProxyURL(u)}
+		pollHTTPClient.Transport = transport
+		sendHTTPClient.Transport = transport
 		slog.Info("telegram: using proxy", "proxy", u.Host, "auth", proxyUser != "")
 	}
 
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	enableReactions, _ := opts["enable_reactions"].(bool)
-	return &Platform{token: token, allowFrom: allowFrom, groupReplyAll: groupReplyAll, shareSessionInChannel: shareSessionInChannel, enableReactions: enableReactions, httpClient: httpClient}, nil
+	return &Platform{
+		token:                 token,
+		allowFrom:             allowFrom,
+		groupReplyAll:         groupReplyAll,
+		shareSessionInChannel: shareSessionInChannel,
+		enableReactions:       enableReactions,
+		pollHTTPClient:        pollHTTPClient,
+		httpClient:            sendHTTPClient,
+	}, nil
 }
 
 func (p *Platform) Name() string { return "telegram" }
@@ -204,7 +247,7 @@ func (p *Platform) SetLifecycleHandler(h core.PlatformLifecycleHandler) {
 	p.lifecycleHandler = h
 }
 
-func defaultNewBot(token string, onUpdate func(context.Context, *models.Update), httpClient *http.Client) (telegramBot, *models.User, func(context.Context), error) {
+func defaultNewBot(token string, onUpdate func(context.Context, *models.Update), httpClient tgbot.HttpClient) (telegramBot, *models.User, func(context.Context), error) {
 	handler := func(ctx context.Context, b *tgbot.Bot, update *models.Update) {
 		onUpdate(ctx, update)
 	}
@@ -276,7 +319,15 @@ func (p *Platform) connectLoop(ctx context.Context) {
 
 func (p *Platform) runConnection(ctx context.Context) error {
 	factory := p.getNewBot()
-	b, me, startPoll, err := factory(p.token, p.processUpdate, p.httpClient)
+	// The SDK uses a single HttpClient for the long-poll and for every other
+	// API call. Wrap so getUpdates honours pollHTTPClient's 90s ceiling while
+	// sendDocument/sendPhoto/... fall through to httpClient with no fixed
+	// timeout (large file uploads, see telegramHTTPClient).
+	var sdkClient tgbot.HttpClient = p.httpClient
+	if p.pollHTTPClient != nil {
+		sdkClient = &telegramHTTPClient{poll: p.pollHTTPClient, send: p.httpClient}
+	}
+	b, me, startPoll, err := factory(p.token, p.processUpdate, sdkClient)
 	if err != nil {
 		cause := retryCauseInitialConnectFailure
 		if p.hasEverConnected() {

--- a/platform/telegram/telegram_test.go
+++ b/platform/telegram/telegram_test.go
@@ -239,7 +239,7 @@ func TestPlatformStart_RetriesInBackgroundUntilConnected(t *testing.T) {
 	p := &Platform{
 		token:      "token",
 		httpClient: &http.Client{},
-		newBot: func(_ string, _ func(context.Context, *models.Update), _ *http.Client) (telegramBot, *models.User, func(context.Context), error) {
+		newBot: func(_ string, _ func(context.Context, *models.Update), _ tgbot.HttpClient) (telegramBot, *models.User, func(context.Context), error) {
 			if attempts.Add(1) == 1 {
 				return nil, nil, nil, errors.New("dial failed")
 			}
@@ -283,7 +283,7 @@ func TestPlatformStart_InitialConnectFailureEmitsUnavailableOnceBeforeReady(t *t
 	p := &Platform{
 		token:      "token",
 		httpClient: &http.Client{},
-		newBot: func(_ string, _ func(context.Context, *models.Update), _ *http.Client) (telegramBot, *models.User, func(context.Context), error) {
+		newBot: func(_ string, _ func(context.Context, *models.Update), _ tgbot.HttpClient) (telegramBot, *models.User, func(context.Context), error) {
 			if attempts.Add(1) <= 2 {
 				return nil, nil, nil, errors.New("dial failed")
 			}
@@ -379,7 +379,7 @@ func TestPlatformLateReadyIgnoredAfterStop(t *testing.T) {
 	p := &Platform{
 		token:      "token",
 		httpClient: &http.Client{},
-		newBot: func(_ string, _ func(context.Context, *models.Update), _ *http.Client) (telegramBot, *models.User, func(context.Context), error) {
+		newBot: func(_ string, _ func(context.Context, *models.Update), _ tgbot.HttpClient) (telegramBot, *models.User, func(context.Context), error) {
 			close(connectStarted)
 			defer close(connectDone)
 			<-releaseConnect
@@ -964,3 +964,55 @@ func newTelegramTestPlatform(t *testing.T, handler func(http.ResponseWriter, *ht
 		httpClient: server.Client(),
 	}
 }
+
+// TestTelegramHTTPClient_RoutesByPath verifies that getUpdates is routed to the
+// short-timeout poll client while every other Bot API call falls through to the
+// long/no-timeout send client. This is the guard against regressing on issue
+// #539, where a single 90s-timeout client aborted large file uploads.
+func TestTelegramHTTPClient_RoutesByPath(t *testing.T) {
+	type call struct{ poll, send int }
+	var got call
+
+	roundTrip := func(target *int) http.RoundTripper {
+		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			*target++
+			return &http.Response{
+				StatusCode: 200,
+				Body:       http.NoBody,
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		})
+	}
+	c := &telegramHTTPClient{
+		poll: &http.Client{Transport: roundTrip(&got.poll)},
+		send: &http.Client{Transport: roundTrip(&got.send)},
+	}
+
+	paths := []string{
+		"/bot123:abc/getUpdates",   // -> poll
+		"/bot123:abc/sendDocument", // -> send
+		"/bot123:abc/sendMessage",  // -> send
+		"/bot123:abc/sendPhoto",    // -> send
+		"/bot123:abc/getMe",        // -> send
+	}
+	for _, path := range paths {
+		req, err := http.NewRequest(http.MethodPost, "https://api.telegram.org"+path, nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		if _, err := c.Do(req); err != nil {
+			t.Fatalf("Do(%s): %v", path, err)
+		}
+	}
+	if got.poll != 1 {
+		t.Errorf("poll client invocations = %d, want 1", got.poll)
+	}
+	if got.send != 4 {
+		t.Errorf("send client invocations = %d, want 4", got.send)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }


### PR DESCRIPTION
## Summary

The Telegram platform builds a single `*http.Client{Timeout: 90 * time.Second}` and passes it to the bot SDK. The comment on the existing constant explains why 90s is right for the long-poll (server-side `getUpdates` timeout is 59s, +30s headroom so a stuck connection self-recovers). What it misses: the SDK uses the *same* client for every other Bot API call too — including `SendDocument` / `SendPhoto` / `SendVoice`.

cc-connect already enforces a 50 MB attachment cap, so a perfectly legitimate 30–50 MB upload over a slow uplink exceeds 90s and is aborted with `context deadline exceeded (Client.Timeout exceeded while awaiting headers)`. The same ceiling also bounded direct attachment downloads via `p.httpClient.Get`.

## Fix

Split the single client into two with different timeout profiles:

| Client | Timeout | Used for |
|---|---|---|
| `pollHTTPClient` | 90s | `getUpdates` only |
| `sendHTTPClient` | none | every other Bot API call + direct attachment downloads |

The SDK only accepts one `HttpClient` though, so I route by URL via a tiny `telegramHTTPClient` wrapper that selects `pollHTTPClient` for paths ending in `/getUpdates` and falls through to `sendHTTPClient` for the rest. Proxy transport is applied to both clients.

The `botFactory` type widens from `*http.Client` to `tgbot.HttpClient` (the SDK interface) so the wrapper can satisfy it; three test stubs need a one-token type swap (`_ *http.Client` → `_ tgbot.HttpClient`).

`p.httpClient` is now the unbounded `sendHTTPClient`, so the existing `p.httpClient.Get(link)` call site for downloading user attachments also escapes the 90s ceiling at no extra cost.

## Why this approach (vs. alternatives)

- **Just bump the timeout to e.g. 10 min** — works for files but a hung poll then takes 10 min to self-recover instead of 90s. The whole reason the original 90s exists is to bound that. Worse trade-off.
- **Drop `Client.Timeout` entirely** — same problem amplified; relies entirely on TCP keepalives for poll resilience.
- **Bypass the SDK for file ops** — substantial change, fragmenting the call surface.
- **Per-call `context.WithTimeout` for sends** — the engine context (`e.ctx`) reaching `SendFile` has no deadline; we'd need a configurable per-send timeout. Possible but more API surface than this fix.

The wrapper keeps both timeout profiles on their respective code paths with no behaviour change for callers.

## Test plan

- [x] `go vet -tags=no_web ./...` clean
- [x] `go build -tags=no_web ./...` and `GOOS=windows go build ./platform/telegram/...` both succeed
- [x] `go test -race -tags=no_web ./platform/telegram/...` — all existing tests pass
- [x] New `TestTelegramHTTPClient_RoutesByPath` pins the routing table — `getUpdates` → poll, `sendDocument`/`sendMessage`/`sendPhoto`/`getMe` → send

Closes #539