### PR TITLE
fix(core/relay): unblock HandleRelay when agent goes silent past relay timeout

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -12662,7 +12662,40 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 	}
 
 	var textParts []string
-	for event := range agentSession.Events() {
+	events := agentSession.Events()
+	for {
+		// Use select so a timed-out relay context unblocks even when the
+		// agent has gone silent. Without this, `for event := range
+		// events` would park here past the relay deadline if the agent
+		// is stuck on a tool call, waiting on user input, or otherwise
+		// not emitting events — the relay caller would hang well beyond
+		// the configured relay timeout.
+		var (
+			event Event
+			ok    bool
+		)
+		select {
+		case event, ok = <-events:
+			if !ok {
+				// Event channel closed without EventResult.
+				agentSession.Close()
+				if ctx.Err() != nil {
+					return relayPartialResponseOrError(ctx.Err(), textParts, fromProject, e.name)
+				}
+				if len(textParts) > 0 {
+					return strings.Join(textParts, ""), nil
+				}
+				return "", fmt.Errorf("relay: agent process exited without response")
+			}
+		case <-ctx.Done():
+			// Relay timed out (or was cancelled by the caller). Let the
+			// agent finish its turn in the background so the session
+			// state is saved cleanly and the session remains resumable
+			// for the next relay call.
+			go e.drainRelaySession(agentSession, session, relaySessionKey)
+			return relayPartialResponseOrError(ctx.Err(), textParts, fromProject, e.name)
+		}
+
 		switch event.Type {
 		case EventText:
 			if event.Content != "" {
@@ -12724,25 +12757,12 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, chatID, message s
 			})
 		}
 		if ctx.Err() != nil {
-			// Relay timed out. Let the agent finish its turn in the
-			// background so the session state is saved cleanly and the
-			// session remains resumable for the next relay call.
+			// Relay timed out while we were processing this event. Same
+			// drain path as the select case above.
 			go e.drainRelaySession(agentSession, session, relaySessionKey)
 			return relayPartialResponseOrError(ctx.Err(), textParts, fromProject, e.name)
 		}
 	}
-
-	// Event channel closed without EventResult.
-	agentSession.Close()
-
-	if ctx.Err() != nil {
-		return relayPartialResponseOrError(ctx.Err(), textParts, fromProject, e.name)
-	}
-
-	if len(textParts) > 0 {
-		return strings.Join(textParts, ""), nil
-	}
-	return "", fmt.Errorf("relay: agent process exited without response")
 }
 
 func relayPartialResponseOrError(ctxErr error, textParts []string, fromProject, toProject string) (string, error) {

--- a/core/relay_test.go
+++ b/core/relay_test.go
@@ -91,6 +91,65 @@ func TestHandleRelay_ReturnsPartialOnTimeout(t *testing.T) {
 	}
 }
 
+// TestHandleRelay_UnblocksWhenAgentGoesSilent pins the bug where the
+// event loop used `for event := range agentSession.Events()`, so the
+// goroutine parked on the receive even after the relay context had
+// timed out. If the agent went silent (stuck tool call, slow upstream,
+// hung subprocess), the relay caller waited indefinitely past the
+// configured timeout. With the fix the loop selects on ctx.Done()
+// alongside the event channel, so a silent agent no longer blocks the
+// relay from returning. The agent process is left running by design;
+// drainRelaySession finishes the turn in the background.
+func TestHandleRelay_UnblocksWhenAgentGoesSilent(t *testing.T) {
+	e := newTestEngine()
+	session := newControllableSession("relay-session")
+	e.agent = &controllableAgent{nextSession: session}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	type relayResult struct {
+		resp string
+		err  error
+	}
+	done := make(chan relayResult, 1)
+	go func() {
+		resp, err := e.HandleRelay(ctx, "source", "chat-1", "hello")
+		done <- relayResult{resp: resp, err: err}
+	}()
+
+	// Emit a single text event before going completely silent. We do
+	// NOT send any event after the timeout — the production bug was
+	// exactly that the relay would hang waiting for one.
+	session.events <- Event{Type: EventText, Content: "partial response"}
+
+	// The relay must return within a generous bound: the underlying
+	// ctx deadline is 20ms, so HandleRelay should observe ctx.Done()
+	// within a few hundred ms even with scheduler jitter. Without the
+	// fix the goroutine parks on the channel receive forever.
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("HandleRelay() error = %v, want nil", got.err)
+		}
+		if got.resp != "partial response" {
+			t.Fatalf("HandleRelay() response = %q, want %q", got.resp, "partial response")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleRelay did not return after relay timeout while agent was silent")
+	}
+
+	// Unblock the background drain goroutine so it can close the
+	// session cleanly. (The drain has its own select-on-events; we
+	// still need to send something for it to consume.)
+	session.events <- Event{Type: EventResult, Content: "done"}
+	select {
+	case <-session.closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background drain goroutine did not close the session")
+	}
+}
+
 func TestHandleRelay_TimeoutWithoutTextReturnsContextError(t *testing.T) {
 	e := newTestEngine()
 	session := newControllableSession("relay-session")


### PR DESCRIPTION
## Summary

\`Engine.HandleRelay\` in \`core/engine.go\` reads agent events with:

\`\`\`go
for event := range agentSession.Events() {
    switch event.Type { ... }
    if ctx.Err() != nil {
        go e.drainRelaySession(...)
        return relayPartialResponseOrError(...)
    }
}
\`\`\`

The \`ctx.Err()\` check fires only *after* a new event arrives. If the agent stops emitting events — stuck tool call, hung subprocess, slow upstream LLM, waiting on user input — the range loop parks on the receive past the configured relay timeout (\`relayTimeout\` defaults to 120 s). The relay caller (the other bot) hangs indefinitely; the timeout becomes effectively unbounded as long as the agent isn't talking.

The existing tests work around this by explicitly sending an extra event after the timeout to unblock the for-range. The inline comment in \`TestHandleRelay_TimeoutWithoutTextReturnsContextError\` even says \"One event to unblock HandleRelay's for-range, one for the drain goroutine.\" That workaround is not available in production.

## Fix

Replace the for-range with a select that watches both the events channel and \`ctx.Done()\`. When ctx times out while the agent is silent, spawn the same \`drainRelaySession\` goroutine that already handles the mid-event timeout path, and return through the existing \`relayPartialResponseOrError\` helper. No public API change.

## Tests

\`TestHandleRelay_UnblocksWhenAgentGoesSilent\` emits a single text event then stops sending — the agent silence the production bug relies on. The relay timeout is 20 ms and the test asserts \`HandleRelay\` returns within 2 s.

- With the production fix: \`HandleRelay\` observes \`ctx.Done()\` from the select and returns the partial response immediately.
- Without the fix: stash-reverting \`core/engine.go\` and running this test trips \`HandleRelay did not return after relay timeout while agent was silent\` (verified — see PR description).

The three pre-existing relay tests (\`ReturnsPartialOnTimeout\`, \`TimeoutWithoutTextReturnsContextError\`, \`ResumeFailureFallsBackToFreshSession\`) all continue to pass — the select form is strictly more permissive than the for-range.

## Test plan

- [x] \`go test -tags no_web -count=1 -run TestHandleRelay ./core/\`
- [x] \`go vet -tags no_web ./core/\`
- [x] Full \`./core/\` test pass (pre-existing macOS \`TestProcessInteractiveEvents_*\` and \`TestResolveLocalDirPath_AcceptsSubdir\` failures reproduce on plain \`main\` — unrelated)