### PR TITLE
feat: Feishu worktree-per-topic routing, idle session sweep, and fixes

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -34,7 +34,9 @@ func init() {
 //   - "auto":              Claude's automatic permission classifier
 //   - "bypassPermissions": auto-approve everything (alias: yolo)
 type Agent struct {
-	workDir          string
+	workDir            string
+	worktreePerSession bool     // route each session key to its own git worktree (opt-in)
+	worktreeCache      sync.Map // slug -> resolved worktree path
 	cliBin           string   // CLI binary name or path (default: "claude")
 	cliExtraArgs     []string // extra args parsed from cli_path (e.g. ["code", "-t", "foo"])
 	configEnv        []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
@@ -211,8 +213,11 @@ func New(opts map[string]any) (core.Agent, error) {
 		}
 	}
 
+	worktreePerSession, _ := opts["worktree_per_session"].(bool)
+
 	return &Agent{
-		workDir:          workDir,
+		workDir:            workDir,
+		worktreePerSession: worktreePerSession,
 		cliBin:           cliBin,
 		cliExtraArgs:     cliExtraArgs,
 		cliArgsFlag:      cliArgsFlag,
@@ -417,6 +422,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	effort := a.reasoningEffort
 	workDir := a.workDir
+	wps := a.worktreePerSession
 	mode := a.mode
 	extraEnv := a.runtimeEnvLocked()
 
@@ -440,6 +446,23 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	// (verbose emits non-JSON text to stdout that corrupts the JSON stream).
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
+
+	// Per-session worktree routing (opt-in). Each session key (e.g. a Feishu
+	// chat topic) gets its own git worktree + isolated DB/ports, created on
+	// first use and reused after. Computed from the immutable session key in
+	// ctx, so concurrent topics never race on shared work_dir state.
+	if wps {
+		if key := core.SessionKeyFromContext(ctx); key != "" {
+			if wd, err := a.ensureWorktree(workDir, key); err != nil {
+				slog.Error("claudecode: worktree routing failed, using shared work_dir",
+					"session_key", key, "error", err)
+			} else {
+				workDir = wd
+				// 活动标记:每条消息刷新 mtime,供 worktree reaper 判闲置(超时只清真没人动的)
+				_ = os.WriteFile(filepath.Join(wd, ".cc-last-active"), []byte(time.Now().Format(time.RFC3339)), 0o644)
+			}
+		}
+	}
 
 	return newClaudeSession(ctx, workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, mode, systemPrompt, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
 }

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -43,6 +43,10 @@ type claudeSession struct {
 	done            chan struct{}
 	alive           atomic.Bool
 
+	// toolNames maps a tool_use id → tool name, so a later tool_result (which
+	// only carries tool_use_id) can be labeled with the tool it came from.
+	toolNames sync.Map
+
 	// activeModel stores the model id reported by the CLI's init event (e.g.
 	// "claude-opus-4-7[1m]"). It may be empty if the init event hasn't
 	// carried a model field yet; callers should fall back to the Agent's
@@ -446,6 +450,9 @@ func (cs *claudeSession) handleAssistant(raw map[string]any) {
 			if toolName == "AskUserQuestion" {
 				continue
 			}
+			if id, _ := item["id"].(string); id != "" {
+				cs.toolNames.Store(id, toolName)
+			}
 			inputSummary := summarizeInput(toolName, item["input"])
 			evt := core.Event{Type: core.EventToolUse, ToolName: toolName, ToolInput: inputSummary}
 			select {
@@ -492,11 +499,56 @@ func (cs *claudeSession) handleUser(raw map[string]any) {
 		contentType, _ := item["type"].(string)
 		if contentType == "tool_result" {
 			isError, _ := item["is_error"].(bool)
+			resultText := toolResultText(item["content"])
+			toolName := ""
+			if id, _ := item["tool_use_id"].(string); id != "" {
+				if v, ok := cs.toolNames.LoadAndDelete(id); ok {
+					toolName, _ = v.(string)
+				}
+			}
+			success := !isError
+			evt := core.Event{
+				Type:        core.EventToolResult,
+				ToolName:    toolName,
+				ToolResult:  resultText,
+				Content:     resultText,
+				ToolSuccess: &success,
+			}
+			select {
+			case cs.events <- evt:
+			case <-cs.ctx.Done():
+				return
+			}
 			if isError {
-				result, _ := item["content"].(string)
-				slog.Debug("claudeSession: tool error", "content", result)
+				slog.Debug("claudeSession: tool error", "content", resultText)
 			}
 		}
+	}
+}
+
+// toolResultText extracts displayable text from a tool_result's content, which
+// claude streams as either a plain string or an array of content blocks.
+func toolResultText(v any) string {
+	switch c := v.(type) {
+	case string:
+		return c
+	case []any:
+		var b strings.Builder
+		for _, blk := range c {
+			m, ok := blk.(map[string]any)
+			if !ok {
+				continue
+			}
+			if t, _ := m["text"].(string); t != "" {
+				if b.Len() > 0 {
+					b.WriteString("\n")
+				}
+				b.WriteString(t)
+			}
+		}
+		return b.String()
+	default:
+		return ""
 	}
 }
 

--- a/agent/claudecode/worktree.go
+++ b/agent/claudecode/worktree.go
@@ -1,0 +1,94 @@
+package claudecode
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var worktreeSlugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// sessionSlug turns a session key like "feishu:oc_xxx:om_yyy" into a
+// filesystem- and git-branch-safe slug.
+func sessionSlug(key string) string {
+	s := strings.ToLower(key)
+	s = worktreeSlugRe.ReplaceAllString(s, "_")
+	s = strings.Trim(s, "_")
+	if len(s) > 60 {
+		s = strings.Trim(s[:60], "_")
+	}
+	return s
+}
+
+// ensureWorktree returns the working directory for a given session key,
+// creating an isolated git worktree (with its own DB/ports) on first use and
+// reusing it afterward. Provisioning is delegated to
+// <base>/.claude/hooks/cc-connect-worktree.sh when present (so DB/port logic
+// lives in an editable script, not compiled Go); otherwise it falls back to a
+// plain `git worktree add`. On any error it returns base (the shared work_dir)
+// so the session still runs rather than failing outright.
+func (a *Agent) ensureWorktree(base, key string) (string, error) {
+	slug := sessionSlug(key)
+	if slug == "" {
+		return base, fmt.Errorf("empty slug for session key %q", key)
+	}
+
+	// Reuse a previously-resolved worktree if it still exists on disk.
+	if v, ok := a.worktreeCache.Load(slug); ok {
+		if p, _ := v.(string); p != "" {
+			if st, err := os.Stat(p); err == nil && st.IsDir() {
+				return p, nil
+			}
+			a.worktreeCache.Delete(slug)
+		}
+	}
+
+	script := filepath.Join(base, ".claude", "hooks", "cc-connect-worktree.sh")
+	var path string
+	if st, err := os.Stat(script); err == nil && !st.IsDir() {
+		payload, _ := json.Marshal(map[string]string{"name": slug, "session_key": key})
+		cmd := exec.Command("bash", script)
+		cmd.Dir = base
+		cmd.Stdin = bytes.NewReader(payload)
+		var out, errBuf bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &errBuf
+		if err := cmd.Run(); err != nil {
+			return base, fmt.Errorf("cc-connect-worktree.sh failed: %w; stderr: %s", err, strings.TrimSpace(errBuf.String()))
+		}
+		path = lastNonEmptyLine(out.String())
+		if path == "" {
+			return base, fmt.Errorf("cc-connect-worktree.sh produced no path; stderr: %s", strings.TrimSpace(errBuf.String()))
+		}
+	} else {
+		// Fallback: plain git worktree, no DB/port isolation.
+		path = filepath.Join(base, ".claude", "worktrees", slug)
+		if st, err := os.Stat(path); err != nil || !st.IsDir() {
+			cmd := exec.Command("git", "worktree", "add", path, "-b", "worktree-"+slug)
+			cmd.Dir = base
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return base, fmt.Errorf("git worktree add failed: %w; %s", err, strings.TrimSpace(string(out)))
+			}
+		}
+	}
+
+	a.worktreeCache.Store(slug, path)
+	slog.Info("claudecode: routed session to worktree", "session_key", key, "slug", slug, "work_dir", path)
+	return path, nil
+}
+
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if t := strings.TrimSpace(lines[i]); t != "" {
+			return t
+		}
+	}
+	return ""
+}

--- a/agent/claudecode/worktree_test.go
+++ b/agent/claudecode/worktree_test.go
@@ -1,0 +1,42 @@
+package claudecode
+
+import "testing"
+
+func TestSessionSlug(t *testing.T) {
+	cases := map[string]string{
+		"feishu:oc_abc:om_123": "feishu_oc_abc_om_123",
+		"FEISHU:OC_ABC":        "feishu_oc_abc",
+		"::feishu::":           "feishu",
+		"a/b\\c.d":             "a_b_c_d",
+		"":                     "",
+	}
+	for in, want := range cases {
+		if got := sessionSlug(in); got != want {
+			t.Errorf("sessionSlug(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	// Long keys are truncated to <=60 and not left with a trailing underscore.
+	long := ""
+	for i := 0; i < 100; i++ {
+		long += "x"
+	}
+	if got := sessionSlug(long + ":" + long); len(got) > 60 {
+		t.Errorf("slug not truncated: len=%d", len(got))
+	}
+}
+
+func TestLastNonEmptyLine(t *testing.T) {
+	cases := map[string]string{
+		"/path/to/wt\n":            "/path/to/wt",
+		"log line\n/path/to/wt\n":  "/path/to/wt",
+		"  /path/with/spaces  \n":  "/path/with/spaces",
+		"":                         "",
+		"\n\n":                     "",
+	}
+	for in, want := range cases {
+		if got := lastNonEmptyLine(in); got != want {
+			t.Errorf("lastNonEmptyLine(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -44,6 +44,14 @@ const (
 	slowAgentFirstEvent = 15 * time.Second // time from send to first agent event
 )
 
+// idleAgentCloseDuration is how long an interactive session's claude process may
+// sit idle (no new user message) before the background sweep closes it to free
+// memory (~200MB each). The cc-connect Session and its claude session id are
+// KEPT, so the next message resumes the conversation via `claude --resume` with
+// full context — only the warm process is released, never the conversation.
+// (reset_on_idle_mins, by contrast, rotates to a fresh session and loses context.)
+const idleAgentCloseDuration = 30 * time.Minute
+
 const (
 	replyFooterUsageTimeout  = 1500 * time.Millisecond
 	replyFooterUsageCacheTTL = 30 * time.Second
@@ -495,6 +503,89 @@ func (e *Engine) runIdleReaper() {
 		case <-ticker.C:
 			e.reapIdleWorkspaces()
 		}
+	}
+}
+
+// runAgentIdleSweep periodically closes idle warm claude processes to free
+// memory (keeping the session for --resume). Started unconditionally from
+// Start() — unlike runIdleReaper, which only runs in multi-workspace mode.
+func (e *Engine) runAgentIdleSweep() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-e.ctx.Done():
+			return
+		case <-ticker.C:
+			e.reapIdleAgentSessions()
+		}
+	}
+}
+
+// reapIdleAgentSessions closes claude processes for interactive sessions idle
+// longer than idleAgentCloseDuration, freeing memory without losing context.
+// cleanupInteractiveState releases the process + interactive state but KEEPS the
+// cc-connect Session, so the next message resumes via `claude --resume`. Runs
+// proactively (every minute) — unlike reset_on_idle_mins, which only fires on
+// the next message and also rotates the session (losing context).
+//
+// Safety: snapshot under the lock, then do all per-session checks and the close
+// OUTSIDE the lock (no nested lock acquisition → no lock-ordering deadlock). A
+// turn in progress holds the session lock, so TryLock skips busy sessions; any
+// per-session lookup that can't resolve simply skips (fail-safe: under-reap,
+// never wrong-reap). cleanupInteractiveState's expected-guard skips a session
+// whose state was replaced by a new turn between snapshot and close.
+func (e *Engine) reapIdleAgentSessions() {
+	now := time.Now()
+
+	type cand struct {
+		key   string
+		state *interactiveState
+		as    AgentSession
+	}
+	var cands []cand
+	e.interactiveMu.Lock()
+	for key, state := range e.interactiveStates {
+		if state == nil {
+			continue
+		}
+		state.mu.Lock()
+		as := state.agentSession
+		state.mu.Unlock()
+		if as == nil {
+			continue
+		}
+		cands = append(cands, cand{key: key, state: state, as: as})
+	}
+	e.interactiveMu.Unlock()
+
+	for _, c := range cands {
+		if !c.as.Alive() {
+			continue // process already gone — nothing to free
+		}
+		id := e.sessions.ActiveSessionID(c.key)
+		if id == "" {
+			continue
+		}
+		sess := e.sessions.FindByID(id)
+		if sess == nil {
+			continue
+		}
+		last := sess.GetLastUserActivity()
+		if last.IsZero() {
+			last = sess.GetUpdatedAt()
+		}
+		if last.IsZero() || now.Sub(last) < idleAgentCloseDuration {
+			continue // still recently active
+		}
+		if !sess.TryLock() {
+			continue // a turn is in progress — don't touch it
+		}
+		sess.UnlockWithoutUpdate()
+
+		slog.Info("idle agent sweep: closing idle session process (session kept for --resume)",
+			"session_key", c.key, "idle", now.Sub(last).Round(time.Second))
+		e.cleanupInteractiveState(c.key, c.state)
 	}
 }
 
@@ -1581,6 +1672,9 @@ func (e *Engine) Start() error {
 	} else {
 		slog.Info("engine started", "project", e.name, "agent", e.agent.Name(), "platforms", len(e.platforms))
 	}
+
+	// Free idle warm claude processes (~200MB each) without losing context.
+	go e.runAgentIdleSweep()
 
 	// Only return error if ALL platforms failed
 	if len(startErrs) == len(e.platforms) && len(e.platforms) > 0 {
@@ -2978,7 +3072,10 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	startSessionID := session.GetAgentSessionID()
 	isResume := startSessionID != ""
 	startAt := time.Now()
-	agentSession, err := agent.StartSession(e.ctx, startSessionID)
+	// Carry the session key so worktree-per-session agents can route work_dir
+	// per chat topic (no-op for agents that ignore it).
+	sctx := WithSessionKey(e.ctx, sessionKey)
+	agentSession, err := agent.StartSession(sctx, startSessionID)
 	startElapsed := time.Since(startAt)
 	if err != nil {
 		// If resume/continue failed, try a fresh session as fallback.
@@ -2991,7 +3088,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 			session.SetAgentSessionID("", agent.Name())
 			sessions.Save()
 			startAt = time.Now()
-			agentSession, err = agent.StartSession(e.ctx, "")
+			agentSession, err = agent.StartSession(sctx, "")
 			startElapsed = time.Since(startAt)
 			if err == nil {
 				slog.Info("fresh session started after resume failure",

--- a/core/sessionkey_ctx.go
+++ b/core/sessionkey_ctx.go
@@ -1,0 +1,27 @@
+package core
+
+import "context"
+
+// sessionKeyCtxKeyT is an unexported context key type so values set here can't
+// collide with context values from other packages.
+type sessionKeyCtxKeyT struct{}
+
+var sessionKeyCtxKey = sessionKeyCtxKeyT{}
+
+// WithSessionKey returns a child context carrying the cc-connect session key
+// (e.g. "feishu:{chatID}:{threadRootID}"). It is set per StartSession call so
+// agents can route per-session resources (e.g. a git worktree per chat topic)
+// without mutating shared agent state — context values are immutable and
+// per-call, so concurrent topics never race.
+func WithSessionKey(ctx context.Context, key string) context.Context {
+	if key == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, sessionKeyCtxKey, key)
+}
+
+// SessionKeyFromContext returns the session key set by WithSessionKey, or "".
+func SessionKeyFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(sessionKeyCtxKey).(string)
+	return v
+}

--- a/core/sessionkey_ctx_test.go
+++ b/core/sessionkey_ctx_test.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSessionKeyContextRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	if got := SessionKeyFromContext(ctx); got != "" {
+		t.Fatalf("empty ctx: want \"\", got %q", got)
+	}
+
+	key := "feishu:oc_abc:om_123"
+	ctx = WithSessionKey(ctx, key)
+	if got := SessionKeyFromContext(ctx); got != key {
+		t.Fatalf("round-trip: want %q, got %q", key, got)
+	}
+
+	// Empty key must not wrap (so it can't shadow a real key set upstream).
+	if WithSessionKey(context.Background(), "") != context.Background() {
+		t.Fatal("WithSessionKey with empty key should return ctx unchanged")
+	}
+}

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -278,6 +278,10 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	if domain != lark.FeishuBaseUrl {
 		clientOpts = append(clientOpts, lark.WithOpenBaseUrl(domain))
 	}
+	// WSL2 NAT silently drops idle keep-alive connections; Go's default pool
+	// reuses a dead one and hangs (e.g. GetChatMembers -> "context deadline
+	// exceeded"). Force a fresh connection per request, like curl.
+	clientOpts = append(clientOpts, lark.WithHttpClient(newNoKeepAliveHTTPClient()))
 
 	base := &Platform{
 		platformName:               name,
@@ -1485,43 +1489,71 @@ type chatMemberEntry struct {
 }
 
 // fetchChatMembers retrieves all members of a chat and returns a name->openID map.
+//
+// NOTE: the lark SDK's GetChatMembers iterator hangs in some environments
+// (observed in WSL2: iter.Next() blocks ~9s until the context deadline while a
+// raw HTTP GET to the exact same endpoint returns in ~1.5s). We therefore bypass
+// the SDK iterator and call the REST endpoint directly via net/http.
 func (p *Platform) fetchChatMembers(ctx context.Context, chatID string) (map[string]string, error) {
-	if p.client == nil {
-		return nil, fmt.Errorf("%s: client not initialized", p.tag())
-	}
 	members := make(map[string]string)
-	req := larkim.NewGetChatMembersReqBuilder().
-		ChatId(chatID).
-		MemberIdType("open_id").
-		PageSize(100).
-		Build()
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	token, err := p.fetchFreshTenantAccessToken(timeoutCtx)
 	if err != nil {
 		return nil, fmt.Errorf("%s: fetch tenant token for chat members: %w", p.tag(), err)
 	}
-	iter, err := p.client.Im.ChatMembers.GetByIterator(timeoutCtx, req, larkcore.WithTenantAccessToken(token))
-	if err != nil {
-		return nil, fmt.Errorf("%s: list chat members: %w", p.tag(), err)
+	base := p.domain
+	if base == "" {
+		base = lark.FeishuBaseUrl
 	}
+	httpClient := newNoKeepAliveHTTPClient()
+	pageToken := ""
 	for {
-		hasMore, member, err := iter.Next()
+		u := fmt.Sprintf("%s/open-apis/im/v1/chats/%s/members?member_id_type=open_id&page_size=100&page_token=%s",
+			strings.TrimRight(base, "/"), url.PathEscape(chatID), url.QueryEscape(pageToken))
+		req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, u, nil)
 		if err != nil {
-			slog.Debug(p.tag()+": fetch chat members page error", "chat_id", chatID, "error", err)
-			break
+			return nil, fmt.Errorf("%s: build chat members request: %w", p.tag(), err)
 		}
-		if member != nil && member.Name != nil && member.MemberId != nil {
-			name := *member.Name
-			if _, exists := members[name]; !exists {
-				members[name] = *member.MemberId
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("%s: list chat members: %w", p.tag(), err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		var parsed struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+			Data struct {
+				Items []struct {
+					MemberID string `json:"member_id"`
+					Name     string `json:"name"`
+				} `json:"items"`
+				PageToken string `json:"page_token"`
+				HasMore   bool   `json:"has_more"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			return nil, fmt.Errorf("%s: parse chat members: %w", p.tag(), err)
+		}
+		if parsed.Code != 0 {
+			return nil, fmt.Errorf("%s: list chat members code=%d msg=%s", p.tag(), parsed.Code, parsed.Msg)
+		}
+		for _, it := range parsed.Data.Items {
+			if it.Name == "" || it.MemberID == "" {
+				continue
+			}
+			if _, exists := members[it.Name]; !exists {
+				members[it.Name] = it.MemberID
 			} else {
-				members[name] = ""
+				members[it.Name] = "" // duplicate display name -> ambiguous, skip
 			}
 		}
-		if !hasMore {
+		if !parsed.Data.HasMore || parsed.Data.PageToken == "" {
 			break
 		}
+		pageToken = parsed.Data.PageToken
 	}
 	return members, nil
 }
@@ -1547,6 +1579,14 @@ func (p *Platform) getChatMembers(ctx context.Context, chatID string) map[string
 // (before JSON serialization). Reverse-matches against the chat member list,
 // longest name first. Uses the correct at syntax based on predicted message type.
 func (p *Platform) resolveMentionsInContent(ctx context.Context, chatID, content string) string {
+	return p.resolveMentionsInContentFmt(ctx, chatID, content, predictMsgType(content) == larkim.MsgTypeInteractive)
+}
+
+// resolveMentionsInContentFmt is like resolveMentionsInContent but lets the
+// caller force the card at-syntax. The streaming card-update path
+// (UpdateMessage / UpdateMessageWithStatusFooter) always renders a card, so it
+// must pass useCardFormat=true regardless of predictMsgType.
+func (p *Platform) resolveMentionsInContentFmt(ctx context.Context, chatID, content string, useCardFormat bool) string {
 	if !p.resolveMentions || chatID == "" || !strings.Contains(content, "@") {
 		return content
 	}
@@ -1561,7 +1601,6 @@ func (p *Platform) resolveMentionsInContent(ctx context.Context, chatID, content
 	}
 	sort.Slice(names, func(i, j int) bool { return len(names[i]) > len(names[j]) })
 
-	useCardFormat := predictMsgType(content) == larkim.MsgTypeInteractive
 	result := content
 	for _, name := range names {
 		pattern := "@" + name
@@ -2975,7 +3014,9 @@ func isBotMentioned(mentions []*larkim.MentionEvent, botOpenID string) bool {
 // already-engaged thread without an explicit @bot mention.
 func isAttachmentMsgType(msgType string) bool {
 	switch msgType {
-	case "image", "file", "audio", "media":
+	case "image", "file", "audio", "media", "merge_forward":
+		// merge_forward 也算"附件类":用户主动合并转发进活跃话题的一捆内容
+		// (文字+多文件)无法 @ 机器人,放行后由 parseMergeForward 合成一轮。
 		return true
 	}
 	return false
@@ -3171,10 +3212,26 @@ func (p *Platform) replayAPIClient() *lark.Client {
 func newFeishuReplayClient(appID, appSecret, domain string) *lark.Client {
 	var opts []lark.ClientOptionFunc
 	opts = append(opts, lark.WithEnableTokenCache(false))
+	opts = append(opts, lark.WithHttpClient(newNoKeepAliveHTTPClient()))
 	if domain != "" && domain != lark.FeishuBaseUrl {
 		opts = append(opts, lark.WithOpenBaseUrl(domain))
 	}
 	return lark.NewClient(appID, appSecret, opts...)
+}
+
+// newNoKeepAliveHTTPClient returns an HTTP client that disables connection reuse.
+// In WSL2 the NAT layer silently drops idle TCP connections; Go's default
+// transport keeps them pooled and may reuse a dead one, hanging the request
+// until its context deadline (observed as GetChatMembers "context deadline
+// exceeded" while curl, which opens a fresh connection each time, succeeds in
+// ~0.3s). Proxy settings are still honored for cross-GFW endpoints.
+func newNoKeepAliveHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:             http.ProxyFromEnvironment,
+			DisableKeepAlives: true,
+		},
+	}
 }
 
 func isTenantAccessTokenInvalid(err error) bool {
@@ -4103,9 +4160,12 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 	} else if payload, ok := core.ParseProgressCardPayload(content); ok {
 		cardJSON = buildProgressCardJSONFromPayload(payload)
 	} else {
-		processed := content
-		if containsMarkdown(content) {
-			processed = preprocessFeishuMarkdown(content)
+		// Resolve @name -> Feishu at tag on the streaming card-update path too
+		// (forced card syntax). Without this, mentions in agent replies that
+		// stream via cards never become real @notifications.
+		processed := p.resolveMentionsInContentFmt(ctx, h.chatID, content, true)
+		if containsMarkdown(processed) {
+			processed = preprocessFeishuMarkdown(processed)
 		}
 		cardJSON = buildCardJSON(sanitizeMarkdownURLs(processed))
 	}
@@ -4136,10 +4196,9 @@ func (p *Platform) UpdateMessageWithStatusFooter(ctx context.Context, previewHan
 	if !ok {
 		return fmt.Errorf("%s: invalid preview handle type %T", p.tag(), previewHandle)
 	}
-	// Mirror UpdateMessage's existing behavior: it does not resolve
-	// @mentions on the card-edit path either. SendWithStatusFooter does
-	// resolve since the matching Send path resolves on the chat-thread API.
-	processedBody := sanitizeMarkdownURLs(preprocessFeishuMarkdown(content))
+	// Resolve @name -> Feishu at tag (forced card syntax) so mentions in
+	// streamed agent replies become real @notifications.
+	processedBody := sanitizeMarkdownURLs(preprocessFeishuMarkdown(p.resolveMentionsInContentFmt(ctx, h.chatID, content, true)))
 	processedFooter := sanitizeMarkdownURLs(preprocessFeishuMarkdown(footer))
 	cardJSON := buildCardJSONWithStatusFooter(processedBody, processedFooter)
 	// Same card-entity routing as UpdateMessage above.


### PR DESCRIPTION
Local patches for driving Claude Code from a Feishu group via cc-connect:

- feishu: per-session git worktree routing (opt-in worktree_per_session) so each chat topic runs the agent in its own worktree; session key carried via context so concurrent topics don't race on a shared work_dir.
- feishu: resolve @mentions on the streaming card-edit path; fetch chat members via raw net/http (lark SDK GetByIterator hangs in this WSL2 env).
- claudecode: emit EventToolResult so tool outputs render in progress cards.
- engine: background sweep closes idle warm claude processes (~200MB each) while keeping the cc-connect session, so the next message resumes via `claude --resume` with full context (no rotation/context loss).
- feishu: allow merge_forward through an already-engaged thread without a fresh @mention, so a forwarded bundle (text + multiple files) is handled in one turn.