### PR TITLE
fix(daemon): stub CheckLinger on non-Linux platforms

### DIFF
--- a/daemon/linger_other.go
+++ b/daemon/linger_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package daemon
+
+import "os"
+
+// CheckLinger is a no-op on non-Linux platforms. Linger is a systemd concept
+// that only applies to Linux user services. Returns true so callers treat the
+// state as "no action needed".
+func CheckLinger() (enabled bool, user string) {
+	user = os.Getenv("USER")
+	if user == "" {
+		user = "unknown"
+	}
+	return true, user
+}


### PR DESCRIPTION
## Summary

`CheckLinger` is only defined in `daemon/systemd.go` with `//go:build linux`, but `cmd/cc-connect/daemon.go:109` calls it unconditionally. This breaks the build on darwin and windows:

```
cmd/cc-connect/daemon.go:109:27: undefined: daemon.CheckLinger
make: *** [build-noweb] Error 1
```

Although the call is guarded at runtime by `strings.Contains(mgr.Platform(), "user")` — which is only ever true for Linux user-mode systemd — Go still needs the symbol to resolve at compile time.

Introduced in #965.

## Fix

Add `daemon/linger_other.go` with `//go:build !linux` that stubs `CheckLinger` to return `enabled=true`. On platforms where linger is not a concept, callers naturally skip the warning.

## Note on CI

This regression slipped through because `.github/workflows/ci.yml` only runs on `ubuntu-latest`. Worth considering a build matrix that adds `macos-latest` and `windows-latest` so this class of bug is caught before merge — happy to send that as a follow-up if you'd like.

## Test plan

- [x] `make build-noweb` succeeds on darwin (arm64)
- [x] `make build-noweb` succeeds on linux (unchanged path)
- [x] `make build-noweb` succeeds on windows