### PR TITLE
fix(wecom): strip multi-token @-mentions before slash commands

### DIFF
--- a/platform/wecom/mention_strip.go
+++ b/platform/wecom/mention_strip.go
@@ -1,6 +1,10 @@
 package wecom
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
 
 // stripWeComAtMentions removes @<botId> / ＠<botId> segments so group replies like
 // "允许 @机器人" still match engine permission keywords (#98). Only affects wecom.
@@ -60,6 +64,19 @@ func removeAllEqualFold(s, sub string) string {
 	}
 }
 
+// stripLeadingDisplayMentionCommand removes any leading @-mentions before a
+// slash-command (/) or shell-bang (!) marker. WeCom's WS aibot callback does
+// not deliver structured @-mention metadata, so the bot's display name is
+// embedded directly in Text.Content. The previous implementation used
+// strings.Fields(s)[0] as the mention token, which silently failed when:
+//   - the bot's display name contains spaces (e.g. "Claude Code"),
+//   - the user @-mentions multiple parties before the command
+//     (e.g. "@张三 @机器人 /list"),
+//   - or the mention token contains punctuation other than whitespace.
+// The fix scans for the first '/' or '!' that appears at a token boundary
+// (i.e. preceded by whitespace) and treats everything before it as the
+// mention prefix. Matching at a token boundary avoids false positives on
+// things like "https://", "1/2", or display names containing those chars.
 func stripLeadingDisplayMentionCommand(s string) string {
 	if s == "" {
 		return s
@@ -67,13 +84,17 @@ func stripLeadingDisplayMentionCommand(s string) string {
 	if !strings.HasPrefix(s, "@") && !strings.HasPrefix(s, "＠") {
 		return s
 	}
-	fields := strings.Fields(s)
-	if len(fields) < 2 {
-		return s
-	}
-	rest := strings.TrimSpace(strings.TrimPrefix(s, fields[0]))
-	if strings.HasPrefix(rest, "/") || strings.HasPrefix(rest, "!") {
-		return rest
+	for i, r := range s {
+		if r != '/' && r != '!' {
+			continue
+		}
+		if i == 0 {
+			return s
+		}
+		prev, _ := utf8.DecodeLastRuneInString(s[:i])
+		if unicode.IsSpace(prev) {
+			return strings.TrimSpace(s[i:])
+		}
 	}
 	return s
 }

--- a/platform/wecom/mention_strip_test.go
+++ b/platform/wecom/mention_strip_test.go
@@ -20,6 +20,19 @@ func TestStripWeComAtMentions(t *testing.T) {
 		{"display mention before slash command", "@小口不休息 /whoami", []string{"robot01"}, "/whoami"},
 		{"display mention before bang command", "＠小口不休息 !pwd", []string{"robot01"}, "!pwd"},
 		{"display mention before normal text preserved", "@小口不休息 你好", []string{"robot01"}, "@小口不休息 你好"},
+		// --- Regression tests: see issue on @bot + /command in group chat. ---
+		// Display name with spaces ("Claude Code"): old strip took fields[0]="@Claude",
+		// leaving "Code /list" which doesn't start with "/", so /list was never dispatched.
+		{"display name with spaces before slash", "@Claude Code /list", []string{"robot01"}, "/list"},
+		{"display name with spaces before bang", "@Claude Code !pwd", []string{"robot01"}, "!pwd"},
+		// Multiple @-mentions before the command: old strip only removed the first token.
+		{"multiple mentions before slash", "@张三 @机器人 /list", []string{"robot01"}, "/list"},
+		{"multiple mentions fullwidth before slash", "＠张三 ＠机器人 /list", []string{"robot01"}, "/list"},
+		// Display name containing punctuation that strings.Fields wouldn't split on cleanly.
+		{"display name with bang inside before slash", "@Wow!Bot /list", []string{"robot01"}, "/list"},
+		// Safety: don't strip when the slash isn't at a token boundary (e.g. URLs).
+		{"url after mention preserved", "@bot https://example.com", []string{"robot01"}, "@bot https://example.com"},
+		{"path-like text without slash command preserved", "@bot 1/2 是分数", []string{"robot01"}, "@bot 1/2 是分数"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
 Fixes #1224

  ## 问题

  企业微信群聊中 `@机器人 /list` 等内置命令不生效，被当成自然语言转发给底层 agent。详细根因见 #1224。

  ## 修复

  `platform/wecom/mention_strip.go` 的 `stripLeadingDisplayMentionCommand` 原本用 `strings.Fields(s)[0]` 取第一个 token 作为 mention，假设显示名无空格、且只有一个
  @。改为**正向扫描第一个位于词边界（前一字符为 unicode 空白）的 `/` 或 `!`**，把它前面的整段视作 mention 前缀剥掉。

  跟飞书的 `larkim.MentionEvent`（结构化）不同，企业微信 WS aibot 协议只能从裸文本里取显示名，所以这里只能靠启发式 —— 但词边界判断保证不会误伤 `https://`、`1/2` 这类 token 内部的 `/`、`!`。

  ## 测试

  新增 6 个用例（`platform/wecom/mention_strip_test.go`）：

  | 用例 | 输入 | 期望 |
  |---|---|---|
  | 显示名带空格 | `@Claude Code /list` | `/list` |
  | 多个 @ | `@张三 @机器人 /list` | `/list` |
  | 全角多个 @ | `＠张三 ＠机器人 /list` | `/list` |
  | 显示名含 `!` | `@Wow!Bot /list` | `/list` |
  | URL 不被误剥 | `@bot https://example.com` | （原样保留） |
  | 分数不被误剥 | `@bot 1/2 是分数` | （原样保留） |

  ```bash
  go test ./platform/wecom/ -run TestStripWeComAtMentions -v
  ```

  原有测试用例全部保持通过。

  ## 影响范围

  只改 `platform/wecom/`，对 `wecom.go`（webhook 路径）、`websocket.go` / `websocket_media.go`（WS aibot 路径）所有 4 处 `stripWeComAtMentions` 调用点都生效。其他平台（feishu / dingtalk /
  slack 等）不受影响。