### PR TITLE
fix(cron): merge provider env vars into cron shell environment

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1289,6 +1289,20 @@ func (e *Engine) executeCronShell(p Platform, replyCtx any, job *CronJob) error 
 	}
 	shellCmd.Dir = workDir
 
+	// Merge provider env vars (e.g. CLAUDE_CODE_USE_BEDROCK) into the shell
+	// so cron scripts inherit the same environment the agent subprocess sees.
+	if ps, ok := e.agent.(ProviderSwitcher); ok {
+		var extra []string
+		for _, prov := range ps.ListProviders() {
+			for k, v := range prov.Env {
+				extra = append(extra, k+"="+v)
+			}
+		}
+		if len(extra) > 0 {
+			shellCmd.Env = MergeEnv(shellCmd.Env, extra)
+		}
+	}
+
 	stdout, err := shellCmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("shell: stdout pipe: %w", err)


### PR DESCRIPTION
## Summary

- Cron shell commands previously only inherited `os.Environ()` plus `CC_PROJECT` and `CC_DATA_DIR`. Provider-level env vars (e.g. `CLAUDE_CODE_USE_BEDROCK`) were missing, causing cron scripts that depend on these variables to fail.
- Now provider env is merged using `MergeEnv` so provider values properly override base env, matching the environment the agent subprocess sees.

## Test plan

- [x] `go build ./...` passes
- [ ] Verify cron scripts can access provider env vars after this change

🤖 Generated with [kscc](https://claude.com/claude-code)