### PR TITLE
fix(pi): sanitize attachment FileName to prevent path traversal in saveImagesToDisk

### DIFF
--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -363,6 +363,81 @@ func TestSaveImagesToDisk_Empty(t *testing.T) {
 	}
 }
 
+// TestSaveImagesToDisk_RejectsPathTraversal is a regression test for a path
+// traversal vulnerability in saveImagesToDisk: the user-supplied
+// ImageAttachment.FileName (sourced from IM upload metadata) was passed
+// directly to filepath.Join, so a malicious uploader could escape the
+// attachments directory by using `../` segments. This mirrors the same
+// issue and fix in core.SaveFilesToDisk.
+func TestSaveImagesToDisk_RejectsPathTraversal(t *testing.T) {
+	workDir := t.TempDir()
+	attachDir := filepath.Join(workDir, ".cc-connect", "attachments")
+
+	images := []core.ImageAttachment{
+		// Two levels up — escapes attachments/ and .cc-connect/.
+		{MimeType: "image/png", Data: []byte("payload"), FileName: "../../escape.png"},
+		// Three levels up — would land outside workDir entirely.
+		{MimeType: "image/png", Data: []byte("payload"), FileName: "../../../way-up.png"},
+		// Windows-style separators must also be stripped on Linux.
+		{MimeType: "image/png", Data: []byte("payload"), FileName: `..\..\winescape.png`},
+		// Plain name still works.
+		{MimeType: "image/png", Data: []byte("payload"), FileName: "ok.png"},
+		// "." sanitizes to empty so the generated-name fallback kicks in,
+		// not a write to the attachments directory itself.
+		{MimeType: "image/png", Data: []byte("payload"), FileName: "."},
+	}
+
+	paths := saveImagesToDisk(workDir, images)
+
+	// Every returned path must live inside attachDir.
+	for _, p := range paths {
+		if !strings.HasPrefix(p, attachDir+string(filepath.Separator)) {
+			t.Errorf("saveImagesToDisk wrote outside attachments dir: %q (attachDir=%q)", p, attachDir)
+		}
+	}
+
+	// Walk workDir and assert no file exists outside attachDir.
+	if err := filepath.Walk(workDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		if !strings.HasPrefix(path, attachDir+string(filepath.Separator)) {
+			t.Errorf("found stray attachment outside attachments dir: %q", path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// Sanity: legitimate "ok.png" must still have been saved.
+	if _, err := os.Stat(filepath.Join(attachDir, "ok.png")); err != nil {
+		t.Errorf("legitimate ok.png not saved: %v", err)
+	}
+}
+
+func TestSanitizePiAttachmentName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"image.png", "image.png"},
+		{"subdir/file.png", "file.png"},
+		{"../../escape.png", "escape.png"},
+		{`..\..\winescape.png`, "winescape.png"},
+		{"/etc/passwd", "passwd"},
+		{"..", ""},
+		{".", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := sanitizePiAttachmentName(tt.in)
+			if got != tt.want {
+				t.Errorf("sanitizePiAttachmentName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 // ── cleanAttachments ─────────────────────────────────────────
 
 func TestCleanAttachments(t *testing.T) {

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -421,6 +421,12 @@ func cleanAttachments(workDir string) {
 
 // saveImagesToDisk saves image attachments to workDir/.cc-connect/attachments/
 // and returns the list of absolute file paths.
+//
+// img.FileName originates from IM upload metadata and is treated as
+// untrusted: directory components are stripped (both `/` and `\`, the
+// latter so Linux strips Windows-style paths too) before joining into
+// attachDir. Without this, FileName="../../escape.png" wrote to
+// workDir/escape.png — outside the intended attachments directory.
 func saveImagesToDisk(workDir string, images []core.ImageAttachment) []string {
 	attachDir := filepath.Join(workDir, ".cc-connect", "attachments")
 	if err := os.MkdirAll(attachDir, 0o755); err != nil {
@@ -439,7 +445,7 @@ func saveImagesToDisk(workDir string, images []core.ImageAttachment) []string {
 		case "image/webp":
 			ext = ".webp"
 		}
-		fname := img.FileName
+		fname := sanitizePiAttachmentName(img.FileName)
 		if fname == "" {
 			fname = fmt.Sprintf("image_%d_%d%s", time.Now().UnixMilli(), i, ext)
 		}
@@ -451,6 +457,21 @@ func saveImagesToDisk(workDir string, images []core.ImageAttachment) []string {
 		paths = append(paths, fpath)
 	}
 	return paths
+}
+
+// sanitizePiAttachmentName reduces a user-supplied attachment filename to a
+// safe basename for joining into an attachment directory. Strips directory
+// components (handling both `/` and `\` so an attacker can't bypass via
+// Windows-style separators on Linux), and rejects parent / current-directory
+// references so the caller's empty-name fallback can substitute a generated
+// name. Mirrors core.SaveFilesToDisk's sanitization.
+func sanitizePiAttachmentName(name string) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	name = filepath.Base(name)
+	if name == "" || name == "." || name == ".." {
+		return ""
+	}
+	return name
 }
 
 func truncStr(s string, maxRunes int) string {


### PR DESCRIPTION
## Summary

`agent/pi/saveImagesToDisk` has the same path-traversal pattern that PR #918 fixed in `core.SaveFilesToDisk`, just on a different code path (pi's image-attachment writer). The attacker-controlled `ImageAttachment.FileName` (sourced from IM upload metadata) flows straight into `filepath.Join`:

```go
fname := img.FileName
if fname == "" { fname = \"image_<ts>_<i>.png\" }
fpath := filepath.Join(attachDir, fname)
os.WriteFile(fpath, img.Data, 0o644)
```

`filepath.Join` collapses `..` segments, so an upload whose filename contains `../` writes outside the attachments directory.

### Reproducer (against the real `saveImagesToDisk`)

```go
imgs := []core.ImageAttachment{
    {MimeType: \"image/png\", Data: ..., FileName: \"../../escape.png\"},
    {MimeType: \"image/png\", Data: ..., FileName: \"../../../way-up.png\"},
    {MimeType: \"image/png\", Data: ..., FileName: `..\\..\\winescape.png`},
}
```

| Filename | Where it actually lands | Where it should land |
|---|---|---|
| `../../escape.png` | **workDir/escape.png** (escapes!) | attachments/escape.png |
| `../../../way-up.png` | **parent of workDir/way-up.png** (escapes!) | attachments/way-up.png |
| `..\\..\\winescape.png` | **workDir/winescape.png** on Windows | attachments/winescape.png |

## Fix

Mirror the same sanitization as `core.SaveFilesToDisk` (PR #918): a tiny `sanitizePiAttachmentName` helper that:

1. Normalizes `\\` to `/` so `filepath.Base` strips Windows-style separators on Linux.
2. Takes `filepath.Base` to drop directory components.
3. Rejects the resulting `\"\"`, `\".\"`, `\"..\"` values so the existing empty-name fallback substitutes a generated `image_<ts>_<i>.<ext>`.

The two PRs are independent — they touch different files. This one stands alone if #918 hasn't merged yet.

## Test plan

- [x] `TestSaveImagesToDisk_RejectsPathTraversal` is an end-to-end repro: walks `workDir` afterwards and asserts no file landed outside `attachDir`, plus that the legitimate `ok.png` was still saved.
- [x] `TestSanitizePiAttachmentName` covers 8 unit cases including Windows-style paths and the `..` / `.` / `\"\"` edge cases.
- [x] **Verified regression-catching**: temporarily reverting the live call back to `fname := img.FileName` makes `TestSaveImagesToDisk_RejectsPathTraversal` fail with the exact escape symptoms (`escape.png` and `way-up.png` landing outside `attachDir`). Restoring the sanitization makes it green.
- [x] All pre-existing pi tests still pass.
- [x] `go vet -tags=no_web ./...` clean
- [x] `go build -tags=no_web ./...` succeeds