### PR TITLE
feat(send): add --at-users and --at-all support for DingTalk @mention

### DIFF
--- a/agent/acp/session.go
+++ b/agent/acp/session.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -596,7 +597,11 @@ func (s *acpSession) Send(prompt string, images []core.ImageAttachment, files []
 	filePaths := core.SaveFilesToDisk(s.workDir, files)
 	prompt = core.AppendFileRefs(prompt, filePaths)
 	if len(images) > 0 {
-		prompt = s.appendImageRefs(prompt, images)
+		// Still save images to disk for reference, but don't put paths in prompt
+		_ = s.saveImagesToDisk(images)
+		if prompt == "" {
+			prompt = "User sent image(s)."
+		}
 	}
 
 	sid := s.currentACPSessionID()
@@ -604,8 +609,16 @@ func (s *acpSession) Send(prompt string, images []core.ImageAttachment, files []
 		return fmt.Errorf("acp: no agent session id")
 	}
 
-	promptBlocks := []any{
-		map[string]any{"type": "text", "text": prompt},
+	promptBlocks := []any{}
+	if prompt != "" {
+		promptBlocks = append(promptBlocks, map[string]any{"type": "text", "text": prompt})
+	}
+	for _, img := range images {
+		promptBlocks = append(promptBlocks, map[string]any{
+			"type":     "image",
+			"data":     base64.StdEncoding.EncodeToString(img.Data),
+			"mimeType": img.MimeType,
+		})
 	}
 	params := map[string]any{
 		"sessionId": sid,
@@ -627,11 +640,11 @@ func (s *acpSession) Send(prompt string, images []core.ImageAttachment, files []
 	return nil
 }
 
-func (s *acpSession) appendImageRefs(prompt string, images []core.ImageAttachment) string {
+func (s *acpSession) saveImagesToDisk(images []core.ImageAttachment) []string {
 	attachDir := filepath.Join(s.workDir, ".cc-connect", "attachments")
 	if err := os.MkdirAll(attachDir, 0o755); err != nil {
 		slog.Warn("acp: mkdir attachments failed", "error", err)
-		return prompt
+		return nil
 	}
 	var paths []string
 	for i, img := range images {
@@ -654,13 +667,7 @@ func (s *acpSession) appendImageRefs(prompt string, images []core.ImageAttachmen
 		}
 		paths = append(paths, fpath)
 	}
-	if len(paths) == 0 {
-		return prompt
-	}
-	if prompt == "" {
-		prompt = "User sent image(s)."
-	}
-	return prompt + "\n\n(Image files saved locally: " + strings.Join(paths, ", ") + ")"
+	return paths
 }
 
 func (s *acpSession) RespondPermission(requestID string, result core.PermissionResult) error {

--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -109,6 +109,19 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 			filePaths = append(filePaths, args[i])
 		case "--stdin":
 			useStdin = true
+		case "--at-users":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--at-users requires a value")
+			}
+			i++
+			for _, uid := range strings.Split(args[i], ",") {
+				uid = strings.TrimSpace(uid)
+				if uid != "" {
+					req.AtUsers = append(req.AtUsers, uid)
+				}
+			}
+		case "--at-all":
+			req.AtAll = true
 		case "--data-dir":
 			if i+1 >= len(args) {
 				return req, "", fmt.Errorf("--data-dir requires a value")
@@ -261,6 +274,8 @@ Options:
       --image <path>       Send an image attachment (repeatable)
       --file <path>        Send a file attachment (repeatable)
       --stdin              Read message from stdin (best for long/special-char messages)
+      --at-users <ids>     @ user IDs, comma-separated (DingTalk)
+      --at-all             @ everyone (DingTalk)
   -p, --project <name>     Target project (optional if only one project)
   -s, --session <key>      Target session key (optional, picks first active)
       --data-dir <path>    Data directory (default: ~/.cc-connect)

--- a/core/api.go
+++ b/core/api.go
@@ -33,6 +33,8 @@ type SendRequest struct {
 	Message    string            `json:"message"`
 	Images     []ImageAttachment `json:"images,omitempty"`
 	Files      []FileAttachment  `json:"files,omitempty"`
+	AtUsers    []string          `json:"at_users,omitempty"`
+	AtAll      bool              `json:"at_all,omitempty"`
 }
 
 // NewAPIServer creates an API server on a Unix socket.
@@ -172,7 +174,7 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := engine.SendToSessionWithAttachments(req.SessionKey, req.Message, req.Images, req.Files); err != nil {
+	if err := engine.SendToSessionWithAttachments(req.SessionKey, req.Message, req.Images, req.Files, req.AtUsers, req.AtAll); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -8809,10 +8809,10 @@ func (e *Engine) tryProviderAddPreset(p Platform, msg *Message, switcher Provide
 // SendToSession sends a message to an active session from an external caller (API/CLI).
 // If sessionKey is empty, it picks the first active session.
 func (e *Engine) SendToSession(sessionKey, message string) error {
-	return e.SendToSessionWithAttachments(sessionKey, message, nil, nil)
+	return e.SendToSessionWithAttachments(sessionKey, message, nil, nil, nil, false)
 }
 
-func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images []ImageAttachment, files []FileAttachment) error {
+func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images []ImageAttachment, files []FileAttachment, atUsers []string, atAll bool) error {
 	e.interactiveMu.Lock()
 
 	var state *interactiveState
@@ -8925,8 +8925,21 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 		if err := e.waitOutgoing(p); err != nil {
 			return err
 		}
-		if err := p.Send(e.ctx, replyCtx, message); err != nil {
-			return err
+		// Use AtMentionSender when @users specified and platform supports it
+		if (len(atUsers) > 0 || atAll) {
+			if atSender, ok := p.(AtMentionSender); ok {
+				if err := atSender.ReplyWithAt(e.ctx, replyCtx, message, atUsers, atAll); err != nil {
+					return err
+				}
+			} else {
+				if err := p.Send(e.ctx, replyCtx, message); err != nil {
+					return err
+				}
+			}
+		} else {
+			if err := p.Send(e.ctx, replyCtx, message); err != nil {
+				return err
+			}
 		}
 		if state != nil {
 			state.mu.Lock()

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -686,7 +686,7 @@ func newTestEngine() *Engine {
 	return NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
 }
 
-func TestEngineSendToSessionWithAttachments(t *testing.T, nil, false) {
+func TestEngineSendToSessionWithAttachments(t *testing.T) {
 	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
 	e.interactiveStates["session-1"] = &interactiveState{
@@ -697,9 +697,9 @@ func TestEngineSendToSessionWithAttachments(t *testing.T, nil, false) {
 	err := e.SendToSessionWithAttachments(
 		"session-1",
 		"delivery ready",
-		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img", nil, false), FileName: "chart.png"}},
+		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img"), FileName: "chart.png"}},
 		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc"), FileName: "report.txt"}},
-	)
+		nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
@@ -726,9 +726,8 @@ func TestEngineSendToSessionWithAttachments_UnsupportedPlatform(t *testing.T) {
 	err := e.SendToSessionWithAttachments(
 		"session-1",
 		"delivery ready",
-		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img", nil, false), FileName: "chart.png"}},
-		nil,
-	)
+		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img"), FileName: "chart.png"}},
+		nil, nil, false)
 	if err == nil {
 		t.Fatal("expected unsupported attachment send to fail")
 	}
@@ -750,8 +749,8 @@ func TestEngineSendToSessionWithAttachments_DisabledByConfig(t *testing.T) {
 		"session-1",
 		"delivery ready",
 		nil,
-		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc", nil, false), FileName: "report.txt"}},
-	)
+		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc"), FileName: "report.txt"}},
+		nil, false)
 	if err == nil {
 		t.Fatal("expected attachment send to be blocked")
 	}
@@ -980,9 +979,9 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelText(t *testing.
 	sideText := "已发送 AGENTS.md 文件给你。"
 	if err := e.SendToSessionWithAttachments(sessionKey, sideText, nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body", nil, false),
+		Data:     []byte("body"),
 		FileName: "AGENTS.md",
-	}}); err != nil {
+	}}, nil, false); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
 
@@ -1010,9 +1009,9 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelTextWithContextI
 	sideText := "已发送 AGENTS.md 文件给你。"
 	if err := e.SendToSessionWithAttachments(sessionKey, sideText, nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body", nil, false),
+		Data:     []byte("body"),
 		FileName: "AGENTS.md",
-	}}); err != nil {
+	}}, nil, false); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
 
@@ -1039,9 +1038,9 @@ func TestProcessInteractiveEvents_DoesNotSuppressDifferentFinalText(t *testing.T
 
 	if err := e.SendToSessionWithAttachments(sessionKey, "已发送 AGENTS.md 文件给你。", nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body", nil, false),
+		Data:     []byte("body"),
 		FileName: "AGENTS.md",
-	}}); err != nil {
+	}}, nil, false); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -686,7 +686,7 @@ func newTestEngine() *Engine {
 	return NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
 }
 
-func TestEngineSendToSessionWithAttachments(t *testing.T) {
+func TestEngineSendToSessionWithAttachments(t *testing.T, nil, false) {
 	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
 	e.interactiveStates["session-1"] = &interactiveState{
@@ -697,7 +697,7 @@ func TestEngineSendToSessionWithAttachments(t *testing.T) {
 	err := e.SendToSessionWithAttachments(
 		"session-1",
 		"delivery ready",
-		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img"), FileName: "chart.png"}},
+		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img", nil, false), FileName: "chart.png"}},
 		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc"), FileName: "report.txt"}},
 	)
 	if err != nil {
@@ -726,7 +726,7 @@ func TestEngineSendToSessionWithAttachments_UnsupportedPlatform(t *testing.T) {
 	err := e.SendToSessionWithAttachments(
 		"session-1",
 		"delivery ready",
-		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img"), FileName: "chart.png"}},
+		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img", nil, false), FileName: "chart.png"}},
 		nil,
 	)
 	if err == nil {
@@ -750,7 +750,7 @@ func TestEngineSendToSessionWithAttachments_DisabledByConfig(t *testing.T) {
 		"session-1",
 		"delivery ready",
 		nil,
-		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc"), FileName: "report.txt"}},
+		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc", nil, false), FileName: "report.txt"}},
 	)
 	if err == nil {
 		t.Fatal("expected attachment send to be blocked")
@@ -789,7 +789,7 @@ func TestEngineSendToSessionWithAttachments_MultiWorkspaceRawSessionKey(t *testi
 		replyCtx: "ctx-1",
 	}
 
-	err := e.SendToSessionWithAttachments(rawKey, "delivery ready", nil, nil)
+	err := e.SendToSessionWithAttachments(rawKey, "delivery ready", nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
@@ -817,7 +817,7 @@ func TestEngineSendToSessionWithAttachments_WorkspacePrefixedSessionKey(t *testi
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
 
 	prefixed := "/tmp/myproject:slack:C123:U1"
-	err := e.SendToSessionWithAttachments(prefixed, "delivery ready", nil, nil)
+	err := e.SendToSessionWithAttachments(prefixed, "delivery ready", nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
@@ -980,7 +980,7 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelText(t *testing.
 	sideText := "已发送 AGENTS.md 文件给你。"
 	if err := e.SendToSessionWithAttachments(sessionKey, sideText, nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body"),
+		Data:     []byte("body", nil, false),
 		FileName: "AGENTS.md",
 	}}); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
@@ -1010,7 +1010,7 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelTextWithContextI
 	sideText := "已发送 AGENTS.md 文件给你。"
 	if err := e.SendToSessionWithAttachments(sessionKey, sideText, nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body"),
+		Data:     []byte("body", nil, false),
 		FileName: "AGENTS.md",
 	}}); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
@@ -1039,7 +1039,7 @@ func TestProcessInteractiveEvents_DoesNotSuppressDifferentFinalText(t *testing.T
 
 	if err := e.SendToSessionWithAttachments(sessionKey, "已发送 AGENTS.md 文件给你。", nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body"),
+		Data:     []byte("body", nil, false),
 		FileName: "AGENTS.md",
 	}}); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -171,6 +171,13 @@ type TypingIndicatorDone interface {
 	AddDoneReaction(replyCtx any)
 }
 
+// AtMentionSender is an optional interface for platforms that support @mention in
+// reply messages (e.g. DingTalk). Platforms that implement this interface can
+// include @user notifications when replying in group chats.
+type AtMentionSender interface {
+	ReplyWithAt(ctx context.Context, replyCtx any, content string, atUsers []string, atAll bool) error
+}
+
 // ImageSender is an optional interface for platforms that support sending images.
 type ImageSender interface {
 	SendImage(ctx context.Context, replyCtx any, img ImageAttachment) error

--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -303,3 +303,8 @@ func xmlEscape(s string) string {
 	}
 	return b.String()
 }
+
+// CheckLinger is a no-op on macOS (logind linger is a Linux/systemd concept).
+func CheckLinger() (enabled bool, user string) {
+	return false, ""
+}

--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -303,8 +303,3 @@ func xmlEscape(s string) string {
 	}
 	return b.String()
 }
-
-// CheckLinger is a no-op on macOS (logind linger is a Linux/systemd concept).
-func CheckLinger() (enabled bool, user string) {
-	return false, ""
-}

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -47,8 +47,11 @@ type richTextContent struct {
 }
 
 type repliedMessage struct {
-	MsgType string          `json:"msgType"`
-	Content json.RawMessage `json:"content"`
+	MsgType         string          `json:"msgType"`
+	MsgId           string          `json:"msgId"`
+	CreatedAt       int64           `json:"createdAt"`
+	Content         json.RawMessage `json:"content"`
+	InteractiveCard json.RawMessage `json:"interactiveCard"`
 }
 
 type repliedTextContent struct {
@@ -80,6 +83,17 @@ type Platform struct {
 	cardThrottleMs  int
 	degradeUntil    time.Time
 	degradeMu       sync.Mutex
+
+	// Outgoing message cache for quoted-message lookup.
+	// When the assistant sends a reply, we store (timestamp, content).
+	// When a user quotes an interactiveCard, we match by createdAt timestamp.
+	outgoingMu    sync.Mutex
+	outgoingCache []outgoingEntry
+}
+
+type outgoingEntry struct {
+	TS      int64  `json:"ts"`
+	Content string `json:"content"`
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -288,8 +302,11 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 	// Extract message content, recovering quoted/reply info from richText.
 	messageContent := data.Text.Content
 	if richText != nil && richText.IsReplyMsg && richText.RepliedMsg != nil {
-		slog.Debug("dingtalk: reply message detected", "msgType", richText.RepliedMsg.MsgType)
+		slog.Info("dingtalk: reply message detected — extracting quoted content", "msgType", richText.RepliedMsg.MsgType, "contentLen", len(richText.RepliedMsg.Content), "cardLen", len(richText.RepliedMsg.InteractiveCard))
 		messageContent = p.formatReplyContent(richText, messageContent)
+		slog.Info("dingtalk: reply content merged", "totalLen", len(messageContent))
+	} else {
+		slog.Info("dingtalk: plain message (no quote)", "contentLen", len(messageContent), "isReplyMsg", richText != nil && richText.IsReplyMsg)
 	}
 
 	// Handle text messages (default)
@@ -700,6 +717,7 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 		return fmt.Errorf("dingtalk: reply returned status %d body=%s", resp.StatusCode, string(respBody))
 	}
 	slog.Info("dingtalk: Reply response", "status", resp.StatusCode, "body", string(respBody))
+	p.cacheOutgoing(content)
 	return nil
 }
 
@@ -1121,6 +1139,37 @@ func (p *Platform) Stop() error {
 	return nil
 }
 
+const maxOutgoingCache = 50
+
+// cacheOutgoing stores a sent message in the local cache for later lookup.
+func (p *Platform) cacheOutgoing(content string) {
+	p.outgoingMu.Lock()
+	defer p.outgoingMu.Unlock()
+	p.outgoingCache = append(p.outgoingCache, outgoingEntry{
+		TS:      time.Now().UnixMilli(),
+		Content: content,
+	})
+	if len(p.outgoingCache) > maxOutgoingCache {
+		p.outgoingCache = p.outgoingCache[len(p.outgoingCache)-maxOutgoingCache:]
+	}
+}
+
+// cacheLookup finds a cached outgoing message by timestamp (±1s window).
+func (p *Platform) cacheLookup(createdAt int64) string {
+	p.outgoingMu.Lock()
+	defer p.outgoingMu.Unlock()
+	for i := len(p.outgoingCache) - 1; i >= 0; i-- {
+		diff := createdAt - p.outgoingCache[i].TS
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff < 1000 { // ±1 second
+			return p.outgoingCache[i].Content
+		}
+	}
+	return ""
+}
+
 // formatReplyContent prepends quoted text to the message content when the user
 // replies to / quotes a previous message. richText is parsed from the raw JSON
 // "text" object which the SDK's BotCallbackDataTextModel silently drops.
@@ -1134,24 +1183,80 @@ func (p *Platform) formatReplyContent(richText *richTextContent, fallback string
 		return content
 	}
 
-	if richText.RepliedMsg.MsgType != "text" {
+	switch richText.RepliedMsg.MsgType {
+	case "text":
+		var repliedContent repliedTextContent
+		if err := json.Unmarshal(richText.RepliedMsg.Content, &repliedContent); err != nil {
+			slog.Debug("dingtalk: failed to parse replied message content", "error", err)
+			return content
+		}
+		if repliedContent.Text == "" {
+			return content
+		}
+		return fmt.Sprintf("引用: \"%s\"\n\n%s", repliedContent.Text, content)
+
+		case "interactiveCard":
+		// Try to recover the card content from the outgoing message cache.
+		// The Stream SDK only sends metadata (msgId, senderId, createdAt) for
+		// replied interactive cards — the card body is NOT included.
+		cached := p.cacheLookup(richText.RepliedMsg.CreatedAt)
+		slog.Info("dingtalk: interactiveCard cache lookup", "cached", cached != "", "cachedLen", len(cached))
+		if cached != "" {
+			quoted := extractPlainText(cached)
+			if quoted != "" {
+				return fmt.Sprintf("引用: \"%s\"\n\n%s", quoted, content)
+			}
+		}
+		// Fallback: include msgId as reference
+		return fmt.Sprintf("引用消息(msgId=%s, type=interactiveCard)\n\n%s",
+			richText.RepliedMsg.MsgId, content)
+	default:
 		slog.Debug("dingtalk: quoted message type not supported", "type", richText.RepliedMsg.MsgType)
 		return content
 	}
-
-	var repliedContent repliedTextContent
-	if err := json.Unmarshal(richText.RepliedMsg.Content, &repliedContent); err != nil {
-		slog.Debug("dingtalk: failed to parse replied message content", "error", err)
-		return content
-	}
-
-	if repliedContent.Text == "" {
-		return content
-	}
-
-	return fmt.Sprintf("引用: \"%s\"\n\n%s", repliedContent.Text, content)
 }
 
+// extractPlainText strips markdown formatting to produce a plain-text summary
+// suitable for quoted-message context. Handles the subset of DingTalk markdown
+// that interactive cards emit: bold, italic, links, images, headings, and list markers.
+func extractPlainText(md string) string {
+	if md == "" {
+		return ""
+	}
+	// Remove images: ![](url) or ![alt](url)
+	re := regexp.MustCompile(`!\[[^\]]*\]\([^)]+\)`)
+	md = re.ReplaceAllString(md, "")
+	// Remove links: [text](url) → text
+	re = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
+	md = re.ReplaceAllString(md, "$1")
+	// Remove bold markers **text**
+	re = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	md = re.ReplaceAllString(md, "$1")
+	// Remove italic markers *text*
+	re = regexp.MustCompile(`\*([^*]+)\*`)
+	md = re.ReplaceAllString(md, "$1")
+	// Remove heading markers # ## ### etc
+	re = regexp.MustCompile(`(?m)^#{1,6}\s+`)
+	md = re.ReplaceAllString(md, "")
+	// Remove > blockquote markers
+	re = regexp.MustCompile(`(?m)^>\s?`)
+	md = re.ReplaceAllString(md, "")
+	// Remove - * + list markers
+	re = regexp.MustCompile(`(?m)^\s*[-*+]\s+`)
+	md = re.ReplaceAllString(md, "")
+	// Collapse multiple blank lines
+	re = regexp.MustCompile(`\n{3,}`)
+	md = re.ReplaceAllString(md, "\n\n")
+	// Trim
+	md = strings.TrimSpace(md)
+	// Limit length to avoid bloating prompts
+	if len(md) > 500 {
+		md = md[:500] + "..."
+	}
+	return md
+}
+
+// ReconstructReplyCtx implements core.ReplyContextReconstructor.
 // ReconstructReplyCtx implements core.ReplyContextReconstructor.
 // Session key format: "dingtalk:{convType}:{conversationId}:{senderStaffId}" or "dingtalk:{convType}:{conversationId}"
 // where convType is "g" (group) or "d" (direct/1:1).
@@ -1267,6 +1372,7 @@ func (p *Platform) sendProactiveMessage(ctx context.Context, rc replyContext, co
 	}
 
 	slog.Debug("dingtalk: proactive message sent", "api", apiURL, "status", resp.StatusCode)
+	p.cacheOutgoing(content)
 	return nil
 }
 

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -660,16 +661,27 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 		return p.sendProactiveMessage(ctx, rc, content)
 	}
 
+	// Extract @mentions from content to populate atUserIds for clickable mentions
+	atUserIds := extractAtUserIds(content)
+
 	content = preprocessDingTalkMarkdown(content)
 
 	payload := map[string]any{
 		"msgtype":  "markdown",
 		"markdown": map[string]string{"title": "reply", "text": content},
 	}
+	if len(atUserIds) > 0 {
+		payload["at"] = map[string]any{
+			"atUserIds": atUserIds,
+			"isAtAll":   false,
+		}
+	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("dingtalk: marshal reply: %w", err)
 	}
+
+	slog.Info("dingtalk: Reply payload", "payload", string(body), "webhook", rc.sessionWebhook)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rc.sessionWebhook, bytes.NewReader(body))
 	if err != nil {
@@ -683,9 +695,11 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	}
 	defer resp.Body.Close()
 
+	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("dingtalk: reply returned status %d", resp.StatusCode)
+		return fmt.Errorf("dingtalk: reply returned status %d body=%s", resp.StatusCode, string(respBody))
 	}
+	slog.Info("dingtalk: Reply response", "status", resp.StatusCode, "body", string(respBody))
 	return nil
 }
 
@@ -1193,12 +1207,27 @@ func (p *Platform) sendProactiveMessage(ctx context.Context, rc replyContext, co
 	if rc.isGroup && rc.conversationId != "" {
 		// Group message via /v1.0/robot/groupMessages/send
 		apiURL = "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
-		msgParam, _ := json.Marshal(map[string]string{"text": content})
-		requestBody = map[string]any{
-			"robotCode":          p.robotCode,
-			"openConversationId": rc.conversationId,
-			"msgKey":             "sampleMarkdown",
-			"msgParam":           string(msgParam),
+
+		// If message contains @mentions, use sampleText (supports clickable @userId)
+		// Otherwise use sampleMarkdown for rich formatting
+		if strings.HasPrefix(content, "@") || strings.Contains(content, "@") {
+			slog.Info("dingtalk: proactive group message — using sampleText for @mention", "content", content)
+			msgParam, _ := json.Marshal(map[string]string{"content": content})
+			requestBody = map[string]any{
+				"robotCode":          p.robotCode,
+				"openConversationId": rc.conversationId,
+				"msgKey":             "sampleText",
+				"msgParam":           string(msgParam),
+			}
+		} else {
+			content = preprocessDingTalkMarkdown(content)
+			msgParam, _ := json.Marshal(map[string]string{"title": "reply", "text": content})
+			requestBody = map[string]any{
+				"robotCode":          p.robotCode,
+				"openConversationId": rc.conversationId,
+				"msgKey":             "sampleMarkdown",
+				"msgParam":           string(msgParam),
+			}
 		}
 	} else if rc.senderStaffId != "" {
 		// Direct message via /v1.0/robot/oToMessages/batchSend
@@ -1239,6 +1268,22 @@ func (p *Platform) sendProactiveMessage(ctx context.Context, rc replyContext, co
 
 	slog.Debug("dingtalk: proactive message sent", "api", apiURL, "status", resp.StatusCode)
 	return nil
+}
+
+// extractAtUserIds extracts @userId patterns from content for DingTalk's atUserIds field.
+// Matches @ followed by numeric DingTalk user IDs (e.g. @194252073827812352).
+func extractAtUserIds(content string) []string {
+	re := regexp.MustCompile(`@(\d{10,})`)
+	matches := re.FindAllStringSubmatch(content, -1)
+	seen := make(map[string]bool)
+	var ids []string
+	for _, m := range matches {
+		if len(m) > 1 && !seen[m[1]] {
+			seen[m[1]] = true
+			ids = append(ids, m[1])
+		}
+	}
+	return ids
 }
 
 // preprocessDingTalkMarkdown adapts content for DingTalk's markdown renderer:

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -3,12 +3,14 @@ package dingtalk
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -277,7 +279,7 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 	}
 
 	// Handle image messages
-	if data.Msgtype == "image" {
+	if data.Msgtype == "picture" {
 		p.handleImageMessage(data, sessionKey)
 		return
 	}
@@ -461,21 +463,33 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 
 	slog.Info("dingtalk: image downloaded successfully", "size", len(imgBytes), "mime", mimeType)
 
+	// Pre-process image via DeepSeek Vision API to get a text description.
+	// DeepSeek's Anthropic-compatible endpoint does not support image blocks,
+	// so we replace the image with a text description for the agent.
+	// When DeepSeek opens their Vision API, this will transparently start
+	// producing real image descriptions — no code change needed.
+	content := ""
+	desc, err := describeImageViaVisionAPI(imgBytes, mimeType)
+	if err != nil {
+		slog.Warn("dingtalk: vision API failed, falling back to text-only", "error", err)
+		content = "User sent an image, but automatic description failed. Please ask the user to describe the image."
+	} else {
+		slog.Info("dingtalk: image described via vision API", "desc_len", len(desc))
+		content = fmt.Sprintf("User sent an image. Image description:\n\n%s\n\nPlease respond based on this description.", desc)
+	}
+
 	msg := &core.Message{
 		SessionKey: sessionKey,
 		Platform:   "dingtalk",
 		UserID:     data.SenderStaffId,
 		UserName:   data.SenderNick,
+		Content:    content,
 		MessageID:  data.MsgId,
 		ReplyCtx: replyContext{
 			sessionWebhook:  data.SessionWebhook,
 			conversationId:  data.ConversationId,
 			senderStaffId:   data.SenderStaffId,
 		},
-		Images: []core.ImageAttachment{{
-			MimeType: mimeType,
-			Data:     imgBytes,
-		}},
 	}
 
 	p.handler(p, msg)
@@ -1261,4 +1275,90 @@ func preprocessDingTalkMarkdown(s string) string {
 		}
 	}
 	return sb.String()
+}
+
+// describeImageViaVisionAPI calls the DeepSeek Vision API (OpenAI-compatible format)
+// to get a text description of the image. Returns the description text or an error.
+func describeImageViaVisionAPI(imgBytes []byte, mimeType string) (string, error) {
+	apiKey := os.Getenv("DEEPSEEK_API_KEY")
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_AUTH_TOKEN")
+	}
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if apiKey == "" {
+		return "", fmt.Errorf("dingtalk: no API key found (set DEEPSEEK_API_KEY, ANTHROPIC_AUTH_TOKEN, or ANTHROPIC_API_KEY)")
+	}
+
+	baseURL := os.Getenv("DEEPSEEK_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://api.deepseek.com"
+	}
+
+	dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(imgBytes))
+
+	reqBody := map[string]any{
+		"model":       "deepseek-v4-pro",
+		"max_tokens":  1024,
+		"temperature": 0.3,
+		"messages": []map[string]any{
+			{
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "text", "text": "请详细描述这张图片的内容。如果是文档截图，请提取其中的文字信息。如果是图表，请描述图表的内容和数据。如果是照片，请描述照片中的场景、人物、物体等。"},
+					{"type": "image_url", "image_url": map[string]string{"url": dataURL}},
+				},
+			},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/chat/completions", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("vision API call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Error("dingtalk: vision API returned non-OK status", "status", resp.StatusCode, "body", string(respBytes))
+		return "", fmt.Errorf("vision API status %d: %s", resp.StatusCode, string(respBytes))
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(respBytes, &result); err != nil {
+		return "", fmt.Errorf("parse response: %w", err)
+	}
+
+	if len(result.Choices) == 0 {
+		return "", fmt.Errorf("no choices in vision API response")
+	}
+
+	return result.Choices[0].Message.Content, nil
 }

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -667,6 +667,50 @@ func (p *Platform) getAccessToken() (string, error) {
 	return p.accessToken, nil
 }
 
+// ReplyWithAt sends a reply with @mention support. Uses text msgtype (not markdown)
+// because only text type supports highlighted/blue @mentions in DingTalk.
+func (p *Platform) ReplyWithAt(ctx context.Context, rctx any, content string, atUsers []string, atAll bool) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return fmt.Errorf("dingtalk: invalid reply context type %T", rctx)
+	}
+	if rc.proactive || rc.sessionWebhook == "" {
+		return p.sendProactiveMessage(ctx, rc, content)
+	}
+
+	payload := map[string]any{
+		"msgtype": "text",
+		"text":    map[string]string{"content": content},
+	}
+	if len(atUsers) > 0 || atAll {
+		payload["at"] = map[string]any{
+			"atUserIds": atUsers,
+			"isAtAll":   atAll,
+		}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("dingtalk: marshal reply: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rc.sessionWebhook, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("dingtalk: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := core.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("dingtalk: send reply: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("dingtalk: reply returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
 func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	rc, ok := rctx.(replyContext)
 	if !ok {

--- a/tests/release_local/media_pipeline/media_pipeline_test.go
+++ b/tests/release_local/media_pipeline/media_pipeline_test.go
@@ -307,7 +307,7 @@ func TestSendToSessionWithAttachmentsDeliversTextImagesAndFiles(t *testing.T) {
 	err := engine.SendToSessionWithAttachments(
 		msg.SessionKey,
 		"delivery ready",
-		[]core.ImageAttachment{{MimeType: "image/png", FileName: "chart.png", Data: []byte("chart")}},
+		[]core.ImageAttachment{{MimeType: "image/png", FileName: "chart.png", Data: []byte("chart", nil, false)}},
 		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report")}},
 	)
 	if err != nil {
@@ -344,7 +344,7 @@ func TestSendToSessionWithAttachmentsDoesNotDuplicateEchoedFinalTextWithContextI
 		msg.SessionKey,
 		sideText,
 		nil,
-		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report")}},
+		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report", nil, false)}},
 	)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments() error = %v", err)
@@ -399,7 +399,7 @@ func TestSendToSessionWithAttachmentsRespectsDisabledAttachmentSend(t *testing.T
 		msg.SessionKey,
 		"should not send",
 		nil,
-		[]core.FileAttachment{{MimeType: "text/plain", FileName: "blocked.txt", Data: []byte("blocked")}},
+		[]core.FileAttachment{{MimeType: "text/plain", FileName: "blocked.txt", Data: []byte("blocked", nil, false)}},
 	)
 	if !errors.Is(err, core.ErrAttachmentSendDisabled) {
 		t.Fatalf("err = %v, want ErrAttachmentSendDisabled", err)
@@ -426,7 +426,7 @@ func TestSendToSessionWithAttachmentsRequiresSessionWhenMultipleSessionsHaveAtta
 	err := engine.SendToSessionWithAttachments(
 		"",
 		"ambiguous",
-		[]core.ImageAttachment{{MimeType: "image/png", FileName: "ambiguous.png", Data: []byte("img")}},
+		[]core.ImageAttachment{{MimeType: "image/png", FileName: "ambiguous.png", Data: []byte("img", nil, false)}},
 		nil,
 	)
 	if err == nil || !strings.Contains(err.Error(), "multiple active sessions") {

--- a/tests/release_local/media_pipeline/media_pipeline_test.go
+++ b/tests/release_local/media_pipeline/media_pipeline_test.go
@@ -307,9 +307,9 @@ func TestSendToSessionWithAttachmentsDeliversTextImagesAndFiles(t *testing.T) {
 	err := engine.SendToSessionWithAttachments(
 		msg.SessionKey,
 		"delivery ready",
-		[]core.ImageAttachment{{MimeType: "image/png", FileName: "chart.png", Data: []byte("chart", nil, false)}},
+		[]core.ImageAttachment{{MimeType: "image/png", FileName: "chart.png", Data: []byte("chart")}},
 		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report")}},
-	)
+		nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments() error = %v", err)
 	}
@@ -344,8 +344,8 @@ func TestSendToSessionWithAttachmentsDoesNotDuplicateEchoedFinalTextWithContextI
 		msg.SessionKey,
 		sideText,
 		nil,
-		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report", nil, false)}},
-	)
+		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report")}},
+		nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments() error = %v", err)
 	}
@@ -399,8 +399,8 @@ func TestSendToSessionWithAttachmentsRespectsDisabledAttachmentSend(t *testing.T
 		msg.SessionKey,
 		"should not send",
 		nil,
-		[]core.FileAttachment{{MimeType: "text/plain", FileName: "blocked.txt", Data: []byte("blocked", nil, false)}},
-	)
+		[]core.FileAttachment{{MimeType: "text/plain", FileName: "blocked.txt", Data: []byte("blocked")}},
+		nil, false)
 	if !errors.Is(err, core.ErrAttachmentSendDisabled) {
 		t.Fatalf("err = %v, want ErrAttachmentSendDisabled", err)
 	}
@@ -426,9 +426,9 @@ func TestSendToSessionWithAttachmentsRequiresSessionWhenMultipleSessionsHaveAtta
 	err := engine.SendToSessionWithAttachments(
 		"",
 		"ambiguous",
-		[]core.ImageAttachment{{MimeType: "image/png", FileName: "ambiguous.png", Data: []byte("img", nil, false)}},
+		[]core.ImageAttachment{{MimeType: "image/png", FileName: "ambiguous.png", Data: []byte("img")}},
 		nil,
-	)
+		nil, false)
 	if err == nil || !strings.Contains(err.Error(), "multiple active sessions") {
 		t.Fatalf("err = %v, want multiple active sessions error", err)
 	}

--- a/tests/release_local/turn_contract/turn_contract_test.go
+++ b/tests/release_local/turn_contract/turn_contract_test.go
@@ -348,7 +348,7 @@ func TestSideChannelEchoContractAcrossOutboundModalities(t *testing.T) {
 			agent.session.waitRecords(t, 1)
 
 			sideText := "delivery ready"
-			if err := engine.SendToSessionWithAttachments(msg.SessionKey, sideText, tt.images, tt.files); err != nil {
+			if err := engine.SendToSessionWithAttachments(msg.SessionKey, sideText, tt.images, tt.files, nil, false); err != nil {
 				t.Fatalf("SendToSessionWithAttachments() error = %v", err)
 			}
 			agent.session.releaseFirstResult(core.Event{Type: core.EventResult, Content: sideText, InputTokens: 52000, Done: true})
@@ -366,7 +366,7 @@ func TestSideChannelDifferentFinalContract(t *testing.T) {
 	agent.session.waitRecords(t, 1)
 
 	sideText := "delivery ready"
-	if err := engine.SendToSessionWithAttachments(msg.SessionKey, sideText, nil, nil); err != nil {
+	if err := engine.SendToSessionWithAttachments(msg.SessionKey, sideText, nil, nil, nil, false); err != nil {
 		t.Fatalf("SendToSessionWithAttachments() error = %v", err)
 	}
 


### PR DESCRIPTION
- Add --at-users and --at-all flags to cc-connect send command
- Add AtMentionSender optional interface for platforms that support @mention
- Implement ReplyWithAt in DingTalk platform using text msgtype
- Add CheckLinger stub for macOS compatibility