### PR TITLE
fix(cron): expand /skill slash prompts via skill registry

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1103,12 +1103,23 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		return e.executeCronShell(effectivePlatform, replyCtx, job)
 	}
 
+	content := job.Prompt
+	if strings.HasPrefix(content, "/") {
+		parts := strings.Fields(content)
+		if len(parts) > 0 {
+			cmd := strings.ToLower(strings.TrimPrefix(parts[0], "/"))
+			if skill := e.skills.Resolve(cmd); skill != nil {
+				content = BuildSkillInvocationPrompt(skill, parts[1:])
+			}
+		}
+	}
+
 	msg := &Message{
 		SessionKey:   sessionKey,
 		Platform:     platformName,
 		UserID:       "cron",
 		UserName:     "cron",
-		Content:      job.Prompt,
+		Content:      content,
 		ReplyCtx:     replyCtx,
 		ModeOverride: job.Mode,
 	}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -10766,6 +10766,91 @@ func TestExecuteCronJob_WorkspacePrefixedSessionKey(t *testing.T) {
 	}
 }
 
+func TestExecuteCronJob_ExpandsSlashSkillPrompt(t *testing.T) {
+	tests := []struct {
+		name          string
+		prompt        string
+		wantContains  []string
+		wantNotExpand bool // true = expected to be passed through literally
+	}{
+		{
+			name:         "registered skill expands with args",
+			prompt:       "/daily-brief today",
+			wantContains: []string{"## Skill:", "daily-brief", "Prompt body", "today"},
+		},
+		{
+			name:         "registered skill expands with no args",
+			prompt:       "/daily-brief",
+			wantContains: []string{"## Skill:", "daily-brief", "Prompt body"},
+		},
+		{
+			name:          "unknown slash command passes through literally",
+			prompt:        "/no-such-skill arg",
+			wantContains:  []string{"/no-such-skill arg"},
+			wantNotExpand: true,
+		},
+		{
+			name:          "non-slash prompt passes through unchanged",
+			prompt:        "summarize today's activity",
+			wantContains:  []string{"summarize today's activity"},
+			wantNotExpand: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skillRoot := t.TempDir()
+			writeSkillFile(t, filepath.Join(skillRoot, "daily-brief", "SKILL.md"), "Daily brief skill")
+
+			dir := t.TempDir()
+			store, err := NewCronStore(dir)
+			if err != nil {
+				t.Fatalf("NewCronStore() error = %v", err)
+			}
+
+			platform := &stubCronReplyTargetPlatform{
+				stubPlatformEngine: stubPlatformEngine{n: "discord"},
+			}
+			agentSession := newResultAgentSession("ok")
+			agent := &resultAgent{session: agentSession}
+
+			e := NewEngine("test", agent, []Platform{platform}, "", LangEnglish)
+			defer e.cancel()
+			e.skills.SetDirs([]string{skillRoot})
+
+			job := &CronJob{
+				ID:         "job-skill",
+				SessionKey: "discord:channel-1:user-1",
+				Prompt:     tt.prompt,
+			}
+			if err := store.Add(job); err != nil {
+				t.Fatalf("store.Add() error = %v", err)
+			}
+
+			if err := e.ExecuteCronJob(job); err != nil {
+				t.Fatalf("ExecuteCronJob() error = %v", err)
+			}
+
+			if len(agentSession.sentPrompts) != 1 {
+				t.Fatalf("sentPrompts = %d, want 1: %#v", len(agentSession.sentPrompts), agentSession.sentPrompts)
+			}
+			got := agentSession.sentPrompts[0]
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("agent prompt does not contain %q\ngot: %s", want, got)
+				}
+			}
+			if tt.wantNotExpand && strings.Contains(got, "## Skill Instructions:") {
+				t.Errorf("expected raw passthrough, but prompt was skill-expanded\ngot: %s", got)
+			}
+			// Stored prompt must not be rewritten on the job itself.
+			if job.Prompt != tt.prompt {
+				t.Errorf("job.Prompt = %q, want %q (unchanged)", job.Prompt, tt.prompt)
+			}
+		})
+	}
+}
+
 func TestExtractSessionKeyParts(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

A cron job configured with a slash-prefixed prompt like `/daily-brief today` was sent to the agent as literal text — the skill's prompt body was never resolved, so scheduled jobs could not reuse the same skills as chat-triggered invocations.

This change makes ` Engine.ExecuteCronJob` mirror the interactive command path: when `job.Prompt` starts with `/`, look up the leading token in the engine skill registry and, if found, replace the message content with `BuildSkillInvocationPrompt(skill, args)`. Unknown slash commands and non-slash prompts pass through unchanged.

Fixes #856.

## What changed

- `core/engine.go` — Resolve `/skill` slash prompts through `e.skills.Resolve` before constructing the cron `Message`. Only the message body sent to the agent is rewritten; `job.Prompt` itself is left untouched so the cron run notice and listing keep showing what the user configured.
- `core/engine_test.go` — New table-driven test `TestExecuteCronJob_ExpandsSlashSkillPrompt` covering four cases:
  1. registered skill expands with args
  2. registered skill expands with no args
  3. unknown slash command passes through literally
  4. non-slash prompt passes through unchanged

The patch is ~10 lines plus the new test, scoped strictly to the cron flow.

## Test plan

- [x] `go build -tags no_web ./...` clean
- [x] `go test -race -tags no_web -run TestExecuteCronJob_ ./core/` — all cron subtests pass
- [x] `go test -race -tags no_web ./core/... ./agent/... ./platform/... ./config/... ./cmd/...` — full suite green on the changed packages (one pre-existing `daemon/launchd` failure on `TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable` reproduces on `main` too — unrelated environment-dependent test).