### PR TITLE
fix(markdown): stop StripMarkdown corrupting snake_case and dunder identifiers

### DIFF
--- a/core/markdown.go
+++ b/core/markdown.go
@@ -9,9 +9,7 @@ var (
 	reCodeBlock   = regexp.MustCompile("(?s)```[a-zA-Z]*\n?(.*?)```")
 	reInlineCode  = regexp.MustCompile("`([^`]+)`")
 	reBoldAst     = regexp.MustCompile(`\*\*(.+?)\*\*`)
-	reBoldUnd     = regexp.MustCompile(`__(.+?)__`)
 	reItalicAst   = regexp.MustCompile(`\*(.+?)\*`)
-	reItalicUnd   = regexp.MustCompile(`_(.+?)_`)
 	reStrike      = regexp.MustCompile(`~~(.+?)~~`)
 	reLink        = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
 	reHeading     = regexp.MustCompile(`(?m)^#{1,6}\s+`)
@@ -21,6 +19,16 @@ var (
 
 // StripMarkdown converts Markdown-formatted text to clean plain text.
 // Useful for platforms that don't support Markdown rendering (WeChat, LINE, etc.).
+//
+// Note: the underscore forms of bold (`__bold__`) and italic (`_italic_`) are
+// intentionally not stripped. The patterns `_..._` and `__...__` are
+// indistinguishable from snake_case and dunder identifiers (`my_func_name`,
+// Python's `__init__`), and stripping them silently corrupted code-related
+// text into things like `myfuncname` or `init`. Agents reliably emit the
+// asterisk forms (`**bold**`, `*italic*`), so dropping the underscore forms
+// is the safe trade-off here. Inputs containing literal `_italic_` will keep
+// their underscores; this is a small cosmetic loss vs. losing identifier
+// integrity in TTS / LINE / WeChat output.
 func StripMarkdown(s string) string {
 	// Preserve code block content but remove fences
 	s = reCodeBlock.ReplaceAllString(s, "$1")
@@ -30,9 +38,7 @@ func StripMarkdown(s string) string {
 
 	// Bold / italic / strikethrough — keep text
 	s = reBoldAst.ReplaceAllString(s, "$1")
-	s = reBoldUnd.ReplaceAllString(s, "$1")
 	s = reItalicAst.ReplaceAllString(s, "$1")
-	s = reItalicUnd.ReplaceAllString(s, "$1")
 	s = reStrike.ReplaceAllString(s, "$1")
 
 	// Links [text](url) → text (url)

--- a/core/markdown_test.go
+++ b/core/markdown_test.go
@@ -1,0 +1,46 @@
+package core
+
+import "testing"
+
+func TestStripMarkdown(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Asterisk forms keep working — these are what agents typically emit.
+		{"bold asterisk", "this is **bold** text", "this is bold text"},
+		{"italic asterisk", "this is *italic* text", "this is italic text"},
+		{"bold italic combined", "**bold** and *italic*", "bold and italic"},
+
+		// Strikethrough, links, headings, code — unchanged behavior.
+		{"strikethrough", "~~struck~~", "struck"},
+		{"link", "[GitHub](https://github.com)", "GitHub (https://github.com)"},
+		{"heading", "# Title\nbody", "Title\nbody"},
+		{"inline code", "use `os.path.join`", "use os.path.join"},
+		{"fenced code block", "```go\nfmt.Println(\"hi\")\n```", "fmt.Println(\"hi\")"},
+
+		// Regression: underscore forms must NOT be stripped, since the same
+		// patterns appear in legitimate identifiers. Stripping them used to
+		// produce e.g. "mysnakecase_var" and "init", corrupting code
+		// references in TTS / LINE / WeChat output.
+		{"snake_case identifier", "call my_func_name() to start", "call my_func_name() to start"},
+		{"two-underscore snake_case", "use module_name_var here", "use module_name_var here"},
+		{"python dunder", "Python's __init__ method", "Python's __init__ method"},
+		{"version dunder", "the __version__ string", "the __version__ string"},
+		{"single underscore identifier", "function_name", "function_name"},
+
+		// Underscore-form bold/italic is now kept literal (rare in practice).
+		{"underscore italic kept literal", "_italic_ text", "_italic_ text"},
+		{"underscore bold kept literal", "__bold__ text", "__bold__ text"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripMarkdown(tt.in)
+			if got != tt.want {
+				t.Errorf("StripMarkdown(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`core.StripMarkdown` is used to flatten Markdown to plain text for platforms that don't render Markdown (LINE `Reply` / WeCom `Reply`) and for TTS synthesis (`engine.go:12431`). It strips `**bold**` / `*italic*` / `~~strike~~` / links / headings / code fences — fine. It also strips the **underscore** variants:

```go
reBoldUnd   = regexp.MustCompile(`__(.+?)__`)
reItalicUnd = regexp.MustCompile(`_(.+?)_`)
```

Both happily match identifier fragments. With these enabled, `StripMarkdown` silently rewrites:

| Input | Output (before) | Output (after) |
|---|---|---|
| `call my_func_name() to start` | `call myfuncname() to start` | `call my_func_name() to start` |
| `use module_name_var here` | `use modulenamevar here` | `use module_name_var here` |
| `Python's __init__ method` | `Python's init method` | `Python's __init__ method` |
| `the __version__ string` | `the version string` | `the __version__ string` |
| `_italic_ text` | `italic text` | `_italic_ text` |
| `__bold__ text` | `bold text` | `__bold__ text` |

That is, exactly the things an agent writes whenever it talks about code. The corrupted text then ships out to LINE / WeCom messages and TTS audio, where the underscores are gone and the user can no longer copy-paste or pronounce the identifier correctly.

## Why removal, not a smarter regex

Go's `regexp` package has no lookbehind, so `_italic_` can't be narrowed to "not adjacent to a word char" with a one-line regex change. And the dunder case (`__init__` flanked by spaces) is shape-identical to `__bold__` flanked by spaces — there's no structural way to distinguish them. Any context-aware fix needs `FindAllStringSubmatchIndex` plus a manual flank check, which still can't tell `__init__` from `__bold__`.

Real-world agent output overwhelmingly uses `**bold**` / `*italic*` (asterisk form). The underscore forms are mostly a hazard with little upside in this codebase, so the safe minimal fix is to drop them. Inputs containing literal `_italic_` now keep the underscores — small cosmetic loss vs. losing identifier integrity on TTS/LINE/WeCom.

## Test plan

- [x] Added `core/markdown_test.go` (no test file previously existed) covering both the preserved asterisk paths and every regression case in the table above. Confirmed to **fail on main** and **pass on this branch**.
- [x] `go vet -tags=no_web ./core/...` clean
- [x] `go build -tags=no_web ./...` succeeds
- [x] `go test -tags=no_web ./core/ -run \"TestStripMarkdown|TestMarkdown\"` passes
- [x] `go test -tags=no_web ./platform/line/... ./platform/wecom/...` (the two non-TTS callers) — both packages green