### PR TITLE
fix(config): support show_context_indicator and reply_footer in global [display]

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -274,15 +274,10 @@ func main() {
 		}
 
 		engine := core.NewEngine(proj.Name, agent, platforms, sessionFile, lang)
-		showCtx := true
-		if proj.ShowContextIndicator != nil {
-			showCtx = *proj.ShowContextIndicator
-		}
+		// Wire display settings including show_context_indicator and reply_footer
+		// Global [display] config can be overridden by project-level settings
+		_, _, _, _, _, showCtx, showFooter := config.EffectiveDisplay(cfg, &proj)
 		engine.SetShowContextIndicator(showCtx)
-		showFooter := true
-		if proj.ReplyFooter != nil {
-			showFooter = *proj.ReplyFooter
-		}
 		engine.SetReplyFooterEnabled(showFooter)
 		engine.SetAttachmentSendEnabled(cfg.AttachmentSend != "off")
 		engine.SetFilterExternalSessions(proj.FilterExternalSessions != nil && *proj.FilterExternalSessions)
@@ -399,7 +394,7 @@ func main() {
 
 		// Wire display truncation settings (includes legacy quiet → display mapping)
 		{
-			mode, tm, tool, tmlen, toollen := config.EffectiveDisplay(cfg, &proj)
+			mode, tm, tool, tmlen, toollen, _, _ := config.EffectiveDisplay(cfg, &proj)
 			engine.SetDisplayConfig(core.DisplayCfg{
 				Mode:             mode,
 				CardMode:         config.EffectiveCardMode(cfg, &proj),
@@ -1433,7 +1428,7 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 	}
 
 	// Reload display config (includes legacy quiet → display mapping)
-	mode, tm, tool, tmlen, toollen := config.EffectiveDisplay(cfg, proj)
+	mode, tm, tool, tmlen, toollen, showCtx, showFooter := config.EffectiveDisplay(cfg, proj)
 	engine.SetDisplayConfig(core.DisplayCfg{
 		Mode:             mode,
 		CardMode:         config.EffectiveCardMode(cfg, proj),
@@ -1443,6 +1438,10 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 		ToolMessages:     tool,
 	})
 	result.DisplayUpdated = true
+
+	// Wire show_context_indicator and reply_footer from display config
+	engine.SetShowContextIndicator(showCtx)
+	engine.SetReplyFooterEnabled(showFooter)
 
 	// Reload auto-compress settings
 	if proj.AutoCompress.Enabled != nil && *proj.AutoCompress.Enabled {
@@ -1464,17 +1463,6 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 		slog.Info("project: reset_on_idle_mins not set, applying default — set reset_on_idle_mins = 0 to opt out, see docs/usage.md",
 			"project", proj.Name, "default_minutes", defaultResetOnIdleMins)
 	}
-
-	showCtx := true
-	if proj.ShowContextIndicator != nil {
-		showCtx = *proj.ShowContextIndicator
-	}
-	engine.SetShowContextIndicator(showCtx)
-	showFooter := true
-	if proj.ReplyFooter != nil {
-		showFooter = *proj.ReplyFooter
-	}
-	engine.SetReplyFooterEnabled(showFooter)
 
 	// Reload instant reply
 	if cfg.InstantReply.Enabled != nil && *cfg.InstantReply.Enabled {

--- a/config.example.toml
+++ b/config.example.toml
@@ -98,6 +98,10 @@ level = "info" # debug, info, warn, error
 # thinking_max_len = 300    # Max chars for thinking messages (default: 300) / 思考消息最大字符数（默认 300）
 # tool_max_len = 500        # Max chars for tool use messages (default: 500) / 工具调用消息最大字符数（默认 500）
 # tool_messages = true      # Show/hide tool progress messages (default: true) / 是否显示工具进度消息（默认 true）
+# show_context_indicator = true  # Show "[ctx: ~N%]" suffix on assistant replies (default: true)
+#                                # 在助手回复末尾显示「[ctx: ~N%]」上下文占用提示（默认 true 显示）
+# reply_footer = true            # Show Codex-like footer on assistant replies (default: true)
+#                                # 在助手回复底部显示类似 Codex 的状态行（默认 true 显示）
 
 # Per-project override: each [[projects]] entry may have its own [projects.display]
 # block that overrides individual fields of the global [display] block above.

--- a/config/config.go
+++ b/config/config.go
@@ -175,12 +175,14 @@ const (
 
 // DisplayConfig controls how intermediate messages (thinking, tool output) are shown.
 type DisplayConfig struct {
-	Mode             *string `toml:"mode"`              // "full" (default), "compact", or "quiet"
-	CardMode         *string `toml:"card_mode"`         // "legacy" (default) or "rich" (Card 2.0 Feishu)
-	ThinkingMessages *bool   `toml:"thinking_messages"` // whether thinking messages are shown; default true
-	ThinkingMaxLen   *int    `toml:"thinking_max_len"`  // max chars for thinking messages; 0 = no truncation; default 300
-	ToolMaxLen       *int    `toml:"tool_max_len"`      // max chars for tool use messages; 0 = no truncation; default 500
-	ToolMessages     *bool   `toml:"tool_messages"`     // whether tool progress messages are shown; default true
+	Mode               *string `toml:"mode"`                 // "full" (default), "compact", or "quiet"
+	CardMode           *string `toml:"card_mode"`            // "legacy" (default) or "rich" (Card 2.0 Feishu)
+	ThinkingMessages   *bool   `toml:"thinking_messages"`    // whether thinking messages are shown; default true
+	ThinkingMaxLen     *int    `toml:"thinking_max_len"`     // max chars for thinking messages; 0 = no truncation; default 300
+	ToolMaxLen         *int    `toml:"tool_max_len"`         // max chars for tool use messages; 0 = no truncation; default 500
+	ToolMessages       *bool   `toml:"tool_messages"`        // whether tool progress messages are shown; default true
+	ShowContextIndicator *bool `toml:"show_context_indicator"` // whether [ctx: ~N%] suffix is shown; default true
+	ReplyFooter        *bool   `toml:"reply_footer"`         // whether Codex-like footer is shown; default true
 }
 
 // StreamPreviewConfig controls real-time streaming preview in IM.
@@ -636,7 +638,7 @@ func projectQuietEffective(cfg *Config, proj *ProjectConfig) bool {
 //  1. project-level [projects.display].<field> (highest precedence)
 //  2. global [display].<field>
 //  3. mode-derived default (compact/quiet → false, full → true)
-func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMessages, toolMessages bool, thinkingMaxLen, toolMaxLen int) {
+func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMessages, toolMessages bool, thinkingMaxLen, toolMaxLen int, showContextIndicator, replyFooter bool) {
 	var projDisp *DisplayConfig
 	if proj != nil {
 		projDisp = proj.Display
@@ -711,6 +713,29 @@ func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMe
 		cfg.Display.ToolMaxLen,
 		500,
 	)
+
+	// ShowContextIndicator precedence: proj.ShowContextIndicator > proj.Display.ShowContextIndicator > cfg.Display.ShowContextIndicator > default true
+	if proj != nil && proj.ShowContextIndicator != nil {
+		showContextIndicator = *proj.ShowContextIndicator
+	} else if projDisp != nil && projDisp.ShowContextIndicator != nil {
+		showContextIndicator = *projDisp.ShowContextIndicator
+	} else if cfg.Display.ShowContextIndicator != nil {
+		showContextIndicator = *cfg.Display.ShowContextIndicator
+	} else {
+		showContextIndicator = true
+	}
+
+	// ReplyFooter precedence: proj.ReplyFooter > proj.Display.ReplyFooter > cfg.Display.ReplyFooter > default true
+	if proj != nil && proj.ReplyFooter != nil {
+		replyFooter = *proj.ReplyFooter
+	} else if projDisp != nil && projDisp.ReplyFooter != nil {
+		replyFooter = *projDisp.ReplyFooter
+	} else if cfg.Display.ReplyFooter != nil {
+		replyFooter = *cfg.Display.ReplyFooter
+	} else {
+		replyFooter = true
+	}
+
 	return
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -299,7 +299,7 @@ func TestEffectiveDisplayQuiet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mode, tm, tool, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
+			mode, tm, tool, _, _, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
 			if mode != tt.wantMode {
 				t.Fatalf("Mode = %q, want %q", mode, tt.wantMode)
 			}
@@ -412,7 +412,7 @@ func TestEffectiveDisplay_ProjectOverride(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, tm, tool, thinkLen, toolMaxLen := EffectiveDisplay(&tt.cfg, &tt.proj)
+			_, tm, tool, thinkLen, toolMaxLen, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
 			if tm != tt.wantTM {
 				t.Errorf("ThinkingMessages = %v, want %v", tm, tt.wantTM)
 			}

--- a/tests/release_local/config_matrix/config_matrix_test.go
+++ b/tests/release_local/config_matrix/config_matrix_test.go
@@ -84,7 +84,7 @@ app_secret = "secret"
 		t.Fatalf("ResetOnIdleMins = %#v, want explicit 0", proj.ResetOnIdleMins)
 	}
 
-	mode, thinking, tools, thinkingMax, toolMax := config.EffectiveDisplay(cfg, proj)
+	mode, thinking, tools, thinkingMax, toolMax, _, _ := config.EffectiveDisplay(cfg, proj)
 	if mode != config.DisplayModeFull {
 		t.Fatalf("mode = %q, want project full override", mode)
 	}
@@ -111,7 +111,7 @@ func TestReleaseConfig_DefaultsKeepAttachmentsAndFullDisplayEnabled(t *testing.T
 	if cfg.AttachmentSend != "on" {
 		t.Fatalf("AttachmentSend = %q, want default on", cfg.AttachmentSend)
 	}
-	mode, thinking, tools, _, _ := config.EffectiveDisplay(cfg, &cfg.Projects[0])
+	mode, thinking, tools, _, _, _, _ := config.EffectiveDisplay(cfg, &cfg.Projects[0])
 	if mode != config.DisplayModeFull || !thinking || !tools {
 		t.Fatalf("display = mode:%s thinking:%v tools:%v, want full/true/true", mode, thinking, tools)
 	}
@@ -181,7 +181,7 @@ app_secret = "secret"
 	if strings.Join(proj.DisabledCommands, ",") != "restart,shell" {
 		t.Fatalf("disabled_commands = %#v", proj.DisabledCommands)
 	}
-	mode, thinking, tools, _, _ := config.EffectiveDisplay(cfg, proj)
+	mode, thinking, tools, _, _, _, _ := config.EffectiveDisplay(cfg, proj)
 	if mode != config.DisplayModeQuiet || thinking || tools {
 		t.Fatalf("display = mode:%s thinking:%v tools:%v, want quiet/false/false", mode, thinking, tools)
 	}


### PR DESCRIPTION
## Summary
- Add `ShowContextIndicator` and `ReplyFooter` to `DisplayConfig` struct
- Extend `EffectiveDisplay` to return these values with proper precedence
- Update all call sites in main.go and test files
- Document new options in config.example.toml

## Root Cause
Users setting `show_context_indicator = false` under `[display]` section were seeing `[ctx: ~N%]` still appear. This was because these settings only existed in `ProjectConfig`, not `DisplayConfig`, so the global config was silently ignored.

## Fix
Now `[display]` section supports `show_context_indicator` and `reply_footer` as global defaults, which can be overridden at project level.

Precedence: `proj.ShowContextIndicator` > `proj.Display.ShowContextIndicator` > `cfg.Display.ShowContextIndicator` > default `true`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes

Fixes #941