### PR TITLE
fix(daemon/launchd): SuccessfulExit polarity is inverted — crashes never restart

### DIFF
--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -260,7 +260,7 @@ func buildPlist(cfg Config) string {
 	<key>KeepAlive</key>
 	<dict>
 		<key>SuccessfulExit</key>
-		<true/>
+		<false/>
 	</dict>
 	<key>EnvironmentVariables</key>
 	<dict>

--- a/daemon/launchd_test.go
+++ b/daemon/launchd_test.go
@@ -26,6 +26,17 @@ func TestBuildPlist_KeepAliveDoesNotRestartOnCleanExit(t *testing.T) {
 	if strings.Contains(xml, "<key>KeepAlive</key>\n\t<true/>") {
 		t.Fatal("plist must not use boolean KeepAlive true")
 	}
+	// launchd.plist(5): SuccessfulExit=true means restart ONLY after a successful
+	// (exit 0) exit; false means restart ONLY after an unsuccessful exit. cc-connect
+	// returns 0 on graceful SIGTERM shutdown but a non-zero status on crash, so the
+	// daemon's "restart on failure but not on graceful stop" intent maps to
+	// SuccessfulExit=false. The previous wiring used <true/>, which was the inverse:
+	// it respawned after every clean SIGTERM shutdown and did NOT recover from
+	// crashes. Pin the correct value here so a future edit can't silently re-invert
+	// it.
+	if !strings.Contains(xml, "<key>SuccessfulExit</key>\n\t\t<false/>") {
+		t.Fatalf("plist must set SuccessfulExit=false so crashes restart and clean SIGTERM does not respawn; got:\n%s", xml)
+	}
 	if !strings.Contains(xml, "<key>LimitLoadToSessionType</key>") ||
 		!strings.Contains(xml, "<string>Aqua</string>") ||
 		!strings.Contains(xml, "<string>Background</string>") {


### PR DESCRIPTION
## Summary

The macOS LaunchAgent plist generated by `daemon/launchd.go` has its `KeepAlive` policy backwards. The current value:

```xml
<key>KeepAlive</key>
<dict>
    <key>SuccessfulExit</key>
    <true/>
</dict>
```

`launchd.plist(5)` says:

> `SuccessfulExit <boolean>` — If `true`, the job will be restarted as long as the program exits with a successful exit status. If `false`, the job will be restarted in the inverse condition.

So `SuccessfulExit=true` means **restart only after a clean exit 0**, not the other way around. The shipped plist therefore has two backwards behaviours:

| event | exit status | current launchd behaviour | desired |
|---|---|---|---|
| graceful `SIGTERM` (cc-connect's normal stop path falls through to a clean `main()` return → Go runtime exits 0) | 0 | **respawns** — exactly what #153 was meant to stop | should not respawn |
| crash / panic / SIGKILL | non-zero | **does not restart** — LaunchAgent silently disappears on first crash | should restart |

## How this happened

PR #304 (commit `a456ab3b`) added the dict with the comment

> "Use KeepAlive with SuccessfulExit=true so only unclean exits are restarted, matching systemd Restart=on-failure behavior."

The intent is correct (`Restart=on-failure` → restart only on non-zero), but the launchd flag's polarity is the opposite of what the author thought, so the wiring ended up doing the inverse on both axes. The accompanying test only asserted the `<key>SuccessfulExit</key>` was *present*, never its value, so it stayed green either way.

## Fix

Flip the value to `<false/>`:

```xml
<key>KeepAlive</key>
<dict>
    <key>SuccessfulExit</key>
    <false/>
</dict>
```

Now: clean exit (SIGTERM) → no respawn, crash → restart. Matches the stated systemd `Restart=on-failure` parity.

Tighten the existing `TestBuildPlist_KeepAliveDoesNotRestartOnCleanExit` to assert the exact `<false/>` value with an inline comment explaining the inversion so a future edit can't silently flip it back. Confirmed the strengthened assertion **fails on `main`** (the `<true/>` polarity) and **passes on this branch**.

## Test plan

- [x] `go test -tags=no_web ./daemon/... -run TestBuildPlist_KeepAliveDoesNotRestartOnCleanExit` passes on this branch and fails on main
- [x] `go vet -tags=no_web ./daemon/...` clean
- [x] `go build -tags=no_web ./...` succeeds
- [x] Pre-existing `TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable` flake reproduces on `main` without this change — unrelated

## Migration note

Existing users who installed the daemon with the old plist will keep the wrong KeepAlive policy until they refresh it. Re-running `cc-connect daemon install --force` rewrites the plist, the same migration step that PR #304 already documented in its commit message.