### PR TITLE
fix(speech): honor context cancellation in ConvertAudioToMP3

### DIFF
--- a/core/speech.go
+++ b/core/speech.go
@@ -298,7 +298,9 @@ func (g *GeminiSTT) Transcribe(ctx context.Context, audio []byte, format string,
 
 // ConvertAudioToMP3 uses ffmpeg to convert audio from unsupported formats to mp3.
 // Returns the mp3 bytes. If ffmpeg is not installed, returns an error.
-func ConvertAudioToMP3(audio []byte, srcFormat string) ([]byte, error) {
+// The ctx is honored: cancellation kills the ffmpeg subprocess, matching the
+// behavior of the other Convert* helpers in this file.
+func ConvertAudioToMP3(ctx context.Context, audio []byte, srcFormat string) ([]byte, error) {
 	ffmpegPath, err := exec.LookPath("ffmpeg")
 	if err != nil {
 		return nil, fmt.Errorf("ffmpeg not found in PATH: install ffmpeg to enable voice message support")
@@ -306,7 +308,7 @@ func ConvertAudioToMP3(audio []byte, srcFormat string) ([]byte, error) {
 
 	var cmd *exec.Cmd
 	if srcFormat == "amr" || srcFormat == "silk" {
-		cmd = exec.Command(ffmpegPath,
+		cmd = exec.CommandContext(ctx, ffmpegPath,
 			"-f", srcFormat,
 			"-i", "pipe:0",
 			"-f", "mp3",
@@ -316,7 +318,7 @@ func ConvertAudioToMP3(audio []byte, srcFormat string) ([]byte, error) {
 			"pipe:1",
 		)
 	} else {
-		cmd = exec.Command(ffmpegPath,
+		cmd = exec.CommandContext(ctx, ffmpegPath,
 			"-i", "pipe:0",
 			"-f", "mp3",
 			"-ac", "1",
@@ -518,7 +520,7 @@ func TranscribeAudio(ctx context.Context, stt SpeechToText, audio *AudioAttachme
 
 	if NeedsConversion(format) {
 		slog.Debug("speech: converting audio", "from", format, "to", "mp3")
-		converted, err := ConvertAudioToMP3(data, format)
+		converted, err := ConvertAudioToMP3(ctx, data, format)
 		if err != nil {
 			return "", err
 		}

--- a/core/speech_test.go
+++ b/core/speech_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -160,5 +161,23 @@ func TestGeminiSTT_Transcribe_InvalidJSON(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "parse response") {
 		t.Errorf("expected 'parse response' in error, got: %v", err)
+	}
+}
+
+// TestConvertAudioToMP3_HonorsContextCancellation asserts that a cancelled
+// context aborts the ffmpeg subprocess rather than running it to completion.
+// Skips when ffmpeg is not installed (the conversion helper returns the
+// "not found" error before the context is ever consulted).
+func TestConvertAudioToMP3_HonorsContextCancellation(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not in PATH")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ConvertAudioToMP3(ctx, []byte{0, 1, 2, 3}, "mp3")
+	if err == nil {
+		t.Fatal("expected error after context cancellation, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

\`ConvertAudioToMP3\` in \`core/speech.go\` is the only ffmpeg helper in that file that does not use \`exec.CommandContext\`. All its siblings — \`ConvertAudioToOpus\`, \`ConvertAudioToAMR\`, \`ConvertMP3ToOGG\`, \`ConvertMP3ToAMR\` — already take a \`context.Context\` and use \`exec.CommandContext\` so the caller can abort the subprocess. \`ConvertAudioToMP3\` used \`exec.Command\` and ignored its caller's context entirely.

The caller \`TranscribeAudio\` accepts a \`context.Context\` and forwards it to the STT provider, but the conversion step that runs first was unbounded. If ffmpeg stalls on malformed input or its stdin/stdout pipes get wedged, a cancelled \`TranscribeAudio\` call leaks a running ffmpeg process until ffmpeg's own internal timeout (if any) fires.

## Fix

- Add \`ctx context.Context\` as the first parameter of \`ConvertAudioToMP3\`.
- Switch both \`exec.Command(ffmpegPath, ...)\` call sites to \`exec.CommandContext(ctx, ffmpegPath, ...)\`.
- Thread the caller's \`ctx\` through \`TranscribeAudio → ConvertAudioToMP3\`.

\`ConvertAudioToMP3\` is exported but its only call site in this repo is \`TranscribeAudio\` in the same file (grepped). The API surface change is contained to the conversion helper itself.

## Test plan

- [x] \`TestConvertAudioToMP3_HonorsContextCancellation\` — calls \`ConvertAudioToMP3\` with an already-cancelled context and asserts an error is returned. Skips cleanly when ffmpeg is not in \`PATH\` (the \"ffmpeg not found\" check runs before the context is consulted, so the test cannot otherwise assert plumbing).
- [x] \`go test ./core/ -run TestGeminiSTT\` and other existing tests pass.
- [x] \`go build ./...\` (excluding \`web/embed.go\`'s \`all:dist\` pattern which needs the JS bundle).
- [x] Pre-existing macOS-specific test failures (\`TestProcessInteractiveEvents_*Footer*\`, \`TestResolveLocalDirPath_AcceptsSubdir\`) reproduce on \`main\` without this change — unrelated.