### PR TITLE
fix(daemon): stub CheckLinger on non-Linux to unbreak macOS/Windows build

### DIFF
--- a/daemon/check_linger_other.go
+++ b/daemon/check_linger_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package daemon
+
+// CheckLinger is a stub for non-Linux platforms where systemd linger does not
+// apply. Returns (true, "") so callers skip the linger warning.
+func CheckLinger() (enabled bool, user string) {
+	return true, ""
+}


### PR DESCRIPTION
## Summary

#965 added `daemon.CheckLinger()` in `daemon/systemd.go` (build-tagged `//go:build linux`), and `cmd/cc-connect/daemon.go:109` calls it unconditionally. The caller has no build tag, so any non-Linux build fails:

```
cmd/cc-connect/daemon.go:109:27: undefined: daemon.CheckLinger
```

Reproduced on `darwin/arm64` against current `main` (`a2cc0ab1`) with `make build`.

## Fix

Add a `!linux` stub that returns `(true, "")` so callers skip the systemd-linger warning on platforms where the concept doesn't apply. The existing runtime check in `cmd/cc-connect/daemon.go`

```go
if strings.Contains(mgr.Platform(), "user") {
    enabled, user := daemon.CheckLinger()
    ...
}
```

still gates the warning to systems where it's meaningful (Linux user-mode systemd); the stub just keeps the symbol resolvable cross-platform.

Alternative considered: build-tag the caller block. Rejected as more invasive — the surrounding `daemonInstall` function is shared across platforms, and splitting it would scatter the logic.

## Test plan

- [x] `make build` on `darwin/arm64` passes after the change (failed before).
- [ ] Linux build still works (no changes to Linux files; `daemon/systemd.go` stays authoritative on Linux because the new stub's `!linux` tag excludes it there).
- [ ] Windows build (untested locally, but `daemon/windows.go` uses `//go:build windows` and the stub's `!linux` includes Windows, so behavior should match macOS).

Fixes the regression introduced in #965.