### PR TITLE
feat(wecom): implement SendFile for WebSocket mode

### DIFF
--- a/platform/wecom/websocket_outbound_media.go
+++ b/platform/wecom/websocket_outbound_media.go
@@ -155,4 +155,51 @@ func wsImageFileName(img core.ImageAttachment) string {
 	}
 }
 
+// SendFile uploads and sends a file through the WeCom AI Bot WebSocket API.
+func (p *WSPlatform) SendFile(ctx context.Context, rctx any, file core.FileAttachment) error {
+	rc, ok := rctx.(wsReplyContext)
+	if !ok {
+		return fmt.Errorf("wecom-ws: SendFile: invalid reply context type %T", rctx)
+	}
+	if rc.chatID == "" {
+		return fmt.Errorf("wecom-ws: chatID is empty, cannot send file")
+	}
+	if len(file.Data) == 0 {
+		return fmt.Errorf("wecom-ws: file data is empty")
+	}
+
+	mediaID, err := p.uploadWSMedia(ctx, "file", wsFileFileName(file), file.Data)
+	if err != nil {
+		return fmt.Errorf("wecom-ws: send file: %w", err)
+	}
+	if err := p.sendWSMediaMessage(ctx, rc.chatID, "file", mediaID); err != nil {
+		return fmt.Errorf("wecom-ws: send file: %w", err)
+	}
+	return nil
+}
+
+func wsFileFileName(file core.FileAttachment) string {
+	name := filepath.Base(strings.TrimSpace(file.FileName))
+	if name != "" && name != "." {
+		return name
+	}
+	switch strings.ToLower(file.MimeType) {
+	case "text/html":
+		return "file.html"
+	case "application/pdf":
+		return "file.pdf"
+	case "text/plain":
+		return "file.txt"
+	case "text/markdown":
+		return "file.md"
+	case "application/json":
+		return "file.json"
+	case "application/zip":
+		return "file.zip"
+	default:
+		return "file.bin"
+	}
+}
+
 var _ core.ImageSender = (*WSPlatform)(nil)
+var _ core.FileSender = (*WSPlatform)(nil)

--- a/platform/wecom/websocket_test.go
+++ b/platform/wecom/websocket_test.go
@@ -625,7 +625,7 @@ func TestWSPlatformSendFile_UploadsAndSendsMedia(t *testing.T) {
 			serverDone <- err
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		serverDone <- assertWeComWSSendFileFrames(conn, fileData)
 	}))
 	defer server.Close()
@@ -635,7 +635,7 @@ func TestWSPlatformSendFile_UploadsAndSendsMedia(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial test websocket: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	p := &WSPlatform{conn: conn}
 	go func() {

--- a/platform/wecom/websocket_test.go
+++ b/platform/wecom/websocket_test.go
@@ -611,6 +611,174 @@ func assertWeComWSSendImageFrames(conn *websocket.Conn, imageData []byte) error 
 }
 
 // ---------------------------------------------------------------------------
+// SendFile
+// ---------------------------------------------------------------------------
+
+func TestWSPlatformSendFile_UploadsAndSendsMedia(t *testing.T) {
+	fileData := []byte("<html><body>hello</body></html>")
+	serverDone := make(chan error, 1)
+	upgrader := websocket.Upgrader{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer conn.Close()
+		serverDone <- assertWeComWSSendFileFrames(conn, fileData)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[len("http"):]
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial test websocket: %v", err)
+	}
+	defer conn.Close()
+
+	p := &WSPlatform{conn: conn}
+	go func() {
+		for {
+			var frame wsFrame
+			if err := conn.ReadJSON(&frame); err != nil {
+				return
+			}
+			p.handleFrame(frame)
+		}
+	}()
+
+	err = p.SendFile(context.Background(), wsReplyContext{chatID: "chat1", userID: "u1"}, core.FileAttachment{
+		MimeType: "text/html",
+		Data:     fileData,
+		FileName: "hello.html",
+	})
+	if err != nil {
+		t.Fatalf("SendFile returned error: %v", err)
+	}
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not observe all expected frames")
+	}
+}
+
+func assertWeComWSSendFileFrames(conn *websocket.Conn, fileData []byte) error {
+	var initFrame struct {
+		Cmd     string         `json:"cmd"`
+		Headers wsFrameHeaders `json:"headers"`
+		Body    struct {
+			Type        string `json:"type"`
+			Filename    string `json:"filename"`
+			TotalSize   int    `json:"total_size"`
+			TotalChunks int    `json:"total_chunks"`
+			MD5         string `json:"md5"`
+		} `json:"body"`
+	}
+	if err := conn.ReadJSON(&initFrame); err != nil {
+		return fmt.Errorf("read init frame: %w", err)
+	}
+	sum := md5.Sum(fileData)
+	if initFrame.Cmd != "aibot_upload_media_init" ||
+		initFrame.Body.Type != "file" ||
+		initFrame.Body.Filename != "hello.html" ||
+		initFrame.Body.TotalSize != len(fileData) ||
+		initFrame.Body.TotalChunks != 1 ||
+		initFrame.Body.MD5 != hex.EncodeToString(sum[:]) {
+		return fmt.Errorf("unexpected init frame: %#v", initFrame)
+	}
+	if err := conn.WriteJSON(map[string]any{
+		"headers": initFrame.Headers,
+		"errcode": 0,
+		"errmsg":  "ok",
+		"body":    map[string]string{"upload_id": "upload-f1"},
+	}); err != nil {
+		return fmt.Errorf("write init ack: %w", err)
+	}
+
+	var chunkFrame struct {
+		Cmd     string         `json:"cmd"`
+		Headers wsFrameHeaders `json:"headers"`
+		Body    struct {
+			UploadID   string `json:"upload_id"`
+			ChunkIndex int    `json:"chunk_index"`
+			Base64Data string `json:"base64_data"`
+		} `json:"body"`
+	}
+	if err := conn.ReadJSON(&chunkFrame); err != nil {
+		return fmt.Errorf("read chunk frame: %w", err)
+	}
+	if chunkFrame.Cmd != "aibot_upload_media_chunk" ||
+		chunkFrame.Body.UploadID != "upload-f1" ||
+		chunkFrame.Body.ChunkIndex != 0 ||
+		chunkFrame.Body.Base64Data != base64.StdEncoding.EncodeToString(fileData) {
+		return fmt.Errorf("unexpected chunk frame: %#v", chunkFrame)
+	}
+	if err := conn.WriteJSON(map[string]any{
+		"headers": chunkFrame.Headers,
+		"errcode": 0,
+		"errmsg":  "ok",
+	}); err != nil {
+		return fmt.Errorf("write chunk ack: %w", err)
+	}
+
+	var finishFrame struct {
+		Cmd     string         `json:"cmd"`
+		Headers wsFrameHeaders `json:"headers"`
+		Body    struct {
+			UploadID string `json:"upload_id"`
+		} `json:"body"`
+	}
+	if err := conn.ReadJSON(&finishFrame); err != nil {
+		return fmt.Errorf("read finish frame: %w", err)
+	}
+	if finishFrame.Cmd != "aibot_upload_media_finish" || finishFrame.Body.UploadID != "upload-f1" {
+		return fmt.Errorf("unexpected finish frame: %#v", finishFrame)
+	}
+	if err := conn.WriteJSON(map[string]any{
+		"headers": finishFrame.Headers,
+		"errcode": 0,
+		"errmsg":  "ok",
+		"body":    map[string]string{"media_id": "media-f1"},
+	}); err != nil {
+		return fmt.Errorf("write finish ack: %w", err)
+	}
+
+	var sendFrame struct {
+		Cmd     string         `json:"cmd"`
+		Headers wsFrameHeaders `json:"headers"`
+		Body    struct {
+			ChatID  string `json:"chatid"`
+			MsgType string `json:"msgtype"`
+			File    struct {
+				MediaID string `json:"media_id"`
+			} `json:"file"`
+		} `json:"body"`
+	}
+	if err := conn.ReadJSON(&sendFrame); err != nil {
+		return fmt.Errorf("read send frame: %w", err)
+	}
+	if sendFrame.Cmd != "aibot_send_msg" ||
+		sendFrame.Body.ChatID != "chat1" ||
+		sendFrame.Body.MsgType != "file" ||
+		sendFrame.Body.File.MediaID != "media-f1" {
+		return fmt.Errorf("unexpected send frame: %#v", sendFrame)
+	}
+	if err := conn.WriteJSON(map[string]any{
+		"headers": sendFrame.Headers,
+		"errcode": 0,
+		"errmsg":  "ok",
+	}); err != nil {
+		return fmt.Errorf("write send ack: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
 // generateReqID — concurrency safety
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The WeCom platform package implements `SendImage` but not `SendFile`. When Claude tries to deliver a generated file via `cc-connect send --file /path/to/x.html` (per the system prompt's documented attachment protocol), `core.Engine` checks `p.(core.FileSender)` on the WeCom platform, gets `false`, and falls back to a plain-text reply — Claude tells the user "I cannot send files" even though the WeCom AI Bot WebSocket protocol fully supports `file` / `image` / `video` msgtypes through the same `aibot_upload_media_*` chunked upload flow that `SendImage` already uses.

The README's feature snapshot table currently shows WeCom as ✅ for "Images & files" — this PR makes that actually true (for WebSocket mode).

## Fix

Adds `SendFile` to `WSPlatform`, mirroring `SendImage`:

- **`WSPlatform.SendFile`** — calls `uploadWSMedia` with `mediaType="file"` and `sendWSMediaMessage` to deliver the resulting `media_id`. Reuses 100% of the existing chunked upload path; no new wire protocol.
- **`wsFileFileName`** — sensible filename fallback by `MimeType` when `FileAttachment.FileName` is empty (`.html` / `.pdf` / `.txt` / `.md` / `.json` / `.zip` / `.bin`).
- **`var _ core.FileSender = (*WSPlatform)(nil)`** — interface assertion so the engine's capability check resolves correctly.

## Tests

`TestWSPlatformSendFile_UploadsAndSendsMedia` mirrors the existing `TestWSPlatformSendImage_UploadsAndSendsMedia` and validates the full init/chunk/finish/send WebSocket frame sequence with a representative HTML payload.

\`\`\`
$ go test ./platform/wecom/... -run "TestWSPlatformSend" -v
=== RUN   TestWSPlatformSendImage_UploadsAndSendsMedia
--- PASS: TestWSPlatformSendImage_UploadsAndSendsMedia (0.00s)
=== RUN   TestWSPlatformSendFile_UploadsAndSendsMedia
--- PASS: TestWSPlatformSendFile_UploadsAndSendsMedia (0.00s)
PASS
\`\`\`

Also dogfooded end-to-end: a Claude Code session in WebSocket mode generated a hello-world HTML file and delivered it via WeCom to a real phone client; the file arrived as a previewable attachment.

## Not in scope

Webhook mode (`Platform` in `wecom.go`) still does not implement `SendFile`. The chunked upload sequence in webhook mode goes through a different HTTP API and is a meaningfully separate change — happy to do it as a follow-up PR if there's demand.

## Risk

Low. Pure additive change to one platform package. No public-API or core-engine surface modified. The new code paths only execute when `Engine` is already trying to deliver a `FileAttachment`, which today is a dead end for WeCom users.