### PR TITLE
fix(kimi): handle string content in stream-json responses

### DIFF
--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -316,7 +316,17 @@ func (ks *kimiSession) handleEvent(raw map[string]any) {
 }
 
 func (ks *kimiSession) handleAssistant(raw map[string]any) {
-	content, _ := raw["content"].([]any)
+	// Kimi CLI may emit content as a plain string (simple responses) or as an
+	// array of typed blocks (structured responses with think/text/etc.).
+	var content []any
+	switch v := raw["content"].(type) {
+	case []any:
+		content = v
+	case string:
+		if v != "" {
+			ks.pendingMsgs = append(ks.pendingMsgs, v)
+		}
+	}
 	for _, item := range content {
 		block, ok := item.(map[string]any)
 		if !ok {
@@ -372,7 +382,25 @@ func (ks *kimiSession) handleAssistant(raw map[string]any) {
 
 func (ks *kimiSession) handleTool(raw map[string]any) {
 	toolCallID, _ := raw["tool_call_id"].(string)
-	content, _ := raw["content"].([]any)
+	var content []any
+	switch v := raw["content"].(type) {
+	case []any:
+		content = v
+	case string:
+		if v != "" {
+			slog.Debug("kimiSession: tool result", "tool_call_id", toolCallID)
+			evt := core.Event{
+				Type:       core.EventToolResult,
+				ToolName:   toolCallID,
+				ToolResult: truncate(strings.TrimSpace(v), 500),
+			}
+			select {
+			case ks.events <- evt:
+			case <-ks.ctx.Done():
+			}
+			return
+		}
+	}
 	var outputParts []string
 	for _, item := range content {
 		block, ok := item.(map[string]any)

--- a/agent/kimi/session_test.go
+++ b/agent/kimi/session_test.go
@@ -56,6 +56,21 @@ func TestHandleAssistantWithText(t *testing.T) {
 	assert.Equal(t, "Hello!", ks.pendingMsgs[0])
 }
 
+func TestHandleAssistantWithStringContent(t *testing.T) {
+	ctx := context.Background()
+	ks, _ := newKimiSession(ctx, "kimi", "/tmp", "", "default", "", nil, 0)
+	defer ks.Close()
+
+	// Kimi CLI can emit content as a plain string instead of an array.
+	ks.handleEvent(map[string]any{
+		"role":    "assistant",
+		"content": "你好！有什么我可以帮你的吗？",
+	})
+
+	assert.Len(t, ks.pendingMsgs, 1)
+	assert.Equal(t, "你好！有什么我可以帮你的吗？", ks.pendingMsgs[0])
+}
+
 func TestHandleAssistantWithThink(t *testing.T) {
 	ctx := context.Background()
 	ks, _ := newKimiSession(ctx, "kimi", "/tmp", "", "default", "", nil, 0)
@@ -125,6 +140,25 @@ func TestHandleTool(t *testing.T) {
 	assert.Equal(t, core.EventToolResult, events[0].Type)
 	assert.Equal(t, "tool_abc", events[0].ToolName)
 	assert.Contains(t, events[0].ToolResult, "hello")
+}
+
+func TestHandleToolWithStringContent(t *testing.T) {
+	ctx := context.Background()
+	ks, _ := newKimiSession(ctx, "kimi", "/tmp", "", "default", "", nil, 0)
+	defer ks.Close()
+
+	// Kimi CLI can emit tool content as a plain string.
+	ks.handleEvent(map[string]any{
+		"role":         "tool",
+		"tool_call_id": "tool_xyz",
+		"content":      "command output here",
+	})
+
+	events := drainEvents(ks.events, 1)
+	require.Len(t, events, 1)
+	assert.Equal(t, core.EventToolResult, events[0].Type)
+	assert.Equal(t, "tool_xyz", events[0].ToolName)
+	assert.Equal(t, "command output here", events[0].ToolResult)
 }
 
 func TestFlushPendingAsText(t *testing.T) {


### PR DESCRIPTION
## Problem

When using Kimi CLI as the backend, cc-connect returns empty responses to the frontend. The logs show Kimi CLI produces valid output, but the parsed content is empty.

**Root cause:** `handleAssistant()` and `handleTool()` use `raw["content"].([]any)` to parse the content field. However, Kimi CLI can emit content as a **plain string** (`"content":"你好！"`) rather than the expected array of typed blocks (`"content":[{"type":"text","text":"你好！"}]`). The type assertion silently returns `nil` for string content, so the text is dropped.

## Fix

Use a type switch to handle both formats:
- `[]any` → existing array-of-blocks parsing (unchanged)
- `string` → treat as plain text and buffer/emit directly

Applied to both `handleAssistant()` (assistant text) and `handleTool()` (tool results).

## Testing

- Added `TestHandleAssistantWithStringContent` — verifies plain-string assistant content is buffered
- Added `TestHandleToolWithStringContent` — verifies plain-string tool content emits EventToolResult
- All existing tests pass: `go test ./agent/kimi/ -v` (20 pass, 2 skip)

Closes #1059