### PR TITLE
fix(cron): reject empty session_key in validateCronJob so management API doesn't persist unrunnable jobs

### DIFF
--- a/core/cron.go
+++ b/core/cron.go
@@ -81,6 +81,15 @@ func NormalizeCronSessionMode(s string) string {
 }
 
 func validateCronJob(j *CronJob) error {
+	// SessionKey anchors the cron execution to a platform (ExecuteCronJob
+	// derives platformName from the prefix before ":"). Without it the job
+	// is persisted but fails at fire-time with the unhelpful
+	// `platform "" not found for session ""`. Reject it up front so the
+	// caller (management API, /cron/add, /cron edit) sees an immediate
+	// 400 instead of a job that silently never runs.
+	if strings.TrimSpace(j.SessionKey) == "" {
+		return fmt.Errorf("session_key is required")
+	}
 	mode := NormalizeCronSessionMode(j.SessionMode)
 	if mode != "" && mode != "new_per_run" {
 		return fmt.Errorf("invalid session_mode %q (want reuse, new_per_run, or new-per-run)", j.SessionMode)

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -443,6 +443,42 @@ func TestCronScheduler_AddJob_NegativeTimeoutMins(t *testing.T) {
 	}
 }
 
+// TestCronScheduler_AddJob_EmptySessionKey verifies that AddJob refuses to
+// persist a job without a session_key. Without this guard, ExecuteCronJob
+// later fails at fire-time with `platform "" not found for session ""`,
+// leaving an unrunnable job lingering in the store.
+func TestCronScheduler_AddJob_EmptySessionKey(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		sessionKey string
+	}{
+		{"empty", ""},
+		{"whitespace", "   "},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := NewCronStore(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cs := NewCronScheduler(store)
+			err = cs.AddJob(&CronJob{
+				ID: "j1", Project: "p", SessionKey: tt.sessionKey,
+				CronExpr: "0 6 * * *", Prompt: "hi",
+			})
+			if err == nil {
+				t.Fatalf("expected error for empty session_key, got nil")
+			}
+			if !strings.Contains(err.Error(), "session_key") {
+				t.Errorf("error %q should mention session_key", err.Error())
+			}
+			if jobs := store.List(); len(jobs) != 0 {
+				t.Errorf("store should be empty after rejected AddJob, got %d job(s)", len(jobs))
+			}
+		})
+	}
+}
+
 func TestCronScheduler_AddJob_NormalizesSessionMode(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewCronStore(dir)

--- a/core/management_test.go
+++ b/core/management_test.go
@@ -1520,9 +1520,10 @@ func TestMgmt_CronPatch(t *testing.T) {
 
 	// Add a job
 	r := mgmtPost(t, ts.URL+"/api/v1/cron", "tok", map[string]any{
-		"project":   "test-project",
-		"cron_expr": "0 9 * * *",
-		"prompt":    "hello",
+		"project":     "test-project",
+		"session_key": "test:chan:user",
+		"cron_expr":   "0 9 * * *",
+		"prompt":      "hello",
 	})
 	if !r.OK {
 		t.Fatalf("cron add failed: %s", r.Error)


### PR DESCRIPTION
## Summary

\`CronJob.SessionKey\` is the platform anchor that \`Engine.ExecuteCronJob\` uses to find the target platform — it derives \`platformName\` from the prefix before the first \`:\`, walks \`e.platforms\`, and bails with

\`\`\`
platform \"\" not found for session \"\"
\`\`\`

if \`session_key\` is empty.

\`validateCronJob\` checks \`session_mode\`, \`mode\`, and \`timeout_mins\`, but **not** \`session_key\`. The constraint is only enforced by the unix-socket handler in \`core/api.go\` (\`handleCronAdd\`), which both auto-detects from active sessions and returns 400 when nothing resolves.

The management API path skips that pre-flight entirely:

\`\`\`go
// core/management.go handleCron POST
job := &CronJob{ ... SessionKey: req.SessionKey, ... }
if err := m.cronScheduler.AddJob(job); err != nil { ... }
mgmtJSON(w, http.StatusOK, job)
\`\`\`

\`AddJob\` calls \`validateCronJob\` (passes, since \`session_key\` isn't checked), persists the job to \`jobs.json\`, and \`scheduleJob\` attaches a cron entry to it. The job lives forever in visible-but-unrunnable state — every fire-time logs the cryptic \`platform \"\" not found for session \"\"\` and \`MarkRun\` writes that as \`last_error\`, but the operator never sees a 400 at create time.

## Fix

Add the \`session_key\` check inside \`validateCronJob\` so every \`AddJob\` caller — management API today, any future caller tomorrow — rejects the bad input at write time instead of leaking it into the store and the scheduler. \`api.go\`'s pre-flight remains: callers that want the auto-detect convenience still get it; callers that go straight to \`AddJob\` now get a clean error.

## Tests

- \`TestCronScheduler_AddJob_EmptySessionKey\` covers empty + whitespace-only \`session_key\` (subtests). Stash-revert just \`core/cron.go\` on this branch and the test fails with \`expected error for empty session_key, got nil\`, confirming the regression guard.
- The pre-existing \`TestMgmt_CronPatch\` was building its fixture by POSTing a job without \`session_key\` (i.e., exercising the buggy management path). Updated to pass \`session_key=\"test:chan:user\"\` so it goes through the canonical entry shape and still exercises the PATCH flow.

## Test plan

- [x] \`go test ./core/ -run \"TestCron|TestMgmt_Cron\" -count=1\` — all cron + management cron tests pass.
- [x] \`go build ./...\` (excluding \`web/embed.go\`'s \`all:dist\` pattern which needs the JS bundle).
- [x] Pre-existing macOS-specific failures (\`TestProcessInteractiveEvents_*Footer*\`, \`TestResolveLocalDirPath_AcceptsSubdir\`) reproduce on \`main\` without this change — unrelated.