### PR TITLE
fix(observe): match Claude project key encoding for workdirs containing _, space, ~, non-ASCII

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1226,14 +1226,47 @@ func resolveClaudeProjectDir(workDir string) string {
 	if err != nil {
 		return ""
 	}
-	// Claude Code encodes paths by replacing os.PathSeparator with "-"
-	// e.g. /home/leigh/workspace/cc-connect -> -home-leigh-workspace-cc-connect
-	encoded := strings.ReplaceAll(workDir, string(os.PathSeparator), "-")
-	dir := filepath.Join(homeDir, ".claude", "projects", encoded)
-	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
-		return ""
+	projectsBase := filepath.Join(homeDir, ".claude", "projects")
+	// Claude Code encodes paths by replacing '/', ':', '_', ' ', '~' and any
+	// non-ASCII rune with '-'. Replacing only os.PathSeparator misses common
+	// workdir shapes (snake_case dirs, spaces, '~/Library/Mobile Documents/...',
+	// non-ASCII directory names), causing the observer to silently disable.
+	encoded := encodeClaudeProjectKey(workDir)
+	dir := filepath.Join(projectsBase, encoded)
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		return dir
 	}
-	return dir
+	// Fall back to the legacy encoding for backward compatibility with on-disk
+	// project keys created before the encoder above.
+	legacy := strings.ReplaceAll(workDir, string(os.PathSeparator), "-")
+	if legacy != encoded {
+		dir = filepath.Join(projectsBase, legacy)
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+	return ""
+}
+
+// encodeClaudeProjectKey mirrors agent/claudecode.encodeClaudeProjectKey: it
+// normalizes backslashes to forward slashes, then replaces '/', ':', '_', ' ',
+// '~' and non-ASCII runes with '-'. Kept in sync manually because the agent
+// helper is unexported.
+func encodeClaudeProjectKey(absPath string) string {
+	normalized := strings.ReplaceAll(absPath, "\\", "/")
+	var b strings.Builder
+	b.Grow(len(normalized))
+	for _, r := range normalized {
+		switch {
+		case r == '/' || r == ':' || r == '_' || r == ' ' || r == '~':
+			b.WriteByte('-')
+		case r < 128:
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
 }
 
 // resolveConfigPath determines which config file to use.

--- a/cmd/cc-connect/observe_path_test.go
+++ b/cmd/cc-connect/observe_path_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEncodeClaudeProjectKey(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain absolute path",
+			in:   "/home/leigh/workspace/cc-connect",
+			want: "-home-leigh-workspace-cc-connect",
+		},
+		{
+			name: "underscore in directory name",
+			in:   "/home/alice/my_project",
+			want: "-home-alice-my-project",
+		},
+		{
+			name: "space in directory name",
+			in:   "/Users/x/Library/Mobile Documents/foo",
+			want: "-Users-x-Library-Mobile-Documents-foo",
+		},
+		{
+			name: "tilde in path component",
+			in:   "/Users/x/com~apple~CloudDocs/foo",
+			want: "-Users-x-com-apple-CloudDocs-foo",
+		},
+		{
+			name: "non-ASCII directory name",
+			in:   "/Users/张三/projects/demo",
+			want: "-Users----projects-demo",
+		},
+		{
+			name: "windows-style backslashes",
+			in:   `C:\Users\Alice\Project`,
+			want: "C--Users-Alice-Project",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := encodeClaudeProjectKey(tt.in); got != tt.want {
+				t.Fatalf("encodeClaudeProjectKey(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveClaudeProjectDir_HandlesUnderscoreWorkdir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// macOS UserHomeDir falls back to $HOME when set, so this is enough on
+	// the platforms the test runs on (Linux/macOS).
+
+	workDir := "/Users/alice/my_project"
+	// Claude Code encodes the underscore as a hyphen.
+	want := filepath.Join(home, ".claude", "projects", "-Users-alice-my-project")
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	got := resolveClaudeProjectDir(workDir)
+	if got != want {
+		t.Fatalf("resolveClaudeProjectDir(%q) = %q, want %q", workDir, got, want)
+	}
+}
+
+func TestResolveClaudeProjectDir_HandlesSpaceWorkdir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	workDir := "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/foo"
+	// Spaces and tildes are encoded as hyphens.
+	want := filepath.Join(home, ".claude", "projects", "-Users-x-Library-Mobile-Documents-com-apple-CloudDocs-foo")
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	got := resolveClaudeProjectDir(workDir)
+	if got != want {
+		t.Fatalf("resolveClaudeProjectDir(%q) = %q, want %q", workDir, got, want)
+	}
+}
+
+func TestResolveClaudeProjectDir_ReturnsEmptyWhenMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if got := resolveClaudeProjectDir("/no/such/workdir"); got != "" {
+		t.Fatalf("resolveClaudeProjectDir(missing) = %q, want empty", got)
+	}
+}
+
+func TestResolveClaudeProjectDir_FallsBackToLegacyEncoding(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Older deployments may have on-disk project keys produced by the old
+	// "replace os.PathSeparator only" encoding; tilde was left intact.
+	workDir := "/Users/x/com~apple~CloudDocs/foo"
+	legacy := "-Users-x-com~apple~CloudDocs-foo"
+	want := filepath.Join(home, ".claude", "projects", legacy)
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	got := resolveClaudeProjectDir(workDir)
+	if got != want {
+		t.Fatalf("resolveClaudeProjectDir(%q) = %q, want %q", workDir, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

`resolveClaudeProjectDir` in `cmd/cc-connect/main.go` builds the path to `~/.claude/projects/<key>/` by replacing only `os.PathSeparator` with `-`. However, the on-disk project key written by the editor encodes a broader set of characters as `-`: `/`, `:`, `_`, ` `, `~`, and any non-ASCII rune. The same encoding lives in `agent/claudecode/encodeClaudeProjectKey` already.

For any user running `--observe` with a workdir that contains those characters, `os.Stat` misses the real directory and observe mode silently disables itself:

```
WARN observe: could not find Claude Code project directory workDir=...
```

Common cases this hits:

- Workdirs with `snake_case` directory names (`/Users/alice/my_project`).
- Paths under iCloud / Mobile Documents (`/Users/x/Library/Mobile Documents/com~apple~CloudDocs/...`) — spaces and `~`.
- Workspaces with non-ASCII directory names.

## Fix

- Replace the simplistic encoding in `resolveClaudeProjectDir` with the same per-character encoding rules as `encodeClaudeProjectKey` (helper duplicated locally because the agent helper is unexported).
- Keep a fallback to the legacy separator-only encoding so on-disk keys produced before this change still resolve.

## Tests

New `cmd/cc-connect/observe_path_test.go` covers:

- `encodeClaudeProjectKey` table tests for underscores, spaces, `~`, non-ASCII, and Windows-style backslashes.
- `resolveClaudeProjectDir` end-to-end resolution with `t.TempDir()` mocks of `~/.claude/projects/<encoded>/` for underscored and spaced workdirs.
- A "missing dir → empty" guard.
- A legacy-encoding fallback case (on-disk key with `~` intact).

I also confirmed the regression guard pins the bug by stash-reverting `cmd/cc-connect/main.go`: the resolver returns `""` instead of the expected encoded path, just like the WARN in the real `--observe` startup.

## Test plan

- [x] `go test -tags no_web ./cmd/cc-connect/`
- [x] `go test -tags no_web -count=1 ./...` (core / daemon failures observed on plain `main` on macOS; HOME tilde shortening and `/var` → `/private/var` symlink — unrelated to this change)