### PR TITLE
fix(api): /send rejects unknown project name instead of silent fallback

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -147,22 +147,27 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.RLock()
-	engine, ok := s.engines[req.Project]
+	var engine *Engine
+	var ok bool
+	if req.Project != "" {
+		engine, ok = s.engines[req.Project]
+	} else if len(s.engines) == 1 {
+		// No project specified and only one engine: use it by default.
+		// Do NOT silently fall back when a non-empty project name is unknown —
+		// that misroutes the message to the wrong engine. Mirrors the resolve
+		// pattern in webhook.go and handleCronAdd.
+		for _, e := range s.engines {
+			engine = e
+			ok = true
+		}
+	}
 	s.mu.RUnlock()
 
 	if !ok {
-		// If only one engine, use it by default
-		s.mu.RLock()
-		if len(s.engines) == 1 {
-			for _, e := range s.engines {
-				engine = e
-				ok = true
-			}
+		if req.Project == "" {
+			http.Error(w, "project is required (multiple projects configured)", http.StatusBadRequest)
+			return
 		}
-		s.mu.RUnlock()
-	}
-
-	if !ok {
 		http.Error(w, fmt.Sprintf("project %q not found", req.Project), http.StatusNotFound)
 		return
 	}

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -36,5 +37,92 @@ func TestHandleSend_AllowsAttachmentOnly(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSend_UnknownProjectReturns404 ensures the API does NOT silently
+// fall back to the only registered engine when the caller named a different
+// project. Previously a typo'd project name routed messages to whatever
+// single engine happened to be loaded.
+func TestHandleSend_UnknownProjectReturns404(t *testing.T) {
+	engine := NewEngine("projectA", &stubAgent{}, []Platform{&stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}}, "", LangEnglish)
+	engine.interactiveStates["session-1"] = &interactiveState{
+		platform: &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}},
+		replyCtx: "reply-ctx",
+	}
+
+	api := &APIServer{engines: map[string]*Engine{"projectA": engine}}
+	body, err := json.Marshal(SendRequest{
+		Project:    "projectB", // typo; does NOT match the loaded engine
+		SessionKey: "session-1",
+		Message:    "hi",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"projectB"`) {
+		t.Errorf("body should mention the unknown project name, got: %s", rec.Body.String())
+	}
+}
+
+// TestHandleSend_EmptyProjectFallsBackToSingleEngine documents the intended
+// convenience behavior: when the caller omits project entirely AND only one
+// engine is loaded, the API picks it automatically.
+func TestHandleSend_EmptyProjectFallsBackToSingleEngine(t *testing.T) {
+	engine := NewEngine("solo", &stubAgent{}, []Platform{&stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}}, "", LangEnglish)
+	engine.interactiveStates["session-1"] = &interactiveState{
+		platform: &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}},
+		replyCtx: "reply-ctx",
+	}
+
+	api := &APIServer{engines: map[string]*Engine{"solo": engine}}
+	body, err := json.Marshal(SendRequest{
+		// Project deliberately omitted.
+		SessionKey: "session-1",
+		Message:    "hi",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSend_EmptyProjectMultipleEnginesRequiresName ensures the API
+// refuses to guess when more than one engine is loaded and the caller did
+// not specify which one to send to.
+func TestHandleSend_EmptyProjectMultipleEnginesRequiresName(t *testing.T) {
+	engineA := NewEngine("a", &stubAgent{}, []Platform{&stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}}, "", LangEnglish)
+	engineB := NewEngine("b", &stubAgent{}, []Platform{&stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}}, "", LangEnglish)
+	api := &APIServer{engines: map[string]*Engine{"a": engineA, "b": engineB}}
+
+	body, err := json.Marshal(SendRequest{
+		SessionKey: "session-1",
+		Message:    "hi",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

`APIServer.handleSend` resolved the target engine in two steps:

```go
engine, ok := s.engines[req.Project]
if !ok {
    // If only one engine, use it by default
    if len(s.engines) == 1 { ... pick the lone engine ... }
}
```

The second step fired whenever the first lookup missed — including when the caller passed a **typo'd** project name. With a single engine loaded, `project="projectB"` against `{"projectA": ...}` returned `200 OK` and delivered the message to `projectA`, the exact opposite of "project not found".

This is the only resolver in the codebase with that loose semantics; `webhook.go`'s `resolveEngine` and `api.go`'s own `handleCronAdd` both fall back **only** when the project name is empty.

## Fix

Rewrite resolution to gate the single-engine fallback on `req.Project == ""`:

| `Project` field | engines loaded | behavior |
|---|---|---|
| `""` | 1 | auto-pick the lone engine (convenience preserved) |
| `""` | >1 | `400 project is required (multiple projects configured)` |
| `"name"` | matches | use it |
| `"name"` | does not match | `404 project %q not found` |

## Tests

`core/api_test.go` adds three tests beside the existing `TestHandleSend_AllowsAttachmentOnly`:

1. `TestHandleSend_UnknownProjectReturns404` — typo'd project name → `404` (formerly `200` with silent misrouting).
2. `TestHandleSend_EmptyProjectFallsBackToSingleEngine` — pins the preserved convenience path.
3. `TestHandleSend_EmptyProjectMultipleEnginesRequiresName` — multi-engine, empty project → `400` (formerly `404 project \"\" not found`).

Verified the new tests fail against the pre-fix production code with the diff reverted in place; restored before commit.

## Test plan

- [x] `go build -tags no_web ./...` clean
- [x] `go test -race -tags no_web -run 'TestHandleSend|TestApi|TestAPI' ./core/` green
- [x] Reverted fix locally, confirmed `TestHandleSend_UnknownProjectReturns404` and `TestHandleSend_EmptyProjectMultipleEnginesRequiresName` fail with the buggy behavior, then restored the fix.