### PR TITLE
fix(dingtalk): fall back to 7200s when access-token expireIn is missing or non-positive

### DIFF
--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -615,9 +615,17 @@ func (p *Platform) getAccessToken() (string, error) {
 		return "", fmt.Errorf("empty accessToken in response")
 	}
 
-	// Cache token with 5 minutes buffer before expiry
+	// Cache token with 5 minutes buffer before expiry.
+	// When the server omits expireIn (or sends 0/negative), fall back to the
+	// documented DingTalk default (7200s = 2h) — without this, tokenExpiry
+	// would land at time.Now() and every subsequent getAccessToken() would
+	// re-fetch a fresh token, hammering the access-token API.
 	p.accessToken = tokenResp.AccessToken
 	expiry := tokenResp.ExpireIn
+	if expiry <= 0 {
+		slog.Warn("dingtalk: missing/invalid expireIn in token response, defaulting to 7200s", "got", tokenResp.ExpireIn)
+		expiry = 7200
+	}
 	if expiry > 300 {
 		expiry -= 300 // 5 minute buffer
 	}

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -2,7 +2,9 @@ package dingtalk
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -436,5 +438,90 @@ func TestExtractRichText(t *testing.T) {
 				t.Errorf("extractRichText() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
+// Token expiry fallback when server returns missing/invalid expireIn
+// ──────────────────────────────────────────────────────────────
+
+// fakeAccessTokenRT serves a single canned /oauth2/accessToken response
+// regardless of the request URL — enough to exercise getAccessToken's
+// caching arithmetic without hitting the real DingTalk API.
+type fakeAccessTokenRT struct {
+	body string
+}
+
+func (f *fakeAccessTokenRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestGetAccessToken_ZeroExpireIn_FallsBackToDefault(t *testing.T) {
+	p := &Platform{
+		clientID:     "test_client",
+		clientSecret: "test_secret",
+		httpClient: &http.Client{
+			Transport: &fakeAccessTokenRT{body: `{"accessToken":"tok-zero","expireIn":0}`},
+		},
+	}
+
+	before := time.Now()
+	tok, err := p.getAccessToken()
+	if err != nil {
+		t.Fatalf("getAccessToken() error = %v", err)
+	}
+	if tok != "tok-zero" {
+		t.Fatalf("token = %q, want %q", tok, "tok-zero")
+	}
+
+	// Without the fallback, tokenExpiry would land at "before" (now+0s), making
+	// time.Now().Before(tokenExpiry) immediately false — every subsequent call
+	// would re-fetch a token. Assert the cache window is meaningful (>= 1h).
+	gotWindow := p.tokenExpiry.Sub(before)
+	if gotWindow < time.Hour {
+		t.Errorf("tokenExpiry window = %v from response, want >= 1h (zero-expireIn should fall back, not cache for 0s)", gotWindow)
+	}
+}
+
+func TestGetAccessToken_NegativeExpireIn_FallsBackToDefault(t *testing.T) {
+	p := &Platform{
+		clientID:     "test_client",
+		clientSecret: "test_secret",
+		httpClient: &http.Client{
+			Transport: &fakeAccessTokenRT{body: `{"accessToken":"tok-neg","expireIn":-1}`},
+		},
+	}
+
+	before := time.Now()
+	if _, err := p.getAccessToken(); err != nil {
+		t.Fatalf("getAccessToken() error = %v", err)
+	}
+	if p.tokenExpiry.Sub(before) < time.Hour {
+		t.Errorf("tokenExpiry window for expireIn=-1 = %v, want >= 1h", p.tokenExpiry.Sub(before))
+	}
+}
+
+func TestGetAccessToken_NormalExpireIn_AppliesBuffer(t *testing.T) {
+	p := &Platform{
+		clientID:     "test_client",
+		clientSecret: "test_secret",
+		httpClient: &http.Client{
+			Transport: &fakeAccessTokenRT{body: `{"accessToken":"tok-7200","expireIn":7200}`},
+		},
+	}
+
+	before := time.Now()
+	if _, err := p.getAccessToken(); err != nil {
+		t.Fatalf("getAccessToken() error = %v", err)
+	}
+	// 7200 - 300 buffer = 6900s = 115min. Allow tolerance for elapsed time.
+	gotWindow := p.tokenExpiry.Sub(before)
+	if gotWindow < 100*time.Minute || gotWindow > 116*time.Minute {
+		t.Errorf("tokenExpiry window for expireIn=7200 = %v, want ~6900s (100-116min)", gotWindow)
 	}
 }


### PR DESCRIPTION
## Summary

\`getAccessToken\` in \`platform/dingtalk/dingtalk.go\` takes \`expireIn\` from the \`/v1.0/oauth2/accessToken\` response and uses it to compute when the cached token should be refreshed:

\`\`\`go
expiry := tokenResp.ExpireIn   // 0 when field missing or server-side bug
if expiry > 300 {
    expiry -= 300              // 5-minute buffer, skipped for expiry <= 300
}
p.tokenExpiry = time.Now().Add(time.Duration(expiry) * time.Second)
\`\`\`

When the response is \`{\"accessToken\":\"...\",\"expireIn\":0}\` (or any non-positive value — e.g., field missing in some edge cases or a backend regression), \`tokenExpiry\` lands at \`time.Now()\`. The very next call to \`getAccessToken\` sees:

\`\`\`go
if p.accessToken != \"\" && time.Now().Before(p.tokenExpiry) {
    return p.accessToken, nil
}
\`\`\`

\`time.Now().Before(p.tokenExpiry)\` is \`false\` immediately, so the function falls through to the cache-miss branch and refetches a fresh token. Because all callers serialize on \`tokenMu\`, this becomes a tight loop of token round-trips, easily fast enough to trip DingTalk's access-token rate limit and turn every \`Reply\`/\`Send\`/AI Card streaming call into an extra \`/accessToken\` request.

## Fix

DingTalk's documented default token lifetime is 7200 seconds. When the server omits \`expireIn\` (or sends \`<= 0\`), treat it as if the server had sent \`7200\`, log a warning so an operator can notice a backend regression, and keep the existing 5-minute buffer subtraction for the normal case.

\`\`\`go
expiry := tokenResp.ExpireIn
if expiry <= 0 {
    slog.Warn(\"dingtalk: missing/invalid expireIn in token response, defaulting to 7200s\", \"got\", tokenResp.ExpireIn)
    expiry = 7200
}
if expiry > 300 {
    expiry -= 300 // 5 minute buffer
}
\`\`\`

## Tests

- \`TestGetAccessToken_ZeroExpireIn_FallsBackToDefault\` — asserts the cache window is at least 1h after \`{\"expireIn\":0}\`. With the fix reverted on this branch, the test reports a window of \`~440µs\` (effectively zero) and fails.
- \`TestGetAccessToken_NegativeExpireIn_FallsBackToDefault\` — symmetric \`expireIn=-1\` case.
- \`TestGetAccessToken_NormalExpireIn_AppliesBuffer\` — keeps the existing \`7200 → ~6900s\` buffer behavior covered so the new fallback can't drift the normal path.

All three use a small \`http.RoundTripper\` stub on \`Platform.httpClient\`; no network access is required.

## Test plan

- [x] \`go test ./platform/dingtalk/ -count=1 -timeout 30s\` — all tests pass.
- [x] Stash-revert just \`dingtalk.go\` while keeping the new tests — \`ZeroExpireIn\` and \`NegativeExpireIn\` cases fail with the expected sub-second window, confirming the regression guard.
- [x] \`go build ./...\` (excluding \`web/embed.go\`'s \`all:dist\` pattern which needs the JS bundle).