### PR TITLE
fix(core): extract channel/user IDs correctly for 3-segment type-tagged session keys

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -13024,11 +13024,11 @@ func (e *Engine) buildSenderPrompt(content, userID, userName, platform, sessionK
 func extractChannelID(sessionKey string) string {
 	// Format: "platform:channelID:userID" or "platform:channelID"
 	// Some platforms encode a short type tag as an extra segment, e.g.
-	// "platform:t:channelID:userID" where t is a single-char tag.
-	// When 4+ segments exist and parts[1] is a single char, treat parts[2]
-	// as the real channel ID.
+	// "platform:t:channelID:userID" or "platform:t:channelID" (shared session)
+	// where t is a single-char tag. When parts[1] is a single char and at
+	// least one more segment follows, treat parts[2] as the real channel ID.
 	parts := strings.SplitN(sessionKey, ":", 4)
-	if len(parts) >= 4 && len(parts[1]) == 1 {
+	if len(parts) >= 3 && len(parts[1]) == 1 {
 		return parts[2]
 	}
 	if len(parts) >= 2 {
@@ -13039,11 +13039,15 @@ func extractChannelID(sessionKey string) string {
 
 func extractUserID(sessionKey string) string {
 	// Format: "platform:channelID:userID" or "platform:type:channelID:userID"
-	// When 4+ segments exist and parts[1] is a single-char type tag, the
-	// user ID is in parts[3].
+	// When parts[1] is a single-char type tag, the user ID is in parts[3]
+	// (4-segment form). The 3-segment form with a type tag (shared session,
+	// e.g. "dingtalk:g:cid") has no per-user ID, so return "".
 	parts := strings.SplitN(sessionKey, ":", 5)
-	if len(parts) >= 4 && len(parts[1]) == 1 {
-		return parts[3]
+	if len(parts) >= 3 && len(parts[1]) == 1 {
+		if len(parts) >= 4 {
+			return parts[3]
+		}
+		return ""
 	}
 	if len(parts) >= 3 {
 		return parts[2]

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -8272,6 +8272,11 @@ func TestExtractChannelID(t *testing.T) {
 		{"a:bb:c:d", "bb"},
 		{"dingtalk:g:cidXXX:staff1", "cidXXX"},
 		{"dingtalk:d:cidYYY:staff2", "cidYYY"},
+		// 3-segment shared-session keys with single-char type tag — used by
+		// dingtalk/qq/qqbot when share_session_in_channel is enabled.
+		{"dingtalk:g:cidZZZ", "cidZZZ"},
+		{"qq:g:12345", "12345"},
+		{"qqbot:g:openid_abc", "openid_abc"},
 	}
 	for _, tt := range tests {
 		got := extractChannelID(tt.key)
@@ -10782,6 +10787,8 @@ func TestExtractSessionKeyParts(t *testing.T) {
 		{"empty string", "", "", "", "", ""},
 		{"just platform colon user", "line::user1", "line", "", "", "user1"},
 		{"four-segment with type tag", "dingtalk:g:cidXXX:staff1", "dingtalk", "cidXXX", "dingtalk:cidXXX", "staff1"},
+		{"three-segment with type tag (shared session)", "dingtalk:g:cidZZZ", "dingtalk", "cidZZZ", "dingtalk:cidZZZ", ""},
+		{"three-segment qq group", "qq:g:12345", "qq", "12345", "qq:12345", ""},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

\`extractChannelID\` and \`extractUserID\` in \`core/engine.go\` only handled the 4-segment session key form \`platform:t:channelID:userID\` (where \`t\` is a single-char type tag). Three platforms emit a 3-segment form when a single session is shared across a whole group/channel:

- \`dingtalk:g:cid\` — DingTalk with \`share_session_in_channel = true\` (added by #702)
- \`qq:g:groupID\` — QQ group session (\`platform/qq/qq.go:207\`)
- \`qqbot:g:groupOpenID\` — QQ Bot group session (\`platform/qqbot/qqbot.go:988\`)

For these keys:

- \`extractChannelID\` returned the tag \`\"g\"\` / \`\"d\"\` instead of the conversation ID.
- \`extractUserID\` returned the conversation ID as if it were a user ID.

Callers that take \`extractChannelID(sessionKey)\` directly (rather than going through \`effectiveChannelID(msg)\` which prefers \`msg.ChannelKey\`) silently used the wrong key:

- \`core/engine.go:1123\` — multi-workspace resolution (\`extractChannelID\` → \`resolveWorkspace\`)
- \`core/observer.go:98\` — observer channel id from \`observeSessionKey\`
- \`core/engine.go:13015\` — \`buildSenderPrompt\` fallback when \`channelKey\` is empty
- \`core/engine.go:9254/9280/9296/9311\` — \`extractUserID\` for status/cron card ownership

## Fix

Treat any 3+ segment key whose \`parts[1]\` is a single character as a type-tagged form and use \`parts[2]\` as the channel. The 3-segment form has no per-user ID, so \`extractUserID\` returns \`\"\"\`. Existing 4-segment behavior is preserved.

## Test plan

- [x] \`go test ./core/ -run \"TestExtractChannelID|TestExtractSessionKeyParts\"\` — new rows for \`dingtalk:g:cidZZZ\`, \`qq:g:12345\`, \`qqbot:g:openid_abc\` pass.
- [x] \`go test ./core/ -run \"TestMultiWorkspace|TestObserve|TestWorkspaceBinding|TestExtract|TestEffective|TestBuildSenderPrompt\"\` — all related suites pass.
- [x] \`go build ./...\` (excluding the \`web/embed.go\` \`all:dist\` pattern which requires the JS bundle).
- [x] Pre-existing \`TestProcessInteractiveEvents_*Footer*\` and \`TestResolveLocalDirPath_AcceptsSubdir\` failures verified to also fail on \`main\` (macOS HOME-tilde / \`/var\`↔\`/private/var\` symlink env issues, unrelated to this change).