### PR TITLE
feat(slack,tmux): per-thread session scope and per-session tmux windows

### DIFF
--- a/agent/tmux/tmux.go
+++ b/agent/tmux/tmux.go
@@ -32,7 +32,12 @@ type Agent struct {
 	pollMs          int
 	stripInputBlock bool     // strip the ───/❯/─── input area block from output
 	stripPatterns   []string // per-line regex patterns to strip from output
-	mu              sync.RWMutex
+	// windowPerSession, when true, gives each cc-connect session its own tmux
+	// window (and thus its own init_command/agent instance) instead of sharing
+	// the single session:pane target. Required for true per-session isolation
+	// (e.g. session_scope = "thread" on the platform).
+	windowPerSession bool
+	mu               sync.RWMutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -114,22 +119,25 @@ func New(opts map[string]any) (core.Agent, error) {
 		stripPatterns = []string{`⏵⏵.*\(shift\+tab to cycle\)`}
 	}
 
+	windowPerSession, _ := opts["window_per_session"].(bool)
+
 	if _, err := exec.LookPath("tmux"); err != nil {
 		return nil, fmt.Errorf("tmux: 'tmux' not found in PATH")
 	}
 
 	return &Agent{
-		sessionName:     sessionName,
-		pane:            pane,
-		workDir:         workDir,
-		autoCreate:      autoCreate,
-		shell:           shell,
-		initCmd:         initCmd,
-		startupWaitMs:   startupWaitMs,
-		promptPat:       promptPat,
-		pollMs:          pollMs,
-		stripInputBlock: stripInputBlock,
-		stripPatterns:   stripPatterns,
+		sessionName:      sessionName,
+		pane:             pane,
+		workDir:          workDir,
+		autoCreate:       autoCreate,
+		shell:            shell,
+		initCmd:          initCmd,
+		startupWaitMs:    startupWaitMs,
+		promptPat:        promptPat,
+		pollMs:           pollMs,
+		stripInputBlock:  stripInputBlock,
+		stripPatterns:    stripPatterns,
+		windowPerSession: windowPerSession,
 	}, nil
 }
 
@@ -150,11 +158,17 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	stripPatterns := a.stripPatterns
 	a.mu.RUnlock()
 
-	// When workDir is a real path (set via SetWorkDir in multi-workspace mode, or
-	// configured directly), use a dedicated tmux window named after the directory so
-	// each workspace gets its own Claude Code instance.  Otherwise fall back to the
-	// legacy session:pane target.
-	target, windowName := a.resolveTarget(sessionName, pane, workDir)
+	// Decide which tmux window this session drives:
+	//   - window_per_session: a dedicated window per cc-connect session (true
+	//     isolation; each gets its own init_command/agent instance).
+	//   - else, when workDir is a real path: a window named after the directory
+	//     so each workspace gets its own instance.
+	//   - else: the legacy session:pane target.
+	// windowForSession may allocate a fresh window name when sessionID is empty;
+	// the returned ID is persisted by the engine so resumes reuse the same window.
+	windowName, effectiveSessionID := a.windowForSession(sessionName, pane, workDir, sessionID)
+	sessionID = effectiveSessionID
+	target := sessionName + ":" + windowName
 
 	sessionExists := tmuxSessionExists(sessionName)
 	windowExists := sessionExists && tmuxWindowExists(target)
@@ -216,6 +230,43 @@ func (a *Agent) resolveTarget(sessionName, pane, workDir string) (target, window
 	return sessionName + ":" + pane, pane
 }
 
+// windowForSession returns the tmux window name to use for a StartSession call
+// and the effective agent session ID. When window_per_session is enabled, each
+// cc-connect session gets its own window: an existing (resumed) sessionID maps
+// back to its window, while an empty sessionID allocates a fresh window whose
+// name doubles as the agent session ID (persisted by the engine for resumes).
+// When disabled, behaviour is unchanged (per-workDir window or legacy pane).
+func (a *Agent) windowForSession(sessionName, pane, workDir, sessionID string) (windowName, effectiveID string) {
+	if a.windowPerSession {
+		if sessionID != "" {
+			return sessionID, sessionID
+		}
+		name := allocateWindowName(sessionName)
+		return name, name
+	}
+	_, windowName = a.resolveTarget(sessionName, pane, workDir)
+	return windowName, sessionID
+}
+
+// allocateWindowName returns a fresh window name not currently present in the
+// tmux session. The name is randomized (see below) so it never repeats across
+// process restarts or collides across the per-workspace Agent instances that
+// share a single tmux session in multi-workspace mode.
+func allocateWindowName(sessionName string) string {
+	for {
+		// Use a random suffix rather than a counter: counters reset to 0 on
+		// process restart and could re-hand-out "cc-1" to a brand-new
+		// conversation, which would then collide with an older session whose
+		// persisted agent ID is still "cc-1" (mixing two conversations into one
+		// window). A random name does not repeat across restarts; the existence
+		// check guards against the (astronomically rare) live collision.
+		name := "cc-" + core.GenerateToken(4)
+		if !tmuxWindowExists(sessionName + ":" + name) {
+			return name
+		}
+	}
+}
+
 // uniqueWindowName builds a tmux window name that is unique per workDir path.
 // It appends a 4-hex-char FNV hash of the full path so that directories with
 // the same basename do not collide (e.g. /repo/a/app → "app-1a2b",
@@ -250,16 +301,17 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return map[string]any{
-		"session":           a.sessionName,
-		"pane":              a.pane,
-		"auto_create":       a.autoCreate,
-		"shell":             a.shell,
-		"init_command":      a.initCmd,
-		"startup_wait_ms":   a.startupWaitMs,
-		"prompt_pattern":    a.promptPat,
-		"poll_interval_ms":  a.pollMs,
-		"strip_input_block": a.stripInputBlock,
-		"strip_patterns":    a.stripPatterns,
+		"session":            a.sessionName,
+		"pane":               a.pane,
+		"auto_create":        a.autoCreate,
+		"shell":              a.shell,
+		"init_command":       a.initCmd,
+		"startup_wait_ms":    a.startupWaitMs,
+		"prompt_pattern":     a.promptPat,
+		"poll_interval_ms":   a.pollMs,
+		"strip_input_block":  a.stripInputBlock,
+		"strip_patterns":     a.stripPatterns,
+		"window_per_session": a.windowPerSession,
 	}
 }
 

--- a/agent/tmux/window_per_session_test.go
+++ b/agent/tmux/window_per_session_test.go
@@ -1,0 +1,79 @@
+package tmux
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// requireTmux skips tests that must call New(), which probes for the tmux
+// binary; CI hosts without tmux would otherwise fail before exercising logic.
+func requireTmux(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed; New() requires the tmux binary")
+	}
+}
+
+func TestNewParsesWindowPerSession(t *testing.T) {
+	requireTmux(t)
+	base := map[string]any{"session": "claude-work"}
+
+	a, err := New(base)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if a.(*Agent).windowPerSession {
+		t.Fatalf("windowPerSession should default to false")
+	}
+
+	base["window_per_session"] = true
+	a, err = New(base)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !a.(*Agent).windowPerSession {
+		t.Fatalf("windowPerSession should be true when configured")
+	}
+}
+
+func TestWindowForSession_Disabled(t *testing.T) {
+	a := &Agent{windowPerSession: false}
+
+	// Real workDir -> per-directory window, sessionID passes through unchanged.
+	win, id := a.windowForSession("claude-work", "0", "/repo/app", "")
+	if win != uniqueWindowName("/repo/app") {
+		t.Errorf("window = %q, want %q", win, uniqueWindowName("/repo/app"))
+	}
+	if id != "" {
+		t.Errorf("effectiveID = %q, want empty (unchanged)", id)
+	}
+
+	// No workDir -> legacy pane.
+	win, _ = a.windowForSession("claude-work", "0", "", "")
+	if win != "0" {
+		t.Errorf("window = %q, want legacy pane %q", win, "0")
+	}
+}
+
+func TestWindowForSession_EnabledResumeReusesWindow(t *testing.T) {
+	a := &Agent{windowPerSession: true}
+
+	// A non-empty (resumed) sessionID maps straight back to its own window,
+	// independent of workDir — so the same thread always reuses one window.
+	win, id := a.windowForSession("claude-work", "0", "/repo/app", "cc-7")
+	if win != "cc-7" || id != "cc-7" {
+		t.Errorf("got window=%q id=%q, want both %q", win, id, "cc-7")
+	}
+}
+
+// WorkspaceAgentOptions is the snapshot used to rebuild a per-workspace agent
+// in multi-workspace mode; window_per_session must survive the round-trip or
+// workspace sessions silently lose isolation. Construct Agent directly so the
+// test does not depend on the tmux binary.
+func TestWorkspaceAgentOptionsPreservesWindowPerSession(t *testing.T) {
+	a := &Agent{sessionName: "claude-work", windowPerSession: true}
+	opts := a.WorkspaceAgentOptions()
+	if opts["window_per_session"] != true {
+		t.Fatalf("WorkspaceAgentOptions dropped window_per_session: %v", opts["window_per_session"])
+	}
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -1069,6 +1069,11 @@ app_secret = "your-feishu-app-secret"
 # app_token = "xapp-your-app-level-token"
 # allow_from = "*"  # Allowed Slack user IDs / 允许的 Slack 用户 ID
 # share_session_in_channel = false  # If true, all users in a channel share one agent session / 频道共享会话
+# session_scope = "user"  # Session granularity: "user" (default, per channel+user) |
+#                         # "channel" (one session per channel, same as share_session_in_channel) |
+#                         # "thread" (one session per Slack thread — a new top-level message starts
+#                         #  a fresh session, replies in the same thread continue it).
+#                         # 会话粒度："user"(默认) | "channel"(整个频道一个会话) | "thread"(每个 Slack 话题串一个会话)
 
 # Discord (uncomment to enable / 取消注释以启用)
 # 1. Create an app at https://discord.com/developers/applications / 创建应用
@@ -1489,6 +1494,12 @@ app_secret = "your-feishu-app-secret"
 # startup_wait_ms = 2000       # milliseconds to wait after init_command before accepting messages (default: 2000 when init_command is set)
 # prompt_pattern = '[\$#>%]\s*$'  # regex to detect shell prompt = command done (default shown)
 # poll_interval_ms = 200       # output poll interval in milliseconds (default: 200)
+# window_per_session = false   # When true, each cc-connect session gets its OWN tmux window
+#                              # (own init_command/agent instance) instead of sharing one pane.
+#                              # Enable this for true isolation when the platform splits sessions
+#                              # (e.g. Slack session_scope = "thread"); otherwise all sessions
+#                              # share a single agent and their conversations interleave.
+#                              # 为 true 时每个会话独占一个 tmux 窗口（独立 agent 实例），实现真正隔离。
 #
 # --- Running Claude Code inside tmux ---
 # Set init_command to start claude automatically; adjust prompt_pattern to match

--- a/platform/slack/session_scope_test.go
+++ b/platform/slack/session_scope_test.go
@@ -1,0 +1,80 @@
+package slack
+
+import "testing"
+
+func TestNormalizeSessionScope(t *testing.T) {
+	cases := []struct {
+		raw   any
+		share bool
+		want  string
+	}{
+		{nil, false, "user"},
+		{nil, true, "channel"},
+		{"", false, "user"},
+		{"", true, "channel"},
+		{"user", true, "user"},
+		{"channel", false, "channel"},
+		{"thread", false, "thread"},
+		{"Thread", false, "thread"},     // case-insensitive
+		{" channel ", false, "channel"}, // trimmed
+		{"bogus", false, "user"},        // unknown -> share-derived default
+		{"bogus", true, "channel"},
+	}
+	for _, c := range cases {
+		if got := normalizeSessionScope(c.raw, c.share); got != c.want {
+			t.Errorf("normalizeSessionScope(%v, share=%v) = %q, want %q", c.raw, c.share, got, c.want)
+		}
+	}
+}
+
+func TestBuildSessionKey(t *testing.T) {
+	const (
+		ch     = "C123"
+		user   = "U456"
+		thread = "1717000000.000100"
+	)
+	cases := []struct {
+		scope    string
+		threadTS string
+		want     string
+	}{
+		{"user", thread, "slack:C123:U456"}, // thread ignored in user scope
+		{"channel", thread, "slack:C123"},   // user/thread ignored in channel scope
+		{"thread", thread, "slack:C123:t:1717000000.000100"},
+		{"thread", "", "slack:C123:U456"}, // no thread context -> falls back to user
+		{"", thread, "slack:C123:U456"},   // empty scope behaves as user
+	}
+	for _, c := range cases {
+		p := &Platform{sessionScope: c.scope}
+		if got := p.buildSessionKey(ch, user, c.threadTS); got != c.want {
+			t.Errorf("scope=%q threadTS=%q: buildSessionKey = %q, want %q", c.scope, c.threadTS, got, c.want)
+		}
+	}
+}
+
+func TestReconstructReplyCtx(t *testing.T) {
+	p := &Platform{}
+	cases := []struct {
+		key       string
+		channel   string
+		timestamp string // thread_ts, "" when none
+	}{
+		{"slack:C123:U456", "C123", ""},                                 // user scope -> no thread
+		{"slack:C123", "C123", ""},                                      // channel scope
+		{"slack:C123:t:1717000000.000100", "C123", "1717000000.000100"}, // thread scope -> thread ts
+	}
+	for _, c := range cases {
+		got, err := p.ReconstructReplyCtx(c.key)
+		if err != nil {
+			t.Fatalf("ReconstructReplyCtx(%q) error: %v", c.key, err)
+		}
+		rc := got.(replyContext)
+		if rc.channel != c.channel || rc.timestamp != c.timestamp {
+			t.Errorf("ReconstructReplyCtx(%q) = {channel:%q timestamp:%q}, want {channel:%q timestamp:%q}",
+				c.key, rc.channel, rc.timestamp, c.channel, c.timestamp)
+		}
+	}
+	if _, err := p.ReconstructReplyCtx("telegram:123"); err == nil {
+		t.Error("ReconstructReplyCtx should reject non-slack keys")
+	}
+}

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -30,17 +30,17 @@ type replyContext struct {
 }
 
 type Platform struct {
-	botToken              string
-	appToken              string
-	allowFrom             string
-	shareSessionInChannel bool
-	client                *slack.Client
-	socket                *socketmode.Client
-	handler               core.MessageHandler
-	cancel                context.CancelFunc
-	channelNameCache      map[string]string
-	channelCacheMu        sync.RWMutex
-	userNameCache         sync.Map // userID -> display name
+	botToken         string
+	appToken         string
+	allowFrom        string
+	sessionScope     string // "user" (default) | "channel" | "thread"
+	client           *slack.Client
+	socket           *socketmode.Client
+	handler          core.MessageHandler
+	cancel           context.CancelFunc
+	channelNameCache map[string]string
+	channelCacheMu   sync.RWMutex
+	userNameCache    sync.Map // userID -> display name
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -52,13 +52,71 @@ func New(opts map[string]any) (core.Platform, error) {
 	if botToken == "" || appToken == "" {
 		return nil, fmt.Errorf("slack: bot_token and app_token are required")
 	}
+	scope := normalizeSessionScope(opts["session_scope"], shareSessionInChannel)
 	return &Platform{
-		botToken:              botToken,
-		appToken:              appToken,
-		allowFrom:             allowFrom,
-		shareSessionInChannel: shareSessionInChannel,
-		channelNameCache:      make(map[string]string),
+		botToken:         botToken,
+		appToken:         appToken,
+		allowFrom:        allowFrom,
+		sessionScope:     scope,
+		channelNameCache: make(map[string]string),
 	}, nil
+}
+
+// normalizeSessionScope resolves the configured session_scope option to one of
+// "user" | "channel" | "thread". For backward compatibility, when session_scope
+// is unset, share_session_in_channel = true maps to "channel"; otherwise the
+// default is "user". Unknown values fall back to the share-derived default.
+func normalizeSessionScope(raw any, shareInChannel bool) string {
+	fallback := "user"
+	if shareInChannel {
+		fallback = "channel"
+	}
+	s, _ := raw.(string)
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "user":
+		return "user"
+	case "channel":
+		return "channel"
+	case "thread":
+		return "thread"
+	case "":
+		return fallback
+	default:
+		slog.Warn("slack: unknown session_scope, falling back", "session_scope", s, "using", fallback)
+		return fallback
+	}
+}
+
+// buildSessionKey derives the engine session key for an incoming Slack event
+// according to the configured session_scope:
+//   - "channel": one session per channel            -> slack:<channel>
+//   - "thread":  one session per thread (parent ts)  -> slack:<channel>:t:<threadTS>
+//   - "user":    one session per (channel, user)     -> slack:<channel>:<user>  (default)
+//
+// threadTS must be the thread root timestamp; pass "" when no thread context is
+// available (e.g. slash commands), in which case "thread" falls back to "user".
+func (p *Platform) buildSessionKey(channel, user, threadTS string) string {
+	switch p.sessionScope {
+	case "channel":
+		return fmt.Sprintf("slack:%s", channel)
+	case "thread":
+		if threadTS != "" {
+			return fmt.Sprintf("slack:%s:t:%s", channel, threadTS)
+		}
+		return fmt.Sprintf("slack:%s:%s", channel, user)
+	default:
+		return fmt.Sprintf("slack:%s:%s", channel, user)
+	}
+}
+
+// threadRootTS returns the thread parent timestamp for an event: the existing
+// thread_ts when the message is already in a thread, otherwise the message's
+// own ts (which becomes the thread root once the bot replies in-thread).
+func threadRootTS(threadTS, msgTS string) string {
+	if threadTS != "" {
+		return threadTS
+	}
+	return msgTS
 }
 
 func (p *Platform) Name() string { return "slack" }
@@ -134,12 +192,8 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					return
 				}
 
-				var sessionKey string
-				if p.shareSessionInChannel {
-					sessionKey = fmt.Sprintf("slack:%s", ev.Channel)
-				} else {
-					sessionKey = fmt.Sprintf("slack:%s:%s", ev.Channel, ev.User)
-				}
+				threadTS := threadRootTS(ev.ThreadTimeStamp, ev.TimeStamp)
+				sessionKey := p.buildSessionKey(ev.Channel, ev.User, threadTS)
 
 				var shareFiles []slackevents.File
 				if cb, ok := data.Data.(*slackevents.EventsAPICallbackEvent); ok {
@@ -159,7 +213,7 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					Files:     docFiles,
 					Audio:     audio,
 					MessageID: ev.TimeStamp,
-					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: ev.TimeStamp},
+					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: threadTS},
 				}
 				p.handler(p, msg)
 
@@ -200,12 +254,12 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					return
 				}
 
-				var sessionKey string
-				if p.shareSessionInChannel {
-					sessionKey = fmt.Sprintf("slack:%s", ev.Channel)
-				} else {
-					sessionKey = fmt.Sprintf("slack:%s:%s", ev.Channel, ev.User)
-				}
+				// Use the same timestamp the reply will be routed to
+				// (assistantOrThreadTS): thread root in a thread, the message ts
+				// for a top-level channel message, and "" for a top-level DM —
+				// so DMs fall back to the user-scoped key and stay continuous.
+				threadTS := assistantOrThreadTS(ev)
+				sessionKey := p.buildSessionKey(ev.Channel, ev.User, threadTS)
 				ts := ev.TimeStamp
 
 				images, audio, docFiles := p.processSlackFileShares(ev.Files)
@@ -220,7 +274,7 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					ChatName: p.resolveChannelNameForMsg(ev.Channel),
 					Content:  ev.Text, Images: images, Files: docFiles, Audio: audio,
 					MessageID: ts,
-					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: assistantOrThreadTS(ev)},
+					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: threadTS},
 				}
 				p.handler(p, msg)
 			}
@@ -249,12 +303,7 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 			content += " " + cmd.Text
 		}
 
-		var sessionKey string
-		if p.shareSessionInChannel {
-			sessionKey = fmt.Sprintf("slack:%s", cmd.ChannelID)
-		} else {
-			sessionKey = fmt.Sprintf("slack:%s:%s", cmd.ChannelID, cmd.UserID)
-		}
+		sessionKey := p.buildSessionKey(cmd.ChannelID, cmd.UserID, "")
 
 		msg := &core.Message{
 			SessionKey: sessionKey, Platform: "slack",
@@ -365,7 +414,6 @@ func slackFileDisplayName(f slackevents.File) string {
 	}
 	return f.Title
 }
-
 
 // assistantOrThreadTS returns the thread_ts to use for the bot's reply.
 //
@@ -538,12 +586,19 @@ func (p *Platform) downloadSlackFile(url string) ([]byte, error) {
 }
 
 func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
-	// slack:{channel}:{user}
+	// slack:{channel}:{user}  |  slack:{channel}:t:{threadTS}  |  slack:{channel}
 	parts := strings.SplitN(sessionKey, ":", 3)
 	if len(parts) < 2 || parts[0] != "slack" {
 		return nil, fmt.Errorf("slack: invalid session key %q", sessionKey)
 	}
-	return replyContext{channel: parts[1]}, nil
+	rc := replyContext{channel: parts[1]}
+	// Thread-scoped keys carry the thread root ts as a "t:<ts>" suffix; preserve
+	// it so proactive replies (cron, send-to-session, restart/model/delete
+	// notifications) post into the original thread instead of the channel root.
+	if len(parts) == 3 && strings.HasPrefix(parts[2], "t:") {
+		rc.timestamp = strings.TrimPrefix(parts[2], "t:")
+	}
+	return rc, nil
 }
 
 func (p *Platform) resolveUserName(userID string) string {


### PR DESCRIPTION
## Summary

Adds two complementary options so a single chat platform can drive **isolated conversations per Slack thread**:

1. **`session_scope` for the Slack platform** — `"user"` (default) | `"channel"` | `"thread"`.
   `"thread"` keys each cc-connect session to the Slack **thread root**, so a new top-level
   message starts a fresh conversation and replies inside a thread continue it.

2. **`window_per_session` for the tmux agent** — each cc-connect session gets its own tmux
   **window** (and thus its own `init_command`/agent instance) instead of sharing one pane.
   Without this, `session_scope="thread"` over a tmux agent still funnels every thread into a
   single shared CLI, so concurrent threads interleave; with it, each thread is fully isolated.

## Motivation

Today a Slack channel maps to one session per `(channel, user)`. Power users often want a
**separate conversation per thread** (one thread = one task). These two options make that
possible end-to-end, including for the tmux agent (which previously shared a single pane).

## Config

```toml
# Slack: one session per thread
[projects.platforms.options]   # type = "slack"
session_scope = "thread"       # "user" (default) | "channel" | "thread"

# tmux agent: a dedicated window (and Claude instance) per session
[projects.agent.options]       # type = "tmux"
window_per_session = true
```

## Behaviour details

- Slack session keys: `slack:<ch>:<user>` (user) · `slack:<ch>` (channel) · `slack:<ch>:t:<threadTS>` (thread).
- **Top-level DMs** (no thread) fall back to the user-scoped key, so DMs stay continuous
  (uses the same `assistantOrThreadTS` value that routes the reply).
- **App mentions** key + reply on the same thread root for consistency.
- `ReconstructReplyCtx` parses the `t:<ts>` suffix, so **proactive** replies (cron,
  send-to-session, restart/model/delete notifications) post back into the original thread.
- tmux window names are **randomised** (not a counter), so they never repeat across process
  restarts and never collide across the per-workspace agents that share one tmux session.
- `WorkspaceAgentOptions` carries `window_per_session` through multi-workspace mode.

## Backward compatibility

Both options default off; existing configs are unaffected. When `session_scope` is unset the
previous behaviour is preserved, and `share_session_in_channel = true` maps to `"channel"`.

## Limitations

- Slash commands don't carry a `thread_ts`, so under `session_scope="thread"` they fall back to
  the user-scoped key (documented).

## Testing

- `go test ./platform/slack/ ./agent/tmux/` — added unit tests for `normalizeSessionScope`,
  `buildSessionKey`, `ReconstructReplyCtx`, `windowForSession`, and the `WorkspaceAgentOptions`
  round-trip.
- Manual: built and ran against a real Slack workspace — distinct threads produced distinct
  cc-connect sessions, distinct tmux windows, and independent agent memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
