### PR TITLE
fix(opencode): correct sessionID location and step_finish handling

### DIFF
--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -36,6 +36,7 @@ type opencodeSession struct {
 	wg                sync.WaitGroup
 	alive             atomic.Bool
 	expectingContinue atomic.Bool // true when compaction_continue received, waiting for next step
+	resultSent        atomic.Bool // true when EventResult has been sent for this turn
 }
 
 func newOpencodeSession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string) (*opencodeSession, error) {
@@ -72,6 +73,9 @@ func (s *opencodeSession) Send(prompt string, images []core.ImageAttachment, fil
 	if !s.alive.Load() {
 		return fmt.Errorf("session is closed")
 	}
+
+	s.resultSent.Store(false)
+	s.expectingContinue.Store(false)
 
 	chatID := s.CurrentSessionID()
 	isResume := chatID != ""
@@ -231,14 +235,8 @@ func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBu
 		return
 	}
 
-	// Emit EventResult after all steps are done and the process has finished writing.
-	sid := s.CurrentSessionID()
-	slog.Debug("opencodeSession: readLoop complete, sending fallback EventResult", "session_id", sid)
-	evt := core.Event{Type: core.EventResult, SessionID: sid, Done: true}
-	select {
-	case s.events <- evt:
-	case <-s.ctx.Done():
-	}
+	slog.Debug("opencodeSession: readLoop complete, sending fallback EventResult", "session_id", s.CurrentSessionID())
+	s.sendEventResult()
 }
 
 // OpenCode NDJSON event structure:
@@ -437,11 +435,13 @@ func extractErrorMessage(raw map[string]any) string {
 }
 
 func (s *opencodeSession) handleStepStart(raw map[string]any) {
-	part, _ := raw["part"].(map[string]any)
-	if part == nil {
-		return
+	sessionID, _ := raw["sessionID"].(string)
+	if sessionID == "" {
+		part, _ := raw["part"].(map[string]any)
+		if part != nil {
+			sessionID, _ = part["sessionID"].(string)
+		}
 	}
-	sessionID, _ := part["sessionID"].(string)
 	if sessionID != "" {
 		s.chatID.Store(sessionID)
 		slog.Debug("opencodeSession: session started", "session_id", sessionID)
@@ -450,8 +450,29 @@ func (s *opencodeSession) handleStepStart(raw map[string]any) {
 
 func (s *opencodeSession) handleStepFinish(raw map[string]any) {
 	part, _ := raw["part"].(map[string]any)
-	reason, _ := part["reason"].(string)
+	reason := ""
+	if part != nil {
+		reason, _ = part["reason"].(string)
+	}
 	slog.Debug("opencodeSession: step finished", "reason", reason, "session_id", s.CurrentSessionID())
+
+	if reason == "stop" {
+		s.sendEventResult()
+	}
+}
+
+func (s *opencodeSession) sendEventResult() {
+	if s.resultSent.Load() {
+		slog.Debug("opencodeSession: EventResult already sent, skipping", "session_id", s.CurrentSessionID())
+		return
+	}
+	s.resultSent.Store(true)
+	sid := s.CurrentSessionID()
+	evt := core.Event{Type: core.EventResult, SessionID: sid, Done: true}
+	select {
+	case s.events <- evt:
+	case <-s.ctx.Done():
+	}
 }
 
 // RespondPermission is a no-op — OpenCode handles permissions internally.

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -115,6 +116,129 @@ func TestOpencodeSessionBuildRunArgsIncludesImagesAsFiles(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+// TestHandleStepStart_SessionIDFromTopLevel verifies that handleStepStart
+// prefers the sessionID from the top-level JSON field when both top-level
+// and part-level sessionID are present. This matches OpenCode's stdout format.
+func TestHandleStepStart_SessionIDFromTopLevel(t *testing.T) {
+	jsonData := `{"type":"step_start","sessionID":"ses_top_level","part":{"sessionID":"ses_part_level"}}`
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonData), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	s := &opencodeSession{}
+	s.handleStepStart(raw)
+
+	if got := s.CurrentSessionID(); got != "ses_top_level" {
+		t.Errorf("sessionID = %q, want %q (should prefer top-level)", got, "ses_top_level")
+	}
+}
+
+// TestHandleStepStart_SessionIDFromPart verifies that handleStepStart
+// falls back to the sessionID inside part when top-level sessionID is absent.
+func TestHandleStepStart_SessionIDFromPart(t *testing.T) {
+	jsonData := `{"type":"step_start","part":{"sessionID":"ses_part_level"}}`
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonData), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	s := &opencodeSession{}
+	s.handleStepStart(raw)
+
+	if got := s.CurrentSessionID(); got != "ses_part_level" {
+		t.Errorf("sessionID = %q, want %q (should fallback to part)", got, "ses_part_level")
+	}
+}
+
+// TestHandleStepStopSendsEventResult verifies that handleStepFinish sends
+// an EventResult when reason="stop", signaling turn completion to the engine.
+func TestHandleStepStopSendsEventResult(t *testing.T) {
+	jsonData := `{"type":"step_finish","part":{"reason":"stop"}}`
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonData), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{events: make(chan core.Event, 1), ctx: ctx}
+	s.handleStepFinish(raw)
+
+	select {
+	case evt := <-s.events:
+		if evt.Type != core.EventResult {
+			t.Errorf("event type = %q, want EventResult", evt.Type)
+		}
+		if !evt.Done {
+			t.Errorf("event.Done = false, want true")
+		}
+	default:
+		t.Error("expected EventResult to be sent when reason=stop")
+	}
+}
+
+// TestHandleStepToolCallsNoEventResult verifies that handleStepFinish does NOT
+// send EventResult when reason="tool-calls", allowing the agent to continue
+// with subsequent tool execution steps.
+func TestHandleStepToolCallsNoEventResult(t *testing.T) {
+	jsonData := `{"type":"step_finish","part":{"reason":"tool-calls"}}`
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonData), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{events: make(chan core.Event, 1), ctx: ctx}
+	s.handleStepFinish(raw)
+
+	select {
+	case evt := <-s.events:
+		t.Errorf("unexpected event sent when reason=tool-calls: %v", evt)
+	default:
+	}
+}
+
+// TestHandleStepDuplicateEventResultPrevented verifies that calling
+// handleStepFinish multiple times with reason="stop" only sends one
+// EventResult, preventing duplicate completion signals to the engine.
+func TestHandleStepDuplicateEventResultPrevented(t *testing.T) {
+	jsonData := `{"type":"step_finish","part":{"reason":"stop"}}`
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonData), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{
+		events:     make(chan core.Event, 2),
+		ctx:        ctx,
+		resultSent: atomic.Bool{},
+	}
+
+	s.handleStepFinish(raw)
+	s.handleStepFinish(raw)
+
+	count := 0
+	for len(s.events) > 0 {
+		evt := <-s.events
+		if evt.Type == core.EventResult {
+			count++
+		}
+	}
+
+	if count != 1 {
+		t.Errorf("EventResult count = %d, want 1 (duplicate should be prevented)", count)
 	}
 }
 


### PR DESCRIPTION
- Fix handleStepStart: prefer sessionID from top-level JSON field, fallback to part
- Fix handleStepFinish: send EventResult when reason=stop, not when tool-calls
- Add resultSent atomic.Bool to prevent duplicate EventResult
- Add unit tests with JSON string construction style matching existing tests 
This fixes empty response issue when opencode uses tools (issue #1094, PR #697)

Closes #1094
