### PR TITLE
fix(opencode): skip permissions in yolo mode + macOS CheckLinger stub

### DIFF
--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -164,6 +164,12 @@ func (s *opencodeSession) buildRunArgs(prompt string, imagePaths []string, chatI
 	// Enable thinking blocks.
 	args = append(args, "--thinking")
 
+	// In yolo/auto mode, skip permission prompts entirely so headless
+	// runs don't get stuck with auto-rejected external-directory ops.
+	if s.mode == "yolo" {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+
 	for _, imagePath := range imagePaths {
 		if imagePath == "" {
 			continue

--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -298,3 +298,9 @@ func xmlEscape(s string) string {
 	}
 	return b.String()
 }
+
+// CheckLinger is a Linux/systemd concept; on macOS launchd there is no
+// equivalent. Always return enabled so the warning in daemon.go is skipped.
+func CheckLinger() (enabled bool, user string) {
+	return true, ""
+}


### PR DESCRIPTION
## Problem

When cc-connect runs opencode in yolo mode via `opencode run --format json`, the agent auto-rejects external-directory permission requests (e.g. superpowers `/init` trying to modify `~/.config/opencode/opencode.jsonc`). Since there's no text output after the rejection, cc-connect delivers an empty response to the user.

## Changes

### 1. `agent/opencode/session.go`
Added `--dangerously-skip-permissions` flag when the agent mode is `yolo`. This aligns with the intent of yolo mode (auto-approve all permissions) and prevents empty responses in headless operation.

### 2. `daemon/launchd.go`
Added `CheckLinger()` stub function for macOS. This function is referenced in `daemon.go` but was only defined in `daemon/systemd.go` (Linux-only build tag), causing compilation failure on darwin.

## Testing
- Verified opencode with `--dangerously-skip-permissions` produces normal text output for commands that previously returned empty responses (e.g. `/init` with superpowers plugin).
- Confirmed `go build` succeeds on darwin/arm64 after adding the CheckLinger stub.