### PR TITLE
fix(feishu): admit attachment-only messages into active threads without @bot

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -158,6 +158,13 @@ type Platform struct {
 	// session key, enabling async card refreshes via the Patch API.
 	cardActionMsgMu  sync.Mutex
 	cardActionMsgIDs map[string]string // sessionKey → messageID
+	// activeThreadSessions tracks thread sessionKeys that have already been
+	// accepted by the bot. In group chats with thread_isolation, once a thread
+	// has been engaged (the first @bot message), subsequent attachment-only
+	// messages (image/file/audio) inside the same thread are passed through
+	// without requiring another @bot mention. Value is the last-seen time so
+	// stale entries can be expired by a future TTL sweep if needed.
+	activeThreadSessions sync.Map // sessionKey -> time.Time
 }
 
 type interactivePlatform struct {
@@ -999,12 +1006,25 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 		"thread_isolation", p.threadIsolation,
 	)
 
+	// Pre-compute sessionKey so the @bot filter below can consult the active
+	// thread set; sessionKey is also used downstream for dispatch.
+	sessionKey := p.makeSessionKey(msg, chatID, userID)
+
 	if chatType == "group" && !p.groupReplyAll && p.botOpenID != "" {
 		if !isBotMentioned(msg.Mentions, p.botOpenID) {
+			switch {
 			// Feishu @all sends {"text":"@_all"} with 0 mentions.
-			if p.respondToAtEveryoneAndHere && msg.Content != nil && strings.Contains(*msg.Content, "@_all") {
+			case p.respondToAtEveryoneAndHere && msg.Content != nil && strings.Contains(*msg.Content, "@_all"):
 				slog.Debug(p.tag()+": responding to @all message", "chat_id", chatID)
-			} else {
+			// Once a thread has been engaged via @bot, allow follow-up
+			// attachment-only messages (image/file/audio) in the same thread
+			// through without re-mentioning the bot. Plain text and rich-text
+			// posts still require an explicit @bot to avoid pulling in
+			// unrelated chatter.
+			case p.threadIsolation && isAttachmentMsgType(msgType) && p.isActiveThreadSession(sessionKey):
+				slog.Debug(p.tag()+": passing attachment through active thread without mention",
+					"chat_id", chatID, "session_key", sessionKey, "msg_type", msgType, "message_id", messageID)
+			default:
 				slog.Debug(p.tag()+": ignoring group message without bot mention", "chat_id", chatID)
 				return nil
 			}
@@ -1038,13 +1058,16 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	mentions := msg.Mentions
 	parentID := stringValue(msg.ParentId)
 
-	sessionKey := p.makeSessionKey(msg, chatID, userID)
 	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
 	slog.Debug(p.tag()+": routed inbound message",
 		"message_id", messageID,
 		"session_key", sessionKey,
 		"reply_in_thread", p.shouldReplyInThread(rctx),
 	)
+
+	// Mark this thread as bot-engaged so subsequent attachment-only messages
+	// in the same thread can pass through without re-mentioning the bot.
+	p.markThreadSessionActive(sessionKey)
 
 	// Dispatch message handling asynchronously so the SDK event loop is not
 	// blocked by IO-heavy operations (image/audio download, handler HTTP calls).
@@ -2770,6 +2793,38 @@ func isBotMentioned(mentions []*larkim.MentionEvent, botOpenID string) bool {
 		}
 	}
 	return false
+}
+
+// isAttachmentMsgType reports whether a Feishu message type carries only an
+// attachment payload (no free-form text the user could use to address another
+// human). These are the message types we are willing to admit into an
+// already-engaged thread without an explicit @bot mention.
+func isAttachmentMsgType(msgType string) bool {
+	switch msgType {
+	case "image", "file", "audio", "media":
+		return true
+	}
+	return false
+}
+
+// markThreadSessionActive records that a thread sessionKey has been engaged
+// by an @bot message, enabling attachment-only follow-ups inside the thread.
+// No-op when thread isolation is disabled or sessionKey is not a thread key.
+func (p *Platform) markThreadSessionActive(sessionKey string) {
+	if !p.threadIsolation || !isThreadSessionKey(sessionKey) {
+		return
+	}
+	p.activeThreadSessions.Store(sessionKey, time.Now())
+}
+
+// isActiveThreadSession reports whether the given sessionKey corresponds to a
+// thread that has previously been engaged by an @bot message.
+func (p *Platform) isActiveThreadSession(sessionKey string) bool {
+	if !p.threadIsolation || !isThreadSessionKey(sessionKey) {
+		return false
+	}
+	_, ok := p.activeThreadSessions.Load(sessionKey)
+	return ok
 }
 
 // stripMentions processes @mention placeholders (e.g. @_user_1) in text.

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -814,5 +815,214 @@ func TestResolveBotSenderName_NilMap(t *testing.T) {
 	}
 	if got := p.resolveBotSenderName(""); got != "Bot" {
 		t.Errorf("nil peerBots + empty id: got %q, want %q", got, "Bot")
+	}
+}
+
+func TestIsAttachmentMsgType(t *testing.T) {
+	tests := []struct {
+		msgType string
+		want    bool
+	}{
+		{"image", true},
+		{"file", true},
+		{"audio", true},
+		{"media", true},
+		{"text", false},
+		{"post", false},
+		{"sticker", false},
+		{"merge_forward", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isAttachmentMsgType(tt.msgType); got != tt.want {
+			t.Errorf("isAttachmentMsgType(%q) = %v, want %v", tt.msgType, got, tt.want)
+		}
+	}
+}
+
+func TestMarkAndIsActiveThreadSession(t *testing.T) {
+	const threadKey = "feishu:oc_chat:root:om_root"
+	const directKey = "feishu:oc_chat:ou_user"
+
+	t.Run("thread isolation disabled is no-op", func(t *testing.T) {
+		p := &Platform{threadIsolation: false}
+		p.markThreadSessionActive(threadKey)
+		if p.isActiveThreadSession(threadKey) {
+			t.Fatal("expected no-op when thread_isolation is off")
+		}
+	})
+
+	t.Run("non-thread sessionKey is ignored", func(t *testing.T) {
+		p := &Platform{threadIsolation: true}
+		p.markThreadSessionActive(directKey)
+		if p.isActiveThreadSession(directKey) {
+			t.Fatal("expected non-thread sessionKey to be ignored")
+		}
+	})
+
+	t.Run("thread sessionKey is recorded", func(t *testing.T) {
+		p := &Platform{threadIsolation: true}
+		if p.isActiveThreadSession(threadKey) {
+			t.Fatal("thread should not be active before mark")
+		}
+		p.markThreadSessionActive(threadKey)
+		if !p.isActiveThreadSession(threadKey) {
+			t.Fatal("thread should be active after mark")
+		}
+	})
+}
+
+// TestOnMessageThreadIsolationAdmitsAttachmentWithoutMention covers the fix
+// for the case where a user @mentions the bot in a thread, then drops follow-up
+// images into the same thread without re-mentioning. Pre-fix, those images
+// were silently dropped by the group @bot filter; post-fix they should pass
+// through and be dispatched.
+func TestOnMessageThreadIsolationAdmitsAttachmentWithoutMention(t *testing.T) {
+	const appID = "cli_thread_admit"
+	const appSecret = "secret-thread-admit"
+	const botOpenID = "ou_bot"
+	const userOpenID = "ou_user"
+	const chatID = "oc_chat"
+	const rootMsgID = "om_root"
+	const imageKey = "img_in_thread"
+
+	imageBytes := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/resources/"+imageKey):
+			w.Header().Set("Content-Type", "image/png")
+			if _, err := w.Write(imageBytes); err != nil {
+				t.Fatalf("write image: %v", err)
+			}
+		default:
+			// Unknown calls (e.g. user/chat info lookups) return empty success
+			// so dispatch can continue past optional metadata fetches.
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success", "data": map[string]any{}})
+		}
+	}))
+	defer srv.Close()
+
+	received := make(chan *core.Message, 8)
+	p := &Platform{
+		platformName:    "feishu",
+		domain:          srv.URL,
+		appID:           appID,
+		appSecret:       appSecret,
+		botOpenID:       botOpenID,
+		threadIsolation: true,
+		dedup:           &core.MessageDedup{},
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			received <- msg
+		},
+	}
+
+	chatType := "group"
+	senderType := "user"
+	now := time.Now().UnixMilli()
+	createTime := func() *string {
+		s := strconv.FormatInt(now, 10)
+		now++
+		return &s
+	}
+
+	buildEvent := func(msgID, msgType, content string, mentions []*larkim.MentionEvent, rootID string) *larkim.P2MessageReceiveV1 {
+		ev := &larkim.P2MessageReceiveV1{
+			Event: &larkim.P2MessageReceiveV1Data{
+				Sender: &larkim.EventSender{
+					SenderId:   &larkim.UserId{OpenId: stringPtr(userOpenID)},
+					SenderType: &senderType,
+				},
+				Message: &larkim.EventMessage{
+					MessageId:   stringPtr(msgID),
+					ChatId:      stringPtr(chatID),
+					ChatType:    &chatType,
+					MessageType: stringPtr(msgType),
+					Content:     stringPtr(content),
+					CreateTime:  createTime(),
+					Mentions:    mentions,
+				},
+			},
+		}
+		if rootID != "" {
+			ev.Event.Message.RootId = stringPtr(rootID)
+		}
+		return ev
+	}
+
+	botMention := []*larkim.MentionEvent{
+		{
+			Key:  stringPtr("@_user_1"),
+			Id:   &larkim.UserId{OpenId: stringPtr(botOpenID)},
+			Name: stringPtr("claude code"),
+		},
+	}
+
+	// Step 1: opening message @mentions the bot — establishes the thread.
+	if err := p.onMessage(context.Background(), buildEvent(rootMsgID, "text", `{"text":"@_user_1 看看这个"}`, botMention, "")); err != nil {
+		t.Fatalf("onMessage(root) error = %v", err)
+	}
+	threadKey := "feishu:" + chatID + ":root:" + rootMsgID
+	if !p.isActiveThreadSession(threadKey) {
+		t.Fatalf("thread %q should be marked active after @bot text", threadKey)
+	}
+	select {
+	case <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the opening @bot text to dispatch")
+	}
+
+	// Step 2: follow-up image in the same thread, no @mention — should pass through.
+	imgContent := `{"image_key":"` + imageKey + `"}`
+	if err := p.onMessage(context.Background(), buildEvent("om_thread_img", "image", imgContent, nil, rootMsgID)); err != nil {
+		t.Fatalf("onMessage(image in thread) error = %v", err)
+	}
+	select {
+	case msg := <-received:
+		if msg.MessageID != "om_thread_img" {
+			t.Fatalf("expected dispatched image om_thread_img, got %q", msg.MessageID)
+		}
+		if len(msg.Images) != 1 {
+			t.Fatalf("expected dispatched image to carry 1 attachment, got %d", len(msg.Images))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected image in active thread to be dispatched without @mention")
+	}
+
+	// Step 3: image in a *different* thread without @mention — should still be dropped.
+	if err := p.onMessage(context.Background(), buildEvent("om_other_img", "image", imgContent, nil, "om_other_root")); err != nil {
+		t.Fatalf("onMessage(image in unrelated thread) error = %v", err)
+	}
+	select {
+	case msg := <-received:
+		t.Fatalf("image in unrelated thread should be dropped, but handler received %q", msg.MessageID)
+	case <-time.After(300 * time.Millisecond):
+		// expected: nothing dispatched
+	}
+
+	// Step 4: text without @mention in the active thread — should be dropped
+	// (only attachments are admitted; otherwise unrelated thread chatter would
+	// flood the agent).
+	if err := p.onMessage(context.Background(), buildEvent("om_thread_text", "text", `{"text":"刚才那张图能看到吗"}`, nil, rootMsgID)); err != nil {
+		t.Fatalf("onMessage(text in thread without mention) error = %v", err)
+	}
+	select {
+	case msg := <-received:
+		t.Fatalf("text in active thread without @mention should be dropped, got %q", msg.MessageID)
+	case <-time.After(300 * time.Millisecond):
+		// expected
 	}
 }


### PR DESCRIPTION
## Summary

In group chats with `thread_isolation`, any message without an explicit @bot mention is dropped before image/file download. Users naturally drop screenshots into a thread after their opening @bot text, so all follow-up images are silently lost — the agent only ever sees the text and can never see the attachments, despite Feishu having delivered them.

## Fix

Track threads that have already been engaged by an @bot message. While the @bot filter is otherwise unchanged, allow `image`/`file`/`audio`/`media` messages to pass through inside an active thread. Plain `text` and rich-text `post` still require an explicit mention so unrelated thread chatter does not leak into the agent.

## Test plan

- [x] `go test ./platform/feishu/...` passes
- [x] New unit tests for `isAttachmentMsgType`, `markThreadSessionActive`, `isActiveThreadSession`
- [x] New end-to-end `onMessage` test covering:
  - opening @bot text establishes the thread
  - in-thread attachment without @ is admitted
  - cross-thread attachment without @ is still dropped
  - in-thread text without @ is still dropped
