### PR TITLE
Add WeCom WebSocket image send-back

### DIFF
--- a/docs/wecom.md
+++ b/docs/wecom.md
@@ -8,8 +8,8 @@
 
 | 模式 | 优势 | 要求 |
 |------|------|------|
-| **WebSocket 长连接**（推荐） | 无需公网 URL、无需消息加解密、无需 IP 白名单 | 创建「智能机器人」 |
-| **Webhook 回调** | 支持图片/语音消息、Markdown 格式 | 公网 URL + 可信 IP |
+| **WebSocket 长连接**（推荐） | 无需公网 URL、无需消息加解密、无需 IP 白名单，支持图片接收与图片回传 | 创建「智能机器人」 |
+| **Webhook 回调** | 兼容企业微信自建应用回调模式 | 公网 URL + 可信 IP |
 
 ---
 
@@ -92,13 +92,14 @@ level=INFO msg="wecom-ws: subscribed successfully" bot_id=your-bot-id
 - **认证方式**：连接后发送 `aibot_subscribe`（bot_id + secret）
 - **心跳**：每 30 秒发送 `ping`
 - **自动重连**：连接断开后指数退避重连（1s → 2s → 4s → ... → 30s max）
+- **图片回传**：通过 `aibot_upload_media_*` 上传临时素材，再用 `aibot_send_msg` 发送图片
 - **限制**：同一机器人仅支持 1 个长连接；30 条/分钟、1000 条/小时
 
 ---
 
 ## 模式二：Webhook 回调
 
-> 💡 如果你不需要图片/语音消息或 Markdown 格式，推荐使用上方的 WebSocket 长连接模式，配置更简单。
+> 💡 推荐优先使用上方的 WebSocket 长连接模式。只有在你已有企业微信自建应用回调部署、或需要兼容旧配置时，再使用 Webhook 回调模式。
 
 ### 前置要求
 

--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -209,7 +209,12 @@ func (p *WSPlatform) runConnection() error {
 		// not guaranteed safe by the sync.Map contract.
 		var staleKeys []any
 		p.pendingAcks.Range(func(key, value any) bool {
-			notifyAckResult(value, wsAckResult{err: fmt.Errorf("wecom-ws: connection closed")})
+			if ch, ok := value.(chan wsAckResult); ok {
+				select {
+				case ch <- wsAckResult{err: fmt.Errorf("wecom-ws: connection closed")}:
+				default:
+				}
+			}
 			staleKeys = append(staleKeys, key)
 			return true
 		})
@@ -313,22 +318,12 @@ func (p *WSPlatform) dispatchAck(reqID string, result wsAckResult) {
 	if !ok {
 		return
 	}
-	if notifyAckResult(ch, result) {
+	resultCh, ok := ch.(chan wsAckResult)
+	if !ok {
+		slog.Warn("wecom-ws: unexpected ack channel type", "req_id", reqID)
 		return
 	}
-	slog.Warn("wecom-ws: unexpected ack channel type", "req_id", reqID)
-}
-
-func notifyAckResult(ch any, result wsAckResult) bool {
-	switch c := ch.(type) {
-	case chan wsAckResult:
-		c <- result
-		return true
-	case chan error:
-		c <- result.err
-		return true
-	}
-	return false
+	resultCh <- result
 }
 
 func (p *WSPlatform) heartbeat(ctx context.Context, conn *websocket.Conn) {

--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -3,6 +3,7 @@ package wecom
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -35,10 +36,15 @@ type WSPlatform struct {
 	dedup       core.MessageDedup
 	reqSeq      atomic.Int64 // monotonic counter for generating unique req_id
 	missedPong  atomic.Int32 // consecutive heartbeat acks not received
-	pendingAcks sync.Map     // req_id -> chan error, for sequential send with ack waiting
+	pendingAcks sync.Map     // req_id -> chan wsAckResult, for sequential send with ack waiting
 }
 
-const wsAckTimeout = 5 * time.Second
+const (
+	wsAckTimeout      = 5 * time.Second
+	wsMediaAckTimeout = 30 * time.Second
+)
+
+var errWSAckTimeout = errors.New("wecom-ws: ack timeout")
 
 // wsReplyContext holds the context needed to reply to a specific message.
 type wsReplyContext struct {
@@ -63,6 +69,11 @@ type wsFrame struct {
 
 type wsFrameHeaders struct {
 	ReqID string `json:"req_id"`
+}
+
+type wsAckResult struct {
+	frame wsFrame
+	err   error
 }
 
 // wsMsgCallbackBody is the body of an aibot_msg_callback frame.
@@ -198,12 +209,7 @@ func (p *WSPlatform) runConnection() error {
 		// not guaranteed safe by the sync.Map contract.
 		var staleKeys []any
 		p.pendingAcks.Range(func(key, value any) bool {
-			if ch, ok := value.(chan error); ok {
-				select {
-				case ch <- fmt.Errorf("wecom-ws: connection closed"):
-				default:
-				}
-			}
+			notifyAckResult(value, wsAckResult{err: fmt.Errorf("wecom-ws: connection closed")})
 			staleKeys = append(staleKeys, key)
 			return true
 		})
@@ -295,13 +301,34 @@ func (p *WSPlatform) handleFrame(frame wsFrame) {
 			} else {
 				slog.Debug("wecom-ws: reply/send ack ok", "req_id", reqID)
 			}
-			if ch, ok := p.pendingAcks.LoadAndDelete(reqID); ok {
-				ch.(chan error) <- ackErr
-			}
+			p.dispatchAck(reqID, wsAckResult{frame: frame, err: ackErr})
 		}
 	default:
 		slog.Debug("wecom-ws: unhandled cmd", "cmd", frame.Cmd)
 	}
+}
+
+func (p *WSPlatform) dispatchAck(reqID string, result wsAckResult) {
+	ch, ok := p.pendingAcks.LoadAndDelete(reqID)
+	if !ok {
+		return
+	}
+	if notifyAckResult(ch, result) {
+		return
+	}
+	slog.Warn("wecom-ws: unexpected ack channel type", "req_id", reqID)
+}
+
+func notifyAckResult(ch any, result wsAckResult) bool {
+	switch c := ch.(type) {
+	case chan wsAckResult:
+		c <- result
+		return true
+	case chan error:
+		c <- result.err
+		return true
+	}
+	return false
 }
 
 func (p *WSPlatform) heartbeat(ctx context.Context, conn *websocket.Conn) {
@@ -547,23 +574,52 @@ func (p *WSPlatform) writeJSON(v any) error {
 // writeAndWaitAck sends a frame and waits for the server ack before returning.
 // Falls back to non-blocking on timeout to avoid deadlocks.
 func (p *WSPlatform) writeAndWaitAck(ctx context.Context, frame map[string]any, reqID string) error {
-	ch := make(chan error, 1)
+	return p.writeAndWaitAckWithTimeout(ctx, frame, reqID, wsAckTimeout)
+}
+
+func (p *WSPlatform) writeAndWaitAckWithTimeout(ctx context.Context, frame map[string]any, reqID string, timeout time.Duration) error {
+	result, err := p.writeAndWaitResult(ctx, frame, reqID, timeout)
+	if errors.Is(err, errWSAckTimeout) {
+		slog.Debug("wecom-ws: ack timeout, proceeding", "req_id", reqID)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return result.err
+}
+
+func (p *WSPlatform) writeAndWaitFrameWithTimeout(ctx context.Context, frame map[string]any, reqID string, timeout time.Duration) (wsFrame, error) {
+	result, err := p.writeAndWaitResult(ctx, frame, reqID, timeout)
+	if errors.Is(err, errWSAckTimeout) {
+		return wsFrame{}, fmt.Errorf("wecom-ws: ack timeout waiting for %s", reqID)
+	}
+	if err != nil {
+		return wsFrame{}, err
+	}
+	if result.err != nil {
+		return wsFrame{}, result.err
+	}
+	return result.frame, nil
+}
+
+func (p *WSPlatform) writeAndWaitResult(ctx context.Context, frame map[string]any, reqID string, timeout time.Duration) (wsAckResult, error) {
+	ch := make(chan wsAckResult, 1)
 	p.pendingAcks.Store(reqID, ch)
 
 	if err := p.writeJSON(frame); err != nil {
 		p.pendingAcks.Delete(reqID)
-		return err
+		return wsAckResult{}, err
 	}
 
 	select {
-	case err := <-ch:
-		return err
+	case result := <-ch:
+		return result, nil
 	case <-ctx.Done():
 		p.pendingAcks.Delete(reqID)
-		return ctx.Err()
-	case <-time.After(wsAckTimeout):
+		return wsAckResult{}, ctx.Err()
+	case <-time.After(timeout):
 		p.pendingAcks.Delete(reqID)
-		slog.Debug("wecom-ws: ack timeout, proceeding", "req_id", reqID)
-		return nil
+		return wsAckResult{}, errWSAckTimeout
 	}
 }

--- a/platform/wecom/websocket_outbound_media.go
+++ b/platform/wecom/websocket_outbound_media.go
@@ -1,0 +1,158 @@
+package wecom
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+const (
+	wecomWSUploadChunkSize = 512 * 1024
+	wecomWSUploadMaxChunks = 100
+)
+
+// SendImage uploads and sends an image through the WeCom AI Bot WebSocket API.
+func (p *WSPlatform) SendImage(ctx context.Context, rctx any, img core.ImageAttachment) error {
+	rc, ok := rctx.(wsReplyContext)
+	if !ok {
+		return fmt.Errorf("wecom-ws: SendImage: invalid reply context type %T", rctx)
+	}
+	if rc.chatID == "" {
+		return fmt.Errorf("wecom-ws: chatID is empty, cannot send image")
+	}
+	if len(img.Data) == 0 {
+		return fmt.Errorf("wecom-ws: image data is empty")
+	}
+
+	mediaID, err := p.uploadWSMedia(ctx, "image", wsImageFileName(img), img.Data)
+	if err != nil {
+		return fmt.Errorf("wecom-ws: send image: %w", err)
+	}
+	if err := p.sendWSMediaMessage(ctx, rc.chatID, "image", mediaID); err != nil {
+		return fmt.Errorf("wecom-ws: send image: %w", err)
+	}
+	return nil
+}
+
+func (p *WSPlatform) uploadWSMedia(ctx context.Context, mediaType, filename string, data []byte) (string, error) {
+	totalChunks := (len(data) + wecomWSUploadChunkSize - 1) / wecomWSUploadChunkSize
+	if totalChunks == 0 {
+		return "", fmt.Errorf("empty media data")
+	}
+	if totalChunks > wecomWSUploadMaxChunks {
+		return "", fmt.Errorf("media too large: %d chunks exceeds maximum %d", totalChunks, wecomWSUploadMaxChunks)
+	}
+
+	sum := md5.Sum(data)
+	initReqID := p.generateReqID("aibot_upload_media_init")
+	initFrame := map[string]any{
+		"cmd":     "aibot_upload_media_init",
+		"headers": map[string]string{"req_id": initReqID},
+		"body": map[string]any{
+			"type":         mediaType,
+			"filename":     filename,
+			"total_size":   len(data),
+			"total_chunks": totalChunks,
+			"md5":          hex.EncodeToString(sum[:]),
+		},
+	}
+	initResp, err := p.writeAndWaitFrameWithTimeout(ctx, initFrame, initReqID, wsMediaAckTimeout)
+	if err != nil {
+		return "", fmt.Errorf("upload init: %w", err)
+	}
+	var initBody struct {
+		UploadID string `json:"upload_id"`
+	}
+	if err := json.Unmarshal(initResp.Body, &initBody); err != nil {
+		return "", fmt.Errorf("decode upload init response: %w", err)
+	}
+	if initBody.UploadID == "" {
+		return "", fmt.Errorf("upload init: empty upload_id")
+	}
+
+	for i := 0; i < totalChunks; i++ {
+		start := i * wecomWSUploadChunkSize
+		end := start + wecomWSUploadChunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		reqID := p.generateReqID("aibot_upload_media_chunk")
+		chunkFrame := map[string]any{
+			"cmd":     "aibot_upload_media_chunk",
+			"headers": map[string]string{"req_id": reqID},
+			"body": map[string]any{
+				"upload_id":   initBody.UploadID,
+				"chunk_index": i,
+				"base64_data": base64.StdEncoding.EncodeToString(data[start:end]),
+			},
+		}
+		if _, err := p.writeAndWaitFrameWithTimeout(ctx, chunkFrame, reqID, wsMediaAckTimeout); err != nil {
+			return "", fmt.Errorf("upload chunk %d: %w", i, err)
+		}
+	}
+
+	finishReqID := p.generateReqID("aibot_upload_media_finish")
+	finishFrame := map[string]any{
+		"cmd":     "aibot_upload_media_finish",
+		"headers": map[string]string{"req_id": finishReqID},
+		"body": map[string]any{
+			"upload_id": initBody.UploadID,
+		},
+	}
+	finishResp, err := p.writeAndWaitFrameWithTimeout(ctx, finishFrame, finishReqID, wsMediaAckTimeout)
+	if err != nil {
+		return "", fmt.Errorf("upload finish: %w", err)
+	}
+	var finishBody struct {
+		MediaID string `json:"media_id"`
+	}
+	if err := json.Unmarshal(finishResp.Body, &finishBody); err != nil {
+		return "", fmt.Errorf("decode upload finish response: %w", err)
+	}
+	if finishBody.MediaID == "" {
+		return "", fmt.Errorf("upload finish: empty media_id")
+	}
+	return finishBody.MediaID, nil
+}
+
+func (p *WSPlatform) sendWSMediaMessage(ctx context.Context, chatID, mediaType, mediaID string) error {
+	reqID := p.generateReqID("aibot_send_msg")
+	frame := map[string]any{
+		"cmd":     "aibot_send_msg",
+		"headers": map[string]string{"req_id": reqID},
+		"body": map[string]any{
+			"chatid":  chatID,
+			"msgtype": mediaType,
+			mediaType: map[string]string{
+				"media_id": mediaID,
+			},
+		},
+	}
+	return p.writeAndWaitAck(ctx, frame, reqID)
+}
+
+func wsImageFileName(img core.ImageAttachment) string {
+	name := filepath.Base(strings.TrimSpace(img.FileName))
+	if name != "" && name != "." {
+		return name
+	}
+	switch strings.ToLower(img.MimeType) {
+	case "image/jpeg", "image/jpg":
+		return "image.jpg"
+	case "image/gif":
+		return "image.gif"
+	case "image/webp":
+		return "image.webp"
+	default:
+		return "image.png"
+	}
+}
+
+var _ core.ImageSender = (*WSPlatform)(nil)

--- a/platform/wecom/websocket_test.go
+++ b/platform/wecom/websocket_test.go
@@ -2,13 +2,19 @@ package wecom
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/chenhg5/cc-connect/core"
+	"github.com/gorilla/websocket"
 )
 
 // ---------------------------------------------------------------------------
@@ -91,15 +97,31 @@ func TestSplitByBytes_ReassemblesLargeContent(t *testing.T) {
 // handleMsgCallback — chatID fallback to userID for single chats
 // ---------------------------------------------------------------------------
 
-func TestHandleMsgCallback_SingleChat_ChatIDFallback(t *testing.T) {
-	p := &WSPlatform{
-		allowFrom: "*",
-	}
-
+func newCapturedWSPlatform() (*WSPlatform, <-chan *core.Message) {
+	p := &WSPlatform{allowFrom: "*"}
 	captured := make(chan *core.Message, 1)
 	p.handler = func(_ core.Platform, msg *core.Message) {
 		captured <- msg
 	}
+	return p, captured
+}
+
+func wsCallbackFrame(t *testing.T, reqID string, body wsMsgCallbackBody) wsFrame {
+	t.Helper()
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal callback body: %v", err)
+	}
+	return wsFrame{
+		Cmd:     "aibot_msg_callback",
+		Headers: wsFrameHeaders{ReqID: reqID},
+		Body:    bodyBytes,
+	}
+}
+
+func TestHandleMsgCallback_SingleChat_ChatIDFallback(t *testing.T) {
+	p, captured := newCapturedWSPlatform()
 
 	body := wsMsgCallbackBody{
 		MsgID:    "msg_001",
@@ -111,14 +133,7 @@ func TestHandleMsgCallback_SingleChat_ChatIDFallback(t *testing.T) {
 	body.Text.Content = "hello"
 	body.CreateTime = time.Now().Unix()
 
-	bodyBytes, _ := json.Marshal(body)
-	frame := wsFrame{
-		Cmd:     "aibot_msg_callback",
-		Headers: wsFrameHeaders{ReqID: "req_123"},
-		Body:    bodyBytes,
-	}
-
-	p.handleMsgCallback(frame)
+	p.handleMsgCallback(wsCallbackFrame(t, "req_123", body))
 
 	select {
 	case msg := <-captured:
@@ -135,14 +150,7 @@ func TestHandleMsgCallback_SingleChat_ChatIDFallback(t *testing.T) {
 }
 
 func TestHandleMsgCallback_GroupChat_ChatIDPreserved(t *testing.T) {
-	p := &WSPlatform{
-		allowFrom: "*",
-	}
-
-	captured := make(chan *core.Message, 1)
-	p.handler = func(_ core.Platform, msg *core.Message) {
-		captured <- msg
-	}
+	p, captured := newCapturedWSPlatform()
 
 	body := wsMsgCallbackBody{
 		MsgID:    "msg_002",
@@ -154,14 +162,7 @@ func TestHandleMsgCallback_GroupChat_ChatIDPreserved(t *testing.T) {
 	body.Text.Content = "hi group"
 	body.CreateTime = time.Now().Unix()
 
-	bodyBytes, _ := json.Marshal(body)
-	frame := wsFrame{
-		Cmd:     "aibot_msg_callback",
-		Headers: wsFrameHeaders{ReqID: "req_456"},
-		Body:    bodyBytes,
-	}
-
-	p.handleMsgCallback(frame)
+	p.handleMsgCallback(wsCallbackFrame(t, "req_456", body))
 
 	select {
 	case msg := <-captured:
@@ -178,15 +179,8 @@ func TestHandleMsgCallback_GroupChat_ChatIDPreserved(t *testing.T) {
 }
 
 func TestHandleMsgCallback_StripsBotMention(t *testing.T) {
-	p := &WSPlatform{
-		allowFrom: "*",
-		botID:     "robot01",
-	}
-
-	captured := make(chan *core.Message, 1)
-	p.handler = func(_ core.Platform, msg *core.Message) {
-		captured <- msg
-	}
+	p, captured := newCapturedWSPlatform()
+	p.botID = "robot01"
 
 	body := wsMsgCallbackBody{
 		MsgID:    "msg_mention",
@@ -199,14 +193,7 @@ func TestHandleMsgCallback_StripsBotMention(t *testing.T) {
 	body.Text.Content = "允许 @Robot01"
 	body.CreateTime = time.Now().Unix()
 
-	bodyBytes, _ := json.Marshal(body)
-	frame := wsFrame{
-		Cmd:     "aibot_msg_callback",
-		Headers: wsFrameHeaders{ReqID: "req_m"},
-		Body:    bodyBytes,
-	}
-
-	p.handleMsgCallback(frame)
+	p.handleMsgCallback(wsCallbackFrame(t, "req_m", body))
 
 	select {
 	case msg := <-captured:
@@ -461,6 +448,174 @@ func TestGenerateReqID_Format(t *testing.T) {
 	if id2 != "aibot_send_msg_2" {
 		t.Fatalf("expected aibot_send_msg_2, got %s", id2)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// SendImage
+// ---------------------------------------------------------------------------
+
+func TestWSPlatformSendImage_UploadsAndSendsMedia(t *testing.T) {
+	imageData := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 1, 2, 3}
+	serverDone := make(chan error, 1)
+	upgrader := websocket.Upgrader{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer conn.Close()
+		serverDone <- assertWeComWSSendImageFrames(conn, imageData)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial test websocket: %v", err)
+	}
+	defer conn.Close()
+
+	p := &WSPlatform{conn: conn}
+	go func() {
+		for {
+			var frame wsFrame
+			if err := conn.ReadJSON(&frame); err != nil {
+				return
+			}
+			p.handleFrame(frame)
+		}
+	}()
+
+	err = p.SendImage(context.Background(), wsReplyContext{chatID: "chat1", userID: "u1"}, core.ImageAttachment{
+		MimeType: "image/png",
+		Data:     imageData,
+		FileName: "chart.png",
+	})
+	if err != nil {
+		t.Fatalf("SendImage returned error: %v", err)
+	}
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not observe all expected frames")
+	}
+}
+
+func assertWeComWSSendImageFrames(conn *websocket.Conn, imageData []byte) error {
+	var initFrame struct {
+		Cmd     string         `json:"cmd"`
+		Headers wsFrameHeaders `json:"headers"`
+		Body    struct {
+			Type        string `json:"type"`
+			Filename    string `json:"filename"`
+			TotalSize   int    `json:"total_size"`
+			TotalChunks int    `json:"total_chunks"`
+			MD5         string `json:"md5"`
+		} `json:"body"`
+	}
+	if err := conn.ReadJSON(&initFrame); err != nil {
+		return fmt.Errorf("read init frame: %w", err)
+	}
+	sum := md5.Sum(imageData)
+	if initFrame.Cmd != "aibot_upload_media_init" ||
+		initFrame.Body.Type != "image" ||
+		initFrame.Body.Filename != "chart.png" ||
+		initFrame.Body.TotalSize != len(imageData) ||
+		initFrame.Body.TotalChunks != 1 ||
+		initFrame.Body.MD5 != hex.EncodeToString(sum[:]) {
+		return fmt.Errorf("unexpected init frame: %#v", initFrame)
+	}
+	if err := conn.WriteJSON(map[string]any{
+		"headers": initFrame.Headers,
+		"errcode": 0,
+		"errmsg":  "ok",
+		"body":    map[string]string{"upload_id": "upload-1"},
+	}); err != nil {
+		return fmt.Errorf("write init ack: %w", err)
+	}
+
+	var chunkFrame struct {
+		Cmd     string         `json:"cmd"`
+		Headers wsFrameHeaders `json:"headers"`
+		Body    struct {
+			UploadID   string `json:"upload_id"`
+			ChunkIndex int    `json:"chunk_index"`
+			Base64Data string `json:"base64_data"`
+		} `json:"body"`
+	}
+	if err := conn.ReadJSON(&chunkFrame); err != nil {
+		return fmt.Errorf("read chunk frame: %w", err)
+	}
+	if chunkFrame.Cmd != "aibot_upload_media_chunk" ||
+		chunkFrame.Body.UploadID != "upload-1" ||
+		chunkFrame.Body.ChunkIndex != 0 ||
+		chunkFrame.Body.Base64Data != base64.StdEncoding.EncodeToString(imageData) {
+		return fmt.Errorf("unexpected chunk frame: %#v", chunkFrame)
+	}
+	if err := conn.WriteJSON(map[string]any{
+		"headers": chunkFrame.Headers,
+		"errcode": 0,
+		"errmsg":  "ok",
+	}); err != nil {
+		return fmt.Errorf("write chunk ack: %w", err)
+	}
+
+	var finishFrame struct {
+		Cmd     string         `json:"cmd"`
+		Headers wsFrameHeaders `json:"headers"`
+		Body    struct {
+			UploadID string `json:"upload_id"`
+		} `json:"body"`
+	}
+	if err := conn.ReadJSON(&finishFrame); err != nil {
+		return fmt.Errorf("read finish frame: %w", err)
+	}
+	if finishFrame.Cmd != "aibot_upload_media_finish" || finishFrame.Body.UploadID != "upload-1" {
+		return fmt.Errorf("unexpected finish frame: %#v", finishFrame)
+	}
+	if err := conn.WriteJSON(map[string]any{
+		"headers": finishFrame.Headers,
+		"errcode": 0,
+		"errmsg":  "ok",
+		"body":    map[string]string{"media_id": "media-1"},
+	}); err != nil {
+		return fmt.Errorf("write finish ack: %w", err)
+	}
+
+	var sendFrame struct {
+		Cmd     string         `json:"cmd"`
+		Headers wsFrameHeaders `json:"headers"`
+		Body    struct {
+			ChatID  string `json:"chatid"`
+			MsgType string `json:"msgtype"`
+			Image   struct {
+				MediaID string `json:"media_id"`
+			} `json:"image"`
+		} `json:"body"`
+	}
+	if err := conn.ReadJSON(&sendFrame); err != nil {
+		return fmt.Errorf("read send frame: %w", err)
+	}
+	if sendFrame.Cmd != "aibot_send_msg" ||
+		sendFrame.Body.ChatID != "chat1" ||
+		sendFrame.Body.MsgType != "image" ||
+		sendFrame.Body.Image.MediaID != "media-1" {
+		return fmt.Errorf("unexpected send frame: %#v", sendFrame)
+	}
+	if err := conn.WriteJSON(map[string]any{
+		"headers": sendFrame.Headers,
+		"errcode": 0,
+		"errmsg":  "ok",
+	}); err != nil {
+		return fmt.Errorf("write send ack: %w", err)
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/platform/wecom/websocket_test.go
+++ b/platform/wecom/websocket_test.go
@@ -245,63 +245,50 @@ func TestWriteAndWaitAck_SuccessfulAck(t *testing.T) {
 	p := &WSPlatform{}
 
 	reqID := "send_1"
-	ch := make(chan error, 1)
+	ch := make(chan wsAckResult, 1)
 	p.pendingAcks.Store(reqID, ch)
 
 	// Simulate receiving ack in another goroutine
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		if v, ok := p.pendingAcks.LoadAndDelete(reqID); ok {
-			v.(chan error) <- nil
-		}
+		p.dispatchAck(reqID, wsAckResult{})
 	}()
 
-	ctx := context.Background()
-	select {
-	case err := <-ch:
-		if err != nil {
-			t.Fatalf("expected nil ack error, got %v", err)
+	assertAckResult(t, ch, func(result wsAckResult) {
+		if result.err != nil {
+			t.Fatalf("expected nil ack error, got %v", result.err)
 		}
-	case <-ctx.Done():
-		t.Fatal("context cancelled unexpectedly")
-	case <-time.After(1 * time.Second):
-		t.Fatal("timed out waiting for ack")
-	}
+	})
 }
 
 func TestWriteAndWaitAck_AckWithError(t *testing.T) {
 	p := &WSPlatform{}
 
 	reqID := "send_2"
-	ch := make(chan error, 1)
+	ch := make(chan wsAckResult, 1)
 	p.pendingAcks.Store(reqID, ch)
 
 	ackErr := fmt.Errorf("wecom-ws: ack error: errcode=40001 errmsg=invalid token")
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		if v, ok := p.pendingAcks.LoadAndDelete(reqID); ok {
-			v.(chan error) <- ackErr
-		}
+		p.dispatchAck(reqID, wsAckResult{err: ackErr})
 	}()
 
-	select {
-	case err := <-ch:
-		if err == nil {
+	assertAckResult(t, ch, func(result wsAckResult) {
+		if result.err == nil {
 			t.Fatal("expected ack error, got nil")
 		}
-		if err.Error() != ackErr.Error() {
-			t.Fatalf("unexpected error: %v", err)
+		if result.err.Error() != ackErr.Error() {
+			t.Fatalf("unexpected error: %v", result.err)
 		}
-	case <-time.After(1 * time.Second):
-		t.Fatal("timed out waiting for ack")
-	}
+	})
 }
 
 func TestWriteAndWaitAck_Timeout(t *testing.T) {
 	p := &WSPlatform{}
 
 	reqID := "send_timeout"
-	ch := make(chan error, 1)
+	ch := make(chan wsAckResult, 1)
 	p.pendingAcks.Store(reqID, ch)
 
 	// Nobody sends ack → should timeout
@@ -325,7 +312,7 @@ func TestWriteAndWaitAck_ContextCancelled(t *testing.T) {
 	p := &WSPlatform{}
 
 	reqID := "send_cancel"
-	ch := make(chan error, 1)
+	ch := make(chan wsAckResult, 1)
 	p.pendingAcks.Store(reqID, ch)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -355,7 +342,7 @@ func TestHandleFrame_AckDispatch(t *testing.T) {
 	p := &WSPlatform{}
 
 	reqID := "aibot_send_msg_1"
-	ch := make(chan error, 1)
+	ch := make(chan wsAckResult, 1)
 	p.pendingAcks.Store(reqID, ch)
 
 	errCode := 0
@@ -368,21 +355,18 @@ func TestHandleFrame_AckDispatch(t *testing.T) {
 
 	p.handleFrame(frame)
 
-	select {
-	case err := <-ch:
-		if err != nil {
-			t.Fatalf("expected nil error for successful ack, got %v", err)
+	assertAckResult(t, ch, func(result wsAckResult) {
+		if result.err != nil {
+			t.Fatalf("expected nil error for successful ack, got %v", result.err)
 		}
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("ack not dispatched")
-	}
+	})
 }
 
 func TestHandleFrame_AckDispatch_WithError(t *testing.T) {
 	p := &WSPlatform{}
 
 	reqID := "aibot_send_msg_2"
-	ch := make(chan error, 1)
+	ch := make(chan wsAckResult, 1)
 	p.pendingAcks.Store(reqID, ch)
 
 	errCode := 40001
@@ -395,11 +379,19 @@ func TestHandleFrame_AckDispatch_WithError(t *testing.T) {
 
 	p.handleFrame(frame)
 
-	select {
-	case err := <-ch:
-		if err == nil {
+	assertAckResult(t, ch, func(result wsAckResult) {
+		if result.err == nil {
 			t.Fatal("expected error for failed ack, got nil")
 		}
+	})
+}
+
+func assertAckResult(t *testing.T, ch <-chan wsAckResult, check func(wsAckResult)) {
+	t.Helper()
+
+	select {
+	case result := <-ch:
+		check(result)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("ack not dispatched")
 	}


### PR DESCRIPTION
## Summary

Adds outbound image delivery for WeCom AI Bot WebSocket mode.

This implements `core.ImageSender` for the WeCom WebSocket platform by uploading local image bytes through the AI Bot media frame sequence, then sending the returned `media_id` with `aibot_send_msg`.

## Changes

- Implements WebSocket image upload with `aibot_upload_media_init`, `aibot_upload_media_chunk`, and `aibot_upload_media_finish`.
- Sends uploaded images through `aibot_send_msg` using the returned `media_id`.
- Uses a longer ACK timeout for media upload frames; live WeCom returned chunk ACKs after roughly 10 seconds.
- Simplifies ACK handling so `pendingAcks` consistently uses `chan wsAckResult`.
- Adds regression tests for successful upload, upload ACK errors, timeout paths, and image send-back.
- Updates WeCom docs to describe WebSocket image send-back support.

## Verification

Automated:

```bash
go test -count=1 ./platform/wecom
go build -tags 'no_acp no_claudecode no_cursor no_devin no_gemini no_iflow no_kimi no_opencode no_pi no_qoder no_telegram no_discord no_slack no_feishu no_dingtalk no_weixin no_qq no_qqbot no_line no_weibo no_max no_web' ./cmd/cc-connect
```

Manual:

- Verified live WeCom WebSocket E2E image send with `cc-connect send --image /Users/rael/Documents/IMG_8202.jpg`.
- Confirmed text send, media init, media chunk, media finish, and image send all returned ACK.
- Confirmed the CLI returned `Message sent successfully.`

## Compatibility

- This is scoped to WeCom WebSocket mode.
- Platforms without image send support keep their existing behavior.
- The media frame sequence follows `@wecom/aibot-node-sdk` v1.0.6.
