### PR TITLE
fix(daemon): add CheckLinger stub for non-Linux platforms

### DIFF
--- a/daemon/linger_stub.go
+++ b/daemon/linger_stub.go
@@ -1,0 +1,19 @@
+//go:build !linux
+
+package daemon
+
+import (
+	"os"
+)
+
+// CheckLinger checks if systemd linger is enabled for the current user.
+// On non-Linux platforms, this is not applicable, so we return true (enabled)
+// and the current user.
+func CheckLinger() (enabled bool, user string) {
+	user = os.Getenv("USER")
+	if user == "" {
+		user = "unknown"
+	}
+	// Linger is a systemd concept, not applicable on macOS/Windows
+	return true, user
+}


### PR DESCRIPTION
## Summary

- Add `daemon/linger_stub.go` with `//go:build !linux` to provide a no-op `CheckLinger` implementation for macOS/Windows
- Fixes cross-platform compilation failure introduced by PR #965

## Problem

PR #965 added `daemon.CheckLinger()` call in `cmd/cc-connect/daemon.go` (line 109), but only implemented the function in `daemon/systemd.go` which has `//go:build linux` constraint.

This caused compilation failure on macOS and Windows:

```
cmd/cc-connect/daemon.go:109:27: undefined: daemon.CheckLinger
```

## Solution

Added `daemon/linger_stub.go` with `//go:build !linux` constraint:

```go
//go:build !linux

package daemon

func CheckLinger() (enabled bool, user string) {
    user = os.Getenv("USER")
    if user == "" {
        user = "unknown"
    }
    // Linger is a systemd concept, not applicable on macOS/Windows
    return true, user
}
```

## Test plan

- [x] `go build -o cc-connect ./cmd/cc-connect` passes on macOS
- [x] `GOOS=windows GOARCH=amd64 go build -o cc-connect.exe ./cmd/cc-connect` passes
- [x] `go vet ./daemon/` passes

Fixes cross-platform compilation issue from #965