### PR TITLE
fix(codex): preserve explicit stdio app-server URL

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -56,12 +56,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	codexHome, _ := opts["codex_home"].(string)
 	mode = normalizeMode(mode)
 	backend = normalizeBackend(backend)
-
-	if appServerURL == "" {
-		appServerURL = "ws://127.0.0.1:3845"
-	} else if strings.EqualFold(strings.TrimSpace(appServerURL), "stdio") {
-		appServerURL = ""
-	}
+	appServerURL = normalizeAppServerURL(appServerURL)
 
 	// cli_path allows overriding the binary, e.g. "omx" or "omx --flag val"
 	cliBin := "codex"
@@ -99,6 +94,17 @@ func normalizeBackend(raw string) string {
 	default:
 		return "exec"
 	}
+}
+
+func normalizeAppServerURL(raw string) string {
+	url := strings.TrimSpace(raw)
+	if url == "" {
+		return "ws://127.0.0.1:3845"
+	}
+	if strings.EqualFold(url, "stdio") {
+		return "stdio://"
+	}
+	return url
 }
 
 func normalizeMode(raw string) string {

--- a/agent/codex/codex_model_test.go
+++ b/agent/codex/codex_model_test.go
@@ -55,3 +55,29 @@ func TestGetModel_PrefersActiveProviderModel(t *testing.T) {
 		t.Fatalf("GetModel() = %q, want gpt-5.4", got)
 	}
 }
+
+func TestNormalizeAppServerURL_StdIOIsExplicit(t *testing.T) {
+	for _, raw := range []string{"stdio", " stdio "} {
+		if got := normalizeAppServerURL(raw); got != "stdio://" {
+			t.Fatalf("normalizeAppServerURL(%q) = %q, want stdio://", raw, got)
+		}
+	}
+}
+
+func TestNormalizeAppServerURL_EmptyKeepsWebSocketDefault(t *testing.T) {
+	if got := normalizeAppServerURL(""); got != "ws://127.0.0.1:3845" {
+		t.Fatalf("normalizeAppServerURL(empty) = %q, want ws://127.0.0.1:3845", got)
+	}
+}
+
+func TestWorkspaceAgentOptions_PreservesStdIOAppServerURL(t *testing.T) {
+	a := &Agent{
+		backend:      "app_server",
+		appServerURL: normalizeAppServerURL("stdio"),
+	}
+
+	opts := a.WorkspaceAgentOptions()
+	if got := opts["app_server_url"]; got != "stdio://" {
+		t.Fatalf("WorkspaceAgentOptions()[app_server_url] = %#v, want stdio://", got)
+	}
+}


### PR DESCRIPTION
## Summary
- normalize explicit `app_server_url = "stdio"` to `stdio://` instead of clearing it
- keep the existing WebSocket default when `app_server_url` is omitted
- preserve explicit stdio transport when constructing per-workspace Codex agents

## Why
When the Codex app-server backend is configured with `app_server_url = "stdio"`, the top-level agent normalizes it to an empty string. Workspace agent options then omit the empty URL, so workspace agents fall back to `ws://127.0.0.1:3845`. The appserver session still communicates over stdio pipes, causing initialization to time out.

## Tests
- `go test ./agent/codex`