### PR TITLE
fix(pi): pipe prompt via stdin to avoid CLI option parsing

### DIFF
--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -107,9 +107,6 @@ func (s *piSession) Send(prompt string, images []core.ImageAttachment, files []c
 		args = append(args, "@"+f)
 	}
 
-	// Append prompt as positional arg
-	args = append(args, prompt)
-
 	slog.Debug("piSession: launching", "resume", sid != "", "args", core.RedactArgs(args))
 
 	cmd := exec.CommandContext(s.ctx, s.cmd, args...)
@@ -119,6 +116,10 @@ func (s *piSession) Send(prompt string, images []core.ImageAttachment, files []c
 		env = core.MergeEnv(env, s.extraEnv)
 	}
 	cmd.Env = env
+
+	// Pipe prompt via stdin so leading "---" (from reply chain headers) is
+	// not misinterpreted as a CLI option flag.
+	cmd.Stdin = strings.NewReader(prompt)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary

Pipe pi agent prompts through stdin instead of as positional CLI arguments, so leading `---` (reply chain header) is not misinterpreted as a CLI option flag.

## Problem

Reply chain headers start with `--- Reply chain (N messages) ---`. When this text reaches `piSession.Send()`, it's appended as a positional CLI argument. Pi's option parser sees `---` and interprets it as an option flag, producing:

```
Error: Unknown option: --- Reply chain (2 messages) ---
```

The same issue affects any prompt text beginning with `--` (e.g., `--help` prints usage instead of accepting it as the prompt).

## Solution

Pipe prompt via `cmd.Stdin = strings.NewReader(prompt)` instead of passing it as a positional CLI argument. Content via stdin bypasses option parsing — only actual CLI flags are parsed. This is consistent with how gemini and codex agents already handle prompts.

## Changes

| File | Change |
|------|--------|
| agent/pi/session.go | Remove prompt from CLI args, pipe via stdin |

## Test plan

- [x] go test ./agent/pi/ — 74 tests pass
- [x] go build ./agent/pi/ passes
- [x] Prompt starting with `--- Reply chain` via stdin → treated as prompt text
- [x] Prompt starting with `--help` via stdin → treated as prompt text (old CLI-arg way: pi printed help docs)
- [x] Verified in production Feishu environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)