### PR TITLE
fix(shell): show usage when /shell is called with no arguments

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -5981,13 +5981,19 @@ func updaterFor(p Platform) MessageUpdater {
 func (e *Engine) cmdShell(p Platform, msg *Message, raw string) {
 	// Strip the command prefix ("/shell ", "/sh ", "/exec ", "/run ")
 	shellCmd := raw
+	lower := strings.ToLower(strings.TrimSpace(raw))
 	for _, prefix := range []string{"/shell ", "/sh ", "/exec ", "/run "} {
-		if strings.HasPrefix(strings.ToLower(raw), prefix) {
+		if strings.HasPrefix(lower, prefix) {
 			shellCmd = raw[len(prefix):]
 			break
 		}
 	}
 	shellCmd = strings.TrimSpace(shellCmd)
+
+	// Handle bare command with no arguments (e.g. "/shell" without trailing space).
+	if lower == "/shell" || lower == "/sh" || lower == "/exec" || lower == "/run" {
+		shellCmd = ""
+	}
 
 	if shellCmd == "" {
 		e.reply(p, msg.ReplyCtx, "Usage: /shell [--timeout <seconds>] <command>\nExample: /shell ls -la\nExample: /shell --timeout 300 npm install")

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -8913,6 +8913,33 @@ func TestCmdShell_EmptyCommand_ShowsUsage(t *testing.T) {
 	}
 }
 
+func TestCmdShell_BareCommand_ShowsUsage(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetAdminFrom("admin")
+
+	// "/shell" with no arguments and no trailing space should show usage.
+	msg := &Message{
+		SessionKey: "test:ch:admin",
+		Content:    "/shell",
+		ReplyCtx:   "ctx",
+		UserID:     "admin",
+		Platform:   "test",
+	}
+	e.cmdShell(p, msg, "/shell")
+
+	sent := p.getSent()
+	foundUsage := false
+	for _, s := range sent {
+		if strings.Contains(s, "Usage") {
+			foundUsage = true
+		}
+	}
+	if !foundUsage {
+		t.Fatalf("expected usage message for bare /shell, got %v", sent)
+	}
+}
+
 func TestCmdShell_MultiWorkspaceUsesSharedBindingWorkDir(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)


### PR DESCRIPTION
## Summary

When a user types `/shell` (or `/sh`, `/exec`, `/run`) without any arguments, `cmdShell` should show a usage message. Instead, the bare command string (e.g. `/shell`) gets passed to `sh -c` as-is, producing a confusing shell error:

```
fish: Unknown command: /shell
```

The root cause is in the prefix-stripping loop which only matches `/shell ` (with trailing space):

```go
for _, prefix := range []string{"/shell ", "/sh ", "/exec ", "/run "} {
    if strings.HasPrefix(strings.ToLower(raw), prefix) {
        shellCmd = raw[len(prefix):]
        break
    }
}
```

When the input is `/shell` with no trailing space, no prefix matches, `shellCmd` stays as `"/shell"`, `TrimSpace` is a no-op, and the `shellCmd == ""` check is bypassed.

## Fix

Add a bare-command check after the prefix loop and `TrimSpace`:

```go
if lower == "/shell" || lower == "/sh" || lower == "/exec" || lower == "/run" {
    shellCmd = ""
}
```

This catches the no-argument case and routes it to the existing usage-message path.

## Test

`TestCmdShell_BareCommand_ShowsUsage` calls `cmdShell(p, msg, "/shell")` (no trailing space) and asserts the reply contains `"Usage"`.

## Test plan

- [x] `go test ./core/ -run TestCmdShell -v` — all 6 shell tests pass.
- [x] `go build ./...` — builds successfully.