### PR TITLE
fix(opencode): surface tool rejection error as text to prevent empty response

### DIFF
--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -349,6 +349,24 @@ func (s *opencodeSession) handleToolUse(raw map[string]any) {
 		case <-s.ctx.Done():
 			return
 		}
+
+		// When a tool call is rejected (e.g. permission denied in default mode),
+		// opencode exits without generating any follow-up text. Surface the rejection
+		// reason so the engine has something meaningful to send rather than "(空响应)".
+		// This covers the common case where the user has not configured tool permissions
+		// and needs guidance to use mode="yolo" or update opencode settings.
+		if status == "error" && state != nil {
+			errMsg, _ := state["error"].(string)
+			if errMsg != "" {
+				slog.Info("opencodeSession: tool rejected, surfacing error as text", "tool", toolName, "error", errMsg)
+				errEvt := core.Event{Type: core.EventText, Content: errMsg}
+				select {
+				case s.events <- errEvt:
+				case <-s.ctx.Done():
+					return
+				}
+			}
+		}
 	}
 }
 

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -239,6 +240,97 @@ func TestHandleStepDuplicateEventResultPrevented(t *testing.T) {
 
 	if count != 1 {
 		t.Errorf("EventResult count = %d, want 1 (duplicate should be prevented)", count)
+	}
+}
+
+// TestHandleToolUsePermissionDeniedEmitsEventText verifies that when opencode
+// rejects a tool call (status="error"), the error message is emitted as an
+// EventText so the engine has something meaningful to deliver instead of
+// the generic "(空响应)" / "(empty response)" placeholder.
+// Reproduces the scenario in issue #178 where running bash commands in
+// default mode silently produced an empty response.
+func TestHandleToolUsePermissionDeniedEmitsEventText(t *testing.T) {
+	jsonData := `{"type":"tool_use","part":{"tool":"bash","state":{"status":"error","error":"The user rejected permission to use this specific tool call.","input":{"command":"ls","description":"List files in current directory"}}}}`
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonData), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{events: make(chan core.Event, 4), ctx: ctx}
+	s.handleToolUse(raw)
+
+	var events []core.Event
+	for len(s.events) > 0 {
+		events = append(events, <-s.events)
+	}
+
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events (EventToolUse + EventText), got %d: %v", len(events), events)
+	}
+	if events[0].Type != core.EventToolUse {
+		t.Errorf("events[0].Type = %v, want EventToolUse", events[0].Type)
+	}
+	if events[1].Type != core.EventText {
+		t.Errorf("events[1].Type = %v, want EventText (error text so engine has content)", events[1].Type)
+	}
+	if !strings.Contains(events[1].Content, "rejected permission") {
+		t.Errorf("EventText.Content = %q, want it to contain the rejection reason", events[1].Content)
+	}
+}
+
+// TestHandleToolUseCompletedDoesNotEmitExtraText verifies that a successfully
+// completed tool call does NOT emit an EventText (regression guard).
+func TestHandleToolUseCompletedDoesNotEmitExtraText(t *testing.T) {
+	jsonData := `{"type":"tool_use","part":{"tool":"bash","state":{"status":"completed","output":"file1.txt file2.txt","input":{"command":"ls"}}}}`
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonData), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{events: make(chan core.Event, 4), ctx: ctx}
+	s.handleToolUse(raw)
+
+	var events []core.Event
+	for len(s.events) > 0 {
+		events = append(events, <-s.events)
+	}
+
+	for _, evt := range events {
+		if evt.Type == core.EventText {
+			t.Errorf("unexpected EventText for completed tool: %q", evt.Content)
+		}
+	}
+	if len(events) < 2 {
+		t.Errorf("expected EventToolUse + EventToolResult for completed tool, got %d events", len(events))
+	}
+}
+
+// TestHandleToolUseErrorNoMessageNoText verifies that a tool error with empty
+// error message does NOT emit a spurious empty EventText.
+func TestHandleToolUseErrorNoMessageNoText(t *testing.T) {
+	jsonData := `{"type":"tool_use","part":{"tool":"bash","state":{"status":"error"}}}`
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(jsonData), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{events: make(chan core.Event, 4), ctx: ctx}
+	s.handleToolUse(raw)
+
+	for len(s.events) > 0 {
+		evt := <-s.events
+		if evt.Type == core.EventText {
+			t.Errorf("unexpected EventText for error with no message: %q", evt.Content)
+		}
 	}
 }
 


### PR DESCRIPTION
## 问题分析

关联 issue #178。

### 三类根因分析

| 类型 | 状态 | 说明 |
|------|------|------|
| step_finish reason=tool-calls 提前触发 EventResult | ✅ 已被 #1140 修复 | handleStepFinish 现只在 reason=stop 时触发 EventResult |
| agent 进程崩溃 (stale session ID / stderr) | ✅ 已被 #720 修复 | readLoop 先检查 stderr 再发 fallback EventResult |
| 权限拒绝导致无文本输出 | ❌ **本 PR 修复** | default 模式下 bash 被拒绝后进程直接退出，无 text 事件 |

### 核心 Bug（本 PR 修复）

在 `default` 模式下，用户运行命令（如 "执行 ls"）时：

1. opencode 尝试调用 bash 工具
2. 权限未配置 → 发出 `tool_use` 事件，`status="error"`，`error="The user rejected permission..."`
3. 发出 `step_finish`，`reason="tool-calls"`
4. **进程直接退出，未生成任何 text 事件**
5. readLoop 触发 fallback EventResult，`textParts` 为空
6. Engine：`fullResponse == ""` → 使用 `MsgEmptyResponse` → 用户看到 "(空响应)"

### 修复方案

在 `handleToolUse` 中，当 `status="error"` 且 `state["error"]` 非空时，额外发一个 `EventText` 包含拒绝原因。这样 `textParts` 有内容，engine 就能发出有意义的响应，而不是 "(空响应)"。

**用户实际看到的变化**：
- 之前：`(空响应)`
- 之后：`The user rejected permission to use this specific tool call.`

同时建议用户配置权限或使用 `mode = "yolo"`。

### 未覆盖的场景

- **"一问你好你是谁就空响应"**（2026-05-22/30 报告）：根据代码分析，这类简单对话的空响应最可能是 #1140 修复的 step_finish 提前触发问题，已于 2026-05-27 修复。若用户升级到最新版本后仍有问题，需要提供 debug 日志（特别是 step_finish reason 的值）。

## 变更

- `agent/opencode/session.go`: 在 `handleToolUse` 的 error 路径中发送 EventText
- `agent/opencode/session_test.go`: 三个新测试（permission denied → EventText；completed → 无额外 EventText；error 无消息 → 无空 EventText）

## 测试

```
go test ./agent/opencode/... -count=1 -run 'TestHandleToolUse' -v
--- PASS: TestHandleToolUsePermissionDeniedEmitsEventText (0.00s)
--- PASS: TestHandleToolUseCompletedDoesNotEmitExtraText (0.00s)
--- PASS: TestHandleToolUseErrorNoMessageNoText (0.00s)
```

Fixes #178

Made with [Cursor](https://cursor.com)