### PR TITLE
fix(agent/codex): capture workDir under mutex in StartSession and SkillDirs

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -339,6 +339,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	codexHome := a.codexHome
 	cliBin := a.cliBin
 	cliExtraArgs := a.cliExtraArgs
+	workDir := a.workDir
 	extraEnv := a.providerEnvLocked()
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	var baseURL string
@@ -361,13 +362,13 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 
 	if backend == "app_server" {
-		return newAppServerSession(ctx, appServerURL, a.workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome)
+		return newAppServerSession(ctx, appServerURL, workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome)
 	}
 	if codexHome != "" {
 		extraEnv = append(extraEnv, "CODEX_HOME="+codexHome)
 	}
 
-	return newCodexSession(ctx, cliBin, cliExtraArgs, a.workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv, provName)
+	return newCodexSession(ctx, cliBin, cliExtraArgs, workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv, provName)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
@@ -438,11 +439,15 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 // ── SkillProvider implementation ──────────────────────────────
 
 func (a *Agent) SkillDirs() []string {
-	absDir, err := filepath.Abs(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	codexHome := a.codexHome
+	a.mu.RUnlock()
+	absDir, err := filepath.Abs(workDir)
 	if err != nil {
-		absDir = a.workDir
+		absDir = workDir
 	}
-	return codexSkillDirs(absDir, a.codexHome)
+	return codexSkillDirs(absDir, codexHome)
 }
 
 // ── ContextCompressor implementation ──────────────────────────

--- a/agent/codex/skilldirs_test.go
+++ b/agent/codex/skilldirs_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 )
 
@@ -87,4 +88,34 @@ func setTestHome(t *testing.T, home string) {
 		t.Setenv("HOMEDRIVE", "")
 		t.Setenv("HOMEPATH", "")
 	}
+}
+
+// TestSkillDirs_RaceFreeAgainstSetWorkDir pins the bug where SkillDirs
+// read a.workDir and a.codexHome without holding a.mu, while
+// SetWorkDir writes a.workDir under the lock. Run with -race to detect
+// the data race; with the production fix the test stays clean.
+func TestSkillDirs_RaceFreeAgainstSetWorkDir(t *testing.T) {
+	tmp := t.TempDir()
+	a := &Agent{workDir: tmp, codexHome: filepath.Join(tmp, "codex")}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				a.SetWorkDir(filepath.Join(tmp, "a"))
+			} else {
+				a.SetWorkDir(filepath.Join(tmp, "b"))
+			}
+		}(i)
+	}
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = a.SkillDirs()
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

In \`agent/codex/codex.go\`, two methods read \`a.workDir\` without holding \`a.mu\`, while \`SetWorkDir\` mutates it under the lock:

- \`StartSession\` (line 333-371): the locked block captures \`mode\`, \`model\`, \`reasoningEffort\`, \`backend\`, \`appServerURL\`, \`codexHome\`, \`cliBin\`, \`cliExtraArgs\`, providers — but **not** \`a.workDir\`. After \`a.mu.Unlock()\`, the two return sites at lines 364 and 370 then read \`a.workDir\` to pass to \`newAppServerSession\` / \`newCodexSession\`.
- \`SkillDirs\` (line 440-446): reads \`a.workDir\` and \`a.codexHome\` directly.

When a user issues \`/workspace <dir>\` on one channel/goroutine and a turn starts or a skill lookup runs on another, the readers race with \`SetWorkDir\`. Go strings carry a \`(pointer, length)\` pair, and a torn read of a different-length string can produce a frankenstring whose pointer doesn't match its length, leading to memory-safety failures.

The same agent's \`ListSessions\`, \`GetSessionHistory\`, and \`DeleteSession\` already follow the canonical \"capture under RLock\" pattern; \`StartSession\` and \`SkillDirs\` were the inconsistent ones.

## Fix

- Add \`workDir := a.workDir\` inside the locked block in \`StartSession\`, then pass the local through to both \`newAppServerSession\` and \`newCodexSession\` instead of re-reading \`a.workDir\` after \`Unlock()\`.
- Capture both \`workDir\` and \`codexHome\` under \`a.mu.RLock()\` in \`SkillDirs\` before computing the absolute path.

No behaviour change; no public API change.

## Tests

\`TestSkillDirs_RaceFreeAgainstSetWorkDir\` (in \`agent/codex/skilldirs_test.go\`) spawns 30 concurrent \`SetWorkDir\` writers and 30 concurrent \`SkillDirs\` readers under \`-race\`. With the fix the race detector stays quiet; stash-reverting just \`agent/codex/codex.go\` confirms the test trips \"DATA RACE detected\".

## Test plan

- [x] \`go test -tags no_web -race -count=1 -run TestSkillDirs_RaceFreeAgainstSetWorkDir ./agent/codex/\`
- [x] \`go test -tags no_web -count=1 ./agent/codex/\`
- [x] \`go vet -tags no_web ./agent/codex/\`