### PR TITLE
fix(max): webhook handler goroutine inherits platform cancellation context

### DIFF
--- a/platform/max/max.go
+++ b/platform/max/max.go
@@ -70,6 +70,7 @@ type Platform struct {
 
 	mu           sync.RWMutex
 	handler      core.MessageHandler
+	ctx          context.Context
 	cancel       context.CancelFunc
 	stopping     bool
 	client       *http.Client // general API calls — httpTimeout
@@ -160,6 +161,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 	p.handler = handler
 
 	ctx, cancel := context.WithCancel(context.Background())
+	p.ctx = ctx
 	p.cancel = cancel
 
 	// Verify token at startup
@@ -304,16 +306,16 @@ func (p *Platform) webhookHandler(w http.ResponseWriter, r *http.Request) {
 	// never let agent latency back-pressure the delivery side.
 	go func() {
 		p.mu.RLock()
-		ctx := context.Background()
-		if p.cancel != nil {
-			// Use the platform's own cancellation context so a Stop() also
-			// short-circuits in-flight handler work.
-			ctx2, cancel := context.WithCancel(ctx)
-			_ = cancel
-			ctx = ctx2
-		}
+		parent := p.ctx
 		p.mu.RUnlock()
-		p.handleUpdate(ctx, &upd)
+		// Use the platform's own cancellation context so a Stop() also
+		// short-circuits in-flight handler work. Fall back to Background
+		// only when the platform was never Start-ed (test paths that call
+		// webhookHandler directly).
+		if parent == nil {
+			parent = context.Background()
+		}
+		p.handleUpdate(parent, &upd)
 	}()
 	w.WriteHeader(http.StatusOK)
 }

--- a/platform/max/max_test.go
+++ b/platform/max/max_test.go
@@ -857,3 +857,39 @@ func TestWebhookHandlerWrongMethod(t *testing.T) {
 		t.Fatalf("got %d, want 405", rec.Code)
 	}
 }
+
+// TestStartStoresLifecycleContext verifies that Start captures the platform's
+// cancellation context onto p.ctx so webhookHandler's async goroutine has a
+// lifecycle parent to inherit from. Without this wiring, webhookHandler falls
+// back to context.Background() and Stop() cannot short-circuit in-flight
+// handler work.
+func TestStartStoresLifecycleContext(t *testing.T) {
+	m := newMockAPI(t)
+	defer m.close()
+	p := newTestPlatform(t, m.server.URL)
+
+	if got := p.ctx; got != nil {
+		t.Fatalf("p.ctx already set before Start: %v", got)
+	}
+	if err := p.Start(func(_ core.Platform, _ *core.Message) {}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	ctx := p.ctx
+	if ctx == nil {
+		t.Fatal("p.ctx not stored after Start; webhookHandler goroutine will fall back to context.Background and Stop cannot cancel it")
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("p.ctx already Done after Start")
+	default:
+	}
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	select {
+	case <-ctx.Done():
+		// expected — Stop's cancel cascaded into p.ctx.
+	case <-time.After(time.Second):
+		t.Fatal("p.ctx not Done one second after Stop")
+	}
+}


### PR DESCRIPTION
### Problem

`platform/max/max.go` `webhookHandler` dispatches incoming updates from a goroutine, and a comment claims the goroutine uses the platform's own cancellation context so `Stop()` can short-circuit in-flight handler work:

```go
go func() {
    p.mu.RLock()
    ctx := context.Background()
    if p.cancel != nil {
        // Use the platform's own cancellation context so a Stop() also
        // short-circuits in-flight handler work.
        ctx2, cancel := context.WithCancel(ctx)
        _ = cancel                       // discarded
        ctx = ctx2
    }
    p.mu.RUnlock()
    p.handleUpdate(ctx, &upd)            // detached from p.cancel
}()
```

The platform only stores `p.cancel` (a `CancelFunc`), not the parent context — `ctx2` is derived from `context.Background()`, not from anything `p.cancel` controls, and `cancel` is immediately thrown away. The comment vs. behavior mismatch means in webhook delivery mode:

- `Stop()` calls `p.cancel()` to abort polling and webhook re-subscription, but every in-flight webhook handler (which fans out into `p.handleUpdate` → `p.handler` → engine work, agent calls, attachment downloads, HTTP retries) keeps running with an uncancelable context.
- Process shutdown returns immediately while handlers keep posting to MAX using credentials from a "stopped" platform — bypassing the documented Stop semantics other transports honor.

The long-poll path (`pollLoop` → `handleUpdate` at line 926) does propagate the correct parent ctx via `go p.pollLoop(ctx)` in `Start`, so this is webhook-mode-only and was introduced together with webhook delivery in PR #818.

### Fix

Store the parent context on the platform alongside `cancel` in `Start`, then derive the per-request work context from it in `webhookHandler`. Fall back to `context.Background()` only when `Start` was never called (e.g. test paths that call `webhookHandler` directly).

No behavior change in poll mode; webhook mode now honors `Stop()`.

### Test

Adds `TestStartStoresLifecycleContext` asserting:
- `p.ctx` is nil before `Start`.
- After `Start`, `p.ctx` is non-nil and not Done.
- After `Stop`, `p.ctx` is Done within 1s.

This pins the field wiring (without the fix the test fails to compile because `p.ctx` does not exist). End-to-end cancellation propagation through the webhook goroutine + `sendChatAction` HTTP path is structurally guaranteed once the parent context flows through — verifiable from the 9-line diff.

Existing `TestPollLoopStopsOnCtxCancel` and the suite of `TestWebhookHandler*` tests continue to pass.