### PR TITLE
fix(build): normalize dash → underscore in AGENTS / PLATFORMS_INCLUDE / EXCLUDE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,20 +42,28 @@ COMMA := ,
 # Compute exclusion tags from AGENTS / PLATFORMS_INCLUDE / EXCLUDE variables
 _EXCLUDE_TAGS :=
 
+# Normalize comma-separated user input into the form used by ALL_AGENTS /
+# ALL_PLATFORMS (space-separated, dashes folded to underscores). Without
+# the dash→underscore fold, an agent registered under a hyphenated name
+# (e.g. AGENTS=foo-bar with build tag `no_foo_bar`) would fail to match
+# `foo_bar` in the ALL list and silently emit `no_foo_bar` via filter-out
+# — excluding the very plugin the user asked to include.
+_normalize = $(subst -,_,$(subst $(COMMA), ,$(1)))
+
 ifdef AGENTS
-  _WANTED_AGENTS := $(subst $(COMMA), ,$(AGENTS))
+  _WANTED_AGENTS := $(call _normalize,$(AGENTS))
   _EXCLUDE_AGENTS := $(filter-out $(_WANTED_AGENTS),$(ALL_AGENTS))
   _EXCLUDE_TAGS += $(addprefix no_,$(_EXCLUDE_AGENTS))
 endif
 
 ifdef PLATFORMS_INCLUDE
-  _WANTED_PLATFORMS := $(subst $(COMMA), ,$(PLATFORMS_INCLUDE))
+  _WANTED_PLATFORMS := $(call _normalize,$(PLATFORMS_INCLUDE))
   _EXCLUDE_PLATFORMS := $(filter-out $(_WANTED_PLATFORMS),$(ALL_PLATFORMS))
   _EXCLUDE_TAGS += $(addprefix no_,$(_EXCLUDE_PLATFORMS))
 endif
 
 ifdef EXCLUDE
-  _EXCLUDE_TAGS += $(addprefix no_,$(subst $(COMMA), ,$(EXCLUDE)))
+  _EXCLUDE_TAGS += $(addprefix no_,$(call _normalize,$(EXCLUDE)))
 endif
 
 ifdef NO_WEB


### PR DESCRIPTION
## Summary

Tiny build-tooling fix.

Build tags use underscores (`no_foo_bar`) but `ALL_AGENTS` / `ALL_PLATFORMS` entries are bare names. When a downstream / fork plugin's registered name contains a dash (e.g. an agent named \`foo-bar\` whose build tag is \`no_foo_bar\`), the user-facing flag value `AGENTS=foo-bar` was passed through unchanged. The `filter-out` then failed to match `foo_bar` in the ALL list, so the agent was **added** to the exclusion set — i.e. the build silently dropped the very plugin the user asked to include.

Introduce a tiny `_normalize` define that runs the comma-split and a dash→underscore fold in one step, and use it everywhere user-supplied plugin lists feed into `filter-out` / `addprefix`.

## Behaviour

- Existing underscore-or-bare names: unchanged (verified via `make -n build EXCLUDE=feishu` and `make -n build AGENTS=claudecode,codex` producing identical tag lists before/after).
- Hyphenated names like `AGENTS=foo-bar` now correctly resolve to `no_*` tags for the other agents.

No new ALL_AGENTS / ALL_PLATFORMS entries are added by this PR — purely input normalization so downstream additions with hyphenated names work as the existing help text suggests.

## Test plan

- [x] `make -n build EXCLUDE=feishu` → produces `no_feishu` as before
- [x] `make -n build AGENTS=claudecode,codex` → excludes all other agents correctly
- [ ] Try `make build AGENTS=some-hyphenated-name` if you have a hyphenated agent registered downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)