### PR TITLE
feat(codex): prefer Codex model_catalog_json as highest-priority model source

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/BurntSushi/toml"
+
 	"github.com/chenhg5/cc-connect/core"
 )
 
@@ -217,6 +219,9 @@ func (a *Agent) configuredModels() []core.ModelOption {
 }
 
 func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
+	if models := readCodexModelCatalog(); len(models) > 0 {
+		return models
+	}
 	if models := a.configuredModels(); len(models) > 0 {
 		return models
 	}
@@ -303,19 +308,23 @@ func (a *Agent) fetchModelsFromAPI(ctx context.Context) []core.ModelOption {
 }
 
 func readCodexCachedModels() []core.ModelOption {
-	codexHome := os.Getenv("CODEX_HOME")
+	codexHome, _ := resolveCodexHome(nil)
 	if codexHome == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil
-		}
-		codexHome = filepath.Join(home, ".codex")
+		return nil
 	}
 	path := filepath.Join(codexHome, "models_cache.json")
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil
 	}
+	return parseCodexModelsJSON(b)
+}
+
+
+// parseCodexModelsJSON parses a Codex models JSON file (model_catalog.json
+// or models_cache.json) into a deduplicated, filtered slice of ModelOption.
+// It is shared by readCodexCachedModels and readCodexModelCatalog.
+func parseCodexModelsJSON(data []byte) []core.ModelOption {
 	var payload struct {
 		Models []struct {
 			Slug           string `json:"slug"`
@@ -325,7 +334,7 @@ func readCodexCachedModels() []core.ModelOption {
 			SupportedInAPI bool   `json:"supported_in_api"`
 		} `json:"models"`
 	}
-	if err := json.Unmarshal(b, &payload); err != nil {
+	if err := json.Unmarshal(data, &payload); err != nil {
 		return nil
 	}
 
@@ -357,6 +366,62 @@ func readCodexCachedModels() []core.ModelOption {
 	return models
 }
 
+
+// readCodexModelCatalog reads $CODEX_HOME/config.toml to find the
+// model_catalog_json setting, then reads and parses that JSON file.
+// This is the authoritative source of model metadata for Codex CLI,
+// maintained by the Codex distribution itself.
+func readCodexModelCatalog() []core.ModelOption {
+	codexHome, _ := resolveCodexHome(nil)
+	if codexHome == "" {
+		return nil
+	}
+
+	// Parse CODEX_HOME/config.toml to find model_catalog_json path
+	cfgPath := filepath.Join(codexHome, "config.toml")
+	var cfg struct {
+		ModelCatalogJSON string `toml:"model_catalog_json"`
+	}
+	if _, err := toml.DecodeFile(cfgPath, &cfg); err != nil {
+		slog.Debug("codex: failed to read config.toml for model_catalog_json", "error", err)
+		return nil
+	}
+	if cfg.ModelCatalogJSON == "" {
+		return nil
+	}
+
+	// Expand ~ and resolve relative paths against CODEX_HOME
+	catalogPath := cfg.ModelCatalogJSON
+	switch {
+	case strings.HasPrefix(catalogPath, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			slog.Debug("codex: cannot resolve home dir for model_catalog_json", "error", err)
+			return nil
+		}
+		catalogPath = filepath.Join(home, catalogPath[2:])
+	case catalogPath == "~":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		catalogPath = home
+	case !filepath.IsAbs(catalogPath):
+		catalogPath = filepath.Join(codexHome, catalogPath)
+	}
+
+	b, err := os.ReadFile(catalogPath)
+	if err != nil {
+		slog.Debug("codex: failed to read model_catalog_json", "path", catalogPath, "error", err)
+		return nil
+	}
+
+	models := parseCodexModelsJSON(b)
+	if models == nil {
+		slog.Debug("codex: failed to parse model_catalog_json", "path", catalogPath)
+	}
+	return models
+}
 func (a *Agent) SetSessionEnv(env []string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/codex/codex_cache_test.go
+++ b/agent/codex/codex_cache_test.go
@@ -40,3 +40,73 @@ func TestAvailableModels_FallbackToModelsCache(t *testing.T) {
 		t.Fatalf("models = %v, want [gpt-5.4 gpt-5.3-codex]", models)
 	}
 }
+
+// TestAvailableModels_UsesModelCatalog tests that when CODEX_HOME/config.toml
+// contains model_catalog_json, readCodexModelCatalog reads and parses that file
+// as the highest-priority model source.
+func TestAvailableModels_UsesModelCatalog(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+
+	config := `model_catalog_json = "model_catalog.json"
+`
+	if err := os.WriteFile(tmp+"/config.toml", []byte(config), 0o644); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+
+	// Mix of models: list-visible API-supported, hidden, non-API, and
+	// one with an empty slug that falls back to display_name.
+	catalog := `{
+  "models": [
+    {"slug":"gpt-5.4","display_name":"GPT-5.4","description":"Latest frontier agentic coding model.","visibility":"list","supported_in_api":true},
+    {"slug":"gpt-5.3-codex","display_name":"GPT-5.3 Codex","description":"Great for coding","visibility":"list","supported_in_api":true},
+    {"slug":"hidden-internal","visibility":"hidden","supported_in_api":true},
+    {"slug":"tool-only","visibility":"list","supported_in_api":false},
+    {"slug":"","display_name":"MissingSlug","visibility":"list","supported_in_api":true}
+  ]
+}`
+	if err := os.WriteFile(tmp+"/model_catalog.json", []byte(catalog), 0o644); err != nil {
+		t.Fatalf("write model_catalog.json: %v", err)
+	}
+
+	t.Setenv("CODEX_HOME", tmp)
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENAI_BASE_URL", srv.URL)
+
+	a := &Agent{activeIdx: -1}
+	models := a.AvailableModels(context.Background())
+
+	// 3 visible+supported: gpt-5.4, gpt-5.3-codex, MissingSlug (slug empty → display_name fallback)
+	if len(models) != 3 {
+		t.Fatalf("models length = %d, want 3, models=%v", len(models), models)
+	}
+	if models[0].Name != "gpt-5.4" || models[0].Desc != "Latest frontier agentic coding model." {
+		t.Errorf("models[0] = %+v, want gpt-5.4 with description", models[0])
+	}
+	if models[1].Name != "gpt-5.3-codex" || models[1].Desc != "Great for coding" {
+		t.Errorf("models[1] = %+v, want gpt-5.3-codex with description", models[1])
+	}
+	if models[2].Name != "MissingSlug" || models[2].Desc != "" {
+		t.Errorf("models[2] = %+v, want MissingSlug (display_name fallback)", models[2])
+	}
+}
+
+// TestReadCodexModelCatalog_NoConfigFile tests graceful fallback when
+// CODEX_HOME/config.toml does not exist.
+func TestReadCodexModelCatalog_NoConfigFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CODEX_HOME", tmp)
+
+	a := &Agent{activeIdx: -1}
+	models := a.AvailableModels(context.Background())
+
+	// No config.toml → no model_catalog.json → no models_cache.json
+	// → no OPENAI_API_KEY → all the way to hardcoded fallback (6 models)
+	if len(models) != 6 {
+		t.Fatalf("expected 6 hardcoded fallback models, got %d: %v", len(models), models)
+	}
+}


### PR DESCRIPTION
## Summary

Codex CLI supports a `model_catalog_json` field in `$CODEX_HOME/config.toml` that points to a JSON file containing a curated list of models. Currently `AvailableModels()` ignores this field entirely, falling through to the provider config, API, cache, or hardcoded fallback. This means users who configure a custom model catalog in their Codex config don't see those models when switching models via the CC-Connect UI.

This PR adds `$CODEX_HOME/config.toml` → `model_catalog_json` as the **highest-priority** model source, so the user's explicitly configured catalog takes precedence over everything else.

## Fix

- Add `readCodexModelCatalog()` that reads `$CODEX_HOME/config.toml`, resolves the `model_catalog_json` path (expand ~, relative to CODEX_HOME), and parses the JSON as the primary model list.
- Extract shared `parseCodexModelsJSON()` to deduplicate JSON parsing logic between `readCodexCachedModels` and `readCodexModelCatalog`.
- Refactor `readCodexCachedModels()` to reuse `resolveCodexHome(nil)`.
- Update `AvailableModels()` priority:
  1. `model_catalog_json` (new, highest)
  2. provider config
  3. `GET /v1/models` API
  4. `models_cache.json`
  5. hardcoded fallback

## Tests

`TestAvailableModels_UsesModelCatalog` verifies that when a valid `$CODEX_HOME/config.toml` with `model_catalog_json` exists, `AvailableModels()` returns the models from that catalog. `TestReadCodexModelCatalog_NoConfigFile` verifies graceful fallback when no config file exists.

## Test plan

- [x] `go test -count=1 -run "TestAvailableModels_UsesModelCatalog|TestReadCodexModelCatalog_NoConfigFile|TestAvailableModels_FallbackToModelsCache" ./agent/codex/`
- [x] `go test -count=1 ./agent/codex/`
- [x] Manual: `/model` command in Feishu now lists models from the custom catalog JSON instead of only hardcoded defaults.

## Notes

`go test ./...` is not fully green due to existing environment and unrelated test issues (e.g. missing external dependencies), not introduced by this PR.
