### PR TITLE
feat(tts): add Xiaomi MiMo-V2.5-TTS provider

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -641,6 +641,16 @@ func main() {
 				} else {
 					slog.Warn("tts: minimax provider enabled but api_key is empty")
 				}
+			case "mimo":
+				apiKey := cfg.TTS.Mimo.APIKey
+				baseURL := cfg.TTS.Mimo.BaseURL
+				model := cfg.TTS.Mimo.Model
+				if apiKey != "" {
+					ttsCfg.TTS = core.NewMimoTTS(apiKey, baseURL, model, nil)
+					ttsCfg.Provider = "mimo"
+				} else {
+					slog.Warn("tts: mimo provider enabled but api_key is empty")
+				}
 			case "espeak":
 				voice := cfg.TTS.Voice
 				if voice == "" {

--- a/config.example.toml
+++ b/config.example.toml
@@ -425,8 +425,8 @@ level = "info" # debug, info, warn, error
 
 # [tts]
 # enabled  = true
-# provider = "qwen"          # "qwen" | "openai" | "minimax"
-# voice    = "Cherry"        # default voice / 默认音色（千问支持：Cherry/Serena/Ethan/Chelsie 等）
+# provider = "qwen"          # "qwen" | "openai" | "minimax" | "mimo" | "espeak" | "pico" | "edge"
+# voice    = "Cherry"        # default voice / 默认音色（千问支持：Cherry/Serena/Ethan/Chelsie 等；MiMo 支持：mimo_default/冰糖/茉莉/苏打/白桦/Mia/Chloe/Milo/Dean）
 # tts_mode = "voice_only"    # "voice_only" (default) | "always"
 # max_text_len = 0           # max rune count before skipping TTS; 0 = no limit
 #                            # 超过此长度则跳过 TTS；0 表示不限制
@@ -453,6 +453,15 @@ level = "info" # debug, info, warn, error
 # api_key  = "your-minimax-api-key"
 # base_url = ""              # optional: default "https://api.minimax.io" / 留空使用默认地址
 # model    = "speech-2.8-hd" # "speech-2.8-hd" | "speech-2.8"
+#
+# # Alternative: Xiaomi MiMo-V2.5-TTS (OpenAI-compatible chat completions style)
+# # 备选：小米 MiMo-V2.5-TTS（OpenAI 兼容的 chat completions 风格）
+# # Docs: https://platform.xiaomimimo.com/#/docs/usage-guide/speech-synthesis
+# [tts.mimo]
+# api_key  = "your-mimo-api-key"
+# base_url = ""              # optional: default "https://api.xiaomimimo.com/v1" / 留空使用默认地址
+#                            # Token Plan 国内地址：https://token-plan-cn.xiaomimimo.com/v1
+# model    = "mimo-v2.5-tts" # "mimo-v2.5-tts" | "mimo-v2.5-tts-voicedesign" | "mimo-v2.5-tts-voiceclone"
 
 # =============================================================================
 # Daemon Mode / 守护进程模式

--- a/config/config.go
+++ b/config/config.go
@@ -266,8 +266,8 @@ type SpeechConfig struct {
 // TTSConfig configures text-to-speech output (mirrors SpeechConfig style).
 type TTSConfig struct {
 	Enabled    bool   `toml:"enabled"`
-	Provider   string `toml:"provider"`     // "qwen" | "openai" | "minimax" | "espeak" | "pico" | "edge"
-	Voice      string `toml:"voice"`        // default voice name (for edge: "zh-CN-XiaoxiaoNeural"; for pico: "zh-CN"; for espeak: "zh")
+	Provider   string `toml:"provider"`     // "qwen" | "openai" | "minimax" | "mimo" | "espeak" | "pico" | "edge"
+	Voice      string `toml:"voice"`        // default voice name (for edge: "zh-CN-XiaoxiaoNeural"; for pico: "zh-CN"; for espeak: "zh"; for mimo: "mimo_default" / "冰糖" / "Mia" …)
 	TTSMode    string `toml:"tts_mode"`     // "voice_only" (default) | "always"
 	MaxTextLen int    `toml:"max_text_len"` // max rune count before skipping TTS; 0 = no limit
 	OpenAI     struct {
@@ -285,6 +285,11 @@ type TTSConfig struct {
 		BaseURL string `toml:"base_url"`
 		Model   string `toml:"model"`
 	} `toml:"minimax"`
+	Mimo struct {
+		APIKey  string `toml:"api_key"`
+		BaseURL string `toml:"base_url"`
+		Model   string `toml:"model"`
+	} `toml:"mimo"`
 }
 
 // HeartbeatConfig controls periodic heartbeat for a project.

--- a/core/tts.go
+++ b/core/tts.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -377,6 +378,123 @@ func (m *MiniMaxTTS) Synthesize(ctx context.Context, text string, opts TTSSynthe
 		return nil, "", fmt.Errorf("minimax tts: no audio data received")
 	}
 	return audioBuf.Bytes(), "mp3", nil
+}
+
+// ──────────────────────────────────────────────────────────────
+// MimoTTS — Xiaomi MiMo-V2.5-TTS implementation
+// ──────────────────────────────────────────────────────────────
+
+// MimoTTS implements TextToSpeech using the Xiaomi MiMo-V2.5-TTS API,
+// which is shaped like OpenAI chat completions: the synthesis text rides
+// on an assistant message and audio bytes come back base64-encoded inside
+// choices[0].message.audio.data.
+//
+// Docs: https://platform.xiaomimimo.com/#/docs/usage-guide/speech-synthesis
+type MimoTTS struct {
+	APIKey  string
+	BaseURL string
+	Model   string
+	Client  *http.Client
+}
+
+// NewMimoTTS creates a new MimoTTS instance.
+func NewMimoTTS(apiKey, baseURL, model string, client *http.Client) *MimoTTS {
+	if baseURL == "" {
+		baseURL = "https://api.xiaomimimo.com/v1"
+	}
+	if model == "" {
+		model = "mimo-v2.5-tts"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &MimoTTS{
+		APIKey:  apiKey,
+		BaseURL: baseURL,
+		Model:   model,
+		Client:  client,
+	}
+}
+
+// Synthesize calls MiMo /chat/completions and returns the decoded WAV bytes.
+func (m *MimoTTS) Synthesize(ctx context.Context, text string, opts TTSSynthesisOpts) ([]byte, string, error) {
+	voice := opts.Voice
+	if voice == "" {
+		voice = "mimo_default"
+	}
+
+	// Per MiMo docs: synthesis text MUST live on an assistant message; the
+	// user message is optional for built-in-voice mode but required for
+	// voicedesign. Sending an empty user content stays valid across all
+	// three model variants.
+	reqBody := map[string]any{
+		"model": m.Model,
+		"messages": []map[string]any{
+			{"role": "user", "content": ""},
+			{"role": "assistant", "content": text},
+		},
+		"audio": map[string]any{
+			"format": "wav",
+			"voice":  voice,
+		},
+	}
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, "", fmt.Errorf("mimo tts: marshal request: %w", err)
+	}
+
+	url := strings.TrimRight(m.BaseURL, "/") + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, "", fmt.Errorf("mimo tts: create request: %w", err)
+	}
+	// MiMo authenticates via "api-key" header, not "Authorization: Bearer".
+	req.Header.Set("api-key", m.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.Client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("mimo tts: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("mimo tts: read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("mimo tts API %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				Audio struct {
+					Data string `json:"data"`
+				} `json:"audio"`
+			} `json:"message"`
+		} `json:"choices"`
+		Error *struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    any    `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, "", fmt.Errorf("mimo tts: parse response: %w", err)
+	}
+	if result.Error != nil && result.Error.Message != "" {
+		return nil, "", fmt.Errorf("mimo tts API error: %s", result.Error.Message)
+	}
+	if len(result.Choices) == 0 || result.Choices[0].Message.Audio.Data == "" {
+		return nil, "", fmt.Errorf("mimo tts: empty audio data in response")
+	}
+
+	audio, err := base64.StdEncoding.DecodeString(result.Choices[0].Message.Audio.Data)
+	if err != nil {
+		return nil, "", fmt.Errorf("mimo tts: decode audio base64: %w", err)
+	}
+	return audio, "wav", nil
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/core/tts_test.go
+++ b/core/tts_test.go
@@ -293,6 +293,190 @@ func TestMiniMaxTTS_EmptyAudio(t *testing.T) {
 }
 
 // ──────────────────────────────────────────────────────────────
+// MimoTTS tests
+// ──────────────────────────────────────────────────────────────
+
+func TestMimoTTS_Success(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("api-key"); got != "test-key" {
+			t.Errorf("expected api-key header 'test-key', got %q", got)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("Authorization header must not be set, got %q", auth)
+		}
+		var req struct {
+			Model    string `json:"model"`
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+			Audio struct {
+				Format string `json:"format"`
+				Voice  string `json:"voice"`
+			} `json:"audio"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if req.Model != "mimo-v2.5-tts" {
+			t.Errorf("expected model mimo-v2.5-tts, got %q", req.Model)
+		}
+		if len(req.Messages) != 2 || req.Messages[1].Role != "assistant" || req.Messages[1].Content != "你好" {
+			t.Errorf("expected assistant message with synthesis text, got %+v", req.Messages)
+		}
+		if req.Audio.Format != "wav" {
+			t.Errorf("expected audio.format wav, got %q", req.Audio.Format)
+		}
+		if req.Audio.Voice != "Chloe" {
+			t.Errorf("expected audio.voice Chloe, got %q", req.Audio.Voice)
+		}
+		// "fake-wav" base64-encoded
+		b64 := "ZmFrZS13YXY="
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{
+						"audio": map[string]any{
+							"data": b64,
+						},
+					},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer apiServer.Close()
+
+	tts := NewMimoTTS("test-key", apiServer.URL, "", nil)
+	audio, format, err := tts.Synthesize(context.Background(), "你好", TTSSynthesisOpts{Voice: "Chloe"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if format != "wav" {
+		t.Errorf("expected wav, got %q", format)
+	}
+	if string(audio) != "fake-wav" {
+		t.Errorf("unexpected audio data: %q", audio)
+	}
+}
+
+func TestMimoTTS_DefaultVoice(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Audio struct {
+				Voice string `json:"voice"`
+			} `json:"audio"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Audio.Voice != "mimo_default" {
+			t.Errorf("expected default voice mimo_default, got %q", req.Audio.Voice)
+		}
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"audio": map[string]any{"data": "ZmFrZQ=="}}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer apiServer.Close()
+
+	tts := NewMimoTTS("test-key", apiServer.URL, "", nil)
+	_, _, err := tts.Synthesize(context.Background(), "hi", TTSSynthesisOpts{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMimoTTS_APIError(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer apiServer.Close()
+
+	tts := NewMimoTTS("bad-key", apiServer.URL, "", nil)
+	_, _, err := tts.Synthesize(context.Background(), "hello", TTSSynthesisOpts{})
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+}
+
+func TestMimoTTS_EmptyAudio(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"audio": map[string]any{"data": ""}}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer apiServer.Close()
+
+	tts := NewMimoTTS("test-key", apiServer.URL, "", nil)
+	_, _, err := tts.Synthesize(context.Background(), "hello", TTSSynthesisOpts{})
+	if err == nil {
+		t.Fatal("expected error for empty audio data")
+	}
+}
+
+func TestMimoTTS_BusinessError(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"error": map[string]any{
+				"message": "quota exceeded",
+				"type":    "rate_limit",
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer apiServer.Close()
+
+	tts := NewMimoTTS("test-key", apiServer.URL, "", nil)
+	_, _, err := tts.Synthesize(context.Background(), "hello", TTSSynthesisOpts{})
+	if err == nil {
+		t.Fatal("expected error for business error")
+	}
+}
+
+func TestMimoTTS_BadBase64(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"audio": map[string]any{"data": "!!!not-base64!!!"}}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer apiServer.Close()
+
+	tts := NewMimoTTS("test-key", apiServer.URL, "", nil)
+	_, _, err := tts.Synthesize(context.Background(), "hello", TTSSynthesisOpts{})
+	if err == nil {
+		t.Fatal("expected error for invalid base64 audio")
+	}
+}
+
+func TestMimoTTS_Constructors(t *testing.T) {
+	tts := NewMimoTTS("k", "", "", nil)
+	if tts.BaseURL != "https://api.xiaomimimo.com/v1" {
+		t.Errorf("expected default base URL, got %q", tts.BaseURL)
+	}
+	if tts.Model != "mimo-v2.5-tts" {
+		t.Errorf("expected default model mimo-v2.5-tts, got %q", tts.Model)
+	}
+	tts = NewMimoTTS("k", "https://example.com/v1", "mimo-v2.5-tts-voicedesign", nil)
+	if tts.BaseURL != "https://example.com/v1" {
+		t.Errorf("expected custom base URL, got %q", tts.BaseURL)
+	}
+	if tts.Model != "mimo-v2.5-tts-voicedesign" {
+		t.Errorf("expected custom model, got %q", tts.Model)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
 // MaxTextLen skip test (via TTSCfg)
 // ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds a new TTS provider for Xiaomi **MiMo-V2.5-TTS**, alongside the existing `qwen` / `openai` / `minimax` / `espeak` / `pico` / `edge` providers.

MiMo's API does not match any of the existing providers — it's shaped like OpenAI chat completions:

- Endpoint: `POST {base}/chat/completions` (not `/audio/speech` or `/t2a_v2`)
- Auth: `api-key:` header (not `Authorization: Bearer`)
- Request body uses `messages[]` (synthesis text on an `assistant` message) + a top-level `audio: {format, voice}` block
- Response is JSON with base64-encoded audio inside `choices[0].message.audio.data`

So adding a dedicated `MimoTTS` implementation is needed; flipping `base_url` on `openai` or `qwen` cannot reach it.

Docs: https://platform.xiaomimimo.com/#/docs/usage-guide/speech-synthesis

### Changes

- **`core/tts.go`** — new `MimoTTS` struct + `NewMimoTTS` + `Synthesize` that POSTs to `/chat/completions`, sets the `api-key` header, decodes base64 audio, and returns WAV bytes. Defaults: `base_url = https://api.xiaomimimo.com/v1`, `model = mimo-v2.5-tts`, `voice = mimo_default`.
- **`config/config.go`** — `TTSConfig` gains a `Mimo` sub-struct (`api_key` / `base_url` / `model`); provider/voice comments updated to list `mimo` and its built-in voice IDs.
- **`cmd/cc-connect/main.go`** — TTS provider switch wires the new `case "mimo":` branch with the same empty-api-key warning pattern as the others.
- **`config.example.toml`** — `[tts.mimo]` example block + provider option list refreshed.
- **`core/tts_test.go`** — 7 new unit tests using `httptest`: success path (verifies POST path, `api-key` header presence, `Authorization` absence, request body shape, base64 decode), default voice, non-200 error, empty audio, OpenAI-style `error` field in 200 response, malformed base64, and constructor defaults.

### Config example

```toml
[tts]
enabled  = true
provider = "mimo"
voice    = "Chloe"          # mimo_default / 冰糖 / 茉莉 / 苏打 / 白桦 / Mia / Chloe / Milo / Dean
tts_mode = "voice_only"

[tts.mimo]
api_key  = "your-mimo-api-key"
base_url = ""               # defaults to https://api.xiaomimimo.com/v1
model    = "mimo-v2.5-tts"  # | mimo-v2.5-tts-voicedesign | mimo-v2.5-tts-voiceclone
```

## Test plan

- [x] `go build -tags no_web ./cmd/cc-connect` succeeds
- [x] `go test ./core/ -run "Mimo|TTS"` — all 27 TTS-related tests pass (the 7 new `TestMimoTTS_*` cases pass alongside the existing Qwen / OpenAI / MiniMax / Espeak / Pico / Edge tests)
- [x] `go test ./config/ -run "TTS"` — 2 existing TTS config tests still pass; new `Mimo` sub-struct unmarshals cleanly
- [x] Manual diff review against existing provider patterns (Qwen / OpenAI / MiniMax)
- [ ] Live smoke test against real MiMo endpoint (requires API key — left for reviewer / maintainer)

### Pre-existing test failures (not introduced by this PR)

On Windows, the following tests fail on `main` as well and are unrelated to TTS:
- `core/TestSkillRegistryListAll_*` — require admin privilege to create symlinks
- `core/TestWorkspacePool_ReapIdle*` — path-separator mismatch (`/` vs `\`)
- `config/TestLoad_DefaultsDataDir` / `TestLoad_ResolvesEnvPlaceholders` — same path-separator issue
- `cmd/cc-connect` test build — `doctor_runas_test.go` references POSIX-only symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)