### PR TITLE
feat(claudecode): support custom append_system_prompt config

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -52,6 +52,8 @@ type Agent struct {
 	routerAPIKey     string // Claude Code Router API key (optional)
 	systemPrompt     string // Custom system prompt to pass to Claude CLI
 
+	appendSystemPrompt string // Custom text appended to the system prompt (keeps Claude's default)
+
 	providerProxy  *core.ProviderProxy // local proxy for third-party providers
 	proxyLocalURL  string              // local URL of the proxy
 	platformPrompt string              // platform-specific formatting instructions
@@ -134,6 +136,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	mode, _ := opts["mode"].(string)
 	mode = normalizePermissionMode(mode)
 	systemPrompt, _ := opts["system_prompt"].(string)
+	appendSystemPrompt, _ := opts["append_system_prompt"].(string)
 
 	var allowedTools []string
 	if tools, ok := opts["allowed_tools"].([]any); ok {
@@ -228,6 +231,8 @@ func New(opts map[string]any) (core.Agent, error) {
 		routerURL:        routerURL,
 		routerAPIKey:     routerAPIKey,
 		spawnOpts:        spawnOpts,
+
+		appendSystemPrompt: appendSystemPrompt,
 	}, nil
 }
 
@@ -436,12 +441,13 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 		"providerCount", len(a.providers))
 	platformPrompt := a.platformPrompt
 	systemPrompt := a.systemPrompt
+	appendSystemPrompt := a.appendSystemPrompt
 	// When router_url is set, --verbose conflicts with --output-format stream-json
 	// (verbose emits non-JSON text to stdout that corrupts the JSON stream).
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, mode, systemPrompt, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
+	return newClaudeSession(ctx, workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -70,7 +70,26 @@ type claudeSession struct {
 // know about (e.g. bypassPermissions downgraded to auto under root).
 func (cs *claudeSession) StartupWarning() string { return cs.startupWarning }
 
-func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
+// buildAppendSystemPrompt concatenates the cc-connect functionality prompt,
+// platform formatting instructions, and the user's custom append prompt into
+// the single string passed to Claude's --append-system-prompt flag. That flag
+// only honors its last occurrence (a second flag overwrites the first), so all
+// appended content must be merged here. Returns "" when nothing is to append.
+func buildAppendSystemPrompt(agentPrompt, platformPrompt, userAppend string) string {
+	var parts []string
+	if agentPrompt != "" {
+		if platformPrompt != "" {
+			agentPrompt += "\n## Formatting\n" + platformPrompt + "\n"
+		}
+		parts = append(parts, agentPrompt)
+	}
+	if userAppend != "" {
+		parts = append(parts, userAppend)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	// Claude Code rejects bypassPermissions when running as root.
@@ -113,17 +132,17 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		innerArgs = append(innerArgs, "--disallowedTools", strings.Join(disallowedTools, ","))
 	}
 
-	// Handle custom system prompt
+	// Handle custom system prompt (replaces Claude's default system prompt).
 	if systemPrompt != "" {
 		innerArgs = append(innerArgs, "--system-prompt", systemPrompt)
 	}
 
-	// Always append cc-connect system prompt for functionality awareness
-	if sysPrompt := core.AgentSystemPrompt(); sysPrompt != "" {
-		if platformPrompt != "" {
-			sysPrompt += "\n## Formatting\n" + platformPrompt + "\n"
-		}
-		innerArgs = append(innerArgs, "--append-system-prompt", sysPrompt)
+	// Append the cc-connect functionality prompt, platform formatting hints,
+	// and the user's custom append prompt — all as a single flag. Claude's
+	// --append-system-prompt only honors its last occurrence, so the pieces
+	// must be concatenated here rather than passed as repeated flags.
+	if appended := buildAppendSystemPrompt(core.AgentSystemPrompt(), platformPrompt, appendSystemPrompt); appended != "" {
+		innerArgs = append(innerArgs, "--append-system-prompt", appended)
 	}
 
 	if effort != "" {

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -362,6 +362,34 @@ func TestShellJoinArgs(t *testing.T) {
 	}
 }
 
+func TestBuildAppendSystemPrompt(t *testing.T) {
+	tests := []struct {
+		name           string
+		agentPrompt    string
+		platformPrompt string
+		userAppend     string
+		want           string
+	}{
+		{"all_empty", "", "", "", ""},
+		{"agent_only", "AGENT", "", "", "AGENT"},
+		{"agent_and_platform", "AGENT", "PLAT", "", "AGENT\n## Formatting\nPLAT\n"},
+		{"user_only", "", "", "USER", "USER"},
+		{"user_only_platform_ignored", "", "PLAT", "USER", "USER"},
+		{"agent_and_user", "AGENT", "", "USER", "AGENT\nUSER"},
+		{"all_three", "AGENT", "PLAT", "USER", "AGENT\n## Formatting\nPLAT\n\nUSER"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildAppendSystemPrompt(tt.agentPrompt, tt.platformPrompt, tt.userAppend)
+			if got != tt.want {
+				t.Errorf("buildAppendSystemPrompt(%q, %q, %q)\n  got  = %q\n  want = %q",
+					tt.agentPrompt, tt.platformPrompt, tt.userAppend, got, tt.want)
+			}
+		})
+	}
+}
+
 func helperCommand(ctx context.Context, mode string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess", "--", mode)
 	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")

--- a/config.example.toml
+++ b/config.example.toml
@@ -774,7 +774,17 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "auto" | "bypassP
 # disallowed_tools = ["WebSearch", "WebFetch"]
 
 # Optional: specify a custom system prompt / 可选：指定自定义系统提示
+# Replaces Claude's default system prompt (passed via --system-prompt).
+# 替换 Claude 默认系统提示（通过 --system-prompt 传入）。
 # system_prompt = "You are a helpful AI assistant that specializes in Python development."
+
+# Optional: append extra text to the system prompt / 可选：向系统提示追加额外内容
+# Keeps Claude's default system prompt and appends this text (via --append-system-prompt).
+# Use this instead of system_prompt when you want to add instructions without
+# discarding Claude's defaults. Can be combined with system_prompt.
+# 保留 Claude 默认系统提示，并在其后追加本内容（通过 --append-system-prompt）。
+# 想在不丢弃默认提示的前提下补充指令时用它；可与 system_prompt 同时使用。
+# append_system_prompt = "Always respond in Chinese and prefer concise answers."
 
 # Optional: specify a model / 可选：指定模型
 # model = "claude-sonnet-4-20250514"


### PR DESCRIPTION
Add an `append_system_prompt` option for the Claude Code agent so users can inject extra system-prompt text while keeping Claude's default system prompt — unlike `system_prompt`, which replaces it entirely.

Claude CLI's --append-system-prompt only honors its last occurrence (a second flag overwrites the first), so the cc-connect functionality prompt, platform formatting hints, and the user's custom text are concatenated into a single flag value via the new buildAppendSystemPrompt helper.