### PR TITLE
Handle WeCom display mentions before commands

### DIFF
--- a/platform/wecom/mention_strip.go
+++ b/platform/wecom/mention_strip.go
@@ -17,7 +17,7 @@ func stripWeComAtMentions(s string, botIDs ...string) string {
 	for strings.Contains(s, "  ") {
 		s = strings.ReplaceAll(s, "  ", " ")
 	}
-	return strings.TrimSpace(s)
+	return stripLeadingDisplayMentionCommand(strings.TrimSpace(s))
 }
 
 func stripOneWeComAtMention(s, botID string) string {
@@ -58,4 +58,22 @@ func removeAllEqualFold(s, sub string) string {
 		}
 		s = s[:idx] + s[idx+len(sub):]
 	}
+}
+
+func stripLeadingDisplayMentionCommand(s string) string {
+	if s == "" {
+		return s
+	}
+	if !strings.HasPrefix(s, "@") && !strings.HasPrefix(s, "＠") {
+		return s
+	}
+	fields := strings.Fields(s)
+	if len(fields) < 2 {
+		return s
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(s, fields[0]))
+	if strings.HasPrefix(rest, "/") || strings.HasPrefix(rest, "!") {
+		return rest
+	}
+	return s
 }

--- a/platform/wecom/mention_strip_test.go
+++ b/platform/wecom/mention_strip_test.go
@@ -17,6 +17,9 @@ func TestStripWeComAtMentions(t *testing.T) {
 		{"fullwidth at", "允许 ＠mybot", []string{"mybot"}, "允许"},
 		{"two ids second", "ok @a @b", []string{"a", "b"}, "ok"},
 		{"unrelated at", "email x@y.com", []string{"mybot"}, "email x@y.com"},
+		{"display mention before slash command", "@小口不休息 /whoami", []string{"robot01"}, "/whoami"},
+		{"display mention before bang command", "＠小口不休息 !pwd", []string{"robot01"}, "!pwd"},
+		{"display mention before normal text preserved", "@小口不休息 你好", []string{"robot01"}, "@小口不休息 你好"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes WeCom group commands when the user types the display mention before the command, such as `@bot /whoami` or `＠bot !pwd`.

## Problem

In some WeCom group messages, the webhook payload does not include the bot id form that `stripWeComAtMentions` can remove. The visible text may still begin with the display mention, so command detection sees `@bot /whoami` instead of `/whoami` and does not route it as a command.

## Changes

- Strips a leading display-style mention only when the remaining text begins with `/` or `!`.
- Preserves normal text such as `@bot hello` to avoid over-stripping user content.
- Adds regression tests for slash commands, bang commands, and normal text preservation.

## Verification

```bash
go test -count=1 ./platform/wecom
```

## Compatibility

- Scoped to WeCom mention stripping.
- Does not alter regular mention removal when the bot id is present.
- Does not strip display mentions from non-command text.
