### PR TITLE
feat(codex): add project-aware workdirs

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -38,7 +38,7 @@ type Agent struct {
 	cliBin          string   // CLI binary name, default "codex"
 	cliExtraArgs    []string // extra args parsed from cli_path after the binary
 	providers       []core.ProviderConfig
-	activeIdx       int // -1 = no provider set
+	activeIdx       int      // -1 = no provider set
 	configEnv       []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
 	sessionEnv      []string
 	mu              sync.RWMutex
@@ -407,6 +407,13 @@ func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error)
 	workDir := a.workDir
 	a.mu.RUnlock()
 	return listCodexSessions(workDir, codexHome)
+}
+
+func (a *Agent) ListWorkdirs(_ context.Context) ([]core.AgentWorkdirInfo, error) {
+	a.mu.RLock()
+	codexHome := a.codexHome
+	a.mu.RUnlock()
+	return listCodexWorkdirs(codexHome)
 }
 
 func (a *Agent) GetSessionHistory(_ context.Context, sessionID string, limit int) ([]core.HistoryEntry, error) {

--- a/agent/codex/list.go
+++ b/agent/codex/list.go
@@ -134,18 +134,6 @@ func filterCodexProjectSessions(sessions []core.AgentSessionInfo, projectRoots [
 	return filtered
 }
 
-func codexProjectRootForCwd(cwd string, projectRoots []string) string {
-	return core.WorkdirRootForCwd(cwd, projectRoots)
-}
-
-func codexPathContains(root, child string) bool {
-	return core.WorkdirContains(root, child)
-}
-
-func normalizeCodexPath(path string) string {
-	return core.NormalizeWorkdirPath(path)
-}
-
 func listAllCodexSessions(codexHome string) []core.AgentSessionInfo {
 	home := resolveCodexHomeDir(codexHome)
 	index := loadCodexSessionIndex(home)
@@ -223,10 +211,6 @@ func mergeCodexSession(merged map[string]core.AgentSessionInfo, next core.AgentS
 	merged[next.ID] = cur
 }
 
-func matchesCodexCwd(sessionCwd, filterCwd string, filterIsProjectRoot bool) bool {
-	return core.MatchSessionWorkdir(sessionCwd, filterCwd, filterIsProjectRoot)
-}
-
 func listCodexSessionFiles(codexHome string) []string {
 	var files []string
 	root := filepath.Join(codexHome, "sessions")
@@ -254,7 +238,7 @@ func loadCodexSessionIndex(codexHome string) map[string]codexSessionIndexEntry {
 	if err != nil {
 		return nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	index := make(map[string]codexSessionIndexEntry)
 	scanner := bufio.NewScanner(f)
@@ -282,7 +266,7 @@ func listCodexDatabaseSessions(codexHome string) []core.AgentSessionInfo {
 	if err != nil {
 		return nil
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	query := `
 		select id, cwd, title, updated_at, updated_at_ms
@@ -295,7 +279,7 @@ func listCodexDatabaseSessions(codexHome string) []core.AgentSessionInfo {
 	if err != nil {
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var sessions []core.AgentSessionInfo
 	for rows.Next() {
@@ -328,7 +312,7 @@ func codexThreadsHasColumn(db *sql.DB, name string) bool {
 	if err != nil {
 		return false
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		var cid int
@@ -355,7 +339,7 @@ func listCodexArchivedSessionIDs(codexHome string) map[string]struct{} {
 	if err != nil {
 		return nil
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	var where []string
 	if codexThreadsHasColumn(db, "archived") {
@@ -372,7 +356,7 @@ func listCodexArchivedSessionIDs(codexHome string) map[string]struct{} {
 	if err != nil {
 		return nil
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	ids := make(map[string]struct{})
 	for rows.Next() {
@@ -407,7 +391,7 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 	if err != nil {
 		return nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	stat, err := f.Stat()
 	if err != nil {
@@ -457,7 +441,8 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 				} `json:"content"`
 			}
 			if json.Unmarshal(entry.Payload, &item) == nil {
-				if item.Role == "user" {
+				switch item.Role {
+				case "user":
 					userMsgSeen++
 					msgCount++
 					// The actual user prompt is the last user response_item
@@ -468,7 +453,7 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 							summary = c.Text
 						}
 					}
-				} else if item.Role == "assistant" {
+				case "assistant":
 					msgCount++
 				}
 			}
@@ -525,7 +510,7 @@ func getSessionHistory(sessionID, codexHome string, limit int) ([]core.HistoryEn
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var entries []core.HistoryEntry
 

--- a/agent/codex/list.go
+++ b/agent/codex/list.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"bufio"
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/chenhg5/cc-connect/core"
+	_ "modernc.org/sqlite"
 )
 
 // resolveCodexHomeDir returns the effective CODEX_HOME directory.
@@ -30,18 +32,205 @@ func resolveCodexHomeDir(explicit string) string {
 	return filepath.Join(homeDir, ".codex")
 }
 
-// listCodexSessions scans the codex sessions directory for JSONL transcript
-// files whose cwd matches workDir.
+// listCodexSessions merges Codex CLI JSONL transcripts with the Codex App
+// index/database, then filters sessions whose cwd matches workDir.
 func listCodexSessions(workDir, codexHome string) ([]core.AgentSessionInfo, error) {
-	absWorkDir, err := filepath.Abs(workDir)
-	if err != nil {
-		absWorkDir = workDir
+	home := resolveCodexHomeDir(codexHome)
+	filterCwd := core.NormalizeWorkdirPath(workDir)
+	projectRoots := loadCodexProjectRoots(home)
+	filterIsProjectRoot := core.WorkdirRootForCwd(filterCwd, projectRoots) == filterCwd
+
+	allSessions := listAllCodexSessions(codexHome)
+	var sessions []core.AgentSessionInfo
+	for _, info := range allSessions {
+		if !core.MatchSessionWorkdir(info.Cwd, filterCwd, filterIsProjectRoot) {
+			continue
+		}
+		patchSessionSource(info.ID, codexHome)
+		sessions = append(sessions, info)
 	}
 
-	sessionsDir := filepath.Join(resolveCodexHomeDir(codexHome), "sessions")
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].ModifiedAt.After(sessions[j].ModifiedAt)
+	})
 
+	return sessions, nil
+}
+
+func listCodexWorkdirs(codexHome string) ([]core.AgentWorkdirInfo, error) {
+	home := resolveCodexHomeDir(codexHome)
+	allSessions := listAllCodexSessions(codexHome)
+	state := loadCodexSidebarState(home)
+	projectRoots := state.projectRoots
+	if state.loaded {
+		allSessions = filterCodexProjectSessions(allSessions, projectRoots)
+	}
+	return core.GroupAgentWorkdirs(allSessions, projectRoots), nil
+}
+
+type codexGlobalState struct {
+	ProjectOrder            []string `json:"project-order"`
+	ElectronSavedWorkspaces []string `json:"electron-saved-workspace-roots"`
+	ProjectlessThreadIDs    []string `json:"projectless-thread-ids"`
+}
+
+type codexSidebarState struct {
+	loaded             bool
+	projectRoots       []string
+	projectlessThreads map[string]struct{}
+}
+
+func loadCodexProjectRoots(codexHome string) []string {
+	return loadCodexSidebarState(codexHome).projectRoots
+}
+
+func loadCodexSidebarState(codexHome string) codexSidebarState {
+	path := filepath.Join(codexHome, ".codex-global-state.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return codexSidebarState{}
+	}
+	var state codexGlobalState
+	if json.Unmarshal(data, &state) != nil {
+		return codexSidebarState{}
+	}
+	var roots []string
+	seen := make(map[string]struct{})
+	for _, raw := range append(state.ProjectOrder, state.ElectronSavedWorkspaces...) {
+		root := core.NormalizeWorkdirPath(raw)
+		if root == "" {
+			continue
+		}
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		roots = append(roots, root)
+	}
+	projectless := make(map[string]struct{}, len(state.ProjectlessThreadIDs))
+	for _, id := range state.ProjectlessThreadIDs {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			projectless[id] = struct{}{}
+		}
+	}
+	return codexSidebarState{
+		loaded:             true,
+		projectRoots:       roots,
+		projectlessThreads: projectless,
+	}
+}
+
+func filterCodexProjectSessions(sessions []core.AgentSessionInfo, projectRoots []string) []core.AgentSessionInfo {
+	if len(projectRoots) == 0 {
+		return nil
+	}
+	filtered := make([]core.AgentSessionInfo, 0, len(sessions))
+	for _, session := range sessions {
+		if core.WorkdirRootForCwd(session.Cwd, projectRoots) != "" {
+			filtered = append(filtered, session)
+		}
+	}
+	return filtered
+}
+
+func codexProjectRootForCwd(cwd string, projectRoots []string) string {
+	return core.WorkdirRootForCwd(cwd, projectRoots)
+}
+
+func codexPathContains(root, child string) bool {
+	return core.WorkdirContains(root, child)
+}
+
+func normalizeCodexPath(path string) string {
+	return core.NormalizeWorkdirPath(path)
+}
+
+func listAllCodexSessions(codexHome string) []core.AgentSessionInfo {
+	home := resolveCodexHomeDir(codexHome)
+	index := loadCodexSessionIndex(home)
+	archivedIDs := listCodexArchivedSessionIDs(home)
+	merged := make(map[string]core.AgentSessionInfo)
+
+	for _, info := range listCodexDatabaseSessions(home) {
+		if _, archived := archivedIDs[info.ID]; archived {
+			continue
+		}
+		mergeCodexSession(merged, info)
+	}
+
+	for _, path := range listCodexSessionFiles(home) {
+		info := parseCodexSessionFile(path, "")
+		if info != nil {
+			if _, archived := archivedIDs[info.ID]; archived {
+				continue
+			}
+			mergeCodexSession(merged, *info)
+		}
+	}
+
+	for id, entry := range index {
+		if _, archived := archivedIDs[id]; archived {
+			continue
+		}
+		info := merged[id]
+		info.ID = id
+		if entry.ThreadName != "" {
+			info.Summary = entry.ThreadName
+		}
+		if t := parseCodexIndexTime(entry.UpdatedAt); !t.IsZero() && t.After(info.ModifiedAt) {
+			info.ModifiedAt = t
+		}
+		if info.Summary != "" || !info.ModifiedAt.IsZero() {
+			merged[id] = info
+		}
+	}
+
+	sessions := make([]core.AgentSessionInfo, 0, len(merged))
+	for _, info := range merged {
+		if info.ID == "" {
+			continue
+		}
+		sessions = append(sessions, info)
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].ModifiedAt.After(sessions[j].ModifiedAt)
+	})
+	return sessions
+}
+
+func mergeCodexSession(merged map[string]core.AgentSessionInfo, next core.AgentSessionInfo) {
+	if next.ID == "" {
+		return
+	}
+	cur := merged[next.ID]
+	if cur.ID == "" {
+		merged[next.ID] = next
+		return
+	}
+	if strings.TrimSpace(cur.Summary) == "" && strings.TrimSpace(next.Summary) != "" {
+		cur.Summary = next.Summary
+	}
+	if strings.TrimSpace(cur.Cwd) == "" && strings.TrimSpace(next.Cwd) != "" {
+		cur.Cwd = next.Cwd
+	}
+	if cur.MessageCount == 0 && next.MessageCount != 0 {
+		cur.MessageCount = next.MessageCount
+	}
+	if next.ModifiedAt.After(cur.ModifiedAt) {
+		cur.ModifiedAt = next.ModifiedAt
+	}
+	merged[next.ID] = cur
+}
+
+func matchesCodexCwd(sessionCwd, filterCwd string, filterIsProjectRoot bool) bool {
+	return core.MatchSessionWorkdir(sessionCwd, filterCwd, filterIsProjectRoot)
+}
+
+func listCodexSessionFiles(codexHome string) []string {
 	var files []string
-	_ = filepath.Walk(sessionsDir, func(path string, info os.FileInfo, err error) error {
+	root := filepath.Join(codexHome, "sessions")
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return nil
 		}
@@ -50,25 +239,165 @@ func listCodexSessions(workDir, codexHome string) ([]core.AgentSessionInfo, erro
 		}
 		return nil
 	})
+	return files
+}
 
-	if len(files) == 0 {
-		return nil, nil
+type codexSessionIndexEntry struct {
+	ID         string `json:"id"`
+	ThreadName string `json:"thread_name"`
+	UpdatedAt  string `json:"updated_at"`
+}
+
+func loadCodexSessionIndex(codexHome string) map[string]codexSessionIndexEntry {
+	path := filepath.Join(codexHome, "session_index.jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
 	}
+	defer f.Close()
+
+	index := make(map[string]codexSessionIndexEntry)
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry codexSessionIndexEntry
+		if json.Unmarshal([]byte(line), &entry) != nil || entry.ID == "" {
+			continue
+		}
+		index[entry.ID] = entry
+	}
+	return index
+}
+
+func listCodexDatabaseSessions(codexHome string) []core.AgentSessionInfo {
+	path := filepath.Join(codexHome, "state_5.sqlite")
+	if _, err := os.Stat(path); err != nil {
+		return nil
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil
+	}
+	defer db.Close()
+
+	query := `
+		select id, cwd, title, updated_at, updated_at_ms
+		from threads
+	`
+	if codexThreadsHasColumn(db, "archived") {
+		query += ` where archived = 0`
+	}
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
 
 	var sessions []core.AgentSessionInfo
-	for _, f := range files {
-		info := parseCodexSessionFile(f, absWorkDir)
-		if info != nil {
-			patchSessionSource(info.ID, codexHome)
-			sessions = append(sessions, *info)
+	for rows.Next() {
+		var id, cwd, title sql.NullString
+		var updatedAt, updatedAtMS sql.NullInt64
+		if err := rows.Scan(&id, &cwd, &title, &updatedAt, &updatedAtMS); err != nil {
+			continue
+		}
+		if !id.Valid || id.String == "" {
+			continue
+		}
+		modified := time.Time{}
+		if updatedAtMS.Valid && updatedAtMS.Int64 > 0 {
+			modified = time.UnixMilli(updatedAtMS.Int64)
+		} else if updatedAt.Valid && updatedAt.Int64 > 0 {
+			modified = time.Unix(updatedAt.Int64, 0)
+		}
+		sessions = append(sessions, core.AgentSessionInfo{
+			ID:         id.String,
+			Summary:    title.String,
+			ModifiedAt: modified,
+			Cwd:        cwd.String,
+		})
+	}
+	return sessions
+}
+
+func codexThreadsHasColumn(db *sql.DB, name string) bool {
+	rows, err := db.Query(`pragma table_info(threads)`)
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var colName, colType string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &colName, &colType, &notNull, &defaultValue, &pk); err != nil {
+			continue
+		}
+		if strings.EqualFold(colName, name) {
+			return true
 		}
 	}
+	return false
+}
 
-	sort.Slice(sessions, func(i, j int) bool {
-		return sessions[i].ModifiedAt.After(sessions[j].ModifiedAt)
-	})
+func listCodexArchivedSessionIDs(codexHome string) map[string]struct{} {
+	path := filepath.Join(codexHome, "state_5.sqlite")
+	if _, err := os.Stat(path); err != nil {
+		return nil
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil
+	}
+	defer db.Close()
 
-	return sessions, nil
+	var where []string
+	if codexThreadsHasColumn(db, "archived") {
+		where = append(where, `coalesce(archived, 0) != 0`)
+	}
+	if codexThreadsHasColumn(db, "archived_at") {
+		where = append(where, `archived_at is not null`)
+	}
+	if len(where) == 0 {
+		return nil
+	}
+
+	rows, err := db.Query(`select id from threads where ` + strings.Join(where, ` or `))
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	ids := make(map[string]struct{})
+	for rows.Next() {
+		var id sql.NullString
+		if err := rows.Scan(&id); err != nil {
+			continue
+		}
+		if id.Valid && strings.TrimSpace(id.String) != "" {
+			ids[id.String] = struct{}{}
+		}
+	}
+	return ids
+}
+
+func parseCodexIndexTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05.999999-07:00", "2006-01-02 15:04:05-07:00"} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
 }
 
 // parseCodexSessionFile reads a Codex JSONL transcript.
@@ -164,6 +493,7 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 		Summary:      summary,
 		MessageCount: msgCount,
 		ModifiedAt:   stat.ModTime(),
+		Cwd:          sessionCwd,
 	}
 }
 

--- a/agent/codex/list_test.go
+++ b/agent/codex/list_test.go
@@ -79,7 +79,7 @@ func writeTestCodexStateDB(t *testing.T, codexHome string, rows ...struct {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	_, err = db.Exec(`create table threads (
 		id text primary key,
 		cwd text,

--- a/agent/codex/list_test.go
+++ b/agent/codex/list_test.go
@@ -1,0 +1,325 @@
+package codex
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeTestCodexSession(t *testing.T, codexHome, day, id, cwd, prompt string, modified time.Time) {
+	t.Helper()
+	writeTestCodexSessionInRoot(t, codexHome, "sessions", day, id, cwd, prompt, modified)
+}
+
+func writeTestCodexSessionInRoot(t *testing.T, codexHome, root, day, id, cwd, prompt string, modified time.Time) {
+	t.Helper()
+	dir := filepath.Join(codexHome, root, "2026", "05", day)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions dir: %v", err)
+	}
+	path := filepath.Join(dir, "rollout-2026-05-"+day+"T12-00-00-"+id+".jsonl")
+	body := strings.Join([]string{
+		`{"type":"session_meta","payload":{"id":"` + id + `","cwd":"` + cwd + `"}}`,
+		`{"type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"` + prompt + `"}]}}`,
+		`{"type":"response_item","payload":{"role":"assistant","content":[{"type":"output_text","text":"ok"}]}}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	if err := os.Chtimes(path, modified, modified); err != nil {
+		t.Fatalf("chtimes session: %v", err)
+	}
+}
+
+func writeTestCodexGlobalState(t *testing.T, codexHome string, projectOrder, savedRoots []string) {
+	t.Helper()
+	writeTestCodexGlobalStateWithProjectless(t, codexHome, projectOrder, savedRoots, nil)
+}
+
+func writeTestCodexGlobalStateWithProjectless(t *testing.T, codexHome string, projectOrder, savedRoots, projectlessIDs []string) {
+	t.Helper()
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("mkdir codex home: %v", err)
+	}
+	body := struct {
+		ProjectOrder            []string `json:"project-order"`
+		ElectronSavedWorkspaces []string `json:"electron-saved-workspace-roots"`
+		ProjectlessThreadIDs    []string `json:"projectless-thread-ids"`
+	}{
+		ProjectOrder:            projectOrder,
+		ElectronSavedWorkspaces: savedRoots,
+		ProjectlessThreadIDs:    projectlessIDs,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal global state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexHome, ".codex-global-state.json"), data, 0o644); err != nil {
+		t.Fatalf("write global state: %v", err)
+	}
+}
+
+func writeTestCodexStateDB(t *testing.T, codexHome string, rows ...struct {
+	id          string
+	cwd         string
+	title       string
+	updatedAtMS int64
+	archived    bool
+}) {
+	t.Helper()
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("mkdir codex home: %v", err)
+	}
+	db, err := sql.Open("sqlite", filepath.Join(codexHome, "state_5.sqlite"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`create table threads (
+		id text primary key,
+		cwd text,
+		title text,
+		updated_at integer,
+		updated_at_ms integer,
+		archived integer not null default 0
+	)`)
+	if err != nil {
+		t.Fatalf("create threads: %v", err)
+	}
+	for _, row := range rows {
+		archived := 0
+		if row.archived {
+			archived = 1
+		}
+		_, err = db.Exec(`insert into threads (id, cwd, title, updated_at, updated_at_ms, archived) values (?, ?, ?, ?, ?, ?)`,
+			row.id, row.cwd, row.title, row.updatedAtMS/1000, row.updatedAtMS, archived)
+		if err != nil {
+			t.Fatalf("insert thread: %v", err)
+		}
+	}
+}
+
+func TestListCodexWorkdirsGroupsByCwd(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	projectA := filepath.Join(t.TempDir(), "project-a")
+	projectB := filepath.Join(t.TempDir(), "project-b")
+	newer := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	older := newer.Add(-time.Hour)
+
+	writeTestCodexSession(t, codexHome, "24", "a1", projectA, "first task", older)
+	writeTestCodexSession(t, codexHome, "24", "a2", projectA, "latest task", newer)
+	writeTestCodexSession(t, codexHome, "23", "b1", projectB, "other task", older.Add(-time.Hour))
+
+	got, err := listCodexWorkdirs(codexHome)
+	if err != nil {
+		t.Fatalf("listCodexWorkdirs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %#v", len(got), got)
+	}
+	if got[0].Cwd != projectA {
+		t.Fatalf("first cwd = %q, want %q", got[0].Cwd, projectA)
+	}
+	if got[0].SessionCount != 2 {
+		t.Fatalf("projectA sessions = %d, want 2", got[0].SessionCount)
+	}
+	if got[0].MessageCount != 4 {
+		t.Fatalf("projectA messages = %d, want 4", got[0].MessageCount)
+	}
+	if got[0].LatestSummary != "latest task" {
+		t.Fatalf("projectA latest summary = %q, want latest task", got[0].LatestSummary)
+	}
+	if got[1].Cwd != projectB {
+		t.Fatalf("second cwd = %q, want %q", got[1].Cwd, projectB)
+	}
+}
+
+func TestListCodexWorkdirsGroupsSavedProjectsByRoot(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	rootA := filepath.Join(t.TempDir(), "project-a")
+	nestedA := filepath.Join(rootA, "service")
+	rootB := filepath.Join(t.TempDir(), "project-b")
+	loose := filepath.Join(t.TempDir(), "loose")
+	newer := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	older := newer.Add(-time.Hour)
+
+	writeTestCodexGlobalState(t, codexHome, []string{rootB, rootA}, []string{rootA, rootB})
+	writeTestCodexSession(t, codexHome, "24", "a1", rootA, "root task", older)
+	writeTestCodexSession(t, codexHome, "24", "a2", nestedA, "nested task", newer)
+	writeTestCodexSession(t, codexHome, "24", "b1", rootB, "project b", older)
+	writeTestCodexSession(t, codexHome, "24", "c1", loose, "loose task", newer.Add(-2*time.Hour))
+
+	got, err := listCodexWorkdirs(codexHome)
+	if err != nil {
+		t.Fatalf("listCodexWorkdirs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %#v", len(got), got)
+	}
+	if got[0].Cwd != rootB {
+		t.Fatalf("first cwd = %q, want project-order rootB %q", got[0].Cwd, rootB)
+	}
+	if got[1].Cwd != rootA {
+		t.Fatalf("second cwd = %q, want project-order rootA %q", got[1].Cwd, rootA)
+	}
+	if got[1].SessionCount != 2 {
+		t.Fatalf("rootA sessions = %d, want 2", got[1].SessionCount)
+	}
+	if got[1].MessageCount != 4 {
+		t.Fatalf("rootA messages = %d, want 4", got[1].MessageCount)
+	}
+	if got[1].LatestSummary != "nested task" {
+		t.Fatalf("rootA latest summary = %q, want nested task", got[1].LatestSummary)
+	}
+}
+
+func TestListCodexSessionsIncludesNestedSessionsForSavedProjectRoot(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	rootA := filepath.Join(t.TempDir(), "project-a")
+	nestedA := filepath.Join(rootA, "service")
+	loose := filepath.Join(t.TempDir(), "loose")
+	modified := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+
+	writeTestCodexGlobalState(t, codexHome, []string{rootA}, []string{rootA})
+	writeTestCodexSession(t, codexHome, "24", "a1", rootA, "root task", modified)
+	writeTestCodexSession(t, codexHome, "24", "a2", nestedA, "nested task", modified.Add(time.Minute))
+	writeTestCodexSession(t, codexHome, "24", "b1", loose, "loose task", modified.Add(2*time.Minute))
+
+	got, err := listCodexSessions(rootA, codexHome)
+	if err != nil {
+		t.Fatalf("listCodexSessions: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %#v", len(got), got)
+	}
+	if got[0].ID != "a2" || got[1].ID != "a1" {
+		t.Fatalf("session ids = [%s %s], want [a2 a1]", got[0].ID, got[1].ID)
+	}
+}
+
+func TestListCodexWorkdirsSkipsProjectlessThreadsFromGlobalState(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	rootA := filepath.Join(t.TempDir(), "project-a")
+	projectless := filepath.Join(t.TempDir(), "projectless")
+	hidden := filepath.Join(t.TempDir(), "hidden")
+	modified := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+
+	writeTestCodexGlobalStateWithProjectless(t, codexHome, []string{rootA}, []string{rootA}, []string{"p1"})
+	writeTestCodexSession(t, codexHome, "24", "a1", rootA, "saved task", modified)
+	writeTestCodexSession(t, codexHome, "24", "p1", projectless, "projectless task", modified.Add(time.Minute))
+	writeTestCodexSession(t, codexHome, "24", "h1", hidden, "hidden task", modified.Add(2*time.Minute))
+
+	got, err := listCodexWorkdirs(codexHome)
+	if err != nil {
+		t.Fatalf("listCodexWorkdirs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].Cwd != rootA {
+		t.Fatalf("first cwd = %q, want saved root %q", got[0].Cwd, rootA)
+	}
+	for _, wd := range got {
+		if wd.Cwd == projectless || wd.Cwd == hidden {
+			t.Fatalf("unexpected non-project workdir: %#v", wd)
+		}
+	}
+}
+
+func TestListCodexWorkdirsSkipsArchivedSessionFiles(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	projectA := filepath.Join(t.TempDir(), "project-a")
+	modified := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+
+	writeTestCodexSessionInRoot(t, codexHome, "archived_sessions", "24", "a1", projectA, "archived task", modified)
+
+	got, err := listCodexWorkdirs(codexHome)
+	if err != nil {
+		t.Fatalf("listCodexWorkdirs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len = %d, want 0: %#v", len(got), got)
+	}
+}
+
+func TestListCodexSessionsUsesAppIndexTitleAndDatabaseCwd(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	projectA := filepath.Join(t.TempDir(), "project-a")
+	updated := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
+
+	writeTestCodexSession(t, codexHome, "24", "a1", projectA, "jsonl prompt", updated.Add(-time.Hour))
+	writeTestCodexStateDB(t, codexHome, struct {
+		id          string
+		cwd         string
+		title       string
+		updatedAtMS int64
+		archived    bool
+	}{id: "a1", cwd: projectA, title: "database title", updatedAtMS: updated.UnixMilli()})
+	if err := os.WriteFile(filepath.Join(codexHome, "session_index.jsonl"), []byte(`{"id":"a1","thread_name":"app sidebar title","updated_at":"2026-05-24T13:30:00Z"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session index: %v", err)
+	}
+
+	got, err := listCodexSessions(projectA, codexHome)
+	if err != nil {
+		t.Fatalf("listCodexSessions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].Summary != "app sidebar title" {
+		t.Fatalf("summary = %q, want app sidebar title", got[0].Summary)
+	}
+	if got[0].MessageCount != 2 {
+		t.Fatalf("message count = %d, want 2", got[0].MessageCount)
+	}
+}
+
+func TestListCodexWorkdirsSkipsArchivedDatabaseThreads(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	projectA := filepath.Join(t.TempDir(), "project-a")
+	updated := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
+
+	writeTestCodexSession(t, codexHome, "24", "a1", projectA, "archived jsonl task", updated)
+	writeTestCodexStateDB(t, codexHome, struct {
+		id          string
+		cwd         string
+		title       string
+		updatedAtMS int64
+		archived    bool
+	}{id: "a1", cwd: projectA, title: "archived database title", updatedAtMS: updated.UnixMilli(), archived: true})
+
+	got, err := listCodexWorkdirs(codexHome)
+	if err != nil {
+		t.Fatalf("listCodexWorkdirs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len = %d, want 0: %#v", len(got), got)
+	}
+}
+
+func TestListCodexWorkdirsSkipsArchivedIndexOnlyThread(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), ".codex")
+	projectA := filepath.Join(t.TempDir(), "project-a")
+	updated := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC)
+
+	writeTestCodexStateDB(t, codexHome, struct {
+		id          string
+		cwd         string
+		title       string
+		updatedAtMS int64
+		archived    bool
+	}{id: "a1", cwd: projectA, title: "archived database title", updatedAtMS: updated.UnixMilli(), archived: true})
+	if err := os.WriteFile(filepath.Join(codexHome, "session_index.jsonl"), []byte(`{"id":"a1","thread_name":"archived app title","updated_at":"2026-05-24T13:30:00Z"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session index: %v", err)
+	}
+
+	got := listAllCodexSessions(codexHome)
+	if len(got) != 0 {
+		t.Fatalf("len = %d, want 0: %#v", len(got), got)
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -5496,7 +5496,7 @@ func (e *Engine) cmdWorkdirs(p Platform, msg *Message, args []string) {
 		sb.WriteString(e.i18n.Tf(MsgWorkdirsItem, marker, i+1, wd.Cwd, wd.SessionCount, wd.MessageCount, wd.ModifiedAt.Format("01-02 15:04")))
 	}
 	if totalPages > 1 {
-		sb.WriteString(fmt.Sprintf(e.i18n.T(MsgWorkdirsPageHint), page, totalPages))
+		fmt.Fprintf(&sb, e.i18n.T(MsgWorkdirsPageHint), page, totalPages)
 	}
 	sb.WriteString(e.i18n.T(MsgWorkdirsHint))
 	e.reply(p, msg.ReplyCtx, sb.String())

--- a/core/engine.go
+++ b/core/engine.go
@@ -4747,6 +4747,7 @@ var builtinCommands = []struct {
 }{
 	{[]string{"new"}, "new"},
 	{[]string{"list", "sessions"}, "list"},
+	{[]string{"workdirs", "workdirlist"}, "workdirs"},
 	{[]string{"switch"}, "switch"},
 	{[]string{"name", "rename"}, "name"},
 	{[]string{"current"}, "current"},
@@ -4916,6 +4917,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdNew(p, msg, args)
 	case "list":
 		e.cmdList(p, msg, args)
+	case "workdirs":
+		e.cmdWorkdirs(p, msg, args)
 	case "switch":
 		e.cmdSwitch(p, msg, args)
 	case "name":
@@ -5427,6 +5430,76 @@ func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 		return
 	}
 	e.replyWithCard(p, msg.ReplyCtx, card)
+}
+
+func (e *Engine) cmdWorkdirs(p Platform, msg *Message, args []string) {
+	agent, _, _, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+	lister, ok := agent.(WorkdirLister)
+	if !ok {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWorkdirsNotSupported))
+		return
+	}
+
+	page := 1
+	if len(args) > 0 {
+		if n, err := strconv.Atoi(args[0]); err == nil && n > 0 {
+			page = n
+		}
+	}
+
+	if supportsCards(p) {
+		e.replyWithCard(p, msg.ReplyCtx, e.renderWorkdirsCardSafe(msg.SessionKey, page))
+		return
+	}
+
+	workdirs, err := lister.ListWorkdirs(e.ctx)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWorkdirsError, err))
+		return
+	}
+	if len(workdirs) == 0 {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgWorkdirsEmpty))
+		return
+	}
+
+	total := len(workdirs)
+	totalPages := (total + listPageSize - 1) / listPageSize
+	if page > totalPages {
+		page = totalPages
+	}
+	start := (page - 1) * listPageSize
+	end := start + listPageSize
+	if end > total {
+		end = total
+	}
+
+	currentDir := ""
+	if sw, ok := agent.(WorkDirSwitcher); ok {
+		currentDir = sw.GetWorkDir()
+	}
+	var sb strings.Builder
+	if totalPages > 1 {
+		sb.WriteString(e.i18n.Tf(MsgWorkdirsTitlePaged, total, page, totalPages))
+	} else {
+		sb.WriteString(e.i18n.Tf(MsgWorkdirsTitle, total))
+	}
+	for i := start; i < end; i++ {
+		wd := workdirs[i]
+		marker := "◻"
+		if wd.Cwd == currentDir {
+			marker = "▶"
+		}
+		sb.WriteString(e.i18n.Tf(MsgWorkdirsItem, marker, i+1, wd.Cwd, wd.SessionCount, wd.MessageCount, wd.ModifiedAt.Format("01-02 15:04")))
+	}
+	if totalPages > 1 {
+		sb.WriteString(fmt.Sprintf(e.i18n.T(MsgWorkdirsPageHint), page, totalPages))
+	}
+	sb.WriteString(e.i18n.T(MsgWorkdirsHint))
+	e.reply(p, msg.ReplyCtx, sb.String())
 }
 
 func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
@@ -7017,6 +7090,15 @@ func (e *Engine) renderListCardSafe(sessionKey string, page int) *Card {
 	return card
 }
 
+// renderWorkdirsCardSafe wraps renderWorkdirsCard and returns an error card on failure.
+func (e *Engine) renderWorkdirsCardSafe(sessionKey string, page int) *Card {
+	card, err := e.renderWorkdirsCard(sessionKey, page)
+	if err != nil {
+		return e.simpleCard(strings.TrimSpace(e.i18n.Tf(MsgWorkdirsTitle, 0)), "red", err.Error())
+	}
+	return card
+}
+
 // renderDirCardSafe wraps renderDirCard and returns an error card on failure.
 func (e *Engine) renderDirCardSafe(sessionKey string, page int) *Card {
 	card, err := e.renderDirCard(sessionKey, page)
@@ -7352,6 +7434,7 @@ func helpCardGroups() []helpCardGroup {
 			items: []helpCardItem{
 				{command: "/new", action: "act:/new"},
 				{command: "/list", action: "nav:/list"},
+				{command: "/workdirs", action: "nav:/workdirs"},
 				{command: "/current", action: "nav:/current"},
 				{command: "/switch", action: "nav:/list"},
 				{command: "/search", action: "cmd:/search"},
@@ -9502,6 +9585,14 @@ func (e *Engine) handleCardNav(action string, sessionKey string) *Card {
 			}
 		}
 		return e.renderListCardSafe(sessionKey, page)
+	case "/workdirs":
+		page := 1
+		if args != "" {
+			if n, err := strconv.Atoi(args); err == nil && n > 0 {
+				page = n
+			}
+		}
+		return e.renderWorkdirsCardSafe(sessionKey, page)
 	case "/dir":
 		page := 1
 		if args != "" {
@@ -9815,6 +9906,30 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		errMsg, _ := e.dirApply(agent, sessions, ik, sessionKey, applyArgs)
 		if errMsg != "" {
 			slog.Debug("dir card action failed", "message", errMsg)
+		}
+
+	case "/workdirs":
+		fields := strings.Fields(args)
+		if len(fields) < 2 || fields[0] != "select" {
+			return
+		}
+		idx, err := strconv.Atoi(fields[1])
+		if err != nil || idx <= 0 {
+			return
+		}
+		agent, sessions := e.sessionContextForKey(sessionKey)
+		lister, ok := agent.(WorkdirLister)
+		if !ok {
+			return
+		}
+		workdirs, err := lister.ListWorkdirs(e.ctx)
+		if err != nil || idx > len(workdirs) {
+			return
+		}
+		ik := e.interactiveKeyForSessionKey(sessionKey)
+		errMsg, _ := e.dirApply(agent, sessions, ik, sessionKey, []string{workdirs[idx-1].Cwd})
+		if errMsg != "" {
+			slog.Debug("workdirs card action failed", "message", errMsg)
 		}
 
 	case "/stop":
@@ -10601,6 +10716,72 @@ func dirCardTruncPath(absPath string) string {
 		return absPath
 	}
 	return string(r[:53]) + "…"
+}
+
+func (e *Engine) renderWorkdirsCard(sessionKey string, page int) (*Card, error) {
+	agent, _ := e.sessionContextForKey(sessionKey)
+	lister, ok := agent.(WorkdirLister)
+	if !ok {
+		return nil, fmt.Errorf("%s", e.i18n.T(MsgWorkdirsNotSupported))
+	}
+	workdirs, err := lister.ListWorkdirs(e.ctx)
+	if err != nil {
+		return nil, fmt.Errorf(e.i18n.T(MsgWorkdirsError), err)
+	}
+	if len(workdirs) == 0 {
+		return e.simpleCard(strings.TrimSpace(e.i18n.Tf(MsgWorkdirsTitle, 0)), "turquoise", e.i18n.T(MsgWorkdirsEmpty)), nil
+	}
+
+	currentDir := ""
+	if sw, ok := agent.(WorkDirSwitcher); ok {
+		currentDir = sw.GetWorkDir()
+	}
+
+	total := len(workdirs)
+	totalPages := (total + listPageSize - 1) / listPageSize
+	if page < 1 {
+		page = 1
+	}
+	if page > totalPages {
+		page = totalPages
+	}
+	start := (page - 1) * listPageSize
+	end := start + listPageSize
+	if end > total {
+		end = total
+	}
+
+	var title string
+	if totalPages > 1 {
+		title = strings.TrimSpace(e.i18n.Tf(MsgWorkdirsTitlePaged, total, page, totalPages))
+	} else {
+		title = strings.TrimSpace(e.i18n.Tf(MsgWorkdirsTitle, total))
+	}
+	cb := NewCard().Title(title, "turquoise")
+	for i := start; i < end; i++ {
+		wd := workdirs[i]
+		marker := "◻"
+		btnType := "default"
+		if wd.Cwd == currentDir {
+			marker = "▶"
+			btnType = "primary"
+		}
+		displayPath := dirCardTruncPath(wd.Cwd)
+		desc := e.i18n.Tf(MsgWorkdirsItem, marker, i+1, displayPath, wd.SessionCount, wd.MessageCount, wd.ModifiedAt.Format("01-02 15:04"))
+		cb.ListItemBtn(strings.TrimSpace(desc), fmt.Sprintf("#%d", i+1), btnType, fmt.Sprintf("act:/workdirs select %d", i+1))
+	}
+
+	var navBtns []CardButton
+	if page > 1 {
+		navBtns = append(navBtns, e.cardPrevButton(fmt.Sprintf("nav:/workdirs %d", page-1)))
+	}
+	navBtns = append(navBtns, e.cardBackButton())
+	if page < totalPages {
+		navBtns = append(navBtns, e.cardNextButton(fmt.Sprintf("nav:/workdirs %d", page+1)))
+	}
+	cb.Buttons(navBtns...)
+	cb.Note(strings.TrimSpace(e.i18n.T(MsgWorkdirsHint)))
+	return cb.Build(), nil
 }
 
 func (e *Engine) renderDirCard(sessionKey string, page int) (*Card, error) {

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -218,6 +218,14 @@ const (
 	MsgListPageHint              MsgKey = "list_page_hint"
 	MsgListSwitchHint            MsgKey = "list_switch_hint"
 	MsgListError                 MsgKey = "list_error"
+	MsgWorkdirsTitle             MsgKey = "workdirs_title"
+	MsgWorkdirsTitlePaged        MsgKey = "workdirs_title_paged"
+	MsgWorkdirsEmpty             MsgKey = "workdirs_empty"
+	MsgWorkdirsNotSupported      MsgKey = "workdirs_not_supported"
+	MsgWorkdirsError             MsgKey = "workdirs_error"
+	MsgWorkdirsItem              MsgKey = "workdirs_item"
+	MsgWorkdirsPageHint          MsgKey = "workdirs_page_hint"
+	MsgWorkdirsHint              MsgKey = "workdirs_hint"
 	MsgHistoryEmpty              MsgKey = "history_empty"
 	MsgNameUsage                 MsgKey = "name_usage"
 	MsgNameSet                   MsgKey = "name_set"
@@ -521,6 +529,7 @@ const (
 
 	MsgBuiltinCmdNew       MsgKey = "new"
 	MsgBuiltinCmdList      MsgKey = "list"
+	MsgBuiltinCmdWorkdirs  MsgKey = "workdirs"
 	MsgBuiltinCmdSearch    MsgKey = "search"
 	MsgBuiltinCmdSwitch    MsgKey = "switch"
 	MsgBuiltinCmdDelete    MsgKey = "delete"
@@ -943,6 +952,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangEnglish: "📖 Available Commands\n\n" +
 			"/new [name]\n  Start a new session\n\n" +
 			"/list\n  List agent sessions\n\n" +
+			"/workdirs\n  List switchable project directories\n\n" +
 			"/search <keyword>\n  Search sessions by name or ID\n\n" +
 			"/switch <number>\n  Resume a session by its list number\n\n" +
 			"/delete <number>|1,2,3|3-7|1,3-5,8\n  Delete sessions by list number(s)\n\n" +
@@ -986,6 +996,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangChinese: "📖 可用命令\n\n" +
 			"/new [名称]\n  创建新会话\n\n" +
 			"/list\n  列出 Agent 会话列表\n\n" +
+			"/workdirs\n  列出可切换的项目目录\n\n" +
 			"/search <关键词>\n  搜索会话名称或 ID\n\n" +
 			"/switch <序号>\n  按列表序号切换会话\n\n" +
 			"/delete <序号>|1,2,3|3-7|1,3-5,8\n  按列表序号批量/单个删除会话\n\n" +
@@ -1029,6 +1040,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "📖 可用命令\n\n" +
 			"/new [名稱]\n  建立新會話\n\n" +
 			"/list\n  列出 Agent 會話列表\n\n" +
+			"/workdirs\n  列出可切換的專案目錄\n\n" +
 			"/search <關鍵詞>\n  搜尋會話名稱或 ID\n\n" +
 			"/switch <序號>\n  按列表序號切換會話\n\n" +
 			"/delete <序號>|1,2,3|3-7|1,3-5,8\n  按列表序號批量/單筆刪除會話\n\n" +
@@ -1071,6 +1083,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese: "📖 利用可能なコマンド\n\n" +
 			"/new [名前]\n  新しいセッションを開始\n\n" +
 			"/list\n  エージェントセッション一覧\n\n" +
+			"/workdirs\n  切り替え可能なプロジェクトディレクトリ一覧\n\n" +
 			"/switch <番号>\n  リスト番号でセッションを切り替え\n\n" +
 			"/delete <番号>|1,2,3|3-7|1,3-5,8\n  リスト番号でセッションを単体/複数削除\n\n" +
 			"/name [番号] <名前>\n  セッションに名前を付ける\n\n" +
@@ -1112,6 +1125,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish: "📖 Comandos disponibles\n\n" +
 			"/new [nombre]\n  Iniciar una nueva sesión\n\n" +
 			"/list\n  Listar sesiones del agente\n\n" +
+			"/workdirs\n  Listar directorios de proyecto conmutables\n\n" +
 			"/switch <número>\n  Reanudar sesión por su número en la lista\n\n" +
 			"/delete <número>|1,2,3|3-7|1,3-5,8\n  Eliminar una o varias sesiones por número de lista\n\n" +
 			"/name [número] <texto>\n  Nombrar una sesión para fácil identificación\n\n" +
@@ -1162,6 +1176,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangEnglish: "**Session Management**\n" +
 			"/new [name] — Start a new session\n" +
 			"/list — List agent sessions\n" +
+			"/workdirs — List switchable project directories\n" +
 			"/search <keyword> — Search sessions\n" +
 			"/switch <number> — Resume a session\n" +
 			"/delete <number>|1,2,3|3-7|1,3-5,8 — Delete session(s)\n" +
@@ -1171,6 +1186,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangChinese: "**会话管理**\n" +
 			"/new [名称] — 创建新会话\n" +
 			"/list — 列出会话列表\n" +
+			"/workdirs — 列出可切换的项目目录\n" +
 			"/search <关键词> — 搜索会话\n" +
 			"/switch <序号> — 切换会话\n" +
 			"/delete <序号>|1,2,3|3-7|1,3-5,8 — 删除会话\n" +
@@ -1180,6 +1196,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "**會話管理**\n" +
 			"/new [名稱] — 建立新會話\n" +
 			"/list — 列出會話列表\n" +
+			"/workdirs — 列出可切換的專案目錄\n" +
 			"/search <關鍵詞> — 搜尋會話\n" +
 			"/switch <序號> — 切換會話\n" +
 			"/delete <序號>|1,2,3|3-7|1,3-5,8 — 刪除會話\n" +
@@ -1189,6 +1206,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese: "**セッション管理**\n" +
 			"/new [名前] — 新しいセッションを開始\n" +
 			"/list — セッション一覧\n" +
+			"/workdirs — 切り替え可能なプロジェクトディレクトリ一覧\n" +
 			"/search <キーワード> — セッション検索\n" +
 			"/switch <番号> — セッション切り替え\n" +
 			"/delete <番号>|1,2,3|3-7|1,3-5,8 — セッション削除\n" +
@@ -1198,6 +1216,7 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish: "**Gestión de sesiones**\n" +
 			"/new [nombre] — Iniciar nueva sesión\n" +
 			"/list — Listar sesiones\n" +
+			"/workdirs — Listar directorios de proyecto conmutables\n" +
 			"/search <keyword> — Buscar sesiones\n" +
 			"/switch <número> — Reanudar sesión\n" +
 			"/delete <número>|1,2,3|3-7|1,3-5,8 — Eliminar sesión(es)\n" +
@@ -1396,6 +1415,62 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "❌ 取得會話列表失敗: %v",
 		LangJapanese:           "❌ セッション一覧の取得に失敗しました: %v",
 		LangSpanish:            "❌ Error al listar sesiones: %v",
+	},
+	MsgWorkdirsTitle: {
+		LangEnglish:            "**Agent Workdirs** (%d)\n\n",
+		LangChinese:            "**Agent 项目目录** (%d)\n\n",
+		LangTraditionalChinese: "**Agent 專案目錄** (%d)\n\n",
+		LangJapanese:           "**エージェント作業ディレクトリ** (%d)\n\n",
+		LangSpanish:            "**Directorios del agente** (%d)\n\n",
+	},
+	MsgWorkdirsTitlePaged: {
+		LangEnglish:            "**Agent Workdirs** (%d) · Page %d/%d\n\n",
+		LangChinese:            "**Agent 项目目录** (%d) · 第 %d/%d 页\n\n",
+		LangTraditionalChinese: "**Agent 專案目錄** (%d) · 第 %d/%d 頁\n\n",
+		LangJapanese:           "**エージェント作業ディレクトリ** (%d) · %d/%d ページ\n\n",
+		LangSpanish:            "**Directorios del agente** (%d) · Página %d/%d\n\n",
+	},
+	MsgWorkdirsEmpty: {
+		LangEnglish:            "No agent workdirs found.",
+		LangChinese:            "未找到 Agent 项目目录。",
+		LangTraditionalChinese: "未找到 Agent 專案目錄。",
+		LangJapanese:           "エージェント作業ディレクトリが見つかりません。",
+		LangSpanish:            "No se encontraron directorios del agente.",
+	},
+	MsgWorkdirsNotSupported: {
+		LangEnglish:            "Current agent does not support global workdir listing.",
+		LangChinese:            "当前 Agent 不支持全局项目目录列表。",
+		LangTraditionalChinese: "目前 Agent 不支援全域專案目錄列表。",
+		LangJapanese:           "現在のエージェントは全体の作業ディレクトリ一覧に対応していません。",
+		LangSpanish:            "El agente actual no admite listar directorios globales.",
+	},
+	MsgWorkdirsError: {
+		LangEnglish:            "❌ Failed to list workdirs: %v",
+		LangChinese:            "❌ 获取项目目录列表失败: %v",
+		LangTraditionalChinese: "❌ 取得專案目錄列表失敗: %v",
+		LangJapanese:           "❌ 作業ディレクトリ一覧の取得に失敗しました: %v",
+		LangSpanish:            "❌ Error al listar directorios: %v",
+	},
+	MsgWorkdirsItem: {
+		LangEnglish:            "%s **%d.** `%s` · **%d** sessions · **%d** msgs · %s\n",
+		LangChinese:            "%s **%d.** `%s` · **%d** 会话 · **%d** 消息 · %s\n",
+		LangTraditionalChinese: "%s **%d.** `%s` · **%d** 會話 · **%d** 訊息 · %s\n",
+		LangJapanese:           "%s **%d.** `%s` · **%d** セッション · **%d** メッセージ · %s\n",
+		LangSpanish:            "%s **%d.** `%s` · **%d** sesiones · **%d** mensajes · %s\n",
+	},
+	MsgWorkdirsPageHint: {
+		LangEnglish:            "\n\nPage %d/%d \n\n`/workdirs <page>` for more\n",
+		LangChinese:            "\n\n第 %d/%d 页 \n\n`/workdirs <页码>` 翻页\n",
+		LangTraditionalChinese: "\n\n第 %d/%d 頁 \n\n`/workdirs <頁碼>` 翻頁\n",
+		LangJapanese:           "\n\n%d/%d ページ \n\n`/workdirs <ページ>` で移動\n",
+		LangSpanish:            "\n\nPágina %d/%d \n\n`/workdirs <página>` para más\n",
+	},
+	MsgWorkdirsHint: {
+		LangEnglish:            "\n`/workdirs <page>` to browse; tap a button or run `/dir <path>` to switch.",
+		LangChinese:            "\n`/workdirs <页码>` 翻页；点按钮切换目录，也可手动发 `/dir <路径>`。",
+		LangTraditionalChinese: "\n`/workdirs <頁碼>` 翻頁；點按鈕切換目錄，也可手動發 `/dir <路徑>`。",
+		LangJapanese:           "\n`/workdirs <ページ>` で移動。ボタンを押すか `/dir <path>` を送信してください。",
+		LangSpanish:            "\n`/workdirs <página>` para navegar; toca un botón o usa `/dir <ruta>`.",
 	},
 	MsgHistoryEmpty: {
 		LangEnglish:            "No history in current session.",
@@ -3319,6 +3394,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "列出 Agent 會話列表",
 		LangJapanese:           "エージェントセッション一覧",
 		LangSpanish:            "Listar sesiones del agente",
+	},
+	MsgBuiltinCmdWorkdirs: {
+		LangEnglish:            "List switchable project directories",
+		LangChinese:            "列出可切换的项目目录",
+		LangTraditionalChinese: "列出可切換的專案目錄",
+		LangJapanese:           "切り替え可能なプロジェクトディレクトリ一覧",
+		LangSpanish:            "Listar directorios de proyecto conmutables",
 	},
 	MsgBuiltinCmdSearch: {
 		LangEnglish:            "Search sessions by name or ID, arg: <keyword>",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -319,6 +319,12 @@ type HistoryProvider interface {
 	GetSessionHistory(ctx context.Context, sessionID string, limit int) ([]HistoryEntry, error)
 }
 
+// WorkdirLister is an optional interface for agents that can enumerate all
+// known session working directories, not just the current one.
+type WorkdirLister interface {
+	ListWorkdirs(ctx context.Context) ([]AgentWorkdirInfo, error)
+}
+
 // ProviderConfig holds API provider settings for an agent.
 type ProviderConfig struct {
 	Name     string

--- a/core/message.go
+++ b/core/message.go
@@ -245,4 +245,14 @@ type AgentSessionInfo struct {
 	MessageCount int
 	ModifiedAt   time.Time
 	GitBranch    string
+	Cwd          string
+}
+
+// AgentWorkdirInfo summarizes agent sessions grouped by working directory.
+type AgentWorkdirInfo struct {
+	Cwd           string
+	SessionCount  int
+	MessageCount  int
+	ModifiedAt    time.Time
+	LatestSummary string
 }

--- a/core/workdirs.go
+++ b/core/workdirs.go
@@ -1,0 +1,136 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// NormalizeWorkdirPath returns a stable absolute path for comparing agent
+// working directories.
+func NormalizeWorkdirPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = filepath.Clean(path)
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return path
+}
+
+// WorkdirContains reports whether child is root or under root.
+func WorkdirContains(root, child string) bool {
+	root = NormalizeWorkdirPath(root)
+	child = NormalizeWorkdirPath(child)
+	if root == "" || child == "" {
+		return false
+	}
+	if root == child {
+		return true
+	}
+	rel, err := filepath.Rel(root, child)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+// WorkdirRootForCwd returns the most specific project root that contains cwd.
+func WorkdirRootForCwd(cwd string, projectRoots []string) string {
+	cwd = NormalizeWorkdirPath(cwd)
+	var best string
+	for _, root := range projectRoots {
+		root = NormalizeWorkdirPath(root)
+		if WorkdirContains(root, cwd) && len(root) > len(best) {
+			best = root
+		}
+	}
+	return best
+}
+
+// MatchSessionWorkdir reports whether a session cwd belongs to the requested
+// filter. When filterIsProjectRoot is true, nested session directories match.
+func MatchSessionWorkdir(sessionCwd, filterCwd string, filterIsProjectRoot bool) bool {
+	filterCwd = NormalizeWorkdirPath(filterCwd)
+	if filterCwd == "" {
+		return true
+	}
+	cwd := NormalizeWorkdirPath(sessionCwd)
+	if cwd == "" {
+		return false
+	}
+	if filterIsProjectRoot {
+		return WorkdirContains(filterCwd, cwd)
+	}
+	return cwd == filterCwd
+}
+
+// GroupAgentWorkdirs summarizes sessions by cwd. If projectRoots is provided,
+// sessions under a root are grouped by the root and roots are emitted in the
+// provider's order before ungrouped workdirs sorted by latest activity.
+func GroupAgentWorkdirs(sessions []AgentSessionInfo, projectRoots []string) []AgentWorkdirInfo {
+	roots := normalizeUniqueWorkdirRoots(projectRoots)
+	byCwd := make(map[string]*AgentWorkdirInfo)
+	for _, info := range sessions {
+		cwd := NormalizeWorkdirPath(info.Cwd)
+		if cwd == "" {
+			continue
+		}
+		groupCwd := WorkdirRootForCwd(cwd, roots)
+		if groupCwd == "" {
+			groupCwd = cwd
+		}
+		group := byCwd[groupCwd]
+		if group == nil {
+			group = &AgentWorkdirInfo{Cwd: groupCwd}
+			byCwd[groupCwd] = group
+		}
+		group.SessionCount++
+		group.MessageCount += info.MessageCount
+		if info.ModifiedAt.After(group.ModifiedAt) {
+			group.ModifiedAt = info.ModifiedAt
+			group.LatestSummary = info.Summary
+		}
+	}
+
+	workdirs := make([]AgentWorkdirInfo, 0, len(byCwd))
+	seen := make(map[string]struct{}, len(byCwd))
+	for _, root := range roots {
+		if info := byCwd[root]; info != nil {
+			workdirs = append(workdirs, *info)
+			seen[root] = struct{}{}
+		}
+	}
+	var ungrouped []AgentWorkdirInfo
+	for cwd, info := range byCwd {
+		if _, ok := seen[cwd]; ok {
+			continue
+		}
+		ungrouped = append(ungrouped, *info)
+	}
+	sort.Slice(ungrouped, func(i, j int) bool {
+		return ungrouped[i].ModifiedAt.After(ungrouped[j].ModifiedAt)
+	})
+	workdirs = append(workdirs, ungrouped...)
+	return workdirs
+}
+
+func normalizeUniqueWorkdirRoots(projectRoots []string) []string {
+	roots := make([]string, 0, len(projectRoots))
+	seen := make(map[string]struct{}, len(projectRoots))
+	for _, raw := range projectRoots {
+		root := NormalizeWorkdirPath(raw)
+		if root == "" {
+			continue
+		}
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		roots = append(roots, root)
+	}
+	return roots
+}

--- a/core/workdirs_test.go
+++ b/core/workdirs_test.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGroupAgentWorkdirsGroupsByCwd(t *testing.T) {
+	projectA := filepath.Join(t.TempDir(), "project-a")
+	projectB := filepath.Join(t.TempDir(), "project-b")
+	newer := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	older := newer.Add(-time.Hour)
+
+	got := GroupAgentWorkdirs([]AgentSessionInfo{
+		{ID: "a1", Cwd: projectA, Summary: "first", MessageCount: 2, ModifiedAt: older},
+		{ID: "a2", Cwd: projectA, Summary: "latest", MessageCount: 3, ModifiedAt: newer},
+		{ID: "b1", Cwd: projectB, Summary: "other", MessageCount: 1, ModifiedAt: older.Add(-time.Hour)},
+	}, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2: %#v", len(got), got)
+	}
+	if got[0].Cwd != projectA {
+		t.Fatalf("first cwd = %q, want %q", got[0].Cwd, projectA)
+	}
+	if got[0].SessionCount != 2 || got[0].MessageCount != 5 {
+		t.Fatalf("first counts = %d/%d, want 2/5", got[0].SessionCount, got[0].MessageCount)
+	}
+	if got[0].LatestSummary != "latest" {
+		t.Fatalf("latest summary = %q, want latest", got[0].LatestSummary)
+	}
+	if got[1].Cwd != projectB {
+		t.Fatalf("second cwd = %q, want %q", got[1].Cwd, projectB)
+	}
+}
+
+func TestGroupAgentWorkdirsGroupsByProviderRoots(t *testing.T) {
+	rootA := filepath.Join(t.TempDir(), "project-a")
+	nestedA := filepath.Join(rootA, "service")
+	rootB := filepath.Join(t.TempDir(), "project-b")
+	loose := filepath.Join(t.TempDir(), "loose")
+	newer := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+
+	got := GroupAgentWorkdirs([]AgentSessionInfo{
+		{ID: "a1", Cwd: rootA, Summary: "root", MessageCount: 2, ModifiedAt: newer.Add(-time.Hour)},
+		{ID: "a2", Cwd: nestedA, Summary: "nested", MessageCount: 2, ModifiedAt: newer},
+		{ID: "b1", Cwd: rootB, Summary: "b", MessageCount: 2, ModifiedAt: newer.Add(-2 * time.Hour)},
+		{ID: "c1", Cwd: loose, Summary: "loose", MessageCount: 2, ModifiedAt: newer.Add(time.Hour)},
+	}, []string{rootB, rootA})
+
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3: %#v", len(got), got)
+	}
+	if got[0].Cwd != rootB || got[1].Cwd != rootA || got[2].Cwd != loose {
+		t.Fatalf("cwd order = [%q %q %q], want provider roots then loose", got[0].Cwd, got[1].Cwd, got[2].Cwd)
+	}
+	if got[1].SessionCount != 2 || got[1].LatestSummary != "nested" {
+		t.Fatalf("rootA = %#v, want 2 sessions with nested latest", got[1])
+	}
+}
+
+func TestMatchSessionWorkdirProjectRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "project")
+	nested := filepath.Join(root, "service")
+
+	if !MatchSessionWorkdir(nested, root, true) {
+		t.Fatalf("nested session should match project root")
+	}
+	if MatchSessionWorkdir(nested, root, false) {
+		t.Fatalf("nested session should not match exact cwd")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a project-aware `/workdirs` command through an optional `WorkdirLister` agent capability, and implements it for the Codex agent using Codex Desktop state.

For Codex, the command now:

- reads Codex Desktop saved workspace roots from `.codex-global-state.json`
- groups nested session cwd values under their saved project root
- filters out sessions outside saved Codex Desktop projects when sidebar state is available
- merges Codex JSONL transcripts with app session index/database metadata
- skips archived session files and archived database/index threads
- lets card users switch directories by tapping a listed workdir, reusing existing `/dir` state-reset behavior

Claude Code intentionally does not implement `WorkdirLister`; it does not have a reliable project directory list distinct from historical session cwd values.

## Test plan

- `go test ./agent/codex`
- `go test ./core -run 'TestGroupAgentWorkdirs|TestMatchSessionWorkdir|Workdirs|workdirs|Test.*Workdir'`
- `git diff --check`

`go test ./...` was also attempted from a clean GitHub checkout, but it is blocked before full completion by the existing missing `web/dist` embed setup in `cmd/cc-connect`/`web`; after continuing, unrelated existing core reply-footer path truncation tests also fail on current `main`.
