### PR TITLE
fix(engine): cmdProvider routes through commandContext in multi-workspace mode

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -8218,7 +8218,12 @@ func (e *Engine) cmdAllow(p Platform, msg *Message, args []string) {
 }
 
 func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
-	switcher, ok := e.agent.(ProviderSwitcher)
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+	switcher, ok := agent.(ProviderSwitcher)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProviderNotSupported))
 		return
@@ -8303,7 +8308,7 @@ func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
 			e.reply(p, msg.ReplyCtx, "Usage: /provider switch <name>")
 			return
 		}
-		e.switchProvider(p, msg, switcher, args[1])
+		e.switchProvider(p, msg, switcher, sessions, interactiveKey, args[1])
 
 	case "current":
 		current := switcher.GetActiveProvider()
@@ -8315,12 +8320,12 @@ func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
 
 	case "clear", "reset", "none":
 		switcher.SetActiveProvider("")
-		e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+		e.cleanupInteractiveState(interactiveKey)
 		{
-			s := e.sessions.GetOrCreateActive(msg.SessionKey)
+			s := sessions.GetOrCreateActive(msg.SessionKey)
 			s.SetAgentSessionID("", "")
 			s.ClearHistory()
-			e.sessions.Save()
+			sessions.Save()
 		}
 		if e.providerSaveFunc != nil {
 			if err := e.providerSaveFunc(""); err != nil {
@@ -8330,7 +8335,7 @@ func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgProviderCleared))
 
 	default:
-		e.switchProvider(p, msg, switcher, args[0])
+		e.switchProvider(p, msg, switcher, sessions, interactiveKey, args[0])
 	}
 }
 
@@ -8472,17 +8477,17 @@ func (e *Engine) resetAllSessions() {
 	e.sessions.Save()
 }
 
-func (e *Engine) switchProvider(p Platform, msg *Message, switcher ProviderSwitcher, name string) {
+func (e *Engine) switchProvider(p Platform, msg *Message, switcher ProviderSwitcher, sessions *SessionManager, interactiveKey, name string) {
 	if !switcher.SetActiveProvider(name) {
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgProviderNotFound), name))
 		return
 	}
-	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(msg.SessionKey))
+	e.cleanupInteractiveState(interactiveKey)
 
-	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s := sessions.GetOrCreateActive(msg.SessionKey)
 	s.SetAgentSessionID("", "")
 	s.ClearHistory()
-	e.sessions.Save()
+	sessions.Save()
 
 	if e.providerSaveFunc != nil {
 		if err := e.providerSaveFunc(name); err != nil {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3822,6 +3822,59 @@ func TestCmdModel_MultiWorkspaceUsesWorkspaceAgentAndSessions(t *testing.T) {
 	}
 }
 
+func TestCmdProvider_MultiWorkspaceUsesWorkspaceAgentAndSessions(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	globalAgent := &stubModelModeAgent{
+		providers: []ProviderConfig{
+			{Name: "openai", Model: "gpt-4.1-mini"},
+			{Name: "azure", Model: "gpt-4.1-mini"},
+		},
+		active: "openai",
+	}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+
+	baseDir := t.TempDir()
+	bindingPath := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindingPath)
+
+	wsDir := normalizeWorkspacePath(t.TempDir())
+	channelID := "C-provider"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", wsDir)
+
+	ws := e.workspacePool.GetOrCreate(wsDir)
+	wsAgent := &stubModelModeAgent{
+		providers: []ProviderConfig{
+			{Name: "openai", Model: "gpt-4.1-mini"},
+			{Name: "azure", Model: "gpt-4.1-mini"},
+		},
+		active: "openai",
+	}
+	ws.agent = wsAgent
+	ws.sessions = NewSessionManager("")
+
+	msg := &Message{SessionKey: "feishu:" + channelID + ":u1", ReplyCtx: "ctx"}
+
+	globalSession := e.sessions.GetOrCreateActive(msg.SessionKey)
+	globalSession.SetAgentSessionID("global-session", "test")
+	wsSession := ws.sessions.GetOrCreateActive(msg.SessionKey)
+	wsSession.SetAgentSessionID("workspace-session", "test")
+
+	e.cmdProvider(p, msg, []string{"switch", "azure"})
+
+	if got := wsAgent.GetActiveProvider(); got == nil || got.Name != "azure" {
+		t.Fatalf("workspace agent active provider = %#v, want azure", got)
+	}
+	if got := globalAgent.GetActiveProvider(); got == nil || got.Name != "openai" {
+		t.Fatalf("global agent active provider = %#v, want unchanged openai", got)
+	}
+	if got := ws.sessions.GetOrCreateActive(msg.SessionKey).AgentSessionID; got != "" {
+		t.Fatalf("workspace session id = %q, want cleared after provider switch", got)
+	}
+	if got := e.sessions.GetOrCreateActive(msg.SessionKey).AgentSessionID; got != "global-session" {
+		t.Fatalf("global session id = %q, want untouched", got)
+	}
+}
+
 func TestCmdModel_MultiWorkspaceSwitchDoesNotMutateProviderModel(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	globalAgent := &stubModelModeAgent{model: "gpt-4.1-mini"}


### PR DESCRIPTION
### Problem

`cmdProvider` and the `switchProvider` helper in `core/engine.go` resolve the agent and session manager from `e.agent` / `e.sessions` directly, and use `e.interactiveKeyForSessionKey(msg.SessionKey)` for cleanup.

In multi-workspace mode, each channel binding has its own agent + session manager (resolved via `commandContextWithWorkspace`). The current code path therefore:

- mutates the **global** agent's active provider on `/provider switch <name>` instead of the workspace-bound agent — the workspace's subsequent prompts keep using the wrong provider, and the global agent is silently mutated;
- on `/provider clear`, calls `ClearHistory` / `SetAgentSessionID("")` on the global session manager rather than the workspace one;
- cleans up the global interactive key while the workspace's interactive state (keyed `workspace:sessionKey`) is left dangling.

This is the same routing bug already fixed for `cmdModel` and just-merged for `cmdMode` (#1025); `cmdReasoning` has it open in #993.

### Fix

`cmdProvider` now resolves `(agent, sessions, interactiveKey)` via `e.commandContext(p, msg)`. `switchProvider` takes `sessions` and `interactiveKey` as parameters instead of touching globals. No behavior change in single-workspace mode, since `commandContext` returns `(e.agent, e.sessions, msg.SessionKey, nil)` when `!e.multiWorkspace`.

`cmdProviderAdd` / `cmdProviderRemove` already receive `switcher` as a parameter, so they pick up the workspace-bound switcher automatically.

### Test

Adds `TestCmdProvider_MultiWorkspaceUsesWorkspaceAgentAndSessions` modeled on `TestCmdModel_MultiWorkspaceUsesWorkspaceAgentAndSessions`. Verified the new test fails on unfixed `core/engine.go` (stash-revert: `workspace agent active provider = openai, want azure`) and passes with the fix.

Pre-existing macOS-only failures in `core/` (`TestProcessInteractiveEvents_*ReplyFooter*`, `TestResolveLocalDirPath_AcceptsSubdir`) reproduce on `main` and are tied to HOME-tilde rendering / `/var` ↔ `/private/var` symlinks — unrelated to this change.