### PR TITLE
feat: add sonnet[1m] to hardcoded fallback model list

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -330,6 +330,7 @@ func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
 	}
 	return []core.ModelOption{
 		{Name: "sonnet", Desc: "Claude Sonnet (balanced)"},
+		{Name: "sonnet[1m]", Desc: "Claude Sonnet (1M context)"},
 		{Name: "opus", Desc: "Claude Opus (most capable)"},
 		{Name: "opus[1m]", Desc: "Claude Opus (1M context)"},
 		{Name: "haiku", Desc: "Claude Haiku (fastest)"},


### PR DESCRIPTION
## Problem

The available models fallback list in `agent/claudecode/claudecode.go` included `opus[1m]` but was missing `sonnet[1m]`, making it impossible to use 1M context with Sonnet models when `config.toml` has no explicit models configured and the API fails to return model aliases.

## Solution

Add `sonnet[1m]` to the hardcoded fallback model list, one-line fix.

## Test plan

- [x] Build passes: `go build ./...`
- [x] cc-connect runs with `sonnet[1m]` model selectable via config

🤖 Generated with [Claude Code](https://claude.com/claude-code)