### PR TITLE
fix(core): route /reasoning through commandContext for multi-workspace

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -7664,7 +7664,13 @@ func (e *Engine) switchModelOnAgent(agent Agent, target string, persistConfig bo
 }
 
 func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
-	switcher, ok := e.agent.(ReasoningEffortSwitcher)
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	switcher, ok := agent.(ReasoningEffortSwitcher)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgReasoningNotSupported))
 		return
@@ -7734,12 +7740,12 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 	}
 
 	switcher.SetReasoningEffort(target)
-	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+	e.cleanupInteractiveState(interactiveKey)
 
-	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s := sessions.GetOrCreateActive(msg.SessionKey)
 	s.SetAgentSessionID("", "")
 	s.ClearHistory()
-	e.sessions.Save()
+	sessions.Save()
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgReasoningChanged, target))
 }

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3822,6 +3822,47 @@ func TestCmdModel_MultiWorkspaceUsesWorkspaceAgentAndSessions(t *testing.T) {
 	}
 }
 
+func TestCmdReasoning_MultiWorkspaceUsesWorkspaceAgentAndSessions(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	globalAgent := &stubModelModeAgent{reasoningEffort: "low"}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+
+	baseDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindingPath)
+
+	wsDir := normalizeWorkspacePath(t.TempDir())
+	channelID := "C-reasoning"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", wsDir)
+
+	ws := e.workspacePool.GetOrCreate(wsDir)
+	wsAgent := &stubModelModeAgent{reasoningEffort: "low"}
+	ws.agent = wsAgent
+	ws.sessions = NewSessionManager("")
+
+	msg := &Message{SessionKey: "feishu:" + channelID + ":u1", ReplyCtx: "ctx"}
+
+	globalSession := e.sessions.GetOrCreateActive(msg.SessionKey)
+	globalSession.SetAgentSessionID("global-session", "test")
+	wsSession := ws.sessions.GetOrCreateActive(msg.SessionKey)
+	wsSession.SetAgentSessionID("workspace-session", "test")
+
+	e.cmdReasoning(p, msg, []string{"high"})
+
+	if wsAgent.reasoningEffort != "high" {
+		t.Fatalf("workspace agent reasoning = %q, want high", wsAgent.reasoningEffort)
+	}
+	if globalAgent.reasoningEffort != "low" {
+		t.Fatalf("global agent reasoning = %q, want unchanged", globalAgent.reasoningEffort)
+	}
+	if got := ws.sessions.GetOrCreateActive(msg.SessionKey).AgentSessionID; got != "" {
+		t.Fatalf("workspace session id = %q, want cleared", got)
+	}
+	if got := e.sessions.GetOrCreateActive(msg.SessionKey).AgentSessionID; got != "global-session" {
+		t.Fatalf("global session id = %q, want untouched", got)
+	}
+}
+
 func TestCmdModel_MultiWorkspaceSwitchDoesNotMutateProviderModel(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	globalAgent := &stubModelModeAgent{model: "gpt-4.1-mini"}


### PR DESCRIPTION
## Summary

`cmdReasoning` resolved its `ReasoningEffortSwitcher` off `e.agent` and persisted session state through `e.sessions` directly. Under multi-workspace mode the active agent and `SessionManager` live on the per-workspace binding, so `/reasoning <effort>` ran against the wrong agent and saved the cleared `agent_session_id` into the wrong store — visually claiming the switch succeeded while the workspace session kept its old effort.

`cmdModel` already addresses this via `switchModelOnAgent` (now on main). This PR aligns `cmdReasoning` with the same pattern: take `agent`, `sessions`, and `interactiveKey` from `e.commandContext(p, msg)` and use them in place of the engine-global accessors.

## Context

This supersedes the relevant half of #209 (`cmdReasoning` + `cmdModel`). The `cmdModel` portion of that PR was made obsolete by main's `switchModelOnAgent` refactor, so #209 is being closed. This PR carries only the `cmdReasoning` fix and adds a regression test mirroring the existing `TestCmdModel_MultiWorkspaceUsesWorkspaceAgentAndSessions` coverage.

## Test plan

- [x] `go test ./core/ -run "CmdReasoning|CmdModel" -v` — all existing tests still green, plus new `TestCmdReasoning_MultiWorkspaceUsesWorkspaceAgentAndSessions` passes
- [x] `go test -race ./core/ -run "CmdReasoning|CmdModel"` — no races
- [x] `go vet ./core/...` clean
- [x] `go build -tags no_web ./...` clean
- [ ] Manual: in multi-workspace mode, `/reasoning high` in a workspace-bound chat updates the workspace agent, leaves the global agent's effort untouched, and clears only the workspace `agent_session_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)