### PR TITLE
fix(core): clean up tmp file in AtomicWriteFile when rename fails

### DIFF
--- a/core/atomicwrite.go
+++ b/core/atomicwrite.go
@@ -34,5 +34,17 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, path)
+	if err := os.Rename(tmpPath, path); err != nil {
+		// Rename can fail when the destination is a directory, the
+		// destination's filesystem differs from the temp dir's (rare given
+		// CreateTemp uses the same dir, but possible with bind mounts), or
+		// the destination is locked by another process on Windows. In any
+		// of those cases the temp file is now an orphaned `.tmp-*` we
+		// created — clean it up so repeated failures don't litter the
+		// directory and confuse later directory scans (e.g. cron / session
+		// stores that walk their parent dir).
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }

--- a/core/atomicwrite_test.go
+++ b/core/atomicwrite_test.go
@@ -71,3 +71,35 @@ func TestAtomicWriteFile_NoTempLeftOnSuccess(t *testing.T) {
 		}
 	}
 }
+
+// TestAtomicWriteFile_NoTempLeftWhenRenameFails is a regression test for a
+// `.tmp-*` leak in the rename-failure path. Before the fix, AtomicWriteFile
+// returned the rename error directly without removing the tmp file it had
+// just created — so repeated failures would litter the parent directory
+// with stale `.tmp-*` files and confuse callers that scan that directory
+// (cron store, session store, etc.).
+//
+// We force a rename failure by writing to a path that already exists as a
+// directory; os.Rename refuses to replace a non-empty directory with a
+// regular file on every supported platform.
+func TestAtomicWriteFile_NoTempLeftWhenRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "blocked")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+
+	if err := AtomicWriteFile(target, []byte("payload"), 0o644); err == nil {
+		t.Fatal("AtomicWriteFile should fail when target is an existing directory")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "blocked" {
+			t.Errorf("rename failure left orphan file %q in %s; cleanup is missing", e.Name(), dir)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Every other failure path in `AtomicWriteFile` (`Write` / `Sync` / `Close` / `Chmod`) calls `os.Remove(tmpPath)` before returning the error, so the `.tmp-*` file `os.CreateTemp` produced does not survive an aborted write. The rename branch — the most common failure mode in practice — forgot to do the same:

```go
return os.Rename(tmpPath, path)
```

If `os.Rename` returns a non-nil error (target is an existing directory, target is locked by another process on Windows, cross-filesystem rename via bind mount, …) the caller gets the error but the orphaned `.tmp-*` file is left behind. Repeated failures litter the parent directory with stale temp files; that's especially nasty for the cron and session stores that scan their *own* directory looking for state files (`core/cron.go:134`, `core/session.go:621`, `core/dir_history.go:165`, …).

## Reproducer

Works on every supported platform: pass a path that is already an existing directory.

```go
dir := os.MkdirTemp("", "atomic-test-*")
target := filepath.Join(dir, "blocked")
os.MkdirAll(target, 0o755)
core.AtomicWriteFile(target, []byte("payload"), 0o644)

// Before this fix, ReadDir(dir) returns:
//   blocked       (dir, expected)
//   .tmp-XXXXXX   (orphan — leaked!)
```

## Fix

Mirror the cleanup pattern from the other failure branches:

```go
if err := os.Rename(tmpPath, path); err != nil {
    os.Remove(tmpPath)
    return err
}
return nil
```

Plus an inline comment listing the realistic failure causes so the next reader doesn't think this is defensive paranoia.

## Test plan

- [x] New `TestAtomicWriteFile_NoTempLeftWhenRenameFails` regression test writes to an existing-directory path, asserts the call errors out, and asserts the parent contains no stray `.tmp-*` file. Confirmed to **fail on `main`** (`rename failure left orphan file ".tmp-3844312333"`) and **pass on this branch**.
- [x] All four pre-existing `TestAtomicWriteFile_*` tests still pass.
- [x] `go vet -tags=no_web ./core/...` clean
- [x] `go build -tags=no_web ./...` succeeds