### PR TITLE
fix(core): add panic recovery to engine goroutines

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2127,7 +2127,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 			// and the queue append. Re-try TryLock — if it succeeds, no one is
 			// draining the queue so we must start a processor ourselves.
 			if session.TryLock() {
-				go e.drainOrphanedQueue(session, sessions, interactiveKey, agent, resolvedWorkspace)
+				e.safeGo(func() { e.drainOrphanedQueue(session, sessions, interactiveKey, agent, resolvedWorkspace) })
 			}
 			return
 		}
@@ -2156,7 +2156,7 @@ sessionLocked:
 		"session", session.ID,
 	)
 
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey)
+	e.safeGo(func() { e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey) })
 }
 
 func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session) *Session {
@@ -2707,6 +2707,12 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	// EventPermissionRequest while blocked — the event loop must run in parallel.
 	sendDone := make(chan error, 1)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in agent Send", "error", r, "session", interactiveKey)
+				sendDone <- fmt.Errorf("panic in agent Send: %v", r)
+			}
+		}()
 		sendDone <- state.agentSession.Send(promptContent, msg.Images, msg.Files)
 	}()
 
@@ -3131,6 +3137,11 @@ func (e *Engine) closeAgentSessionWithTimeout(sessionKey string, agentSession Ag
 
 	done := make(chan struct{})
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in agent session Close", "error", r, "session", sessionKey)
+			}
+		}()
 		agentSession.Close()
 		close(done)
 	}()
@@ -3251,7 +3262,7 @@ func (e *Engine) startUnsolicitedReader(state *interactiveState, session *Sessio
 	state.unsolicitedDone = done
 	state.mu.Unlock()
 
-	go e.runUnsolicitedReader(ctx, cancel, done, state, agentSession, session, sessions, sessionKey, workspaceDir)
+	e.safeGo(func() { e.runUnsolicitedReader(ctx, cancel, done, state, agentSession, session, sessions, sessionKey, workspaceDir) })
 }
 
 // runUnsolicitedReader is the goroutine body for the unsolicited event reader.
@@ -3423,6 +3434,11 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 				reqID := event.RequestID
 				respondCtx := ctx // capture current unsolicited reader context
 				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+							slog.Error("panic in RespondPermission", "error", r)
+						}
+					}()
 					// Run in a goroutine to keep reader iterations fast, but honour
 					// the reader's context so we don't call into a dead session after
 					// stopUnsolicitedReader cancels the context.
@@ -4434,7 +4450,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 				nextSend := make(chan error, 1)
 				go func() {
-					nextSend <- state.agentSession.Send(queuedPrompt, queued.images, queued.files)
+					nextSend <- func() error {
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("panic in agent Send (queued)", "error", r, "session", sessionKey)
+					}
+				}()
+				return state.agentSession.Send(queuedPrompt, queued.images, queued.files)
+			}()
 				}()
 				pendingSend = nextSend
 
@@ -4722,7 +4745,14 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 
 		sendDone := make(chan error, 1)
 		go func() {
-			sendDone <- state.agentSession.Send(prompt, queued.images, queued.files)
+			sendDone <- func() error {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("panic in agent Send (drain)", "error", r, "session", sessionKey)
+				}
+			}()
+			return state.agentSession.Send(prompt, queued.images, queued.files)
+			}()
 		}()
 
 		var stopTyping func()
@@ -11775,7 +11805,7 @@ func (e *Engine) executeCustomCommand(p Platform, msg *Message, cmd *CustomComma
 	)
 
 	msg.Content = prompt
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey)
+	e.safeGo(func() { e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey) })
 }
 
 // executeShellCommand runs a shell command and sends the output to the user.
@@ -12003,7 +12033,7 @@ func (e *Engine) executeSkill(p Platform, msg *Message, skill *Skill, args []str
 	)
 
 	msg.Content = prompt
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey)
+	e.safeGo(func() { e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey) })
 }
 
 func (e *Engine) cmdSkills(p Platform, msg *Message) {

--- a/core/recover.go
+++ b/core/recover.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// safeGo launches fn in a new goroutine with panic recovery.
+// If fn panics, the panic value and stack trace are logged and written
+// to a crash log file under dataDir/crashes/ so operators can diagnose
+// unexpected restarts.
+func (e *Engine) safeGo(fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				const depth = 32
+				pcs := make([]uintptr, depth)
+				n := runtime.Callers(2, pcs)
+				pcs = pcs[:n]
+				frames := runtime.CallersFrames(pcs)
+
+				var stack string
+				for {
+					frame, more := frames.Next()
+					stack += fmt.Sprintf("  %s\n\t%s:%d\n", frame.Function, frame.File, frame.Line)
+					if !more {
+						break
+					}
+				}
+
+				slog.Error("panic recovered in goroutine",
+					"error", r, "stack", stack, "project", e.name)
+
+				e.writeCrashLog(r, stack)
+			}
+		}()
+		fn()
+	}()
+}
+
+// writeCrashLog appends a crash record to dataDir/crashes/crash.log.
+// Best-effort: failures are logged but never panic.
+func (e *Engine) writeCrashLog(r any, stack string) {
+	dir := filepath.Join(e.dataDir, "crashes")
+	_ = os.MkdirAll(dir, 0o755)
+
+	path := filepath.Join(dir, "crash.log")
+	entry := fmt.Sprintf("--- %s ---\npanic: %v\nproject: %s\nstack:\n%s\n\n",
+		time.Now().Format(time.RFC3339), r, e.name, stack)
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		slog.Error("crash log: open failed", "path", path, "error", err)
+		return
+	}
+	defer f.Close()
+	if _, err := fmt.Fprint(f, entry); err != nil {
+		slog.Error("crash log: write failed", "error", err)
+	}
+}

--- a/core/recover_test.go
+++ b/core/recover_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSafeGo_RecoversPanic(t *testing.T) {
+	e := &Engine{
+		name:    "test-project",
+		dataDir: t.TempDir(),
+	}
+
+	panicked := make(chan struct{})
+	e.safeGo(func() {
+		panic("test panic")
+	})
+
+	// The goroutine should recover and not crash the process.
+	select {
+	case <-panicked:
+		t.Fatal("should not reach here")
+	default:
+	}
+
+	// Give the goroutine time to write the crash log.
+	crashLog := filepath.Join(e.dataDir, "crashes", "crash.log")
+	for i := 0; i < 100; i++ {
+		time.Sleep(10 * time.Millisecond)
+		if data, err := os.ReadFile(crashLog); err == nil {
+			content := string(data)
+			if !strings.Contains(content, "test panic") {
+				t.Fatalf("crash log should contain panic value, got:\n%s", content)
+			}
+			if !strings.Contains(content, "test-project") {
+				t.Fatalf("crash log should contain project name, got:\n%s", content)
+			}
+			return
+		}
+	}
+	t.Fatal("crash log was not written")
+}
+
+func TestSafeGo_NormalExecution(t *testing.T) {
+	e := &Engine{
+		name:    "test-project",
+		dataDir: t.TempDir(),
+	}
+
+	done := make(chan struct{})
+	e.safeGo(func() {
+		close(done)
+	})
+
+	select {
+	case <-done:
+		// Normal execution completed.
+	case <-time.After(2 * time.Second):
+		t.Fatal("safeGo should complete normally")
+	}
+
+	// No crash log should be written.
+	crashLog := filepath.Join(e.dataDir, "crashes", "crash.log")
+	if _, err := os.Stat(crashLog); !os.IsNotExist(err) {
+		t.Fatal("crash log should not exist for normal execution")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Engine.safeGo`: goroutine launcher with `recover()` that logs panics and writes crash records to `dataDir/crashes/crash.log` for post-restart diagnosis
- Wrap all engine-managed goroutine launches with `safeGo`: `processInteractiveMessageWith`, `drainOrphanedQueue`, `runUnsolicitedReader`
- Add inline `recover()` to `agentSession.Send` and `Close` goroutines to prevent silent goroutine death

## Motivation

Currently, a panic in any engine goroutine kills that goroutine silently. The main process stays alive (since launchd/systemd only restart on process exit), so the bridge appears healthy but is actually non-functional — messages are accepted but never processed, and there's no way to diagnose the failure after the fact.

## Test plan
- [x] `TestSafeGo_RecoversPanic` — panic is recovered, crash log is written
- [x] `TestSafeGo_NormalExecution` — no crash log for normal runs
- [x] `TestExecuteCronJob_ResolvesCronReplyTarget` — cron test still passes
- [ ] Manual: verify crash logs appear under `dataDir/crashes/` on panic