### PR TITLE
fix(telegram): use MessageThreadID instead of IsForum for callback thread routing

### DIFF
--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -727,7 +727,10 @@ func (p *Platform) handleCallbackQuery(ctx context.Context, cb *models.CallbackQ
 
 	isGroupChat := msg.Chat.Type == models.ChatTypeGroup || msg.Chat.Type == models.ChatTypeSupergroup
 	threadID := 0
-	if msg.Chat.IsForum || !isGroupChat {
+	// IsForum is not reliably present in the Chat object embedded in a CallbackQuery
+	// message. Use MessageThreadID directly: non-zero means we're in a forum topic,
+	// zero means a regular group (no topic isolation needed).
+	if !isGroupChat || msg.MessageThreadID != 0 {
 		threadID = msg.MessageThreadID
 	}
 	sessionKey := p.buildSessionKey(chatID, threadID, cb.From.ID)


### PR DESCRIPTION
## Summary

- `IsForum` is not reliably present in the `Chat` object embedded inside a `CallbackQuery` message from Telegram's Bot API
- For forum groups (Topics enabled), this caused `threadID` to resolve as `0` in `handleCallbackQuery`, building a wrong session key (e.g. `telegram:-100xxx:0:uid` instead of `telegram:-100xxx:31:uid`)
- The callback was routed to a non-existent session and silently dropped — clicking Allow / Deny / Allow All had no effect

Fix: replace `msg.Chat.IsForum` check with `msg.MessageThreadID != 0`, which is always populated when the message is in a topic thread.

```go
// Before
if msg.Chat.IsForum || !isGroupChat {
    threadID = msg.MessageThreadID
}

// After
if !isGroupChat || msg.MessageThreadID != 0 {
    threadID = msg.MessageThreadID
}
```

This correctly handles all cases:
- **DM**: `isGroupChat=false` → uses `MessageThreadID` (always 0, correct)
- **Regular group** (no topics): `isGroupChat=true`, `MessageThreadID=0` → `threadID=0`, correct
- **Forum group** (with topics): `isGroupChat=true`, `MessageThreadID=31` → `threadID=31`, correct ✅

Closes #1002

## Test plan

- [ ] In a Telegram forum group with `thread_isolation = true`, trigger a permission request and click Allow — should now respond correctly
- [ ] Verify regular group and DM callback behavior is unchanged