### PR TITLE
fix(core): dir card and status card show wrong workDir in multi-workspace mode

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -6219,7 +6219,7 @@ func (e *Engine) dirApply(agent Agent, sessions *SessionManager, interactiveKey,
 }
 
 func (e *Engine) cmdDir(p Platform, msg *Message, args []string) {
-	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	agent, sessions, interactiveKey, _, err := e.commandContextWithWorkspace(p, msg)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
 		return
@@ -6230,7 +6230,7 @@ func (e *Engine) cmdDir(p Platform, msg *Message, args []string) {
 		return
 	}
 
-	currentDir := switcher.GetWorkDir()
+	currentDir := e.resolveCurrentWorkDir(msg.SessionKey, switcher)
 
 	if len(args) == 0 {
 		if supportsCards(p) {
@@ -6871,8 +6871,8 @@ func (e *Engine) renderStatusCard(sessionKey string, userID string) *Card {
 	}
 
 	workDirStr := ""
-	if wd, ok := agent.(interface{ GetWorkDir() string }); ok {
-		workDirStr = strings.TrimSpace(wd.GetWorkDir())
+	if wd, ok := agent.(WorkDirSwitcher); ok {
+		workDirStr = strings.TrimSpace(e.resolveCurrentWorkDir(sessionKey, wd))
 	}
 	if workDirStr == "" {
 		workDirStr, _ = os.Getwd()
@@ -10363,7 +10363,7 @@ func (e *Engine) renderDirCard(sessionKey string, page int) (*Card, error) {
 	if !ok {
 		return nil, fmt.Errorf("%s", e.i18n.T(MsgDirNotSupported))
 	}
-	currentDir := switcher.GetWorkDir()
+	currentDir := e.resolveCurrentWorkDir(sessionKey, switcher)
 	var history []string
 	if e.dirHistory != nil {
 		history = e.dirHistory.List(e.name)
@@ -13130,6 +13130,27 @@ func (e *Engine) commandContextWithWorkspace(p Platform, msg *Message) (Agent, *
 		return nil, nil, "", "", err
 	}
 	return agent, sessions, interactiveKey, effectiveDir, nil
+}
+
+// resolveCurrentWorkDir returns the effective current working directory for a
+// session, checking projectState dir overrides in multi-workspace mode. This
+// is needed because dirApply stores overrides in projectState without updating
+// the agent's workDir in multi-workspace mode.
+func (e *Engine) resolveCurrentWorkDir(sessionKey string, switcher WorkDirSwitcher) string {
+	if e.multiWorkspace && e.projectState != nil {
+		if channelKey := extractWorkspaceChannelKey(sessionKey); channelKey != "" {
+			if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
+				workspace := normalizeWorkspacePath(b.Workspace)
+				interactiveKey := workspace + ":" + sessionKey
+				if override := e.projectState.WorkspaceDirOverride(interactiveKey); override != "" {
+					if info, err := os.Stat(override); err == nil && info.IsDir() {
+						return override
+					}
+				}
+			}
+		}
+	}
+	return switcher.GetWorkDir()
 }
 
 // sessionContextForKey resolves the agent and session manager for a sessionKey.

--- a/core/engine.go
+++ b/core/engine.go
@@ -13140,7 +13140,10 @@ func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager
 	}
 	if channelKey := extractWorkspaceChannelKey(sessionKey); channelKey != "" {
 		if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
-			if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(normalizeWorkspacePath(b.Workspace)); err == nil {
+			workspace := normalizeWorkspacePath(b.Workspace)
+			interactiveKey := workspace + ":" + sessionKey
+			effectiveDir := e.resolveChannelWorkDir(workspace, interactiveKey)
+			if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(effectiveDir); err == nil {
 				return wsAgent, wsSessions
 			}
 		}


### PR DESCRIPTION
## Problem

In multi-workspace mode, `/dir` successfully switches the working directory (confirmed via `/shell pwd`), but:

1. The Feishu interactive card highlights the original workspace init path instead of the currently active one
2. The displayed "current working directory" in both the `/dir` text output and card shows the initial workspace path, not the `/dir` override
3. The `/status` card also displays the wrong working directory

## Root Cause

Two separate issues:

**Issue 1**: `sessionContextForKey` resolves the workspace agent using the binding's original path without checking `projectState` dir overrides. `renderDirCard` calls `sessionContextForKey` → `GetWorkDir()`, which returns the init path instead of the `/dir` override.

**Issue 2**: `dirApply` stores overrides in `projectState` without updating the agent's `workDir` in multi-workspace mode (by design — the agent is shared). But `renderDirCard`, `renderStatusCard`, and `cmdDir` all used `switcher.GetWorkDir()` directly, which always returns the initial workspace path.

## Fix

1. Apply `resolveChannelWorkDir` in `sessionContextForKey` before `getOrCreateWorkspaceAgent`, matching the same pattern used by `workspaceContext`
2. Add `resolveCurrentWorkDir` helper that checks `projectState` for workspace dir overrides before falling back to the agent's `workDir`
3. Use the helper in `renderDirCard`, `renderStatusCard`, and `cmdDir`

## Changes

- `core/engine.go`:
  - `sessionContextForKey`: add `resolveChannelWorkDir` call before `getOrCreateWorkspaceAgent`
  - Add `resolveCurrentWorkDir(sessionKey, switcher)` helper
  - `renderDirCard`: use `resolveCurrentWorkDir` for display and highlight
  - `renderStatusCard`: use `resolveCurrentWorkDir` for workDir display
  - `cmdDir`: use `resolveCurrentWorkDir` for text output

## Test plan

- [x] `go test ./core/ -count=1` — no new failures
- [x] `/dir <path>` in multi-workspace mode → card correctly highlights the new directory
- [x] `/dir` text output shows the correct current directory
- [x] `/status` card shows the correct working directory
- [x] Without override → behavior unchanged