### PR TITLE
Pass Feishu quoted images to agents

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1049,9 +1049,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	// Skip quote injection when thread_isolation is enabled and the message is
 	// inside a thread — the thread already provides conversational context, and
 	// long quoted prefixes can drown out the user's actual text (issue #764).
-	quotedPrefix := ""
+	var quoted quotedMessage
 	if parentID != "" && !(p.threadIsolation && isThreadSessionKey(sessionKey)) {
-		quotedPrefix = p.fetchQuotedMessage(ctx, parentID)
+		quoted = p.fetchQuotedMessage(ctx, parentID)
 	}
 
 	switch msgType {
@@ -1076,7 +1076,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quotedPrefix, ReplyCtx: rctx,
+			Content: text, ExtraContent: quoted.text, Images: quoted.images, ReplyCtx: rctx,
 		})
 
 	case "image":
@@ -1144,7 +1144,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quotedPrefix, Images: images,
+			Content: text, ExtraContent: quoted.text, Images: append(quoted.images, images...),
 			ReplyCtx: rctx,
 		})
 
@@ -1213,7 +1213,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 				SessionKey: sessionKey, Platform: p.platformName,
 				MessageID: messageID,
 				UserID:    userID, UserName: userName, ChatName: chatName,
-				Content: "[sticker]", ExtraContent: quotedPrefix, ReplyCtx: rctx,
+				Content: "[sticker]", ExtraContent: quoted.text, ReplyCtx: rctx,
 			})
 			return
 		}
@@ -1257,7 +1257,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quotedPrefix, Images: images, ReplyCtx: rctx,
+			Content: text, ExtraContent: quoted.text, Images: images, ReplyCtx: rctx,
 		})
 
 	default:
@@ -1477,7 +1477,13 @@ type chainMessage struct {
 	senderName string
 	senderType string // "user" or "app"
 	text       string
+	images     []core.ImageAttachment
 	parentID   string
+}
+
+type quotedMessage struct {
+	text   string
+	images []core.ImageAttachment
 }
 
 // maxReplyChainDepth is the maximum number of parent messages to traverse
@@ -1485,17 +1491,17 @@ type chainMessage struct {
 const maxReplyChainDepth = 5
 
 // fetchQuotedMessage retrieves the content of a parent message that the user
-// is replying to, and returns a formatted prefix string for context injection.
+// is replying to, and returns formatted context plus downloaded attachments.
 // For multi-level reply chains, it traces parent_id links up to maxReplyChainDepth
 // levels and returns the full conversation chain.
-// Returns empty string on any failure (graceful degradation — the user's own
+// Returns empty content on any failure (graceful degradation — the user's own
 // message is still delivered without the quote).
-func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) string {
+func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) quotedMessage {
 	chain := p.fetchReplyChain(ctx, parentID, maxReplyChainDepth)
 	if len(chain) == 0 {
-		return ""
+		return quotedMessage{}
 	}
-	return formatReplyChain(chain)
+	return quotedMessage{text: formatReplyChain(chain), images: collectReplyChainImages(chain)}
 }
 
 // resolveBotSenderName returns a display name for a bot sender in a quoted
@@ -1552,6 +1558,7 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 
 	// Extract plain text based on message type.
 	var text string
+	var images []core.ImageAttachment
 	switch item.MsgType {
 	case "text":
 		var textBody struct {
@@ -1561,7 +1568,25 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 			text = replaceMentions(textBody.Text, item.Mentions)
 		}
 	case "post":
-		text = extractPostPlainText(content)
+		textParts, postImages := p.parsePostContent(messageID, content)
+		text = replaceMentions(strings.Join(textParts, "\n"), item.Mentions)
+		images = postImages
+		if text == "" && len(images) > 0 {
+			text = "[image]"
+		}
+	case "image":
+		text = "[image]"
+		var imgBody struct {
+			ImageKey string `json:"image_key"`
+		}
+		if err := json.Unmarshal([]byte(content), &imgBody); err == nil && imgBody.ImageKey != "" {
+			imgData, mimeType, err := p.downloadImage(messageID, imgBody.ImageKey)
+			if err != nil {
+				slog.Error(p.tag()+": download quoted image failed", "error", err, "message_id", messageID, "key", imgBody.ImageKey)
+			} else {
+				images = append(images, core.ImageAttachment{MimeType: mimeType, Data: imgData})
+			}
+		}
 	case "interactive":
 		text = extractInteractiveCardText(content)
 	default:
@@ -1591,8 +1616,17 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		senderName: senderName,
 		senderType: item.Sender.SenderType,
 		text:       text,
+		images:     images,
 		parentID:   item.ParentID,
 	}
+}
+
+func collectReplyChainImages(chain []chainMessage) []core.ImageAttachment {
+	var images []core.ImageAttachment
+	for _, msg := range chain {
+		images = append(images, msg.images...)
+	}
+	return images
 }
 
 // fetchReplyChain iteratively traverses parent_id links to build a reply chain.

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -85,6 +85,127 @@ func TestDispatchMessageDropsRecalledMessageBeforeHandler(t *testing.T) {
 	}
 }
 
+func TestDispatchMessageIncludesQuotedImage(t *testing.T) {
+	const appID = "cli_quote_image"
+	const appSecret = "secret-quote-image"
+	const parentMessageID = "om_parent_image"
+	const imageKey = "img_parent"
+
+	imageData := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+
+	tests := []struct {
+		name    string
+		msgType string
+		content string
+	}{
+		{
+			name:    "text reply",
+			msgType: "text",
+			content: `{"text":"这是什么图"}`,
+		},
+		{
+			name:    "post reply",
+			msgType: "post",
+			content: `{"content":[[{"tag":"text","text":"这是什么图"}]]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := make(chan *core.Message, 1)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+					w.Header().Set("Content-Type", "application/json")
+					writeJSON(t, w, map[string]any{
+						"code":                0,
+						"msg":                 "success",
+						"expire":              7200,
+						"tenant_access_token": "tenant-token",
+					})
+				case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID:
+					w.Header().Set("Content-Type", "application/json")
+					writeJSON(t, w, map[string]any{
+						"code": 0,
+						"msg":  "success",
+						"data": map[string]any{
+							"items": []map[string]any{
+								{
+									"msg_type":  "image",
+									"parent_id": "",
+									"sender": map[string]any{
+										"id":          "",
+										"sender_type": "user",
+									},
+									"body": map[string]any{
+										"content": `{"image_key":"` + imageKey + `"}`,
+									},
+								},
+							},
+						},
+					})
+				case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID+"/resources/"+imageKey:
+					if r.URL.Query().Get("type") != "image" {
+						t.Fatalf("resource type = %q, want image", r.URL.Query().Get("type"))
+					}
+					w.Header().Set("Content-Type", "image/png")
+					if _, err := w.Write(imageData); err != nil {
+						t.Fatalf("write image: %v", err)
+					}
+				default:
+					t.Fatalf("unexpected path %s", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+
+			p := &Platform{
+				platformName: "feishu",
+				domain:       srv.URL,
+				appID:        appID,
+				appSecret:    appSecret,
+				client: lark.NewClient(appID, appSecret,
+					lark.WithOpenBaseUrl(srv.URL),
+					lark.WithHttpClient(srv.Client()),
+				),
+				handler: func(_ core.Platform, msg *core.Message) {
+					got <- msg
+				},
+			}
+
+			p.dispatchMessage(
+				context.Background(),
+				tc.msgType,
+				tc.content,
+				nil,
+				"om_child",
+				"feishu:oc_chat:ou_user",
+				"",
+				"",
+				replyContext{messageID: "om_child", sessionKey: "feishu:oc_chat:ou_user"},
+				parentMessageID,
+			)
+
+			select {
+			case msg := <-got:
+				if msg.Content != "这是什么图" {
+					t.Fatalf("Content = %q, want question text", msg.Content)
+				}
+				if !strings.Contains(msg.ExtraContent, "[image]") {
+					t.Fatalf("ExtraContent = %q, want quoted image marker", msg.ExtraContent)
+				}
+				if len(msg.Images) != 1 {
+					t.Fatalf("len(Images) = %d, want 1", len(msg.Images))
+				}
+				if string(msg.Images[0].Data) != string(imageData) {
+					t.Fatal("quoted image data did not match downloaded resource")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for dispatched message")
+			}
+		})
+	}
+}
+
 func TestIsMessageRecalledDetectsWithdrawnMessageFromGetAPI(t *testing.T) {
 	const appID = "cli_recall_probe"
 	const appSecret = "secret-recall-probe"


### PR DESCRIPTION
## Summary

Passes images from Feishu quoted/replied messages through to agents.

When a user replies to or quotes a Feishu image message and asks the bot a text or rich-text question, cc-connect now fetches the quoted image, keeps the quoted text context, and includes the image in `core.Message.Images`.

## Problem

Feishu already exposed reply context through `parent_id`, and cc-connect already fetched quoted message text. However, quoted attachments were flattened into textual markers such as `[image]`.

That made these cases inconsistent:

- Direct rich-text image message: image reached the agent.
- Text question quoting an image: only quoted text reached the agent.
- Rich-text question quoting an image: only quoted text reached the agent.

## Changes

- Replaces string-only quoted context with a `quotedMessage` value carrying text and images.
- Fetches quoted `image` messages by parent message id and image key.
- Reuses rich-text post parsing so quoted `post` messages can contribute text and embedded images.
- Adds quoted images to `core.Message.Images` for text replies.
- Merges quoted images with current-message images for rich-text replies.
- Adds regression coverage for text and rich-text replies to quoted image messages.

## Verification

Automated:

```bash
go test -count=1 ./platform/feishu
# also checked targeted quote/image parser tests and git diff whitespace
```

Manual:

- Verified in a Feishu group that quoting an image and asking the bot about it succeeds.
- Verified direct rich-text image handling still works.
- Verified outbound Feishu image sending still works.

## Compatibility

- Existing text-only quote behavior is preserved through `ExtraContent`.
- If quoted image download fails, the user message still proceeds with textual quoted context.
- The change is scoped to Feishu quoted/replied message handling.
