### PR TITLE
fix(daemon/launchd): xml-escape user-supplied paths in the plist template

### DIFF
--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"encoding/xml"
 	"fmt"
 	"os"
 	"os/exec"
@@ -238,6 +239,11 @@ func buildPlist(cfg Config) string {
 	if envPATH == "" {
 		envPATH = "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
 	}
+	// User-supplied paths can legitimately contain XML-special characters
+	// ('&', '<', '>', '"', '\''). Without escaping, `launchctl bootstrap`
+	// rejects the plist with a parse error and daemon install fails. The
+	// label is a hard-coded constant so it does not need escaping; LogMaxSize
+	// is an int.
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -277,5 +283,18 @@ func buildPlist(cfg Config) string {
 	<string>/dev/null</string>
 </dict>
 </plist>
-`, launchdLabel, cfg.BinaryPath, cfg.WorkDir, cfg.LogFile, cfg.LogMaxSize, envPATH)
+`, launchdLabel, xmlEscape(cfg.BinaryPath), xmlEscape(cfg.WorkDir), xmlEscape(cfg.LogFile), cfg.LogMaxSize, xmlEscape(envPATH))
+}
+
+// xmlEscape escapes the five XML-reserved characters in a string so it can
+// be safely embedded inside a plist <string> element.
+func xmlEscape(s string) string {
+	var b strings.Builder
+	if err := xml.EscapeText(&b, []byte(s)); err != nil {
+		// xml.EscapeText only fails when the underlying writer fails; a
+		// strings.Builder never returns a write error. Fall back to the
+		// raw value defensively rather than panicking.
+		return s
+	}
+	return b.String()
 }

--- a/daemon/launchd_test.go
+++ b/daemon/launchd_test.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"encoding/xml"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -232,6 +233,31 @@ func TestRestartKeepsUserDomainWhenGUIDomainUnavailable(t *testing.T) {
 	}
 }
 
+// collectXMLText walks the XML stream and returns every chardata text node.
+// Used by the plist-escape test to verify path values round-trip through
+// xml.Decoder regardless of how deeply they are nested.
+func collectXMLText(t *testing.T, data []byte) []string {
+	t.Helper()
+	dec := xml.NewDecoder(strings.NewReader(string(data)))
+	var out []string
+	for {
+		tok, err := dec.Token()
+		if tok == nil {
+			break
+		}
+		if err != nil {
+			t.Fatalf("xml decode token: %v", err)
+		}
+		if cd, ok := tok.(xml.CharData); ok {
+			s := strings.TrimSpace(string(cd))
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}
+
 func containsCall(calls []string, want string) bool {
 	for _, call := range calls {
 		if call == want {
@@ -239,4 +265,61 @@ func containsCall(calls []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// TestBuildPlist_EscapesXMLSpecialCharsInPaths pins the bug where unescaped
+// '&', '<', '>', '"', and '\'' in cfg paths produced malformed XML that
+// `launchctl bootstrap` rejected.
+func TestBuildPlist_EscapesXMLSpecialCharsInPaths(t *testing.T) {
+	cfg := Config{
+		BinaryPath: "/opt/cc-connect/bin & <tools>/cc-connect",
+		WorkDir:    "/Users/jane/Projects/dev & test/cc-connect",
+		LogFile:    "/Users/jane/Library/Logs/cc \"connect\".log",
+		LogMaxSize: 10485760,
+		EnvPATH:    "/usr/bin:/path/with'apostrophe/bin",
+	}
+	out := buildPlist(cfg)
+
+	// 1) Result must parse as well-formed XML — without escaping, bare '&'
+	//    or unbalanced '<' inside <string> elements break the parser.
+	if err := xml.Unmarshal([]byte(out), new(struct{ XMLName xml.Name })); err != nil {
+		t.Fatalf("buildPlist output is not valid XML: %v\n%s", err, out)
+	}
+
+	// 2) Round-trip the values through the XML parser and make sure the
+	//    original characters survive the encode/decode cycle. Walk every
+	//    text node rather than relying on a positional path, since the
+	//    plist nests <array>/<dict>/<string> at multiple depths.
+	values := collectXMLText(t, []byte(out))
+	mustContain := []string{cfg.BinaryPath, cfg.WorkDir, cfg.LogFile, cfg.EnvPATH}
+	for _, want := range mustContain {
+		found := false
+		for _, got := range values {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("decoded plist does not contain expected value %q\nvalues = %#v", want, values)
+		}
+	}
+
+	// 3) The raw XML output must not contain a bare '&' followed by anything
+	//    other than a recognized entity reference — that's what would crash
+	//    launchctl.
+	for i := 0; i < len(out); i++ {
+		if out[i] != '&' {
+			continue
+		}
+		rest := out[i:]
+		if !(strings.HasPrefix(rest, "&amp;") ||
+			strings.HasPrefix(rest, "&lt;") ||
+			strings.HasPrefix(rest, "&gt;") ||
+			strings.HasPrefix(rest, "&quot;") ||
+			strings.HasPrefix(rest, "&apos;") ||
+			strings.HasPrefix(rest, "&#")) {
+			t.Fatalf("bare '&' at offset %d (not a valid entity ref): %q", i, rest[:min(len(rest), 30)])
+		}
+	}
 }


### PR DESCRIPTION
## Summary

\`daemon/launchd.go:buildPlist\` embeds \`cfg.BinaryPath\`, \`cfg.WorkDir\`, \`cfg.LogFile\`, and \`cfg.EnvPATH\` into the launchd \`.plist\` template using plain \`fmt.Sprintf(\"%s\", …)\`. None of them is XML-escaped.

If any of those values contains one of XML's five reserved characters — \`&\`, \`<\`, \`>\`, \`\"\`, \`'\` — the resulting plist is malformed and \`launchctl bootstrap\` refuses to load it with a parse error. \`cc-connect daemon install\` then fails before the daemon is ever registered.

Concrete triggers users hit in real environments:

- A working directory like \`/Users/jane/Projects/dev & test/cc-connect\` (the \`&\` makes the plist invalid XML).
- A log file path under a home directory that contains an apostrophe.
- Any path that has been pre-quoted with embedded \`\"\`.

The Windows daemon manager already escapes user values via \`powerShellLiteral\`. The launchd manager was the inconsistent path.

## Fix

- Pass each user-supplied \`%s\` placeholder through a new \`xmlEscape\` helper that delegates to \`encoding/xml.EscapeText\` (the canonical escaper, handles all five reserved chars correctly).
- Leave \`launchdLabel\` (compile-time constant) and \`cfg.LogMaxSize\` (\`%d\`) unchanged — neither needs escaping.

## Tests

\`TestBuildPlist_EscapesXMLSpecialCharsInPaths\` asserts that:

1. Output is well-formed XML (parses with \`encoding/xml\`).
2. The original path values round-trip through \`xml.Decoder\` — confirming escaped entities decode back to the literal characters.
3. There are no bare \`&\` characters in the output that are not part of a valid entity reference (the precise condition launchctl rejects on).

Regression guard verified by stash-revert: without the production fix, the test fails at the XML-parse step.

## Test plan

- [x] \`go test -tags no_web -count=1 ./daemon/\` (the pre-existing \`TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable\` failure reproduces on plain \`main\` on this macOS host and is unrelated)
- [x] \`go vet -tags no_web ./daemon/\`