### PR TITLE
fix: show native session title in current session

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -6430,21 +6430,50 @@ func (e *Engine) cmdName(p Platform, msg *Message, args []string) {
 
 func (e *Engine) cmdCurrent(p Platform, msg *Message) {
 	if !supportsCards(p) {
-		_, sessions, _, err := e.commandContext(p, msg)
+		agent, sessions, _, err := e.commandContext(p, msg)
 		if err != nil {
 			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
 			return
 		}
 		s := sessions.GetOrCreateActive(msg.SessionKey)
 		agentID := s.GetAgentSessionID()
+		displayName := e.currentSessionDisplayName(agent, sessions, s)
 		if agentID == "" {
 			agentID = e.i18n.T(MsgSessionNotStarted)
 		}
-		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCurrentSession), s.Name, agentID, len(s.History)))
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCurrentSession), displayName, agentID, len(s.History)))
 		return
 	}
 
 	e.replyWithCard(p, msg.ReplyCtx, e.renderCurrentCard(msg.SessionKey))
+}
+
+func (e *Engine) currentSessionDisplayName(agent Agent, sessions *SessionManager, s *Session) string {
+	agentID := s.GetAgentSessionID()
+	if agentID != "" {
+		if name := sessions.GetSessionName(agentID); name != "" {
+			return name
+		}
+		if agent != nil {
+			agentSessions, err := agent.ListSessions(e.ctx)
+			if err == nil {
+				for _, info := range e.applySessionFilter(agentSessions, sessions) {
+					if info.ID == agentID {
+						if summary := compactSessionDisplayName(info.Summary); summary != "" {
+							return summary
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+	return s.GetName()
+}
+
+func compactSessionDisplayName(name string) string {
+	name = strings.ReplaceAll(name, "\n", " ")
+	return strings.Join(strings.Fields(name), " ")
 }
 
 func (e *Engine) cmdStatus(p Platform, msg *Message) {
@@ -10440,13 +10469,14 @@ func (e *Engine) renderDirCard(sessionKey string, page int) (*Card, error) {
 // ──────────────────────────────────────────────────────────────
 
 func (e *Engine) renderCurrentCard(sessionKey string) *Card {
-	_, sessions := e.sessionContextForKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(sessionKey)
 	s := sessions.GetOrCreateActive(sessionKey)
 	agentID := s.GetAgentSessionID()
+	displayName := e.currentSessionDisplayName(agent, sessions, s)
 	if agentID == "" {
 		agentID = e.i18n.T(MsgSessionNotStarted)
 	}
-	content := fmt.Sprintf(e.i18n.T(MsgCurrentSession), s.Name, agentID, len(s.History))
+	content := fmt.Sprintf(e.i18n.T(MsgCurrentSession), displayName, agentID, len(s.History))
 	return NewCard().
 		Title(e.i18n.T(MsgCardTitleCurrentSession), "turquoise").
 		Markdown(content).

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3060,6 +3060,89 @@ func TestCmdCurrent_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	}
 }
 
+func TestCmdCurrent_UsesNativeSummaryForCurrentAgentSession(t *testing.T) {
+	nativeSessions := []AgentSessionInfo{
+		{ID: "agent-current", Summary: "Native generated title", MessageCount: 4, ModifiedAt: time.Now()},
+		{ID: "agent-other", Summary: "Other title", MessageCount: 2, ModifiedAt: time.Now()},
+	}
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubListAgent{sessions: nativeSessions}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	session := e.sessions.GetOrCreateActive(msg.SessionKey)
+	session.Name = "latest user message"
+	session.SetAgentSessionID("agent-current", "codex")
+	session.AddHistory("user", "latest user message")
+
+	e.cmdCurrent(p, msg)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "Name: Native generated title") {
+		t.Fatalf("/current = %q, want native summary display name", p.sent[0])
+	}
+	if strings.Contains(p.sent[0], "Name: latest user message") {
+		t.Fatalf("/current = %q, should not use local Session.Name when native summary exists", p.sent[0])
+	}
+
+	p.sent = nil
+	e.cmdList(p, msg, nil)
+	if len(p.sent) != 1 {
+		t.Fatalf("list sent messages = %d, want 1", len(p.sent))
+	}
+	if got := strings.Count(p.sent[0], "msgs"); got != len(nativeSessions) {
+		t.Fatalf("/list item count = %d, want %d\n%s", got, len(nativeSessions), p.sent[0])
+	}
+}
+
+func TestCmdCurrent_CustomNameOverridesNativeSummary(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubListAgent{sessions: []AgentSessionInfo{
+		{ID: "agent-current", Summary: "Native generated title", MessageCount: 4, ModifiedAt: time.Now()},
+	}}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	session := e.sessions.GetOrCreateActive(msg.SessionKey)
+	session.Name = "latest user message"
+	session.SetAgentSessionID("agent-current", "codex")
+	e.sessions.SetSessionName("agent-current", "Pinned custom name")
+
+	e.cmdCurrent(p, msg)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "Name: Pinned custom name") {
+		t.Fatalf("/current = %q, want custom session name", p.sent[0])
+	}
+	if strings.Contains(p.sent[0], "Native generated title") {
+		t.Fatalf("/current = %q, custom name should override native summary", p.sent[0])
+	}
+}
+
+func TestRenderCurrentCard_UsesNativeSummaryForCurrentAgentSession(t *testing.T) {
+	p := &stubCardPlatform{stubPlatformEngine: stubPlatformEngine{n: "card"}}
+	e := NewEngine("test", &stubListAgent{sessions: []AgentSessionInfo{
+		{ID: "agent-current", Summary: "Native card title", MessageCount: 4, ModifiedAt: time.Now()},
+	}}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	session := e.sessions.GetOrCreateActive(msg.SessionKey)
+	session.Name = "latest user message"
+	session.SetAgentSessionID("agent-current", "codex")
+
+	e.cmdCurrent(p, msg)
+
+	if len(p.repliedCards) != 1 {
+		t.Fatalf("replied cards = %d, want 1", len(p.repliedCards))
+	}
+	text := p.repliedCards[0].RenderText()
+	if !strings.Contains(text, "Name: Native card title") {
+		t.Fatalf("current card = %q, want native summary display name", text)
+	}
+	if strings.Contains(text, "Name: latest user message") {
+		t.Fatalf("current card = %q, should not use local Session.Name when native summary exists", text)
+	}
+}
+
 func TestCmdDelete_BatchCommaList(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	agent := &stubDeleteAgent{stubListAgent: stubListAgent{sessions: []AgentSessionInfo{


### PR DESCRIPTION
## Summary

Fix `/current` so it shows the same user-facing session title source as `/list` for the active native agent session.

Previously, `/current` used the local `Session.Name` directly. In some flows, that local name could be the latest user message or an internal generated name, while `/list` showed the native agent session summary or a custom `/name`.

This change makes `/current` and the current-session card prefer:

1. Custom `/name` stored for the active agent session ID
2. Native agent session `Summary` from `agent.ListSessions()`
3. Local `Session.Name` as a fallback

## Scope

This intentionally does not change the Web session list source.

It also does not change:

- `/list` cardinality
- `/switch` matching
- Web console session listing/detail behavior

## Tests

```bash
go test ./core -run TestCmdCurrent|TestRenderCurrentCard|TestCmdList_
go test ./agent/codex ./agent/gemini
```

## Acknowledgement

Development and debugging were assisted by OpenAI Codex/GPT.