### PR TITLE
docs: add community tools page

### DIFF
--- a/docs/community-tools.md
+++ b/docs/community-tools.md
@@ -1,0 +1,21 @@
+# Community Tools
+
+This page lists community-maintained tools and helpers built around cc-connect.
+
+These tools are not official cc-connect components unless explicitly stated. Please report issues, feature requests, and support questions to each tool's own repository.
+
+## CC-Tray
+
+A lightweight Windows tray controller for an already configured `cc-connect daemon` running inside WSL.
+
+- Repository: https://github.com/STAR-REIN/CC-Tray
+- Platform: Windows + WSL
+- Package: single native exe, about 260 KiB
+- Features:
+  - daemon status/start/restart/stop
+  - WSL distribution/user detection
+  - optional keep-running mode
+  - optional Windows startup
+  - optional stop-on-exit
+  - EN/ZH/KO/JA/FR menu language support
+- Maintainer: [STAR-REIN](https://github.com/STAR-REIN)


### PR DESCRIPTION
## Summary

Adds a new `docs/community-tools.md` page for community-maintained tools around cc-connect.

The first entry is CC-Tray, a lightweight Windows tray controller for users who run `cc-connect daemon` inside WSL.

## Notes

- The page clearly states that listed tools are community-maintained and not official cc-connect components.
- CC-Tray does not replace cc-connect or configure providers/platform credentials; it only provides tray controls for an already configured WSL daemon.