### PR TITLE
fix(core/cron): CronStore.Get returns shallow copy so callers don't race with writers

### DIFF
--- a/core/cron.go
+++ b/core/cron.go
@@ -252,12 +252,22 @@ func (s *CronStore) ListBySessionKey(sessionKey string) []*CronJob {
 	return out
 }
 
+// Get returns a shallow copy of the job matching id, or nil if not
+// found. Returning a copy (rather than the stored pointer) is what
+// lets callers — executeJob, the management cron PATCH handler, the
+// /cron/edit API echo, etc. — read mutable fields like Prompt,
+// SessionKey, Enabled, LastRun without racing with concurrent
+// Update / SetEnabled / MarkRun writers that grab s.mu. The pointer
+// fields on CronJob (Silent, TimeoutMins) are only ever reassigned
+// to a fresh local in updateJobField, never mutated in place, so a
+// shallow copy is sufficient.
 func (s *CronStore) Get(id string) *CronJob {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, j := range s.jobs {
 		if j.ID == id {
-			return j
+			cp := *j
+			return &cp
 		}
 	}
 	return nil

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -564,4 +565,88 @@ func TestCronStore_ListByProject(t *testing.T) {
 	if len(list3) != 0 {
 		t.Errorf("ListByProject(nonexistent) = %d jobs, want 0", len(list3))
 	}
+}
+
+// TestCronStore_GetReturnsSnapshot pins the bug where CronStore.Get
+// returned the stored *CronJob, so callers (executeJob,
+// handleCronByID's PATCH echo, handleCronEdit's response, the
+// engine's ExecuteCronJob consumer) read mutable fields without
+// holding s.mu while concurrent Update / SetEnabled / MarkRun
+// writers grabbed the lock and rewrote the same fields.
+//
+// With the production fix Get returns a shallow copy, so concurrent
+// readers operate on the snapshot and the race detector stays quiet.
+func TestCronStore_GetReturnsSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job := &CronJob{
+		ID:         "race-target",
+		Project:    "proj",
+		SessionKey: "test:ch1",
+		CronExpr:   "0 6 * * *",
+		Prompt:     "initial",
+		Enabled:    true,
+		CreatedAt:  time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// The returned pointer must NOT alias the stored job. Mutating
+	// the snapshot must leave the store untouched, and the store's
+	// own Update must not be visible through an earlier snapshot.
+	snap := store.Get("race-target")
+	if snap == nil {
+		t.Fatal("Get returned nil for stored job")
+	}
+	snap.Prompt = "mutated by caller"
+	if got := store.Get("race-target").Prompt; got != "initial" {
+		t.Fatalf("caller mutation leaked into store: Prompt = %q, want %q", got, "initial")
+	}
+
+	// Hammer the store with concurrent Updates while readers call
+	// Get and read mutable fields. Under -race, an unsynchronized
+	// read of *job would trip "DATA RACE detected".
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				value := "writer-" + strings.Repeat("x", w%3+1)
+				store.Update("race-target", "prompt", value)
+				store.MarkRun("race-target", nil)
+			}
+		}(w)
+	}
+	for r := 0; r < 8; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				j := store.Get("race-target")
+				if j == nil {
+					continue
+				}
+				_ = j.Prompt
+				_ = j.SessionKey
+				_ = j.Enabled
+				_ = j.LastError
+				_ = j.LastRun
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
 }


### PR DESCRIPTION
## Summary

\`CronStore.Get\` returned the stored \`*CronJob\` directly. The pointer aliased the internal slice entry, so every caller — \`executeJob\`, the management cron PATCH echo (\`core/management.go:1580\`), the \`/cron/edit\` API echo (\`core/api.go:420\`), and the \`engine.ExecuteCronJob\` consumer that reads ~10 fields — then read mutable fields (\`Prompt\`, \`SessionKey\`, \`Enabled\`, \`Project\`, \`LastRun\`, \`LastError\`, \`Mute\`, \`Mode\`, \`SessionMode\`, \`WorkDir\`, \`CronExpr\`) without holding \`s.mu\`.

Meanwhile \`Update\`, \`SetEnabled\`, \`MarkRun\`, \`SetMute\`, and \`ToggleMute\` write those same fields under \`s.mu\`. So:

- A \`cc-connect cron edit <id> prompt …\` landing while the scheduler fires the same job races on the \`Prompt\` string. Go strings carry a \`(pointer, length)\` pair; a torn read of a different-length new prompt can produce a frankenstring with one's pointer and the other's length, leading to memory-safety failures or garbled prompt content reaching the agent.
- The JSON-echo handlers in \`handleCronByID\` and \`handleCronEdit\` race likewise against edits from another API client.

## Fix

Return a shallow copy of the matched \`*CronJob\` from \`Get\`. The pointer fields on \`CronJob\` (\`Silent\`, \`TimeoutMins\`) are only reassigned to a fresh local in \`updateJobField\` — never mutated in place — so a shallow copy is sufficient. The function signature is unchanged: callers still receive \`*CronJob\`, now pointing to a snapshot.

I verified each in-tree caller is compatible with the snapshot semantics:

- \`EnableJob\` (line 503) → reads \`job.ID\` / \`job.CronExpr\` and passes to \`scheduleJob\` (which uses the same two stable fields).
- \`UpdateJob\` first Get (line 530) → existence check only.
- \`UpdateJob\` second Get (line 587) → reads \`Enabled\`, \`ID\`, \`CronExpr\` after the write; a snapshot of the post-write state.
- \`executeJob\` (line 629) → reads many fields and forwards the pointer to \`engine.ExecuteCronJob\`; the engine never mutates the pointed-to struct, just reads fields.
- Management \`/cron PATCH\` (line 1580) and \`/cron/edit\` (api.go:420) → JSON-marshal the result.

## Tests

\`TestCronStore_GetReturnsSnapshot\` covers two legs of the bug:

1. Mutating the returned snapshot must not leak into the store (structural).
2. Under \`-race\`, hammering 8 \`Update\` / \`MarkRun\` writer goroutines against 8 \`Get\` reader goroutines reading \`Prompt\` / \`SessionKey\` / \`Enabled\` / \`LastRun\` / \`LastError\` must produce no data race.

Without the production fix the first leg fails immediately with \`caller mutation leaked into store: Prompt = \"mutated by caller\"\`; with the fix both legs pass clean under \`-race\`.

## Test plan

- [x] \`go test -tags no_web -race -count=1 -run TestCronStore_GetReturnsSnapshot ./core/\`
- [x] \`go test -tags no_web -count=1 -run TestCronStore ./core/\`
- [x] \`go vet -tags no_web ./core/\`
- [x] Full \`./core/\` test pass (pre-existing \`TestProcessInteractiveEvents_*\` and \`TestResolveLocalDirPath_AcceptsSubdir\` failures reproduce on plain \`main\` on macOS — unrelated)