### PR TITLE
fix(feishu): handle mention-only quoted replies

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1957,7 +1957,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	}
 
 	content := strings.TrimSpace(msg.Content)
-	if content == "" && len(msg.Images) == 0 && len(msg.Files) == 0 && msg.Location == nil {
+	if content == "" && msg.ExtraContent == "" && len(msg.Images) == 0 && len(msg.Files) == 0 && msg.Location == nil {
 		return
 	}
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -4980,6 +4980,28 @@ func TestHandleMessage_ExtraContentPreservedThroughAlias(t *testing.T) {
 	}
 }
 
+func TestHandleMessage_ExtraContentOnlyIsProcessed(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	agent := &stubAgent{}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	msg := &Message{
+		SessionKey:   "test:user1",
+		ReplyCtx:     "ctx",
+		Content:      "",
+		ExtraContent: "> quoted reply context",
+		Platform:     "test",
+		UserID:       "user1",
+		MessageID:    "m-extra-only",
+	}
+
+	e.handleMessage(p, msg)
+
+	if msg.Content != "> quoted reply context" {
+		t.Fatalf("Content = %q, want ExtraContent to become message content", msg.Content)
+	}
+}
+
 func TestCmdDiff_RejectsDashTarget(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -560,48 +560,48 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 				},
 			}, nil
 		}
-	if p.cardNavHandler != nil {
-		done := make(chan *core.Card, 1)
-		go func() {
-			done <- p.cardNavHandler(actionVal, sessionKey)
-		}()
+		if p.cardNavHandler != nil {
+			done := make(chan *core.Card, 1)
+			go func() {
+				done <- p.cardNavHandler(actionVal, sessionKey)
+			}()
 
-		select {
-		case card := <-done:
-			if card != nil {
+			select {
+			case card := <-done:
+				if card != nil {
+					return &callback.CardActionTriggerResponse{
+						Card: &callback.Card{
+							Type: "raw",
+							Data: renderCardMap(card, sessionKey),
+						},
+					}, nil
+				}
+			case <-time.After(cardNavTimeout):
+				go func() {
+					card := <-done
+					if card == nil {
+						return
+					}
+					if refresher, ok := p.self.(core.CardRefresher); ok {
+						if err := refresher.RefreshCard(context.Background(), sessionKey, card); err != nil {
+							slog.Warn(p.tag()+": async card refresh failed", "action", actionVal, "err", err)
+						}
+					}
+				}()
 				return &callback.CardActionTriggerResponse{
-					Card: &callback.Card{
-						Type: "raw",
-						Data: renderCardMap(card, sessionKey),
+					Toast: &callback.Toast{
+						Type:    "info",
+						Content: "⏳ Loading... / 加载中...",
 					},
 				}, nil
 			}
-		case <-time.After(cardNavTimeout):
-			go func() {
-				card := <-done
-				if card == nil {
-					return
-				}
-				if refresher, ok := p.self.(core.CardRefresher); ok {
-					if err := refresher.RefreshCard(context.Background(), sessionKey, card); err != nil {
-						slog.Warn(p.tag()+": async card refresh failed", "action", actionVal, "err", err)
-					}
-				}
-			}()
-			return &callback.CardActionTriggerResponse{
-				Toast: &callback.Toast{
-					Type:    "info",
-					Content: "⏳ Loading... / 加载中...",
-				},
-			}, nil
 		}
-	}
-	if strings.HasPrefix(actionVal, "act:") {
-		slog.Debug(p.tag()+": card action produced no card update", "action", actionVal)
+		if strings.HasPrefix(actionVal, "act:") {
+			slog.Debug(p.tag()+": card action produced no card update", "action", actionVal)
+			return nil, nil
+		}
+		slog.Warn(p.tag()+": card nav returned nil, ignoring", "action", actionVal)
 		return nil, nil
-	}
-	slog.Warn(p.tag()+": card nav returned nil, ignoring", "action", actionVal)
-	return nil, nil
 	}
 
 	// perm: — permission response with in-place card update
@@ -1091,7 +1091,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			return
 		}
 		text := stripMentions(textBody.Text, mentions, p.botOpenID)
-		if text == "" {
+		if text == "" && quoted.text == "" && len(quoted.images) == 0 {
 			slog.Debug(p.tag()+": dropping empty text after mention stripping",
 				"message_id", messageID,
 				"raw_text_len", len(textBody.Text),
@@ -1164,7 +1164,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	case "post":
 		textParts, images := p.parsePostContent(messageID, content)
 		text := stripMentions(strings.Join(textParts, "\n"), mentions, p.botOpenID)
-		if text == "" && len(images) == 0 {
+		if text == "" && len(images) == 0 && quoted.text == "" && len(quoted.images) == 0 {
 			return
 		}
 		p.dispatchCoreMessage(&core.Message{

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -206,6 +206,98 @@ func TestDispatchMessageIncludesQuotedImage(t *testing.T) {
 	}
 }
 
+func TestDispatchMessageKeepsMentionOnlyQuotedText(t *testing.T) {
+	const appID = "cli_quote_text"
+	const appSecret = "secret-quote-text"
+	const parentMessageID = "om_parent_text"
+
+	got := make(chan *core.Message, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID:
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"items": []map[string]any{
+						{
+							"msg_type":  "text",
+							"parent_id": "",
+							"sender": map[string]any{
+								"id":          "ou_parent",
+								"sender_type": "user",
+							},
+							"body": map[string]any{
+								"content": `{"text":"请总结这条消息"}`,
+							},
+						},
+					},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/contact/v3/users/"):
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/im/v1/chats/"):
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		botOpenID:    "ou_bot",
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			got <- msg
+		},
+	}
+
+	p.dispatchMessage(
+		context.Background(),
+		"text",
+		`{"text":"@bot"}`,
+		[]*larkim.MentionEvent{
+			{Key: strPtr("@bot"), Id: &larkim.UserId{OpenId: strPtr("ou_bot")}, Name: strPtr("Bot")},
+		},
+		"om_child",
+		"feishu:oc_chat:ou_user",
+		"ou_user",
+		"oc_chat",
+		replyContext{messageID: "om_child", sessionKey: "feishu:oc_chat:ou_user"},
+		parentMessageID,
+	)
+
+	select {
+	case msg := <-got:
+		if msg.Content != "" {
+			t.Fatalf("Content = %q, want empty user text after bot mention stripping", msg.Content)
+		}
+		if !strings.Contains(msg.ExtraContent, "请总结这条消息") {
+			t.Fatalf("ExtraContent = %q, want quoted text", msg.ExtraContent)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for mention-only quoted text message")
+	}
+}
+
 func TestIsMessageRecalledDetectsWithdrawnMessageFromGetAPI(t *testing.T) {
 	const appID = "cli_recall_probe"
 	const appSecret = "secret-recall-probe"


### PR DESCRIPTION
## Summary
- keep Feishu text/post messages alive when bot mention stripping leaves empty text but quoted reply context exists
- allow core to process ExtraContent-only messages so quoted context can become the prompt
- add regression coverage for mention-only quoted text and ExtraContent-only handling

## Why
In Feishu group chats, replying to a message with only an @mention of the bot currently emits an inbound event with `parent_id/root_id` and mentions, but the adapter strips the bot mention and drops the message as empty before core sees the quoted context. DingTalk and WeCom do not require extra text for this interaction pattern.

## Tests
- `go test ./core -run 'TestHandleMessage_ExtraContent'`\n- `go test ./platform/feishu -run 'TestDispatchMessageKeepsMentionOnlyQuotedText|TestDispatchMessageIncludesQuotedImage|TestStripMentions'`\n- `go test ./platform/feishu`\n\nNote: on this machine, `go test ./core` against upstream/main currently has unrelated reply-footer path expectation failures; the targeted core regression test above passes.