### PR TITLE
fix(core): prevent session confusion after /new

### DIFF
--- a/cmd/cc-connect/sessions.go
+++ b/cmd/cc-connect/sessions.go
@@ -17,12 +17,12 @@ import (
 // sessionFileData mirrors the unexported sessionSnapshot in core/session.go
 // for JSON deserialization of session files.
 type sessionFileData struct {
-	Sessions      map[string]*sessionData    `json:"sessions"`
-	ActiveSession map[string]string          `json:"active_session"`
-	UserSessions  map[string][]string        `json:"user_sessions"`
-	Counter       int64                      `json:"counter"`
-	SessionNames  map[string]string          `json:"session_names,omitempty"`
-	UserMeta      map[string]*userMetaData   `json:"user_meta,omitempty"`
+	Sessions      map[string]*sessionData  `json:"sessions"`
+	ActiveSession map[string]string        `json:"active_session"`
+	UserSessions  map[string][]string      `json:"user_sessions"`
+	Counter       int64                    `json:"counter"`
+	SessionNames  map[string]string        `json:"session_names,omitempty"`
+	UserMeta      map[string]*userMetaData `json:"user_meta,omitempty"`
 }
 
 type userMetaData struct {
@@ -52,6 +52,10 @@ type sessionRecord struct {
 	Messages   int
 	LastActive time.Time
 	History    []core.HistoryEntry
+}
+
+type sessionLoadOptions struct {
+	includeHistorical bool
 }
 
 func runSessions(args []string) {
@@ -121,7 +125,12 @@ func resolveDataDir(flagValue string) string {
 	return ".cc-connect"
 }
 
-func loadAllSessions(dataDir string) ([]sessionRecord, error) {
+func loadAllSessions(dataDir string, opts ...sessionLoadOptions) ([]sessionRecord, error) {
+	loadOpts := sessionLoadOptions{includeHistorical: true}
+	if len(opts) > 0 {
+		loadOpts = opts[0]
+	}
+
 	sessionsDir := filepath.Join(dataDir, "sessions")
 	entries, err := os.ReadDir(sessionsDir)
 	if err != nil {
@@ -152,6 +161,11 @@ func loadAllSessions(dataDir string) ([]sessionRecord, error) {
 			continue
 		}
 
+		activeIDs := make(map[string]bool, len(fileData.ActiveSession))
+		for _, sid := range fileData.ActiveSession {
+			activeIDs[sid] = true
+		}
+
 		// Build reverse index: session_id -> user_key
 		sessionToUserKey := make(map[string]string)
 		for userKey, sids := range fileData.UserSessions {
@@ -164,6 +178,9 @@ func loadAllSessions(dataDir string) ([]sessionRecord, error) {
 
 		for _, s := range fileData.Sessions {
 			if s == nil {
+				continue
+			}
+			if !loadOpts.includeHistorical && len(activeIDs) > 0 && !activeIDs[s.ID] {
 				continue
 			}
 			platform, groupUser := "", ""
@@ -202,6 +219,18 @@ func loadAllSessions(dataDir string) ([]sessionRecord, error) {
 	return records, nil
 }
 
+func loadSessionsForList(dataDir string) ([]sessionRecord, error) {
+	return loadAllSessions(dataDir, sessionLoadOptions{includeHistorical: false})
+}
+
+func loadSessionsForShowID(dataDir, id string) ([]sessionRecord, error) {
+	idStr := strings.TrimPrefix(id, "#")
+	if _, err := strconv.Atoi(idStr); err == nil {
+		return loadSessionsForList(dataDir)
+	}
+	return loadAllSessions(dataDir)
+}
+
 func parseSessionKey(key string) (platform, groupUser string) {
 	if i := strings.Index(key, ":"); i >= 0 {
 		return key[:i], key[i+1:]
@@ -210,7 +239,7 @@ func parseSessionKey(key string) (platform, groupUser string) {
 }
 
 func runSessionsList(dataDir string) {
-	records, err := loadAllSessions(dataDir)
+	records, err := loadSessionsForList(dataDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -237,7 +266,7 @@ func runSessionsList(dataDir string) {
 }
 
 func runSessionsShow(dataDir, id string, limit int) {
-	records, err := loadAllSessions(dataDir)
+	records, err := loadSessionsForShowID(dataDir, id)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/cmd/cc-connect/sessions_test.go
+++ b/cmd/cc-connect/sessions_test.go
@@ -166,6 +166,143 @@ func TestLoadAllSessions(t *testing.T) {
 	}
 }
 
+func TestLoadSessionsForListOnlyIncludesActiveSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionsDir := filepath.Join(tmpDir, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	writeSessionFile(t, sessionsDir, "project_a.json", sessionFileData{
+		Sessions: map[string]*sessionData{
+			"s1": {
+				ID:        "s1",
+				Name:      "old",
+				UpdatedAt: now.Add(-time.Hour),
+			},
+			"s2": {
+				ID:        "s2",
+				Name:      "new",
+				UpdatedAt: now,
+			},
+		},
+		ActiveSession: map[string]string{
+			"feishu:oc_chat:ou_user": "s2",
+		},
+		UserSessions: map[string][]string{
+			"feishu:oc_chat:ou_user": {"s1", "s2"},
+		},
+	})
+
+	records, err := loadSessionsForList(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	if records[0].GlobalID != "project_a:s2" {
+		t.Fatalf("record GlobalID = %q, want %q", records[0].GlobalID, "project_a:s2")
+	}
+
+	all, err := loadAllSessions(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasSessionRecord(all, "project_a:s1") {
+		t.Fatal("historical loader did not include project_a:s1")
+	}
+}
+
+func TestLoadSessionsForShowIndexMatchesList(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionsDir := filepath.Join(tmpDir, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	writeSessionFile(t, sessionsDir, "project_a.json", sessionFileData{
+		Sessions: map[string]*sessionData{
+			"s1": {ID: "s1", Name: "old", UpdatedAt: now.Add(-time.Hour)},
+			"s2": {ID: "s2", Name: "new", UpdatedAt: now},
+		},
+		ActiveSession: map[string]string{
+			"feishu:oc_chat:ou_user": "s2",
+		},
+		UserSessions: map[string][]string{
+			"feishu:oc_chat:ou_user": {"s1", "s2"},
+		},
+	})
+
+	listRecords, err := loadSessionsForList(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexRecords, err := loadSessionsForShowID(tmpDir, "#1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listRecords) != 1 || len(indexRecords) != 1 {
+		t.Fatalf("list records=%d index records=%d, want 1 each", len(listRecords), len(indexRecords))
+	}
+	if indexRecords[0].GlobalID != listRecords[0].GlobalID {
+		t.Fatalf("show index first record = %q, want list first record %q", indexRecords[0].GlobalID, listRecords[0].GlobalID)
+	}
+
+	explicitRecords, err := loadSessionsForShowID(tmpDir, "project_a:s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasSessionRecord(explicitRecords, "project_a:s1") {
+		t.Fatal("explicit project:sid lookup path did not include historical project_a:s1")
+	}
+}
+
+func TestLoadSessionsForListFallsBackWhenActiveSessionMissingOrEmpty(t *testing.T) {
+	tests := []struct {
+		name          string
+		activeSession map[string]string
+	}{
+		{name: "missing", activeSession: nil},
+		{name: "empty", activeSession: map[string]string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			sessionsDir := filepath.Join(tmpDir, "sessions")
+			if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			now := time.Now()
+			writeSessionFile(t, sessionsDir, "project_a.json", sessionFileData{
+				Sessions: map[string]*sessionData{
+					"s1": {ID: "s1", Name: "old", UpdatedAt: now.Add(-time.Hour)},
+					"s2": {ID: "s2", Name: "new", UpdatedAt: now},
+				},
+				ActiveSession: tt.activeSession,
+				UserSessions: map[string][]string{
+					"feishu:oc_chat:ou_user": {"s1", "s2"},
+				},
+			})
+
+			records, err := loadSessionsForList(tmpDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(records) != 2 {
+				t.Fatalf("got %d records, want 2", len(records))
+			}
+			if !hasSessionRecord(records, "project_a:s1") || !hasSessionRecord(records, "project_a:s2") {
+				t.Fatalf("records = %#v, want both project_a:s1 and project_a:s2", records)
+			}
+		})
+	}
+}
+
 func TestLoadAllSessionsSkipsMalformed(t *testing.T) {
 	tmpDir := t.TempDir()
 	sessionsDir := filepath.Join(tmpDir, "sessions")
@@ -224,6 +361,15 @@ func TestLoadAllSessionsNoDir(t *testing.T) {
 	if records != nil {
 		t.Fatalf("got %v, want nil", records)
 	}
+}
+
+func hasSessionRecord(records []sessionRecord, globalID string) bool {
+	for i := range records {
+		if records[i].GlobalID == globalID {
+			return true
+		}
+	}
+	return false
 }
 
 func writeSessionFile(t *testing.T, dir, name string, data sessionFileData) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -510,7 +510,7 @@ func (e *Engine) reapIdleWorkspaces() {
 	e.interactiveMu.Unlock()
 
 	for _, target := range targets {
-		e.cleanupInteractiveState(target.key, target.state)
+		e.cleanupInteractiveStateIfCurrent(target.key, target.state)
 	}
 	for _, ws := range reaped {
 		slog.Info("workspace idle-reaped", "workspace", ws)
@@ -2953,10 +2953,18 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 // IMPORTANT: The state is deleted from the map AFTER the agent session is closed
 // to avoid race conditions where concurrent requests see an empty map while the
 // agent session is still being shut down (which can take up to 130s for Stop hooks).
-func (e *Engine) cleanupInteractiveState(sessionKey string, expected ...*interactiveState) {
+func (e *Engine) cleanupInteractiveState(sessionKey string) {
+	e.cleanupInteractiveStateWithExpectation(sessionKey, false, nil)
+}
+
+func (e *Engine) cleanupInteractiveStateIfCurrent(sessionKey string, expected *interactiveState) {
+	e.cleanupInteractiveStateWithExpectation(sessionKey, true, expected)
+}
+
+func (e *Engine) cleanupInteractiveStateWithExpectation(sessionKey string, hasExpected bool, expected *interactiveState) {
 	e.interactiveMu.Lock()
 	state, ok := e.interactiveStates[sessionKey]
-	if len(expected) > 0 && expected[0] != nil && state != expected[0] {
+	if hasExpected && state != expected {
 		// Another turn has already replaced the state — skip cleanup.
 		e.interactiveMu.Unlock()
 		return
@@ -3004,7 +3012,7 @@ func (e *Engine) cleanupInteractiveState(sessionKey string, expected ...*interac
 	e.interactiveMu.Lock()
 	// Re-check that the state hasn't been replaced during the close
 	currentState, currentOk := e.interactiveStates[sessionKey]
-	if currentOk && len(expected) > 0 && expected[0] != nil && currentState != expected[0] {
+	if currentOk && hasExpected && currentState != expected {
 		// Another turn has replaced the state during our close — don't delete it.
 		e.interactiveMu.Unlock()
 		return
@@ -3086,7 +3094,6 @@ func buildCardContent(thinking string, tools []cardToolEntry, answer string) str
 	}
 	return sb.String()
 }
-
 
 // unsolicitedReaderStopTimeout bounds how long stopUnsolicitedReader waits
 // for the reader goroutine to exit. The reader is structured so its iterations
@@ -3430,8 +3437,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 	// Streaming card: aggregate entire turn into a single updatable card.
 	var streamCard StreamingCard
-	var cardToolCalls []cardToolEntry // track tool calls for card content
-	var cardThinkingText string       // latest thinking text
+	var cardToolCalls []cardToolEntry  // track tool calls for card content
+	var cardThinkingText string        // latest thinking text
 	var cardAnswerText strings.Builder // accumulated answer text
 
 	if scp, ok := state.platform.(StreamingCardPlatform); ok {
@@ -3491,7 +3498,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 				e.notifyDroppedQueuedMessages(state, err)
 				if state.agentSession == nil || !state.agentSession.Alive() {
-					e.cleanupInteractiveState(sessionKey, state)
+					e.cleanupInteractiveStateIfCurrent(sessionKey, state)
 				}
 				state.mu.Lock()
 				p := state.platform
@@ -3510,7 +3517,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			p := state.platform
 			state.mu.Unlock()
 			e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), "agent session timed out (no response)"))
-			e.cleanupInteractiveState(sessionKey, state)
+			e.cleanupInteractiveStateIfCurrent(sessionKey, state)
 			return
 		case <-e.ctx.Done():
 			state.mu.Lock()
@@ -4425,7 +4432,7 @@ channelClosed:
 	state.eventsNeedResync = true
 	state.mu.Unlock()
 	e.notifyDroppedQueuedMessages(state, fmt.Errorf("agent process exited"))
-	e.cleanupInteractiveState(sessionKey, state)
+	e.cleanupInteractiveStateIfCurrent(sessionKey, state)
 
 	if len(textParts) > 0 {
 		state.mu.Lock()
@@ -5130,21 +5137,26 @@ func (e *Engine) cmdNew(p Platform, msg *Message, args []string) {
 		return
 	}
 
-	slog.Info("cmdNew: cleaning up old session", "session_key", msg.SessionKey)
-	e.cleanupInteractiveState(interactiveKey)
-	slog.Info("cmdNew: cleanup done, creating new session", "session_key", msg.SessionKey)
+	e.interactiveMu.Lock()
+	expectedNew := e.interactiveStates[interactiveKey]
+	e.interactiveMu.Unlock()
 
 	// Clear old session's agent session ID so it cannot be resumed
 	old := sessions.GetOrCreateActive(msg.SessionKey)
 	old.SetAgentSessionID("", "")
 	old.ClearHistory()
-	sessions.Save()
 
 	name := ""
 	if len(args) > 0 {
 		name = strings.Join(args, " ")
 	}
 	sessions.NewSession(msg.SessionKey, name)
+	sessions.Save()
+
+	slog.Info("cmdNew: cleaning up old session", "session_key", msg.SessionKey)
+	e.cleanupInteractiveStateIfCurrent(interactiveKey, expectedNew)
+	slog.Info("cmdNew: cleanup done", "session_key", msg.SessionKey)
+
 	if name != "" {
 		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgNewSessionCreatedName), name))
 	} else {
@@ -8087,7 +8099,7 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 			return
 		case event, ok = <-events:
 			if !ok {
-				e.cleanupInteractiveState(sessionKey, state)
+				e.cleanupInteractiveStateIfCurrent(sessionKey, state)
 				if !auto {
 					if len(textParts) > 0 {
 						e.send(p, replyCtx, strings.Join(textParts, ""))
@@ -8102,7 +8114,7 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 			if !auto {
 				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), "compress timed out"))
 			}
-			e.cleanupInteractiveState(sessionKey, state)
+			e.cleanupInteractiveStateIfCurrent(sessionKey, state)
 			e.notifyDroppedQueuedMessages(state, fmt.Errorf("compress timed out"))
 			return
 		case <-e.ctx.Done():
@@ -9910,7 +9922,7 @@ func (e *Engine) performModelSwitchAsync(sessionKey string, state *interactiveSt
 		state.mu.Unlock()
 	}
 	e.pushModelSwitchResultCard(sessionKey, resultCard)
-	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(sessionKey), state)
+	e.cleanupInteractiveStateIfCurrent(e.interactiveKeyForSessionKey(sessionKey), state)
 }
 
 func (e *Engine) pushModelSwitchResultCard(sessionKey string, card *Card) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -5589,7 +5589,7 @@ func TestCleanupCAS_SkipsWhenStateReplaced(t *testing.T) {
 	e.interactiveMu.Unlock()
 
 	// Old goroutine calls cleanup with the OLD state pointer — should be skipped.
-	e.cleanupInteractiveState(key, oldState)
+	e.cleanupInteractiveStateIfCurrent(key, oldState)
 
 	e.interactiveMu.Lock()
 	current := e.interactiveStates[key]
@@ -5612,7 +5612,7 @@ func TestCleanupCAS_DeletesWhenStateMatches(t *testing.T) {
 	e.interactiveStates[key] = state
 	e.interactiveMu.Unlock()
 
-	e.cleanupInteractiveState(key, state)
+	e.cleanupInteractiveStateIfCurrent(key, state)
 
 	e.interactiveMu.Lock()
 	current := e.interactiveStates[key]
@@ -5689,6 +5689,170 @@ func TestCleanupCAS_ConcurrentUnconditionalCloseOnce(t *testing.T) {
 		t.Fatal("expected state to be deleted after cleanup")
 	}
 	e.interactiveMu.Unlock()
+}
+
+func TestCleanupIfCurrent_NilExpectedDoesNotDeleteNewState(t *testing.T) {
+	e := newTestEngine()
+	key := "test:user1"
+
+	var expected *interactiveState
+	newState := &interactiveState{agentSession: newControllableSession("new")}
+
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = newState
+	e.interactiveMu.Unlock()
+
+	e.cleanupInteractiveStateIfCurrent(key, expected)
+
+	e.interactiveMu.Lock()
+	got := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+	if got != newState {
+		t.Fatal("nil-expected cleanup deleted a newly created state")
+	}
+}
+
+func TestCmdNew_SwitchesActiveBeforeBlockingCleanup(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	agent := &stubAgent{}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	key := "test:ch:user1"
+
+	old := e.sessions.GetOrCreateActive(key)
+	oldID := old.ID
+	old.SetAgentSessionID("old-agent", agent.Name())
+
+	blocker := newBlockingCloseSession("old-agent")
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = &interactiveState{agentSession: blocker}
+	e.interactiveMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		e.cmdNew(p, &Message{SessionKey: key, Content: "/new", ReplyCtx: "ctx"}, nil)
+		close(done)
+	}()
+
+	<-blocker.closeStarted
+
+	active := e.sessions.GetOrCreateActive(key)
+	if active.ID == oldID {
+		t.Fatal("active session still points to old session while cleanup is blocked")
+	}
+	if got := old.GetAgentSessionID(); got != "" {
+		t.Fatalf("old session AgentSessionID = %q, want cleared", got)
+	}
+
+	close(blocker.releaseClose)
+	<-done
+}
+
+func TestIssue600_CmdNewConcurrentMessageUsesNewSessionAndKeepsReplacementState(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	agent := &stubAgent{}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	key := "test:ch:user1"
+
+	old := e.sessions.GetOrCreateActive(key)
+	oldID := old.ID
+	old.SetAgentSessionID("old-agent", agent.Name())
+
+	blocker := newBlockingCloseSession("old-agent")
+	oldState := &interactiveState{agentSession: blocker}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = oldState
+	e.interactiveMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		e.cmdNew(p, &Message{SessionKey: key, Content: "/new", ReplyCtx: "ctx"}, nil)
+		close(done)
+	}()
+
+	<-blocker.closeStarted
+
+	activeDuringCleanup := e.sessions.GetOrCreateActive(key)
+	if activeDuringCleanup.ID == oldID {
+		t.Fatal("concurrent message would use the old active session during /new cleanup")
+	}
+
+	replacement := &interactiveState{agentSession: newControllableSession("replacement")}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = replacement
+	e.interactiveMu.Unlock()
+
+	close(blocker.releaseClose)
+	<-done
+
+	e.interactiveMu.Lock()
+	got := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+	if got != replacement {
+		t.Fatal("/new stale cleanup deleted replacement interactive state")
+	}
+}
+
+// TestCmdNew_PreservesConcurrentState verifies that cmdNew passes the current
+// interactive state as `expected` to cleanupInteractiveState, so that a
+// concurrent message's state created during the blocking close is not deleted.
+func TestCmdNew_PreservesConcurrentState(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	key := "test:ch:user1"
+
+	// Create an old interactive state (simulating an active session).
+	oldSession := newControllableSession("old")
+	oldState := &interactiveState{agentSession: oldSession}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = oldState
+	e.interactiveMu.Unlock()
+
+	// Call cmdNew — this captures `expected` = oldState, then calls
+	// cleanupInteractiveStateIfCurrent(key, oldState).
+	msg := &Message{SessionKey: key, Content: "/new", ReplyCtx: "ctx"}
+	e.cmdNew(p, msg, nil)
+
+	// After cmdNew, the old state should be cleaned up and no state should remain.
+	e.interactiveMu.Lock()
+	current := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+
+	if current != nil {
+		t.Fatal("expected old state to be deleted after /new")
+	}
+
+	// Verify old agent session was closed (save ref before cleanup nils it).
+	if oldSession.Alive() {
+		t.Error("expected old agent session to be closed after /new")
+	}
+}
+
+// TestCmdNew_ConcurrentStateSurvivesCleanup verifies the race scenario:
+// cmdNew captures expected=oldState, then during the blocking close a concurrent
+// message replaces the state. The second re-check in cleanupInteractiveState
+// should detect the replacement and skip the delete.
+func TestCmdNew_ConcurrentStateSurvivesCleanup(t *testing.T) {
+	e := newTestEngine()
+	key := "test:user1"
+
+	oldState := &interactiveState{agentSession: newControllableSession("old")}
+	newState := &interactiveState{agentSession: newControllableSession("new")}
+
+	// Simulate: concurrent message already replaced the state before cleanup starts.
+	// The first re-check detects state != expected and returns early.
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = newState
+	e.interactiveMu.Unlock()
+
+	e.cleanupInteractiveStateIfCurrent(key, oldState)
+
+	e.interactiveMu.Lock()
+	survived := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+
+	if survived != newState {
+		t.Fatal("expected-based cleanup deleted the concurrent state — race not prevented")
+	}
 }
 
 // TestSessionMismatch_RecyclesStaleAgent verifies that getOrCreateInteractiveStateWith
@@ -5893,7 +6057,7 @@ func TestStaleGoroutineCleanup_RaceSimulation(t *testing.T) {
 
 	// Step 4: Old goroutine exits and calls cleanup with OLD state pointer.
 	// This simulates processInteractiveEvents channelClosed path.
-	e.cleanupInteractiveState(key, oldState)
+	e.cleanupInteractiveStateIfCurrent(key, oldState)
 
 	// Verify: new state must survive.
 	e.interactiveMu.Lock()
@@ -10871,9 +11035,9 @@ func (p *stubStreamingCardPlatform) CreateStreamingCard(_ context.Context, _ any
 // stubStreamingCard is a minimal StreamingCard for tests.
 type stubStreamingCard struct{}
 
-func (c *stubStreamingCard) Update(_ context.Context, _ string) error { return nil }
+func (c *stubStreamingCard) Update(_ context.Context, _ string) error   { return nil }
 func (c *stubStreamingCard) Finalize(_ context.Context, _ string) error { return nil }
-func (c *stubStreamingCard) Failed() bool                                { return false }
+func (c *stubStreamingCard) Failed() bool                               { return false }
 
 func TestHandleMessage_InstantReply_SendsConfirmationWhenEnabled(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}


### PR DESCRIPTION
## Summary
Fixes #600.

- Switch /new to create and persist the new active session before closing the old agent session, so concurrent messages no longer continue on the old active session while cleanup blocks.
- Add expected-state cleanup for current interactive states, preventing stale cleanup paths from deleting replacement interactive state.
- Update cc-connect sessions list and numeric sessions show #n to use active sessions only, while preserving exact historical lookup via sessions show <project:sid>.
- Add regression tests for the /new race and active-session CLI listing behavior.

## Test plan
- [x] go test ./core -run "TestCleanupCAS|TestCleanupIfCurrent|TestCmdNew|TestIssue600|TestSessionManager" -count=1
- [x] go test .\cmd\cc-connect\sessions.go .\cmd\cc-connect\sessions_tui.go .\cmd\cc-connect\sessions_test.go -run "TestLoadSessionsForList|TestLoadSessionsForShowIndex|TestLoadAllSessions|TestParseSessionKey" -count=1

## Notes
Full go test ./... is not green in this Windows workspace due existing environment and unrelated test issues, including missing Unix commands in PATH, Windows symlink privileges, path separator expectations, and existing cmd/cc-connect test compile errors.