### PR TITLE
fix(send): use CC_DATA_DIR env var for custom data_dir socket path

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -288,6 +288,7 @@ func main() {
 		engine.SetFilterExternalSessions(proj.FilterExternalSessions != nil && *proj.FilterExternalSessions)
 		engine.SetBaseWorkDir(workDir)
 		engine.SetProjectStateStore(projectState)
+		engine.SetDataDir(cfg.DataDir)
 
 		// Wire multi-workspace mode
 		if proj.Mode == "multi-workspace" {

--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -236,6 +236,10 @@ func resolveSocketPath(dataDir string) string {
 	if dataDir != "" {
 		return filepath.Join(dataDir, "run", "api.sock")
 	}
+	// Check CC_DATA_DIR env var for custom data_dir configuration
+	if envDataDir := strings.TrimSpace(os.Getenv("CC_DATA_DIR")); envDataDir != "" {
+		return filepath.Join(envDataDir, "run", "api.sock")
+	}
 	if home, err := os.UserHomeDir(); err == nil {
 		return filepath.Join(home, ".cc-connect", "run", "api.sock")
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -268,6 +268,9 @@ type Engine struct {
 	// /web command callbacks
 	webSetupFunc  func() (port int, token string, needRestart bool, err error)
 	webStatusFunc func() (url string)
+
+	// Data directory for socket path injection
+	dataDir string
 }
 
 // workspaceInitFlow tracks a channel that is being onboarded to a workspace.
@@ -958,6 +961,10 @@ func (e *Engine) SetBaseWorkDir(dir string) {
 
 func (e *Engine) SetProjectStateStore(store *ProjectStateStore) {
 	e.projectState = store
+}
+
+func (e *Engine) SetDataDir(dir string) {
+	e.dataDir = dir
 }
 
 // RemoveCommand removes a custom command by name. Returns false if not found.
@@ -2834,6 +2841,9 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		envVars := []string{
 			"CC_PROJECT=" + e.name,
 			"CC_SESSION_KEY=" + ccKey,
+		}
+		if e.dataDir != "" {
+			envVars = append(envVars, "CC_DATA_DIR="+e.dataDir)
 		}
 		if exePath, err := os.Executable(); err == nil {
 			binDir := filepath.Dir(exePath)


### PR DESCRIPTION
## Summary

- Add `CC_DATA_DIR` env var injection when starting agent sessions
- Add `Engine.dataDir` field and `SetDataDir` setter
- Update `resolveSocketPath` in `send.go` to check `CC_DATA_DIR` env var

This fixes the issue where `cc-connect send --image/--file` failed from agent sessions when cc-connect was running with a custom `data_dir`. The agent session had `CC_PROJECT` and `CC_SESSION_KEY` set, but the send command still looked for the default socket path.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./...` passes (all tests)
- [ ] Manual verification: start cc-connect with custom data_dir, verify agent can use cc-connect send without --data-dir

Fixes #966