### PR TITLE
fix(qq): start readLoop before callAPI so get_login_info actually populates selfID

### DIFF
--- a/platform/qq/qq.go
+++ b/platform/qq/qq.go
@@ -77,6 +77,15 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 
 	slog.Info("qq: connected to OneBot", "url", p.wsURL)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	p.cancel = cancel
+
+	// Start readLoop BEFORE callAPI: callAPI's response is routed by readLoop,
+	// so calling it first would always time out after 15s and leave selfID=0,
+	// which disables the self-message filter in handleMessage and lets the bot
+	// respond to its own messages.
+	go p.readLoop(ctx)
+
 	// Get bot self info
 	if info, err := p.callAPI("get_login_info", nil); err == nil {
 		if uid, ok := info["user_id"].(float64); ok {
@@ -84,12 +93,9 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 		}
 		nick, _ := info["nickname"].(string)
 		slog.Info("qq: logged in", "qq", p.selfID, "nickname", nick)
+	} else {
+		slog.Warn("qq: get_login_info failed; self-message filter disabled until next reconnect", "error", err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	p.cancel = cancel
-
-	go p.readLoop(ctx)
 
 	return nil
 }

--- a/platform/qq/qq_test.go
+++ b/platform/qq/qq_test.go
@@ -1,9 +1,16 @@
 package qq
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
+
+	"github.com/gorilla/websocket"
 )
 
 func TestPlatform_Name(t *testing.T) {
@@ -78,3 +85,67 @@ func TestNew_ShareSessionInChannel(t *testing.T) {
 
 // verify Platform implements core.Platform
 var _ core.Platform = (*Platform)(nil)
+
+// TestStart_FetchesSelfIDWithoutTimeout verifies that Start() completes
+// promptly with selfID populated from the get_login_info OneBot API call.
+// Regression for a bug where Start invoked callAPI BEFORE launching readLoop,
+// so the API response had no consumer and callAPI always timed out after 15s
+// — leaving selfID=0 and disabling the self-message filter in handleMessage.
+func TestStart_FetchesSelfIDWithoutTimeout(t *testing.T) {
+	const botUserID = 999999
+
+	upgrader := websocket.Upgrader{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		for {
+			_, msg, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			var req map[string]any
+			if err := json.Unmarshal(msg, &req); err != nil {
+				continue
+			}
+			if req["action"] == "get_login_info" {
+				echo, _ := req["echo"].(string)
+				resp := map[string]any{
+					"status":  "ok",
+					"retcode": 0,
+					"echo":    echo,
+					"data":    map[string]any{"user_id": botUserID, "nickname": "TestBot"},
+				}
+				raw, _ := json.Marshal(resp)
+				_ = c.WriteMessage(websocket.TextMessage, raw)
+			}
+		}
+	}))
+	defer ts.Close()
+
+	p := &Platform{
+		wsURL: "ws" + strings.TrimPrefix(ts.URL, "http"),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Start(func(core.Platform, *core.Message) {})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		_ = p.Stop()
+		t.Fatal("Start did not complete within 5s; readLoop likely starts after callAPI, so get_login_info never gets a response")
+	}
+	defer p.Stop()
+
+	if p.selfID != botUserID {
+		t.Errorf("selfID = %d, want %d (self-message filter would be disabled)", p.selfID, botUserID)
+	}
+}


### PR DESCRIPTION
## Summary

\`Platform.Start\` in \`platform/qq/qq.go\` dialed the OneBot WebSocket and then immediately called \`p.callAPI(\"get_login_info\", nil)\` **before** launching the read loop:

\`\`\`go
conn, _, err := websocket.DefaultDialer.Dial(p.wsURL, header)
...
p.conn = conn

// Get bot self info
if info, err := p.callAPI(\"get_login_info\", nil); err == nil {
    if uid, ok := info[\"user_id\"].(float64); ok {
        p.selfID = int64(uid)
    }
    ...
}

ctx, cancel := context.WithCancel(context.Background())
p.cancel = cancel

go p.readLoop(ctx)
\`\`\`

\`callAPI\` writes the request and waits on a per-echo channel that is only ever fed by \`readLoop\`. With the read loop not yet running, the OneBot response sits in the WebSocket receive buffer with no consumer, and \`callAPI\` always hits its 15-second timeout:

\`\`\`go
select {
case raw := <-ch:
    ...
case <-time.After(15 * time.Second):
    return nil, fmt.Errorf(\"qq: API %s timeout\", action)
}
\`\`\`

The error branch in \`Start\` was silent (\`if info, err := p.callAPI(...); err == nil\`), so the boot path took a 15s stall and quietly left \`p.selfID = 0\`. \`handleMessage\` then short-circuits on \`userID == p.selfID\` to filter out the bot's own messages — with \`selfID = 0\`, no real QQ user ever matches and the bot ends up processing its own outbound messages. With OneBot clients that echo bot-sent messages back as events (e.g. NapCat group sessions by default), this is a straight infinite-reply loop.

## Fix

Move the context/cancel setup and \`go p.readLoop(ctx)\` so they run **before** the \`get_login_info\` call. The response can now reach the read loop and be routed back to the waiting \`callAPI\`. If the API still fails (real network issue, OneBot misconfigured), log a warning instead of swallowing it — at least the operator can see why the self-filter is inactive.

## Test

\`TestStart_FetchesSelfIDWithoutTimeout\` stands up a mock \`gorilla/websocket\` server that answers \`get_login_info\` with \`user_id=999999\`, calls \`Start\` in a goroutine, and asserts:

- \`Start\` returns within 5s (the buggy ordering would block for the 15s timeout).
- \`p.selfID == 999999\` after \`Start\`.

Reverting only \`qq.go\` on this branch makes the test fail with \`Start did not complete within 5s\` — verified locally.

## Test plan

- [x] \`go test ./platform/qq/ -count=1 -timeout 30s\` — all tests pass.
- [x] Stash-revert just \`qq.go\` while keeping the new test — test fails with the expected 5s timeout, confirming the regression guard.
- [x] \`go build ./...\` (excluding \`web/embed.go\`'s \`all:dist\` pattern which needs the JS bundle).