### PR TITLE
codex: use workspace-write for app-server suggest mode

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -344,7 +344,7 @@ func appServerModeSettings(mode string) (approval string, sandbox string) {
 	case "yolo":
 		return "never", "danger-full-access"
 	default:
-		return "on-request", "read-only"
+		return "on-request", "workspace-write"
 	}
 }
 

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -25,6 +25,26 @@ func TestAppServerSession_ApplyThreadRuntimeState(t *testing.T) {
 	}
 }
 
+func TestAppServerModeSettingsSuggestUsesOnRequestWorkspaceWrite(t *testing.T) {
+	approval, sandbox := appServerModeSettings("suggest")
+	if approval != "on-request" {
+		t.Fatalf("approval = %q, want on-request", approval)
+	}
+	if sandbox != "workspace-write" {
+		t.Fatalf("sandbox = %q, want workspace-write", sandbox)
+	}
+}
+
+func TestAppServerThreadRequestParamsIncludesApprovalAndSandbox(t *testing.T) {
+	s := &appServerSession{mode: "suggest"}
+	params := s.threadRequestParams()
+	if got := params["approvalPolicy"]; got != "on-request" {
+		t.Fatalf("approvalPolicy = %#v, want on-request", got)
+	}
+	if got := params["sandbox"]; got != "workspace-write" {
+		t.Fatalf("sandbox = %#v, want workspace-write", got)
+	}
+}
 func TestAppServerSession_HandleRateLimitsUpdatedCachesUsage(t *testing.T) {
 	s := &appServerSession{}
 	raw, err := json.Marshal(appServerRateLimitsResponse{

--- a/docs/codex-appserver-onrequest.md
+++ b/docs/codex-appserver-onrequest.md
@@ -1,0 +1,31 @@
+# Codex app-server on-request install
+
+This branch changes Codex app-server `suggest` mode to start threads with:
+
+```toml
+approvalPolicy = "on-request"
+sandbox = "workspace-write"
+```
+
+## One-line install from a fork branch
+
+PowerShell:
+
+```powershell
+$repo='https://github.com/<your-user>/cc-connect.git'; $branch='codex-appserver-onrequest-workspace'; $dir="$env:TEMP\cc-connect-patched"; Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue; git clone --depth 1 --branch $branch $repo $dir; Push-Location $dir; go build -tags no_web -o cc-connect.exe ./cmd/cc-connect; New-Item -ItemType Directory -Force "$env:APPDATA\npm\node_modules\cc-connect\bin" | Out-Null; Copy-Item .\cc-connect.exe "$env:APPDATA\npm\node_modules\cc-connect\bin\cc-connect.exe" -Force; Pop-Location; cc-connect --version
+```
+
+Replace `<your-user>` with the fork owner.
+
+Recommended `config.toml` for Feishu/Codex approval cards:
+
+```toml
+[projects.agent.options]
+work_dir = "C:/Users/Administrator"
+mode = "suggest"
+backend = "app_server"
+app_server_url = "stdio"
+
+[projects.platforms.options]
+enable_feishu_card = true
+```


### PR DESCRIPTION
Summary:
- Change Codex app-server suggest mode to use approvalPolicy=on-request with sandbox=workspace-write.
- Add unit coverage for the mode mapping and thread request parameters.
- Add a short fork-branch install note for testing patched builds.

Testing:
- go test ./agent/codex -count=1