### PR TITLE
fix(markdown_html): use decimal placeholder keys to avoid HTML-escape collision

### DIFF
--- a/core/markdown_html.go
+++ b/core/markdown_html.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -295,8 +296,17 @@ func convertInlineHTML(s string) string {
 	var phs []placeholder
 	phIdx := 0
 
+	// The placeholder key embeds phIdx as decimal digits. The previous
+	// `string(rune('0'+phIdx))` form rolled past '9' once phIdx hit 10, so
+	// phIdx == 12 produced a key containing '<' and phIdx == 14 produced one
+	// containing '>'. Step 3 (escapeHTML on the entire string) then rewrote
+	// '<'/'>' inside those keys to "&lt;"/"&gt;" before step 8 could restore
+	// them, leaking literal "\x00PH<\x00" / "\x00PH>\x00" fragments into the
+	// rendered Telegram message and dropping the original code/link content.
+	// Decimal digits stay in the safe ASCII range regardless of phIdx, and
+	// no two indices collide.
 	nextPH := func(html string) string {
-		key := "\x00PH" + string(rune('0'+phIdx)) + "\x00"
+		key := "\x00PH" + strconv.Itoa(phIdx) + "\x00"
 		phs = append(phs, placeholder{key: key, html: html})
 		phIdx++
 		return key

--- a/core/markdown_html_test.go
+++ b/core/markdown_html_test.go
@@ -578,3 +578,32 @@ func TestMarkdownToSimpleHTML_Callout(t *testing.T) {
 		})
 	}
 }
+
+// TestMarkdownToSimpleHTML_ManyInlineCodePlaceholders is a regression test for
+// a placeholder-collision bug in convertInlineHTML: the placeholder key used
+// to encode the index as `string(rune('0'+phIdx))`, which rolled past '9' once
+// phIdx hit 10. phIdx == 12 produced a key containing '<' and phIdx == 14 one
+// containing '>'. The whole-string escapeHTML pass then rewrote those chars
+// inside the keys to "&lt;" / "&gt;", so the restore pass at the end could no
+// longer find the keys and the final HTML leaked literal "\x00PH<\x00" /
+// "\x00PH>\x00" fragments while losing the original code/link content.
+func TestMarkdownToSimpleHTML_ManyInlineCodePlaceholders(t *testing.T) {
+	// 15 inline-code segments forces phIdx through 12 ('<') and 14 ('>').
+	in := "Functions are " +
+		"`f0`, `f1`, `f2`, `f3`, `f4`, `f5`, `f6`, `f7`, " +
+		"`f8`, `f9`, `fA`, `fB`, `fC`, `fD`, `fE` here."
+	out := MarkdownToSimpleHTML(in)
+
+	if strings.ContainsRune(out, 0) {
+		t.Fatalf("output leaked NUL placeholder: %q", out)
+	}
+	if strings.Contains(out, "PH&lt;") || strings.Contains(out, "PH&gt;") {
+		t.Fatalf("output leaked escaped placeholder fragment: %q", out)
+	}
+	for _, name := range []string{"f0", "f1", "f9", "fA", "fB", "fC", "fD", "fE"} {
+		want := "<code>" + name + "</code>"
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %s, got %q", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`convertInlineHTML` (used by `MarkdownToSimpleHTML`, the Telegram outbound rendering path) protects code/link content as placeholders before running `escapeHTML` across the whole string, then restores them at the end. The placeholder key was:

```go
key := \"\x00PH\" + string(rune('0' + phIdx)) + \"\x00\"
```

That single rune rolls past `'9'` once `phIdx` reaches 10:

| phIdx | char |
|---|---|
| 9 | `'9'` |
| 10 | `':'` |
| 11 | `';'` |
| **12** | **`'<'`** |
| 13 | `'='` |
| **14** | **`'>'`** |

So once a single message contains 13+ inline-code spans (or links), the placeholder key includes `<`. The whole-string `escapeHTML` pass then rewrites it to `&lt;` *inside* the key, and the restore pass at the end can no longer find the original key. The final HTML leaks literal `\x00PH<\x00` / `\x00PH>\x00` fragments and silently drops the original code/link content.

### Reproduction (before the fix)

Input: 15 inline-code spans in one message, `\` `f0` `\`, `\` `f1` `\`, …, `\` `fE` `\`:

```
in:  \"Functions are `f0`, `f1`, ..., `fC`, `fD`, `fE` here.\"
out: \"Functions are <code>f0</code>, ..., <code>fB</code>,
       \\x00PH&lt;\\x00, <code>fD</code>, \\x00PH&gt;\\x00 here.\"
```

`fC` and `fE` are gone, replaced with junk that Telegram renders as raw text (NUL chars and all).

## Fix

Switch the placeholder key from `string(rune('0'+phIdx))` to `strconv.Itoa(phIdx)`. Decimal digits stay in the safe ASCII range regardless of `phIdx`, never overlap with HTML-special chars, and the keys remain unique.

```go
key := \"\x00PH\" + strconv.Itoa(phIdx) + \"\x00\"
```

Single-character change in the live path; +1 import.

## Test plan

- [x] New `TestMarkdownToSimpleHTML_ManyInlineCodePlaceholders` regression test fires 15 inline-code spans through `MarkdownToSimpleHTML` and asserts the output contains no NUL byte, no escaped placeholder fragment, and that every code span is preserved. Confirmed to **fail on main** (catches the leaked `\\x00PH&lt;\\x00` / `\\x00PH&gt;\\x00`) and **pass on this branch**.
- [x] `go vet -tags=no_web ./core/...` clean
- [x] `go build -tags=no_web ./...` succeeds
- [x] `go test -race -tags=no_web ./core/ -run TestMarkdown` — all markdown tests pass
- [x] `go test -tags=no_web ./platform/telegram/... ./platform/discord/...` — both downstream packages green