### PR TITLE
Reply to unauthorized IM senders

### DIFF
--- a/core/message.go
+++ b/core/message.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+// UnauthorizedAccessMessage is safe to show to an inbound sender when the
+// platform boundary rejects their identity. Keep it user-facing: do not mention
+// allow_from, user IDs, or chat IDs.
+const UnauthorizedAccessMessage = "角色未授权，请联系管理员添加权限。"
+
 // MergeEnv returns base env with entries from extra overriding same-key entries.
 // This prevents duplicate keys (e.g. two PATH entries) which cause the override
 // to be silently ignored on Linux (getenv returns the first match).

--- a/core/message_test.go
+++ b/core/message_test.go
@@ -39,6 +39,15 @@ func TestSanitizeAttachmentFileName(t *testing.T) {
 	}
 }
 
+func TestUnauthorizedAccessMessage(t *testing.T) {
+	if !strings.Contains(UnauthorizedAccessMessage, "角色未授权") {
+		t.Fatalf("UnauthorizedAccessMessage = %q, want user-facing authorization hint", UnauthorizedAccessMessage)
+	}
+	if strings.Contains(UnauthorizedAccessMessage, "allow_from") {
+		t.Fatalf("UnauthorizedAccessMessage leaks implementation details: %q", UnauthorizedAccessMessage)
+	}
+}
+
 // TestSaveFilesToDisk_RejectsPathTraversal is a regression test for a real
 // path-traversal vulnerability in SaveFilesToDisk: the attachment FileName
 // (which comes from user-controlled IM/HTTP upload metadata) was passed

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -232,6 +232,7 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 
 	if !core.AllowList(p.allowFrom, data.SenderStaffId) {
 		slog.Debug("dingtalk: message from unauthorized user", "user", data.SenderStaffId)
+		p.replyUnauthorized(data)
 		return
 	}
 
@@ -312,6 +313,23 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 	}
 
 	p.handler(p, msg)
+}
+
+func (p *Platform) replyUnauthorized(data *chatbot.BotCallbackDataModel) {
+	if data == nil || data.SessionWebhook == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := p.Reply(ctx, replyContext{
+		sessionWebhook: data.SessionWebhook,
+		conversationId: data.ConversationId,
+		senderStaffId:  data.SenderStaffId,
+		isGroup:        data.ConversationType == "2",
+	}, core.UnauthorizedAccessMessage)
+	if err != nil {
+		slog.Warn("dingtalk: unauthorized reply failed", "error", err)
+	}
 }
 
 // extractRichText extracts plain text from a DingTalk richText content payload.

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/chenhg5/cc-connect/core"
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
 )
 
 // ──────────────────────────────────────────────────────────────
@@ -792,5 +794,49 @@ func TestGetAccessToken_NormalExpireIn_AppliesBuffer(t *testing.T) {
 	gotWindow := p.tokenExpiry.Sub(before)
 	if gotWindow < 100*time.Minute || gotWindow > 116*time.Minute {
 		t.Errorf("tokenExpiry window for expireIn=7200 = %v, want ~6900s (100-116min)", gotWindow)
+	}
+}
+
+func TestOnMessageRepliesToUnauthorizedSender(t *testing.T) {
+	gotReply := make(chan string, 1)
+	sessionWebhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Markdown struct {
+				Text string `json:"text"`
+			} `json:"markdown"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode reply payload: %v", err)
+		}
+		gotReply <- payload.Markdown.Text
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sessionWebhook.Close()
+
+	p := &Platform{
+		allowFrom: "allowed-user",
+		handler: func(core.Platform, *core.Message) {
+			t.Fatal("handler should not run for unauthorized sender")
+		},
+	}
+
+	p.onMessage(&chatbot.BotCallbackDataModel{
+		MsgId:            "msg_unauthorized",
+		Msgtype:          "text",
+		SenderStaffId:    "blocked-user",
+		SenderNick:       "Blocked User",
+		ConversationId:   "cid_direct",
+		ConversationType: "1",
+		SessionWebhook:   sessionWebhook.URL,
+		Text:             chatbot.BotCallbackDataTextModel{Content: "hello"},
+	}, nil)
+
+	select {
+	case got := <-gotReply:
+		if got != core.UnauthorizedAccessMessage {
+			t.Fatalf("reply = %q, want %q", got, core.UnauthorizedAccessMessage)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unauthorized reply")
 	}
 }

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1076,6 +1076,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 
 	if !core.AllowList(p.allowFrom, userID) {
 		slog.Debug(p.tag()+": message from unauthorized user", "user", userID)
+		p.replyUnauthorizedAccess(ctx, replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey})
 		return nil
 	}
 
@@ -1119,6 +1120,15 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID)
 
 	return nil
+}
+
+func (p *Platform) replyUnauthorizedAccess(ctx context.Context, rctx replyContext) {
+	if rctx.messageID == "" && rctx.chatID == "" {
+		return
+	}
+	if err := p.Reply(ctx, rctx, core.UnauthorizedAccessMessage); err != nil {
+		slog.Warn(p.tag()+": unauthorized reply failed", "error", err)
+	}
 }
 
 // dispatchMessage handles the message content parsing, media download, and
@@ -1971,7 +1981,9 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 			if label == "" {
 				// label may be in property.text.property.content
 				var textElem struct {
-					Property struct{ Content string `json:"content"` } `json:"property"`
+					Property struct {
+						Content string `json:"content"`
+					} `json:"property"`
 				}
 				if json.Unmarshal(elem.Property.Text, &textElem) == nil {
 					label = textElem.Property.Content

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -2,6 +2,7 @@ package feishu
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -296,6 +297,99 @@ func TestDispatchMessageKeepsMentionOnlyQuotedText(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for mention-only quoted text message")
+	}
+}
+
+func TestOnMessageRepliesToUnauthorizedMention(t *testing.T) {
+	const appID = "cli_unauthorized"
+	const appSecret = "secret-unauthorized"
+	const botOpenID = "ou_bot"
+	const userOpenID = "ou_blocked"
+
+	replyBodies := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/reply"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read reply body: %v", err)
+			}
+			replyBodies <- string(body)
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{"message_id": "om_reply_ok"},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		allowFrom:    "ou_allowed",
+		botOpenID:    botOpenID,
+		dedup:        &core.MessageDedup{},
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(core.Platform, *core.Message) {
+			t.Fatal("handler should not run for unauthorized sender")
+		},
+	}
+
+	chatType := "group"
+	msgType := "text"
+	senderType := "user"
+	content := `{"text":"@_user_1 hello"}`
+	createTime := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	err := p.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: stringPtr(userOpenID)},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   stringPtr("om_unauthorized"),
+				ChatId:      stringPtr("oc_group"),
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     &content,
+				CreateTime:  &createTime,
+				Mentions: []*larkim.MentionEvent{
+					{
+						Key:  stringPtr("@_user_1"),
+						Id:   &larkim.UserId{OpenId: stringPtr(botOpenID)},
+						Name: stringPtr("bot"),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onMessage() error = %v", err)
+	}
+
+	select {
+	case got := <-replyBodies:
+		if !strings.Contains(got, core.UnauthorizedAccessMessage) {
+			t.Fatalf("reply body = %q, want unauthorized message", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unauthorized reply")
 	}
 }
 

--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -378,23 +378,26 @@ func (p *WSPlatform) handleMsgCallback(frame wsFrame) {
 		}
 	}
 
-	if !core.AllowList(p.allowFrom, body.From.UserID) {
-		slog.Debug("wecom-ws: message from unauthorized user", "user", body.From.UserID)
-		return
-	}
-
 	chatID := body.ChatID
 	if chatID == "" {
 		chatID = body.From.UserID
 	}
-
-	sessionKey := fmt.Sprintf("wecom:%s:%s", chatID, body.From.UserID)
 	rctx := wsReplyContext{
 		reqID:    reqID,
 		chatID:   chatID,
 		chatType: body.ChatType,
 		userID:   body.From.UserID,
 	}
+
+	if !core.AllowList(p.allowFrom, body.From.UserID) {
+		slog.Debug("wecom-ws: message from unauthorized user", "user", body.From.UserID)
+		if err := p.Reply(context.Background(), rctx, core.UnauthorizedAccessMessage); err != nil {
+			slog.Warn("wecom-ws: unauthorized reply failed", "error", err)
+		}
+		return
+	}
+
+	sessionKey := fmt.Sprintf("wecom:%s:%s", chatID, body.From.UserID)
 
 	// WS mode does not provide display names; the protocol only carries userID.
 	// Name resolution would require a separate HTTP API call with corpSecret,

--- a/platform/wecom/websocket_test.go
+++ b/platform/wecom/websocket_test.go
@@ -178,6 +178,83 @@ func TestHandleMsgCallback_GroupChat_ChatIDPreserved(t *testing.T) {
 	}
 }
 
+func TestHandleMsgCallback_RepliesToUnauthorizedSender(t *testing.T) {
+	serverDone := make(chan error, 1)
+	upgrader := websocket.Upgrader{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+		var frame wsFrame
+		if err := conn.ReadJSON(&frame); err != nil {
+			serverDone <- err
+			return
+		}
+		var body struct {
+			Stream struct {
+				Content string `json:"content"`
+			} `json:"stream"`
+		}
+		if err := json.Unmarshal(frame.Body, &body); err != nil {
+			serverDone <- err
+			return
+		}
+		if frame.Cmd != "aibot_respond_msg" {
+			serverDone <- fmt.Errorf("cmd = %q, want aibot_respond_msg", frame.Cmd)
+			return
+		}
+		if got := body.Stream.Content; got != core.UnauthorizedAccessMessage {
+			serverDone <- fmt.Errorf("content = %q, want %q", got, core.UnauthorizedAccessMessage)
+			return
+		}
+		serverDone <- nil
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial test websocket: %v", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	p := &WSPlatform{
+		allowFrom: "allowed-user",
+		conn:      conn,
+		handler: func(core.Platform, *core.Message) {
+			t.Fatal("handler should not run for unauthorized sender")
+		},
+	}
+
+	body := wsMsgCallbackBody{
+		MsgID:    "msg_unauthorized",
+		ChatID:   "chat_group",
+		ChatType: "group",
+		MsgType:  "text",
+	}
+	body.From.UserID = "blocked-user"
+	body.Text.Content = "@bot hello"
+	body.CreateTime = time.Now().Unix()
+	p.handleMsgCallback(wsCallbackFrame(t, "req_unauthorized", body))
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unauthorized reply frame")
+	}
+}
+
 func TestHandleMsgCallback_StripsBotMention(t *testing.T) {
 	p, captured := newCapturedWSPlatform()
 	p.botID = "robot01"


### PR DESCRIPTION
## Summary
- add a shared user-facing unauthorized-access message
- reply to triggered DingTalk, Feishu, and WeCom WebSocket messages rejected by allow_from
- keep implementation details such as allow_from, user IDs, and chat IDs out of user-facing replies
- add adapter-level regression tests

## Verification
- go test -tags no_web ./core ./platform/dingtalk ./platform/feishu ./platform/wecom -run 'TestUnauthorizedAccessMessage|TestOnMessageRepliesToUnauthorizedSender|TestOnMessageRepliesToUnauthorizedMention|TestHandleMsgCallback_RepliesToUnauthorizedSender' -count=1\n- git diff --check\n\nNote: a full `go test -tags no_web ./core ./platform/dingtalk ./platform/feishu ./platform/wecom -count=1` run currently hits existing upstream/main footer path expectation failures in core interactive event tests; this PR does not touch that path.