### PR TITLE
fix(agent): skip bypass-permissions flags when running as root

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -54,6 +54,13 @@ type claudeSession struct {
 func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
+	// Claude Code rejects bypassPermissions when running as root.
+	// Downgrade to "auto" which auto-approves internally in cc-connect.
+	if mode == "bypassPermissions" && os.Geteuid() == 0 {
+		slog.Warn("claudeSession: bypassPermissions not allowed under root, downgrading to auto mode")
+		mode = "auto"
+	}
+
 	// innerArgs are Claude Code CLI flags — when a wrapper is used with
 	// cliArgsFlag these get bundled into a single passthrough string.
 	// outerArgs are flags the wrapper itself understands (e.g. --model).

--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -76,7 +76,11 @@ func (qs *qoderSession) Send(prompt string, images []core.ImageAttachment, files
 	}
 
 	if qs.mode == "yolo" {
-		args = append(args, "--dangerously-skip-permissions")
+		if os.Geteuid() == 0 {
+			slog.Warn("qoderSession: --dangerously-skip-permissions not allowed under root, skipping flag")
+		} else {
+			args = append(args, "--dangerously-skip-permissions")
+		}
 	}
 
 	if qs.model != "" {


### PR DESCRIPTION
## Summary

When cc-connect runs as root (EUID 0), Claude Code rejects `--permission-mode bypassPermissions` with:

```
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
```

This causes the Claude session to fail immediately. The nil `agentSession` then triggers a panic in the engine's interactive message handler (reported at `core/engine.go:2179`).

## Changes

**`agent/claudecode/session.go`**: Detect root before building CLI args. When mode is `bypassPermissions` and EUID is 0, downgrade to `auto` mode — which auto-approves permissions internally in cc-connect without passing the flag to Claude Code CLI. Logs a warning so the user knows why YOLO mode is degraded.

**`agent/qoder/session.go`**: Same root detection for `--dangerously-skip-permissions`. Skip the flag under root and log a warning.

## Why `auto` mode?

The codebase already has a comment explaining this pattern (session.go line 29):

> In "auto" mode, permission requests are auto-approved internally (avoiding --dangerously-skip-permissions which fails under root).

`auto` mode handles permissions inside cc-connect's permission prompt handler rather than delegating to the CLI flag, so it works regardless of EUID.

## Testing

- `go test ./agent/claudecode/ ./agent/qoder/` — all pass
- `go vet ./agent/claudecode/ ./agent/qoder/` — clean
- Full test suite (`go test ./...` excluding web/cmd) — all pass

Closes #1054