### PR TITLE
fix(tts): honor ctx cancellation in EspeakTTS and PicoTTS subprocesses

### DIFF
--- a/core/tts.go
+++ b/core/tts.go
@@ -429,7 +429,7 @@ func (e *EspeakTTS) Synthesize(ctx context.Context, text string, opts TTSSynthes
 
 	// Execute espeak command
 	// Use Output() instead of CombinedOutput() to avoid mixing stderr warnings with audio data
-	cmd := exec.Command(e.Path, args...)
+	cmd := exec.CommandContext(ctx, e.Path, args...)
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, "", fmt.Errorf("espeak: voice=%s text=%q: %w", voice, text, err)
@@ -489,7 +489,7 @@ func (p *PicoTTS) Synthesize(ctx context.Context, text string, opts TTSSynthesis
 	}
 
 	// Execute pico2wave command
-	cmd := exec.Command(p.Path, args...)
+	cmd := exec.CommandContext(ctx, p.Path, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, "", fmt.Errorf("pico2wave: voice=%s text=%q: %w, output: %s", voice, text, err, string(output))

--- a/core/tts_test.go
+++ b/core/tts_test.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -447,6 +450,63 @@ func TestPicoTTS_Synthesize_Integration(t *testing.T) {
 	}
 	if len(audio) == 0 {
 		t.Error("expected non-empty audio data")
+	}
+}
+
+// writeFakeTTSBinary creates a temp shell script that sleeps long enough to
+// outlive a normal test timeout. Used to verify that subprocess-based TTS
+// providers honor ctx cancellation by killing the spawned process.
+func writeFakeTTSBinary(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake TTS binary uses /bin/sh; not portable to windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fake-tts.sh")
+	script := "#!/bin/sh\nsleep 30\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tts script: %v", err)
+	}
+	return path
+}
+
+func TestEspeakTTS_HonorsContextCancellation(t *testing.T) {
+	fakePath := writeFakeTTSBinary(t)
+	tts := NewEspeakTTS(fakePath, "en")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel: a correctly wired CommandContext kills immediately.
+
+	start := time.Now()
+	_, _, err := tts.Synthesize(ctx, "hello", TTSSynthesisOpts{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected error from cancelled context, got nil after %v", elapsed)
+	}
+	// 5s is generous: a fix using exec.CommandContext returns in well under a
+	// second; the bug (plain exec.Command) would wait the full 30s sleep.
+	if elapsed > 5*time.Second {
+		t.Fatalf("Synthesize ignored ctx cancellation, took %v (want < 5s); err=%v", elapsed, err)
+	}
+}
+
+func TestPicoTTS_HonorsContextCancellation(t *testing.T) {
+	fakePath := writeFakeTTSBinary(t)
+	tts := NewPicoTTS(fakePath, "en-US")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, _, err := tts.Synthesize(ctx, "hello", TTSSynthesisOpts{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected error from cancelled context, got nil after %v", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("Synthesize ignored ctx cancellation, took %v (want < 5s); err=%v", elapsed, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`EspeakTTS.Synthesize` and `PicoTTS.Synthesize` accept a `context.Context` parameter but spawn the underlying `espeak` / `pico2wave` processes via `exec.Command`, so the context is silently ignored. When the caller cancels (session stop, request timeout, etc.) the subprocess keeps running to natural completion, leaking CPU and a process slot per cancelled request.

Sibling `EdgeTTS.Synthesize` already correctly uses `exec.CommandContext`.

## Fix

Two-line change: switch both call sites in `core/tts.go` to `exec.CommandContext(ctx, ...)`.

## Test

Added `TestEspeakTTS_HonorsContextCancellation` and `TestPicoTTS_HonorsContextCancellation` in `core/tts_test.go`. Each writes a temp shell script that sleeps 30 s, points the corresponding TTS struct at it, calls `Synthesize` with a pre-cancelled context, and asserts the call returns in well under 5 s with a non-nil error.

Verified the new tests catch the bug:
- With the fix → both tests pass in `0.00s`.
- After reverting only the `EspeakTTS` change → `TestEspeakTTS_HonorsContextCancellation` waits the full 30 s and fails. Restored the fix afterwards.

Tests skip on Windows since the fake binary uses `/bin/sh`.

## Test plan

- [x] `go build -tags no_web ./...` clean
- [x] `go test -race -tags no_web -run 'TTS|Tts|tts' ./core/` — all TTS tests pass
- [x] New regression tests pass under `-race`
- [x] Five pre-existing test failures on `core/` (footer ctx-indicator and resolve-local-dir-path) reproduce on `main` and are unrelated to this change (tilde-expansion / `/private` symlink on macOS).