### PR TITLE
fix(cursor): discover CLI chat storage and show readable session titles

### DIFF
--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -205,7 +206,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	return newCursorSession(ctx, cmd, workDir, model, mode, sessionID, extraEnv)
 }
 
-// ListSessions reads sessions from ~/.cursor/chats/<workspace_hash>/.
+// ListSessions reads sessions from Cursor Agent CLI chat storage.
+// The CLI may store chats under ~/.cursor/chats or ~/.config/Cursor/chats
+// depending on XDG_CONFIG_HOME and platform; all known locations are scanned.
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
 	workDir := a.GetWorkDir()
 	return listCursorSessions(workDir)
@@ -217,10 +220,9 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 		return fmt.Errorf("cursor: cannot determine home dir: %w", err)
 	}
 	workDir := a.GetWorkDir()
-	hash := workspaceHash(workDir)
-	dir := filepath.Join(homeDir, ".cursor", "chats", hash, sessionID)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return fmt.Errorf("session not found: %s", sessionID)
+	dir, err := findCursorSessionDir(homeDir, workDir, sessionID)
+	if err != nil {
+		return err
 	}
 	return os.RemoveAll(dir)
 }
@@ -341,60 +343,109 @@ func workspaceHash(workDir string) string {
 	return hex.EncodeToString(h[:])
 }
 
+// cursorChatsBaseDirs returns candidate Cursor Agent CLI chat roots, in priority order.
+// When XDG_CONFIG_HOME is set the CLI stores under $XDG_CONFIG_HOME/Cursor/chats;
+// otherwise it may use ~/.config/Cursor/chats or the legacy ~/.cursor/chats.
+func cursorChatsBaseDirs(homeDir string) []string {
+	var dirs []string
+	seen := make(map[string]struct{})
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		dirs = append(dirs, path)
+	}
+
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+		add(filepath.Join(xdg, "Cursor", "chats"))
+	}
+	add(filepath.Join(homeDir, ".config", "Cursor", "chats"))
+	add(filepath.Join(homeDir, ".cursor", "chats"))
+	return dirs
+}
+
+func workspaceChatsDirs(homeDir, workDir string) []string {
+	hash := workspaceHash(workDir)
+	var dirs []string
+	for _, base := range cursorChatsBaseDirs(homeDir) {
+		dir := filepath.Join(base, hash)
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			dirs = append(dirs, dir)
+		}
+	}
+	return dirs
+}
+
+func findCursorSessionDir(homeDir, workDir, sessionID string) (string, error) {
+	for _, chatsDir := range workspaceChatsDirs(homeDir, workDir) {
+		dir := filepath.Join(chatsDir, sessionID)
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir, nil
+		}
+	}
+	return "", fmt.Errorf("session not found: %s", sessionID)
+}
+
 func listCursorSessions(workDir string) ([]core.AgentSessionInfo, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("cursor: cannot determine home dir: %w", err)
 	}
 
-	hash := workspaceHash(workDir)
-	chatsDir := filepath.Join(homeDir, ".cursor", "chats", hash)
-
-	entries, err := os.ReadDir(chatsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("cursor: read chats dir: %w", err)
+	chatsDirs := workspaceChatsDirs(homeDir, workDir)
+	if len(chatsDirs) == 0 {
+		return nil, nil
 	}
 
-	var sessions []core.AgentSessionInfo
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		sessionID := entry.Name()
-		dbPath := filepath.Join(chatsDir, sessionID, "store.db")
-		if _, err := os.Stat(dbPath); err != nil {
-			continue
-		}
-
-		info, err := entry.Info()
+	byID := make(map[string]core.AgentSessionInfo)
+	for _, chatsDir := range chatsDirs {
+		entries, err := os.ReadDir(chatsDir)
 		if err != nil {
-			continue
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("cursor: read chats dir %s: %w", chatsDir, err)
 		}
 
-		meta := readSessionMeta(dbPath)
-		msgCount, firstUserMsg := countSessionMessages(dbPath, meta.RootBlobID)
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			sessionID := entry.Name()
+			dbPath := filepath.Join(chatsDir, sessionID, "store.db")
+			if _, err := os.Stat(dbPath); err != nil {
+				continue
+			}
 
-		summary := meta.Name
-		if summary == "" || summary == "New Agent" {
-			if firstUserMsg != "" {
-				summary = firstUserMsg
-			} else {
-				summary = sessionID[:12] + "..."
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+
+			meta := readSessionMeta(dbPath)
+			msgCount, firstUserMsg := countSessionMessages(dbPath, meta.RootBlobID)
+
+			summary := cursorSessionSummary(meta.Name, firstUserMsg, sessionID)
+
+			candidate := core.AgentSessionInfo{
+				ID:           sessionID,
+				Summary:      summary,
+				MessageCount: msgCount,
+				ModifiedAt:   info.ModTime(),
+			}
+			if existing, ok := byID[sessionID]; !ok || candidate.ModifiedAt.After(existing.ModifiedAt) {
+				byID[sessionID] = candidate
 			}
 		}
-		if utf8.RuneCountInString(summary) > 60 {
-			summary = string([]rune(summary)[:60]) + "..."
-		}
+	}
 
-		sessions = append(sessions, core.AgentSessionInfo{
-			ID:           sessionID,
-			Summary:      summary,
-			MessageCount: msgCount,
-			ModifiedAt:   info.ModTime(),
-		})
+	sessions := make([]core.AgentSessionInfo, 0, len(byID))
+	for _, s := range byID {
+		sessions = append(sessions, s)
 	}
 
 	sort.Slice(sessions, func(i, j int) bool {
@@ -450,6 +501,73 @@ func readSessionMeta(dbPath string) sessionMeta {
 	}
 
 	return sessionMeta{AgentID: m.AgentID, Name: m.Name, Mode: m.Mode, RootBlobID: m.RootBlobID}
+}
+
+var cursorUserQueryRE = regexp.MustCompile(`(?is)<user_query>\s*(.*?)\s*</user_query>`)
+
+func cursorSessionSummary(metaName, firstUserMsg, sessionID string) string {
+	summary := strings.TrimSpace(metaName)
+	if summary == "" || strings.EqualFold(summary, "New Agent") {
+		summary = strings.TrimSpace(firstUserMsg)
+	}
+	if summary == "" {
+		if len(sessionID) > 12 {
+			summary = sessionID[:12] + "..."
+		} else {
+			summary = sessionID
+		}
+	}
+	if utf8.RuneCountInString(summary) > 60 {
+		summary = string([]rune(summary)[:60]) + "..."
+	}
+	return summary
+}
+
+func cursorMessageContentText(content any) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []any:
+		var parts []string
+		for _, item := range v {
+			m, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := m["text"].(string); ok && strings.TrimSpace(text) != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	default:
+		return ""
+	}
+}
+
+func extractCursorUserSummary(content any) string {
+	text := strings.TrimSpace(cursorMessageContentText(content))
+	if text == "" {
+		return ""
+	}
+
+	if m := cursorUserQueryRE.FindStringSubmatch(text); len(m) == 2 {
+		if query := strings.TrimSpace(m[1]); query != "" {
+			return query
+		}
+	}
+
+	lower := strings.ToLower(text)
+	if strings.HasPrefix(lower, "<user_info>") ||
+		strings.HasPrefix(lower, "<open_and_recently_viewed_files>") ||
+		strings.HasPrefix(lower, "<attached_files>") ||
+		strings.HasPrefix(lower, "<agent_transcripts>") {
+		return ""
+	}
+
+	if strings.HasPrefix(text, "<") {
+		return ""
+	}
+	return text
 }
 
 // countSessionMessages reads the root blob from store.db and counts conversation
@@ -544,15 +662,8 @@ func countSessionMessages(dbPath, rootBlobID string) (int, string) {
 		}
 		roleCount[msg.Role]++
 		if msg.Role == "user" && firstUserMsg == "" {
-			if s, ok := msg.Content.(string); ok {
-				s = strings.TrimSpace(s)
-				// Skip injected context (XML tags, conversation summaries, etc.)
-				if len(s) > 0 && !strings.HasPrefix(s, "<") && !strings.HasPrefix(s, "[") && !strings.HasPrefix(s, "{") {
-					if utf8.RuneCountInString(s) > 50 {
-						s = string([]rune(s)[:50]) + "..."
-					}
-					firstUserMsg = s
-				}
+			if summary := extractCursorUserSummary(msg.Content); summary != "" {
+				firstUserMsg = summary
 			}
 		}
 	}

--- a/agent/cursor/cursor_chats_test.go
+++ b/agent/cursor/cursor_chats_test.go
@@ -1,0 +1,129 @@
+package cursor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCursorChatsBaseDirs_XDGAndLegacy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+	got := cursorChatsBaseDirs(home)
+	want := []string{
+		filepath.Join(home, "xdg", "Cursor", "chats"),
+		filepath.Join(home, ".config", "Cursor", "chats"),
+		filepath.Join(home, ".cursor", "chats"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("cursorChatsBaseDirs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("cursorChatsBaseDirs()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestListCursorSessions_ConfigCursorPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	workDir := filepath.Join(home, "project")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := workspaceHash(workDir)
+	sessionID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	chatsDir := filepath.Join(home, ".config", "Cursor", "chats", hash, sessionID)
+	if err := os.MkdirAll(chatsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(chatsDir, "store.db"), []byte("sqlite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := listCursorSessions(workDir)
+	if err != nil {
+		t.Fatalf("listCursorSessions() error: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("listCursorSessions() len = %d, want 1", len(sessions))
+	}
+	if sessions[0].ID != sessionID {
+		t.Fatalf("session ID = %q, want %q", sessions[0].ID, sessionID)
+	}
+}
+
+func TestExtractCursorUserSummary_UserQuery(t *testing.T) {
+	content := "<user_info>\nOS Version: darwin\n</user_info>\n\n<user_query>\n用一句话说明我们上次在做什么\n</user_query>"
+	got := extractCursorUserSummary(content)
+	want := "用一句话说明我们上次在做什么"
+	if got != want {
+		t.Fatalf("extractCursorUserSummary() = %q, want %q", got, want)
+	}
+}
+
+func TestExtractCursorUserSummary_ArrayContent(t *testing.T) {
+	content := []any{
+		map[string]any{
+			"type": "text",
+			"text": "<user_query>\nlist\n</user_query>",
+		},
+	}
+	got := extractCursorUserSummary(content)
+	if got != "list" {
+		t.Fatalf("extractCursorUserSummary() = %q, want %q", got, "list")
+	}
+}
+
+func TestExtractCursorUserSummary_SkipsUserInfo(t *testing.T) {
+	content := "<user_info>\nOS Version: darwin\n</user_info>"
+	if got := extractCursorUserSummary(content); got != "" {
+		t.Fatalf("extractCursorUserSummary() = %q, want empty", got)
+	}
+}
+
+func TestCursorSessionSummary_PrefersNamedSession(t *testing.T) {
+	got := cursorSessionSummary("CC Visibility", "", "175712b9-19d6-49eb-93b1-db74b9d598b3")
+	if got != "CC Visibility" {
+		t.Fatalf("cursorSessionSummary() = %q, want %q", got, "CC Visibility")
+	}
+}
+
+func TestListCursorSessions_AlephPlatformHash(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("integration test requires local Cursor chat storage")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workDir := "/Users/Ref/codes/aleph-platform"
+	chatsDir := filepath.Join(home, ".config", "Cursor", "chats", workspaceHash(workDir))
+	if _, err := os.Stat(chatsDir); err != nil {
+		t.Skipf("aleph chat dir not present: %s", chatsDir)
+	}
+
+	sessions, err := listCursorSessions(workDir)
+	if err != nil {
+		t.Fatalf("listCursorSessions() error: %v", err)
+	}
+	if len(sessions) == 0 {
+		t.Fatalf("expected aleph-platform sessions from %s", chatsDir)
+	}
+	for _, s := range sessions {
+		if strings.HasSuffix(s.Summary, "...") && len(s.Summary) <= 15 {
+			t.Errorf("session %s still shows opaque summary %q", s.ID, s.Summary)
+		}
+	}
+	t.Logf("found %d sessions for aleph-platform", len(sessions))
+	for _, s := range sessions {
+		t.Logf("  %s -> %s", s.ID[:8], s.Summary)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two issues that made Cursor Agent sessions unusable from messaging platforms (e.g. Feishu `/list`):

- **Empty session list**: cc-connect only scanned `~/.cursor/chats/`, but Cursor Agent CLI often stores sessions under `~/.config/Cursor/chats/` (especially when `XDG_CONFIG_HOME` is set). Sessions existed on disk but `/list` returned 0.
- **Unreadable titles**: Most CLI sessions keep the default name `New Agent`. The real user prompt is wrapped in `<user_query>...</user_query>`, but the old extractor skipped any content starting with `<`, so the UI fell back to opaque session IDs like `175712b9-19d6...`.

## Why this happens

Cursor Agent CLI and Cursor IDE use **separate storage** (confirmed by Cursor team):
- CLI: SQLite `store.db` under a workspace-hash directory
- IDE: `~/.cursor/projects/.../agent-transcripts/`

cc-connect integrates with the CLI, so it must read the CLI path. The storage root is not fixed:
- Some environments write to `~/.cursor/chats/`
- Others (including macOS setups with `XDG_CONFIG_HOME=/Users/.../.config`) write to `~/.config/Cursor/chats/`

This matches reports on the Cursor forum where chats are present on disk but invisible to `/resume` tooling when the resolved path differs.

For titles, Cursor CLI persists `name: "New Agent"` in `store.db` meta for most sessions. User-visible text lives inside injected XML blocks (`<user_info>`, `<user_query>`, etc.). The previous logic treated all XML-prefixed content as noise and never reached the actual query text.

## What changed

- Scan all known CLI chat roots in priority order:
  1. `$XDG_CONFIG_HOME/Cursor/chats/`
  2. `~/.config/Cursor/chats/`
  3. `~/.cursor/chats/` (legacy fallback)
- Merge/dedupe sessions across roots; apply the same lookup for delete.
- Extract readable summaries from `<user_query>` (string or array content), skip injected context blocks, and keep explicit Cursor names when present.

## Test plan

- [x] `go test ./agent/cursor/ -count=1`
- [x] Unit tests for XDG/config/legacy path discovery
- [x] Unit tests for `<user_query>` summary extraction
- [x] Local integration check against real aleph-platform storage (8 sessions listed with readable titles)

## Notes

- Does **not** add IDE `agent-transcripts` support; that is a different storage backend and would be a separate feature.
- Users can still override display names via `/rename` when they want custom labels.


Made with [Cursor](https://cursor.com)