### PR TITLE
fix(weixin): start pollLoop after ilink ready signal

### DIFF
--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -65,6 +65,12 @@ type Platform struct {
 	cancel   context.CancelFunc
 	stopping bool
 
+	// lifecycleHandler receives readiness callbacks once the ilink long-poll
+	// actually confirms a working session (first successful getUpdates).
+	// This is what distinguishes ready-for-poll from a Start()-time
+	// ready-for-publish signal that does not yet mean "messages can flow".
+	lifecycleHandler core.PlatformLifecycleHandler
+
 	syncBufMu   sync.Mutex
 	syncBuf     string
 	syncBufPath string
@@ -312,6 +318,17 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 	return nil
 }
 
+// SetLifecycleHandler registers a handler that will be notified once the ilink
+// long-poll has confirmed a working session. Implements
+// core.AsyncRecoverablePlatform so the engine waits for the actual
+// ready-for-poll signal before logging "platform ready" and initialising
+// platform-level capabilities.
+func (p *Platform) SetLifecycleHandler(h core.PlatformLifecycleHandler) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lifecycleHandler = h
+}
+
 func (p *Platform) Stop() error {
 	p.mu.Lock()
 	if p.cancel != nil {
@@ -326,6 +343,7 @@ func (p *Platform) Stop() error {
 func (p *Platform) pollLoop(ctx context.Context) {
 	backoff := time.Second
 	const maxBackoff = 30 * time.Second
+	readyNotified := false
 	for {
 		if ctx.Err() != nil {
 			return
@@ -367,6 +385,22 @@ func (p *Platform) pollLoop(ctx context.Context) {
 		}
 		if resp.Ret != 0 && resp.Errmsg != "" {
 			slog.Warn("weixin: getUpdates ret", "ret", resp.Ret, "errcode", resp.Errcode, "errmsg", resp.Errmsg)
+		}
+
+		// First successful getUpdates round-trip: ilink has accepted our token
+		// and the long-poll plumbing is alive. Treat this as the authoritative
+		// ready-for-poll signal; surface it to the engine so it can finish
+		// initialising platform-level capabilities and stop gating the
+		// "platform ready" log on a Start()-time promise.
+		if !readyNotified {
+			readyNotified = true
+			p.mu.RLock()
+			handler := p.lifecycleHandler
+			p.mu.RUnlock()
+			if handler != nil {
+				slog.Info("weixin: ilink ready-for-poll")
+				handler.OnPlatformReady(p)
+			}
 		}
 
 		p.mu.RLock()
@@ -746,4 +780,5 @@ var (
 	_ core.ImageSender                   = (*Platform)(nil)
 	_ core.FileSender                    = (*Platform)(nil)
 	_ core.TypingIndicator               = (*Platform)(nil)
+	_ core.AsyncRecoverablePlatform      = (*Platform)(nil)
 )

--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -6,7 +6,12 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
 )
 
 func TestBodyFromItemList_Text(t *testing.T) {
@@ -197,4 +202,145 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+// testLifecycleHandler captures lifecycle callbacks from a platform so tests
+// can assert that OnPlatformReady is invoked at the right moment.
+type testLifecycleHandler struct {
+	mu          sync.Mutex
+	readyCount  int32
+	readyCh     chan struct{}
+	unavailable []error
+}
+
+func newTestLifecycleHandler() *testLifecycleHandler {
+	return &testLifecycleHandler{readyCh: make(chan struct{}, 1)}
+}
+
+func (h *testLifecycleHandler) OnPlatformReady(p core.Platform) {
+	if atomic.AddInt32(&h.readyCount, 1) == 1 {
+		h.readyCh <- struct{}{}
+	}
+}
+
+func (h *testLifecycleHandler) OnPlatformUnavailable(p core.Platform, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.unavailable = append(h.unavailable, err)
+}
+
+func (h *testLifecycleHandler) ReadyCount() int {
+	return int(atomic.LoadInt32(&h.readyCount))
+}
+
+// newILinkTestServer returns an httptest.Server that responds to ilink
+// long-poll getUpdates calls with the provided body and status. Tests can
+// inspect callCount to confirm pollLoop actually issued requests.
+type ilinkTestServer struct {
+	server    *httptest.Server
+	callCount atomic.Int32
+	body      string
+	status    int
+}
+
+func newILinkTestServer(status int, body string) *ilinkTestServer {
+	s := &ilinkTestServer{body: body, status: status}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	return s
+}
+
+func (s *ilinkTestServer) Close() { s.server.Close() }
+func (s *ilinkTestServer) URL() string {
+	return s.server.URL
+}
+
+func TestPollLoop_NotifiesReadyForPollAfterFirstSuccessfulGetUpdates(t *testing.T) {
+	body := `{"ret":0,"errcode":0,"msgs":[],"get_updates_buf":"buf-1"}`
+	srv := newILinkTestServer(http.StatusOK, body)
+	defer srv.Close()
+
+	p := &Platform{
+		token:         "tok",
+		baseURL:       srv.URL(),
+		longPollMS:    100,
+		accountLabel:  "default",
+		httpClient:    &http.Client{},
+		dedup:         make(map[string]time.Time),
+		typingTickets: make(map[string]typingTicketEntry),
+	}
+	p.api = newAPIClient(srv.URL(), "tok", "", p.httpClient)
+
+	handler := newTestLifecycleHandler()
+	p.SetLifecycleHandler(handler)
+
+	if err := p.Start(func(core.Platform, *core.Message) {}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Stop() })
+
+	select {
+	case <-handler.readyCh:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("OnPlatformReady not observed within timeout (readyCount=%d, getUpdatesCalls=%d)",
+			handler.ReadyCount(), srv.callCount.Load())
+	}
+
+	// Give pollLoop enough time to issue at least one more getUpdates; the
+	// ready signal must remain a one-shot event.
+	time.Sleep(400 * time.Millisecond)
+
+	if got := handler.ReadyCount(); got != 1 {
+		t.Fatalf("ready callbacks = %d, want exactly 1 (one-shot)", got)
+	}
+	if got := srv.callCount.Load(); got < 2 {
+		t.Fatalf("getUpdates calls = %d, want >= 2 (pollLoop should keep polling)", got)
+	}
+}
+
+func TestPollLoop_DoesNotNotifyReadyForPollWhileGetUpdatesFails(t *testing.T) {
+	srv := newILinkTestServer(http.StatusInternalServerError, `{"ret":-1}`)
+	defer srv.Close()
+
+	p := &Platform{
+		token:         "tok",
+		baseURL:       srv.URL(),
+		longPollMS:    100,
+		accountLabel:  "default",
+		httpClient:    &http.Client{},
+		dedup:         make(map[string]time.Time),
+		typingTickets: make(map[string]typingTicketEntry),
+	}
+	p.api = newAPIClient(srv.URL(), "tok", "", p.httpClient)
+
+	handler := newTestLifecycleHandler()
+	p.SetLifecycleHandler(handler)
+
+	if err := p.Start(func(core.Platform, *core.Message) {}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Stop() })
+
+	// While every getUpdates returns 500, the backoff grows (1s, 2s, 4s, …).
+	// Within 2.5s we expect at least one more failed attempt but never a
+	// ready-for-poll signal.
+	time.Sleep(2500 * time.Millisecond)
+
+	if got := handler.ReadyCount(); got != 0 {
+		t.Fatalf("ready callbacks = %d, want 0 while getUpdates fails", got)
+	}
+	if got := srv.callCount.Load(); got < 1 {
+		t.Fatalf("getUpdates calls = %d, want >= 1 (pollLoop should be retrying)", got)
+	}
+}
+
+func TestPlatform_ImplementsAsyncRecoverablePlatform(t *testing.T) {
+	var p core.Platform = &Platform{}
+	if _, ok := p.(core.AsyncRecoverablePlatform); !ok {
+		t.Fatal("weixin Platform must implement core.AsyncRecoverablePlatform so the engine waits for ready-for-poll")
+	}
 }


### PR DESCRIPTION
Fixes #906

## 变更说明
- `platform/weixin/weixin.go`: 给 weixin `Platform` 增加 `lifecycleHandler` 字段和 `SetLifecycleHandler` 方法,实现 `core.AsyncRecoverablePlatform`。`pollLoop` 在第一次成功 `getUpdates` 后调用 `lifecycleHandler.OnPlatformReady(p)` 一次,并写入 `weixin: ilink ready-for-poll` 日志。
- `platform/weixin/weixin.go`: 在 `var (...)` 断言中增加 `core.AsyncRecoverablePlatform`,以编译期保证接口实现完整。
- `platform/weixin/weixin_test.go`: 新增三个测试:
  - `TestPollLoop_NotifiesReadyForPollAfterFirstSuccessfulGetUpdates`: 用 `httptest` 模拟 ilink long-poll 成功响应,验证 `OnPlatformReady` 在第一次成功 `getUpdates` 后触发,且不会在后续成功时重复触发。
  - `TestPollLoop_DoesNotNotifyReadyForPollWhileGetUpdatesFails`: 模拟持续 HTTP 500,验证在重试窗口内不会错误地把失败状态上报为 ready。
  - `TestPlatform_ImplementsAsyncRecoverablePlatform`: 编译期断言,防止接口被改回非 async 形态。

## 根因
v1.3.3-beta.4 的 weixin 平台在 `Start()` 返回 nil 后,引擎立即调用 `e.onPlatformReady(p)` 并打出 `platform ready` 日志,意味着"我们认为 ilink 通道已经可用"。但实际 `pollLoop` 是否在真正执行 `getUpdates`,以及 ilink 是否真的接受了 token、当前账号是否处于 `ready-for-publish` 之外的状态,都还未知。

`ilink` 的 ready 信号在不同账号状态下含义可能不同(扫码后未确认 / 二次校验未通过 / 风控暂停等),直接信任 `Start()` 的"返回即就绪"会留下一个虚假的 ready 信号,导致用户对端根本收不到任何消息,而 cc-connect 一侧看起来一切正常。

## 修复
让 weixin 实现 `core.AsyncRecoverablePlatform`,把"就绪"重定义为 *first successful `getUpdates` round-trip*。只有真的把 long-poll 拉起来并拿到一次合法响应,才通知引擎。这一改动同时带来:

1. 引擎的 `platform ready` 日志现在与 ilink 实际可用状态绑定,便于排障;
2. 引擎在收到 ready 之前不会调用 `initPlatformCapabilities`,避免在账号未就绪时执行菜单注册等副作用;
3. 与 Telegram / Discord 等其他 async 平台保持一致的 lifecycle 语义,降低后续维护负担。

## 风险
- 兼容性: 实现 `AsyncRecoverablePlatform` 是 *additional* 接口,引擎通过 type-assertion 动态启用,非 weixin 平台完全不受影响。
- 启动时序: 在 `pollLoop` 第一次成功 `getUpdates` 之前,引擎不会再走 `onPlatformReady` 路径——这正是本次修复想要的行为。但任何依赖 weixin 平台"Start 返回即就绪"的下游代码(例如基于 `engine.platformReady` 的判断)都会延后触发,这种代码如果存在应当已经通过 `AsyncRecoverablePlatform` 的契约处理。
- 单元测试只覆盖了 httptest 模拟路径,真实 ilink 网关的边界场景(例如返回 ret=0 但 errmsg 不为空)仍需在用户端验证。

## 测试
- `go test -count=1 -tags no_web ./platform/weixin/...` ✅
- `go test -count=1 -tags no_web ./cmd/...` ✅
- `go test -count=1 -tags no_web ./core/...` ✅

新增 3 个测试用例,全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)