### PR TITLE
fix(dir): normalize Windows drive letter case for session interop

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -110,6 +110,10 @@ func New(opts map[string]any) (core.Agent, error) {
 	if workDir == "" {
 		workDir = "."
 	}
+	// Normalize Windows drive letter (see #1040).
+	if len(workDir) >= 2 && workDir[1] == ':' && workDir[0] >= 'a' && workDir[0] <= 'z' {
+		workDir = string(workDir[0]-32) + workDir[1:]
+	}
 	cliBin := "claude"
 	var cliExtraArgs []string
 	if cliPath, _ := opts["cli_path"].(string); cliPath != "" {
@@ -266,6 +270,11 @@ func (a *Agent) CLIBinaryName() string  { return a.cliBin }
 func (a *Agent) CLIDisplayName() string { return "Claude" }
 
 func (a *Agent) SetWorkDir(dir string) {
+	// Normalize Windows drive letter to uppercase so that the encoded project
+	// path matches the one produced by the desktop CLI (see #1040).
+	if len(dir) >= 2 && dir[1] == ':' && dir[0] >= 'a' && dir[0] <= 'z' {
+		dir = string(dir[0]-32) + dir[1:]
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.workDir = dir

--- a/core/engine.go
+++ b/core/engine.go
@@ -6100,6 +6100,18 @@ func (e *Engine) diff2html(ctx context.Context, diff []byte, workDir, title stri
 	return cmd.Output()
 }
 
+// normalizeVolume uppercases the Windows drive letter so that the encoded
+// project path matches the one produced by the desktop CLI.  On non-Windows
+// systems or paths without a drive letter the input is returned as-is.
+func normalizeVolume(p string) string {
+	if len(p) >= 2 && p[1] == ':' && ((p[0] >= 'a' && p[0] <= 'z') || (p[0] >= 'A' && p[0] <= 'Z')) {
+		if p[0] >= 'a' && p[0] <= 'z' {
+			return string(p[0]-32) + p[1:]
+		}
+	}
+	return p
+}
+
 // dirApply applies /dir mutations (same semantics as cmdDir). sessionKey is used for GetOrCreateActive.
 // On failure returns a non-empty errMsg; on success returns ("", successMsg) for plain-text replies.
 func (e *Engine) dirApply(agent Agent, sessions *SessionManager, interactiveKey, sessionKey string, args []string) (errMsg, successMsg string) {
@@ -6122,6 +6134,7 @@ func (e *Engine) dirApply(agent Agent, sessions *SessionManager, interactiveKey,
 			if absDir, err := filepath.Abs(baseDir); err == nil {
 				baseDir = absDir
 			}
+			baseDir = normalizeVolume(baseDir)
 
 			if !e.multiWorkspace {
 				switcher.SetWorkDir(baseDir)
@@ -6187,6 +6200,7 @@ func (e *Engine) dirApply(agent Agent, sessions *SessionManager, interactiveKey,
 	if absDir, err := filepath.Abs(newDir); err == nil {
 		newDir = absDir
 	}
+	newDir = normalizeVolume(newDir)
 
 	info, err := os.Stat(newDir)
 	if err != nil || !info.IsDir() {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -12478,3 +12478,25 @@ func TestBtwAlias_ResolvesToPs(t *testing.T) {
 		t.Fatalf("matchPrefix(\"ps\") = %q, want \"ps\"", id2)
 	}
 }
+
+// TestNormalizeVolume verifies that Windows drive letters are uppercased
+// while non-Windows paths and paths without volumes are returned as-is.
+func TestNormalizeVolume(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"/usr/local", "/usr/local"},
+		{"relative/path", "relative/path"},
+		{`D:\Users\test`, `D:\Users\test`},
+		{`d:\Users\test`, `D:\Users\test`},
+		{`c:\`, `C:\`},
+		{`C:\`, `C:\`},
+	}
+	for _, tt := range tests {
+		got := normalizeVolume(tt.in)
+		if got != tt.want {
+			t.Errorf("normalizeVolume(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

On Windows, the `/dir` command may receive a lowercase drive letter from the chat platform (e.g. `d:\path`), while the desktop CLI always uses uppercase (`D:\path`). Claude Code encodes these as different project directory names under `~/.claude/projects/`, making sessions created via cc-connect invisible to the desktop CLI and vice versa.

**Root cause:** `filepath.Abs` on Windows does not normalize drive letter case. A path like `d:\Users\test` stays lowercase after `Abs()`.

## Changes

- Add `normalizeVolume()` helper in `core/engine.go` that uppercases the drive letter when present (`d:` → `D:`). No-op on non-Windows paths.
- Apply normalization in `dirApply()` after `filepath.Abs()` — this covers all agents going through the `/dir` command.
- Apply normalization in `agent/claudecode` constructor and `SetWorkDir()` as belt-and-suspenders for paths that bypass `dirApply`.
- Add `TestNormalizeVolume` with table-driven test cases.

## Testing

- `go test ./core/ -run TestNormalizeVolume` — PASS
- `go test ./core/` — all tests pass (42s)
- `go build ./agent/claudecode/` — compiles clean

Closes #1040

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.