### PR TITLE
test(core): regression test for nil agentSession after force-kill (#1181)

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -8577,6 +8577,78 @@ func TestQueueMessage_NilAgentSession_DuringStartup(t *testing.T) {
 	state.mu.Unlock()
 }
 
+// TestProcessInteractiveMessageWith_NilAgentSession_NoPanic is a regression
+// test for issue #1181. When a long-running agent turn is force-killed
+// (e.g. by max_turn_time_mins) the cleanup path may leave an interactive
+// state in the map with agentSession==nil. A subsequent message routed to
+// that state must NOT panic with a nil-pointer deref at the old engine.go
+// v1.3.2 line 2164 site (drainEvents(state.agentSession.Events())) —
+// processInteractiveMessageWith should detect the nil state, send a
+// user-visible failure reply, and return cleanly.
+func TestProcessInteractiveMessageWith_NilAgentSession_NoPanic(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	agent := &controllableAgent{
+		startSessionFn: func(_ context.Context, _ string) (AgentSession, error) {
+			return nil, fmt.Errorf("simulated agent start failure")
+		},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	sessionKey := "test:user-nil-after-abandon"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	if !session.TryLock() {
+		t.Fatal("expected session lock")
+	}
+
+	// First call: agent.StartSession fails, leaving state.agentSession == nil.
+	// The nil guard at engine.go:2851 must send a failure reply and return
+	// without panicking. This branch protects against the v1.3.2 panic at
+	// the old line 2164.
+	done := make(chan struct{})
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("processInteractiveMessageWith panicked on nil agentSession: %v", r)
+			}
+			close(done)
+		}()
+		e.processInteractiveMessageWith(p, &Message{
+			SessionKey: sessionKey,
+			UserID:     "user-nil",
+			Content:    "trigger nil guard",
+			ReplyCtx:   "ctx-nil",
+		}, session, e.agent, e.sessions, sessionKey, "", sessionKey)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("processInteractiveMessageWith did not return after nil agentSession")
+	}
+
+	sent := p.getSent()
+	if len(sent) == 0 {
+		t.Fatal("expected a failure reply on the platform, got none")
+	}
+	if !strings.Contains(sent[0], e.i18n.T(MsgFailedToStartAgentSession)) {
+		t.Fatalf("expected MsgFailedToStartAgentSession, got %q", sent[0])
+	}
+
+	// State must still be present (cleanup did NOT run) and agentSession must
+	// still be nil — the user should be able to retry with a fresh message.
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[sessionKey]
+	e.interactiveMu.Unlock()
+	if !ok || state == nil {
+		t.Fatal("expected interactive state to remain in the map for retry")
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.agentSession != nil {
+		t.Fatal("expected agentSession to remain nil after failed start")
+	}
+}
+
 // --- 2. /compress flow ---
 
 type stubCompressorAgent struct {


### PR DESCRIPTION
## Summary

Issue #1181 reports a nil-pointer panic at the v1.3.2 line 2164 site
(`drainEvents(state.agentSession.Events())`) after a long-running agent
turn is force-killed by `max_turn_time_mins`.

Investigation on `origin/main` (2afceb73) found that BOTH sub-problems
are already addressed by commits in `main`:

1. **Timeout (the "agent send hang" sub-problem)** — `992b82ef` added
   `max_turn_time_mins` config + `SetMaxTurnTime` API + a deadline timer
   in `processInteractiveEvents` (engine.go:3780-3784). When the deadline
   fires, the engine uses a two-phase shutdown: first a graceful stop
   so the agent can persist its state, then a 10s grace period before
   force-kill via `cleanupInteractiveState`.

2. **Nil pointer (the panic sub-problem)** — The nil guard at
   `core/engine.go:2851`
   ```go
   if state.agentSession == nil {
       e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFailedToStartAgentSession))
       return
   }
   ```
   is reached BEFORE the old line 2164 site, so `drainEvents` is no
   longer reachable when `agentSession` is nil.

## What's in this PR

This PR adds a regression test that exercises the nil-after-startup
code path so the guard at line 2851 cannot be removed without breaking
CI:

- `TestProcessInteractiveMessageWith_NilAgentSession_NoPanic`
  forces `agent.StartSession` to return an error, which leaves
  `state.agentSession == nil` in the map. The test calls
  `processInteractiveMessageWith` directly and asserts:
  - no panic
  - a `MsgFailedToStartAgentSession` reply reaches the platform
  - the interactive state remains in the map so the user can retry
  - `state.agentSession` stays nil

## Verification

```
$ go test -count=1 -timeout 60s -run "TestProcessInteractiveMessageWith_NilAgentSession_NoPanic" -v ./core/
=== RUN   TestProcessInteractiveMessageWith_NilAgentSession_NoPanic
--- PASS: TestProcessInteractiveMessageWith_NilAgentSession_NoPanic (0.00s)
PASS

$ go test -count=1 -timeout 600s ./core/
ok  	github.com/chenhg5/cc-connect/core	42.288s
```

## Out of scope / open

- The `safeGo` panic recovery commits (`302fb72d`, `5320f37f`) live on
  `pr-1171` and have NOT been merged to `main`. They wrap engine-managed
  goroutines (including `processInteractiveMessageWith`) with a
  `recover()` that writes a crash log to `dataDir/crashes/crash.log`.
  Worth merging for defense-in-depth, but not required for #1181 since
  the nil guard already prevents the specific panic reported.

- No code change in `core/engine.go` is needed.

Closes #1181