### PR TITLE
fix(core): clear AgentSessionID on /stop and resume failure to prevent recycling loop

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2938,6 +2938,10 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 			slog.Error("session resume failed, falling back to fresh session",
 				"session_key", sessionKey, "failed_session_id", startSessionID,
 				"error", err, "elapsed", startElapsed)
+			// Clear the stale session ID so CompareAndSetAgentSessionID can
+			// write the new ID, matching the relay fallback at line 12640.
+			session.SetAgentSessionID("", agent.Name())
+			sessions.Save()
 			startAt = time.Now()
 			agentSession, err = agent.StartSession(e.ctx, "")
 			startElapsed = time.Since(startAt)
@@ -8014,6 +8018,17 @@ func (e *Engine) cmdTTS(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdStop(p Platform, msg *Message) {
+	// clearStaleSessionID removes the stale AgentSessionID so the next message
+	// starts a fresh agent instead of trying to resume the killed session
+	// (recycling loop — see issue #830).
+	clearStaleSessionID := func() {
+		if _, sessions, _, err := e.commandContext(p, msg); err == nil {
+			s := sessions.GetOrCreateActive(msg.SessionKey)
+			s.SetAgentSessionID("", "")
+			sessions.Save()
+		}
+	}
+
 	iKey := e.interactiveKeyForSessionKey(msg.SessionKey)
 	if !e.stopInteractiveSession(iKey, p, msg.ReplyCtx) {
 		// Fallback: try suffix scan in case interactiveKeyForSessionKey
@@ -8021,6 +8036,7 @@ func (e *Engine) cmdStop(p Platform, msg *Message) {
 		// (e.g. workspace binding lookup inconsistency).
 		if found := e.findInteractiveKeyForSession(msg.SessionKey); found != "" && found != iKey {
 			if e.stopInteractiveSession(found, p, msg.ReplyCtx) {
+				clearStaleSessionID()
 				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgExecutionStopped))
 				return
 			}
@@ -8028,6 +8044,7 @@ func (e *Engine) cmdStop(p Platform, msg *Message) {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgNoExecution))
 		return
 	}
+	clearStaleSessionID()
 	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgExecutionStopped))
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -5860,12 +5860,16 @@ func (s *controllableAgentSession) Close() error {
 
 // controllableAgent lets tests control which session is returned by StartSession.
 type controllableAgent struct {
-	nextSession AgentSession
-	listFn      func() ([]AgentSessionInfo, error)
+	nextSession     AgentSession
+	listFn          func() ([]AgentSessionInfo, error)
+	startSessionFn  func(ctx context.Context, sessionID string) (AgentSession, error)
 }
 
 func (a *controllableAgent) Name() string { return "controllable" }
-func (a *controllableAgent) StartSession(_ context.Context, _ string) (AgentSession, error) {
+func (a *controllableAgent) StartSession(ctx context.Context, sessionID string) (AgentSession, error) {
+	if a.startSessionFn != nil {
+		return a.startSessionFn(ctx, sessionID)
+	}
 	if a.nextSession != nil {
 		return a.nextSession, nil
 	}
@@ -6159,6 +6163,78 @@ func TestSessionIDWriteback_DoesNotOverwriteExisting(t *testing.T) {
 
 	if got != "existing-uuid" {
 		t.Fatalf("AgentSessionID = %q, want %q — writeback should not overwrite", got, "existing-uuid")
+	}
+}
+
+// TestCmdStop_ClearsAgentSessionID verifies that /stop clears the stale
+// AgentSessionID so the next message starts a fresh agent instead of trying
+// to resume the killed session (issue #830).
+func TestCmdStop_ClearsAgentSessionID(t *testing.T) {
+	sess := newControllableSession("agent-1")
+	agent := &controllableAgent{nextSession: sess}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+
+	// Seed a live interactive state.
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Unlock()
+
+	// Set the Session's AgentSessionID to match (simulates a normal turn).
+	active := e.sessions.GetOrCreateActive(key)
+	active.SetAgentSessionID("agent-1", "controllable")
+	e.sessions.Save()
+
+	// Simulate /stop: it uses interactiveKeyForSessionKey internally.
+	msg := &Message{SessionKey: key, ReplyCtx: "ctx"}
+	e.cmdStop(p, msg)
+
+	// After /stop, AgentSessionID must be cleared.
+	got := active.GetAgentSessionID()
+	if got != "" {
+		t.Fatalf("AgentSessionID = %q, want empty after /stop", got)
+	}
+}
+
+// TestResumeFallback_ClearsStaleSessionID verifies that when agent.StartSession
+// fails with a stale session ID and falls back to a fresh session, the stale
+// AgentSessionID is cleared so CompareAndSetAgentSessionID can write the new ID
+// (issue #830, matching the relay fallback at engine.go:12640).
+func TestResumeFallback_ClearsStaleSessionID(t *testing.T) {
+	freshSess := newControllableSession("fresh-id")
+	agent := &controllableAgent{
+		startSessionFn: func(_ context.Context, sessionID string) (AgentSession, error) {
+			if sessionID != "" {
+				return nil, errors.New("session not found")
+			}
+			return freshSess, nil
+		},
+	}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+
+	// Session has a stale AgentSessionID from a previously killed agent.
+	session := &Session{AgentSessionID: "stale-id", AgentType: "controllable"}
+
+	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+
+	// The new agent session should be the fresh one.
+	if state.agentSession != freshSess {
+		t.Fatal("expected fresh agent session from fallback")
+	}
+
+	// The stale ID should have been replaced with the new ID.
+	got := session.GetAgentSessionID()
+	if got != "fresh-id" {
+		t.Fatalf("AgentSessionID = %q, want %q — stale ID should be replaced", got, "fresh-id")
 	}
 }
 


### PR DESCRIPTION
## Summary

After `/stop`, the stale `AgentSessionID` remained on the `Session` object. When the next message arrived, `getOrCreateInteractiveStateWith` passed the dead session ID to `agent.StartSession`, which either failed or produced a new ID that `CompareAndSetAgentSessionID` silently rejected (the old non-empty ID was still stored). This created a **recycling loop** where every message tore down and re-created the agent, losing context.

The same stale-ID problem also existed in the interactive resume fallback path: when `agent.StartSession(ctx, staleID)` failed and fell back to a fresh session, the old ID was never cleared, so `CompareAndSetAgentSessionID` could not write the new ID. The relay path (line 12640) already handled this correctly; the interactive path did not.

## Fix

Two changes in `core/engine.go`:

1. **`cmdStop` (line 7942)**: After stopping the interactive session, look up the `Session` via `commandContext` and call `SetAgentSessionID("", "")` + `Save()`. This prevents the stale ID from causing a recycling loop on the next message.

2. **`getOrCreateInteractiveStateWith` (line 2884)**: When `agent.StartSession(ctx, staleID)` fails and the code falls back to `agent.StartSession(ctx, "")`, clear the stale `AgentSessionID` first via `session.SetAgentSessionID("", agent.Name())` + `sessions.Save()`. This matches the relay fallback pattern at line 12640 and ensures `CompareAndSetAgentSessionID` can write the new ID.

## Tests

- **`TestCmdStop_ClearsAgentSessionID`**: Seeds a live interactive state with `AgentSessionID="agent-1"`, calls `cmdStop`, asserts `AgentSessionID` is empty afterward.
- **`TestResumeFallback_ClearsStaleSessionID`**: Uses a custom `startSessionFn` that fails on resume (non-empty session ID) and succeeds on fresh. Asserts the stale ID is cleared and replaced with the new ID.
- Extended `controllableAgent` test stub with `startSessionFn` field (backward compatible — existing tests pass unchanged).

## Test plan

- [x] `go build ./...`
- [x] `go test ./core/ -run TestCmdStop_ClearsAgentSessionID -v`
- [x] `go test ./core/ -run TestResumeFallback_ClearsStaleSessionID -v`
- [x] `go test ./core/ -run "TestSession|TestCleanup" -v` (existing tests, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)