### PR TITLE
[codex] Capture runtime metadata and configurable Slack mentions

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -49,6 +50,10 @@ type claudeSession struct {
 	// Stop hook timeout. The wait ends as soon as the process exits,
 	// so typical shutdowns take seconds, not the full timeout.
 	gracefulStopTimeout time.Duration
+
+	runtimeMu    sync.RWMutex
+	runtimeModel string
+	contextUsage *core.ContextUsage
 }
 
 func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
@@ -203,6 +208,7 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		done:                make(chan struct{}),
 		gracefulStopTimeout: 120 * time.Second,
 	}
+	cs.storeRuntimeModel(model)
 	cs.setPermissionMode(mode)
 	cs.sessionID.Store(sessionID)
 	cs.alive.Store(true)
@@ -336,6 +342,9 @@ func (cs *claudeSession) handleReadLoopLine(line string) {
 }
 
 func (cs *claudeSession) handleSystem(raw map[string]any) {
+	if model, ok := raw["model"].(string); ok {
+		cs.storeRuntimeModel(model)
+	}
 	if sid, ok := raw["session_id"].(string); ok && sid != "" {
 		cs.sessionID.Store(sid)
 		evt := core.Event{Type: core.EventText, SessionID: sid}
@@ -351,6 +360,9 @@ func (cs *claudeSession) handleAssistant(raw map[string]any) {
 	msg, ok := raw["message"].(map[string]any)
 	if !ok {
 		return
+	}
+	if model, ok := msg["model"].(string); ok {
+		cs.storeRuntimeModel(model)
 	}
 	contentArr, ok := msg["content"].([]any)
 	if !ok {
@@ -429,6 +441,10 @@ func (cs *claudeSession) handleResult(raw map[string]any) {
 	}
 	if sid, ok := raw["session_id"].(string); ok && sid != "" {
 		cs.sessionID.Store(sid)
+	}
+	if model, usage := claudeModelUsage(raw, cs.GetModel()); model != "" || usage != nil {
+		cs.storeRuntimeModel(model)
+		cs.storeContextUsage(usage)
 	}
 
 	var inputTokens, outputTokens int
@@ -691,6 +707,18 @@ func (cs *claudeSession) CurrentSessionID() string {
 	return v
 }
 
+func (cs *claudeSession) GetModel() string {
+	cs.runtimeMu.RLock()
+	defer cs.runtimeMu.RUnlock()
+	return cs.runtimeModel
+}
+
+func (cs *claudeSession) GetContextUsage() *core.ContextUsage {
+	cs.runtimeMu.RLock()
+	defer cs.runtimeMu.RUnlock()
+	return cloneClaudeContextUsage(cs.contextUsage)
+}
+
 func (cs *claudeSession) Alive() bool {
 	return cs.alive.Load()
 }
@@ -780,4 +808,102 @@ func filterEnv(env []string, key string) []string {
 		}
 	}
 	return out
+}
+
+func (cs *claudeSession) storeRuntimeModel(model string) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return
+	}
+	cs.runtimeMu.Lock()
+	defer cs.runtimeMu.Unlock()
+	cs.runtimeModel = model
+}
+
+func (cs *claudeSession) storeContextUsage(usage *core.ContextUsage) {
+	if usage == nil {
+		return
+	}
+	cs.runtimeMu.Lock()
+	defer cs.runtimeMu.Unlock()
+	cs.contextUsage = cloneClaudeContextUsage(usage)
+}
+
+func cloneClaudeContextUsage(usage *core.ContextUsage) *core.ContextUsage {
+	if usage == nil {
+		return nil
+	}
+	cloned := *usage
+	return &cloned
+}
+
+func claudeModelUsage(raw map[string]any, preferredModel string) (string, *core.ContextUsage) {
+	modelUsage, ok := raw["modelUsage"].(map[string]any)
+	if !ok || len(modelUsage) == 0 {
+		return "", nil
+	}
+
+	model := strings.TrimSpace(preferredModel)
+	if model != "" {
+		if _, ok := modelUsage[model]; !ok {
+			model = ""
+		}
+	}
+	if model == "" {
+		keys := make([]string, 0, len(modelUsage))
+		for key := range modelUsage {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		model = keys[0]
+	}
+
+	entry, ok := modelUsage[model].(map[string]any)
+	if !ok {
+		return model, nil
+	}
+
+	inputTokens := intFromJSONValue(entry["inputTokens"])
+	outputTokens := intFromJSONValue(entry["outputTokens"])
+	cacheReadTokens := intFromJSONValue(entry["cacheReadInputTokens"])
+	cacheCreationTokens := intFromJSONValue(entry["cacheCreationInputTokens"])
+	reasoningOutputTokens := intFromJSONValue(entry["reasoningOutputTokens"])
+	contextWindow := intFromJSONValue(entry["contextWindow"])
+	usedTokens := inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens + reasoningOutputTokens
+	if usedTokens <= 0 || contextWindow <= 0 {
+		return model, nil
+	}
+
+	return model, &core.ContextUsage{
+		UsedTokens:            usedTokens,
+		TotalTokens:           usedTokens,
+		InputTokens:           inputTokens,
+		CachedInputTokens:     cacheReadTokens + cacheCreationTokens,
+		OutputTokens:          outputTokens,
+		ReasoningOutputTokens: reasoningOutputTokens,
+		ContextWindow:         contextWindow,
+	}
+}
+
+func intFromJSONValue(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		if i, err := strconv.Atoi(v.String()); err == nil {
+			return i
+		}
+		if f, err := strconv.ParseFloat(v.String(), 64); err == nil {
+			return int(f)
+		}
+	case string:
+		if i, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return i
+		}
+	}
+	return 0
 }

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -44,6 +44,94 @@ func TestHandleResultParsesUsage(t *testing.T) {
 	}
 }
 
+func TestHandleSystemStoresRuntimeModel(t *testing.T) {
+	cs := &claudeSession{}
+
+	cs.handleSystem(map[string]any{
+		"type":  "system",
+		"model": "claude-sonnet-4-6",
+	})
+
+	if got := cs.GetModel(); got != "claude-sonnet-4-6" {
+		t.Fatalf("GetModel() = %q, want claude-sonnet-4-6", got)
+	}
+}
+
+func TestHandleAssistantStoresRuntimeModel(t *testing.T) {
+	cs := &claudeSession{}
+
+	cs.handleAssistant(map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"model":   "claude-opus-4-5",
+			"content": []any{},
+		},
+	})
+
+	if got := cs.GetModel(); got != "claude-opus-4-5" {
+		t.Fatalf("GetModel() = %q, want claude-opus-4-5", got)
+	}
+}
+
+func TestHandleResultStoresModelUsageContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("test-session")
+	cs.alive.Store(true)
+
+	raw := map[string]any{
+		"type":       "result",
+		"result":     "done",
+		"session_id": "test-session",
+		"usage": map[string]any{
+			"input_tokens":  float64(3),
+			"output_tokens": float64(4),
+		},
+		"modelUsage": map[string]any{
+			"claude-sonnet-4-6": map[string]any{
+				"inputTokens":              float64(3),
+				"outputTokens":             float64(4),
+				"cacheReadInputTokens":     float64(1000),
+				"cacheCreationInputTokens": float64(25358),
+				"reasoningOutputTokens":    float64(12),
+				"contextWindow":            float64(200000),
+			},
+		},
+	}
+
+	cs.handleResult(raw)
+
+	if got := cs.GetModel(); got != "claude-sonnet-4-6" {
+		t.Fatalf("GetModel() = %q, want claude-sonnet-4-6", got)
+	}
+	usage := cs.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage() = nil, want usage")
+	}
+	if usage.UsedTokens != 26377 {
+		t.Fatalf("UsedTokens = %d, want 26377", usage.UsedTokens)
+	}
+	if usage.ContextWindow != 200000 {
+		t.Fatalf("ContextWindow = %d, want 200000", usage.ContextWindow)
+	}
+	if usage.CachedInputTokens != 26358 {
+		t.Fatalf("CachedInputTokens = %d, want 26358", usage.CachedInputTokens)
+	}
+	if usage.ReasoningOutputTokens != 12 {
+		t.Fatalf("ReasoningOutputTokens = %d, want 12", usage.ReasoningOutputTokens)
+	}
+
+	usage.UsedTokens = 1
+	if got := cs.GetContextUsage().UsedTokens; got != 26377 {
+		t.Fatalf("GetContextUsage() returned mutable pointer, got UsedTokens %d", got)
+	}
+}
+
 func TestHandleResultNoUsage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/agent/gemini/session.go
+++ b/agent/gemini/session.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -39,6 +41,10 @@ type geminiSession struct {
 	alive    atomic.Bool
 
 	pendingMsgs []string // buffered assistant messages awaiting classification
+
+	runtimeMu    sync.RWMutex
+	runtimeModel string
+	contextUsage *core.ContextUsage
 }
 
 func newGeminiSession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*geminiSession, error) {
@@ -55,6 +61,7 @@ func newGeminiSession(ctx context.Context, cmd, workDir, model, mode, resumeID s
 		ctx:      sessionCtx,
 		cancel:   cancel,
 	}
+	gs.storeRuntimeModel(model)
 	gs.alive.Store(true)
 
 	if resumeID != "" && resumeID != core.ContinueSession {
@@ -292,6 +299,7 @@ func (gs *geminiSession) handleEvent(raw map[string]any) {
 func (gs *geminiSession) handleInit(raw map[string]any) {
 	sid, _ := raw["session_id"].(string)
 	model, _ := raw["model"].(string)
+	gs.storeRuntimeModel(model)
 
 	if sid != "" {
 		gs.chatID.Store(sid)
@@ -395,6 +403,9 @@ func (gs *geminiSession) handleResult(raw map[string]any) {
 	gs.flushPendingAsText()
 
 	status, _ := raw["status"].(string)
+	model, usage := geminiStatsUsage(raw, gs.GetModel())
+	gs.storeRuntimeModel(model)
+	gs.storeContextUsage(usage)
 
 	var errMsg string
 	if status == "error" {
@@ -406,15 +417,22 @@ func (gs *geminiSession) handleResult(raw map[string]any) {
 
 	sid := gs.CurrentSessionID()
 
+	evt := core.Event{
+		Type:         core.EventResult,
+		SessionID:    sid,
+		Done:         true,
+		InputTokens:  inputTokensFromContextUsage(usage),
+		OutputTokens: outputTokensFromContextUsage(usage),
+	}
 	if errMsg != "" {
-		evt := core.Event{Type: core.EventResult, Content: errMsg, SessionID: sid, Done: true, Error: fmt.Errorf("%s", errMsg)}
+		evt.Content = errMsg
+		evt.Error = fmt.Errorf("%s", errMsg)
 		select {
 		case gs.events <- evt:
 		case <-gs.ctx.Done():
 			return
 		}
 	} else {
-		evt := core.Event{Type: core.EventResult, SessionID: sid, Done: true}
 		select {
 		case gs.events <- evt:
 		case <-gs.ctx.Done():
@@ -465,6 +483,18 @@ func (gs *geminiSession) Events() <-chan core.Event {
 func (gs *geminiSession) CurrentSessionID() string {
 	v, _ := gs.chatID.Load().(string)
 	return v
+}
+
+func (gs *geminiSession) GetModel() string {
+	gs.runtimeMu.RLock()
+	defer gs.runtimeMu.RUnlock()
+	return gs.runtimeModel
+}
+
+func (gs *geminiSession) GetContextUsage() *core.ContextUsage {
+	gs.runtimeMu.RLock()
+	defer gs.runtimeMu.RUnlock()
+	return cloneGeminiContextUsage(gs.contextUsage)
 }
 
 func (gs *geminiSession) Alive() bool {
@@ -695,4 +725,148 @@ func truncate(s string, maxRunes int) string {
 		return s
 	}
 	return string([]rune(s)[:maxRunes]) + "..."
+}
+
+func (gs *geminiSession) storeRuntimeModel(model string) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return
+	}
+	gs.runtimeMu.Lock()
+	defer gs.runtimeMu.Unlock()
+	gs.runtimeModel = model
+}
+
+func (gs *geminiSession) storeContextUsage(usage *core.ContextUsage) {
+	if usage == nil {
+		return
+	}
+	gs.runtimeMu.Lock()
+	defer gs.runtimeMu.Unlock()
+	gs.contextUsage = cloneGeminiContextUsage(usage)
+}
+
+func cloneGeminiContextUsage(usage *core.ContextUsage) *core.ContextUsage {
+	if usage == nil {
+		return nil
+	}
+	cloned := *usage
+	return &cloned
+}
+
+func geminiStatsUsage(raw map[string]any, preferredModel string) (string, *core.ContextUsage) {
+	stats, ok := raw["stats"].(map[string]any)
+	if !ok || len(stats) == 0 {
+		return "", nil
+	}
+
+	model := strings.TrimSpace(preferredModel)
+	modelStats := map[string]any(nil)
+	if models, ok := stats["models"].(map[string]any); ok && len(models) > 0 {
+		if model != "" {
+			if entry, ok := models[model].(map[string]any); ok {
+				modelStats = entry
+			}
+		}
+		if modelStats == nil {
+			keys := make([]string, 0, len(models))
+			for key := range models {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			model = keys[0]
+			modelStats, _ = models[model].(map[string]any)
+		}
+	}
+
+	totalTokens := intFromGeminiJSONValue(stats["total_tokens"])
+	inputTokens := intFromGeminiJSONValue(stats["input_tokens"])
+	outputTokens := intFromGeminiJSONValue(stats["output_tokens"])
+	cachedTokens := intFromGeminiJSONValue(stats["cached"])
+	if modelStats != nil {
+		if totalTokens == 0 {
+			totalTokens = intFromGeminiJSONValue(modelStats["total_tokens"])
+		}
+		if inputTokens == 0 {
+			inputTokens = intFromGeminiJSONValue(modelStats["input_tokens"])
+		}
+		if outputTokens == 0 {
+			outputTokens = intFromGeminiJSONValue(modelStats["output_tokens"])
+		}
+		if cachedTokens == 0 {
+			cachedTokens = intFromGeminiJSONValue(modelStats["cached"])
+		}
+	}
+	if totalTokens <= 0 {
+		totalTokens = inputTokens + outputTokens + cachedTokens
+	}
+	if totalTokens <= 0 && inputTokens <= 0 && outputTokens <= 0 {
+		return model, nil
+	}
+
+	return model, &core.ContextUsage{
+		UsedTokens:        totalTokens,
+		TotalTokens:       totalTokens,
+		InputTokens:       inputTokens,
+		CachedInputTokens: cachedTokens,
+		OutputTokens:      outputTokens,
+		ContextWindow:     geminiStatsContextWindow(stats, modelStats),
+	}
+}
+
+func geminiStatsContextWindow(stats, modelStats map[string]any) int {
+	for _, source := range []map[string]any{modelStats, stats} {
+		if source == nil {
+			continue
+		}
+		for _, key := range []string{
+			"contextWindow",
+			"context_window",
+			"inputTokenLimit",
+			"input_token_limit",
+			"input_token_limit_tokens",
+		} {
+			if v := intFromGeminiJSONValue(source[key]); v > 0 {
+				return v
+			}
+		}
+	}
+	return 0
+}
+
+func intFromGeminiJSONValue(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		if i, err := strconv.Atoi(v.String()); err == nil {
+			return i
+		}
+		if f, err := strconv.ParseFloat(v.String(), 64); err == nil {
+			return int(f)
+		}
+	case string:
+		if i, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return i
+		}
+	}
+	return 0
+}
+
+func inputTokensFromContextUsage(usage *core.ContextUsage) int {
+	if usage == nil {
+		return 0
+	}
+	return usage.InputTokens
+}
+
+func outputTokensFromContextUsage(usage *core.ContextUsage) int {
+	if usage == nil {
+		return 0
+	}
+	return usage.OutputTokens
 }

--- a/agent/gemini/session_test.go
+++ b/agent/gemini/session_test.go
@@ -68,6 +68,107 @@ func drainEvents(ch <-chan core.Event, timeout time.Duration) []core.Event {
 	}
 }
 
+func TestHandleInitStoresRuntimeModel(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":       "init",
+		"session_id": "test-session",
+		"model":      "gemini-3.1-pro-preview",
+	})
+
+	if got := gs.GetModel(); got != "gemini-3.1-pro-preview" {
+		t.Fatalf("GetModel() = %q, want gemini-3.1-pro-preview", got)
+	}
+}
+
+func TestHandleResultParsesStatsUsage(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+	gs.chatID.Store("test-session")
+	gs.storeRuntimeModel("gemini-3.1-pro-preview")
+
+	gs.handleEvent(map[string]any{
+		"type":   "result",
+		"status": "success",
+		"stats": map[string]any{
+			"total_tokens":  float64(9401),
+			"input_tokens":  float64(9289),
+			"output_tokens": float64(2),
+			"cached":        float64(0),
+			"models": map[string]any{
+				"gemini-3.1-pro-preview": map[string]any{
+					"total_tokens":  float64(9401),
+					"input_tokens":  float64(9289),
+					"output_tokens": float64(2),
+					"cached":        float64(0),
+				},
+			},
+		},
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != core.EventResult {
+		t.Fatalf("event type = %v, want EventResult", events[0].Type)
+	}
+	if events[0].InputTokens != 9289 {
+		t.Fatalf("InputTokens = %d, want 9289", events[0].InputTokens)
+	}
+	if events[0].OutputTokens != 2 {
+		t.Fatalf("OutputTokens = %d, want 2", events[0].OutputTokens)
+	}
+
+	usage := gs.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage() = nil, want usage")
+	}
+	if usage.UsedTokens != 9401 {
+		t.Fatalf("UsedTokens = %d, want 9401", usage.UsedTokens)
+	}
+	if usage.ContextWindow != 0 {
+		t.Fatalf("ContextWindow = %d, want 0 when stream-json omits context window", usage.ContextWindow)
+	}
+
+	usage.UsedTokens = 1
+	if got := gs.GetContextUsage().UsedTokens; got != 9401 {
+		t.Fatalf("GetContextUsage() returned mutable pointer, got UsedTokens %d", got)
+	}
+}
+
+func TestHandleResultParsesStatsContextWindowWhenPresent(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":   "result",
+		"status": "success",
+		"stats": map[string]any{
+			"total_tokens":    json.Number("12000"),
+			"input_tokens":    json.Number("11000"),
+			"output_tokens":   json.Number("1000"),
+			"inputTokenLimit": json.Number("1048576"),
+		},
+	})
+
+	usage := gs.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage() = nil, want usage")
+	}
+	if usage.ContextWindow != 1048576 {
+		t.Fatalf("ContextWindow = %d, want 1048576", usage.ContextWindow)
+	}
+}
+
 func TestHandleMessage_DeltaEmitsEventTextImmediately(t *testing.T) {
 	gs := &geminiSession{
 		events: make(chan core.Event, 64),
@@ -250,9 +351,9 @@ func TestHandleMessage_MixedDeltaAndNonDelta(t *testing.T) {
 		"content": "Let me look at the files.",
 	})
 	gs.handleEvent(map[string]any{
-		"type":      "tool_use",
-		"tool_name": "shell",
-		"tool_id":   "t1",
+		"type":       "tool_use",
+		"tool_name":  "shell",
+		"tool_id":    "t1",
 		"parameters": map[string]any{"command": "ls"},
 	})
 	gs.handleEvent(map[string]any{
@@ -445,10 +546,10 @@ func TestSessionMessage_TextContent(t *testing.T) {
 
 func TestComputeLineDiff(t *testing.T) {
 	tests := []struct {
-		name     string
-		old      string
-		new_     string
-		want     string
+		name string
+		old  string
+		new_ string
+		want string
 	}{
 		{
 			"single line fully different",

--- a/config.example.toml
+++ b/config.example.toml
@@ -990,8 +990,10 @@ app_secret = "your-feishu-app-secret"
 # Slack (uncomment to enable / 取消注释以启用)
 # 1. Create an app at https://api.slack.com/apps / 创建应用
 # 2. Enable Socket Mode (Settings > Socket Mode) / 开启 Socket Mode
-# 3. Subscribe to bot events: message.channels, message.im
-#    订阅事件：message.channels, message.im
+# 3. Subscribe to bot events: app_mention, message.im
+#    订阅事件：app_mention, message.im
+#    Channel/private-channel/thread messages require @mention; DMs do not.
+#    频道/私有频道/thread 中需要 @mention 才会回复；DM 不需要。
 # 4. Install app to workspace, copy Bot Token (xoxb-...) and App Token (xapp-...)
 #    安装应用到工作区，复制 Bot Token 和 App Token
 # Connection: Socket Mode WebSocket (no public URL needed) / 无需公网 IP

--- a/config.example.toml
+++ b/config.example.toml
@@ -992,8 +992,8 @@ app_secret = "your-feishu-app-secret"
 # 2. Enable Socket Mode (Settings > Socket Mode) / 开启 Socket Mode
 # 3. Subscribe to bot events: app_mention, message.im
 #    订阅事件：app_mention, message.im
-#    Channel/private-channel/thread messages require @mention; DMs do not.
-#    频道/私有频道/thread 中需要 @mention 才会回复；DM 不需要。
+#    Add message.channels/message.groups only if you allow no-mention replies in specific channels or threads.
+#    只有当你允许某些频道或 thread 无需 @mention 回复时，才额外订阅 message.channels/message.groups。
 # 4. Install app to workspace, copy Bot Token (xoxb-...) and App Token (xapp-...)
 #    安装应用到工作区，复制 Bot Token 和 App Token
 # Connection: Socket Mode WebSocket (no public URL needed) / 无需公网 IP
@@ -1006,6 +1006,12 @@ app_secret = "your-feishu-app-secret"
 # app_token = "xapp-your-app-level-token"
 # allow_from = "*"  # Allowed Slack user IDs / 允许的 Slack 用户 ID
 # share_session_in_channel = false  # If true, all users in a channel share one agent session / 频道共享会话
+# require_mention = true  # Default for channel/private-channel/thread messages; DMs never require @mention
+#                         # 频道/私有频道/thread 默认需要 @mention；DM 永远不需要
+# require_mention_channels = { "C0123456789" = false, "G0123456789" = true }
+#                         # Per-channel overrides. C... = public channel, G... = private channel / 按频道覆盖
+# require_mention_threads = { "C0123456789:1778324804.987389" = false }
+#                         # Per-thread overrides. Prefer channel_id:thread_ts; thread_ts alone also works / 按 thread 覆盖
 
 # Discord (uncomment to enable / 取消注释以启用)
 # 1. Create an app at https://discord.com/developers/applications / 创建应用

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -173,6 +173,7 @@ type = "slack"
 [projects.platforms.options]
 bot_token = "xoxb-xxxxxxx..."
 app_token = "xapp-xxxxxxx..."
+require_mention = true
 ```
 
 ### Token Reference
@@ -219,6 +220,21 @@ level=INFO msg="cc-connect is running" projects=1
 1. Add the bot to a channel (`/invite @cc_connect`)
 2. @mention the bot: `@cc_connect help me analyze the code`
 3. The bot will respond
+
+By default, channel, private-channel, and thread messages require @mention.
+DMs never require @mention. You can override the mention requirement globally,
+per channel, or per thread:
+
+```toml
+[projects.platforms.options]
+require_mention = true
+require_mention_channels = { "C0123456789" = false, "G0123456789" = true }
+require_mention_threads = { "C0123456789:1778324804.987389" = false }
+```
+
+When you set any channel or thread to `false`, subscribe the Slack app to
+`message.channels` for public channels and `message.groups` for private
+channels, in addition to `app_mention` and `message.im`.
 
 ---
 

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -127,7 +127,7 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					}
 				}
 
-				slog.Debug("slack: app_mention received", "user", ev.User, "channel", ev.Channel)
+				slog.Debug("slack: app_mention received", "user", ev.User, "channel", ev.Channel, "thread_ts", ev.ThreadTimeStamp)
 
 				if !core.AllowList(p.allowFrom, ev.User) {
 					slog.Debug("slack: app_mention from unauthorized user", "user", ev.User)
@@ -159,7 +159,7 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					Files:     docFiles,
 					Audio:     audio,
 					MessageID: ev.TimeStamp,
-					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: ev.TimeStamp},
+					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: appMentionReplyTS(ev)},
 				}
 				p.handler(p, msg)
 
@@ -193,7 +193,16 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					}
 				}
 
-				slog.Debug("slack: message received", "user", ev.User, "channel", ev.Channel)
+				slog.Debug("slack: message received", "user", ev.User, "channel", ev.Channel, "channel_type", ev.ChannelType, "thread_ts", ev.ThreadTimeStamp)
+
+				if !shouldHandleSlackMessageEvent(ev) {
+					slog.Debug("slack: ignoring non-DM message without app mention",
+						"user", ev.User,
+						"channel", ev.Channel,
+						"channel_type", ev.ChannelType,
+						"thread_ts", ev.ThreadTimeStamp)
+					return
+				}
 
 				if !core.AllowList(p.allowFrom, ev.User) {
 					slog.Debug("slack: message from unauthorized user", "user", ev.User)
@@ -281,6 +290,30 @@ func stripAppMentionText(text string) string {
 	return text
 }
 
+func appMentionReplyTS(ev *slackevents.AppMentionEvent) string {
+	if ev == nil {
+		return ""
+	}
+	if ev.ThreadTimeStamp != "" {
+		return ev.ThreadTimeStamp
+	}
+	return ev.TimeStamp
+}
+
+func shouldHandleSlackMessageEvent(ev *slackevents.MessageEvent) bool {
+	return isSlackDirectMessage(ev)
+}
+
+func isSlackDirectMessage(ev *slackevents.MessageEvent) bool {
+	if ev == nil {
+		return false
+	}
+	if ev.ChannelType == "im" {
+		return true
+	}
+	return ev.ChannelType == "" && strings.HasPrefix(ev.Channel, "D")
+}
+
 // parseSlackInnerEventFiles extracts the files array from a raw Events API inner
 // event. AppMentionEvent is unmarshaled without a Files field in slack-go, but
 // Slack still includes "files" in the JSON when a mention is sent with uploads.
@@ -366,7 +399,6 @@ func slackFileDisplayName(f slackevents.File) string {
 	return f.Title
 }
 
-
 // assistantOrThreadTS returns the thread_ts to use for the bot's reply.
 //
 // For Slack Assistant apps (Agent toggle on), the user's "Chat" tab is a
@@ -378,17 +410,20 @@ func slackFileDisplayName(f slackevents.File) string {
 //
 // For regular channel messages (not DM, not already in a thread): use the
 // message's own TimeStamp so replies are threaded under the user's message,
-// preserving the old behavior of keeping conversations in threads.
+// preserving the old behavior for any non-DM message path.
 //
 // For DM messages (channel_type=im) that are not in an Assistant thread:
 // return empty so replies go top-level (natural 1-on-1 conversation).
 func assistantOrThreadTS(ev *slackevents.MessageEvent) string {
+	if ev == nil {
+		return ""
+	}
 	if ev.ThreadTimeStamp != "" {
 		// Already in a thread (Assistant Chat tab or regular thread reply).
 		return ev.ThreadTimeStamp
 	}
 	// For non-DM channels, thread under the user's message.
-	if ev.ChannelType != "im" {
+	if !isSlackDirectMessage(ev) {
 		return ev.TimeStamp
 	}
 	// DM top-level: top-level reply is natural.

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -29,18 +29,94 @@ type replyContext struct {
 	timestamp string // thread_ts for threading replies
 }
 
+type slackMentionPolicy struct {
+	requireMention         bool
+	requireMentionChannels map[string]bool
+	requireMentionThreads  map[string]bool
+}
+
 type Platform struct {
 	botToken              string
 	appToken              string
 	allowFrom             string
 	shareSessionInChannel bool
+	mentionPolicy         slackMentionPolicy
 	client                *slack.Client
 	socket                *socketmode.Client
 	handler               core.MessageHandler
 	cancel                context.CancelFunc
+	botUserID             string
 	channelNameCache      map[string]string
 	channelCacheMu        sync.RWMutex
+	seenEvents            sync.Map // channel:ts dedup across message and app_mention events
 	userNameCache         sync.Map // userID -> display name
+}
+
+func defaultSlackMentionPolicy() slackMentionPolicy {
+	return slackMentionPolicy{requireMention: true}
+}
+
+func newSlackMentionPolicy(opts map[string]any) (slackMentionPolicy, error) {
+	policy := defaultSlackMentionPolicy()
+	if v, ok := opts["require_mention"]; ok {
+		b, ok := v.(bool)
+		if !ok {
+			return policy, fmt.Errorf("slack: require_mention must be a boolean")
+		}
+		policy.requireMention = b
+	}
+
+	var err error
+	policy.requireMentionChannels, err = parseSlackBoolMapOption("require_mention_channels", opts["require_mention_channels"])
+	if err != nil {
+		return policy, err
+	}
+	policy.requireMentionThreads, err = parseSlackBoolMapOption("require_mention_threads", opts["require_mention_threads"])
+	if err != nil {
+		return policy, err
+	}
+
+	return policy, nil
+}
+
+func parseSlackBoolMapOption(name string, raw any) (map[string]bool, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	if values, ok := raw.(map[string]bool); ok {
+		out := make(map[string]bool, len(values))
+		for k, v := range values {
+			key := strings.TrimSpace(k)
+			if key == "" {
+				return nil, fmt.Errorf("slack: %s contains an empty key", name)
+			}
+			out[key] = v
+		}
+		if len(out) == 0 {
+			return nil, nil
+		}
+		return out, nil
+	}
+	values, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("slack: %s must be a map of Slack IDs to booleans", name)
+	}
+	out := make(map[string]bool, len(values))
+	for k, v := range values {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			return nil, fmt.Errorf("slack: %s contains an empty key", name)
+		}
+		b, ok := v.(bool)
+		if !ok {
+			return nil, fmt.Errorf("slack: %s[%q] must be a boolean", name, k)
+		}
+		out[key] = b
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -49,6 +125,10 @@ func New(opts map[string]any) (core.Platform, error) {
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom("slack", allowFrom)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
+	mentionPolicy, err := newSlackMentionPolicy(opts)
+	if err != nil {
+		return nil, err
+	}
 	if botToken == "" || appToken == "" {
 		return nil, fmt.Errorf("slack: bot_token and app_token are required")
 	}
@@ -57,6 +137,7 @@ func New(opts map[string]any) (core.Platform, error) {
 		appToken:              appToken,
 		allowFrom:             allowFrom,
 		shareSessionInChannel: shareSessionInChannel,
+		mentionPolicy:         mentionPolicy,
 		channelNameCache:      make(map[string]string),
 	}, nil
 }
@@ -69,6 +150,14 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 	p.client = slack.New(p.botToken,
 		slack.OptionAppLevelToken(p.appToken),
 	)
+	authCtx, authCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	if auth, err := p.client.AuthTestContext(authCtx); err != nil {
+		slog.Warn("slack: auth.test failed; mention stripping may be less precise", "error", err)
+	} else {
+		p.botUserID = auth.UserID
+	}
+	authCancel()
+
 	p.socket = socketmode.New(p.client)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -150,6 +239,10 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 				if content == "" && len(images) == 0 && audio == nil && len(docFiles) == 0 {
 					return
 				}
+				if !p.rememberSlackEvent(ev.Channel, ev.TimeStamp) {
+					slog.Debug("slack: ignoring duplicate app_mention event", "channel", ev.Channel, "ts", ev.TimeStamp)
+					return
+				}
 				msg := &core.Message{
 					SessionKey: sessionKey, Platform: "slack",
 					UserID: ev.User, UserName: p.resolveUserName(ev.User),
@@ -195,8 +288,8 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 
 				slog.Debug("slack: message received", "user", ev.User, "channel", ev.Channel, "channel_type", ev.ChannelType, "thread_ts", ev.ThreadTimeStamp)
 
-				if !shouldHandleSlackMessageEvent(ev) {
-					slog.Debug("slack: ignoring non-DM message without app mention",
+				if !shouldHandleSlackMessageEvent(ev, p.mentionPolicy) {
+					slog.Debug("slack: ignoring message because mention is required",
 						"user", ev.User,
 						"channel", ev.Channel,
 						"channel_type", ev.ChannelType,
@@ -219,7 +312,12 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 
 				images, audio, docFiles := p.processSlackFileShares(ev.Files)
 
-				if ev.Text == "" && len(images) == 0 && audio == nil && len(docFiles) == 0 {
+				content := stripSlackBotMentionText(ev.Text, p.botUserID)
+				if content == "" && len(images) == 0 && audio == nil && len(docFiles) == 0 {
+					return
+				}
+				if !p.rememberSlackEvent(ev.Channel, ev.TimeStamp) {
+					slog.Debug("slack: ignoring duplicate message event", "channel", ev.Channel, "ts", ev.TimeStamp)
 					return
 				}
 
@@ -227,7 +325,7 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					SessionKey: sessionKey, Platform: "slack",
 					UserID: ev.User, UserName: p.resolveUserName(ev.User),
 					ChatName: p.resolveChannelNameForMsg(ev.Channel),
-					Content:  ev.Text, Images: images, Files: docFiles, Audio: audio,
+					Content:  content, Images: images, Files: docFiles, Audio: audio,
 					MessageID: ts,
 					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: assistantOrThreadTS(ev)},
 				}
@@ -290,6 +388,27 @@ func stripAppMentionText(text string) string {
 	return text
 }
 
+func stripSlackBotMentionText(text, botUserID string) string {
+	if botUserID == "" || text == "" {
+		return text
+	}
+	text = strings.ReplaceAll(text, "<@"+botUserID+">", "")
+	text = strings.ReplaceAll(text, "<@!"+botUserID+">", "")
+	return strings.TrimSpace(text)
+}
+
+func (p *Platform) rememberSlackEvent(channel, ts string) bool {
+	if channel == "" || ts == "" {
+		return true
+	}
+	key := channel + ":" + ts
+	if _, loaded := p.seenEvents.LoadOrStore(key, struct{}{}); loaded {
+		return false
+	}
+	time.AfterFunc(2*time.Minute, func() { p.seenEvents.Delete(key) })
+	return true
+}
+
 func appMentionReplyTS(ev *slackevents.AppMentionEvent) string {
 	if ev == nil {
 		return ""
@@ -300,8 +419,37 @@ func appMentionReplyTS(ev *slackevents.AppMentionEvent) string {
 	return ev.TimeStamp
 }
 
-func shouldHandleSlackMessageEvent(ev *slackevents.MessageEvent) bool {
-	return isSlackDirectMessage(ev)
+func shouldHandleSlackMessageEvent(ev *slackevents.MessageEvent, policy slackMentionPolicy) bool {
+	if ev == nil {
+		return false
+	}
+	return !policy.requiresMention(ev)
+}
+
+func (p slackMentionPolicy) requiresMention(ev *slackevents.MessageEvent) bool {
+	if ev == nil || isSlackDirectMessage(ev) {
+		return false
+	}
+	if v, ok := p.threadOverride(ev); ok {
+		return v
+	}
+	if v, ok := p.requireMentionChannels[ev.Channel]; ok {
+		return v
+	}
+	return p.requireMention
+}
+
+func (p slackMentionPolicy) threadOverride(ev *slackevents.MessageEvent) (bool, bool) {
+	if ev == nil || ev.ThreadTimeStamp == "" {
+		return false, false
+	}
+	if ev.Channel != "" {
+		if v, ok := p.requireMentionThreads[ev.Channel+":"+ev.ThreadTimeStamp]; ok {
+			return v, true
+		}
+	}
+	v, ok := p.requireMentionThreads[ev.ThreadTimeStamp]
+	return v, ok
 }
 
 func isSlackDirectMessage(ev *slackevents.MessageEvent) bool {

--- a/platform/slack/slack_test.go
+++ b/platform/slack/slack_test.go
@@ -41,6 +41,140 @@ func TestStripAppMentionText(t *testing.T) {
 	}
 }
 
+func TestShouldHandleSlackMessageEventRequiresMentionOutsideDM(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   *slackevents.MessageEvent
+		want bool
+	}{
+		{
+			name: "dm message is handled",
+			ev:   &slackevents.MessageEvent{ChannelType: "im", Channel: "D123", Text: "hello"},
+			want: true,
+		},
+		{
+			name: "assistant dm thread is handled",
+			ev:   &slackevents.MessageEvent{ChannelType: "im", Channel: "D123", ThreadTimeStamp: "1710000000.000001", Text: "hello"},
+			want: true,
+		},
+		{
+			name: "channel message is ignored",
+			ev:   &slackevents.MessageEvent{ChannelType: "channel", Channel: "C123", Text: "hello"},
+			want: false,
+		},
+		{
+			name: "channel thread reply is ignored",
+			ev:   &slackevents.MessageEvent{ChannelType: "channel", Channel: "C123", ThreadTimeStamp: "1710000000.000001", Text: "hello"},
+			want: false,
+		},
+		{
+			name: "private channel message is ignored",
+			ev:   &slackevents.MessageEvent{ChannelType: "group", Channel: "G123", Text: "hello"},
+			want: false,
+		},
+		{
+			name: "mpim message is ignored",
+			ev:   &slackevents.MessageEvent{ChannelType: "mpim", Channel: "G123", Text: "hello"},
+			want: false,
+		},
+		{
+			name: "empty channel type falls back to dm channel id",
+			ev:   &slackevents.MessageEvent{Channel: "D123", Text: "hello"},
+			want: true,
+		},
+		{
+			name: "empty channel type non-dm channel is ignored",
+			ev:   &slackevents.MessageEvent{Channel: "C123", Text: "hello"},
+			want: false,
+		},
+		{
+			name: "nil event is ignored",
+			ev:   nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldHandleSlackMessageEvent(tt.ev); got != tt.want {
+				t.Fatalf("shouldHandleSlackMessageEvent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppMentionReplyTSUsesExistingThread(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   *slackevents.AppMentionEvent
+		want string
+	}{
+		{
+			name: "top-level mention replies under mention message",
+			ev:   &slackevents.AppMentionEvent{TimeStamp: "1710000000.000001"},
+			want: "1710000000.000001",
+		},
+		{
+			name: "thread mention replies in existing thread",
+			ev: &slackevents.AppMentionEvent{
+				TimeStamp:       "1710000001.000002",
+				ThreadTimeStamp: "1710000000.000001",
+			},
+			want: "1710000000.000001",
+		},
+		{
+			name: "nil mention has no reply timestamp",
+			ev:   nil,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appMentionReplyTS(tt.ev); got != tt.want {
+				t.Fatalf("appMentionReplyTS() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssistantOrThreadTSForDirectMessages(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   *slackevents.MessageEvent
+		want string
+	}{
+		{
+			name: "dm top-level reply stays top-level",
+			ev:   &slackevents.MessageEvent{ChannelType: "im", Channel: "D123", TimeStamp: "1710000000.000001"},
+			want: "",
+		},
+		{
+			name: "dm fallback by channel id stays top-level",
+			ev:   &slackevents.MessageEvent{Channel: "D123", TimeStamp: "1710000000.000001"},
+			want: "",
+		},
+		{
+			name: "assistant thread reply stays in thread",
+			ev: &slackevents.MessageEvent{
+				ChannelType:     "im",
+				Channel:         "D123",
+				TimeStamp:       "1710000001.000002",
+				ThreadTimeStamp: "1710000000.000001",
+			},
+			want: "1710000000.000001",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := assistantOrThreadTS(tt.ev); got != tt.want {
+				t.Fatalf("assistantOrThreadTS() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDownloadSlackFile_HTMLDetection(t *testing.T) {
 	// Test that we detect HTML responses (Slack login page) and return an error
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/platform/slack/slack_test.go
+++ b/platform/slack/slack_test.go
@@ -41,65 +41,228 @@ func TestStripAppMentionText(t *testing.T) {
 	}
 }
 
-func TestShouldHandleSlackMessageEventRequiresMentionOutsideDM(t *testing.T) {
+func TestStripSlackBotMentionText(t *testing.T) {
 	tests := []struct {
-		name string
-		ev   *slackevents.MessageEvent
-		want bool
+		name      string
+		text      string
+		botUserID string
+		want      string
 	}{
 		{
-			name: "dm message is handled",
-			ev:   &slackevents.MessageEvent{ChannelType: "im", Channel: "D123", Text: "hello"},
-			want: true,
+			name:      "strips bot mention",
+			text:      "hey <@U0BOT123> run tests",
+			botUserID: "U0BOT123",
+			want:      "hey  run tests",
 		},
 		{
-			name: "assistant dm thread is handled",
-			ev:   &slackevents.MessageEvent{ChannelType: "im", Channel: "D123", ThreadTimeStamp: "1710000000.000001", Text: "hello"},
-			want: true,
+			name:      "strips bot nick mention",
+			text:      "<@!U0BOT123> run tests",
+			botUserID: "U0BOT123",
+			want:      "run tests",
 		},
 		{
-			name: "channel message is ignored",
-			ev:   &slackevents.MessageEvent{ChannelType: "channel", Channel: "C123", Text: "hello"},
-			want: false,
+			name:      "keeps other user mention",
+			text:      "ask <@U0OTHER> about it",
+			botUserID: "U0BOT123",
+			want:      "ask <@U0OTHER> about it",
 		},
 		{
-			name: "channel thread reply is ignored",
-			ev:   &slackevents.MessageEvent{ChannelType: "channel", Channel: "C123", ThreadTimeStamp: "1710000000.000001", Text: "hello"},
-			want: false,
-		},
-		{
-			name: "private channel message is ignored",
-			ev:   &slackevents.MessageEvent{ChannelType: "group", Channel: "G123", Text: "hello"},
-			want: false,
-		},
-		{
-			name: "mpim message is ignored",
-			ev:   &slackevents.MessageEvent{ChannelType: "mpim", Channel: "G123", Text: "hello"},
-			want: false,
-		},
-		{
-			name: "empty channel type falls back to dm channel id",
-			ev:   &slackevents.MessageEvent{Channel: "D123", Text: "hello"},
-			want: true,
-		},
-		{
-			name: "empty channel type non-dm channel is ignored",
-			ev:   &slackevents.MessageEvent{Channel: "C123", Text: "hello"},
-			want: false,
-		},
-		{
-			name: "nil event is ignored",
-			ev:   nil,
-			want: false,
+			name:      "empty bot id keeps text",
+			text:      "<@U0BOT123> run tests",
+			botUserID: "",
+			want:      "<@U0BOT123> run tests",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldHandleSlackMessageEvent(tt.ev); got != tt.want {
+			if got := stripSlackBotMentionText(tt.text, tt.botUserID); got != tt.want {
+				t.Fatalf("stripSlackBotMentionText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRememberSlackEventDedupsChannelTimestamp(t *testing.T) {
+	p := &Platform{}
+	if !p.rememberSlackEvent("C123", "1710000000.000001") {
+		t.Fatal("first event should be remembered")
+	}
+	if p.rememberSlackEvent("C123", "1710000000.000001") {
+		t.Fatal("duplicate event should be rejected")
+	}
+	if !p.rememberSlackEvent("C123", "1710000000.000002") {
+		t.Fatal("different timestamp should be accepted")
+	}
+	if !p.rememberSlackEvent("G123", "1710000000.000001") {
+		t.Fatal("same timestamp in different channel should be accepted")
+	}
+}
+
+func TestShouldHandleSlackMessageEventMentionPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy slackMentionPolicy
+		ev     *slackevents.MessageEvent
+		want   bool
+	}{
+		{
+			name:   "dm message is handled with default policy",
+			policy: defaultSlackMentionPolicy(),
+			ev:     &slackevents.MessageEvent{ChannelType: "im", Channel: "D123", Text: "hello"},
+			want:   true,
+		},
+		{
+			name:   "assistant dm thread is handled with default policy",
+			policy: defaultSlackMentionPolicy(),
+			ev:     &slackevents.MessageEvent{ChannelType: "im", Channel: "D123", ThreadTimeStamp: "1710000000.000001", Text: "hello"},
+			want:   true,
+		},
+		{
+			name:   "channel message is ignored by default",
+			policy: defaultSlackMentionPolicy(),
+			ev:     &slackevents.MessageEvent{ChannelType: "channel", Channel: "C123", Text: "hello"},
+			want:   false,
+		},
+		{
+			name:   "channel thread reply is ignored by default",
+			policy: defaultSlackMentionPolicy(),
+			ev:     &slackevents.MessageEvent{ChannelType: "channel", Channel: "C123", ThreadTimeStamp: "1710000000.000001", Text: "hello"},
+			want:   false,
+		},
+		{
+			name:   "private channel message is ignored by default",
+			policy: defaultSlackMentionPolicy(),
+			ev:     &slackevents.MessageEvent{ChannelType: "group", Channel: "G123", Text: "hello"},
+			want:   false,
+		},
+		{
+			name:   "mpim message is ignored by default",
+			policy: defaultSlackMentionPolicy(),
+			ev:     &slackevents.MessageEvent{ChannelType: "mpim", Channel: "G123", Text: "hello"},
+			want:   false,
+		},
+		{
+			name:   "empty channel type falls back to dm channel id",
+			policy: defaultSlackMentionPolicy(),
+			ev:     &slackevents.MessageEvent{Channel: "D123", Text: "hello"},
+			want:   true,
+		},
+		{
+			name:   "empty channel type non-dm channel is ignored by default",
+			policy: defaultSlackMentionPolicy(),
+			ev:     &slackevents.MessageEvent{Channel: "C123", Text: "hello"},
+			want:   false,
+		},
+		{
+			name:   "global no-mention policy handles channel messages",
+			policy: slackMentionPolicy{requireMention: false},
+			ev:     &slackevents.MessageEvent{ChannelType: "channel", Channel: "C123", Text: "hello"},
+			want:   true,
+		},
+		{
+			name: "channel override can allow no-mention messages",
+			policy: slackMentionPolicy{
+				requireMention:         true,
+				requireMentionChannels: map[string]bool{"C123": false},
+			},
+			ev:   &slackevents.MessageEvent{ChannelType: "channel", Channel: "C123", Text: "hello"},
+			want: true,
+		},
+		{
+			name: "channel override can require mention when global allows",
+			policy: slackMentionPolicy{
+				requireMention:         false,
+				requireMentionChannels: map[string]bool{"C123": true},
+			},
+			ev:   &slackevents.MessageEvent{ChannelType: "channel", Channel: "C123", Text: "hello"},
+			want: false,
+		},
+		{
+			name: "thread override can allow no-mention replies",
+			policy: slackMentionPolicy{
+				requireMention:        true,
+				requireMentionThreads: map[string]bool{"C123:1710000000.000001": false},
+			},
+			ev: &slackevents.MessageEvent{
+				ChannelType:     "channel",
+				Channel:         "C123",
+				ThreadTimeStamp: "1710000000.000001",
+				Text:            "hello",
+			},
+			want: true,
+		},
+		{
+			name: "thread override wins over channel override",
+			policy: slackMentionPolicy{
+				requireMention:         true,
+				requireMentionChannels: map[string]bool{"C123": false},
+				requireMentionThreads:  map[string]bool{"C123:1710000000.000001": true},
+			},
+			ev: &slackevents.MessageEvent{
+				ChannelType:     "channel",
+				Channel:         "C123",
+				ThreadTimeStamp: "1710000000.000001",
+				Text:            "hello",
+			},
+			want: false,
+		},
+		{
+			name: "thread timestamp shorthand is accepted",
+			policy: slackMentionPolicy{
+				requireMention:        true,
+				requireMentionThreads: map[string]bool{"1710000000.000001": false},
+			},
+			ev: &slackevents.MessageEvent{
+				ChannelType:     "group",
+				Channel:         "G123",
+				ThreadTimeStamp: "1710000000.000001",
+				Text:            "hello",
+			},
+			want: true,
+		},
+		{
+			name:   "nil event is ignored",
+			policy: defaultSlackMentionPolicy(),
+			ev:     nil,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldHandleSlackMessageEvent(tt.ev, tt.policy); got != tt.want {
 				t.Fatalf("shouldHandleSlackMessageEvent() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewSlackMentionPolicyFromOptions(t *testing.T) {
+	policy, err := newSlackMentionPolicy(map[string]any{
+		"require_mention": false,
+		"require_mention_channels": map[string]any{
+			"C123": true,
+			"G123": false,
+		},
+		"require_mention_threads": map[string]bool{
+			"C123:1710000000.000001": false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("newSlackMentionPolicy() error = %v", err)
+	}
+	if policy.requireMention {
+		t.Fatal("requireMention = true, want false")
+	}
+	if got := policy.requireMentionChannels["C123"]; !got {
+		t.Fatalf("channel override C123 = %v, want true", got)
+	}
+	if got := policy.requireMentionChannels["G123"]; got {
+		t.Fatalf("channel override G123 = %v, want false", got)
+	}
+	if got := policy.requireMentionThreads["C123:1710000000.000001"]; got {
+		t.Fatalf("thread override = %v, want false", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Capture runtime model and token/context metadata from Claude Code and Gemini CLI stream events so reply footers can show actual session state without requiring hardcoded configured model values. Also add a configurable Slack mention policy so DMs work directly while channel/private-channel/thread messages can require or skip @mention by global, per-channel, or per-thread config.

## Root Cause

Claude Code and Gemini CLI both emit runtime metadata in their stream-json outputs, but cc-connect was not caching the session-level values that the reply footer reads. Claude Code emitted the active model and context-window usage, while Gemini CLI emitted the active model plus token stats but no context window in headless stream-json mode.

Slack subscribed to message events and treated ordinary channel/thread messages like direct messages, so any channel message could trigger an agent response. The first fix made channel/thread mentions mandatory globally, but that was too coarse: some channels or threads intentionally need no-mention replies.

## Changes

- Store Claude Code runtime model from system and assistant stream-json payloads.
- Parse Claude Code result.modelUsage into core.ContextUsage for footer context percentage.
- Store Gemini CLI runtime model from init events.
- Parse Gemini CLI result.stats into event token counts and session context usage.
- Only expose Gemini context-window percentages when a context-window field is actually present in the stream data.
- Add Slack `require_mention` default policy for non-DM messages.
- Add Slack `require_mention_channels` and `require_mention_threads` overrides, with thread override taking precedence over channel override.
- Keep Slack DMs and Slack Assistant Chat working without mention.
- Keep Slack `app_mention` as an always-valid trigger and reply into the existing thread when the mention happens inside a thread.
- Deduplicate Slack `message`/`app_mention` delivery for the same channel timestamp and strip only this bot's mention in the ordinary message path.
- Update Slack config example and docs for `app_mention`, `message.im`, and optional `message.channels`/`message.groups` subscriptions.
- Return defensive copies of context usage to avoid external mutation.
- Add unit tests for Claude Code, Gemini CLI, Slack mention policy, and Slack event dedup behavior.

## Validation

- go test ./agent/claudecode
- go test ./agent/gemini ./agent/claudecode
- go test ./platform/slack
- go test ./platform/slack ./agent/gemini ./agent/claudecode
- go test ./config ./platform/slack ./agent/gemini ./agent/claudecode
- make build

## Notes

Gemini CLI interactive footer can show context percentage because it has access to internal TUI state and tokenLimit(config.getModel()). Headless stream-json currently emits simplified token stats but does not include a context window, so cc-connect does not hardcode Gemini context limits.