### PR TITLE
fix(dingtalk): SendImage/SendFile/SendAudio honor replyContext.isGroup

### DIFF
--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -706,11 +706,9 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 	}
 
 	msgParamBytes, _ := json.Marshal(map[string]string{"photoURL": mediaID})
-	requestBody := map[string]any{
-		"robotCode": p.robotCode,
-		"userIds":   []string{rc.senderStaffId},
-		"msgKey":    "sampleImageMsg",
-		"msgParam":  string(msgParamBytes),
+	apiURL, requestBody, err := p.mediaSendTarget(rc, "sampleImageMsg", string(msgParamBytes))
+	if err != nil {
+		return fmt.Errorf("dingtalk: send image: %w", err)
 	}
 
 	body, err := json.Marshal(requestBody)
@@ -718,9 +716,7 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 		return fmt.Errorf("dingtalk: marshal image message: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		"https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend",
-		bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("dingtalk: create image request: %w", err)
 	}
@@ -799,11 +795,9 @@ func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachm
 		"fileName": name,
 		"fileType": ext,
 	})
-	requestBody := map[string]any{
-		"robotCode": p.robotCode,
-		"userIds":   []string{rc.senderStaffId},
-		"msgKey":    "sampleFile",
-		"msgParam":  string(msgParamBytes),
+	apiURL, requestBody, err := p.mediaSendTarget(rc, "sampleFile", string(msgParamBytes))
+	if err != nil {
+		return fmt.Errorf("dingtalk: send file: %w", err)
 	}
 
 	body, err := json.Marshal(requestBody)
@@ -811,9 +805,7 @@ func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachm
 		return fmt.Errorf("dingtalk: marshal file message: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		"https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend",
-		bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("dingtalk: create file request: %w", err)
 	}
@@ -919,14 +911,12 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 		return fmt.Errorf("dingtalk: get access token: %w", err)
 	}
 
-	// Build oToMessages API request with sampleAudio msgKey
-	// msgParam must be a JSON string, not an object
+	// Build the API request with sampleAudio msgKey, routing on rc.isGroup.
+	// msgParam must be a JSON string, not an object.
 	msgParamJSON := fmt.Sprintf(`{"mediaId":"%s","duration":"%d"}`, mediaID, durationMs)
-	requestBody := map[string]interface{}{
-		"robotCode": p.robotCode,
-		"userIds":   []string{rc.senderStaffId},
-		"msgKey":    "sampleAudio",
-		"msgParam":  msgParamJSON,
+	apiURL, requestBody, err := p.mediaSendTarget(rc, "sampleAudio", msgParamJSON)
+	if err != nil {
+		return fmt.Errorf("dingtalk: send audio: %w", err)
 	}
 
 	body, err := json.Marshal(requestBody)
@@ -934,11 +924,9 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 		return fmt.Errorf("dingtalk: marshal audio message: %w", err)
 	}
 
-	slog.Debug("dingtalk: sending voice via oToMessages API", "media_id", mediaID, "duration", durationMs, "user_id", rc.senderStaffId)
+	slog.Debug("dingtalk: sending voice", "media_id", mediaID, "duration", durationMs, "api_url", apiURL, "is_group", rc.isGroup)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		"https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend",
-		bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("dingtalk: create audio request: %w", err)
 	}
@@ -1152,6 +1140,34 @@ func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 		isGroup:        convType == "g",
 		proactive:      true,
 	}, nil
+}
+
+// mediaSendTarget returns the DingTalk API URL and request body for sending
+// a media message (image / file / audio), mirroring the routing in
+// sendProactiveMessage: group sessions go through
+// /v1.0/robot/groupMessages/send with openConversationId, 1:1 sessions go
+// through /v1.0/robot/oToMessages/batchSend with userIds. msgParam must
+// already be a JSON-encoded string per DingTalk's API contract.
+func (p *Platform) mediaSendTarget(rc replyContext, msgKey, msgParam string) (string, map[string]any, error) {
+	if rc.isGroup && rc.conversationId != "" {
+		return "https://api.dingtalk.com/v1.0/robot/groupMessages/send",
+			map[string]any{
+				"robotCode":          p.robotCode,
+				"openConversationId": rc.conversationId,
+				"msgKey":             msgKey,
+				"msgParam":           msgParam,
+			}, nil
+	}
+	if rc.senderStaffId == "" {
+		return "", nil, fmt.Errorf("dingtalk: media send requires conversationId (group) or senderStaffId (direct)")
+	}
+	return "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend",
+		map[string]any{
+			"robotCode": p.robotCode,
+			"userIds":   []string{rc.senderStaffId},
+			"msgKey":    msgKey,
+			"msgParam":  msgParam,
+		}, nil
 }
 
 // sendProactiveMessage sends a message using the DingTalk group/direct message API

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -1,11 +1,16 @@
 package dingtalk
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/chenhg5/cc-connect/core"
 )
 
 // ──────────────────────────────────────────────────────────────
@@ -350,6 +355,176 @@ func TestProactiveRouting_DirectSessionUsesDirectAPI(t *testing.T) {
 	}
 	if rc.senderStaffId != "user111" {
 		t.Errorf("direct routing: senderStaffId=%q, want %q", rc.senderStaffId, "user111")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────
+// mediaSendTarget: image/file/audio sends must route on rc.isGroup the
+// same way sendProactiveMessage does. Without this, an image generated
+// in a group session is delivered to a 1:1 DM with the original sender
+// instead of being posted back to the group.
+// ──────────────────────────────────────────────────────────────
+
+func TestMediaSendTarget_GroupRoutesToGroupAPI(t *testing.T) {
+	p := &Platform{robotCode: "robot-x"}
+	rc := replyContext{
+		isGroup:        true,
+		conversationId: "cidGroupA",
+		senderStaffId:  "staff_42",
+	}
+	url, body, err := p.mediaSendTarget(rc, "sampleImageMsg", `{"photoURL":"@media-id"}`)
+	if err != nil {
+		t.Fatalf("mediaSendTarget: %v", err)
+	}
+	if url != "https://api.dingtalk.com/v1.0/robot/groupMessages/send" {
+		t.Errorf("group URL = %q, want groupMessages/send", url)
+	}
+	if got, ok := body["openConversationId"].(string); !ok || got != "cidGroupA" {
+		t.Errorf("openConversationId = %v, want \"cidGroupA\"", body["openConversationId"])
+	}
+	if _, hasUserIds := body["userIds"]; hasUserIds {
+		t.Errorf("group body must not include userIds: %v", body)
+	}
+}
+
+func TestMediaSendTarget_DirectRoutesToOToAPI(t *testing.T) {
+	p := &Platform{robotCode: "robot-x"}
+	rc := replyContext{
+		isGroup:       false,
+		senderStaffId: "staff_42",
+	}
+	url, body, err := p.mediaSendTarget(rc, "sampleImageMsg", `{"photoURL":"@media-id"}`)
+	if err != nil {
+		t.Fatalf("mediaSendTarget: %v", err)
+	}
+	if url != "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend" {
+		t.Errorf("direct URL = %q, want oToMessages/batchSend", url)
+	}
+	ids, ok := body["userIds"].([]string)
+	if !ok || len(ids) != 1 || ids[0] != "staff_42" {
+		t.Errorf("userIds = %v, want [\"staff_42\"]", body["userIds"])
+	}
+	if _, hasOpen := body["openConversationId"]; hasOpen {
+		t.Errorf("direct body must not include openConversationId: %v", body)
+	}
+}
+
+func TestMediaSendTarget_GroupWithEmptyConversationIdFallsBack(t *testing.T) {
+	p := &Platform{robotCode: "robot-x"}
+	rc := replyContext{
+		isGroup:        true,
+		conversationId: "",
+		senderStaffId:  "staff_99",
+	}
+	url, body, err := p.mediaSendTarget(rc, "sampleFile", `{"mediaId":"m"}`)
+	if err != nil {
+		t.Fatalf("mediaSendTarget: %v", err)
+	}
+	if url != "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend" {
+		t.Errorf("fallback URL = %q, want oToMessages/batchSend when conversationId empty", url)
+	}
+	if _, ok := body["userIds"]; !ok {
+		t.Errorf("fallback must use userIds, got body=%v", body)
+	}
+}
+
+func TestMediaSendTarget_NoTargetReturnsError(t *testing.T) {
+	p := &Platform{robotCode: "robot-x"}
+	rc := replyContext{} // no isGroup, no senderStaffId
+	_, _, err := p.mediaSendTarget(rc, "sampleImageMsg", `{}`)
+	if err == nil {
+		t.Fatal("expected error when neither group nor direct target is available")
+	}
+}
+
+// stubDingTalkRT intercepts every outbound HTTP call made by the dingtalk
+// Platform so a send test can run without real network. It records the URL
+// path of each request, returns stub success bodies for the token / upload
+// / send endpoints, and 404s anything else.
+type stubDingTalkRT struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func (rt *stubDingTalkRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.mu.Lock()
+	rt.paths = append(rt.paths, req.URL.Path)
+	rt.mu.Unlock()
+	mk := func(body string) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}
+	}
+	switch {
+	case strings.Contains(req.URL.Path, "/media/upload"):
+		return mk(`{"errcode":0,"media_id":"@fake-media","type":"image"}`), nil
+	case strings.Contains(req.URL.Path, "/oToMessages/batchSend"),
+		strings.Contains(req.URL.Path, "/groupMessages/send"):
+		return mk(`{"processQueryKey":"abc"}`), nil
+	default:
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found")), Header: make(http.Header)}, nil
+	}
+}
+
+func (rt *stubDingTalkRT) hit(suffix string) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for _, p := range rt.paths {
+		if strings.HasSuffix(p, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func newSendTestPlatform() (*Platform, *stubDingTalkRT) {
+	rt := &stubDingTalkRT{}
+	p := &Platform{
+		clientID:     "test",
+		clientSecret: "test",
+		robotCode:    "robot-x",
+		httpClient:   &http.Client{Transport: rt, Timeout: 10 * time.Second},
+		accessToken:  "cached-fake-token",
+		tokenExpiry:  time.Now().Add(time.Hour),
+	}
+	return p, rt
+}
+
+func TestSendImage_GroupSessionPostsToGroupAPI(t *testing.T) {
+	p, rt := newSendTestPlatform()
+	rc := replyContext{isGroup: true, conversationId: "cidGroupA", senderStaffId: "staff_42"}
+	if err := p.SendImage(context.Background(), rc, core.ImageAttachment{Data: []byte("png"), FileName: "x.png"}); err != nil {
+		t.Fatalf("SendImage: %v", err)
+	}
+	if !rt.hit("/groupMessages/send") {
+		t.Errorf("group SendImage did not hit /groupMessages/send; got paths=%v", rt.paths)
+	}
+	if rt.hit("/oToMessages/batchSend") {
+		t.Errorf("group SendImage also hit 1:1 oToMessages/batchSend (would deliver as private DM); paths=%v", rt.paths)
+	}
+}
+
+func TestSendImage_DirectSessionPostsTo1on1API(t *testing.T) {
+	p, rt := newSendTestPlatform()
+	rc := replyContext{senderStaffId: "staff_99"}
+	if err := p.SendImage(context.Background(), rc, core.ImageAttachment{Data: []byte("png"), FileName: "y.png"}); err != nil {
+		t.Fatalf("SendImage: %v", err)
+	}
+	if !rt.hit("/oToMessages/batchSend") {
+		t.Errorf("direct SendImage did not hit /oToMessages/batchSend; got paths=%v", rt.paths)
+	}
+}
+
+func TestSendFile_GroupSessionPostsToGroupAPI(t *testing.T) {
+	p, rt := newSendTestPlatform()
+	rc := replyContext{isGroup: true, conversationId: "cidGroupB", senderStaffId: "staff_42"}
+	if err := p.SendFile(context.Background(), rc, core.FileAttachment{Data: []byte("doc"), FileName: "x.txt"}); err != nil {
+		t.Fatalf("SendFile: %v", err)
+	}
+	if !rt.hit("/groupMessages/send") {
+		t.Errorf("group SendFile did not hit /groupMessages/send; got paths=%v", rt.paths)
 	}
 }
 


### PR DESCRIPTION
### Problem

In `platform/dingtalk/dingtalk.go`, the outbound media senders all hard-code the 1:1 `oToMessages/batchSend` endpoint and `userIds: [rc.senderStaffId]`, regardless of `rc.isGroup`:

- `SendImage` at line ~685, posts to `/v1.0/robot/oToMessages/batchSend` (line 722)
- `SendFile` at line ~769, same hardcoded URL (line 815)
- `SendAudio` at line ~846, same hardcoded URL (line 940)

The text path `sendProactiveMessage` (line ~1160) already branches correctly: groups with non-empty `conversationId` go to `/v1.0/robot/groupMessages/send` with `openConversationId`; 1:1 sessions go to `oToMessages/batchSend` with `userIds`. And the inbound handlers (`onMessage`, `handleImageMessage`) populate `rc.isGroup` for every message type. The outbound media path was simply never updated.

Concrete failure: a user in a DingTalk group asks the agent to generate a chart / take a screenshot / produce a voice reply. The agent generates the image / audio and calls `SendImage` (or `SendAudio`). The request goes to `oToMessages/batchSend` with `userIds: [originalSender]` — the chart is delivered as a private DM to that one user; the rest of the group never sees it. The accompanying text reply (which goes through `sendProactiveMessage`) lands correctly in the group, producing a confusing split between text and media.

### Fix

Factor the routing decision into a small `mediaSendTarget(rc, msgKey, msgParam) (url, body, err)` helper that mirrors `sendProactiveMessage`. Each of the three `Send*` callers swaps its hardcoded URL + body literal for the helper output. No behavior change for 1:1 sessions; group sessions now post to `/v1.0/robot/groupMessages/send` with `openConversationId`, matching the text path.

### Test

Unit tests on the helper (`TestMediaSendTarget_GroupRoutesToGroupAPI`, `TestMediaSendTarget_DirectRoutesToOToAPI`, `TestMediaSendTarget_GroupWithEmptyConversationIdFallsBack`, `TestMediaSendTarget_NoTargetReturnsError`) plus integration tests on the call sites (`TestSendImage_GroupSessionPostsToGroupAPI`, `TestSendImage_DirectSessionPostsTo1on1API`, `TestSendFile_GroupSessionPostsToGroupAPI`) using a `http.RoundTripper` stub that intercepts all outbound HTTP and records URL paths.

Verified with a targeted revert that `TestSendImage_GroupSessionPostsToGroupAPI` fails on the unfixed call site (`group SendImage did not hit /groupMessages/send; got paths=[/media/upload /v1.0/robot/oToMessages/batchSend]`) and passes with the fix.

Pre-existing tests in `platform/dingtalk/` continue to pass.