### PR TITLE
fix: 微信 ilink QR 码主动刷新，防止扫码时过期

### DIFF
--- a/cmd/cc-connect/weixin.go
+++ b/cmd/cc-connect/weixin.go
@@ -29,6 +29,11 @@ const (
 	defaultWeixinBotType = "3"
 	weixinQRPollTimeout  = 35 * time.Second
 	weixinMaxQRRefresh   = 3
+
+	// 微信 ilink QR 码有效期约 120 秒，在预估过期前 30 秒主动刷新，
+	// 避免用户正在扫码时 QR 码过期导致的糟糕体验。
+	weixinQREstimatedTTL       = 110 * time.Second
+	weixinQRProactiveRefreshAt = 80 * time.Second
 )
 
 type weixinBotQRResponse struct {
@@ -276,6 +281,7 @@ func runWeixinQRLoginFlow(opts weixinQRLoginOptions) (*weixinQRLoginResult, erro
 	qrKey := qrPayload.QRCode
 	refreshCount := 1
 	scannedPrinted := false
+	qrFetchedAt := time.Now() // 追踪 QR 码生成时间，用于主动刷新
 
 	for time.Now().Before(deadline) {
 		status, err := weixinPollQRStatus(ctx, opts.APIBaseURL, qrKey, opts.RouteTag, opts.Debug)
@@ -285,6 +291,37 @@ func runWeixinQRLoginFlow(opts weixinQRLoginOptions) (*weixinQRLoginResult, erro
 
 		switch status.Status {
 		case "wait", "":
+			// 主动刷新：在 QR 码预估过期前自动获取新码，避免用户扫码时 QR 过期
+			if time.Since(qrFetchedAt) > weixinQRProactiveRefreshAt && refreshCount < weixinMaxQRRefresh {
+				refreshCount++
+				fmt.Printf("\n⏳ 二维码即将过期，正在自动刷新 (%d/%d)…\n", refreshCount, weixinMaxQRRefresh)
+				newQR, err := weixinFetchBotQRCode(ctx, opts.APIBaseURL, botType, opts.RouteTag, opts.Debug)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: proactive QR refresh failed: %v\n", err)
+					// 不中断流程，继续用当前 QR 轮询
+					time.Sleep(time.Second)
+					continue
+				}
+				qrKey = newQR.QRCode
+				qrFetchedAt = time.Now()
+				scannedPrinted = false
+				newURL := strings.TrimSpace(newQR.QRCodeImgContent)
+				if newURL != "" {
+					fmt.Println("请扫描新二维码：")
+					fmt.Printf("URL: %s\n\n", newURL)
+					tryPrintTerminalQRCode(newURL)
+				}
+				// 刷新时同步更新 QR 图片文件
+				if opts.QRImage != "" {
+					if err := saveQRCodeImage(newURL, opts.QRImage); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: failed to update QR image: %v\n", err)
+					} else {
+						fmt.Printf("QR code updated at: %s\n\n", opts.QRImage)
+					}
+				}
+				time.Sleep(time.Second)
+				continue
+			}
 			time.Sleep(time.Second)
 			continue
 		case "scaned":
@@ -305,12 +342,21 @@ func runWeixinQRLoginFlow(opts weixinQRLoginOptions) (*weixinQRLoginResult, erro
 				return nil, fmt.Errorf("refresh QR: %w", err)
 			}
 			qrKey = newQR.QRCode
+			qrFetchedAt = time.Now()
 			scannedPrinted = false
 			newURL := strings.TrimSpace(newQR.QRCodeImgContent)
 			if newURL != "" {
 				fmt.Println("请扫描新二维码：")
 				fmt.Printf("URL: %s\n\n", newURL)
 				tryPrintTerminalQRCode(newURL)
+			}
+			// 过期刷新时同步更新 QR 图片文件
+			if opts.QRImage != "" {
+				if err := saveQRCodeImage(newURL, opts.QRImage); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to update QR image: %v\n", err)
+				} else {
+					fmt.Printf("QR code updated at: %s\n\n", opts.QRImage)
+				}
 			}
 			time.Sleep(time.Second)
 			continue

--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -298,3 +298,9 @@ func xmlEscape(s string) string {
 	}
 	return b.String()
 }
+
+// CheckLinger returns true on macOS because launchd user agents are not
+// subject to systemd-style linger; they persist independently of login sessions.
+func CheckLinger() (enabled bool, user string) {
+	return true, ""
+}


### PR DESCRIPTION
## 问题

微信 ilink API 生成的 QR 码有效期约 120 秒，原有实现被动等待服务端返回 `expired` 状态后才刷新 QR。在终端环境下，用户从看到 QR 码到打开手机微信完成扫码存在天然延迟，经常在扫码过程中 QR 码过期，导致 setup 反复失败（issue #1102）。

## 修复

### 1. 主动刷新 QR 码（`cmd/cc-connect/weixin.go`）

- 新增 `weixinQREstimatedTTL`（110s）和 `weixinQRProactiveRefreshAt`（80s）常量
- 追踪 `qrFetchedAt` 时间戳，在 QR 码活跃 80 秒后（预估过期前 30 秒），**在用户还未扫码前**主动获取新 QR 码
- 主动刷新仅在处于 `wait` 状态（尚未扫码）时触发，避免打断已扫码正在确认的用户

### 2. QR 图片文件同步更新（`cmd/cc-connect/weixin.go`）

- 原有实现在 QR 被动过期刷新时未更新 `--qr-image` 文件，导致用户打开的是旧 QR 码
- 现在每次刷新（主动/被动）都会调用 `saveQRCodeImage` 更新本地文件

### 3. macOS 编译修复（`daemon/launchd.go`）

- 新增 `CheckLinger()` 函数桩，修复 macOS 上因 systemd `CheckLinger` 函数缺失导致的编译失败

## 测试

- `go build ./cmd/cc-connect/` 编译通过
- `go test ./daemon/ -v` 全部通过（包括新增 CheckLinger 相关的所有测试）

## 关联 Issue

Closes #1102