### PR TITLE
fix(agent/iflow): capture workDir under mutex in ListSessions/DeleteSession/ProjectMemoryFile

### DIFF
--- a/agent/iflow/iflow.go
+++ b/agent/iflow/iflow.go
@@ -163,7 +163,10 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
-	return listIFlowSessions(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	return listIFlowSessions(workDir)
 }
 
 func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
@@ -176,7 +179,10 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 		return fmt.Errorf("iflow: cannot determine home dir: %w", err)
 	}
 
-	absDir := iflowResolvedWorkDir(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absDir := iflowResolvedWorkDir(workDir)
 
 	candidates := []string{
 		filepath.Join(homeDir, ".iflow", "projects", iflowProjectKey(absDir), sessionID+".jsonl"),
@@ -227,9 +233,12 @@ func (a *Agent) CompressCommand() string { return "/compress" }
 // -- MemoryFileProvider --
 
 func (a *Agent) ProjectMemoryFile() string {
-	absDir, err := filepath.Abs(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absDir, err := filepath.Abs(workDir)
 	if err != nil {
-		absDir = a.workDir
+		absDir = workDir
 	}
 	return filepath.Join(absDir, "IFLOW.md")
 }

--- a/agent/iflow/iflow_test.go
+++ b/agent/iflow/iflow_test.go
@@ -1,9 +1,11 @@
 package iflow
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -166,4 +168,44 @@ func contains(list []string, target string) bool {
 		}
 	}
 	return false
+}
+
+// TestIFlowAgent_WorkDirRaceFreeReaders pins the bug where ListSessions,
+// DeleteSession, and ProjectMemoryFile read a.workDir without holding
+// a.mu, while SetWorkDir mutates it under the lock. Running this with
+// -race flags the data race; with the fix the race detector stays quiet.
+func TestIFlowAgent_WorkDirRaceFreeReaders(t *testing.T) {
+	dir := t.TempDir()
+	a := &Agent{workDir: dir}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				a.SetWorkDir(filepath.Join(dir, "a"))
+			} else {
+				a.SetWorkDir(filepath.Join(dir, "b"))
+			}
+		}(i)
+	}
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = a.ListSessions(context.Background())
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = a.DeleteSession(context.Background(), "no-such-session")
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = a.ProjectMemoryFile()
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

In \`agent/iflow/iflow.go\`, \`SetWorkDir\` (line 97) writes \`a.workDir\` under \`a.mu\` and \`StartSession\` (line 151) reads it under the lock. But three other readers access \`a.workDir\` without holding \`a.mu\`:

- \`ListSessions\` (line 166): \`return listIFlowSessions(a.workDir)\`
- \`DeleteSession\` (line 179): \`absDir := iflowResolvedWorkDir(a.workDir)\`
- \`ProjectMemoryFile\` (line 230/232): \`filepath.Abs(a.workDir)\` / fallback

This races with \`SetWorkDir\` when a user issues \`/workspace <dir>\` on one channel/goroutine while \`/list\`, \`/delete\`, or a memory-file lookup runs on another.

Strings in Go are not torn-read-safe — a concurrent write of a new string (different pointer and length) against an unsynchronized read can yield a frankenstring of pointer-from-one-write + length-from-another, leading to memory-safety failures or empty/garbled paths.

The \`codex\` agent's \`ListSessions\` already uses the canonical \"capture under RLock\" pattern; \`iflow\` was the inconsistent one.

## Fix

In each of the three readers, capture \`workDir := a.workDir\` while holding \`a.mu.RLock()\`, then use the local variable afterwards. No public API or behaviour changes.

## Tests

Added \`TestIFlowAgent_WorkDirRaceFreeReaders\` in \`agent/iflow/iflow_test.go\`:

- 20 goroutines call \`SetWorkDir\` with alternating paths.
- 20 each call \`ListSessions\` / \`DeleteSession\` / \`ProjectMemoryFile\` concurrently.
- The test passes under \`-race\` once the readers acquire the lock.

Stash-revert of \`agent/iflow/iflow.go\` confirms the regression guard pins the bug: \`go test -tags no_web -race ./agent/iflow/\` then reports \"DATA RACE detected\". With the fix applied, the same command is clean.

## Test plan

- [x] \`go test -tags no_web -race -count=1 ./agent/iflow/\`
- [x] \`go test -tags no_web -count=1 ./agent/iflow/\`
- [x] \`go vet -tags no_web ./agent/iflow/\`