### PR TITLE
fix(dingtalk): extract @userid from content in natural Reply

### DIFF
--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -744,11 +745,19 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 		return p.sendProactiveMessage(ctx, rc, content)
 	}
 
+	atUserIds := extractAtUserIds(content)
+
 	content = preprocessDingTalkMarkdown(content)
 
 	payload := map[string]any{
 		"msgtype":  "markdown",
 		"markdown": map[string]string{"title": "reply", "text": content},
+	}
+	if len(atUserIds) > 0 {
+		payload["at"] = map[string]any{
+			"atUserIds": atUserIds,
+			"isAtAll":   false,
+		}
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -1588,6 +1597,23 @@ func (p *Platform) sendProactiveMessage(ctx context.Context, rc replyContext, co
 
 	slog.Debug("dingtalk: proactive message sent", "api", apiURL, "status", resp.StatusCode)
 	return nil
+}
+
+var atUserIDRegexp = regexp.MustCompile(`@(\d{4,})`)
+
+// extractAtUserIds extracts @userId patterns from content for DingTalk's atUserIds field.
+// Matches @ followed by numeric DingTalk user IDs (e.g. @194252073827812352).
+func extractAtUserIds(content string) []string {
+	matches := atUserIDRegexp.FindAllStringSubmatch(content, -1)
+	seen := make(map[string]bool)
+	var ids []string
+	for _, m := range matches {
+		if len(m) > 1 && !seen[m[1]] {
+			seen[m[1]] = true
+			ids = append(ids, m[1])
+		}
+	}
+	return ids
 }
 
 // preprocessDingTalkMarkdown adapts content for DingTalk's markdown renderer:

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -1083,3 +1083,108 @@ func TestOnMessageRepliesToUnauthorizedSender(t *testing.T) {
 		t.Fatal("timed out waiting for unauthorized reply")
 	}
 }
+
+func TestExtractAtUserIds(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{name: "empty string", content: "", want: nil},
+		{name: "plain text no at", content: "hello world", want: nil},
+		{name: "3-digit not matched", content: "@123", want: nil},
+		{name: "4-digit match", content: "@1234", want: []string{"1234"}},
+		{name: "9-digit match", content: "@194252073", want: []string{"194252073"}},
+		{name: "18-digit match", content: "@194252073827812352", want: []string{"194252073827812352"}},
+		{name: "alphabetic no-match", content: "@user @admin", want: nil},
+		{name: "dedup", content: "@1234 @1234 @1234", want: []string{"1234"}},
+		{name: "multiple distinct", content: "@1234 @5678", want: []string{"1234", "5678"}},
+		{name: "embedded in text", content: "hello @1234 world", want: []string{"1234"}},
+		{name: "mixed valid and invalid", content: "@123 @1234 @user @567890", want: []string{"1234", "567890"}},
+		{name: "only at sign no digits", content: "@ @ @@", want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAtUserIds(tt.content)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return // both nil/empty
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("extractAtUserIds(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("extractAtUserIds(%q) = %v, want %v", tt.content, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestReply_IncludesExtractedAtUserIds(t *testing.T) {
+	gotPayload := make(chan map[string]any, 1)
+	sessionWebhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode reply payload: %v", err)
+		}
+		gotPayload <- payload
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sessionWebhook.Close()
+
+	p := &Platform{}
+
+	rc := replyContext{sessionWebhook: sessionWebhook.URL}
+	err := p.Reply(context.Background(), rc, "hello @12345678 world")
+	if err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	select {
+	case payload := <-gotPayload:
+		at, ok := payload["at"].(map[string]any)
+		if !ok {
+			t.Fatal("expected 'at' field in payload")
+		}
+		atUserIds, ok := at["atUserIds"].([]any)
+		if !ok {
+			t.Fatal("expected 'at.atUserIds' field in payload")
+		}
+		if len(atUserIds) != 1 || atUserIds[0] != "12345678" {
+			t.Fatalf("atUserIds = %v, want [\"12345678\"]", atUserIds)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reply")
+	}
+}
+
+func TestReply_NoAtUserIdsWhenNoMention(t *testing.T) {
+	gotPayload := make(chan map[string]any, 1)
+	sessionWebhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode reply payload: %v", err)
+		}
+		gotPayload <- payload
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sessionWebhook.Close()
+
+	p := &Platform{}
+
+	rc := replyContext{sessionWebhook: sessionWebhook.URL}
+	err := p.Reply(context.Background(), rc, "hello world, no mentions here")
+	if err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	select {
+	case payload := <-gotPayload:
+		if _, ok := payload["at"]; ok {
+			t.Fatal("expected no 'at' field when content has no @userId")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reply")
+	}
+}


### PR DESCRIPTION
## Summary
- 钉钉自然 Reply 路径自动从内容中提取 @userId 并填入 `at.atUserIds`
- regex 仅匹配 4+ 位数字 ID（`@(\d{4,})`），避免误匹配 `@123` 等短引用
- 支持去重，保持首次出现顺序

## QA Review Fixes (P2)
- regexp 提升为包级变量，避免每次 Reply 重复编译
- 补 gofmt 空行
- 新增 `TestExtractAtUserIds`（12 子用例）、`TestReply_IncludesExtractedAtUserIds`、`TestReply_NoAtUserIdsWhenNoMention`

## Test plan
- [x] 钉钉群聊中 @ 短 ID 用户能正确提取
- [x] `go build ./platform/dingtalk/` 通过
- [x] `go test ./platform/dingtalk/` 通过
- [x] `gofmt` / `go vet` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)