### PR TITLE
fix(agent): capture workDir under mutex in qoder + cursor StartSession

### DIFF
--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -193,6 +193,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	mode := a.mode
 	cmd := a.cmd
+	workDir := a.workDir
 	extraEnv := a.providerEnvLocked()
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
@@ -202,7 +203,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
-	return newCursorSession(ctx, cmd, a.workDir, model, mode, sessionID, extraEnv)
+	return newCursorSession(ctx, cmd, workDir, model, mode, sessionID, extraEnv)
 }
 
 // ListSessions reads sessions from ~/.cursor/chats/<workspace_hash>/.

--- a/agent/cursor/cursor_concurrent_test.go
+++ b/agent/cursor/cursor_concurrent_test.go
@@ -1,0 +1,40 @@
+package cursor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestAgent_StartSessionWorkDirRace exercises concurrent SetWorkDir + StartSession.
+// Without the fix, StartSession reads a.workDir without holding a.mu while
+// SetWorkDir writes it under the lock, which Go's -race detector flags as a
+// data race. With the fix, the field is captured inside the existing critical
+// section and no race is reported.
+//
+// newCursorSession only initialises the session struct; it does not spawn the
+// Cursor agent CLI until Send() is called, so this test runs without requiring
+// the binary on PATH.
+func TestAgent_StartSessionWorkDirRace(t *testing.T) {
+	a := &Agent{cmd: "agent", workDir: "/initial"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			a.SetWorkDir(fmt.Sprintf("/path-%d", i))
+		}(i)
+		go func() {
+			defer wg.Done()
+			sess, err := a.StartSession(context.Background(), "")
+			if err != nil {
+				t.Errorf("StartSession: %v", err)
+				return
+			}
+			_ = sess.Close()
+		}()
+	}
+	wg.Wait()
+}

--- a/agent/qoder/qoder.go
+++ b/agent/qoder/qoder.go
@@ -105,10 +105,11 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	a.mu.Lock()
 	mode := a.mode
 	model := a.model
+	workDir := a.workDir
 	extraEnv := append([]string{}, a.sessionEnv...)
 	a.mu.Unlock()
 
-	return newQoderSession(ctx, a.workDir, model, mode, sessionID, extraEnv)
+	return newQoderSession(ctx, workDir, model, mode, sessionID, extraEnv)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/qoder/qoder_test.go
+++ b/agent/qoder/qoder_test.go
@@ -4,11 +4,44 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
+
+// TestAgent_StartSessionWorkDirRace exercises concurrent SetWorkDir + StartSession.
+// Without the fix, StartSession reads a.workDir without holding a.mu while
+// SetWorkDir writes it under the lock, which Go's -race detector flags as a
+// data race. With the fix, the field is captured inside the existing critical
+// section and no race is reported.
+//
+// newQoderSession only initialises the session struct; it does not spawn the
+// qodercli binary until Send() is called, so this test runs without requiring
+// the CLI on PATH.
+func TestAgent_StartSessionWorkDirRace(t *testing.T) {
+	a := &Agent{workDir: "/initial"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			a.SetWorkDir(fmt.Sprintf("/path-%d", i))
+		}(i)
+		go func() {
+			defer wg.Done()
+			sess, err := a.StartSession(context.Background(), "")
+			if err != nil {
+				t.Errorf("StartSession: %v", err)
+				return
+			}
+			_ = sess.Close()
+		}()
+	}
+	wg.Wait()
+}
 
 func TestQoderSession(t *testing.T) {
 	if os.Getenv("QODER_INTEGRATION") == "" {


### PR DESCRIPTION
## Summary

`StartSession` in both `agent/qoder` and `agent/cursor` reads `a.workDir` **outside** the agent's own mutex, while `SetWorkDir` (and `GetWorkDir`) consistently take the lock. Since the `/dir` command lets users hot-swap the workspace at runtime, these two paths can race in production. `go test -race` confirms the race deterministically.

### qoder (`agent/qoder/qoder.go`)

```go
func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentSession, error) {
    a.mu.Lock()
    mode := a.mode
    model := a.model
    extraEnv := append([]string{}, a.sessionEnv...)
    a.mu.Unlock()

    return newQoderSession(ctx, a.workDir /* unlocked read */, model, mode, sessionID, extraEnv)
}
```

### cursor (`agent/cursor/cursor.go`)

Same shape — every other field is captured under `a.mu.Lock()`, but `a.workDir` is read in the call to `newCursorSession` after the unlock.

Sibling agents already do this correctly: `gemini.go`, `opencode.go`, `kimi.go`, and `acp/agent.go` all capture `workDir := a.workDir` before unlocking. PR #157 (`fix/pi-thinking-data-race`) applied the same pattern to `agent/pi` for the `thinking` field.

## Fix

One added line per agent: bind `workDir := a.workDir` inside the existing critical section, then thread the local through to the session constructor.

## Tests

Adds `TestAgent_StartSessionWorkDirRace` in both `agent/qoder/qoder_test.go` and a new `agent/cursor/cursor_concurrent_test.go`. Each test launches 50 pairs of goroutines: one running `SetWorkDir`, the other running `StartSession`.

`newQoderSession` and `newCursorSession` only initialise their session structs (the CLI is not spawned until `Send`), so the tests don't need `qodercli` or the Cursor agent binary on `PATH`.

Verified deterministically:

- **With the fix** (`go test -race -run TestAgent_StartSessionWorkDirRace ./agent/qoder/ ./agent/cursor/`): both pass.
- **Reverting only the production code** (kept the tests in place) and re-running `-race`: each agent fails with `testing.go:1617: race detected during execution of test`.

Fix restored before commit.

## Test plan

- [x] `go build -tags no_web ./...` clean
- [x] `go test -race -tags no_web ./agent/qoder/ ./agent/cursor/` — full suites pass
- [x] Race regression: reverted, re-ran, observed `race detected`, restored.