### PR TITLE
fix(core): sanitize attachment FileName to prevent path traversal in SaveFilesToDisk

### DIFF
--- a/core/message.go
+++ b/core/message.go
@@ -81,6 +81,12 @@ type FileAttachment struct {
 // SaveFilesToDisk saves file attachments to workDir/.cc-connect/attachments/
 // and returns the list of absolute file paths. Agents can reference these paths
 // in their prompts so the CLI can read them with built-in tools.
+//
+// The attachment FileName is treated as untrusted user input (it comes from
+// the IM/HTTP upload metadata) and is sanitized to a basename before being
+// joined into attachDir. Without this, FileName="../../escape.txt" was
+// written to workDir/escape.txt — outside the intended attachments
+// directory.
 func SaveFilesToDisk(workDir string, files []FileAttachment) []string {
 	if len(files) == 0 {
 		return nil
@@ -92,7 +98,7 @@ func SaveFilesToDisk(workDir string, files []FileAttachment) []string {
 
 	var paths []string
 	for i, f := range files {
-		fname := f.FileName
+		fname := sanitizeAttachmentFileName(f.FileName)
 		if fname == "" {
 			fname = fmt.Sprintf("file_%d_%d", time.Now().UnixMilli(), i)
 		}
@@ -105,6 +111,23 @@ func SaveFilesToDisk(workDir string, files []FileAttachment) []string {
 		slog.Debug("SaveFilesToDisk: file saved", "path", fpath, "name", f.FileName, "mime", f.MimeType, "size", len(f.Data))
 	}
 	return paths
+}
+
+// sanitizeAttachmentFileName reduces a user-supplied attachment filename to a
+// safe basename suitable for joining into an attachment directory. It strips
+// any directory components (both `/` and `\`, the latter so Linux strips
+// Windows-style paths too) and rejects parent / current-directory references.
+// Returns "" when the input cannot produce a safe basename, so callers can
+// fall back to a generated name.
+func sanitizeAttachmentFileName(name string) string {
+	// Normalize backslashes to forward slashes so filepath.Base on Linux
+	// strips Windows-style separators in attacker-supplied paths too.
+	name = strings.ReplaceAll(name, "\\", "/")
+	name = filepath.Base(name)
+	if name == "" || name == "." || name == ".." {
+		return ""
+	}
+	return name
 }
 
 // AppendFileRefs appends file path references to a prompt string.

--- a/core/message_test.go
+++ b/core/message_test.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSanitizeAttachmentFileName covers the basename-stripping rules used by
+// SaveFilesToDisk to reject path-traversal in user-supplied filenames.
+func TestSanitizeAttachmentFileName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"image.png", "image.png"},
+		{"subdir/file.txt", "file.txt"},
+		{"../../escape.txt", "escape.txt"},
+		{"/etc/passwd", "passwd"},
+		// Windows-style separators get normalized so Linux strips them too.
+		{`..\..\windows-escape.txt`, "windows-escape.txt"},
+		{`C:\Users\foo\bar.exe`, "bar.exe"},
+		// Anything that would still join to a parent / current directory is
+		// returned as "" so the caller falls back to a generated name.
+		{"..", ""},
+		{".", ""},
+		{"", ""},
+		{"../", ""},
+		{`..\`, ""},
+		{"./../foo", "foo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := sanitizeAttachmentFileName(tt.in)
+			if got != tt.want {
+				t.Errorf("sanitizeAttachmentFileName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSaveFilesToDisk_RejectsPathTraversal is a regression test for a real
+// path-traversal vulnerability in SaveFilesToDisk: the attachment FileName
+// (which comes from user-controlled IM/HTTP upload metadata) was passed
+// directly to filepath.Join, so an attacker uploading a file named
+// "../../escape.txt" wrote outside the intended attachments directory into
+// the agent's workDir / above. The fix sanitizes FileName to a basename;
+// this test asserts every file lands inside attachDir, with no escapees.
+func TestSaveFilesToDisk_RejectsPathTraversal(t *testing.T) {
+	workDir := t.TempDir()
+	attachDir := filepath.Join(workDir, ".cc-connect", "attachments")
+
+	files := []FileAttachment{
+		// The original repro: walks two levels up out of attachments and
+		// out of .cc-connect/, landing directly in workDir.
+		{FileName: "../../escape.txt", Data: []byte("payload")},
+		// Three levels up — would land in workDir's parent without the fix.
+		{FileName: "../../../way-up.txt", Data: []byte("payload")},
+		// Windows-style separators must also be stripped on Linux so a
+		// cross-platform attacker can't bypass the basename guard.
+		{FileName: `..\..\winescape.txt`, Data: []byte("payload")},
+		// Subdirectory in the name — file should land in attachDir, not in
+		// a created subdir, since we strip directory components.
+		{FileName: "subdir/inner.txt", Data: []byte("payload")},
+		// Plain name should still work normally.
+		{FileName: "ok.txt", Data: []byte("payload")},
+		// A name that sanitizes to empty should fall back to a generated
+		// name in attachDir, not crash and not escape.
+		{FileName: "..", Data: []byte("payload")},
+	}
+
+	paths := SaveFilesToDisk(workDir, files)
+
+	// Every returned path must live inside attachDir.
+	for _, p := range paths {
+		if !strings.HasPrefix(p, attachDir+string(filepath.Separator)) {
+			t.Errorf("SaveFilesToDisk wrote outside attachments dir: %q (attachDir=%q)", p, attachDir)
+		}
+	}
+
+	// Walk the workDir tree and confirm no file landed above attachDir.
+	if err := filepath.Walk(workDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		if !strings.HasPrefix(path, attachDir+string(filepath.Separator)) {
+			t.Errorf("found stray attachment outside attachments dir: %q", path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// Sanity: at minimum the legitimate "ok.txt" must have been written.
+	okPath := filepath.Join(attachDir, "ok.txt")
+	if _, err := os.Stat(okPath); err != nil {
+		t.Errorf("legitimate ok.txt not saved: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`core.SaveFilesToDisk` takes the user-supplied `FileAttachment.FileName` and joins it directly into `workDir/.cc-connect/attachments/`:

```go
fpath := filepath.Join(attachDir, f.FileName)
os.WriteFile(fpath, f.Data, 0o644)
```

`FileName` originates from IM / HTTP upload metadata — Telegram document filenames, Slack `file_share`, Feishu file events, etc. — and is fully attacker-controlled. `filepath.Join` collapses `..` segments, so an upload whose filename contains `../` writes outside the attachments directory.

### Reproducer

```go
workDir := t.TempDir()
SaveFilesToDisk(workDir, []FileAttachment{
    {FileName: \"../../escape.txt\",       Data: []byte(\"x\")},  //  -> workDir/escape.txt
    {FileName: \"../../../way-up.txt\",     Data: []byte(\"x\")},  //  -> parent of workDir
    {FileName: `..\\..\\winescape.txt`,    Data: []byte(\"x\")},  //  -> workDir on Windows
})
```

`escape.txt` lands two levels above the intended attachments directory; `way-up.txt` lands above `workDir` entirely.

## Fix

Add a single `sanitizeAttachmentFileName` helper, called once before the join. It:

1. Normalizes `\\` to `/` so `filepath.Base` strips Windows-style separators on Linux too (an attacker doesn't get a free pass just because cc-connect runs on Linux).
2. Takes `filepath.Base` to drop directory components.
3. Rejects the `\"\"`, `\".\"`, `\"..\"` results — they would still join to attachDir or its parent — so the existing empty-name fallback kicks in and a generated `file_<ts>_<i>` name is used instead.

After the fix:

| Input | Old output | New output |
|---|---|---|
| `image.png` | attachments/image.png | attachments/image.png |
| `subdir/file.txt` | attachments/subdir/file.txt (mkdir not done → write fails silently) | attachments/file.txt |
| `../../escape.txt` | **workDir/escape.txt** (escapes!) | attachments/escape.txt |
| `../../../way-up.txt` | **parent of workDir/way-up.txt** (escapes!) | attachments/way-up.txt |
| `..\\..\\winescape.txt` | **workDir/winescape.txt** on Windows | attachments/winescape.txt |
| `..` | attempts to overwrite `attachments/..` | falls back to `file_<ts>_<i>` |

All eight call sites — `agent/{claudecode,codex,cursor,iflow,opencode,qoder,acp,pi}/session.go` — go through this central function and inherit the fix; no per-agent change needed.

## Test plan

- [x] New `core/message_test.go` covers:
  - 12 `sanitizeAttachmentFileName` unit cases including the four traversal vectors, Windows-style paths, `..` / `.` / `\"\"` edge cases.
  - `TestSaveFilesToDisk_RejectsPathTraversal` is a real end-to-end repro: walks the `workDir` tree afterwards and asserts no file landed outside `attachDir`, plus that the legitimate `ok.txt` was still written.
- [x] **Verified regression-catching**: temporarily reverting the live call back to `fname := f.FileName` (sanitization off) makes the integration test fail with the exact escape symptoms — `escape.txt` and `way-up.txt` landing outside `attachDir`. Restoring the sanitization makes it green.
- [x] `go vet -tags=no_web ./core/...` clean
- [x] `go build -tags=no_web ./...` succeeds
- [x] `go test -tags=no_web ./core/ -run \"TestSanitize|TestSaveFilesToDisk\"` all pass