### PR TITLE
fix(core/tts): EspeakTTS and PicoTTS honor context cancellation

### DIFF
--- a/core/tts.go
+++ b/core/tts.go
@@ -429,7 +429,7 @@ func (e *EspeakTTS) Synthesize(ctx context.Context, text string, opts TTSSynthes
 
 	// Execute espeak command
 	// Use Output() instead of CombinedOutput() to avoid mixing stderr warnings with audio data
-	cmd := exec.Command(e.Path, args...)
+	cmd := exec.CommandContext(ctx, e.Path, args...)
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, "", fmt.Errorf("espeak: voice=%s text=%q: %w", voice, text, err)
@@ -489,7 +489,7 @@ func (p *PicoTTS) Synthesize(ctx context.Context, text string, opts TTSSynthesis
 	}
 
 	// Execute pico2wave command
-	cmd := exec.Command(p.Path, args...)
+	cmd := exec.CommandContext(ctx, p.Path, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, "", fmt.Errorf("pico2wave: voice=%s text=%q: %w, output: %s", voice, text, err, string(output))

--- a/core/tts_test.go
+++ b/core/tts_test.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -473,5 +476,72 @@ func TestEdgeTTS_Synthesize_Integration(t *testing.T) {
 	}
 	if len(audio) == 0 {
 		t.Error("expected non-empty audio data")
+	}
+}
+
+// writeSleepStub creates a temporary executable shell script that ignores all
+// args and sleeps for the given number of seconds. Used by subprocess
+// cancellation tests to stand in for espeak / pico2wave so the test does not
+// depend on those binaries being installed.
+func writeSleepStub(t *testing.T, seconds int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tts-stub.sh")
+	body := fmt.Sprintf("#!/bin/sh\nsleep %d\n", seconds)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return path
+}
+
+func TestEspeakTTS_Synthesize_RespectsContextCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not portable on windows")
+	}
+
+	stub := writeSleepStub(t, 30)
+	tts := NewEspeakTTS(stub, "en")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, _, err := tts.Synthesize(ctx, "hello", TTSSynthesisOpts{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error after context cancel, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("Synthesize took %v after ctx cancel; expected subprocess to be killed promptly", elapsed)
+	}
+}
+
+func TestPicoTTS_Synthesize_RespectsContextCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub not portable on windows")
+	}
+
+	stub := writeSleepStub(t, 30)
+	tts := NewPicoTTS(stub, "en-US")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, _, err := tts.Synthesize(ctx, "hello", TTSSynthesisOpts{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error after context cancel, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("Synthesize took %v after ctx cancel; expected subprocess to be killed promptly", elapsed)
 	}
 }


### PR DESCRIPTION
### Problem

`EspeakTTS.Synthesize` (`core/tts.go:432`) and `PicoTTS.Synthesize` (`core/tts.go:492`) accept a `context.Context` per the `TextToSpeech` interface, but build the subprocess with `exec.Command` instead of `exec.CommandContext`. Their sibling `EdgeTTS.Synthesize` (`core/tts.go:556`) uses `exec.CommandContext(ctx, ...)` for the same interface, so the deviation is unambiguous.

Concrete scenario:

- `Engine.sendTTSReply` (`core/engine.go`) runs `Synthesize` from a goroutine fired after `EventResult` and passes `e.ctx`.
- On engine shutdown `e.cancel()` cancels that context. `EdgeTTS` exits immediately; `EspeakTTS` / `PicoTTS` keep the `espeak` / `pico2wave` child running to completion, blocking shutdown and leaking the goroutine.
- Same hazard for any caller-side per-request timeout context: the timeout silently fails to abort a hung subprocess.

### Fix

Switch both call sites to `exec.CommandContext(ctx, ...)`. No other change required — the local `ctx` parameter is already in scope at both lines.

### Test

Adds `TestEspeakTTS_Synthesize_RespectsContextCancel` and `TestPicoTTS_Synthesize_RespectsContextCancel`. Both write a tempfile shell-script stub that sleeps 30s, point `NewEspeakTTS` / `NewPicoTTS` at it (so the test does not require `espeak` or `pico2wave` to be installed), cancel the context after 100ms, and assert `Synthesize` returns within 5s with a non-nil error.

Verified on the unfixed code with `git stash` the tests fail: Espeak case returns `nil` error (subprocess completed normally after 30s), Pico case takes 31.3s. With the fix both tests pass in ~100ms.

Skipped on Windows where the shell-script stub is not portable.

Pre-existing macOS-only failures in `core/` (`TestProcessInteractiveEvents_*ReplyFooter*`, `TestResolveLocalDirPath_AcceptsSubdir`) reproduce on `main` and are tied to HOME-tilde rendering / `/var` ↔ `/private/var` symlinks — unrelated to this change.