### PR TITLE
fix(engine): cmdMode routes through commandContext in multi-workspace mode

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -7745,7 +7745,13 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
-	switcher, ok := e.agent.(ModeSwitcher)
+	agent, _, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+
+	switcher, ok := agent.(ModeSwitcher)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgModeNotSupported))
 		return
@@ -7803,7 +7809,7 @@ func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
 	appliedLive := e.applyLiveModeChange(msg.SessionKey, newMode)
 
 	if !appliedLive {
-		e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+		e.cleanupInteractiveState(interactiveKey)
 	}
 
 	modes := switcher.PermissionModes()

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3822,6 +3822,36 @@ func TestCmdModel_MultiWorkspaceUsesWorkspaceAgentAndSessions(t *testing.T) {
 	}
 }
 
+func TestCmdMode_MultiWorkspaceUsesWorkspaceAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	globalAgent := &stubModelModeAgent{mode: "default"}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+
+	baseDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindingPath)
+
+	wsDir := normalizeWorkspacePath(t.TempDir())
+	channelID := "C-mode"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", wsDir)
+
+	ws := e.workspacePool.GetOrCreate(wsDir)
+	wsAgent := &stubModelModeAgent{mode: "default"}
+	ws.agent = wsAgent
+	ws.sessions = NewSessionManager("")
+
+	msg := &Message{SessionKey: "feishu:" + channelID + ":u1", ReplyCtx: "ctx"}
+
+	e.cmdMode(p, msg, []string{"yolo"})
+
+	if wsAgent.mode != "yolo" {
+		t.Fatalf("workspace agent mode = %q, want yolo", wsAgent.mode)
+	}
+	if globalAgent.mode != "default" {
+		t.Fatalf("global agent mode = %q, want unchanged", globalAgent.mode)
+	}
+}
+
 func TestCmdModel_MultiWorkspaceSwitchDoesNotMutateProviderModel(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	globalAgent := &stubModelModeAgent{model: "gpt-4.1-mini"}


### PR DESCRIPTION
### Problem

`cmdMode` (`core/engine.go`) reads `e.agent.(ModeSwitcher)` directly and, when the live session can not absorb the change, cleans up interactive state via `e.interactiveKeyForSessionKey(msg.SessionKey)`.

In multi-workspace mode, the `/mode` command is then applied to the **global** agent rather than the workspace-bound agent that actually serves that channel:

- `switcher.SetMode(target)` mutates global agent state — the persistent mode on the workspace agent is unchanged, so after `/new` or idle reset the mode silently reverts.
- `cleanupInteractiveState` is called with the session-key-derived global key, not the workspace-prefixed interactive key that the workspace path actually uses.

`cmdModel` already resolves both via `e.commandContext(p, msg)`; `cmdReasoning` has the same bug shape and is being fixed in #993.

### Fix

Route `cmdMode` through `e.commandContext(p, msg)` and use the returned `agent` and `interactiveKey`. No behavior change in single-workspace mode (`commandContext` returns `(e.agent, e.sessions, msg.SessionKey, nil)` when `!e.multiWorkspace`).

### Test

Adds `TestCmdMode_MultiWorkspaceUsesWorkspaceAgent` modeled on `TestCmdModel_MultiWorkspaceUsesWorkspaceAgentAndSessions`. Verified the test fails on unfixed `core/engine.go` (stash-revert) and passes with the fix.

The remaining macOS test failures in `core/` (`TestProcessInteractiveEvents_*ReplyFooter*`, `TestResolveLocalDirPath_AcceptsSubdir`) are pre-existing on `main` and tied to HOME-tilde rendering and `/var` ↔ `/private/var` symlinks — unrelated to this change.