### PR TITLE
fix(api): validate work_dir exists before creating project

### DIFF
--- a/core/management_test.go
+++ b/core/management_test.go
@@ -906,6 +906,75 @@ func TestMgmt_AddPlatformToNewProject_DoesNotRequireEngine(t *testing.T) {
 	}
 }
 
+func TestMgmt_AddPlatform_RejectsNonexistentWorkDir(t *testing.T) {
+	mgmt, ts, _ := testManagementServer(t, "tok")
+
+	called := false
+	mgmt.SetAddPlatformToProject(func(proj, platType string, opts map[string]any, workDir, agentType string) error {
+		called = true
+		return nil
+	})
+
+	// Non-existent work_dir should be rejected.
+	r := mgmtPost(t, ts.URL+"/api/v1/projects/test-proj/add-platform", "tok", map[string]any{
+		"type":     "feishu",
+		"work_dir": "/nonexistent/path/that/does/not/exist",
+	})
+	if r.OK {
+		t.Fatal("expected error for non-existent work_dir, got success")
+	}
+	if !strings.Contains(r.Error, "work_dir does not exist") {
+		t.Fatalf("error = %q, want work_dir does not exist", r.Error)
+	}
+	if called {
+		t.Fatal("addPlatformToProject should not be called when work_dir is invalid")
+	}
+}
+
+func TestMgmt_AddPlatform_AcceptsValidWorkDir(t *testing.T) {
+	mgmt, ts, _ := testManagementServer(t, "tok")
+
+	var savedWorkDir string
+	mgmt.SetAddPlatformToProject(func(proj, platType string, opts map[string]any, workDir, agentType string) error {
+		savedWorkDir = workDir
+		return nil
+	})
+
+	// Valid directory should pass.
+	validDir := t.TempDir()
+	r := mgmtPost(t, ts.URL+"/api/v1/projects/test-proj/add-platform", "tok", map[string]any{
+		"type":     "feishu",
+		"work_dir": validDir,
+	})
+	if !r.OK {
+		t.Fatalf("expected success for valid work_dir, got: %s", r.Error)
+	}
+	if savedWorkDir != validDir {
+		t.Fatalf("saved work_dir = %q, want %q", savedWorkDir, validDir)
+	}
+}
+
+func TestMgmt_AddPlatform_AcceptsEmptyWorkDir(t *testing.T) {
+	mgmt, ts, _ := testManagementServer(t, "tok")
+
+	called := false
+	mgmt.SetAddPlatformToProject(func(proj, platType string, opts map[string]any, workDir, agentType string) error {
+		called = true
+		return nil
+	})
+
+	// Empty work_dir should pass (uses default).
+	r := mgmtPost(t, ts.URL+"/api/v1/projects/test-proj/add-platform", "tok", map[string]any{
+		"type": "feishu",
+	})
+	if !r.OK {
+		t.Fatalf("expected success for empty work_dir, got: %s", r.Error)
+	}
+	if !called {
+		t.Fatal("addPlatformToProject should be called when work_dir is empty")
+	}
+}
+
 func TestMgmt_OtherRoutesStillRequireEngine(t *testing.T) {
 	_, ts, _ := testManagementServer(t, "tok")
 

--- a/core/setup.go
+++ b/core/setup.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -475,6 +477,22 @@ func (m *ManagementServer) handleProjectAddPlatform(w http.ResponseWriter, r *ht
 	if req.Type == "" {
 		mgmtError(w, http.StatusBadRequest, "type is required")
 		return
+	}
+	if wd := strings.TrimSpace(req.WorkDir); wd != "" {
+		abs, err := filepath.Abs(wd)
+		if err != nil {
+			mgmtError(w, http.StatusBadRequest, fmt.Sprintf("invalid work_dir: %s", err))
+			return
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			mgmtError(w, http.StatusBadRequest, fmt.Sprintf("work_dir does not exist: %s", abs))
+			return
+		}
+		if !info.IsDir() {
+			mgmtError(w, http.StatusBadRequest, fmt.Sprintf("work_dir is not a directory: %s", abs))
+			return
+		}
 	}
 	if m.addPlatformToProject == nil {
 		mgmtError(w, http.StatusServiceUnavailable, "config persistence not available")


### PR DESCRIPTION
## Problem

When creating a project via the web UI, if the user fills in a non-existent path for the working directory, the project is created successfully. However, when the user later sends a message through the connected platform (e.g., Feishu), it fails with:

> ❌ 错误: 启动 Agent 会话失败

The root cause is that `handleProjectAddPlatform` in `core/setup.go` does not validate the `work_dir` path before persisting the project config.

## Fix

Added path validation in `handleProjectAddPlatform` before calling `addPlatformToProject`:

1. If `work_dir` is non-empty, resolve to absolute path and check with `os.Stat`
2. Return HTTP 400 if the path does not exist or is not a directory
3. Empty `work_dir` (default) is still accepted

## Tests

Added 3 test cases in `core/management_test.go`:
- `TestMgmt_AddPlatform_RejectsNonexistentWorkDir` — non-existent path returns error
- `TestMgmt_AddPlatform_AcceptsValidWorkDir` — valid directory passes through
- `TestMgmt_AddPlatform_AcceptsEmptyWorkDir` — empty work_dir uses default

All `go test ./core/` pass (42s, existing + new tests).

Closes #1068