### PR TITLE
fix(core): protect Session.Name writes with the session mutex

### DIFF
--- a/core/management.go
+++ b/core/management.go
@@ -992,13 +992,13 @@ func (m *ManagementServer) handleProjectSessions(w http.ResponseWriter, r *http.
 
 		s := e.sessions.GetOrCreateActive(body.SessionKey)
 		if body.Name != "" {
-			s.Name = body.Name
+			s.SetName(body.Name)
 		}
 		e.sessions.Save()
 
 		mgmtJSON(w, http.StatusOK, map[string]any{
 			"session_key": body.SessionKey,
-			"name":        s.Name,
+			"name":        s.GetName(),
 		})
 
 	default:

--- a/core/management_test.go
+++ b/core/management_test.go
@@ -346,6 +346,45 @@ func TestMgmt_SessionDetail(t *testing.T) {
 	}
 }
 
+// TestMgmt_SessionsConcurrentNameWriteAndList pins the bug where the
+// POST /sessions handler wrote s.Name = body.Name directly without
+// holding s.mu, while the GET handler reads s.Name through s.mu.Lock().
+// Run with -race to detect the data race; with the production fix
+// the test stays clean.
+func TestMgmt_SessionsConcurrentNameWriteAndList(t *testing.T) {
+	_, ts, e := testManagementServer(t, "tok")
+
+	// Pre-create the session so both handlers operate on the same instance.
+	e.sessions.GetOrCreateActive("user1")
+
+	listURL := ts.URL + "/api/v1/projects/test-project/sessions"
+	postURL := listURL
+
+	var wg sync.WaitGroup
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := "a"
+			if i%2 == 0 {
+				name = "b"
+			}
+			_ = mgmtPost(t, postURL, "tok", map[string]string{
+				"session_key": "user1",
+				"name":        name,
+			})
+		}(i)
+	}
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = mgmtGet(t, listURL, "tok")
+		}()
+	}
+	wg.Wait()
+}
+
 func TestMgmt_SessionDelete(t *testing.T) {
 	_, ts, e := testManagementServer(t, "tok")
 

--- a/core/session.go
+++ b/core/session.go
@@ -111,6 +111,15 @@ func (s *Session) GetAgentSessionID() string {
 	return s.AgentSessionID
 }
 
+// SetName atomically updates the session's display name. The management
+// API used to write s.Name directly, which raced with GetName / listing
+// handlers that read it under s.mu.
+func (s *Session) SetName(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Name = name
+}
+
 // GetName atomically reads the session name.
 func (s *Session) GetName() string {
 	s.mu.Lock()

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -931,3 +931,34 @@ func TestLegacyData_ClearsAfterFirstNewCommand(t *testing.T) {
 		t.Fatal("thread-new should be in known as current ID")
 	}
 }
+
+// TestSession_SetName_RaceFree pins the bug where management.go used to
+// write s.Name = body.Name without holding s.mu. Readers (GetName, the
+// /sessions listing handler) lock s.mu, so concurrent reads + writes
+// were a data race. With SetName acquiring s.mu the race detector stays
+// quiet; without the production fix it reports DATA RACE.
+func TestSession_SetName_RaceFree(t *testing.T) {
+	sm := NewSessionManager("")
+	s := sm.GetOrCreateActive("user1")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 40; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				s.SetName("primary")
+			} else {
+				s.SetName("secondary")
+			}
+		}(i)
+	}
+	for i := 0; i < 40; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.GetName()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

\`handleProjectSessions\` POST in \`core/management.go\` mutates the session's display name by writing the field directly:

\`\`\`go
s := e.sessions.GetOrCreateActive(body.SessionKey)
if body.Name != \"\" {
    s.Name = body.Name
}
\`\`\`

The GET branch of the same handler iterates sessions and reads \`s.Name\` inside \`s.mu.Lock()\`. \`Session.SetAgentInfo\`, the other place that writes \`s.Name\`, also acquires \`s.mu\`. The management POST handler was the inconsistent one, so two clients hitting \`POST /sessions\` (rename) and \`GET /sessions\` (list) concurrently race on the \`Name\` string field. Go strings carry a pointer and a length; a torn read against a write of a different-length name can produce a frankenstring whose pointer doesn't match its length, leading to memory-safety failures or garbled output.

## Fix

- Add \`Session.SetName(name string)\` that acquires \`s.mu\` (mirrors \`SetAgentSessionID\`, \`SetAgentInfo\`).
- Switch the management POST handler to call \`s.SetName(body.Name)\` and read back via \`s.GetName()\` so the response body also goes through the lock.

## Tests

Two regression guards added:

- \`TestSession_SetName_RaceFree\` — direct test of the new method: 40 concurrent \`SetName\` writers and 40 concurrent \`GetName\` readers run under \`-race\`. With the fix the test is clean; without the new method the build fails.
- \`TestMgmt_SessionsConcurrentNameWriteAndList\` — behavioral test that fires 30 concurrent POST + 30 concurrent GET against the management API for the same session_key. Stash-reverting just \`core/management.go\` while keeping the new \`SetName\` method confirms the test trips \"DATA RACE detected\" — pinning the management-API integration, not just the helper.

## Test plan

- [x] \`go test -tags no_web -race -count=1 -run TestSession_SetName_RaceFree ./core/\`
- [x] \`go test -tags no_web -race -count=1 -run TestMgmt_SessionsConcurrentNameWriteAndList ./core/\`
- [x] \`go test -tags no_web -count=1 ./core/\` (pre-existing \`TestProcessInteractiveEvents_*\` and \`TestResolveLocalDirPath_AcceptsSubdir\` failures reproduce on plain \`main\` on macOS — unrelated to this change)
- [x] \`go vet -tags no_web ./core/\`