### PR TITLE
feat(pi): add ContextUsageReporter for reply footer token stats

### DIFF
--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -321,7 +321,11 @@ func loadModelsContextWindows() map[string]int {
 	path := filepath.Join(dir, "models.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		slog.Warn("pi: read models.json", "path", path, "error", err)
+		if os.IsNotExist(err) {
+			slog.Info("pi: models.json not found, using 200K fallback", "path", path)
+		} else {
+			slog.Warn("pi: read models.json", "path", path, "error", err)
+		}
 		return nil
 	}
 	var cfg modelsJSON

--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -295,6 +295,50 @@ func (a *Agent) SkillDirs() []string {
 	return dirs
 }
 
+// ── Models JSON helpers ─────────────────────────────────────
+
+// modelsJSON represents the structure of ~/.pi/agent/models.json.
+type modelsJSON struct {
+	Providers map[string]struct {
+		Models []struct {
+			ID            string `json:"id"`
+			ContextWindow int    `json:"contextWindow"`
+		} `json:"models"`
+	} `json:"providers"`
+}
+
+// loadModelsContextWindows reads ~/.pi/agent/models.json and returns
+// a map of model ID → contextWindow. Keys include both the short ID
+// (e.g. "deepseek/deepseek-v4-pro") and the fully-qualified
+// provider/ID (e.g. "my-provider/my-model").
+// Returns nil on any error (caller falls back to 200K).
+func loadModelsContextWindows() map[string]int {
+	dir := piSettingsDir()
+	if dir == "" {
+		slog.Warn("pi: cannot determine pi settings dir for models.json")
+		return nil
+	}
+	path := filepath.Join(dir, "models.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		slog.Warn("pi: read models.json", "path", path, "error", err)
+		return nil
+	}
+	var cfg modelsJSON
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		slog.Warn("pi: parse models.json", "path", path, "error", err)
+		return nil
+	}
+	m := make(map[string]int)
+	for provider, p := range cfg.Providers {
+		for _, mdl := range p.Models {
+			m[mdl.ID] = mdl.ContextWindow
+			m[provider+"/"+mdl.ID] = mdl.ContextWindow
+		}
+	}
+	return m
+}
+
 // ── Settings helpers ─────────────────────────────────────────
 
 // piSettingsDir returns the pi agent config directory.

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1447,9 +1447,9 @@ func TestLoadModelsContextWindows(t *testing.T) {
 	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
 	t.Cleanup(func() {
 		if savedEnv != "" {
-			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+			_ = os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
 		} else {
-			os.Unsetenv("PI_CODING_AGENT_DIR")
+			_ = os.Unsetenv("PI_CODING_AGENT_DIR")
 		}
 	})
 
@@ -1472,7 +1472,9 @@ func TestLoadModelsContextWindows(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(modelsJSON)
-	os.WriteFile(filepath.Join(tmpDir, "models.json"), data, 0o644)
+	if err := os.WriteFile(filepath.Join(tmpDir, "models.json"), data, 0o644); err != nil {
+		t.Fatalf("write models.json: %v", err)
+	}
 
 	m := loadModelsContextWindows()
 	if m == nil {
@@ -1503,9 +1505,9 @@ func TestLoadModelsContextWindows_FileNotFound(t *testing.T) {
 	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
 	t.Cleanup(func() {
 		if savedEnv != "" {
-			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+			_ = os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
 		} else {
-			os.Unsetenv("PI_CODING_AGENT_DIR")
+			_ = os.Unsetenv("PI_CODING_AGENT_DIR")
 		}
 	})
 
@@ -1523,15 +1525,17 @@ func TestLoadModelsContextWindows_MalformedJSON(t *testing.T) {
 	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
 	t.Cleanup(func() {
 		if savedEnv != "" {
-			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+			_ = os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
 		} else {
-			os.Unsetenv("PI_CODING_AGENT_DIR")
+			_ = os.Unsetenv("PI_CODING_AGENT_DIR")
 		}
 	})
 
 	tmpDir := t.TempDir()
 	t.Setenv("PI_CODING_AGENT_DIR", tmpDir)
-	os.WriteFile(filepath.Join(tmpDir, "models.json"), []byte("{invalid"), 0o644)
+	if err := os.WriteFile(filepath.Join(tmpDir, "models.json"), []byte("{invalid"), 0o644); err != nil {
+		t.Fatalf("write models.json: %v", err)
+	}
 
 	m := loadModelsContextWindows()
 	if m != nil {

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1440,3 +1440,416 @@ loop:
 		t.Errorf("sessionID = %q, want echo-sess", s.CurrentSessionID())
 	}
 }
+
+// ── loadModelsContextWindows ─────────────────────────────────
+
+func TestLoadModelsContextWindows(t *testing.T) {
+	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
+	t.Cleanup(func() {
+		if savedEnv != "" {
+			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+		} else {
+			os.Unsetenv("PI_CODING_AGENT_DIR")
+		}
+	})
+
+	tmpDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", tmpDir)
+
+	modelsJSON := map[string]any{
+		"providers": map[string]any{
+			"provider-a": map[string]any{
+				"models": []any{
+					map[string]any{"id": "model-alpha", "contextWindow": float64(128_000)},
+					map[string]any{"id": "model-beta", "contextWindow": float64(200_000)},
+				},
+			},
+			"provider-b": map[string]any{
+				"models": []any{
+					map[string]any{"id": "model-gamma", "contextWindow": float64(1_000_000)},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(modelsJSON)
+	os.WriteFile(filepath.Join(tmpDir, "models.json"), data, 0o644)
+
+	m := loadModelsContextWindows()
+	if m == nil {
+		t.Fatal("loadModelsContextWindows returned nil")
+	}
+
+	// Bare IDs.
+	if m["model-alpha"] != 128_000 {
+		t.Errorf("model-alpha = %d, want 128_000", m["model-alpha"])
+	}
+	if m["model-beta"] != 200_000 {
+		t.Errorf("model-beta = %d, want 200_000", m["model-beta"])
+	}
+	if m["model-gamma"] != 1_000_000 {
+		t.Errorf("model-gamma = %d, want 1_000_000", m["model-gamma"])
+	}
+
+	// Fully-qualified provider/ID.
+	if m["provider-a/model-alpha"] != 128_000 {
+		t.Errorf("provider-a/model-alpha = %d, want 128_000", m["provider-a/model-alpha"])
+	}
+	if m["provider-b/model-gamma"] != 1_000_000 {
+		t.Errorf("provider-b/model-gamma = %d, want 1_000_000", m["provider-b/model-gamma"])
+	}
+}
+
+func TestLoadModelsContextWindows_FileNotFound(t *testing.T) {
+	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
+	t.Cleanup(func() {
+		if savedEnv != "" {
+			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+		} else {
+			os.Unsetenv("PI_CODING_AGENT_DIR")
+		}
+	})
+
+	tmpDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", tmpDir)
+	// No models.json written.
+
+	m := loadModelsContextWindows()
+	if m != nil {
+		t.Errorf("expected nil for missing models.json, got %v", m)
+	}
+}
+
+func TestLoadModelsContextWindows_MalformedJSON(t *testing.T) {
+	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
+	t.Cleanup(func() {
+		if savedEnv != "" {
+			os.Setenv("PI_CODING_AGENT_DIR", savedEnv)
+		} else {
+			os.Unsetenv("PI_CODING_AGENT_DIR")
+		}
+	})
+
+	tmpDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", tmpDir)
+	os.WriteFile(filepath.Join(tmpDir, "models.json"), []byte("{invalid"), 0o644)
+
+	m := loadModelsContextWindows()
+	if m != nil {
+		t.Errorf("expected nil for malformed JSON, got %v", m)
+	}
+}
+
+// ── handleAgentEnd ───────────────────────────────────────────
+
+func TestHandleAgentEnd(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+	s.modelsCW = map[string]int{
+		"test-model":               200_000,
+		"test-provider/test-model": 200_000,
+	}
+
+	s.handleEvent(map[string]any{
+		"type": "agent_end",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "hello"},
+				},
+			},
+			map[string]any{
+				"role":  "assistant",
+				"model": "test-model",
+				"content": []any{
+					map[string]any{"type": "text", "text": "hi there"},
+				},
+				"usage": map[string]any{
+					"input":      float64(5000),
+					"output":     float64(300),
+					"cacheRead":  float64(40000),
+					"cacheWrite": float64(2000),
+				},
+			},
+		},
+	})
+
+	usage := s.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage returned nil after agent_end with usage")
+	}
+
+	// UsedTokens = input + cacheWrite + cacheRead (mirrors claudecode pattern).
+	wantUsed := 5000 + 2000 + 40000 // 47000
+	if usage.UsedTokens != wantUsed {
+		t.Errorf("UsedTokens = %d, want %d", usage.UsedTokens, wantUsed)
+	}
+	// TotalTokens = UsedTokens + output.
+	wantTotal := wantUsed + 300 // 47300
+	if usage.TotalTokens != wantTotal {
+		t.Errorf("TotalTokens = %d, want %d", usage.TotalTokens, wantTotal)
+	}
+	if usage.InputTokens != 5000 {
+		t.Errorf("InputTokens = %d, want 5000", usage.InputTokens)
+	}
+	if usage.OutputTokens != 300 {
+		t.Errorf("OutputTokens = %d, want 300", usage.OutputTokens)
+	}
+	if usage.CachedInputTokens != 40000 {
+		t.Errorf("CachedInputTokens = %d, want 40000", usage.CachedInputTokens)
+	}
+	if usage.CacheCreationInputTokens != 2000 {
+		t.Errorf("CacheCreationInputTokens = %d, want 2000", usage.CacheCreationInputTokens)
+	}
+	if usage.ContextWindow != 200_000 {
+		t.Errorf("ContextWindow = %d, want 200_000", usage.ContextWindow)
+	}
+}
+
+func TestHandleAgentEnd_NoMessages(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type":     "agent_end",
+		"messages": []any{},
+	})
+
+	if s.GetContextUsage() != nil {
+		t.Error("GetContextUsage should be nil when agent_end has no messages")
+	}
+}
+
+func TestHandleAgentEnd_NoAssistantMessage(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "agent_end",
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "hello"},
+				},
+			},
+		},
+	})
+
+	if s.GetContextUsage() != nil {
+		t.Error("GetContextUsage should be nil when no assistant message exists")
+	}
+}
+
+func TestHandleAgentEnd_NoUsage(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "agent_end",
+		"messages": []any{
+			map[string]any{
+				"role":  "assistant",
+				"model": "test-model",
+				"content": []any{
+					map[string]any{"type": "text", "text": "hi"},
+				},
+				// no "usage" key
+			},
+		},
+	})
+
+	if s.GetContextUsage() != nil {
+		t.Error("GetContextUsage should be nil when assistant message has no usage")
+	}
+}
+
+func TestHandleAgentEnd_FallbackContextWindow(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+	// Empty modelsCW (no entry for "unknown-model").
+	s.modelsCW = map[string]int{}
+
+	s.handleEvent(map[string]any{
+		"type": "agent_end",
+		"messages": []any{
+			map[string]any{
+				"role":  "assistant",
+				"model": "unknown-model",
+				"usage": map[string]any{
+					"input":      float64(1000),
+					"output":     float64(100),
+					"cacheRead":  float64(0),
+					"cacheWrite": float64(0),
+				},
+			},
+		},
+	})
+
+	usage := s.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage returned nil")
+	}
+	if usage.ContextWindow != 200_000 {
+		t.Errorf("ContextWindow = %d, want 200_000 (fallback)", usage.ContextWindow)
+	}
+}
+
+func TestHandleAgentEnd_NilModelsCW(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+	// modelsCW is nil (not loaded).
+	s.modelsCW = nil
+
+	s.handleEvent(map[string]any{
+		"type": "agent_end",
+		"messages": []any{
+			map[string]any{
+				"role":  "assistant",
+				"model": "any-model",
+				"usage": map[string]any{
+					"input":      float64(500),
+					"output":     float64(50),
+					"cacheRead":  float64(0),
+					"cacheWrite": float64(0),
+				},
+			},
+		},
+	})
+
+	usage := s.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage returned nil")
+	}
+	if usage.ContextWindow != 200_000 {
+		t.Errorf("ContextWindow = %d, want 200_000 (nil-map fallback)", usage.ContextWindow)
+	}
+}
+
+// ── GetContextUsage ──────────────────────────────────────────
+
+func TestGetContextUsage_NilBeforeAgentEnd(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+
+	if usage := s.GetContextUsage(); usage != nil {
+		t.Errorf("GetContextUsage should be nil before any agent_end, got %+v", usage)
+	}
+}
+
+func TestGetContextUsage_ReturnsCopy(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+	s.modelsCW = map[string]int{"m": 100_000}
+
+	s.handleEvent(map[string]any{
+		"type": "agent_end",
+		"messages": []any{
+			map[string]any{
+				"role":  "assistant",
+				"model": "m",
+				"usage": map[string]any{
+					"input":      float64(100),
+					"output":     float64(50),
+					"cacheRead":  float64(0),
+					"cacheWrite": float64(0),
+				},
+			},
+		},
+	})
+
+	u1 := s.GetContextUsage()
+	u2 := s.GetContextUsage()
+	if u1 == u2 {
+		t.Error("GetContextUsage should return different pointers (copy)")
+	}
+	if u1.UsedTokens != u2.UsedTokens {
+		t.Error("copies should have same values")
+	}
+}
+
+func TestHandleAgentEnd_WalksBackwardsForLastAssistant(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+	s.modelsCW = map[string]int{"model-a": 100_000, "model-b": 200_000}
+
+	// Two assistant messages — only the last one's usage should be captured.
+	s.handleEvent(map[string]any{
+		"type": "agent_end",
+		"messages": []any{
+			map[string]any{
+				"role":  "assistant",
+				"model": "model-a",
+				"usage": map[string]any{
+					"input":  float64(100),
+					"output": float64(10),
+				},
+			},
+			map[string]any{
+				"role":  "assistant",
+				"model": "model-b",
+				"usage": map[string]any{
+					"input":      float64(8000),
+					"output":     float64(500),
+					"cacheRead":  float64(3000),
+					"cacheWrite": float64(1000),
+				},
+			},
+		},
+	})
+
+	usage := s.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage returned nil")
+	}
+	// Should use model-b (last assistant), not model-a.
+	if usage.ContextWindow != 200_000 {
+		t.Errorf("ContextWindow = %d, want 200_000 (from model-b)", usage.ContextWindow)
+	}
+	if usage.InputTokens != 8000 {
+		t.Errorf("InputTokens = %d, want 8000 (from model-b)", usage.InputTokens)
+	}
+	if usage.OutputTokens != 500 {
+		t.Errorf("OutputTokens = %d, want 500 (from model-b)", usage.OutputTokens)
+	}
+}
+
+func TestHandleAgentEnd_SkipsAssistantWithoutUsage(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+	s.modelsCW = map[string]int{"real-model": 500_000}
+
+	// First assistant has no usage, second has usage — walk backwards should
+	// skip the first and pick the second.
+	s.handleEvent(map[string]any{
+		"type": "agent_end",
+		"messages": []any{
+			map[string]any{
+				"role":  "assistant",
+				"model": "no-usage-model",
+				// no "usage"
+			},
+			map[string]any{
+				"role":  "assistant",
+				"model": "real-model",
+				"usage": map[string]any{
+					"input":      float64(3000),
+					"output":     float64(200),
+					"cacheRead":  float64(1000),
+					"cacheWrite": float64(500),
+				},
+			},
+		},
+	})
+
+	usage := s.GetContextUsage()
+	if usage == nil {
+		t.Fatal("GetContextUsage returned nil — should have found the second assistant")
+	}
+	if usage.ContextWindow != 500_000 {
+		t.Errorf("ContextWindow = %d, want 500_000", usage.ContextWindow)
+	}
+	if usage.InputTokens != 3000 {
+		t.Errorf("InputTokens = %d, want 3000", usage.InputTokens)
+	}
+}

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -42,6 +42,10 @@ type piSession struct {
 
 	// modelsCW is a cached map of model ID → contextWindow, loaded once
 	// from ~/.pi/agent/models.json so every turn can look up the window.
+	// Loaded at session start and never refreshed — if models.json changes
+	// mid-session the new context windows won't be visible until restart.
+	// Sessions are typically short-lived and the 200K fallback handles
+	// unknown models, so a session-lifetime cache is acceptable.
 	modelsCW map[string]int
 
 	usageMu   sync.Mutex
@@ -414,17 +418,19 @@ func (s *piSession) handleAgentEnd(raw map[string]any) {
 		outputTokens, _ := usageRaw["output"].(float64)
 		cacheReadTokens, _ := usageRaw["cacheRead"].(float64)
 		cacheWriteTokens, _ := usageRaw["cacheWrite"].(float64)
-		totalTokens, _ := usageRaw["totalTokens"].(float64)
 
 		input := int(inputTokens)
 		output := int(outputTokens)
 		cr := int(cacheReadTokens)
+		cw := int(cacheWriteTokens)
 
-		total := int(totalTokens)
-		if total <= 0 {
-			cw := int(cacheWriteTokens)
-			total = input + output + cr + cw
-		}
+		// UsedTokens mirrors claudecode's per-sub-call pattern: track input
+		// + cache tokens from the last assistant message. The LLM API's
+		// input_tokens already counts the full conversation history, so this
+		// naturally represents cumulative context load across turns.
+		// TotalTokens = context load + output for this turn.
+		used := input + cw + cr
+		total := used + output
 
 		// Look up context window from models.json, fallback to 200K.
 		ctxWindow := s.modelsCW[model]
@@ -434,13 +440,16 @@ func (s *piSession) handleAgentEnd(raw map[string]any) {
 
 		s.usageMu.Lock()
 		s.lastUsage = &core.ContextUsage{
-			UsedTokens:               total,
+			UsedTokens:               used,
 			TotalTokens:              total,
 			InputTokens:              input,
 			OutputTokens:             output,
 			CachedInputTokens:        cr,
-			CacheCreationInputTokens: int(cacheWriteTokens),
+			CacheCreationInputTokens: cw,
 			ContextWindow:            ctxWindow,
+			// BaselineTokens and ReasoningOutputTokens are left zero — pi's
+			// RPC protocol does not report these. The engine's UI must handle
+			// zero values (e.g. hide the "baseline" or "reasoning" segments).
 		}
 		s.usageMu.Unlock()
 		return

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -39,6 +39,13 @@ type piSession struct {
 	alive     atomic.Bool
 
 	thinkingBuf strings.Builder // accumulates thinking_delta chunks
+
+	// modelsCW is a cached map of model ID → contextWindow, loaded once
+	// from ~/.pi/agent/models.json so every turn can look up the window.
+	modelsCW map[string]int
+
+	usageMu   sync.Mutex
+	lastUsage *core.ContextUsage
 }
 
 func newPiSession(ctx context.Context, cmd, workDir, model, mode, thinking, resumeID string, extraEnv []string) (*piSession, error) {
@@ -53,9 +60,10 @@ func newPiSession(ctx context.Context, cmd, workDir, model, mode, thinking, resu
 		extraEnv: extraEnv,
 		attachDir: filepath.Join(workDir, ".cc-connect", "attachments",
 			fmt.Sprintf("pi_%d", time.Now().UnixNano())),
-		events: make(chan core.Event, 64),
-		ctx:    sessionCtx,
-		cancel: cancel,
+		events:   make(chan core.Event, 64),
+		ctx:      sessionCtx,
+		cancel:   cancel,
+		modelsCW: loadModelsContextWindows(),
 	}
 	s.alive.Store(true)
 
@@ -220,7 +228,10 @@ func (s *piSession) handleEvent(raw map[string]any) {
 	case "message_end":
 		s.handleMessageEnd(raw)
 
-	case "agent_start", "agent_end", "turn_start", "turn_end", "message_start":
+	case "agent_end":
+		s.handleAgentEnd(raw)
+
+	case "agent_start", "turn_start", "turn_end", "message_start":
 		// Logged for debugging but no action needed.
 		slog.Debug("piSession: lifecycle event", "type", eventType)
 
@@ -373,6 +384,79 @@ func extractToolInput(item map[string]any) string {
 	}
 	b, _ := json.Marshal(args)
 	return truncStr(string(b), 200)
+}
+
+// handleAgentEnd processes the "agent_end" event from pi's RPC protocol.
+// It extracts the last assistant message's usage + model to populate
+// ContextUsage for the reply footer.
+func (s *piSession) handleAgentEnd(raw map[string]any) {
+	msgs, _ := raw["messages"].([]any)
+	if len(msgs) == 0 {
+		return
+	}
+
+	// Walk backwards to find the last assistant message with usage data.
+	for i := len(msgs) - 1; i >= 0; i-- {
+		msg, _ := msgs[i].(map[string]any)
+		if msg == nil {
+			continue
+		}
+		role, _ := msg["role"].(string)
+		if role != "assistant" {
+			continue
+		}
+		usageRaw, _ := msg["usage"].(map[string]any)
+		if usageRaw == nil {
+			continue
+		}
+		model, _ := msg["model"].(string)
+		inputTokens, _ := usageRaw["input"].(float64)
+		outputTokens, _ := usageRaw["output"].(float64)
+		cacheReadTokens, _ := usageRaw["cacheRead"].(float64)
+		cacheWriteTokens, _ := usageRaw["cacheWrite"].(float64)
+		totalTokens, _ := usageRaw["totalTokens"].(float64)
+
+		input := int(inputTokens)
+		output := int(outputTokens)
+		cr := int(cacheReadTokens)
+
+		total := int(totalTokens)
+		if total <= 0 {
+			cw := int(cacheWriteTokens)
+			total = input + output + cr + cw
+		}
+
+		// Look up context window from models.json, fallback to 200K.
+		ctxWindow := s.modelsCW[model]
+		if ctxWindow == 0 {
+			ctxWindow = 200_000
+		}
+
+		s.usageMu.Lock()
+		s.lastUsage = &core.ContextUsage{
+			UsedTokens:               total,
+			TotalTokens:              total,
+			InputTokens:              input,
+			OutputTokens:             output,
+			CachedInputTokens:        cr,
+			CacheCreationInputTokens: int(cacheWriteTokens),
+			ContextWindow:            ctxWindow,
+		}
+		s.usageMu.Unlock()
+		return
+	}
+}
+
+// GetContextUsage implements core.ContextUsageReporter.
+// Returns a copy to prevent concurrent readers from seeing mutations.
+func (s *piSession) GetContextUsage() *core.ContextUsage {
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+	if s.lastUsage == nil {
+		return nil
+	}
+	u := *s.lastUsage
+	return &u
 }
 
 func (s *piSession) RespondPermission(_ string, _ core.PermissionResult) error {


### PR DESCRIPTION
## Summary

pi agent now reports real runtime token usage for the reply footer, matching what claudecode already does. Footer shows context consumption (input/output/cache tokens, context window %) instead of the generic fallback.

## What changed

- **`agent/pi/pi.go`**: Added `loadModelsContextWindows()` — reads `~/.pi/agent/models.json` to map model IDs → context window sizes. Falls back to 200K when file is missing or model unknown.
- **`agent/pi/session.go`**:
  - Handles `agent_end` RPC event: extracts last assistant message's usage data (input/output/cache tokens, model) and maps to `core.ContextUsage`
  - Implements `core.ContextUsageReporter` via `GetContextUsage()` — thread-safe, returns a copy
  - Caches `modelsCW` at session start

## How it works

1. Session init loads model→contextWindow map from pi's `models.json`
2. On each `agent_end` event, walks messages backwards to find last assistant message with usage data
3. `GetContextUsage()` returns latest snapshot for the engine's reply footer rendering

## Test plan

- [x] Verified in Feishu: reply footer shows `cw N cr N · ctx N%` for pi agent responses
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] models.json absent → graceful fallback to 200K context window
- [x] `agent_end` event without usage data → nil returned, generic footer fallback