### PR TITLE
fix(core): add panic recovery to critical goroutines

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2127,7 +2127,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 			// and the queue append. Re-try TryLock — if it succeeds, no one is
 			// draining the queue so we must start a processor ourselves.
 			if session.TryLock() {
-				go e.drainOrphanedQueue(session, sessions, interactiveKey, agent, resolvedWorkspace)
+				e.safeGo(func() { e.drainOrphanedQueue(session, sessions, interactiveKey, agent, resolvedWorkspace) })
 			}
 			return
 		}
@@ -2156,7 +2156,7 @@ sessionLocked:
 		"session", session.ID,
 	)
 
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey)
+	e.safeGo(func() { e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey) })
 }
 
 func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session) *Session {
@@ -2707,6 +2707,12 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	// EventPermissionRequest while blocked — the event loop must run in parallel.
 	sendDone := make(chan error, 1)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in agent Send", "error", r, "session", msg.SessionKey)
+				sendDone <- fmt.Errorf("panic in Send: %v", r)
+			}
+		}()
 		sendDone <- state.agentSession.Send(promptContent, msg.Images, msg.Files)
 	}()
 
@@ -3131,6 +3137,11 @@ func (e *Engine) closeAgentSessionWithTimeout(sessionKey string, agentSession Ag
 
 	done := make(chan struct{})
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in agent Close", "error", r, "session", sessionKey)
+			}
+		}()
 		agentSession.Close()
 		close(done)
 	}()
@@ -3251,7 +3262,7 @@ func (e *Engine) startUnsolicitedReader(state *interactiveState, session *Sessio
 	state.unsolicitedDone = done
 	state.mu.Unlock()
 
-	go e.runUnsolicitedReader(ctx, cancel, done, state, agentSession, session, sessions, sessionKey, workspaceDir)
+	e.safeGo(func() { e.runUnsolicitedReader(ctx, cancel, done, state, agentSession, session, sessions, sessionKey, workspaceDir) })
 }
 
 // runUnsolicitedReader is the goroutine body for the unsolicited event reader.
@@ -4434,6 +4445,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 				nextSend := make(chan error, 1)
 				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+							slog.Error("panic in agent Send (queued)", "error", r)
+							nextSend <- fmt.Errorf("panic in Send: %v", r)
+						}
+					}()
 					nextSend <- state.agentSession.Send(queuedPrompt, queued.images, queued.files)
 				}()
 				pendingSend = nextSend
@@ -4722,6 +4739,12 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 
 		sendDone := make(chan error, 1)
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("panic in agent Send (drain)", "error", r)
+					sendDone <- fmt.Errorf("panic in Send: %v", r)
+				}
+			}()
 			sendDone <- state.agentSession.Send(prompt, queued.images, queued.files)
 		}()
 
@@ -11775,7 +11798,7 @@ func (e *Engine) executeCustomCommand(p Platform, msg *Message, cmd *CustomComma
 	)
 
 	msg.Content = prompt
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey)
+	e.safeGo(func() { e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey) })
 }
 
 // executeShellCommand runs a shell command and sends the output to the user.
@@ -12003,7 +12026,7 @@ func (e *Engine) executeSkill(p Platform, msg *Message, skill *Skill, args []str
 	)
 
 	msg.Content = prompt
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey)
+	e.safeGo(func() { e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey) })
 }
 
 func (e *Engine) cmdSkills(p Platform, msg *Message) {

--- a/core/recover.go
+++ b/core/recover.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// safeGo launches fn in a new goroutine with panic recovery.
+// If fn panics, the panic value and stack trace are logged and written
+// to a crash log file under dataDir/crashes/ so operators can diagnose
+// unexpected restarts.
+func (e *Engine) safeGo(fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				const depth = 32
+				pcs := make([]uintptr, depth)
+				n := runtime.Callers(2, pcs)
+				pcs = pcs[:n]
+				frames := runtime.CallersFrames(pcs)
+
+				var stack string
+				for {
+					frame, more := frames.Next()
+					stack += fmt.Sprintf("  %s\n\t%s:%d\n", frame.Function, frame.File, frame.Line)
+					if !more {
+						break
+					}
+				}
+
+				slog.Error("panic recovered in goroutine",
+					"error", r, "stack", stack, "project", e.name)
+
+				e.writeCrashLog(r, stack)
+			}
+		}()
+		fn()
+	}()
+}
+
+// writeCrashLog appends a crash record to dataDir/crashes/crash.log.
+// Best-effort: failures are logged but never panic.
+func (e *Engine) writeCrashLog(r any, stack string) {
+	dir := filepath.Join(e.dataDir, "crashes")
+	_ = os.MkdirAll(dir, 0o755)
+
+	path := filepath.Join(dir, "crash.log")
+	entry := fmt.Sprintf("--- %s ---\npanic: %v\nproject: %s\nstack:\n%s\n\n",
+		time.Now().Format(time.RFC3339), r, e.name, stack)
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		slog.Error("crash log: open failed", "path", path, "error", err)
+		return
+	}
+	defer f.Close()
+	if _, err := fmt.Fprint(f, entry); err != nil {
+		slog.Error("crash log: write failed", "error", err)
+	}
+}

--- a/core/recover_test.go
+++ b/core/recover_test.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSafeGo_RecoversPanic(t *testing.T) {
+	tmpDir := t.TempDir()
+	e := &Engine{
+		name:    "test",
+		dataDir: tmpDir,
+	}
+
+	e.safeGo(func() {
+		panic("test panic")
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	crashLog := filepath.Join(tmpDir, "crashes", "crash.log")
+	data, err := os.ReadFile(crashLog)
+	if err != nil {
+		t.Fatalf("crash log not created: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("crash log is empty")
+	}
+}
+
+func TestSafeGo_NormalExecution(t *testing.T) {
+	tmpDir := t.TempDir()
+	e := &Engine{
+		name:    "test",
+		dataDir: tmpDir,
+	}
+
+	var executed atomic.Bool
+	e.safeGo(func() {
+		executed.Store(true)
+	})
+
+	time.Sleep(50 * time.Millisecond)
+	if !executed.Load() {
+		t.Error("safeGo function was not executed")
+	}
+
+	crashLog := filepath.Join(tmpDir, "crashes", "crash.log")
+	if _, err := os.Stat(crashLog); !os.IsNotExist(err) {
+		t.Error("crash log should not exist for normal execution")
+	}
+}


### PR DESCRIPTION
## Summary

A panic in any engine goroutine silently kills that goroutine. The main process stays alive (launchd/systemd only restart on process exit), so the bridge appears healthy but is non-functional — messages are accepted but never processed, and there is no way to diagnose the failure after the fact.

This PR adds two layers of protection:

- **`Engine.safeGo`**: goroutine launcher with `recover()` that logs panics (value + full stack trace) and writes crash records to `dataDir/crashes/crash.log` for post-restart diagnosis. Used to wrap the three most critical goroutine launches: `processInteractiveMessageWith`, `drainOrphanedQueue`, and `runUnsolicitedReader`.
- **Inline `recover()`**: added to `agentSession.Send` and `Close` goroutines to prevent silent goroutine death from leaving sessions in a stuck state.

## Test plan

- [x] `go build ./...` passes
- [x] `TestSafeGo_RecoversPanic` — panic is recovered, crash log is written
- [x] `TestSafeGo_NormalExecution` — no crash log for normal runs
- [ ] Manual: verify crash logs appear under `dataDir/crashes/` on panic
- [ ] Manual: verify the bridge gracefully handles panics in agent session Send/Close

🤖 Generated with [kscc](https://claude.com/claude-code)