### PR TITLE
fix(core/observer): advance tail offset on scanner error to prevent re-forwarding

### DIFF
--- a/core/observer.go
+++ b/core/observer.go
@@ -229,10 +229,17 @@ func (o *sessionObserver) tailFile(ctx context.Context, path string, offset int6
 
 	// Use file size as new offset when we've read to EOF cleanly.
 	// This avoids offset drift from line-length calculation (e.g. \r\n vs \n).
-	if scanner.Err() == nil {
-		return info.Size()
+	if err := scanner.Err(); err != nil {
+		// A JSONL line exceeded the scanner buffer cap (e.g. a Claude Code
+		// session entry containing a large embedded image / base64 payload).
+		// Returning the original offset here would cause the next poll to
+		// re-forward every line preceding the oversize one, every tick,
+		// forever. Advance past the file we've already seen instead — at
+		// the cost of skipping lines appended between this poll and the
+		// next, which is rare and recoverable.
+		slog.Warn("observe: scanner error during tail; advancing offset to avoid duplicate forwards", "path", path, "err", err)
 	}
-	return offset
+	return info.Size()
 }
 
 // forward sends a parsed observation to the target platform.

--- a/core/observer_test.go
+++ b/core/observer_test.go
@@ -243,6 +243,77 @@ func TestSessionObserverInitOffsetsSkipsExisting(t *testing.T) {
 	}
 }
 
+// TestSessionObserverOversizeLineDoesNotReforward verifies that a JSONL line
+// that exceeds the scanner buffer cap (e.g. a Claude Code session entry with
+// a large embedded image / base64 payload) does not cause the earlier valid
+// lines to be re-forwarded on every subsequent poll. Without the fix in
+// tailFile, scanner.Err() returns bufio.ErrTooLong and the function returns
+// the original offset, so each tick re-emits every line preceding the
+// oversize one.
+func TestSessionObserverOversizeLineDoesNotReforward(t *testing.T) {
+	dir := t.TempDir()
+
+	var received []string
+	var mu sync.Mutex
+	target := &mockObserverTargetCapture{
+		fn: func(_ context.Context, _, text string) error {
+			mu.Lock()
+			received = append(received, text)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	obs := newSessionObserver(dir, target, "C123")
+	sessionFile := filepath.Join(dir, "oversize.jsonl")
+	if err := os.WriteFile(sessionFile, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	obs.initOffsets()
+
+	appendLine := func(line string) {
+		t.Helper()
+		f, err := os.OpenFile(sessionFile, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString(line); err != nil {
+			f.Close()
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 1. Append a short, valid line.
+	appendLine(`{"type":"user","message":{"role":"user","content":"first"},"entrypoint":"cli"}` + "\n")
+	// 2. Append a line exceeding the scanner's 1MiB buffer cap. JSON is
+	// well-formed but unparseable in the same Scan call because of size.
+	bigContent := strings.Repeat("x", 1100*1024)
+	appendLine(`{"type":"user","message":{"role":"user","content":"` + bigContent + `"},"entrypoint":"cli"}` + "\n")
+
+	obs.poll(context.Background())
+	mu.Lock()
+	afterFirstPoll := len(received)
+	mu.Unlock()
+	if afterFirstPoll < 1 {
+		t.Fatalf("expected the short line to be forwarded once; received=%d", afterFirstPoll)
+	}
+
+	// Poll several more times without appending. The short line must NOT be
+	// re-emitted, regardless of whether the oversize line is skipped.
+	for i := 0; i < 5; i++ {
+		obs.poll(context.Background())
+	}
+	mu.Lock()
+	afterRepeatPolls := len(received)
+	mu.Unlock()
+	if afterRepeatPolls != afterFirstPoll {
+		t.Fatalf("repeat polls re-forwarded prior lines: started at %d, now %d (delta %d)", afterFirstPoll, afterRepeatPolls, afterRepeatPolls-afterFirstPoll)
+	}
+}
+
 func TestSessionObserverTruncation(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
### Problem

`core/observer.go` `tailFile` (around line 200) reads new JSONL lines from a Claude Code session log via `bufio.Scanner` with a 1 MiB max token size, forwards each parsed observation, then returns the new offset. On a clean EOF it returns `info.Size()`; on any scanner error it returns the original `offset`:

```go
if scanner.Err() == nil {
    return info.Size()
}
return offset
```

The lines preceding the failing scan are already forwarded via `o.forward` inside the loop. Returning the original offset means the next poll (every 2s) re-reads from the same starting point and forwards those same lines again. With a persistent scanner error (e.g. a JSONL line ≥ 1 MiB — common when Claude Code embeds a large base64 image / attachment in a session entry), the duplicates re-emit on every tick.

User-visible symptom: an Observe-enabled Slack channel starts spamming duplicate `user:` / `Claude:` messages on a stuck loop once a single oversize JSONL line lands in the session file, and keeps spamming forever, every 2 seconds, until the file is rotated or the daemon restarts.

### Fix

Advance the offset to `info.Size()` on scanner error too, after logging a warning that includes the path and the scanner error. Lines that happened to be appended in the narrow window between the failing scan and the offset advance may be skipped on this poll — far better than perpetual duplicate forwards, and self-correcting on the next file append (whose bytes land past `info.Size()`).

```go
if err := scanner.Err(); err != nil {
    slog.Warn("observe: scanner error during tail; advancing offset to avoid duplicate forwards", "path", path, "err", err)
}
return info.Size()
```

### Test

Adds `TestSessionObserverOversizeLineDoesNotReforward`: writes a short valid line, then a JSONL line exceeding the 1 MiB scanner cap, polls once, then polls 5 more times without appending. Asserts the short line is forwarded exactly once across all polls. Verified the test fails on unfixed code (`repeat polls re-forwarded prior lines: started at 1, now 6 (delta 5)`) and passes with the fix.

Pre-existing macOS-only failures in `core/` (`TestProcessInteractiveEvents_*ReplyFooter*`, `TestResolveLocalDirPath_AcceptsSubdir`) reproduce on `main` and are tied to HOME-tilde rendering / `/var` ↔ `/private/var` symlinks — unrelated to this change.