### PR TITLE
agent/tmux: forward image attachments as on-disk files

### DIFF
--- a/agent/tmux/session.go
+++ b/agent/tmux/session.go
@@ -386,7 +386,8 @@ var ansiRe = regexp.MustCompile(
 //  2. TUI redraws (e.g. Claude Code) — terminal overwrites lines in place; find the
 //     longest common line prefix shared by both snapshots, then return the new lines
 //     that follow it in current, stripping the repeated trailing prompt lines.
-//  3. Terminal scrolled — baseline has partially scrolled off; use a shrinking anchor.
+//  3. Terminal scrolled and/or the volatile prompt was redrawn — anchor on a
+//     stable multi-line block of baseline's content (sliding up past the input box).
 func extractNew(baseline, current string) string {
 	if current == baseline {
 		return ""
@@ -426,21 +427,71 @@ func extractNew(baseline, current string) string {
 		}
 	}
 
-	// Scroll path: baseline has partially scrolled off the top; try progressively
-	// shorter anchors from the end of baseline to find where new content begins.
-	maxAnchor := 10
-	if len(baseLines) < maxAnchor {
-		maxAnchor = len(baseLines)
-	}
-	for n := maxAnchor; n >= 1; n-- {
-		anchor := strings.Join(baseLines[len(baseLines)-n:], "\n")
-		if idx := strings.LastIndex(current, anchor); idx >= 0 {
-			rest := strings.TrimLeft(current[idx+len(anchor):], "\n")
-			if rest != "" {
-				return rest
+	// Scroll path: the top of baseline scrolled off the buffer (so the prefix path
+	// found nothing) and/or the volatile bottom — a TUI input box / prompt that the
+	// agent redraws every turn — changed, so an exact tail match also misses. Slide
+	// a small multi-line window upward from the bottom of baseline and take its LAST
+	// occurrence in current: that is the lowest stable block the two snapshots still
+	// share, i.e. the boundary between old content and the agent's new output.
+	//
+	// A multi-line block (not a single line) avoids latching onto a lone repeated
+	// line such as a bare prompt, and LastIndex avoids latching onto an identical
+	// block from far back in history — the bug where stale scrollback was returned.
+	const win = 3
+	if len(baseLines) >= win {
+		for end := len(baseLines); end >= win; end-- {
+			block := baseLines[end-win : end]
+			start := lastIndexOfBlock(curLines, block)
+			if start < 0 {
+				continue
+			}
+			newLines := trimCommonTail(curLines[start+win:], baseLines)
+			if res := strings.TrimRight(strings.Join(newLines, "\n"), "\n"); res != "" {
+				return res
 			}
 		}
 	}
 
-	return current
+	// No shared block: baseline and current barely overlap, so current is
+	// effectively all-new (e.g. the buffer fully scrolled). Emit at most the last
+	// visibleFallbackLines lines so a stale multi-thousand-line scrollback can
+	// never be returned as "the response".
+	const visibleFallbackLines = 60
+	if len(curLines) > visibleFallbackLines {
+		curLines = curLines[len(curLines)-visibleFallbackLines:]
+	}
+	return strings.TrimRight(strings.Join(curLines, "\n"), "\n")
+}
+
+// lastIndexOfBlock returns the start index of the last contiguous occurrence of
+// block within lines, or -1 if block does not occur.
+func lastIndexOfBlock(lines, block []string) int {
+	if len(block) == 0 || len(block) > len(lines) {
+		return -1
+	}
+	for i := len(lines) - len(block); i >= 0; i-- {
+		match := true
+		for j := range block {
+			if lines[i+j] != block[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+// trimCommonTail drops trailing lines of newLines that duplicate the tail of
+// baseLines — the unchanged remnants of a redrawn input box / prompt, which are
+// not part of the agent's response.
+func trimCommonTail(newLines, baseLines []string) []string {
+	b := len(baseLines)
+	for len(newLines) > 0 && b > 0 && newLines[len(newLines)-1] == baseLines[b-1] {
+		newLines = newLines[:len(newLines)-1]
+		b--
+	}
+	return newLines
 }

--- a/agent/tmux/session.go
+++ b/agent/tmux/session.go
@@ -72,9 +72,19 @@ func newTmuxSession(ctx context.Context, target, sessionID, promptPattern string
 	return s, nil
 }
 
-func (s *tmuxSession) Send(prompt string, _ []core.ImageAttachment, files []core.FileAttachment) error {
+func (s *tmuxSession) Send(prompt string, images []core.ImageAttachment, files []core.FileAttachment) error {
 	if !s.alive.Load() {
 		return fmt.Errorf("tmux: session closed")
+	}
+
+	// Promote images to files so they are saved to disk and referenced by path.
+	// The CLI running in the pane (e.g. Claude Code) can then read them directly.
+	for _, img := range images {
+		files = append(files, core.FileAttachment{
+			MimeType: img.MimeType,
+			Data:     img.Data,
+			FileName: img.FileName,
+		})
 	}
 
 	// Save attached files and append their paths to the prompt

--- a/agent/tmux/session.go
+++ b/agent/tmux/session.go
@@ -381,13 +381,10 @@ var ansiRe = regexp.MustCompile(
 )
 
 // extractNew returns the response text that appeared in current after the baseline.
-// It handles three cases:
 //  1. Linear shell output — current is baseline + new lines (HasPrefix fast path).
-//  2. TUI redraws (e.g. Claude Code) — terminal overwrites lines in place; find the
-//     longest common line prefix shared by both snapshots, then return the new lines
-//     that follow it in current, stripping the repeated trailing prompt lines.
-//  3. Terminal scrolled and/or the volatile prompt was redrawn — anchor on a
-//     stable multi-line block of baseline's content (sliding up past the input box).
+//  2. Otherwise (TUI redraw and/or scrolled-off history) — align the top of current
+//     into baseline, then return the lines that follow the shared history run, with
+//     the redrawn trailing prompt / input box trimmed off.
 func extractNew(baseline, current string) string {
 	if current == baseline {
 		return ""
@@ -404,55 +401,40 @@ func extractNew(baseline, current string) string {
 	baseLines := strings.Split(baseline, "\n")
 	curLines := strings.Split(current, "\n")
 
-	// TUI path: find how many leading lines the two snapshots share (the static
-	// frame/header), then return the new lines that follow in current.
-	commonLen := 0
-	for i := 0; i < len(baseLines) && i < len(curLines); i++ {
-		if baseLines[i] != curLines[i] {
-			break
-		}
-		commonLen = i + 1
-	}
-	if commonLen > 0 && commonLen < len(curLines) {
-		newLines := curLines[commonLen:]
-		// Strip trailing lines that duplicate the baseline's suffix (e.g. the prompt ">").
-		bl := baseLines
-		for len(newLines) > 0 && len(bl) > 0 && newLines[len(newLines)-1] == bl[len(bl)-1] {
-			newLines = newLines[:len(newLines)-1]
-			bl = bl[:len(bl)-1]
-		}
-		result := strings.TrimRight(strings.Join(newLines, "\n"), "\n")
-		if result != "" {
-			return result
-		}
-	}
-
-	// Scroll path: the top of baseline scrolled off the buffer (so the prefix path
-	// found nothing) and/or the volatile bottom — a TUI input box / prompt that the
-	// agent redraws every turn — changed, so an exact tail match also misses. Slide
-	// a small multi-line window upward from the bottom of baseline and take its LAST
-	// occurrence in current: that is the lowest stable block the two snapshots still
-	// share, i.e. the boundary between old content and the agent's new output.
+	// The agent's new output is sandwiched between two stable regions: old history
+	// above it and a redrawn input box / prompt below it. Anchoring on the bottom is
+	// unreliable — the input-box borders are byte-identical every turn, so a bottom
+	// search lands *below* the response and yields only the trailing status line.
 	//
-	// A multi-line block (not a single line) avoids latching onto a lone repeated
-	// line such as a bare prompt, and LastIndex avoids latching onto an identical
-	// block from far back in history — the bug where stale scrollback was returned.
-	const win = 3
-	if len(baseLines) >= win {
-		for end := len(baseLines); end >= win; end-- {
-			block := baseLines[end-win : end]
-			start := lastIndexOfBlock(curLines, block)
-			if start < 0 {
-				continue
-			}
-			newLines := trimCommonTail(curLines[start+win:], baseLines)
-			if res := strings.TrimRight(strings.Join(newLines, "\n"), "\n"); res != "" {
-				return res
-			}
+	// Instead anchor on the TOP. curLines[0] is the oldest line still in the buffer
+	// (frozen history). Find the offset in baseLines where current begins and the
+	// longest run of history that follows it; everything in current after that run
+	// is the new output. This also covers the no-scroll case (offset 0 == the old
+	// common-prefix path) and the scrolled-off case (offset > 0) with one mechanism.
+	bestRun := 0
+	for d := 0; d < len(baseLines); d++ {
+		if baseLines[d] != curLines[0] {
+			continue
+		}
+		run := 0
+		for d+run < len(baseLines) && run < len(curLines) && baseLines[d+run] == curLines[run] {
+			run++
+		}
+		if run > bestRun {
+			bestRun = run
 		}
 	}
 
-	// No shared block: baseline and current barely overlap, so current is
+	if bestRun > 0 {
+		// curLines[:bestRun] is the shared history; the rest is new output, with the
+		// redrawn input box / prompt trimmed off its tail.
+		newLines := trimCommonTail(curLines[bestRun:], baseLines)
+		if res := strings.TrimRight(strings.Join(newLines, "\n"), "\n"); res != "" {
+			return res
+		}
+	}
+
+	// No shared history: baseline and current barely overlap, so current is
 	// effectively all-new (e.g. the buffer fully scrolled). Emit at most the last
 	// visibleFallbackLines lines so a stale multi-thousand-line scrollback can
 	// never be returned as "the response".
@@ -461,27 +443,6 @@ func extractNew(baseline, current string) string {
 		curLines = curLines[len(curLines)-visibleFallbackLines:]
 	}
 	return strings.TrimRight(strings.Join(curLines, "\n"), "\n")
-}
-
-// lastIndexOfBlock returns the start index of the last contiguous occurrence of
-// block within lines, or -1 if block does not occur.
-func lastIndexOfBlock(lines, block []string) int {
-	if len(block) == 0 || len(block) > len(lines) {
-		return -1
-	}
-	for i := len(lines) - len(block); i >= 0; i-- {
-		match := true
-		for j := range block {
-			if lines[i+j] != block[j] {
-				match = false
-				break
-			}
-		}
-		if match {
-			return i
-		}
-	}
-	return -1
 }
 
 // trimCommonTail drops trailing lines of newLines that duplicate the tail of

--- a/agent/tmux/session.go
+++ b/agent/tmux/session.go
@@ -428,13 +428,13 @@ func extractNew(baseline, current string) string {
 
 	// Scroll path: baseline has partially scrolled off the top; try progressively
 	// shorter anchors from the end of baseline to find where new content begins.
-	maxAnchor := 5
+	maxAnchor := 10
 	if len(baseLines) < maxAnchor {
 		maxAnchor = len(baseLines)
 	}
 	for n := maxAnchor; n >= 1; n-- {
 		anchor := strings.Join(baseLines[len(baseLines)-n:], "\n")
-		if idx := strings.Index(current, anchor); idx >= 0 {
+		if idx := strings.LastIndex(current, anchor); idx >= 0 {
 			rest := strings.TrimLeft(current[idx+len(anchor):], "\n")
 			if rest != "" {
 				return rest

--- a/agent/tmux/session.go
+++ b/agent/tmux/session.go
@@ -337,28 +337,33 @@ func shellQuote(s string) string {
 // trailing characters on the prompt line.
 var tuiInputBlockRe = regexp.MustCompile("(?m)^─+\n❯[^\n]*\n─+")
 
+// consecutiveBlankRe matches three or more consecutive newlines (two or more
+// blank lines) so they can be collapsed to a single blank line.
+var consecutiveBlankRe = regexp.MustCompile(`\n{3,}`)
+
 func (s *tmuxSession) cleanTUIContent(text string) string {
 	if s.stripInputBlock {
 		text = tuiInputBlockRe.ReplaceAllString(text, "")
 	}
-	if len(s.stripPatterns) == 0 {
-		return strings.TrimRight(text, "\n")
-	}
-	lines := strings.Split(text, "\n")
-	out := lines[:0]
-	for _, line := range lines {
-		drop := false
-		for _, re := range s.stripPatterns {
-			if re.MatchString(line) {
-				drop = true
-				break
+	if len(s.stripPatterns) > 0 {
+		lines := strings.Split(text, "\n")
+		out := lines[:0]
+		for _, line := range lines {
+			drop := false
+			for _, re := range s.stripPatterns {
+				if re.MatchString(line) {
+					drop = true
+					break
+				}
+			}
+			if !drop {
+				out = append(out, line)
 			}
 		}
-		if !drop {
-			out = append(out, line)
-		}
+		text = strings.Join(out, "\n")
 	}
-	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+	text = consecutiveBlankRe.ReplaceAllString(text, "\n\n")
+	return strings.TrimRight(text, "\n")
 }
 
 // normalizeCapture trims trailing whitespace per line and strips ANSI codes.

--- a/agent/tmux/session.go
+++ b/agent/tmux/session.go
@@ -80,11 +80,7 @@ func (s *tmuxSession) Send(prompt string, images []core.ImageAttachment, files [
 	// Promote images to files so they are saved to disk and referenced by path.
 	// The CLI running in the pane (e.g. Claude Code) can then read them directly.
 	for _, img := range images {
-		files = append(files, core.FileAttachment{
-			MimeType: img.MimeType,
-			Data:     img.Data,
-			FileName: img.FileName,
-		})
+		files = append(files, core.FileAttachment(img))
 	}
 
 	// Save attached files and append their paths to the prompt

--- a/agent/tmux/tmux_test.go
+++ b/agent/tmux/tmux_test.go
@@ -2,8 +2,11 @@ package tmux
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/chenhg5/cc-connect/core"
 )
 
 func TestExtractNew(t *testing.T) {
@@ -159,5 +162,51 @@ func TestNewTmuxSessionWorkDir(t *testing.T) {
 
 	if s.workDir != "/tmp/workspace" {
 		t.Errorf("workDir = %q, want /tmp/workspace", s.workDir)
+	}
+}
+
+// TestSend_ImagesPromotedToFiles verifies that image attachments are saved to
+// disk alongside file attachments and referenced by path in the prompt, rather
+// than being silently dropped.
+func TestSend_ImagesPromotedToFiles(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s, err := newTmuxSession(ctx, "sess:win", "sid1", "", 200*time.Millisecond, false, nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	images := []core.ImageAttachment{
+		{MimeType: "image/png", Data: []byte("\x89PNG\r\n"), FileName: "screenshot.png"},
+	}
+	files := []core.FileAttachment{
+		{MimeType: "text/plain", Data: []byte("hello"), FileName: "note.txt"},
+	}
+
+	// Build the promoted file list the same way Send() does, without calling
+	// tmux (which isn't available in unit tests).
+	for _, img := range images {
+		files = append(files, core.FileAttachment{
+			MimeType: img.MimeType,
+			Data:     img.Data,
+			FileName: img.FileName,
+		})
+	}
+	paths := core.SaveFilesToDisk(dir, files)
+
+	if len(paths) != 2 {
+		t.Fatalf("saved %d paths, want 2 (file + image)", len(paths))
+	}
+	hasImage := false
+	for _, p := range paths {
+		if strings.HasSuffix(p, "screenshot.png") {
+			hasImage = true
+		}
+	}
+	if !hasImage {
+		t.Errorf("paths = %v, want screenshot.png among them", paths)
 	}
 }

--- a/agent/tmux/tmux_test.go
+++ b/agent/tmux/tmux_test.go
@@ -76,6 +76,16 @@ func TestExtractNew(t *testing.T) {
 	}
 }
 
+func TestCleanTUIContent_CollapsesConsecutiveBlanks(t *testing.T) {
+	s := &tmuxSession{}
+	input := " ✻ Thinking...\n\n\n  tokens:22k"
+	got := s.cleanTUIContent(input)
+	want := " ✻ Thinking...\n\n  tokens:22k"
+	if got != want {
+		t.Errorf("cleanTUIContent() = %q, want %q", got, want)
+	}
+}
+
 func TestNormalizeCapture(t *testing.T) {
 	tests := []struct {
 		name string

--- a/agent/tmux/tmux_test.go
+++ b/agent/tmux/tmux_test.go
@@ -199,11 +199,7 @@ func TestSend_ImagesPromotedToFiles(t *testing.T) {
 	// Build the promoted file list the same way Send() does, without calling
 	// tmux (which isn't available in unit tests).
 	for _, img := range images {
-		files = append(files, core.FileAttachment{
-			MimeType: img.MimeType,
-			Data:     img.Data,
-			FileName: img.FileName,
-		})
+		files = append(files, core.FileAttachment(img))
 	}
 	paths := core.SaveFilesToDisk(dir, files)
 

--- a/agent/tmux/tmux_test.go
+++ b/agent/tmux/tmux_test.go
@@ -67,13 +67,23 @@ func TestExtractNew(t *testing.T) {
 		{
 			// Real bug: a long session fills the tmux scrollback so the oldest
 			// lines (h1, h2) scroll off the top — defeating the prefix path — and
-			// the response lands above the unchanged input box (UIa, UIb). The old
-			// tail-anchor scroll path returned the whole capture (stale history);
-			// the block-anchor path must return only RESP.
+			// the response lands above the unchanged input box (UIa, UIb). Must
+			// return only RESP, not the whole stale capture.
 			name:     "scrolled off top, response above stable input box",
 			baseline: "h1\nh2\nh3\nh4\nh5\nUIa\nUIb",
 			current:  "h3\nh4\nh5\nRESP\nUIa\nUIb",
 			want:     "RESP",
+		},
+		{
+			// "Only the statusline" bug: the response sits above an input box whose
+			// borders (B1,B2,B3) are byte-identical every turn but whose status line
+			// (S) changes. A bottom-anchored search latches onto the box at current's
+			// bottom and returns only the trailing status. Top-anchoring returns the
+			// response (box borders are trimmed downstream by cleanTUIContent).
+			name:     "response above redrawn input box, top scrolled",
+			baseline: "h1\nh2\nh3\nB1\nB2\nB3\nS_old",
+			current:  "h3\nR1\nR2\nB1\nB2\nB3\nS_new",
+			want:     "R1\nR2\nB1\nB2\nB3\nS_new",
 		},
 	}
 

--- a/agent/tmux/tmux_test.go
+++ b/agent/tmux/tmux_test.go
@@ -189,7 +189,7 @@ func TestNewTmuxSessionWorkDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	if s.workDir != "/tmp/workspace" {
 		t.Errorf("workDir = %q, want /tmp/workspace", s.workDir)
@@ -208,7 +208,7 @@ func TestSend_ImagesPromotedToFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	images := []core.ImageAttachment{
 		{MimeType: "image/png", Data: []byte("\x89PNG\r\n"), FileName: "screenshot.png"},

--- a/agent/tmux/tmux_test.go
+++ b/agent/tmux/tmux_test.go
@@ -64,6 +64,17 @@ func TestExtractNew(t *testing.T) {
 			current:  "header\n\nLine one.\nLine two.\n\n>",
 			want:     "Line one.\nLine two.",
 		},
+		{
+			// Real bug: a long session fills the tmux scrollback so the oldest
+			// lines (h1, h2) scroll off the top — defeating the prefix path — and
+			// the response lands above the unchanged input box (UIa, UIb). The old
+			// tail-anchor scroll path returned the whole capture (stale history);
+			// the block-anchor path must return only RESP.
+			name:     "scrolled off top, response above stable input box",
+			baseline: "h1\nh2\nh3\nh4\nh5\nUIa\nUIb",
+			current:  "h3\nh4\nh5\nRESP\nUIa\nUIb",
+			want:     "RESP",
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/engine.go
+++ b/core/engine.go
@@ -3297,7 +3297,7 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 					if e.showContextIndicator && event.InputTokens >= 100 {
 						fullResponse += contextIndicator(event.InputTokens)
 					}
-					for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+					for _, chunk := range SplitMessageCodeFenceAware(fullResponse, maxPlatformMessageLen) {
 						e.send(p, replyCtx, chunk)
 					}
 				}
@@ -3629,7 +3629,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					} else {
 						segment := strings.Join(textParts[segmentStart:], "")
 						if segment != "" {
-							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+							for _, chunk := range SplitMessageCodeFenceAware(segment, maxPlatformMessageLen) {
 								sendWorkspace(p, replyCtx, chunk)
 							}
 						}
@@ -3652,7 +3652,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					if !previewActive {
 						segment := strings.Join(textParts[segmentStart:], "")
 						if segment != "" {
-							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+							for _, chunk := range SplitMessageCodeFenceAware(segment, maxPlatformMessageLen) {
 								sendWorkspace(p, replyCtx, chunk)
 							}
 						}
@@ -3716,7 +3716,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					} else {
 						segment := strings.Join(textParts[segmentStart:], "")
 						if segment != "" {
-							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+							for _, chunk := range SplitMessageCodeFenceAware(segment, maxPlatformMessageLen) {
 								sendWorkspace(p, replyCtx, chunk)
 							}
 						}
@@ -3760,7 +3760,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					if !previewActive {
 						segment := strings.Join(textParts[segmentStart:], "")
 						if segment != "" {
-							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+							for _, chunk := range SplitMessageCodeFenceAware(segment, maxPlatformMessageLen) {
 								sendWorkspace(p, replyCtx, chunk)
 							}
 						}
@@ -3936,7 +3936,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				if !previewActive {
 					segment := strings.Join(textParts[segmentStart:], "")
 					if segment != "" {
-						for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
+						for _, chunk := range SplitMessageCodeFenceAware(segment, maxPlatformMessageLen) {
 							sendWorkspace(p, replyCtx, chunk)
 						}
 					}
@@ -4134,7 +4134,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				if err := streamCard.Finalize(e.ctx, finalContent); err != nil {
 					slog.Error("streaming card finalize failed, sending fallback", "error", err)
 					// Fallback: send the response as a normal message
-					for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+					for _, chunk := range SplitMessageCodeFenceAware(fullResponse, maxPlatformMessageLen) {
 						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
 							return
 						}
@@ -4198,7 +4198,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					unsent = appendFinalMetadataToSegment(unsent, fullResponse)
 				}
 				if unsent != "" {
-					for _, chunk := range splitMessage(unsent, maxPlatformMessageLen) {
+					for _, chunk := range SplitMessageCodeFenceAware(unsent, maxPlatformMessageLen) {
 						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
 							return
 						}
@@ -4210,8 +4210,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			} else if sp.finish(fullResponse) {
 				slog.Debug("EventResult: finalized stream preview in-place", "response_len", len(fullResponse))
 			} else {
-				slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "chunks", len(splitMessage(fullResponse, maxPlatformMessageLen)))
-				for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+				slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "chunks", len(SplitMessageCodeFenceAware(fullResponse, maxPlatformMessageLen)))
+				for _, chunk := range SplitMessageCodeFenceAware(fullResponse, maxPlatformMessageLen) {
 					if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
 						return
 					}
@@ -4480,7 +4480,7 @@ channelClosed:
 			if segmentStart < len(textParts) {
 				unsent := strings.Join(textParts[segmentStart:], "")
 				if unsent != "" {
-					for _, chunk := range splitMessage(unsent, maxPlatformMessageLen) {
+					for _, chunk := range SplitMessageCodeFenceAware(unsent, maxPlatformMessageLen) {
 						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
 							return
 						}
@@ -4488,7 +4488,7 @@ channelClosed:
 				}
 			}
 		} else {
-			for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+			for _, chunk := range SplitMessageCodeFenceAware(fullResponse, maxPlatformMessageLen) {
 				if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
 					return
 				}


### PR DESCRIPTION
Image attachments were silently dropped (blank-named parameter). Promote each ImageAttachment to a FileAttachment so images are saved to workDir alongside other files and their paths appended to the prompt, consistent with every other agent that can't embed images natively. Files remain in workDir for multi-turn reference.