### PR TITLE
feat(feishu): add thread-only isolation mode

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -940,6 +940,9 @@ app_secret = "your-feishu-app-secret"
 #                                   # 设为 true 时，群聊内所有用户共享同一个 Agent 会话
 # thread_isolation = false  # If true, group messages use Feishu reply threads as session boundaries (one thread/root = one agent session)
 #                           # 设为 true 时，群聊按飞书话题/根消息隔离会话（一个 thread/root 对应一个 Agent 会话）
+# feishu_thread_isolation_mode = "reply_and_thread"  # reply_and_thread | thread_only; only used when thread_isolation=true
+#                                                    # reply_and_thread：每条顶层 @bot 消息成为独立任务线，后续同根普通回复/话题回复进入同一会话
+#                                                    # thread_only：普通 @bot/普通回复沿用群聊会话，只有飞书话题开独立子会话
 # reply_to_trigger = true   # Default: bot uses “reply to message” API (quotes the user’s message). Set false to post plain chat messages instead.
 #                           # 默认 true：用「回复消息」API（引用用户消息）。设为 false 则在会话里发普通消息、不引用触发消息。
 # progress_style = "legacy" # Progress rendering style: legacy | compact | card

--- a/core/engine.go
+++ b/core/engine.go
@@ -630,7 +630,6 @@ func (e *Engine) SetSkipGit(skipGit bool) {
 	e.skipGit = skipGit
 }
 
-
 // SetInjectSender controls whether sender identity (platform and user ID) is
 // prepended to each message before forwarding it to the agent. When enabled,
 // the agent receives a preamble line like:
@@ -3631,7 +3630,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			state.markStopped()
 			gracePeriod := 10 * time.Second
 			graceTimer := time.NewTimer(gracePeriod)
-			graceLoop:
+		graceLoop:
 			for {
 				select {
 				case evt, ok := <-state.agentSession.Events():
@@ -5765,15 +5764,8 @@ func compactReplyFooterPath(path string) string {
 		return ""
 	}
 	path = normalizeWorkspacePath(path)
-	if home, err := os.UserHomeDir(); err == nil {
-		home = normalizeWorkspacePath(home)
-		if path == home {
-			return "~"
-		}
-		prefix := home + string(os.PathSeparator)
-		if strings.HasPrefix(path, prefix) {
-			return "~" + filepath.ToSlash(strings.TrimPrefix(path, home))
-		}
+	if rel := compactHomeRelativeReplyFooterPath(path); rel != "" {
+		return rel
 	}
 
 	slash := filepath.ToSlash(path)
@@ -5793,6 +5785,44 @@ func compactReplyFooterPath(path string) string {
 		return "…/" + strings.Join(parts[start:], "/")
 	}
 	return slash
+}
+
+func compactHomeRelativeReplyFooterPath(path string) string {
+	for _, home := range []string{os.Getenv("HOME"), os.Getenv("USERPROFILE")} {
+		home = strings.TrimSpace(home)
+		if home == "" {
+			continue
+		}
+		if rel := compactPathUnderHome(path, home); rel != "" {
+			return rel
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return compactPathUnderHome(path, home)
+	}
+	return ""
+}
+
+func compactPathUnderHome(path, home string) string {
+	candidates := []string{filepath.Clean(home), normalizeWorkspacePath(home)}
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		if path == candidate {
+			return "~"
+		}
+		prefix := candidate + string(os.PathSeparator)
+		if strings.HasPrefix(path, prefix) {
+			return "~" + filepath.ToSlash(strings.TrimPrefix(path, candidate))
+		}
+	}
+	return ""
 }
 
 func appendReplyFooter(content, footer string) string {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -5890,9 +5890,9 @@ func (s *controllableAgentSession) Close() error {
 
 // controllableAgent lets tests control which session is returned by StartSession.
 type controllableAgent struct {
-	nextSession     AgentSession
-	listFn          func() ([]AgentSessionInfo, error)
-	startSessionFn  func(ctx context.Context, sessionID string) (AgentSession, error)
+	nextSession    AgentSession
+	listFn         func() ([]AgentSessionInfo, error)
+	startSessionFn func(ctx context.Context, sessionID string) (AgentSession, error)
 }
 
 func (a *controllableAgent) Name() string { return "controllable" }
@@ -8779,8 +8779,8 @@ func TestResolveLocalDirPath_AcceptsSubdir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got != sub {
-		t.Fatalf("expected %q, got %q", sub, got)
+	if normalizeWorkspacePath(got) != normalizeWorkspacePath(sub) {
+		t.Fatalf("expected %q, got %q", normalizeWorkspacePath(sub), normalizeWorkspacePath(got))
 	}
 }
 

--- a/daemon/launchd_test.go
+++ b/daemon/launchd_test.go
@@ -70,6 +70,20 @@ func TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable(t *testing.T) {
 	orig := runLaunchctl
 	t.Cleanup(func() { runLaunchctl = orig })
 
+	dir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", dir)
+	if origHome != "" {
+		t.Cleanup(func() { _ = os.Setenv("HOME", origHome) })
+	}
+	plistPath := launchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("plist"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
 	guiDomain := launchdGUIDomain()
 	userDomain := launchdUserDomain()
 	guiTarget := launchdTarget(guiDomain)
@@ -279,8 +293,8 @@ func containsCall(calls []string, want string) bool {
 }
 
 // TestBuildPlist_EscapesXMLSpecialCharsInPaths pins the bug where unescaped
-// '&', '<', '>', '"', and '\'' in cfg paths produced malformed XML that
-// `launchctl bootstrap` rejected.
+// ampersands, angle brackets, quotes, and apostrophes in cfg paths produced
+// malformed XML that `launchctl bootstrap` rejected.
 func TestBuildPlist_EscapesXMLSpecialCharsInPaths(t *testing.T) {
 	cfg := Config{
 		BinaryPath: "/opt/cc-connect/bin & <tools>/cc-connect",

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -110,12 +110,13 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # domain = "https://open.feishu.cn" # 可选：覆盖运行时 API/WebSocket 域名
 # enable_feishu_card = true  # 可选：关闭后统一回退纯文本回复
 # thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
+# feishu_thread_isolation_mode = "reply_and_thread" # 可选：reply_and_thread | thread_only
 # progress_style = "legacy"  # 可选：legacy | compact | card
 # done_emoji = "none"          # 可选：agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 ```
 
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
-> 如果开启 `thread_isolation = true`，群聊里每个根消息 / reply thread 会对应一个独立 agent session；私聊行为保持原样。
+> 如果开启 `thread_isolation = true`，私聊行为保持原样，群聊行为由 `feishu_thread_isolation_mode` 决定。默认 `"reply_and_thread"` 保持历史行为：每条顶层 `@bot` 消息会成为一条独立任务线，bot 的回复会尽量发在飞书话题里，后续围绕同一根消息的普通 Reply / 话题回复继续进入同一个 agent session。如果设为 `"thread_only"`，普通 `@bot` 和普通 Reply 不会拆出新 session，只有用户显式进入飞书 Reply in Thread / 话题、事件带 `ThreadId` 时才会开启独立子会话；普通 Reply 仍会作为引用上下文注入。
 > `progress_style = "compact"` 会把思考/工具进度合并到一条可更新消息里，减少刷屏；`legacy` 保持原有逐条发送；`card` 会使用结构化卡片（标题 + 进度块）持续更新同一条消息，观感比纯文本更清晰。
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
 > `done_emoji` 设置后，agent 每次完成回复时会在用户消息上添加指定表情（如 `"Done"` → ✅）。先移除 "OnIt" 表情（如果有），再添加 done 表情。在 quiet 模式下特别有用，因为飞书卡片原地更新不触发推送，done 表情可以通知用户 agent 已完成。设为 `"none"` 或不配置则禁用。

--- a/docs/plans/2026-05-31-feishu-thread-isolation-context.md
+++ b/docs/plans/2026-05-31-feishu-thread-isolation-context.md
@@ -1,0 +1,291 @@
+# 飞书 Reply in Thread 会话隔离与上下文设计
+
+**日期：** 2026-05-31
+**状态：** 第一阶段已实现
+
+## 目标
+
+让飞书群聊里的普通 Reply 和显式 Reply in Thread 有清楚区分。
+
+普通 Reply 应该继续作为“引用上下文”处理，不应该自动开新 agent session。Reply in Thread 是用户显式打开的子会话，更适合作为独立 agent session 边界。
+
+这个设计需要满足几件事：
+
+- 默认行为不破坏已有用户。
+- 不引入跨 adapter 的抽象误导。
+- 用户扫码接入 Feishu Bot 后，不应该再被要求去开放平台手动申请额外权限，至少第一阶段不能依赖这种额外步骤。
+
+## 当前行为
+
+当前飞书实现里混在一起的是两件事：
+
+- `thread_isolation = true` 时，群聊 session key 来自 `RootId`，没有 `RootId` 时回退到当前 `MessageId`。
+- 普通 Reply 的上下文注入通过 `ParentId` 追溯引用链，然后把格式化结果放进 `core.Message.ExtraContent`。
+
+也就是说，当前飞书的 `thread_isolation` 实际更像“按回复链隔离”：
+
+- 普通群消息没有 `RootId`：按当前 `MessageId` 隔离。
+- 普通 Reply 有 `RootId`：按回复根消息隔离。
+- Reply in Thread 也会被隔离，但它不是因为被识别成飞书原生 thread，而是走了同一套 `RootId` 逻辑。
+
+代码现在已经会打印这些字段：
+
+- `root_id`
+- `parent_id`
+- `thread_id`
+
+关键缺口是：`ThreadId` 才代表飞书原生话题 / thread 身份。`RootId` 和 `ParentId` 只能说明回复链关系，不能说明用户显式打开了一个 thread。
+
+## 配置设计
+
+保留现有总开关：
+
+```toml
+thread_isolation = true
+```
+
+新增飞书专属策略配置：
+
+```toml
+feishu_thread_isolation_mode = "reply_and_thread"
+```
+
+可选值：
+
+- `reply_and_thread`
+- `thread_only`
+
+默认值：
+
+```toml
+feishu_thread_isolation_mode = "reply_and_thread"
+```
+
+默认值保持当前行为，减少上游兼容风险。
+
+### 为什么是飞书专属配置
+
+这个配置不应该做成所有 adapter 共用。
+
+不同平台对 reply、thread、topic、channel 的语义不一样：
+
+- 飞书有普通 Reply，也有原生 Reply in Thread。
+- Discord 的 thread 是真实 thread channel。
+- Telegram 的 Forum Topic 是原生 topic，但普通群 Reply 不应该拆 session。
+- Slack 的 reply 本身就通过 `thread_ts` 表达 thread-like 关系，而且当前 Slack adapter 没有暴露 `thread_isolation`。
+
+所以这里使用 adapter 自己的配置更清楚：
+
+```toml
+feishu_thread_isolation_mode = "thread_only"
+```
+
+如果以后 Discord 也需要类似策略，再由 Discord 自己定义，例如 `discord_thread_isolation_mode`。不要让一个看似通用的配置承载不同平台的不同含义。
+
+## Session Key 行为
+
+### `reply_and_thread`
+
+这是兼容当前实现的模式。
+
+当 `thread_isolation = true`，并且入站消息来自飞书群聊：
+
+1. 如果有 `RootId`，使用 `RootId`。
+2. 如果没有 `RootId`，使用当前 `MessageId`。
+3. session key 继续使用现有 `root` 命名空间。
+
+示例：
+
+```text
+feishu:<chatID>:root:<rootOrMessageID>
+```
+
+### `thread_only`
+
+只有飞书原生 thread / 话题消息才创建独立 agent session。
+
+当 `thread_isolation = true`，`feishu_thread_isolation_mode = "thread_only"`，且入站群消息有非空 `ThreadId`：
+
+```text
+feishu:<chatID>:thread:<threadID>
+```
+
+当 `ThreadId` 为空时，不创建 thread session，回退到普通非 thread session：
+
+- `share_session_in_channel = true`：`feishu:<chatID>`
+- 否则：`feishu:<chatID>:<userID>`
+
+因此在 `thread_only` 模式下，普通 Reply 不会开新 session，只作为引用上下文处理。
+
+## 回复路由
+
+实时收到用户消息时，adapter 手里有当前消息的 `message_id`，所以可以继续用飞书 Reply API 回复。
+
+如果 session key 被识别为 thread session，并且当前 `replyContext` 里有 message ID，就设置：
+
+```go
+ReplyInThread(true)
+```
+
+需要注意：
+
+`ThreadId` 不是 `MessageId`。只存 `thread:<threadID>` 对实时消息处理够用，因为当前入站消息的 message ID 在 `replyContext` 里。但对 cron、延迟发送、重建 reply context 这类离线路径可能不够。
+
+第一阶段不承诺 Feishu thread-only session 的 cron 能可靠回复回原 thread，除非后续额外持久化一个可用的 message ID。
+
+## 上下文注入
+
+第一阶段不要新增一个很大的 `feishu_context_mode` 枚举。
+
+像 `reply_chain`、`recent_chat`、`recent_thread`、`auto` 这类值，对实现者精确，但对用户不够像人话。尤其 `recent_thread` 很容易被理解成“最近的 thread 列表”，而不是“当前 thread 里的最近消息”。
+
+### 保留现有 Reply 引用上下文
+
+继续保留当前普通 Reply 行为：
+
+- 如果入站消息有 `ParentId`，拉取被回复消息 / 回复链。
+- 把格式化后的内容放进 `ExtraContent`。
+- core 在发送给 agent 前，把 `ExtraContent` 拼到用户正文前面。
+
+这个行为在 `feishu_thread_isolation_mode = "thread_only"` 下也应该继续生效。也就是说，普通 Reply 不拆 session，但仍然给 agent 看被引用的内容。
+
+### 后续可选：最近消息上下文
+
+如果后续要做最近消息上下文，不使用复杂枚举，而是使用更直白的布尔开关：
+
+```toml
+feishu_include_recent_messages = false
+feishu_recent_messages_limit = 10
+feishu_recent_messages_max_chars = 4000
+```
+
+含义：
+
+> 当 bot 处理飞书消息时，把最近几条飞书消息作为补充上下文给 agent。
+
+用户不需要理解 chat/thread 容器差异，adapter 自己判断：
+
+- 如果入站消息有 `ThreadId`，拉当前飞书 thread 里的最近消息。
+- 否则，如果是群聊消息，拉当前群聊里的最近消息。
+- 如果拉取失败，不阻断当前消息处理，只记录日志并降级为只处理当前消息。
+
+这个能力不应该依赖 `thread_isolation`。普通群聊里 @bot 时，即使没有开启 thread session 隔离，也可能需要最近群消息作为上下文。
+
+最近消息上下文是第二阶段功能。第一阶段先把 session 边界做准。
+
+## 权限与工具调用
+
+从目前扫码创建 Bot 的权限截图看，飞书 QR onboarding 似乎会授予比较完整的机器人权限，包括读取单聊和群聊消息。实现上仍然要把历史消息读取当成 best-effort：
+
+- 不因为最近消息权限不可用而启动失败。
+- 不因为历史消息 API 返回权限或可见性错误而阻断当前消息。
+- 日志里记录足够排查的信息。
+
+第一阶段不依赖 agent 自己调用飞书工具。cc-connect 已经持有 Feishu app 凭证，adapter 可以直接调用飞书 API。
+
+后续可以考虑“提示 agent 自己查飞书上下文”，但那需要另外确认：
+
+- 本机是否安装了对应 CLI。
+- CLI 是否已经以正确身份鉴权。
+- agent 是否能知道 chat/thread ID。
+- 当前 agent permission mode 是否允许这种工具调用。
+
+因此第一阶段不做 agent 侧工具提示。
+
+## 实现计划
+
+### 第一阶段：飞书 Thread 隔离模式
+
+1. 在 `platform/feishu.Platform` 增加 `feishuThreadIsolationMode string`。
+2. 在 `newPlatform` 里读取 `opts["feishu_thread_isolation_mode"]`。
+3. 空值默认成 `reply_and_thread`。
+4. 非法值直接返回清晰错误。
+5. 修改 `makeSessionKey`：
+   - `reply_and_thread`：保持当前 `RootId` 行为。
+   - `thread_only`：只使用 `ThreadId`；没有 `ThreadId` 时回退普通 session key。
+6. 确保 thread session helper 能识别 `thread:` 命名空间。
+7. 确保 `thread_only` 下普通 Reply 回退到非 thread session 后，仍会注入引用上下文。
+8. 更新 `config.example.toml`。
+9. 更新 `docs/feishu.md`。
+
+### 第二阶段：可选最近消息上下文
+
+第一阶段验证后再做。
+
+1. 增加 `feishu_include_recent_messages`。
+2. 增加消息条数和字符数限制。
+3. 实现 Feishu 最近消息拉取逻辑。
+4. 把最近消息格式化成“不可信外部聊天上下文”。
+5. 排除当前触发消息，避免重复。
+6. 对权限、可见性、API 错误做优雅降级。
+
+## 测试矩阵
+
+### 配置解析
+
+- 空 `feishu_thread_isolation_mode` 默认是 `reply_and_thread`。
+- `reply_and_thread` 合法。
+- `thread_only` 合法。
+- 未知值返回错误。
+
+### Session Key 派生
+
+`thread_isolation = true` 且 `reply_and_thread`：
+
+- 群聊根消息使用 `root:<messageID>`。
+- 普通 Reply 使用 `root:<rootID>`。
+- Reply in Thread 即使同时有 `RootId` 和 `ThreadId`，仍使用 `root:<rootID>`，保持兼容。
+
+`thread_isolation = true` 且 `thread_only`：
+
+- Reply in Thread 使用 `thread:<threadID>`。
+- 普通 Reply 有 `ParentId` / `RootId` 但没有 `ThreadId` 时，回退普通 session key。
+- 普通群消息没有 `ThreadId` 时，回退普通 session key。
+- `share_session_in_channel = true` 时，回退为 `feishu:<chatID>`。
+
+`thread_isolation = false`：
+
+- `feishu_thread_isolation_mode` 不产生影响。
+
+### 回复路由
+
+- thread session 回复会设置 `ReplyInThread(true)`。
+- 普通 fallback session 回复不会设置 `ReplyInThread(true)`。
+
+### 引用上下文注入
+
+- `thread_only` 模式下，普通 Reply 仍然拉取并注入引用上下文。
+- Reply in Thread 默认不走普通 Reply quote chain，除非后续设计明确改变。
+
+### Active Thread 附件跟进
+
+- `thread:<threadID>` session 可以被标记为 active。
+- 已 active 的飞书 thread 内，附件类消息可以沿用现有免再次 @bot 逻辑。
+- 非 thread session 不会被标记为 active。
+
+## 需要确认的问题
+
+1. 实际飞书事件字段样本：
+   - 普通群消息
+   - 普通 Reply
+   - Reply in Thread
+
+   当前设计假设 Reply in Thread 会稳定带非空 `ThreadId`。
+
+2. 是否需要在 Feishu thread session key 里额外持久化 message ID。
+
+   实时回复可以依赖当前入站消息 ID，但 cron / 延迟发送可能需要真实可用的 Feishu message ID。
+
+3. 第二阶段最近消息上下文要走 Feishu API 还是本地滚动缓存。
+
+   API 方案更简单，也避免长期存储无关群消息；但依赖飞书历史消息可见性。
+
+4. 需要实验：扫码创建出来的 Bot，在截图权限集下，是否能用 `container_id_type=thread` 读取 thread 内消息。
+
+## 非目标
+
+- 不改 core session 管理。
+- 不新增跨 adapter 的 thread isolation mode。
+- 不改变 Discord、Slack、Telegram 行为。
+- 第一阶段不要求用户手动去飞书开放平台申请额外权限。
+- 第一阶段不加入 agent 侧飞书 CLI / 工具调用提示。

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -111,6 +111,29 @@ type replyContext struct {
 	sessionKey string
 }
 
+const (
+	feishuThreadIsolationReplyAndThread = "reply_and_thread"
+	feishuThreadIsolationThreadOnly     = "thread_only"
+)
+
+func normalizeFeishuThreadIsolationMode(name string, raw any) (string, error) {
+	if raw == nil {
+		return feishuThreadIsolationReplyAndThread, nil
+	}
+	mode, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("%s: invalid feishu_thread_isolation_mode %v (want reply_and_thread or thread_only)", name, raw)
+	}
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", feishuThreadIsolationReplyAndThread:
+		return feishuThreadIsolationReplyAndThread, nil
+	case feishuThreadIsolationThreadOnly:
+		return feishuThreadIsolationThreadOnly, nil
+	default:
+		return "", fmt.Errorf("%s: invalid feishu_thread_isolation_mode %q (want reply_and_thread or thread_only)", name, mode)
+	}
+}
+
 type Platform struct {
 	mu                         sync.RWMutex
 	platformName               string
@@ -129,6 +152,7 @@ type Platform struct {
 	respondToAtEveryoneAndHere bool
 	shareSessionInChannel      bool
 	threadIsolation            bool
+	feishuThreadIsolationMode  string
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
 	noReplyToTrigger bool
 	resolveMentions  bool
@@ -221,6 +245,10 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
+	feishuThreadIsolationMode, err := normalizeFeishuThreadIsolationMode(name, opts["feishu_thread_isolation_mode"])
+	if err != nil {
+		return nil, err
+	}
 	resolveMentionsOpt, _ := opts["resolve_mentions"].(bool)
 	noReplyToTrigger := false
 	if v, ok := opts["reply_to_trigger"].(bool); ok && !v {
@@ -284,6 +312,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
 		shareSessionInChannel:      shareSessionInChannel,
 		threadIsolation:            threadIsolation,
+		feishuThreadIsolationMode:  feishuThreadIsolationMode,
 		resolveMentions:            resolveMentionsOpt,
 		noReplyToTrigger:           noReplyToTrigger,
 		client:                     lark.NewClient(appID, appSecret, clientOpts...),
@@ -1047,6 +1076,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 		"mentions", mentionCount,
 		"group_reply_all", p.groupReplyAll,
 		"thread_isolation", p.threadIsolation,
+		"feishu_thread_isolation_mode", p.feishuThreadIsolationMode,
 	)
 
 	// Pre-compute sessionKey so the @bot filter below can consult the active
@@ -1108,6 +1138,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 		"reply_in_thread", p.shouldReplyInThread(rctx),
 	)
 
+	threadSessionAlreadyActive := p.isActiveThreadSession(sessionKey)
 	// Mark this thread as bot-engaged so subsequent attachment-only messages
 	// in the same thread can pass through without re-mentioning the bot.
 	p.markThreadSessionActive(sessionKey)
@@ -1116,7 +1147,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	// blocked by IO-heavy operations (image/audio download, handler HTTP calls).
 	// The dedup and old-message checks above remain synchronous to guarantee
 	// correctness before spawning the goroutine.
-	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID)
+	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID, threadSessionAlreadyActive)
 
 	return nil
 }
@@ -1124,7 +1155,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 // dispatchMessage handles the message content parsing, media download, and
 // handler invocation. It runs in its own goroutine so that onMessage returns
 // quickly and does not block the SDK event loop.
-func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, chatID string, rctx replyContext, parentID string) {
+func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, chatID string, rctx replyContext, parentID string, threadSessionAlreadyActive bool) {
 	if p.isMessageRecalled(messageID) {
 		slog.Debug(p.tag()+": recalled message ignored in async dispatch", "message_id", messageID)
 		return
@@ -1139,12 +1170,21 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 
 	// If this message is a reply to another message, fetch the quoted content
 	// and prepend it so the agent has full context.
-	// Skip quote injection when thread_isolation is enabled and the message is
-	// inside a thread — the thread already provides conversational context, and
-	// long quoted prefixes can drown out the user's actual text (issue #764).
+	// In thread sessions, avoid repeatedly prepending quoted history; the thread
+	// already carries conversational context. The exception is the first native
+	// Feishu thread message in thread_only mode, where the parent/root message is
+	// the user's chosen starting context for the new child session.
 	var quoted quotedMessage
-	if parentID != "" && !(p.threadIsolation && isThreadSessionKey(sessionKey)) {
+	if p.shouldFetchQuotedMessage(parentID, sessionKey, threadSessionAlreadyActive) {
 		quoted = p.fetchQuotedMessage(ctx, parentID)
+		if quoted.text != "" || len(quoted.images) > 0 {
+			slog.Debug(p.tag()+": injected quoted message context",
+				"parent_id", parentID,
+				"session_key", sessionKey,
+				"quoted_text_len", len(quoted.text),
+				"quoted_images", len(quoted.images),
+			)
+		}
 	}
 
 	switch msgType {
@@ -1971,7 +2011,9 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 			if label == "" {
 				// label may be in property.text.property.content
 				var textElem struct {
-					Property struct{ Content string `json:"content"` } `json:"property"`
+					Property struct {
+						Content string `json:"content"`
+					} `json:"property"`
 				}
 				if json.Unmarshal(elem.Property.Text, &textElem) == nil {
 					label = textElem.Property.Content
@@ -2906,6 +2948,18 @@ func (p *Platform) isActiveThreadSession(sessionKey string) bool {
 	return ok
 }
 
+func (p *Platform) shouldFetchQuotedMessage(parentID, sessionKey string, threadSessionAlreadyActive bool) bool {
+	if parentID == "" {
+		return false
+	}
+	if !p.threadIsolation || !isThreadSessionKey(sessionKey) {
+		return true
+	}
+	return p.feishuThreadIsolationMode == feishuThreadIsolationThreadOnly &&
+		isNativeThreadSessionKey(sessionKey) &&
+		!threadSessionAlreadyActive
+}
+
 // stripMentions processes @mention placeholders (e.g. @_user_1) in text.
 // The bot's own mention is removed; other user mentions are replaced with
 // their display name so the agent can see who was referenced.
@@ -2932,12 +2986,19 @@ func stripMentions(text string, mentions []*larkim.MentionEvent, botOpenID strin
 // Should revisit thread/root handling without changing thread_isolation=false behavior.
 func (p *Platform) makeSessionKey(msg *larkim.EventMessage, chatID, userID string) string {
 	if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
-		rootID := stringValue(msg.RootId)
-		if rootID == "" {
-			rootID = stringValue(msg.MessageId)
-		}
-		if rootID != "" {
-			return fmt.Sprintf("%s:%s:root:%s", p.tag(), chatID, rootID)
+		if p.feishuThreadIsolationMode == feishuThreadIsolationThreadOnly {
+			threadID := stringValue(msg.ThreadId)
+			if threadID != "" {
+				return fmt.Sprintf("%s:%s:thread:%s", p.tag(), chatID, threadID)
+			}
+		} else {
+			rootID := stringValue(msg.RootId)
+			if rootID == "" {
+				rootID = stringValue(msg.MessageId)
+			}
+			if rootID != "" {
+				return fmt.Sprintf("%s:%s:root:%s", p.tag(), chatID, rootID)
+			}
 		}
 	}
 	if p.shareSessionInChannel {
@@ -3219,6 +3280,15 @@ func isThreadSessionKey(sessionKey string) bool {
 	}
 	_, ok := parseThreadRootID(parts[2])
 	return ok
+}
+
+func isNativeThreadSessionKey(sessionKey string) bool {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) != 3 {
+		return false
+	}
+	threadID := strings.TrimPrefix(parts[2], "thread:")
+	return threadID != "" && threadID != parts[2]
 }
 
 // feishuPreviewHandle stores the message ID for an editable preview message.

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -79,6 +79,7 @@ func TestDispatchMessageDropsRecalledMessageBeforeHandler(t *testing.T) {
 		"",
 		replyContext{messageID: "om_drop", sessionKey: "feishu:ou_user:ou_user"},
 		"",
+		false,
 	)
 
 	if called {
@@ -184,6 +185,7 @@ func TestDispatchMessageIncludesQuotedImage(t *testing.T) {
 				"",
 				replyContext{messageID: "om_child", sessionKey: "feishu:oc_chat:ou_user"},
 				parentMessageID,
+				false,
 			)
 
 			select {
@@ -257,11 +259,13 @@ func TestDispatchMessageKeepsMentionOnlyQuotedText(t *testing.T) {
 	defer srv.Close()
 
 	p := &Platform{
-		platformName: "feishu",
-		domain:       srv.URL,
-		appID:        appID,
-		appSecret:    appSecret,
-		botOpenID:    "ou_bot",
+		platformName:              "feishu",
+		domain:                    srv.URL,
+		appID:                     appID,
+		appSecret:                 appSecret,
+		botOpenID:                 "ou_bot",
+		threadIsolation:           true,
+		feishuThreadIsolationMode: feishuThreadIsolationThreadOnly,
 		client: lark.NewClient(appID, appSecret,
 			lark.WithOpenBaseUrl(srv.URL),
 			lark.WithHttpClient(srv.Client()),
@@ -284,6 +288,7 @@ func TestDispatchMessageKeepsMentionOnlyQuotedText(t *testing.T) {
 		"oc_chat",
 		replyContext{messageID: "om_child", sessionKey: "feishu:oc_chat:ou_user"},
 		parentMessageID,
+		false,
 	)
 
 	select {
@@ -296,6 +301,178 @@ func TestDispatchMessageKeepsMentionOnlyQuotedText(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for mention-only quoted text message")
+	}
+}
+
+func TestDispatchMessageThreadOnlyFirstNativeThreadMessageInjectsQuote(t *testing.T) {
+	const appID = "cli_thread_quote"
+	const appSecret = "secret-thread-quote"
+	const parentMessageID = "om_thread_root"
+	const sessionKey = "feishu:oc_chat:thread:omt_thread"
+
+	got := make(chan *core.Message, 1)
+	parentFetches := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case "/open-apis/im/v1/messages/" + parentMessageID:
+			parentFetches++
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"items": []map[string]any{
+						{
+							"msg_type":  "text",
+							"parent_id": "",
+							"sender": map[string]any{
+								"id":          "cli_parent",
+								"sender_type": "app",
+							},
+							"body": map[string]any{
+								"content": `{"text":"@codex 测试 秦始皇多久出生的"}`,
+							},
+						},
+					},
+				},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:              "feishu",
+		domain:                    srv.URL,
+		appID:                     appID,
+		appSecret:                 appSecret,
+		botOpenID:                 "ou_bot",
+		threadIsolation:           true,
+		feishuThreadIsolationMode: feishuThreadIsolationThreadOnly,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			got <- msg
+		},
+	}
+
+	p.dispatchMessage(
+		context.Background(),
+		"text",
+		`{"text":"@bot 谢谢，我们之前都聊了啥"}`,
+		[]*larkim.MentionEvent{
+			{Key: strPtr("@bot"), Id: &larkim.UserId{OpenId: strPtr("ou_bot")}, Name: strPtr("Bot")},
+		},
+		"om_child",
+		sessionKey,
+		"",
+		"",
+		replyContext{messageID: "om_child", sessionKey: sessionKey},
+		parentMessageID,
+		false,
+	)
+
+	select {
+	case msg := <-got:
+		if msg.Content != "谢谢，我们之前都聊了啥" {
+			t.Fatalf("Content = %q, want stripped thread message", msg.Content)
+		}
+		if !strings.Contains(msg.ExtraContent, "秦始皇多久出生的") {
+			t.Fatalf("ExtraContent = %q, want thread root quote", msg.ExtraContent)
+		}
+		if parentFetches != 1 {
+			t.Fatalf("parent fetches = %d, want 1", parentFetches)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first native thread message")
+	}
+}
+
+func TestDispatchMessageThreadOnlyActiveNativeThreadSkipsRepeatedQuote(t *testing.T) {
+	const appID = "cli_thread_no_repeat"
+	const appSecret = "secret-thread-no-repeat"
+	const parentMessageID = "om_thread_root"
+	const sessionKey = "feishu:oc_chat:thread:omt_thread"
+
+	got := make(chan *core.Message, 1)
+	parentFetches := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case "/open-apis/im/v1/messages/" + parentMessageID:
+			parentFetches++
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success", "data": map[string]any{"items": []map[string]any{}}})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:              "feishu",
+		domain:                    srv.URL,
+		appID:                     appID,
+		appSecret:                 appSecret,
+		botOpenID:                 "ou_bot",
+		threadIsolation:           true,
+		feishuThreadIsolationMode: feishuThreadIsolationThreadOnly,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			got <- msg
+		},
+	}
+
+	p.dispatchMessage(
+		context.Background(),
+		"text",
+		`{"text":"@bot 继续"}`,
+		[]*larkim.MentionEvent{
+			{Key: strPtr("@bot"), Id: &larkim.UserId{OpenId: strPtr("ou_bot")}, Name: strPtr("Bot")},
+		},
+		"om_child",
+		sessionKey,
+		"",
+		"",
+		replyContext{messageID: "om_child", sessionKey: sessionKey},
+		parentMessageID,
+		true,
+	)
+
+	select {
+	case msg := <-got:
+		if msg.Content != "继续" {
+			t.Fatalf("Content = %q, want stripped follow-up text", msg.Content)
+		}
+		if msg.ExtraContent != "" {
+			t.Fatalf("ExtraContent = %q, want no repeated quote", msg.ExtraContent)
+		}
+		if parentFetches != 0 {
+			t.Fatalf("parent fetches = %d, want 0", parentFetches)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for active native thread message")
 	}
 }
 
@@ -933,13 +1110,14 @@ func TestIsAttachmentMsgType(t *testing.T) {
 }
 
 func TestMarkAndIsActiveThreadSession(t *testing.T) {
-	const threadKey = "feishu:oc_chat:root:om_root"
+	const rootThreadKey = "feishu:oc_chat:root:om_root"
+	const nativeThreadKey = "feishu:oc_chat:thread:omt_thread"
 	const directKey = "feishu:oc_chat:ou_user"
 
 	t.Run("thread isolation disabled is no-op", func(t *testing.T) {
 		p := &Platform{threadIsolation: false}
-		p.markThreadSessionActive(threadKey)
-		if p.isActiveThreadSession(threadKey) {
+		p.markThreadSessionActive(rootThreadKey)
+		if p.isActiveThreadSession(rootThreadKey) {
 			t.Fatal("expected no-op when thread_isolation is off")
 		}
 	})
@@ -954,12 +1132,23 @@ func TestMarkAndIsActiveThreadSession(t *testing.T) {
 
 	t.Run("thread sessionKey is recorded", func(t *testing.T) {
 		p := &Platform{threadIsolation: true}
-		if p.isActiveThreadSession(threadKey) {
+		if p.isActiveThreadSession(rootThreadKey) {
 			t.Fatal("thread should not be active before mark")
 		}
-		p.markThreadSessionActive(threadKey)
-		if !p.isActiveThreadSession(threadKey) {
+		p.markThreadSessionActive(rootThreadKey)
+		if !p.isActiveThreadSession(rootThreadKey) {
 			t.Fatal("thread should be active after mark")
+		}
+	})
+
+	t.Run("native thread sessionKey is recorded", func(t *testing.T) {
+		p := &Platform{threadIsolation: true}
+		if p.isActiveThreadSession(nativeThreadKey) {
+			t.Fatal("native thread should not be active before mark")
+		}
+		p.markThreadSessionActive(nativeThreadKey)
+		if !p.isActiveThreadSession(nativeThreadKey) {
+			t.Fatal("native thread should be active after mark")
 		}
 	})
 }

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -568,6 +568,72 @@ func TestNewFeishu_InvalidCustomDomain(t *testing.T) {
 	}
 }
 
+func TestNewFeishu_ThreadIsolationMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		options map[string]any
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "default keeps reply and thread behavior",
+			options: map[string]any{},
+			want:    feishuThreadIsolationReplyAndThread,
+		},
+		{
+			name: "explicit reply and thread",
+			options: map[string]any{
+				"feishu_thread_isolation_mode": "reply_and_thread",
+			},
+			want: feishuThreadIsolationReplyAndThread,
+		},
+		{
+			name: "explicit thread only",
+			options: map[string]any{
+				"feishu_thread_isolation_mode": "thread_only",
+			},
+			want: feishuThreadIsolationThreadOnly,
+		},
+		{
+			name: "invalid mode",
+			options: map[string]any{
+				"feishu_thread_isolation_mode": "root",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid non-string mode",
+			options: map[string]any{
+				"feishu_thread_isolation_mode": true,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": false}
+			for k, v := range tt.options {
+				opts[k] = v
+			}
+			p, err := New(opts)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			base := p.(*Platform)
+			if base.feishuThreadIsolationMode != tt.want {
+				t.Fatalf("feishuThreadIsolationMode = %q, want %q", base.feishuThreadIsolationMode, tt.want)
+			}
+		})
+	}
+}
+
 func TestLark_SessionKeyPrefix(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
@@ -747,6 +813,114 @@ func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t
 	}
 }
 
+func TestFeishuMakeSessionKey_ThreadIsolationMode(t *testing.T) {
+	chatType := "group"
+	messageID := "om_message"
+	rootID := "om_root"
+	parentID := "om_parent"
+	threadID := "omt_thread"
+	msg := &larkim.EventMessage{
+		MessageId: &messageID,
+		RootId:    &rootID,
+		ParentId:  &parentID,
+		ThreadId:  &threadID,
+		ChatType:  &chatType,
+	}
+	replyMsgWithoutThread := &larkim.EventMessage{
+		MessageId: &messageID,
+		RootId:    &rootID,
+		ParentId:  &parentID,
+		ChatType:  &chatType,
+	}
+	rootMsgWithoutRootID := &larkim.EventMessage{
+		MessageId: &messageID,
+		ChatType:  &chatType,
+	}
+
+	tests := []struct {
+		name string
+		p    *Platform
+		msg  *larkim.EventMessage
+		want string
+	}{
+		{
+			name: "empty mode preserves reply and thread behavior",
+			p:    &Platform{platformName: "feishu", threadIsolation: true},
+			msg:  msg,
+			want: "feishu:oc_chat:root:om_root",
+		},
+		{
+			name: "reply and thread mode prefers root id even when thread id exists",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           true,
+				feishuThreadIsolationMode: feishuThreadIsolationReplyAndThread,
+			},
+			msg:  msg,
+			want: "feishu:oc_chat:root:om_root",
+		},
+		{
+			name: "reply and thread mode falls back to message id",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           true,
+				feishuThreadIsolationMode: feishuThreadIsolationReplyAndThread,
+			},
+			msg:  rootMsgWithoutRootID,
+			want: "feishu:oc_chat:root:om_message",
+		},
+		{
+			name: "thread only mode uses native thread id",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           true,
+				feishuThreadIsolationMode: feishuThreadIsolationThreadOnly,
+			},
+			msg:  msg,
+			want: "feishu:oc_chat:thread:omt_thread",
+		},
+		{
+			name: "thread only mode keeps normal reply in user session",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           true,
+				feishuThreadIsolationMode: feishuThreadIsolationThreadOnly,
+			},
+			msg:  replyMsgWithoutThread,
+			want: "feishu:oc_chat:ou_user",
+		},
+		{
+			name: "thread only mode falls back to shared channel session",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           true,
+				feishuThreadIsolationMode: feishuThreadIsolationThreadOnly,
+				shareSessionInChannel:     true,
+			},
+			msg:  replyMsgWithoutThread,
+			want: "feishu:oc_chat",
+		},
+		{
+			name: "thread isolation disabled ignores mode",
+			p: &Platform{
+				platformName:              "feishu",
+				feishuThreadIsolationMode: feishuThreadIsolationThreadOnly,
+			},
+			msg:  msg,
+			want: "feishu:oc_chat:ou_user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.p.makeSessionKey(tt.msg, "oc_chat", "ou_user")
+			if got != tt.want {
+				t.Fatalf("makeSessionKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -758,6 +932,12 @@ func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 			name:          "thread isolation enabled",
 			platform:      &Platform{threadIsolation: true},
 			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:om_root"},
+			wantThreading: true,
+		},
+		{
+			name:          "thread id session is threaded",
+			platform:      &Platform{threadIsolation: true},
+			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:thread:omt_thread"},
 			wantThreading: true,
 		},
 		{


### PR DESCRIPTION
## Summary

Refs #1079  
Context: https://github.com/chenhg5/cc-connect/issues/1079#issuecomment-4585368630

This PR adds a Feishu-specific session isolation mode:

```toml
thread_isolation = true
feishu_thread_isolation_mode = "thread_only"
```

The default remains:

```toml
feishu_thread_isolation_mode = "reply_and_thread"
```

so existing users keep the current behavior.

## Why

Feishu already supports `thread_isolation = true`, and the current behavior can isolate real Feishu topic/thread messages.

However, the current behavior is broader than “topic/thread isolation”. When `thread_isolation = true`, the Feishu adapter derives the session key from `RootId`, or falls back to the current `MessageId`. In practice this means:

- every top-level group `@bot` message starts a separate `root:<message_id>` session
- normal Reply / quoted reply can enter a separate `root:<root_id>` session
- real Feishu Reply in Thread / topic also enters a separate `root:<root_id>` session

This works for task-style isolation, but it is not always the desired group-chat UX.

In a group chat, normal Reply is usually part of the main conversation. It is often just a way to quote or point at previous context, not an explicit request to fork the agent into a new session. If every normal reply can create or enter an isolated session, the bot loses the feel of being a persistent participant in the group. The conversation becomes fragmented across accidental reply chains, and the long-lived group persona / shared session is harder to maintain.

By contrast, Feishu Reply in Thread / topic is an explicit user action. It is a much clearer signal that the user wants to move a task into a child conversation.

This PR adds a Feishu-specific mode for that model, so the group chat can keep a stable main session while explicit Feishu topics/threads still get isolated child sessions.

## What Changed

The default remains unchanged:

```toml
feishu_thread_isolation_mode = "reply_and_thread"
```

This preserves the existing behavior:

- top-level group messages can become `root:<MessageId>` sessions
- normal replies can use `root:<RootId>`
- Feishu topic/thread messages also use the root-based isolated session

This PR adds:

```toml
feishu_thread_isolation_mode = "thread_only"
```

In `thread_only` mode:

- only messages with a real Feishu `ThreadId` create an isolated child session:
  ```text
  feishu:<chatID>:thread:<threadID>
  ```
- normal group messages stay in the normal group/user session
- normal Reply / quoted reply does not fork a new session
- normal Reply still injects the quoted `ParentId` message as context
- fallback still respects `share_session_in_channel`

## Notes

- This PR does not change Discord, Slack, Telegram, or core session semantics.
- This PR does not add recent chat/thread history injection. That can be handled separately later.
- `thread_only` depends on Feishu events carrying `ThreadId` for native topic/thread messages.

## Tests

- `pnpm --dir web build`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `git diff --check`
