### PR TITLE
fix(web): render agent-type-aware permission mode options in ProjectDetail (#233)

### DIFF
--- a/web/src/pages/Projects/ProjectDetail.tsx
+++ b/web/src/pages/Projects/ProjectDetail.tsx
@@ -29,6 +29,29 @@ const PLATFORM_OPTIONS: { key: string; label: string; color: string; abbr: strin
   { key: 'weibo', label: 'Weibo (微博)', abbr: 'WB', color: 'bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400' },
 ];
 
+// Permission mode options per agent type. The values must match the keys
+// emitted by each agent's `normalizeMode` / `PermissionModes` so that
+// "save" round-trips correctly. See:
+//   claudecode: agent/claudecode/claudecode.go:818  (PermissionModes)
+//   codex:      agent/codex/codex.go:129            (normalizeMode)
+const CLAUDECODE_MODE_OPTIONS: { value: string; label: string }[] = [
+  { value: 'default', label: 'default' },
+  { value: 'acceptEdits', label: 'acceptEdits (edit)' },
+  { value: 'plan', label: 'plan' },
+  { value: 'bypassPermissions', label: 'bypassPermissions (yolo)' },
+  { value: 'dontAsk', label: 'dontAsk' },
+];
+const CODEX_MODE_OPTIONS: { value: string; label: string }[] = [
+  { value: 'suggest', label: 'suggest (default)' },
+  { value: 'auto-edit', label: 'auto-edit' },
+  { value: 'full-auto', label: 'full-auto' },
+  { value: 'yolo', label: 'yolo (bypass)' },
+];
+const MODE_OPTIONS_BY_AGENT: Record<string, { value: string; label: string }[]> = {
+  claudecode: CLAUDECODE_MODE_OPTIONS,
+  codex: CODEX_MODE_OPTIONS,
+};
+
 const isQRPlatform = (type: string) => type === 'feishu' || type === 'lark' || type === 'weixin';
 
 type Tab = 'overview' | 'providers' | 'heartbeat' | 'settings';
@@ -83,6 +106,13 @@ export default function ProjectDetail() {
   const navigate = useNavigate();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  // Permission mode options track the *effective* agent type: a freshly-picked
+  // type overrides the saved one so the dropdown matches what would be saved.
+  // Unknown agent types fall back to ClaudeCode (matches the previous hardcoded
+  // behavior) so this change is non-breaking for other agents.
+  const effectiveAgentType = selectedAgentType || project?.agent_type || '';
+  const modeOptions = MODE_OPTIONS_BY_AGENT[effectiveAgentType] || CLAUDECODE_MODE_OPTIONS;
 
   const handleDeleteProject = async () => {
     if (!name) return;
@@ -519,11 +549,12 @@ export default function ProjectDetail() {
                 onChange={(e) => setAgentMode(e.target.value)}
                 className="w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-accent/50"
               >
-                <option value="default">default</option>
-                <option value="acceptEdits">acceptEdits (edit)</option>
-                <option value="plan">plan</option>
-                <option value="bypassPermissions">bypassPermissions (yolo)</option>
-                <option value="dontAsk">dontAsk</option>
+                {modeOptions.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+                {agentMode && !modeOptions.some((o) => o.value === agentMode) && (
+                  <option value={agentMode}>{agentMode}</option>
+                )}
               </select>
             </div>
           </div>


### PR DESCRIPTION
Fixes #233

## Summary

Issue #233 reports that selecting yolo (or any non-ClaudeCode mode) on a
Codex project does not actually persist. The dropdown is hardcoded to
five ClaudeCode options at `web/src/pages/Projects/ProjectDetail.tsx:517-527`,
so Codex users never see the yolo option that the Codex backend actually
supports.

This PR makes the dropdown render agent-type-aware options. No backend
changes, no new dependencies, no breaking renames.

## What changed

Single file: `web/src/pages/Projects/ProjectDetail.tsx` (+36 / -5)

- Two new const arrays `CLAUDECODE_MODE_OPTIONS` and `CODEX_MODE_OPTIONS`
  with the exact mode keys emitted by each backend's
  `normalizeMode` / `PermissionModes`:
  - ClaudeCode: `default`, `acceptEdits`, `plan`, `bypassPermissions`, `dontAsk`
    (matches `agent/claudecode/claudecode.go:818` `PermissionModes`)
  - Codex: `suggest`, `auto-edit`, `full-auto`, `yolo`
    (matches `agent/codex/codex.go:129` `normalizeMode`)
- A `MODE_OPTIONS_BY_AGENT` lookup map plus a derived `modeOptions`
  inside the component that picks the right list from the *effective*
  agent type (`selectedAgentType || project.agent_type`).
- The five hardcoded `<option>` tags are replaced with a map over
  `modeOptions`, plus a defensive escape hatch that keeps the
  currently-saved value visible if it is no longer in the agent's
  list (handles a saved Codex mode on a ClaudeCode project, or
  any future rename).
- Unknown agent types fall back to the ClaudeCode list, matching the
  previous hardcoded behavior, so this is non-breaking for other
  agents (cursor, opencode, gemini, …).

## Reference / non-goals

The reference fix in commit `847758f8` (PR #816) also switches on agent
type, but bundles a **breaking rename** of the Codex modes
("auto-review" / "full-access" instead of the current "auto-edit" /
"full-auto"). This PR keeps the current normalized Codex keys, so a
project with `agent_mode = "yolo"` in config.toml loads the same value
back in the UI. If a breaking rename is desired later, that can be
a separate, coordinated backend+web change.

A similar hardcoded list exists in `web/src/pages/Cron/CronList.tsx:13`
(`MODE_OPTIONS = ['bypassPermissions', 'acceptEdits', 'auto', 'plan', 'dontAsk']`).
Per #233's scope (project settings) I left it alone, but the same
agent-type-aware approach should be applied there in a follow-up.
Cron's mode is per-job rather than per-project so the fix shape will
differ (need to look up the owning project's agent type).

## Verification

The web project has no test infrastructure (no vitest, jest, etc.) —
the only automated checks are TypeScript compilation and the Vite
production build. Both pass on this branch:

```
$ npx tsc -b
(clean)

$ npx vite build
✓ 2143 modules transformed.
dist/assets/index-CfJ4AY6L.css   81.46 kB
dist/assets/index-DURKlfiX.js   890.80 kB
✓ built in 4.34s
```

### Manual verification steps

1. Start the Web UI (`pnpm dev` or via the running service) against a
   project whose `agent_type` is `codex`.
2. Open the project's **Settings** tab.
3. The **Permission mode** dropdown should now show:
   `suggest (default)`, `auto-edit`, `full-auto`, `yolo (bypass)`.
4. Pick `yolo (bypass)` and click **Save**. The save response should
   return no error, and after `fetchAll` the dropdown should still
   show `yolo (bypass)` (not silently fall back to `default`).
5. Trigger a new agent turn and confirm the Codex subprocess starts
   with `--dangerously-bypass-approvals-and-sandbox` (look in the
   cc-connect logs or in the running Codex process arguments).
6. Switch the project's agent type back to `claudecode` and save. The
   dropdown should switch back to the original five options.
7. (Edge case) With a project whose saved `agent_mode` is `yolo` but
   whose `agent_type` is now `claudecode`, the dropdown should
   additionally render a `<option value="yolo">yolo</option>` so the
   stale value is still visible and not lost on the next save.

## Checklist

- [x] Branch is `agent/cc-connect/dev-claudecode/t-20260606-v49zct-webui-mode`
      (independent worktree, not the shared main checkout).
- [x] Based on `origin/main` @ 2afceb73.
- [x] No backend changes, no breaking renames.
- [x] `tsc -b` and `vite build` both pass.
- [x] No automated test framework exists for the web project, so
      verification is manual (steps above).
- [x] PR does NOT auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)