### PR TITLE
fix(codex): honor [projects.agent.options.env] from config.toml

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -39,6 +39,7 @@ type Agent struct {
 	cliExtraArgs    []string // extra args parsed from cli_path after the binary
 	providers       []core.ProviderConfig
 	activeIdx       int // -1 = no provider set
+	configEnv       []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
 	sessionEnv      []string
 	mu              sync.RWMutex
 }
@@ -78,6 +79,23 @@ func New(opts map[string]any) (core.Agent, error) {
 		return nil, fmt.Errorf("codex: %q CLI not found in PATH, install with: npm install -g @openai/codex", cliBin)
 	}
 
+	// Parse project-level env from opts["env"] (set via [projects.agent.options.env] in config.toml).
+	// Stored separately from runtime sessionEnv so SetSessionEnv calls cannot overwrite it.
+	// MergeEnv semantics ensure these override any same-named keys inherited from os.Environ()
+	// when the codex subprocess is spawned (e.g. user-scoped HTTPS_PROXY leaking into the agent).
+	var configEnv []string
+	if envMap, ok := opts["env"].(map[string]string); ok {
+		for k, v := range envMap {
+			configEnv = append(configEnv, k+"="+v)
+		}
+	} else if envMap, ok := opts["env"].(map[string]any); ok {
+		for k, v := range envMap {
+			if s, ok := v.(string); ok {
+				configEnv = append(configEnv, k+"="+s)
+			}
+		}
+	}
+
 	return &Agent{
 		workDir:         workDir,
 		model:           model,
@@ -88,6 +106,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		codexHome:       strings.TrimSpace(codexHome),
 		cliBin:          cliBin,
 		cliExtraArgs:    cliExtraArgs,
+		configEnv:       configEnv,
 		activeIdx:       -1,
 	}, nil
 }
@@ -340,7 +359,12 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	cliBin := a.cliBin
 	cliExtraArgs := a.cliExtraArgs
 	workDir := a.workDir
-	extraEnv := a.providerEnvLocked()
+	// Order matters for MergeEnv override semantics (later wins):
+	//   1. configEnv — static env from [projects.agent.options.env]
+	//   2. providerEnv — per-provider keys (OPENAI_API_KEY etc.)
+	//   3. sessionEnv — runtime overrides from /env or admin actions
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	var baseURL string
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {

--- a/agent/codex/project_env_test.go
+++ b/agent/codex/project_env_test.go
@@ -1,0 +1,98 @@
+package codex
+
+import (
+	"testing"
+)
+
+// TestNew_ParsesProjectEnvFromOpts verifies that env vars declared under
+// [projects.agent.options.env] in config.toml are loaded into the agent's
+// configEnv field. Without this, user-scoped env (e.g. HTTPS_PROXY in the
+// shell that launched cc-connect) silently overrides the values intended
+// for the codex subprocess.
+//
+// Regression for: codex agent ignoring opts["env"] in factory.
+func TestNew_ParsesProjectEnvFromOpts(t *testing.T) {
+	// Use "go" as cliBin to satisfy exec.LookPath without requiring codex
+	// to be installed on the test runner.
+	opts := map[string]any{
+		"work_dir": t.TempDir(),
+		"cli_path": "go",
+		"env": map[string]string{
+			"HTTPS_PROXY": "http://127.0.0.1:10808",
+			"HTTP_PROXY":  "http://127.0.0.1:10808",
+			"ALL_PROXY":   "http://127.0.0.1:10808",
+		},
+	}
+
+	a, err := New(opts)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	agent := a.(*Agent)
+	agent.mu.RLock()
+	got := envSliceToMap(agent.configEnv)
+	agent.mu.RUnlock()
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 env vars, got %d: %v", len(got), agent.configEnv)
+	}
+	if v := got["HTTPS_PROXY"]; v != "http://127.0.0.1:10808" {
+		t.Errorf("HTTPS_PROXY = %q, want http://127.0.0.1:10808", v)
+	}
+	if v := got["ALL_PROXY"]; v != "http://127.0.0.1:10808" {
+		t.Errorf("ALL_PROXY = %q, want http://127.0.0.1:10808", v)
+	}
+}
+
+// TestNew_ParsesProjectEnvFromMapStringAny covers the TOML decoder path
+// where the env table arrives as map[string]any rather than map[string]string.
+func TestNew_ParsesProjectEnvFromMapStringAny(t *testing.T) {
+	opts := map[string]any{
+		"work_dir": t.TempDir(),
+		"cli_path": "go",
+		"env": map[string]any{
+			"OPENAI_BASE_URL": "https://api.example.com/v1",
+			"CUSTOM_FLAG":     "yes",
+		},
+	}
+
+	a, err := New(opts)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	agent := a.(*Agent)
+	agent.mu.RLock()
+	got := envSliceToMap(agent.configEnv)
+	agent.mu.RUnlock()
+
+	if v := got["OPENAI_BASE_URL"]; v != "https://api.example.com/v1" {
+		t.Errorf("OPENAI_BASE_URL = %q", v)
+	}
+	if v := got["CUSTOM_FLAG"]; v != "yes" {
+		t.Errorf("CUSTOM_FLAG = %q", v)
+	}
+}
+
+// TestNew_NoEnvOpts ensures the absence of an env block produces an empty
+// configEnv slice (no panics, no surprise inheritance).
+func TestNew_NoEnvOpts(t *testing.T) {
+	opts := map[string]any{
+		"work_dir": t.TempDir(),
+		"cli_path": "go",
+	}
+
+	a, err := New(opts)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	agent := a.(*Agent)
+	agent.mu.RLock()
+	defer agent.mu.RUnlock()
+
+	if len(agent.configEnv) != 0 {
+		t.Fatalf("expected 0 env vars, got %d: %v", len(agent.configEnv), agent.configEnv)
+	}
+}


### PR DESCRIPTION
## Summary

The codex agent factory (`agent/codex/codex.go` `New()`) never read `opts[\"env\"]`, so env vars declared under `[projects.agent.options.env]` in `config.toml` were silently dropped. This mirrors the existing `configEnv` pattern in `agent/claudecode`.

## The bug

```toml
[[projects]]
[projects.agent]
type = \"codex\"
[projects.agent.options]
env = { HTTPS_PROXY = \"http://127.0.0.1:10808\" }   # silently ignored
```

When the shell that launched cc-connect had `HTTPS_PROXY` set to something else (e.g. a stale or unreachable proxy), the codex subprocess inherited that value instead of the one in config. Concretely, with `MergeEnv(os.Environ(), extraEnv)` — `extraEnv` only contained `providerEnvLocked() + sessionEnv`, both of which produce no proxy keys, so `os.Environ()`'s HTTPS_PROXY won.

Surface symptom: codex spawns, reaches `thread.started` and `turn.started`, then fails the model call with:

```
{\"type\":\"error\",\"message\":\"Reconnecting... 1/5 (stream disconnected before completion: tls handshake eof)\"}
...
{\"type\":\"turn.failed\",\"error\":{\"message\":\"stream disconnected before completion: error sending request for url (https://chatgpt.com/backend-api/codex/responses)\"}}
```

— easy to misread as a network/codex/chatgpt issue. Took a `slog.Info` of `cmd.Env` to localise.

## The fix

`agent/codex/codex.go`:
1. Add `configEnv []string` field on `Agent`.
2. Parse `opts[\"env\"]` in `New()` — supports both `map[string]string` and `map[string]any` (the two shapes the TOML decoder produces depending on path).
3. Prepend `configEnv` to `extraEnv` in `StartSession()` so `MergeEnv` override semantics let config win over `os.Environ()` inheritance.

Order in `StartSession()` (later wins):
1. `configEnv` — static, from config.toml
2. `providerEnv` — per-provider keys (OPENAI_API_KEY etc.)
3. `sessionEnv` — runtime overrides via `SetSessionEnv`

This matches what `agent/claudecode` already does at `claudecode.go:199` (`configEnv`).

## Test plan

- [x] New `agent/codex/project_env_test.go` covering:
  - `map[string]string` decoded shape
  - `map[string]any` decoded shape
  - absent `env` produces empty `configEnv`
  - tests use `cli_path = \"go\"` to satisfy `exec.LookPath` without requiring the codex binary on CI
- [x] `go test -tags no_web ./agent/codex/...` — PASS
- [x] End-to-end on Windows: configured `env = { HTTPS_PROXY = \"http://127.0.0.1:10808\", ... }`, sent a Feishu message → codex now reaches chatgpt.com via the configured proxy and replies normally
- [x] Verified the same failing tests in `core/` and `tests/release_local/` fail identically on `main@8e04d66` without this patch — they are pre-existing Windows-specific issues unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)