### PR TITLE
fix(cron): validate UpdateJob enabled value type before removing schedule

### DIFF
--- a/core/cron.go
+++ b/core/cron.go
@@ -554,6 +554,17 @@ func (cs *CronScheduler) UpdateJob(id string, field string, value any) error {
 		}
 	}
 
+	// Validate enabled type up-front. Without this, a non-bool value (e.g. a
+	// JSON string "true" from a misbehaving API client) reaches updateJobField
+	// only after we've already removed the cron entry below, and store.Update
+	// then fails on the type mismatch — leaving the job marked Enabled in the
+	// store but never firing again until the daemon restarts.
+	if field == "enabled" {
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("enabled must be a boolean")
+		}
+	}
+
 	// Check if reschedule is needed
 	needsReschedule := field == "cron_expr" || field == "enabled"
 

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -565,3 +565,51 @@ func TestCronStore_ListByProject(t *testing.T) {
 		t.Errorf("ListByProject(nonexistent) = %d jobs, want 0", len(list3))
 	}
 }
+
+// TestCronScheduler_UpdateJob_EnabledNonBoolPreservesSchedule verifies that
+// passing a non-bool value for the "enabled" field is rejected up-front and
+// does NOT silently leave the scheduled cron entry removed. Before this fix,
+// UpdateJob removed the entry before delegating to store.Update, so a type
+// mismatch left the job marked Enabled but with no scheduled tick — the only
+// recovery was a daemon restart.
+func TestCronScheduler_UpdateJob_EnabledNonBoolPreservesSchedule(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := NewCronScheduler(store)
+
+	job := &CronJob{
+		ID: "e1", Project: "p", SessionKey: "test:1:1",
+		CronExpr: "0 6 * * *", Prompt: "hi", Enabled: true,
+	}
+	if err := cs.AddJob(job); err != nil {
+		t.Fatal(err)
+	}
+
+	cs.mu.RLock()
+	_, scheduledBefore := cs.entries[job.ID]
+	cs.mu.RUnlock()
+	if !scheduledBefore {
+		t.Fatal("precondition: enabled job should be scheduled after AddJob")
+	}
+
+	// String "true" instead of bool true — what a misbehaving HTTP/management
+	// API client could send.
+	if err := cs.UpdateJob(job.ID, "enabled", "true"); err == nil {
+		t.Fatal("UpdateJob with non-bool enabled value should return an error")
+	}
+
+	cs.mu.RLock()
+	_, scheduledAfter := cs.entries[job.ID]
+	cs.mu.RUnlock()
+	if !scheduledAfter {
+		t.Fatal("schedule was removed even though update failed; job will never fire again")
+	}
+
+	stored := store.Get(job.ID)
+	if stored == nil || !stored.Enabled {
+		t.Fatalf("stored job state should be unchanged on validation error, got %+v", stored)
+	}
+}


### PR DESCRIPTION
## Summary

`CronScheduler.UpdateJob` pre-validates the value type for `cron_expr`, `mode`, and `session_mode` before touching anything, but the `enabled` field is missed — even though `enabled` is also in the `needsReschedule` set. Today the flow on a bad type is:

1. `needsReschedule := field == \"cron_expr\" || field == \"enabled\"` → `true`
2. Remove the cron entry from the in-memory scheduler.
3. Call `store.Update(id, \"enabled\", value)`.
4. `updateJobField` switch on `case \"enabled\"` requires `value.(bool)`; a JSON string `\"true\"` falls through, the reflection fallback can't set a bool field via a string, and `store.Update` returns `false`.
5. `UpdateJob` returns an error.

Net effect: the cron entry is gone but the job is still marked `Enabled: true` in the store, so it never fires again until the daemon restarts (or the user toggles `disable` then `enable` to round-trip through `EnableJob`/`DisableJob`).

The CLI (`cmd/cc-connect/cron.go`) coerces to bool before sending, but the HTTP API in `core/api.go` and the management PATCH endpoint in `core/management.go` both accept arbitrary JSON, so a misbehaving client or test can trigger this.

## Fix

Mirror the existing up-front type validation for `cron_expr` and reject non-bool `enabled` values **before** removing the cron entry. Minimal change, no behavior change for callers that already send the correct type.

## Test plan

- [x] New regression test `TestCronScheduler_UpdateJob_EnabledNonBoolPreservesSchedule` asserts the schedule entry is still present after a rejected update and the stored `Enabled` flag is unchanged. The test fails on `main` and passes with the fix.
- [x] `go test -race -tags no_web -run TestCron ./core/...` — all green.
- [x] `go vet -tags no_web ./core/...` clean.
- [x] `go build -tags no_web ./...` clean.