### PR TITLE
fix(core/setup): handle url.Parse error in weixin poll handler to avoid nil-pointer panic

### DIFF
--- a/core/management_test.go
+++ b/core/management_test.go
@@ -2615,3 +2615,45 @@ func TestMgmt_CCSwitchProviders_MethodNotAllowed(t *testing.T) {
 		t.Fatal("expected DELETE on cc-switch to fail")
 	}
 }
+
+// TestMgmt_SetupWeixinPoll_RejectsMalformedAPIURL is a regression test for a
+// nil-pointer panic in handleSetupWeixinPoll. The handler did
+// `u, _ := url.Parse(apiBase + "/")` and then immediately called
+// `u.JoinPath(...)`. For inputs like "://" or "%zz", url.Parse returns a nil
+// URL plus an error; the discarded error meant the next line crashed the
+// management server with `runtime error: invalid memory address or nil
+// pointer dereference`. handleSetupWeixinBegin already validated this same
+// field; this test pins the symmetric handling here.
+func TestMgmt_SetupWeixinPoll_RejectsMalformedAPIURL(t *testing.T) {
+	mgmt := NewManagementServer(0, "", nil)
+
+	for _, bad := range []string{"://", "://malformed", "%zz"} {
+		body := map[string]any{
+			"qr_key":  "abc",
+			"api_url": bad,
+		}
+		buf := new(bytes.Buffer)
+		if err := json.NewEncoder(buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/weixin/poll", buf)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		// Recover any panic so the test reports a meaningful failure rather
+		// than crashing the test binary, then assert the handler returned a
+		// 4xx (not 5xx and not a panic) for the bad input.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("handleSetupWeixinPoll panicked on api_url=%q: %v", bad, r)
+				}
+			}()
+			mgmt.handleSetupWeixinPoll(w, req)
+		}()
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("api_url=%q: status=%d, want %d (body=%s)", bad, w.Code, http.StatusBadRequest, w.Body.String())
+		}
+	}
+}

--- a/core/setup.go
+++ b/core/setup.go
@@ -347,7 +347,16 @@ func (m *ManagementServer) handleSetupWeixinPoll(w http.ResponseWriter, r *http.
 		apiBase = strings.TrimRight(req.APIURL, "/")
 	}
 
-	u, _ := url.Parse(apiBase + "/")
+	// Validate api_url before dereferencing — url.Parse returns a nil URL for
+	// inputs like "://" or "%zz", and the previous `u, _ := url.Parse(...)`
+	// then crashed the management server with a nil-pointer panic on the
+	// next u.JoinPath call. handleSetupWeixinBegin already validates the
+	// same field; mirror that here.
+	u, err := url.Parse(apiBase + "/")
+	if err != nil {
+		mgmtError(w, http.StatusBadRequest, "invalid api_url")
+		return
+	}
 	u = u.JoinPath("ilink", "bot", "get_qrcode_status")
 	q := u.Query()
 	q.Set("qrcode", req.QRKey)


### PR DESCRIPTION
## Summary

`handleSetupWeixinPoll` (`core/setup.go:350`) does:

```go
u, _ := url.Parse(apiBase + \"/\")
u = u.JoinPath(\"ilink\", \"bot\", \"get_qrcode_status\")
```

For inputs like `\"://\"`, `\"://malformed\"`, or `\"%zz\"`, `url.Parse` returns a **nil `*URL`** along with a non-nil error. The discarded error means the next line dereferences a nil pointer and crashes the management server:

```
runtime error: invalid memory address or nil pointer dereference
```

Reproduced (test included): a single POST to `/api/v1/setup/weixin/poll` with `{\"qr_key\": \"x\", \"api_url\": \"://\"}` panics the handler goroutine.

The management API is authenticated, but an operator pasting a typo into the WeChat setup form (or any web client posting a malformed URL) is enough to bring the daemon down. The sibling handler `handleSetupWeixinBegin` already validates the same parse and returns HTTP 400 on error — this PR mirrors that handling in the poll handler.

## Fix

```go
u, err := url.Parse(apiBase + \"/\")
if err != nil {
    mgmtError(w, http.StatusBadRequest, \"invalid api_url\")
    return
}
```

Plus an inline comment so the next reader doesn't think this is defensive paranoia.

## Test plan

- [x] New `TestMgmt_SetupWeixinPoll_RejectsMalformedAPIURL` covers three malformed inputs (`\"://\"`, `\"://malformed\"`, `\"%zz\"`). The test wraps the handler call in a `defer/recover` so a regression to the panicking behaviour produces a clear test failure rather than crashing the test binary, then asserts the response is HTTP 400. Confirmed to **fail on `main`** with `handleSetupWeixinPoll panicked on api_url=\"://\": runtime error: invalid memory address or nil pointer dereference` and **pass on this branch**.
- [x] `go test -tags=no_web ./core/ -run TestMgmt` — all management tests pass
- [x] `go vet -tags=no_web ./core/...` clean
- [x] `go build -tags=no_web ./...` succeeds