### PR TITLE
fix(cron): preserve explicit session_mode=reuse override over global default

### DIFF
--- a/core/cron.go
+++ b/core/cron.go
@@ -31,7 +31,7 @@ type CronJob struct {
 	Enabled     bool      `json:"enabled"`
 	Silent      *bool     `json:"silent,omitempty"`       // suppress start notification; nil = use global default
 	Mute        bool      `json:"mute,omitempty"`         // suppress ALL messages (start + result); job runs silently
-	SessionMode string    `json:"session_mode,omitempty"` // "" or "reuse" = share active session; "new_per_run" = fresh session each run
+	SessionMode string    `json:"session_mode,omitempty"` // "" = use global default; "reuse" = share active session; "new_per_run" = fresh session each run
 	Mode        string    `json:"mode,omitempty"`         // permission mode override for this job; "" = use project default
 	TimeoutMins *int      `json:"timeout_mins,omitempty"` // nil = default 30m wait; 0 = no limit; >0 = minutes
 	CreatedAt   time.Time `json:"created_at"`
@@ -65,14 +65,20 @@ func (j *CronJob) UsesNewSessionPerRun() bool {
 	return NormalizeCronSessionMode(j.SessionMode) == "new_per_run"
 }
 
-// NormalizeCronSessionMode maps CLI/API aliases to canonical values ("", "new_per_run").
+// NormalizeCronSessionMode maps CLI/API aliases to canonical values
+// ("", "reuse", "new_per_run"). The empty string means "unspecified" — the
+// scheduler falls back to the global default. "reuse" means the user
+// explicitly opted out of new-per-run, and is preserved separately so it can
+// override a global default of new_per_run on a per-job basis.
 // Returns the original string if unrecognized (caller should validate).
 func NormalizeCronSessionMode(s string) string {
 	s = strings.TrimSpace(s)
 	low := strings.ToLower(s)
 	switch low {
-	case "", "reuse":
+	case "":
 		return ""
+	case "reuse":
+		return "reuse"
 	case "new_per_run", "new-per-run":
 		return "new_per_run"
 	default:
@@ -82,7 +88,7 @@ func NormalizeCronSessionMode(s string) string {
 
 func validateCronJob(j *CronJob) error {
 	mode := NormalizeCronSessionMode(j.SessionMode)
-	if mode != "" && mode != "new_per_run" {
+	if mode != "" && mode != "reuse" && mode != "new_per_run" {
 		return fmt.Errorf("invalid session_mode %q (want reuse, new_per_run, or new-per-run)", j.SessionMode)
 	}
 	if j.Mode != "" {

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -462,6 +462,35 @@ func TestCronScheduler_AddJob_NormalizesSessionMode(t *testing.T) {
 	}
 }
 
+// TestCronScheduler_AddJob_PreservesReuseOverride is a regression test for a
+// bug where AddJob normalized SessionMode="reuse" to "" before storage, which
+// then made cs.UsesNewSession fall back to the global default — silently
+// flipping an explicit reuse override into new_per_run. The job should retain
+// the explicit "reuse" intent end-to-end.
+func TestCronScheduler_AddJob_PreservesReuseOverride(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := NewCronScheduler(store)
+	cs.SetDefaultSessionMode("new_per_run")
+
+	job := &CronJob{
+		ID: "r1", Project: "p", SessionKey: "test:1:1",
+		CronExpr: "0 6 * * *", Prompt: "hi", SessionMode: "reuse",
+	}
+	if err := cs.AddJob(job); err != nil {
+		t.Fatal(err)
+	}
+	if job.SessionMode != "reuse" {
+		t.Errorf("after AddJob, SessionMode = %q, want \"reuse\"", job.SessionMode)
+	}
+	if cs.UsesNewSession(job) {
+		t.Error("explicit reuse must override global new_per_run, but UsesNewSession returned true")
+	}
+}
+
 func TestCronScheduler_UsesNewSession_GlobalDefault(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewCronStore(dir)


### PR DESCRIPTION
## Summary

When the global `cron.session_mode` default is `"new_per_run"`, a per-job override of `session_mode = "reuse"` is silently lost: the job runs in `new_per_run` mode anyway, contradicting the user's explicit setting.

## Root cause

`NormalizeCronSessionMode` collapses both `""` (unspecified) and `"reuse"` to a single canonical value `""`:

```go
case "", "reuse":
    return ""
```

`AddJob` then runs `job.SessionMode = NormalizeCronSessionMode(job.SessionMode)` — so an inbound `"reuse"` is stored as `""`. At dispatch time, `UsesNewSession` does:

```go
if job.SessionMode != "" {
    return job.UsesNewSessionPerRun()
}
return cs.defaultSessionMode == "new_per_run"
```

Since `SessionMode == ""`, the per-job branch is skipped and the global default wins — exactly the case the user was trying to override.

The existing `TestCronScheduler_UsesNewSession_GlobalDefault` test passes only because it bypasses `AddJob` and assigns `job.SessionMode = \"reuse\"` directly:

```go
// Test 2: per-job \"reuse\" overrides global \"new_per_run\"
job.SessionMode = \"reuse\"          // ← raw assignment, skips Normalize
if cs.UsesNewSession(job) { ... }
```

So the unit test demonstrates the *intended* behaviour, while the production code path silently loses the override.

## Fix

Make `\"reuse\"` a third canonical value alongside `\"\"` and `\"new_per_run\"`:

| Stored value | Meaning |
|---|---|
| `\"\"` | unspecified — fall back to global default |
| `\"reuse\"` | explicit opt-out of new_per_run |
| `\"new_per_run\"` | explicit opt-in to fresh session per run |

`UsesNewSession` already routes through `job.UsesNewSessionPerRun()` whenever `SessionMode` is non-empty, and `UsesNewSessionPerRun` calls `NormalizeCronSessionMode(...) == \"new_per_run\"`. With the normalization preserving `\"reuse\"`, the chain returns `false` correctly. No call-site changes needed.

Also widen `validateCronJob` to accept the new canonical `\"reuse\"` and update the `SessionMode` JSON tag comment.

## Migration

Existing jobs on disk with `SessionMode = \"\"` keep their previous (buggy) behaviour: they continue to follow the global default. No data migration. Users whose explicit `\"reuse\"` was being clobbered just need to re-issue `cc-connect cron add --session-mode reuse …` (or `cron edit … session_mode reuse`) once the patch is in.

## Test plan

- [x] New `TestCronScheduler_AddJob_PreservesReuseOverride` regression test that goes through `AddJob` and asserts both storage and `UsesNewSession` semantics. Confirmed to **fail on main** and **pass on this branch**.
- [x] `go test -race -tags=no_web ./core/ -run \"TestCron|Cron\"` — all cron tests pass.
- [x] `go vet -tags=no_web ./core/...` clean.
- [x] `go build -tags=no_web ./...` succeeds.