### PR TITLE
fix(agent/opencode): capture cmd/workDir under mutex in ListSessions and ProjectMemoryFile

### DIFF
--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -473,7 +473,11 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 
 // ListSessions runs `opencode session list` and parses the JSON output.
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
-	return listOpencodeSessions(a.cmd, a.workDir)
+	a.mu.RLock()
+	cmd := a.cmd
+	workDir := a.workDir
+	a.mu.RUnlock()
+	return listOpencodeSessions(cmd, workDir)
 }
 
 func (a *Agent) Stop() error { return nil }
@@ -522,9 +526,12 @@ func (a *Agent) CompressCommand() string { return "/compact" }
 // -- MemoryFileProvider --
 
 func (a *Agent) ProjectMemoryFile() string {
-	absDir, err := filepath.Abs(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absDir, err := filepath.Abs(workDir)
 	if err != nil {
-		absDir = a.workDir
+		absDir = workDir
 	}
 	return filepath.Join(absDir, "OPENCODE.md")
 }

--- a/agent/opencode/opencode_workdir_race_test.go
+++ b/agent/opencode/opencode_workdir_race_test.go
@@ -1,0 +1,48 @@
+package opencode
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestOpencodeAgent_WorkDirRaceFreeReaders pins the bug where
+// ListSessions and ProjectMemoryFile read a.workDir (and a.cmd, in
+// ListSessions' case) without holding a.mu, while SetWorkDir writes
+// a.workDir under the lock. Run with -race to detect the data race;
+// with the production fix the test stays clean.
+func TestOpencodeAgent_WorkDirRaceFreeReaders(t *testing.T) {
+	dir := t.TempDir()
+	a := &Agent{workDir: dir, cmd: "opencode"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				a.SetWorkDir(filepath.Join(dir, "a"))
+			} else {
+				a.SetWorkDir(filepath.Join(dir, "b"))
+			}
+		}(i)
+	}
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// ListSessions execs `opencode session list`; with a
+			// non-existent binary it returns an error immediately.
+			// The race detector still observes the unlocked field
+			// reads before the exec attempt.
+			_, _ = a.ListSessions(context.Background())
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = a.ProjectMemoryFile()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

In \`agent/opencode/opencode.go\`, two methods access agent fields without holding \`a.mu\`:

- \`ListSessions\` (line 475-477) reads both \`a.cmd\` and \`a.workDir\`.
- \`ProjectMemoryFile\` (line 524-530) reads \`a.workDir\`.

\`SetWorkDir\` writes \`a.workDir\` under \`a.mu\`, and the sibling \`DeleteSession\` already follows the canonical \"capture under RLock\" pattern. \`ListSessions\` and \`ProjectMemoryFile\` were the inconsistent ones.

When a user issues \`/workspace <dir>\` on one channel/goroutine while \`/list\` or a memory-file lookup runs on another, the readers race with the writer. Go strings carry a \`(pointer, length)\` pair; a torn read of a different-length string can produce a frankenstring whose pointer doesn't match its length, leading to memory-safety failures or empty/garbled paths.

## Fix

- Capture \`cmd\` and \`workDir\` under \`a.mu.RLock()\` in \`ListSessions\` before calling \`listOpencodeSessions\`.
- Capture \`workDir\` under \`a.mu.RLock()\` in \`ProjectMemoryFile\` before computing the absolute path.

No public API or behaviour change.

## Tests

\`TestOpencodeAgent_WorkDirRaceFreeReaders\` (new file \`agent/opencode/opencode_workdir_race_test.go\`) spawns 30 concurrent \`SetWorkDir\` writers and 30 concurrent \`ListSessions\` / \`ProjectMemoryFile\` readers under \`-race\`. With the fix the race detector stays quiet; stash-reverting just \`agent/opencode/opencode.go\` confirms the test trips \"DATA RACE detected\".

## Test plan

- [x] \`go test -tags no_web -race -count=1 -run TestOpencodeAgent_WorkDirRaceFreeReaders ./agent/opencode/\`
- [x] \`go test -tags no_web -count=1 ./agent/opencode/\`
- [x] \`go vet -tags no_web ./agent/opencode/\`