### PR TITLE
Fix setup commands for bound workspaces

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -11356,7 +11356,7 @@ func (e *Engine) cmdCronMute(p Platform, msg *Message, args []string, mute bool)
 }
 
 func (e *Engine) cmdCronSetup(p Platform, msg *Message) {
-	result, baseName, err := e.setupMemoryFile()
+	result, baseName, err := e.setupMemoryFileForMessage(p, msg)
 	switch result {
 	case setupNative:
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgSetupNative))
@@ -13060,14 +13060,31 @@ const (
 	setupError                       // write error
 )
 
-// setupMemoryFile appends AgentSystemPrompt() to the agent's project memory
-// file. It returns the result, the filename (for messages), and any error.
+// setupMemoryFile appends AgentSystemPrompt() to the engine agent's project
+// memory file. It returns the result, the filename (for messages), and any
+// error.
 func (e *Engine) setupMemoryFile() (setupResult, string, error) {
-	if _, ok := e.agent.(SystemPromptSupporter); ok {
+	return setupMemoryFileForAgent(e.agent)
+}
+
+func (e *Engine) setupMemoryFileForMessage(p Platform, msg *Message) (setupResult, string, error) {
+	agent := e.agent
+	if e.multiWorkspace {
+		resolved, _, _, err := e.commandContext(p, msg)
+		if err != nil {
+			return setupError, "", err
+		}
+		agent = resolved
+	}
+	return setupMemoryFileForAgent(agent)
+}
+
+func setupMemoryFileForAgent(agent Agent) (setupResult, string, error) {
+	if _, ok := agent.(SystemPromptSupporter); ok {
 		return setupNative, "", nil
 	}
 
-	mp, ok := e.agent.(MemoryFileProvider)
+	mp, ok := agent.(MemoryFileProvider)
 	if !ok {
 		return setupNoMemory, "", nil
 	}
@@ -13111,7 +13128,7 @@ func (e *Engine) setupMemoryFile() (setupResult, string, error) {
 }
 
 func (e *Engine) cmdBindSetup(p Platform, msg *Message) {
-	result, baseName, err := e.setupMemoryFile()
+	result, baseName, err := e.setupMemoryFileForMessage(p, msg)
 	switch result {
 	case setupNative:
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgSetupNative))

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -18,6 +19,17 @@ func (a *namedTestAgent) StartSession(_ context.Context, _ string) (AgentSession
 }
 func (a *namedTestAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) { return nil, nil }
 func (a *namedTestAgent) Stop() error                                                { return nil }
+
+type workspaceMemoryAgent struct {
+	*namedTestAgent
+	workDir string
+}
+
+func (a *workspaceMemoryAgent) ProjectMemoryFile() string {
+	return filepath.Join(a.workDir, "AGENTS.md")
+}
+
+func (a *workspaceMemoryAgent) GlobalMemoryFile() string { return "" }
 
 // mockChannelResolver implements both Platform and ChannelNameResolver.
 type mockChannelResolver struct {
@@ -669,6 +681,59 @@ func TestCommandContextWithWorkspace_BoundChannel(t *testing.T) {
 	wantKey := wantWS + ":" + msg.SessionKey
 	if interactiveKey != wantKey {
 		t.Errorf("interactiveKey = %q, want %q", interactiveKey, wantKey)
+	}
+}
+
+func TestCmdBindSetup_WritesBoundWorkspaceInstructions(t *testing.T) {
+	baseDir := t.TempDir()
+	globalDir := filepath.Join(baseDir, "global")
+	wsDir := filepath.Join(baseDir, "bound-workspace")
+	for _, dir := range []string{globalDir, wsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	agentName := "workspace-bind-setup-memory-agent"
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		workDir, _ := opts["work_dir"].(string)
+		return &workspaceMemoryAgent{
+			namedTestAgent: &namedTestAgent{name: agentName},
+			workDir:        workDir,
+		}, nil
+	})
+
+	parent := &workspaceMemoryAgent{
+		namedTestAgent: &namedTestAgent{name: agentName},
+		workDir:        globalDir,
+	}
+	e := NewEngine("test", parent, nil, "", LangEnglish)
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+
+	channelID := "C-bound-setup"
+	channelKey := "test-platform:" + channelID
+	e.workspaceBindings.Bind("project:test", channelKey, "bound-channel", wsDir)
+
+	p := &stubPlatformEngine{n: "test-platform"}
+	msg := &Message{
+		Platform:   "test-platform",
+		ChannelKey: channelID,
+		SessionKey: channelKey + ":U-001",
+		ReplyCtx:   "ctx",
+	}
+
+	e.cmdBindSetup(p, msg)
+
+	if _, err := os.Stat(filepath.Join(wsDir, "AGENTS.md")); err != nil {
+		t.Fatalf("expected bound workspace AGENTS.md to be written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(globalDir, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("global AGENTS.md should not be written, err=%v", err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(wsDir, "AGENTS.md"))
+	if !strings.Contains(string(content), "cc-connect send --file") {
+		t.Fatalf("workspace AGENTS.md missing attachment instructions: %q", string(content))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Resolve setup memory writes through the message command context in multi-workspace mode.
- Keep the existing engine-agent setup helper for non-workspace callers.
- Add a regression test that verifies `/bind setup` writes the bound workspace `AGENTS.md` instead of the global memory file.

## Test Plan
- `go test ./core -run TestCmdBindSetup_WritesBoundWorkspaceInstructions -count=1`
- `go test ./core -run 'TestSetupMemoryFile|TestCmdCronSetup|TestCmdBindSetup|TestCommandContextWithWorkspace' -count=1`\n- `go test ./core -count=1`\n- `go test ./...`\n- `git diff --check`\n\n## Notes\n- `golangci-lint` was not available in PATH locally.