### PR TITLE
fix(max): wire async webhook handler ctx to platform Stop()

### DIFF
--- a/platform/max/max.go
+++ b/platform/max/max.go
@@ -70,6 +70,7 @@ type Platform struct {
 
 	mu           sync.RWMutex
 	handler      core.MessageHandler
+	ctx          context.Context
 	cancel       context.CancelFunc
 	stopping     bool
 	client       *http.Client // general API calls — httpTimeout
@@ -160,6 +161,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 	p.handler = handler
 
 	ctx, cancel := context.WithCancel(context.Background())
+	p.ctx = ctx
 	p.cancel = cancel
 
 	// Verify token at startup
@@ -266,6 +268,20 @@ func (p *Platform) resubscribeLoop(ctx context.Context) {
 	}
 }
 
+// webhookCtx returns the parent context for an asynchronous webhook handler
+// goroutine. While the platform is running, it returns the same context that
+// Stop() cancels via p.cancel so in-flight handler work short-circuits on
+// shutdown. Before Start (or after a no-op New), it falls back to Background
+// so unit tests calling webhookHandler directly still get a usable ctx.
+func (p *Platform) webhookCtx() context.Context {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.ctx != nil {
+		return p.ctx
+	}
+	return context.Background()
+}
+
 // webhookHandler accepts a POST from MAX with a single update and routes it
 // through the same handleUpdate path used by long-polling.
 func (p *Platform) webhookHandler(w http.ResponseWriter, r *http.Request) {
@@ -303,17 +319,7 @@ func (p *Platform) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	// MAX expects a fast 200 — process the update asynchronously so we
 	// never let agent latency back-pressure the delivery side.
 	go func() {
-		p.mu.RLock()
-		ctx := context.Background()
-		if p.cancel != nil {
-			// Use the platform's own cancellation context so a Stop() also
-			// short-circuits in-flight handler work.
-			ctx2, cancel := context.WithCancel(ctx)
-			_ = cancel
-			ctx = ctx2
-		}
-		p.mu.RUnlock()
-		p.handleUpdate(ctx, &upd)
+		p.handleUpdate(p.webhookCtx(), &upd)
 	}()
 	w.WriteHeader(http.StatusOK)
 }

--- a/platform/max/max_test.go
+++ b/platform/max/max_test.go
@@ -847,6 +847,58 @@ func TestWebhookHandlerSecretMissing(t *testing.T) {
 	}
 }
 
+// TestWebhookCtx_FallsBackToBackgroundBeforeStart pins the contract that
+// webhookHandler can be exercised in unit tests before Start has run.
+func TestWebhookCtx_FallsBackToBackgroundBeforeStart(t *testing.T) {
+	p, _ := New(map[string]any{"token": "t"})
+	pl := p.(*Platform)
+	ctx := pl.webhookCtx()
+	if ctx == nil {
+		t.Fatal("webhookCtx returned nil")
+	}
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatal("expected no deadline on Background fallback")
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("ctx.Err = %v, want nil", err)
+	}
+}
+
+// TestWebhookCtx_CanceledByStop pins the bug where the async webhook handler
+// goroutine derived a brand-new WithCancel from context.Background() and
+// discarded the cancel func, leaving in-flight handlers running after Stop().
+// With the fix, webhookCtx returns the same context that Stop()/p.cancel
+// cancels, so handlers short-circuit on shutdown.
+func TestWebhookCtx_CanceledByStop(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	if err := p.Start(func(_ core.Platform, _ *core.Message) {}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx := p.webhookCtx()
+	if ctx == nil {
+		t.Fatal("webhookCtx returned nil after Start")
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("webhookCtx already canceled before Stop")
+	default:
+	}
+
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	select {
+	case <-ctx.Done():
+		// expected: Stop() must propagate to in-flight webhook handlers.
+	case <-time.After(2 * time.Second):
+		t.Fatal("webhookCtx was not canceled after Stop")
+	}
+}
+
 func TestWebhookHandlerWrongMethod(t *testing.T) {
 	p, _ := New(map[string]any{"token": "t"})
 	pl := p.(*Platform)


### PR DESCRIPTION
## Summary

`webhookHandler` in `platform/max/max.go` spawns a goroutine for each incoming MAX update with a comment promising that \`Stop()\` will short-circuit in-flight handler work:

\`\`\`go
go func() {
    p.mu.RLock()
    ctx := context.Background()
    if p.cancel != nil {
        // Use the platform's own cancellation context so a Stop() also
        // short-circuits in-flight handler work.
        ctx2, cancel := context.WithCancel(ctx)
        _ = cancel
        ctx = ctx2
    }
    p.mu.RUnlock()
    p.handleUpdate(ctx, &upd)
}()
\`\`\`

The derived \`ctx2\` is a child of \`context.Background()\`, not of the parent context that \`p.cancel\` cancels. So:

- \`Stop()\` calling \`p.cancel()\` does **not** cancel the goroutine's ctx.
- The \`cancel\` returned by \`WithCancel\` is captured and immediately discarded (\`_ = cancel\`).
- Downstream cancellable work that ctx feeds — \`sendChatAction\`, \`fetchAttachments\`, \`p.client.Do(req)\` via \`NewRequestWithContext\` — keeps running until each request's HTTP client timeout instead of being short-circuited by shutdown.

## Fix

- Store the parent context the platform creates in \`Start\` on a new \`Platform.ctx\` field, alongside the existing \`Platform.cancel\`.
- Extract \`webhookCtx()\` which returns \`p.ctx\` when the platform is running and \`context.Background()\` as a unit-test fallback for callers that invoke \`webhookHandler\` directly.
- Replace the broken \`WithCancel + discarded cancel\` block in the webhook goroutine with a single \`p.webhookCtx()\` call.

The long-polling path (\`go p.pollLoop(ctx)\` in \`Start\`) was already correctly wired to \`p.cancel\` and is unchanged.

## Tests

Added to \`platform/max/max_test.go\`:

- \`TestWebhookCtx_FallsBackToBackgroundBeforeStart\` — pins the unit-test fallback so existing webhook tests that exercise \`webhookHandler\` without \`Start\` keep working.
- \`TestWebhookCtx_CanceledByStop\` — starts a platform against the mock API, captures \`webhookCtx()\`, calls \`Stop()\`, and asserts the context's \`Done\` channel closes within 2s. Before the fix this asserts on a field/method that doesn't exist; after the fix it observes real cancellation propagation.

Stash-revert of \`platform/max/max.go\` confirms the regression guard pins the bug (test file fails to compile against the un-fixed production code).

## Test plan

- [x] \`go test -tags no_web -count=1 ./platform/max/\`
- [x] \`go vet -tags no_web ./platform/max/\`
- [x] \`go test -tags no_web -count=1 ./...\` (pre-existing failures in \`core\` / \`daemon\` / \`agent/codex\` reproduce on plain \`main\` on macOS; unrelated to this change)