### PR TITLE
[codex] configure relay group visibility

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1056,6 +1056,7 @@ func main() {
 				relayMgr.SetTimeout(time.Duration(secs) * time.Second)
 			}
 		}
+		relayMgr.SetVisibility(cfg.Relay.Visibility)
 		apiSrv.SetRelayManager(relayMgr)
 
 		// Create shared DirHistory for all engines

--- a/config.example.toml
+++ b/config.example.toml
@@ -255,12 +255,17 @@ level = "info" # debug, info, warn, error
 # =============================================================================
 # Relay Settings / Relay 设置
 # =============================================================================
-# Bot-to-bot relay timeout. Controls how long cc-connect waits for the target
-# bot to finish responding during `cc-connect relay send`.
-# Bot 间 relay 超时。控制 `cc-connect relay send` 时等待目标 bot 完成回复的最长时间。
+# Bot-to-bot relay settings. timeout_secs controls how long cc-connect waits for
+# the target bot to finish responding during `cc-connect relay send`.
+# visibility controls the extra group-chat echo only; the caller still receives
+# the target response from the relay command when visibility is "none".
+# Bot 间 relay 设置。timeout_secs 控制 `cc-connect relay send` 等待目标 bot
+# 完成回复的最长时间。visibility 只控制群内额外可见消息；设为 "none" 时调用方
+# 仍会从 relay 命令拿到目标回复。
 
 # [relay]
 # timeout_secs = 120        # Max relay wait in seconds; 0 = disabled (default: 120) / relay 最大等待秒数；0 = 禁用（默认 120）
+# visibility = "full"       # "full" (default), "summary", or "none" / 群内可见消息：完整、摘要或不显示
 
 # =============================================================================
 # Auto-Compress / 自动压缩
@@ -1856,4 +1861,3 @@ app_secret = "your-feishu-app-secret"
 # [[projects.agent.providers]]
 # name = "google"
 # api_key = "your-gemini-api-key"    # GEMINI_API_KEY
-

--- a/config/config.go
+++ b/config/config.go
@@ -110,8 +110,8 @@ type Config struct {
 	Bridge             BridgeConfig            `toml:"bridge"`
 	Management         ManagementConfig        `toml:"management"`
 	Hooks              []HookConfig            `toml:"hooks"`
-	IdleTimeoutMins    *int                    `toml:"idle_timeout_mins,omitempty"`    // max minutes between consecutive agent events; 0 = no timeout; default 120
-	MaxTurnTimeMins    *int                    `toml:"max_turn_time_mins,omitempty"`   // absolute wall-clock cap per turn in minutes; 0 = disabled (default)
+	IdleTimeoutMins    *int                    `toml:"idle_timeout_mins,omitempty"`  // max minutes between consecutive agent events; 0 = no timeout; default 120
+	MaxTurnTimeMins    *int                    `toml:"max_turn_time_mins,omitempty"` // absolute wall-clock cap per turn in minutes; 0 = disabled (default)
 	// WorkspaceIdleTimeoutMins controls the workspace idle reaper timeout
 	// (multi-workspace mode) for every engine in the process. 0 disables
 	// reaping. Default: 15 minutes. Defined as a top-level (process-global)
@@ -176,14 +176,14 @@ const (
 
 // DisplayConfig controls how intermediate messages (thinking, tool output) are shown.
 type DisplayConfig struct {
-	Mode               *string `toml:"mode"`                 // "full" (default), "compact", or "quiet"
-	CardMode           *string `toml:"card_mode"`            // "legacy" (default) or "rich" (Card 2.0 Feishu)
-	ThinkingMessages   *bool   `toml:"thinking_messages"`    // whether thinking messages are shown; default true
-	ThinkingMaxLen     *int    `toml:"thinking_max_len"`     // max chars for thinking messages; 0 = no truncation; default 300
-	ToolMaxLen         *int    `toml:"tool_max_len"`         // max chars for tool use messages; 0 = no truncation; default 500
-	ToolMessages       *bool   `toml:"tool_messages"`        // whether tool progress messages are shown; default true
-	ShowContextIndicator *bool `toml:"show_context_indicator"` // whether [ctx: ~N%] suffix is shown; default true
-	ReplyFooter        *bool   `toml:"reply_footer"`         // whether Codex-like footer is shown; default true
+	Mode                 *string `toml:"mode"`                   // "full" (default), "compact", or "quiet"
+	CardMode             *string `toml:"card_mode"`              // "legacy" (default) or "rich" (Card 2.0 Feishu)
+	ThinkingMessages     *bool   `toml:"thinking_messages"`      // whether thinking messages are shown; default true
+	ThinkingMaxLen       *int    `toml:"thinking_max_len"`       // max chars for thinking messages; 0 = no truncation; default 300
+	ToolMaxLen           *int    `toml:"tool_max_len"`           // max chars for tool use messages; 0 = no truncation; default 500
+	ToolMessages         *bool   `toml:"tool_messages"`          // whether tool progress messages are shown; default true
+	ShowContextIndicator *bool   `toml:"show_context_indicator"` // whether [ctx: ~N%] suffix is shown; default true
+	ReplyFooter          *bool   `toml:"reply_footer"`           // whether Codex-like footer is shown; default true
 }
 
 // StreamPreviewConfig controls real-time streaming preview in IM.
@@ -238,7 +238,8 @@ type RoleConfig struct {
 
 // RelayConfig controls bot-to-bot relay behavior.
 type RelayConfig struct {
-	TimeoutSecs *int `toml:"timeout_secs"` // max seconds to wait for relay response; 0 = disabled; default 120
+	TimeoutSecs *int   `toml:"timeout_secs"`         // max seconds to wait for relay response; 0 = disabled; default 120
+	Visibility  string `toml:"visibility,omitempty"` // "full" (default), "summary", or "none" for group visibility echoes
 }
 
 // SpeechConfig configures speech-to-text for voice messages.
@@ -782,6 +783,11 @@ func (c *Config) validate() error {
 	}
 	if c.Relay.TimeoutSecs != nil && *c.Relay.TimeoutSecs < 0 {
 		return fmt.Errorf("config: relay.timeout_secs must be >= 0")
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Relay.Visibility)) {
+	case "", "full", "summary", "none":
+	default:
+		return fmt.Errorf("config: relay.visibility must be \"full\", \"summary\", or \"none\"")
 	}
 	if len(c.Projects) == 0 {
 		return fmt.Errorf("config: at least one [[projects]] entry is required")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1165,6 +1165,7 @@ bot_token = "token_xxx"
 const relayConfigFixture = `
 [relay]
 timeout_secs = 300
+visibility = "none"
 
 [[projects]]
 name = "alpha"
@@ -1185,6 +1186,26 @@ bot_token = "token_xxx"
 const relayConfigNegativeFixture = `
 [relay]
 timeout_secs = -1
+
+[[projects]]
+name = "alpha"
+
+[projects.agent]
+type = "codex"
+
+[projects.agent.options]
+work_dir = "/tmp/alpha"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+bot_token = "token_xxx"
+`
+
+const relayConfigInvalidVisibilityFixture = `
+[relay]
+visibility = "verbose"
 
 [[projects]]
 name = "alpha"
@@ -1742,6 +1763,9 @@ func TestLoadRelayTimeoutConfig(t *testing.T) {
 	if *cfg.Relay.TimeoutSecs != 300 {
 		t.Fatalf("cfg.Relay.TimeoutSecs = %d, want 300", *cfg.Relay.TimeoutSecs)
 	}
+	if cfg.Relay.Visibility != "none" {
+		t.Fatalf("cfg.Relay.Visibility = %q, want none", cfg.Relay.Visibility)
+	}
 }
 
 func TestLoadRejectsNegativeRelayTimeout(t *testing.T) {
@@ -1753,6 +1777,18 @@ func TestLoadRejectsNegativeRelayTimeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "relay.timeout_secs must be >= 0") {
 		t.Fatalf("error = %q, want contains %q", err.Error(), "relay.timeout_secs must be >= 0")
+	}
+}
+
+func TestLoadRejectsInvalidRelayVisibility(t *testing.T) {
+	configPath := writeConfigFixture(t, relayConfigInvalidVisibilityFixture)
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("expected error for invalid relay visibility, got nil")
+	}
+	if !strings.Contains(err.Error(), `relay.visibility must be "full", "summary", or "none"`) {
+		t.Fatalf("error = %q, want relay.visibility validation error", err.Error())
 	}
 }
 func writeConfigFixture(t *testing.T, content string) string {

--- a/core/relay.go
+++ b/core/relay.go
@@ -14,6 +14,12 @@ import (
 
 const relayTimeout = 120 * time.Second
 
+const (
+	RelayVisibilityFull    = "full"
+	RelayVisibilitySummary = "summary"
+	RelayVisibilityNone    = "none"
+)
+
 // RelayBinding represents a bot-to-bot relay binding in a group chat.
 type RelayBinding struct {
 	Platform string            `json:"platform"`
@@ -23,18 +29,20 @@ type RelayBinding struct {
 
 // RelayManager coordinates bot-to-bot message relay across engines.
 type RelayManager struct {
-	mu        sync.RWMutex
-	engines   map[string]*Engine       // project name → engine (runtime only)
-	bindings  map[string]*RelayBinding // chatID → binding
-	storePath string                   // empty = no persistence
-	timeout   time.Duration
+	mu         sync.RWMutex
+	engines    map[string]*Engine       // project name → engine (runtime only)
+	bindings   map[string]*RelayBinding // chatID → binding
+	storePath  string                   // empty = no persistence
+	timeout    time.Duration
+	visibility string
 }
 
 func NewRelayManager(dataDir string) *RelayManager {
 	rm := &RelayManager{
-		engines:  make(map[string]*Engine),
-		bindings: make(map[string]*RelayBinding),
-		timeout:  relayTimeout,
+		engines:    make(map[string]*Engine),
+		bindings:   make(map[string]*RelayBinding),
+		timeout:    relayTimeout,
+		visibility: RelayVisibilityFull,
 	}
 	if dataDir != "" {
 		rm.storePath = filepath.Join(dataDir, "relay_bindings.json")
@@ -57,6 +65,15 @@ func (rm *RelayManager) SetTimeout(d time.Duration) {
 		d = 0
 	}
 	rm.timeout = d
+}
+
+// SetVisibility controls whether relay request/response visibility messages are
+// echoed into the source group chat. The relay transport still returns the
+// target response to the caller regardless of this setting.
+func (rm *RelayManager) SetVisibility(mode string) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.visibility = normalizeRelayVisibility(mode)
 }
 
 // Bind establishes a relay binding between bots in a group chat.
@@ -195,6 +212,7 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 	binding := rm.bindings[chatID]
 	targetEngine := rm.engines[req.To]
 	sourceEngine := rm.engines[req.From]
+	visibility := rm.visibility
 	rm.mu.RUnlock()
 
 	if binding == nil {
@@ -222,10 +240,10 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 		toName = binding.Bots[req.To]
 	}
 
-	// Post the forwarded message to the group chat for visibility
+	// Post the forwarded message to the group chat for visibility.
 	groupSessionKey := platform + ":" + chatID + ":relay"
-	if sourceEngine != nil {
-		label := fmt.Sprintf("[%s → %s] %s", fromName, toName, req.Message)
+	if sourceEngine != nil && visibility != RelayVisibilityNone {
+		label := relayVisibilityRequestLabel(visibility, fromName, toName, req.Message)
 		rm.sendToGroup(ctx, sourceEngine, platform, groupSessionKey, label)
 	}
 
@@ -238,9 +256,9 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 		return nil, fmt.Errorf("relay: %w", err)
 	}
 
-	// Post the response to the group chat for visibility
-	if targetEngine != nil {
-		label := fmt.Sprintf("[%s] %s", toName, truncateRelay(response, 2000))
+	// Post the response to the group chat for visibility.
+	if targetEngine != nil && visibility != RelayVisibilityNone {
+		label := relayVisibilityResponseLabel(visibility, toName, response)
 		rm.sendToGroup(ctx, targetEngine, platform, groupSessionKey, label)
 	}
 
@@ -275,6 +293,33 @@ func truncateRelay(s string, maxLen int) string {
 		return s
 	}
 	return string(runes[:maxLen]) + "…"
+}
+
+func normalizeRelayVisibility(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case RelayVisibilityNone:
+		return RelayVisibilityNone
+	case RelayVisibilitySummary:
+		return RelayVisibilitySummary
+	case "", RelayVisibilityFull:
+		return RelayVisibilityFull
+	default:
+		return RelayVisibilityFull
+	}
+}
+
+func relayVisibilityRequestLabel(mode, fromName, toName, message string) string {
+	if normalizeRelayVisibility(mode) == RelayVisibilitySummary {
+		return fmt.Sprintf("[%s → %s] relay request sent", fromName, toName)
+	}
+	return fmt.Sprintf("[%s → %s] %s", fromName, toName, message)
+}
+
+func relayVisibilityResponseLabel(mode, toName, response string) string {
+	if normalizeRelayVisibility(mode) == RelayVisibilitySummary {
+		return fmt.Sprintf("[%s] relay response ready (%d chars)", toName, len([]rune(response)))
+	}
+	return fmt.Sprintf("[%s] %s", toName, truncateRelay(response, 2000))
 }
 
 func (rm *RelayManager) relayContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/core/relay_test.go
+++ b/core/relay_test.go
@@ -48,6 +48,114 @@ func TestRelayManager_RelayContextDisablesTimeoutAtZero(t *testing.T) {
 	}
 }
 
+type relayVisibilityPlatform struct {
+	stubPlatformEngine
+	reconstructed []string
+}
+
+func (p *relayVisibilityPlatform) ReconstructReplyCtx(sessionKey string) (any, error) {
+	p.mu.Lock()
+	p.reconstructed = append(p.reconstructed, sessionKey)
+	p.mu.Unlock()
+	return sessionKey, nil
+}
+
+func runRelayVisibilityScenario(t *testing.T, visibility string) (resp string, sourceSent []string, targetSent []string) {
+	t.Helper()
+
+	sourcePlatform := &relayVisibilityPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	targetPlatform := &relayVisibilityPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	sourceEngine := NewEngine("source", &stubAgent{}, []Platform{sourcePlatform}, "", LangEnglish)
+	targetSession := newControllableSession("target-session")
+	targetEngine := NewEngine("target", &controllableAgent{nextSession: targetSession}, []Platform{targetPlatform}, "", LangEnglish)
+
+	rm := NewRelayManager("")
+	rm.Bind("feishu", "chat-1", map[string]string{
+		"source": "source-bot",
+		"target": "target-bot",
+	})
+	rm.RegisterEngine("source", sourceEngine)
+	rm.RegisterEngine("target", targetEngine)
+	if visibility != "" {
+		rm.SetVisibility(visibility)
+	}
+
+	type relayResult struct {
+		resp string
+		err  error
+	}
+	done := make(chan relayResult, 1)
+	go func() {
+		result, err := rm.Send(context.Background(), RelayRequest{
+			From:       "source",
+			To:         "target",
+			SessionKey: "feishu:chat-1:user-1",
+			Message:    "please ask target",
+		})
+		if result != nil {
+			done <- relayResult{resp: result.Response, err: err}
+			return
+		}
+		done <- relayResult{err: err}
+	}()
+
+	targetSession.events <- Event{Type: EventResult, Content: "target says long answer"}
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("RelayManager.Send() error = %v", got.err)
+		}
+		resp = got.resp
+	case <-time.After(2 * time.Second):
+		t.Fatal("RelayManager.Send() did not return")
+	}
+
+	return resp, sourcePlatform.getSent(), targetPlatform.getSent()
+}
+
+func TestRelayManager_DefaultVisibilityEchoesFullMessages(t *testing.T) {
+	resp, sourceSent, targetSent := runRelayVisibilityScenario(t, "")
+
+	if resp != "target says long answer" {
+		t.Fatalf("response = %q, want target response", resp)
+	}
+	if len(sourceSent) != 1 || sourceSent[0] != "[source-bot → target-bot] please ask target" {
+		t.Fatalf("source sent = %#v, want full relay request", sourceSent)
+	}
+	if len(targetSent) != 1 || targetSent[0] != "[target-bot] target says long answer" {
+		t.Fatalf("target sent = %#v, want full relay response", targetSent)
+	}
+}
+
+func TestRelayManager_VisibilitySummarySuppressesBodies(t *testing.T) {
+	resp, sourceSent, targetSent := runRelayVisibilityScenario(t, RelayVisibilitySummary)
+
+	if resp != "target says long answer" {
+		t.Fatalf("response = %q, want target response", resp)
+	}
+	if len(sourceSent) != 1 || sourceSent[0] != "[source-bot → target-bot] relay request sent" {
+		t.Fatalf("source sent = %#v, want summary relay request", sourceSent)
+	}
+	if len(targetSent) != 1 || targetSent[0] != "[target-bot] relay response ready (23 chars)" {
+		t.Fatalf("target sent = %#v, want summary relay response", targetSent)
+	}
+}
+
+func TestRelayManager_VisibilityNoneSuppressesGroupEcho(t *testing.T) {
+	resp, sourceSent, targetSent := runRelayVisibilityScenario(t, RelayVisibilityNone)
+
+	if resp != "target says long answer" {
+		t.Fatalf("response = %q, want target response", resp)
+	}
+	if len(sourceSent) != 0 {
+		t.Fatalf("source sent = %#v, want no relay request echo", sourceSent)
+	}
+	if len(targetSent) != 0 {
+		t.Fatalf("target sent = %#v, want no relay response echo", targetSent)
+	}
+}
+
 func TestHandleRelay_ReturnsPartialOnTimeout(t *testing.T) {
 	e := newTestEngine()
 	session := newControllableSession("relay-session")


### PR DESCRIPTION
## Summary
- add `[relay].visibility` with `full`, `summary`, and `none` modes
- keep `full` as the default so existing relay group echoes remain unchanged
- allow callers to disable relay request/response echo messages in group chats while still receiving the target bot response from `cc-connect relay send`

## Why
Relay currently always mirrors both the forwarded request and the target response back into the source group. That is useful for visibility, but noisy in multi-bot group workflows where the initiating bot already owns the user-facing response card.

This keeps the relay transport unchanged and only makes the extra group visibility messages configurable.

## Validation
- `git diff --cached --check`
- `go test ./core -run 'TestRelayManager_(DefaultVisibilityEchoesFullMessages|VisibilitySummarySuppressesBodies|VisibilityNoneSuppressesGroupEcho|RelayContext|DefaultTimeout)|TestHandleRelay' -count=1`
- `go test ./config -run 'TestLoadRelay(TimeoutConfig|RejectsNegativeRelayTimeout|RejectsInvalidRelayVisibility)' -count=1`
- `go test -tags no_web ./cmd/cc-connect -run '^$' -count=1`

## Notes
- `go test -tags no_web ./cmd/cc-connect ./core ./config -count=1` was also run locally. `cmd/cc-connect` and `config` passed; `core` reproduced existing macOS footer path expectation failures unrelated to relay visibility.
