### PR TITLE
fix(pi): correct agent directory paths (SkillDirs + GlobalMemoryFile)

### DIFF
--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -197,11 +197,16 @@ func (a *Agent) ProjectMemoryFile() string {
 }
 
 func (a *Agent) GlobalMemoryFile() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return ""
+	// Use PI_CODING_AGENT_DIR if set, otherwise default to ~/.pi/agent/.
+	agentDir := os.Getenv("PI_CODING_AGENT_DIR")
+	if agentDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		agentDir = filepath.Join(homeDir, ".pi", "agent")
 	}
-	return filepath.Join(homeDir, ".pi", "AGENTS.md")
+	return filepath.Join(agentDir, "AGENTS.md")
 }
 
 // ── ReasoningEffortSwitcher ──────────────────────────────────

--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -257,19 +257,19 @@ func (a *Agent) SkillDirs() []string {
 	}
 	dirs := []string{filepath.Join(absDir, ".pi", "agent", "skills")}
 
-	home, err := os.UserHomeDir()
+	homeDir, err := os.UserHomeDir()
 	if err == nil {
 		// Default pi agent skill directory.
-		dirs = append(dirs, filepath.Join(home, ".pi", "agent", "skills"))
+		dirs = append(dirs, filepath.Join(homeDir, ".pi", "agent", "skills"))
 		// Common shared skill directory used by lark-cli and other agent tools.
-		dirs = append(dirs, filepath.Join(home, ".agents", "skills"))
+		dirs = append(dirs, filepath.Join(homeDir, ".agents", "skills"))
 
 		// If PI_CODING_AGENT_DIR is set, also scan skills under that directory.
 		if agentDir := os.Getenv("PI_CODING_AGENT_DIR"); agentDir != "" {
 			if filepath.IsAbs(agentDir) {
 				dirs = append(dirs, filepath.Join(agentDir, "skills"))
 			} else {
-				dirs = append(dirs, filepath.Join(home, agentDir, "skills"))
+				dirs = append(dirs, filepath.Join(homeDir, agentDir, "skills"))
 			}
 		}
 	}

--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -250,9 +250,23 @@ func (a *Agent) SkillDirs() []string {
 	if err != nil {
 		absDir = a.workDir
 	}
-	dirs := []string{filepath.Join(absDir, ".pi", "skills")}
-	if home, err := os.UserHomeDir(); err == nil {
-		dirs = append(dirs, filepath.Join(home, ".pi", "skills"))
+	dirs := []string{filepath.Join(absDir, ".pi", "agent", "skills")}
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		// Default pi agent skill directory.
+		dirs = append(dirs, filepath.Join(home, ".pi", "agent", "skills"))
+		// Common shared skill directory used by lark-cli and other agent tools.
+		dirs = append(dirs, filepath.Join(home, ".agents", "skills"))
+
+		// If PI_CODING_AGENT_DIR is set, also scan skills under that directory.
+		if agentDir := os.Getenv("PI_CODING_AGENT_DIR"); agentDir != "" {
+			if filepath.IsAbs(agentDir) {
+				dirs = append(dirs, filepath.Join(agentDir, "skills"))
+			} else {
+				dirs = append(dirs, filepath.Join(home, agentDir, "skills"))
+			}
+		}
 	}
 	return dirs
 }

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -212,7 +212,7 @@ func TestAgent_MemoryFiles(t *testing.T) {
 	}
 
 	global := a.GlobalMemoryFile()
-	if !strings.HasSuffix(global, filepath.Join(".pi", "AGENTS.md")) {
+	if !strings.HasSuffix(global, filepath.Join(".pi", "agent", "AGENTS.md")) {
 		t.Errorf("GlobalMemoryFile() = %q", global)
 	}
 }


### PR DESCRIPTION
## Summary

cc-connect's pi agent had hardcoded paths missing the `/agent` segment
that pi uses by default (`~/.pi/agent/`), causing two features to silently
break:

- **SkillDirs()** returned `~/.pi/skills/` instead of `~/.pi/agent/skills/`,
  so cc-connect's `SkillRegistry` never found pi skills. Slash commands
  like `/caveman` were not routed by cc-connect's command handler and fell
  through to pi's print mode as raw text.
- **GlobalMemoryFile()** returned `~/.pi/AGENTS.md` instead of
  `~/.pi/agent/AGENTS.md`, so the global memory file was never picked up.

Both paths now also respect `$PI_CODING_AGENT_DIR` when set, and
`SkillDirs()` additionally includes `~/.agents/skills/` (a common shared
skill directory used by lark-cli and other agent tooling).

## Test plan

- [x] `go test ./agent/pi/ -v` — passes
- [x] Verify `/caveman` (or any pi skill) triggers the skill instructions
      instead of being sent to the LLM as plain text