### PR TITLE
feat(daemon): warn about systemd linger on daemon install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -723,6 +723,26 @@ cc-connect daemon install --work-dir ~/.cc-connect
 
 Optional flags: `--config PATH`, `--log-file PATH`, `--log-max-size N` (MB), `--work-dir DIR`, `--force` (overwrite existing unit). `--config` points to a config file, while `--work-dir` points to the directory containing `config.toml`.
 
+### Linux systemd: Keep service running after SSH disconnect
+
+When installed as a user-level systemd service (non-root), cc-connect runs under `user@UID.service`. By default, systemd stops this service when your last login session ends (e.g., SSH disconnect). This is controlled by the "linger" setting.
+
+To keep cc-connect running persistently, enable linger for your user:
+
+```bash
+sudo loginctl enable-linger $USER
+```
+
+After enabling linger, `user@UID.service` remains active even when you log out. The daemon install command will warn you if linger is not enabled.
+
+Alternatively, you can install as a system-level service (requires root):
+
+```bash
+sudo cc-connect daemon install --config ~/.cc-connect/config.toml
+```
+
+System-level services are independent of login sessions.
+
 ### Control the service
 
 ```bash

--- a/cmd/cc-connect/daemon.go
+++ b/cmd/cc-connect/daemon.go
@@ -103,6 +103,18 @@ func daemonInstall(args []string) {
 	fmt.Println("  cc-connect daemon restart   - Restart")
 	fmt.Println("  cc-connect daemon stop      - Stop")
 	fmt.Println("  cc-connect daemon uninstall - Remove")
+
+	// Check linger for user-mode systemd
+	if strings.Contains(mgr.Platform(), "user") {
+		enabled, user := daemon.CheckLinger()
+		if !enabled {
+			fmt.Println()
+			fmt.Println("⚠️  Warning: Linger is not enabled for this user.")
+			fmt.Println("   cc-connect will stop when your last login session ends (e.g., SSH disconnect).")
+			fmt.Println("   To keep it running persistently, run:")
+			fmt.Printf("     sudo loginctl enable-linger %s\n", user)
+		}
+	}
 }
 
 func parseDaemonInstallArgs(args []string) (daemon.Config, bool, error) {

--- a/daemon/systemd.go
+++ b/daemon/systemd.go
@@ -280,3 +280,29 @@ func parseKeyValue(text string) map[string]string {
 	}
 	return m
 }
+
+// CheckLinger returns true if linger is enabled for the user, false otherwise.
+// If linger is not enabled, user-level systemd services will stop when
+// the user's last login session ends (e.g., SSH disconnect).
+func CheckLinger() (enabled bool, user string) {
+	user = os.Getenv("USER")
+	if user == "" {
+		user = "unknown"
+	}
+
+	// Check if we're in system mode (root)
+	if os.Getuid() == 0 {
+		return true, user // Linger check not relevant for system mode
+	}
+
+	// Check linger status via loginctl
+	out, err := exec.Command("loginctl", "show-user", user, "-p", "Linger").Output()
+	if err != nil {
+		// loginctl not available or error - assume linger is disabled
+		slog.Debug("linger check failed", "error", err)
+		return false, user
+	}
+
+	linger := strings.TrimSpace(string(out))
+	return linger == "Linger=yes", user
+}


### PR DESCRIPTION
## Summary
- Add `CheckLinger` function in `daemon/systemd.go` to check linger status
- Add warning in `daemon install` output when linger is disabled
- Document linger setting in `INSTALL.md`

## Problem
When cc-connect is installed as a user-level systemd service (non-root), the service stops when the user's last login session ends (SSH disconnect). This is because systemd's default `Linger=no` behavior stops `user@UID.service` when all login sessions close.

## Solution
1. **Post-install warning**: After `daemon install` succeeds, check linger status and warn if not enabled
2. **Documentation**: Explain the issue and fix (`loginctl enable-linger $USER`) in INSTALL.md

## Warning output (when linger=no)
```
⚠️  Warning: Linger is not enabled for this user.
   cc-connect will stop when your last login session ends (e.g., SSH disconnect).
   To keep it running persistently, run:
     sudo loginctl enable-linger $USER
```

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes

Fixes #960