### PR TITLE
fix(claudecode): encode dot and @ in project key to match Claude Code behavior

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -1342,10 +1342,12 @@ func encodeClaudeProjectKey(absPath string) string {
 	// First, normalize to forward slashes for consistent processing
 	normalized := strings.ReplaceAll(absPath, "\\", "/")
 
-	// Build the encoded key character by character
+	// Build the encoded key character by character.
+	// Claude Code replaces path separators, special punctuation, and non-ASCII
+	// characters with hyphens when deriving the project directory name.
 	var result strings.Builder
 	for _, r := range normalized {
-		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' {
+		if r == '/' || r == ':' || r == '_' || r == ' ' || r == '~' || r == '.' || r == '@' {
 			result.WriteRune('-')
 		} else if r < 128 { // ASCII range (0-127)
 			result.WriteRune(r)

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -408,6 +408,21 @@ func TestEncodeClaudeProjectKey(t *testing.T) {
 			expected: "-Users-username---folder-english---", // "/中文" = 3 hyphens, "/文件夹" = 4 hyphens
 		},
 		{
+			name:     "path with dots (hidden dirs and version numbers)",
+			input:    "/home/user/.nvm/versions/node/v22.22.2/lib",
+			expected: "-home-user--nvm-versions-node-v22-22-2-lib",
+		},
+		{
+			name:     "path with @ (scoped npm packages)",
+			input:    "/home/user/node_modules/@anthropic-ai/claude-code",
+			expected: "-home-user-node-modules--anthropic-ai-claude-code",
+		},
+		{
+			name:     "path with both dots and @",
+			input:    "/home/user/.local/share/@org/my.project",
+			expected: "-home-user--local-share--org-my-project",
+		},
+		{
 			name:     "empty path",
 			input:    "",
 			expected: "",


### PR DESCRIPTION
## Problem

`/list` always returns empty for users whose work directory contains `.` (hidden directories like `.nvm`, version numbers like `v22.22.2`) or `@` (scoped npm packages like `@anthropic-ai/claude-code`).

## Root Cause

Claude Code derives project directory names by replacing special characters with `-`. The existing `encodeClaudeProjectKey()` function handles `/`, `:`, `_`, ` `, `~`, and non-ASCII characters — but **not `.` or `@`**.

This causes `findProjectDir()` to generate a key that doesn't match Claude Code's on-disk directory name, so session lookup fails silently.

**Evidence from observed `~/.claude/projects/` entries:**
- `/home/user/.nvm/versions/node/v22.22.2/...` → `-home-user--nvm-versions-node-v22-22-2-...`
- `.../node_modules/@anthropic-ai/claude-code` → `...-node-modules--anthropic-ai-claude-code`

Both `.` and `@` are clearly replaced with `-`.

## Fix

Add `.` and `@` to the character replacement set in `encodeClaudeProjectKey()`.

## Testing

- Added 3 test cases covering dots, `@`, and combined scenarios
- All existing tests still pass (`go test ./agent/claudecode/` — 15 PASS)
- Full suite passes (except pre-existing `web/embed.go` dist dependency)

Closes #1046