### PR TITLE
fix(wecom): verify callback signature in constant time

### DIFF
--- a/platform/wecom/wecom.go
+++ b/platform/wecom/wecom.go
@@ -6,8 +6,10 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/sha1"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -712,13 +714,17 @@ func (p *Platform) Stop() error {
 // --- Crypto helpers ---
 
 // verifySignature checks SHA1(sort(token, timestamp, nonce, encrypt)).
+// The comparison uses subtle.ConstantTimeCompare to match the
+// constant-time credential check pattern used by core/webhook.go,
+// core/bridge.go, core/management.go, and platform/max — wecom was
+// the only signature path doing a plain string equality.
 func (p *Platform) verifySignature(expected, timestamp, nonce, encrypt string) bool {
 	parts := []string{p.token, timestamp, nonce, encrypt}
 	sort.Strings(parts)
 	h := sha1.New()
 	h.Write([]byte(strings.Join(parts, "")))
-	got := fmt.Sprintf("%x", h.Sum(nil))
-	return got == expected
+	got := hex.EncodeToString(h.Sum(nil))
+	return subtle.ConstantTimeCompare([]byte(got), []byte(expected)) == 1
 }
 
 // decodeAESKey converts the 43-char Base64 EncodingAESKey to 32 bytes.

--- a/platform/wecom/wecom_test.go
+++ b/platform/wecom/wecom_test.go
@@ -1,7 +1,11 @@
 package wecom
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"net/url"
+	"sort"
+	"strings"
 	"testing"
 )
 
@@ -68,6 +72,60 @@ func TestNew_CustomAPIBaseURL_TrimTrailingSlash(t *testing.T) {
 	}
 	if p.apiBaseURL != "https://wecom.internal.example.com" {
 		t.Fatalf("apiBaseURL = %q, want %q", p.apiBaseURL, "https://wecom.internal.example.com")
+	}
+}
+
+// wecomSignature is a local re-implementation of the signature scheme so
+// the test exercises verifySignature against expected outputs without
+// depending on the production helper itself.
+func wecomSignature(token, timestamp, nonce, encrypt string) string {
+	parts := []string{token, timestamp, nonce, encrypt}
+	sort.Strings(parts)
+	h := sha1.New()
+	h.Write([]byte(strings.Join(parts, "")))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func TestVerifySignature_AcceptsMatchingDigest(t *testing.T) {
+	p := &Platform{token: "tok"}
+	sig := wecomSignature(p.token, "1700000000", "abc", "ciphertext")
+	if !p.verifySignature(sig, "1700000000", "abc", "ciphertext") {
+		t.Fatalf("verifySignature should accept a matching SHA1 digest")
+	}
+}
+
+func TestVerifySignature_RejectsMismatchedDigest(t *testing.T) {
+	p := &Platform{token: "tok"}
+	good := wecomSignature(p.token, "1700000000", "abc", "ciphertext")
+	cases := []string{
+		"",                                  // empty signature
+		"deadbeef",                          // too short
+		good[:len(good)-1] + "x",            // last byte wrong
+		"y" + good[1:],                      // first byte wrong
+		good + "0",                          // length mismatch (longer)
+		good[:len(good)-1],                  // length mismatch (shorter)
+		"INVALID-NON-HEX-SIGNATURE-VALUE!!", // garbage
+	}
+	for _, bad := range cases {
+		if p.verifySignature(bad, "1700000000", "abc", "ciphertext") {
+			t.Errorf("verifySignature should reject %q", bad)
+		}
+	}
+}
+
+func TestVerifySignature_DigestIsLowercaseHex(t *testing.T) {
+	p := &Platform{token: "tok"}
+	good := wecomSignature(p.token, "1700000000", "abc", "ciphertext")
+	if good != strings.ToLower(good) {
+		t.Fatalf("local helper produced non-lowercase digest %q", good)
+	}
+	// Uppercase variant must not be accepted by a constant-time comparator.
+	upper := strings.ToUpper(good)
+	if upper == good {
+		t.Skip("digest has no letters; case check is degenerate")
+	}
+	if p.verifySignature(upper, "1700000000", "abc", "ciphertext") {
+		t.Fatalf("verifySignature should reject uppercase-hex digest (constant-time compare is case sensitive)")
 	}
 }
 


### PR DESCRIPTION
## Summary

\`Platform.verifySignature\` in \`platform/wecom/wecom.go\` compares the locally-computed SHA1 digest against the caller-supplied \`msg_signature\` using plain string equality:

\`\`\`go
got := fmt.Sprintf(\"%x\", h.Sum(nil))
return got == expected
\`\`\`

Every other credential or signature comparison in the project uses \`subtle.ConstantTimeCompare\`:

- \`core/webhook.go\` — webhook token (Bearer / X-Webhook-Token / query param)
- \`core/bridge.go\` — bridge token
- \`core/management.go\` — management API token
- \`platform/max/max.go\` — webhook secret

wecom was the only signature path short-circuiting on the first mismatching byte, which is inconsistent with the project's documented security pattern.

## Fix

- Switch the comparison to \`subtle.ConstantTimeCompare\`.
- Use \`encoding/hex.EncodeToString\` for the digest instead of \`fmt.Sprintf(\"%x\", ...)\` (avoids a \`fmt\` round trip and matches how the constant-time helper is used elsewhere).

## Tests

Added to \`platform/wecom/wecom_test.go\`:

- \`TestVerifySignature_AcceptsMatchingDigest\` — happy path.
- \`TestVerifySignature_RejectsMismatchedDigest\` — empty / too short / too long / last-byte / first-byte / non-hex variants.
- \`TestVerifySignature_DigestIsLowercaseHex\` — constant-time compare is byte-exact, so uppercase-hex must still be rejected.

A local \`wecomSignature\` helper re-implements the digest scheme so the assertions don't depend on the production helper they're verifying.

## Test plan

- [x] \`go test -tags no_web -count=1 ./platform/wecom/\`
- [x] \`go vet -tags no_web ./platform/wecom/\`