### PR TITLE
feat(qqbot): add support for inline keyboard buttons and interaction events

### DIFF
--- a/platform/qqbot/qqbot.go
+++ b/platform/qqbot/qqbot.go
@@ -26,8 +26,8 @@ func init() {
 }
 
 const (
-	// Default intent: GROUP_AND_C2C_EVENT (1 << 25)
-	defaultIntents = 1 << 25
+	// Default intents: GROUP_AT_MESSAGE_CREATE (1 << 25) | INTERACTION_CREATE (1 << 26)
+	defaultIntents = (1 << 25) | (1 << 26)
 
 	maxReconnectBackoff  = 60 * time.Second
 	maxReconnectAttempts = 30
@@ -70,7 +70,7 @@ type Platform struct {
 	intents               int
 	markdownSupport       bool // enable markdown messages (msg_type: 2)
 	handler               core.MessageHandler
-	ctx                   context.Context    // lifetime context for the platform
+	ctx                   context.Context // lifetime context for the platform
 	cancel                context.CancelFunc
 
 	// OAuth2 token management
@@ -378,6 +378,10 @@ func (p *Platform) apiRequestJSON(method, url string, body any, result any) erro
 
 var _ core.ImageSender = (*Platform)(nil)
 
+// buttonDataPrefix is the prefix for QQ Bot keyboard button_data values.
+// Format: perm:<decision>:<session_key>
+const buttonDataPrefix = "perm:"
+
 // SendFile uploads and sends a file via QQ Bot rich media API.
 // Implements core.FileSender.
 func (p *Platform) SendFile(ctx context.Context, replyCtx any, file core.FileAttachment) error {
@@ -414,6 +418,110 @@ func (p *Platform) SendFile(ctx context.Context, replyCtx any, file core.FileAtt
 }
 
 var _ core.FileSender = (*Platform)(nil)
+var _ core.InlineButtonSender = (*Platform)(nil)
+
+// SendWithButtons sends a message with QQ Bot inline keyboard buttons.
+// Implements core.InlineButtonSender.
+func (p *Platform) SendWithButtons(ctx context.Context, replyCtx any, content string, buttons [][]core.ButtonOption) error {
+	rctx, ok := replyCtx.(*replyContext)
+	if !ok {
+		return fmt.Errorf("qqbot: SendWithButtons: invalid reply context type %T", replyCtx)
+	}
+
+	// Build session key from replyContext to embed in button_data
+	var sessionKey string
+	switch rctx.messageType {
+	case "group":
+		sessionKey = fmt.Sprintf("qqbot:%s:%s", rctx.groupOpenID, rctx.userOpenID)
+	case "c2c":
+		sessionKey = fmt.Sprintf("qqbot:%s", rctx.userOpenID)
+	default:
+		return fmt.Errorf("qqbot: unknown message type %q", rctx.messageType)
+	}
+
+	// Build QQ Bot keyboard rows from button options
+	var rows []map[string]any
+	for i, row := range buttons {
+		var btns []map[string]any
+		for j, btn := range row {
+			// Encode decision + session key into button_data so we can route
+			// the INTERACTION_CREATE event back to the right session.
+			// btn.Data is already "perm:allow", "perm:deny", or "perm:allow_all"
+			buttonData := btn.Data + ":" + sessionKey
+
+			btnID := fmt.Sprintf("b_%d_%d", i, j)
+			visitedLabel := "已操作"
+			style := 1 // blue
+			if strings.Contains(btn.Data, "deny") {
+				visitedLabel = "已拒绝"
+				style = 0 // grey
+			} else if strings.Contains(btn.Data, "allow_all") || strings.Contains(btn.Data, "allow all") {
+				visitedLabel = "已始终允许"
+			} else if strings.Contains(btn.Data, "allow") {
+				visitedLabel = "已允许"
+			}
+
+			btns = append(btns, map[string]any{
+				"id": btnID,
+				"render_data": map[string]any{
+					"label":         btn.Text,
+					"visited_label": visitedLabel,
+					"style":         style,
+				},
+				"action": map[string]any{
+					"type":        1, // callback
+					"data":        buttonData,
+					"permission":  map[string]int{"type": 2},
+					"click_limit": 1,
+				},
+				"group_id": "perm",
+			})
+		}
+		rows = append(rows, map[string]any{"buttons": btns})
+	}
+
+	keyboard := map[string]any{
+		"content": map[string]any{"rows": rows},
+	}
+
+	// Send message with keyboard.
+	// When markdown support is enabled, use msg_type 2 so QQ Bot
+	// properly renders the keyboard alongside markdown content.
+	msgType := 0
+	sendContent := content
+	if p.markdownSupport {
+		msgType = 2
+	}
+	body := map[string]any{
+		"msg_type": msgType,
+		"keyboard": keyboard,
+	}
+	if p.markdownSupport {
+		body["markdown"] = map[string]any{"content": sendContent}
+	} else {
+		body["content"] = sendContent
+	}
+	if rctx.eventMsgID != "" {
+		body["msg_id"] = rctx.eventMsgID
+		body["msg_seq"] = p.nextMsgSeq(rctx.eventMsgID)
+	}
+
+	var url string
+	switch rctx.messageType {
+	case "group":
+		url = fmt.Sprintf("%s/v2/groups/%s/messages", p.apiBase(), rctx.groupOpenID)
+	case "c2c":
+		url = fmt.Sprintf("%s/v2/users/%s/messages", p.apiBase(), rctx.userOpenID)
+	default:
+		return fmt.Errorf("qqbot: unknown message type %q", rctx.messageType)
+	}
+
+	slog.Debug("qqbot: sending message with keyboard",
+		"type", rctx.messageType, "session_key", sessionKey,
+		"num_buttons", len(rows), "content_len", len(content))
+
+	return p.apiRequest("POST", url, body)
+}
 
 // Stop shuts down the platform.
 func (p *Platform) Stop() error {
@@ -921,11 +1029,127 @@ func (p *Platform) handleDispatch(eventType string, data json.RawMessage) {
 		p.handleGroupMessage(data)
 	case "C2C_MESSAGE_CREATE":
 		p.handleC2CMessage(data)
+	case "INTERACTION_CREATE":
+		p.handleInteractionCreate(data)
 	case "RESUMED":
 		slog.Info("qqbot: session resumed successfully")
 	default:
 		slog.Debug("qqbot: unhandled event", "type", eventType)
 	}
+}
+
+// handleInteractionCreate handles inline keyboard button click events.
+// When a user clicks a button on a message with keyboard, QQ Bot dispatches
+// an INTERACTION_CREATE event. This method parses the button_data to extract
+// the permission decision and session key, then creates a synthetic message
+// so the engine can process it as a permission response.
+func (p *Platform) handleInteractionCreate(data json.RawMessage) {
+	var d struct {
+		ID                string `json:"id"`
+		GroupOpenID       string `json:"group_openid"`
+		GroupMemberOpenID string `json:"group_member_openid"`
+		UserOpenID        string `json:"user_openid"`
+		ChatType          int    `json:"chat_type"` // 1=group, 2=c2c
+		Data              struct {
+			Type     int `json:"type"`
+			Resolved struct {
+				ButtonData string `json:"button_data"`
+				ButtonID   string `json:"button_id"`
+			} `json:"resolved"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &d); err != nil {
+		slog.Warn("qqbot: failed to parse interaction create event", "error", err)
+		return
+	}
+
+	if d.ID == "" {
+		return
+	}
+	slog.Debug("qqbot: INTERACTION_CREATE", "id", d.ID, "button_data", d.Data.Resolved.ButtonData)
+
+	// ACK the interaction (required by QQ Bot API to prevent "请求超时" on buttons)
+	p.ackInteraction(d.ID)
+
+	// Parse button_data: perm:<decision>:<session_key>
+	buttonData := d.Data.Resolved.ButtonData
+	if !strings.HasPrefix(buttonData, buttonDataPrefix) {
+		slog.Debug("qqbot: unknown interaction button_data format", "data", buttonData)
+		return
+	}
+
+	rest := strings.TrimPrefix(buttonData, buttonDataPrefix)
+	// rest = "<decision>:<session_key>"
+	colonIdx := strings.Index(rest, ":")
+	if colonIdx < 0 {
+		slog.Warn("qqbot: invalid interaction button_data", "data", buttonData)
+		return
+	}
+	decision := rest[:colonIdx]
+	sessionKey := rest[colonIdx+1:]
+	if decision == "" || sessionKey == "" {
+		slog.Warn("qqbot: empty decision or session_key in button_data", "data", buttonData)
+		return
+	}
+
+	// Map decision to response text the engine understands
+	var responseText string
+	switch decision {
+	case "allow":
+		responseText = "allow"
+	case "deny":
+		responseText = "deny"
+	case "allow_all":
+		responseText = "allow all"
+	default:
+		slog.Warn("qqbot: unknown interaction decision", "decision", decision)
+		return
+	}
+
+	// Build reply context for sending confirmation messages
+	var rctx *replyContext
+	var userID string
+	switch d.ChatType {
+	case 1: // group
+		rctx = &replyContext{
+			messageType: "group",
+			groupOpenID: d.GroupOpenID,
+			userOpenID:  d.GroupMemberOpenID,
+		}
+		userID = d.GroupMemberOpenID
+	case 2: // c2c
+		rctx = &replyContext{
+			messageType: "c2c",
+			userOpenID:  d.UserOpenID,
+		}
+		userID = d.UserOpenID
+	default:
+		slog.Warn("qqbot: unknown interaction chat_type", "chat_type", d.ChatType)
+		return
+	}
+
+	// Create synthetic message and forward to engine as a permission response
+	msg := &core.Message{
+		SessionKey: sessionKey,
+		Platform:   "qqbot",
+		MessageID:  d.ID,
+		UserID:     userID,
+		Content:    responseText,
+		ReplyCtx:   rctx,
+	}
+
+	slog.Debug("qqbot: forwarding button click as permission response",
+		"decision", decision, "session_key", sessionKey, "chat_type", d.ChatType)
+	p.handler(p, msg)
+}
+
+// ackInteraction acknowledges an INTERACTION_CREATE event.
+// Uses the same pattern as hermes-agent: PUT /interactions/{id}
+// with JSON body {"code": 0}. Note: no /v2/ prefix for this endpoint.
+func (p *Platform) ackInteraction(interactionID string) error {
+	url := fmt.Sprintf("%s/interactions/%s", p.apiBase(), interactionID)
+	body := map[string]int{"code": 0}
+	return p.apiRequestJSON("PUT", url, body, nil)
 }
 
 func (p *Platform) handleGroupMessage(data json.RawMessage) {

--- a/platform/qqbot/qqbot_test.go
+++ b/platform/qqbot/qqbot_test.go
@@ -1,10 +1,12 @@
 package qqbot
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,8 +85,9 @@ func TestNew_DefaultIntents(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	platform := p.(*Platform)
-	if platform.intents != defaultIntents {
-		t.Errorf("intents = %d, want %d (defaultIntents)", platform.intents, defaultIntents)
+	want := (1 << 25) | (1 << 26) // GROUP_AT_MESSAGE_CREATE | INTERACTION_CREATE
+	if platform.intents != want {
+		t.Errorf("intents = %d, want %d", platform.intents, want)
 	}
 }
 
@@ -560,12 +563,12 @@ func TestHandleGroupMessage_QuoteFromMsgElements(t *testing.T) {
 	// Simulate a group quote message (message_type=103) with msg_elements[0]
 	msgType := 103
 	payload := map[string]any{
-		"id":             "msg-new",
-		"group_openid":   "group-1",
-		"content":        "<@!bot123>  看看这个",
-		"timestamp":      time.Now().Format(time.RFC3339),
-		"message_type":   msgType,
-		"msg_elements":   []map[string]any{
+		"id":           "msg-new",
+		"group_openid": "group-1",
+		"content":      "<@!bot123>  看看这个",
+		"timestamp":    time.Now().Format(time.RFC3339),
+		"message_type": msgType,
+		"msg_elements": []map[string]any{
 			{"content": "之前的讨论内容"},
 		},
 		"author": map[string]any{
@@ -585,5 +588,573 @@ func TestHandleGroupMessage_QuoteFromMsgElements(t *testing.T) {
 	want := "[引用消息]\n之前的讨论内容\n\n看看这个"
 	if got.Content != want {
 		t.Fatalf("content = %q, want %q", got.Content, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SendWithButtons tests
+// ---------------------------------------------------------------------------
+
+func TestSendWithButtons_GroupMessage(t *testing.T) {
+	var receivedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": "msg-out"}`)
+	}))
+	defer server.Close()
+
+	origClient := core.HTTPClient
+	t.Cleanup(func() { core.HTTPClient = origClient })
+	core.HTTPClient = server.Client()
+
+	origProd := apiBaseProduction
+	apiBaseProduction = server.URL
+	t.Cleanup(func() { apiBaseProduction = origProd })
+
+	p := &Platform{
+		token:       "test-token",
+		tokenExpiry: time.Now().Add(time.Hour),
+	}
+	ctx := context.Background()
+	rctx := &replyContext{
+		messageType: "group",
+		groupOpenID: "group-1",
+		userOpenID:  "user-1",
+		eventMsgID:  "evt-123",
+	}
+
+	buttons := [][]core.ButtonOption{
+		{
+			{Text: "允许", Data: "perm:allow"},
+			{Text: "拒绝", Data: "perm:deny"},
+		},
+		{
+			{Text: "允许所有", Data: "perm:allow_all"},
+		},
+	}
+
+	err := p.SendWithButtons(ctx, rctx, "权限请求", buttons)
+	if err != nil {
+		t.Fatalf("SendWithButtons returned error: %v", err)
+	}
+
+	if receivedBody == nil {
+		t.Fatal("expected API request body")
+	}
+
+	// Check basic message fields
+	if got, ok := receivedBody["content"].(string); !ok || got != "权限请求" {
+		t.Errorf("content = %v, want %q", receivedBody["content"], "权限请求")
+	}
+	if got, ok := receivedBody["msg_type"].(float64); !ok || got != 0 {
+		t.Errorf("msg_type = %v, want 0", receivedBody["msg_type"])
+	}
+	if got, ok := receivedBody["msg_id"].(string); !ok || got != "evt-123" {
+		t.Errorf("msg_id = %v, want %q", receivedBody["msg_id"], "evt-123")
+	}
+	if _, ok := receivedBody["msg_seq"]; !ok {
+		t.Error("msg_seq is missing")
+	}
+
+	// Check keyboard structure
+	keyboard, ok := receivedBody["keyboard"].(map[string]any)
+	if !ok {
+		t.Fatal("keyboard is missing or not a map")
+	}
+	content, ok := keyboard["content"].(map[string]any)
+	if !ok {
+		t.Fatal("keyboard.content is missing or not a map")
+	}
+	rows, ok := content["rows"].([]any)
+	if !ok {
+		t.Fatal("keyboard.content.rows is missing or not a slice")
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	// Row 0: two buttons (allow, deny)
+	row0, _ := rows[0].(map[string]any)
+	btns0, _ := row0["buttons"].([]any)
+	if len(btns0) != 2 {
+		t.Fatalf("row 0: expected 2 buttons, got %d", len(btns0))
+	}
+
+	// Button 0: allow
+	btn0, _ := btns0[0].(map[string]any)
+	rd0, _ := btn0["render_data"].(map[string]any)
+	if rd0["label"] != "允许" {
+		t.Errorf("allow button label = %v, want %q", rd0["label"], "允许")
+	}
+	if rd0["visited_label"] != "已允许" {
+		t.Errorf("allow button visited_label = %v", rd0["visited_label"])
+	}
+	act0, _ := btn0["action"].(map[string]any)
+	if data, ok := act0["data"].(string); !ok || !strings.HasPrefix(data, "perm:allow:qqbot:group-1:user-1") {
+		t.Errorf("allow button_data = %v", act0["data"])
+	}
+	if act0["type"] != float64(1) {
+		t.Errorf("allow action type = %v, want 1", act0["type"])
+	}
+	if btn0["group_id"] != "perm" {
+		t.Errorf("allow button group_id = %v", btn0["group_id"])
+	}
+
+	// Button 1: deny
+	btn1, _ := btns0[1].(map[string]any)
+	rd1, _ := btn1["render_data"].(map[string]any)
+	if rd1["label"] != "拒绝" {
+		t.Errorf("deny button label = %v", rd1["label"])
+	}
+	if rd1["visited_label"] != "已拒绝" {
+		t.Errorf("deny button visited_label = %v", rd1["visited_label"])
+	}
+	if style, ok := rd1["style"].(float64); !ok || style != 0 {
+		t.Errorf("deny button style = %v, want 0 (grey)", style)
+	}
+	act1, _ := btn1["action"].(map[string]any)
+	if data, ok := act1["data"].(string); !ok || !strings.HasPrefix(data, "perm:deny:qqbot:group-1:user-1") {
+		t.Errorf("deny button_data = %v", act1["data"])
+	}
+
+	// Row 1: allow_all button
+	row1, _ := rows[1].(map[string]any)
+	btns1, _ := row1["buttons"].([]any)
+	if len(btns1) != 1 {
+		t.Fatalf("row 1: expected 1 button, got %d", len(btns1))
+	}
+	btn2, _ := btns1[0].(map[string]any)
+	rd2, _ := btn2["render_data"].(map[string]any)
+	if rd2["label"] != "允许所有" {
+		t.Errorf("allow_all button label = %v", rd2["label"])
+	}
+	if rd2["visited_label"] != "已始终允许" {
+		t.Errorf("allow_all button visited_label = %v", rd2["visited_label"])
+	}
+	act2, _ := btn2["action"].(map[string]any)
+	if data, ok := act2["data"].(string); !ok || !strings.HasPrefix(data, "perm:allow_all:qqbot:group-1:user-1") {
+		t.Errorf("allow_all button_data = %v", act2["data"])
+	}
+}
+
+func TestSendWithButtons_C2CMessage(t *testing.T) {
+	var receivedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": "msg-out"}`)
+	}))
+	defer server.Close()
+
+	origClient := core.HTTPClient
+	t.Cleanup(func() { core.HTTPClient = origClient })
+	core.HTTPClient = server.Client()
+
+	origProd := apiBaseProduction
+	apiBaseProduction = server.URL
+	t.Cleanup(func() { apiBaseProduction = origProd })
+
+	p := &Platform{
+		token:       "test-token",
+		tokenExpiry: time.Now().Add(time.Hour),
+	}
+	rctx := &replyContext{
+		messageType: "c2c",
+		userOpenID:  "user-1",
+	}
+
+	buttons := [][]core.ButtonOption{
+		{{Text: "允许", Data: "perm:allow"}},
+	}
+
+	err := p.SendWithButtons(context.Background(), rctx, "test", buttons)
+	if err != nil {
+		t.Fatalf("SendWithButtons returned error: %v", err)
+	}
+
+	// Verify C2C session key in button_data
+	keyboard := receivedBody["keyboard"].(map[string]any)
+	content := keyboard["content"].(map[string]any)
+	rows := content["rows"].([]any)
+	row0 := rows[0].(map[string]any)
+	btns0 := row0["buttons"].([]any)
+	btn0 := btns0[0].(map[string]any)
+	act0 := btn0["action"].(map[string]any)
+
+	if data, ok := act0["data"].(string); !ok || !strings.HasPrefix(data, "perm:allow:qqbot:user-1") {
+		t.Errorf("C2C button_data = %v, want prefix perm:allow:qqbot:user-1", act0["data"])
+	}
+}
+
+func TestSendWithButtons_InvalidReplyCtx(t *testing.T) {
+	p := &Platform{}
+	err := p.SendWithButtons(context.Background(), "invalid", "test", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid reply context, got nil")
+	}
+}
+
+func TestSendWithButtons_EmptyEventMsgID(t *testing.T) {
+	var receivedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": "msg-out"}`)
+	}))
+	defer server.Close()
+
+	origClient := core.HTTPClient
+	t.Cleanup(func() { core.HTTPClient = origClient })
+	core.HTTPClient = server.Client()
+
+	origProd := apiBaseProduction
+	apiBaseProduction = server.URL
+	t.Cleanup(func() { apiBaseProduction = origProd })
+
+	p := &Platform{
+		token:       "test-token",
+		tokenExpiry: time.Now().Add(time.Hour),
+	}
+	rctx := &replyContext{
+		messageType: "c2c",
+		userOpenID:  "user-1",
+		// eventMsgID is empty
+	}
+
+	err := p.SendWithButtons(context.Background(), rctx, "test", [][]core.ButtonOption{{{Text: "允许", Data: "perm:allow"}}})
+	if err != nil {
+		t.Fatalf("SendWithButtons returned error: %v", err)
+	}
+
+	// msg_id should NOT be present when eventMsgID is empty
+	if _, ok := receivedBody["msg_id"]; ok {
+		t.Error("msg_id should not be present when eventMsgID is empty")
+	}
+	if _, ok := receivedBody["msg_seq"]; ok {
+		t.Error("msg_seq should not be present when eventMsgID is empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleInteractionCreate tests
+// ---------------------------------------------------------------------------
+
+func TestHandleInteractionCreate_Allow(t *testing.T) {
+	p := &Platform{
+		allowFrom: "*",
+	}
+	var got *core.Message
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		got = msg
+	}
+
+	// Create an interaction event for group allow
+	payload := map[string]any{
+		"id":                  "interact-1",
+		"group_openid":        "group-1",
+		"group_member_openid": "user-1",
+		"user_openid":         "user-1",
+		"chat_type":           1,
+		"data": map[string]any{
+			"type": 11,
+			"resolved": map[string]any{
+				"button_data": "perm:allow:qqbot:group-1:user-1",
+				"button_id":   "b_0_0",
+			},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	p.handleInteractionCreate(data)
+
+	if got == nil {
+		t.Fatal("expected synthetic message, got nil")
+	}
+	if got.Content != "allow" {
+		t.Errorf("content = %q, want %q", got.Content, "allow")
+	}
+	if got.SessionKey != "qqbot:group-1:user-1" {
+		t.Errorf("session_key = %q", got.SessionKey)
+	}
+	if got.MessageID != "interact-1" {
+		t.Errorf("message_id = %q", got.MessageID)
+	}
+	if got.Platform != "qqbot" {
+		t.Errorf("platform = %q", got.Platform)
+	}
+
+	// Verify reply context
+	rctx, ok := got.ReplyCtx.(*replyContext)
+	if !ok {
+		t.Fatal("replyCtx is not *replyContext")
+	}
+	if rctx.messageType != "group" {
+		t.Errorf("messageType = %q", rctx.messageType)
+	}
+	if rctx.groupOpenID != "group-1" {
+		t.Errorf("groupOpenID = %q", rctx.groupOpenID)
+	}
+	if rctx.userOpenID != "user-1" {
+		t.Errorf("userOpenID = %q", rctx.userOpenID)
+	}
+}
+
+func TestHandleInteractionCreate_Deny(t *testing.T) {
+	p := &Platform{
+		allowFrom: "*",
+	}
+	var got *core.Message
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		got = msg
+	}
+
+	payload := map[string]any{
+		"id":          "interact-2",
+		"user_openid": "user-1",
+		"chat_type":   2,
+		"data": map[string]any{
+			"type": 11,
+			"resolved": map[string]any{
+				"button_data": "perm:deny:qqbot:user-1",
+				"button_id":   "b_0_1",
+			},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	p.handleInteractionCreate(data)
+
+	if got == nil {
+		t.Fatal("expected synthetic message, got nil")
+	}
+	if got.Content != "deny" {
+		t.Errorf("content = %q, want %q", got.Content, "deny")
+	}
+	if got.SessionKey != "qqbot:user-1" {
+		t.Errorf("session_key = %q", got.SessionKey)
+	}
+
+	rctx, ok := got.ReplyCtx.(*replyContext)
+	if !ok {
+		t.Fatal("replyCtx is not *replyContext")
+	}
+	if rctx.messageType != "c2c" {
+		t.Errorf("messageType = %q", rctx.messageType)
+	}
+	if rctx.userOpenID != "user-1" {
+		t.Errorf("userOpenID = %q", rctx.userOpenID)
+	}
+}
+
+func TestHandleInteractionCreate_AllowAll(t *testing.T) {
+	p := &Platform{
+		allowFrom: "*",
+	}
+	var got *core.Message
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		got = msg
+	}
+
+	payload := map[string]any{
+		"id":                  "interact-3",
+		"group_openid":        "group-1",
+		"group_member_openid": "user-2",
+		"user_openid":         "user-2",
+		"chat_type":           1,
+		"data": map[string]any{
+			"type": 11,
+			"resolved": map[string]any{
+				"button_data": "perm:allow_all:qqbot:group-1:user-2",
+				"button_id":   "b_1_0",
+			},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	p.handleInteractionCreate(data)
+
+	if got == nil {
+		t.Fatal("expected synthetic message, got nil")
+	}
+	if got.Content != "allow all" {
+		t.Errorf("content = %q, want %q", got.Content, "allow all")
+	}
+	if got.SessionKey != "qqbot:group-1:user-2" {
+		t.Errorf("session_key = %q", got.SessionKey)
+	}
+}
+
+func TestHandleInteractionCreate_UnknownButtonData(t *testing.T) {
+	p := &Platform{
+		allowFrom: "*",
+	}
+	called := false
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		called = true
+	}
+
+	payload := map[string]any{
+		"id":        "interact-4",
+		"chat_type": 2,
+		"data": map[string]any{
+			"type": 11,
+			"resolved": map[string]any{
+				"button_data": "something_else:data",
+				"button_id":   "unknown",
+			},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	p.handleInteractionCreate(data)
+
+	if called {
+		t.Error("handler should not be called for unknown button_data prefix")
+	}
+}
+
+func TestHandleInteractionCreate_InvalidFormat(t *testing.T) {
+	p := &Platform{
+		allowFrom: "*",
+	}
+	called := false
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		called = true
+	}
+
+	payload := map[string]any{
+		"id":        "interact-5",
+		"chat_type": 2,
+		"data": map[string]any{
+			"type": 11,
+			"resolved": map[string]any{
+				"button_data": "perm:",
+				"button_id":   "bad",
+			},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	p.handleInteractionCreate(data)
+
+	if called {
+		t.Error("handler should not be called for empty button_data")
+	}
+}
+
+func TestHandleInteractionCreate_EmptyID(t *testing.T) {
+	p := &Platform{
+		allowFrom: "*",
+	}
+	called := false
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		called = true
+	}
+
+	payload := map[string]any{
+		"id":        "",
+		"chat_type": 2,
+		"data": map[string]any{
+			"resolved": map[string]any{
+				"button_data": "perm:allow:qqbot:user-1",
+			},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	p.handleInteractionCreate(data)
+
+	if called {
+		t.Error("handler should not be called for empty interaction ID")
+	}
+}
+
+func TestHandleInteractionCreate_ACKFailure(t *testing.T) {
+	// Test that interaction processing proceeds even if ACK fails
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	p := &Platform{
+		allowFrom:   "*",
+		token:       "test-token",
+		tokenExpiry: time.Now().Add(time.Hour),
+	}
+	// Point to test server
+	origProd := apiBaseProduction
+	apiBaseProduction = server.URL
+	t.Cleanup(func() { apiBaseProduction = origProd })
+
+	var got *core.Message
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		got = msg
+	}
+
+	payload := map[string]any{
+		"id":          "interact-ack",
+		"user_openid": "user-1",
+		"chat_type":   2,
+		"data": map[string]any{
+			"type": 11,
+			"resolved": map[string]any{
+				"button_data": "perm:allow:qqbot:user-1",
+				"button_id":   "b_0_0",
+			},
+		},
+	}
+	data, _ := json.Marshal(payload)
+
+	// Should not panic, handler should still receive the message
+	p.handleInteractionCreate(data)
+	if got == nil {
+		t.Fatal("expected synthetic message even when ACK fails")
+	}
+	if got.Content != "allow" {
+		t.Errorf("content = %q, want %q", got.Content, "allow")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ackInteraction tests
+// ---------------------------------------------------------------------------
+
+func TestAckInteraction(t *testing.T) {
+	var method, reqURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		reqURL = r.URL.String()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	origClient := core.HTTPClient
+	t.Cleanup(func() { core.HTTPClient = origClient })
+	core.HTTPClient = server.Client()
+
+	p := &Platform{
+		token:       "test-token",
+		tokenExpiry: time.Now().Add(time.Hour),
+	}
+	// Point to test server
+	origProd := apiBaseProduction
+	apiBaseProduction = server.URL
+	t.Cleanup(func() { apiBaseProduction = origProd })
+
+	err := p.ackInteraction("interact-1")
+	if err != nil {
+		t.Fatalf("ackInteraction returned error: %v", err)
+	}
+	if method != "PUT" {
+		t.Errorf("method = %q, want %q", method, "PUT")
+	}
+	if reqURL != "/v2/interactions/interact-1" {
+		t.Errorf("url = %q, want %q", reqURL, "/v2/interactions/interact-1")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance tests
+// ---------------------------------------------------------------------------
+
+func TestPlatformImplementsInlineButtonSender(t *testing.T) {
+	p := &Platform{}
+	if _, ok := any(p).(core.InlineButtonSender); !ok {
+		t.Error("Platform does not implement core.InlineButtonSender")
 	}
 }


### PR DESCRIPTION
- Update default intents to include INTERACTION_CREATE
- Implement SendWithButtons to send messages with inline keyboard buttons
- Encode permission decisions and session key in button_data for routing callbacks
- Handle INTERACTION_CREATE events to process button clicks as permission responses
- Create synthetic message for permission decisions and forward to engine
- Add ackInteraction to acknowledge INTERACTION_CREATE events via API call
- Add extensive tests for sending buttons, handling interactions, and edge cases