### PR TITLE
fix(relay): parseSessionKeyParts must skip single-char type tag to get the real chatID

### DIFF
--- a/core/relay.go
+++ b/core/relay.go
@@ -290,12 +290,21 @@ func (rm *RelayManager) relayContext(ctx context.Context) (context.Context, cont
 func parseSessionKeyParts(sessionKey string) (platform, chatID string, err error) {
 	// Format: "platform:chatID:userID"
 	// Relay session format: "relay:sourceProject:chatID"
-	parts := strings.SplitN(sessionKey, ":", 3)
+	// Some platforms (dingtalk, qq, qqbot) encode a single-char conversation
+	// type tag as an extra segment, e.g. "dingtalk:g:cidXXX", "qq:g:groupID",
+	// "qqbot:g:openid". For those, the real chatID is parts[2], not parts[1].
+	// Without this handling, every shared-session key on those platforms maps
+	// to chatID="g", so /bind bindings collide across different groups and
+	// relay routing leaks across chats.
+	parts := strings.SplitN(sessionKey, ":", 4)
 	if len(parts) < 2 {
 		return "", "", fmt.Errorf("invalid session key format: %q", sessionKey)
 	}
-	if parts[0] == "relay" && len(parts) == 3 {
+	if parts[0] == "relay" && len(parts) >= 3 {
 		// For relay sessions, chatID is the third part: "relay:sourceProject:chatID"
+		return parts[0], parts[2], nil
+	}
+	if len(parts) >= 3 && len(parts[1]) == 1 {
 		return parts[0], parts[2], nil
 	}
 	return parts[0], parts[1], nil

--- a/core/relay_test.go
+++ b/core/relay_test.go
@@ -187,3 +187,60 @@ func TestHandleRelay_ResumeFailureFallsBackToFreshSession(t *testing.T) {
 		t.Fatal("session was not closed after EventResult")
 	}
 }
+
+// TestParseSessionKeyParts_TypeTaggedKeys covers session keys that prefix the
+// channel with a single-char conversation type tag (dingtalk's "g"/"d", qq's
+// "g", qqbot's "g"). The previous parser returned the tag itself as chatID, so
+// every shared-session group on those platforms collapsed to chatID="g" — all
+// /bind bindings ended up at rm.bindings["g"] and relay messages from any
+// group routed to the first-bound chat.
+func TestParseSessionKeyParts_TypeTaggedKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		key         string
+		wantPlat    string
+		wantChat    string
+	}{
+		// Existing shapes we mustn't regress.
+		{"feishu plain", "feishu:oc_chat:user42", "feishu", "oc_chat"},
+		{"slack plain", "slack:C123:U456", "slack", "C123"},
+		{"telegram thread", "telegram:12345:67:89", "telegram", "12345"},
+		{"relay 3 segments", "relay:src:cidXX", "relay", "cidXX"},
+		// Type-tagged keys — these were broken (returned the tag as chatID).
+		{"dingtalk group shared", "dingtalk:g:cidXXX", "dingtalk", "cidXXX"},
+		{"dingtalk group per-user", "dingtalk:g:cidXXX:staff1", "dingtalk", "cidXXX"},
+		{"dingtalk direct", "dingtalk:d:cidYYY:staff2", "dingtalk", "cidYYY"},
+		{"qq group shared", "qq:g:12345", "qq", "12345"},
+		{"qqbot group shared", "qqbot:g:groupOpenID", "qqbot", "groupOpenID"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			plat, chat, err := parseSessionKeyParts(tt.key)
+			if err != nil {
+				t.Fatalf("parseSessionKeyParts(%q) error = %v", tt.key, err)
+			}
+			if plat != tt.wantPlat {
+				t.Errorf("platform = %q, want %q", plat, tt.wantPlat)
+			}
+			if chat != tt.wantChat {
+				t.Errorf("chatID = %q, want %q", chat, tt.wantChat)
+			}
+		})
+	}
+}
+
+func TestParseSessionKeyParts_DistinctGroupsDontCollide(t *testing.T) {
+	// Regression for: two dingtalk groups, /bind run in each, both bindings
+	// collapse to chatID="g" so the second group's binding overwrites the
+	// first and relay routes to the wrong chat.
+	_, chatA, err := parseSessionKeyParts("dingtalk:g:cid_groupA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, chatB, err := parseSessionKeyParts("dingtalk:g:cid_groupB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if chatA == chatB {
+		t.Fatalf("two distinct dingtalk groups produced the same chatID %q — bindings will collide", chatA)
+	}
+}


### PR DESCRIPTION
## Summary

\`parseSessionKeyParts\` in \`core/relay.go\` splits the session key on \`\":\"\` and returns \`parts[1]\` as \`chatID\`, treating the format as \`platform:chatID:userID\`. That ignores the single-char conversation type tag that **dingtalk**, **qq**, and **qqbot** put between the platform name and the real chat identifier:

\`\`\`
dingtalk:g:cidXXX            (group, shared session)
dingtalk:g:cidXXX:staff1     (group, per-user session)
dingtalk:d:cidYYY:staff2     (direct/1:1 session)
qq:g:12345                   (group shared session)
qqbot:g:groupOpenID          (group shared session)
\`\`\`

For all of those, \`parts[1]\` is the literal tag \`\"g\"\` / \`\"d\"\` — not a channel ID. The returned \`chatID\` collapses **every shared-session group on those platforms to the same string** (\"g\" or \"d\").

The relay layer keys its state by \`chatID\`:

\`\`\`go
rm.bindings[chatID] = &RelayBinding{...}
\`\`\`

So \`/bind\` in dingtalk **group A** and \`/bind\` in dingtalk **group B** both end up under \`rm.bindings[\"g\"]\` — the second bind silently overwrites the first. Any subsequent relay message from group B reads group A's binding, and its

\`\`\`go
groupSessionKey := platform + \":\" + chatID + \":relay\"
\`\`\`

produces \`\"dingtalk:g:relay\"\`, which dingtalk's \`ReconstructReplyCtx\` then routes to whichever chat the binding points at — a real cross-group leak.

\`cmdBind\`, \`cmdBindStatus\`, \`RelayManager.Send\`, and the relay group-echo path all go through the same parser, so this fixes routing for every flow that uses it.

## Fix

Apply the same single-char tag heuristic that \`extractChannelID\` in \`core/engine.go\` (PR #955) already uses: when \`parts[1]\` is exactly one character and a third segment is present, treat \`parts[2]\` as the real \`chatID\`.

\`\`\`go
parts := strings.SplitN(sessionKey, \":\", 4)
// ...
if len(parts) >= 3 && len(parts[1]) == 1 {
    return parts[0], parts[2], nil
}
return parts[0], parts[1], nil
\`\`\`

## Tests

- \`TestParseSessionKeyParts_TypeTaggedKeys\` exercises feishu / slack / telegram / relay (must not regress) plus dingtalk-shared, dingtalk-per-user, dingtalk-direct, qq, and qqbot shapes (must now return the real chat id).
- \`TestParseSessionKeyParts_DistinctGroupsDontCollide\` asserts that two distinct dingtalk groups (\`cid_groupA\`, \`cid_groupB\`) produce two distinct \`chatID\`s — directly pinning the cross-group routing regression.

Stash-reverting just \`core/relay.go\` on this branch makes both new cases fail, confirming the regression guard.

## Test plan

- [x] \`go test ./core/ -run \"TestParseSessionKeyParts\" -count=1\` — all new + existing parser tests pass.
- [x] \`go test ./core/ -count=1\` — only the pre-existing macOS-specific failures (\`TestProcessInteractiveEvents_*Footer*\`, \`TestResolveLocalDirPath_AcceptsSubdir\`) reproduce on \`main\` without this change — unrelated.
- [x] \`go build ./...\` (excluding \`web/embed.go\`'s \`all:dist\` pattern which needs the JS bundle).