### PR TITLE
fix(agent/claudecode): capture workDir under mutex across all readers

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -409,6 +409,8 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	maxTok := a.maxContextTokens
 	model := a.model
 	effort := a.reasoningEffort
+	workDir := a.workDir
+	mode := a.mode
 	extraEnv := a.runtimeEnvLocked()
 
 	activeIdx := a.activeIdx
@@ -432,7 +434,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, a.workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, a.mode, systemPrompt, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
+	return newClaudeSession(ctx, workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, mode, systemPrompt, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {
@@ -441,7 +443,10 @@ func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, erro
 		return nil, fmt.Errorf("claudecode: cannot determine home dir: %w", err)
 	}
 
-	absWorkDir, err := filepath.Abs(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absWorkDir, err := filepath.Abs(workDir)
 	if err != nil {
 		return nil, fmt.Errorf("claudecode: resolve work_dir: %w", err)
 	}
@@ -494,7 +499,10 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 	if err != nil {
 		return fmt.Errorf("claudecode: cannot determine home dir: %w", err)
 	}
-	absWorkDir, err := filepath.Abs(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absWorkDir, err := filepath.Abs(workDir)
 	if err != nil {
 		return fmt.Errorf("claudecode: resolve work_dir: %w", err)
 	}
@@ -559,7 +567,10 @@ func (a *Agent) GetSessionHistory(_ context.Context, sessionID string, limit int
 	if err != nil {
 		return nil, err
 	}
-	absWorkDir, _ := filepath.Abs(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absWorkDir, _ := filepath.Abs(workDir)
 	projectDir := findProjectDir(homeDir, absWorkDir)
 	if projectDir == "" {
 		return nil, fmt.Errorf("claudecode: project dir not found")
@@ -833,9 +844,12 @@ func (a *Agent) GetDisallowedTools() []string {
 // ── CommandProvider implementation ────────────────────────────
 
 func (a *Agent) CommandDirs() []string {
-	absDir, err := filepath.Abs(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absDir, err := filepath.Abs(workDir)
 	if err != nil {
-		absDir = a.workDir
+		absDir = workDir
 	}
 	dirs := []string{filepath.Join(absDir, ".claude", "commands")}
 	if home, err := os.UserHomeDir(); err == nil {
@@ -847,9 +861,12 @@ func (a *Agent) CommandDirs() []string {
 // ── SkillProvider implementation ──────────────────────────────
 
 func (a *Agent) SkillDirs() []string {
-	absDir, err := filepath.Abs(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absDir, err := filepath.Abs(workDir)
 	if err != nil {
-		absDir = a.workDir
+		absDir = workDir
 	}
 	return appendProjectClaudeSkillDirs(absDir, claudeConfigHomeDir())
 }
@@ -943,9 +960,12 @@ func uniqueSkillDirs(paths []string) []string {
 // ── MemoryFileProvider implementation ─────────────────────────
 
 func (a *Agent) ProjectMemoryFile() string {
-	absDir, err := filepath.Abs(a.workDir)
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absDir, err := filepath.Abs(workDir)
 	if err != nil {
-		absDir = a.workDir
+		absDir = workDir
 	}
 	return filepath.Join(absDir, "CLAUDE.md")
 }

--- a/agent/claudecode/claudecode_workdir_race_test.go
+++ b/agent/claudecode/claudecode_workdir_race_test.go
@@ -1,0 +1,53 @@
+package claudecode
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestClaudecodeAgent_WorkDirRaceFreeReaders pins the bug where
+// ListSessions, DeleteSession, GetSessionHistory, CommandDirs,
+// SkillDirs, and ProjectMemoryFile read a.workDir without holding
+// a.mu, while SetWorkDir writes a.workDir under the lock. Run with
+// -race to detect the data race; with the production fix the
+// detector stays quiet.
+//
+// claudecode is the primary agent and exposes the most readers of
+// the workDir field across the project, so the cumulative impact of
+// this race is the largest of any agent.
+func TestClaudecodeAgent_WorkDirRaceFreeReaders(t *testing.T) {
+	dir := t.TempDir()
+	a := &Agent{workDir: dir}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				a.SetWorkDir(filepath.Join(dir, "a"))
+			} else {
+				a.SetWorkDir(filepath.Join(dir, "b"))
+			}
+		}(i)
+	}
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = a.CommandDirs()
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = a.SkillDirs()
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = a.ProjectMemoryFile()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

\`agent/claudecode/claudecode.go\` has six methods that read \`a.workDir\` (and \`a.mode\` in \`StartSession\`) without holding \`a.mu\`, while \`SetWorkDir\` and \`SetMode\` mutate those fields under the lock. claudecode is the primary agent the project ships against, so this race has the largest cumulative impact of any agent.

Affected readers:

- \`StartSession\` (line 403-435) — the locked block already captures ~10 fields but reads \`a.workDir\` and \`a.mode\` AFTER \`a.mu.Unlock()\` when calling \`newClaudeSession\`.
- \`ListSessions\` (line 444), \`DeleteSession\` (line 497), \`GetSessionHistory\` (line 562) — each calls \`filepath.Abs(a.workDir)\` without the lock.
- \`CommandDirs\` (line 836), \`SkillDirs\` (line 850), \`ProjectMemoryFile\` (line 946) — each reads \`a.workDir\` directly when building user-facing config / skill / memory paths.

When a user issues \`/workspace <dir>\` on one channel/goroutine and a turn start, \`/list\`, a memory-file lookup, or a skill scan runs on another, the readers race with \`SetWorkDir\`. Go strings carry a \`(pointer, length)\` pair; a torn read of a different-length string can produce a frankenstring whose pointer doesn't match its length, leading to memory-safety failures or empty/garbled paths.

The pattern mirrors my recent fixes for codex (#1005), opencode (#1006), and iflow (#996), but is consolidated into one PR for claudecode because all six readers share the same fix shape and live in a single file.

## Fix

- In \`StartSession\`, capture \`workDir := a.workDir\` and \`mode := a.mode\` inside the locked block, then pass the locals to \`newClaudeSession\` instead of re-reading the fields after \`Unlock()\`.
- In each remaining reader, capture \`workDir\` under \`a.mu.RLock()\` and operate on the local copy.

No public API or behaviour change. \`cliBin\`, \`cliExtraArgs\`, \`cliArgsFlag\`, \`routerURL\`, \`spawnOpts\` are set once in \`New\` and never mutated, so they don't need locking — only \`workDir\` and \`mode\` were unsafe.

## Tests

\`TestClaudecodeAgent_WorkDirRaceFreeReaders\` (new file \`agent/claudecode/claudecode_workdir_race_test.go\`) spawns 30 concurrent \`SetWorkDir\` writers and 30 concurrent \`CommandDirs\` / \`SkillDirs\` / \`ProjectMemoryFile\` readers under \`-race\`. With the production fix the race detector stays quiet; stash-reverting just \`agent/claudecode/claudecode.go\` confirms the test trips \"DATA RACE detected\".

## Test plan

- [x] \`go test -tags no_web -race -count=1 -run TestClaudecodeAgent_WorkDirRaceFreeReaders ./agent/claudecode/\`
- [x] \`go test -tags no_web -count=1 ./agent/claudecode/\`
- [x] \`go vet -tags no_web ./agent/claudecode/\`