### PR TITLE
 feat(send): 支持 --at-users / --at-all 命令行参数，DingTalk @mention 通知

### DIFF
--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -109,6 +109,19 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 			filePaths = append(filePaths, args[i])
 		case "--stdin":
 			useStdin = true
+		case "--at-users":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--at-users requires a value")
+			}
+			i++
+			for _, uid := range strings.Split(args[i], ",") {
+				uid = strings.TrimSpace(uid)
+				if uid != "" {
+					req.AtUsers = append(req.AtUsers, uid)
+				}
+			}
+		case "--at-all":
+			req.AtAll = true
 		case "--data-dir":
 			if i+1 >= len(args) {
 				return req, "", fmt.Errorf("--data-dir requires a value")
@@ -261,6 +274,8 @@ Options:
       --image <path>       Send an image attachment (repeatable)
       --file <path>        Send a file attachment (repeatable)
       --stdin              Read message from stdin (best for long/special-char messages)
+      --at-users <ids>     @ user IDs, comma-separated (DingTalk)
+      --at-all             @ everyone (DingTalk)
   -p, --project <name>     Target project (optional if only one project)
   -s, --session <key>      Target session key (optional, picks first active)
       --data-dir <path>    Data directory (default: ~/.cc-connect)

--- a/core/api.go
+++ b/core/api.go
@@ -33,6 +33,8 @@ type SendRequest struct {
 	Message    string            `json:"message"`
 	Images     []ImageAttachment `json:"images,omitempty"`
 	Files      []FileAttachment  `json:"files,omitempty"`
+	AtUsers    []string          `json:"at_users,omitempty"`
+	AtAll      bool              `json:"at_all,omitempty"`
 }
 
 // NewAPIServer creates an API server on a Unix socket.
@@ -172,7 +174,7 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := engine.SendToSessionWithAttachments(req.SessionKey, req.Message, req.Images, req.Files); err != nil {
+	if err := engine.SendToSessionWithAttachments(req.SessionKey, req.Message, req.Images, req.Files, req.AtUsers, req.AtAll); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -8917,10 +8917,10 @@ func (e *Engine) tryProviderAddPreset(p Platform, msg *Message, switcher Provide
 // SendToSession sends a message to an active session from an external caller (API/CLI).
 // If sessionKey is empty, it picks the first active session.
 func (e *Engine) SendToSession(sessionKey, message string) error {
-	return e.SendToSessionWithAttachments(sessionKey, message, nil, nil)
+	return e.SendToSessionWithAttachments(sessionKey, message, nil, nil, nil, false)
 }
 
-func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images []ImageAttachment, files []FileAttachment) error {
+func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images []ImageAttachment, files []FileAttachment, atUsers []string, atAll bool) error {
 	e.interactiveMu.Lock()
 
 	var state *interactiveState
@@ -9033,8 +9033,21 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 		if err := e.waitOutgoing(p); err != nil {
 			return err
 		}
-		if err := p.Send(e.ctx, replyCtx, message); err != nil {
-			return err
+		// Use AtMentionSender when @users specified and platform supports it
+		if (len(atUsers) > 0 || atAll) {
+			if atSender, ok := p.(AtMentionSender); ok {
+				if err := atSender.ReplyWithAt(e.ctx, replyCtx, message, atUsers, atAll); err != nil {
+					return err
+				}
+			} else {
+				if err := p.Send(e.ctx, replyCtx, message); err != nil {
+					return err
+				}
+			}
+		} else {
+			if err := p.Send(e.ctx, replyCtx, message); err != nil {
+				return err
+			}
 		}
 		if state != nil {
 			state.mu.Lock()

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -687,7 +687,7 @@ func newTestEngine() *Engine {
 	return NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
 }
 
-func TestEngineSendToSessionWithAttachments(t *testing.T, nil, false) {
+func TestEngineSendToSessionWithAttachments(t *testing.T) {
 	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
 	e.interactiveStates["session-1"] = &interactiveState{
@@ -698,9 +698,9 @@ func TestEngineSendToSessionWithAttachments(t *testing.T, nil, false) {
 	err := e.SendToSessionWithAttachments(
 		"session-1",
 		"delivery ready",
-		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img", nil, false), FileName: "chart.png"}},
+		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img"), FileName: "chart.png"}},
 		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc"), FileName: "report.txt"}},
-	)
+		nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
@@ -727,9 +727,8 @@ func TestEngineSendToSessionWithAttachments_UnsupportedPlatform(t *testing.T) {
 	err := e.SendToSessionWithAttachments(
 		"session-1",
 		"delivery ready",
-		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img", nil, false), FileName: "chart.png"}},
-		nil,
-	)
+		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img"), FileName: "chart.png"}},
+		nil, nil, false)
 	if err == nil {
 		t.Fatal("expected unsupported attachment send to fail")
 	}
@@ -751,8 +750,8 @@ func TestEngineSendToSessionWithAttachments_DisabledByConfig(t *testing.T) {
 		"session-1",
 		"delivery ready",
 		nil,
-		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc", nil, false), FileName: "report.txt"}},
-	)
+		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc"), FileName: "report.txt"}},
+		nil, false)
 	if err == nil {
 		t.Fatal("expected attachment send to be blocked")
 	}
@@ -981,9 +980,9 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelText(t *testing.
 	sideText := "已发送 AGENTS.md 文件给你。"
 	if err := e.SendToSessionWithAttachments(sessionKey, sideText, nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body", nil, false),
+		Data:     []byte("body"),
 		FileName: "AGENTS.md",
-	}}); err != nil {
+	}}, nil, false); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
 
@@ -1011,9 +1010,9 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelTextWithContextI
 	sideText := "已发送 AGENTS.md 文件给你。"
 	if err := e.SendToSessionWithAttachments(sessionKey, sideText, nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body", nil, false),
+		Data:     []byte("body"),
 		FileName: "AGENTS.md",
-	}}); err != nil {
+	}}, nil, false); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
 
@@ -1040,9 +1039,9 @@ func TestProcessInteractiveEvents_DoesNotSuppressDifferentFinalText(t *testing.T
 
 	if err := e.SendToSessionWithAttachments(sessionKey, "已发送 AGENTS.md 文件给你。", nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body", nil, false),
+		Data:     []byte("body"),
 		FileName: "AGENTS.md",
-	}}); err != nil {
+	}}, nil, false); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -687,7 +687,7 @@ func newTestEngine() *Engine {
 	return NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
 }
 
-func TestEngineSendToSessionWithAttachments(t *testing.T) {
+func TestEngineSendToSessionWithAttachments(t *testing.T, nil, false) {
 	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
 	e.interactiveStates["session-1"] = &interactiveState{
@@ -698,7 +698,7 @@ func TestEngineSendToSessionWithAttachments(t *testing.T) {
 	err := e.SendToSessionWithAttachments(
 		"session-1",
 		"delivery ready",
-		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img"), FileName: "chart.png"}},
+		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img", nil, false), FileName: "chart.png"}},
 		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc"), FileName: "report.txt"}},
 	)
 	if err != nil {
@@ -727,7 +727,7 @@ func TestEngineSendToSessionWithAttachments_UnsupportedPlatform(t *testing.T) {
 	err := e.SendToSessionWithAttachments(
 		"session-1",
 		"delivery ready",
-		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img"), FileName: "chart.png"}},
+		[]ImageAttachment{{MimeType: "image/png", Data: []byte("img", nil, false), FileName: "chart.png"}},
 		nil,
 	)
 	if err == nil {
@@ -751,7 +751,7 @@ func TestEngineSendToSessionWithAttachments_DisabledByConfig(t *testing.T) {
 		"session-1",
 		"delivery ready",
 		nil,
-		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc"), FileName: "report.txt"}},
+		[]FileAttachment{{MimeType: "text/plain", Data: []byte("doc", nil, false), FileName: "report.txt"}},
 	)
 	if err == nil {
 		t.Fatal("expected attachment send to be blocked")
@@ -790,7 +790,7 @@ func TestEngineSendToSessionWithAttachments_MultiWorkspaceRawSessionKey(t *testi
 		replyCtx: "ctx-1",
 	}
 
-	err := e.SendToSessionWithAttachments(rawKey, "delivery ready", nil, nil)
+	err := e.SendToSessionWithAttachments(rawKey, "delivery ready", nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
@@ -818,7 +818,7 @@ func TestEngineSendToSessionWithAttachments_WorkspacePrefixedSessionKey(t *testi
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
 
 	prefixed := "/tmp/myproject:slack:C123:U1"
-	err := e.SendToSessionWithAttachments(prefixed, "delivery ready", nil, nil)
+	err := e.SendToSessionWithAttachments(prefixed, "delivery ready", nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
 	}
@@ -981,7 +981,7 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelText(t *testing.
 	sideText := "已发送 AGENTS.md 文件给你。"
 	if err := e.SendToSessionWithAttachments(sessionKey, sideText, nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body"),
+		Data:     []byte("body", nil, false),
 		FileName: "AGENTS.md",
 	}}); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
@@ -1011,7 +1011,7 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelTextWithContextI
 	sideText := "已发送 AGENTS.md 文件给你。"
 	if err := e.SendToSessionWithAttachments(sessionKey, sideText, nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body"),
+		Data:     []byte("body", nil, false),
 		FileName: "AGENTS.md",
 	}}); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)
@@ -1040,7 +1040,7 @@ func TestProcessInteractiveEvents_DoesNotSuppressDifferentFinalText(t *testing.T
 
 	if err := e.SendToSessionWithAttachments(sessionKey, "已发送 AGENTS.md 文件给你。", nil, []FileAttachment{{
 		MimeType: "text/markdown",
-		Data:     []byte("body"),
+		Data:     []byte("body", nil, false),
 		FileName: "AGENTS.md",
 	}}); err != nil {
 		t.Fatalf("SendToSessionWithAttachments returned error: %v", err)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -173,6 +173,13 @@ type TypingIndicatorDone interface {
 	AddDoneReaction(replyCtx any)
 }
 
+// AtMentionSender is an optional interface for platforms that support @mention in
+// reply messages (e.g. DingTalk). Platforms that implement this interface can
+// include @user notifications when replying in group chats.
+type AtMentionSender interface {
+	ReplyWithAt(ctx context.Context, replyCtx any, content string, atUsers []string, atAll bool) error
+}
+
 // ImageSender is an optional interface for platforms that support sending images.
 type ImageSender interface {
 	SendImage(ctx context.Context, replyCtx any, img ImageAttachment) error

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -440,7 +440,7 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 		slog.Error("dingtalk: failed to download image", "error", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		slog.Error("dingtalk: image download returned status", "status", resp.StatusCode)
@@ -497,7 +497,7 @@ func (p *Platform) downloadAudio(downloadCode string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", fmt.Errorf("http get: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, "", fmt.Errorf("download returned status %d", resp.StatusCode)
@@ -548,7 +548,7 @@ func (p *Platform) getDownloadURL(downloadCode string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("do request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("api returned status %d", resp.StatusCode)
@@ -600,7 +600,7 @@ func (p *Platform) getAccessToken() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("do request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -675,7 +675,7 @@ func (p *Platform) ReplyWithAt(ctx context.Context, rctx any, content string, at
 	if err != nil {
 		return fmt.Errorf("dingtalk: send reply: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("dingtalk: reply returned status %d", resp.StatusCode)
@@ -715,7 +715,7 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	if err != nil {
 		return fmt.Errorf("dingtalk: send reply: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("dingtalk: reply returned status %d", resp.StatusCode)
@@ -787,7 +787,7 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 	if err != nil {
 		return fmt.Errorf("dingtalk: send image request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	slog.Debug("dingtalk: oToMessages image response", "status", resp.StatusCode, "body", string(respBody))
@@ -880,7 +880,7 @@ func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachm
 	if err != nil {
 		return fmt.Errorf("dingtalk: send file request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	slog.Debug("dingtalk: oToMessages file response", "status", resp.StatusCode, "body", string(respBody))
@@ -1005,7 +1005,7 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 	if err != nil {
 		return fmt.Errorf("dingtalk: send audio request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	slog.Debug("dingtalk: oToMessages API response", "status", resp.StatusCode, "body", string(respBody))
@@ -1096,7 +1096,7 @@ func (p *Platform) uploadMedia(ctx context.Context, data []byte, fileName, media
 	if err != nil {
 		return "", fmt.Errorf("upload request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -1416,7 +1416,7 @@ func (p *Platform) sendProactiveMessage(ctx context.Context, rc replyContext, co
 	if err != nil {
 		return fmt.Errorf("dingtalk: proactive send request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -639,6 +639,50 @@ func (p *Platform) getAccessToken() (string, error) {
 	return p.accessToken, nil
 }
 
+// ReplyWithAt sends a reply with @mention support. Uses text msgtype (not markdown)
+// because only text type supports highlighted/blue @mentions in DingTalk.
+func (p *Platform) ReplyWithAt(ctx context.Context, rctx any, content string, atUsers []string, atAll bool) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return fmt.Errorf("dingtalk: invalid reply context type %T", rctx)
+	}
+	if rc.proactive || rc.sessionWebhook == "" {
+		return p.sendProactiveMessage(ctx, rc, content)
+	}
+
+	payload := map[string]any{
+		"msgtype": "text",
+		"text":    map[string]string{"content": content},
+	}
+	if len(atUsers) > 0 || atAll {
+		payload["at"] = map[string]any{
+			"atUserIds": atUsers,
+			"isAtAll":   atAll,
+		}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("dingtalk: marshal reply: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rc.sessionWebhook, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("dingtalk: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := core.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("dingtalk: send reply: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("dingtalk: reply returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
 func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	rc, ok := rctx.(replyContext)
 	if !ok {

--- a/tests/release_local/media_pipeline/media_pipeline_test.go
+++ b/tests/release_local/media_pipeline/media_pipeline_test.go
@@ -307,7 +307,7 @@ func TestSendToSessionWithAttachmentsDeliversTextImagesAndFiles(t *testing.T) {
 	err := engine.SendToSessionWithAttachments(
 		msg.SessionKey,
 		"delivery ready",
-		[]core.ImageAttachment{{MimeType: "image/png", FileName: "chart.png", Data: []byte("chart")}},
+		[]core.ImageAttachment{{MimeType: "image/png", FileName: "chart.png", Data: []byte("chart", nil, false)}},
 		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report")}},
 	)
 	if err != nil {
@@ -344,7 +344,7 @@ func TestSendToSessionWithAttachmentsDoesNotDuplicateEchoedFinalTextWithContextI
 		msg.SessionKey,
 		sideText,
 		nil,
-		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report")}},
+		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report", nil, false)}},
 	)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments() error = %v", err)
@@ -399,7 +399,7 @@ func TestSendToSessionWithAttachmentsRespectsDisabledAttachmentSend(t *testing.T
 		msg.SessionKey,
 		"should not send",
 		nil,
-		[]core.FileAttachment{{MimeType: "text/plain", FileName: "blocked.txt", Data: []byte("blocked")}},
+		[]core.FileAttachment{{MimeType: "text/plain", FileName: "blocked.txt", Data: []byte("blocked", nil, false)}},
 	)
 	if !errors.Is(err, core.ErrAttachmentSendDisabled) {
 		t.Fatalf("err = %v, want ErrAttachmentSendDisabled", err)
@@ -426,7 +426,7 @@ func TestSendToSessionWithAttachmentsRequiresSessionWhenMultipleSessionsHaveAtta
 	err := engine.SendToSessionWithAttachments(
 		"",
 		"ambiguous",
-		[]core.ImageAttachment{{MimeType: "image/png", FileName: "ambiguous.png", Data: []byte("img")}},
+		[]core.ImageAttachment{{MimeType: "image/png", FileName: "ambiguous.png", Data: []byte("img", nil, false)}},
 		nil,
 	)
 	if err == nil || !strings.Contains(err.Error(), "multiple active sessions") {

--- a/tests/release_local/media_pipeline/media_pipeline_test.go
+++ b/tests/release_local/media_pipeline/media_pipeline_test.go
@@ -307,9 +307,9 @@ func TestSendToSessionWithAttachmentsDeliversTextImagesAndFiles(t *testing.T) {
 	err := engine.SendToSessionWithAttachments(
 		msg.SessionKey,
 		"delivery ready",
-		[]core.ImageAttachment{{MimeType: "image/png", FileName: "chart.png", Data: []byte("chart", nil, false)}},
+		[]core.ImageAttachment{{MimeType: "image/png", FileName: "chart.png", Data: []byte("chart")}},
 		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report")}},
-	)
+		nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments() error = %v", err)
 	}
@@ -344,8 +344,8 @@ func TestSendToSessionWithAttachmentsDoesNotDuplicateEchoedFinalTextWithContextI
 		msg.SessionKey,
 		sideText,
 		nil,
-		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report", nil, false)}},
-	)
+		[]core.FileAttachment{{MimeType: "text/plain", FileName: "report.txt", Data: []byte("report")}},
+		nil, false)
 	if err != nil {
 		t.Fatalf("SendToSessionWithAttachments() error = %v", err)
 	}
@@ -399,8 +399,8 @@ func TestSendToSessionWithAttachmentsRespectsDisabledAttachmentSend(t *testing.T
 		msg.SessionKey,
 		"should not send",
 		nil,
-		[]core.FileAttachment{{MimeType: "text/plain", FileName: "blocked.txt", Data: []byte("blocked", nil, false)}},
-	)
+		[]core.FileAttachment{{MimeType: "text/plain", FileName: "blocked.txt", Data: []byte("blocked")}},
+		nil, false)
 	if !errors.Is(err, core.ErrAttachmentSendDisabled) {
 		t.Fatalf("err = %v, want ErrAttachmentSendDisabled", err)
 	}
@@ -426,9 +426,9 @@ func TestSendToSessionWithAttachmentsRequiresSessionWhenMultipleSessionsHaveAtta
 	err := engine.SendToSessionWithAttachments(
 		"",
 		"ambiguous",
-		[]core.ImageAttachment{{MimeType: "image/png", FileName: "ambiguous.png", Data: []byte("img", nil, false)}},
+		[]core.ImageAttachment{{MimeType: "image/png", FileName: "ambiguous.png", Data: []byte("img")}},
 		nil,
-	)
+		nil, false)
 	if err == nil || !strings.Contains(err.Error(), "multiple active sessions") {
 		t.Fatalf("err = %v, want multiple active sessions error", err)
 	}

--- a/tests/release_local/turn_contract/turn_contract_test.go
+++ b/tests/release_local/turn_contract/turn_contract_test.go
@@ -348,7 +348,7 @@ func TestSideChannelEchoContractAcrossOutboundModalities(t *testing.T) {
 			agent.session.waitRecords(t, 1)
 
 			sideText := "delivery ready"
-			if err := engine.SendToSessionWithAttachments(msg.SessionKey, sideText, tt.images, tt.files); err != nil {
+			if err := engine.SendToSessionWithAttachments(msg.SessionKey, sideText, tt.images, tt.files, nil, false); err != nil {
 				t.Fatalf("SendToSessionWithAttachments() error = %v", err)
 			}
 			agent.session.releaseFirstResult(core.Event{Type: core.EventResult, Content: sideText, InputTokens: 52000, Done: true})
@@ -366,7 +366,7 @@ func TestSideChannelDifferentFinalContract(t *testing.T) {
 	agent.session.waitRecords(t, 1)
 
 	sideText := "delivery ready"
-	if err := engine.SendToSessionWithAttachments(msg.SessionKey, sideText, nil, nil); err != nil {
+	if err := engine.SendToSessionWithAttachments(msg.SessionKey, sideText, nil, nil, nil, false); err != nil {
 		t.Fatalf("SendToSessionWithAttachments() error = %v", err)
 	}
 


### PR DESCRIPTION
 ## 概述

  新增 `--at-users` 和 `--at-all` CLI/API 参数，支持在 DingTalk 群聊中 @ 指定用户或 @所有人。

  ## 变更说明
  
  ### 新增功能
  - **CLI**: `cc-connect send --at-users <ids> --at-all` 参数，逗号分隔用户 ID
  - **API**: `SendRequest` 新增 `at_users` / `at_all` 字段
  - **接口**: `AtMentionSender` 可选接口，平台可选择性实现 `ReplyWithAt`

  ### DingTalk 实现
  - `ReplyWithAt` 使用 `msgtype: text`（仅 text 类型支持高亮 @mention）
  - 通过 webhook 发送，携带 `at.atUserIds` / `at.isAtAll` 字段

  ### 引擎逻辑
  - `SendToSessionWithAttachments` 检测 `AtMentionSender` 能力
  - 指定 @ 参数时优先调用 `ReplyWithAt`，否则 fallback 到普通 `Send`

  ## 变更文件

  | 文件 | 变更 |
  |------|------|
  | `cmd/cc-connect/send.go` | +15 新增 CLI 参数解析 |
  | `core/api.go` | +2 AtUsers/AtAll 字段 |
  | `core/engine.go` | +21 AtMentionSender 能力检测与调用 |
  | `core/interfaces.go` | +7 AtMentionSender 接口 |
  | `platform/dingtalk/dingtalk.go` | +44 ReplyWithAt 实现 |
  | `core/engine_test.go` | 更新调用方签名 |
  | `tests/.../media_pipeline_test.go` | 更新调用方签名 |
  | `tests/.../turn_contract_test.go` | 更新调用方签名 |