### PR TITLE
feat(cron): align manual trigger command with exec

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -529,16 +529,19 @@ Examples:
   cc-connect cron add --cron "0 6 * * *" --prompt "Collect GitHub trending repos and send a summary" --desc "Daily GitHub Trending"
   cc-connect cron add --cron "0 9 * * 1" --prompt "Generate a weekly project status report" --desc "Weekly Report"
 
-To list, edit, or delete cron jobs:
+To list, run, edit, or delete cron jobs:
   cc-connect cron list
+  cc-connect cron exec <job-id>
   cc-connect cron edit <job-id> <field> <value>
   cc-connect cron del <job-id>
 
+Use `cron exec <job-id>` to run an existing scheduled task immediately; this is different from the `--exec <command>` flag used when creating a shell-command cron job.
 Use `cron edit` to modify a single field instead of delete-and-recreate.
 Common editable fields: cron_expr, prompt, exec, description, enabled (true/false), mute (true/false), timeout_mins (int).
 Run `cc-connect cron edit --help` for the full field list.
 
 Examples:
+  cc-connect cron exec abc123
   cc-connect cron edit abc123 cron_expr "0 9 * * *"
   cc-connect cron edit abc123 enabled false
   cc-connect cron edit abc123 prompt "Updated daily summary task"

--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -19,7 +19,7 @@ func runCron(args []string) {
 		return
 	}
 
-	switch args[0] {
+	switch canonicalCronSubcommand(args[0]) {
 	case "add":
 		runCronAdd(args[1:])
 	case "list":
@@ -28,7 +28,7 @@ func runCron(args []string) {
 		runCronEdit(args[1:])
 	case "info":
 		runCronInfo(args[1:])
-	case "exec", "run", "trigger":
+	case "exec":
 		runCronExec(args[1:])
 	case "del", "delete", "rm", "remove":
 		runCronDel(args[1:])
@@ -38,6 +38,15 @@ func runCron(args []string) {
 		fmt.Fprintf(os.Stderr, "Unknown cron subcommand: %s\n", args[0])
 		printCronUsage()
 		os.Exit(1)
+	}
+}
+
+func canonicalCronSubcommand(sub string) string {
+	switch sub {
+	case "run", "trigger":
+		return "exec"
+	default:
+		return sub
 	}
 }
 

--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -28,6 +28,8 @@ func runCron(args []string) {
 		runCronEdit(args[1:])
 	case "info":
 		runCronInfo(args[1:])
+	case "run":
+		runCronRun(args[1:])
 	case "del", "delete", "rm", "remove":
 		runCronDel(args[1:])
 	case "--help", "-h", "help":
@@ -269,6 +271,54 @@ func runCronList(args []string) {
 		}
 		fmt.Printf("  %s %s  %s  %s\n", enabled, id, expr, display)
 	}
+}
+
+func runCronRun(args []string) {
+	var id, dataDir string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--data-dir":
+			if i+1 < len(args) {
+				i++
+				dataDir = args[i]
+			}
+		case "--help", "-h":
+			printCronRunUsage()
+			return
+		default:
+			if id == "" {
+				id = args[i]
+			}
+		}
+	}
+
+	if id == "" {
+		fmt.Fprintln(os.Stderr, "Error: job ID is required")
+		printCronRunUsage()
+		os.Exit(1)
+	}
+
+	sockPath := resolveSocketPath(dataDir)
+	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		os.Exit(1)
+	}
+
+	payload, _ := json.Marshal(map[string]any{"id": id})
+	resp, err := apiPost(sockPath, "/cron/run", payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", strings.TrimSpace(string(body)))
+		os.Exit(1)
+	}
+
+	fmt.Printf("Triggered cron job: %s\n", id)
 }
 
 func runCronDel(args []string) {
@@ -534,6 +584,7 @@ func printCronUsage() {
 Commands:
   add       Create a new scheduled task
   list      List all scheduled tasks
+  run <id>  Trigger a scheduled task immediately
   edit      Edit a scheduled task field
   info <id> [field]  Show detailed info of a scheduled task
                      (optionally filter to a single field)
@@ -563,6 +614,19 @@ Examples:
   cc-connect cron add --cron "0 6 * * *" --prompt "Collect GitHub trending data" --desc "Daily Trending"
   cc-connect cron add --cron "*/30 * * * *" --exec "df -h" --desc "Disk usage check"
   cc-connect cron add 0 6 * * * Collect GitHub trending data and send me a summary`)
+}
+
+func printCronRunUsage() {
+	fmt.Println(`Usage: cc-connect cron run <id> [options]
+
+Trigger an existing scheduled task immediately.
+
+Options:
+      --data-dir <path>      Data directory (default: ~/.cc-connect)
+  -h, --help                 Show this help
+
+Example:
+  cc-connect cron run abc123`)
 }
 
 func printCronEditUsage() {

--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -50,6 +50,12 @@ func canonicalCronSubcommand(sub string) string {
 	}
 }
 
+func closeCronResponseBody(body io.Closer) {
+	if err := body.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: close response body: %v\n", err)
+	}
+}
+
 func runCronAdd(args []string) {
 	var project, sessionKey, cronExpr, prompt, execCmd, desc, dataDir, sessionMode string
 	var timeoutMins *int
@@ -170,7 +176,7 @@ func runCronAdd(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer closeCronResponseBody(resp.Body)
 
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
@@ -237,7 +243,7 @@ func runCronList(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer closeCronResponseBody(resp.Body)
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
@@ -319,7 +325,7 @@ func runCronExec(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer closeCronResponseBody(resp.Body)
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
@@ -363,7 +369,7 @@ func runCronDel(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer closeCronResponseBody(resp.Body)
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
@@ -419,7 +425,7 @@ func runCronInfo(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer closeCronResponseBody(resp.Body)
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusNotFound {
@@ -526,7 +532,7 @@ func runCronEdit(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer closeCronResponseBody(resp.Body)
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {

--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -28,8 +28,8 @@ func runCron(args []string) {
 		runCronEdit(args[1:])
 	case "info":
 		runCronInfo(args[1:])
-	case "run":
-		runCronRun(args[1:])
+	case "exec", "run", "trigger":
+		runCronExec(args[1:])
 	case "del", "delete", "rm", "remove":
 		runCronDel(args[1:])
 	case "--help", "-h", "help":
@@ -273,7 +273,7 @@ func runCronList(args []string) {
 	}
 }
 
-func runCronRun(args []string) {
+func runCronExec(args []string) {
 	var id, dataDir string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -283,7 +283,7 @@ func runCronRun(args []string) {
 				dataDir = args[i]
 			}
 		case "--help", "-h":
-			printCronRunUsage()
+			printCronExecUsage()
 			return
 		default:
 			if id == "" {
@@ -294,7 +294,7 @@ func runCronRun(args []string) {
 
 	if id == "" {
 		fmt.Fprintln(os.Stderr, "Error: job ID is required")
-		printCronRunUsage()
+		printCronExecUsage()
 		os.Exit(1)
 	}
 
@@ -305,7 +305,7 @@ func runCronRun(args []string) {
 	}
 
 	payload, _ := json.Marshal(map[string]any{"id": id})
-	resp, err := apiPost(sockPath, "/cron/run", payload)
+	resp, err := apiPost(sockPath, "/cron/exec", payload)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -584,7 +584,7 @@ func printCronUsage() {
 Commands:
   add       Create a new scheduled task
   list      List all scheduled tasks
-  run <id>  Trigger a scheduled task immediately
+  exec <id> Trigger a scheduled task immediately
   edit      Edit a scheduled task field
   info <id> [field]  Show detailed info of a scheduled task
                      (optionally filter to a single field)
@@ -616,8 +616,8 @@ Examples:
   cc-connect cron add 0 6 * * * Collect GitHub trending data and send me a summary`)
 }
 
-func printCronRunUsage() {
-	fmt.Println(`Usage: cc-connect cron run <id> [options]
+func printCronExecUsage() {
+	fmt.Println(`Usage: cc-connect cron exec <id> [options]
 
 Trigger an existing scheduled task immediately.
 
@@ -626,6 +626,7 @@ Options:
   -h, --help                 Show this help
 
 Example:
+  cc-connect cron exec abc123
   cc-connect cron run abc123`)
 }
 

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1355,7 +1355,7 @@ Commands:
   cron               Manage scheduled tasks
     add              Create a scheduled task (-c <expr> --prompt <text>)
     list             List scheduled tasks
-    run              Trigger a scheduled task immediately
+    exec             Trigger a scheduled task immediately
     del              Delete a scheduled task by ID
 
   sessions           Browse session history

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1355,6 +1355,7 @@ Commands:
   cron               Manage scheduled tasks
     add              Create a scheduled task (-c <expr> --prompt <text>)
     list             List scheduled tasks
+    run              Trigger a scheduled task immediately
     del              Delete a scheduled task by ID
 
   sessions           Browse session history

--- a/cmd/cc-connect/main_test.go
+++ b/cmd/cc-connect/main_test.go
@@ -332,3 +332,11 @@ func TestPrintUsage_ListsCronExecCommand(t *testing.T) {
 		t.Fatalf("printUsage() output missing cron exec command:\n%s", out)
 	}
 }
+
+func TestCanonicalCronSubcommand_ManualTriggerAliases(t *testing.T) {
+	for _, sub := range []string{"exec", "run", "trigger"} {
+		if got := canonicalCronSubcommand(sub); got != "exec" {
+			t.Fatalf("canonicalCronSubcommand(%q) = %q, want exec", sub, got)
+		}
+	}
+}

--- a/cmd/cc-connect/main_test.go
+++ b/cmd/cc-connect/main_test.go
@@ -322,13 +322,13 @@ func captureStderr(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-func TestPrintUsage_ListsCronRunCommand(t *testing.T) {
+func TestPrintUsage_ListsCronExecCommand(t *testing.T) {
 	out := captureStderr(t, printUsage)
 
 	if !strings.Contains(out, "Manage scheduled tasks") {
 		t.Fatalf("printUsage() output missing cron section:\n%s", out)
 	}
-	if !strings.Contains(out, "run              Trigger a scheduled task immediately") {
-		t.Fatalf("printUsage() output missing cron run command:\n%s", out)
+	if !strings.Contains(out, "exec             Trigger a scheduled task immediately") {
+		t.Fatalf("printUsage() output missing cron exec command:\n%s", out)
 	}
 }

--- a/cmd/cc-connect/main_test.go
+++ b/cmd/cc-connect/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -289,5 +292,43 @@ func TestStartInitialRefresh_AfterProjectStateOverride(t *testing.T) {
 	}
 	if agent.workDir != overrideDir {
 		t.Fatalf("agent workDir at refresh = %q, want %q", agent.workDir, overrideDir)
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = old
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy stderr: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close reader: %v", err)
+	}
+	return buf.String()
+}
+
+func TestPrintUsage_ListsCronRunCommand(t *testing.T) {
+	out := captureStderr(t, printUsage)
+
+	if !strings.Contains(out, "Manage scheduled tasks") {
+		t.Fatalf("printUsage() output missing cron section:\n%s", out)
+	}
+	if !strings.Contains(out, "run              Trigger a scheduled task immediately") {
+		t.Fatalf("printUsage() output missing cron run command:\n%s", out)
 	}
 }

--- a/core/api.go
+++ b/core/api.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -68,6 +69,7 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 	s.mux.HandleFunc("/cron/info", s.handleCronInfo)
 	s.mux.HandleFunc("/cron/edit", s.handleCronEdit)
 	s.mux.HandleFunc("/cron/del", s.handleCronDel)
+	s.mux.HandleFunc("/cron/run", s.handleCronRun)
 	s.mux.HandleFunc("/relay/send", s.handleRelaySend)
 	s.mux.HandleFunc("/relay/bind", s.handleRelayBind)
 	s.mux.HandleFunc("/relay/binding", s.handleRelayBinding)
@@ -357,6 +359,43 @@ func (s *APIServer) handleCronDel(w http.ResponseWriter, r *http.Request) {
 	} else {
 		http.Error(w, fmt.Sprintf("job %q not found", req.ID), http.StatusNotFound)
 	}
+}
+
+func (s *APIServer) handleCronRun(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.cron == nil {
+		http.Error(w, "cron scheduler not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.ID == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.cron.RunJobNow(req.ID); err != nil {
+		if errors.Is(err, ErrCronJobNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	apiJSON(w, http.StatusAccepted, map[string]string{
+		"id":     req.ID,
+		"status": "triggered",
+	})
 }
 
 func (s *APIServer) handleCronInfo(w http.ResponseWriter, r *http.Request) {

--- a/core/api.go
+++ b/core/api.go
@@ -69,7 +69,8 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 	s.mux.HandleFunc("/cron/info", s.handleCronInfo)
 	s.mux.HandleFunc("/cron/edit", s.handleCronEdit)
 	s.mux.HandleFunc("/cron/del", s.handleCronDel)
-	s.mux.HandleFunc("/cron/run", s.handleCronRun)
+	s.mux.HandleFunc("/cron/exec", s.handleCronExec)
+	s.mux.HandleFunc("/cron/run", s.handleCronExec)
 	s.mux.HandleFunc("/relay/send", s.handleRelaySend)
 	s.mux.HandleFunc("/relay/bind", s.handleRelayBind)
 	s.mux.HandleFunc("/relay/binding", s.handleRelayBinding)
@@ -361,7 +362,7 @@ func (s *APIServer) handleCronDel(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *APIServer) handleCronRun(w http.ResponseWriter, r *http.Request) {
+func (s *APIServer) handleCronExec(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "POST only", http.StatusMethodNotAllowed)
 		return

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -181,6 +181,61 @@ func TestHandleCronExec_TriggersJob(t *testing.T) {
 	t.Fatalf("timed out waiting for local api trigger, sent=%v", platform.getSent())
 }
 
+func TestHandleCronExec_RunAliasRouteTriggersJob(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agentSession := newResultAgentSession("triggered from local api alias")
+	engine := NewEngine("test", &resultAgent{session: agentSession}, []Platform{platform}, "", LangEnglish)
+	defer engine.cancel()
+	engine.cronScheduler = scheduler
+	scheduler.RegisterEngine("test", engine)
+
+	job := &CronJob{
+		ID:          "job-run-api-alias",
+		Project:     "test",
+		SessionKey:  "discord:channel-1:user-1",
+		CronExpr:    "0 6 * * *",
+		Prompt:      "run alias now",
+		Description: "Run from API alias",
+		Enabled:     false,
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	api := &APIServer{engines: map[string]*Engine{"test": engine}, cron: scheduler, mux: http.NewServeMux()}
+	api.mux.HandleFunc("/cron/exec", api.handleCronExec)
+	api.mux.HandleFunc("/cron/run", api.handleCronExec)
+	body, err := json.Marshal(map[string]any{"id": job.ID})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/cron/run", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(platform.getSent()) >= 2 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for local api alias trigger, sent=%v", platform.getSent())
+}
+
 func TestHandleCronExec_ProjectMissingIsBadRequest(t *testing.T) {
 	store, err := NewCronStore(t.TempDir())
 	if err != nil {

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHandleSend_AllowsAttachmentOnly(t *testing.T) {
@@ -124,5 +125,92 @@ func TestHandleSend_EmptyProjectMultipleEnginesRequiresName(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleCronRun_TriggersJob(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agentSession := newResultAgentSession("triggered from local api")
+	engine := NewEngine("test", &resultAgent{session: agentSession}, []Platform{platform}, "", LangEnglish)
+	defer engine.cancel()
+	engine.cronScheduler = scheduler
+	scheduler.RegisterEngine("test", engine)
+
+	job := &CronJob{
+		ID:          "job-run-api",
+		Project:     "test",
+		SessionKey:  "discord:channel-1:user-1",
+		CronExpr:    "0 6 * * *",
+		Prompt:      "run now",
+		Description: "Run from API",
+		Enabled:     false,
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	api := &APIServer{engines: map[string]*Engine{"test": engine}, cron: scheduler}
+	body, err := json.Marshal(map[string]any{"id": job.ID})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/cron/run", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleCronRun(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(platform.getSent()) >= 2 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for local api trigger, sent=%v", platform.getSent())
+}
+
+func TestHandleCronRun_ProjectMissingIsBadRequest(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	job := &CronJob{
+		ID:         "job-run-missing-project",
+		Project:    "ghost",
+		SessionKey: "discord:channel-1:user-1",
+		CronExpr:   "0 6 * * *",
+		Prompt:     "run now",
+		Enabled:    true,
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	api := &APIServer{cron: scheduler}
+	body, err := json.Marshal(map[string]any{"id": job.ID})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/cron/run", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleCronRun(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 	}
 }

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -128,7 +128,7 @@ func TestHandleSend_EmptyProjectMultipleEnginesRequiresName(t *testing.T) {
 	}
 }
 
-func TestHandleCronRun_TriggersJob(t *testing.T) {
+func TestHandleCronExec_TriggersJob(t *testing.T) {
 	store, err := NewCronStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -163,9 +163,9 @@ func TestHandleCronRun_TriggersJob(t *testing.T) {
 		t.Fatalf("marshal request: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/cron/run", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/cron/exec", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	api.handleCronRun(rec, req)
+	api.handleCronExec(rec, req)
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
@@ -181,7 +181,7 @@ func TestHandleCronRun_TriggersJob(t *testing.T) {
 	t.Fatalf("timed out waiting for local api trigger, sent=%v", platform.getSent())
 }
 
-func TestHandleCronRun_ProjectMissingIsBadRequest(t *testing.T) {
+func TestHandleCronExec_ProjectMissingIsBadRequest(t *testing.T) {
 	store, err := NewCronStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -206,9 +206,9 @@ func TestHandleCronRun_ProjectMissingIsBadRequest(t *testing.T) {
 		t.Fatalf("marshal request: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/cron/run", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/cron/exec", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	api.handleCronRun(rec, req)
+	api.handleCronExec(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())

--- a/core/cron.go
+++ b/core/cron.go
@@ -5,11 +5,12 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
-	"reflect"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -45,6 +46,11 @@ func (j *CronJob) IsShellJob() bool {
 }
 
 const defaultCronJobTimeout = 30 * time.Minute
+
+var (
+	ErrCronJobNotFound     = errors.New("cron job not found")
+	ErrCronProjectNotFound = errors.New("cron project not found")
+)
 
 // ExecutionTimeout returns how long the scheduler waits for the job goroutine to finish.
 // nil TimeoutMins uses 30 minutes. *TimeoutMins == 0 means wait without a time limit.
@@ -405,13 +411,13 @@ func toExportedFieldName(s string) string {
 
 // CronScheduler runs cron jobs by injecting synthetic messages into engines.
 type CronScheduler struct {
-	store         *CronStore
-	cron          *cron.Cron
-	engines       map[string]*Engine // project name → engine
-	mu            sync.RWMutex
-	entries       map[string]cron.EntryID // job ID → cron entry
-	defaultSilent      bool   // global default for suppressing cron start notifications
-	defaultSessionMode string // global default session mode; "" = reuse, "new_per_run" = fresh session each run
+	store              *CronStore
+	cron               *cron.Cron
+	engines            map[string]*Engine // project name → engine
+	mu                 sync.RWMutex
+	entries            map[string]cron.EntryID // job ID → cron entry
+	defaultSilent      bool                    // global default for suppressing cron start notifications
+	defaultSessionMode string                  // global default session mode; "" = reuse, "new_per_run" = fresh session each run
 }
 
 func NewCronScheduler(store *CronStore) *CronScheduler {
@@ -647,7 +653,35 @@ func (cs *CronScheduler) scheduleJob(job *CronJob) error {
 
 func (cs *CronScheduler) executeJob(jobID string) {
 	job := cs.store.Get(jobID)
-	if job == nil || !job.Enabled {
+	if job == nil {
+		return
+	}
+	cs.runJob(job, false)
+}
+
+// RunJobNow triggers a persisted cron job immediately in the background.
+// Disabled jobs are allowed to run manually; only scheduled executions enforce Enabled.
+func (cs *CronScheduler) RunJobNow(id string) error {
+	job := cs.store.Get(id)
+	if job == nil {
+		return fmt.Errorf("%w: %q", ErrCronJobNotFound, id)
+	}
+	cs.mu.RLock()
+	_, ok := cs.engines[job.Project]
+	cs.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrCronProjectNotFound, job.Project)
+	}
+	snapshot := *job
+	go cs.runJob(&snapshot, true)
+	return nil
+}
+
+func (cs *CronScheduler) runJob(job *CronJob, manual bool) {
+	if job == nil {
+		return
+	}
+	if !manual && !job.Enabled {
 		return
 	}
 
@@ -656,12 +690,12 @@ func (cs *CronScheduler) executeJob(jobID string) {
 	cs.mu.RUnlock()
 
 	if !ok {
-		slog.Error("cron: project not found", "job", jobID, "project", job.Project)
-		cs.store.MarkRun(jobID, fmt.Errorf("project %q not found", job.Project))
+		slog.Error("cron: project not found", "job", job.ID, "project", job.Project, "manual", manual)
+		cs.store.MarkRun(job.ID, fmt.Errorf("project %q not found", job.Project))
 		return
 	}
 
-	slog.Info("cron: executing job", "id", jobID, "project", job.Project, "prompt", truncateStr(job.Prompt, 60))
+	slog.Info("cron: executing job", "id", job.ID, "project", job.Project, "manual", manual, "prompt", truncateStr(job.Prompt, 60))
 
 	done := make(chan error, 1)
 	go func() {
@@ -680,12 +714,12 @@ func (cs *CronScheduler) executeJob(jobID string) {
 		err = <-done
 	}
 
-	cs.store.MarkRun(jobID, err)
+	cs.store.MarkRun(job.ID, err)
 
 	if err != nil {
-		slog.Error("cron: job failed", "id", jobID, "error", err)
+		slog.Error("cron: job failed", "id", job.ID, "manual", manual, "error", err)
 	} else {
-		slog.Info("cron: job completed", "id", jobID)
+		slog.Info("cron: job completed", "id", job.ID, "manual", manual)
 	}
 }
 

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -365,6 +366,174 @@ func TestCronStore_JobsPath(t *testing.T) {
 	if store.path != expected {
 		t.Errorf("store path = %q, want %q", store.path, expected)
 	}
+}
+
+func TestCronScheduler_RunJobNow_DisabledJobStillRuns(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agentSession := newResultAgentSession("manual run complete")
+	agent := &resultAgent{session: agentSession}
+
+	e := NewEngine("test", agent, []Platform{platform}, "", LangEnglish)
+	defer e.cancel()
+	e.cronScheduler = scheduler
+	scheduler.RegisterEngine("test", e)
+
+	job := &CronJob{
+		ID:          "manual1",
+		Project:     "test",
+		SessionKey:  "discord:channel-1:user-1",
+		CronExpr:    "0 6 * * *",
+		Prompt:      "summarize activity",
+		Description: "Disabled daily summary",
+		Enabled:     false,
+		CreatedAt:   time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := scheduler.RunJobNow("manual1"); err != nil {
+		t.Fatalf("RunJobNow() error = %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		sent := platform.getSent()
+		if len(sent) >= 2 {
+			if sent[0] != "⏰ Disabled daily summary" {
+				t.Fatalf("sent[0] = %q, want cron start notice", sent[0])
+			}
+			if sent[1] != "manual run complete" {
+				t.Fatalf("sent[1] = %q, want final result", sent[1])
+			}
+			stored := store.Get("manual1")
+			if stored == nil {
+				t.Fatal("expected stored job")
+			}
+			if stored.LastRun.IsZero() {
+				t.Fatal("expected LastRun to be set after manual run")
+			}
+			if stored.LastError != "" {
+				t.Fatalf("LastError = %q, want empty", stored.LastError)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for manual run messages, sent=%v", platform.getSent())
+}
+
+func TestCronScheduler_RunJobNow_NotFound(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	err = scheduler.RunJobNow("missing")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("RunJobNow() error = %v, want not found", err)
+	}
+}
+
+func TestCronScheduler_RunJobNow_ProjectMissingFailsSynchronously(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	job := &CronJob{
+		ID:         "missing-project",
+		Project:    "ghost",
+		SessionKey: "discord:channel-1:user-1",
+		CronExpr:   "0 6 * * *",
+		Prompt:     "hello",
+		Enabled:    true,
+		CreatedAt:  time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	err = scheduler.RunJobNow("missing-project")
+	if err == nil || !errors.Is(err, ErrCronProjectNotFound) || !strings.Contains(err.Error(), `"ghost"`) {
+		t.Fatalf("RunJobNow() error = %v, want missing project", err)
+	}
+}
+
+func TestCronScheduler_RunJobNow_UsesSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewCronStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewCronScheduler(store)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agentSession := newResultAgentSession("snapshot complete")
+	agent := &resultAgent{session: agentSession}
+
+	e := NewEngine("test", agent, []Platform{platform}, "", LangEnglish)
+	defer e.cancel()
+	e.cronScheduler = scheduler
+	scheduler.RegisterEngine("test", e)
+
+	job := &CronJob{
+		ID:          "snapshot1",
+		Project:     "test",
+		SessionKey:  "discord:channel-1:user-1",
+		CronExpr:    "0 6 * * *",
+		Prompt:      "original prompt",
+		Description: "Original description",
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := scheduler.RunJobNow("snapshot1"); err != nil {
+		t.Fatalf("RunJobNow() error = %v", err)
+	}
+	if !store.Update("snapshot1", "prompt", "mutated prompt") {
+		t.Fatal("Update(prompt) returned false")
+	}
+	if !store.Update("snapshot1", "description", "Mutated description") {
+		t.Fatal("Update(description) returned false")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		sent := platform.getSent()
+		if len(sent) >= 2 {
+			if sent[0] != "⏰ Original description" {
+				t.Fatalf("sent[0] = %q, want original description", sent[0])
+			}
+			if len(agentSession.sentPrompts) != 1 || !strings.Contains(agentSession.sentPrompts[0], "original prompt") {
+				t.Fatalf("agent prompts = %#v, want original prompt", agentSession.sentPrompts)
+			}
+			if strings.Contains(agentSession.sentPrompts[0], "mutated prompt") {
+				t.Fatalf("agent prompt used mutated value: %#v", agentSession.sentPrompts)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for snapshot run, sent=%v", platform.getSent())
 }
 
 func TestCronJob_ExecutionTimeout(t *testing.T) {

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -415,15 +415,16 @@ func TestCronScheduler_RunJobNow_DisabledJobStillRuns(t *testing.T) {
 			if sent[1] != "manual run complete" {
 				t.Fatalf("sent[1] = %q, want final result", sent[1])
 			}
-			stored := store.Get("manual1")
-			if stored == nil {
+			found, lastRunSet, lastErr := cronJobRunStatus(store, "manual1")
+			if !found {
 				t.Fatal("expected stored job")
 			}
-			if stored.LastRun.IsZero() {
-				t.Fatal("expected LastRun to be set after manual run")
+			if !lastRunSet {
+				time.Sleep(10 * time.Millisecond)
+				continue
 			}
-			if stored.LastError != "" {
-				t.Fatalf("LastError = %q, want empty", stored.LastError)
+			if lastErr != "" {
+				t.Fatalf("LastError = %q, want empty", lastErr)
 			}
 			return
 		}
@@ -528,12 +529,31 @@ func TestCronScheduler_RunJobNow_UsesSnapshot(t *testing.T) {
 			if strings.Contains(agentSession.sentPrompts[0], "mutated prompt") {
 				t.Fatalf("agent prompt used mutated value: %#v", agentSession.sentPrompts)
 			}
+			found, lastRunSet, _ := cronJobRunStatus(store, "snapshot1")
+			if !found {
+				t.Fatal("expected stored job")
+			}
+			if !lastRunSet {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
 	t.Fatalf("timed out waiting for snapshot run, sent=%v", platform.getSent())
+}
+
+func cronJobRunStatus(store *CronStore, id string) (found bool, lastRunSet bool, lastErr string) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	for _, job := range store.jobs {
+		if job.ID == id {
+			return true, !job.LastRun.IsZero(), job.LastError
+		}
+	}
+	return false, false, ""
 }
 
 func TestCronJob_ExecutionTimeout(t *testing.T) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -11473,6 +11473,15 @@ func (e *Engine) cmdCronExec(p Platform, msg *Message, args []string) {
 		return
 	}
 	id := args[0]
+	job := e.cronScheduler.store.Get(id)
+	if job == nil {
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCronNotFound), id))
+		return
+	}
+	if job.IsShellJob() && !e.isAdmin(msg.UserID) {
+		e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgAdminRequired), "/cron exec"))
+		return
+	}
 	if err := e.cronScheduler.RunJobNow(id); err != nil {
 		switch {
 		case errors.Is(err, ErrCronJobNotFound):

--- a/core/engine.go
+++ b/core/engine.go
@@ -11317,7 +11317,7 @@ func (e *Engine) cmdCron(p Platform, msg *Message, args []string) {
 	}
 
 	sub := matchSubCommand(strings.ToLower(args[0]), []string{
-		"add", "addexec", "list", "del", "delete", "rm", "remove", "enable", "disable", "mute", "unmute", "setup",
+		"add", "addexec", "list", "run", "del", "delete", "rm", "remove", "enable", "disable", "mute", "unmute", "setup",
 	})
 	switch sub {
 	case "add":
@@ -11326,6 +11326,8 @@ func (e *Engine) cmdCron(p Platform, msg *Message, args []string) {
 		e.cmdCronAddExec(p, msg, args[1:])
 	case "list":
 		e.cmdCronList(p, msg)
+	case "run":
+		e.cmdCronRun(p, msg, args[1:])
 	case "del", "delete", "rm", "remove":
 		e.cmdCronDel(p, msg, args[1:])
 	case "enable":
@@ -11463,6 +11465,26 @@ func (e *Engine) cmdCronList(p Platform, msg *Message) {
 
 	sb.WriteString(fmt.Sprintf("\n%s", e.i18n.T(MsgCronListFooter)))
 	e.reply(p, msg.ReplyCtx, sb.String())
+}
+
+func (e *Engine) cmdCronRun(p Platform, msg *Message, args []string) {
+	if len(args) == 0 {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgCronRunUsage))
+		return
+	}
+	id := args[0]
+	if err := e.cronScheduler.RunJobNow(id); err != nil {
+		switch {
+		case errors.Is(err, ErrCronJobNotFound):
+			e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCronNotFound), id))
+		case errors.Is(err, ErrCronProjectNotFound):
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgCronProjectUnavailable))
+		default:
+			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgError, err))
+		}
+		return
+	}
+	e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgCronTriggered), id))
 }
 
 func (e *Engine) cmdCronDel(p Platform, msg *Message, args []string) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -630,7 +630,6 @@ func (e *Engine) SetSkipGit(skipGit bool) {
 	e.skipGit = skipGit
 }
 
-
 // SetInjectSender controls whether sender identity (platform and user ID) is
 // prepended to each message before forwarding it to the agent. When enabled,
 // the agent receives a preamble line like:
@@ -5764,35 +5763,40 @@ func compactReplyFooterPath(path string) string {
 	if path == "" {
 		return ""
 	}
-	path = normalizeWorkspacePath(path)
+	cleaned := filepath.Clean(path)
+	normalized := normalizeWorkspacePath(cleaned)
 	if home, err := os.UserHomeDir(); err == nil {
-		home = normalizeWorkspacePath(home)
-		if path == home {
-			return "~"
-		}
-		prefix := home + string(os.PathSeparator)
-		if strings.HasPrefix(path, prefix) {
-			return "~" + filepath.ToSlash(strings.TrimPrefix(path, home))
+		homeCleaned := filepath.Clean(home)
+		homeNormalized := normalizeWorkspacePath(homeCleaned)
+		for _, candidate := range []struct {
+			path string
+			home string
+		}{
+			{cleaned, homeCleaned},
+			{normalized, homeNormalized},
+			{cleaned, homeNormalized},
+			{normalized, homeCleaned},
+		} {
+			if display, ok := replyFooterHomeRelativePath(candidate.path, candidate.home); ok {
+				return display
+			}
 		}
 	}
+	return filepath.ToSlash(normalized)
+}
 
-	slash := filepath.ToSlash(path)
-	if filepath.IsAbs(path) {
-		trimmed := strings.Trim(slash, "/")
-		if trimmed == "" {
-			return "/"
-		}
-		parts := strings.Split(trimmed, "/")
-		if len(parts) == 1 {
-			return parts[0]
-		}
-		start := len(parts) - 2
-		if start < 0 {
-			start = 0
-		}
-		return "…/" + strings.Join(parts[start:], "/")
+func replyFooterHomeRelativePath(path, home string) (string, bool) {
+	if path == "" || home == "" {
+		return "", false
 	}
-	return slash
+	if path == home {
+		return "~", true
+	}
+	prefix := home + string(os.PathSeparator)
+	if strings.HasPrefix(path, prefix) {
+		return "~" + filepath.ToSlash(strings.TrimPrefix(path, home)), true
+	}
+	return "", false
 }
 
 func appendReplyFooter(content, footer string) string {

--- a/core/engine.go
+++ b/core/engine.go
@@ -11317,7 +11317,7 @@ func (e *Engine) cmdCron(p Platform, msg *Message, args []string) {
 	}
 
 	sub := matchSubCommand(strings.ToLower(args[0]), []string{
-		"add", "addexec", "list", "run", "del", "delete", "rm", "remove", "enable", "disable", "mute", "unmute", "setup",
+		"add", "addexec", "list", "exec", "run", "trigger", "del", "delete", "rm", "remove", "enable", "disable", "mute", "unmute", "setup",
 	})
 	switch sub {
 	case "add":
@@ -11326,8 +11326,8 @@ func (e *Engine) cmdCron(p Platform, msg *Message, args []string) {
 		e.cmdCronAddExec(p, msg, args[1:])
 	case "list":
 		e.cmdCronList(p, msg)
-	case "run":
-		e.cmdCronRun(p, msg, args[1:])
+	case "exec", "run", "trigger":
+		e.cmdCronExec(p, msg, args[1:])
 	case "del", "delete", "rm", "remove":
 		e.cmdCronDel(p, msg, args[1:])
 	case "enable":
@@ -11467,9 +11467,9 @@ func (e *Engine) cmdCronList(p Platform, msg *Message) {
 	e.reply(p, msg.ReplyCtx, sb.String())
 }
 
-func (e *Engine) cmdCronRun(p Platform, msg *Message, args []string) {
+func (e *Engine) cmdCronExec(p Platform, msg *Message, args []string) {
 	if len(args) == 0 {
-		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgCronRunUsage))
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgCronExecUsage))
 		return
 	}
 	id := args[0]

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6590,6 +6590,15 @@ func TestCmdCronExec_UsageWhenMissingID(t *testing.T) {
 }
 
 func TestCmdCronExec_TriggersJob(t *testing.T) {
+	sentContains := func(sent []string, needle string) bool {
+		for _, msg := range sent {
+			if strings.Contains(msg, needle) {
+				return true
+			}
+		}
+		return false
+	}
+
 	for _, subcommand := range []string{"exec", "run", "trigger"} {
 		t.Run(subcommand, func(t *testing.T) {
 			store, err := NewCronStore(t.TempDir())
@@ -6622,15 +6631,10 @@ func TestCmdCronExec_TriggersJob(t *testing.T) {
 			msg := &Message{SessionKey: "plain:user1", ReplyCtx: "ctx"}
 			e.cmdCron(platform, msg, []string{subcommand, job.ID})
 
-			sent := platform.getSent()
-			if len(sent) == 0 || !strings.Contains(sent[0], "triggered") {
-				t.Fatalf("reply = %v, want localized trigger confirmation", sent)
-			}
-
 			deadline := time.Now().Add(2 * time.Second)
 			for time.Now().Before(deadline) {
-				sent = platform.getSent()
-				if len(sent) >= 3 {
+				sent := platform.getSent()
+				if sentContains(sent, "triggered") && sentContains(sent, "manual run complete") {
 					return
 				}
 				time.Sleep(10 * time.Millisecond)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3025,8 +3025,8 @@ func TestCmdHelp_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	if strings.Contains(p.sent[0], "cc-connect 帮助") {
 		t.Fatalf("help text = %q, should not be card title fallback", p.sent[0])
 	}
-	if !strings.Contains(p.sent[0], "/cron [add|list|run|del|enable|disable]") {
-		t.Fatalf("help text = %q, want explicit cron run usage", p.sent[0])
+	if !strings.Contains(p.sent[0], "/cron [add|list|exec|del|enable|disable]") {
+		t.Fatalf("help text = %q, want explicit cron exec usage", p.sent[0])
 	}
 }
 
@@ -5500,7 +5500,7 @@ func TestHandleCardNav_HelpSwitchesTabs(t *testing.T) {
 	}
 }
 
-func TestHandleCardNav_HelpToolsShowsCronRunUsage(t *testing.T) {
+func TestHandleCardNav_HelpToolsShowsCronExecUsage(t *testing.T) {
 	e := NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
 
 	card := e.handleCardNav("nav:/help tools", "test:user1")
@@ -5509,8 +5509,8 @@ func TestHandleCardNav_HelpToolsShowsCronRunUsage(t *testing.T) {
 	}
 	text := card.RenderText()
 
-	if !strings.Contains(text, "**/cron**  Manage scheduled tasks, arg: [add|list|run|del|enable|disable]") {
-		t.Fatalf("tools help text = %q, want explicit cron run usage", text)
+	if !strings.Contains(text, "**/cron**  Manage scheduled tasks, arg: [add|list|exec|del|enable|disable]") {
+		t.Fatalf("tools help text = %q, want explicit cron exec usage", text)
 	}
 }
 
@@ -6566,7 +6566,7 @@ func TestCmdCronSetup_NativeAgentSkips(t *testing.T) {
 	}
 }
 
-func TestCmdCronRun_UsageWhenMissingID(t *testing.T) {
+func TestCmdCronExec_UsageWhenMissingID(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
 	store, err := NewCronStore(t.TempDir())
@@ -6576,20 +6576,20 @@ func TestCmdCronRun_UsageWhenMissingID(t *testing.T) {
 	e.cronScheduler = NewCronScheduler(store)
 
 	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
-	e.cmdCron(p, msg, []string{"run"})
+	e.cmdCron(p, msg, []string{"exec"})
 
 	if len(p.sent) != 1 {
 		t.Fatalf("sent = %d, want 1", len(p.sent))
 	}
 	if strings.Contains(p.sent[0], "/cron add") {
-		t.Fatalf("reply = %q, want dedicated run usage instead of general cron help", p.sent[0])
+		t.Fatalf("reply = %q, want dedicated exec usage instead of general cron help", p.sent[0])
 	}
-	if !strings.Contains(p.sent[0], "/cron run <id>") {
-		t.Fatalf("reply = %q, want run command in usage", p.sent[0])
+	if !strings.Contains(p.sent[0], "/cron exec <id>") {
+		t.Fatalf("reply = %q, want exec command in usage", p.sent[0])
 	}
 }
 
-func TestCmdCronRun_TriggersJob(t *testing.T) {
+func TestCmdCronExec_TriggersJob(t *testing.T) {
 	store, err := NewCronStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
@@ -6636,7 +6636,7 @@ func TestCmdCronRun_TriggersJob(t *testing.T) {
 	t.Fatalf("timed out waiting for run output, sent=%v", platform.getSent())
 }
 
-func TestCmdCronRun_ProjectMissingReply(t *testing.T) {
+func TestCmdCronExec_ProjectMissingReply(t *testing.T) {
 	store, err := NewCronStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3025,6 +3025,9 @@ func TestCmdHelp_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	if strings.Contains(p.sent[0], "cc-connect 帮助") {
 		t.Fatalf("help text = %q, should not be card title fallback", p.sent[0])
 	}
+	if !strings.Contains(p.sent[0], "/cron [add|list|run|del|enable|disable]") {
+		t.Fatalf("help text = %q, want explicit cron run usage", p.sent[0])
+	}
 }
 
 func TestCmdList_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
@@ -5497,6 +5500,20 @@ func TestHandleCardNav_HelpSwitchesTabs(t *testing.T) {
 	}
 }
 
+func TestHandleCardNav_HelpToolsShowsCronRunUsage(t *testing.T) {
+	e := NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
+
+	card := e.handleCardNav("nav:/help tools", "test:user1")
+	if card == nil {
+		t.Fatal("expected help nav card")
+	}
+	text := card.RenderText()
+
+	if !strings.Contains(text, "**/cron**  Manage scheduled tasks, arg: [add|list|run|del|enable|disable]") {
+		t.Fatalf("tools help text = %q, want explicit cron run usage", text)
+	}
+}
+
 // --- AskUserQuestion tests ---
 
 func testQuestions() []UserQuestion {
@@ -6546,6 +6563,110 @@ func TestCmdCronSetup_NativeAgentSkips(t *testing.T) {
 	}
 	if !strings.Contains(p.sent[0], "natively supports") {
 		t.Errorf("reply = %q, want native support message", p.sent[0])
+	}
+}
+
+func TestCmdCronRun_UsageWhenMissingID(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.cronScheduler = NewCronScheduler(store)
+
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	e.cmdCron(p, msg, []string{"run"})
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent = %d, want 1", len(p.sent))
+	}
+	if strings.Contains(p.sent[0], "/cron add") {
+		t.Fatalf("reply = %q, want dedicated run usage instead of general cron help", p.sent[0])
+	}
+	if !strings.Contains(p.sent[0], "/cron run <id>") {
+		t.Fatalf("reply = %q, want run command in usage", p.sent[0])
+	}
+}
+
+func TestCmdCronRun_TriggersJob(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewCronScheduler(store)
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "plain"},
+	}
+	agentSession := newResultAgentSession("manual run complete")
+	e := NewEngine("test", &resultAgent{session: agentSession}, []Platform{platform}, "", LangEnglish)
+	e.cronScheduler = scheduler
+	scheduler.RegisterEngine("test", e)
+
+	job := &CronJob{
+		ID:          "run-from-chat",
+		Project:     "test",
+		SessionKey:  "plain:user1",
+		CronExpr:    "0 6 * * *",
+		Prompt:      "summarize",
+		Description: "Run from chat",
+		Enabled:     false,
+		CreatedAt:   time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	msg := &Message{SessionKey: "plain:user1", ReplyCtx: "ctx"}
+	e.cmdCron(platform, msg, []string{"run", job.ID})
+
+	sent := platform.getSent()
+	if len(sent) == 0 || !strings.Contains(sent[0], "triggered") {
+		t.Fatalf("reply = %v, want localized trigger confirmation", sent)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		sent = platform.getSent()
+		if len(sent) >= 3 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for run output, sent=%v", platform.getSent())
+}
+
+func TestCmdCronRun_ProjectMissingReply(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewCronScheduler(store)
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.cronScheduler = scheduler
+
+	job := &CronJob{
+		ID:         "run-missing-project",
+		Project:    "ghost",
+		SessionKey: "test:user1",
+		CronExpr:   "0 6 * * *",
+		Prompt:     "hello",
+		Enabled:    true,
+		CreatedAt:  time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	e.cmdCron(p, msg, []string{"run", job.ID})
+
+	if len(p.sent) != 1 {
+		t.Fatalf("sent = %d, want 1", len(p.sent))
+	}
+	if strings.Contains(p.sent[0], "cron project not found") || strings.Contains(p.sent[0], "ghost") {
+		t.Fatalf("reply = %q, want user-facing project unavailable message", p.sent[0])
 	}
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -5907,9 +5907,9 @@ func (s *controllableAgentSession) Close() error {
 
 // controllableAgent lets tests control which session is returned by StartSession.
 type controllableAgent struct {
-	nextSession     AgentSession
-	listFn          func() ([]AgentSessionInfo, error)
-	startSessionFn  func(ctx context.Context, sessionID string) (AgentSession, error)
+	nextSession    AgentSession
+	listFn         func() ([]AgentSessionInfo, error)
+	startSessionFn func(ctx context.Context, sessionID string) (AgentSession, error)
 }
 
 func (a *controllableAgent) Name() string { return "controllable" }
@@ -8948,8 +8948,12 @@ func TestResolveLocalDirPath_AcceptsSubdir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got != sub {
-		t.Fatalf("expected %q, got %q", sub, got)
+	want, err := filepath.EvalSymlinks(sub)
+	if err != nil {
+		t.Fatalf("resolve expected path: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
 	}
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6590,50 +6590,94 @@ func TestCmdCronExec_UsageWhenMissingID(t *testing.T) {
 }
 
 func TestCmdCronExec_TriggersJob(t *testing.T) {
+	for _, subcommand := range []string{"exec", "run", "trigger"} {
+		t.Run(subcommand, func(t *testing.T) {
+			store, err := NewCronStore(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			scheduler := NewCronScheduler(store)
+			platform := &stubCronReplyTargetPlatform{
+				stubPlatformEngine: stubPlatformEngine{n: "plain"},
+			}
+			agentSession := newResultAgentSession("manual run complete")
+			e := NewEngine("test", &resultAgent{session: agentSession}, []Platform{platform}, "", LangEnglish)
+			e.cronScheduler = scheduler
+			scheduler.RegisterEngine("test", e)
+
+			job := &CronJob{
+				ID:          "run-from-chat",
+				Project:     "test",
+				SessionKey:  "plain:user1",
+				CronExpr:    "0 6 * * *",
+				Prompt:      "summarize",
+				Description: "Run from chat",
+				Enabled:     false,
+				CreatedAt:   time.Now(),
+			}
+			if err := store.Add(job); err != nil {
+				t.Fatal(err)
+			}
+
+			msg := &Message{SessionKey: "plain:user1", ReplyCtx: "ctx"}
+			e.cmdCron(platform, msg, []string{subcommand, job.ID})
+
+			sent := platform.getSent()
+			if len(sent) == 0 || !strings.Contains(sent[0], "triggered") {
+				t.Fatalf("reply = %v, want localized trigger confirmation", sent)
+			}
+
+			deadline := time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) {
+				sent = platform.getSent()
+				if len(sent) >= 3 {
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			t.Fatalf("timed out waiting for run output, sent=%v", platform.getSent())
+		})
+	}
+}
+
+func TestCmdCronExec_BlocksShellJobForNonAdmin(t *testing.T) {
 	store, err := NewCronStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
 	scheduler := NewCronScheduler(store)
-	platform := &stubCronReplyTargetPlatform{
-		stubPlatformEngine: stubPlatformEngine{n: "plain"},
-	}
-	agentSession := newResultAgentSession("manual run complete")
-	e := NewEngine("test", &resultAgent{session: agentSession}, []Platform{platform}, "", LangEnglish)
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetAdminFrom("admin1")
 	e.cronScheduler = scheduler
 	scheduler.RegisterEngine("test", e)
 
 	job := &CronJob{
-		ID:          "run-from-chat",
+		ID:          "shell-from-chat",
 		Project:     "test",
 		SessionKey:  "plain:user1",
 		CronExpr:    "0 6 * * *",
-		Prompt:      "summarize",
-		Description: "Run from chat",
-		Enabled:     false,
+		Exec:        "echo should-not-run",
+		Description: "Shell from chat",
+		Enabled:     true,
 		CreatedAt:   time.Now(),
 	}
 	if err := store.Add(job); err != nil {
 		t.Fatal(err)
 	}
 
-	msg := &Message{SessionKey: "plain:user1", ReplyCtx: "ctx"}
-	e.cmdCron(platform, msg, []string{"run", job.ID})
+	msg := &Message{SessionKey: "plain:user1", UserID: "user1", ReplyCtx: "ctx"}
+	e.cmdCron(p, msg, []string{"trigger", job.ID})
 
-	sent := platform.getSent()
-	if len(sent) == 0 || !strings.Contains(sent[0], "triggered") {
-		t.Fatalf("reply = %v, want localized trigger confirmation", sent)
+	if len(p.sent) != 1 {
+		t.Fatalf("sent = %d, want 1", len(p.sent))
 	}
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		sent = platform.getSent()
-		if len(sent) >= 3 {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
+	if !strings.Contains(strings.ToLower(p.sent[0]), "admin") {
+		t.Fatalf("reply = %q, want admin required", p.sent[0])
 	}
-	t.Fatalf("timed out waiting for run output, sent=%v", platform.getSent())
+	if strings.Contains(p.sent[0], "triggered") {
+		t.Fatalf("reply = %q, should not trigger shell cron", p.sent[0])
+	}
 }
 
 func TestCmdCronExec_ProjectMissingReply(t *testing.T) {

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -266,30 +266,33 @@ const (
 	MsgHeartbeatUsage        MsgKey = "heartbeat_usage"
 	MsgHeartbeatInvalidMins  MsgKey = "heartbeat_invalid_mins"
 
-	MsgCronNotAvailable MsgKey = "cron_not_available"
-	MsgCronUsage        MsgKey = "cron_usage"
-	MsgCronAddUsage     MsgKey = "cron_add_usage"
-	MsgCronAdded        MsgKey = "cron_added"
-	MsgCronAddedExec    MsgKey = "cron_added_exec"
-	MsgCronAddExecUsage MsgKey = "cron_addexec_usage"
-	MsgCronEmpty        MsgKey = "cron_empty"
-	MsgCronListTitle    MsgKey = "cron_list_title"
-	MsgCronListFooter   MsgKey = "cron_list_footer"
-	MsgCronDelUsage     MsgKey = "cron_del_usage"
-	MsgCronDeleted      MsgKey = "cron_deleted"
-	MsgCronNotFound     MsgKey = "cron_not_found"
-	MsgCronEnabled      MsgKey = "cron_enabled"
-	MsgCronDisabled     MsgKey = "cron_disabled"
-	MsgCronMuted        MsgKey = "cron_muted"
-	MsgCronUnmuted      MsgKey = "cron_unmuted"
-	MsgCronCardHint     MsgKey = "cron_card_hint"
-	MsgCronNextShort    MsgKey = "cron_next_short"
-	MsgCronLastShort    MsgKey = "cron_last_short"
-	MsgCronBtnEnable    MsgKey = "cron_btn_enable"
-	MsgCronBtnDisable   MsgKey = "cron_btn_disable"
-	MsgCronBtnMute      MsgKey = "cron_btn_mute"
-	MsgCronBtnUnmute    MsgKey = "cron_btn_unmute"
-	MsgCronBtnDelete    MsgKey = "cron_btn_delete"
+	MsgCronNotAvailable       MsgKey = "cron_not_available"
+	MsgCronUsage              MsgKey = "cron_usage"
+	MsgCronAddUsage           MsgKey = "cron_add_usage"
+	MsgCronAdded              MsgKey = "cron_added"
+	MsgCronAddedExec          MsgKey = "cron_added_exec"
+	MsgCronAddExecUsage       MsgKey = "cron_addexec_usage"
+	MsgCronEmpty              MsgKey = "cron_empty"
+	MsgCronListTitle          MsgKey = "cron_list_title"
+	MsgCronListFooter         MsgKey = "cron_list_footer"
+	MsgCronRunUsage           MsgKey = "cron_run_usage"
+	MsgCronTriggered          MsgKey = "cron_triggered"
+	MsgCronProjectUnavailable MsgKey = "cron_project_unavailable"
+	MsgCronDelUsage           MsgKey = "cron_del_usage"
+	MsgCronDeleted            MsgKey = "cron_deleted"
+	MsgCronNotFound           MsgKey = "cron_not_found"
+	MsgCronEnabled            MsgKey = "cron_enabled"
+	MsgCronDisabled           MsgKey = "cron_disabled"
+	MsgCronMuted              MsgKey = "cron_muted"
+	MsgCronUnmuted            MsgKey = "cron_unmuted"
+	MsgCronCardHint           MsgKey = "cron_card_hint"
+	MsgCronNextShort          MsgKey = "cron_next_short"
+	MsgCronLastShort          MsgKey = "cron_last_short"
+	MsgCronBtnEnable          MsgKey = "cron_btn_enable"
+	MsgCronBtnDisable         MsgKey = "cron_btn_disable"
+	MsgCronBtnMute            MsgKey = "cron_btn_mute"
+	MsgCronBtnUnmute          MsgKey = "cron_btn_unmute"
+	MsgCronBtnDelete          MsgKey = "cron_btn_delete"
 
 	MsgStatusTitle           MsgKey = "status_title"
 	MsgReplyFooterRemaining  MsgKey = "reply_footer_remaining"
@@ -962,7 +965,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/show <ref>\n  View a file, directory, or code snippet by reference\n\n" +
 			"/dir [path|reset]\n  Show, switch, or reset agent working directory\n\n" +
 			"/stop\n  Stop current execution\n\n" +
-			"/cron [add|list|del|enable|disable]\n  Manage scheduled tasks\n\n" +
+			"/cron [add|list|run|del|enable|disable]\n  Manage scheduled tasks\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  Manage heartbeat\n\n" +
 			"/commands [add|del]\n  Manage custom slash commands\n\n" +
 			"/alias [add|del]\n  Manage command aliases (e.g. 帮助 → /help)\n\n" +
@@ -1005,7 +1008,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/show <引用>\n  按引用查看文件、目录或代码片段\n\n" +
 			"/dir [路径|reset]\n  查看、切换或重置 Agent 工作目录\n\n" +
 			"/stop\n  停止当前执行\n\n" +
-			"/cron [add|list|del|enable|disable]\n  管理定时任务\n\n" +
+			"/cron [add|list|run|del|enable|disable]\n  管理定时任务\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  管理心跳\n\n" +
 			"/commands [add|del]\n  管理自定义命令\n\n" +
 			"/alias [add|del]\n  管理命令别名（如 帮助 → /help）\n\n" +
@@ -1047,7 +1050,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell [--timeout <秒>] <命令>\n  執行 Shell 命令並返回結果（快捷方式：!命令）\n\n" +
 			"/dir [路徑|reset]\n  查看、切換或重置 Agent 工作目錄\n\n" +
 			"/stop\n  停止當前執行\n\n" +
-			"/cron [add|list|del|enable|disable]\n  管理定時任務\n\n" +
+			"/cron [add|list|run|del|enable|disable]\n  管理定時任務\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  管理心跳\n\n" +
 			"/commands [add|del]\n  管理自訂命令\n\n" +
 			"/alias [add|del]\n  管理命令別名（如 幫助 → /help）\n\n" +
@@ -1088,7 +1091,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell [--timeout <秒>] <コマンド>\n  シェルコマンドを実行して結果を返す（ショートカット：!コマンド）\n\n" +
 			"/dir [パス|reset]\n  エージェントの作業ディレクトリを表示/切り替え/リセット\n\n" +
 			"/stop\n  現在の実行を停止\n\n" +
-			"/cron [add|list|del|enable|disable]\n  スケジュールタスク管理\n\n" +
+			"/cron [add|list|run|del|enable|disable]\n  スケジュールタスク管理\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  ハートビート管理\n\n" +
 			"/commands [add|del]\n  カスタムコマンド管理\n\n" +
 			"/alias [add|del]\n  コマンドエイリアス管理（例: ヘルプ → /help）\n\n" +
@@ -1129,7 +1132,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell [--timeout <seg>] <comando>\n  Ejecutar un comando shell y devolver la salida (atajo: !comando)\n\n" +
 			"/dir [ruta|reset]\n  Ver, cambiar o restablecer el directorio de trabajo del agente\n\n" +
 			"/stop\n  Detener ejecución actual\n\n" +
-			"/cron [add|list|del|enable|disable]\n  Gestionar tareas programadas\n\n" +
+			"/cron [add|list|run|del|enable|disable]\n  Gestionar tareas programadas\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  Gestionar heartbeat\n\n" +
 			"/commands [add|del]\n  Gestionar comandos personalizados\n\n" +
 			"/alias [add|del]\n  Gestionar alias de comandos (ej. ayuda → /help)\n\n" +
@@ -1247,7 +1250,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <command> — Run a shell command (! shortcut)\n" +
 			"/show <ref> — View file / directory / snippet by reference\n" +
 			"/dir [path|reset] — Show, switch, or reset work directory\n" +
-			"/cron [add|list|del|...] — Scheduled tasks\n" +
+			"/cron [add|list|run|del|...] — Scheduled tasks\n" +
 			"/commands [add|del] — Custom commands\n" +
 			"/alias [add|del] — Command aliases\n" +
 			"/skills — List agent skills\n" +
@@ -1257,7 +1260,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <命令> — 执行 Shell 命令（!快捷方式）\n" +
 			"/show <引用> — 按引用查看文件、目录或代码片段\n" +
 			"/dir [路径|reset] — 查看、切换或重置工作目录\n" +
-			"/cron [add|list|del|...] — 定时任务\n" +
+			"/cron [add|list|run|del|...] — 定时任务\n" +
 			"/commands [add|del] — 自定义命令\n" +
 			"/alias [add|del] — 命令别名\n" +
 			"/skills — 列出 Agent Skills\n" +
@@ -1267,7 +1270,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <命令> — 執行 Shell 命令（!快捷方式）\n" +
 			"/show <引用> — 按引用查看檔案、目錄或程式碼片段\n" +
 			"/dir [路徑|reset] — 查看、切換或重置工作目錄\n" +
-			"/cron [add|list|del|...] — 定時任務\n" +
+			"/cron [add|list|run|del|...] — 定時任務\n" +
 			"/commands [add|del] — 自訂命令\n" +
 			"/alias [add|del] — 命令別名\n" +
 			"/skills — 列出 Agent Skills\n" +
@@ -1277,7 +1280,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <コマンド> — シェルコマンド実行（!ショートカット）\n" +
 			"/show <参照> — ファイル/ディレクトリ/スニペットを参照で表示\n" +
 			"/dir [パス|reset] — 作業ディレクトリの表示/切り替え/リセット\n" +
-			"/cron [add|list|del|...] — スケジュールタスク\n" +
+			"/cron [add|list|run|del|...] — スケジュールタスク\n" +
 			"/commands [add|del] — カスタムコマンド\n" +
 			"/alias [add|del] — コマンドエイリアス\n" +
 			"/skills — エージェントスキル一覧\n" +
@@ -1287,7 +1290,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <comando> — Ejecutar comando shell (! atajo)\n" +
 			"/show <ref> — Ver archivo/directorio/fragmento por referencia\n" +
 			"/dir [ruta|reset] — Ver, cambiar o restablecer directorio de trabajo\n" +
-			"/cron [add|list|del|...] — Tareas programadas\n" +
+			"/cron [add|list|run|del|...] — Tareas programadas\n" +
 			"/commands [add|del] — Comandos personalizados\n" +
 			"/alias [add|del] — Alias de comandos\n" +
 			"/skills — Listar skills del agente\n" +
@@ -1759,11 +1762,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "El programador de tareas no está disponible.",
 	},
 	MsgCronUsage: {
-		LangEnglish:            "Usage:\n/cron add <min> <hour> <day> <month> <weekday> <prompt>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — write cc-connect instructions to agent memory file",
-		LangChinese:            "用法：\n/cron add <分> <时> <日> <月> <周> <任务描述>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 静音/取消静音\n/cron setup — 将 cc-connect 指令写入 agent 记忆文件",
-		LangTraditionalChinese: "用法：\n/cron add <分> <時> <日> <月> <週> <任務描述>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 靜音/取消靜音\n/cron setup — 將 cc-connect 指令寫入 agent 記憶檔案",
-		LangJapanese:           "使い方:\n/cron add <分> <時> <日> <月> <曜日> <タスク内容>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> ミュート/解除\n/cron setup — cc-connect の指示をエージェントのメモリファイルに書き込む",
-		LangSpanish:            "Uso:\n/cron add <min> <hora> <día> <mes> <día_semana> <tarea>\n/cron list\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — escribir las instrucciones de cc-connect en el archivo de memoria del agente",
+		LangEnglish:            "Usage:\n/cron add <min> <hour> <day> <month> <weekday> <prompt>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — write cc-connect instructions to agent memory file",
+		LangChinese:            "用法：\n/cron add <分> <时> <日> <月> <周> <任务描述>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 静音/取消静音\n/cron setup — 将 cc-connect 指令写入 agent 记忆文件",
+		LangTraditionalChinese: "用法：\n/cron add <分> <時> <日> <月> <週> <任務描述>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 靜音/取消靜音\n/cron setup — 將 cc-connect 指令寫入 agent 記憶檔案",
+		LangJapanese:           "使い方:\n/cron add <分> <時> <日> <月> <曜日> <タスク内容>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> ミュート/解除\n/cron setup — cc-connect の指示をエージェントのメモリファイルに書き込む",
+		LangSpanish:            "Uso:\n/cron add <min> <hora> <día> <mes> <día_semana> <tarea>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — escribir las instrucciones de cc-connect en el archivo de memoria del agente",
 	},
 	MsgCronAddUsage: {
 		LangEnglish:            "Usage: /cron add <min> <hour> <day> <month> <weekday> <prompt>\nExample: /cron add 0 6 * * * Collect GitHub trending data and send me a summary",
@@ -1808,11 +1811,32 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "⏰ Tareas programadas (%d)",
 	},
 	MsgCronListFooter: {
-		LangEnglish:            "`/cron del <id>` remove · `/cron enable/disable <id>` toggle · `/cron mute/unmute <id>` mute",
-		LangChinese:            "`/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
-		LangTraditionalChinese: "`/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
-		LangJapanese:           "`/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
-		LangSpanish:            "`/cron del <id>` eliminar · `/cron enable/disable <id>` activar/desactivar · `/cron mute/unmute <id>` silenciar",
+		LangEnglish:            "`/cron run <id>` trigger now · `/cron del <id>` remove · `/cron enable/disable <id>` toggle · `/cron mute/unmute <id>` mute",
+		LangChinese:            "`/cron run <id>` 立即触发 · `/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
+		LangTraditionalChinese: "`/cron run <id>` 立即觸發 · `/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
+		LangJapanese:           "`/cron run <id>` 今すぐ実行 · `/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
+		LangSpanish:            "`/cron run <id>` ejecutar ahora · `/cron del <id>` eliminar · `/cron enable/disable <id>` activar/desactivar · `/cron mute/unmute <id>` silenciar",
+	},
+	MsgCronRunUsage: {
+		LangEnglish:            "Usage: /cron run <id>",
+		LangChinese:            "用法：/cron run <id>",
+		LangTraditionalChinese: "用法：/cron run <id>",
+		LangJapanese:           "使い方: /cron run <id>",
+		LangSpanish:            "Uso: /cron run <id>",
+	},
+	MsgCronTriggered: {
+		LangEnglish:            "▶️ Cron job `%s` triggered.",
+		LangChinese:            "▶️ 定时任务 `%s` 已触发。",
+		LangTraditionalChinese: "▶️ 定時任務 `%s` 已觸發。",
+		LangJapanese:           "▶️ スケジュールタスク `%s` を実行しました。",
+		LangSpanish:            "▶️ Tarea programada `%s` ejecutada.",
+	},
+	MsgCronProjectUnavailable: {
+		LangEnglish:            "❌ This cron job cannot be triggered because its project is no longer available.",
+		LangChinese:            "❌ 该定时任务关联的项目已不可用，无法触发。",
+		LangTraditionalChinese: "❌ 該定時任務關聯的專案已不可用，無法觸發。",
+		LangJapanese:           "❌ このスケジュールタスクは、関連するプロジェクトが利用できないため実行できません。",
+		LangSpanish:            "❌ Esta tarea programada no puede ejecutarse porque su proyecto ya no está disponible.",
 	},
 	MsgCronDelUsage: {
 		LangEnglish:            "Usage: /cron del <id>",
@@ -1864,11 +1888,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "🔔 Tarea programada `%s` reactivada.",
 	},
 	MsgCronCardHint: {
-		LangEnglish:            "💡 `/cron add` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
-		LangChinese:            "💡 `/cron add` 添加 · `/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
-		LangTraditionalChinese: "💡 `/cron add` 新增 · `/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
-		LangJapanese:           "💡 `/cron add` 追加 · `/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
-		LangSpanish:            "💡 `/cron add` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
+		LangEnglish:            "💡 `/cron add` · `/cron run <id>` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
+		LangChinese:            "💡 `/cron add` 添加 · `/cron run <id>` 触发 · `/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
+		LangTraditionalChinese: "💡 `/cron add` 新增 · `/cron run <id>` 觸發 · `/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
+		LangJapanese:           "💡 `/cron add` 追加 · `/cron run <id>` 実行 · `/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
+		LangSpanish:            "💡 `/cron add` · `/cron run <id>` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
 	},
 	MsgCronBtnEnable: {
 		LangEnglish:            "Enable",
@@ -3433,11 +3457,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Detener ejecución actual",
 	},
 	MsgBuiltinCmdCron: {
-		LangEnglish:            "Manage scheduled tasks, arg: [add|list|del|enable|disable]",
-		LangChinese:            "管理定时任务，参数: [add|list|del|enable|disable]",
-		LangTraditionalChinese: "管理定時任務，參數: [add|list|del|enable|disable]",
-		LangJapanese:           "スケジュールタスク管理、引数: [add|list|del|enable|disable]",
-		LangSpanish:            "Gestionar tareas programadas, arg: [add|list|del|enable|disable]",
+		LangEnglish:            "Manage scheduled tasks, arg: [add|list|run|del|enable|disable]",
+		LangChinese:            "管理定时任务，参数: [add|list|run|del|enable|disable]",
+		LangTraditionalChinese: "管理定時任務，參數: [add|list|run|del|enable|disable]",
+		LangJapanese:           "スケジュールタスク管理、引数: [add|list|run|del|enable|disable]",
+		LangSpanish:            "Gestionar tareas programadas, arg: [add|list|run|del|enable|disable]",
 	},
 	MsgBuiltinCmdCommands: {
 		LangEnglish:            "Manage custom slash commands, arg: [add|del]",

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -275,7 +275,7 @@ const (
 	MsgCronEmpty              MsgKey = "cron_empty"
 	MsgCronListTitle          MsgKey = "cron_list_title"
 	MsgCronListFooter         MsgKey = "cron_list_footer"
-	MsgCronRunUsage           MsgKey = "cron_run_usage"
+	MsgCronExecUsage          MsgKey = "cron_exec_usage"
 	MsgCronTriggered          MsgKey = "cron_triggered"
 	MsgCronProjectUnavailable MsgKey = "cron_project_unavailable"
 	MsgCronDelUsage           MsgKey = "cron_del_usage"
@@ -965,7 +965,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/show <ref>\n  View a file, directory, or code snippet by reference\n\n" +
 			"/dir [path|reset]\n  Show, switch, or reset agent working directory\n\n" +
 			"/stop\n  Stop current execution\n\n" +
-			"/cron [add|list|run|del|enable|disable]\n  Manage scheduled tasks\n\n" +
+			"/cron [add|list|exec|del|enable|disable]\n  Manage scheduled tasks\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  Manage heartbeat\n\n" +
 			"/commands [add|del]\n  Manage custom slash commands\n\n" +
 			"/alias [add|del]\n  Manage command aliases (e.g. 帮助 → /help)\n\n" +
@@ -1008,7 +1008,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/show <引用>\n  按引用查看文件、目录或代码片段\n\n" +
 			"/dir [路径|reset]\n  查看、切换或重置 Agent 工作目录\n\n" +
 			"/stop\n  停止当前执行\n\n" +
-			"/cron [add|list|run|del|enable|disable]\n  管理定时任务\n\n" +
+			"/cron [add|list|exec|del|enable|disable]\n  管理定时任务\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  管理心跳\n\n" +
 			"/commands [add|del]\n  管理自定义命令\n\n" +
 			"/alias [add|del]\n  管理命令别名（如 帮助 → /help）\n\n" +
@@ -1050,7 +1050,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell [--timeout <秒>] <命令>\n  執行 Shell 命令並返回結果（快捷方式：!命令）\n\n" +
 			"/dir [路徑|reset]\n  查看、切換或重置 Agent 工作目錄\n\n" +
 			"/stop\n  停止當前執行\n\n" +
-			"/cron [add|list|run|del|enable|disable]\n  管理定時任務\n\n" +
+			"/cron [add|list|exec|del|enable|disable]\n  管理定時任務\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  管理心跳\n\n" +
 			"/commands [add|del]\n  管理自訂命令\n\n" +
 			"/alias [add|del]\n  管理命令別名（如 幫助 → /help）\n\n" +
@@ -1091,7 +1091,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell [--timeout <秒>] <コマンド>\n  シェルコマンドを実行して結果を返す（ショートカット：!コマンド）\n\n" +
 			"/dir [パス|reset]\n  エージェントの作業ディレクトリを表示/切り替え/リセット\n\n" +
 			"/stop\n  現在の実行を停止\n\n" +
-			"/cron [add|list|run|del|enable|disable]\n  スケジュールタスク管理\n\n" +
+			"/cron [add|list|exec|del|enable|disable]\n  スケジュールタスク管理\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  ハートビート管理\n\n" +
 			"/commands [add|del]\n  カスタムコマンド管理\n\n" +
 			"/alias [add|del]\n  コマンドエイリアス管理（例: ヘルプ → /help）\n\n" +
@@ -1132,7 +1132,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell [--timeout <seg>] <comando>\n  Ejecutar un comando shell y devolver la salida (atajo: !comando)\n\n" +
 			"/dir [ruta|reset]\n  Ver, cambiar o restablecer el directorio de trabajo del agente\n\n" +
 			"/stop\n  Detener ejecución actual\n\n" +
-			"/cron [add|list|run|del|enable|disable]\n  Gestionar tareas programadas\n\n" +
+			"/cron [add|list|exec|del|enable|disable]\n  Gestionar tareas programadas\n\n" +
 			"/heartbeat [status|pause|resume|run|interval]\n  Gestionar heartbeat\n\n" +
 			"/commands [add|del]\n  Gestionar comandos personalizados\n\n" +
 			"/alias [add|del]\n  Gestionar alias de comandos (ej. ayuda → /help)\n\n" +
@@ -1250,7 +1250,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <command> — Run a shell command (! shortcut)\n" +
 			"/show <ref> — View file / directory / snippet by reference\n" +
 			"/dir [path|reset] — Show, switch, or reset work directory\n" +
-			"/cron [add|list|run|del|...] — Scheduled tasks\n" +
+			"/cron [add|list|exec|del|...] — Scheduled tasks\n" +
 			"/commands [add|del] — Custom commands\n" +
 			"/alias [add|del] — Command aliases\n" +
 			"/skills — List agent skills\n" +
@@ -1260,7 +1260,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <命令> — 执行 Shell 命令（!快捷方式）\n" +
 			"/show <引用> — 按引用查看文件、目录或代码片段\n" +
 			"/dir [路径|reset] — 查看、切换或重置工作目录\n" +
-			"/cron [add|list|run|del|...] — 定时任务\n" +
+			"/cron [add|list|exec|del|...] — 定时任务\n" +
 			"/commands [add|del] — 自定义命令\n" +
 			"/alias [add|del] — 命令别名\n" +
 			"/skills — 列出 Agent Skills\n" +
@@ -1270,7 +1270,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <命令> — 執行 Shell 命令（!快捷方式）\n" +
 			"/show <引用> — 按引用查看檔案、目錄或程式碼片段\n" +
 			"/dir [路徑|reset] — 查看、切換或重置工作目錄\n" +
-			"/cron [add|list|run|del|...] — 定時任務\n" +
+			"/cron [add|list|exec|del|...] — 定時任務\n" +
 			"/commands [add|del] — 自訂命令\n" +
 			"/alias [add|del] — 命令別名\n" +
 			"/skills — 列出 Agent Skills\n" +
@@ -1280,7 +1280,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <コマンド> — シェルコマンド実行（!ショートカット）\n" +
 			"/show <参照> — ファイル/ディレクトリ/スニペットを参照で表示\n" +
 			"/dir [パス|reset] — 作業ディレクトリの表示/切り替え/リセット\n" +
-			"/cron [add|list|run|del|...] — スケジュールタスク\n" +
+			"/cron [add|list|exec|del|...] — スケジュールタスク\n" +
 			"/commands [add|del] — カスタムコマンド\n" +
 			"/alias [add|del] — コマンドエイリアス\n" +
 			"/skills — エージェントスキル一覧\n" +
@@ -1290,7 +1290,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/shell <comando> — Ejecutar comando shell (! atajo)\n" +
 			"/show <ref> — Ver archivo/directorio/fragmento por referencia\n" +
 			"/dir [ruta|reset] — Ver, cambiar o restablecer directorio de trabajo\n" +
-			"/cron [add|list|run|del|...] — Tareas programadas\n" +
+			"/cron [add|list|exec|del|...] — Tareas programadas\n" +
 			"/commands [add|del] — Comandos personalizados\n" +
 			"/alias [add|del] — Alias de comandos\n" +
 			"/skills — Listar skills del agente\n" +
@@ -1762,11 +1762,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "El programador de tareas no está disponible.",
 	},
 	MsgCronUsage: {
-		LangEnglish:            "Usage:\n/cron add <min> <hour> <day> <month> <weekday> <prompt>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — write cc-connect instructions to agent memory file",
-		LangChinese:            "用法：\n/cron add <分> <时> <日> <月> <周> <任务描述>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 静音/取消静音\n/cron setup — 将 cc-connect 指令写入 agent 记忆文件",
-		LangTraditionalChinese: "用法：\n/cron add <分> <時> <日> <月> <週> <任務描述>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 靜音/取消靜音\n/cron setup — 將 cc-connect 指令寫入 agent 記憶檔案",
-		LangJapanese:           "使い方:\n/cron add <分> <時> <日> <月> <曜日> <タスク内容>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> ミュート/解除\n/cron setup — cc-connect の指示をエージェントのメモリファイルに書き込む",
-		LangSpanish:            "Uso:\n/cron add <min> <hora> <día> <mes> <día_semana> <tarea>\n/cron list\n/cron run <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — escribir las instrucciones de cc-connect en el archivo de memoria del agente",
+		LangEnglish:            "Usage:\n/cron add <min> <hour> <day> <month> <weekday> <prompt>\n/cron list\n/cron exec <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — write cc-connect instructions to agent memory file",
+		LangChinese:            "用法：\n/cron add <分> <时> <日> <月> <周> <任务描述>\n/cron list\n/cron exec <id> 立即执行\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 静音/取消静音\n/cron setup — 将 cc-connect 指令写入 agent 记忆文件",
+		LangTraditionalChinese: "用法：\n/cron add <分> <時> <日> <月> <週> <任務描述>\n/cron list\n/cron exec <id> 立即執行\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> 靜音/取消靜音\n/cron setup — 將 cc-connect 指令寫入 agent 記憶檔案",
+		LangJapanese:           "使い方:\n/cron add <分> <時> <日> <月> <曜日> <タスク内容>\n/cron list\n/cron exec <id> 今すぐ実行\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id> ミュート/解除\n/cron setup — cc-connect の指示をエージェントのメモリファイルに書き込む",
+		LangSpanish:            "Uso:\n/cron add <min> <hora> <día> <mes> <día_semana> <tarea>\n/cron list\n/cron exec <id>\n/cron del <id>\n/cron enable <id> · /cron disable <id>\n/cron mute <id> · /cron unmute <id>\n/cron setup — escribir las instrucciones de cc-connect en el archivo de memoria del agente",
 	},
 	MsgCronAddUsage: {
 		LangEnglish:            "Usage: /cron add <min> <hour> <day> <month> <weekday> <prompt>\nExample: /cron add 0 6 * * * Collect GitHub trending data and send me a summary",
@@ -1811,18 +1811,18 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "⏰ Tareas programadas (%d)",
 	},
 	MsgCronListFooter: {
-		LangEnglish:            "`/cron run <id>` trigger now · `/cron del <id>` remove · `/cron enable/disable <id>` toggle · `/cron mute/unmute <id>` mute",
-		LangChinese:            "`/cron run <id>` 立即触发 · `/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
-		LangTraditionalChinese: "`/cron run <id>` 立即觸發 · `/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
-		LangJapanese:           "`/cron run <id>` 今すぐ実行 · `/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
-		LangSpanish:            "`/cron run <id>` ejecutar ahora · `/cron del <id>` eliminar · `/cron enable/disable <id>` activar/desactivar · `/cron mute/unmute <id>` silenciar",
+		LangEnglish:            "`/cron exec <id>` trigger now · `/cron del <id>` remove · `/cron enable/disable <id>` toggle · `/cron mute/unmute <id>` mute",
+		LangChinese:            "`/cron exec <id>` 立即触发 · `/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
+		LangTraditionalChinese: "`/cron exec <id>` 立即觸發 · `/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
+		LangJapanese:           "`/cron exec <id>` 今すぐ実行 · `/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
+		LangSpanish:            "`/cron exec <id>` ejecutar ahora · `/cron del <id>` eliminar · `/cron enable/disable <id>` activar/desactivar · `/cron mute/unmute <id>` silenciar",
 	},
-	MsgCronRunUsage: {
-		LangEnglish:            "Usage: /cron run <id>",
-		LangChinese:            "用法：/cron run <id>",
-		LangTraditionalChinese: "用法：/cron run <id>",
-		LangJapanese:           "使い方: /cron run <id>",
-		LangSpanish:            "Uso: /cron run <id>",
+	MsgCronExecUsage: {
+		LangEnglish:            "Usage: /cron exec <id>",
+		LangChinese:            "用法：/cron exec <id>",
+		LangTraditionalChinese: "用法：/cron exec <id>",
+		LangJapanese:           "使い方: /cron exec <id>",
+		LangSpanish:            "Uso: /cron exec <id>",
 	},
 	MsgCronTriggered: {
 		LangEnglish:            "▶️ Cron job `%s` triggered.",
@@ -1888,11 +1888,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "🔔 Tarea programada `%s` reactivada.",
 	},
 	MsgCronCardHint: {
-		LangEnglish:            "💡 `/cron add` · `/cron run <id>` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
-		LangChinese:            "💡 `/cron add` 添加 · `/cron run <id>` 触发 · `/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
-		LangTraditionalChinese: "💡 `/cron add` 新增 · `/cron run <id>` 觸發 · `/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
-		LangJapanese:           "💡 `/cron add` 追加 · `/cron run <id>` 実行 · `/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
-		LangSpanish:            "💡 `/cron add` · `/cron run <id>` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
+		LangEnglish:            "💡 `/cron add` · `/cron exec <id>` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
+		LangChinese:            "💡 `/cron add` 添加 · `/cron exec <id>` 触发 · `/cron del <id>` 删除 · `/cron enable/disable <id>` 启停 · `/cron mute/unmute <id>` 静音",
+		LangTraditionalChinese: "💡 `/cron add` 新增 · `/cron exec <id>` 觸發 · `/cron del <id>` 刪除 · `/cron enable/disable <id>` 啟停 · `/cron mute/unmute <id>` 靜音",
+		LangJapanese:           "💡 `/cron add` 追加 · `/cron exec <id>` 実行 · `/cron del <id>` 削除 · `/cron enable/disable <id>` 切替 · `/cron mute/unmute <id>` ミュート",
+		LangSpanish:            "💡 `/cron add` · `/cron exec <id>` · `/cron del <id>` · `/cron enable/disable <id>` · `/cron mute/unmute <id>`",
 	},
 	MsgCronBtnEnable: {
 		LangEnglish:            "Enable",
@@ -3457,11 +3457,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Detener ejecución actual",
 	},
 	MsgBuiltinCmdCron: {
-		LangEnglish:            "Manage scheduled tasks, arg: [add|list|run|del|enable|disable]",
-		LangChinese:            "管理定时任务，参数: [add|list|run|del|enable|disable]",
-		LangTraditionalChinese: "管理定時任務，參數: [add|list|run|del|enable|disable]",
-		LangJapanese:           "スケジュールタスク管理、引数: [add|list|run|del|enable|disable]",
-		LangSpanish:            "Gestionar tareas programadas, arg: [add|list|run|del|enable|disable]",
+		LangEnglish:            "Manage scheduled tasks, arg: [add|list|exec|del|enable|disable]",
+		LangChinese:            "管理定时任务，参数: [add|list|exec|del|enable|disable]",
+		LangTraditionalChinese: "管理定時任務，參數: [add|list|exec|del|enable|disable]",
+		LangJapanese:           "スケジュールタスク管理、引数: [add|list|exec|del|enable|disable]",
+		LangSpanish:            "Gestionar tareas programadas, arg: [add|list|exec|del|enable|disable]",
 	},
 	MsgBuiltinCmdCommands: {
 		LangEnglish:            "Manage custom slash commands, arg: [add|del]",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -98,13 +98,15 @@ Examples:
   cc-connect cron add --cron "0 9 * * 1" --prompt "Generate a weekly project status report" --desc "Weekly Report"
   cc-connect cron add --cron "*/2 * * * *" --exec "ipconfig" --session-mode new-per-run --desc "Every 2 min ipconfig"
 
-You can also list, inspect, edit, or delete cron jobs:
+You can also list, inspect, run, edit, or delete cron jobs:
   cc-connect cron list
   cc-connect cron info <job-id> [field]
+  cc-connect cron exec <job-id>
   cc-connect cron edit <job-id> <field> <value>
   cc-connect cron del <job-id>
 
 When changing an existing job, first run ` + "`cc-connect cron info <job-id>`" + ` to inspect the current values, then use ` + "`cron edit`" + ` for only the field(s) the user asked to change.
+Use ` + "`cron exec <job-id>`" + ` to run an existing scheduled task immediately; this is different from the ` + "`--exec <command>`" + ` flag used when creating a shell-command cron job.
 Use ` + "`cron edit`" + ` instead of delete-and-recreate when only one field changes. Do not delete and recreate a job unless the user explicitly asks to replace it.
 Common editable fields:
   cron_expr     new schedule, e.g. "0 9 * * *"
@@ -116,6 +118,7 @@ Common editable fields:
 Run ` + "`cc-connect cron edit --help`" + ` for the full field list.
 
 Examples:
+  cc-connect cron exec abc123
   cc-connect cron edit abc123 cron_expr "0 9 * * *"
   cc-connect cron edit abc123 enabled false
   cc-connect cron edit abc123 prompt "Updated daily summary task"

--- a/core/management.go
+++ b/core/management.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -1551,14 +1552,29 @@ func (m *ManagementServer) handleCronByID(w http.ResponseWriter, r *http.Request
 		mgmtError(w, http.StatusServiceUnavailable, "cron scheduler not available")
 		return
 	}
-	id := strings.TrimPrefix(r.URL.Path, "/api/v1/cron/")
-	if id == "" {
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/cron/")
+	path = strings.Trim(path, "/")
+	if path == "" {
 		mgmtError(w, http.StatusBadRequest, "cron job id required")
 		return
+	}
+	parts := strings.Split(path, "/")
+	if len(parts) > 2 {
+		mgmtError(w, http.StatusNotFound, "unknown cron route")
+		return
+	}
+	id := parts[0]
+	action := ""
+	if len(parts) > 1 {
+		action = parts[1]
 	}
 
 	switch r.Method {
 	case http.MethodDelete:
+		if action != "" {
+			mgmtError(w, http.StatusNotFound, "unknown cron route")
+			return
+		}
 		if m.cronScheduler.RemoveJob(id) {
 			mgmtOK(w, "cron job deleted")
 		} else {
@@ -1566,6 +1582,10 @@ func (m *ManagementServer) handleCronByID(w http.ResponseWriter, r *http.Request
 		}
 
 	case http.MethodPatch:
+		if action != "" {
+			mgmtError(w, http.StatusNotFound, "unknown cron route")
+			return
+		}
 		var updates map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
 			mgmtError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -1584,8 +1604,26 @@ func (m *ManagementServer) handleCronByID(w http.ResponseWriter, r *http.Request
 		}
 		mgmtJSON(w, http.StatusOK, job)
 
+	case http.MethodPost:
+		if action != "run" {
+			mgmtError(w, http.StatusNotFound, "unknown cron route")
+			return
+		}
+		if err := m.cronScheduler.RunJobNow(id); err != nil {
+			if errors.Is(err, ErrCronJobNotFound) {
+				mgmtError(w, http.StatusNotFound, err.Error())
+				return
+			}
+			mgmtError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		mgmtJSON(w, http.StatusAccepted, map[string]string{
+			"id":     id,
+			"status": "triggered",
+		})
+
 	default:
-		mgmtError(w, http.StatusMethodNotAllowed, "DELETE or PATCH only")
+		mgmtError(w, http.StatusMethodNotAllowed, "DELETE, PATCH, or POST only")
 	}
 }
 

--- a/core/management.go
+++ b/core/management.go
@@ -1605,7 +1605,7 @@ func (m *ManagementServer) handleCronByID(w http.ResponseWriter, r *http.Request
 		mgmtJSON(w, http.StatusOK, job)
 
 	case http.MethodPost:
-		if action != "run" {
+		if action != "exec" && action != "run" {
 			mgmtError(w, http.StatusNotFound, "unknown cron route")
 			return
 		}

--- a/core/management_test.go
+++ b/core/management_test.go
@@ -553,7 +553,7 @@ func TestMgmt_CronWithScheduler(t *testing.T) {
 	}
 }
 
-func TestMgmt_CronRunByID(t *testing.T) {
+func TestMgmt_CronExecByID(t *testing.T) {
 	mgmt, ts, e := testManagementServer(t, "tok")
 	store, err := NewCronStore(t.TempDir())
 	if err != nil {
@@ -585,9 +585,9 @@ func TestMgmt_CronRunByID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := mgmtPost(t, ts.URL+"/api/v1/cron/"+job.ID+"/run", "tok", map[string]any{})
+	r := mgmtPost(t, ts.URL+"/api/v1/cron/"+job.ID+"/exec", "tok", map[string]any{})
 	if !r.OK {
-		t.Fatalf("cron run failed: %s", r.Error)
+		t.Fatalf("cron exec failed: %s", r.Error)
 	}
 
 	var data map[string]any
@@ -604,14 +604,45 @@ func TestMgmt_CronRunByID(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if len(platform.getSent()) >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(platform.getSent()) < 2 {
+		t.Fatalf("timed out waiting for triggered cron exec, sent=%v", platform.getSent())
+	}
+
+	aliasJob := &CronJob{
+		ID:          "cron-run-alias-1",
+		Project:     "test-project",
+		SessionKey:  "discord:channel-2:user-2",
+		CronExpr:    "0 9 * * *",
+		Prompt:      "hello alias",
+		Description: "Run alias now",
+		Enabled:     false,
+		CreatedAt:   time.Now(),
+	}
+	if err := store.Add(aliasJob); err != nil {
+		t.Fatal(err)
+	}
+
+	e.agent = &resultAgent{session: newResultAgentSession("triggered from management alias")}
+	alias := mgmtPost(t, ts.URL+"/api/v1/cron/"+aliasJob.ID+"/run", "tok", map[string]any{})
+	if !alias.OK {
+		t.Fatalf("cron run compatibility alias failed: %s", alias.Error)
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(platform.getSent()) >= 4 {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for triggered cron run, sent=%v", platform.getSent())
+	t.Fatalf("timed out waiting for triggered cron run alias, sent=%v", platform.getSent())
 }
 
-func TestMgmt_CronRunByID_RejectsExtraPathSegments(t *testing.T) {
+func TestMgmt_CronExecByID_RejectsExtraPathSegments(t *testing.T) {
 	mgmt, ts, e := testManagementServer(t, "tok")
 	store, err := NewCronStore(t.TempDir())
 	if err != nil {
@@ -634,7 +665,7 @@ func TestMgmt_CronRunByID_RejectsExtraPathSegments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := mgmtPost(t, ts.URL+"/api/v1/cron/"+job.ID+"/run/extra", "tok", map[string]any{})
+	r := mgmtPost(t, ts.URL+"/api/v1/cron/"+job.ID+"/exec/extra", "tok", map[string]any{})
 	if r.OK {
 		t.Fatal("expected extra cron path segment to be rejected")
 	}
@@ -643,7 +674,7 @@ func TestMgmt_CronRunByID_RejectsExtraPathSegments(t *testing.T) {
 	}
 }
 
-func TestMgmt_CronRunByID_ProjectMissingIsBadRequest(t *testing.T) {
+func TestMgmt_CronExecByID_ProjectMissingIsBadRequest(t *testing.T) {
 	mgmt, ts, e := testManagementServer(t, "tok")
 	store, err := NewCronStore(t.TempDir())
 	if err != nil {
@@ -666,9 +697,9 @@ func TestMgmt_CronRunByID_ProjectMissingIsBadRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := mgmtPost(t, ts.URL+"/api/v1/cron/"+job.ID+"/run", "tok", map[string]any{})
+	r := mgmtPost(t, ts.URL+"/api/v1/cron/"+job.ID+"/exec", "tok", map[string]any{})
 	if r.OK {
-		t.Fatal("expected run to fail when project is missing")
+		t.Fatal("expected exec to fail when project is missing")
 	}
 	if !strings.Contains(r.Error, "project") {
 		t.Fatalf("error = %q, want project error", r.Error)

--- a/core/management_test.go
+++ b/core/management_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 type deadlineAwareModelAgent struct {
@@ -549,6 +550,131 @@ func TestMgmt_CronWithScheduler(t *testing.T) {
 	r = mgmtDelete(t, ts.URL+"/api/v1/cron/nonexistent", "tok")
 	if r.OK {
 		t.Fatal("expected 404 for nonexistent cron job")
+	}
+}
+
+func TestMgmt_CronRunByID(t *testing.T) {
+	mgmt, ts, e := testManagementServer(t, "tok")
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := NewCronScheduler(store)
+	mgmt.SetCronScheduler(cs)
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+	agentSession := newResultAgentSession("triggered from management")
+	e.platforms = []Platform{platform}
+	e.agent = &resultAgent{session: agentSession}
+	e.cronScheduler = cs
+	cs.RegisterEngine("test-project", e)
+
+	job := &CronJob{
+		ID:          "cron-run-1",
+		Project:     "test-project",
+		SessionKey:  "discord:channel-1:user-1",
+		CronExpr:    "0 9 * * *",
+		Prompt:      "hello",
+		Description: "Run me now",
+		Enabled:     false,
+		CreatedAt:   time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	r := mgmtPost(t, ts.URL+"/api/v1/cron/"+job.ID+"/run", "tok", map[string]any{})
+	if !r.OK {
+		t.Fatalf("cron run failed: %s", r.Error)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(r.Data, &data); err != nil {
+		t.Fatalf("unmarshal run response: %v", err)
+	}
+	if data["status"] != "triggered" {
+		t.Fatalf("status = %v, want triggered", data["status"])
+	}
+	if data["id"] != job.ID {
+		t.Fatalf("id = %v, want %s", data["id"], job.ID)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(platform.getSent()) >= 2 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for triggered cron run, sent=%v", platform.getSent())
+}
+
+func TestMgmt_CronRunByID_RejectsExtraPathSegments(t *testing.T) {
+	mgmt, ts, e := testManagementServer(t, "tok")
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := NewCronScheduler(store)
+	mgmt.SetCronScheduler(cs)
+	cs.RegisterEngine("test-project", e)
+
+	job := &CronJob{
+		ID:         "cron-run-extra",
+		Project:    "test-project",
+		SessionKey: "discord:channel-1:user-1",
+		CronExpr:   "0 9 * * *",
+		Prompt:     "hello",
+		Enabled:    true,
+		CreatedAt:  time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	r := mgmtPost(t, ts.URL+"/api/v1/cron/"+job.ID+"/run/extra", "tok", map[string]any{})
+	if r.OK {
+		t.Fatal("expected extra cron path segment to be rejected")
+	}
+	if !strings.Contains(r.Error, "unknown cron route") {
+		t.Fatalf("error = %q, want unknown cron route", r.Error)
+	}
+}
+
+func TestMgmt_CronRunByID_ProjectMissingIsBadRequest(t *testing.T) {
+	mgmt, ts, e := testManagementServer(t, "tok")
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := NewCronScheduler(store)
+	mgmt.SetCronScheduler(cs)
+	cs.RegisterEngine("test-project", e)
+
+	job := &CronJob{
+		ID:         "cron-run-missing-project",
+		Project:    "ghost",
+		SessionKey: "discord:channel-1:user-1",
+		CronExpr:   "0 9 * * *",
+		Prompt:     "hello",
+		Enabled:    true,
+		CreatedAt:  time.Now(),
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatal(err)
+	}
+
+	r := mgmtPost(t, ts.URL+"/api/v1/cron/"+job.ID+"/run", "tok", map[string]any{})
+	if r.OK {
+		t.Fatal("expected run to fail when project is missing")
+	}
+	if !strings.Contains(r.Error, "project") {
+		t.Fatalf("error = %q, want project error", r.Error)
+	}
+	if !strings.Contains(r.Error, "not found") {
+		t.Fatalf("error = %q, want missing project details", r.Error)
 	}
 }
 

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -956,6 +956,22 @@ Deletes a cron job.
 }
 ```
 
+#### POST /api/v1/cron/{id}/run
+
+Triggers an existing cron job immediately. Disabled jobs can still be triggered manually.
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "data": {
+    "id": "cron_xyz789",
+    "status": "triggered"
+  }
+}
+```
+
 ---
 
 ### 5.6 Heartbeat

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -956,9 +956,10 @@ Deletes a cron job.
 }
 ```
 
-#### POST /api/v1/cron/{id}/run
+#### POST /api/v1/cron/{id}/exec
 
 Triggers an existing cron job immediately. Disabled jobs can still be triggered manually.
+`/api/v1/cron/{id}/run` is accepted as a compatibility alias.
 
 **Response:**
 

--- a/docs/management-api.zh-CN.md
+++ b/docs/management-api.zh-CN.md
@@ -928,6 +928,22 @@ GET /api/v1/status?token=mgmt-secret
 }
 ```
 
+#### POST /api/v1/cron/{id}/run
+
+立即触发一个已存在的 cron 任务。即使任务已禁用，仍然允许手动触发。
+
+**响应：**
+
+```json
+{
+  "ok": true,
+  "data": {
+    "id": "cron_xyz789",
+    "status": "triggered"
+  }
+}
+```
+
 ---
 
 ### 5.6 心跳

--- a/docs/management-api.zh-CN.md
+++ b/docs/management-api.zh-CN.md
@@ -928,9 +928,10 @@ GET /api/v1/status?token=mgmt-secret
 }
 ```
 
-#### POST /api/v1/cron/{id}/run
+#### POST /api/v1/cron/{id}/exec
 
 立即触发一个已存在的 cron 任务。即使任务已禁用，仍然允许手动触发。
+`/api/v1/cron/{id}/run` 作为兼容别名仍可使用。
 
 **响应：**
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -775,6 +775,7 @@ Example:
 cc-connect cron add --cron "0 6 * * *" --prompt "Summarize GitHub trending" --desc "Daily Trending"
 cc-connect cron list
 cc-connect cron edit <job-id> <field> <value>   # e.g. cron_expr, prompt, enabled, mute, timeout_mins
+cc-connect cron run <job-id>
 cc-connect cron del <job-id>
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -775,7 +775,7 @@ Example:
 cc-connect cron add --cron "0 6 * * *" --prompt "Summarize GitHub trending" --desc "Daily Trending"
 cc-connect cron list
 cc-connect cron edit <job-id> <field> <value>   # e.g. cron_expr, prompt, enabled, mute, timeout_mins
-cc-connect cron run <job-id>
+cc-connect cron exec <job-id>
 cc-connect cron del <job-id>
 ```
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -687,6 +687,7 @@ cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/ch
 cc-connect cron add --cron "0 6 * * *" --prompt "总结 GitHub trending" --desc "每日趋势"
 cc-connect cron list
 cc-connect cron edit <job-id> <field> <value>   # 可改 cron_expr / prompt / enabled / mute / timeout_mins 等
+cc-connect cron run <job-id>
 cc-connect cron del <job-id>
 ```
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -687,7 +687,7 @@ cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/ch
 cc-connect cron add --cron "0 6 * * *" --prompt "总结 GitHub trending" --desc "每日趋势"
 cc-connect cron list
 cc-connect cron edit <job-id> <field> <value>   # 可改 cron_expr / prompt / enabled / mute / timeout_mins 等
-cc-connect cron run <job-id>
+cc-connect cron exec <job-id>
 cc-connect cron del <job-id>
 ```
 

--- a/tests/release_local/turn_contract/turn_contract_test.go
+++ b/tests/release_local/turn_contract/turn_contract_test.go
@@ -688,13 +688,13 @@ func TestReplyMetadataConfigurationMatrix(t *testing.T) {
 			name:       "context_and_footer_on_share_one_line",
 			showCtx:    true,
 			showFooter: true,
-			want:       []string{"answer", "[ctx: ~14%] · glm-5.1 · …/tmp/release-agent"},
+			want:       []string{"answer", "[ctx: ~14%] · glm-5.1 · /tmp/release-agent"},
 		},
 		{
 			name:       "context_off_footer_on_keeps_model_footer",
 			showCtx:    false,
 			showFooter: true,
-			want:       []string{"answer", "glm-5.1 · …/tmp/release-agent"},
+			want:       []string{"answer", "glm-5.1 · /tmp/release-agent"},
 			forbid:     []string{"[ctx:"},
 		},
 		{

--- a/tests/release_local/turn_contract/turn_contract_test.go
+++ b/tests/release_local/turn_contract/turn_contract_test.go
@@ -688,13 +688,13 @@ func TestReplyMetadataConfigurationMatrix(t *testing.T) {
 			name:       "context_and_footer_on_share_one_line",
 			showCtx:    true,
 			showFooter: true,
-			want:       []string{"answer", "*[ctx: ~14%] · glm-5.1 · …/tmp/release-agent*"},
+			want:       []string{"answer", "[ctx: ~14%] · glm-5.1 · …/tmp/release-agent"},
 		},
 		{
 			name:       "context_off_footer_on_keeps_model_footer",
 			showCtx:    false,
 			showFooter: true,
-			want:       []string{"answer", "*glm-5.1 · …/tmp/release-agent*"},
+			want:       []string{"answer", "glm-5.1 · …/tmp/release-agent"},
 			forbid:     []string{"[ctx:"},
 		},
 		{

--- a/web/src/api/cron.ts
+++ b/web/src/api/cron.ts
@@ -25,3 +25,4 @@ export const listCronJobs = (project?: string) =>
 export const createCronJob = (body: Partial<CronJob>) => api.post<CronJob>('/cron', body);
 export const updateCronJob = (id: string, fields: Record<string, any>) => api.patch<CronJob>(`/cron/${id}`, fields);
 export const deleteCronJob = (id: string) => api.delete(`/cron/${id}`);
+export const triggerCronJob = (id: string) => api.post<{ id: string; status: string }>(`/cron/${id}/run`);

--- a/web/src/api/cron.ts
+++ b/web/src/api/cron.ts
@@ -25,4 +25,4 @@ export const listCronJobs = (project?: string) =>
 export const createCronJob = (body: Partial<CronJob>) => api.post<CronJob>('/cron', body);
 export const updateCronJob = (id: string, fields: Record<string, any>) => api.patch<CronJob>(`/cron/${id}`, fields);
 export const deleteCronJob = (id: string) => api.delete(`/cron/${id}`);
-export const triggerCronJob = (id: string) => api.post<{ id: string; status: string }>(`/cron/${id}/run`);
+export const triggerCronJob = (id: string) => api.post<{ id: string; status: string }>(`/cron/${id}/exec`);

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -114,6 +114,8 @@
     "lastRun": "Last run",
     "lastError": "Last error",
     "add": "Add job",
+    "trigger": "Run now",
+    "triggerPending": "Triggered. Results will update shortly.",
     "delete": "Delete",
     "noJobs": "No scheduled jobs",
     "workDir": "Working directory",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -114,6 +114,8 @@
     "lastRun": "Última ejecución",
     "lastError": "Último error",
     "add": "Añadir tarea",
+    "trigger": "Ejecutar ahora",
+    "triggerPending": "Se activó. Los resultados se actualizarán en breve.",
     "delete": "Eliminar",
     "noJobs": "No hay tareas programadas",
     "workDir": "Directorio de trabajo",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -114,6 +114,8 @@
     "lastRun": "最終実行",
     "lastError": "最後のエラー",
     "add": "ジョブを追加",
+    "trigger": "今すぐ実行",
+    "triggerPending": "実行を開始しました。結果はまもなく更新されます。",
     "delete": "削除",
     "noJobs": "スケジュールジョブがありません",
     "workDir": "作業ディレクトリ",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -114,6 +114,8 @@
     "lastRun": "上次執行",
     "lastError": "上次錯誤",
     "add": "新增工作",
+    "trigger": "立即執行",
+    "triggerPending": "已觸發，結果稍後更新。",
     "delete": "刪除",
     "noJobs": "尚無排程工作",
     "workDir": "工作目錄",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -114,6 +114,8 @@
     "lastRun": "上次运行",
     "lastError": "上次错误",
     "add": "添加任务",
+    "trigger": "立即执行",
+    "triggerPending": "已触发，结果稍后更新。",
     "delete": "删除",
     "noJobs": "暂无定时任务",
     "workDir": "工作目录",

--- a/web/src/pages/Cron/CronList.tsx
+++ b/web/src/pages/Cron/CronList.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  Clock, Plus, Trash2, Terminal, MessageSquare, Pencil, Power, X,
+  Clock, Play, Plus, Trash2, Terminal, MessageSquare, Power,
   ChevronDown,
 } from 'lucide-react';
-import { Card, Button, Badge, Modal, Input, Textarea, EmptyState } from '@/components/ui';
-import { listCronJobs, createCronJob, updateCronJob, deleteCronJob, type CronJob } from '@/api/cron';
+import { Button, Badge, Modal, Input, Textarea, EmptyState } from '@/components/ui';
+import { listCronJobs, createCronJob, updateCronJob, deleteCronJob, triggerCronJob, type CronJob } from '@/api/cron';
 import { listProjects, type ProjectSummary } from '@/api/projects';
 import { listSessions, type Session } from '@/api/sessions';
 import { formatTime, cn } from '@/lib/utils';
@@ -186,6 +186,7 @@ export default function CronList() {
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState<JobForm>({ ...emptyForm });
   const [saving, setSaving] = useState(false);
+  const [triggeringId, setTriggeringId] = useState<string | null>(null);
   const [sessionKeys, setSessionKeys] = useState<string[]>([]);
 
   const isEdit = !!editJob;
@@ -300,6 +301,19 @@ export default function CronList() {
     }
   };
 
+  const handleTrigger = async (job: CronJob) => {
+    setTriggeringId(job.id);
+    try {
+      await triggerCronJob(job.id);
+      alert(t('cron.triggerPending'));
+      fetchData();
+    } catch (e: any) {
+      alert(e.message);
+    } finally {
+      setTriggeringId(null);
+    }
+  };
+
   if (loading && jobs.length === 0) {
     return <div className="flex items-center justify-center h-64 text-gray-400 animate-pulse">Loading...</div>;
   }
@@ -384,6 +398,17 @@ export default function CronList() {
                 className="absolute top-3 right-3 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
                 onClick={e => e.stopPropagation()}
               >
+                <button
+                  onClick={() => handleTrigger(job)}
+                  disabled={triggeringId === job.id}
+                  className={cn(
+                    'p-1.5 rounded-lg transition-colors',
+                    'text-sky-500 hover:bg-sky-50 dark:hover:bg-sky-900/20 disabled:opacity-50 disabled:cursor-wait',
+                  )}
+                  title={t('cron.trigger')}
+                >
+                  <Play size={14} />
+                </button>
                 <button
                   onClick={() => handleToggleEnabled(job)}
                   className={cn(


### PR DESCRIPTION
Replaces #917 with the same behavior rebased onto the latest upstream main (39df0842).

## What changed
- Adds/keeps manual cron execution support and aligns the command surface around `cron exec`.
- Updates management API, docs, release-local coverage, and the web cron UI/i18n strings.
- Preserves the non-behavioral upstream cleanup of `web/tsconfig.tsbuildinfo` as an ignored generated cache.

## Verification
- `git diff --check origin/main..HEAD`
- `go test -tags no_web ./cmd/cc-connect ./core ./config ./tests/release_local/config_matrix ./tests/release_local/engine_matrix`
- `cd web && pnpm install --frozen-lockfile && pnpm build`