### PR TITLE
fix(setup): handle url.Parse error in handleSetupWeixinPoll to avoid nil-pointer panic

### DIFF
--- a/core/setup.go
+++ b/core/setup.go
@@ -347,7 +347,13 @@ func (m *ManagementServer) handleSetupWeixinPoll(w http.ResponseWriter, r *http.
 		apiBase = strings.TrimRight(req.APIURL, "/")
 	}
 
-	u, _ := url.Parse(apiBase + "/")
+	u, err := url.Parse(apiBase + "/")
+	if err != nil {
+		// Mirror handleSetupWeixinBegin: an invalid api_url should be a 400,
+		// not a nil-pointer panic on the next line.
+		mgmtError(w, http.StatusBadRequest, "invalid api_url")
+		return
+	}
 	u = u.JoinPath("ilink", "bot", "get_qrcode_status")
 	q := u.Query()
 	q.Set("qrcode", req.QRKey)

--- a/core/setup_test.go
+++ b/core/setup_test.go
@@ -1,0 +1,45 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleSetupWeixinPoll_InvalidAPIURL guards against a nil-pointer panic
+// when the caller passes an api_url that net/url.Parse rejects (e.g.
+// "://bad", "%zz", "http://[::1"). The handler used to do
+//
+//	u, _ := url.Parse(apiBase + "/")
+//	u = u.JoinPath(...)   // panic when u is nil
+//
+// and rely on http.Server's per-request recover to turn the panic into an
+// opaque 500. The sibling handleSetupWeixinBegin already validates the URL,
+// so we expect the same 400 path here.
+func TestHandleSetupWeixinPoll_InvalidAPIURL(t *testing.T) {
+	m := &ManagementServer{}
+
+	for _, apiURL := range []string{"://bad", "%zz", "http://[::1"} {
+		t.Run(apiURL, func(t *testing.T) {
+			body, _ := json.Marshal(map[string]string{
+				"qr_key":  "abc",
+				"api_url": apiURL,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/setup/weixin/poll", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			m.handleSetupWeixinPoll(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d. body=%q", w.Code, http.StatusBadRequest, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), "invalid api_url") {
+				t.Errorf("body does not mention invalid api_url: %q", w.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

\`handleSetupWeixinPoll\` in \`core/setup.go\` built the ilink poll URL by ignoring the error from \`url.Parse\` and immediately invoking \`JoinPath\` on the result:

\`\`\`go
u, _ := url.Parse(apiBase + \"/\")
u = u.JoinPath(\"ilink\", \"bot\", \"get_qrcode_status\")
\`\`\`

\`net/url.Parse\` returns \`(nil, err)\` for several malformed inputs that a caller could plausibly send through the \`api_url\` field — \`\"://bad\"\`, \`\"%zz\"\`, \`\"http://[::1\"\`, and anything with whitespace that survives \`strings.TrimRight\`. With \`u\` nil, \`JoinPath\` calls \`(*URL).EscapedPath\` on the nil receiver and panics. \`http.Server\`'s per-request recover turns the panic into an opaque \`500\` with the stack trace in the management server log; no useful error reaches the caller.

The sibling \`handleSetupWeixinBegin\` already validates the URL correctly:

\`\`\`go
u, err := url.Parse(apiBase + \"/\")
if err != nil {
    mgmtError(w, http.StatusBadRequest, \"invalid api_url\")
    return
}
\`\`\`

so the poll handler was just inconsistent. This PR mirrors that check.

## Tests

\`TestHandleSetupWeixinPoll_InvalidAPIURL\` covers three malformed \`api_url\` values that \`net/url.Parse\` rejects (\`\"://bad\"\`, \`\"%zz\"\`, \`\"http://[::1\"\`) and asserts the handler returns \`400\` with \`\"invalid api_url\"\` instead of panicking.

Stash-reverting just \`core/setup.go\` on this branch makes the test fail with the actual panic in \`(*URL).EscapedPath\` called via \`(*URL).JoinPath\` (\`net/url/url.go:723\` / \`url.go:1241\`) — directly pinning the bug.

## Test plan

- [x] \`go test ./core/ -run \"TestHandleSetupWeixinPoll_InvalidAPIURL\" -count=1\` — all three subtests pass.
- [x] \`go test ./core/ -count=1\` — only the pre-existing macOS-specific failures (\`TestProcessInteractiveEvents_*Footer*\`, \`TestResolveLocalDirPath_AcceptsSubdir\`) reproduce on \`main\` without this change — unrelated.
- [x] \`go build ./...\` (excluding \`web/embed.go\`'s \`all:dist\` pattern which needs the JS bundle).