### PR TITLE
feat(core,feishu): per-thread workspace binding with chat-level fallback

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1125,6 +1125,8 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		return e.executeCronShell(effectivePlatform, replyCtx, job)
 	}
 
+	// Expand `/skill ...` prompts to the registered skill's invocation
+	// template (added upstream as the cron skill-expand feature).
 	content := job.Prompt
 	if strings.HasPrefix(content, "/") {
 		parts := strings.Fields(content)
@@ -1136,9 +1138,19 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		}
 	}
 
+	// Set ChannelKey to the platform-supplied thread-aware key so downstream
+	// code (e.g. buildSenderPrompt's [cc-connect chat_id=...] prompt tag)
+	// preserves thread/topic information instead of falling back to
+	// extractChannelID, which would only show the chat ID.
+	var msgChannelKey string
+	if resolver, ok := targetPlatform.(SessionChannelKeyResolver); ok {
+		msgChannelKey = resolver.ChannelKeyForSession(sessionKey)
+	}
+
 	msg := &Message{
 		SessionKey:   sessionKey,
 		Platform:     platformName,
+		ChannelKey:   msgChannelKey,
 		UserID:       "cron",
 		UserName:     "cron",
 		Content:      content,
@@ -1157,8 +1169,8 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		// scheduled inside a topic can find a thread-scoped binding. Fall back
 		// to extractChannelID (chat-only) for platforms with no thread concept.
 		channelID := ""
-		if resolver, ok := targetPlatform.(CronChannelKeyResolver); ok {
-			channelID = resolver.ChannelKeyForCronSession(sessionKey)
+		if resolver, ok := targetPlatform.(SessionChannelKeyResolver); ok {
+			channelID = resolver.ChannelKeyForSession(sessionKey)
 		}
 		if channelID == "" {
 			channelID = extractChannelID(sessionKey)
@@ -13328,6 +13340,35 @@ func extractWorkspaceChannelKey(sessionKey string) string {
 	return workspaceChannelKey(extractPlatformName(sessionKey), extractChannelID(sessionKey))
 }
 
+// workspaceChannelKeyForSessionKey returns the thread-aware workspace binding
+// channel key for a sessionKey. It first asks the owning platform (matched by
+// the session_key prefix) via the optional SessionChannelKeyResolver
+// interface, so platforms that encode thread/topic information into their
+// session keys (Feishu thread_isolation, Discord forum threads, etc.) can
+// preserve that scope. If no platform responds, falls back to
+// extractWorkspaceChannelKey, which is thread-blind.
+//
+// This is used by callers that have a session_key but no live Message —
+// ExecuteCronJob, card renderers like renderListCard, etc.
+func (e *Engine) workspaceChannelKeyForSessionKey(sessionKey string) string {
+	platformName := extractPlatformName(sessionKey)
+	if platformName == "" {
+		return extractWorkspaceChannelKey(sessionKey)
+	}
+	for _, p := range e.platforms {
+		if p.Name() != platformName {
+			continue
+		}
+		if resolver, ok := p.(SessionChannelKeyResolver); ok {
+			if id := resolver.ChannelKeyForSession(sessionKey); id != "" {
+				return workspaceChannelKey(platformName, id)
+			}
+		}
+		break
+	}
+	return extractWorkspaceChannelKey(sessionKey)
+}
+
 // effectiveChannelID returns the channel identifier from a Message.
 // It prefers the platform-provided ChannelKey (e.g. "chatID:threadID" for forum topics)
 // and falls back to parsing the session key.
@@ -13416,7 +13457,11 @@ func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager
 	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return e.agent, e.sessions
 	}
-	if channelKey := extractWorkspaceChannelKey(sessionKey); channelKey != "" {
+	// Use the thread-aware key when the owning platform supports it, so
+	// thread-scoped bindings created by `/workspace bind -t` are honored by
+	// card renderers, /switch, /list, /current, and other lookups that only
+	// have the sessionKey.
+	if channelKey := e.workspaceChannelKeyForSessionKey(sessionKey); channelKey != "" {
 		if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
 			if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(normalizeWorkspacePath(b.Workspace)); err == nil {
 				return wsAgent, wsSessions
@@ -13499,7 +13544,7 @@ func (e *Engine) interactiveKeyForSessionKeyLocked(sessionKey string) string {
 	if _, ok := e.interactiveStates[sessionKey]; ok {
 		return sessionKey
 	}
-	if channelKey := extractWorkspaceChannelKey(sessionKey); channelKey != "" {
+	if channelKey := e.workspaceChannelKeyForSessionKey(sessionKey); channelKey != "" {
 		if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
 			return normalizeWorkspacePath(b.Workspace) + ":" + sessionKey
 		}

--- a/core/engine.go
+++ b/core/engine.go
@@ -13273,6 +13273,37 @@ func effectiveWorkspaceChannelKey(msg *Message) string {
 	return extractWorkspaceChannelKey(msg.SessionKey)
 }
 
+// parentWorkspaceChannelKey returns the parent-scope workspace binding key by
+// stripping the last colon-separated segment, while preserving the platform
+// prefix. Used for hierarchical fallback (e.g. thread → chat). Returns "" if
+// the key is already at the platform-scoped chat level or has no parent.
+func parentWorkspaceChannelKey(channelKey string) string {
+	if channelKey == "" {
+		return ""
+	}
+	i := strings.LastIndexByte(channelKey, ':')
+	if i <= 0 {
+		return ""
+	}
+	parent := channelKey[:i]
+	// Refuse to strip below the platform prefix: "feishu" alone is not a key.
+	if !strings.ContainsRune(parent, ':') {
+		return ""
+	}
+	return parent
+}
+
+// parentChannelID returns the parent scope of a channel identifier by
+// stripping the last colon-separated segment. Used by name resolution for
+// hierarchical scope ascent (e.g. "chatID:threadID" → "chatID"). Returns ""
+// when there is no further parent.
+func parentChannelID(channelID string) string {
+	if i := strings.LastIndexByte(channelID, ':'); i > 0 {
+		return channelID[:i]
+	}
+	return ""
+}
+
 // commandContext resolves the appropriate agent, session manager, and interactive key
 // for a command. In multi-workspace mode, it routes to the bound workspace if present.
 func (e *Engine) commandContext(p Platform, msg *Message) (Agent, *SessionManager, string, error) {
@@ -13449,22 +13480,41 @@ func findInteractiveKeyInStatesLocked(states map[string]*interactiveState, sessi
 
 // lookupEffectiveWorkspaceBinding returns the effective binding for a channel
 // plus whether the bound workspace is currently usable.
+//
+// When the exact channel key has no binding, the lookup ascends to parent
+// scopes (e.g. "feishu:chatID:rootID" → "feishu:chatID") so that messages in
+// a thread/topic inherit the parent chat's workspace by default. A
+// thread-specific binding (created by running `/workspace bind` inside the
+// thread) shadows the parent and is returned first.
 func (e *Engine) lookupEffectiveWorkspaceBinding(channelKey string) (*WorkspaceBinding, string, bool) {
 	if !e.multiWorkspace || e.workspaceBindings == nil || channelKey == "" {
 		return nil, "", false
 	}
 
 	projectKey := "project:" + e.name
-	b, bindingKey := e.workspaceBindings.LookupEffective(projectKey, channelKey)
+	lookupKey := channelKey
+	var b *WorkspaceBinding
+	var bindingKey string
+	for {
+		b, bindingKey = e.workspaceBindings.LookupEffective(projectKey, lookupKey)
+		if b != nil {
+			break
+		}
+		parent := parentWorkspaceChannelKey(lookupKey)
+		if parent == "" {
+			break
+		}
+		lookupKey = parent
+	}
 	if b == nil {
 		return nil, "", false
 	}
 
 	if _, err := os.Stat(b.Workspace); err != nil {
 		slog.Warn("bound workspace directory missing",
-			"workspace", b.Workspace, "channel_key", channelKey, "binding_scope", bindingKey)
+			"workspace", b.Workspace, "channel_key", lookupKey, "binding_scope", bindingKey)
 		if bindingKey != sharedWorkspaceBindingsKey {
-			e.workspaceBindings.Unbind(bindingKey, channelKey)
+			e.workspaceBindings.Unbind(bindingKey, lookupKey)
 		}
 		return b, bindingKey, false
 	}
@@ -13478,7 +13528,8 @@ func (e *Engine) lookupEffectiveWorkspaceBinding(channelKey string) (*WorkspaceB
 func (e *Engine) resolveWorkspace(p Platform, channelID string) (string, string, error) {
 	channelKey := workspaceChannelKey(p.Name(), channelID)
 
-	// Step 1: Check existing binding
+	// Step 1: Check existing binding (with hierarchical fallback to parent
+	// scopes, e.g. thread → chat).
 	if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); b != nil {
 		if !usable {
 			return "", b.ChannelName, nil
@@ -13486,14 +13537,27 @@ func (e *Engine) resolveWorkspace(p Platform, channelID string) (string, string,
 		return normalizeWorkspacePath(b.Workspace), b.ChannelName, nil
 	}
 
-	// Step 2: Resolve channel name for convention match
+	// Step 2: Resolve channel name for convention match. For sub-scopes
+	// (e.g. "chatID:rootID"), ascend to the parent ID — the platform's
+	// name resolver typically only knows the chat itself, not its threads.
+	nameLookupID := channelID
+	nameLookupKey := channelKey
 	channelName := ""
 	if resolver, ok := p.(ChannelNameResolver); ok {
-		name, err := resolver.ResolveChannelName(channelID)
-		if err != nil {
-			slog.Warn("failed to resolve channel name", "channel", channelID, "err", err)
-		} else {
-			channelName = name
+		for {
+			name, err := resolver.ResolveChannelName(nameLookupID)
+			if err != nil {
+				slog.Warn("failed to resolve channel name", "channel", nameLookupID, "err", err)
+			} else if name != "" {
+				channelName = name
+				break
+			}
+			parent := parentChannelID(nameLookupID)
+			if parent == "" {
+				break
+			}
+			nameLookupID = parent
+			nameLookupKey = workspaceChannelKey(p.Name(), nameLookupID)
 		}
 	}
 
@@ -13501,15 +13565,16 @@ func (e *Engine) resolveWorkspace(p Platform, channelID string) (string, string,
 		return "", "", nil
 	}
 
-	// Step 3: Convention match — check if base_dir/<channel-name> exists
+	// Step 3: Convention match — check if base_dir/<channel-name> exists.
+	// Auto-bind under the scope that resolved the name (typically chat-level,
+	// not thread-level) so sibling threads inherit the same workspace.
 	candidate := filepath.Join(e.baseDir, channelName)
 	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-		// Auto-bind
 		projectKey := "project:" + e.name
 		normalized := normalizeWorkspacePath(candidate)
-		e.workspaceBindings.Bind(projectKey, channelKey, channelName, normalized)
+		e.workspaceBindings.Bind(projectKey, nameLookupKey, channelName, normalized)
 		slog.Info("workspace auto-bound by convention",
-			"channel", channelName, "workspace", normalized)
+			"channel", channelName, "workspace", normalized, "binding_key", nameLookupKey)
 		return normalized, channelName, nil
 	}
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -1153,7 +1153,16 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 	workspaceDir := ""
 
 	if e.multiWorkspace {
-		channelID := extractChannelID(sessionKey)
+		// Prefer the platform-supplied thread-aware channel key so cron jobs
+		// scheduled inside a topic can find a thread-scoped binding. Fall back
+		// to extractChannelID (chat-only) for platforms with no thread concept.
+		channelID := ""
+		if resolver, ok := targetPlatform.(CronChannelKeyResolver); ok {
+			channelID = resolver.ChannelKeyForCronSession(sessionKey)
+		}
+		if channelID == "" {
+			channelID = extractChannelID(sessionKey)
+		}
 		if channelID != "" {
 			workspace, _, err := e.resolveWorkspace(targetPlatform, channelID)
 			if err == nil && workspace != "" {
@@ -4946,8 +4955,46 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 
 func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string) {
 	channelID := effectiveChannelID(msg)
-	channelKey := effectiveWorkspaceChannelKey(msg)
+	// threadKey is the most specific channel key (chat:thread for platforms in
+	// thread/topic mode). chatKey is always the chat-level key (thread stripped).
+	// Write operations default to chatKey so a single bind covers the whole
+	// group; the -t / --topic flag opts in to threadKey for per-topic overrides.
+	// Read operations (status, list) continue to use threadKey so the existing
+	// thread→chat hierarchical fallback in lookupEffectiveWorkspaceBinding
+	// still produces the correct effective binding for any message.
+	threadKey := effectiveWorkspaceChannelKey(msg)
+	chatKey := workspaceChannelKey(p.Name(), extractChannelID(msg.SessionKey))
 	projectKey := "project:" + e.name
+
+	// parseScopeFlag scans args for -t / --topic (any position), returns the
+	// flag value and the remaining positional args in order.
+	parseScopeFlag := func(in []string) (bool, []string) {
+		threadScope := false
+		rest := make([]string, 0, len(in))
+		for _, a := range in {
+			if a == "-t" || a == "--topic" {
+				threadScope = true
+				continue
+			}
+			rest = append(rest, a)
+		}
+		return threadScope, rest
+	}
+
+	// pickBindingKey returns the channel key to use for a write op based on
+	// the -t flag. Without -t: chat scope. With -t: thread scope, unless the
+	// current message has no thread context (DM / non-isolated group), in
+	// which case it sends an error reply and returns ok=false.
+	pickBindingKey := func(threadScope bool) (string, bool) {
+		if !threadScope {
+			return chatKey, true
+		}
+		if threadKey == "" || threadKey == chatKey {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsTopicFlagInvalid))
+			return "", false
+		}
+		return threadKey, true
+	}
 	resolveChannelName := func() func() string {
 		resolved := false
 		channelName := ""
@@ -4969,7 +5016,7 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 		}
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsInfo, b.Workspace, b.BoundAt.Format(time.RFC3339)))
 	}
-	routeWorkspace := func(bindingKey string, pathParts []string, usageKey, successKey MsgKey) bool {
+	routeWorkspace := func(bindingKey, channelKey string, pathParts []string, usageKey, successKey MsgKey) bool {
 		routePath := strings.TrimSpace(strings.Join(pathParts, " "))
 		if routePath == "" {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(usageKey))
@@ -4999,7 +5046,7 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(successKey, normalizedPath))
 		return true
 	}
-	bindWorkspace := func(bindingKey, wsName string, successKey MsgKey) bool {
+	bindWorkspace := func(bindingKey, channelKey, wsName string, successKey MsgKey) bool {
 		wsPath := filepath.Join(e.baseDir, wsName)
 
 		// Check if workspace directory exists
@@ -5012,7 +5059,7 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(successKey, wsName))
 		return true
 	}
-	initWorkspace := func(bindingKey, target string, successKey MsgKey) bool {
+	initWorkspace := func(bindingKey, channelKey, target string, localKey, existingKey, cloneKey MsgKey) bool {
 		// Support local directory paths (absolute or relative to baseDir).
 		if e.workspaceInitAllowLocalPaths && looksLikeLocalDir(target) {
 			dirPath, err := resolveLocalDirPath(target, e.baseDir)
@@ -5026,7 +5073,7 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 				return false
 			}
 			e.workspaceBindings.Bind(bindingKey, channelKey, resolveChannelName(), normalizeWorkspacePath(dirPath))
-			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsBindSuccess, dirPath))
+			e.reply(p, msg.ReplyCtx, e.i18n.Tf(localKey, dirPath))
 			return true
 		}
 		if !e.workspaceInitAllowLocalPaths && looksLikeLocalDir(target) && !looksLikeGitURL(target) {
@@ -5044,7 +5091,7 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 
 		if _, err := os.Stat(cloneTo); err == nil {
 			e.workspaceBindings.Bind(bindingKey, channelKey, resolveChannelName(), normalizeWorkspacePath(cloneTo))
-			e.reply(p, msg.ReplyCtx, e.i18n.Tf(successKey, cloneTo))
+			e.reply(p, msg.ReplyCtx, e.i18n.Tf(existingKey, cloneTo))
 			return true
 		}
 
@@ -5056,7 +5103,7 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 		}
 
 		e.workspaceBindings.Bind(bindingKey, channelKey, resolveChannelName(), normalizeWorkspacePath(cloneTo))
-		e.reply(p, msg.ReplyCtx, e.i18n.Tf(successKey, cloneTo))
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(cloneKey, cloneTo))
 		return true
 	}
 	listBindings := func(bindingKey string, emptyKey, titleKey MsgKey) {
@@ -5084,7 +5131,9 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 
 	switch subCmd {
 	case "":
-		b, bindingKey, usable := e.lookupEffectiveWorkspaceBinding(channelKey)
+		// Status lookup uses the thread-aware key so the hierarchical fallback
+		// in lookupEffectiveWorkspaceBinding can ascend thread → chat.
+		b, bindingKey, usable := e.lookupEffectiveWorkspaceBinding(threadKey)
 		if !usable {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsNoBinding))
 		} else {
@@ -5092,34 +5141,53 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 		}
 
 	case "bind":
-		if len(args) < 2 {
+		threadScope, rest := parseScopeFlag(args[1:])
+		if len(rest) < 1 {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsBindUsage))
 			return
 		}
-		bindWorkspace(projectKey, args[1], MsgWsBindSuccess)
+		key, ok := pickBindingKey(threadScope)
+		if !ok {
+			return
+		}
+		bindWorkspace(projectKey, key, rest[0], MsgWsBindSuccess)
 
 	case "route":
-		if len(args) < 2 {
+		threadScope, rest := parseScopeFlag(args[1:])
+		if len(rest) < 1 {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsRouteUsage))
 			return
 		}
-		routeWorkspace(projectKey, args[1:], MsgWsRouteUsage, MsgWsRouteSuccess)
+		key, ok := pickBindingKey(threadScope)
+		if !ok {
+			return
+		}
+		routeWorkspace(projectKey, key, rest, MsgWsRouteUsage, MsgWsRouteSuccess)
 
 	case "init":
-		if len(args) < 2 {
+		threadScope, rest := parseScopeFlag(args[1:])
+		if len(rest) < 1 {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsInitUsage))
 			return
 		}
-		initWorkspace(projectKey, args[1], MsgWsCloneSuccess)
+		key, ok := pickBindingKey(threadScope)
+		if !ok {
+			return
+		}
+		initWorkspace(projectKey, key, rest[0], MsgWsBindLocalSuccess, MsgWsBindExistingSuccess, MsgWsCloneSuccess)
 
 	case "shared":
+		// Shared bindings are a cross-project fallback layer. Topic-scope
+		// shared bindings are niche enough that we keep this subcommand
+		// chat-only — simpler API, simpler docs. Use the regular
+		// `/workspace bind -t` if you need per-topic granularity.
 		sharedSubCmd := ""
 		if len(args) > 1 {
 			sharedSubCmd = matchSubCommand(args[1], []string{"init", "bind", "route", "unbind", "list"})
 		}
 		switch sharedSubCmd {
 		case "":
-			b := e.workspaceBindings.Lookup(sharedWorkspaceBindingsKey, channelKey)
+			b := e.workspaceBindings.Lookup(sharedWorkspaceBindingsKey, chatKey)
 			if b == nil {
 				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsSharedNoBinding))
 			} else {
@@ -5131,28 +5199,28 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsSharedUsage))
 				return
 			}
-			bindWorkspace(sharedWorkspaceBindingsKey, args[2], MsgWsSharedBindSuccess)
+			bindWorkspace(sharedWorkspaceBindingsKey, chatKey, args[2], MsgWsSharedBindSuccess)
 			return
 		case "route":
 			if len(args) < 3 {
 				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsSharedUsage))
 				return
 			}
-			routeWorkspace(sharedWorkspaceBindingsKey, args[2:], MsgWsSharedUsage, MsgWsSharedRouteSuccess)
+			routeWorkspace(sharedWorkspaceBindingsKey, chatKey, args[2:], MsgWsSharedUsage, MsgWsSharedRouteSuccess)
 			return
 		case "init":
 			if len(args) < 3 {
 				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsSharedUsage))
 				return
 			}
-			initWorkspace(sharedWorkspaceBindingsKey, args[2], MsgWsSharedBindSuccess)
+			initWorkspace(sharedWorkspaceBindingsKey, chatKey, args[2], MsgWsSharedBindSuccess, MsgWsSharedBindSuccess, MsgWsSharedBindSuccess)
 			return
 		case "unbind":
-			if e.workspaceBindings.Lookup(sharedWorkspaceBindingsKey, channelKey) == nil {
+			if e.workspaceBindings.Lookup(sharedWorkspaceBindingsKey, chatKey) == nil {
 				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsSharedNoBinding))
 				return
 			}
-			e.workspaceBindings.Unbind(sharedWorkspaceBindingsKey, channelKey)
+			e.workspaceBindings.Unbind(sharedWorkspaceBindingsKey, chatKey)
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsSharedUnbindSuccess))
 			return
 		case "list":
@@ -5164,15 +5232,20 @@ func (e *Engine) handleWorkspaceCommand(p Platform, msg *Message, args []string)
 		}
 
 	case "unbind":
-		if e.workspaceBindings.Lookup(projectKey, channelKey) == nil {
-			if e.workspaceBindings.Lookup(sharedWorkspaceBindingsKey, channelKey) != nil {
+		threadScope, _ := parseScopeFlag(args[1:])
+		key, ok := pickBindingKey(threadScope)
+		if !ok {
+			return
+		}
+		if e.workspaceBindings.Lookup(projectKey, key) == nil {
+			if e.workspaceBindings.Lookup(sharedWorkspaceBindingsKey, key) != nil {
 				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsSharedOnlyHint))
 			} else {
 				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsNoBinding))
 			}
 			return
 		}
-		e.workspaceBindings.Unbind(projectKey, channelKey)
+		e.workspaceBindings.Unbind(projectKey, key)
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWsUnbindSuccess))
 
 	case "list":

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -10072,6 +10072,43 @@ func TestWorkspace_Init_LocalDirAbsolute(t *testing.T) {
 	}
 }
 
+func TestWorkspace_Init_LocalDirUsesBindWording(t *testing.T) {
+	// Regression: /workspace init <local-dir> previously replied with the
+	// "Repository cloned successfully" message even though no clone occurred.
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+
+	baseDir := t.TempDir()
+	wsDir := filepath.Join(baseDir, "my-project")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bindStore := filepath.Join(t.TempDir(), "bindings.json")
+	e.SetMultiWorkspace(baseDir, bindStore)
+	e.SetWorkspaceInitAllowLocalPaths(true)
+
+	msg := &Message{
+		SessionKey: "test:ch1:user1",
+		Content:    "/workspace init " + wsDir,
+		ReplyCtx:   "ctx",
+		UserID:     "user1",
+	}
+	e.handleCommand(p, msg, msg.Content)
+
+	sent := p.getSent()
+	if len(sent) == 0 {
+		t.Fatalf("expected a reply, got none")
+	}
+	for _, m := range sent {
+		if strings.Contains(strings.ToLower(m), "clone") {
+			t.Fatalf("reply should not mention clone for local-dir init, got: %v", sent)
+		}
+	}
+	if !strings.Contains(sent[0], "bound") {
+		t.Fatalf("expected reply to mention 'bound', got: %v", sent)
+	}
+}
+
 func TestWorkspace_Init_LocalDirRelative(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -612,10 +612,13 @@ const (
 	MsgWsResolutionError        MsgKey = "ws_resolution_error"
 	MsgWsCloneProgress          MsgKey = "ws_clone_progress"
 	MsgWsCloneSuccess           MsgKey = "ws_clone_success"
+	MsgWsBindLocalSuccess       MsgKey = "ws_bind_local_success"
+	MsgWsBindExistingSuccess    MsgKey = "ws_bind_existing_success"
 	MsgWsCloneFailed            MsgKey = "ws_clone_failed"
 	MsgWsInitDirNotFound        MsgKey = "ws_init_dir_not_found"
 	MsgWsInitInvalidTarget      MsgKey = "ws_init_invalid_target"
 	MsgWsInitLocalPathsDisabled MsgKey = "ws_init_local_paths_disabled"
+	MsgWsTopicFlagInvalid       MsgKey = "ws_topic_flag_invalid"
 	MsgBackgroundAutoDenied     MsgKey = "background_auto_denied"
 )
 
@@ -3757,18 +3760,18 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Uso: `/workspace [bind <nombre> | route <ruta-absoluta> | init <url> | unbind | list | shared ...]`",
 	},
 	MsgWsInitUsage: {
-		LangEnglish:            "Usage: `/workspace init <git-url or directory-path>`",
-		LangChinese:            "用法: `/workspace init <git仓库地址或目录路径>`",
-		LangTraditionalChinese: "用法: `/workspace init <git倉庫地址或目錄路徑>`",
-		LangJapanese:           "使い方: `/workspace init <git-urlまたはディレクトリパス>`",
-		LangSpanish:            "Uso: `/workspace init <git-url o ruta-de-directorio>`",
+		LangEnglish:            "Usage: `/workspace init [-t|--topic] <git-url or directory-path>` — defaults to chat scope; -t binds only the current topic.",
+		LangChinese:            "用法: `/workspace init [-t|--topic] <git仓库地址或目录路径>` — 默认绑定整个群,-t 仅绑定当前话题。",
+		LangTraditionalChinese: "用法: `/workspace init [-t|--topic] <git倉庫地址或目錄路徑>` — 預設綁定整個群,-t 僅綁定當前話題。",
+		LangJapanese:           "使い方: `/workspace init [-t|--topic] <git-urlまたはディレクトリパス>` — 既定でチャット全体、-t を付けると現在のトピックのみ。",
+		LangSpanish:            "Uso: `/workspace init [-t|--topic] <git-url o ruta-de-directorio>` — por defecto vincula todo el chat; -t vincula solo el tema actual.",
 	},
 	MsgWsBindUsage: {
-		LangEnglish:            "Usage: `/workspace bind <workspace-name>`",
-		LangChinese:            "用法: `/workspace bind <工作区名称>`",
-		LangTraditionalChinese: "用法: `/workspace bind <工作區名稱>`",
-		LangJapanese:           "使い方: `/workspace bind <ワークスペース名>`",
-		LangSpanish:            "Uso: `/workspace bind <nombre-workspace>`",
+		LangEnglish:            "Usage: `/workspace bind [-t|--topic] <workspace-name>` — defaults to chat scope; -t binds only the current topic.",
+		LangChinese:            "用法: `/workspace bind [-t|--topic] <工作区名称>` — 默认绑定整个群,-t 仅绑定当前话题。",
+		LangTraditionalChinese: "用法: `/workspace bind [-t|--topic] <工作區名稱>` — 預設綁定整個群,-t 僅綁定當前話題。",
+		LangJapanese:           "使い方: `/workspace bind [-t|--topic] <ワークスペース名>` — 既定でチャット全体、-t を付けると現在のトピックのみ。",
+		LangSpanish:            "Uso: `/workspace bind [-t|--topic] <nombre-workspace>` — por defecto vincula todo el chat; -t vincula solo el tema actual.",
 	},
 	MsgWsBindSuccess: {
 		LangEnglish:            "✅ Workspace bound: `%s`",
@@ -3785,11 +3788,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Workspace no encontrado: `%s`",
 	},
 	MsgWsRouteUsage: {
-		LangEnglish:            "Usage: `/workspace route <absolute-path>`",
-		LangChinese:            "用法: `/workspace route <绝对路径>`",
-		LangTraditionalChinese: "用法: `/workspace route <絕對路徑>`",
-		LangJapanese:           "使い方: `/workspace route <絶対パス>`",
-		LangSpanish:            "Uso: `/workspace route <ruta-absoluta>`",
+		LangEnglish:            "Usage: `/workspace route [-t|--topic] <absolute-path>` — defaults to chat scope; -t binds only the current topic.",
+		LangChinese:            "用法: `/workspace route [-t|--topic] <绝对路径>` — 默认绑定整个群,-t 仅绑定当前话题。",
+		LangTraditionalChinese: "用法: `/workspace route [-t|--topic] <絕對路徑>` — 預設綁定整個群,-t 僅綁定當前話題。",
+		LangJapanese:           "使い方: `/workspace route [-t|--topic] <絶対パス>` — 既定でチャット全体、-t を付けると現在のトピックのみ。",
+		LangSpanish:            "Uso: `/workspace route [-t|--topic] <ruta-absoluta>` — por defecto vincula todo el chat; -t vincula solo el tema actual.",
 	},
 	MsgWsRouteSuccess: {
 		LangEnglish:            "✅ Workspace routed: `%s`",
@@ -3848,11 +3851,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "No hay workspace compartido vinculado a este canal.",
 	},
 	MsgWsSharedUsage: {
-		LangEnglish:            "Usage: `/workspace shared [bind <name> | route <absolute-path> | init <url> | unbind | list]`",
-		LangChinese:            "用法: `/workspace shared [bind <名称> | route <绝对路径> | init <仓库地址> | unbind | list]`",
-		LangTraditionalChinese: "用法: `/workspace shared [bind <名稱> | route <絕對路徑> | init <倉庫地址> | unbind | list]`",
-		LangJapanese:           "使い方: `/workspace shared [bind <名前> | route <絶対パス> | init <url> | unbind | list]`",
-		LangSpanish:            "Uso: `/workspace shared [bind <nombre> | route <ruta-absoluta> | init <url> | unbind | list]`",
+		LangEnglish:            "Usage: `/workspace shared [bind <name> | route <absolute-path> | init <url> | unbind | list]` — chat-scope only.",
+		LangChinese:            "用法: `/workspace shared [bind <名称> | route <绝对路径> | init <仓库地址> | unbind | list]` — 仅支持群级绑定。",
+		LangTraditionalChinese: "用法: `/workspace shared [bind <名稱> | route <絕對路徑> | init <倉庫地址> | unbind | list]` — 僅支援群級綁定。",
+		LangJapanese:           "使い方: `/workspace shared [bind <名前> | route <絶対パス> | init <url> | unbind | list]` — チャット全体のみ。",
+		LangSpanish:            "Uso: `/workspace shared [bind <nombre> | route <ruta-absoluta> | init <url> | unbind | list]` — solo a nivel de chat.",
 	},
 	MsgWsSharedBindSuccess: {
 		LangEnglish:            "✅ Shared workspace bound: `%s`",
@@ -3931,6 +3934,20 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "✅ リポジトリのクローンに成功しました: `%s`",
 		LangSpanish:            "✅ Repositorio clonado exitosamente: `%s`",
 	},
+	MsgWsBindLocalSuccess: {
+		LangEnglish:            "✅ Local directory bound: `%s`",
+		LangChinese:            "✅ 已绑定本地目录: `%s`",
+		LangTraditionalChinese: "✅ 已綁定本地目錄: `%s`",
+		LangJapanese:           "✅ ローカルディレクトリをバインドしました: `%s`",
+		LangSpanish:            "✅ Directorio local vinculado: `%s`",
+	},
+	MsgWsBindExistingSuccess: {
+		LangEnglish:            "✅ Directory already exists, bound: `%s`",
+		LangChinese:            "✅ 目录已存在，已绑定: `%s`",
+		LangTraditionalChinese: "✅ 目錄已存在，已綁定: `%s`",
+		LangJapanese:           "✅ ディレクトリは既に存在します。バインドしました: `%s`",
+		LangSpanish:            "✅ El directorio ya existe, vinculado: `%s`",
+	},
 	MsgWsCloneFailed: {
 		LangEnglish:            "❌ Failed to clone repository: %v",
 		LangChinese:            "❌ 克隆仓库失败: %v",
@@ -3958,6 +3975,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "`/workspace init` 未啟用本機目錄目標。請使用 git 倉庫地址，或在此專案配置 `workspace_init_allow_local_paths = true`。",
 		LangJapanese:           "`/workspace init` ではローカルディレクトリ対象が無効です。git URL を使うか、このプロジェクトで `workspace_init_allow_local_paths = true` を有効にしてください。",
 		LangSpanish:            "Los destinos de directorio local están deshabilitados para `/workspace init`. Use una URL de git o habilite `workspace_init_allow_local_paths = true` para este proyecto.",
+	},
+	MsgWsTopicFlagInvalid: {
+		LangEnglish:            "`-t`/`--topic` is only valid inside a topic/thread; this channel has no topic scope.",
+		LangChinese:            "`-t`/`--topic` 只能在话题/线程内使用,当前频道没有话题维度。",
+		LangTraditionalChinese: "`-t`/`--topic` 只能在話題/執行緒內使用,當前頻道沒有話題維度。",
+		LangJapanese:           "`-t`/`--topic` はトピック/スレッド内でのみ有効です。このチャンネルにはトピック粒度がありません。",
+		LangSpanish:            "`-t`/`--topic` solo es válido dentro de un tema/hilo; este canal no tiene ese alcance.",
 	},
 }
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -42,6 +42,19 @@ type CronReplyTargetResolver interface {
 	ResolveCronReplyTarget(sessionKey string, title string) (resolvedSessionKey string, replyCtx any, err error)
 }
 
+// CronChannelKeyResolver is an optional interface for platforms that encode
+// thread/topic information into their session keys. ExecuteCronJob calls this
+// to derive the workspace-binding channel ID (e.g. "chat:thread") when looking
+// up a per-thread workspace binding, instead of falling back to the
+// thread-blind extractChannelID. Platforms that have no thread concept can
+// omit this interface; the engine will use extractChannelID by default.
+//
+// Returning an empty string is equivalent to "no thread info" and falls back
+// to extractChannelID.
+type CronChannelKeyResolver interface {
+	ChannelKeyForCronSession(sessionKey string) string
+}
+
 // SessionEnvInjector is an optional interface for agents that accept
 // per-session environment variables (e.g. CC_PROJECT, CC_SESSION_KEY).
 type SessionEnvInjector interface {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -42,17 +42,21 @@ type CronReplyTargetResolver interface {
 	ResolveCronReplyTarget(sessionKey string, title string) (resolvedSessionKey string, replyCtx any, err error)
 }
 
-// CronChannelKeyResolver is an optional interface for platforms that encode
-// thread/topic information into their session keys. ExecuteCronJob calls this
-// to derive the workspace-binding channel ID (e.g. "chat:thread") when looking
-// up a per-thread workspace binding, instead of falling back to the
-// thread-blind extractChannelID. Platforms that have no thread concept can
-// omit this interface; the engine will use extractChannelID by default.
+// SessionChannelKeyResolver is an optional interface for platforms that encode
+// thread/topic information into their session keys. The engine calls this to
+// derive the workspace-binding channel ID (e.g. "chat:thread") for any code
+// path that has a sessionKey but no live Message — cron triggers, card
+// renderers (/list, /switch, /current cards), background lookups, etc.
 //
+// Without this interface, the engine falls back to extractChannelID, which
+// only returns the chat ID and drops thread/topic information — making any
+// thread-scoped workspace binding invisible to those code paths.
+//
+// Platforms that have no thread concept can omit this interface.
 // Returning an empty string is equivalent to "no thread info" and falls back
 // to extractChannelID.
-type CronChannelKeyResolver interface {
-	ChannelKeyForCronSession(sessionKey string) string
+type SessionChannelKeyResolver interface {
+	ChannelKeyForSession(sessionKey string) string
 }
 
 // SessionEnvInjector is an optional interface for agents that accept

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -1139,21 +1139,22 @@ func TestHandleWorkspaceCommand_InitDefaultsToChatScope(t *testing.T) {
 	}
 }
 
-// cronChannelKeyMock is a stub platform that implements the new
-// CronChannelKeyResolver interface so we can verify ExecuteCronJob asks the
+// threadKeyMock is a stub platform that implements the new
+// SessionChannelKeyResolver interface so we can verify the engine asks the
 // platform for a thread-aware channel key (instead of falling back to the
-// thread-blind extractChannelID derivation).
-type cronChannelKeyMock struct {
+// thread-blind extractChannelID derivation) — both for cron and for any other
+// code path that resolves bindings from a sessionKey.
+type threadKeyMock struct {
 	stubPlatformEngine
 	threadKey      string
 	resolverCalled bool
 }
 
-func (p *cronChannelKeyMock) ReconstructReplyCtx(_ string) (any, error) {
+func (p *threadKeyMock) ReconstructReplyCtx(_ string) (any, error) {
 	return "rctx", nil
 }
 
-func (p *cronChannelKeyMock) ChannelKeyForCronSession(_ string) string {
+func (p *threadKeyMock) ChannelKeyForSession(_ string) string {
 	p.resolverCalled = true
 	return p.threadKey
 }
@@ -1177,7 +1178,7 @@ func (a *namedResultAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, 
 func (a *namedResultAgent) Stop() error { return nil }
 
 // TestExecuteCronJob_UsesPlatformThreadAwareChannelKey verifies that when a
-// platform implements CronChannelKeyResolver, ExecuteCronJob uses the
+// platform implements SessionChannelKeyResolver, ExecuteCronJob uses the
 // platform-supplied (thread-aware) channel key for workspace lookup. Without
 // this, a thread-scoped binding (created by `/workspace bind -t`) is invisible
 // to the cron path because extractChannelID drops the thread suffix from the
@@ -1219,7 +1220,7 @@ func TestExecuteCronJob_UsesPlatformThreadAwareChannelKey(t *testing.T) {
 	e.workspaceBindings.Bind("project:test", bindingKey, "tradingagents",
 		normalizeWorkspacePath(wsDir))
 
-	p := &cronChannelKeyMock{
+	p := &threadKeyMock{
 		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
 		threadKey:          threadOnlyKey,
 	}
@@ -1239,10 +1240,63 @@ func TestExecuteCronJob_UsesPlatformThreadAwareChannelKey(t *testing.T) {
 	}
 
 	if !p.resolverCalled {
-		t.Fatal("expected platform.ChannelKeyForCronSession to be called")
+		t.Fatal("expected platform.ChannelKeyForSession to be called")
 	}
 	if ws := e.workspacePool.Get(normalizeWorkspacePath(wsDir)); ws == nil {
 		t.Fatalf("expected workspace pool entry for %q after cron resolved its thread-scoped binding", wsDir)
+	}
+}
+
+// TestSessionContextForKey_UsesPlatformThreadAwareChannelKey verifies that
+// when a platform implements SessionChannelKeyResolver, sessionContextForKey
+// (used by /list cards, /switch, /current, and many other lookups) honors the
+// platform-supplied thread-aware channel key. Without this, the engine falls
+// back to extractChannelID — which drops the thread suffix — and would route
+// to the chat-scope binding instead of the thread-scope one.
+func TestSessionContextForKey_UsesPlatformThreadAwareChannelKey(t *testing.T) {
+	baseDir := t.TempDir()
+	wsDir := filepath.Join(baseDir, "thread-ws")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	agentName := "session-context-test-agent"
+	RegisterAgent(agentName, func(_ map[string]any) (Agent, error) {
+		return &namedResultAgent{name: agentName, session: newResultAgentSession("done")}, nil
+	})
+
+	tmpDir := t.TempDir()
+	bindingPath := filepath.Join(tmpDir, "bindings.json")
+	sessionPath := filepath.Join(tmpDir, "sessions.json")
+	e := NewEngine("test", &namedResultAgent{name: agentName}, nil, sessionPath, LangEnglish)
+	e.SetMultiWorkspace(baseDir, bindingPath)
+	defer e.cancel()
+
+	chatID := "oc_AAA"
+	threadID := "om_BBB"
+	threadOnlyKey := chatID + ":" + threadID
+	// Bind workspace at thread scope only.
+	bindingKey := workspaceChannelKey("feishu", threadOnlyKey)
+	e.workspaceBindings.Bind("project:test", bindingKey, "thread-ws",
+		normalizeWorkspacePath(wsDir))
+
+	p := &threadKeyMock{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		threadKey:          threadOnlyKey,
+	}
+	e.AddPlatform(p)
+
+	sessionKey := "feishu:" + chatID + ":root:" + threadID
+	agent, _ := e.sessionContextForKey(sessionKey)
+
+	if !p.resolverCalled {
+		t.Fatal("expected platform.ChannelKeyForSession to be called by sessionContextForKey")
+	}
+	if agent == e.agent {
+		t.Fatal("expected workspace-bound agent, got global agent — thread-scope binding was missed")
+	}
+	if ws := e.workspacePool.Get(normalizeWorkspacePath(wsDir)); ws == nil {
+		t.Fatalf("expected workspace pool entry for %q, got nil", wsDir)
 	}
 }
 

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -704,3 +704,168 @@ func TestCommandContextWithWorkspace_UnboundChannelFallsBack(t *testing.T) {
 		t.Errorf("expected interactiveKey to equal sessionKey when unbound, got %q want %q", interactiveKey, msg.SessionKey)
 	}
 }
+
+func TestParentWorkspaceChannelKey(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"feishu", ""},
+		{"feishu:chatA", ""},
+		{"feishu:chatA:rootX", "feishu:chatA"},
+		{"telegram:123:456", "telegram:123"},
+		{"feishu:chatA:rootX:extra", "feishu:chatA:rootX"},
+		// Legacy bare key without platform prefix has no parent (lookups
+		// don't pass these in — included for safety).
+		{"chatA", ""},
+	}
+	for _, tt := range tests {
+		if got := parentWorkspaceChannelKey(tt.in); got != tt.want {
+			t.Errorf("parentWorkspaceChannelKey(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParentChannelID(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"chatA", ""},
+		{"chatA:rootX", "chatA"},
+		{"chatA:rootX:nested", "chatA:rootX"},
+	}
+	for _, tt := range tests {
+		if got := parentChannelID(tt.in); got != tt.want {
+			t.Errorf("parentChannelID(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestResolveWorkspace_ThreadInheritsChatBinding verifies that a thread-scoped
+// channel ID (e.g. "chatID:rootID") resolves to the chat-level binding when no
+// thread-specific binding exists. This preserves the pre-existing UX where a
+// new thread inside a bound chat works immediately without requiring re-bind.
+func TestResolveWorkspace_ThreadInheritsChatBinding(t *testing.T) {
+	baseDir := t.TempDir()
+	wsDir := filepath.Join(baseDir, "chat-workspace")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	p := &mockChannelResolver{names: map[string]string{"chatA": "chat-workspace"}}
+
+	// Bind the chat-level scope.
+	chatKey := workspaceChannelKey(p.Name(), "chatA")
+	e.workspaceBindings.Bind("project:test", chatKey, "chat-workspace", normalizeWorkspacePath(wsDir))
+
+	// Resolve from a thread inside that chat. Fallback should pick up the
+	// chat binding.
+	ws, name, err := e.resolveWorkspace(p, "chatA:rootX")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := normalizeWorkspacePath(wsDir); ws != want {
+		t.Errorf("ws = %q, want %q", ws, want)
+	}
+	if name != "chat-workspace" {
+		t.Errorf("name = %q, want %q", name, "chat-workspace")
+	}
+}
+
+// TestResolveWorkspace_ThreadOverridesChat verifies that a thread-specific
+// binding shadows the chat-level binding when both exist.
+func TestResolveWorkspace_ThreadOverridesChat(t *testing.T) {
+	baseDir := t.TempDir()
+	chatWS := filepath.Join(baseDir, "chat-ws")
+	threadWS := filepath.Join(baseDir, "thread-ws")
+	for _, d := range []string{chatWS, threadWS} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	p := &mockChannelResolver{}
+
+	chatKey := workspaceChannelKey(p.Name(), "chatA")
+	threadKey := workspaceChannelKey(p.Name(), "chatA:rootX")
+	e.workspaceBindings.Bind("project:test", chatKey, "chat-ws", normalizeWorkspacePath(chatWS))
+	e.workspaceBindings.Bind("project:test", threadKey, "thread-ws", normalizeWorkspacePath(threadWS))
+
+	// Thread message uses thread-specific binding.
+	ws, _, err := e.resolveWorkspace(p, "chatA:rootX")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := normalizeWorkspacePath(threadWS); ws != want {
+		t.Errorf("thread ws = %q, want %q", ws, want)
+	}
+
+	// A different thread (no specific binding) still inherits from chat.
+	ws, _, err = e.resolveWorkspace(p, "chatA:rootY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := normalizeWorkspacePath(chatWS); ws != want {
+		t.Errorf("sibling thread ws = %q, want %q", ws, want)
+	}
+
+	// And a non-thread message in the same chat also uses chat binding.
+	ws, _, err = e.resolveWorkspace(p, "chatA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := normalizeWorkspacePath(chatWS); ws != want {
+		t.Errorf("chat ws = %q, want %q", ws, want)
+	}
+}
+
+// TestResolveWorkspace_ConventionAutoBindsToParent verifies that when a thread
+// message hits the convention path (no binding at any scope), the name
+// resolver ascends to the chat, and the auto-bind is created at chat scope so
+// sibling threads share the workspace.
+func TestResolveWorkspace_ConventionAutoBindsToParent(t *testing.T) {
+	baseDir := t.TempDir()
+	channelName := "team-proj"
+	if err := os.MkdirAll(filepath.Join(baseDir, channelName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	// Resolver only knows the chat ID, not the thread suffix.
+	p := &mockChannelResolver{names: map[string]string{"chatB": channelName}}
+
+	ws, name, err := e.resolveWorkspace(p, "chatB:rootZ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != channelName {
+		t.Errorf("name = %q, want %q", name, channelName)
+	}
+	want := normalizeWorkspacePath(filepath.Join(baseDir, channelName))
+	if ws != want {
+		t.Errorf("ws = %q, want %q", ws, want)
+	}
+
+	// Auto-bind must have been recorded under the chat key, not the thread key.
+	chatKey := workspaceChannelKey(p.Name(), "chatB")
+	if b := e.workspaceBindings.Lookup("project:test", chatKey); b == nil || b.Workspace != want {
+		t.Errorf("expected chat-level binding at %q, got %+v", chatKey, b)
+	}
+	threadKey := workspaceChannelKey(p.Name(), "chatB:rootZ")
+	if b := e.workspaceBindings.Lookup("project:test", threadKey); b != nil {
+		t.Errorf("did not expect thread-level binding at %q, got %+v", threadKey, b)
+	}
+
+	// A sibling thread now resolves via the chat binding without re-running
+	// the convention match.
+	ws2, _, err := e.resolveWorkspace(p, "chatB:rootOther")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ws2 != want {
+		t.Errorf("sibling thread ws = %q, want %q", ws2, want)
+	}
+}

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -867,5 +868,404 @@ func TestResolveWorkspace_ConventionAutoBindsToParent(t *testing.T) {
 	}
 	if ws2 != want {
 		t.Errorf("sibling thread ws = %q, want %q", ws2, want)
+	}
+}
+
+// makeThreadMsg builds a Message that handleWorkspaceCommand would see for a
+// platform message inside a thread (Feishu topic mode, Slack thread, etc.).
+// ChannelKey embeds the thread root so effectiveWorkspaceChannelKey yields the
+// thread-scoped binding key.
+func makeThreadMsg(platform, chatID, threadID string) *Message {
+	return &Message{
+		Platform:   platform,
+		SessionKey: platform + ":" + chatID + ":root:" + threadID,
+		ChannelKey: chatID + ":" + threadID,
+		ReplyCtx:   "rctx",
+	}
+}
+
+// makeDMMsg builds a Message that handleWorkspaceCommand would see for a
+// platform message outside any thread (Feishu DM, Telegram private chat, etc.).
+func makeDMMsg(platform, chatID, userID string) *Message {
+	return &Message{
+		Platform:   platform,
+		SessionKey: platform + ":" + chatID + ":" + userID,
+		ChannelKey: chatID,
+		ReplyCtx:   "rctx",
+	}
+}
+
+// TestHandleWorkspaceCommand_BindDefaultsToChatScope verifies that /workspace
+// bind without -t writes the binding at chat scope, restoring pre-PR semantics
+// so that all topics in the same chat inherit by default.
+func TestHandleWorkspaceCommand_BindDefaultsToChatScope(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(baseDir, "myproj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+	msg := makeThreadMsg("feishu", "oc_AAA", "om_BBB")
+
+	e.handleWorkspaceCommand(p, msg, []string{"bind", "myproj"})
+
+	chatKey := workspaceChannelKey("feishu", "oc_AAA")
+	threadKey := workspaceChannelKey("feishu", "oc_AAA:om_BBB")
+	if b := e.workspaceBindings.Lookup("project:test", chatKey); b == nil {
+		t.Fatalf("expected chat-scope binding at %q, got nil", chatKey)
+	}
+	if b := e.workspaceBindings.Lookup("project:test", threadKey); b != nil {
+		t.Fatalf("did not expect thread-scope binding at %q, got %+v", threadKey, b)
+	}
+}
+
+// TestHandleWorkspaceCommand_BindWithTopicFlag verifies that /workspace bind -t
+// writes the binding at thread scope, allowing power users to override the
+// chat default for a single topic.
+func TestHandleWorkspaceCommand_BindWithTopicFlag(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(baseDir, "myproj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, flag := range []string{"-t", "--topic"} {
+		t.Run(flag, func(t *testing.T) {
+			e := newTestEngineWithMultiWorkspace(t, baseDir)
+			p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+			msg := makeThreadMsg("feishu", "oc_AAA", "om_BBB")
+
+			e.handleWorkspaceCommand(p, msg, []string{"bind", flag, "myproj"})
+
+			chatKey := workspaceChannelKey("feishu", "oc_AAA")
+			threadKey := workspaceChannelKey("feishu", "oc_AAA:om_BBB")
+			if b := e.workspaceBindings.Lookup("project:test", threadKey); b == nil {
+				t.Fatalf("expected thread-scope binding at %q, got nil", threadKey)
+			}
+			if b := e.workspaceBindings.Lookup("project:test", chatKey); b != nil {
+				t.Fatalf("did not expect chat-scope binding at %q, got %+v", chatKey, b)
+			}
+		})
+	}
+}
+
+// TestHandleWorkspaceCommand_BindTopicFlagOrderInvariant verifies that the
+// flag can appear before or after the positional arg.
+func TestHandleWorkspaceCommand_BindTopicFlagOrderInvariant(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(baseDir, "myproj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"bind", "-t", "myproj"},
+		{"bind", "myproj", "-t"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			e := newTestEngineWithMultiWorkspace(t, baseDir)
+			p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+			msg := makeThreadMsg("feishu", "oc_AAA", "om_BBB")
+
+			e.handleWorkspaceCommand(p, msg, args)
+
+			threadKey := workspaceChannelKey("feishu", "oc_AAA:om_BBB")
+			if b := e.workspaceBindings.Lookup("project:test", threadKey); b == nil {
+				t.Fatalf("expected thread-scope binding for args=%v", args)
+			}
+		})
+	}
+}
+
+// TestHandleWorkspaceCommand_BindTopicRejectedInDM verifies that asking for
+// thread-scope (-t) on a session without a thread (DM, non-isolated group)
+// returns an error and writes no binding.
+func TestHandleWorkspaceCommand_BindTopicRejectedInDM(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(baseDir, "myproj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+	msg := makeDMMsg("feishu", "oc_DM", "ou_USER")
+
+	e.handleWorkspaceCommand(p, msg, []string{"bind", "-t", "myproj"})
+
+	chatKey := workspaceChannelKey("feishu", "oc_DM")
+	if b := e.workspaceBindings.Lookup("project:test", chatKey); b != nil {
+		t.Fatalf("expected no binding written when -t is invalid on DM, got %+v", b)
+	}
+}
+
+// TestHandleWorkspaceCommand_UnbindDefaultsToChatScope verifies symmetry with
+// bind: /workspace unbind (no flag) removes the chat-scope binding and leaves
+// any thread-scope override intact.
+func TestHandleWorkspaceCommand_UnbindDefaultsToChatScope(t *testing.T) {
+	baseDir := t.TempDir()
+	wsChat := filepath.Join(baseDir, "chat-ws")
+	wsThread := filepath.Join(baseDir, "thread-ws")
+	for _, d := range []string{wsChat, wsThread} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+	msg := makeThreadMsg("feishu", "oc_AAA", "om_BBB")
+
+	chatKey := workspaceChannelKey("feishu", "oc_AAA")
+	threadKey := workspaceChannelKey("feishu", "oc_AAA:om_BBB")
+	e.workspaceBindings.Bind("project:test", chatKey, "", normalizeWorkspacePath(wsChat))
+	e.workspaceBindings.Bind("project:test", threadKey, "", normalizeWorkspacePath(wsThread))
+
+	e.handleWorkspaceCommand(p, msg, []string{"unbind"})
+
+	if b := e.workspaceBindings.Lookup("project:test", chatKey); b != nil {
+		t.Fatalf("expected chat-scope binding to be removed, got %+v", b)
+	}
+	if b := e.workspaceBindings.Lookup("project:test", threadKey); b == nil {
+		t.Fatalf("expected thread-scope binding to remain after unbind without -t")
+	}
+}
+
+// TestHandleWorkspaceCommand_UnbindWithTopicFlag verifies that /workspace
+// unbind -t removes only the thread-scope override.
+func TestHandleWorkspaceCommand_UnbindWithTopicFlag(t *testing.T) {
+	baseDir := t.TempDir()
+	wsChat := filepath.Join(baseDir, "chat-ws")
+	wsThread := filepath.Join(baseDir, "thread-ws")
+	for _, d := range []string{wsChat, wsThread} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+	msg := makeThreadMsg("feishu", "oc_AAA", "om_BBB")
+
+	chatKey := workspaceChannelKey("feishu", "oc_AAA")
+	threadKey := workspaceChannelKey("feishu", "oc_AAA:om_BBB")
+	e.workspaceBindings.Bind("project:test", chatKey, "", normalizeWorkspacePath(wsChat))
+	e.workspaceBindings.Bind("project:test", threadKey, "", normalizeWorkspacePath(wsThread))
+
+	e.handleWorkspaceCommand(p, msg, []string{"unbind", "-t"})
+
+	if b := e.workspaceBindings.Lookup("project:test", threadKey); b != nil {
+		t.Fatalf("expected thread-scope binding to be removed, got %+v", b)
+	}
+	if b := e.workspaceBindings.Lookup("project:test", chatKey); b == nil {
+		t.Fatalf("expected chat-scope binding to remain after unbind -t")
+	}
+}
+
+// TestHandleWorkspaceCommand_RouteDefaultsToChatScope verifies that the
+// scope-flag refactor applies uniformly to /workspace route (absolute path
+// binding) just like /workspace bind.
+func TestHandleWorkspaceCommand_RouteDefaultsToChatScope(t *testing.T) {
+	baseDir := t.TempDir()
+	wsDir := filepath.Join(baseDir, "absolute-target")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+	msg := makeThreadMsg("feishu", "oc_AAA", "om_BBB")
+
+	e.handleWorkspaceCommand(p, msg, []string{"route", wsDir})
+
+	chatKey := workspaceChannelKey("feishu", "oc_AAA")
+	threadKey := workspaceChannelKey("feishu", "oc_AAA:om_BBB")
+	if b := e.workspaceBindings.Lookup("project:test", chatKey); b == nil {
+		t.Fatalf("expected chat-scope route binding at %q, got nil", chatKey)
+	}
+	if b := e.workspaceBindings.Lookup("project:test", threadKey); b != nil {
+		t.Fatalf("did not expect thread-scope route binding, got %+v", b)
+	}
+}
+
+// TestHandleWorkspaceCommand_RouteWithTopicFlag verifies the -t flag on
+// /workspace route.
+func TestHandleWorkspaceCommand_RouteWithTopicFlag(t *testing.T) {
+	baseDir := t.TempDir()
+	wsDir := filepath.Join(baseDir, "absolute-target")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+	msg := makeThreadMsg("feishu", "oc_AAA", "om_BBB")
+
+	e.handleWorkspaceCommand(p, msg, []string{"route", "-t", wsDir})
+
+	chatKey := workspaceChannelKey("feishu", "oc_AAA")
+	threadKey := workspaceChannelKey("feishu", "oc_AAA:om_BBB")
+	if b := e.workspaceBindings.Lookup("project:test", threadKey); b == nil {
+		t.Fatalf("expected thread-scope route binding at %q, got nil", threadKey)
+	}
+	if b := e.workspaceBindings.Lookup("project:test", chatKey); b != nil {
+		t.Fatalf("did not expect chat-scope route binding, got %+v", b)
+	}
+}
+
+// TestHandleWorkspaceCommand_InitDefaultsToChatScope verifies that /workspace
+// init (local-dir target form) follows the same chat-scope default.
+func TestHandleWorkspaceCommand_InitDefaultsToChatScope(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(baseDir, "initproj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	// `/workspace init <local-dir>` requires this opt-in (added in main after
+	// this PR branched). Enable it so the test exercises the local-dir path
+	// rather than failing the gate.
+	e.SetWorkspaceInitAllowLocalPaths(true)
+	p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+	msg := makeThreadMsg("feishu", "oc_AAA", "om_BBB")
+
+	e.handleWorkspaceCommand(p, msg, []string{"init", "initproj"})
+
+	chatKey := workspaceChannelKey("feishu", "oc_AAA")
+	threadKey := workspaceChannelKey("feishu", "oc_AAA:om_BBB")
+	if b := e.workspaceBindings.Lookup("project:test", chatKey); b == nil {
+		t.Fatalf("expected chat-scope init binding at %q, got nil", chatKey)
+	}
+	if b := e.workspaceBindings.Lookup("project:test", threadKey); b != nil {
+		t.Fatalf("did not expect thread-scope init binding, got %+v", b)
+	}
+}
+
+// cronChannelKeyMock is a stub platform that implements the new
+// CronChannelKeyResolver interface so we can verify ExecuteCronJob asks the
+// platform for a thread-aware channel key (instead of falling back to the
+// thread-blind extractChannelID derivation).
+type cronChannelKeyMock struct {
+	stubPlatformEngine
+	threadKey      string
+	resolverCalled bool
+}
+
+func (p *cronChannelKeyMock) ReconstructReplyCtx(_ string) (any, error) {
+	return "rctx", nil
+}
+
+func (p *cronChannelKeyMock) ChannelKeyForCronSession(_ string) string {
+	p.resolverCalled = true
+	return p.threadKey
+}
+
+// namedResultAgent is a resultAgent variant whose Name() can be configured.
+// We need this so the same name can be used as the global agent's identity
+// AND as a registered factory name (workspace-pool agent creation calls
+// CreateAgent(e.agent.Name(), opts) to spawn per-workspace agents).
+type namedResultAgent struct {
+	name    string
+	session AgentSession
+}
+
+func (a *namedResultAgent) Name() string { return a.name }
+func (a *namedResultAgent) StartSession(_ context.Context, _ string) (AgentSession, error) {
+	return a.session, nil
+}
+func (a *namedResultAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) {
+	return nil, nil
+}
+func (a *namedResultAgent) Stop() error { return nil }
+
+// TestExecuteCronJob_UsesPlatformThreadAwareChannelKey verifies that when a
+// platform implements CronChannelKeyResolver, ExecuteCronJob uses the
+// platform-supplied (thread-aware) channel key for workspace lookup. Without
+// this, a thread-scoped binding (created by `/workspace bind -t`) is invisible
+// to the cron path because extractChannelID drops the thread suffix from the
+// session key.
+func TestExecuteCronJob_UsesPlatformThreadAwareChannelKey(t *testing.T) {
+	baseDir := t.TempDir()
+	wsDir := filepath.Join(baseDir, "tradingagents")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Register an agent factory whose session emits an immediate result so
+	// processInteractiveMessageWith returns instead of hanging. Both the global
+	// agent and the workspace-pool agent must terminate so the test fails (not
+	// hangs) regardless of which branch ExecuteCronJob takes.
+	agentName := "cron-thread-test-agent"
+	RegisterAgent(agentName, func(_ map[string]any) (Agent, error) {
+		return &namedResultAgent{name: agentName, session: newResultAgentSession("ws-done")}, nil
+	})
+
+	tmpDir := t.TempDir()
+	bindingPath := filepath.Join(tmpDir, "bindings.json")
+	sessionPath := filepath.Join(tmpDir, "sessions.json")
+	globalAgent := &namedResultAgent{name: agentName, session: newResultAgentSession("global-done")}
+	e := NewEngine("test", globalAgent, nil, sessionPath, LangEnglish)
+	e.SetMultiWorkspace(baseDir, bindingPath)
+	defer e.cancel()
+
+	store, err := NewCronStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewCronStore() error = %v", err)
+	}
+	e.cronScheduler = NewCronScheduler(store)
+
+	chatID := "oc_AAA"
+	threadID := "om_BBB"
+	threadOnlyKey := chatID + ":" + threadID
+	bindingKey := workspaceChannelKey("feishu", threadOnlyKey)
+	e.workspaceBindings.Bind("project:test", bindingKey, "tradingagents",
+		normalizeWorkspacePath(wsDir))
+
+	p := &cronChannelKeyMock{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		threadKey:          threadOnlyKey,
+	}
+	e.AddPlatform(p)
+
+	job := &CronJob{
+		ID:         "job-thread",
+		SessionKey: "feishu:" + chatID + ":root:" + threadID,
+		Prompt:     "hello",
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatalf("store.Add() error = %v", err)
+	}
+
+	if err := e.ExecuteCronJob(job); err != nil {
+		t.Fatalf("ExecuteCronJob() error = %v", err)
+	}
+
+	if !p.resolverCalled {
+		t.Fatal("expected platform.ChannelKeyForCronSession to be called")
+	}
+	if ws := e.workspacePool.Get(normalizeWorkspacePath(wsDir)); ws == nil {
+		t.Fatalf("expected workspace pool entry for %q after cron resolved its thread-scoped binding", wsDir)
+	}
+}
+
+// TestHandleWorkspaceCommand_SharedBindDefaultsToChatScope verifies the same
+// chat-default semantics for the shared-binding namespace.
+func TestHandleWorkspaceCommand_SharedBindDefaultsToChatScope(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(baseDir, "myproj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newTestEngineWithMultiWorkspace(t, baseDir)
+	p := &mockChannelResolver{name: "feishu", names: map[string]string{}}
+	msg := makeThreadMsg("feishu", "oc_AAA", "om_BBB")
+
+	e.handleWorkspaceCommand(p, msg, []string{"shared", "bind", "myproj"})
+
+	chatKey := workspaceChannelKey("feishu", "oc_AAA")
+	threadKey := workspaceChannelKey("feishu", "oc_AAA:om_BBB")
+	if b := e.workspaceBindings.Lookup(sharedWorkspaceBindingsKey, chatKey); b == nil {
+		t.Fatalf("expected shared chat-scope binding at %q, got nil", chatKey)
+	}
+	if b := e.workspaceBindings.Lookup(sharedWorkspaceBindingsKey, threadKey); b != nil {
+		t.Fatalf("did not expect shared thread-scope binding, got %+v", b)
 	}
 }

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -539,6 +539,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		chatID = userID
 	}
 	sessionKey := p.sessionKeyFromCardAction(chatID, userID, event.Event.Action.Value)
+	channelKey := p.channelKeyForBinding(chatID, sessionKey)
 
 	// nav: / act: — synchronous card update
 	if strings.HasPrefix(actionVal, "nav:") || strings.HasPrefix(actionVal, "act:") {
@@ -621,6 +622,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
 		go p.handler(p.dispatchPlatform(), &core.Message{
 			SessionKey: sessionKey,
+			ChannelKey: channelKey,
 			Platform:   p.platformName,
 			UserID:     userID,
 			UserName:   p.resolveUserName(userID),
@@ -652,6 +654,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
 		go p.handler(p.dispatchPlatform(), &core.Message{
 			SessionKey: sessionKey,
+			ChannelKey: channelKey,
 			Platform:   p.platformName,
 			UserID:     userID,
 			UserName:   p.resolveUserName(userID),
@@ -687,6 +690,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 
 		go p.handler(p.dispatchPlatform(), &core.Message{
 			SessionKey: sessionKey,
+			ChannelKey: channelKey,
 			Platform:   p.platformName,
 			UserID:     userID,
 			UserName:   p.resolveUserName(userID),
@@ -1081,6 +1085,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		quoted = p.fetchQuotedMessage(ctx, parentID)
 	}
 
+	channelKey := p.channelKeyForBinding(chatID, sessionKey)
+
 	switch msgType {
 	case "text":
 		var textBody struct {
@@ -1101,8 +1107,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
-			MessageID: messageID,
-			UserID:    userID, UserName: userName, ChatName: chatName,
+			ChannelKey: channelKey,
+			MessageID:  messageID,
+			UserID:     userID, UserName: userName, ChatName: chatName,
 			Content: text, ExtraContent: quoted.text, Images: quoted.images, ReplyCtx: rctx,
 		})
 
@@ -1124,8 +1131,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
-			MessageID: messageID,
-			UserID:    userID, UserName: userName, ChatName: chatName,
+			ChannelKey: channelKey,
+			MessageID:  messageID,
+			UserID:     userID, UserName: userName, ChatName: chatName,
 			Images:   []core.ImageAttachment{{MimeType: mimeType, Data: imgData}},
 			ReplyCtx: rctx,
 		})
@@ -1150,8 +1158,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
-			MessageID: messageID,
-			UserID:    userID, UserName: userName, ChatName: chatName,
+			ChannelKey: channelKey,
+			MessageID:  messageID,
+			UserID:     userID, UserName: userName, ChatName: chatName,
 			Audio: &core.AudioAttachment{
 				MimeType: "audio/opus",
 				Data:     audioData,
@@ -1169,8 +1178,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
-			MessageID: messageID,
-			UserID:    userID, UserName: userName, ChatName: chatName,
+			ChannelKey: channelKey,
+			MessageID:  messageID,
+			UserID:     userID, UserName: userName, ChatName: chatName,
 			Content: text, ExtraContent: quoted.text, Images: append(quoted.images, images...),
 			ReplyCtx: rctx,
 		})
@@ -1197,8 +1207,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		mimeType := detectMimeType(fileData)
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
-			MessageID: messageID,
-			UserID:    userID, UserName: userName, ChatName: chatName,
+			ChannelKey: channelKey,
+			MessageID:  messageID,
+			UserID:     userID, UserName: userName, ChatName: chatName,
 			Files: []core.FileAttachment{{
 				MimeType: mimeType,
 				Data:     fileData,
@@ -1215,8 +1226,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		coreMsg := &core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
-			MessageID: messageID,
-			UserID:    userID, UserName: userName, ChatName: chatName,
+			ChannelKey: channelKey,
+			MessageID:  messageID,
+			UserID:     userID, UserName: userName, ChatName: chatName,
 			Content:  text,
 			Images:   images,
 			Files:    files,
@@ -1246,8 +1258,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
-			MessageID: messageID,
-			UserID:    userID, UserName: userName, ChatName: chatName,
+			ChannelKey: channelKey,
+			MessageID:  messageID,
+			UserID:     userID, UserName: userName, ChatName: chatName,
 			Images:   []core.ImageAttachment{{MimeType: mimeType, Data: imgData}},
 			ReplyCtx: rctx,
 		})
@@ -1282,8 +1295,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
-			MessageID: messageID,
-			UserID:    userID, UserName: userName, ChatName: chatName,
+			ChannelKey: channelKey,
+			MessageID:  messageID,
+			UserID:     userID, UserName: userName, ChatName: chatName,
 			Content: text, ExtraContent: quoted.text, Images: images, ReplyCtx: rctx,
 		})
 
@@ -3085,6 +3099,22 @@ func isThreadSessionKey(sessionKey string) bool {
 	}
 	_, ok := parseThreadRootID(parts[2])
 	return ok
+}
+
+// channelKeyForBinding returns the platform-provided channel key for workspace
+// binding. When thread_isolation is enabled and the message is inside a thread,
+// the key embeds the thread root ID so each thread can bind to its own
+// workspace; otherwise it returns the chat ID and preserves per-chat binding.
+func (p *Platform) channelKeyForBinding(chatID, sessionKey string) string {
+	if p.threadIsolation {
+		parts := strings.SplitN(sessionKey, ":", 3)
+		if len(parts) == 3 {
+			if rootID, ok := parseThreadRootID(parts[2]); ok {
+				return chatID + ":" + rootID
+			}
+		}
+	}
+	return chatID
 }
 
 // feishuPreviewHandle stores the message ID for an editable preview message.

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -3117,11 +3117,92 @@ func (p *Platform) channelKeyForBinding(chatID, sessionKey string) string {
 	return chatID
 }
 
-// ChannelKeyForCronSession satisfies core.CronChannelKeyResolver. It maps a
-// cron session_key back to the channel key used for workspace bindings,
-// preserving thread/topic information when thread_isolation is on. Without
-// this, the engine would fall back to extractChannelID which drops the
-// "root:rootID" suffix, making thread-scoped bindings invisible to cron.
+// ResolveCronReplyTarget satisfies core.CronReplyTargetResolver. For groups
+// in topic mode (thread_isolation=true), each cron run posts a "📌 <title>"
+// anchor as a new top-level message — which becomes a new topic in the group
+// — and returns a reply context targeting that topic. Subsequent cron
+// messages (the engine's "⏰ <desc>" start notice + the agent's streamed
+// output and final reply) all thread inside that topic instead of each one
+// spawning its own.
+//
+// Returns ErrNotSupported when thread_isolation is off, so the engine falls
+// back to ReconstructReplyCtx and messages are sent directly without anchor.
+func (p *Platform) ResolveCronReplyTarget(sessionKey, title string) (string, any, error) {
+	if !p.threadIsolation {
+		return "", nil, core.ErrNotSupported
+	}
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) < 2 || parts[0] != p.platformName || parts[1] == "" {
+		return "", nil, core.ErrNotSupported
+	}
+	chatID := parts[1]
+
+	anchor := strings.TrimSpace(title)
+	if anchor == "" {
+		anchor = "cron"
+	}
+	anchor = "📌 " + anchor
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	msgID, err := p.createTopLevelTextMessage(ctx, chatID, anchor)
+	if err != nil {
+		return "", nil, fmt.Errorf("%s: post cron topic anchor: %w", p.tag(), err)
+	}
+
+	newSessionKey := fmt.Sprintf("%s:%s:root:%s", p.platformName, chatID, msgID)
+	return newSessionKey, replyContext{
+		chatID:     chatID,
+		messageID:  msgID,
+		sessionKey: newSessionKey,
+	}, nil
+}
+
+// createTopLevelTextMessage posts a plain-text message at top level (no
+// reply parent) and returns the new message's ID. Used by
+// ResolveCronReplyTarget to plant the topic anchor.
+func (p *Platform) createTopLevelTextMessage(ctx context.Context, chatID, content string) (string, error) {
+	body, err := json.Marshal(map[string]string{"text": content})
+	if err != nil {
+		return "", fmt.Errorf("%s: marshal anchor text: %w", p.tag(), err)
+	}
+	req := larkim.NewCreateMessageReqBuilder().
+		ReceiveIdType(larkim.ReceiveIdTypeChatId).
+		Body(larkim.NewCreateMessageReqBodyBuilder().
+			ReceiveId(chatID).
+			MsgType(larkim.MsgTypeText).
+			Content(string(body)).
+			Build()).
+		Build()
+	var resp *larkim.CreateMessageResp
+	if err := p.withTransientRetry(ctx, "cron anchor", func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, "cron anchor", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			var err error
+			resp, err = client.Im.Message.Create(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: cron anchor api call: %w", p.tag(), err)
+			}
+			if !resp.Success() {
+				return fmt.Errorf("%s: cron anchor failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			}
+			return nil
+		})
+	}); err != nil {
+		return "", err
+	}
+	if resp == nil || resp.Data == nil || resp.Data.MessageId == nil || *resp.Data.MessageId == "" {
+		return "", fmt.Errorf("%s: cron anchor: no message ID returned", p.tag())
+	}
+	return *resp.Data.MessageId, nil
+}
+
+// ChannelKeyForSession satisfies core.SessionChannelKeyResolver. It maps a
+// session_key back to the channel key used for workspace bindings, preserving
+// thread/topic information when thread_isolation is on. Without this, the
+// engine would fall back to extractChannelID which drops the "root:rootID"
+// suffix, making thread-scoped bindings invisible to cron, card renderers,
+// and other lookups that do not have access to the originating Message.
 //
 // Session-key shapes handled:
 //   - "feishu:chatID:userID"        → "chatID"          (DM / non-thread)
@@ -3130,7 +3211,7 @@ func (p *Platform) channelKeyForBinding(chatID, sessionKey string) string {
 //
 // Returns an empty string for non-feishu prefixes or malformed keys; the engine
 // then falls back to extractChannelID.
-func (p *Platform) ChannelKeyForCronSession(sessionKey string) string {
+func (p *Platform) ChannelKeyForSession(sessionKey string) string {
 	parts := strings.SplitN(sessionKey, ":", 3)
 	if len(parts) < 2 || parts[0] != p.platformName {
 		return ""

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -3117,6 +3117,31 @@ func (p *Platform) channelKeyForBinding(chatID, sessionKey string) string {
 	return chatID
 }
 
+// ChannelKeyForCronSession satisfies core.CronChannelKeyResolver. It maps a
+// cron session_key back to the channel key used for workspace bindings,
+// preserving thread/topic information when thread_isolation is on. Without
+// this, the engine would fall back to extractChannelID which drops the
+// "root:rootID" suffix, making thread-scoped bindings invisible to cron.
+//
+// Session-key shapes handled:
+//   - "feishu:chatID:userID"        → "chatID"          (DM / non-thread)
+//   - "feishu:chatID:root:rootID"   → "chatID:rootID"   (thread, isolation on)
+//   - "feishu:chatID"               → "chatID"          (share_session_in_channel)
+//
+// Returns an empty string for non-feishu prefixes or malformed keys; the engine
+// then falls back to extractChannelID.
+func (p *Platform) ChannelKeyForCronSession(sessionKey string) string {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) < 2 || parts[0] != p.platformName {
+		return ""
+	}
+	chatID := parts[1]
+	if chatID == "" {
+		return ""
+	}
+	return p.channelKeyForBinding(chatID, sessionKey)
+}
+
 // feishuPreviewHandle stores the message ID for an editable preview message.
 // Card 2.0 path needs mu/status/lastContent to let SetPreviewStatus patch
 // the header color without re-rendering the whole card.

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -745,6 +745,100 @@ func TestChannelKeyForBinding(t *testing.T) {
 	}
 }
 
+// TestChannelKeyForCronSession verifies the CronChannelKeyResolver
+// implementation. ExecuteCronJob calls this to discover thread-scoped
+// workspace bindings; without it the engine would fall back to extractChannelID
+// which strips the "root:rootID" suffix and misses any thread-scoped binding.
+func TestChannelKeyForCronSession(t *testing.T) {
+	tests := []struct {
+		name            string
+		platformName    string
+		threadIsolation bool
+		sessionKey      string
+		want            string
+	}{
+		{
+			name:            "thread isolation on, thread session_key",
+			platformName:    "feishu",
+			threadIsolation: true,
+			sessionKey:      "feishu:oc_chat:root:om_root",
+			want:            "oc_chat:om_root",
+		},
+		{
+			name:            "thread isolation on, DM-style session_key (no thread)",
+			platformName:    "feishu",
+			threadIsolation: true,
+			sessionKey:      "feishu:oc_chat:ou_user",
+			want:            "oc_chat",
+		},
+		{
+			name:            "thread isolation off, group session_key",
+			platformName:    "feishu",
+			threadIsolation: false,
+			sessionKey:      "feishu:oc_chat:ou_user",
+			want:            "oc_chat",
+		},
+		{
+			name:            "thread isolation off, ignores root-shaped session_key",
+			platformName:    "feishu",
+			threadIsolation: false,
+			sessionKey:      "feishu:oc_chat:root:om_root",
+			want:            "oc_chat",
+		},
+		{
+			name:            "shared_session_in_channel format (2 parts)",
+			platformName:    "feishu",
+			threadIsolation: true,
+			sessionKey:      "feishu:oc_chat",
+			want:            "oc_chat",
+		},
+		{
+			name:            "lark prefix matches platformName=lark",
+			platformName:    "lark",
+			threadIsolation: true,
+			sessionKey:      "lark:oc_chat:root:om_root",
+			want:            "oc_chat:om_root",
+		},
+		{
+			name:            "foreign prefix returns empty (lets engine fall back)",
+			platformName:    "feishu",
+			threadIsolation: true,
+			sessionKey:      "slack:C123:U456",
+			want:            "",
+		},
+		{
+			name:            "malformed: only platform segment",
+			platformName:    "feishu",
+			threadIsolation: true,
+			sessionKey:      "feishu",
+			want:            "",
+		},
+		{
+			name:            "malformed: empty chatID",
+			platformName:    "feishu",
+			threadIsolation: true,
+			sessionKey:      "feishu::ou_user",
+			want:            "",
+		},
+		{
+			name:            "empty session_key",
+			platformName:    "feishu",
+			threadIsolation: true,
+			sessionKey:      "",
+			want:            "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Platform{platformName: tt.platformName, threadIsolation: tt.threadIsolation}
+			got := p.ChannelKeyForCronSession(tt.sessionKey)
+			if got != tt.want {
+				t.Errorf("ChannelKeyForCronSession(%q) = %q, want %q", tt.sessionKey, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -682,6 +682,67 @@ func TestLark_ThreadIsolationUsesRootSessionKey(t *testing.T) {
 	if receivedMsg.SessionKey != "lark:oc_test:root:om_root" {
 		t.Fatalf("SessionKey = %q, want lark:oc_test:root:om_root", receivedMsg.SessionKey)
 	}
+	// ChannelKey must embed the thread root so workspace binding can be
+	// scoped per thread (with engine-level fallback to the chat-level key).
+	if receivedMsg.ChannelKey != "oc_test:om_root" {
+		t.Fatalf("ChannelKey = %q, want oc_test:om_root", receivedMsg.ChannelKey)
+	}
+}
+
+func TestChannelKeyForBinding(t *testing.T) {
+	tests := []struct {
+		name            string
+		threadIsolation bool
+		chatID          string
+		sessionKey      string
+		wantChannelKey  string
+	}{
+		{
+			name:            "thread isolation off, plain group",
+			threadIsolation: false,
+			chatID:          "oc_chat",
+			sessionKey:      "feishu:oc_chat:ou_user",
+			wantChannelKey:  "oc_chat",
+		},
+		{
+			name:            "thread isolation off, ignores root-shaped session key",
+			threadIsolation: false,
+			chatID:          "oc_chat",
+			sessionKey:      "feishu:oc_chat:root:om_root",
+			wantChannelKey:  "oc_chat",
+		},
+		{
+			name:            "thread isolation on, top-level (no thread)",
+			threadIsolation: true,
+			chatID:          "oc_chat",
+			sessionKey:      "feishu:oc_chat:ou_user",
+			wantChannelKey:  "oc_chat",
+		},
+		{
+			name:            "thread isolation on, in thread (root: prefix)",
+			threadIsolation: true,
+			chatID:          "oc_chat",
+			sessionKey:      "feishu:oc_chat:root:om_root",
+			wantChannelKey:  "oc_chat:om_root",
+		},
+		{
+			name:            "thread isolation on, in thread (thread: prefix)",
+			threadIsolation: true,
+			chatID:          "oc_chat",
+			sessionKey:      "feishu:oc_chat:thread:om_root",
+			wantChannelKey:  "oc_chat:om_root",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Platform{threadIsolation: tt.threadIsolation}
+			got := p.channelKeyForBinding(tt.chatID, tt.sessionKey)
+			if got != tt.wantChannelKey {
+				t.Errorf("channelKeyForBinding(%q, %q) = %q, want %q",
+					tt.chatID, tt.sessionKey, got, tt.wantChannelKey)
+			}
+		})
+	}
 }
 
 func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t *testing.T) {

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -745,11 +746,50 @@ func TestChannelKeyForBinding(t *testing.T) {
 	}
 }
 
-// TestChannelKeyForCronSession verifies the CronChannelKeyResolver
-// implementation. ExecuteCronJob calls this to discover thread-scoped
-// workspace bindings; without it the engine would fall back to extractChannelID
-// which strips the "root:rootID" suffix and misses any thread-scoped binding.
-func TestChannelKeyForCronSession(t *testing.T) {
+// TestResolveCronReplyTarget_GatedByThreadIsolation verifies the early-return
+// gates of the CronReplyTargetResolver implementation. When thread_isolation
+// is off, the resolver must return ErrNotSupported so the engine falls back
+// to ReconstructReplyCtx (no topic anchor posted). When the session_key is
+// malformed or platform prefix doesn't match, also returns ErrNotSupported.
+// The on-success path that actually posts to Feishu API is exercised by
+// real-world cron runs, not unit tests.
+func TestResolveCronReplyTarget_GatedByThreadIsolation(t *testing.T) {
+	tests := []struct {
+		name            string
+		platformName    string
+		threadIsolation bool
+		sessionKey      string
+		wantErr         error
+	}{
+		{"isolation off rejects", "feishu", false, "feishu:oc_chat:ou_user", core.ErrNotSupported},
+		{"foreign prefix rejects", "feishu", true, "slack:C1:U1", core.ErrNotSupported},
+		{"empty key rejects", "feishu", true, "", core.ErrNotSupported},
+		{"single segment rejects", "feishu", true, "feishu", core.ErrNotSupported},
+		{"empty chatID rejects", "feishu", true, "feishu::ou_user", core.ErrNotSupported},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Platform{platformName: tt.platformName, threadIsolation: tt.threadIsolation}
+			sk, rctx, err := p.ResolveCronReplyTarget(tt.sessionKey, "test title")
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if sk != "" {
+				t.Errorf("sessionKey = %q, want empty on rejection", sk)
+			}
+			if rctx != nil {
+				t.Errorf("replyCtx = %#v, want nil on rejection", rctx)
+			}
+		})
+	}
+}
+
+// TestChannelKeyForSession verifies the SessionChannelKeyResolver
+// implementation. Cron / card renderers / background lookups call this to
+// discover thread-scoped workspace bindings; without it the engine would fall
+// back to extractChannelID which strips the "root:rootID" suffix and misses
+// any thread-scoped binding.
+func TestChannelKeyForSession(t *testing.T) {
 	tests := []struct {
 		name            string
 		platformName    string
@@ -831,9 +871,9 @@ func TestChannelKeyForCronSession(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Platform{platformName: tt.platformName, threadIsolation: tt.threadIsolation}
-			got := p.ChannelKeyForCronSession(tt.sessionKey)
+			got := p.ChannelKeyForSession(tt.sessionKey)
 			if got != tt.want {
-				t.Errorf("ChannelKeyForCronSession(%q) = %q, want %q", tt.sessionKey, got, tt.want)
+				t.Errorf("ChannelKeyForSession(%q) = %q, want %q", tt.sessionKey, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Implements per-thread workspace binding for Feishu/Lark group topics, following the `conversation scope -> workspace` direction discussed in #243 (PR #287 added the shared-routing infrastructure this builds on).

When `thread_isolation = true`, each Feishu thread can be bound to its own workspace via `/workspace bind` inside the thread. A thread with no specific binding transparently inherits from the parent chat — so the existing UX of "open a new topic and start chatting immediately" is preserved when the chat is already bound (or auto-bound by convention).

The core fallback is platform-agnostic, so Telegram forum topics also gain chat-level inheritance.

## Behaviour matrix

| Scenario | Workspace resolved |
|---|---|
| Chat bound to A, message in main channel | A |
| Chat bound to A, new thread, no thread binding | A (via fallback) |
| Chat bound to A, \`/workspace bind B\` inside thread | B for that thread; siblings still A |
| No chat binding, \`base_dir/<chat-name>\` exists | Auto-bind at *chat* scope; siblings inherit |
| No binding at any scope | Init flow as before |

## What changes

**\`core/engine.go\`**
- \`parentWorkspaceChannelKey\` / \`parentChannelID\` helpers strip the last colon-separated segment while preserving the platform prefix.
- \`lookupEffectiveWorkspaceBinding\` ascends to parent scopes; a thread-specific binding still shadows the parent.
- \`resolveWorkspace\` does the same ascent for \`ResolveChannelName\`, and records convention auto-bind at the scope that resolved the name so sibling threads inherit.

**\`platform/feishu/feishu.go\`**
- New \`channelKeyForBinding\` helper.
- Set \`core.Message.ChannelKey\` on all 12 dispatch sites (9 in \`dispatchMessage\`, 3 in \`onCardAction\`).
- \`thread_isolation = false\` and non-thread messages: no behaviour change (key equals \`chatID\`).

## Tests

- \`core\`: \`TestParentWorkspaceChannelKey\`, \`TestParentChannelID\`, \`TestResolveWorkspace_ThreadInheritsChatBinding\`, \`TestResolveWorkspace_ThreadOverridesChat\`, \`TestResolveWorkspace_ConventionAutoBindsToParent\`
- \`platform/feishu\`: \`TestChannelKeyForBinding\` (table-driven), plus a \`ChannelKey\` assertion on \`TestLark_ThreadIsolationUsesRootSessionKey\`

\`go test ./core/ ./platform/feishu/\` passes apart from 5 env-dependent pre-existing failures unrelated to this change (HOME-path abbreviation tests + macOS \`/var\` symlink). Confirmed they also fail on clean upstream \`main\` (14abab17) with no patch applied.

## Backward compatibility

- \`thread_isolation = false\`: identical key (\`chatID\`) to before.
- \`thread_isolation = true\` without thread bindings: identical resolution via the parent-scope fallback.
- Existing \`feishu:chatID\` bindings continue to be hit by both exact lookups and parent-scope fallback from threads.

Refs: #243, #287