### PR TITLE
fix(opencode): pass prompt via stdin to avoid Windows .cmd newline truncation

### DIFF
--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -95,6 +95,7 @@ func (s *opencodeSession) Send(prompt string, images []core.ImageAttachment, fil
 
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
+	cmd.Stdin = strings.NewReader(prompt)
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("opencodeSession: start: %w", err)
@@ -170,9 +171,6 @@ func (s *opencodeSession) buildRunArgs(prompt string, imagePaths []string, chatI
 		args = append(args, "--file", imagePath)
 	}
 
-	// Use "--" to separate flags from the positional prompt so that
-	// --file (yargs [array]) does not greedily consume the prompt text.
-	args = append(args, "--", prompt)
 	return args
 }
 

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -112,7 +112,6 @@ func TestOpencodeSessionBuildRunArgsIncludesImagesAsFiles(t *testing.T) {
 		"--thinking",
 		"--file", "/tmp/a.png",
 		"--file", "/tmp/b.jpg",
-		"--", "describe these images",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %#v, want %#v", got, want)


### PR DESCRIPTION
## Summary
- Fix Windows .cmd newline truncation issue when passing prompt as positional argument
- Pass prompt via stdin instead of command-line argument to preserve newlines and special characters
- Update test to match new args format (remove `--` separator and prompt from args)

## Problem
On Windows, when opencode CLI is invoked via `.cmd` wrapper, passing prompt as positional argument causes newline truncation. This is because Windows command-line parsing differs from Unix, and newlines in arguments are often stripped or incorrectly handled by cmd.exe.

## Solution
Pass prompt via stdin instead of command-line argument:
- Remove `args = append(args, --, prompt)` from buildRunArgs
- Add `cmd.Stdin = strings.NewReader(prompt)` before launching process

This approach is already used in Gemini agent (PR #695) for similar reasons (preserve newlines in prompts).

## Test Plan
- Updated TestOpencodeSessionBuildRunArgsIncludesImagesAsFiles to expect args without prompt
- Manual testing on Windows confirms newlines are preserved in stdin-passed prompts
- All existing tests pass

## References
- Similar approach in Gemini agent: commit 1c25dd42 (PR #695)
- No existing issue/PR for OpenCode stdin prompt in upstream