### PR TITLE
fix(weixin): improve context_token missing error handling

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -9080,7 +9080,16 @@ func (e *Engine) sendWithError(p Platform, replyCtx any, content string) error {
 func (e *Engine) sendAlreadyRenderedWithError(p Platform, replyCtx any, content string) error {
 	start := time.Now()
 	if err := p.Send(e.ctx, replyCtx, content); err != nil {
-		slog.Error("platform send failed", "platform", p.Name(), "error", err, "content_len", len(content))
+		// Check for context_token missing error (common for Weixin platform)
+		if strings.Contains(err.Error(), "missing context_token") {
+			slog.Error("platform send failed: context_token missing",
+				"platform", p.Name(),
+				"error", err,
+				"content_len", len(content),
+				"hint", "user needs to send a new message to refresh context_token")
+		} else {
+			slog.Error("platform send failed", "platform", p.Name(), "error", err, "content_len", len(content))
+		}
 		return err
 	}
 	if elapsed := time.Since(start); elapsed >= slowPlatformSend {

--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -607,7 +607,11 @@ func (p *Platform) sendChunks(ctx context.Context, replyCtx any, content string)
 		rc.contextToken = p.getContextToken(rc.peerUserID)
 	}
 	if strings.TrimSpace(rc.contextToken) == "" {
-		return fmt.Errorf("weixin: missing context_token for peer %q", rc.peerUserID)
+		slog.Error("weixin: cannot send message - missing context_token",
+			"peer", rc.peerUserID,
+			"content_preview", truncatePreview(content, 100),
+			"hint", "user needs to send a new message to refresh context_token")
+		return fmt.Errorf("weixin: missing context_token for peer %q - user must send a new message first", rc.peerUserID)
 	}
 	if strings.TrimSpace(content) == "" {
 		return nil
@@ -684,6 +688,13 @@ func (p *Platform) sendChunkWithRetry(ctx context.Context, rc *replyContext, chu
 		return err
 	}
 	return lastErr
+}
+
+func truncatePreview(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
 }
 
 func splitUTF8(s string, maxRunes int) []string {


### PR DESCRIPTION
## Summary
- Add prominent error logging in `sendChunks` when context_token is missing
- Add truncatePreview helper for content preview in logs
- Improve error message with actionable guidance for users
- Add special handling in engine for context_token missing errors

## Root Cause
When sending authorization prompts to Weixin, if context_token is missing (API didn't provide it or stored token is empty), the send fails silently. Users don't receive prompts and don't know to send a new message to refresh the token.

## Fix
The improved error logging helps operators diagnose the issue. The error message now includes guidance: "user must send a new message first".

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes

Fixes #929