### PR TITLE
feat(dingtalk): add reaction emoji support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -989,6 +989,10 @@ app_secret = "your-feishu-app-secret"
 # client_secret = "your-dingtalk-client-secret"
 # allow_from = "*"  # Allowed staff IDs / 允许的员工 ID
 # share_session_in_channel = false  # If true, all users in a group share one agent session / 群聊共享会话
+# reaction_emoji = "🤔Thinking"  # Emotion on incoming messages (default: "🤔Thinking"); set to "none" to disable
+#                                 # 收到消息时添加的表情回复（默认 "🤔Thinking"）；设为 "none" 可禁用
+# done_emoji = "none"             # Emotion when agent finishes a reply (e.g. "🥳Done"); set to "none" to disable
+#                                 # Agent 完成回复后添加的表情回复（如 "🥳Done"）；设为 "none" 可禁用
 
 # WPS Xiezuo / WPS 协作 (uncomment to enable / 取消注释以启用)
 # 1. Create a WPS Open Platform app and enable event WebSocket delivery

--- a/core/engine.go
+++ b/core/engine.go
@@ -630,7 +630,6 @@ func (e *Engine) SetSkipGit(skipGit bool) {
 	e.skipGit = skipGit
 }
 
-
 // SetInjectSender controls whether sender identity (platform and user ID) is
 // prepended to each message before forwarding it to the agent. When enabled,
 // the agent receives a preamble line like:
@@ -3631,7 +3630,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			state.markStopped()
 			gracePeriod := 10 * time.Second
 			graceTimer := time.NewTimer(gracePeriod)
-			graceLoop:
+		graceLoop:
 			for {
 				select {
 				case evt, ok := <-state.agentSession.Events():
@@ -4513,11 +4512,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 			}
 
-			// Add a "done" reaction when the preview was updated in-place
-			// (user only got a push for the initial send). Skip for silent
-			// (NO_REPLY) turns and for rich card mode (the card itself shows
-			// the done status already).
-			if !isSilent && !hasRichCard && sp.needsDoneReaction() {
+			// Add a "done" reaction after the final answer when supported. Skip
+			// silent turns and rich card mode (the card itself shows done status).
+			if !isSilent && !hasRichCard {
 				if doneTI, ok := p.(TypingIndicatorDone); ok {
 					doneReaction = func() { doneTI.AddDoneReaction(replyCtx) }
 				}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -408,6 +408,28 @@ func (p *stubCompactProgressPlatform) getPreviewEdits() []string {
 	return out
 }
 
+type stubDoneReactionPlatform struct {
+	stubPlatformEngine
+	doneMu    sync.Mutex
+	doneCount int
+	doneCtxs  []any
+}
+
+func (p *stubDoneReactionPlatform) AddDoneReaction(replyCtx any) {
+	p.doneMu.Lock()
+	defer p.doneMu.Unlock()
+	p.doneCount++
+	p.doneCtxs = append(p.doneCtxs, replyCtx)
+}
+
+func (p *stubDoneReactionPlatform) doneSnapshot() (int, []any) {
+	p.doneMu.Lock()
+	defer p.doneMu.Unlock()
+	ctxs := make([]any, len(p.doneCtxs))
+	copy(ctxs, p.doneCtxs)
+	return p.doneCount, ctxs
+}
+
 type stubModelModeAgent struct {
 	stubAgent
 	model           string
@@ -1209,6 +1231,32 @@ func TestProcessInteractiveEvents_DropsStandaloneEllipsisProgress(t *testing.T) 
 	sent := p.getSent()
 	if len(sent) != 1 || sent[0] != "done" {
 		t.Fatalf("sent = %#v, want only final answer without standalone ellipsis progress", sent)
+	}
+}
+
+func TestProcessInteractiveEvents_AddsDoneReactionAfterNormalReply(t *testing.T) {
+	p := &stubDoneReactionPlatform{stubPlatformEngine: stubPlatformEngine{n: "dingtalk"}}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+
+	sessionKey := "dingtalk:user-done"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-done")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-done",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-done", time.Now(), nil, nil, state.replyCtx)
+
+	count, ctxs := p.doneSnapshot()
+	if count != 1 {
+		t.Fatalf("done reactions = %d, want 1", count)
+	}
+	if len(ctxs) != 1 || ctxs[0] != "ctx-done" {
+		t.Fatalf("done reaction contexts = %#v, want [ctx-done]", ctxs)
 	}
 }
 
@@ -5890,9 +5938,9 @@ func (s *controllableAgentSession) Close() error {
 
 // controllableAgent lets tests control which session is returned by StartSession.
 type controllableAgent struct {
-	nextSession     AgentSession
-	listFn          func() ([]AgentSessionInfo, error)
-	startSessionFn  func(ctx context.Context, sessionID string) (AgentSession, error)
+	nextSession    AgentSession
+	listFn         func() ([]AgentSessionInfo, error)
+	startSessionFn func(ctx context.Context, sessionID string) (AgentSession, error)
 }
 
 func (a *controllableAgent) Name() string { return "controllable" }

--- a/docs/dingtalk.md
+++ b/docs/dingtalk.md
@@ -74,7 +74,18 @@ type = "dingtalk"
 [projects.platforms.options]
 client_id = "dingxxxxxxxxxxxxxxx"
 client_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+reaction_emoji = "🤔Thinking"  # 可选：收到消息时贴的表情；设为 "none" 禁用
+done_emoji = "none"            # 可选：完成回复后贴的表情，例如 "🥳Done"；设为 "none" 禁用
 ```
+
+### 2.4 处理状态表情
+
+钉钉平台支持在用户消息上贴表情，让用户知道消息已经进入处理流程：
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `reaction_emoji` | `🤔Thinking` | 收到用户消息并开始处理时添加，处理结束后会撤回；设为 `none` 可禁用 |
+| `done_emoji` | `none` | Agent 完成回复后添加，例如 `🥳Done`；设为 `none` 或不配置则禁用 |
 
 ---
 

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -30,6 +30,7 @@ type replyContext struct {
 	sessionWebhook string
 	conversationId string
 	senderStaffId  string
+	messageID      string
 	isGroup        bool
 	proactive      bool // true when constructed by ReconstructReplyCtx (no sessionWebhook)
 }
@@ -54,6 +55,12 @@ type repliedTextContent struct {
 
 const maxQuotedMessageRunes = 4000
 
+const (
+	defaultReactionEmoji        = "🤔Thinking"
+	customTextEmotionID         = "2659900"
+	customTextEmotionBackground = "im_bg_1"
+)
+
 type downloadResponse struct {
 	DownloadUrl string `json:"downloadUrl"`
 }
@@ -73,6 +80,8 @@ type Platform struct {
 	tokenMu               sync.Mutex
 	accessToken           string
 	tokenExpiry           time.Time
+	reactionEmoji         string
+	doneEmoji             string
 	// AI Card configuration
 	cardTemplateID  string
 	cardTemplateKey string
@@ -97,6 +106,20 @@ func New(opts map[string]any) (core.Platform, error) {
 	// Validate robot_code format (should not be empty after fallback)
 	if robotCode == "" {
 		return nil, fmt.Errorf("dingtalk: robot_code is required (or client_id)")
+	}
+
+	reactionEmoji, _ := opts["reaction_emoji"].(string)
+	reactionEmoji = strings.TrimSpace(reactionEmoji)
+	if reactionEmoji == "" {
+		reactionEmoji = defaultReactionEmoji
+	}
+	if strings.EqualFold(reactionEmoji, "none") {
+		reactionEmoji = ""
+	}
+	doneEmoji, _ := opts["done_emoji"].(string)
+	doneEmoji = strings.TrimSpace(doneEmoji)
+	if strings.EqualFold(doneEmoji, "none") {
+		doneEmoji = ""
 	}
 
 	// agent_id is required for work notifications API (numeric type)
@@ -134,6 +157,8 @@ func New(opts map[string]any) (core.Platform, error) {
 		allowFrom:             allowFrom,
 		shareSessionInChannel: shareSessionInChannel,
 		httpClient:            &http.Client{Timeout: 30 * time.Second},
+		reactionEmoji:         reactionEmoji,
+		doneEmoji:             doneEmoji,
 		cardTemplateID:        cardTemplateID,
 		cardTemplateKey:       cardTemplateKey,
 		cardThrottleMs:        cardThrottleMs,
@@ -272,6 +297,8 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 				sessionWebhook: data.SessionWebhook,
 				conversationId: data.ConversationId,
 				senderStaffId:  data.SenderStaffId,
+				messageID:      data.MsgId,
+				isGroup:        data.ConversationType == "2",
 			},
 		}
 		p.handler(p, msg)
@@ -307,6 +334,7 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 			sessionWebhook: data.SessionWebhook,
 			conversationId: data.ConversationId,
 			senderStaffId:  data.SenderStaffId,
+			messageID:      data.MsgId,
 			isGroup:        data.ConversationType == "2",
 		},
 	}
@@ -375,6 +403,7 @@ func (p *Platform) handleAudioMessage(data *chatbot.BotCallbackDataModel, sessio
 					sessionWebhook: data.SessionWebhook,
 					conversationId: data.ConversationId,
 					senderStaffId:  data.SenderStaffId,
+					messageID:      data.MsgId,
 					isGroup:        data.ConversationType == "2",
 				},
 				FromVoice: true,
@@ -399,6 +428,7 @@ func (p *Platform) handleAudioMessage(data *chatbot.BotCallbackDataModel, sessio
 			sessionWebhook: data.SessionWebhook,
 			conversationId: data.ConversationId,
 			senderStaffId:  data.SenderStaffId,
+			messageID:      data.MsgId,
 			isGroup:        data.ConversationType == "2",
 		},
 		FromVoice: true,
@@ -475,6 +505,8 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 			sessionWebhook: data.SessionWebhook,
 			conversationId: data.ConversationId,
 			senderStaffId:  data.SenderStaffId,
+			messageID:      data.MsgId,
+			isGroup:        data.ConversationType == "2",
 		},
 		Images: []core.ImageAttachment{{
 			MimeType: mimeType,
@@ -692,6 +724,117 @@ func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 	return p.Reply(ctx, rctx, content)
 }
 
+type dingtalkTextEmotion struct {
+	EmotionID    string `json:"emotionId"`
+	EmotionName  string `json:"emotionName"`
+	Text         string `json:"text"`
+	BackgroundID string `json:"backgroundId"`
+}
+
+type dingtalkEmotionRequest struct {
+	RobotCode          string              `json:"robotCode"`
+	OpenMsgID          string              `json:"openMsgId"`
+	OpenConversationID string              `json:"openConversationId"`
+	EmotionType        int                 `json:"emotionType"`
+	EmotionName        string              `json:"emotionName"`
+	TextEmotion        dingtalkTextEmotion `json:"textEmotion"`
+}
+
+func (p *Platform) sendEmotion(ctx context.Context, rc replyContext, emoji string, recall bool) error {
+	emoji = strings.TrimSpace(emoji)
+	if emoji == "" || rc.messageID == "" || rc.conversationId == "" {
+		return nil
+	}
+	if p.httpClient == nil {
+		p.httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	token, err := p.getAccessToken()
+	if err != nil {
+		return fmt.Errorf("dingtalk: get access token for emotion: %w", err)
+	}
+
+	path := "/v1.0/robot/emotion/reply"
+	if recall {
+		path = "/v1.0/robot/emotion/recall"
+	}
+	requestBody := dingtalkEmotionRequest{
+		RobotCode:          p.robotCode,
+		OpenMsgID:          rc.messageID,
+		OpenConversationID: rc.conversationId,
+		EmotionType:        2,
+		EmotionName:        emoji,
+		TextEmotion: dingtalkTextEmotion{
+			EmotionID:    customTextEmotionID,
+			EmotionName:  emoji,
+			Text:         emoji,
+			BackgroundID: customTextEmotionBackground,
+		},
+	}
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("dingtalk: marshal emotion request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.dingtalk.com"+path, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("dingtalk: create emotion request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-acs-dingtalk-access-token", token)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("dingtalk: emotion request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("dingtalk: emotion returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+	if len(respBody) == 0 {
+		return nil
+	}
+	var result struct {
+		Success *bool `json:"success"`
+	}
+	if err := json.Unmarshal(respBody, &result); err == nil && result.Success != nil && !*result.Success {
+		return fmt.Errorf("dingtalk: emotion returned success=false")
+	}
+	return nil
+}
+
+// StartTyping adds a DingTalk emotion to the user's message while the agent is processing.
+func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
+	rc, ok := rctx.(replyContext)
+	if !ok || p.reactionEmoji == "" || rc.messageID == "" || rc.conversationId == "" {
+		return func() {}
+	}
+	if err := p.sendEmotion(ctx, rc, p.reactionEmoji, false); err != nil {
+		slog.Debug("dingtalk: add typing emotion failed", "error", err)
+	}
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := p.sendEmotion(ctx, rc, p.reactionEmoji, true); err != nil {
+			slog.Debug("dingtalk: recall typing emotion failed", "error", err)
+		}
+	}
+}
+
+// AddDoneReaction adds a DingTalk done emotion when configured.
+func (p *Platform) AddDoneReaction(rctx any) {
+	rc, ok := rctx.(replyContext)
+	if !ok || p.doneEmoji == "" || rc.messageID == "" || rc.conversationId == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := p.sendEmotion(ctx, rc, p.doneEmoji, false); err != nil {
+		slog.Debug("dingtalk: add done emotion failed", "error", err)
+	}
+}
+
 // SendImage uploads and sends an image via DingTalk oToMessages API.
 // Implements core.ImageSender.
 func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttachment) error {
@@ -759,6 +902,8 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 var _ core.ImageSender = (*Platform)(nil)
 var _ core.StreamingCardPlatform = (*Platform)(nil)
 var _ core.ReplyContextReconstructor = (*Platform)(nil)
+var _ core.TypingIndicator = (*Platform)(nil)
+var _ core.TypingIndicatorDone = (*Platform)(nil)
 
 // CreateStreamingCard creates a new streaming card for the given reply context.
 // Implements core.StreamingCardPlatform.

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -786,7 +786,7 @@ func (p *Platform) sendEmotion(ctx context.Context, rc replyContext, emoji strin
 	if err != nil {
 		return fmt.Errorf("dingtalk: emotion request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -1,6 +1,7 @@
 package dingtalk
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -138,6 +139,54 @@ func TestPlatform_AccessTokenFieldsExist(t *testing.T) {
 	}
 
 	t.Log("Platform token caching fields exist and are accessible")
+}
+
+func TestNewConfiguresReactionEmoji(t *testing.T) {
+	plat, err := New(map[string]any{
+		"client_id":     "cid",
+		"client_secret": "secret",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	p := plat.(*Platform)
+	if p.reactionEmoji != "🤔Thinking" {
+		t.Fatalf("default reactionEmoji = %q, want %q", p.reactionEmoji, "🤔Thinking")
+	}
+	if p.doneEmoji != "" {
+		t.Fatalf("default doneEmoji = %q, want empty", p.doneEmoji)
+	}
+
+	plat, err = New(map[string]any{
+		"client_id":      "cid",
+		"client_secret":  "secret",
+		"reaction_emoji": "none",
+		"done_emoji":     "none",
+	})
+	if err != nil {
+		t.Fatalf("New() with disabled emoji error = %v", err)
+	}
+	p = plat.(*Platform)
+	if p.reactionEmoji != "" {
+		t.Fatalf("disabled reactionEmoji = %q, want empty", p.reactionEmoji)
+	}
+	if p.doneEmoji != "" {
+		t.Fatalf("disabled doneEmoji = %q, want empty", p.doneEmoji)
+	}
+
+	plat, err = New(map[string]any{
+		"client_id":      "cid",
+		"client_secret":  "secret",
+		"reaction_emoji": "🧠Working",
+		"done_emoji":     "🥳Done",
+	})
+	if err != nil {
+		t.Fatalf("New() with custom emoji error = %v", err)
+	}
+	p = plat.(*Platform)
+	if p.reactionEmoji != "🧠Working" || p.doneEmoji != "🥳Done" {
+		t.Fatalf("emoji config = (%q, %q), want (🧠Working, 🥳Done)", p.reactionEmoji, p.doneEmoji)
+	}
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -532,6 +581,52 @@ func TestOnRawMessage_QuotedInteractiveCardEnrichesMessageContent(t *testing.T) 
 	}
 }
 
+func TestOnRawMessage_IncludesReactionReplyContext(t *testing.T) {
+	var got *core.Message
+	p := &Platform{
+		handler: func(_ core.Platform, msg *core.Message) {
+			got = msg
+		},
+	}
+
+	p.onRawMessage(`{
+		"msgtype": "text",
+		"msgId": "msg-reaction-1",
+		"conversationType": "2",
+		"conversationId": "conv-1",
+		"conversationTitle": "team chat",
+		"senderStaffId": "user-1",
+		"senderNick": "Alice",
+		"sessionWebhook": "https://example.invalid/webhook",
+		"text": {
+			"content": "hi"
+		}
+	}`)
+
+	if got == nil {
+		t.Fatal("handler was not called")
+	}
+	if got.MessageID != "msg-reaction-1" {
+		t.Fatalf("MessageID = %q, want %q", got.MessageID, "msg-reaction-1")
+	}
+	rc, ok := got.ReplyCtx.(replyContext)
+	if !ok {
+		t.Fatalf("ReplyCtx type = %T, want replyContext", got.ReplyCtx)
+	}
+	if rc.messageID != "msg-reaction-1" {
+		t.Errorf("replyContext.messageID = %q, want %q", rc.messageID, "msg-reaction-1")
+	}
+	if rc.conversationId != "conv-1" {
+		t.Errorf("replyContext.conversationId = %q, want %q", rc.conversationId, "conv-1")
+	}
+	if rc.senderStaffId != "user-1" {
+		t.Errorf("replyContext.senderStaffId = %q, want %q", rc.senderStaffId, "user-1")
+	}
+	if !rc.isGroup {
+		t.Error("replyContext.isGroup = false, want true")
+	}
+}
+
 func TestFormatReplyContent_EmptyQuotedText(t *testing.T) {
 	p := &Platform{}
 	repliedContent, _ := json.Marshal(repliedTextContent{Text: ""})
@@ -688,6 +783,154 @@ func (f *fakeAccessTokenRT) RoundTrip(req *http.Request) (*http.Response, error)
 		Header:     make(http.Header),
 		Request:    req,
 	}, nil
+}
+
+type dingtalkEmotionCall struct {
+	path   string
+	header string
+	body   map[string]any
+}
+
+type fakeDingTalkEmotionRT struct {
+	calls []dingtalkEmotionCall
+}
+
+func (f *fakeDingTalkEmotionRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path == "/v1.0/oauth2/accessToken" {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"accessToken":"tok-emotion","expireIn":7200}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	f.calls = append(f.calls, dingtalkEmotionCall{
+		path:   req.URL.Path,
+		header: req.Header.Get("x-acs-dingtalk-access-token"),
+		body:   body,
+	})
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"success":true}`)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestSendEmotionReply(t *testing.T) {
+	rt := &fakeDingTalkEmotionRT{}
+	p := &Platform{
+		clientID:     "cid",
+		clientSecret: "secret",
+		robotCode:    "robot-code",
+		httpClient:   &http.Client{Transport: rt},
+	}
+
+	err := p.sendEmotion(context.Background(), replyContext{
+		messageID:      "msg-1",
+		conversationId: "conv-1",
+	}, "🤔Thinking", false)
+	if err != nil {
+		t.Fatalf("sendEmotion() error = %v", err)
+	}
+	if len(rt.calls) != 1 {
+		t.Fatalf("HTTP emotion calls = %d, want 1", len(rt.calls))
+	}
+	call := rt.calls[0]
+	if call.path != "/v1.0/robot/emotion/reply" {
+		t.Fatalf("path = %q, want /v1.0/robot/emotion/reply", call.path)
+	}
+	if call.header != "tok-emotion" {
+		t.Fatalf("access token header = %q, want tok-emotion", call.header)
+	}
+	if call.body["robotCode"] != "robot-code" {
+		t.Errorf("robotCode = %v, want robot-code", call.body["robotCode"])
+	}
+	if call.body["openMsgId"] != "msg-1" {
+		t.Errorf("openMsgId = %v, want msg-1", call.body["openMsgId"])
+	}
+	if call.body["openConversationId"] != "conv-1" {
+		t.Errorf("openConversationId = %v, want conv-1", call.body["openConversationId"])
+	}
+	if call.body["emotionType"] != float64(2) {
+		t.Errorf("emotionType = %v, want 2", call.body["emotionType"])
+	}
+	if call.body["emotionName"] != "🤔Thinking" {
+		t.Errorf("emotionName = %v, want 🤔Thinking", call.body["emotionName"])
+	}
+	textEmotion, ok := call.body["textEmotion"].(map[string]any)
+	if !ok {
+		t.Fatalf("textEmotion type = %T, want object", call.body["textEmotion"])
+	}
+	if textEmotion["emotionId"] != "2659900" {
+		t.Errorf("textEmotion.emotionId = %v, want 2659900", textEmotion["emotionId"])
+	}
+	if textEmotion["emotionName"] != "🤔Thinking" || textEmotion["text"] != "🤔Thinking" {
+		t.Errorf("textEmotion = %#v, want matching custom text emoji", textEmotion)
+	}
+	if textEmotion["backgroundId"] != "im_bg_1" {
+		t.Errorf("textEmotion.backgroundId = %v, want im_bg_1", textEmotion["backgroundId"])
+	}
+}
+
+func TestSendEmotionRecall(t *testing.T) {
+	rt := &fakeDingTalkEmotionRT{}
+	p := &Platform{
+		clientID:     "cid",
+		clientSecret: "secret",
+		robotCode:    "robot-code",
+		httpClient:   &http.Client{Transport: rt},
+	}
+
+	err := p.sendEmotion(context.Background(), replyContext{
+		messageID:      "msg-1",
+		conversationId: "conv-1",
+	}, "🤔Thinking", true)
+	if err != nil {
+		t.Fatalf("sendEmotion(recall) error = %v", err)
+	}
+	if len(rt.calls) != 1 {
+		t.Fatalf("HTTP emotion calls = %d, want 1", len(rt.calls))
+	}
+	if rt.calls[0].path != "/v1.0/robot/emotion/recall" {
+		t.Fatalf("path = %q, want /v1.0/robot/emotion/recall", rt.calls[0].path)
+	}
+}
+
+func TestStartTypingAndDoneReaction(t *testing.T) {
+	rt := &fakeDingTalkEmotionRT{}
+	p := &Platform{
+		clientID:      "cid",
+		clientSecret:  "secret",
+		robotCode:     "robot-code",
+		reactionEmoji: "🤔Thinking",
+		doneEmoji:     "🥳Done",
+		httpClient:    &http.Client{Transport: rt},
+	}
+	rc := replyContext{messageID: "msg-1", conversationId: "conv-1"}
+
+	stop := p.StartTyping(context.Background(), rc)
+	stop()
+	p.AddDoneReaction(rc)
+
+	if len(rt.calls) != 3 {
+		t.Fatalf("HTTP emotion calls = %d, want 3", len(rt.calls))
+	}
+	if rt.calls[0].path != "/v1.0/robot/emotion/reply" || rt.calls[0].body["emotionName"] != "🤔Thinking" {
+		t.Fatalf("typing add call = (%s, %v), want reply 🤔Thinking", rt.calls[0].path, rt.calls[0].body["emotionName"])
+	}
+	if rt.calls[1].path != "/v1.0/robot/emotion/recall" || rt.calls[1].body["emotionName"] != "🤔Thinking" {
+		t.Fatalf("typing stop call = (%s, %v), want recall 🤔Thinking", rt.calls[1].path, rt.calls[1].body["emotionName"])
+	}
+	if rt.calls[2].path != "/v1.0/robot/emotion/reply" || rt.calls[2].body["emotionName"] != "🥳Done" {
+		t.Fatalf("done call = (%s, %v), want reply 🥳Done", rt.calls[2].path, rt.calls[2].body["emotionName"])
+	}
 }
 
 func TestOnRawMessage_PictureMsgTypeNotDroppedAsEmptyText(t *testing.T) {


### PR DESCRIPTION
## 摘要

为 DingTalk 渠道新增 `reaction_emoji` 和 `done_emoji` 支持。

Closes #1212。

## 为什么需要

DingTalk 用户给机器人发消息后，如果 Agent 回复耗时较长，当前没有明确的“已收到、正在处理”反馈。用户只能等待最终回复，不容易判断机器人是否已经开始处理。

Feishu 渠道已经支持 `reaction_emoji` 和 `done_emoji`。DingTalk 机器人也提供了贴表情能力，因此可以补齐类似体验。

## 改了什么

- 新增 DingTalk `reaction_emoji` 配置，默认值为 `🤔Thinking`；设置为 `"none"` 可禁用。
- 新增 DingTalk `done_emoji` 配置，默认不启用；设置为 `"none"` 也会禁用。
- 在 DingTalk `replyContext` 中保存 `msgId`，用于把表情贴到原始用户消息上。
- DingTalk 平台实现 `core.TypingIndicator`：
  - 开始处理时贴 `reaction_emoji`。
  - 处理结束时撤回 `reaction_emoji`。
- DingTalk 平台实现 `core.TypingIndicatorDone`：
  - 最终回复完成后贴配置的 `done_emoji`。
- 调整 core engine 的完成逻辑，使普通最终回复也能触发 `TypingIndicatorDone`，而不是只在预览消息原地更新后触发。
- 更新 `config.example.toml` 和 `docs/dingtalk.md` 中的 DingTalk 配置说明。

## API 细节

DingTalk 实现调用机器人表情 API：

- `POST /v1.0/robot/emotion/reply`
- `POST /v1.0/robot/emotion/recall`

请求中包含 `robotCode`、`openMsgId`、`openConversationId`、`emotionType`、`emotionName` 和自定义文字表情 payload，结构与 DingTalk SDK 的行为保持一致。

表情 API 调用失败时只记录 debug 日志，不阻断 Agent 正常回复。

## 验证

- `go test ./platform/dingtalk -count=1`
- `go test ./core -run TestProcessInteractiveEvents_AddsDoneReactionAfterNormalReply -count=1`
- `go test ./core -run 'TestProcessInteractiveEvents_(AddsDoneReactionAfterNormalReply|DropsStandaloneEllipsisProgress|DoesNotAppendReplyFooterWhenDisabled)' -count=1`
- `make build-noweb`

另外，本地用真实 DingTalk 机器人做过 live 验证：`reaction_emoji` 可以贴上和撤回，`done_emoji` 可以贴上。
