### PR TITLE
fix(codex): stream each round's agent_message as EventText instead of buffering

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -1207,9 +1207,7 @@ func (s *appServerSession) handleItemCompleted(item map[string]any) {
 	case "agentMessage":
 		text, _ := item["text"].(string)
 		if strings.TrimSpace(text) != "" {
-			s.stateMu.Lock()
 			s.emit(core.Event{Type: core.EventText, Content: text})
-			s.stateMu.Unlock()
 		}
 
 	case "commandExecution":

--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -505,7 +505,6 @@ func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, fi
 
 	s.stateMu.Lock()
 	s.currentTurn = resp.Turn.ID
-	s.pendingMsgs = s.pendingMsgs[:0]
 	s.stateMu.Unlock()
 
 	return nil
@@ -607,7 +606,6 @@ func (s *appServerSession) handleApprovalRequest(rawID json.RawMessage, method s
 	s.pendingApprovals[requestID] = ch
 	s.approvalsMu.Unlock()
 
-	s.flushPendingAsThinking()
 	s.emit(core.Event{
 		Type:         core.EventPermissionRequest,
 		RequestID:    requestID,
@@ -654,7 +652,6 @@ func (s *appServerSession) handlePermissionsApproval(rawID json.RawMessage, para
 	s.pendingApprovals[requestID] = ch
 	s.approvalsMu.Unlock()
 
-	s.flushPendingAsThinking()
 	s.emit(core.Event{
 		Type:         core.EventPermissionRequest,
 		RequestID:    requestID,
@@ -722,7 +719,6 @@ func (s *appServerSession) handleRequestUserInput(rawID json.RawMessage, paramsR
 	s.pendingApprovals[requestID] = ch
 	s.approvalsMu.Unlock()
 
-	s.flushPendingAsThinking()
 	s.emit(core.Event{
 		Type:         core.EventPermissionRequest,
 		RequestID:    requestID,
@@ -1106,7 +1102,6 @@ func (s *appServerSession) handleNotification(method string, paramsRaw json.RawM
 		if err := json.Unmarshal(paramsRaw, &notif); err == nil {
 			s.stateMu.Lock()
 			s.currentTurn = notif.Turn.ID
-			s.pendingMsgs = s.pendingMsgs[:0]
 			s.stateMu.Unlock()
 			s.storeContextUsage(nil)
 		}
@@ -1172,8 +1167,6 @@ func (s *appServerSession) handleItemStarted(item map[string]any) {
 		return
 	}
 
-	s.flushPendingAsThinking()
-
 	switch itemType {
 	case "commandExecution":
 		command, _ := item["command"].(string)
@@ -1215,7 +1208,7 @@ func (s *appServerSession) handleItemCompleted(item map[string]any) {
 		text, _ := item["text"].(string)
 		if strings.TrimSpace(text) != "" {
 			s.stateMu.Lock()
-			s.pendingMsgs = append(s.pendingMsgs, text)
+			s.emit(core.Event{Type: core.EventText, Content: text})
 			s.stateMu.Unlock()
 		}
 
@@ -1516,34 +1509,7 @@ func (s *appServerSession) completeTurn() {
 	}
 	s.currentTurn = ""
 	s.stateMu.Unlock()
-	s.flushPendingAsText()
 	s.emit(core.Event{Type: core.EventResult, SessionID: s.CurrentSessionID(), Done: true})
-}
-
-func (s *appServerSession) flushPendingAsThinking() {
-	s.stateMu.Lock()
-	msgs := append([]string(nil), s.pendingMsgs...)
-	s.pendingMsgs = s.pendingMsgs[:0]
-	s.stateMu.Unlock()
-
-	for _, text := range msgs {
-		if strings.TrimSpace(text) != "" {
-			s.emit(core.Event{Type: core.EventThinking, Content: text})
-		}
-	}
-}
-
-func (s *appServerSession) flushPendingAsText() {
-	s.stateMu.Lock()
-	msgs := append([]string(nil), s.pendingMsgs...)
-	s.pendingMsgs = s.pendingMsgs[:0]
-	s.stateMu.Unlock()
-
-	for _, text := range msgs {
-		if strings.TrimSpace(text) != "" {
-			s.emit(core.Event{Type: core.EventText, Content: text})
-		}
-	}
 }
 
 func (s *appServerSession) emit(event core.Event) {

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -44,8 +44,6 @@ type codexSession struct {
 	cmdMu          sync.Mutex
 	cmds           map[*exec.Cmd]struct{}
 
-	pendingMsgs []string // buffered agent_message texts awaiting classification
-
 	runtimeCfgMu       sync.Mutex
 	runtimeCfgModel    string
 	runtimeCfgEffort   string
@@ -384,7 +382,6 @@ func (cs *codexSession) handleEvent(raw map[string]any) {
 		}
 
 	case "turn.started":
-		cs.pendingMsgs = cs.pendingMsgs[:0]
 		cs.contextMu.Lock()
 		cs.contextUsage = nil
 		cs.contextMu.Unlock()
@@ -398,7 +395,6 @@ func (cs *codexSession) handleEvent(raw map[string]any) {
 
 	case "turn.completed":
 		cs.refreshContextUsageFromRollout()
-		cs.flushPendingAsText()
 		evt := core.Event{Type: core.EventResult, SessionID: cs.CurrentSessionID(), Done: true}
 		select {
 		case cs.events <- evt:
@@ -435,44 +431,6 @@ func (cs *codexSession) handleEvent(raw map[string]any) {
 	}
 }
 
-// flushPendingAsThinking emits all buffered agent_messages as EventThinking.
-func (cs *codexSession) flushPendingAsThinking() {
-	if cs.ctx.Err() != nil {
-		return
-	}
-	for _, text := range cs.pendingMsgs {
-		if cs.ctx.Err() != nil {
-			return
-		}
-		evt := core.Event{Type: core.EventThinking, Content: text}
-		select {
-		case cs.events <- evt:
-		case <-cs.ctx.Done():
-			return
-		}
-	}
-	cs.pendingMsgs = cs.pendingMsgs[:0]
-}
-
-// flushPendingAsText emits all buffered agent_messages as EventText (final response).
-func (cs *codexSession) flushPendingAsText() {
-	if cs.ctx.Err() != nil {
-		return
-	}
-	for _, text := range cs.pendingMsgs {
-		if cs.ctx.Err() != nil {
-			return
-		}
-		evt := core.Event{Type: core.EventText, Content: text}
-		select {
-		case cs.events <- evt:
-		case <-cs.ctx.Done():
-			return
-		}
-	}
-	cs.pendingMsgs = cs.pendingMsgs[:0]
-}
-
 var codexToolNames = map[string]string{
 	"web_search":       "WebSearch",
 	"file_search":      "FileSearch",
@@ -493,9 +451,6 @@ func (cs *codexSession) handleItemStarted(raw map[string]any) {
 	if itemType == "agent_message" || itemType == "message" || itemType == "reasoning" {
 		return
 	}
-
-	// Any non-message item is a tool use; flush pending messages as thinking first.
-	cs.flushPendingAsThinking()
 
 	switch itemType {
 	case "command_execution":
@@ -544,7 +499,12 @@ func (cs *codexSession) handleItemCompleted(raw map[string]any) {
 	case "agent_message", "message":
 		text := extractItemText(item, "content", "output_text")
 		if text != "" {
-			cs.pendingMsgs = append(cs.pendingMsgs, text)
+			evt := core.Event{Type: core.EventText, Content: text}
+			select {
+			case cs.events <- evt:
+			case <-cs.ctx.Done():
+				return
+			}
 		}
 
 	case "command_execution":
@@ -921,7 +881,6 @@ func (cs *codexSession) Close() error {
 			return nil
 		case <-time.After(codexSessionForceKillWait):
 			// Do not close(cs.events) here: readLoop may still be in handleEvent
-			// (e.g. turn.completed -> flushPendingAsText) and would panic on send.
 			slog.Warn("codexSession: force kill wait timed out, deferring events channel close until readLoop exits",
 				"wait", codexSessionForceKillWait)
 			go func() {


### PR DESCRIPTION
## Summary

Codex agent messages from intermediate rounds are buffered in `pendingMsgs` and only flushed as `EventThinking` when the next tool call starts. Only the final round's text is emitted as `EventText`. This means the Feishu card shows intermediate round text only as "thinking" (or hides it entirely when ThinkingMessages is disabled), and only the last round appears as the actual answer.

This PR changes both `session.go` (CLI backend) and `appserver_session.go` (AppServer backend) to emit `EventText` immediately on each `agent_message` item completion, matching Claude Code's streaming behavior where every round's output is appended to the dynamic card.

## Fix

- Remove `pendingMsgs` buffer, `flushPendingAsThinking()`, and `flushPendingAsText()` from both `session.go` and `appserver_session.go`.
- In `handleItemCompleted`, emit `EventText` directly instead of appending to `pendingMsgs`.
- Remove the now-unnecessary `stateMu` lock around the `emit()` call in the `agentMessage` branch of `appserver_session.go` — `emit()` is already concurrency-safe (writes to a buffered channel with select/default).

No public API or behaviour change beyond the streaming improvement.

## Tests

No new tests. Existing tests in `session_test.go` and `appserver_session_test.go` cover the session lifecycle and should continue to pass. The removed code (`pendingMsgs`, `flushPendingAsThinking`, `flushPendingAsText`) had no dedicated tests.

## Test plan

- [x] `go test -count=1 -run "TestAppServerSession_ApplyThreadRuntimeState|TestAppServerSession_HandleRateLimitsUpdatedCachesUsage|TestAppServerSession_HandleThreadTokenUsageUpdatedCachesContextUsage|TestMapAppServerRateLimits_PrefersMultiBucketView" ./agent/codex/`
- [x] `go test -count=1 -run "TestSend_WithImages_PassesImageArgsAndDefaultPrompt|TestSend_HandlesLargeJSONLines|TestClose_ForceKillsProcessGroupAfterGracefulTimeout" ./agent/codex/`
- [x] `go test -count=1 ./agent/codex/`
- [x] Manual: Send a multi-round prompt to Codex via Feishu; each round's agent_message now streams into the card as real-time text instead of only showing the final round.

## Notes

`go test ./...` is not fully green due to existing environment and unrelated test issues, not introduced by this PR.
