### PR TITLE
fix(config): preserve project-level thinking_messages across mode changes

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -399,7 +399,7 @@ func main() {
 
 		// Wire display truncation settings (includes legacy quiet → display mapping)
 		{
-			mode, tm, tool, tmlen, toollen := config.EffectiveDisplay(cfg, &proj)
+			mode, tm, tool, tmlen, toollen, tmExplicit, toolExplicit := config.EffectiveDisplay(cfg, &proj)
 			engine.SetDisplayConfig(core.DisplayCfg{
 				Mode:             mode,
 				CardMode:         config.EffectiveCardMode(cfg, &proj),
@@ -407,6 +407,8 @@ func main() {
 				ThinkingMaxLen:   tmlen,
 				ToolMaxLen:       toollen,
 				ToolMessages:     tool,
+				ThinkingExplicit: tmExplicit,
+				ToolExplicit:     toolExplicit,
 			})
 		}
 
@@ -1433,7 +1435,7 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 	}
 
 	// Reload display config (includes legacy quiet → display mapping)
-	mode, tm, tool, tmlen, toollen := config.EffectiveDisplay(cfg, proj)
+	mode, tm, tool, tmlen, toollen, tmExplicit, toolExplicit := config.EffectiveDisplay(cfg, proj)
 	engine.SetDisplayConfig(core.DisplayCfg{
 		Mode:             mode,
 		CardMode:         config.EffectiveCardMode(cfg, proj),
@@ -1441,6 +1443,8 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 		ThinkingMaxLen:   tmlen,
 		ToolMaxLen:       toollen,
 		ToolMessages:     tool,
+		ThinkingExplicit: tmExplicit,
+		ToolExplicit:     toolExplicit,
 	})
 	result.DisplayUpdated = true
 

--- a/config/config.go
+++ b/config/config.go
@@ -636,7 +636,7 @@ func projectQuietEffective(cfg *Config, proj *ProjectConfig) bool {
 //  1. project-level [projects.display].<field> (highest precedence)
 //  2. global [display].<field>
 //  3. mode-derived default (compact/quiet → false, full → true)
-func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMessages, toolMessages bool, thinkingMaxLen, toolMaxLen int) {
+func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMessages, toolMessages bool, thinkingMaxLen, toolMaxLen int, thinkingExplicit, toolExplicit bool) {
 	var projDisp *DisplayConfig
 	if proj != nil {
 		projDisp = proj.Display
@@ -691,16 +691,15 @@ func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMe
 		return f(projDisp)
 	}
 
-	thinkingMessages = pickBool(
-		getProjBool(func(d *DisplayConfig) *bool { return d.ThinkingMessages }),
-		cfg.Display.ThinkingMessages,
-		thinkingDefault,
-	)
-	toolMessages = pickBool(
-		getProjBool(func(d *DisplayConfig) *bool { return d.ToolMessages }),
-		cfg.Display.ToolMessages,
-		toolDefault,
-	)
+	projThinking := getProjBool(func(d *DisplayConfig) *bool { return d.ThinkingMessages })
+	projTool := getProjBool(func(d *DisplayConfig) *bool { return d.ToolMessages })
+
+	thinkingMessages = pickBool(projThinking, cfg.Display.ThinkingMessages, thinkingDefault)
+	toolMessages = pickBool(projTool, cfg.Display.ToolMessages, toolDefault)
+
+	// Mark as explicitly set when project-level or global config specifies the value.
+	thinkingExplicit = projThinking != nil || cfg.Display.ThinkingMessages != nil
+	toolExplicit = projTool != nil || cfg.Display.ToolMessages != nil
 	thinkingMaxLen = pickInt(
 		getProjInt(func(d *DisplayConfig) *int { return d.ThinkingMaxLen }),
 		cfg.Display.ThinkingMaxLen,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -299,7 +299,7 @@ func TestEffectiveDisplayQuiet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mode, tm, tool, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
+			mode, tm, tool, _, _, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
 			if mode != tt.wantMode {
 				t.Fatalf("Mode = %q, want %q", mode, tt.wantMode)
 			}
@@ -412,7 +412,7 @@ func TestEffectiveDisplay_ProjectOverride(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, tm, tool, thinkLen, toolMaxLen := EffectiveDisplay(&tt.cfg, &tt.proj)
+			_, tm, tool, thinkLen, toolMaxLen, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
 			if tm != tt.wantTM {
 				t.Errorf("ThinkingMessages = %v, want %v", tm, tt.wantTM)
 			}
@@ -424,6 +424,60 @@ func TestEffectiveDisplay_ProjectOverride(t *testing.T) {
 			}
 			if toolMaxLen != tt.wantToolMaxLen {
 				t.Errorf("ToolMaxLen = %d, want %d", toolMaxLen, tt.wantToolMaxLen)
+			}
+		})
+	}
+}
+
+func TestEffectiveDisplay_ExplicitFlags(t *testing.T) {
+	tru := true
+	fals := false
+
+	tests := []struct {
+		name            string
+		cfg             Config
+		proj            ProjectConfig
+		wantTMExplicit  bool
+		wantToolExplicit bool
+	}{
+		{
+			name: "project thinking_messages=false is explicit",
+			cfg:  Config{},
+			proj: ProjectConfig{Display: &DisplayConfig{ThinkingMessages: &fals}},
+			wantTMExplicit:   true,
+			wantToolExplicit: false,
+		},
+		{
+			name: "global thinking_messages=true is explicit",
+			cfg:  Config{Display: DisplayConfig{ThinkingMessages: &tru}},
+			proj: ProjectConfig{},
+			wantTMExplicit:   true,
+			wantToolExplicit: false,
+		},
+		{
+			name: "neither set is not explicit",
+			cfg:  Config{},
+			proj: ProjectConfig{},
+			wantTMExplicit:   false,
+			wantToolExplicit: false,
+		},
+		{
+			name: "both project and global tool_messages set",
+			cfg:  Config{Display: DisplayConfig{ToolMessages: &tru}},
+			proj: ProjectConfig{Display: &DisplayConfig{ToolMessages: &fals}},
+			wantTMExplicit:   false,
+			wantToolExplicit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, _, _, tmExplicit, toolExplicit := EffectiveDisplay(&tt.cfg, &tt.proj)
+			if tmExplicit != tt.wantTMExplicit {
+				t.Errorf("ThinkingExplicit = %v, want %v", tmExplicit, tt.wantTMExplicit)
+			}
+			if toolExplicit != tt.wantToolExplicit {
+				t.Errorf("ToolExplicit = %v, want %v", toolExplicit, tt.wantToolExplicit)
 			}
 		})
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -147,6 +147,12 @@ type DisplayCfg struct {
 	ThinkingMaxLen   int // max runes for thinking preview; 0 = no truncation
 	ToolMaxLen       int // max runes for tool use preview; 0 = no truncation
 	ToolMessages     bool
+
+	// ThinkingExplicit/ToolExplicit indicate the value was set explicitly
+	// in the config (project-level or global), not derived from the mode.
+	// When true, mode changes (via /quiet toggle) preserve the explicit value.
+	ThinkingExplicit bool
+	ToolExplicit     bool
 }
 
 // InstantReplyCfg controls the immediate confirmation reply sent when a message
@@ -7876,11 +7882,19 @@ func (e *Engine) cmdQuiet(p Platform, msg *Message, args []string) {
 	e.display.Mode = newMode
 	switch newMode {
 	case "compact", "quiet":
-		e.display.ThinkingMessages = false
-		e.display.ToolMessages = false
+		if !e.display.ThinkingExplicit {
+			e.display.ThinkingMessages = false
+		}
+		if !e.display.ToolExplicit {
+			e.display.ToolMessages = false
+		}
 	default:
-		e.display.ThinkingMessages = true
-		e.display.ToolMessages = true
+		if !e.display.ThinkingExplicit {
+			e.display.ThinkingMessages = true
+		}
+		if !e.display.ToolExplicit {
+			e.display.ToolMessages = true
+		}
 	}
 
 	if e.displaySaveFunc != nil {
@@ -11814,12 +11828,20 @@ func (e *Engine) configItems() []configItem {
 				switch v {
 				case "full":
 					e.display.Mode = "full"
-					e.display.ThinkingMessages = true
-					e.display.ToolMessages = true
+					if !e.display.ThinkingExplicit {
+						e.display.ThinkingMessages = true
+					}
+					if !e.display.ToolExplicit {
+						e.display.ToolMessages = true
+					}
 				case "compact", "quiet":
 					e.display.Mode = v
-					e.display.ThinkingMessages = false
-					e.display.ToolMessages = false
+					if !e.display.ThinkingExplicit {
+						e.display.ThinkingMessages = false
+					}
+					if !e.display.ToolExplicit {
+						e.display.ToolMessages = false
+					}
 				default:
 					return fmt.Errorf("must be full, compact, or quiet")
 				}
@@ -11844,6 +11866,7 @@ func (e *Engine) configItems() []configItem {
 					return fmt.Errorf("invalid boolean: %s", v)
 				}
 				e.display.ThinkingMessages = b
+				e.display.ThinkingExplicit = true
 				if e.displaySaveFunc != nil {
 					return e.displaySaveFunc(nil, &b, nil, nil, nil)
 				}
@@ -11885,6 +11908,7 @@ func (e *Engine) configItems() []configItem {
 					return fmt.Errorf("invalid boolean: %s", v)
 				}
 				e.display.ToolMessages = b
+				e.display.ToolExplicit = true
 				if e.displaySaveFunc != nil {
 					return e.displaySaveFunc(nil, nil, nil, nil, &b)
 				}

--- a/tests/release_local/config_matrix/config_matrix_test.go
+++ b/tests/release_local/config_matrix/config_matrix_test.go
@@ -84,7 +84,7 @@ app_secret = "secret"
 		t.Fatalf("ResetOnIdleMins = %#v, want explicit 0", proj.ResetOnIdleMins)
 	}
 
-	mode, thinking, tools, thinkingMax, toolMax := config.EffectiveDisplay(cfg, proj)
+	mode, thinking, tools, thinkingMax, toolMax, _, _ := config.EffectiveDisplay(cfg, proj)
 	if mode != config.DisplayModeFull {
 		t.Fatalf("mode = %q, want project full override", mode)
 	}
@@ -111,7 +111,7 @@ func TestReleaseConfig_DefaultsKeepAttachmentsAndFullDisplayEnabled(t *testing.T
 	if cfg.AttachmentSend != "on" {
 		t.Fatalf("AttachmentSend = %q, want default on", cfg.AttachmentSend)
 	}
-	mode, thinking, tools, _, _ := config.EffectiveDisplay(cfg, &cfg.Projects[0])
+	mode, thinking, tools, _, _, _, _ := config.EffectiveDisplay(cfg, &cfg.Projects[0])
 	if mode != config.DisplayModeFull || !thinking || !tools {
 		t.Fatalf("display = mode:%s thinking:%v tools:%v, want full/true/true", mode, thinking, tools)
 	}
@@ -181,7 +181,7 @@ app_secret = "secret"
 	if strings.Join(proj.DisabledCommands, ",") != "restart,shell" {
 		t.Fatalf("disabled_commands = %#v", proj.DisabledCommands)
 	}
-	mode, thinking, tools, _, _ := config.EffectiveDisplay(cfg, proj)
+	mode, thinking, tools, _, _, _, _ := config.EffectiveDisplay(cfg, proj)
 	if mode != config.DisplayModeQuiet || thinking || tools {
 		t.Fatalf("display = mode:%s thinking:%v tools:%v, want quiet/false/false", mode, thinking, tools)
 	}


### PR DESCRIPTION
## Problem

When a project sets `[projects.display] thinking_messages = false` in config.toml, the setting is correctly loaded at startup. However, switching display mode via `/quiet` toggle or `/config mode full` unconditionally overrides `thinking_messages` based on the new mode — e.g., `mode=full` forces `thinking_messages=true`, discarding the project-level setting.

## Root Cause

The `/quiet` handler and mode setter in `configItems()` directly assign `e.display.ThinkingMessages = true/false` based on the mode, without checking whether the value was explicitly configured at the project or global level.

## Fix

- Add `ThinkingExplicit` and `ToolExplicit` flags to `DisplayCfg` to track whether values come from explicit config (project-level or global) vs. mode-derived defaults
- `EffectiveDisplay()` now returns these flags alongside the resolved values
- Mode changes (`/quiet` toggle and `/config mode` setter) skip overriding `ThinkingMessages`/`ToolMessages` when the corresponding explicit flag is set
- When users explicitly set `thinking_messages` or `tool_messages` via `/config`, the explicit flag is also set

## Testing

- Added `TestEffectiveDisplay_ExplicitFlags` covering project-only, global-only, both, and neither scenarios
- All existing tests pass (`go test ./config/ ./core/`)

Closes #989

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.