### PR TITLE
fix(core): handle reset_on_idle_mins in v1.3.3-beta.4

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3212,6 +3212,7 @@ func TestHandleMessage_AutoResetOnIdle_RotatesToNewSession(t *testing.T) {
 	old.SetAgentSessionID("old-session", "stub")
 	staleAt := time.Now().Add(-2 * time.Hour)
 	old.mu.Lock()
+	old.LastUserActivity = staleAt
 	old.UpdatedAt = staleAt
 	old.mu.Unlock()
 
@@ -3287,6 +3288,7 @@ func TestHandleMessage_AutoResetOnIdle_DoesNotRotateFreshSession(t *testing.T) {
 	session.SetAgentSessionID("existing-session", "stub")
 	recentAt := time.Now().Add(-5 * time.Minute)
 	session.mu.Lock()
+	session.LastUserActivity = recentAt
 	session.UpdatedAt = recentAt
 	session.mu.Unlock()
 
@@ -3325,6 +3327,71 @@ func TestHandleMessage_AutoResetOnIdle_DoesNotRotateFreshSession(t *testing.T) {
 	}
 }
 
+func TestHandleMessage_AutoResetOnIdle_FiresWhenHeartbeatBumpedUpdatedAt(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	agentSession := newResultAgentSession("fresh reply")
+	agent := &resultAgent{session: agentSession}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetResetOnIdle(60 * time.Minute)
+
+	key := "test:user1"
+	old := e.sessions.GetOrCreateActive(key)
+	old.AddHistory("user", "stale context")
+	old.SetAgentSessionID("old-session", "stub")
+
+	// Last user message was a long time ago — well past the idle threshold.
+	staleAt := time.Now().Add(-2 * time.Hour)
+	old.mu.Lock()
+	old.LastUserActivity = staleAt
+	old.mu.Unlock()
+
+	// Simulate a heartbeat (or unsolicited agent response) finishing right
+	// before this test's user message: Unlock() bumps UpdatedAt to now, but
+	// LastUserActivity is intentionally NOT touched by those code paths.
+	old.Unlock()
+
+	if !old.GetUpdatedAt().After(staleAt) {
+		t.Fatalf("expected Unlock to bump UpdatedAt, got %v vs %v", old.GetUpdatedAt(), staleAt)
+	}
+	if !old.GetLastUserActivity().Equal(staleAt) {
+		t.Fatalf("expected LastUserActivity to remain at %v, got %v", staleAt, old.GetLastUserActivity())
+	}
+
+	msg := &Message{
+		SessionKey: key,
+		Platform:   "test",
+		UserID:     "u1",
+		UserName:   "user",
+		Content:    "hello after idle",
+		ReplyCtx:   "ctx",
+	}
+	e.handleMessage(p, msg)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		active := e.sessions.GetOrCreateActive(key)
+		sent := p.getSent()
+		if active.ID != old.ID && len(active.GetHistory(0)) >= 2 && len(sent) >= 2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for idle auto-reset despite heartbeat-bumped UpdatedAt, sent=%v active=%s old=%s", sent, active.ID, old.ID)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	active := e.sessions.GetOrCreateActive(key)
+	if active.ID == old.ID {
+		t.Fatal("expected a new active session after idle auto-reset")
+	}
+	sent := p.getSent()
+	if !strings.Contains(sent[0], "Session auto-reset") {
+		t.Fatalf("first reply = %q, want auto-reset notice", sent[0])
+	}
+}
+
 func TestHandleMessage_AutoResetOnIdle_DoesNotTriggerForSlashCommand(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
@@ -3336,6 +3403,7 @@ func TestHandleMessage_AutoResetOnIdle_DoesNotTriggerForSlashCommand(t *testing.
 	session.SetAgentSessionID("old-session", "stub")
 	staleAt := time.Now().Add(-2 * time.Hour)
 	session.mu.Lock()
+	session.LastUserActivity = staleAt
 	session.UpdatedAt = staleAt
 	session.mu.Unlock()
 


### PR DESCRIPTION
## Summary

In v1.3.3-beta.4, configuring `reset_on_idle_mins` in `[[projects]]`
(e.g. `reset_on_idle_mins = 60`) does not cause the engine to rotate
sessions after the configured idle period. The config field is parsed
correctly, but the runtime check is defeated by `Session.Unlock()` —
which bumps `UpdatedAt` on every agent turn, heartbeat execution, and
unsolicited agent response — so the idle check always sees a fresh
timestamp.

This is the same root cause tracked in upstream #1115; the fix from
that issue is not present in the v1.3.3-beta.4 release line.

Fixes #1221

## Changes

- `core/session.go`: add `Session.LastUserActivity` plus
  `TouchUserActivity()` / `GetLastUserActivity()`. The field is only
  written from the engine when a real user message is processed; it is
  never touched by `Unlock()`. `omitempty` keeps disk compatibility.
- `core/engine.go` (`handleMessage`): after the
  `maybeAutoResetSessionOnIdle` check, call `session.TouchUserActivity()`
  so only real user activity counts toward the idle window.
- `core/engine.go` (`maybeAutoResetSessionOnIdle`): prefer
  `LastUserActivity` for the idle comparison and fall back to
  `UpdatedAt` for sessions persisted before this field existed.
- `core/engine_test.go`: existing tests updated to set
  `LastUserActivity` explicitly so the new semantic is exercised.
  New regression test
  `TestHandleMessage_AutoResetOnIdle_FiresWhenHeartbeatBumpedUpdatedAt`
  stubs a stale `LastUserActivity`, simulates a heartbeat by calling
  `Unlock()` (which bumps only `UpdatedAt`), and verifies the next
  user message still triggers idle rotation.

## Reproduction

```toml
[[projects]]
name = "demo"
reset_on_idle_mins = 30
admin_from = "ou_xxx"
[projects.agent]
type = "codex"
[projects.agent.options]
work_dir = "/tmp/demo"
[[projects.platforms]]
type = "telegram"
[projects.platforms.options]
bot_token = "xxx"
```

Before the patch: the "project: reset_on_idle_mins not set" log is
*not* the symptom here — the field is read, but sessions never rotate
because heartbeats keep `UpdatedAt` fresh. The new test reproduces
exactly that scenario in unit-test form.

## Test plan

- `go test -tags no_web -run 'TestHandleMessage_AutoResetOnIdle' ./core/`
- `go test -tags no_web ./config/`
- `go test -tags no_web -run 'TestResolveResetOnIdle' ./cmd/cc-connect/`

All pass on this branch.