### PR TITLE
fix(wecom): fall back to 7200s when access-token expires_in is missing or non-positive

### DIFF
--- a/platform/wecom/wecom.go
+++ b/platform/wecom/wecom.go
@@ -686,8 +686,21 @@ func (p *Platform) getAccessToken() (string, error) {
 		return "", fmt.Errorf("wecom: get token failed: %d %s", result.ErrCode, result.ErrMsg)
 	}
 
+	// Compute the cache window from expires_in with a 60-second safety
+	// margin. When the server omits or zeroes the field, fall back to
+	// WeCom's documented 7200s default; without this, the raw value would
+	// land at -60 and the cache would be stale on the very next call,
+	// turning every outbound API request into a fresh /gettoken round-trip.
+	expires := result.ExpiresIn
+	if expires <= 0 {
+		slog.Warn("wecom: missing/invalid expires_in in token response, defaulting to 7200s", "got", result.ExpiresIn)
+		expires = 7200
+	}
+	if expires > 60 {
+		expires -= 60
+	}
 	p.tokenCache.token = result.AccessToken
-	p.tokenCache.expiresAt = time.Now().Add(time.Duration(result.ExpiresIn-60) * time.Second)
+	p.tokenCache.expiresAt = time.Now().Add(time.Duration(expires) * time.Second)
 
 	slog.Debug("wecom: access_token refreshed", "expires_in", result.ExpiresIn)
 	return result.AccessToken, nil

--- a/platform/wecom/wecom_test.go
+++ b/platform/wecom/wecom_test.go
@@ -1,8 +1,12 @@
 package wecom
 
 import (
+	"io"
+	"net/http"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestWeComAPIURL_DefaultBase(t *testing.T) {
@@ -68,6 +72,70 @@ func TestNew_CustomAPIBaseURL_TrimTrailingSlash(t *testing.T) {
 	}
 	if p.apiBaseURL != "https://wecom.internal.example.com" {
 		t.Fatalf("apiBaseURL = %q, want %q", p.apiBaseURL, "https://wecom.internal.example.com")
+	}
+}
+
+// fakeWeComTokenRT serves a single canned /cgi-bin/gettoken response so
+// getAccessToken's cache arithmetic can be exercised without network.
+type fakeWeComTokenRT struct {
+	body string
+}
+
+func (f *fakeWeComTokenRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestGetAccessToken_ZeroExpiresIn_FallsBackToDefault(t *testing.T) {
+	p := &Platform{
+		corpID:     "ww_test",
+		corpSecret: "sec_test",
+		apiBaseURL: defaultAPIBaseURL,
+		apiClient: &http.Client{
+			Transport: &fakeWeComTokenRT{body: `{"errcode":0,"errmsg":"ok","access_token":"tok-zero","expires_in":0}`},
+		},
+	}
+
+	before := time.Now()
+	tok, err := p.getAccessToken()
+	if err != nil {
+		t.Fatalf("getAccessToken() error = %v", err)
+	}
+	if tok != "tok-zero" {
+		t.Fatalf("token = %q, want %q", tok, "tok-zero")
+	}
+
+	// Without the fallback, expiresAt = time.Now() - 60s, so the cached
+	// token would be stale on the very next call and every getAccessToken
+	// invocation would re-fetch from /cgi-bin/gettoken.
+	window := p.tokenCache.expiresAt.Sub(before)
+	if window < time.Hour {
+		t.Errorf("tokenCache window for expires_in=0 = %v, want >= 1h (zero should fall back, not cache for -60s)", window)
+	}
+}
+
+func TestGetAccessToken_NormalExpiresIn_AppliesBuffer(t *testing.T) {
+	p := &Platform{
+		corpID:     "ww_test",
+		corpSecret: "sec_test",
+		apiBaseURL: defaultAPIBaseURL,
+		apiClient: &http.Client{
+			Transport: &fakeWeComTokenRT{body: `{"errcode":0,"errmsg":"ok","access_token":"tok-7200","expires_in":7200}`},
+		},
+	}
+
+	before := time.Now()
+	if _, err := p.getAccessToken(); err != nil {
+		t.Fatalf("getAccessToken() error = %v", err)
+	}
+	// 7200 - 60 buffer = 7140s = 119 min. Allow a wide tolerance for elapsed time.
+	window := p.tokenCache.expiresAt.Sub(before)
+	if window < 110*time.Minute || window > 120*time.Minute {
+		t.Errorf("tokenCache window for expires_in=7200 = %v, want ~7140s (110-120min)", window)
 	}
 }
 


### PR DESCRIPTION
## Summary

\`getAccessToken\` in \`platform/wecom/wecom.go\` computed the cache window as:

\`\`\`go
p.tokenCache.expiresAt = time.Now().Add(time.Duration(result.ExpiresIn-60) * time.Second)
\`\`\`

The hard-coded 60-second safety margin assumes \`ExpiresIn\` is large enough to absorb it. If WeCom (or a proxy / private-deployment \`api_base_url\` that strips the field) returns \`expires_in = 0\` (or omits it), the arithmetic lands at **\`-60s\`** — \`time.Now().Add(-60s)\` is 60 seconds *in the past*, so \`p.tokenCache.expiresAt.Before(time.Now())\` returns \`true\` on the very next call.

\`tokenCache.mu\` serializes all callers behind the same mutex, so every outbound API request (send message, download media, refresh typing ticket, etc.) falls through to a fresh \`/cgi-bin/gettoken\` round-trip in a tight loop — easily tripping WeCom's token rate limit and turning every message into a token refetch.

The sibling \`platform/qqbot/qqbot.go\` already guards this with the same pattern (\`if expiresSec <= 0 { expiresSec = 7200 }\`); WeCom was missing it.

## Fix

When \`expires_in\` is missing or non-positive, fall back to WeCom's documented 7200-second default and log a warning so an operator can spot a backend regression. Skip the 60-second buffer subtraction when the (real) \`expires_in\` is itself \`<= 60\` to avoid a negative window on legitimately short-lived tokens.

\`\`\`go
expires := result.ExpiresIn
if expires <= 0 {
    slog.Warn(\"wecom: missing/invalid expires_in in token response, defaulting to 7200s\", \"got\", result.ExpiresIn)
    expires = 7200
}
if expires > 60 {
    expires -= 60
}
p.tokenCache.expiresAt = time.Now().Add(time.Duration(expires) * time.Second)
\`\`\`

## Tests

- \`TestGetAccessToken_ZeroExpiresIn_FallsBackToDefault\` — stubs the \`/cgi-bin/gettoken\` response with \`{\"expires_in\":0}\` and asserts the cache window is at least 1 hour. Stash-revert just \`wecom.go\` on this branch and the test fails with \`tokenCache window = -59.99s\`, confirming the regression guard catches the off-by-margin.
- \`TestGetAccessToken_NormalExpiresIn_AppliesBuffer\` — pins the \`7200 → ~7140s\` buffer behaviour so the fallback can't drift.

Both use a small \`http.RoundTripper\` stub on \`apiClient.Transport\`; no network access required.

## Test plan

- [x] \`go test ./platform/wecom/ -count=1 -timeout 60s\` — all wecom tests pass.
- [x] Stash-revert just \`wecom.go\` while keeping new tests — zero-expires_in case fails with \`-59.99s\` window, confirming bug.
- [x] \`go build ./...\` (excluding \`web/embed.go\`'s \`all:dist\` pattern which needs the JS bundle).