### PR TITLE
fix(feishu): restore P2P permission card actions blocked by allow_chat

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -9584,11 +9584,15 @@ func (e *Engine) sendPermissionPrompt(p Platform, replyCtx any, prompt, toolName
 	if supportsCards(p) {
 		body := fmt.Sprintf(e.i18n.T(MsgPermCardBody), toolName, toolInput)
 		extra := func(label, color string) map[string]string {
-			return map[string]string{
+			m := map[string]string{
 				"perm_label": label,
 				"perm_color": color,
 				"perm_body":  body,
 			}
+			if e.name != "" {
+				m["perm_project"] = e.name
+			}
+			return m
 		}
 		allowBtn := CardButton{Text: e.i18n.T(MsgPermBtnAllow), Type: "primary", Value: "perm:allow",
 			Extra: extra("✅ "+e.i18n.T(MsgPermBtnAllow), "green")}
@@ -9654,6 +9658,7 @@ func (e *Engine) sendAskQuestionPrompt(p Platform, replyCtx any, questions []Use
 				cb.ListItemBtnExtra(desc, opt.Label, "default", answerData, map[string]string{
 					"askq_label":    opt.Label,
 					"askq_question": q.Question,
+					"askq_project":  e.name,
 				})
 			}
 			cb.Note(e.i18n.T(MsgAskQuestionNote))

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -125,6 +125,7 @@ type Platform struct {
 	doneEmoji                  string
 	allowFrom                  string
 	allowChat                  string
+	ccProject                  string // cc-connect project name (from opts["cc_project"])
 	groupOnly                  bool
 	groupReplyAll              bool
 	respondToAtEveryoneAndHere bool
@@ -145,6 +146,7 @@ type Platform struct {
 	peerBots         map[string]string // app_id -> friendly alias, for quoted-reply attribution
 	userNameCache    sync.Map          // open_id -> display name
 	chatNameCache    sync.Map          // chat_id -> chat name
+	chatTypeCache    sync.Map          // chat_id -> chat type ("group" / "p2p")
 	chatMemberCache  sync.Map          // chatID -> *chatMemberEntry
 	recalledMu       sync.Mutex
 	recalledMsgIDs   map[string]time.Time // message_id -> recall time, short TTL race guard
@@ -222,6 +224,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom(name, allowFrom)
 	allowChat, _ := opts["allow_chat"].(string)
+	ccProject, _ := opts["cc_project"].(string)
 	groupOnly, _ := opts["group_only"].(bool)
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	// require_mention = false is equivalent to group_reply_all = true:
@@ -290,6 +293,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		doneEmoji:                  doneEmoji,
 		allowFrom:                  allowFrom,
 		allowChat:                  allowChat,
+		ccProject:                  ccProject,
 		groupOnly:                  groupOnly,
 		groupReplyAll:              groupReplyAll,
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
@@ -553,9 +557,14 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		return nil, nil
 	}
 
-	// Check allow_chat filter: skip card actions from chats this platform doesn't own.
+	// Match onMessage routing: allow_chat applies to group chats only; P2P bypasses
+	// allow_chat unless group_only is set. Card callbacks don't include chat type,
+	// so consult the cache populated from inbound messages.
 	if event.Event.Context != nil && event.Event.Context.OpenChatID != "" {
-		if !core.AllowList(p.allowChat, event.Event.Context.OpenChatID) {
+		chatID := event.Event.Context.OpenChatID
+		if !p.shouldAcceptChat(p.chatTypeForChatID(chatID), chatID) {
+			slog.Debug(p.tag()+": card action from unauthorized chat",
+				"chat_id", chatID, "chat_type", p.chatTypeForChatID(chatID))
 			return nil, nil
 		}
 	}
@@ -662,6 +671,10 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 
 	// perm: — permission response with in-place card update
 	if strings.HasPrefix(actionVal, "perm:") {
+		if !p.cardActionTargetsThisProject(event.Event.Action.Value, "perm_project") {
+			return nil, nil
+		}
+
 		var responseText string
 		switch actionVal {
 		case "perm:allow":
@@ -676,15 +689,20 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 
 		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
 		h := p.getHandler()
-		go h(p.dispatchPlatform(), &core.Message{
-			SessionKey: sessionKey,
-			Platform:   p.platformName,
-			UserID:     userID,
-			UserName:   p.resolveUserName(userID),
-			ChatName:   p.resolveChatName(chatID),
-			Content:    responseText,
-			ReplyCtx:   rctx,
-		})
+		if h != nil {
+			go h(p.dispatchPlatform(), &core.Message{
+				SessionKey: sessionKey,
+				Platform:   p.platformName,
+				UserID:     userID,
+				UserName:   p.resolveUserName(userID),
+				ChatName:   p.resolveChatName(chatID),
+				Content:    responseText,
+				ReplyCtx:   rctx,
+			})
+		} else {
+			slog.Warn(p.tag()+": permission card action dropped, handler not ready",
+				"action", actionVal, "session_key", sessionKey)
+		}
 
 		permLabel, _ := event.Event.Action.Value["perm_label"].(string)
 		permColor, _ := event.Event.Action.Value["perm_color"].(string)
@@ -697,6 +715,10 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 			cb.Markdown(permBody)
 		}
 		return &callback.CardActionTriggerResponse{
+			Toast: &callback.Toast{
+				Type:    "success",
+				Content: permLabel,
+			},
 			Card: &callback.Card{
 				Type: "raw",
 				Data: renderCardMap(cb.Build(), sessionKey),
@@ -706,17 +728,21 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 
 	// askq: — AskUserQuestion option selected, forward as user message
 	if strings.HasPrefix(actionVal, "askq:") {
+		if !p.cardActionTargetsThisProject(event.Event.Action.Value, "askq_project") {
+			return nil, nil
+		}
 		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
-		h := p.getHandler()
-		go h(p.dispatchPlatform(), &core.Message{
-			SessionKey: sessionKey,
-			Platform:   p.platformName,
-			UserID:     userID,
-			UserName:   p.resolveUserName(userID),
-			ChatName:   p.resolveChatName(chatID),
-			Content:    actionVal,
-			ReplyCtx:   rctx,
-		})
+		if h := p.getHandler(); h != nil {
+			go h(p.dispatchPlatform(), &core.Message{
+				SessionKey: sessionKey,
+				Platform:   p.platformName,
+				UserID:     userID,
+				UserName:   p.resolveUserName(userID),
+				ChatName:   p.resolveChatName(chatID),
+				Content:    actionVal,
+				ReplyCtx:   rctx,
+			})
+		}
 
 		answerLabel, _ := event.Event.Action.Value["askq_label"].(string)
 		askqQuestion, _ := event.Event.Action.Value["askq_question"].(string)
@@ -1091,12 +1117,15 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 		return nil
 	}
 
-	if chatType == "group" && !core.AllowList(p.allowChat, chatID) {
-		slog.Debug(p.tag()+": message from unauthorized chat", "chat_id", chatID)
-		return nil
+	if chatID != "" && chatType != "" {
+		p.chatTypeCache.Store(chatID, chatType)
 	}
-	if chatType != "group" && p.groupOnly {
-		slog.Debug(p.tag()+": p2p message skipped (group_only=true)", "chat_type", chatType)
+	if !p.shouldAcceptChat(chatType, chatID) {
+		if chatType == "group" {
+			slog.Debug(p.tag()+": message from unauthorized chat", "chat_id", chatID)
+		} else {
+			slog.Debug(p.tag()+": p2p message skipped (group_only=true)", "chat_type", chatType)
+		}
 		return nil
 	}
 
@@ -3039,6 +3068,52 @@ func (p *Platform) makeSessionKey(msg *larkim.EventMessage, chatID, userID strin
 		return fmt.Sprintf("%s:%s", p.tag(), chatID)
 	}
 	return fmt.Sprintf("%s:%s:%s", p.tag(), chatID, userID)
+}
+
+// shouldAcceptChat mirrors onMessage allow_chat / group_only routing.
+// Group chats must match allow_chat; P2P chats are rejected when group_only is set.
+func (p *Platform) shouldAcceptChat(chatType, chatID string) bool {
+	if chatType == "group" {
+		return core.AllowList(p.allowChat, chatID)
+	}
+	if chatType != "" && p.groupOnly {
+		return false
+	}
+	// Card callbacks may arrive before chat type is cached. For group_only
+	// platforms fall back to allow_chat; P2P-first configs skip the check.
+	if chatType == "" && p.groupOnly {
+		return core.AllowList(p.allowChat, chatID)
+	}
+	return true
+}
+
+func (p *Platform) chatTypeForChatID(chatID string) string {
+	if chatID == "" {
+		return ""
+	}
+	if v, ok := p.chatTypeCache.Load(chatID); ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// cardActionTargetsThisProject returns true when the callback has no project tag
+// (legacy cards) or the tag matches this platform's cc-connect project.
+func (p *Platform) cardActionTargetsThisProject(value map[string]any, projectKey string) bool {
+	if value == nil || projectKey == "" {
+		return true
+	}
+	want, _ := value[projectKey].(string)
+	want = strings.TrimSpace(want)
+	if want == "" {
+		return true
+	}
+	if p.ccProject == "" {
+		return false
+	}
+	return want == p.ccProject
 }
 
 func (p *Platform) sessionKeyFromCardAction(chatID, userID string, value map[string]any) string {

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -524,6 +524,136 @@ func TestInteractivePlatform_CardActionUsesCallbackSessionKey(t *testing.T) {
 	}
 }
 
+func TestInteractivePlatform_CardActionPermissionAllow(t *testing.T) {
+	platformAny, err := New(map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
+		"cc_project": "proj-a",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip := platformAny.(*interactivePlatform)
+
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		msgCh <- msg
+	}
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_test_user"},
+			Action: &callback.CallBackAction{Value: map[string]any{
+				"action":       "perm:allow",
+				"perm_label":   "✅ 允许",
+				"perm_color":   "green",
+				"perm_body":    "Agent wants Bash",
+				"perm_project": "proj-a",
+				"session_key":  "feishu:oc_test_chat:ou_test_user",
+			}},
+			Context: &callback.Context{OpenChatID: "oc_test_chat", OpenMessageID: "om_perm"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp == nil || resp.Card == nil {
+		t.Fatalf("expected card response, got %#v", resp)
+	}
+	if resp.Toast == nil || resp.Toast.Content == "" {
+		t.Fatal("expected toast in permission card action response")
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "allow" {
+			t.Fatalf("message content = %q, want allow", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected permission allow message")
+	}
+}
+
+// Regression: P2P card actions must not be blocked by allow_chat sentinels that
+// only exist to reject group chats (e.g. __kb_p2p_only__).
+func TestInteractivePlatform_CardActionPermissionAllowP2PBypassesAllowChat(t *testing.T) {
+	platformAny, err := New(map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
+		"cc_project": "kb",
+		"allow_chat": "__kb_p2p_only__",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip := platformAny.(*interactivePlatform)
+	ip.chatTypeCache.Store("oc_p2p_chat", "p2p")
+
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		msgCh <- msg
+	}
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_test_user"},
+			Action: &callback.CallBackAction{Value: map[string]any{
+				"action":       "perm:allow",
+				"perm_project": "kb",
+			}},
+			Context: &callback.Context{OpenChatID: "oc_p2p_chat", OpenMessageID: "om_perm"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected card response for P2P permission allow")
+	}
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "allow" {
+			t.Fatalf("message content = %q, want allow", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler should run for P2P card action despite allow_chat sentinel")
+	}
+}
+
+func TestInteractivePlatform_CardActionPermissionProjectRouting(t *testing.T) {
+	platformAny, err := New(map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
+		"cc_project": "proj-a",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip := platformAny.(*interactivePlatform)
+
+	handled := false
+	ip.handler = func(_ core.Platform, _ *core.Message) {
+		handled = true
+	}
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_test_user"},
+			Action: &callback.CallBackAction{Value: map[string]any{
+				"action":       "perm:allow",
+				"perm_project": "proj-b",
+			}},
+			Context: &callback.Context{OpenChatID: "oc_test_chat", OpenMessageID: "om_perm"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response for foreign project, got %#v", resp)
+	}
+	if handled {
+		t.Fatal("handler should not run for foreign project permission action")
+	}
+}
+
 func TestInteractivePlatform_ModelCardActionReturnsCardUpdate(t *testing.T) {
 	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix Feishu permission **Allow/Deny** card buttons being silently dropped in P2P chats when `allow_chat` uses a group-blocking sentinel (e.g. `__kb_p2p_only__`).
- `onCardAction` now uses the same `shouldAcceptChat` routing as `onMessage`: `allow_chat` applies to group chats only; P2P bypasses it unless `group_only` is set.
- Cache inbound chat types (`group` / `p2p`) for card callbacks that lack chat type metadata.
- Tag permission and AskUserQuestion card buttons with `perm_project` / `askq_project` so multi-project bots sharing one Feishu app route callbacks to the correct engine.

## Root cause

Inbound messages in P2P skip `allow_chat`, but card callbacks always checked it. A sentinel value that blocks all group IDs therefore blocked P2P button clicks too — the SDK received `card.action.trigger` but cc-connect returned `nil` with no handler invocation.

## Test plan

- [x] `go test ./platform/feishu/ -run CardActionPermission -v`
- [x] `TestInteractivePlatform_CardActionPermissionAllowP2PBypassesAllowChat` (regression)
- [x] Manual: P2P chat with `allow_chat = "__kb_p2p_only__"`, trigger Bash permission, click **允许** → agent continues


Made with [Cursor](https://cursor.com)