### PR TITLE
docs(config): document card_mode option in config example

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -99,6 +99,7 @@ level = "info" # debug, info, warn, error
 
 # [display]
 # mode = "full"             # Display mode: "full" (default), "compact", or "quiet"
+# card_mode = "legacy"      # Card rendering: "legacy" (default) or "rich" (Feishu Card 2.0)
 #                           # full: show thinking + tool messages as separate messages
 #                           #       显示思考和工具消息，每条单独发送
 #                           # compact: hide thinking/tool, each text segment sent separately


### PR DESCRIPTION
## Summary
- document the existing `[display].card_mode` option in `config.example.toml`
- keep this PR scoped to a docs-only follow-up after the rich card implementation was superseded by #1204

## Context
- The original Feishu rich streaming card implementation from this PR has been replaced by the implementation merged in #1204.
- The current diff only adds the missing config example line for `card_mode`, matching the existing `CardMode` / `EffectiveCardMode` support already on `main`.

## Tests
- Not run for this docs-only update.
- Current GitHub Actions `unit-test` failure is the known `TestCUJ_H2_TwoPlatformsConcurrentNoBleed` flaky failure tracked separately; it is unrelated to this 1-line config example change.
