### PR TITLE
fix(core): show thinking content when agent produces no text response

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3337,6 +3337,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 	var textParts []string
 	var segmentStart int // index into textParts: text before this has been sent/displayed
+	var lastThinkingContent string // tracks last thinking block for thinking-only fallback
 	silentHold := false  // true while accumulated segment text could still resolve to a bare NO_REPLY marker
 	toolCount := 0
 	waitStart := time.Now()
@@ -3487,6 +3488,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		switch event.Type {
 		case EventThinking:
+			if event.Content != "" && !isEllipsisOnly(event.Content) {
+				lastThinkingContent = event.Content
+			}
 			if isEllipsisOnly(event.Content) {
 				break
 			}
@@ -3889,7 +3893,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				fullResponse = strings.Join(textParts, "")
 			}
 			if fullResponse == "" {
-				fullResponse = e.i18n.T(MsgEmptyResponse)
+				if lastThinkingContent != "" {
+					preview := truncateIf(lastThinkingContent, 500)
+					fullResponse = fmt.Sprintf(e.i18n.T(MsgThinkingOnlyResponse), preview)
+					slog.Warn("thinking-only response",
+						"session", session.ID,
+						"thinking_len", len(lastThinkingContent))
+				} else {
+					fullResponse = e.i18n.T(MsgEmptyResponse)
+				}
 			}
 
 			// Context usage indicator: prefer SDK tokens, fall back to self-reported.
@@ -4165,6 +4177,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				msgID = queued.messageID
 				textParts = nil
 				segmentStart = 0
+				lastThinkingContent = ""
 				toolCount = 0
 				turnStart = time.Now()
 				firstEventLogged = false

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -144,6 +144,7 @@ const (
 	MsgFailedToStartAgentSession MsgKey = "failed_to_start_agent_session"
 	MsgFailedToDeleteSession     MsgKey = "failed_to_delete_session"
 	MsgEmptyResponse             MsgKey = "empty_response"
+	MsgThinkingOnlyResponse      MsgKey = "thinking_only_response"
 	MsgPermissionPrompt          MsgKey = "permission_prompt"
 	MsgPermissionAllowed         MsgKey = "permission_allowed"
 	MsgPermissionApproveAll      MsgKey = "permission_approve_all"
@@ -755,6 +756,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "(空回應)",
 		LangJapanese:           "（空のレスポンス）",
 		LangSpanish:            "(respuesta vacía)",
+	},
+	MsgThinkingOnlyResponse: {
+		LangEnglish:            "💭 The agent processed your message but produced no visible reply.\n\n**Agent's reasoning:**\n> %s",
+		LangChinese:            "💭 Agent 处理了你的消息，但没有生成可见的回复。\n\n**Agent 的推理过程：**\n> %s",
+		LangTraditionalChinese: "💭 Agent 處理了你的訊息，但沒有產生可見的回覆。\n\n**Agent 的推理過程：**\n> %s",
+		LangJapanese:           "💭 エージェントはメッセージを処理しましたが、表示可能な返信を生成しませんでした。\n\n**エージェントの推論：**\n> %s",
+		LangSpanish:            "💭 El agente procesó tu mensaje pero no produjo una respuesta visible.\n\n**Razonamiento del agente:**\n> %s",
 	},
 	MsgPermissionPrompt: {
 		LangEnglish:            "⚠️ **Permission Request**\n\nAgent wants to use **%s**:\n\n```\n%s\n```\n\nReply **allow** / **deny** / **allow all** (skip all future prompts this session).",


### PR DESCRIPTION
## Problem

When Claude Code (or other agents with extended thinking) produces only thinking blocks without any text output, cc-connect shows a bare `(empty response)` / `(空响应)` message. This gives users zero context about what happened.

**Real-world scenario**: When a user pastes sensitive content (e.g., API tokens), Claude's safety layer may only produce internal reasoning (thinking blocks) without generating a visible text response. The user gets `(空响应)` repeatedly and the session becomes unresponsive.

## Fix

- Track the last thinking block content via `lastThinkingContent` in the interactive event loop
- When `fullResponse` is empty but thinking content exists, format it as a user-visible message using a new `MsgThinkingOnlyResponse` i18n key (with translations for EN, ZH, ZH-TW, JA, ES)
- Log a `thinking-only response` warning for debugging
- Reset tracking state on new turn boundaries

## Changes

- `core/engine.go`: Add `lastThinkingContent` tracking in `EventThinking` handler, use it as fallback in `EventResult` handler
- `core/i18n.go`: Add `MsgThinkingOnlyResponse` message key with 5 language translations

## Test plan

- [ ] Verify thinking-only responses now show thinking content instead of `(空响应)`
- [ ] Verify normal responses (text + thinking) are unaffected
- [ ] Verify thinking content resets between turns