### PR TITLE
fix(claudecode): handle array content in scanSessionMeta

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -509,6 +509,19 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 	return os.Remove(path)
 }
 
+// extractStringContent attempts to extract a plain string from a json.RawMessage.
+// Returns empty string if the raw message is not a JSON string.
+func extractStringContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
 func scanSessionMeta(path string) (string, int) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -526,7 +539,7 @@ func scanSessionMeta(path string) (string, int) {
 		var entry struct {
 			Type    string `json:"type"`
 			Message struct {
-				Content string `json:"content"`
+				Content json.RawMessage `json:"content"`
 			} `json:"message"`
 		}
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
@@ -534,8 +547,10 @@ func scanSessionMeta(path string) (string, int) {
 		}
 		if entry.Type == "user" || entry.Type == "assistant" {
 			count++
-			if entry.Type == "user" && entry.Message.Content != "" {
-				summary = entry.Message.Content
+			if entry.Type == "user" {
+				if s := extractStringContent(entry.Message.Content); s != "" {
+					summary = s
+				}
 			}
 		}
 	}

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -662,3 +662,91 @@ func TestWorkspaceAgentOptions_RoundTripsThroughNew(t *testing.T) {
 		t.Errorf("routerAPIKey = %q, want secret", child.routerAPIKey)
 	}
 }
+
+func TestScanSessionMeta_ArrayContent(t *testing.T) {
+	// Regression test for: scanSessionMeta skips entries where content is a JSON array
+	// (e.g., assistant messages with thinking blocks, or user messages with tool results).
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.jsonl")
+
+	lines := []string{
+		`{"type": "queue-operation", "operation": "start"}`,
+		`{"type": "user", "message": {"content": "Hello world"}}`,
+		`{"type": "assistant", "message": {"content": [{"type": "thinking", "text": ""}, {"type": "text", "text": "Hi there"}]}}`,
+		`{"type": "user", "message": {"content": [{"tool_use_id": "call_abc", "type": "tool_result", "content": "result data"}]}}`,
+		`{"type": "assistant", "message": {"content": "Plain text reply"}}`,
+		`{"type": "last-prompt", "lastPrompt": "test"}`,
+	}
+
+	data := ""
+	for _, line := range lines {
+		data += line + "\n"
+	}
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatalf("write test jsonl: %v", err)
+	}
+
+	summary, count := scanSessionMeta(path)
+
+	// Expected: 2 user + 2 assistant = 4 messages
+	if count != 4 {
+		t.Errorf("scanSessionMeta count = %d, want 4 (2 user + 2 assistant, array content should not be skipped)", count)
+	}
+
+	// Summary should come from the last user message with string content (line 2)
+	if summary != "Hello world" {
+		t.Errorf("scanSessionMeta summary = %q, want %q", summary, "Hello world")
+	}
+}
+
+func TestScanSessionMeta_AllArrayContent(t *testing.T) {
+	// When all user messages have array content, summary should remain empty
+	// and count should still be correct.
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.jsonl")
+
+	lines := []string{
+		`{"type": "user", "message": {"content": [{"type": "tool_result", "content": "data"}]}}`,
+		`{"type": "assistant", "message": {"content": [{"type": "text", "text": "reply"}]}}`,
+	}
+
+	data := ""
+	for _, line := range lines {
+		data += line + "\n"
+	}
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatalf("write test jsonl: %v", err)
+	}
+
+	summary, count := scanSessionMeta(path)
+
+	if count != 2 {
+		t.Errorf("scanSessionMeta count = %d, want 2", count)
+	}
+	if summary != "" {
+		t.Errorf("scanSessionMeta summary = %q, want empty string when no string user content exists", summary)
+	}
+}
+
+func TestExtractStringContent(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"string", `"hello"`, "hello"},
+		{"empty", `""`, ""},
+		{"array", `[{"type": "text"}]`, ""},
+		{"object", `{"key": "val"}`, ""},
+		{"null", `null`, ""},
+		{"number", `42`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractStringContent([]byte(tt.raw))
+			if got != tt.want {
+				t.Errorf("extractStringContent(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Claude Code changed its JSONL format around April 2026 to use array-type content for assistant messages (thinking+text blocks) and user messages with tool results. The previous `Content string` field caused `json.Unmarshal` to fail on these entries, making `scanSessionMeta` skip them entirely.

This led to `/list` showing severely deflated message counts — e.g., a session with 27 user+assistant entries would display as only 2 messages.

## Changes

- Change `Content string` to `Content json.RawMessage` so unmarshaling succeeds regardless of content type
- Add `extractStringContent` helper to safely extract string content for summary generation
- Add regression tests for array content handling

## Verification

- `go test ./agent/claudecode/` passes
- `go build ./...` passes

Closes #931