### PR TITLE
fix(claudecode): add --replay-user-messages for stream-json protocol ack

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -61,6 +61,7 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--permission-prompt-tool", "stdio",
+		"--replay-user-messages",
 	}
 	if !disableVerbose {
 		innerArgs = append(innerArgs, "--verbose")


### PR DESCRIPTION
## Problem

When cc-connect spawns a Claude Code process with `--input-format stream-json --output-format stream-json`, the `--replay-user-messages` flag is missing. This flag is a standard companion to the stream-json protocol — it causes Claude to echo user messages back on stdout for proper acknowledgment. VSCode Claude Code extension already includes this flag when operating in stream-json mode.

Without it, multi-turn conversation context can be unstable through cc-connect's relay.

## Fix

Added `--replay-user-messages` to `innerArgs` in `agent/claudecode/session.go` (one line).

## Verification

- Flag exists in both Claude Code CLI (2.1.140) and VSCode extension (2.1.128)
- Tested with cc-connect + Claude Code 2.1.140
- Flag only activates with `--input-format=stream-json` and `--output-format=stream-json`, both already present
