### PR TITLE
fix(dingtalk): set replyContext.isGroup in richText and image branches

### DIFF
--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -270,6 +270,7 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 				sessionWebhook: data.SessionWebhook,
 				conversationId: data.ConversationId,
 				senderStaffId:  data.SenderStaffId,
+				isGroup:        data.ConversationType == "2",
 			},
 		}
 		p.handler(p, msg)
@@ -471,6 +472,7 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 			sessionWebhook:  data.SessionWebhook,
 			conversationId:  data.ConversationId,
 			senderStaffId:   data.SenderStaffId,
+			isGroup:         data.ConversationType == "2",
 		},
 		Images: []core.ImageAttachment{{
 			MimeType: mimeType,

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
 )
 
 // ──────────────────────────────────────────────────────────────
@@ -350,6 +353,82 @@ func TestProactiveRouting_DirectSessionUsesDirectAPI(t *testing.T) {
 	}
 	if rc.senderStaffId != "user111" {
 		t.Errorf("direct routing: senderStaffId=%q, want %q", rc.senderStaffId, "user111")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
+// onMessage: richText branch must propagate isGroup so that proactive
+// sends after sessionWebhook expiry route to the group API rather than
+// to a 1:1 DM with the original sender.
+// ──────────────────────────────────────────────────────────────
+
+func TestOnMessage_RichTextInGroup_SetsIsGroup(t *testing.T) {
+	var captured *core.Message
+	p := &Platform{
+		handler: func(_ core.Platform, msg *core.Message) {
+			captured = msg
+		},
+	}
+
+	data := &chatbot.BotCallbackDataModel{
+		MsgId:            "msg-rt-group-1",
+		Msgtype:          "richText",
+		ConversationId:   "conv-group",
+		ConversationType: "2",
+		SenderStaffId:    "user1",
+		SenderNick:       "Alice",
+		Content: map[string]interface{}{
+			"richText": []interface{}{
+				map[string]interface{}{"text": "hello"},
+			},
+		},
+	}
+	p.onMessage(data, &richTextContent{})
+
+	if captured == nil {
+		t.Fatal("handler was not invoked for richText message")
+	}
+	rc, ok := captured.ReplyCtx.(replyContext)
+	if !ok {
+		t.Fatalf("ReplyCtx = %T, want replyContext", captured.ReplyCtx)
+	}
+	if !rc.isGroup {
+		t.Errorf("richText in ConversationType=2 group: isGroup=false, want true (proactive send would misroute to 1:1 DM)")
+	}
+}
+
+func TestOnMessage_RichTextDirect_KeepsIsGroupFalse(t *testing.T) {
+	var captured *core.Message
+	p := &Platform{
+		handler: func(_ core.Platform, msg *core.Message) {
+			captured = msg
+		},
+	}
+
+	data := &chatbot.BotCallbackDataModel{
+		MsgId:            "msg-rt-direct-1",
+		Msgtype:          "richText",
+		ConversationId:   "conv-direct",
+		ConversationType: "1",
+		SenderStaffId:    "user2",
+		SenderNick:       "Bob",
+		Content: map[string]interface{}{
+			"richText": []interface{}{
+				map[string]interface{}{"text": "hi"},
+			},
+		},
+	}
+	p.onMessage(data, &richTextContent{})
+
+	if captured == nil {
+		t.Fatal("handler was not invoked for richText message")
+	}
+	rc, ok := captured.ReplyCtx.(replyContext)
+	if !ok {
+		t.Fatalf("ReplyCtx = %T, want replyContext", captured.ReplyCtx)
+	}
+	if rc.isGroup {
+		t.Errorf("richText in 1:1 chat: isGroup=true, want false")
 	}
 }
 


### PR DESCRIPTION
### Problem

In `platform/dingtalk/dingtalk.go`, the `replyContext` literals built for **richText** (`onMessage`, around line 269) and **image** (`handleImageMessage`, around line 470) messages omit the `isGroup` field. The sibling **text** (line 302) and **audio** (lines 370 and 394) branches already set:

```go
isGroup: data.ConversationType == "2",
```

`sendProactiveMessage` routes on `rc.isGroup`:

- `true` + non-empty conversationId → `/v1.0/robot/groupMessages/send` (group)
- otherwise + non-empty senderStaffId → `/v1.0/robot/oToMessages/batchSend` (1:1 DM to sender)

So a group-chat richText reply (e.g. a user quoting another message — DingTalk encodes this as `Msgtype: "richText"`) or a group-chat image, when the proactive path fires (sessionWebhook expired, cron, `cc-connect send`, etc.), is misrouted to a **1:1 DM with the original sender** instead of being posted back to the group. Wrong chat, often fails when the bot has no DM channel with that user, and leaks the response outside the group's audit context.

### Fix

Add `isGroup: data.ConversationType == "2"` to the two `replyContext` literals so all four message-type branches stay symmetric.

### Test

Adds `TestOnMessage_RichTextInGroup_SetsIsGroup` (group case) and `TestOnMessage_RichTextDirect_KeepsIsGroupFalse` (1:1 case) by invoking `onMessage` with a synthesized `chatbot.BotCallbackDataModel` and asserting the captured `replyContext.isGroup`. Verified on the unfixed code with `git stash` the group test fails (`isGroup=false, want true`) and the direct test still passes. With the fix both pass.

(Image branch shares the same trivial change but requires HTTP plumbing to exercise end-to-end; the richText tests pin the bug class and the image fix is the symmetric 1-line addition.)