### PR TITLE
fix(agent): extend close-events panic fix to kimi, pi, and acp sessions

### DIFF
--- a/agent/acp/session.go
+++ b/agent/acp/session.go
@@ -715,10 +715,10 @@ func (s *acpSession) Close() error {
 	}()
 	select {
 	case <-done:
+		close(s.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("acp: close timed out waiting for I/O loop")
 	}
-	close(s.events)
 	return nil
 }
 

--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -461,10 +461,10 @@ func (ks *kimiSession) Close() error {
 	}()
 	select {
 	case <-done:
+		close(ks.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("kimiSession: close timed out, abandoning wg.Wait")
 	}
-	close(ks.events)
 	return nil
 }
 

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -397,10 +397,10 @@ func (s *piSession) Close() error {
 	}()
 	select {
 	case <-done:
+		close(s.events)
 	case <-time.After(8 * time.Second):
 		slog.Warn("piSession: close timed out, abandoning wg.Wait")
 	}
-	close(s.events)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

PR #133 fixed a `send on closed channel` panic in 6 agent session implementations (codex, opencode, qoder, iflow, cursor, gemini) by only calling `close(events)` inside the `wg.Wait()` success branch of `Close()`. Three session implementations were not included in that PR and still ship the original unsafe pattern:

- agent/kimi/session.go (kimiSession.Close)
- agent/pi/session.go (piSession.Close)
- agent/acp/session.go (acpSession.Close)

Each of them does:

```go
select {
case <-done:
case <-time.After(8 * time.Second):
    slog.Warn(...)
}
close(s.events)
```

so a slow / wedged readLoop can still be selected to send on `s.events` after the 8s timeout fires and `close` runs, producing the same panic PR #133 set out to eliminate.

This change applies the exact same minimal fix used in PR #133 to those three files: move `close(events)` inside the `<-done` case so the channel is only closed when the readLoop goroutine has actually exited. On timeout we now leak the channel rather than risk a panic, matching the pattern in claudeSession.

## Test plan

- [x] `go build -tags no_web ./...`
- [x] `go test -race -tags no_web ./agent/kimi/... ./agent/pi/... ./agent/acp/...` — all pass
- [x] Diff is 3 single-line moves; no behavior change on the happy path (wg.Wait completes)