### PR TITLE
fix: improve sessions, web console routing, telegram albums, and gemini output

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -519,7 +519,13 @@ func sameCodexPath(a, b string) bool {
 	if a == "" || b == "" {
 		return false
 	}
-	return filepath.Clean(a) == filepath.Clean(b)
+	return normalizeCodexPathForCompare(a) == normalizeCodexPathForCompare(b)
+}
+
+func normalizeCodexPathForCompare(path string) string {
+	clean := filepath.Clean(strings.ReplaceAll(path, "\\", "/"))
+	clean = strings.ReplaceAll(clean, "\\", "/")
+	return strings.ToLower(clean)
 }
 
 func uniqueCodexSkillDirs(paths []string) []string {

--- a/agent/codex/list.go
+++ b/agent/codex/list.go
@@ -146,8 +146,9 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 		}
 	}
 
-	// Filter by cwd
-	if filterCwd != "" && sessionCwd != "" && sessionCwd != filterCwd {
+	// Filter by cwd. Codex versions differ on Windows path formatting
+	// (for example, D:/repo vs D:\repo), so compare normalized paths.
+	if filterCwd != "" && sessionCwd != "" && !sameCodexPath(sessionCwd, filterCwd) {
 		return nil
 	}
 

--- a/agent/codex/list_windows_path_test.go
+++ b/agent/codex/list_windows_path_test.go
@@ -1,0 +1,24 @@
+﻿package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseCodexSessionFile_MatchesWindowsSlashVariants(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout.jsonl")
+	content := `{"type":"session_meta","payload":{"id":"session-slash","cwd":"D:/Codex/channels"}}` + "\n" +
+		`{"type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"你好，这条对话是test-b"}]}}` + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info := parseCodexSessionFile(path, `D:\Codex\channels`)
+	if info == nil {
+		t.Fatal("expected session to match slash-variant cwd")
+	}
+	if info.ID != "session-slash" {
+		t.Fatalf("ID = %q", info.ID)
+	}
+}

--- a/agent/codex/path_compare_test.go
+++ b/agent/codex/path_compare_test.go
@@ -1,0 +1,15 @@
+package codex
+
+import "testing"
+
+func TestSameCodexPath_NormalizesWindowsSeparators(t *testing.T) {
+	if !sameCodexPath(`D:/Codex/channels`, `D:\Codex\channels`) {
+		t.Fatal("expected slash and backslash Windows paths to match")
+	}
+}
+
+func TestSameCodexPath_NormalizesWindowsCase(t *testing.T) {
+	if !sameCodexPath(`d:/codex/channels`, `D:\Codex\Channels`) {
+		t.Fatal("expected Windows paths to match case-insensitively")
+	}
+}

--- a/agent/gemini/gemini.go
+++ b/agent/gemini/gemini.go
@@ -234,25 +234,19 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 		return fmt.Errorf("gemini: cannot determine home dir: %w", err)
 	}
 	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", geminiProjectSlug(a.workDir), "chats")
-	// Session files are named session-<timestamp>-<uuid_prefix>.json, not <uuid>.json.
+	// Session files are named session-<timestamp>-<uuid_prefix>.(json|jsonl), not <uuid>.json.
 	// Scan the directory to find the file containing the matching sessionId.
 	entries, err := os.ReadDir(chatsDir)
 	if err != nil {
 		return fmt.Errorf("session file not found: %s", sessionID)
 	}
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+		if entry.IsDir() || !isGeminiSessionFile(entry.Name()) {
 			continue
 		}
 		fpath := filepath.Join(chatsDir, entry.Name())
-		data, err := os.ReadFile(fpath)
-		if err != nil {
-			continue
-		}
-		var sf struct {
-			SessionID string `json:"sessionId"`
-		}
-		if json.Unmarshal(data, &sf) == nil && sf.SessionID == sessionID {
+		sf, err := readGeminiSessionFile(fpath)
+		if err == nil && sf.SessionID == sessionID {
 			return os.Remove(fpath)
 		}
 	}
@@ -472,6 +466,7 @@ type sessionFile struct {
 type sessionMessage struct {
 	Type       string          `json:"type"`
 	RawContent json.RawMessage `json:"content"`
+	Timestamp  time.Time       `json:"timestamp"`
 }
 
 // textContent extracts text from the flexible content field.
@@ -519,17 +514,12 @@ func listGeminiSessions(workDir string) ([]core.AgentSessionInfo, error) {
 
 	var sessions []core.AgentSessionInfo
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+		if entry.IsDir() || !isGeminiSessionFile(entry.Name()) {
 			continue
 		}
 
-		data, err := os.ReadFile(filepath.Join(chatsDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-
-		var sf sessionFile
-		if json.Unmarshal(data, &sf) != nil || sf.SessionID == "" {
+		sf, err := readGeminiSessionFile(filepath.Join(chatsDir, entry.Name()))
+		if err != nil || sf.SessionID == "" {
 			continue
 		}
 
@@ -550,7 +540,7 @@ func listGeminiSessions(workDir string) ([]core.AgentSessionInfo, error) {
 			continue
 		}
 
-		summary := extractSessionSummary(&sf)
+		summary := extractSessionSummary(sf)
 		if utf8.RuneCountInString(summary) > 60 {
 			summary = string([]rune(summary)[:60]) + "..."
 		}
@@ -574,6 +564,105 @@ func listGeminiSessions(workDir string) ([]core.AgentSessionInfo, error) {
 	})
 
 	return sessions, nil
+}
+
+func isGeminiSessionFile(name string) bool {
+	return strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".jsonl")
+}
+
+func readGeminiSessionFile(path string) (*sessionFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasSuffix(path, ".jsonl") {
+		return parseGeminiJSONLSession(data)
+	}
+
+	var sf sessionFile
+	if err := json.Unmarshal(data, &sf); err != nil {
+		return nil, err
+	}
+	return &sf, nil
+}
+
+func parseGeminiJSONLSession(data []byte) (*sessionFile, error) {
+	var sf sessionFile
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			return nil, err
+		}
+
+		if setRaw, ok := raw["$set"]; ok {
+			var set struct {
+				StartTime   time.Time `json:"startTime"`
+				LastUpdated time.Time `json:"lastUpdated"`
+				Kind        string    `json:"kind"`
+			}
+			if json.Unmarshal(setRaw, &set) == nil {
+				if !set.StartTime.IsZero() {
+					sf.StartTime = set.StartTime
+				}
+				if !set.LastUpdated.IsZero() {
+					sf.LastUpdated = set.LastUpdated
+				}
+				if set.Kind != "" {
+					sf.Kind = set.Kind
+				}
+			}
+			continue
+		}
+
+		if _, ok := raw["sessionId"]; ok {
+			var meta struct {
+				SessionID   string    `json:"sessionId"`
+				ProjectHash string    `json:"projectHash"`
+				StartTime   time.Time `json:"startTime"`
+				LastUpdated time.Time `json:"lastUpdated"`
+				Kind        string    `json:"kind"`
+			}
+			if err := json.Unmarshal([]byte(line), &meta); err != nil {
+				return nil, err
+			}
+			if meta.SessionID != "" {
+				sf.SessionID = meta.SessionID
+			}
+			if meta.ProjectHash != "" {
+				sf.ProjectHash = meta.ProjectHash
+			}
+			if !meta.StartTime.IsZero() {
+				sf.StartTime = meta.StartTime
+			}
+			if !meta.LastUpdated.IsZero() {
+				sf.LastUpdated = meta.LastUpdated
+			}
+			if meta.Kind != "" {
+				sf.Kind = meta.Kind
+			}
+			continue
+		}
+
+		if _, ok := raw["type"]; ok {
+			var msg sessionMessage
+			if err := json.Unmarshal([]byte(line), &msg); err != nil {
+				return nil, err
+			}
+			if msg.Type != "" {
+				sf.Messages = append(sf.Messages, msg)
+				if msg.Timestamp.After(sf.LastUpdated) {
+					sf.LastUpdated = msg.Timestamp
+				}
+			}
+		}
+	}
+
+	return &sf, nil
 }
 
 // extractSessionSummary picks the first meaningful user text as the session summary.

--- a/agent/gemini/session.go
+++ b/agent/gemini/session.go
@@ -41,6 +41,8 @@ type geminiSession struct {
 	pendingMsgs []string // buffered assistant messages awaiting classification
 }
 
+const geminiFlattenedThoughtMarker = "[Thought: true]"
+
 func newGeminiSession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*geminiSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
@@ -326,20 +328,9 @@ func (gs *geminiSession) handleMessage(raw map[string]any) {
 		return
 	}
 
-	// Delta messages are incremental streaming fragments — emit immediately
-	// as EventText so engine's stream preview can update in real time.
-	// Non-delta messages (complete text) are buffered for later classification
-	// (thinking vs final text) based on what event follows.
-	delta, _ := raw["delta"].(bool)
-	if delta {
-		evt := core.Event{Type: core.EventText, Content: text}
-		select {
-		case gs.events <- evt:
-		case <-gs.ctx.Done():
-		}
-		return
-	}
-
+	// Gemini CLI can flatten thought parts into ordinary text and append
+	// "[Thought: true]" after each thought. Buffer text until a result/tool
+	// boundary so those markers cannot leak through streaming EventText.
 	gs.pendingMsgs = append(gs.pendingMsgs, text)
 }
 
@@ -453,6 +444,7 @@ func (gs *geminiSession) flushPendingAsThinking() {
 	}
 	text := strings.Join(gs.pendingMsgs, "")
 	gs.pendingMsgs = gs.pendingMsgs[:0]
+	text = stripGeminiFlattenedThoughts(text)
 	if text != "" {
 		evt := core.Event{Type: core.EventThinking, Content: text}
 		select {
@@ -468,6 +460,7 @@ func (gs *geminiSession) flushPendingAsText() {
 	}
 	text := strings.Join(gs.pendingMsgs, "")
 	gs.pendingMsgs = gs.pendingMsgs[:0]
+	text = stripGeminiFlattenedThoughts(text)
 	if text != "" {
 		evt := core.Event{Type: core.EventText, Content: text}
 		select {
@@ -475,6 +468,14 @@ func (gs *geminiSession) flushPendingAsText() {
 		case <-gs.ctx.Done():
 		}
 	}
+}
+
+func stripGeminiFlattenedThoughts(text string) string {
+	idx := strings.LastIndex(text, geminiFlattenedThoughtMarker)
+	if idx < 0 {
+		return text
+	}
+	return strings.TrimLeft(text[idx+len(geminiFlattenedThoughtMarker):], " \t\r\n")
 }
 
 func geminiMessageText(raw map[string]any) (text, thinking string) {

--- a/agent/gemini/session.go
+++ b/agent/gemini/session.go
@@ -276,6 +276,8 @@ func (gs *geminiSession) handleEvent(raw map[string]any) {
 		gs.handleInit(raw)
 	case "message":
 		gs.handleMessage(raw)
+	case "thinking", "thought", "reasoning", "reasoning_chunk":
+		gs.handleThinking(raw)
 	case "tool_use":
 		gs.handleToolUse(raw)
 	case "tool_result":
@@ -308,9 +310,19 @@ func (gs *geminiSession) handleInit(raw map[string]any) {
 
 func (gs *geminiSession) handleMessage(raw map[string]any) {
 	role, _ := raw["role"].(string)
-	content, _ := raw["content"].(string)
+	if role == "user" {
+		return
+	}
 
-	if role == "user" || content == "" {
+	text, thinking := geminiMessageText(raw)
+	if thinking != "" {
+		evt := core.Event{Type: core.EventThinking, Content: thinking}
+		select {
+		case gs.events <- evt:
+		case <-gs.ctx.Done():
+		}
+	}
+	if text == "" {
 		return
 	}
 
@@ -320,7 +332,7 @@ func (gs *geminiSession) handleMessage(raw map[string]any) {
 	// (thinking vs final text) based on what event follows.
 	delta, _ := raw["delta"].(bool)
 	if delta {
-		evt := core.Event{Type: core.EventText, Content: content}
+		evt := core.Event{Type: core.EventText, Content: text}
 		select {
 		case gs.events <- evt:
 		case <-gs.ctx.Done():
@@ -328,7 +340,19 @@ func (gs *geminiSession) handleMessage(raw map[string]any) {
 		return
 	}
 
-	gs.pendingMsgs = append(gs.pendingMsgs, content)
+	gs.pendingMsgs = append(gs.pendingMsgs, text)
+}
+
+func (gs *geminiSession) handleThinking(raw map[string]any) {
+	content := geminiThinkingText(raw)
+	if content == "" {
+		return
+	}
+	evt := core.Event{Type: core.EventThinking, Content: content}
+	select {
+	case gs.events <- evt:
+	case <-gs.ctx.Done():
+	}
 }
 
 func (gs *geminiSession) handleToolUse(raw map[string]any) {
@@ -451,6 +475,140 @@ func (gs *geminiSession) flushPendingAsText() {
 		case <-gs.ctx.Done():
 		}
 	}
+}
+
+func geminiMessageText(raw map[string]any) (text, thinking string) {
+	if s, ok := raw["content"].(string); ok {
+		if isGeminiThinkingMessage(raw) {
+			return "", s
+		}
+		return s, ""
+	}
+
+	parts, ok := raw["content"].([]any)
+	if !ok {
+		return "", ""
+	}
+	for _, part := range parts {
+		pm, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		partText := geminiPartText(pm)
+		if partText == "" {
+			continue
+		}
+		if isGeminiThinkingPart(pm) {
+			thinking += partText
+		} else {
+			text += partText
+		}
+	}
+	return text, thinking
+}
+
+func geminiThinkingText(raw map[string]any) string {
+	if s, ok := raw["content"].(string); ok && s != "" {
+		return s
+	}
+	if s, ok := raw["thought"].(string); ok && s != "" {
+		return s
+	}
+	if s, ok := raw["thinking"].(string); ok && s != "" {
+		return s
+	}
+	if s, ok := raw["reasoning"].(string); ok && s != "" {
+		return s
+	}
+	if delta, ok := raw["delta"].(string); ok && delta != "" {
+		return delta
+	}
+	if thought, ok := raw["thought"].(map[string]any); ok {
+		return joinNonEmpty(
+			stringField(thought, "subject"),
+			stringField(thought, "description"),
+		)
+	}
+	return ""
+}
+
+func geminiPartText(part map[string]any) string {
+	if s, ok := part["text"].(string); ok {
+		return s
+	}
+	if s, ok := part["thought"].(string); ok {
+		return s
+	}
+	if s, ok := part["content"].(string); ok {
+		return s
+	}
+	return ""
+}
+
+func isGeminiThinkingMessage(raw map[string]any) bool {
+	if isTruthy(raw["thought"]) || isTruthy(raw["thinking"]) || isTruthy(raw["reasoning"]) {
+		return true
+	}
+	if kind, _ := raw["kind"].(string); isThinkingLabel(kind) {
+		return true
+	}
+	if subtype, _ := raw["subtype"].(string); isThinkingLabel(subtype) {
+		return true
+	}
+	if meta, ok := raw["_meta"].(map[string]any); ok {
+		if source, _ := meta["source"].(string); isThinkingLabel(source) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGeminiThinkingPart(part map[string]any) bool {
+	if isTruthy(part["thought"]) || isTruthy(part["thinking"]) || isTruthy(part["reasoning"]) {
+		return true
+	}
+	if partType, _ := part["type"].(string); isThinkingLabel(partType) {
+		return true
+	}
+	return false
+}
+
+func isThinkingLabel(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "thought", "thinking", "reasoning", "reasoning_chunk":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTruthy(v any) bool {
+	switch x := v.(type) {
+	case bool:
+		return x
+	case string:
+		trimmed := strings.ToLower(strings.TrimSpace(x))
+		return trimmed != "" && trimmed != "false" && trimmed != "0" && trimmed != "no"
+	case map[string]any:
+		return len(x) > 0
+	default:
+		return false
+	}
+}
+
+func stringField(m map[string]any, key string) string {
+	s, _ := m[key].(string)
+	return s
+}
+
+func joinNonEmpty(parts ...string) string {
+	var out []string
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return strings.Join(out, "\n")
 }
 
 // RespondPermission is a no-op — Gemini CLI permissions are handled via -y / --approval-mode flags.

--- a/agent/gemini/session_test.go
+++ b/agent/gemini/session_test.go
@@ -250,9 +250,9 @@ func TestHandleMessage_MixedDeltaAndNonDelta(t *testing.T) {
 		"content": "Let me look at the files.",
 	})
 	gs.handleEvent(map[string]any{
-		"type":      "tool_use",
-		"tool_name": "shell",
-		"tool_id":   "t1",
+		"type":       "tool_use",
+		"tool_name":  "shell",
+		"tool_id":    "t1",
 		"parameters": map[string]any{"command": "ls"},
 	})
 	gs.handleEvent(map[string]any{
@@ -443,12 +443,41 @@ func TestSessionMessage_TextContent(t *testing.T) {
 	}
 }
 
+func TestParseGeminiJSONLSession(t *testing.T) {
+	data := []byte(strings.Join([]string{
+		`{"sessionId":"66c97d5d-48a6-4386-937d-29dfbe5caaa8","projectHash":"abc","startTime":"2026-05-10T18:32:15.435Z","lastUpdated":"2026-05-10T18:32:15.435Z","kind":"main"}`,
+		`{"id":"u1","timestamp":"2026-05-10T18:32:16.508Z","type":"user","content":[{"text":"hello from jsonl"}]}`,
+		`{"$set":{"lastUpdated":"2026-05-10T18:32:23.150Z"}}`,
+		`{"id":"g1","timestamp":"2026-05-10T18:32:23.150Z","type":"gemini","content":"hi"}`,
+	}, "\n"))
+
+	sf, err := parseGeminiJSONLSession(data)
+	if err != nil {
+		t.Fatalf("parseGeminiJSONLSession() error = %v", err)
+	}
+	if sf.SessionID != "66c97d5d-48a6-4386-937d-29dfbe5caaa8" {
+		t.Fatalf("SessionID = %q", sf.SessionID)
+	}
+	if sf.Kind != "main" {
+		t.Fatalf("Kind = %q", sf.Kind)
+	}
+	if got := len(sf.Messages); got != 2 {
+		t.Fatalf("len(Messages) = %d", got)
+	}
+	if got := extractSessionSummary(sf); got != "hello from jsonl" {
+		t.Fatalf("summary = %q", got)
+	}
+	if sf.LastUpdated.Format(time.RFC3339) != "2026-05-10T18:32:23Z" {
+		t.Fatalf("LastUpdated = %s", sf.LastUpdated.Format(time.RFC3339))
+	}
+}
+
 func TestComputeLineDiff(t *testing.T) {
 	tests := []struct {
-		name     string
-		old      string
-		new_     string
-		want     string
+		name string
+		old  string
+		new_ string
+		want string
 	}{
 		{
 			"single line fully different",

--- a/agent/gemini/session_test.go
+++ b/agent/gemini/session_test.go
@@ -68,13 +68,12 @@ func drainEvents(ch <-chan core.Event, timeout time.Duration) []core.Event {
 	}
 }
 
-func TestHandleMessage_DeltaEmitsEventTextImmediately(t *testing.T) {
+func TestHandleMessage_DeltaBuffersUntilResult(t *testing.T) {
 	gs := &geminiSession{
 		events: make(chan core.Event, 64),
 		ctx:    context.Background(),
 	}
 
-	// Delta message should emit EventText immediately
 	gs.handleEvent(map[string]any{
 		"type":    "message",
 		"role":    "assistant",
@@ -89,19 +88,24 @@ func TestHandleMessage_DeltaEmitsEventTextImmediately(t *testing.T) {
 	})
 
 	events := drainEvents(gs.events, 50*time.Millisecond)
-	if len(events) != 2 {
-		t.Fatalf("expected 2 events, got %d", len(events))
-	}
-	if events[0].Type != core.EventText || events[0].Content != "Hello " {
-		t.Errorf("event 0: expected EventText 'Hello ', got %v %q", events[0].Type, events[0].Content)
-	}
-	if events[1].Type != core.EventText || events[1].Content != "world!" {
-		t.Errorf("event 1: expected EventText 'world!', got %v %q", events[1].Type, events[1].Content)
+	if len(events) != 0 {
+		t.Fatalf("expected no events before result, got %d", len(events))
 	}
 
-	// No pending messages should be buffered
-	if len(gs.pendingMsgs) != 0 {
-		t.Errorf("expected 0 pending messages, got %d", len(gs.pendingMsgs))
+	gs.handleEvent(map[string]any{
+		"type":   "result",
+		"status": "success",
+	})
+
+	events = drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 2 {
+		t.Fatalf("expected EventText and EventResult, got %d", len(events))
+	}
+	if events[0].Type != core.EventText || events[0].Content != "Hello world!" {
+		t.Fatalf("event 0: expected EventText 'Hello world!', got %v %q", events[0].Type, events[0].Content)
+	}
+	if events[1].Type != core.EventResult {
+		t.Fatalf("event 1: expected EventResult, got %v", events[1].Type)
 	}
 }
 
@@ -146,14 +150,26 @@ func TestHandleMessage_MixedContentSeparatesThoughtFromText(t *testing.T) {
 	})
 
 	events := drainEvents(gs.events, 50*time.Millisecond)
-	if len(events) != 2 {
-		t.Fatalf("expected 2 events, got %d", len(events))
+	if len(events) != 1 {
+		t.Fatalf("expected thinking event before result, got %d", len(events))
 	}
 	if events[0].Type != core.EventThinking || events[0].Content != "internal scratchpad" {
 		t.Fatalf("event 0: expected EventThinking, got %v %q", events[0].Type, events[0].Content)
 	}
-	if events[1].Type != core.EventText || events[1].Content != "visible answer" {
-		t.Fatalf("event 1: expected EventText, got %v %q", events[1].Type, events[1].Content)
+
+	gs.handleEvent(map[string]any{
+		"type":   "result",
+		"status": "success",
+	})
+	events = drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 2 {
+		t.Fatalf("expected EventText and EventResult, got %d", len(events))
+	}
+	if events[0].Type != core.EventText || events[0].Content != "visible answer" {
+		t.Fatalf("event 0: expected EventText, got %v %q", events[0].Type, events[0].Content)
+	}
+	if events[1].Type != core.EventResult {
+		t.Fatalf("event 1: expected EventResult, got %v", events[1].Type)
 	}
 }
 
@@ -195,11 +211,73 @@ func TestHandleMessage_FalseThinkingFlagKeepsText(t *testing.T) {
 	})
 
 	events := drainEvents(gs.events, 50*time.Millisecond)
-	if len(events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(events))
+	if len(events) != 0 {
+		t.Fatalf("expected no events before result, got %d", len(events))
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":   "result",
+		"status": "success",
+	})
+	events = drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 2 {
+		t.Fatalf("expected EventText and EventResult, got %d", len(events))
 	}
 	if events[0].Type != core.EventText || events[0].Content != "visible text" {
 		t.Fatalf("expected EventText, got %v %q", events[0].Type, events[0].Content)
+	}
+}
+
+func TestHandleMessage_FlattenedThoughtMarkersKeepOnlyLastSegment(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "Acknowledging success [Thought: true]Celebrating tiny victories ",
+		"delta":   true,
+	})
+	gs.handleEvent(map[string]any{
+		"type":    "message",
+		"role":    "assistant",
+		"content": "[Thought: true]真正回复",
+		"delta":   true,
+	})
+	gs.handleEvent(map[string]any{
+		"type":   "result",
+		"status": "success",
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 2 {
+		t.Fatalf("expected EventText and EventResult, got %d", len(events))
+	}
+	if events[0].Type != core.EventText || events[0].Content != "真正回复" {
+		t.Fatalf("expected final segment only, got %v %q", events[0].Type, events[0].Content)
+	}
+}
+
+func TestStripGeminiFlattenedThoughts(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no marker", "normal answer", "normal answer"},
+		{"single marker", "thought[Thought: true]answer", "answer"},
+		{"multiple markers", "a[Thought: true]b[Thought: true]\n answer", "answer"},
+		{"only thought", "a[Thought: true]", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripGeminiFlattenedThoughts(tt.in); got != tt.want {
+				t.Fatalf("stripGeminiFlattenedThoughts() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -401,13 +479,13 @@ func TestHandleMessage_MixedDeltaAndNonDelta(t *testing.T) {
 
 	events := drainEvents(gs.events, 50*time.Millisecond)
 
-	// Expected sequence: EventThinking, EventToolUse, EventToolResult, EventText, EventText, EventResult
-	if len(events) != 6 {
+	// Expected sequence: EventThinking, EventToolUse, EventToolResult, EventText, EventResult
+	if len(events) != 5 {
 		var types []string
 		for _, e := range events {
 			types = append(types, string(e.Type))
 		}
-		t.Fatalf("expected 6 events, got %d: %v", len(events), types)
+		t.Fatalf("expected 5 events, got %d: %v", len(events), types)
 	}
 
 	expects := []struct {
@@ -417,8 +495,7 @@ func TestHandleMessage_MixedDeltaAndNonDelta(t *testing.T) {
 		{core.EventThinking, "Let me look at the files."},
 		{core.EventToolUse, ""},
 		{core.EventToolResult, ""},
-		{core.EventText, "Here are "},
-		{core.EventText, "the files."},
+		{core.EventText, "Here are the files."},
 		{core.EventResult, ""},
 	}
 

--- a/agent/gemini/session_test.go
+++ b/agent/gemini/session_test.go
@@ -105,6 +105,127 @@ func TestHandleMessage_DeltaEmitsEventTextImmediately(t *testing.T) {
 	}
 }
 
+func TestHandleMessage_DeltaThoughtEmitsThinking(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":  "message",
+		"role":  "assistant",
+		"delta": true,
+		"content": []any{
+			map[string]any{"type": "thought", "thought": "checking long context"},
+		},
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != core.EventThinking || events[0].Content != "checking long context" {
+		t.Fatalf("expected EventThinking, got %v %q", events[0].Type, events[0].Content)
+	}
+}
+
+func TestHandleMessage_MixedContentSeparatesThoughtFromText(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":  "message",
+		"role":  "agent",
+		"delta": true,
+		"content": []any{
+			map[string]any{"type": "thought", "thought": "internal scratchpad"},
+			map[string]any{"type": "text", "text": "visible answer"},
+		},
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != core.EventThinking || events[0].Content != "internal scratchpad" {
+		t.Fatalf("event 0: expected EventThinking, got %v %q", events[0].Type, events[0].Content)
+	}
+	if events[1].Type != core.EventText || events[1].Content != "visible answer" {
+		t.Fatalf("event 1: expected EventText, got %v %q", events[1].Type, events[1].Content)
+	}
+}
+
+func TestHandleMessage_TopLevelThinkingDeltaDoesNotEmitText(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":     "message",
+		"role":     "assistant",
+		"content":  "hidden chain",
+		"delta":    true,
+		"thinking": true,
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != core.EventThinking || events[0].Content != "hidden chain" {
+		t.Fatalf("expected EventThinking, got %v %q", events[0].Type, events[0].Content)
+	}
+}
+
+func TestHandleMessage_FalseThinkingFlagKeepsText(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type":     "message",
+		"role":     "assistant",
+		"content":  "visible text",
+		"delta":    true,
+		"thinking": "false",
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != core.EventText || events[0].Content != "visible text" {
+		t.Fatalf("expected EventText, got %v %q", events[0].Type, events[0].Content)
+	}
+}
+
+func TestHandleThinkingEvent(t *testing.T) {
+	gs := &geminiSession{
+		events: make(chan core.Event, 64),
+		ctx:    context.Background(),
+	}
+
+	gs.handleEvent(map[string]any{
+		"type": "thinking",
+		"thought": map[string]any{
+			"subject":     "Plan",
+			"description": "inspect files",
+		},
+	})
+
+	events := drainEvents(gs.events, 50*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != core.EventThinking || events[0].Content != "Plan\ninspect files" {
+		t.Fatalf("expected EventThinking with subject and description, got %v %q", events[0].Type, events[0].Content)
+	}
+}
+
 func TestHandleMessage_NonDeltaBuffered(t *testing.T) {
 	gs := &geminiSession{
 		events: make(chan core.Event, 64),

--- a/core/bridge.go
+++ b/core/bridge.go
@@ -872,18 +872,19 @@ func (a *bridgeAdapter) handleMessage(raw json.RawMessage) {
 		slog.Warn("bridge: no engine for session", "platform", a.platform, "session_key", m.SessionKey, "project", m.Project)
 		return
 	}
-	if !a.switchTargetSession(ref, m.SessionKey, m.SessionID, m.ReplyCtx) {
+	if !a.validateTargetSession(ref, m.SessionKey, m.SessionID, m.ReplyCtx) {
 		return
 	}
 
 	msg := &Message{
-		SessionKey: m.SessionKey,
-		Platform:   a.platform,
-		MessageID:  m.MsgID,
-		UserID:     m.UserID,
-		UserName:   m.UserName,
-		Content:    m.Content,
-		ReplyCtx:   newBridgeReplyCtx(a, m.SessionKey, m.ReplyCtx),
+		SessionKey:      m.SessionKey,
+		TargetSessionID: m.SessionID,
+		Platform:        a.platform,
+		MessageID:       m.MsgID,
+		UserID:          m.UserID,
+		UserName:        m.UserName,
+		Content:         m.Content,
+		ReplyCtx:        newBridgeReplyCtx(a, m.SessionKey, m.ReplyCtx),
 	}
 
 	for _, img := range m.Images {
@@ -940,7 +941,7 @@ func (a *bridgeAdapter) handleCardAction(raw json.RawMessage) {
 	if ref == nil {
 		return
 	}
-	if !a.switchTargetSession(ref, ca.SessionKey, ca.SessionID, ca.ReplyCtx) {
+	if !a.validateTargetSession(ref, ca.SessionKey, ca.SessionID, ca.ReplyCtx) {
 		return
 	}
 
@@ -957,20 +958,20 @@ func (a *bridgeAdapter) handleCardAction(raw json.RawMessage) {
 		default:
 			return
 		}
-		a.dispatchAsMessage(ref, ca.SessionKey, ca.ReplyCtx, responseText)
+		a.dispatchAsMessage(ref, ca.SessionKey, ca.SessionID, ca.ReplyCtx, responseText)
 		return
 	}
 
 	// askq: — AskUserQuestion answer; forward as a regular message
 	if strings.HasPrefix(ca.Action, "askq:") {
-		a.dispatchAsMessage(ref, ca.SessionKey, ca.ReplyCtx, ca.Action)
+		a.dispatchAsMessage(ref, ca.SessionKey, ca.SessionID, ca.ReplyCtx, ca.Action)
 		return
 	}
 
 	// cmd: — command shortcut from a card button; forward as a message
 	if strings.HasPrefix(ca.Action, "cmd:") {
 		cmdText := strings.TrimPrefix(ca.Action, "cmd:")
-		a.dispatchAsMessage(ref, ca.SessionKey, ca.ReplyCtx, cmdText)
+		a.dispatchAsMessage(ref, ca.SessionKey, ca.SessionID, ca.ReplyCtx, cmdText)
 		return
 	}
 
@@ -999,27 +1000,28 @@ func (a *bridgeAdapter) handleCardAction(raw json.RawMessage) {
 
 // dispatchAsMessage converts a card action into a regular user message
 // and dispatches it to the engine's message handler.
-func (a *bridgeAdapter) dispatchAsMessage(ref *bridgeEngineRef, sessionKey, replyCtx, content string) {
+func (a *bridgeAdapter) dispatchAsMessage(ref *bridgeEngineRef, sessionKey, sessionID, replyCtx, content string) {
 	if ref.platform.handler == nil {
 		return
 	}
 	msg := &Message{
-		SessionKey: sessionKey,
-		Platform:   a.platform,
-		UserID:     "web-admin",
-		UserName:   "Web Admin",
-		Content:    content,
-		ReplyCtx:   newBridgeReplyCtx(a, sessionKey, replyCtx),
+		SessionKey:      sessionKey,
+		TargetSessionID: sessionID,
+		Platform:        a.platform,
+		UserID:          "web-admin",
+		UserName:        "Web Admin",
+		Content:         content,
+		ReplyCtx:        newBridgeReplyCtx(a, sessionKey, replyCtx),
 	}
 	go ref.platform.handler(ref.platform, msg)
 }
 
-func (a *bridgeAdapter) switchTargetSession(ref *bridgeEngineRef, sessionKey, sessionID, replyCtx string) bool {
+func (a *bridgeAdapter) validateTargetSession(ref *bridgeEngineRef, sessionKey, sessionID, replyCtx string) bool {
 	if sessionID == "" {
 		return true
 	}
-	if _, err := ref.engine.sessions.SwitchSessionForRouting(sessionKey, sessionID); err != nil {
-		slog.Warn("bridge: target session switch failed",
+	if _, err := ref.engine.sessions.ResolveSessionForRouting(sessionKey, sessionID); err != nil {
+		slog.Warn("bridge: target session validation failed",
 			"platform", a.platform,
 			"session_key", sessionKey,
 			"session_id", sessionID,

--- a/core/bridge.go
+++ b/core/bridge.go
@@ -109,6 +109,7 @@ type bridgeMessage struct {
 	Type       string            `json:"type"`
 	MsgID      string            `json:"msg_id"`
 	SessionKey string            `json:"session_key"`
+	SessionID  string            `json:"session_id,omitempty"`
 	UserID     string            `json:"user_id"`
 	UserName   string            `json:"user_name,omitempty"`
 	Content    string            `json:"content"`
@@ -122,6 +123,7 @@ type bridgeMessage struct {
 type bridgeCardAction struct {
 	Type       string `json:"type"`
 	SessionKey string `json:"session_key"`
+	SessionID  string `json:"session_id,omitempty"`
 	Action     string `json:"action"`
 	ReplyCtx   string `json:"reply_ctx"`
 	Project    string `json:"project,omitempty"`
@@ -870,6 +872,9 @@ func (a *bridgeAdapter) handleMessage(raw json.RawMessage) {
 		slog.Warn("bridge: no engine for session", "platform", a.platform, "session_key", m.SessionKey, "project", m.Project)
 		return
 	}
+	if !a.switchTargetSession(ref, m.SessionKey, m.SessionID, m.ReplyCtx) {
+		return
+	}
 
 	msg := &Message{
 		SessionKey: m.SessionKey,
@@ -933,6 +938,9 @@ func (a *bridgeAdapter) handleCardAction(raw json.RawMessage) {
 
 	ref := a.server.resolveEngine(ca.SessionKey, ca.Project)
 	if ref == nil {
+		return
+	}
+	if !a.switchTargetSession(ref, ca.SessionKey, ca.SessionID, ca.ReplyCtx) {
 		return
 	}
 
@@ -1004,6 +1012,29 @@ func (a *bridgeAdapter) dispatchAsMessage(ref *bridgeEngineRef, sessionKey, repl
 		ReplyCtx:   newBridgeReplyCtx(a, sessionKey, replyCtx),
 	}
 	go ref.platform.handler(ref.platform, msg)
+}
+
+func (a *bridgeAdapter) switchTargetSession(ref *bridgeEngineRef, sessionKey, sessionID, replyCtx string) bool {
+	if sessionID == "" {
+		return true
+	}
+	if _, err := ref.engine.sessions.SwitchSessionForRouting(sessionKey, sessionID); err != nil {
+		slog.Warn("bridge: target session switch failed",
+			"platform", a.platform,
+			"session_key", sessionKey,
+			"session_id", sessionID,
+			"error", err,
+		)
+		_ = a.server.sendToAdapter(a.platform, map[string]any{
+			"type":        "error",
+			"code":        "session_not_found",
+			"message":     err.Error(),
+			"session_key": sessionKey,
+			"reply_ctx":   replyCtx,
+		})
+		return false
+	}
+	return true
 }
 
 func (a *bridgeAdapter) handlePreviewAck(raw json.RawMessage) {

--- a/core/bridge_test.go
+++ b/core/bridge_test.go
@@ -306,6 +306,99 @@ func TestBridge_MessageRouting(t *testing.T) {
 	}
 }
 
+func TestBridge_MessageRoutingSwitchesTargetSession(t *testing.T) {
+	bs, wsURL := startTestBridge(t, "")
+
+	bp := bs.NewPlatform("test-proj")
+	e := NewEngine("test-proj", &stubAgent{}, []Platform{bp}, "", LangEnglish)
+	bs.RegisterEngine("test-proj", e, bp)
+
+	key := "bridge:web-admin:test-proj"
+	first := e.sessions.GetOrCreateActive(key)
+	second := e.sessions.NewSession(key, "picked")
+	if _, err := e.sessions.SwitchSession(key, first.ID); err != nil {
+		t.Fatalf("reset active session: %v", err)
+	}
+	if active := e.sessions.GetOrCreateActive(key); active.ID != first.ID {
+		t.Fatalf("active before message = %q, want %q", active.ID, first.ID)
+	}
+
+	gotCh := make(chan *Message, 1)
+	bp.handler = func(p Platform, msg *Message) {
+		gotCh <- msg
+	}
+
+	conn := dialWS(t, wsURL, nil)
+	register(t, conn, "bridge", []string{"text"})
+
+	mustWriteJSON(t, conn, map[string]any{
+		"type":        "message",
+		"msg_id":      "m1",
+		"session_key": key,
+		"session_id":  second.ID,
+		"user_id":     "web-admin",
+		"user_name":   "Web Admin",
+		"content":     "hello selected session",
+		"reply_ctx":   key,
+		"project":     "test-proj",
+	})
+
+	select {
+	case msg := <-gotCh:
+		if msg.Content != "hello selected session" {
+			t.Fatalf("content = %q", msg.Content)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected message to be dispatched")
+	}
+
+	if active := e.sessions.GetOrCreateActive(key); active.ID != second.ID {
+		t.Fatalf("active after message = %q, want target %q", active.ID, second.ID)
+	}
+}
+
+func TestBridge_MessageRoutingRestoresPastTargetSession(t *testing.T) {
+	bs, wsURL := startTestBridge(t, "")
+
+	bp := bs.NewPlatform("test-proj")
+	e := NewEngine("test-proj", &stubAgent{}, []Platform{bp}, "", LangEnglish)
+	bs.RegisterEngine("test-proj", e, bp)
+
+	key := "bridge:web-admin:test-proj"
+	e.sessions.GetOrCreateActive(key)
+	past := e.sessions.NewSession(key, "picked old native")
+	past.PastAgentSessionIDs = []string{"thread-old"}
+	past.AgentType = "codex"
+
+	gotCh := make(chan *Message, 1)
+	bp.handler = func(p Platform, msg *Message) {
+		gotCh <- msg
+	}
+
+	conn := dialWS(t, wsURL, nil)
+	register(t, conn, "bridge", []string{"text"})
+
+	mustWriteJSON(t, conn, map[string]any{
+		"type":        "message",
+		"msg_id":      "m1",
+		"session_key": key,
+		"session_id":  past.ID,
+		"user_id":     "web-admin",
+		"content":     "hello restored session",
+		"reply_ctx":   key,
+		"project":     "test-proj",
+	})
+
+	select {
+	case <-gotCh:
+	case <-time.After(time.Second):
+		t.Fatal("expected message to be dispatched")
+	}
+	if got := past.GetAgentSessionID(); got != "thread-old" {
+		t.Fatalf("agent session ID = %q, want restored past ID", got)
+	}
+}
+
 func TestBridge_MessageReplyCtxCarriesProgressHints(t *testing.T) {
 	bs, wsURL := startTestBridge(t, "")
 

--- a/core/bridge_test.go
+++ b/core/bridge_test.go
@@ -306,7 +306,7 @@ func TestBridge_MessageRouting(t *testing.T) {
 	}
 }
 
-func TestBridge_MessageRoutingSwitchesTargetSession(t *testing.T) {
+func TestBridge_MessageRoutingTargetsSessionWithoutChangingActive(t *testing.T) {
 	bs, wsURL := startTestBridge(t, "")
 
 	bp := bs.NewPlatform("test-proj")
@@ -325,6 +325,9 @@ func TestBridge_MessageRoutingSwitchesTargetSession(t *testing.T) {
 
 	gotCh := make(chan *Message, 1)
 	bp.handler = func(p Platform, msg *Message) {
+		if msg.TargetSessionID != second.ID {
+			t.Errorf("TargetSessionID = %q, want %q", msg.TargetSessionID, second.ID)
+		}
 		gotCh <- msg
 	}
 
@@ -352,8 +355,8 @@ func TestBridge_MessageRoutingSwitchesTargetSession(t *testing.T) {
 		t.Fatal("expected message to be dispatched")
 	}
 
-	if active := e.sessions.GetOrCreateActive(key); active.ID != second.ID {
-		t.Fatalf("active after message = %q, want target %q", active.ID, second.ID)
+	if active := e.sessions.GetOrCreateActive(key); active.ID != first.ID {
+		t.Fatalf("active after message = %q, want unchanged %q", active.ID, first.ID)
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -2050,6 +2050,20 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	}
 
 	session := sessions.GetOrCreateActive(msg.SessionKey)
+	if msg.TargetSessionID != "" {
+		targetSession, err := sessions.ResolveSessionForRouting(msg.SessionKey, msg.TargetSessionID)
+		if err != nil {
+			slog.Warn("target session routing failed",
+				"platform", msg.Platform,
+				"session_key", msg.SessionKey,
+				"target_session_id", msg.TargetSessionID,
+				"error", err,
+			)
+			e.reply(p, msg.ReplyCtx, err.Error())
+			return
+		}
+		session = targetSession
+	}
 	sessions.UpdateUserMeta(msg.SessionKey, msg.UserName, msg.ChatName)
 	if !session.TryLock() {
 		if e.stopCurrentMessageIfRecalled(interactiveKey) {
@@ -3087,7 +3101,6 @@ func buildCardContent(thinking string, tools []cardToolEntry, answer string) str
 	return sb.String()
 }
 
-
 // unsolicitedReaderStopTimeout bounds how long stopUnsolicitedReader waits
 // for the reader goroutine to exit. The reader is structured so its iterations
 // are short (blocking adapter calls like RespondPermission are offloaded), so
@@ -3430,8 +3443,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 	// Streaming card: aggregate entire turn into a single updatable card.
 	var streamCard StreamingCard
-	var cardToolCalls []cardToolEntry // track tool calls for card content
-	var cardThinkingText string       // latest thinking text
+	var cardToolCalls []cardToolEntry  // track tool calls for card content
+	var cardThinkingText string        // latest thinking text
 	var cardAnswerText strings.Builder // accumulated answer text
 
 	if scp, ok := state.platform.(StreamingCardPlatform); ok {

--- a/core/engine.go
+++ b/core/engine.go
@@ -6430,21 +6430,50 @@ func (e *Engine) cmdName(p Platform, msg *Message, args []string) {
 
 func (e *Engine) cmdCurrent(p Platform, msg *Message) {
 	if !supportsCards(p) {
-		_, sessions, _, err := e.commandContext(p, msg)
+		agent, sessions, _, err := e.commandContext(p, msg)
 		if err != nil {
 			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
 			return
 		}
 		s := sessions.GetOrCreateActive(msg.SessionKey)
 		agentID := s.GetAgentSessionID()
+		displayName := e.currentSessionDisplayName(agent, sessions, s)
 		if agentID == "" {
 			agentID = e.i18n.T(MsgSessionNotStarted)
 		}
-		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCurrentSession), s.Name, agentID, len(s.History)))
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCurrentSession), displayName, agentID, len(s.History)))
 		return
 	}
 
 	e.replyWithCard(p, msg.ReplyCtx, e.renderCurrentCard(msg.SessionKey))
+}
+
+func (e *Engine) currentSessionDisplayName(agent Agent, sessions *SessionManager, s *Session) string {
+	agentID := s.GetAgentSessionID()
+	if agentID != "" {
+		if name := sessions.GetSessionName(agentID); name != "" {
+			return name
+		}
+		if agent != nil {
+			agentSessions, err := agent.ListSessions(e.ctx)
+			if err == nil {
+				for _, info := range e.applySessionFilter(agentSessions, sessions) {
+					if info.ID == agentID {
+						if summary := compactSessionDisplayName(info.Summary); summary != "" {
+							return summary
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+	return s.GetName()
+}
+
+func compactSessionDisplayName(name string) string {
+	name = strings.ReplaceAll(name, "\n", " ")
+	return strings.Join(strings.Fields(name), " ")
 }
 
 func (e *Engine) cmdStatus(p Platform, msg *Message) {
@@ -10440,13 +10469,14 @@ func (e *Engine) renderDirCard(sessionKey string, page int) (*Card, error) {
 // ──────────────────────────────────────────────────────────────
 
 func (e *Engine) renderCurrentCard(sessionKey string) *Card {
-	_, sessions := e.sessionContextForKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(sessionKey)
 	s := sessions.GetOrCreateActive(sessionKey)
 	agentID := s.GetAgentSessionID()
+	displayName := e.currentSessionDisplayName(agent, sessions, s)
 	if agentID == "" {
 		agentID = e.i18n.T(MsgSessionNotStarted)
 	}
-	content := fmt.Sprintf(e.i18n.T(MsgCurrentSession), s.Name, agentID, len(s.History))
+	content := fmt.Sprintf(e.i18n.T(MsgCurrentSession), displayName, agentID, len(s.History))
 	return NewCard().
 		Title(e.i18n.T(MsgCardTitleCurrentSession), "turquoise").
 		Markdown(content).

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3060,6 +3060,89 @@ func TestCmdCurrent_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	}
 }
 
+func TestCmdCurrent_UsesNativeSummaryForCurrentAgentSession(t *testing.T) {
+	nativeSessions := []AgentSessionInfo{
+		{ID: "agent-current", Summary: "Native generated title", MessageCount: 4, ModifiedAt: time.Now()},
+		{ID: "agent-other", Summary: "Other title", MessageCount: 2, ModifiedAt: time.Now()},
+	}
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubListAgent{sessions: nativeSessions}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	session := e.sessions.GetOrCreateActive(msg.SessionKey)
+	session.Name = "latest user message"
+	session.SetAgentSessionID("agent-current", "codex")
+	session.AddHistory("user", "latest user message")
+
+	e.cmdCurrent(p, msg)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "Name: Native generated title") {
+		t.Fatalf("/current = %q, want native summary display name", p.sent[0])
+	}
+	if strings.Contains(p.sent[0], "Name: latest user message") {
+		t.Fatalf("/current = %q, should not use local Session.Name when native summary exists", p.sent[0])
+	}
+
+	p.sent = nil
+	e.cmdList(p, msg, nil)
+	if len(p.sent) != 1 {
+		t.Fatalf("list sent messages = %d, want 1", len(p.sent))
+	}
+	if got := strings.Count(p.sent[0], "msgs"); got != len(nativeSessions) {
+		t.Fatalf("/list item count = %d, want %d\n%s", got, len(nativeSessions), p.sent[0])
+	}
+}
+
+func TestCmdCurrent_CustomNameOverridesNativeSummary(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubListAgent{sessions: []AgentSessionInfo{
+		{ID: "agent-current", Summary: "Native generated title", MessageCount: 4, ModifiedAt: time.Now()},
+	}}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	session := e.sessions.GetOrCreateActive(msg.SessionKey)
+	session.Name = "latest user message"
+	session.SetAgentSessionID("agent-current", "codex")
+	e.sessions.SetSessionName("agent-current", "Pinned custom name")
+
+	e.cmdCurrent(p, msg)
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(p.sent))
+	}
+	if !strings.Contains(p.sent[0], "Name: Pinned custom name") {
+		t.Fatalf("/current = %q, want custom session name", p.sent[0])
+	}
+	if strings.Contains(p.sent[0], "Native generated title") {
+		t.Fatalf("/current = %q, custom name should override native summary", p.sent[0])
+	}
+}
+
+func TestRenderCurrentCard_UsesNativeSummaryForCurrentAgentSession(t *testing.T) {
+	p := &stubCardPlatform{stubPlatformEngine: stubPlatformEngine{n: "card"}}
+	e := NewEngine("test", &stubListAgent{sessions: []AgentSessionInfo{
+		{ID: "agent-current", Summary: "Native card title", MessageCount: 4, ModifiedAt: time.Now()},
+	}}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	session := e.sessions.GetOrCreateActive(msg.SessionKey)
+	session.Name = "latest user message"
+	session.SetAgentSessionID("agent-current", "codex")
+
+	e.cmdCurrent(p, msg)
+
+	if len(p.repliedCards) != 1 {
+		t.Fatalf("replied cards = %d, want 1", len(p.repliedCards))
+	}
+	text := p.repliedCards[0].RenderText()
+	if !strings.Contains(text, "Name: Native card title") {
+		t.Fatalf("current card = %q, want native summary display name", text)
+	}
+	if strings.Contains(text, "Name: latest user message") {
+		t.Fatalf("current card = %q, should not use local Session.Name when native summary exists", text)
+	}
+}
+
 func TestCmdDelete_BatchCommaList(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	agent := &stubDeleteAgent{stubListAgent: stubListAgent{sessions: []AgentSessionInfo{

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3060,6 +3060,46 @@ func TestCmdCurrent_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	}
 }
 
+func TestHandleMessage_TargetSessionDoesNotChangeActive(t *testing.T) {
+	p := &stubPlatformEngine{n: "bridge"}
+	agentSession := newResultAgentSession("done")
+	e := NewEngine("test", &resultAgent{session: agentSession}, []Platform{p}, "", LangEnglish)
+	sessionKey := "bridge:web-admin:test"
+	active := e.sessions.GetOrCreateActive(sessionKey)
+	target := e.sessions.NewSession(sessionKey, "picked")
+	if _, err := e.sessions.SwitchSession(sessionKey, active.ID); err != nil {
+		t.Fatalf("reset active session: %v", err)
+	}
+
+	e.handleMessage(p, &Message{
+		SessionKey:      sessionKey,
+		TargetSessionID: target.ID,
+		Platform:        "bridge",
+		UserID:          "web-admin",
+		UserName:        "Web Admin",
+		Content:         "hello target",
+		ReplyCtx:        "ctx",
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(target.GetHistory(1)) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if hist := target.GetHistory(2); len(hist) == 0 || hist[0].Content != "hello target" {
+		t.Fatalf("target history = %#v, want routed user message", hist)
+	}
+	if hist := active.GetHistory(1); len(hist) != 0 {
+		t.Fatalf("active history = %#v, should remain untouched", hist)
+	}
+	if current := e.sessions.GetOrCreateActive(sessionKey); current.ID != active.ID {
+		t.Fatalf("active session = %q, want unchanged %q", current.ID, active.ID)
+	}
+}
+
 func TestCmdCurrent_UsesNativeSummaryForCurrentAgentSession(t *testing.T) {
 	nativeSessions := []AgentSessionInfo{
 		{ID: "agent-current", Summary: "Native generated title", MessageCount: 4, ModifiedAt: time.Now()},
@@ -10954,9 +10994,9 @@ func (p *stubStreamingCardPlatform) CreateStreamingCard(_ context.Context, _ any
 // stubStreamingCard is a minimal StreamingCard for tests.
 type stubStreamingCard struct{}
 
-func (c *stubStreamingCard) Update(_ context.Context, _ string) error { return nil }
+func (c *stubStreamingCard) Update(_ context.Context, _ string) error   { return nil }
 func (c *stubStreamingCard) Finalize(_ context.Context, _ string) error { return nil }
-func (c *stubStreamingCard) Failed() bool                                { return false }
+func (c *stubStreamingCard) Failed() bool                               { return false }
 
 func TestHandleMessage_InstantReply_SendsConfirmationWhenEnabled(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}

--- a/core/management.go
+++ b/core/management.go
@@ -1222,6 +1222,7 @@ func (m *ManagementServer) handleProjectSend(w http.ResponseWriter, r *http.Requ
 	}
 	var body struct {
 		SessionKey string `json:"session_key"`
+		SessionID  string `json:"session_id"`
 		Message    string `json:"message"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -1231,6 +1232,16 @@ func (m *ManagementServer) handleProjectSend(w http.ResponseWriter, r *http.Requ
 	if body.Message == "" {
 		mgmtError(w, http.StatusBadRequest, "message is required")
 		return
+	}
+	if body.SessionID != "" {
+		if body.SessionKey == "" {
+			mgmtError(w, http.StatusBadRequest, "session_key is required when session_id is provided")
+			return
+		}
+		if _, err := e.sessions.SwitchSessionForRouting(body.SessionKey, body.SessionID); err != nil {
+			mgmtError(w, http.StatusNotFound, err.Error())
+			return
+		}
 	}
 	if err := e.SendToSession(body.SessionKey, body.Message); err != nil {
 		mgmtError(w, http.StatusInternalServerError, err.Error())

--- a/core/management.go
+++ b/core/management.go
@@ -141,10 +141,10 @@ type GlobalProviderInfo struct {
 		Model string `json:"model"`
 		Alias string `json:"alias,omitempty"`
 	} `json:"models,omitempty"`
-	Endpoints       map[string]string              `json:"endpoints,omitempty"`
-	AgentModels     map[string]string              `json:"agent_models,omitempty"`
-	AgentModelLists map[string][]GlobalModelEntry   `json:"agent_model_lists,omitempty"`
-	Codex           *GlobalCodexConfig              `json:"codex,omitempty"`
+	Endpoints       map[string]string             `json:"endpoints,omitempty"`
+	AgentModels     map[string]string             `json:"agent_models,omitempty"`
+	AgentModelLists map[string][]GlobalModelEntry `json:"agent_model_lists,omitempty"`
+	Codex           *GlobalCodexConfig            `json:"codex,omitempty"`
 }
 
 // GlobalModelEntry is a model entry inside AgentModelLists.
@@ -895,6 +895,43 @@ func (m *ManagementServer) handleProjectUsers(w http.ResponseWriter, r *http.Req
 
 // ── Session endpoints ─────────────────────────────────────────
 
+func (e *Engine) managementSessionDisplayNames() map[string]string {
+	if e == nil || e.agent == nil || e.sessions == nil {
+		return nil
+	}
+	agentSessions, err := e.agent.ListSessions(e.ctx)
+	if err != nil || len(agentSessions) == 0 {
+		return nil
+	}
+	agentSessions = e.applySessionFilter(agentSessions, e.sessions)
+	if len(agentSessions) == 0 {
+		return nil
+	}
+	names := make(map[string]string, len(agentSessions))
+	for _, info := range agentSessions {
+		if summary := compactSessionDisplayName(info.Summary); summary != "" {
+			names[info.ID] = summary
+		}
+	}
+	return names
+}
+
+func (e *Engine) managementSessionDisplayName(s *Session, nativeNames map[string]string) string {
+	if e == nil || e.sessions == nil || s == nil {
+		return ""
+	}
+	agentID := s.GetAgentSessionID()
+	if agentID != "" {
+		if name := e.sessions.GetSessionName(agentID); name != "" {
+			return name
+		}
+		if name := nativeNames[agentID]; name != "" {
+			return name
+		}
+	}
+	return s.GetName()
+}
+
 func (m *ManagementServer) handleProjectSessions(w http.ResponseWriter, r *http.Request, projName string, e *Engine, rest string) {
 	// sub-routes like /sessions/switch
 	if rest == "switch" {
@@ -921,8 +958,10 @@ func (m *ManagementServer) handleProjectSessions(w http.ResponseWriter, r *http.
 
 		idToKey, activeIDs := e.sessions.SessionKeyMap()
 		stored := e.sessions.AllSessions()
+		nativeNames := e.managementSessionDisplayNames()
 		sessions := make([]map[string]any, 0, len(stored))
 		for _, s := range stored {
+			displayName := e.managementSessionDisplayName(s, nativeNames)
 			s.mu.Lock()
 			histCount := len(s.History)
 			var lastMsg map[string]any
@@ -940,7 +979,7 @@ func (m *ManagementServer) handleProjectSessions(w http.ResponseWriter, r *http.
 			}
 			info := map[string]any{
 				"id":            s.ID,
-				"name":          s.Name,
+				"name":          displayName,
 				"session_key":   idToKey[s.ID],
 				"agent_type":    s.AgentType,
 				"active":        activeIDs[s.ID],
@@ -1038,10 +1077,11 @@ func (m *ManagementServer) handleProjectSessionDetail(w http.ResponseWriter, r *
 		_, live := e.interactiveStates[sessionKey]
 		e.interactiveMu.Unlock()
 
+		displayName := e.managementSessionDisplayName(s, e.managementSessionDisplayNames())
 		s.mu.Lock()
 		data := map[string]any{
 			"id":               s.ID,
-			"name":             s.Name,
+			"name":             displayName,
 			"session_key":      sessionKey,
 			"agent_session_id": s.AgentSessionID,
 			"agent_type":       s.AgentType,
@@ -1859,10 +1899,10 @@ func (m *ManagementServer) handleCCSwitchProviders(w http.ResponseWriter, r *htt
 // applying per-agent-type overrides for base_url, model, and models.
 func resolveGlobalProviderForAgent(g GlobalProviderInfo, agentType string) ProviderConfig {
 	pc := ProviderConfig{
-		Name:   g.Name,
-		APIKey: g.APIKey,
+		Name:    g.Name,
+		APIKey:  g.APIKey,
 		BaseURL: g.BaseURL,
-		Model:  g.Model,
+		Model:   g.Model,
 	}
 	if ep, ok := g.Endpoints[agentType]; ok && ep != "" {
 		pc.BaseURL = ep

--- a/core/management.go
+++ b/core/management.go
@@ -552,7 +552,7 @@ func (m *ManagementServer) handleProjects(w http.ResponseWriter, r *http.Request
 			platNames[i] = p.Name()
 		}
 
-		sessCount := len(e.sessions.AllSessions())
+		sessCount := len(managementVisibleSessions(e.sessions.AllSessions()))
 
 		hbEnabled := false
 		if m.heartbeatScheduler != nil {
@@ -642,7 +642,7 @@ func (m *ManagementServer) handleProjectDetail(w http.ResponseWriter, r *http.Re
 			}
 		}
 
-		allSessions := e.sessions.AllSessions()
+		allSessions := managementVisibleSessions(e.sessions.AllSessions())
 		sessCount := len(allSessions)
 
 		e.interactiveMu.Lock()
@@ -932,6 +932,67 @@ func (e *Engine) managementSessionDisplayName(s *Session, nativeNames map[string
 	return s.GetName()
 }
 
+func managementVisibleSessions(stored []*Session) []*Session {
+	currentAgentIDs := make(map[string]struct{})
+	latestPastOnly := make(map[string]*Session)
+	for _, s := range stored {
+		if s == nil {
+			continue
+		}
+		s.mu.Lock()
+		agentID := s.AgentSessionID
+		pastIDs := append([]string(nil), s.PastAgentSessionIDs...)
+		updatedAt := s.UpdatedAt
+		s.mu.Unlock()
+		if agentID != "" {
+			currentAgentIDs[agentID] = struct{}{}
+			continue
+		}
+		for _, pastID := range pastIDs {
+			if pastID == "" {
+				continue
+			}
+			if prev := latestPastOnly[pastID]; prev != nil {
+				prevUpdated := prev.GetUpdatedAt()
+				if !updatedAt.After(prevUpdated) {
+					continue
+				}
+			}
+			latestPastOnly[pastID] = s
+		}
+	}
+
+	visible := make([]*Session, 0, len(stored))
+	for _, s := range stored {
+		if s == nil {
+			continue
+		}
+		s.mu.Lock()
+		agentID := s.AgentSessionID
+		pastIDs := append([]string(nil), s.PastAgentSessionIDs...)
+		s.mu.Unlock()
+
+		if agentID == "" && len(pastIDs) > 0 {
+			shadowed := false
+			for _, pastID := range pastIDs {
+				if _, ok := currentAgentIDs[pastID]; ok {
+					shadowed = true
+					break
+				}
+				if latest := latestPastOnly[pastID]; latest != nil && latest != s {
+					shadowed = true
+					break
+				}
+			}
+			if shadowed {
+				continue
+			}
+		}
+		visible = append(visible, s)
+	}
+	return visible
+}
+
 func (m *ManagementServer) handleProjectSessions(w http.ResponseWriter, r *http.Request, projName string, e *Engine, rest string) {
 	// sub-routes like /sessions/switch
 	if rest == "switch" {
@@ -957,7 +1018,7 @@ func (m *ManagementServer) handleProjectSessions(w http.ResponseWriter, r *http.
 		e.interactiveMu.Unlock()
 
 		idToKey, activeIDs := e.sessions.SessionKeyMap()
-		stored := e.sessions.AllSessions()
+		stored := managementVisibleSessions(e.sessions.AllSessions())
 		nativeNames := e.managementSessionDisplayNames()
 		sessions := make([]map[string]any, 0, len(stored))
 		for _, s := range stored {

--- a/core/management.go
+++ b/core/management.go
@@ -920,12 +920,23 @@ func (e *Engine) managementSessionDisplayName(s *Session, nativeNames map[string
 	if e == nil || e.sessions == nil || s == nil {
 		return ""
 	}
-	agentID := s.GetAgentSessionID()
+	s.mu.Lock()
+	agentID := s.AgentSessionID
+	pastIDs := append([]string(nil), s.PastAgentSessionIDs...)
+	s.mu.Unlock()
 	if agentID != "" {
 		if name := e.sessions.GetSessionName(agentID); name != "" {
 			return name
 		}
 		if name := nativeNames[agentID]; name != "" {
+			return name
+		}
+	}
+	for _, pastID := range pastIDs {
+		if name := e.sessions.GetSessionName(pastID); name != "" {
+			return name
+		}
+		if name := nativeNames[pastID]; name != "" {
 			return name
 		}
 	}

--- a/core/management_test.go
+++ b/core/management_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 type deadlineAwareModelAgent struct {
@@ -381,6 +382,73 @@ func TestMgmt_Sessions_DisplayNamePriority(t *testing.T) {
 	}
 	if detail.Name != "custom name" {
 		t.Fatalf("session detail name = %q, want custom name", detail.Name)
+	}
+}
+
+func TestMgmt_Sessions_HidesShadowedPastSessions(t *testing.T) {
+	_, ts, e := testManagementServer(t, "tok")
+
+	current := e.sessions.NewSession("user1", "native current")
+	current.SetAgentSessionID("agent-1", "codex")
+	shadow := e.sessions.NewSession("user1", "old local shell")
+	shadow.SetAgentSessionID("agent-1", "codex")
+	shadow.SetAgentSessionID("", "")
+
+	r := mgmtGet(t, ts.URL+"/api/v1/projects/test-project/sessions", "tok")
+	if !r.OK {
+		t.Fatalf("sessions list failed: %s", r.Error)
+	}
+	var listData struct {
+		Sessions []struct {
+			ID string `json:"id"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(r.Data, &listData); err != nil {
+		t.Fatalf("unmarshal sessions list: %v", err)
+	}
+	if len(listData.Sessions) != 1 {
+		t.Fatalf("sessions len = %d, want 1", len(listData.Sessions))
+	}
+	if listData.Sessions[0].ID != current.ID {
+		t.Fatalf("visible session = %q, want current %q", listData.Sessions[0].ID, current.ID)
+	}
+	if shadow.ID == current.ID {
+		t.Fatal("test setup failed: shadow and current IDs match")
+	}
+}
+
+func TestMgmt_Sessions_DeduplicatesPastOnlySessions(t *testing.T) {
+	_, ts, e := testManagementServer(t, "tok")
+
+	older := e.sessions.NewSession("user1", "old shell")
+	older.SetAgentSessionID("agent-1", "codex")
+	older.SetAgentSessionID("", "")
+	older.UpdatedAt = time.Now().Add(-time.Minute)
+	newer := e.sessions.NewSession("user1", "new shell")
+	newer.SetAgentSessionID("agent-1", "codex")
+	newer.SetAgentSessionID("", "")
+	newer.UpdatedAt = time.Now()
+
+	r := mgmtGet(t, ts.URL+"/api/v1/projects/test-project/sessions", "tok")
+	if !r.OK {
+		t.Fatalf("sessions list failed: %s", r.Error)
+	}
+	var listData struct {
+		Sessions []struct {
+			ID string `json:"id"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(r.Data, &listData); err != nil {
+		t.Fatalf("unmarshal sessions list: %v", err)
+	}
+	if len(listData.Sessions) != 1 {
+		t.Fatalf("sessions len = %d, want 1", len(listData.Sessions))
+	}
+	if listData.Sessions[0].ID != newer.ID {
+		t.Fatalf("visible session = %q, want newer %q", listData.Sessions[0].ID, newer.ID)
+	}
+	if older.ID == newer.ID {
+		t.Fatal("test setup failed: older and newer IDs match")
 	}
 }
 

--- a/core/management_test.go
+++ b/core/management_test.go
@@ -21,6 +21,15 @@ type deadlineAwareModelAgent struct {
 	hasDeadline bool
 }
 
+type mgmtListAgent struct {
+	stubAgent
+	sessions []AgentSessionInfo
+}
+
+func (a *mgmtListAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) {
+	return a.sessions, nil
+}
+
 func (a *deadlineAwareModelAgent) AvailableModels(ctx context.Context) []ModelOption {
 	a.mu.Lock()
 	_, ok := ctx.Deadline()
@@ -320,6 +329,58 @@ func TestMgmt_Sessions(t *testing.T) {
 	})
 	if !r.OK {
 		t.Fatalf("create session failed: %s", r.Error)
+	}
+}
+
+func TestMgmt_Sessions_DisplayNamePriority(t *testing.T) {
+	agent := &mgmtListAgent{
+		sessions: []AgentSessionInfo{{ID: "agent-1", Summary: "native title"}},
+	}
+	e := NewEngine("test-project", agent, nil, "", LangEnglish)
+	mgmt := NewManagementServer(0, "tok", nil)
+	mgmt.RegisterEngine("test-project", e)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/projects/", mgmt.wrap(mgmt.handleProjectRoutes))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	s := e.sessions.GetOrCreateActive("user1")
+	s.Name = "local name"
+	s.SetAgentSessionID("agent-1", "stub")
+
+	r := mgmtGet(t, ts.URL+"/api/v1/projects/test-project/sessions", "tok")
+	if !r.OK {
+		t.Fatalf("sessions list failed: %s", r.Error)
+	}
+	var listData struct {
+		Sessions []struct {
+			Name string `json:"name"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(r.Data, &listData); err != nil {
+		t.Fatalf("unmarshal sessions list: %v", err)
+	}
+	if len(listData.Sessions) != 1 {
+		t.Fatalf("sessions len = %d, want 1", len(listData.Sessions))
+	}
+	if listData.Sessions[0].Name != "native title" {
+		t.Fatalf("session name = %q, want native title", listData.Sessions[0].Name)
+	}
+
+	e.sessions.SetSessionName("agent-1", "custom name")
+	r = mgmtGet(t, ts.URL+"/api/v1/projects/test-project/sessions/"+s.ID, "tok")
+	if !r.OK {
+		t.Fatalf("session detail failed: %s", r.Error)
+	}
+	var detail struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(r.Data, &detail); err != nil {
+		t.Fatalf("unmarshal session detail: %v", err)
+	}
+	if detail.Name != "custom name" {
+		t.Fatalf("session detail name = %q, want custom name", detail.Name)
 	}
 }
 

--- a/core/management_test.go
+++ b/core/management_test.go
@@ -418,7 +418,17 @@ func TestMgmt_Sessions_HidesShadowedPastSessions(t *testing.T) {
 }
 
 func TestMgmt_Sessions_DeduplicatesPastOnlySessions(t *testing.T) {
-	_, ts, e := testManagementServer(t, "tok")
+	agent := &mgmtListAgent{
+		sessions: []AgentSessionInfo{{ID: "agent-1", Summary: "native past title"}},
+	}
+	e := NewEngine("test-project", agent, nil, "", LangEnglish)
+	mgmt := NewManagementServer(0, "tok", nil)
+	mgmt.RegisterEngine("test-project", e)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/projects/", mgmt.wrap(mgmt.handleProjectRoutes))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
 
 	older := e.sessions.NewSession("user1", "old shell")
 	older.SetAgentSessionID("agent-1", "codex")
@@ -435,7 +445,8 @@ func TestMgmt_Sessions_DeduplicatesPastOnlySessions(t *testing.T) {
 	}
 	var listData struct {
 		Sessions []struct {
-			ID string `json:"id"`
+			ID   string `json:"id"`
+			Name string `json:"name"`
 		} `json:"sessions"`
 	}
 	if err := json.Unmarshal(r.Data, &listData); err != nil {
@@ -446,6 +457,9 @@ func TestMgmt_Sessions_DeduplicatesPastOnlySessions(t *testing.T) {
 	}
 	if listData.Sessions[0].ID != newer.ID {
 		t.Fatalf("visible session = %q, want newer %q", listData.Sessions[0].ID, newer.ID)
+	}
+	if listData.Sessions[0].Name != "native past title" {
+		t.Fatalf("visible session name = %q, want native past title", listData.Sessions[0].Name)
 	}
 	if older.ID == newer.ID {
 		t.Fatal("test setup failed: older and newer IDs match")

--- a/core/message.go
+++ b/core/message.go
@@ -138,23 +138,24 @@ type LocationAttachment struct {
 
 // Message represents a unified incoming message from any platform.
 type Message struct {
-	SessionKey   string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
-	Platform     string
-	MessageID    string // platform message ID for tracing
-	Recalled     bool   // true for platform message recall/delete events targeting MessageID
-	UserID       string
-	UserName     string
-	ChatName     string // human-readable chat/group name (optional)
-	Content      string
-	Images       []ImageAttachment   // attached images (if any)
-	Files        []FileAttachment    // attached files (if any)
-	Audio        *AudioAttachment    // voice message (if any)
-	Location     *LocationAttachment // geographical location (if any)
-	ExtraContent string              // platform-enriched content (e.g. location text, reply quote) prepended for the agent
-	ChannelKey   string              // platform-provided channel identifier for workspace binding (optional)
-	ReplyCtx     any                 // platform-specific context needed for replying
-	FromVoice    bool                // true if message originated from voice transcription
-	ModeOverride string              // if set, temporarily override agent permission mode for this message
+	SessionKey      string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
+	TargetSessionID string // optional local cc-connect session id for one-message routing
+	Platform        string
+	MessageID       string // platform message ID for tracing
+	Recalled        bool   // true for platform message recall/delete events targeting MessageID
+	UserID          string
+	UserName        string
+	ChatName        string // human-readable chat/group name (optional)
+	Content         string
+	Images          []ImageAttachment   // attached images (if any)
+	Files           []FileAttachment    // attached files (if any)
+	Audio           *AudioAttachment    // voice message (if any)
+	Location        *LocationAttachment // geographical location (if any)
+	ExtraContent    string              // platform-enriched content (e.g. location text, reply quote) prepended for the agent
+	ChannelKey      string              // platform-provided channel identifier for workspace binding (optional)
+	ReplyCtx        any                 // platform-specific context needed for replying
+	FromVoice       bool                // true if message originated from voice transcription
+	ModeOverride    string              // if set, temporarily override agent permission mode for this message
 }
 
 // EventType distinguishes different kinds of agent output.

--- a/core/session.go
+++ b/core/session.go
@@ -327,6 +327,27 @@ func (sm *SessionManager) SwitchSession(userKey, target string) (*Session, error
 	return nil, fmt.Errorf("session %q not found", target)
 }
 
+// ResolveSessionForRouting returns target for one-message routing without
+// changing the active session for userKey.
+func (sm *SessionManager) ResolveSessionForRouting(userKey, target string) (*Session, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	for _, sid := range sm.userSessions[userKey] {
+		s := sm.sessions[sid]
+		if s == nil {
+			continue
+		}
+		if s.ID != target && s.Name != target {
+			continue
+		}
+		sm.restorePastAgentSessionLocked(s)
+		sm.saveLocked()
+		return s, nil
+	}
+	return nil, fmt.Errorf("session %q not found", target)
+}
+
 // SwitchSessionForRouting makes target active and restores a past native agent
 // session ID when the local session represents an older native conversation.
 func (sm *SessionManager) SwitchSessionForRouting(userKey, target string) (*Session, error) {
@@ -342,15 +363,22 @@ func (sm *SessionManager) SwitchSessionForRouting(userKey, target string) (*Sess
 			continue
 		}
 		sm.activeSession[userKey] = s.ID
-		s.mu.Lock()
-		if s.AgentSessionID == "" && len(s.PastAgentSessionIDs) > 0 {
-			s.AgentSessionID = s.PastAgentSessionIDs[len(s.PastAgentSessionIDs)-1]
-		}
-		s.mu.Unlock()
+		sm.restorePastAgentSessionLocked(s)
 		sm.saveLocked()
 		return s, nil
 	}
 	return nil, fmt.Errorf("session %q not found", target)
+}
+
+func (sm *SessionManager) restorePastAgentSessionLocked(s *Session) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.AgentSessionID == "" && len(s.PastAgentSessionIDs) > 0 {
+		s.AgentSessionID = s.PastAgentSessionIDs[len(s.PastAgentSessionIDs)-1]
+	}
 }
 
 // SwitchToAgentSession finds or creates an internal session that maps to the

--- a/core/session.go
+++ b/core/session.go
@@ -327,6 +327,32 @@ func (sm *SessionManager) SwitchSession(userKey, target string) (*Session, error
 	return nil, fmt.Errorf("session %q not found", target)
 }
 
+// SwitchSessionForRouting makes target active and restores a past native agent
+// session ID when the local session represents an older native conversation.
+func (sm *SessionManager) SwitchSessionForRouting(userKey, target string) (*Session, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	for _, sid := range sm.userSessions[userKey] {
+		s := sm.sessions[sid]
+		if s == nil {
+			continue
+		}
+		if s.ID != target && s.Name != target {
+			continue
+		}
+		sm.activeSession[userKey] = s.ID
+		s.mu.Lock()
+		if s.AgentSessionID == "" && len(s.PastAgentSessionIDs) > 0 {
+			s.AgentSessionID = s.PastAgentSessionIDs[len(s.PastAgentSessionIDs)-1]
+		}
+		s.mu.Unlock()
+		sm.saveLocked()
+		return s, nil
+	}
+	return nil, fmt.Errorf("session %q not found", target)
+}
+
 // SwitchToAgentSession finds or creates an internal session that maps to the
 // given agent session ID. If an existing session already references agentSID,
 // it becomes the active session. Otherwise a new session is created so the

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -104,6 +104,32 @@ func TestSessionManager_SwitchNotFound(t *testing.T) {
 	}
 }
 
+func TestSessionManager_SwitchSessionForRoutingRestoresPastAgentSessionID(t *testing.T) {
+	sm := NewSessionManager("")
+	userKey := "bridge:web-admin:codex"
+	first := sm.GetOrCreateActive(userKey)
+	target := sm.NewSession(userKey, "past native")
+	target.PastAgentSessionIDs = []string{"thread-old"}
+	target.AgentType = "codex"
+
+	switched, err := sm.SwitchSessionForRouting(userKey, target.ID)
+	if err != nil {
+		t.Fatalf("SwitchSessionForRouting: %v", err)
+	}
+	if switched.ID != target.ID {
+		t.Fatalf("switched ID = %q, want %q", switched.ID, target.ID)
+	}
+	if active := sm.GetOrCreateActive(userKey); active.ID != target.ID {
+		t.Fatalf("active ID = %q, want %q", active.ID, target.ID)
+	}
+	if got := target.GetAgentSessionID(); got != "thread-old" {
+		t.Fatalf("agent session ID = %q, want restored past ID", got)
+	}
+	if first.GetAgentSessionID() != "" {
+		t.Fatalf("first session agent ID changed to %q", first.GetAgentSessionID())
+	}
+}
+
 func TestSessionManager_ListSessions(t *testing.T) {
 	sm := NewSessionManager("")
 	sm.NewSession("user1", "a")

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -130,6 +130,32 @@ func TestSessionManager_SwitchSessionForRoutingRestoresPastAgentSessionID(t *tes
 	}
 }
 
+func TestSessionManager_ResolveSessionForRoutingDoesNotChangeActive(t *testing.T) {
+	sm := NewSessionManager("")
+	userKey := "bridge:web-admin:codex"
+	first := sm.GetOrCreateActive(userKey)
+	target := sm.NewSession(userKey, "past native")
+	target.PastAgentSessionIDs = []string{"thread-old"}
+	target.AgentType = "codex"
+	if _, err := sm.SwitchSession(userKey, first.ID); err != nil {
+		t.Fatalf("reset active session: %v", err)
+	}
+
+	resolved, err := sm.ResolveSessionForRouting(userKey, target.ID)
+	if err != nil {
+		t.Fatalf("ResolveSessionForRouting: %v", err)
+	}
+	if resolved.ID != target.ID {
+		t.Fatalf("resolved ID = %q, want %q", resolved.ID, target.ID)
+	}
+	if active := sm.GetOrCreateActive(userKey); active.ID != first.ID {
+		t.Fatalf("active ID = %q, want unchanged %q", active.ID, first.ID)
+	}
+	if got := target.GetAgentSessionID(); got != "thread-old" {
+		t.Fatalf("agent session ID = %q, want restored past ID", got)
+	}
+}
+
 func TestSessionManager_ListSessions(t *testing.T) {
 	sm := NewSessionManager("")
 	sm.NewSession("user1", "a")

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -125,13 +126,35 @@ type Platform struct {
 	newBot              botFactory
 	newBackoffTimer     func(time.Duration) backoffTimer
 	newTypingTicker     func(time.Duration) typingTicker
+
+	mediaGroupMu       sync.Mutex
+	mediaGroups        map[string]*telegramMediaGroup
+	mediaGroupDebounce time.Duration
 }
 
 const (
 	initialReconnectBackoff = time.Second
 	maxReconnectBackoff     = 30 * time.Second
 	stableConnectionWindow  = 10 * time.Second
+	mediaGroupDebounce      = 900 * time.Millisecond
 )
+
+type telegramMessageContext struct {
+	sessionKey string
+	userID     string
+	userName   string
+	chatName   string
+	channelKey string
+	replyCtx   replyContext
+	isGroup    bool
+}
+
+type telegramMediaGroup struct {
+	ctx      telegramMessageContext
+	messages []*models.Message
+	timer    *time.Timer
+	seq      uint64
+}
 
 func New(opts map[string]any) (core.Platform, error) {
 	token, _ := opts["token"].(string)
@@ -359,6 +382,20 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 		chatName = msg.Chat.Title
 	}
 
+	rctx := replyContext{chatID: msg.Chat.ID, threadID: threadID, messageID: msg.ID}
+	if p.isMediaGroupAttachment(msg) {
+		p.bufferMediaGroup(msg, telegramMessageContext{
+			sessionKey: sessionKey,
+			userID:     userID,
+			userName:   userName,
+			chatName:   chatName,
+			channelKey: channelKey,
+			replyCtx:   rctx,
+			isGroup:    isGroup,
+		})
+		return
+	}
+
 	if isGroup && !p.groupReplyAll {
 		slog.Debug("telegram: checking group message", "text", msg.Text, "is_command", isCommand(msg))
 		if !p.isDirectedAtBot(msg) {
@@ -366,7 +403,6 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 		}
 	}
 
-	rctx := replyContext{chatID: msg.Chat.ID, threadID: threadID, messageID: msg.ID}
 	if p.enableReactions {
 		go p.reactToMessage(ctx, msg.Chat.ID, msg.ID, "⚡")
 	}
@@ -498,6 +534,144 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 		ChannelKey: channelKey,
 		ReplyCtx:   rctx,
 	}, msg)
+}
+
+func (p *Platform) isMediaGroupAttachment(msg *models.Message) bool {
+	return msg.MediaGroupID != "" && (len(msg.Photo) > 0 || msg.Document != nil)
+}
+
+func (p *Platform) bufferMediaGroup(msg *models.Message, msgCtx telegramMessageContext) {
+	key := fmt.Sprintf("%s:%s:%s", msgCtx.channelKey, msgCtx.userID, msg.MediaGroupID)
+	delay := p.mediaGroupDelay()
+
+	p.mediaGroupMu.Lock()
+	defer p.mediaGroupMu.Unlock()
+
+	if p.mediaGroups == nil {
+		p.mediaGroups = make(map[string]*telegramMediaGroup)
+	}
+	group := p.mediaGroups[key]
+	if group == nil {
+		group = &telegramMediaGroup{ctx: msgCtx}
+		p.mediaGroups[key] = group
+	}
+	group.messages = append(group.messages, msg)
+	group.seq++
+	seq := group.seq
+	if group.timer != nil {
+		group.timer.Stop()
+	}
+	group.timer = time.AfterFunc(delay, func() {
+		p.flushMediaGroup(key, seq)
+	})
+}
+
+func (p *Platform) mediaGroupDelay() time.Duration {
+	if p.mediaGroupDebounce > 0 {
+		return p.mediaGroupDebounce
+	}
+	return mediaGroupDebounce
+}
+
+func (p *Platform) flushMediaGroup(key string, seq uint64) {
+	p.mediaGroupMu.Lock()
+	group := p.mediaGroups[key]
+	if group == nil || group.seq != seq {
+		p.mediaGroupMu.Unlock()
+		return
+	}
+	delete(p.mediaGroups, key)
+	p.mediaGroupMu.Unlock()
+
+	if p.isStopping() {
+		return
+	}
+	p.dispatchMediaGroup(group)
+}
+
+func (p *Platform) stopMediaGroups() {
+	p.mediaGroupMu.Lock()
+	defer p.mediaGroupMu.Unlock()
+	for key, group := range p.mediaGroups {
+		if group.timer != nil {
+			group.timer.Stop()
+		}
+		delete(p.mediaGroups, key)
+	}
+}
+
+func (p *Platform) dispatchMediaGroup(group *telegramMediaGroup) {
+	if group == nil || len(group.messages) == 0 {
+		return
+	}
+	sort.SliceStable(group.messages, func(i, j int) bool {
+		return group.messages[i].ID < group.messages[j].ID
+	})
+
+	if group.ctx.isGroup && !p.groupReplyAll {
+		directed := false
+		for _, msg := range group.messages {
+			if p.isDirectedAtBot(msg) {
+				directed = true
+				break
+			}
+		}
+		if !directed {
+			return
+		}
+	}
+
+	botName := p.botUsername()
+	var captions []string
+	var images []core.ImageAttachment
+	var files []core.FileAttachment
+	replyCtx := group.ctx.replyCtx
+	dispatchTGMsg := group.messages[0]
+
+	for _, msg := range group.messages {
+		if caption := stripBotMention(msg.Caption, botName); caption != "" {
+			captions = append(captions, caption)
+			replyCtx.messageID = msg.ID
+			dispatchTGMsg = msg
+		}
+		if len(msg.Photo) > 0 {
+			best := msg.Photo[len(msg.Photo)-1]
+			imgData, err := p.downloadFile(best.FileID)
+			if err != nil {
+				slog.Error("telegram: download media group photo failed", "error", err)
+				continue
+			}
+			images = append(images, core.ImageAttachment{MimeType: "image/jpeg", Data: imgData})
+			continue
+		}
+		if msg.Document != nil {
+			slog.Info("telegram: media group document received", "user", group.ctx.userName, "file_name", msg.Document.FileName, "mime", msg.Document.MimeType)
+			fileData, err := p.downloadFile(msg.Document.FileID)
+			if err != nil {
+				slog.Error("telegram: download media group document failed", "error", err)
+				continue
+			}
+			files = append(files, core.FileAttachment{MimeType: msg.Document.MimeType, Data: fileData, FileName: msg.Document.FileName})
+		}
+	}
+
+	content := strings.Join(captions, "\n")
+	if content == "" && len(images) == 0 && len(files) == 0 {
+		return
+	}
+	p.dispatchMessage(&core.Message{
+		SessionKey: group.ctx.sessionKey,
+		Platform:   "telegram",
+		UserID:     group.ctx.userID,
+		UserName:   group.ctx.userName,
+		ChatName:   group.ctx.chatName,
+		Content:    content,
+		MessageID:  strconv.Itoa(group.messages[0].ID),
+		ChannelKey: group.ctx.channelKey,
+		Images:     images,
+		Files:      files,
+		ReplyCtx:   replyCtx,
+	}, dispatchTGMsg)
 }
 
 func (p *Platform) dispatchMessage(msg *core.Message, tgMsg *models.Message) {
@@ -1476,6 +1650,7 @@ func (p *Platform) Stop() error {
 	if cancel != nil {
 		cancel()
 	}
+	p.stopMediaGroups()
 	return nil
 }
 

--- a/platform/telegram/telegram_test.go
+++ b/platform/telegram/telegram_test.go
@@ -86,6 +86,7 @@ type stubTelegramBot struct {
 	sendErr    error
 	getFileErr error
 	file       *models.File
+	fileURL    string
 }
 
 func newStubTelegramBot() *stubTelegramBot {
@@ -191,17 +192,23 @@ func (b *stubTelegramBot) SetMyCommands(_ context.Context, _ *tgbot.SetMyCommand
 	return true, nil
 }
 
-func (b *stubTelegramBot) GetFile(_ context.Context, _ *tgbot.GetFileParams) (*models.File, error) {
+func (b *stubTelegramBot) GetFile(_ context.Context, params *tgbot.GetFileParams) (*models.File, error) {
 	b.mu.Lock()
 	b.getFileCalls++
 	b.mu.Unlock()
 	if b.getFileErr != nil {
 		return nil, b.getFileErr
 	}
+	if params != nil && params.FileID != "" {
+		return &models.File{FilePath: params.FileID}, nil
+	}
 	return b.file, nil
 }
 
 func (b *stubTelegramBot) FileDownloadLink(f *models.File) string {
+	if b.fileURL != "" {
+		return b.fileURL + "/" + f.FilePath
+	}
 	return "https://test.example.com/file/" + f.FilePath
 }
 
@@ -935,6 +942,233 @@ func TestHandleMessagePrivateTopicUsesThreadID(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("message not handled")
+	}
+}
+
+func TestHandleMessageMediaGroupMergesPhotosAndCaption(t *testing.T) {
+	handled := make(chan *core.Message, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "data:%s", strings.TrimPrefix(r.URL.Path, "/"))
+	}))
+	defer server.Close()
+
+	p := &Platform{
+		token:              "token",
+		httpClient:         server.Client(),
+		groupReplyAll:      true,
+		mediaGroupDebounce: 5 * time.Millisecond,
+	}
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		handled <- msg
+	}
+	stubBot := newStubTelegramBot()
+	stubBot.fileURL = server.URL
+	p.bot = stubBot
+	p.selfUser = &models.User{ID: 42, Username: "mybot"}
+
+	now := int(time.Now().Unix())
+	p.handleMessage(context.Background(), &models.Message{
+		ID:           12,
+		MediaGroupID: "album-1",
+		Date:         now,
+		From:         &models.User{ID: 7, Username: "alice"},
+		Chat:         models.Chat{ID: 100, Type: models.ChatTypePrivate},
+		Photo:        []models.PhotoSize{{FileID: "small"}, {FileID: "photo-b"}},
+	})
+	p.handleMessage(context.Background(), &models.Message{
+		ID:           11,
+		MediaGroupID: "album-1",
+		Caption:      "look @mybot",
+		Date:         now,
+		From:         &models.User{ID: 7, Username: "alice"},
+		Chat:         models.Chat{ID: 100, Type: models.ChatTypePrivate},
+		Photo:        []models.PhotoSize{{FileID: "photo-a"}},
+	})
+
+	select {
+	case got := <-handled:
+		if got.Content != "look" {
+			t.Fatalf("Content = %q, want %q", got.Content, "look")
+		}
+		if len(got.Images) != 2 {
+			t.Fatalf("Images len = %d, want 2", len(got.Images))
+		}
+		if string(got.Images[0].Data) != "data:photo-a" || string(got.Images[1].Data) != "data:photo-b" {
+			t.Fatalf("image data = %q, %q; want ordered photo-a/photo-b", got.Images[0].Data, got.Images[1].Data)
+		}
+		if got.SessionKey != "telegram:100:7" {
+			t.Fatalf("SessionKey = %q, want telegram:100:7", got.SessionKey)
+		}
+		rc := got.ReplyCtx.(replyContext)
+		if rc.messageID != 11 {
+			t.Fatalf("reply messageID = %d, want caption message 11", rc.messageID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("merged media group not handled")
+	}
+
+	select {
+	case extra := <-handled:
+		t.Fatalf("unexpected extra dispatch: %+v", extra)
+	case <-time.After(30 * time.Millisecond):
+	}
+}
+
+func TestHandleMessageSinglePhotoDispatchesImmediately(t *testing.T) {
+	handled := make(chan *core.Message, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "single-photo")
+	}))
+	defer server.Close()
+
+	p := &Platform{
+		token:              "token",
+		httpClient:         server.Client(),
+		groupReplyAll:      true,
+		mediaGroupDebounce: time.Hour,
+	}
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		handled <- msg
+	}
+	stubBot := newStubTelegramBot()
+	stubBot.fileURL = server.URL
+	p.bot = stubBot
+	p.selfUser = &models.User{ID: 42, Username: "mybot"}
+
+	p.handleMessage(context.Background(), &models.Message{
+		ID:      21,
+		Date:    int(time.Now().Unix()),
+		From:    &models.User{ID: 7, Username: "alice"},
+		Chat:    models.Chat{ID: 100, Type: models.ChatTypePrivate},
+		Caption: "one",
+		Photo:   []models.PhotoSize{{FileID: "photo-one"}},
+	})
+
+	select {
+	case got := <-handled:
+		if got.Content != "one" {
+			t.Fatalf("Content = %q, want one", got.Content)
+		}
+		if len(got.Images) != 1 {
+			t.Fatalf("Images len = %d, want 1", len(got.Images))
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("single photo was delayed")
+	}
+}
+
+func TestHandleMessageMediaGroupsDoNotMix(t *testing.T) {
+	handled := make(chan *core.Message, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "data:%s", strings.TrimPrefix(r.URL.Path, "/"))
+	}))
+	defer server.Close()
+
+	p := &Platform{
+		token:              "token",
+		httpClient:         server.Client(),
+		groupReplyAll:      true,
+		mediaGroupDebounce: 5 * time.Millisecond,
+	}
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		handled <- msg
+	}
+	stubBot := newStubTelegramBot()
+	stubBot.fileURL = server.URL
+	p.bot = stubBot
+	p.selfUser = &models.User{ID: 42, Username: "mybot"}
+
+	now := int(time.Now().Unix())
+	for _, item := range []struct {
+		id      int
+		groupID string
+		fileID  string
+		caption string
+	}{
+		{id: 31, groupID: "album-a", fileID: "a", caption: "A"},
+		{id: 32, groupID: "album-b", fileID: "b", caption: "B"},
+	} {
+		p.handleMessage(context.Background(), &models.Message{
+			ID:           item.id,
+			MediaGroupID: item.groupID,
+			Caption:      item.caption,
+			Date:         now,
+			From:         &models.User{ID: 7, Username: "alice"},
+			Chat:         models.Chat{ID: 100, Type: models.ChatTypePrivate},
+			Photo:        []models.PhotoSize{{FileID: item.fileID}},
+		})
+	}
+
+	got := map[string]*core.Message{}
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-handled:
+			got[msg.Content] = msg
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for media groups")
+		}
+	}
+	if len(got["A"].Images) != 1 || string(got["A"].Images[0].Data) != "data:a" {
+		t.Fatalf("album A was mixed or missing: %+v", got["A"])
+	}
+	if len(got["B"].Images) != 1 || string(got["B"].Images[0].Data) != "data:b" {
+		t.Fatalf("album B was mixed or missing: %+v", got["B"])
+	}
+}
+
+func TestHandleMessageGroupMediaGroupDirectedByCaption(t *testing.T) {
+	handled := make(chan *core.Message, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "data:%s", strings.TrimPrefix(r.URL.Path, "/"))
+	}))
+	defer server.Close()
+
+	p := &Platform{
+		token:              "token",
+		httpClient:         server.Client(),
+		groupReplyAll:      false,
+		mediaGroupDebounce: 5 * time.Millisecond,
+	}
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		handled <- msg
+	}
+	stubBot := newStubTelegramBot()
+	stubBot.fileURL = server.URL
+	p.bot = stubBot
+	p.selfUser = &models.User{ID: 42, Username: "mybot"}
+
+	now := int(time.Now().Unix())
+	p.handleMessage(context.Background(), &models.Message{
+		ID:           41,
+		MediaGroupID: "album-group",
+		Date:         now,
+		From:         &models.User{ID: 7, Username: "alice"},
+		Chat:         models.Chat{ID: 100, Type: models.ChatTypeGroup, Title: "group"},
+		Photo:        []models.PhotoSize{{FileID: "first"}},
+	})
+	p.handleMessage(context.Background(), &models.Message{
+		ID:           42,
+		MediaGroupID: "album-group",
+		Caption:      "please inspect @mybot",
+		CaptionEntities: []models.MessageEntity{
+			{Type: models.MessageEntityTypeMention, Offset: 15, Length: 6},
+		},
+		Date:  now,
+		From:  &models.User{ID: 7, Username: "alice"},
+		Chat:  models.Chat{ID: 100, Type: models.ChatTypeGroup, Title: "group"},
+		Photo: []models.PhotoSize{{FileID: "second"}},
+	})
+
+	select {
+	case got := <-handled:
+		if got.Content != "please inspect" {
+			t.Fatalf("Content = %q, want caption without bot mention", got.Content)
+		}
+		if len(got.Images) != 2 {
+			t.Fatalf("Images len = %d, want 2", len(got.Images))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("directed group media group not handled")
 	}
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import ProjectList from '@/pages/Projects/ProjectList';
 import ProjectDetail from '@/pages/Projects/ProjectDetail';
 import ChatList from '@/pages/Chat/ChatList';
 import ChatView from '@/pages/Chat/ChatView';
+import SessionList from '@/pages/Sessions/SessionList';
 import CronList from '@/pages/Cron/CronList';
 import SystemConfig from '@/pages/System/Config';
 import ProviderList from '@/pages/Providers/ProviderList';
@@ -30,6 +31,7 @@ export default function App() {
         <Route path="projects/:name" element={<ProjectDetail />} />
         <Route path="providers" element={<ProviderList />} />
         <Route path="skills" element={<SkillList />} />
+        <Route path="sessions" element={<SessionList />} />
         <Route path="chat" element={<ChatList />} />
         <Route path="chat/:name" element={<ChatView />} />
         <Route path="cron" element={<CronList />} />

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -36,5 +36,5 @@ export const createSession = (project: string, body: { session_key: string; name
 export const deleteSession = (project: string, id: string) => api.delete(`/projects/${project}/sessions/${id}`);
 export const switchSession = (project: string, body: { session_key: string; session_id: string }) =>
   api.post(`/projects/${project}/sessions/switch`, body);
-export const sendMessage = (project: string, body: { session_key: string; message: string }) =>
+export const sendMessage = (project: string, body: { session_key: string; message: string; session_id?: string }) =>
   api.post(`/projects/${project}/send`, body);

--- a/web/src/components/Layout/Header.tsx
+++ b/web/src/components/Layout/Header.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useState, useRef, useEffect } from 'react';
 import {
-  RefreshCw, Sun, Moon, Monitor, LogOut, Languages, ChevronDown,
+  RefreshCw, Sun, Moon, Monitor, LogOut, Languages, Menu,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useThemeStore } from '@/store/theme';
@@ -15,7 +15,11 @@ const languages = [
   { code: 'es', label: 'ES' },
 ];
 
-export default function Header() {
+interface HeaderProps {
+  onMenuClick?: () => void;
+}
+
+export default function Header({ onMenuClick }: HeaderProps) {
   const { t, i18n } = useTranslation();
   const { theme, setTheme } = useThemeStore();
   const logout = useAuthStore((s) => s.logout);
@@ -56,63 +60,69 @@ export default function Header() {
   return (
     <header
       className={cn(
-        'h-14 flex items-center justify-end gap-1 px-4 shrink-0 relative z-20',
+        'h-14 flex items-center justify-between gap-1 px-3 sm:px-4 shrink-0 relative z-20',
         'border-b border-gray-200/80 dark:border-white/[0.08]',
         'bg-white/70 backdrop-blur-xl dark:bg-[rgba(0,0,0,0.72)]',
       )}
     >
-      <button type="button" onClick={handleRefresh} className={btnCls} aria-label={t('common.refresh')}>
-        <RefreshCw size={16} className={spinning ? 'animate-spin' : ''} />
+      <button type="button" onClick={onMenuClick} className={cn(btnCls, 'lg:hidden')} aria-label="Open navigation">
+        <Menu size={18} />
       </button>
+
+      <div className="flex items-center justify-end gap-1 ml-auto">
+        <button type="button" onClick={handleRefresh} className={btnCls} aria-label={t('common.refresh')}>
+          <RefreshCw size={16} className={spinning ? 'animate-spin' : ''} />
+        </button>
 
       {/* Language */}
-      <div className="relative" ref={langRef}>
-        <button type="button" onClick={() => setLangOpen(!langOpen)} className={cn(btnCls, 'flex items-center gap-1')}>
-          <Languages size={16} />
-          <span className="text-xs hidden sm:inline">{languages.find(l => l.code === i18n.language)?.label}</span>
+        <div className="relative" ref={langRef}>
+          <button type="button" onClick={() => setLangOpen(!langOpen)} className={cn(btnCls, 'flex items-center gap-1')}>
+            <Languages size={16} />
+            <span className="text-xs hidden sm:inline">{languages.find(l => l.code === i18n.language)?.label}</span>
+          </button>
+          {langOpen && (
+            <div className={cn(
+              'absolute right-0 top-full mt-1 w-36 rounded-xl py-1 z-50 overflow-hidden',
+              'bg-white/95 backdrop-blur-xl border border-gray-200/80 shadow-xl shadow-black/10',
+              'dark:bg-[rgba(0,0,0,0.88)] dark:border-white/[0.1] dark:shadow-black/40',
+            )}>
+              {languages.map(l => (
+                <button
+                  key={l.code}
+                  type="button"
+                  onClick={() => changeLang(l.code)}
+                  className={cn(
+                    'w-full text-left px-3 py-1.5 text-sm transition-colors',
+                    i18n.language === l.code
+                      ? 'text-accent font-medium bg-accent/10'
+                      : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100/80 dark:hover:bg-white/[0.06]',
+                  )}
+                >
+                  {l.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Theme */}
+        <button type="button" onClick={() => setTheme(nextTheme[theme])} className={btnCls} aria-label="Theme">
+          <ThemeIcon size={16} />
         </button>
-        {langOpen && (
-          <div className={cn(
-            'absolute right-0 top-full mt-1 w-36 rounded-xl py-1 z-50 overflow-hidden',
-            'bg-white/95 backdrop-blur-xl border border-gray-200/80 shadow-xl shadow-black/10',
-            'dark:bg-[rgba(0,0,0,0.88)] dark:border-white/[0.1] dark:shadow-black/40',
-          )}>
-            {languages.map(l => (
-              <button
-                key={l.code}
-                type="button"
-                onClick={() => changeLang(l.code)}
-                className={cn(
-                  'w-full text-left px-3 py-1.5 text-sm transition-colors',
-                  i18n.language === l.code
-                    ? 'text-accent font-medium bg-accent/10'
-                    : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100/80 dark:hover:bg-white/[0.06]',
-                )}
-              >
-                {l.label}
-              </button>
-            ))}
-          </div>
-        )}
+
+        {/* Logout */}
+        <button
+          type="button"
+          onClick={logout}
+          className={cn(
+            'p-2 rounded-lg transition-all duration-200',
+            'text-gray-400 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400',
+          )}
+          aria-label={t('login.logout')}
+        >
+          <LogOut size={16} />
+        </button>
       </div>
-
-      {/* Theme */}
-      <button type="button" onClick={() => setTheme(nextTheme[theme])} className={btnCls} aria-label="Theme">
-        <ThemeIcon size={16} />
-      </button>
-
-      {/* Logout */}
-      <button
-        type="button"
-        onClick={logout}
-        className={cn(
-          'p-2 rounded-lg transition-all duration-200',
-          'text-gray-400 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400',
-        )}
-        aria-label={t('login.logout')}
-      >
-        <LogOut size={16} />
-      </button>
     </header>
   );
 }

--- a/web/src/components/Layout/Header.tsx
+++ b/web/src/components/Layout/Header.tsx
@@ -53,16 +53,16 @@ export default function Header({ onMenuClick }: HeaderProps) {
 
   const btnCls = cn(
     'p-2 rounded-lg transition-all duration-200',
-    'text-gray-500 dark:text-gray-400',
-    'hover:bg-gray-100/90 dark:hover:bg-white/[0.08] hover:text-gray-800 dark:hover:text-white',
+    'text-ink/55',
+    'hover:bg-ink/[0.06] hover:text-ink',
   );
 
   return (
     <header
       className={cn(
         'h-14 flex items-center justify-between gap-1 px-3 sm:px-4 shrink-0 relative z-20',
-        'border-b border-gray-200/80 dark:border-white/[0.08]',
-        'bg-white/70 backdrop-blur-xl dark:bg-[rgba(0,0,0,0.72)]',
+        'border-b border-black/[0.08] dark:border-white/[0.1]',
+        'bg-surface/72 backdrop-blur-xl',
       )}
     >
       <button type="button" onClick={onMenuClick} className={cn(btnCls, 'lg:hidden')} aria-label="Open navigation">
@@ -83,8 +83,8 @@ export default function Header({ onMenuClick }: HeaderProps) {
           {langOpen && (
             <div className={cn(
               'absolute right-0 top-full mt-1 w-36 rounded-xl py-1 z-50 overflow-hidden',
-              'bg-white/95 backdrop-blur-xl border border-gray-200/80 shadow-xl shadow-black/10',
-              'dark:bg-[rgba(0,0,0,0.88)] dark:border-white/[0.1] dark:shadow-black/40',
+              'bg-surface/95 backdrop-blur-xl border border-black/[0.08] shadow-xl shadow-black/10',
+              'dark:border-white/[0.1] dark:shadow-black/40',
             )}>
               {languages.map(l => (
                 <button
@@ -95,7 +95,7 @@ export default function Header({ onMenuClick }: HeaderProps) {
                     'w-full text-left px-3 py-1.5 text-sm transition-colors',
                     i18n.language === l.code
                       ? 'text-accent font-medium bg-accent/10'
-                      : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100/80 dark:hover:bg-white/[0.06]',
+                      : 'text-ink/75 hover:bg-ink/[0.06]',
                   )}
                 >
                   {l.label}
@@ -115,8 +115,8 @@ export default function Header({ onMenuClick }: HeaderProps) {
           type="button"
           onClick={logout}
           className={cn(
-            'p-2 rounded-lg transition-all duration-200',
-            'text-gray-400 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400',
+          'p-2 rounded-lg transition-all duration-200',
+          'text-ink/45 hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400',
           )}
           aria-label={t('login.logout')}
         >

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -3,8 +3,11 @@ import Sidebar from './Sidebar';
 import Header from './Header';
 import Footer from './Footer';
 import { cn } from '@/lib/utils';
+import { useState } from 'react';
 
 export default function Layout() {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
   return (
     <div
       className={cn(
@@ -13,10 +16,10 @@ export default function Layout() {
         'dark:from-gray-950 dark:via-[#0a0a0c] dark:to-gray-950',
       )}
     >
-      <Sidebar />
+      <Sidebar mobileOpen={mobileNavOpen} onMobileClose={() => setMobileNavOpen(false)} />
       <div className="flex-1 flex flex-col overflow-hidden min-w-0">
-        <Header />
-        <main className="flex-1 overflow-y-auto p-6 flex flex-col min-h-0">
+        <Header onMenuClick={() => setMobileNavOpen(true)} />
+        <main className="flex-1 overflow-y-auto p-3 sm:p-4 lg:p-6 flex flex-col min-h-0">
           <div className="flex-1 flex flex-col">
             <Outlet />
           </div>

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -12,8 +12,7 @@ export default function Layout() {
     <div
       className={cn(
         'flex h-screen overflow-hidden',
-        'bg-gradient-to-br from-gray-100 via-white to-gray-100',
-        'dark:from-gray-950 dark:via-[#0a0a0c] dark:to-gray-950',
+        'bg-[rgb(var(--color-surface))] text-[rgb(var(--color-ink))]',
       )}
     >
       <Sidebar mobileOpen={mobileNavOpen} onMobileClose={() => setMobileNavOpen(false)} />

--- a/web/src/components/Layout/Sidebar.tsx
+++ b/web/src/components/Layout/Sidebar.tsx
@@ -84,7 +84,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
               cn(
                 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200',
                 isActive
-                  ? 'bg-accent/14 text-accent ring-1 ring-accent/30'
+                  ? 'bg-accent/[0.14] text-accent ring-1 ring-accent/30'
                   : 'text-ink/70 hover:bg-ink/[0.06] hover:text-ink',
               )
             }
@@ -116,7 +116,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
       <div className="hidden lg:block">{sidebar}</div>
       {mobileOpen && (
         <div className="fixed inset-0 z-50 lg:hidden">
-          <div className="absolute inset-0 bg-black/35 backdrop-blur-[2px]" onClick={onMobileClose} />
+          <div className="absolute inset-0 bg-ink/[0.07] dark:bg-black/25" onClick={onMobileClose} />
           <div className="absolute inset-y-0 left-0 shadow-2xl shadow-black/25">
             {sidebar}
           </div>

--- a/web/src/components/Layout/Sidebar.tsx
+++ b/web/src/components/Layout/Sidebar.tsx
@@ -39,8 +39,8 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
     <aside
       className={cn(
         'h-screen flex flex-col border-r transition-all duration-300 ease-out',
-        'bg-white/90 backdrop-blur-xl border-gray-200/80',
-        'dark:bg-[rgba(10,10,12,0.94)] dark:backdrop-blur-xl dark:border-white/[0.08]',
+        'bg-surface/78 backdrop-blur-xl border-black/[0.08]',
+        'dark:bg-surface/78 dark:backdrop-blur-xl dark:border-white/[0.1]',
         collapsed ? 'lg:w-16' : 'lg:w-56',
         'w-72 max-w-[82vw]',
       )}
@@ -49,7 +49,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
       <div
         className={cn(
           'flex items-center px-4 h-14 border-b transition-colors shrink-0',
-          'border-gray-200/80 dark:border-white/[0.08]',
+          'border-black/[0.08] dark:border-white/[0.1]',
           collapsed ? 'justify-center' : 'gap-0',
         )}
       >
@@ -84,8 +84,8 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
               cn(
                 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200',
                 isActive
-                  ? 'bg-accent/12 text-accent ring-1 ring-accent/25'
-                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100/80 dark:hover:bg-white/[0.06] hover:text-gray-900 dark:hover:text-white',
+                  ? 'bg-accent/14 text-accent ring-1 ring-accent/30'
+                  : 'text-ink/70 hover:bg-ink/[0.06] hover:text-ink',
               )
             }
           >
@@ -96,13 +96,13 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
       </nav>
 
       {/* Collapse toggle */}
-      <div className={cn('border-t p-2', 'border-gray-200/80 dark:border-white/[0.08]')}>
+      <div className={cn('border-t p-2', 'border-black/[0.08] dark:border-white/[0.1]')}>
         <button
           type="button"
           onClick={() => setCollapsed(!collapsed)}
           className={cn(
             'flex items-center justify-center w-full px-3 py-2 rounded-xl transition-colors duration-200',
-            'text-gray-400 hover:bg-gray-100/80 dark:hover:bg-white/[0.06]',
+            'text-ink/45 hover:bg-ink/[0.06] hover:text-ink',
           )}
         >
           {collapsed ? <ChevronRight size={18} /> : <ChevronLeft size={18} />}

--- a/web/src/components/Layout/Sidebar.tsx
+++ b/web/src/components/Layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   ChevronRight,
   Plug,
   Puzzle,
+  X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
@@ -19,22 +20,29 @@ const navItems = [
   { key: 'projects', path: '/projects', icon: FolderKanban },
   { key: 'providers', path: '/providers', icon: Plug },
   { key: 'skills', path: '/skills', icon: Puzzle },
+  { key: 'sessions', path: '/sessions', icon: MessageSquare },
   { key: 'chat', path: '/chat', icon: MessageSquare },
   { key: 'cron', path: '/cron', icon: Clock },
   { key: 'system', path: '/system', icon: Settings },
 ];
 
-export default function Sidebar() {
+interface SidebarProps {
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
+}
+
+export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarProps) {
   const { t } = useTranslation();
   const [collapsed, setCollapsed] = useState(false);
 
-  return (
+  const sidebar = (
     <aside
       className={cn(
         'h-screen flex flex-col border-r transition-all duration-300 ease-out',
-        'bg-white/75 backdrop-blur-xl border-gray-200/80',
-        'dark:bg-[rgba(0,0,0,0.85)] dark:backdrop-blur-xl dark:border-white/[0.08]',
-        collapsed ? 'w-16' : 'w-56',
+        'bg-white/90 backdrop-blur-xl border-gray-200/80',
+        'dark:bg-[rgba(10,10,12,0.94)] dark:backdrop-blur-xl dark:border-white/[0.08]',
+        collapsed ? 'lg:w-16' : 'lg:w-56',
+        'w-72 max-w-[82vw]',
       )}
     >
       {/* Brand */}
@@ -54,6 +62,14 @@ export default function Sidebar() {
             CC<span className="text-accent">-</span>Connect
           </span>
         )}
+        <button
+          type="button"
+          onClick={onMobileClose}
+          className="ml-auto p-1.5 rounded-lg text-gray-400 hover:bg-gray-100 dark:hover:bg-white/[0.06] lg:hidden"
+          aria-label="Close navigation"
+        >
+          <X size={18} />
+        </button>
       </div>
 
       {/* Navigation */}
@@ -63,6 +79,7 @@ export default function Sidebar() {
             key={key}
             to={path}
             end={path === '/'}
+            onClick={onMobileClose}
             className={({ isActive }) =>
               cn(
                 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200',
@@ -92,5 +109,19 @@ export default function Sidebar() {
         </button>
       </div>
     </aside>
+  );
+
+  return (
+    <>
+      <div className="hidden lg:block">{sidebar}</div>
+      {mobileOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden">
+          <div className="absolute inset-0 bg-black/35 backdrop-blur-[2px]" onClick={onMobileClose} />
+          <div className="absolute inset-y-0 left-0 shadow-2xl shadow-black/25">
+            {sidebar}
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/web/src/components/Layout/Sidebar.tsx
+++ b/web/src/components/Layout/Sidebar.tsx
@@ -116,7 +116,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
       <div className="hidden lg:block">{sidebar}</div>
       {mobileOpen && (
         <div className="fixed inset-0 z-50 lg:hidden">
-          <div className="absolute inset-0 bg-ink/[0.07] dark:bg-black/25" onClick={onMobileClose} />
+          <div className="absolute inset-0 bg-transparent dark:bg-black/20" onClick={onMobileClose} />
           <div className="absolute inset-y-0 left-0 shadow-2xl shadow-black/25">
             {sidebar}
           </div>

--- a/web/src/components/ui/Card.tsx
+++ b/web/src/components/ui/Card.tsx
@@ -11,7 +11,7 @@ export function Card({ children, className, hover }: CardProps) {
   return (
     <div
       className={cn(
-        'rounded-xl p-5 transition-all duration-200 animate-float-in',
+        'min-w-0 rounded-xl p-5 transition-all duration-200 animate-float-in',
         'bg-white/80 backdrop-blur-md border border-gray-200/90',
         'dark:bg-[rgba(0,0,0,0.55)] dark:backdrop-blur-xl dark:border-white/[0.08]',
         hover &&
@@ -33,12 +33,13 @@ interface StatCardProps {
 export function StatCard({ label, value, accent }: StatCardProps) {
   return (
     <Card hover>
-      <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+      <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide truncate">
         {label}
       </p>
       <p
+        title={String(value)}
         className={cn(
-          'text-2xl font-bold mt-1',
+          'mt-1 max-w-full text-xl sm:text-2xl font-bold leading-tight break-words [overflow-wrap:anywhere]',
           accent ? 'text-accent' : 'text-gray-900 dark:text-white'
         )}
       >

--- a/web/src/hooks/useBridgeSocket.ts
+++ b/web/src/hooks/useBridgeSocket.ts
@@ -28,11 +28,12 @@ export interface UseBridgeSocketOptions {
   bridgeCfg: BridgeConfig | null;
   platformName?: string;
   sessionKey: string;
+  sessionId?: string;
   projectName?: string;
   onMessage: (msg: BridgeIncoming) => void;
 }
 
-export function useBridgeSocket({ bridgeCfg, platformName = 'web', sessionKey, projectName, onMessage }: UseBridgeSocketOptions) {
+export function useBridgeSocket({ bridgeCfg, platformName = 'web', sessionKey, sessionId, projectName, onMessage }: UseBridgeSocketOptions) {
   const wsRef = useRef<WebSocket | null>(null);
   const onMessageRef = useRef(onMessage);
   onMessageRef.current = onMessage;
@@ -50,23 +51,25 @@ export function useBridgeSocket({ bridgeCfg, platformName = 'web', sessionKey, p
       type: 'message',
       msg_id: `web-${Date.now()}`,
       session_key: sessionKey,
+      session_id: sessionId || undefined,
       user_id: 'web-admin',
       user_name: 'Web Admin',
       content,
       reply_ctx: sessionKey,
       project: projectName || '',
     });
-  }, [send, sessionKey, projectName]);
+  }, [send, sessionKey, sessionId, projectName]);
 
   const sendCardAction = useCallback((action: string) => {
     send({
       type: 'card_action',
       session_key: sessionKey,
+      session_id: sessionId || undefined,
       action,
       reply_ctx: sessionKey,
       project: projectName || '',
     });
-  }, [send, sessionKey, projectName]);
+  }, [send, sessionKey, sessionId, projectName]);
 
   const sendPreviewAck = useCallback((refId: string, handle: string) => {
     send({ type: 'preview_ack', ref_id: refId, preview_handle: handle });

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -5,12 +5,16 @@
 @tailwind utilities;
 
 :root {
-  --color-accent: 22 163 74;
-  --color-accent-dim: 21 128 61;
+  --color-accent: 204 125 94;
+  --color-accent-dim: 178 99 73;
+  --color-surface: 249 249 247;
+  --color-ink: 45 45 43;
 }
 .dark {
-  --color-accent: 66 255 156;
-  --color-accent-dim: 43 200 122;
+  --color-accent: 204 125 94;
+  --color-accent-dim: 221 151 124;
+  --color-surface: 45 45 43;
+  --color-ink: 249 249 247;
 }
 
 body {
@@ -18,6 +22,36 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-ink));
+}
+
+.bg-white,
+.dark .dark\:bg-gray-800,
+.dark .dark\:bg-gray-900,
+.dark .dark\:bg-white\/\[0\.02\],
+.dark .dark\:bg-white\/\[0\.03\] {
+  background-color: rgb(var(--color-surface) / 0.72);
+}
+
+.border-gray-200,
+.border-gray-200\/80,
+.dark .dark\:border-gray-700,
+.dark .dark\:border-gray-800,
+.dark .dark\:border-white\/\[0\.06\],
+.dark .dark\:border-white\/\[0\.08\] {
+  border-color: rgb(var(--color-ink) / 0.1);
+}
+
+.text-gray-900,
+.dark .dark\:text-white {
+  color: rgb(var(--color-ink));
+}
+
+input,
+select,
+textarea {
+  color: rgb(var(--color-ink));
 }
 
 pre code.hljs {

--- a/web/src/pages/Chat/ChatView.tsx
+++ b/web/src/pages/Chat/ChatView.tsx
@@ -325,6 +325,9 @@ export default function ChatView() {
   const sessionKey = userPickedSession && currentSession?.session_key
     ? currentSession.session_key
     : webSessionKey;
+  const targetSessionId = userPickedSession && currentSession?.id
+    ? currentSession.id
+    : '';
   sessionKeyRef.current = sessionKey;
 
   // Load project sessions and auto-select latest
@@ -500,6 +503,7 @@ export default function ChatView() {
   const { status: bridgeStatus, sendMessage: bridgeSend, sendCardAction, sendPreviewAck } = useBridgeSocket({
     bridgeCfg,
     sessionKey,
+    sessionId: targetSessionId,
     projectName: projectName || '',
     onMessage: handleBridgeMessage,
   });

--- a/web/src/pages/Chat/ChatView.tsx
+++ b/web/src/pages/Chat/ChatView.tsx
@@ -32,7 +32,7 @@ function CopyButton({ code }: { code: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="absolute top-2 right-2 p-1.5 rounded-md bg-gray-200/80 dark:bg-gray-700/80 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-500 dark:text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity z-10"
+      className="absolute top-2 right-2 p-1.5 rounded-md bg-surface/85 dark:bg-ink/10 hover:bg-accent/10 text-ink/55 hover:text-accent opacity-0 group-hover:opacity-100 transition-all z-10"
     >
       {copied ? <Check size={12} /> : <Copy size={12} />}
     </button>
@@ -46,12 +46,12 @@ function PreBlock({ children, ...props }: React.HTMLAttributes<HTMLPreElement>) 
   return (
     <div className="not-prose relative group my-4">
       {lang && (
-        <div className="absolute top-0 left-0 px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 rounded-tl-lg rounded-br-lg border-b border-r border-gray-200 dark:border-gray-700 font-mono">
+        <div className="absolute top-0 left-0 px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider text-ink/45 bg-ink/[0.04] dark:bg-white/[0.05] rounded-tl-lg rounded-br-lg border-b border-r border-ink/10 dark:border-white/[0.08] font-mono">
           {lang}
         </div>
       )}
       <CopyButton code={code} />
-      <pre className="overflow-x-auto rounded-lg bg-[#fafafa] dark:bg-[#0d1117] border border-gray-200 dark:border-gray-700/60 p-4 pt-8 text-[13px] leading-[1.6] font-mono" {...props}>
+      <pre className="overflow-x-auto rounded-xl bg-ink/[0.035] dark:bg-black/30 border border-ink/10 dark:border-white/[0.08] p-4 pt-8 text-[13px] leading-[1.6] font-mono shadow-inner" {...props}>
         {children}
       </pre>
     </div>
@@ -61,7 +61,7 @@ function PreBlock({ children, ...props }: React.HTMLAttributes<HTMLPreElement>) 
 function InlineCode({ children, className, ...props }: React.HTMLAttributes<HTMLElement>) {
   if (className) return <code className={className} {...props}>{children}</code>;
   return (
-    <code className="px-1.5 py-0.5 rounded-md bg-gray-100 dark:bg-gray-800 text-pink-600 dark:text-pink-400 text-[0.875em] font-mono border border-gray-200/60 dark:border-gray-700/40" {...props}>
+    <code className="px-1.5 py-0.5 rounded-md bg-accent/[0.08] text-accent text-[0.875em] font-mono border border-accent/15" {...props}>
       {children}
     </code>
   );
@@ -70,7 +70,7 @@ function InlineCode({ children, className, ...props }: React.HTMLAttributes<HTML
 function RenderMarkdown({ content }: { content: string }) {
   return (
     <div className={cn(
-      'prose max-w-none dark:prose-invert',
+      'prose max-w-none dark:prose-invert prose-sm sm:prose-base',
       'prose-headings:font-semibold prose-headings:tracking-tight',
       'prose-h1:text-xl prose-h1:mt-5 prose-h1:mb-3 prose-h1:pb-1.5 prose-h1:border-b prose-h1:border-gray-200 dark:prose-h1:border-gray-700',
       'prose-h2:text-lg prose-h2:mt-5 prose-h2:mb-2',
@@ -78,10 +78,10 @@ function RenderMarkdown({ content }: { content: string }) {
       'prose-p:my-2.5 prose-p:leading-relaxed',
       'prose-li:my-0.5', 'prose-ul:my-2 prose-ol:my-2',
       'prose-a:text-accent prose-a:no-underline hover:prose-a:underline',
-      'prose-strong:text-gray-900 dark:prose-strong:text-white prose-strong:font-semibold',
-      'prose-blockquote:border-l-[3px] prose-blockquote:border-accent/40 prose-blockquote:bg-accent/[0.03] prose-blockquote:rounded-r-lg prose-blockquote:py-0.5 prose-blockquote:px-4 prose-blockquote:my-3 prose-blockquote:not-italic prose-blockquote:text-gray-600 dark:prose-blockquote:text-gray-300',
-      'prose-hr:my-5 prose-hr:border-gray-200 dark:prose-hr:border-gray-700',
-      'prose-table:text-sm prose-th:bg-gray-50 dark:prose-th:bg-gray-800 prose-th:px-3 prose-th:py-2 prose-td:px-3 prose-td:py-2',
+      'prose-strong:text-ink dark:prose-strong:text-ink prose-strong:font-semibold',
+      'prose-blockquote:border-l-[3px] prose-blockquote:border-accent/40 prose-blockquote:bg-accent/[0.04] prose-blockquote:rounded-r-xl prose-blockquote:py-0.5 prose-blockquote:px-4 prose-blockquote:my-3 prose-blockquote:not-italic prose-blockquote:text-ink/70',
+      'prose-hr:my-5 prose-hr:border-ink/10 dark:prose-hr:border-white/[0.08]',
+      'prose-table:text-sm prose-th:bg-ink/[0.04] dark:prose-th:bg-white/[0.05] prose-th:px-3 prose-th:py-2 prose-td:px-3 prose-td:py-2',
       'prose-img:rounded-lg prose-img:shadow-sm',
     )}>
       <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={{ pre: PreBlock as any, code: InlineCode as any }}>
@@ -578,62 +578,62 @@ export default function ChatView() {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-8rem)] animate-fade-in">
+    <div className="flex flex-col h-[calc(100vh-8rem)] min-h-0 animate-fade-in rounded-3xl border border-ink/10 bg-surface/45 shadow-sm shadow-black/[0.03] dark:border-white/[0.08] dark:bg-black/[0.08] overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between pb-3 border-b border-gray-200 dark:border-gray-800 shrink-0">
-        <div className="flex items-center gap-3">
-          <Link to="/chat" className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
-            <ArrowLeft size={18} className="text-gray-400" />
+      <div className="flex items-center justify-between px-3 sm:px-4 py-3 border-b border-ink/10 dark:border-white/[0.08] bg-surface/80 backdrop-blur-xl shrink-0">
+        <div className="flex items-center gap-3 min-w-0">
+          <Link to="/chat" className="p-2 rounded-xl text-ink/45 hover:text-accent hover:bg-accent/10 transition-colors shrink-0">
+            <ArrowLeft size={18} />
           </Link>
-          <div>
-            <div className="flex items-center gap-2">
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{projectName}</h2>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 min-w-0">
+              <h2 className="text-base sm:text-lg font-semibold text-ink truncate">{projectName}</h2>
               <StatusBadge status={bridgeStatus} />
             </div>
             <button
               type="button"
               onClick={() => setDrawerOpen(true)}
-              className="flex items-center gap-1 text-xs text-gray-500 hover:text-accent transition-colors mt-0.5"
+              className="flex max-w-full items-center gap-1 text-xs text-ink/55 hover:text-accent transition-colors mt-0.5"
             >
-              <span>{userPickedSession && currentSession
+              <span className="truncate">{userPickedSession && currentSession
                 ? (currentSession.name || currentSession.id.slice(0, 8))
                 : t('chat.defaultSession')}</span>
-              <ChevronDown size={12} />
+              <ChevronDown size={12} className="shrink-0" />
             </button>
           </div>
         </div>
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto py-6 space-y-5">
+      <div className="flex-1 overflow-y-auto px-3 sm:px-4 py-5 sm:py-6 space-y-4 sm:space-y-5">
         {messages.length === 0 && !loading && (
           <div className="flex flex-col items-center justify-center h-full text-center py-12">
-            <div className="w-16 h-16 rounded-2xl bg-accent/10 flex items-center justify-center mb-4">
+            <div className="w-16 h-16 rounded-3xl bg-accent/10 ring-1 ring-accent/15 flex items-center justify-center mb-4 shadow-sm shadow-accent/10">
               <Bot size={32} className="text-accent" />
             </div>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">{t('chat.emptyHint')}</p>
-            <p className="text-xs text-gray-400 dark:text-gray-500">{t('chat.slashHint')}</p>
+            <p className="text-sm font-medium text-ink/70 mb-1">{t('chat.emptyHint')}</p>
+            <p className="text-xs text-ink/45">{t('chat.slashHint')}</p>
           </div>
         )}
         {messages.map((msg) => {
           const isUser = msg.role === 'user';
           const isEmpty = !msg.content && !msg.card && !msg.buttons && !msg.imageUrl && !msg.fileName;
           return (
-            <div key={msg.id} className={cn('flex gap-3', isUser ? 'justify-end' : 'justify-start')}>
+            <div key={msg.id} className={cn('flex gap-2.5 sm:gap-3', isUser ? 'justify-end' : 'justify-start')}>
               {!isUser && (
-                <div className="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center shrink-0 mt-1">
+                <div className="w-8 h-8 rounded-xl bg-accent/10 ring-1 ring-accent/15 flex items-center justify-center shrink-0 mt-1">
                   <Bot size={16} className="text-accent" />
                 </div>
               )}
               <div className={cn(
-                'group/msg relative rounded-2xl px-5 py-3.5 text-sm',
+                'group/msg relative rounded-[1.35rem] px-4 sm:px-5 py-3 sm:py-3.5 text-sm leading-relaxed transition-shadow',
                 isUser
-                  ? 'max-w-[70%] bg-accent text-black rounded-br-md'
-                  : 'max-w-[85%] bg-white dark:bg-gray-800/80 border border-gray-200 dark:border-gray-700/60 text-gray-900 dark:text-gray-100 rounded-bl-md shadow-sm',
+                  ? 'max-w-[88%] sm:max-w-[70%] bg-accent text-[#1f1713] rounded-br-md shadow-sm shadow-accent/20'
+                  : 'max-w-[92%] sm:max-w-[85%] bg-surface/92 dark:bg-white/[0.045] border border-ink/10 dark:border-white/[0.08] text-ink rounded-bl-md shadow-sm shadow-black/[0.035]',
                 msg.streaming && 'animate-pulse-subtle',
               )}>
                 {isEmpty ? (
-                  <p className="text-xs text-gray-400 dark:text-gray-500 italic">{t('chat.unsupportedMessage', '[Unsupported message]')}</p>
+                  <p className="text-xs text-ink/45 italic">{t('chat.unsupportedMessage', '[Unsupported message]')}</p>
                 ) : msg.format === 'card' ? (
                   <CardBlock card={msg.card} onAction={handleCardAction} />
                 ) : msg.format === 'buttons' && msg.buttons ? (
@@ -643,7 +643,7 @@ export default function ChatView() {
                 ) : msg.format === 'file' && msg.fileName ? (
                   <FileBlock name={msg.fileName} size={msg.fileSize} />
                 ) : isUser ? (
-                  <div className="whitespace-pre-wrap">{msg.content}</div>
+                  <div className="whitespace-pre-wrap break-words">{msg.content}</div>
                 ) : (
                   <RenderMarkdown content={msg.content} />
                 )}
@@ -655,8 +655,8 @@ export default function ChatView() {
                 )}
               </div>
               {isUser && (
-                <div className="w-8 h-8 rounded-lg bg-gray-200 dark:bg-gray-700 flex items-center justify-center shrink-0 mt-1">
-                  <User size={16} className="text-gray-500" />
+                <div className="w-8 h-8 rounded-xl bg-ink/[0.06] dark:bg-white/[0.08] flex items-center justify-center shrink-0 mt-1">
+                  <User size={16} className="text-ink/50" />
                 </div>
               )}
             </div>
@@ -664,14 +664,14 @@ export default function ChatView() {
         })}
         {typing && !messages.some(m => m.streaming) && (
           <div className="flex gap-3 justify-start">
-            <div className="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center shrink-0 mt-1">
+            <div className="w-8 h-8 rounded-xl bg-accent/10 ring-1 ring-accent/15 flex items-center justify-center shrink-0 mt-1">
               <Bot size={16} className="text-accent" />
             </div>
-            <div className="rounded-2xl px-5 py-3.5 text-sm bg-white dark:bg-gray-800/80 border border-gray-200 dark:border-gray-700/60 rounded-bl-md shadow-sm">
+            <div className="rounded-[1.35rem] px-5 py-3.5 text-sm bg-surface/92 dark:bg-white/[0.045] border border-ink/10 dark:border-white/[0.08] rounded-bl-md shadow-sm shadow-black/[0.035]">
               <div className="flex gap-1.5">
-                <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-                <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-                <span className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+                <span className="w-2 h-2 bg-accent/55 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+                <span className="w-2 h-2 bg-accent/55 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+                <span className="w-2 h-2 bg-accent/55 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
               </div>
             </div>
           </div>
@@ -680,7 +680,7 @@ export default function ChatView() {
       </div>
 
       {/* Input area */}
-      <div className="border-t border-gray-200 dark:border-gray-800 pt-3 shrink-0">
+      <div className="border-t border-ink/10 dark:border-white/[0.08] bg-surface/80 backdrop-blur-xl p-3 sm:p-4 shrink-0">
         {canSend ? (
           <div className="relative flex items-end gap-2">
             {/* Command palette trigger */}
@@ -693,7 +693,7 @@ export default function ChatView() {
                   'p-3 rounded-xl transition-all duration-200',
                   cmdOpen
                     ? 'bg-accent/15 text-accent ring-1 ring-accent/30'
-                    : 'text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-white/[0.06]',
+                    : 'text-ink/45 hover:text-accent hover:bg-accent/10',
                 )}
                 title={t('chat.commands')}
               >
@@ -714,7 +714,7 @@ export default function ChatView() {
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={t('chat.inputPlaceholder')}
-                className="w-full px-4 py-3 text-sm rounded-xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors placeholder:text-gray-400"
+                className="w-full px-4 py-3 text-sm rounded-2xl border border-ink/[0.12] dark:border-white/[0.1] bg-surface/90 dark:bg-white/[0.045] text-ink shadow-inner shadow-black/[0.025] focus:outline-none focus:ring-2 focus:ring-accent/35 focus:border-accent/70 transition-all placeholder:text-ink/[0.38]"
                 disabled={sending}
               />
             </div>
@@ -724,23 +724,23 @@ export default function ChatView() {
               type="button"
               onClick={handleSend}
               disabled={sending || !input.trim()}
-              className="p-3 rounded-xl bg-accent text-black hover:bg-accent-dim transition-colors disabled:opacity-50 flex items-center"
+              className="p-3 rounded-2xl bg-accent text-[#1f1713] hover:bg-accent-dim transition-all disabled:opacity-50 flex items-center shadow-sm shadow-accent/20 hover:shadow-md hover:shadow-accent/25"
             >
               {sending ? <Loader2 size={18} className="animate-spin" /> : <Send size={18} />}
             </button>
           </div>
         ) : !bridgeCfg ? (
-          <div className="flex items-center gap-2 px-4 py-3 text-sm text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 rounded-xl">
+          <div className="flex items-center gap-2 px-4 py-3 text-sm text-amber-700 dark:text-amber-300 bg-amber-500/10 rounded-xl">
             <WifiOff size={14} />
             <span>{t('sessions.bridgeNotAvailable')}</span>
           </div>
         ) : bridgeStatus === 'disconnected' || bridgeStatus === 'error' ? (
-          <div className="flex items-center gap-2 px-4 py-3 text-sm text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 rounded-xl">
+          <div className="flex items-center gap-2 px-4 py-3 text-sm text-amber-700 dark:text-amber-300 bg-amber-500/10 rounded-xl">
             <WifiOff size={14} />
             <span>{t('sessions.bridgeDisconnected')}</span>
           </div>
         ) : (
-          <div className="flex items-center gap-2 px-4 py-3 text-sm text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded-xl">
+          <div className="flex items-center gap-2 px-4 py-3 text-sm text-ink/45 bg-ink/[0.04] rounded-xl">
             <Loader2 size={14} className="animate-spin" />
             <span>{t('sessions.bridgeConnecting')}</span>
           </div>

--- a/web/src/pages/Chat/ChatView.tsx
+++ b/web/src/pages/Chat/ChatView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useSearchParams } from 'react-router-dom';
 import {
   ArrowLeft, Send, User, Bot, Circle, WifiOff,
   Copy, Check, FileText, Image as ImageIcon, Loader2,
@@ -290,6 +290,8 @@ function MsgCopyButton({ text }: { text: string }) {
 export default function ChatView() {
   const { t } = useTranslation();
   const { name: projectName } = useParams<{ name: string }>();
+  const [searchParams] = useSearchParams();
+  const requestedSessionId = searchParams.get('session') || '';
 
   // Session state
   const [sessions, setSessions] = useState<Session[]>([]);
@@ -341,9 +343,13 @@ export default function ChatView() {
       setSessions(sorted);
 
       if (sorted.length > 0) {
-        const latest = sorted[0];
-        const detail = await getSession(projectName, latest.id, 200);
+        const requested = requestedSessionId
+          ? sorted.find(s => s.id === requestedSessionId)
+          : undefined;
+        const selected = requested || sorted[0];
+        const detail = await getSession(projectName, selected.id, 200);
         setCurrentSession(detail);
+        setUserPickedSession(!!requested);
         if (detail.history) {
           setMessages(detail.history.map((h, i) => ({
             id: `hist-${i}`,
@@ -360,7 +366,7 @@ export default function ChatView() {
     } finally {
       setLoading(false);
     }
-  }, [projectName]);
+  }, [projectName, requestedSessionId]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 

--- a/web/src/pages/Chat/CommandResultPanel.tsx
+++ b/web/src/pages/Chat/CommandResultPanel.tsx
@@ -168,15 +168,15 @@ export default function CommandResultPanel({ result, onClose, onCardAction }: Pr
   return (
     <>
       <div
-        className="fixed inset-0 bg-black/15 dark:bg-black/30 z-40 transition-opacity"
+        className="fixed inset-0 bg-transparent dark:bg-black/10 z-40 transition-opacity"
         onClick={onClose}
       />
 
       <div className={cn(
         'fixed top-0 right-0 h-full w-[400px] max-w-[90vw] z-50 flex flex-col',
         'translate-x-0 transition-transform duration-300 ease-out',
-        'bg-white dark:bg-[#111] border-l border-gray-200/80 dark:border-white/[0.06]',
-        'shadow-xl shadow-black/8 dark:shadow-black/40',
+        'bg-surface dark:bg-surface border-l border-ink/10 dark:border-white/[0.06]',
+        'shadow-xl shadow-black/[0.08] dark:shadow-black/40',
       )}>
         {/* Header */}
         <div className="flex items-center justify-between px-5 h-14 border-b border-gray-100 dark:border-white/[0.06] shrink-0">

--- a/web/src/pages/Chat/SessionDrawer.tsx
+++ b/web/src/pages/Chat/SessionDrawer.tsx
@@ -33,20 +33,20 @@ export default function SessionDrawer({ open, onClose, sessions, currentSessionI
     <>
       {/* Backdrop */}
       {open && (
-        <div className="fixed inset-0 bg-black/20 dark:bg-black/40 z-40 transition-opacity" onClick={onClose} />
+        <div className="fixed inset-0 bg-transparent dark:bg-black/10 z-40 transition-opacity" onClick={onClose} />
       )}
 
       {/* Drawer */}
       <div
         className={cn(
           'fixed top-0 right-0 h-full w-80 z-50 flex flex-col transition-transform duration-300 ease-out',
-          'bg-white/95 backdrop-blur-xl border-l border-gray-200/80 shadow-2xl shadow-black/15',
-          'dark:bg-[rgba(15,15,15,0.97)] dark:border-white/[0.08] dark:shadow-black/50',
+          'bg-surface/95 backdrop-blur-xl border-l border-ink/10 shadow-2xl shadow-black/[0.12]',
+          'dark:bg-surface/[0.97] dark:border-white/[0.08] dark:shadow-black/50',
           open ? 'translate-x-0' : 'translate-x-full',
         )}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 h-14 border-b border-gray-200/80 dark:border-white/[0.08] shrink-0">
+        <div className="flex items-center justify-between px-4 h-14 border-b border-ink/10 dark:border-white/[0.08] shrink-0">
           <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{t('chat.sessions')}</h3>
           <div className="flex items-center gap-1">
             {onNewSession && (
@@ -81,12 +81,12 @@ export default function SessionDrawer({ open, onClose, sessions, currentSessionI
                   key={s.id}
                   type="button"
                   onClick={() => onSelect(s)}
-                  className={cn(
-                    'w-full text-left p-3 rounded-xl mb-1 transition-all duration-200',
-                    isCurrent
-                      ? 'bg-accent/10 ring-1 ring-accent/30'
-                      : 'hover:bg-gray-100/80 dark:hover:bg-white/[0.04]',
-                  )}
+                    className={cn(
+                      'w-full text-left p-3 rounded-xl mb-1 transition-all duration-200',
+                      isCurrent
+                        ? 'bg-accent/10 ring-1 ring-accent/30'
+                      : 'hover:bg-ink/[0.05] dark:hover:bg-white/[0.04]',
+                    )}
                 >
                   <div className="flex items-start justify-between gap-2 mb-1">
                     <div className="flex items-center gap-1.5 min-w-0">

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -141,7 +141,7 @@ export default function Dashboard() {
             {recentSessions.map((sess) => (
               <Link
                 key={`${sess.project}-${sess.id}`}
-                to={`/chat/${sess.project}`}
+                to={`/chat/${sess.project}?session=${encodeURIComponent(sess.id)}`}
                 className="block p-4 rounded-xl border border-gray-200/80 dark:border-white/[0.06] bg-white dark:bg-white/[0.02] hover:border-accent/40 hover:shadow-md hover:shadow-accent/5 transition-all"
               >
                 <div className="flex items-center gap-2.5 mb-3">

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -10,7 +10,8 @@ import { listProjects, type ProjectSummary } from '@/api/projects';
 import { listSessions, type Session } from '@/api/sessions';
 import { formatUptime, formatTime } from '@/lib/utils';
 
-const MAX_ITEMS = 4;
+const MAX_PROJECTS = 4;
+const MAX_RECENT_SESSIONS = 12;
 
 export default function Dashboard() {
   const { t } = useTranslation();
@@ -41,7 +42,7 @@ export default function Dashboard() {
         }
       }
       allSessions.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
-      setRecentSessions(allSessions.slice(0, MAX_ITEMS));
+      setRecentSessions(allSessions.slice(0, MAX_RECENT_SESSIONS));
     } catch (e: any) {
       setError(e.message);
     } finally {
@@ -91,7 +92,7 @@ export default function Dashboard() {
           </div>
         ) : (
           <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3">
-            {projects.slice(0, MAX_ITEMS).map((p) => (
+            {projects.slice(0, MAX_PROJECTS).map((p) => (
               <Link
                 key={p.name}
                 to={`/chat/${p.name}`}
@@ -128,7 +129,7 @@ export default function Dashboard() {
             <MessageSquare size={14} className="text-gray-400" />
             {t('dashboard.recentSessions')}
           </h3>
-          <Link to="/chat" className="text-xs text-accent hover:underline flex items-center gap-0.5">
+          <Link to="/sessions" className="text-xs text-accent hover:underline flex items-center gap-0.5">
             {t('common.viewAll')} <ChevronRight size={12} />
           </Link>
         </div>
@@ -137,7 +138,7 @@ export default function Dashboard() {
             <p className="text-xs text-gray-400 text-center">{t('sessions.noSessions')}</p>
           </div>
         ) : (
-          <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3">
             {recentSessions.map((sess) => (
               <Link
                 key={`${sess.project}-${sess.id}`}

--- a/web/src/pages/Sessions/SessionList.tsx
+++ b/web/src/pages/Sessions/SessionList.tsx
@@ -96,7 +96,7 @@ export default function SessionList() {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3">
           {filtered.map((s) => (
-            <Link key={`${s._project}-${s.id}`} to={`/sessions/${s._project}/${s.id}`}>
+            <Link key={`${s._project}-${s.id}`} to={`/chat/${s._project}?session=${encodeURIComponent(s.id)}`}>
               <div className={cn(
                 'group relative rounded-xl border p-4 transition-all duration-200 cursor-pointer h-full',
                 'bg-white/60 dark:bg-white/[0.03] backdrop-blur-sm',

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -10,6 +10,8 @@ export default {
           DEFAULT: 'rgb(var(--color-accent) / <alpha-value>)',
           dim: 'rgb(var(--color-accent-dim) / <alpha-value>)',
         },
+        surface: 'rgb(var(--color-surface) / <alpha-value>)',
+        ink: 'rgb(var(--color-ink) / <alpha-value>)',
       },
       animation: {
         'fade-in': 'fadeIn 0.4s ease',


### PR DESCRIPTION
﻿## Summary

This PR collects the session, Web console, Telegram media, and Gemini CLI fixes that have been validated in the temporary community preview branch.

## What changed

### Telegram media fixes

- Fixed Telegram media-group handling so sending multiple images with one caption forms a single cc-connect turn.
- The merged turn preserves the text/caption and forwards all images as `ImageAttachment`s together, instead of processing one image per message.
- Media-group aggregation is bounded so delayed album parts are collected without blocking ordinary single-image or text messages.

### Gemini CLI on Telegram fixes

- Filtered Gemini CLI thinking/reasoning deltas before they are sent back through Telegram.
- Stripped flattened Gemini thought markers that can appear after long-context turns, preventing internal reasoning from leaking into the Telegram message body.
- The fix is scoped to agent output filtering and does not change Web console rendering behavior.

### Web console session routing fixes

- Web console sends now carry the selected session id, so messages from `/chat/<project>?session=<id>` go to the selected session instead of the current/latest session.
- Follow-up routing keeps Telegram `/current` unchanged: sending from a non-current Web session no longer switches the Telegram active session.
- Past native sessions selected in the Web console can be resumed correctly when routing a Web message.

### Telegram / agent session fixes

- Fixed native session discovery so `/list` can find Codex and Gemini sessions reliably.
- Fixed `/switch` so users can switch back into listed native sessions successfully.
- Fixed `/current` so it shows the native session title/summary instead of a local placeholder.
- Fixed `/name` so custom names can be applied successfully and are respected by `/list`, `/current`, `/switch`, and the Web console.
- Unified session-title priority so `/list`, `/current`, `/switch`, `/name`, and Web display names no longer fight each other.

### Web console fixes

- Web console session names now prefer `/name` custom names, then native agent titles/summaries, instead of falling back to local `Session.Name`.
- Web console session titles stay in sync with Telegram session names, so the same conversation has the same readable name in both places.
- Dashboard recent-session cards open the exact clicked session instead of the current/latest session.
- Stale local shadow sessions are hidden/deduplicated, and the Web console can show the full visible session list instead of only a few recent sessions.
- Mobile Web console layout now uses a hamburger menu and slide-out sidebar instead of squeezing content.
- The Web console theme uses a warmer Codex-style palette (`#CC7D5E`, `#F9F9F7`, `#2D2D2B`).

## Tests

```bash
go test ./agent/codex ./agent/gemini -count=1 -timeout 120s
go test ./platform/telegram -run "TestHandleMessageMediaGroup|TestHandleMessageGroupMediaGroup" -count=1 -timeout 120s
go test ./core -run "TestCmdCurrent|TestRenderCurrentCard|TestCmdList_|TestMgmt_Sessions|TestMgmt_SessionDetail|TestHandleMessage_TargetSessionDoesNotChangeActive|TestBridge_MessageRouting|TestSessionManager_.*Routing|TestMgmt_ProjectSend" -count=1 -timeout 120s
cd web && npm run build
```

## Thanks

Thanks to the community members who reproduced and validated these cases in real Telegram/Web console workflows, and thanks to OpenAI Codex for helping investigate, implement, and test the fixes.
