### PR TITLE
fix(core): permission response deadlock in multi-workspace mode

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1991,6 +1991,16 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		}
 	}
 
+	// Select session manager and agent based on workspace mode
+	sessions := e.sessions
+	agent := e.agent
+	interactiveKey := msg.SessionKey
+	if e.multiWorkspace && wsSessions != nil {
+		sessions = wsSessions
+		agent = wsAgent
+		interactiveKey = resolvedWorkspace + ":" + msg.SessionKey
+	}
+
 	if len(msg.Images) == 0 && strings.HasPrefix(content, "/") {
 		if e.handleCommand(p, msg, content) {
 			return
@@ -1998,8 +2008,9 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		// Unrecognized slash command — fall through to agent as normal message
 	}
 
-	// Permission responses bypass the session lock
-	if e.handlePendingPermission(p, msg, content) {
+	// Permission responses bypass the session lock.
+	// Must be after workspace resolution so interactiveKey is correct.
+	if e.handlePendingPermission(p, msg, content, interactiveKey) {
 		return
 	}
 
@@ -2035,18 +2046,8 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	}
 
 	// Pending provider add (card-driven multi-step flow)
-	if e.handlePendingProviderAdd(p, msg, content) {
+	if e.handlePendingProviderAdd(p, msg, content, interactiveKey) {
 		return
-	}
-
-	// Select session manager and agent based on workspace mode
-	sessions := e.sessions
-	agent := e.agent
-	interactiveKey := msg.SessionKey
-	if e.multiWorkspace && wsSessions != nil {
-		sessions = wsSessions
-		agent = wsAgent
-		interactiveKey = resolvedWorkspace + ":" + msg.SessionKey
 	}
 
 	session := sessions.GetOrCreateActive(msg.SessionKey)
@@ -2304,8 +2305,11 @@ func (e *Engine) handleVoiceMessage(p Platform, msg *Message) {
 // Permission handling
 // ──────────────────────────────────────────────────────────────
 
-func (e *Engine) handlePendingPermission(p Platform, msg *Message, content string) bool {
-	iKey := e.interactiveKeyForSessionKey(msg.SessionKey)
+func (e *Engine) handlePendingPermission(p Platform, msg *Message, content string, interactiveKey string) bool {
+	iKey := interactiveKey
+	if iKey == "" {
+		iKey = e.interactiveKeyForSessionKey(msg.SessionKey)
+	}
 	e.interactiveMu.Lock()
 	state, ok := e.interactiveStates[iKey]
 	e.interactiveMu.Unlock()
@@ -7932,6 +7936,15 @@ func (e *Engine) cmdTTS(p Platform, msg *Message, args []string) {
 func (e *Engine) cmdStop(p Platform, msg *Message) {
 	iKey := e.interactiveKeyForSessionKey(msg.SessionKey)
 	if !e.stopInteractiveSession(iKey, p, msg.ReplyCtx) {
+		// Fallback: try suffix scan in case interactiveKeyForSessionKey
+		// resolved a different key than the one used to store the state
+		// (e.g. workspace binding lookup inconsistency).
+		if found := e.findInteractiveKeyForSession(msg.SessionKey); found != "" && found != iKey {
+			if e.stopInteractiveSession(found, p, msg.ReplyCtx) {
+				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgExecutionStopped))
+				return
+			}
+		}
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgNoExecution))
 		return
 	}
@@ -7998,6 +8011,15 @@ func (e *Engine) cmdCompress(p Platform, msg *Message) {
 	e.interactiveMu.Lock()
 	state, hasState := e.interactiveStates[iKey]
 	e.interactiveMu.Unlock()
+
+	if !hasState || state == nil {
+		// Fallback: suffix scan for multi-workspace key mismatch
+		if found := e.findInteractiveKeyForSession(msg.SessionKey); found != "" && found != iKey {
+			e.interactiveMu.Lock()
+			state, hasState = e.interactiveStates[found]
+			e.interactiveMu.Unlock()
+		}
+	}
 
 	if !hasState || state == nil || state.agentSession == nil || !state.agentSession.Alive() {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgCompressNoSession))
@@ -8495,11 +8517,13 @@ func (e *Engine) switchProvider(p Platform, msg *Message, switcher ProviderSwitc
 
 // handlePendingProviderAdd checks for a pending provider add state (from the
 // card-driven add flow) and completes the add if the user sends the required input.
-func (e *Engine) handlePendingProviderAdd(p Platform, msg *Message, content string) bool {
+func (e *Engine) handlePendingProviderAdd(p Platform, msg *Message, content string, interactiveKey string) bool {
 	if strings.HasPrefix(content, "/") {
 		return false
 	}
-	interactiveKey := e.interactiveKeyForSessionKey(msg.SessionKey)
+	if interactiveKey == "" {
+		interactiveKey = e.interactiveKeyForSessionKey(msg.SessionKey)
+	}
 	e.interactiveMu.Lock()
 	state := e.interactiveStates[interactiveKey]
 	e.interactiveMu.Unlock()

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2514,7 +2514,7 @@ func TestHandlePendingPermission_MultiWorkspaceLookup(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	msg := &Message{SessionKey: sessionKey, ReplyCtx: "ctx"}
 
-	if !e.handlePendingPermission(p, msg, "allow") {
+	if !e.handlePendingPermission(p, msg, "allow", "") {
 		t.Fatal("expected pending permission to be handled")
 	}
 
@@ -5353,7 +5353,7 @@ func TestHandlePendingPermission_AskUserQuestion_SingleQuestion(t *testing.T) {
 		UserID:     "user1",
 		Content:    "2",
 		ReplyCtx:   "ctx",
-	}, "2")
+	}, "2", "")
 
 	if !handled {
 		t.Fatal("expected handlePendingPermission to return true")
@@ -5404,7 +5404,7 @@ func TestHandlePendingPermission_AskUserQuestion_MultiQuestion_Sequential(t *tes
 		UserID:     "user1",
 		Content:    "1",
 		ReplyCtx:   "ctx",
-	}, "1")
+	}, "1", "")
 	if !handled {
 		t.Fatal("expected handled=true for question 0")
 	}
@@ -5426,7 +5426,7 @@ func TestHandlePendingPermission_AskUserQuestion_MultiQuestion_Sequential(t *tes
 		UserID:     "user1",
 		Content:    "2",
 		ReplyCtx:   "ctx",
-	}, "2")
+	}, "2", "")
 	if !handled {
 		t.Fatal("expected handled=true for question 1")
 	}
@@ -5480,7 +5480,7 @@ func TestHandlePendingPermission_AskUserQuestion_SkipsPermFlow(t *testing.T) {
 		UserID:     "user1",
 		Content:    "allow",
 		ReplyCtx:   "ctx",
-	}, "allow")
+	}, "allow", "")
 
 	if !handled {
 		t.Fatal("expected handled=true")
@@ -6537,7 +6537,7 @@ func TestProcessInteractiveEvents_PermissionWhileSendBlocked(t *testing.T) {
 		t.Fatal("permission inline buttons not sent while Send blocked")
 	}
 
-	if !e.handlePendingPermission(p, &Message{SessionKey: key, ReplyCtx: "ctx"}, "allow") {
+	if !e.handlePendingPermission(p, &Message{SessionKey: key, ReplyCtx: "ctx"}, "allow", "") {
 		t.Fatal("expected handlePendingPermission to resolve pending request")
 	}
 	close(sess.unblock)
@@ -6680,7 +6680,7 @@ func TestReapIdleWorkspaces_SkipsWorkspaceWaitingForPermission(t *testing.T) {
 		UserID:     "user2",
 		Content:    "allow",
 		ReplyCtx:   "ctx",
-	}, "allow") {
+	}, "allow", "") {
 		t.Fatal("expected pending permission to be handled")
 	}
 	close(sess.unblock)


### PR DESCRIPTION
## Problem

In multi-workspace mode, users hit a complete deadlock when interacting with the agent:

1. Agent enters plan mode → user clicks "Allow" or "Deny" on the permission card → message is received but queued with "📬 消息已收到，将在当前任务完成后处理"
2. Agent asks a question via AskUserQuestion → user clicks any answer or types a reply → same queued message
3. User types `/stop` → responds "没有正在执行的任务"

The session is completely stuck — the permission response will never be processed because the session is blocked waiting for it, and `/stop` can't find the running task to kill it. The only recovery is restarting cc-connect.

This affects **all permission flows** in multi-workspace mode: ExitPlanMode, tool approval, AskUserQuestion, etc.

## Root Cause

The deadlock is caused by an `interactiveKey` resolution inconsistency between `handleMessage` and the permission handler.

In multi-workspace mode, `interactiveKey` is computed as `resolvedWorkspace + ":" + sessionKey`. But the computation happens at **two independent points** with **different lookup logic**:

- `handleMessage` resolves the workspace via `resolveWorkspace()`, which has a convention-match fallback (e.g. binding `proj` matches session `proj:user1`)
- `handlePendingPermission` computes its own key via `interactiveKeyForSessionKey()`, which does a strict binding lookup without the fallback

When these two resolve to different keys, the permission handler looks up `interactiveStates[differentKey]` — finds nothing — returns `false`. The engine then calls `queueMessageForBusySession()`, which queues the response for a session that's blocked waiting for exactly this response. Classic deadlock.

The event loop holds the session lock (`TryLock`) while blocking on `<-pending.Resolved`. Permission responses bypass the lock check (they happen before `TryLock`), but since the key mismatch prevents them from reaching the pending request, the lock is never released.

## Fix

1. **Single key computation** — move workspace resolution and `interactiveKey` computation to the top of `handleMessage`, before any permission or command checks. Pass the pre-computed key to `handlePendingPermission` and `handlePendingProviderAdd` so they use the same key as the event loop.

2. **Suffix scan fallback** in `cmdStop` and `cmdCompress` — if `interactiveKeyForSessionKey()` resolves a different key than the one actually storing the session state (due to the same binding lookup inconsistency), fall back to `findInteractiveKeyForSession()` which scans all keys by suffix match.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (no new failures)
- [x] Manual: ExitPlanMode allow/deny resolves immediately in multi-workspace mode
- [x] Manual: AskUserQuestion answers resolve immediately
- [x] Manual: `/stop` correctly finds and stops running sessions
- [x] Manual: Single-workspace mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)