### PR TITLE
fix(cursor): implement interaction_query permission flow for default mode (#785)

### DIFF
--- a/agent/cursor/permission_test.go
+++ b/agent/cursor/permission_test.go
@@ -1,0 +1,322 @@
+package cursor
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// newTestSession creates a cursorSession suitable for unit tests (no real CLI process).
+func newTestSession(mode string) *cursorSession {
+	ctx, cancel := context.WithCancel(context.Background())
+	cs := &cursorSession{
+		cmd:     "agent",
+		workDir: "/tmp",
+		mode:    mode,
+		events:  make(chan core.Event, 16),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+	cs.alive.Store(true)
+	return cs
+}
+
+// connectStdinPipe wires an in-memory pipe as the session's stdin and returns
+// the reader end so tests can inspect what was written.
+func connectStdinPipe(cs *cursorSession) io.Reader {
+	r, w := io.Pipe()
+	cs.stdinMu.Lock()
+	cs.stdin = w
+	cs.stdinMu.Unlock()
+	return r
+}
+
+// readInteractionResponse reads one JSON line from the reader.
+func readInteractionResponse(t *testing.T, r io.Reader) map[string]any {
+	t.Helper()
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		t.Fatal("expected a line from stdin pipe, got none")
+	}
+	var out map[string]any
+	if err := json.Unmarshal(scanner.Bytes(), &out); err != nil {
+		t.Fatalf("parse stdin JSON: %v (line: %s)", err, scanner.Text())
+	}
+	return out
+}
+
+// webFetchInteractionRequest builds a raw map matching Cursor's interaction_query/request.
+func webFetchInteractionRequest(id int, url string, skipApproval bool) map[string]any {
+	return map[string]any{
+		"type":       "interaction_query",
+		"subtype":    "request",
+		"query_type": "webFetchRequestQuery",
+		"query": map[string]any{
+			"id": float64(id),
+			"webFetchRequestQuery": map[string]any{
+				"args":         map[string]any{"url": url},
+				"skipApproval": skipApproval,
+			},
+		},
+	}
+}
+
+// shellInteractionRequest builds a raw map matching Cursor's shellRequestQuery.
+func shellInteractionRequest(id int, cmd string, skipApproval bool) map[string]any {
+	return map[string]any{
+		"type":       "interaction_query",
+		"subtype":    "request",
+		"query_type": "shellRequestQuery",
+		"query": map[string]any{
+			"id": float64(id),
+			"shellRequestQuery": map[string]any{
+				"args":         map[string]any{"command": cmd},
+				"skipApproval": skipApproval,
+			},
+		},
+	}
+}
+
+// TestHandleInteractionQuery_DefaultMode_EmitsPermissionRequest checks that in
+// default mode an interaction_query/request causes an EventPermissionRequest and
+// no automatic stdin response (user must approve/deny via RespondPermission).
+func TestHandleInteractionQuery_DefaultMode_EmitsPermissionRequest(t *testing.T) {
+	cs := newTestSession("default")
+	defer cs.cancel()
+	_ = connectStdinPipe(cs)
+
+	cs.handleInteractionQuery(webFetchInteractionRequest(0, "https://example.com", false))
+
+	select {
+	case evt := <-cs.events:
+		if evt.Type != core.EventPermissionRequest {
+			t.Fatalf("event type = %q, want EventPermissionRequest", evt.Type)
+		}
+		if evt.ToolName != "WebFetch" {
+			t.Errorf("tool name = %q, want WebFetch", evt.ToolName)
+		}
+		if evt.ToolInput != "https://example.com" {
+			t.Errorf("tool input = %q, want https://example.com", evt.ToolInput)
+		}
+		if evt.RequestID == "" {
+			t.Error("request ID should be non-empty")
+		}
+	default:
+		t.Fatal("expected EventPermissionRequest, got nothing")
+	}
+}
+
+// TestHandleInteractionQuery_DefaultMode_ShellEmitsPermissionRequest checks the
+// same for shellRequestQuery (the originally reported Windows bug scenario).
+func TestHandleInteractionQuery_DefaultMode_ShellEmitsPermissionRequest(t *testing.T) {
+	cs := newTestSession("default")
+	defer cs.cancel()
+	_ = connectStdinPipe(cs)
+
+	cs.handleInteractionQuery(shellInteractionRequest(1, "git clone https://example.com", false))
+
+	select {
+	case evt := <-cs.events:
+		if evt.Type != core.EventPermissionRequest {
+			t.Fatalf("event type = %q, want EventPermissionRequest", evt.Type)
+		}
+		if evt.ToolName != "Bash" {
+			t.Errorf("tool name = %q, want Bash", evt.ToolName)
+		}
+	default:
+		t.Fatal("expected EventPermissionRequest for shell query, got nothing")
+	}
+}
+
+// TestHandleInteractionQuery_SkipApproval_AutoApproves checks that when Cursor
+// marks a request as skipApproval=true, we immediately write an approval response.
+func TestHandleInteractionQuery_SkipApproval_AutoApproves(t *testing.T) {
+	cs := newTestSession("default")
+	defer cs.cancel()
+	r := connectStdinPipe(cs)
+
+	done := make(chan map[string]any, 1)
+	go func() {
+		done <- readInteractionResponse(t, r)
+	}()
+
+	cs.handleInteractionQuery(webFetchInteractionRequest(3, "https://example.com", true))
+
+	resp := <-done
+	if resp["subtype"] != "response" {
+		t.Errorf("subtype = %q, want response", resp["subtype"])
+	}
+	response, _ := resp["response"].(map[string]any)
+	inner, _ := response["webFetchRequestResponse"].(map[string]any)
+	if _, ok := inner["approved"]; !ok {
+		t.Errorf("expected approved in response, got %v", inner)
+	}
+}
+
+// TestHandleInteractionQuery_NonDefaultMode_AutoDenies verifies that in plan/ask
+// mode interaction queries are denied immediately without user intervention.
+func TestHandleInteractionQuery_NonDefaultMode_AutoDenies(t *testing.T) {
+	for _, mode := range []string{"plan", "ask"} {
+		t.Run(mode, func(t *testing.T) {
+			cs := newTestSession(mode)
+			defer cs.cancel()
+			r := connectStdinPipe(cs)
+
+			done := make(chan map[string]any, 1)
+			go func() {
+				done <- readInteractionResponse(t, r)
+			}()
+
+			cs.handleInteractionQuery(webFetchInteractionRequest(0, "https://example.com", false))
+
+			resp := <-done
+			response, _ := resp["response"].(map[string]any)
+			inner, _ := response["webFetchRequestResponse"].(map[string]any)
+			if _, ok := inner["rejected"]; !ok {
+				t.Errorf("mode=%s: expected rejected in response, got %v", mode, inner)
+			}
+
+			// No EventPermissionRequest should be emitted.
+			select {
+			case evt := <-cs.events:
+				t.Errorf("mode=%s: unexpected event %q", mode, evt.Type)
+			default:
+			}
+		})
+	}
+}
+
+// TestRespondPermission_Approve writes an approval for a pending query and checks
+// that the correct JSON is sent to stdin.
+func TestRespondPermission_Approve(t *testing.T) {
+	cs := newTestSession("default")
+	defer cs.cancel()
+	r := connectStdinPipe(cs)
+
+	// Simulate a pending interaction query (as would be set by handleInteractionQuery).
+	cs.pendingMu.Lock()
+	cs.pending = &pendingInteractionQuery{id: 7, queryType: "webFetchRequestQuery"}
+	cs.pendingMu.Unlock()
+
+	done := make(chan map[string]any, 1)
+	go func() {
+		done <- readInteractionResponse(t, r)
+	}()
+
+	if err := cs.RespondPermission("webFetchRequestQuery:7", core.PermissionResult{Behavior: "allow"}); err != nil {
+		t.Fatalf("RespondPermission: %v", err)
+	}
+
+	resp := <-done
+	if resp["type"] != "interaction_query" {
+		t.Errorf("type = %q, want interaction_query", resp["type"])
+	}
+	if resp["subtype"] != "response" {
+		t.Errorf("subtype = %q, want response", resp["subtype"])
+	}
+	if resp["query_type"] != "webFetchRequestQuery" {
+		t.Errorf("query_type = %q, want webFetchRequestQuery", resp["query_type"])
+	}
+	response, _ := resp["response"].(map[string]any)
+	if idVal, _ := response["id"].(float64); int(idVal) != 7 {
+		t.Errorf("response.id = %v, want 7", response["id"])
+	}
+	inner, _ := response["webFetchRequestResponse"].(map[string]any)
+	if _, ok := inner["approved"]; !ok {
+		t.Errorf("expected approved in response body, got %v", inner)
+	}
+
+	// Pending should be cleared.
+	cs.pendingMu.Lock()
+	pending := cs.pending
+	cs.pendingMu.Unlock()
+	if pending != nil {
+		t.Error("pending query should be nil after RespondPermission")
+	}
+}
+
+// TestRespondPermission_Deny verifies denial responses.
+func TestRespondPermission_Deny(t *testing.T) {
+	cs := newTestSession("default")
+	defer cs.cancel()
+	r := connectStdinPipe(cs)
+
+	cs.pendingMu.Lock()
+	cs.pending = &pendingInteractionQuery{id: 2, queryType: "shellRequestQuery"}
+	cs.pendingMu.Unlock()
+
+	done := make(chan map[string]any, 1)
+	go func() {
+		done <- readInteractionResponse(t, r)
+	}()
+
+	if err := cs.RespondPermission("shellRequestQuery:2", core.PermissionResult{
+		Behavior: "deny",
+		Message:  "user rejected",
+	}); err != nil {
+		t.Fatalf("RespondPermission: %v", err)
+	}
+
+	resp := <-done
+	response, _ := resp["response"].(map[string]any)
+	inner, _ := response["shellRequestResponse"].(map[string]any)
+	rejected, _ := inner["rejected"].(map[string]any)
+	if rejected["reason"] != "user rejected" {
+		t.Errorf("reject reason = %q, want \"user rejected\"", rejected["reason"])
+	}
+}
+
+// TestRespondPermission_NoPending is a no-op regression guard: if no query is
+// pending (e.g. force mode or stale call), RespondPermission must not panic.
+func TestRespondPermission_NoPending(t *testing.T) {
+	cs := newTestSession("default")
+	defer cs.cancel()
+
+	if err := cs.RespondPermission("some-id", core.PermissionResult{Behavior: "allow"}); err != nil {
+		t.Fatalf("RespondPermission with no pending: %v", err)
+	}
+}
+
+// TestWriteInteractionResponse_ResponseFormat exercises the JSON shape emitted
+// for both approval and denial paths.
+func TestWriteInteractionResponse_ResponseFormat(t *testing.T) {
+	cases := []struct {
+		name      string
+		queryType string
+		approved  bool
+		wantKey   string
+	}{
+		{"web-approve", "webFetchRequestQuery", true, "approved"},
+		{"web-deny", "webFetchRequestQuery", false, "rejected"},
+		{"shell-approve", "shellRequestQuery", true, "approved"},
+		{"shell-deny", "shellRequestQuery", false, "rejected"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := newTestSession("default")
+			defer cs.cancel()
+			r := connectStdinPipe(cs)
+
+			done := make(chan string, 1)
+			go func() {
+				scanner := bufio.NewScanner(r)
+				if scanner.Scan() {
+					done <- scanner.Text()
+				}
+			}()
+
+			cs.writeInteractionResponse(0, tc.queryType, tc.approved, "test reason")
+
+			line := <-done
+			if !strings.Contains(line, tc.wantKey) {
+				t.Errorf("response JSON does not contain %q: %s", tc.wantKey, line)
+			}
+		})
+	}
+}

--- a/agent/cursor/session.go
+++ b/agent/cursor/session.go
@@ -35,6 +35,20 @@ type cursorSession struct {
 	alive    atomic.Bool
 
 	thinkingBuf strings.Builder // accumulate thinking deltas
+
+	// Permission handling: each Send() creates a new process whose stdin is used
+	// to respond to interaction_query permission requests.
+	stdinMu  sync.Mutex
+	stdin    io.WriteCloser // current process stdin; nil when no process is running
+
+	pendingMu sync.Mutex
+	pending   *pendingInteractionQuery // most recent unresolved interaction_query/request
+}
+
+// pendingInteractionQuery holds the info needed to write a response back to Cursor.
+type pendingInteractionQuery struct {
+	id        int    // query["id"] value from the original request
+	queryType string // e.g. "webFetchRequestQuery", "shellRequestQuery"
 }
 
 func newCursorSession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string) (*cursorSession, error) {
@@ -111,12 +125,24 @@ func (cs *cursorSession) Send(prompt string, images []core.ImageAttachment, file
 		return fmt.Errorf("cursorSession: stdout pipe: %w", err)
 	}
 
+	// Set up a stdin pipe so we can write interaction_query responses back to Cursor.
+	// Without a connected stdin, Cursor gets EOF and auto-rejects all permission requests.
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("cursorSession: stdin pipe: %w", err)
+	}
+
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
 
 	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
 		return fmt.Errorf("cursorSession: start: %w", err)
 	}
+
+	cs.stdinMu.Lock()
+	cs.stdin = stdin
+	cs.stdinMu.Unlock()
 
 	cs.wg.Add(1)
 	go cs.readLoop(cmd, stdout, &stderrBuf)
@@ -126,6 +152,15 @@ func (cs *cursorSession) Send(prompt string, images []core.ImageAttachment, file
 
 func (cs *cursorSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
 	defer cs.wg.Done()
+	defer func() {
+		// Close stdin so Cursor knows the input stream is finished.
+		cs.stdinMu.Lock()
+		if cs.stdin != nil {
+			_ = cs.stdin.Close()
+			cs.stdin = nil
+		}
+		cs.stdinMu.Unlock()
+	}()
 	defer func() {
 		if err := cmd.Wait(); err != nil {
 			stderrMsg := strings.TrimSpace(stderrBuf.String())
@@ -303,17 +338,103 @@ func (cs *cursorSession) handleInteractionQuery(raw map[string]any) {
 		return
 	}
 
-	toolName, input := extractInteractionQueryInfo(queryType, query)
+	// query["id"] is a JSON number — decoded as float64 by Go's json package.
+	idFloat, _ := query["id"].(float64)
+	queryID := int(idFloat)
+
+	toolName, inputStr := extractInteractionQueryInfo(queryType, query)
 	if toolName == "" {
+		// Unknown query type — deny immediately to unblock Cursor.
+		cs.writeInteractionResponse(queryID, queryType, false, "unsupported query type")
 		return
 	}
 
-	evt := core.Event{Type: core.EventToolUse, ToolName: toolName, ToolInput: input}
+	// Check skipApproval flag: some queries are pre-approved by Cursor itself.
+	if skipApproval := extractSkipApproval(queryType, query); skipApproval {
+		cs.writeInteractionResponse(queryID, queryType, true, "")
+		return
+	}
+
+	// In non-default modes there is no interactive approval path; deny to unblock.
+	if cs.mode != "default" {
+		cs.writeInteractionResponse(queryID, queryType, false, "permission mode does not allow interactive approval")
+		return
+	}
+
+	// Store pending query so RespondPermission can write the right response.
+	cs.pendingMu.Lock()
+	cs.pending = &pendingInteractionQuery{id: queryID, queryType: queryType}
+	cs.pendingMu.Unlock()
+
+	// Build a stable requestID that the engine passes back to RespondPermission.
+	requestID := fmt.Sprintf("%s:%d", queryType, queryID)
+
+	slog.Info("cursorSession: permission request", "request_id", requestID, "tool", toolName)
+	evt := core.Event{
+		Type:      core.EventPermissionRequest,
+		RequestID: requestID,
+		ToolName:  toolName,
+		ToolInput: inputStr,
+	}
 	select {
 	case cs.events <- evt:
 	case <-cs.ctx.Done():
 		return
 	}
+}
+
+// writeInteractionResponse writes a Cursor interaction_query response JSON line to the
+// current process stdin.  approved=true → {"approved":{}}; false → {"rejected":{"reason":...}}.
+func (cs *cursorSession) writeInteractionResponse(queryID int, queryType string, approved bool, reason string) {
+	// Derive the response field name from the request query type.
+	// "webFetchRequestQuery" → "webFetchRequestResponse"
+	// "shellRequestQuery"   → "shellRequestResponse"
+	responseKey := strings.TrimSuffix(queryType, "Query") + "Response"
+
+	var resultValue any
+	if approved {
+		resultValue = map[string]any{"approved": map[string]any{}}
+	} else {
+		resultValue = map[string]any{"rejected": map[string]any{"reason": reason}}
+	}
+
+	resp := map[string]any{
+		"type":       "interaction_query",
+		"subtype":    "response",
+		"query_type": queryType,
+		"response": map[string]any{
+			"id":        queryID,
+			responseKey: resultValue,
+		},
+	}
+
+	b, err := json.Marshal(resp)
+	if err != nil {
+		slog.Error("cursorSession: marshal interaction response", "error", err)
+		return
+	}
+	b = append(b, '\n')
+
+	cs.stdinMu.Lock()
+	defer cs.stdinMu.Unlock()
+	if cs.stdin == nil {
+		slog.Warn("cursorSession: stdin unavailable, cannot write interaction response")
+		return
+	}
+	if _, err := cs.stdin.Write(b); err != nil {
+		slog.Warn("cursorSession: write interaction response", "error", err)
+	}
+}
+
+// extractSkipApproval returns true when Cursor marks a query as pre-approved.
+func extractSkipApproval(queryType string, query map[string]any) bool {
+	// The inner query object is nested under the queryType key.
+	inner, _ := query[queryType].(map[string]any)
+	if inner == nil {
+		return false
+	}
+	skip, _ := inner["skipApproval"].(bool)
+	return skip
 }
 
 func extractInteractionQueryInfo(queryType string, query map[string]any) (string, string) {
@@ -435,8 +556,25 @@ func (cs *cursorSession) handleResult(raw map[string]any) {
 	}
 }
 
-// RespondPermission is a no-op — Cursor Agent permissions are handled via CLI default behavior or --force flag.
-func (cs *cursorSession) RespondPermission(_ string, _ core.PermissionResult) error {
+// RespondPermission writes the user's approval/denial decision back to the Cursor Agent
+// CLI via stdin.  Cursor is blocked waiting for this response when in default mode.
+func (cs *cursorSession) RespondPermission(_ string, result core.PermissionResult) error {
+	cs.pendingMu.Lock()
+	pq := cs.pending
+	cs.pending = nil
+	cs.pendingMu.Unlock()
+
+	if pq == nil {
+		// No interaction query is pending — nothing to respond to.
+		return nil
+	}
+
+	approved := result.Behavior == "allow"
+	reason := result.Message
+	if !approved && reason == "" {
+		reason = "User denied"
+	}
+	cs.writeInteractionResponse(pq.id, pq.queryType, approved, reason)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #785: _Cursor Agent in default mode auto-rejects shell commands on Windows without prompting for approval_

### Root cause

When Cursor Agent CLI runs with `--print` in `default` mode it uses a stdin/stdout IPC protocol for permission approval:

1. Cursor writes `{"type":"interaction_query","subtype":"request","query_type":"shellRequestQuery",...}` to stdout
2. The host (cc-connect) is expected to write `{"type":"interaction_query","subtype":"response",...}` to Cursor's stdin
3. If stdin is closed/EOF, Cursor auto-rejects with `{"rejected":{"reason":"User Rejected"}}`

Before this fix, cc-connect never connected a stdin pipe to the Cursor process, so every tool call (Bash, WebFetch, etc.) was immediately rejected with no user prompt.

### Changes — `agent/cursor/session.go`

| What | How |
|---|---|
| Stdin pipe | `Send()` calls `cmd.StdinPipe()` and stores the writer; `readLoop` closes it on exit |
| `handleInteractionQuery` | Now emits `EventPermissionRequest` in `default` mode so the engine can ask the user via the IM platform |
| `writeInteractionResponse` | New helper — marshals the correct Cursor JSON and writes to stdin |
| `RespondPermission` | No longer a no-op; looks up the pending query and calls `writeInteractionResponse` |
| skipApproval | Queries with `skipApproval=true` are auto-approved without user prompt |
| plan/ask modes | Auto-denied immediately (read-only modes, no tool execution) |

### Approval/denial JSON formats written to Cursor stdin

```json
// approve
{"type":"interaction_query","subtype":"response","query_type":"shellRequestQuery","response":{"id":0,"shellRequestResponse":{"approved":{}}}}

// deny
{"type":"interaction_query","subtype":"response","query_type":"shellRequestQuery","response":{"id":0,"shellRequestResponse":{"rejected":{"reason":"User denied"}}}}
```

### Tests — `agent/cursor/permission_test.go` (9 new tests)

- `TestHandleInteractionQuery_DefaultMode_EmitsPermissionRequest` — WebFetch → `EventPermissionRequest`
- `TestHandleInteractionQuery_DefaultMode_ShellEmitsPermissionRequest` — Bash → `EventPermissionRequest` (Windows bug regression)
- `TestHandleInteractionQuery_SkipApproval_AutoApproves` — `skipApproval=true` → approve without user prompt
- `TestHandleInteractionQuery_NonDefaultMode_AutoDenies` — plan/ask modes → deny + no event
- `TestRespondPermission_Approve` — approve response JSON shape
- `TestRespondPermission_Deny` — deny response JSON shape with custom reason
- `TestRespondPermission_NoPending` — no-op when no pending query (no panic)
- `TestWriteInteractionResponse_ResponseFormat` — 4 query×outcome combos

## Test plan

- [x] `go test ./agent/cursor/ -run "TestHandleInteraction|TestRespondPermission|TestWriteInteraction" -v` — all 9 PASS
- [x] `go test ./agent/cursor/ -count=1` — full suite PASS
- [x] `go vet ./agent/cursor/` — clean
- [x] `golangci-lint run --new-from-rev origin/main -E errcheck ./agent/cursor/` — 0 issues

## Note on shell commands rejected at `tool_call` level

From the original report's logs, some shell commands were rejected via `tool_call/completed` (not `interaction_query`). This appears to be Cursor CLI's own sandbox on Windows in `--print` mode. With a connected stdin, those shell commands should now go through `shellRequestQuery` → `interaction_query/request` → user approval flow instead of being silently rejected. Manual verification on a Windows machine with Cursor Agent is still needed to confirm the full end-to-end flow.

Do NOT merge automatically.

Made with [Cursor](https://cursor.com)