### PR TITLE
fix(cursor): remove deprecated --trust CLI option

### DIFF
--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -25,10 +25,10 @@ func init() {
 // Agent drives the Cursor Agent CLI (`agent`) using --print --output-format stream-json.
 //
 // Modes (maps to Cursor agent CLI flags):
-//   - "default":  --trust only (ask permission for tools)
-//   - "force":    --trust --force (auto-approve tools unless explicitly denied)
-//   - "plan":     --trust --mode plan (read-only analysis)
-//   - "ask":      --trust --mode ask (Q&A style, read-only)
+//   - "default":  default permissions (ask permission for tools)
+//   - "force":    --force (auto-approve tools unless explicitly denied)
+//   - "plan":     --mode plan (read-only analysis)
+//   - "ask":      --mode ask (Q&A style, read-only)
 type Agent struct {
 	workDir    string
 	model      string

--- a/agent/cursor/session.go
+++ b/agent/cursor/session.go
@@ -77,7 +77,6 @@ func (cs *cursorSession) Send(prompt string, images []core.ImageAttachment, file
 	args := []string{
 		"--print",
 		"--output-format", "stream-json",
-		"--trust",
 	}
 
 	switch cs.mode {
@@ -436,7 +435,7 @@ func (cs *cursorSession) handleResult(raw map[string]any) {
 	}
 }
 
-// RespondPermission is a no-op — Cursor Agent permissions are handled via --trust/--force flags.
+// RespondPermission is a no-op — Cursor Agent permissions are handled via CLI default behavior or --force flag.
 func (cs *cursorSession) RespondPermission(_ string, _ core.PermissionResult) error {
 	return nil
 }


### PR DESCRIPTION
## Summary
- Remove `--trust` flag from Cursor Agent CLI arguments
- Newer Cursor CLI versions no longer support this option, causing "unknown option '--trust'" error
- Update comments to reflect the change

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./...` passes (all tests)

Fixes #923