### PR TITLE
fix(weixin): skip empty text items in bodyFromItemList so voice transcription survives

### DIFF
--- a/platform/weixin/parse.go
+++ b/platform/weixin/parse.go
@@ -28,6 +28,14 @@ func bodyFromItemList(items []messageItem) string {
 			text := strings.TrimSpace(item.TextItem.Text)
 			ref := item.RefMsg
 			if ref == nil {
+				if text == "" {
+					// Skip placeholder text items with no body and no quoted ref
+					// so the loop can still find a later voice transcription
+					// or text item. Returning "" here drops a voice item that
+					// followed an empty text item — dispatchInbound treats the
+					// message as empty + media-less and silently discards it.
+					continue
+				}
 				return text
 			}
 			if ref.MessageItem != nil && isMediaItemType(ref.MessageItem.Type) {
@@ -44,6 +52,9 @@ func bodyFromItemList(items []messageItem) string {
 				}
 			}
 			if len(parts) == 0 {
+				if text == "" {
+					continue
+				}
 				return text
 			}
 			return fmt.Sprintf("[引用: %s]\n%s", strings.Join(parts, " | "), text)

--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -24,6 +24,42 @@ func TestBodyFromItemList_VoiceText(t *testing.T) {
 	}
 }
 
+// TestBodyFromItemList_EmptyTextFallsThroughToVoice covers the case where an
+// empty text item precedes a voice item with an ASR transcription. The legacy
+// behavior returned "" on the empty text and never reached the voice, which
+// caused dispatchInbound to drop the whole message (collectInboundMedia also
+// skips voice items whose Text is non-empty, so no audio attachment is
+// produced either).
+func TestBodyFromItemList_EmptyTextFallsThroughToVoice(t *testing.T) {
+	got := bodyFromItemList([]messageItem{
+		{Type: messageItemText, TextItem: &textItem{Text: "   "}},
+		{Type: messageItemVoice, VoiceItem: &voiceItem{Text: "voice text"}},
+	})
+	if got != "voice text" {
+		t.Fatalf("got %q, want voice transcription to win when prior text item is empty", got)
+	}
+}
+
+// TestBodyFromItemList_EmptyTextWithEmptyRef ensures the same fall-through
+// holds when the empty text item carries a ref message that also has nothing
+// to contribute. Previously the `if len(parts) == 0 { return text }` branch
+// returned "" and shadowed any later items.
+func TestBodyFromItemList_EmptyTextWithEmptyRefFallsThrough(t *testing.T) {
+	got := bodyFromItemList([]messageItem{
+		{
+			Type:     messageItemText,
+			TextItem: &textItem{Text: ""},
+			RefMsg: &refMessage{
+				MessageItem: &messageItem{Type: messageItemText, TextItem: &textItem{Text: ""}},
+			},
+		},
+		{Type: messageItemVoice, VoiceItem: &voiceItem{Text: "voice survives"}},
+	})
+	if got != "voice survives" {
+		t.Fatalf("got %q, want voice transcription to win", got)
+	}
+}
+
 func TestBodyFromItemList_Quote(t *testing.T) {
 	ref := &refMessage{
 		Title: "t",


### PR DESCRIPTION
## Summary

\`bodyFromItemList\` in \`platform/weixin/parse.go\` walks the inbound \`item_list\` and returns the first user-visible body it finds. The text branch unconditionally returned its trimmed text — even when that text was empty — short-circuiting the search.

Combined with \`collectInboundMedia\` in \`platform/weixin/media_inbound.go\`, which skips voice items whose \`VoiceItem.Text\` is non-empty on the assumption that the caller already grabbed the transcription as text, a message shaped like

\`\`\`json
\"item_list\": [
  { \"type\": \"text\",  \"text_item\":  { \"text\": \"   \" } },
  { \"type\": \"voice\", \"voice_item\": { \"text\": \"ASR result\" } }
]
\`\`\`

ends up with:

- \`body == \"\"\` — the text branch returned the empty string and the voice item was never inspected by \`bodyFromItemList\`.
- \`audio == nil\` — \`collectInboundMedia\` saw the voice item's non-empty \`Text\` and skipped the CDN download.
- \`mediaOnlyItems(...) == false\` — voice item has \`Text\`, so the fallback-text branch in \`dispatchInbound\` doesn't trigger.

\`dispatchInbound\` then sees \`body == \"\"\`, no media, and \`mediaOnlyItems == false\`, and silently \`return\`s — the whole message is dropped, no log, no fallback in chat. WeChat's official client doesn't usually inline an empty text wrapper in front of a voice item, but the ilink layer has been observed to send this shape in the wild, and the symptom is invisible: a missing reply.

## Fix

When a text item carries no body (and either no quoted ref, or a ref that itself contributes nothing), \`continue\` to the next item so a following voice / second text item can still speak.

\`\`\`go
if ref == nil {
    if text == \"\" {
        continue
    }
    return text
}
// ...
if len(parts) == 0 {
    if text == \"\" {
        continue
    }
    return text
}
\`\`\`

## Tests

- \`TestBodyFromItemList_EmptyTextFallsThroughToVoice\`: empty-text placeholder before a voice item with ASR returns the ASR text.
- \`TestBodyFromItemList_EmptyTextWithEmptyRefFallsThrough\`: same fall-through holds when the empty text item carries an equally empty quoted ref (covers the \`len(parts) == 0\` branch).

Both tests fail on \`main\` (\`got \"\"\`) and pass after this change; stash-revert just \`parse.go\` on this branch to confirm.

## Test plan

- [x] \`go test ./platform/weixin/ -count=1 -timeout 60s\` — all weixin tests pass.
- [x] Stash-revert just \`parse.go\` while keeping new tests — both new cases fail with \`got \"\"\`, confirming the regression guard.
- [x] \`go build ./...\` (excluding \`web/embed.go\`'s \`all:dist\` pattern which needs the JS bundle).