### PR TITLE
test(weixin): add regression tests for context_token persistence (#1087)

### DIFF
--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -342,5 +344,102 @@ func TestPlatform_ImplementsAsyncRecoverablePlatform(t *testing.T) {
 	var p core.Platform = &Platform{}
 	if _, ok := p.(core.AsyncRecoverablePlatform); !ok {
 		t.Fatal("weixin Platform must implement core.AsyncRecoverablePlatform so the engine waits for ready-for-poll")
+	}
+}
+
+// TestContextToken_PersistAndReload verifies that context_token values written
+// via setContextToken survive a process restart by being persisted to
+// context_tokens.json and reloaded into the in-memory map on the next startup.
+// This is the regression coverage for #1087.
+func TestContextToken_PersistAndReload(t *testing.T) {
+	dir := t.TempDir()
+	tokensPath := filepath.Join(dir, "context_tokens.json")
+
+	// 1. First "process": store two context_tokens, then verify the file exists
+	//    with the expected JSON content.
+	p1 := &Platform{
+		tokens:     make(map[string]string),
+		tokensPath: tokensPath,
+	}
+	p1.setContextToken("user-aaa", "token-A")
+	p1.setContextToken("user-bbb", "token-B")
+
+	if _, err := os.Stat(tokensPath); err != nil {
+		t.Fatalf("expected context_tokens.json at %s, got: %v", tokensPath, err)
+	}
+
+	// Confirm the on-disk format is a JSON object keyed by peer user ID.
+	raw, err := os.ReadFile(tokensPath)
+	if err != nil {
+		t.Fatalf("read tokens file: %v", err)
+	}
+	var onDisk map[string]string
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("parse tokens file: %v (raw=%q)", err, string(raw))
+	}
+	if onDisk["user-aaa"] != "token-A" || onDisk["user-bbb"] != "token-B" {
+		t.Fatalf("on-disk tokens = %v, want user-aaa=token-A user-bbb=token-B", onDisk)
+	}
+
+	// 2. Second "process": same stateDir, fresh in-memory map. loadTokens()
+	//    must read the file and populate the map.
+	p2 := &Platform{
+		tokens:     make(map[string]string),
+		tokensPath: tokensPath,
+	}
+	p2.loadTokens()
+
+	if got := p2.getContextToken("user-aaa"); got != "token-A" {
+		t.Errorf("after reload, user-aaa = %q, want %q", got, "token-A")
+	}
+	if got := p2.getContextToken("user-bbb"); got != "token-B" {
+		t.Errorf("after reload, user-bbb = %q, want %q", got, "token-B")
+	}
+
+	// 3. ReconstructReplyCtx (the cron / cc-connect send path) must succeed
+	//    using the reloaded token.
+	rc, err := p2.ReconstructReplyCtx(sessionKeyPrefix + "user-aaa")
+	if err != nil {
+		t.Fatalf("ReconstructReplyCtx after reload: %v", err)
+	}
+	concrete, ok := rc.(*replyContext)
+	if !ok {
+		t.Fatalf("ReconstructReplyCtx returned %T, want *replyContext", rc)
+	}
+	if concrete.contextToken != "token-A" {
+		t.Errorf("reloaded contextToken = %q, want %q", concrete.contextToken, "token-A")
+	}
+}
+
+// TestContextToken_LoadMissingFile is a no-op fallback: if the persistence
+// file does not exist (first run, or after a cleanup), loadTokens must not
+// error and the in-memory map must remain empty.
+func TestContextToken_LoadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	p := &Platform{
+		tokens:     make(map[string]string),
+		tokensPath: filepath.Join(dir, "does-not-exist.json"),
+	}
+	// Should not panic, should not return an error.
+	p.loadTokens()
+	if got := p.getContextToken("anyone"); got != "" {
+		t.Errorf("getContextToken on fresh state = %q, want empty", got)
+	}
+}
+
+// TestReconstructReplyCtx_MissingToken verifies the cron / cc-connect send
+// path returns the expected actionable error when no context_token has ever
+// been stored for a peer. This is the "user must message the bot first"
+// case that the original #1087 reporter hit.
+func TestReconstructReplyCtx_MissingToken(t *testing.T) {
+	p := &Platform{
+		tokens: make(map[string]string),
+	}
+	_, err := p.ReconstructReplyCtx(sessionKeyPrefix + "never-messaged-user")
+	if err == nil {
+		t.Fatal("expected error for missing context_token, got nil")
+	}
+	if !containsStr(err.Error(), "no stored context_token") {
+		t.Errorf("error = %q, want it to mention 'no stored context_token'", err.Error())
 	}
 }


### PR DESCRIPTION
## 背景

[Issue #1087](https://github.com/chenhg5/cc-connect/issues/1087) 说 `context_token` 只存在内存里、20-30 分钟失效, 影响 `cc-connect send` 和 cron。

**结论: 修复已在 main 上, 这个 PR 只是补回归测试。**

实际代码层 (从最初 weixin feature [#257](https://github.com/chenhg5/cc-connect/pull/257) 就有了):
- `platform/weixin/weixin.go:78-80` — `tokensMu` / `tokens` / `tokensPath` 字段
- `platform/weixin/weixin.go:186` — `tokensPath = filepath.Join(stateDir, "context_tokens.json")`
- `platform/weixin/weixin.go:188` — 启动时调 `loadTokens()`
- `platform/weixin/weixin.go:231-246` — `loadTokens` 从 JSON 文件读
- `platform/weixin/weixin.go:248-261` — `persistTokens` 写回文件
- `platform/weixin/weixin.go:263-274` — `setContextToken` 写内存 + 落盘
- `platform/weixin/weixin.go:442-445` — 收到 inbound message 时存 token
- `platform/weixin/weixin.go:739-750` — `ReconstructReplyCtx` (cron/send 走的路径) 从存储读 token
- `platform/weixin/weixin.go:663-707` — `sendChunkWithRetry` 在 ret=-2 时尝试用新 token 重试; 拿不到新 token 直接 fail fast

`#1176` (commit `eb868664`) 也加固了 sendChunkWithRetry 的 fail-fast 行为。

**为什么还需要这个 PR**: 上面的路径**没有专门的单测**。修一个未来不小心把 persistence 退化的 PR, CI 不会发现。所以加三个回归测试, 把现有行为锁住。

## 改动

只动一个文件, +99 行测试, 0 行生产代码:

```
platform/weixin/weixin_test.go | 99 ++++++++++++++++++++++++++++++++++++++++++
```

新增 3 个测试:

1. **`TestContextToken_PersistAndReload`** — 写两个 token 到 disk, 验证 JSON 文件存在且结构对, 然后用新 Platform 实例 reload, 验证 `getContextToken` 和 cron/send 走的 `ReconstructReplyCtx` 都能拿到 token。
2. **`TestContextToken_LoadMissingFile`** — 文件不存在时 `loadTokens` 不报错, 内存 map 保持空 (first-run / 清理后场景)。
3. **`TestReconstructReplyCtx_MissingToken`** — 用户从没发过消息时, `ReconstructReplyCtx` 返回的 actionable error 就是 reporter 报的那条 "no stored context_token"。

## 关于 reporter 的 "20-30 分钟失效" 现象

WeChat ilink API 自己对 context_token 强加了 20-30 分钟的服务端有效期 — 这不是 cc-connect 能修复的。`sendChunkWithRetry` (#1176) 现在在 ret=-2 拿不到新 token 时直接 fail fast + 给清晰错误, 不会再傻重试 3 次。

## 测试

本地:
```
go test -count=1 -v ./platform/weixin/
```

18 个用例全过 (3 个新的 + 15 个老的), `go vet` 干净。

## 不做的事

- 不动 production code (没找到 bug)
- 不自动 merge (留给 PM/QA review)
- 不动 `sendChunkWithRetry` / `ReconstructReplyCtx` (已经在 #1176 处理过 fail-fast)
- 也没去碰 reporter 提到的 48 小时扩展 — 那是 WeChat API 限制, cc-connect 这边没法改