### PR TITLE
discord: per-guild mention bypass, reply context, and multi-workspac

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -319,6 +319,9 @@ func main() {
 					engine.SetWorkspaceIdleTimeout(time.Duration(mins) * time.Minute)
 				}
 			}
+			if proj.SkipGit != nil {
+				engine.SetSkipGit(*proj.SkipGit)
+			}
 			slog.Info("multi-workspace mode enabled", "project", proj.Name, "base_dir", baseDir)
 		}
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -605,6 +605,7 @@ level = "info" # debug, info, warn, error
 # [[projects]]
 # name = "claude-multi"
 # mode = "multi-workspace"
+# skip_git = true # skip bind git repo, create a dir directly
 # base_dir = "~/workspace"
 # workspace_init_allow_local_paths = true  # Optional: allow /workspace init <local-dir>; default false keeps init git-URL only
 #
@@ -1070,6 +1071,9 @@ app_secret = "your-feishu-app-secret"
 # guild_id = ""     # Optional: set for instant slash command registration (per-guild)
 #                   # 可选：设置后 slash 命令秒级生效（仅该服务器）
 # group_reply_all = false  # If true, respond to ALL guild messages without @mention / 设为 true 群聊无需 @ 也响应
+# group_reply_all_guilds = ""  # Comma-separated guild IDs where group_reply_all is active (overrides group_reply_all)
+#                              # e.g. "123456789012345678,987654321098765432"; takes precedence over group_reply_all
+#                              # 逗号分隔的服务器 ID，仅在这些服务器无需 @ 也响应（优先于 group_reply_all）
 # share_session_in_channel = false  # If true, all users in a channel share one agent session / 频道共享会话
 # thread_isolation = false  # If true, cc-connect creates/uses Discord threads as session boundaries when the channel supports threads
 #                           # 设为 true 时，cc-connect 会在支持 thread 的 Discord 频道内按 thread 隔离会话

--- a/config/config.go
+++ b/config/config.go
@@ -325,6 +325,7 @@ type ProjectConfig struct {
 	Name    string `toml:"name"`
 	Mode    string `toml:"mode,omitempty"`     // "" or "multi-workspace"
 	BaseDir string `toml:"base_dir,omitempty"` // parent dir for workspaces
+	SkipGit *bool  `toml:"skip_git,omitempty"`
 	// WorkspaceInitAllowLocalPaths allows /workspace init and the conversational
 	// init flow to bind existing local directories. Default false keeps init
 	// limited to git URLs; use /workspace bind or /workspace route for explicit

--- a/core/engine.go
+++ b/core/engine.go
@@ -7772,7 +7772,7 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 	s := sessions.GetOrCreateActive(msg.SessionKey)
 	s.SetAgentSessionID("", "")
 	s.ClearHistory()
-	e.sessions.Save()
+	sessions.Save()
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgReasoningChanged, target))
 }
@@ -8286,7 +8286,7 @@ func (e *Engine) cmdAllow(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
-	agent, _, _, err := e.commandContext(p, msg)
+	agent, sessions, _, err := e.commandContext(p, msg)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
 		return
@@ -8377,7 +8377,7 @@ func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
 			e.reply(p, msg.ReplyCtx, "Usage: /provider switch <name>")
 			return
 		}
-		e.switchProvider(p, msg, switcher, args[1])
+		e.switchProvider(p, msg, sessions, switcher, args[1])
 
 	case "current":
 		current := switcher.GetActiveProvider()
@@ -8391,12 +8391,14 @@ func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
 		switcher.SetActiveProvider("")
 		e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
 		{
-			s := e.sessions.GetOrCreateActive(msg.SessionKey)
+			s := sessions.GetOrCreateActive(msg.SessionKey)
 			s.SetAgentSessionID("", "")
 			s.ClearHistory()
-			e.sessions.Save()
+			sessions.Save()
 		}
-		if e.providerSaveFunc != nil {
+		// Only persist to global config when operating on the global agent;
+		// in workspace mode the provider state lives on the per-workspace agent.
+		if sessions == e.sessions && e.providerSaveFunc != nil {
 			if err := e.providerSaveFunc(""); err != nil {
 				slog.Error("failed to save provider", "error", err)
 			}
@@ -8404,7 +8406,7 @@ func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProviderCleared))
 
 	default:
-		e.switchProvider(p, msg, switcher, args[0])
+		e.switchProvider(p, msg, sessions, switcher, args[0])
 	}
 }
 
@@ -8546,19 +8548,21 @@ func (e *Engine) resetAllSessions() {
 	e.sessions.Save()
 }
 
-func (e *Engine) switchProvider(p Platform, msg *Message, switcher ProviderSwitcher, name string) {
+func (e *Engine) switchProvider(p Platform, msg *Message, sessions *SessionManager, switcher ProviderSwitcher, name string) {
 	if !switcher.SetActiveProvider(name) {
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgProviderNotFound), name))
 		return
 	}
 	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
 
-	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s := sessions.GetOrCreateActive(msg.SessionKey)
 	s.SetAgentSessionID("", "")
 	s.ClearHistory()
-	e.sessions.Save()
+	sessions.Save()
 
-	if e.providerSaveFunc != nil {
+	// Only persist to global config when operating on the global agent;
+	// in workspace mode the provider state lives on the per-workspace agent.
+	if sessions == e.sessions && e.providerSaveFunc != nil {
 		if err := e.providerSaveFunc(name); err != nil {
 			slog.Error("failed to save provider", "error", err)
 		}

--- a/core/engine.go
+++ b/core/engine.go
@@ -244,6 +244,7 @@ type Engine struct {
 	// Multi-workspace mode
 	multiWorkspace               bool
 	baseDir                      string
+	skipGit                      bool
 	workspaceInitAllowLocalPaths bool
 	workspaceBindings            *WorkspaceBindingManager
 	workspacePool                *workspacePool
@@ -620,6 +621,11 @@ func (e *Engine) SetFilterExternalSessions(v bool) {
 
 func (e *Engine) SetWebSetupFunc(fn func() (int, string, bool, error)) { e.webSetupFunc = fn }
 func (e *Engine) SetWebStatusFunc(fn func() string)                    { e.webStatusFunc = fn }
+
+func (e *Engine) SetSkipGit(skipGit bool) {
+	e.skipGit = skipGit
+}
+
 
 // SetInjectSender controls whether sender identity (platform and user ID) is
 // prepended to each message before forwarding it to the agent. When enabled,
@@ -6556,7 +6562,13 @@ func (e *Engine) cmdStatus(p Platform, msg *Message) {
 }
 
 func (e *Engine) cmdUsage(p Platform, msg *Message) {
-	reporter, ok := e.agent.(UsageReporter)
+	agent, _, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	reporter, ok := agent.(UsageReporter)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgUsageNotSupported))
 		return
@@ -7679,7 +7691,13 @@ func (e *Engine) switchModelOnAgent(agent Agent, target string, persistConfig bo
 }
 
 func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
-	switcher, ok := e.agent.(ReasoningEffortSwitcher)
+	agent, sessions, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	switcher, ok := agent.(ReasoningEffortSwitcher)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgReasoningNotSupported))
 		return
@@ -7751,7 +7769,7 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 	switcher.SetReasoningEffort(target)
 	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
 
-	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s := sessions.GetOrCreateActive(msg.SessionKey)
 	s.SetAgentSessionID("", "")
 	s.ClearHistory()
 	e.sessions.Save()
@@ -7760,7 +7778,13 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
-	switcher, ok := e.agent.(ModeSwitcher)
+	agent, _, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	switcher, ok := agent.(ModeSwitcher)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgModeNotSupported))
 		return
@@ -8012,7 +8036,13 @@ func (e *Engine) stopInteractiveSessionWithOptions(sessionKey string, notifyQueu
 }
 
 func (e *Engine) cmdCompress(p Platform, msg *Message) {
-	compressor, ok := e.agent.(ContextCompressor)
+	agent, sessions, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	compressor, ok := agent.(ContextCompressor)
 	if !ok || compressor.CompressCommand() == "" {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgCompressNotSupported))
 		return
@@ -8037,7 +8067,6 @@ func (e *Engine) cmdCompress(p Platform, msg *Message) {
 		return
 	}
 
-	_, sessions := e.sessionContextForKey(msg.SessionKey)
 	session := sessions.GetOrCreateActive(msg.SessionKey)
 	if !session.TryLock() {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
@@ -8224,8 +8253,14 @@ func (e *Engine) drainQueuedMessagesAfterCompress(state *interactiveState, sessi
 }
 
 func (e *Engine) cmdAllow(p Platform, msg *Message, args []string) {
+	agent, _, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
 	if len(args) == 0 {
-		if auth, ok := e.agent.(ToolAuthorizer); ok {
+		if auth, ok := agent.(ToolAuthorizer); ok {
 			tools := auth.GetAllowedTools()
 			if len(tools) == 0 {
 				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgNoToolsAllowed))
@@ -8239,7 +8274,7 @@ func (e *Engine) cmdAllow(p Platform, msg *Message, args []string) {
 	}
 
 	toolName := strings.TrimSpace(args[0])
-	if auth, ok := e.agent.(ToolAuthorizer); ok {
+	if auth, ok := agent.(ToolAuthorizer); ok {
 		if err := auth.AddAllowedTools(toolName); err != nil {
 			e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgToolAllowFailed), err))
 			return
@@ -8251,7 +8286,13 @@ func (e *Engine) cmdAllow(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
-	switcher, ok := e.agent.(ProviderSwitcher)
+	agent, _, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	switcher, ok := agent.(ProviderSwitcher)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProviderNotSupported))
 		return
@@ -10978,7 +11019,13 @@ func (e *Engine) renderUpgradeCard() *Card {
 // ──────────────────────────────────────────────────────────────
 
 func (e *Engine) cmdMemory(p Platform, msg *Message, args []string) {
-	mp, ok := e.agent.(MemoryFileProvider)
+	agent, _, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	mp, ok := agent.(MemoryFileProvider)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgMemoryNotSupported))
 		return
@@ -11757,6 +11804,11 @@ func (e *Engine) cmdCommandsDel(p Platform, msg *Message, args []string) {
 
 func (e *Engine) executeSkill(p Platform, msg *Message, skill *Skill, args []string) {
 	prompt := BuildSkillInvocationPrompt(skill, args)
+	_, _, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
 
 	// Resolve workspace-aware agent in multi-workspace mode. Without this the
 	// skill always runs against the global e.agent (with the project-level
@@ -13427,7 +13479,19 @@ func (e *Engine) handleWorkspaceInitFlow(p Platform, msg *Message, channelName s
 		if strings.HasPrefix(content, "/") && !looksLikeAllowedLocalDir {
 			return false
 		}
-		// Create the flow so that follow-up messages are handled.
+		if e.skipGit {
+			cloneTo := filepath.Join(e.baseDir, channelName)
+			flow = &workspaceInitFlow{
+				state:       "awaiting_confirm",
+				channelName: channelName,
+				cloneTo:     cloneTo,
+			}
+			e.initFlowsMu.Lock()
+			e.initFlows[channelKey] = flow
+			e.initFlowsMu.Unlock()
+			e.reply(p, msg.ReplyCtx, fmt.Sprintf("I'll mkdir `%s` and bind it to this channel. OK? (yes/no)", channelName))
+			return true
+		}
 		flow = &workspaceInitFlow{
 			state:       "awaiting_url",
 			channelName: channelName,
@@ -13511,13 +13575,21 @@ func (e *Engine) handleWorkspaceInitFlow(p Platform, msg *Message, channelName s
 			return true
 		}
 
-		e.reply(p, msg.ReplyCtx, fmt.Sprintf("Cloning `%s` to `%s`...", flow.repoURL, flow.cloneTo))
-
-		if err := gitClone(flow.repoURL, flow.cloneTo); err != nil {
+		var err error
+		var message string
+		if e.skipGit {
+			err = os.MkdirAll(flow.cloneTo, 0o755)
+			message = fmt.Sprintf("mkdir failed: %v", err)
+		} else {
+			e.reply(p, msg.ReplyCtx, fmt.Sprintf("Cloning `%s` to `%s`...", flow.repoURL, flow.cloneTo))
+			err = gitClone(flow.repoURL, flow.cloneTo)
+			message = fmt.Sprintf("Clone failed: %v\nSend a repo URL to try again.", err)
+		}
+		if err != nil {
 			e.initFlowsMu.Lock()
 			delete(e.initFlows, channelKey)
 			e.initFlowsMu.Unlock()
-			e.reply(p, msg.ReplyCtx, fmt.Sprintf("Clone failed: %v\nSend a repo URL to try again.", err))
+			e.reply(p, msg.ReplyCtx, message)
 			return true
 		}
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -4676,6 +4676,162 @@ func TestCmdReasoning_RejectsMinimal(t *testing.T) {
 	}
 }
 
+// TestCmdReasoning_MultiWorkspaceSavesToWorkspaceSessions is a regression test
+// for the bug where cmdReasoning called e.sessions.Save() (global) instead of
+// sessions.Save() (workspace-resolved), leaving workspace session state unsaved.
+func TestCmdReasoning_MultiWorkspaceSavesToWorkspaceSessions(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	globalAgent := &stubModelModeAgent{}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+
+	baseDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindingPath)
+
+	wsDir := normalizeWorkspacePath(t.TempDir())
+	channelID := "C-reasoning-ws"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", wsDir)
+
+	ws := e.workspacePool.GetOrCreate(wsDir)
+	wsAgent := &stubModelModeAgent{}
+	ws.agent = wsAgent
+	ws.sessions = NewSessionManager("")
+
+	msg := &Message{SessionKey: "feishu:" + channelID + ":u1", ReplyCtx: "ctx"}
+
+	wsSession := ws.sessions.GetOrCreateActive(msg.SessionKey)
+	wsSession.SetAgentSessionID("ws-session-id", "test")
+	wsSession.AddHistory("user", "hello")
+
+	globalSession := e.sessions.GetOrCreateActive(msg.SessionKey)
+	globalSession.SetAgentSessionID("global-session-id", "test")
+
+	e.cmdReasoning(p, msg, []string{"3"}) // selects "high"
+
+	if wsAgent.reasoningEffort != "high" {
+		t.Fatalf("workspace agent reasoning effort = %q, want high", wsAgent.reasoningEffort)
+	}
+	if got := wsSession.GetAgentSessionID(); got != "" {
+		t.Fatalf("workspace session id = %q, want cleared", got)
+	}
+	if got := globalSession.GetAgentSessionID(); got != "global-session-id" {
+		t.Fatalf("global session id = %q, want untouched", got)
+	}
+}
+
+// TestCmdProvider_ClearMultiWorkspaceUsesWorkspaceSessions is a regression test
+// for the bug where cmdProvider "clear" used e.sessions (global) instead of
+// the workspace-resolved sessions, and called providerSaveFunc in workspace mode.
+func TestCmdProvider_ClearMultiWorkspaceUsesWorkspaceSessions(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	globalAgent := &stubProviderAgent{
+		providers: []ProviderConfig{{Name: "openai"}},
+		active:    "openai",
+	}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+
+	var savedProvider string
+	e.SetProviderSaveFunc(func(name string) error {
+		savedProvider = name
+		return nil
+	})
+
+	baseDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindingPath)
+
+	wsDir := normalizeWorkspacePath(t.TempDir())
+	channelID := "C-provider-clear-ws"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", wsDir)
+
+	ws := e.workspacePool.GetOrCreate(wsDir)
+	wsAgent := &stubProviderAgent{
+		providers: []ProviderConfig{{Name: "openai"}},
+		active:    "openai",
+	}
+	ws.agent = wsAgent
+	ws.sessions = NewSessionManager("")
+
+	msg := &Message{SessionKey: "feishu:" + channelID + ":u1", ReplyCtx: "ctx"}
+
+	wsSession := ws.sessions.GetOrCreateActive(msg.SessionKey)
+	wsSession.SetAgentSessionID("ws-session-id", "test")
+
+	globalSession := e.sessions.GetOrCreateActive(msg.SessionKey)
+	globalSession.SetAgentSessionID("global-session-id", "test")
+
+	e.cmdProvider(p, msg, []string{"clear"})
+
+	if got := wsSession.GetAgentSessionID(); got != "" {
+		t.Fatalf("workspace session id = %q, want cleared", got)
+	}
+	if got := globalSession.GetAgentSessionID(); got != "global-session-id" {
+		t.Fatalf("global session id = %q, want untouched", got)
+	}
+	// providerSaveFunc must not be called when operating on a workspace agent.
+	if savedProvider != "" {
+		t.Fatalf("providerSaveFunc was called with %q in workspace mode, want no call", savedProvider)
+	}
+}
+
+// TestSwitchProvider_MultiWorkspaceUsesWorkspaceSessions is a regression test
+// for the bug where switchProvider used e.sessions (global) instead of the
+// workspace-resolved sessions, and called providerSaveFunc in workspace mode.
+func TestSwitchProvider_MultiWorkspaceUsesWorkspaceSessions(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	globalAgent := &stubProviderAgent{
+		providers: []ProviderConfig{{Name: "openai"}, {Name: "azure"}},
+		active:    "openai",
+	}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+
+	var savedProvider string
+	e.SetProviderSaveFunc(func(name string) error {
+		savedProvider = name
+		return nil
+	})
+
+	baseDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindingPath)
+
+	wsDir := normalizeWorkspacePath(t.TempDir())
+	channelID := "C-provider-switch-ws"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", wsDir)
+
+	ws := e.workspacePool.GetOrCreate(wsDir)
+	wsAgent := &stubProviderAgent{
+		providers: []ProviderConfig{{Name: "openai"}, {Name: "azure"}},
+		active:    "openai",
+	}
+	ws.agent = wsAgent
+	ws.sessions = NewSessionManager("")
+
+	msg := &Message{SessionKey: "feishu:" + channelID + ":u1", ReplyCtx: "ctx"}
+
+	wsSession := ws.sessions.GetOrCreateActive(msg.SessionKey)
+	wsSession.SetAgentSessionID("ws-session-id", "test")
+
+	globalSession := e.sessions.GetOrCreateActive(msg.SessionKey)
+	globalSession.SetAgentSessionID("global-session-id", "test")
+
+	e.cmdProvider(p, msg, []string{"switch", "azure"})
+
+	if wsAgent.active != "azure" {
+		t.Fatalf("workspace agent active provider = %q, want azure", wsAgent.active)
+	}
+	if got := wsSession.GetAgentSessionID(); got != "" {
+		t.Fatalf("workspace session id = %q, want cleared", got)
+	}
+	if got := globalSession.GetAgentSessionID(); got != "global-session-id" {
+		t.Fatalf("global session id = %q, want untouched", got)
+	}
+	// providerSaveFunc must not be called when operating on a workspace agent.
+	if savedProvider != "" {
+		t.Fatalf("providerSaveFunc was called with %q in workspace mode, want no call", savedProvider)
+	}
+}
+
 func TestCmdMode_UsesInlineButtonsOnButtonOnlyPlatform(t *testing.T) {
 	p := &stubInlineButtonPlatform{stubPlatformEngine: stubPlatformEngine{n: "inline-only"}}
 	agent := &stubModelModeAgent{}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -476,6 +476,17 @@ type WorkDirSwitcher interface {
 	GetWorkDir() string
 }
 
+// AgentOptsProvider is an optional interface for agents that need to carry
+// their full configuration options when the engine clones a per-workspace
+// agent instance in multi-workspace mode. The engine merges the returned map
+// into the workspace opts before calling the agent factory, giving workspace
+// agents access to agent-specific options (e.g. "session" for the tmux agent)
+// that are not covered by the standard GetModel / GetMode accessors.
+// work_dir is always overridden by the engine and must not be returned here.
+type AgentOptsProvider interface {
+	BaseOpts() map[string]any
+}
+
 // ModeSwitcher is an optional interface for agents that support runtime permission mode switching.
 type ModeSwitcher interface {
 	SetMode(mode string)

--- a/core/markdown_html.go
+++ b/core/markdown_html.go
@@ -439,50 +439,106 @@ func tableCellVisualWidth(cell string) int {
 // boundary-aware italic regex.
 var reTableCellItalic = regexp.MustCompile(`\*([^*]+)\*`)
 
-// SplitMessageCodeFenceAware splits text into chunks respecting code fence boundaries.
-// When a chunk boundary falls inside a code block, the fence is closed at the end of
-// the chunk and re-opened at the start of the next chunk.
+// SplitMessageCodeFenceAware splits text into chunks no larger than maxLen runes,
+// preferring line boundaries. When a chunk boundary falls inside a code block,
+// the fence is closed at the end of the chunk and re-opened at the start of the
+// next chunk. If a single line exceeds maxLen, it is split within the line at
+// rune boundaries.
 func SplitMessageCodeFenceAware(text string, maxLen int) []string {
-	if len(text) <= maxLen {
+	if utf8.RuneCountInString(text) <= maxLen {
 		return []string{text}
 	}
 
-	const closingFence = "\n```" // 4 bytes appended when splitting inside a code block
+	// closingFence is appended when flushing a chunk that is inside a code block.
+	const closingFence = "\n```"
+	const closingFenceLen = 4 // rune count of "\n```"
 
 	lines := strings.Split(text, "\n")
 	var chunks []string
 	var current []string
+	// currentLen tracks rune count of strings.Join(current, "\n") + 1.
+	// The invariant is: actual_chunk_runes = currentLen - 1.
+	// This +1 accounting lets the fit check use a single expression.
 	currentLen := 0
-	openFence := "" // the ``` opening line, or "" if outside code block
+	openFence := "" // opening ``` line when inside a code block, else ""
+
+	// effectiveLimit returns the number of "currentLen units" available before
+	// the chunk (plus closingFence if needed) would exceed maxLen.
+	effectiveLimit := func() int {
+		if openFence != "" {
+			return maxLen - closingFenceLen
+		}
+		return maxLen
+	}
+
+	// flush emits the current chunk and resets state, re-seeding with the open
+	// fence header so the next chunk is a valid continuation of the code block.
+	flush := func() {
+		if len(current) == 0 {
+			return
+		}
+		chunk := strings.Join(current, "\n")
+		if openFence != "" {
+			chunk += closingFence
+		}
+		chunks = append(chunks, chunk)
+		current = nil
+		currentLen = 0
+		if openFence != "" {
+			current = append(current, openFence)
+			currentLen = utf8.RuneCountInString(openFence) + 1
+		}
+	}
 
 	for _, line := range lines {
-		lineLen := len(line) + 1 // +1 for newline
+		lineRunes := []rune(line)
+		limit := effectiveLimit()
 
-		// Reserve space for the closing fence when inside a code block,
-		// so the final chunk length stays within maxLen.
-		limit := maxLen
-		if openFence != "" {
-			limit -= len(closingFence)
+		// Fast path: line fits in the current chunk.
+		if currentLen+len(lineRunes)+1 <= limit {
+			current = append(current, line)
+			currentLen += len(lineRunes) + 1
+		} else {
+			// Line doesn't fit; flush and try again with a fresh chunk.
+			flush()
+			limit = effectiveLimit()
+
+			if currentLen+len(lineRunes)+1 <= limit {
+				// Fits after flush.
+				current = append(current, line)
+				currentLen += len(lineRunes) + 1
+			} else {
+				// The line itself exceeds the limit; split within the line at
+				// rune boundaries, flushing between parts as needed.
+				remaining := lineRunes
+				for len(remaining) > 0 {
+					limit = effectiveLimit()
+					// avail = how many runes we can add to current.
+					// Since currentLen = actual_runes + 1, actual_runes = currentLen - 1,
+					// and a new part adds 1 joining \n plus its own runes:
+					//   new_actual = (currentLen-1) + 1 + avail = currentLen + avail
+					// We need new_actual <= limit, so avail <= limit - currentLen.
+					avail := limit - currentLen
+					if avail <= 0 {
+						// Shouldn't happen after flush, but guard against it.
+						flush()
+						limit = effectiveLimit()
+						avail = limit - currentLen
+					}
+					if avail > len(remaining) {
+						avail = len(remaining)
+					}
+					current = append(current, string(remaining[:avail]))
+					currentLen += avail + 1
+					remaining = remaining[avail:]
+					if len(remaining) > 0 {
+						flush()
+					}
+				}
+			}
 		}
 
-		if currentLen+lineLen > limit && len(current) > 0 {
-			chunk := strings.Join(current, "\n")
-			if openFence != "" {
-				chunk += closingFence
-			}
-			chunks = append(chunks, chunk)
-
-			current = nil
-			currentLen = 0
-			if openFence != "" {
-				current = append(current, openFence)
-				currentLen = len(openFence) + 1
-			}
-		}
-
-		current = append(current, line)
-		currentLen += lineLen
-
+		// Track code fence state after processing the line.
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "```") {
 			if openFence != "" {

--- a/core/markdown_html_test.go
+++ b/core/markdown_html_test.go
@@ -507,8 +507,62 @@ func TestSplitMessageCodeFenceAware_ChunkDoesNotExceedMaxLen(t *testing.T) {
 		t.Fatalf("expected multiple chunks, got %d", len(chunks))
 	}
 	for i, chunk := range chunks {
-		if len(chunk) > maxLen {
-			t.Errorf("chunk %d exceeds maxLen (%d): len=%d, content=%q", i, maxLen, len(chunk), chunk)
+		if len([]rune(chunk)) > maxLen {
+			t.Errorf("chunk %d exceeds maxLen (%d): runes=%d, content=%q", i, maxLen, len([]rune(chunk)), chunk)
+		}
+	}
+}
+
+func TestSplitMessageCodeFenceAware_LongSingleLine(t *testing.T) {
+	// A single line that exceeds maxLen must be split within the line.
+	line := strings.Repeat("x", 250)
+	chunks := SplitMessageCodeFenceAware(line, 100)
+	if len(chunks) < 3 {
+		t.Fatalf("expected at least 3 chunks for 250-char line with maxLen=100, got %d", len(chunks))
+	}
+	for i, chunk := range chunks {
+		if len([]rune(chunk)) > 100 {
+			t.Errorf("chunk %d exceeds maxLen: runes=%d", i, len([]rune(chunk)))
+		}
+	}
+	// Content must be fully preserved.
+	joined := strings.Join(chunks, "")
+	if joined != line {
+		t.Errorf("content not preserved after split: got len=%d", len(joined))
+	}
+}
+
+func TestSplitMessageCodeFenceAware_LongSingleLineInCodeBlock(t *testing.T) {
+	// A very long line inside a code block must be split and fences re-opened.
+	longLine := strings.Repeat("a", 200)
+	text := "```go\n" + longLine + "\n```"
+	maxLen := 80
+	chunks := SplitMessageCodeFenceAware(text, maxLen)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for i, chunk := range chunks {
+		if len([]rune(chunk)) > maxLen {
+			t.Errorf("chunk %d exceeds maxLen (%d): runes=%d", i, maxLen, len([]rune(chunk)))
+		}
+	}
+	// Every chunk except the last must end with ``` (closing fence).
+	for i, chunk := range chunks[:len(chunks)-1] {
+		if !strings.HasSuffix(chunk, "```") {
+			t.Errorf("chunk %d missing closing fence: %q", i, chunk)
+		}
+	}
+}
+
+func TestSplitMessageCodeFenceAware_UnicodeLines(t *testing.T) {
+	// Unicode content: rune count != byte count.
+	// Each Chinese character is 3 bytes but 1 rune.
+	line := strings.Repeat("中", 50) // 50 runes, 150 bytes
+	text := line + "\n" + line
+	chunks := SplitMessageCodeFenceAware(text, 60)
+	for i, chunk := range chunks {
+		if len([]rune(chunk)) > 60 {
+			t.Errorf("chunk %d exceeds maxLen in runes: %d", i, len([]rune(chunk)))
 		}
 	}
 }

--- a/core/message.go
+++ b/core/message.go
@@ -165,6 +165,7 @@ type Message struct {
 	Platform     string
 	MessageID    string // platform message ID for tracing
 	Recalled     bool   // true for platform message recall/delete events targeting MessageID
+	ChannelID    string
 	UserID       string
 	UserName     string
 	ChatName     string // human-readable chat/group name (optional)

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -620,24 +620,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 
 		// Prepend the replied-to message's content and images so the agent has context.
 		if m.ReferencedMessage != nil {
-			ref := m.ReferencedMessage
-			author := ""
-			if ref.Author != nil {
-				author = ref.Author.Username
-			}
-			m.Content = "[replying to " + author + ": " + ref.Content + "]\n" + m.Content
-			for _, att := range ref.Attachments {
-				if att.Width > 0 && att.Height > 0 {
-					data, err := downloadURL(att.URL)
-					if err != nil {
-						slog.Error("discord: download referenced attachment failed", "url", att.URL, "error", err)
-						continue
-					}
-					images = append([]core.ImageAttachment{{
-						MimeType: att.ContentType, Data: data, FileName: att.Filename,
-					}}, images...)
-				}
-			}
+			m.Content, images = applyReferencedMessage(m.ReferencedMessage, m.Content, images, downloadURL)
 		}
 
 		msg := &core.Message{
@@ -1382,4 +1365,29 @@ func downloadURL(u string) ([]byte, error) {
 		return nil, fmt.Errorf("download %s: status %d", u, resp.StatusCode)
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, maxDownloadBytes+1))
+}
+
+// applyReferencedMessage prepends the replied-to message's author and content
+// to content and prepends any images from the referenced message's attachments.
+// Image attachments (width > 0) are downloaded via download and prepended so the
+// agent sees them before the current message's own images.
+func applyReferencedMessage(ref *discordgo.Message, content string, images []core.ImageAttachment, download func(string) ([]byte, error)) (string, []core.ImageAttachment) {
+	author := ""
+	if ref.Author != nil {
+		author = ref.Author.Username
+	}
+	content = "[replying to " + author + ": " + ref.Content + "]\n" + content
+	for _, att := range ref.Attachments {
+		if att.Width > 0 && att.Height > 0 {
+			data, err := download(att.URL)
+			if err != nil {
+				slog.Error("discord: download referenced attachment failed", "url", att.URL, "error", err)
+				continue
+			}
+			images = append([]core.ImageAttachment{{
+				MimeType: att.ContentType, Data: data, FileName: att.Filename,
+			}}, images...)
+		}
+	}
+	return content, images
 }

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -22,7 +22,7 @@ func init() {
 	core.RegisterPlatform("discord", New)
 }
 
-const maxDiscordLen = 2000
+const maxDiscordLen = 1900
 
 type replyContext struct {
 	channelID string
@@ -47,9 +47,9 @@ type progressPlatform struct {
 type Platform struct {
 	token                      string
 	allowFrom                  string
-	guildID                    string // optional: per-guild registration (instant) vs global (up to 1h propagation)
+	guildID                    string   // optional: per-guild registration (instant) vs global (up to 1h propagation)
 	progressStyle              string
-	groupReplyAll              bool
+	groupReplyAllGuilds        []string // guild IDs where groupReplyAll is active; "*" = all guilds
 	shareSessionInChannel      bool
 	threadIsolation            bool
 	respondToAtEveryoneAndHere bool
@@ -74,7 +74,16 @@ func New(opts map[string]any) (core.Platform, error) {
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom("discord", allowFrom)
 	guildID, _ := opts["guild_id"].(string)
-	groupReplyAll, _ := opts["group_reply_all"].(bool)
+	var groupReplyAllGuilds []string
+	if guilds, _ := opts["group_reply_all_guilds"].(string); guilds != "" {
+		for _, g := range strings.Split(guilds, ",") {
+			if g = strings.TrimSpace(g); g != "" {
+				groupReplyAllGuilds = append(groupReplyAllGuilds, g)
+			}
+		}
+	} else if all, _ := opts["group_reply_all"].(bool); all {
+		groupReplyAllGuilds = []string{"*"}
+	}
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
@@ -108,7 +117,7 @@ func New(opts map[string]any) (core.Platform, error) {
 		allowFrom:                  allowFrom,
 		guildID:                    guildID,
 		progressStyle:              progressStyle,
-		groupReplyAll:              groupReplyAll,
+		groupReplyAllGuilds:        groupReplyAllGuilds,
 		shareSessionInChannel:      shareSessionInChannel,
 		readyCh:                    make(chan struct{}),
 		threadIsolation:            threadIsolation,
@@ -155,6 +164,15 @@ func (p *progressPlatform) ProgressStyle() string {
 
 func (p *progressPlatform) SupportsProgressCardPayload() bool {
 	return p.ProgressStyle() == "card"
+}
+
+func (p *Platform) isGroupReplyAllGuild(guildID string) bool {
+	for _, g := range p.groupReplyAllGuilds {
+		if g == "*" || g == guildID {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Platform) makeSessionKey(channelID string, userID string) string {
@@ -561,7 +579,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			p.cacheBotRoleIDForGuild(s, m.GuildID, nil)
 			botRoleID = p.botRoleIDForGuild(m.GuildID)
 		}
-		if m.GuildID != "" && !p.groupReplyAll {
+		if m.GuildID != "" && !p.isGroupReplyAllGuild(m.GuildID) {
 			if !isDiscordBotMention(m, p.botID, botRoleID, p.respondToAtEveryoneAndHere) {
 				slog.Debug("discord: ignoring guild message without bot mention", "channel", m.ChannelID)
 				return
@@ -596,17 +614,40 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 
 		images, files, audio := classifyAttachments(m.Attachments, downloadURL)
 
-		if m.Content == "" && len(images) == 0 && len(files) == 0 && audio == nil {
+		if m.Content == "" && len(images) == 0 && len(files) == 0 && audio == nil && m.ReferencedMessage == nil {
 			return
+		}
+
+		// Prepend the replied-to message's content and images so the agent has context.
+		if m.ReferencedMessage != nil {
+			ref := m.ReferencedMessage
+			author := ""
+			if ref.Author != nil {
+				author = ref.Author.Username
+			}
+			m.Content = "[replying to " + author + ": " + ref.Content + "]\n" + m.Content
+			for _, att := range ref.Attachments {
+				if att.Width > 0 && att.Height > 0 {
+					data, err := downloadURL(att.URL)
+					if err != nil {
+						slog.Error("discord: download referenced attachment failed", "url", att.URL, "error", err)
+						continue
+					}
+					images = append([]core.ImageAttachment{{
+						MimeType: att.ContentType, Data: data, FileName: att.Filename,
+					}}, images...)
+				}
+			}
 		}
 
 		msg := &core.Message{
 			SessionKey: sessionKey, ChannelKey: channelKey, Platform: "discord",
+			ChannelID: m.ChannelID,
 			MessageID: m.ID,
 			UserID:    m.Author.ID, UserName: m.Author.Username,
-			ChatName: p.resolveChannelName(m.ChannelID),
-			Content:  m.Content, Images: images, Files: files, Audio: audio, ReplyCtx: rctx,
+			Content: m.Content, Images: images, Files: files, Audio: audio, ReplyCtx: rctx,
 		}
+		msg.ChatName, _ = p.ResolveChannelName(m.ChannelID)
 		p.dispatchMessage(msg)
 	})
 
@@ -698,10 +739,11 @@ func (p *Platform) handleInteraction(s *discordgo.Session, i *discordgo.Interact
 	msg := &core.Message{
 		SessionKey: sessionKey, ChannelKey: channelKey, Platform: "discord",
 		MessageID: i.ID,
+		ChannelID: i.ChannelID,
 		UserID:    userID, UserName: userName,
-		ChatName: p.resolveChannelName(channelID),
 		Content:  cmdText, ReplyCtx: rctx,
 	}
+	msg.ChatName, _ = p.ResolveChannelName(channelID)
 	p.dispatchMessage(msg)
 }
 
@@ -771,6 +813,7 @@ func (p *Platform) handleComponentInteraction(s *discordgo.Session, i *discordgo
 	if i.Message != nil {
 		rc.messageID = i.Message.ID
 	}
+	chatName, _ := p.ResolveChannelName(channelID)
 	p.dispatchMessage(&core.Message{
 		SessionKey: sessionKey,
 		ChannelKey: channelKey,
@@ -778,8 +821,8 @@ func (p *Platform) handleComponentInteraction(s *discordgo.Session, i *discordgo
 		MessageID:  i.ID,
 		UserID:     userID,
 		UserName:   userName,
-		ChatName:   p.resolveChannelName(channelID),
 		Content:    command,
+		ChatName:   chatName,
 		ReplyCtx:   rc,
 	})
 }
@@ -1154,30 +1197,22 @@ func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
 	return func() { close(done) }
 }
 
-// ResolveChannelName implements core.ChannelNameResolver.
 func (p *Platform) ResolveChannelName(channelID string) (string, error) {
-	name := p.resolveChannelName(channelID)
-	if name == channelID {
-		return "", fmt.Errorf("discord: channel name not found for %s", channelID)
-	}
-	return name, nil
-}
-
-func (p *Platform) resolveChannelName(channelID string) string {
 	if cached, ok := p.channelNameCache.Load(channelID); ok {
-		return cached.(string)
+		return cached.(string), nil
 	}
 	ch, err := p.session.Channel(channelID)
 	if err != nil {
 		slog.Debug("discord: resolve channel name failed", "channel", channelID, "error", err)
-		return channelID
+		return channelID, err
 	}
 	name := ch.Name
+	slog.Debug("discord: resolve channel name", "channel", channelID, "name", ch.Name)
 	if name == "" {
-		return channelID
+		return channelID, nil
 	}
 	p.channelNameCache.Store(channelID, name)
-	return name
+	return name, nil
 }
 
 func (p *Platform) Stop() error {

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -1370,3 +1370,196 @@ func TestClassifyAttachments_SkipsFailedDownloadsButKeepsSiblings(t *testing.T) 
 		t.Fatalf("files = %+v, want only good.pdf", files)
 	}
 }
+
+// ── isGroupReplyAllGuild tests ────────────────────────────────
+
+func TestIsGroupReplyAllGuild_EmptyListReturnsFalse(t *testing.T) {
+	p := &Platform{}
+	if p.isGroupReplyAllGuild("G123") {
+		t.Fatal("empty groupReplyAllGuilds should return false")
+	}
+}
+
+func TestIsGroupReplyAllGuild_WildcardMatchesAnyGuild(t *testing.T) {
+	p := &Platform{groupReplyAllGuilds: []string{"*"}}
+	if !p.isGroupReplyAllGuild("any-guild-id") {
+		t.Fatal("wildcard '*' should match any guild ID")
+	}
+}
+
+func TestIsGroupReplyAllGuild_SpecificGuildMatches(t *testing.T) {
+	p := &Platform{groupReplyAllGuilds: []string{"G-A", "G-B"}}
+	if !p.isGroupReplyAllGuild("G-A") {
+		t.Fatal("G-A should match")
+	}
+	if !p.isGroupReplyAllGuild("G-B") {
+		t.Fatal("G-B should match")
+	}
+}
+
+func TestIsGroupReplyAllGuild_UnknownGuildReturnsFalse(t *testing.T) {
+	p := &Platform{groupReplyAllGuilds: []string{"G-A", "G-B"}}
+	if p.isGroupReplyAllGuild("G-OTHER") {
+		t.Fatal("unlisted guild G-OTHER should not match")
+	}
+}
+
+// ── applyReferencedMessage tests ─────────────────────────────
+
+func TestApplyReferencedMessage_PrependsAuthorAndContent(t *testing.T) {
+	ref := &discordgo.Message{
+		Author:  &discordgo.User{Username: "alice"},
+		Content: "hello world",
+	}
+	content, images := applyReferencedMessage(ref, "my reply", nil, nil)
+
+	wantContent := "[replying to alice: hello world]\nmy reply"
+	if content != wantContent {
+		t.Fatalf("content = %q, want %q", content, wantContent)
+	}
+	if len(images) != 0 {
+		t.Fatalf("images = %v, want empty", images)
+	}
+}
+
+func TestApplyReferencedMessage_NoAuthorUsesEmptyString(t *testing.T) {
+	ref := &discordgo.Message{Content: "anon msg"}
+	content, _ := applyReferencedMessage(ref, "reply", nil, nil)
+
+	if !strings.Contains(content, "[replying to : anon msg]") {
+		t.Fatalf("content = %q, want empty author placeholder", content)
+	}
+}
+
+func TestApplyReferencedMessage_DownloadsAndPrependsImages(t *testing.T) {
+	imgData := []byte("fake-png")
+	download := func(u string) ([]byte, error) {
+		return imgData, nil
+	}
+	ref := &discordgo.Message{
+		Author:  &discordgo.User{Username: "bob"},
+		Content: "see this",
+		Attachments: []*discordgo.MessageAttachment{
+			{URL: "https://cdn/img.png", ContentType: "image/png", Filename: "img.png", Width: 100, Height: 100},
+		},
+	}
+	existing := []core.ImageAttachment{{MimeType: "image/jpeg", Data: []byte("existing"), FileName: "old.jpg"}}
+
+	_, images := applyReferencedMessage(ref, "reply", existing, download)
+
+	if len(images) != 2 {
+		t.Fatalf("images len = %d, want 2", len(images))
+	}
+	// Referenced image is prepended — it comes first.
+	if images[0].FileName != "img.png" {
+		t.Fatalf("images[0].FileName = %q, want img.png (referenced image should be prepended)", images[0].FileName)
+	}
+	if images[1].FileName != "old.jpg" {
+		t.Fatalf("images[1].FileName = %q, want old.jpg", images[1].FileName)
+	}
+}
+
+func TestApplyReferencedMessage_SkipsNonImageAttachments(t *testing.T) {
+	ref := &discordgo.Message{
+		Content: "has doc",
+		Attachments: []*discordgo.MessageAttachment{
+			// Width/Height == 0 means it's not an image — must be skipped.
+			{URL: "https://cdn/doc.pdf", ContentType: "application/pdf", Filename: "doc.pdf"},
+		},
+	}
+	download := func(u string) ([]byte, error) {
+		t.Fatal("download should not be called for non-image attachments")
+		return nil, nil
+	}
+
+	_, images := applyReferencedMessage(ref, "reply", nil, download)
+	if len(images) != 0 {
+		t.Fatalf("images = %v, want empty — PDF should not be forwarded as image", images)
+	}
+}
+
+func TestApplyReferencedMessage_SkipsFailedImageDownloads(t *testing.T) {
+	download := func(u string) ([]byte, error) {
+		return nil, fmt.Errorf("network error")
+	}
+	ref := &discordgo.Message{
+		Content: "broken image",
+		Attachments: []*discordgo.MessageAttachment{
+			{URL: "https://cdn/img.png", ContentType: "image/png", Filename: "img.png", Width: 100, Height: 100},
+		},
+	}
+
+	_, images := applyReferencedMessage(ref, "reply", nil, download)
+	if len(images) != 0 {
+		t.Fatalf("images = %v, want empty — failed download should be skipped", images)
+	}
+}
+
+// ── workspace-aware command routing (ChannelKey) test ─────────
+
+// TestDispatchMessage_SetsChannelKeyForThreadIsolation verifies that when
+// thread_isolation is enabled the dispatched message carries a ChannelKey equal
+// to the parent channel ID so that multi-workspace binding resolution uses the
+// parent channel rather than the ephemeral thread ID.
+func TestDispatchMessage_SetsChannelKeyForThreadIsolation(t *testing.T) {
+	parentChannelID := "parent-ch-999"
+	threadID := "thread-999"
+
+	var got *core.Message
+	p := newTestPlatform(func(_ core.Platform, msg *core.Message) {
+		got = msg
+	})
+	p.threadIsolation = true
+	p.botID = "BOT_ID"
+
+	ops := fakeThreadOps{
+		resolveChannel: func(channelID string) (*discordgo.Channel, error) {
+			// The message is in a guild text channel (not a thread), so we return
+			// a non-thread type to trigger the "create thread" path.
+			return &discordgo.Channel{ID: channelID, Type: discordgo.ChannelTypeGuildText}, nil
+		},
+		startThread: func(channelID, messageID, name string, archiveDuration int) (*discordgo.Channel, error) {
+			return &discordgo.Channel{
+				ID:       threadID,
+				Type:     discordgo.ChannelTypeGuildPublicThread,
+				ParentID: parentChannelID,
+			}, nil
+		},
+		joinThread: func(threadID string) error { return nil },
+	}
+
+	m := &discordgo.MessageCreate{Message: &discordgo.Message{
+		ID:        "msg-ws-key",
+		ChannelID: parentChannelID,
+		GuildID:   "G-ws",
+		Content:   "hello",
+		Author:    &discordgo.User{ID: "U1", Username: "user1"},
+	}}
+
+	threadSessionKey, rctx, _, err := resolveThreadReplyContext(m, "BOT_ID", ops)
+	if err != nil {
+		t.Fatalf("resolveThreadReplyContext error: %v", err)
+	}
+
+	msg := &core.Message{
+		SessionKey: threadSessionKey,
+		ChannelKey: parentChannelID,
+		Platform:   "discord",
+		ChannelID:  m.ChannelID,
+		MessageID:  m.Message.ID,
+		UserID:     m.Author.ID,
+		Content:    m.Message.Content,
+		ReplyCtx:   rctx,
+	}
+	p.dispatchMessage(msg)
+
+	if got == nil {
+		t.Fatal("message was not dispatched")
+	}
+	if got.ChannelKey != parentChannelID {
+		t.Fatalf("ChannelKey = %q, want %q", got.ChannelKey, parentChannelID)
+	}
+	if got.SessionKey == got.ChannelKey {
+		t.Fatal("SessionKey should differ from ChannelKey (thread ID vs parent channel)")
+	}
+}


### PR DESCRIPTION

group_reply_all_guilds: comma-separated list of guild IDs where the bot responds to all messages without requiring an @mention. Supports "*" to match all guilds (equivalent to the existing group_reply_all bool).

Reply context: when a message quotes/replies to another message, prepend the referenced message's content and images to the agent input so the agent has full context without the user needing to repeat it.

Multi-workspace: fix session key context propagation so workspace-bound sessions correctly resolve their channel and exec skill commands carry the right workspace context.