### PR TITLE
fix(pi): add SetWorkDir method for runtime workdir switching

### DIFF
--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -223,7 +223,14 @@ func (a *Agent) AvailableReasoningEfforts() []string {
 	return []string{"off", "minimal", "low", "medium", "high", "xhigh"}
 }
 
-// ── GetWorkDir (for /status display) ─────────────────────────
+// ── WorkDirSwitcher ───────────────────────────────────────────
+
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("pi: work_dir changed", "work_dir", dir)
+}
 
 func (a *Agent) GetWorkDir() string { return a.workDir }
 


### PR DESCRIPTION
## Summary

Add `SetWorkDir` method to the pi agent so commands like `/status` and
multi-workspace switching can dynamically change the agent's working
directory at runtime.

## Changes

| File | Change |
|------|--------|
| agent/pi/pi.go | Add `SetWorkDir(dir string)` implementing `WorkDirSwitcher` interface |

## Test plan

- [x] `go build ./agent/pi/` passes
- [x] `go test ./agent/pi/ -count=1` passes
- [x] **Manual (Feishu)**: send `/dir /path/to/project` → verify agent switches to new workdir
- [x] **Manual (Feishu)**: send `/status` → verify displayed workdir matches the new path