### PR TITLE
fix(cron): merge project and provider env vars into cron shell environment

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1289,6 +1289,30 @@ func (e *Engine) executeCronShell(p Platform, replyCtx any, job *CronJob) error 
 	}
 	shellCmd.Dir = workDir
 
+	// Merge project-level and provider env vars into the cron shell
+	// so cron scripts inherit the same environment the agent subprocess sees.
+	shellCmd.Env = os.Environ()
+	shellCmd.Env = append(shellCmd.Env, "CC_PROJECT="+e.name)
+	if e.dataDir != "" {
+		shellCmd.Env = append(shellCmd.Env, "CC_DATA_DIR="+e.dataDir)
+	}
+	if ra, ok := e.agent.(interface{ GetRunAsEnv() []string }); ok {
+		for _, kv := range ra.GetRunAsEnv() {
+			shellCmd.Env = append(shellCmd.Env, kv)
+		}
+	}
+	if ps, ok := e.agent.(ProviderSwitcher); ok {
+		var extra []string
+		for _, prov := range ps.ListProviders() {
+			for k, v := range prov.Env {
+				extra = append(extra, k+"="+v)
+			}
+		}
+		if len(extra) > 0 {
+			shellCmd.Env = MergeEnv(shellCmd.Env, extra)
+		}
+	}
+
 	stdout, err := shellCmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("shell: stdout pipe: %w", err)

--- a/core/engine.go
+++ b/core/engine.go
@@ -1297,9 +1297,7 @@ func (e *Engine) executeCronShell(p Platform, replyCtx any, job *CronJob) error 
 		shellCmd.Env = append(shellCmd.Env, "CC_DATA_DIR="+e.dataDir)
 	}
 	if ra, ok := e.agent.(interface{ GetRunAsEnv() []string }); ok {
-		for _, kv := range ra.GetRunAsEnv() {
-			shellCmd.Env = append(shellCmd.Env, kv)
-		}
+		shellCmd.Env = append(shellCmd.Env, ra.GetRunAsEnv()...)
 	}
 	if ps, ok := e.agent.(ProviderSwitcher); ok {
 		var extra []string


### PR DESCRIPTION
## Summary

Cron shell commands started by `sh -c` inherit only the bridge process's base environment. They miss `CC_PROJECT`, `CC_DATA_DIR`, provider-specific env vars (e.g. `CLAUDE_CODE_USE_BEDROCK`), and any `run_as_user` overrides. Cron scripts that need these variables must manually re-source profiles or hardcode paths.

This PR propagates the same env composition used by interactive sessions into cron shells:
- Start from `os.Environ()`
- Append project keys (`CC_PROJECT`, `CC_DATA_DIR`)
- Append `run_as_user` overrides
- Append provider env vars via `MergeEnv`

## Test plan

- [ ] Configure a cron job that prints `echo $CC_PROJECT` and verify it outputs the project name
- [ ] Configure a provider with env vars (e.g. `CLAUDE_CODE_USE_BEDROCK=1`) and verify a cron job inherits it
- [ ] Verify existing cron jobs without env dependencies still run correctly
- [ ] Run `go build ./...` and `go test ./core/...` to confirm no regressions

🤖 Generated with [kscc](https://claude.com/claude-code)