### PR TITLE
fix(cmd/sessions): strip work_dir hash suffix when deriving project name

### DIFF
--- a/cmd/cc-connect/sessions.go
+++ b/cmd/cc-connect/sessions.go
@@ -121,6 +121,45 @@ func resolveDataDir(flagValue string) string {
 	return ".cc-connect"
 }
 
+// sessionFileHashLen is the length of the hex-encoded work_dir hash the
+// engine writes into session file names — sha256 truncated to 4 bytes,
+// rendered as 8 hex chars (see sessionStorePath in main.go and the
+// "_ws_<hash>" path in core/engine.go).
+const sessionFileHashLen = 8
+
+// extractProjectFromFilename derives the project name from a session
+// file name. The engine writes sessions under one of four naming
+// schemes (see matchesProject in session_id.go):
+//
+//   - <project>.json                — no work_dir
+//   - <project>_<8hex>.json         — single work_dir
+//   - <project>_ws_<8hex>.json      — multi-workspace
+//   - <project>.sessions.json       — legacy
+//
+// Strip the trailing 8-hex hash / "_ws_<8hex>" / ".sessions" so the
+// returned project name matches the user-facing project identifier
+// used by `cc-connect sessions show <project>:<session_id>`. The
+// strict 8-hex length (rather than any-length hex) avoids
+// misclassifying user-chosen project names whose last segment after
+// "_" happens to be valid hex (e.g. "project_a", "foo_dead").
+func extractProjectFromFilename(filename string) string {
+	base := strings.TrimSuffix(filename, ".json")
+	if strings.HasSuffix(base, ".sessions") {
+		return strings.TrimSuffix(base, ".sessions")
+	}
+	if idx := strings.LastIndex(base, "_"); idx >= 0 {
+		suffix := base[idx+1:]
+		if len(suffix) == sessionFileHashLen && isHex(suffix) {
+			stripped := base[:idx]
+			if strings.HasSuffix(stripped, "_ws") {
+				stripped = strings.TrimSuffix(stripped, "_ws")
+			}
+			return stripped
+		}
+	}
+	return base
+}
+
 func loadAllSessions(dataDir string) ([]sessionRecord, error) {
 	sessionsDir := filepath.Join(dataDir, "sessions")
 	entries, err := os.ReadDir(sessionsDir)
@@ -137,7 +176,7 @@ func loadAllSessions(dataDir string) ([]sessionRecord, error) {
 			continue
 		}
 
-		project := strings.TrimSuffix(entry.Name(), ".json")
+		project := extractProjectFromFilename(entry.Name())
 		filePath := filepath.Join(sessionsDir, entry.Name())
 
 		data, err := os.ReadFile(filePath)

--- a/cmd/cc-connect/sessions.go
+++ b/cmd/cc-connect/sessions.go
@@ -150,11 +150,7 @@ func extractProjectFromFilename(filename string) string {
 	if idx := strings.LastIndex(base, "_"); idx >= 0 {
 		suffix := base[idx+1:]
 		if len(suffix) == sessionFileHashLen && isHex(suffix) {
-			stripped := base[:idx]
-			if strings.HasSuffix(stripped, "_ws") {
-				stripped = strings.TrimSuffix(stripped, "_ws")
-			}
-			return stripped
+			return strings.TrimSuffix(base[:idx], "_ws")
 		}
 	}
 	return base

--- a/cmd/cc-connect/sessions_test.go
+++ b/cmd/cc-connect/sessions_test.go
@@ -237,6 +237,80 @@ func writeSessionFile(t *testing.T, dir, name string, data sessionFileData) {
 	}
 }
 
+// TestExtractProjectFromFilename pins the bug where loadAllSessions
+// used to derive the project name by stripping only ".json", leaving
+// the per-work_dir hash suffix in place. That caused
+// `cc-connect sessions list` to display "myproject_a1b2c3d4" and
+// broke `cc-connect sessions show myproject:<sid>` lookups.
+func TestExtractProjectFromFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "myproject.json", "myproject"},
+		{"single-workdir hash", "myproject_a1b2c3d4.json", "myproject"},
+		{"multi-workspace hash", "myproject_ws_a1b2c3d4.json", "myproject"},
+		{"legacy", "myproject.sessions.json", "myproject"},
+		// project names that contain underscores but no 8-hex tail
+		// must be preserved verbatim (regression: previous heuristic
+		// considered any-length hex; now requires exactly 8 hex chars).
+		{"short hex suffix is part of name", "project_a.json", "project_a"},
+		{"4-hex suffix is part of name", "foo_dead.json", "foo_dead"},
+		{"non-hex suffix is part of name", "myproject_extra.json", "myproject_extra"},
+		// real project name happens to end with `_ws_<hex>` pattern
+		{"project with snake_case + hash", "my_project_a1b2c3d4.json", "my_project"},
+		{"project with _ws_ + hash", "my_project_ws_a1b2c3d4.json", "my_project"},
+		// no underscore, no .sessions
+		{"single token", "project.json", "project"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractProjectFromFilename(tt.in); got != tt.want {
+				t.Fatalf("extractProjectFromFilename(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadAllSessions_StripsWorkDirHash exercises loadAllSessions
+// end-to-end against a session file written with the real engine
+// naming convention (myproject_<8hex>.json) and confirms the project
+// name shown to the user no longer carries the hash suffix.
+func TestLoadAllSessions_StripsWorkDirHash(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionsDir := filepath.Join(tmpDir, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	file := sessionFileData{
+		Sessions: map[string]*sessionData{
+			"s1": {ID: "s1", Name: "default", UpdatedAt: now},
+		},
+		UserSessions: map[string][]string{
+			"slack:C123": {"s1"},
+		},
+	}
+	// The 8-hex suffix is what sessionStorePath in main.go produces.
+	writeSessionFile(t, sessionsDir, "myproject_deadbeef.json", file)
+
+	records, err := loadAllSessions(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	if records[0].Project != "myproject" {
+		t.Errorf("Project = %q, want %q", records[0].Project, "myproject")
+	}
+	if records[0].GlobalID != "myproject:s1" {
+		t.Errorf("GlobalID = %q, want %q", records[0].GlobalID, "myproject:s1")
+	}
+}
+
 func TestTruncate(t *testing.T) {
 	tests := []struct {
 		in     string


### PR DESCRIPTION
## Summary

\`loadAllSessions\` in \`cmd/cc-connect/sessions.go\` derived the project label by stripping only the \`.json\` extension:

\`\`\`go
project := strings.TrimSuffix(entry.Name(), \".json\")
\`\`\`

But the engine actually writes session files under four schemes (documented in \`session_id.go:matchesProject\`):

- \`<project>.json\` — no work_dir
- \`<project>_<8hex>.json\` — single work_dir (8-char hash of the absolute path, see \`sessionStorePath\` in \`main.go\`)
- \`<project>_ws_<8hex>.json\` — multi-workspace (see \`core/engine.go\`)
- \`<project>.sessions.json\` — legacy

For a typical session file like \`myproject_deadbeef.json\`, the project label came out as \`myproject_deadbeef\`. That label then went into \`GlobalID = myproject_deadbeef:s1\`, so:

- \`cc-connect sessions list\` displays \`myproject_deadbeef\` instead of \`myproject\`.
- \`cc-connect sessions show myproject:s1\` (the documented address form) can never match — only \`myproject_deadbeef:s1\` does.

## Fix

Add \`extractProjectFromFilename\` that mirrors the four naming schemes and strips the trailing 8-hex hash (or \`_ws_<8hex>\`, or \`.sessions\`). The strict 8-hex length matches the real engine output and avoids misclassifying real project names whose last segment after \`_\` happens to be valid hex (e.g. \`project_a\`, \`foo_dead\`).

No public API change. Existing \`TestLoadAllSessions\` continues to pass because its fixture files (\`project_a.json\`, \`project_b.json\`) don't have an 8-hex tail.

## Tests

- \`TestExtractProjectFromFilename\` — table-tests every scheme, plus the false-positive cases the loose \"any-length hex\" heuristic would have swallowed.
- \`TestLoadAllSessions_StripsWorkDirHash\` — end-to-end: writes a session file named \`myproject_deadbeef.json\` (the real engine format) and asserts \`Project = \"myproject\"\` / \`GlobalID = \"myproject:s1\"\`. With the fix the assertions pass; without the production fix the test reports \`Project = \"myproject_deadbeef\"\`, exactly the buggy output.

## Test plan

- [x] \`go test -tags no_web -count=1 ./cmd/cc-connect/\`
- [x] \`go vet -tags no_web ./cmd/cc-connect/\`