### PR TITLE
feat(minimax): upgrade default model to MiniMax-M3

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -849,7 +849,7 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "auto" | "bypassP
 #
 # # MiniMax — OpenAI-compatible provider with 1M context window
 # # MiniMax — 兼容 OpenAI 接口的大模型，支持 1M 超长上下文
-# # Models: MiniMax-M3 (latest), MiniMax-M2.7 (1M context), MiniMax-M2.7-highspeed
+# # Models: MiniMax-M3 (latest), MiniMax-M2.7 (512K context), MiniMax-M2.7-highspeed
 # # Docs: https://platform.minimaxi.com
 # [[projects.agent.providers]]
 # name = "minimax"

--- a/config.example.toml
+++ b/config.example.toml
@@ -68,7 +68,7 @@ level = "info" # debug, info, warn, error
 # api_key = "${MINIMAXI_API_KEY}"
 # base_url = "https://api.minimaxi.chat/v1"
 # agent_types = ["codex"]
-# model = "MiniMax-M2.7"
+# model = "MiniMax-M3"
 
 # [[providers]]
 # name = "dashscope"
@@ -849,26 +849,23 @@ mode = "default" # "default" | "acceptEdits" (edit) | "plan" | "auto" | "bypassP
 #
 # # MiniMax — OpenAI-compatible provider with 1M context window
 # # MiniMax — 兼容 OpenAI 接口的大模型，支持 1M 超长上下文
-# # Models: MiniMax-M2.7 (flagship, 1M context), MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
+# # Models: MiniMax-M3 (latest), MiniMax-M2.7 (1M context), MiniMax-M2.7-highspeed
 # # Docs: https://platform.minimaxi.com
 # [[projects.agent.providers]]
 # name = "minimax"
 # api_key = "your-minimax-api-key"
 # base_url = "https://api.minimax.io/v1"
-# model = "MiniMax-M2.7"
+# model = "MiniMax-M3"
 # thinking = "disabled"
+# [[projects.agent.providers.models]]
+# model = "MiniMax-M3"
+# alias = "m3"
 # [[projects.agent.providers.models]]
 # model = "MiniMax-M2.7"
 # alias = "m27"
 # [[projects.agent.providers.models]]
 # model = "MiniMax-M2.7-highspeed"
 # alias = "m27fast"
-# [[projects.agent.providers.models]]
-# model = "MiniMax-M2.5"
-# alias = "m25"
-# [[projects.agent.providers.models]]
-# model = "MiniMax-M2.5-highspeed"
-# alias = "m25fast"
 #
 # # For special setups (Bedrock, Vertex, Foundry), use the env map:
 # # 特殊环境（Bedrock、Vertex、Foundry）使用 env 字段：
@@ -1384,7 +1381,7 @@ app_secret = "your-feishu-app-secret"
 # name = "minimax"
 # api_key = "your-minimax-api-key"
 # base_url = "https://api.minimax.io/v1"
-# model = "MiniMax-M2.7"
+# model = "MiniMax-M3"
 #
 # [[projects.platforms]]
 # type = "telegram"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -171,7 +171,7 @@ alias = "haiku"
 name = "minimax"
 api_key = "your-minimax-api-key"
 base_url = "https://api.minimax.io/v1"
-model = "MiniMax-M2.7"
+model = "MiniMax-M3"
 
 # For Bedrock, Vertex, etc.
 [[projects.agent.providers]]

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -169,7 +169,7 @@ alias = "haiku"
 name = "minimax"
 api_key = "your-minimax-api-key"
 base_url = "https://api.minimax.io/v1"
-model = "MiniMax-M2.7"
+model = "MiniMax-M3"
 
 # Bedrock、Vertex 等
 [[projects.agent.providers]]

--- a/provider-presets.json
+++ b/provider-presets.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updated_at": "2026-05-23",
+  "updated_at": "2026-06-02",
   "providers": [
     {
       "name": "minimax",
@@ -14,19 +14,19 @@
       "agents": {
         "claudecode": {
           "base_url": "https://api.minimax.io/anthropic",
-          "model": "MiniMax-M2.7",
-          "models": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5"]
+          "model": "MiniMax-M3",
+          "models": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
         },
         "codex": {
           "base_url": "https://api.minimax.io/v1",
-          "model": "MiniMax-M2.7",
-          "models": ["MiniMax-M2.7", "MiniMax-M2.5"],
+          "model": "MiniMax-M3",
+          "models": ["MiniMax-M3", "MiniMax-M2.7"],
           "codex_config": { "wire_api": "responses" }
         },
         "opencode": {
           "base_url": "https://api.minimax.io/v1",
-          "model": "MiniMax-M2.7",
-          "models": ["MiniMax-M2.7", "MiniMax-M2.5"]
+          "model": "MiniMax-M3",
+          "models": ["MiniMax-M3", "MiniMax-M2.7"]
         }
       }
     },
@@ -42,19 +42,19 @@
       "agents": {
         "claudecode": {
           "base_url": "https://api.minimaxi.com/anthropic",
-          "model": "MiniMax-M2.7",
-          "models": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5"]
+          "model": "MiniMax-M3",
+          "models": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
         },
         "codex": {
           "base_url": "https://api.minimaxi.com/v1",
-          "model": "MiniMax-M2.7",
-          "models": ["MiniMax-M2.7", "MiniMax-M2.5"],
+          "model": "MiniMax-M3",
+          "models": ["MiniMax-M3", "MiniMax-M2.7"],
           "codex_config": { "wire_api": "responses" }
         },
         "opencode": {
           "base_url": "https://api.minimaxi.com/v1",
-          "model": "MiniMax-M2.7",
-          "models": ["MiniMax-M2.7", "MiniMax-M2.5"]
+          "model": "MiniMax-M3",
+          "models": ["MiniMax-M3", "MiniMax-M2.7"]
         }
       }
     },


### PR DESCRIPTION
## Summary

Upgrade the bundled `minimax` / `minimax-cn` provider presets and example configs from `MiniMax-M2.7` to `MiniMax-M3`.

## Changes

- **`provider-presets.json`** — set `MiniMax-M3` as the default `model` for both `minimax` and `minimax-cn` across `claudecode`, `codex`, and `opencode` agents; reorder `models` lists so M3 is first; keep `MiniMax-M2.7` (and `-highspeed` where it was already listed) as fallback options; drop the older `MiniMax-M2.5` entry.
- **`config.example.toml`** — point all `# model = "MiniMax-M2.7"` example lines at `MiniMax-M3`; refresh the model list comment; replace the `M2.5` / `M2.5-highspeed` alias examples with an `M3` alias example, keeping the M2.7 / M2.7-highspeed aliases.
- **`docs/usage.md`** & **`docs/usage.zh-CN.md`** — bump the `model = "MiniMax-M2.7"` snippet to `MiniMax-M3` so the docs match the new default.

API URLs, TTS configuration, and other providers are unchanged. The marketing prose in `README.md` / `README.zh-CN.md` (which references model-specific stats) is left intact.

## Test Plan

- `go test ./config/ ./core/` — passes (config parsing + provider-presets loader tests green).
- `python -c "import json; json.load(open('provider-presets.json'))"` — JSON syntax valid.
- Manual diff inspection: only `minimax` provider blocks are touched; no historical changelog entries modified.