### PR TITLE
[codex] Keep Codex session listing read-only

### DIFF
--- a/agent/codex/list.go
+++ b/agent/codex/list.go
@@ -59,7 +59,6 @@ func listCodexSessions(workDir, codexHome string) ([]core.AgentSessionInfo, erro
 	for _, f := range files {
 		info := parseCodexSessionFile(f, absWorkDir)
 		if info != nil {
-			patchSessionSource(info.ID, codexHome)
 			sessions = append(sessions, *info)
 		}
 	}
@@ -89,6 +88,7 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 	var sessionCwd string
 	var summary string
 	var msgCount int
+	var modifiedAt time.Time
 	userMsgSeen := 0
 
 	scanner := bufio.NewScanner(f)
@@ -101,11 +101,17 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 		}
 
 		var entry struct {
-			Type    string          `json:"type"`
-			Payload json.RawMessage `json:"payload"`
+			Timestamp string          `json:"timestamp"`
+			Type      string          `json:"type"`
+			Payload   json.RawMessage `json:"payload"`
 		}
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
 			continue
+		}
+		if entry.Timestamp != "" {
+			if ts, err := time.Parse(time.RFC3339Nano, entry.Timestamp); err == nil && ts.After(modifiedAt) {
+				modifiedAt = ts
+			}
 		}
 
 		switch entry.Type {
@@ -158,12 +164,15 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 	if len([]rune(summary)) > 60 {
 		summary = string([]rune(summary)[:60]) + "..."
 	}
+	if modifiedAt.IsZero() {
+		modifiedAt = stat.ModTime()
+	}
 
 	return &core.AgentSessionInfo{
 		ID:           sessionID,
 		Summary:      summary,
 		MessageCount: msgCount,
-		ModifiedAt:   stat.ModTime(),
+		ModifiedAt:   modifiedAt,
 	}
 }
 

--- a/agent/codex/list_test.go
+++ b/agent/codex/list_test.go
@@ -1,0 +1,79 @@
+package codex
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestListCodexSessions_DoesNotPatchSessionSource(t *testing.T) {
+	workDir := t.TempDir()
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	sessionID := "readonly-list-session"
+
+	path := writeCodexListSession(t, codexHome, sessionID, workDir, "2026-01-01T00:00:00Z", time.Now())
+
+	sessions, err := listCodexSessions(workDir, codexHome)
+	if err != nil {
+		t.Fatalf("listCodexSessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("len(sessions) = %d, want 1", len(sessions))
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read session file: %v", err)
+	}
+	firstLine := strings.SplitN(string(data), "\n", 2)[0]
+	if !strings.Contains(firstLine, `"source":"exec"`) {
+		t.Fatalf("listCodexSessions modified session_meta source: %s", firstLine)
+	}
+	if !strings.Contains(firstLine, `"originator":"codex_exec"`) {
+		t.Fatalf("listCodexSessions modified session_meta originator: %s", firstLine)
+	}
+}
+
+func TestListCodexSessions_SortsByTranscriptTimestampNotFileMTime(t *testing.T) {
+	workDir := t.TempDir()
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+
+	writeCodexListSession(t, codexHome, "older-transcript-newer-file", workDir, "2026-01-01T00:00:00Z", time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC))
+	writeCodexListSession(t, codexHome, "newer-transcript-older-file", workDir, "2026-02-01T00:00:00Z", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+
+	sessions, err := listCodexSessions(workDir, codexHome)
+	if err != nil {
+		t.Fatalf("listCodexSessions: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("len(sessions) = %d, want 2", len(sessions))
+	}
+	if got, want := sessions[0].ID, "newer-transcript-older-file"; got != want {
+		t.Fatalf("sessions[0].ID = %q, want %q", got, want)
+	}
+}
+
+func writeCodexListSession(t *testing.T, codexHome, sessionID, workDir, timestamp string, mtime time.Time) string {
+	t.Helper()
+
+	sessionsDir := filepath.Join(codexHome, "sessions", "2026", "01", "01")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions dir: %v", err)
+	}
+
+	path := filepath.Join(sessionsDir, "rollout-"+sessionID+".jsonl")
+	lines := []string{
+		fmt.Sprintf(`{"timestamp":%q,"type":"session_meta","payload":{"id":%q,"source":"exec","originator":"codex_exec","cwd":%q}}`, timestamp, sessionID, workDir),
+		fmt.Sprintf(`{"timestamp":%q,"type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"hello"}]}}`, timestamp),
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes session file: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

- Stop `listCodexSessions` from calling `patchSessionSource` while rendering `/list`.
- Use the latest timestamp inside a Codex JSONL transcript for session ordering, falling back to file mtime only when transcript timestamps are unavailable.
- Add regression tests covering read-only listing and timestamp-based ordering.

## Root Cause

`/list` parsed matching Codex sessions and then patched `session_meta` from `source=exec` to `source=cli`. That write refreshed historical transcript mtimes, so old Codex conversations could jump to the top of session lists even though their internal transcript timestamps were old.

## Validation

- `go test -tags no_web ./agent/codex -run 'TestListCodexSessions|TestPatchSessionSource' -count=1 -v`
- `go build -tags no_web ./cmd/cc-connect`

## Notes

`go test ./...` was also attempted in this checkout, but it currently fails outside this change because `web/dist` is not built for the embedded web package, and there are unrelated existing failures in Codex runtime-config and core footer path expectation tests.
