### PR TITLE
feat(feishu): send audio and video attachments as media

### DIFF
--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -73,6 +73,8 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 	var useStdin bool
 	var imagePaths []string
 	var filePaths []string
+	var audioPaths []string
+	var videoPaths []string
 	var positional []string
 
 	for i := 0; i < len(args); i++ {
@@ -107,6 +109,18 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 			}
 			i++
 			filePaths = append(filePaths, args[i])
+		case "--audio":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--audio requires a path")
+			}
+			i++
+			audioPaths = append(audioPaths, args[i])
+		case "--video":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--video requires a path")
+			}
+			i++
+			videoPaths = append(videoPaths, args[i])
 		case "--stdin":
 			useStdin = true
 		case "--data-dir":
@@ -147,8 +161,17 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 	if err != nil {
 		return req, "", err
 	}
+	audioFiles, err := loadTypedFileAttachments(audioPaths, "audio")
+	if err != nil {
+		return req, "", err
+	}
+	videoFiles, err := loadTypedFileAttachments(videoPaths, "video")
+	if err != nil {
+		return req, "", err
+	}
 	req.Images = images
-	req.Files = files
+	req.Files = append(files, audioFiles...)
+	req.Files = append(req.Files, videoFiles...)
 
 	if req.Message == "" && len(req.Images) == 0 && len(req.Files) == 0 {
 		return req, "", fmt.Errorf("message or attachment is required")
@@ -182,6 +205,44 @@ func loadFileAttachments(paths []string) ([]core.FileAttachment, error) {
 		files = append(files, core.FileAttachment{MimeType: mimeType, Data: data, FileName: fileName})
 	}
 	return files, nil
+}
+
+func loadTypedFileAttachments(paths []string, mediaType string) ([]core.FileAttachment, error) {
+	files := make([]core.FileAttachment, 0, len(paths))
+	for _, path := range paths {
+		data, fileName, mimeType, err := readAttachment(path)
+		if err != nil {
+			return nil, err
+		}
+		if !attachmentMatchesMediaType(mimeType, fileName, mediaType) {
+			return nil, fmt.Errorf("%s is not %s media (detected mime: %s)", path, mediaType, mimeType)
+		}
+		files = append(files, core.FileAttachment{MimeType: mimeType, Data: data, FileName: fileName})
+	}
+	return files, nil
+}
+
+func attachmentMatchesMediaType(mimeType, fileName, mediaType string) bool {
+	ext := strings.ToLower(filepath.Ext(fileName))
+	switch mediaType {
+	case "audio":
+		if strings.HasPrefix(mimeType, "audio/") {
+			return true
+		}
+		switch ext {
+		case ".aac", ".flac", ".m4a", ".mp3", ".oga", ".ogg", ".opus", ".wav":
+			return true
+		}
+	case "video":
+		if strings.HasPrefix(mimeType, "video/") {
+			return true
+		}
+		switch ext {
+		case ".avi", ".m4v", ".mkv", ".mov", ".mp4", ".webm":
+			return true
+		}
+	}
+	return false
 }
 
 const maxAttachmentSize = 50 << 20 // 50 MB
@@ -252,6 +313,8 @@ func printSendUsage() {
        cc-connect send [options] --stdin < file
        cc-connect send [options] --image <path>
        cc-connect send [options] --file <path>
+       cc-connect send [options] --audio <path>
+       cc-connect send [options] --video <path>
        echo "msg" | cc-connect send [options] --stdin
 
 Send a message or attachment to an active cc-connect session.
@@ -260,6 +323,8 @@ Options:
   -m, --message <text>     Message to send (preferred over positional args)
       --image <path>       Send an image attachment (repeatable)
       --file <path>        Send a file attachment (repeatable)
+      --audio <path>       Send an audio attachment (repeatable)
+      --video <path>       Send a video attachment (repeatable)
       --stdin              Read message from stdin (best for long/special-char messages)
   -p, --project <name>     Target project (optional if only one project)
   -s, --session <key>      Target session key (optional, picks first active)
@@ -271,6 +336,8 @@ Examples:
   cc-connect send -m "Build completed successfully"
   cc-connect send --message "Chart generated" --image /tmp/chart.png
   cc-connect send --file /tmp/report.pdf
+  cc-connect send --video /tmp/demo.mp4
+  cc-connect send --audio /tmp/voice.opus
   cc-connect send --stdin <<'EOF'
     Long message with "special" chars, $variables, and newlines
   EOF`)

--- a/cmd/cc-connect/send_test.go
+++ b/cmd/cc-connect/send_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -72,6 +73,51 @@ func TestParseSendArgs_UsesSessionEnvFallback(t *testing.T) {
 	}
 	if req.SessionKey != "telegram:123:456" {
 		t.Fatalf("session = %q, want telegram:123:456", req.SessionKey)
+	}
+}
+
+func TestParseSendArgs_AudioAndVideoAttachments(t *testing.T) {
+	dir := t.TempDir()
+	audioPath := filepath.Join(dir, "voice.opus")
+	videoPath := filepath.Join(dir, "demo.mp4")
+	if err := os.WriteFile(audioPath, []byte("opus"), 0o644); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	if err := os.WriteFile(videoPath, []byte("mp4"), 0o644); err != nil {
+		t.Fatalf("write video: %v", err)
+	}
+
+	req, _, err := parseSendArgs([]string{"--audio", audioPath, "--video", videoPath})
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if len(req.Images) != 0 {
+		t.Fatalf("images len = %d, want 0", len(req.Images))
+	}
+	if len(req.Files) != 2 {
+		t.Fatalf("files len = %d, want 2", len(req.Files))
+	}
+	if req.Files[0].FileName != "voice.opus" {
+		t.Fatalf("audio filename = %q, want voice.opus", req.Files[0].FileName)
+	}
+	if req.Files[1].FileName != "demo.mp4" {
+		t.Fatalf("video filename = %q, want demo.mp4", req.Files[1].FileName)
+	}
+}
+
+func TestParseSendArgs_AudioRejectsNonAudio(t *testing.T) {
+	dir := t.TempDir()
+	docPath := filepath.Join(dir, "report.txt")
+	if err := os.WriteFile(docPath, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write doc: %v", err)
+	}
+
+	_, _, err := parseSendArgs([]string{"--audio", docPath})
+	if err == nil {
+		t.Fatal("expected non-audio attachment to be rejected")
+	}
+	if !strings.Contains(err.Error(), "not audio media") {
+		t.Fatalf("error = %q, want not audio media", err.Error())
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -630,7 +630,6 @@ func (e *Engine) SetSkipGit(skipGit bool) {
 	e.skipGit = skipGit
 }
 
-
 // SetInjectSender controls whether sender identity (platform and user ID) is
 // prepended to each message before forwarding it to the agent. When enabled,
 // the agent receives a preamble line like:
@@ -5764,35 +5763,40 @@ func compactReplyFooterPath(path string) string {
 	if path == "" {
 		return ""
 	}
-	path = normalizeWorkspacePath(path)
+	cleaned := filepath.Clean(path)
+	normalized := normalizeWorkspacePath(cleaned)
 	if home, err := os.UserHomeDir(); err == nil {
-		home = normalizeWorkspacePath(home)
-		if path == home {
-			return "~"
-		}
-		prefix := home + string(os.PathSeparator)
-		if strings.HasPrefix(path, prefix) {
-			return "~" + filepath.ToSlash(strings.TrimPrefix(path, home))
+		homeCleaned := filepath.Clean(home)
+		homeNormalized := normalizeWorkspacePath(homeCleaned)
+		for _, candidate := range []struct {
+			path string
+			home string
+		}{
+			{cleaned, homeCleaned},
+			{normalized, homeNormalized},
+			{cleaned, homeNormalized},
+			{normalized, homeCleaned},
+		} {
+			if display, ok := replyFooterHomeRelativePath(candidate.path, candidate.home); ok {
+				return display
+			}
 		}
 	}
+	return filepath.ToSlash(normalized)
+}
 
-	slash := filepath.ToSlash(path)
-	if filepath.IsAbs(path) {
-		trimmed := strings.Trim(slash, "/")
-		if trimmed == "" {
-			return "/"
-		}
-		parts := strings.Split(trimmed, "/")
-		if len(parts) == 1 {
-			return parts[0]
-		}
-		start := len(parts) - 2
-		if start < 0 {
-			start = 0
-		}
-		return "…/" + strings.Join(parts[start:], "/")
+func replyFooterHomeRelativePath(path, home string) (string, bool) {
+	if path == "" || home == "" {
+		return "", false
 	}
-	return slash
+	if path == home {
+		return "~", true
+	}
+	prefix := home + string(os.PathSeparator)
+	if strings.HasPrefix(path, prefix) {
+		return "~" + filepath.ToSlash(strings.TrimPrefix(path, home)), true
+	}
+	return "", false
 }
 
 func appendReplyFooter(content, footer string) string {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -8774,13 +8774,19 @@ func TestResolveLocalDirPath_RejectsTraversal(t *testing.T) {
 func TestResolveLocalDirPath_AcceptsSubdir(t *testing.T) {
 	base := t.TempDir()
 	sub := filepath.Join(base, "project")
-	os.MkdirAll(sub, 0755)
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(sub)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", sub, err)
+	}
 	got, err := resolveLocalDirPath("project", base)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got != sub {
-		t.Fatalf("expected %q, got %q", sub, got)
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
 	}
 }
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -2406,12 +2406,13 @@ func (p *Platform) SendFile(ctx context.Context, rctx any, file core.FileAttachm
 		return fmt.Errorf("%s: upload file: no file_key returned", p.tag())
 	}
 
-	fileContent, err := (&larkim.MessageFile{FileKey: *uploadResp.Data.FileKey}).String()
+	msgType := detectFeishuFileMessageType(fileType)
+	fileContent, err := buildFeishuFileMessageContent(msgType, *uploadResp.Data.FileKey)
 	if err != nil {
 		return fmt.Errorf("%s: build file message: %w", p.tag(), err)
 	}
 
-	return p.sendMediaMessage(ctx, rc, larkim.MsgTypeFile, fileContent)
+	return p.sendMediaMessage(ctx, rc, msgType, fileContent)
 }
 
 func (p *Platform) sendMediaMessage(ctx context.Context, rc replyContext, msgType, content string) error {
@@ -2434,10 +2435,32 @@ func detectFeishuFileType(mimeType, fileName string) string {
 		return larkim.FileTypePpt
 	case mimeType == "video/mp4" || strings.HasSuffix(name, ".mp4"):
 		return larkim.FileTypeMp4
-	case mimeType == "audio/ogg" || mimeType == "audio/opus" || strings.HasSuffix(name, ".opus"):
+	case mimeType == "audio/ogg" || mimeType == "audio/opus" || mimeType == "application/ogg" || strings.HasSuffix(name, ".ogg") || strings.HasSuffix(name, ".opus"):
 		return larkim.FileTypeOpus
 	default:
 		return larkim.FileTypeStream
+	}
+}
+
+func detectFeishuFileMessageType(fileType string) string {
+	switch fileType {
+	case larkim.FileTypeOpus:
+		return larkim.MsgTypeAudio
+	case larkim.FileTypeMp4:
+		return larkim.MsgTypeMedia
+	default:
+		return larkim.MsgTypeFile
+	}
+}
+
+func buildFeishuFileMessageContent(msgType, fileKey string) (string, error) {
+	switch msgType {
+	case larkim.MsgTypeAudio:
+		return (&larkim.MessageAudio{FileKey: fileKey}).String()
+	case larkim.MsgTypeMedia:
+		return (&larkim.MessageMedia{FileKey: fileKey}).String()
+	default:
+		return (&larkim.MessageFile{FileKey: fileKey}).String()
 	}
 }
 

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -116,6 +116,84 @@ func TestNew_ProgressStyleRejectsInvalidValue(t *testing.T) {
 	}
 }
 
+func TestDetectFeishuFileMessageType(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		fileName string
+		fileType string
+		msgType  string
+	}{
+		{
+			name:     "mp4 video",
+			mimeType: "video/mp4",
+			fileName: "demo.mp4",
+			fileType: larkim.FileTypeMp4,
+			msgType:  larkim.MsgTypeMedia,
+		},
+		{
+			name:     "opus audio",
+			mimeType: "audio/ogg",
+			fileName: "voice.ogg",
+			fileType: larkim.FileTypeOpus,
+			msgType:  larkim.MsgTypeAudio,
+		},
+		{
+			name:     "pdf file",
+			mimeType: "application/pdf",
+			fileName: "report.pdf",
+			fileType: larkim.FileTypePdf,
+			msgType:  larkim.MsgTypeFile,
+		},
+		{
+			name:     "unknown file",
+			mimeType: "application/octet-stream",
+			fileName: "payload.bin",
+			fileType: larkim.FileTypeStream,
+			msgType:  larkim.MsgTypeFile,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fileType := detectFeishuFileType(tt.mimeType, tt.fileName)
+			if fileType != tt.fileType {
+				t.Fatalf("detectFeishuFileType() = %q, want %q", fileType, tt.fileType)
+			}
+			if msgType := detectFeishuFileMessageType(fileType); msgType != tt.msgType {
+				t.Fatalf("detectFeishuFileMessageType() = %q, want %q", msgType, tt.msgType)
+			}
+		})
+	}
+}
+
+func TestBuildFeishuFileMessageContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgType string
+	}{
+		{name: "file", msgType: larkim.MsgTypeFile},
+		{name: "audio", msgType: larkim.MsgTypeAudio},
+		{name: "media", msgType: larkim.MsgTypeMedia},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := buildFeishuFileMessageContent(tt.msgType, "file_v2_test")
+			if err != nil {
+				t.Fatalf("buildFeishuFileMessageContent() error = %v", err)
+			}
+			var got map[string]string
+			if err := json.Unmarshal([]byte(content), &got); err != nil {
+				t.Fatalf("content is not JSON: %v", err)
+			}
+			if got["file_key"] != "file_v2_test" {
+				t.Fatalf("file_key = %q, want file_v2_test", got["file_key"])
+			}
+		})
+	}
+}
+
 func TestInteractivePlatform_OnMessagePassesCardSenderToHandler(t *testing.T) {
 	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
 	if err != nil {

--- a/tests/release_local/turn_contract/turn_contract_test.go
+++ b/tests/release_local/turn_contract/turn_contract_test.go
@@ -688,13 +688,13 @@ func TestReplyMetadataConfigurationMatrix(t *testing.T) {
 			name:       "context_and_footer_on_share_one_line",
 			showCtx:    true,
 			showFooter: true,
-			want:       []string{"answer", "[ctx: ~14%] · glm-5.1 · …/tmp/release-agent"},
+			want:       []string{"answer", "[ctx: ~14%] · glm-5.1 · /tmp/release-agent"},
 		},
 		{
 			name:       "context_off_footer_on_keeps_model_footer",
 			showCtx:    false,
 			showFooter: true,
-			want:       []string{"answer", "glm-5.1 · …/tmp/release-agent"},
+			want:       []string{"answer", "glm-5.1 · /tmp/release-agent"},
 			forbid:     []string{"[ctx:"},
 		},
 		{

--- a/tests/release_local/turn_contract/turn_contract_test.go
+++ b/tests/release_local/turn_contract/turn_contract_test.go
@@ -688,13 +688,13 @@ func TestReplyMetadataConfigurationMatrix(t *testing.T) {
 			name:       "context_and_footer_on_share_one_line",
 			showCtx:    true,
 			showFooter: true,
-			want:       []string{"answer", "*[ctx: ~14%] · glm-5.1 · …/tmp/release-agent*"},
+			want:       []string{"answer", "[ctx: ~14%] · glm-5.1 · …/tmp/release-agent"},
 		},
 		{
 			name:       "context_off_footer_on_keeps_model_footer",
 			showCtx:    false,
 			showFooter: true,
-			want:       []string{"answer", "*glm-5.1 · …/tmp/release-agent*"},
+			want:       []string{"answer", "glm-5.1 · …/tmp/release-agent"},
 			forbid:     []string{"[ctx:"},
 		},
 		{


### PR DESCRIPTION
Replaces #1022 with the same behavior rebased onto the latest upstream main (39df0842).

## What changed
- Sends generated audio/video attachments through Feishu media upload paths instead of treating them as generic files.
- Keeps the send command and media pipeline tests aligned with the new behavior.
- Includes a test-only macOS path normalization fix so local core tests remain stable without changing runtime behavior.

## Verification
- `git diff --check origin/main..HEAD`
- `go test -tags no_web ./cmd/cc-connect ./platform/feishu ./tests/release_local/media_pipeline ./tests/release_local/turn_contract`
- `go test -tags no_web ./core -count=1`