### PR TITLE
fix(core): remove leftover merge conflict markers in engine_test.go

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -9621,13 +9621,6 @@ func TestResolveLocalDirPath_AcceptsSubdir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-<<<<<<< HEAD
-	want, err := filepath.EvalSymlinks(sub)
-	if err != nil {
-		t.Fatalf("resolve expected path: %v", err)
-	}
-=======
->>>>>>> pr-1202
 	if got != want {
 		t.Fatalf("expected %q, got %q", want, got)
 	}


### PR DESCRIPTION
Title

  fix(core): remove leftover merge conflict markers in engine_test.go

  Body

  `core/engine_test.go` 里残留了未解决的 git 合并冲突标记（来自 #1202 的合并 6f4e5f6b），导致 main 编译不过，所有 PR 的 CI 都挂了，比如 #1225。

  报错：
  core/engine_test.go:9624:1: syntax error: unexpected <<
  core/engine_test.go:9629:1: expected statement, found '=='

  直接删掉冲突段就行 —— `want` 在前面 5 行已经定义过了，HEAD 侧用 `:=` 重声明本身就会编译报错。

  只删 7 行，零业务逻辑改动。