### PR TITLE
fix(core/i18n): protect lang/detected fields with mutex to fix data race

### DIFF
--- a/core/i18n.go
+++ b/core/i18n.go
@@ -1,6 +1,9 @@
 package core
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // Language represents a supported language
 type Language string
@@ -14,8 +17,15 @@ const (
 	LangSpanish            Language = "es"
 )
 
-// I18n provides internationalized messages
+// I18n provides internationalized messages.
+//
+// All exported methods are safe to call from multiple goroutines: cc-connect
+// fans out platform message handlers concurrently, all of which can call
+// DetectAndSet (writes `detected`) and T / CurrentLang (read `lang`/`detected`)
+// at the same time. Without the mutex `go test -race` flags real data races
+// on the language fields.
 type I18n struct {
+	mu       sync.RWMutex
 	lang     Language
 	detected Language
 	saveFunc func(Language) error
@@ -26,6 +36,8 @@ func NewI18n(lang Language) *I18n {
 }
 
 func (i *I18n) SetSaveFunc(fn func(Language) error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	i.saveFunc = fn
 }
 
@@ -76,21 +88,41 @@ func isSpanishHint(text string) bool {
 }
 
 func (i *I18n) DetectAndSet(text string) {
+	i.mu.RLock()
 	if i.lang != LangAuto {
+		i.mu.RUnlock()
 		return
 	}
+	currentDetected := i.detected
+	i.mu.RUnlock()
+
 	detected := DetectLanguage(text)
-	if i.detected != detected {
-		i.detected = detected
-		if i.saveFunc != nil {
-			if err := i.saveFunc(detected); err != nil {
-				fmt.Printf("failed to save language: %v\n", err)
-			}
+	if currentDetected == detected {
+		return
+	}
+
+	i.mu.Lock()
+	// Re-check under the write lock — another goroutine may have updated
+	// i.detected between our RUnlock above and the Lock here.
+	if i.lang != LangAuto || i.detected == detected {
+		i.mu.Unlock()
+		return
+	}
+	i.detected = detected
+	saveFunc := i.saveFunc
+	i.mu.Unlock()
+
+	if saveFunc != nil {
+		if err := saveFunc(detected); err != nil {
+			fmt.Printf("failed to save language: %v\n", err)
 		}
 	}
 }
 
 func (i *I18n) currentLang() Language {
+	// Caller holds either no lock (most public methods take RLock and call
+	// this) or RLock; this helper just reads the protected fields. All
+	// public methods that call currentLang() acquire i.mu.RLock first.
 	if i.lang == LangAuto {
 		if i.detected != "" {
 			return i.detected
@@ -101,16 +133,24 @@ func (i *I18n) currentLang() Language {
 }
 
 // CurrentLang returns the resolved language (exported for mode display).
-func (i *I18n) CurrentLang() Language { return i.currentLang() }
+func (i *I18n) CurrentLang() Language {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.currentLang()
+}
 
 // IsZhLike returns true for Simplified and Traditional Chinese.
 func (i *I18n) IsZhLike() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
 	l := i.currentLang()
 	return l == LangChinese || l == LangTraditionalChinese
 }
 
 // SetLang overrides the language (disabling auto-detect).
 func (i *I18n) SetLang(lang Language) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	i.lang = lang
 	i.detected = ""
 }
@@ -3898,7 +3938,9 @@ var messages = map[MsgKey]map[Language]string{
 }
 
 func (i *I18n) T(key MsgKey) string {
+	i.mu.RLock()
 	lang := i.currentLang()
+	i.mu.RUnlock()
 	if msg, ok := messages[key]; ok {
 		if translated, ok := msg[lang]; ok {
 			return translated

--- a/core/i18n_test.go
+++ b/core/i18n_test.go
@@ -1,6 +1,9 @@
 package core
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestI18n_DefaultLanguage(t *testing.T) {
 	i := NewI18n(LangEnglish)
@@ -102,6 +105,45 @@ func TestIsChinese(t *testing.T) {
 	if isChinese('ア') {
 		t.Error("Japanese katakana 'ア' should not be Chinese")
 	}
+}
+
+// TestI18n_ConcurrentAccess is a regression test for a real data race on
+// I18n's lang/detected fields. cc-connect fans out platform message
+// handlers concurrently; each one calls DetectAndSet (writes detected),
+// while typing/reply paths call T / CurrentLang concurrently (read
+// lang/detected). Without a mutex `go test -race` flagged real races on
+// these fields. This test exercises the same access pattern under -race
+// so a future edit that drops the mutex breaks loudly instead of
+// silently re-introducing the race.
+func TestI18n_ConcurrentAccess(t *testing.T) {
+	i := NewI18n(LangAuto)
+	i.SetSaveFunc(func(Language) error { return nil })
+
+	const goroutines = 16
+	const iterations = 200
+
+	texts := []string{"hello world", "你好世界", "こんにちは", "¡Hola amigo!"}
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for n := 0; n < iterations; n++ {
+				switch (g + n) % 4 {
+				case 0:
+					i.DetectAndSet(texts[n%len(texts)])
+				case 1:
+					_ = i.T(MsgStarting)
+				case 2:
+					_ = i.CurrentLang()
+				case 3:
+					_ = i.IsZhLike()
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
 }
 
 func TestIsJapanese(t *testing.T) {


### PR DESCRIPTION
## Summary

`I18n` had no synchronization on its mutable state (`lang`, `detected`, `saveFunc`), but the type is shared across every concurrent platform message handler in the engine:

| Method | Field access | Caller |
|---|---|---|
| `DetectAndSet` | **writes** `i.detected` | `processInteractiveMessageWith` + queued-message dequeue (3 sites in `core/engine.go`) |
| `T` / `CurrentLang` / `IsZhLike` | **reads** `i.lang`, `i.detected` | dozens of reply / footer / error / mode-display paths |
| `SetLang` | **writes** both | management API |

Two messages arriving simultaneously from different platforms means two unsynchronized writes to the same `detected` field, and the read paths run alongside.

## Reproducer

```go
func TestI18n_DetectAndSet_Race(t *testing.T) {
    i := NewI18n(LangAuto)
    var wg sync.WaitGroup
    for n := 0; n < 100; n++ {
        wg.Add(2)
        go func() { defer wg.Done(); i.DetectAndSet(\"hello world\") }()
        go func() { defer wg.Done(); i.DetectAndSet(\"你好世界\") }()
    }
    wg.Wait()
}
```

`go test -race` flags:

```
WARNING: DATA RACE
Read at 0x...: core.(*I18n).DetectAndSet
Previous write at 0x...: core.(*I18n).DetectAndSet
...
testing.go:1617: race detected during execution of test
```

## Fix

Add `sync.RWMutex` to `I18n`. Lock policy:

- `DetectAndSet` uses an RLock fast-path so the common case (lang already detected and unchanged) is read-only. Only the mutating branch takes the write lock, and re-checks under it to avoid losing a concurrent update.
- `T` / `CurrentLang` / `IsZhLike` take `RLock` for the duration of the read.
- `SetLang` / `SetSaveFunc` take the write lock.
- `currentLang` stays unexported and assumes the caller holds a lock; every public caller now does.

## Test plan

- [x] New `TestI18n_ConcurrentAccess`: 16 goroutines × 200 iterations fanning `DetectAndSet` / `T` / `CurrentLang` / `IsZhLike` across four input languages (English / Chinese / Japanese / Spanish).
- [x] **Verified regression-catching**: `git stash` of just `core/i18n.go` (keeping the test) and re-running under `-race` reproduces `race detected during execution of test` on main. Restoring the fix makes it green.
- [x] All pre-existing `TestI18n_*` and `TestDetectLanguage` / `TestIsChinese` / `TestIsJapanese` tests still pass.
- [x] `go vet -tags=no_web ./core/...` clean
- [x] `go build -tags=no_web ./...` succeeds
- [x] Confirmed unrelated pre-existing failures in `core/` race run (`TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled` cosmetic footer string, `TestResolveLocalDirPath_AcceptsSubdir` macOS `/private/var` symlink) reproduce on `main` without this change.