### PR TITLE
fix: address P1/P2 issues from post-merge QA review

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -59,16 +59,27 @@ type claudeSession struct {
 	// Stop hook timeout. The wait ends as soon as the process exits,
 	// so typical shutdowns take seconds, not the full timeout.
 	gracefulStopTimeout time.Duration
+
+	// startupWarning holds a one-time message to surface to the IM user at
+	// session start (e.g. when a permission mode was silently downgraded).
+	startupWarning string
 }
+
+// StartupWarning implements core.StartupWarner. Returns a non-empty string
+// when the session was started under degraded conditions that the user should
+// know about (e.g. bypassPermissions downgraded to auto under root).
+func (cs *claudeSession) StartupWarning() string { return cs.startupWarning }
 
 func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	// Claude Code rejects bypassPermissions when running as root.
 	// Downgrade to "auto" which auto-approves internally in cc-connect.
+	var rootDowngradeWarning string
 	if mode == "bypassPermissions" && os.Geteuid() == 0 {
 		slog.Warn("claudeSession: bypassPermissions not allowed under root, downgrading to auto mode")
 		mode = "auto"
+		rootDowngradeWarning = "⚠️ Running as root: bypassPermissions mode is not supported and has been downgraded to auto. The agent may still pause on high-risk operations."
 	}
 
 	// innerArgs are Claude Code CLI flags — when a wrapper is used with
@@ -226,6 +237,7 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		cancel:              cancel,
 		done:                make(chan struct{}),
 		gracefulStopTimeout: 120 * time.Second,
+		startupWarning:      rootDowngradeWarning,
 	}
 	cs.setPermissionMode(mode)
 	cs.sessionID.Store(sessionID)

--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -23,17 +23,23 @@ import (
 // Each Send() spawns `qodercli -p <prompt> -f stream-json -q`.
 // Subsequent turns use `-r <sessionID>` to resume the conversation.
 type qoderSession struct {
-	workDir   string
-	model     string
-	mode      string
-	extraEnv  []string
-	events    chan core.Event
-	sessionID atomic.Value // stores string
-	ctx       context.Context
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
-	alive     atomic.Bool
+	workDir        string
+	model          string
+	mode           string
+	extraEnv       []string
+	events         chan core.Event
+	sessionID      atomic.Value // stores string
+	ctx            context.Context
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+	alive          atomic.Bool
+	startupWarning string
 }
+
+// StartupWarning implements core.StartupWarner. Returns a non-empty string
+// when the session was started under degraded conditions (e.g. yolo mode
+// silently skipped under root).
+func (qs *qoderSession) StartupWarning() string { return qs.startupWarning }
 
 func newQoderSession(ctx context.Context, workDir, model, mode, resumeID string, extraEnv []string) (*qoderSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
@@ -48,6 +54,12 @@ func newQoderSession(ctx context.Context, workDir, model, mode, resumeID string,
 		cancel:   cancel,
 	}
 	qs.alive.Store(true)
+
+	// Detect root-induced yolo downgrade and surface it to the IM user via StartupWarning.
+	// The actual flag skip happens inside Send() when building the CLI args.
+	if mode == "yolo" && os.Geteuid() == 0 {
+		qs.startupWarning = "⚠️ Running as root: --dangerously-skip-permissions (yolo mode) is not supported and has been skipped. The agent may pause on high-risk operations."
+	}
 
 	if resumeID != "" && resumeID != core.ContinueSession {
 		qs.sessionID.Store(resumeID)

--- a/core/engine.go
+++ b/core/engine.go
@@ -3211,6 +3211,13 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		slog.Warn("slow agent session start", "elapsed", startElapsed, "agent", agent.Name(), "session_id", startSessionID)
 	}
 
+	// Surface any startup warning (e.g. permission mode downgrade under root) to the IM user.
+	if warner, ok := agentSession.(StartupWarner); ok {
+		if msg := warner.StartupWarning(); msg != "" {
+			e.send(p, replyCtx, msg)
+		}
+	}
+
 	if newID := agentSession.CurrentSessionID(); newID != "" {
 		// Track the latest session ID Claude reports. Each --resume forks a new
 		// session_id, so the stored ID must follow the live process or a later

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -380,9 +380,9 @@ func (p *stubCompactProgressPlatform) UpdateMessage(_ context.Context, _ any, co
 	return nil
 }
 
-func (p *stubCompactProgressPlatform) BuildRichCard(status CardStatus, title string, steps []ToolStep, markdown string, streaming bool, elapsed time.Duration) string {
+func (p *stubCompactProgressPlatform) BuildRichCard(status CardStatus, title string, steps []ToolStep, markdown string, streaming bool, statusFooter string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "rich status=%s title=%s streaming=%t elapsed=%s\n", status, title, streaming, elapsed)
+	fmt.Fprintf(&b, "rich status=%s title=%s streaming=%t footer=%s\n", status, title, streaming, statusFooter)
 	for _, step := range steps {
 		fmt.Fprintf(&b, "step=%+v\n", step)
 	}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -538,6 +538,15 @@ type LiveModeSwitcher interface {
 	SetLiveMode(mode string) bool
 }
 
+// StartupWarner is an optional interface for agent sessions that need to surface
+// a one-time warning to the IM user at session start (e.g. when a requested
+// permission mode was silently downgraded due to OS constraints). The engine
+// sends the returned message to the IM platform immediately after starting the
+// session. Returns empty string when no warning is needed.
+type StartupWarner interface {
+	StartupWarning() string
+}
+
 // PermissionModeInfo describes a permission mode for display.
 type PermissionModeInfo struct {
 	Key    string

--- a/core/relay.go
+++ b/core/relay.go
@@ -304,6 +304,8 @@ func normalizeRelayVisibility(mode string) string {
 	case "", RelayVisibilityFull:
 		return RelayVisibilityFull
 	default:
+		slog.Warn("relay: unknown visibility mode, falling back to full", "mode", mode,
+			"valid_values", []string{RelayVisibilityNone, RelayVisibilitySummary, RelayVisibilityFull})
 		return RelayVisibilityFull
 	}
 }

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -2497,7 +2497,15 @@ func detectFeishuFileType(mimeType, fileName string) string {
 		return larkim.FileTypeXls
 	case strings.HasSuffix(name, ".ppt") || strings.HasSuffix(name, ".pptx"):
 		return larkim.FileTypePpt
-	case mimeType == "video/mp4" || strings.HasSuffix(name, ".mp4"):
+	// Feishu's file API only has "mp4" as the video type. We map all common
+	// video MIME types and extensions to FileTypeMp4 so the message renders
+	// as a native video player bubble rather than a generic file download.
+	// Actual playback compatibility (e.g. webm/mkv) depends on the Feishu
+	// client platform; mp4 H.264 has the broadest support.
+	case strings.HasPrefix(mimeType, "video/") ||
+		strings.HasSuffix(name, ".mp4") || strings.HasSuffix(name, ".mov") ||
+		strings.HasSuffix(name, ".avi") || strings.HasSuffix(name, ".m4v") ||
+		strings.HasSuffix(name, ".mkv") || strings.HasSuffix(name, ".webm"):
 		return larkim.FileTypeMp4
 	case mimeType == "audio/ogg" || mimeType == "audio/opus" || mimeType == "application/ogg" || strings.HasSuffix(name, ".ogg") || strings.HasSuffix(name, ".opus"):
 		return larkim.FileTypeOpus

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -53,6 +53,11 @@ func New(opts map[string]any) (core.Platform, error) {
 		return nil, fmt.Errorf("slack: bot_token and app_token are required")
 	}
 	scope := normalizeSessionScope(opts["session_scope"], shareSessionInChannel)
+	if scope == "thread" {
+		slog.Warn("slack: session_scope=thread gives each Slack thread its own session; " +
+			"if your agent runtime is tmux, also set window_per_session=true — " +
+			"without it, concurrent threads share a single pane and their output will interleave")
+	}
 	return &Platform{
 		botToken:         botToken,
 		appToken:         appToken,


### PR DESCRIPTION
## Summary

Post-merge QA review identified several issues across the recent batch of merged PRs. This PR fixes the two P1s and three P2s that are safe to patch in a single targeted commit.

## P1 fixes

**1. Test stub `BuildRichCard` signature mismatch (core/engine_test.go)**
- `stubCompactProgressPlatform.BuildRichCard` still had `elapsed time.Duration` as the last parameter after #1204 changed `RichCardSupporter` to `statusFooter string`
- At runtime, the stub silently did NOT satisfy the interface, so all tests using it were bypassing the rich-card code path entirely — tests passed but didn't exercise the intended logic
- Fixed: update signature to `statusFooter string`, update format string accordingly

**2. Slack `session_scope=thread` without `window_per_session` (platform/slack)**
- When `session_scope=thread` is set but the tmux agent's `window_per_session=true` is not, concurrent threads share a single pane causing output interleave
- Fixed: emit a `slog.Warn` at `New()` time so operators see the misconfiguration in startup logs

## P2 fixes

**3. `relay.SetVisibility` silent fallback on unknown value (core/relay.go)**
- `normalizeRelayVisibility` fell back to `"full"` silently for unrecognised values
- Fixed: add a structured `slog.Warn` logging the invalid value and valid options

**4. Feishu video MIME format gap (platform/feishu/feishu.go)**
- CLI `send` accepted `.webm/.mov/.avi/.mkv/.m4v` as video attachments, but `detectFeishuFileType` only mapped `.mp4` → `FileTypeMp4` (Media message type); all others fell through to generic file download
- Fixed: expand video detection to cover all common video MIME types and extensions → `FileTypeMp4`, so they render as native Feishu video player bubbles (playback compatibility depends on client platform)

**5. Root bypass-downgrade not surfaced to IM user (agent/claudecode, agent/qoder, core)**
- When running as root, `bypassPermissions` (Claude Code) and `yolo` (Qoder) were silently downgraded with only a slog.Warn — users saw the agent pausing on permission requests without knowing why
- Fixed: add `StartupWarner` optional interface to `core/interfaces.go`; implement it in both session types; engine emits the warning message to the IM platform immediately after session start

## Test plan

- [ ] `go build ./core/ ./agent/... ./platform/...` passes (verified locally)
- [ ] Slack with `session_scope=thread` logs the warning at startup
- [ ] Feishu: send a `.mov` or `.webm` file via CLI — verify it appears as a video message (not a file attachment) in Feishu
- [ ] Claude Code / Qoder running as root with bypass mode — verify IM receives the downgrade warning on first session start

Made with [Cursor](https://cursor.com)