### PR TITLE
fix(pi): read enabledModels from settings.json for /model

### DIFF
--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -49,6 +49,13 @@ func New(opts map[string]any) (core.Agent, error) {
 		return nil, fmt.Errorf("pi: '%s' not found in PATH, install with: npm install -g @mariozechner/pi-coding-agent", cmd)
 	}
 
+	// If model not specified in opts, try defaultModel from settings.json
+	if model == "" {
+		if def, err := readDefaultModel(); err == nil && def != "" {
+			model = def
+		}
+	}
+
 	return &Agent{
 		cmd:     cmd,
 		workDir: workDir,
@@ -84,7 +91,12 @@ func (a *Agent) GetModel() string {
 }
 
 func (a *Agent) AvailableModels(_ context.Context) []core.ModelOption {
-	return nil // Pi uses its own model registry; no static list here.
+	models, err := readSettingsModels()
+	if err != nil {
+		slog.Debug("pi: AvailableModels: read settings", "error", err)
+		return nil
+	}
+	return models
 }
 
 func (a *Agent) SetSessionEnv(env []string) {
@@ -255,6 +267,88 @@ func (a *Agent) SkillDirs() []string {
 		dirs = append(dirs, filepath.Join(home, ".pi", "skills"))
 	}
 	return dirs
+}
+
+// ── Settings helpers ─────────────────────────────────────────
+
+// piSettingsDir returns the pi agent config directory.
+// Respects PI_CODING_AGENT_DIR env var; defaults to ~/.pi/agent.
+func piSettingsDir() string {
+	if d := os.Getenv("PI_CODING_AGENT_DIR"); d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pi", "agent")
+}
+
+// settingsPath returns the path to settings.json.
+func settingsPath() string {
+	dir := piSettingsDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "settings.json")
+}
+
+// piSettings represents the structure of pi's settings.json relevant fields.
+type piSettings struct {
+	EnabledModels  []string `json:"enabledModels"`
+	DefaultModel   string   `json:"defaultModel"`
+	DefaultProvider string  `json:"defaultProvider"`
+}
+
+// readSettings reads and parses pi's settings.json.
+func readSettings() (*piSettings, error) {
+	path := settingsPath()
+	if path == "" {
+		return nil, fmt.Errorf("pi: cannot determine settings path")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("pi: read settings: %w", err)
+	}
+	var s piSettings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("pi: parse settings: %w", err)
+	}
+	return &s, nil
+}
+
+// readSettingsModels returns the enabledModels from settings.json as ModelOptions.
+func readSettingsModels() ([]core.ModelOption, error) {
+	s, err := readSettings()
+	if err != nil {
+		return nil, err
+	}
+	if len(s.EnabledModels) == 0 {
+		return nil, nil
+	}
+	models := make([]core.ModelOption, 0, len(s.EnabledModels))
+	for _, m := range s.EnabledModels {
+		option := core.ModelOption{Name: m}
+		// Derive a short alias from the last segment after the final "/".
+		if idx := strings.LastIndex(m, "/"); idx >= 0 && idx+1 < len(m) {
+			option.Alias = m[idx+1:]
+		}
+		models = append(models, option)
+	}
+	return models, nil
+}
+
+// readDefaultModel returns the defaultModel from settings.json.
+func readDefaultModel() (string, error) {
+	s, err := readSettings()
+	if err != nil {
+		return "", err
+	}
+	// If defaultProvider is set, qualify the defaultModel with it.
+	if s.DefaultProvider != "" && s.DefaultModel != "" && !strings.Contains(s.DefaultModel, "/") {
+		return s.DefaultProvider + "/" + s.DefaultModel, nil
+	}
+	return s.DefaultModel, nil
 }
 
 // ── Session helpers ──────────────────────────────────────────

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -42,6 +42,17 @@ func TestNormalizeMode(t *testing.T) {
 // ── Agent constructor ────────────────────────────────────────
 
 func TestNew_DefaultValues(t *testing.T) {
+	// Isolate from real settings.json so we test pure defaults.
+	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
+	t.Cleanup(func() {
+		if savedEnv != "" {
+			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+		} else {
+			os.Unsetenv("PI_CODING_AGENT_DIR")
+		}
+	})
+	t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
+
 	// Use a command that exists on all systems.
 	ag, err := New(map[string]any{"cmd": "echo"})
 	if err != nil {
@@ -154,8 +165,168 @@ func TestAgent_ModeGetSet(t *testing.T) {
 
 func TestAgent_AvailableModels(t *testing.T) {
 	a := &Agent{}
-	if models := a.AvailableModels(context.Background()); models != nil {
-		t.Errorf("AvailableModels() = %v, want nil", models)
+	// Without settings.json, should return nil (no error logged — just empty).
+	models := a.AvailableModels(context.Background())
+	if models == nil {
+		// No settings file — acceptable in test environments.
+		return
+	}
+	// If settings.json exists with enabledModels, should return them.
+	for _, m := range models {
+		if m.Name == "" {
+			t.Errorf("model with empty Name: %+v", m)
+		}
+	}
+}
+
+func TestReadSettingsModels(t *testing.T) {
+	// Save and restore settings path.
+	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
+	t.Cleanup(func() {
+		if savedEnv != "" {
+			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+		} else {
+			os.Unsetenv("PI_CODING_AGENT_DIR")
+		}
+	})
+
+	tmpDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", tmpDir)
+
+	// No settings.json -> error.
+	_, err := readSettingsModels()
+	if err == nil {
+		t.Error("expected error for missing settings.json")
+	}
+
+	// Write settings.json with enabledModels.
+	settings := map[string]any{
+		"enabledModels": []string{
+			"provider-a/family-a/model-alpha",
+			"provider-a/family-a/model-beta",
+			"provider-b/family-b/model-gamma",
+		},
+		"defaultModel":  "family-a/model-beta",
+		"defaultProvider": "provider-a",
+	}
+	data, _ := json.Marshal(settings)
+	if err := os.WriteFile(filepath.Join(tmpDir, "settings.json"), data, 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	models, err := readSettingsModels()
+	if err != nil {
+		t.Fatalf("readSettingsModels() error = %v", err)
+	}
+	if len(models) != 3 {
+		t.Fatalf("got %d models, want 3", len(models))
+	}
+
+	tests := []struct {
+		name  string
+		alias string
+	}{
+		{"provider-a/family-a/model-alpha", "model-alpha"},
+		{"provider-a/family-a/model-beta", "model-beta"},
+		{"provider-b/family-b/model-gamma", "model-gamma"},
+	}
+	for i, tt := range tests {
+		if models[i].Name != tt.name {
+			t.Errorf("models[%d].Name = %q, want %q", i, models[i].Name, tt.name)
+		}
+		if models[i].Alias != tt.alias {
+			t.Errorf("models[%d].Alias = %q, want %q", i, models[i].Alias, tt.alias)
+		}
+	}
+}
+
+func TestReadDefaultModel(t *testing.T) {
+	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
+	t.Cleanup(func() {
+		if savedEnv != "" {
+			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+		} else {
+			os.Unsetenv("PI_CODING_AGENT_DIR")
+		}
+	})
+
+	tmpDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", tmpDir)
+
+	// No file -> error.
+	_, err := readDefaultModel()
+	if err == nil {
+		t.Error("expected error for missing settings.json")
+	}
+
+	// Write with both defaultProvider and defaultModel.
+	settings := map[string]any{
+		"defaultModel":    "family-a/model-beta",
+		"defaultProvider": "provider-a",
+	}
+	data, _ := json.Marshal(settings)
+	os.WriteFile(filepath.Join(tmpDir, "settings.json"), data, 0o644)
+
+	model, err := readDefaultModel()
+	if err != nil {
+		t.Fatalf("readDefaultModel() error = %v", err)
+	}
+	if model != "family-a/model-beta" {
+		t.Errorf("defaultModel = %q, want %q", model, "family-a/model-beta")
+	}
+
+	// With model without provider prefix and defaultProvider set.
+	settings2 := map[string]any{
+		"defaultModel":    "gpt-4o",
+		"defaultProvider": "provider-b",
+	}
+	data2, _ := json.Marshal(settings2)
+	os.WriteFile(filepath.Join(tmpDir, "settings.json"), data2, 0o644)
+
+	model2, _ := readDefaultModel()
+	if model2 != "provider-b/gpt-4o" {
+		t.Errorf("qualified defaultModel = %q, want %q", model2, "provider-b/gpt-4o")
+	}
+}
+
+func TestPiSettingsDir(t *testing.T) {
+	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
+	defer func() {
+		if savedEnv != "" {
+			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+		} else {
+			os.Unsetenv("PI_CODING_AGENT_DIR")
+		}
+	}()
+
+	// With env var set.
+	t.Setenv("PI_CODING_AGENT_DIR", "/custom/pi/path")
+	if d := piSettingsDir(); d != "/custom/pi/path" {
+		t.Errorf("piSettingsDir() = %q, want /custom/pi/path", d)
+	}
+
+	// Unset env var -> default.
+	os.Unsetenv("PI_CODING_AGENT_DIR")
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".pi", "agent")
+	if d := piSettingsDir(); d != want {
+		t.Errorf("piSettingsDir() = %q, want %q", d, want)
+	}
+}
+
+func TestSettingsPath(t *testing.T) {
+	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
+	defer func() {
+		if savedEnv != "" {
+			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+		} else {
+			os.Unsetenv("PI_CODING_AGENT_DIR")
+		}
+	}()
+
+	t.Setenv("PI_CODING_AGENT_DIR", "/custom")
+	if p := settingsPath(); p != "/custom/settings.json" {
+		t.Errorf("settingsPath() = %q, want /custom/settings.json", p)
 	}
 }
 

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -297,9 +297,9 @@ func TestPiSettingsDir(t *testing.T) {
 	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
 	defer func() {
 		if savedEnv != "" {
-			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+			_ = os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
 		} else {
-			os.Unsetenv("PI_CODING_AGENT_DIR")
+			_ = os.Unsetenv("PI_CODING_AGENT_DIR")
 		}
 	}()
 
@@ -310,7 +310,7 @@ func TestPiSettingsDir(t *testing.T) {
 	}
 
 	// Unset env var -> default.
-	os.Unsetenv("PI_CODING_AGENT_DIR")
+	_ = os.Unsetenv("PI_CODING_AGENT_DIR")
 	home, _ := os.UserHomeDir()
 	want := filepath.Join(home, ".pi", "agent")
 	if d := piSettingsDir(); d != want {
@@ -322,9 +322,9 @@ func TestSettingsPath(t *testing.T) {
 	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
 	defer func() {
 		if savedEnv != "" {
-			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+			_ = os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
 		} else {
-			os.Unsetenv("PI_CODING_AGENT_DIR")
+			_ = os.Unsetenv("PI_CODING_AGENT_DIR")
 		}
 	}()
 

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -46,9 +46,9 @@ func TestNew_DefaultValues(t *testing.T) {
 	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
 	t.Cleanup(func() {
 		if savedEnv != "" {
-			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+			_ = os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
 		} else {
-			os.Unsetenv("PI_CODING_AGENT_DIR")
+			_ = os.Unsetenv("PI_CODING_AGENT_DIR")
 		}
 	})
 	t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
@@ -184,9 +184,9 @@ func TestReadSettingsModels(t *testing.T) {
 	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
 	t.Cleanup(func() {
 		if savedEnv != "" {
-			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+			_ = os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
 		} else {
-			os.Unsetenv("PI_CODING_AGENT_DIR")
+			_ = os.Unsetenv("PI_CODING_AGENT_DIR")
 		}
 	})
 
@@ -244,9 +244,9 @@ func TestReadDefaultModel(t *testing.T) {
 	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
 	t.Cleanup(func() {
 		if savedEnv != "" {
-			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+			_ = os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
 		} else {
-			os.Unsetenv("PI_CODING_AGENT_DIR")
+			_ = os.Unsetenv("PI_CODING_AGENT_DIR")
 		}
 	})
 
@@ -265,7 +265,9 @@ func TestReadDefaultModel(t *testing.T) {
 		"defaultProvider": "provider-a",
 	}
 	data, _ := json.Marshal(settings)
-	os.WriteFile(filepath.Join(tmpDir, "settings.json"), data, 0o644)
+	if err := os.WriteFile(filepath.Join(tmpDir, "settings.json"), data, 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
 
 	model, err := readDefaultModel()
 	if err != nil {
@@ -281,7 +283,9 @@ func TestReadDefaultModel(t *testing.T) {
 		"defaultProvider": "provider-b",
 	}
 	data2, _ := json.Marshal(settings2)
-	os.WriteFile(filepath.Join(tmpDir, "settings.json"), data2, 0o644)
+	if err := os.WriteFile(filepath.Join(tmpDir, "settings.json"), data2, 0o644); err != nil {
+		t.Fatalf("write settings2: %v", err)
+	}
 
 	model2, _ := readDefaultModel()
 	if model2 != "provider-b/gpt-4o" {


### PR DESCRIPTION
## Summary

The pi agent's `AvailableModels()` returned `nil`, so the `/model` command
never showed a model selection list. Now it reads `enabledModels` from
`~/.pi/agent/settings.json`.

`New()` also falls back to `defaultModel` (+ `defaultProvider`) from
settings.json when no model is specified in config, so the user's
preferred model is used out of the box.

## Changes

| File | Change |
|------|--------|
| agent/pi/pi.go | `AvailableModels()` reads settings.json; `New()` falls back to `defaultModel`; add 6 helpers for settings I/O |
| agent/pi/pi_test.go | Add 5 tests covering settings parsing, default model, settings dir, and env var override |

## Test plan

- [x] `go build ./agent/pi/` passes
- [x] `go test ./agent/pi/ -count=1` passes (49 tests)
- [x] **Manual (Feishu)**: send `/model` → verify card shows current model + dropdown with `enabledModels` from settings.json
- [x] **Manual (Feishu)**: select a model from the dropdown → verify model switches and card shows success
- [x] **Manual (Feishu)**: send `/model switch <model-name>` → verify model changes