### PR TITLE
fix(kimi): remove unsupported --quiet flag, fix session reset on quiet mode (#806)

### DIFF
--- a/agent/kimi/kimi.go
+++ b/agent/kimi/kimi.go
@@ -28,7 +28,8 @@ func init() {
 //   - "default": standard mode (note: --print implicitly enables --yolo)
 //   - "yolo":    auto-approve all tool calls
 //   - "plan":    read-only plan mode
-//   - "quiet":   alias for --quiet (print + text + final-message-only)
+//   - "quiet":   suppress intermediate tool output; cc-connect buffers text until
+//                the final response (Kimi CLI does not have a --quiet flag)
 type Agent struct {
 	workDir    string
 	model      string

--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -63,6 +63,35 @@ func newKimiSession(ctx context.Context, cmd, workDir, model, mode, resumeID str
 	return ks, nil
 }
 
+// buildArgs constructs the Kimi CLI argument slice for the given prompt.
+// It is a pure function (no side-effects) to make the arg construction testable.
+func (ks *kimiSession) buildArgs(prompt string) []string {
+	args := []string{
+		"--print",
+		"--output-format", "stream-json",
+	}
+
+	switch ks.mode {
+	case "plan":
+		args = append(args, "--plan")
+	// "quiet" mode is handled by cc-connect (buffering text until the final response)
+	// rather than by a CLI flag — Kimi CLI does not support --quiet and returns
+	// "Invalid value for --quiet: Quiet mode implies --output-format text" when passed.
+	}
+
+	if sid := ks.CurrentSessionID(); sid != "" {
+		args = append(args, "--resume", sid)
+	}
+	if ks.model != "" {
+		args = append(args, "--model", ks.model)
+	}
+	if ks.workDir != "" {
+		args = append(args, "--work-dir", ks.workDir)
+	}
+	args = append(args, "--prompt", prompt)
+	return args
+}
+
 func (ks *kimiSession) Send(prompt string, images []core.ImageAttachment, files []core.FileAttachment) error {
 	if !ks.alive.Load() {
 		return fmt.Errorf("session is closed")
@@ -122,30 +151,7 @@ func (ks *kimiSession) Send(prompt string, images []core.ImageAttachment, files 
 		fullPrompt += "\n\n[Attached files saved at: " + strings.Join(fileRefs, ", ") + "]"
 	}
 
-	args := []string{
-		"--print",
-		"--output-format", "stream-json",
-	}
-
-	switch ks.mode {
-	case "plan":
-		args = append(args, "--plan")
-	case "quiet":
-		args = append(args, "--quiet")
-	}
-
-	sid := ks.CurrentSessionID()
-	if sid != "" {
-		args = append(args, "--resume", sid)
-	}
-	if ks.model != "" {
-		args = append(args, "--model", ks.model)
-	}
-	if ks.workDir != "" {
-		args = append(args, "--work-dir", ks.workDir)
-	}
-
-	args = append(args, "--prompt", fullPrompt)
+	args := ks.buildArgs(fullPrompt)
 
 	var cancel context.CancelFunc
 	var ctx context.Context
@@ -162,7 +168,7 @@ func (ks *kimiSession) Send(prompt string, images []core.ImageAttachment, files 
 		}
 	}()
 
-	slog.Debug("kimiSession: launching", "resume", sid != "", "args", core.RedactArgs(args))
+	slog.Debug("kimiSession: launching", "resume", ks.CurrentSessionID() != "", "args", core.RedactArgs(args))
 	cmd := exec.CommandContext(ctx, ks.cmd, args...)
 	cmd.WaitDelay = 1 * time.Second
 	cmd.Dir = ks.workDir

--- a/agent/kimi/session_test.go
+++ b/agent/kimi/session_test.go
@@ -162,6 +162,106 @@ func TestTruncate(t *testing.T) {
 	assert.Equal(t, "hello worl...", truncate("hello world", 10))
 }
 
+// TestBuildArgs_QuietModeDoesNotPassQuietFlag is the regression test for issue #806.
+// Kimi CLI does not support --quiet and returns an error when it is passed.
+// Switching to /mode quiet must not produce a --quiet CLI flag.
+func TestBuildArgs_QuietModeDoesNotPassQuietFlag(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", "/tmp", "", "quiet", "", nil, 0)
+	require.NoError(t, err)
+	defer ks.Close()
+
+	args := ks.buildArgs("test prompt")
+
+	for _, arg := range args {
+		if arg == "--quiet" {
+			t.Errorf("buildArgs produced --quiet for quiet mode, Kimi CLI does not support this flag")
+		}
+	}
+}
+
+// TestBuildArgs_PlanModePassesPlanFlag ensures --plan is still passed in plan mode.
+func TestBuildArgs_PlanModePassesPlanFlag(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", "/tmp", "", "plan", "", nil, 0)
+	require.NoError(t, err)
+	defer ks.Close()
+
+	args := ks.buildArgs("test prompt")
+
+	hasPlan := false
+	for _, arg := range args {
+		if arg == "--plan" {
+			hasPlan = true
+		}
+		if arg == "--quiet" {
+			t.Error("plan mode should not pass --quiet")
+		}
+	}
+	if !hasPlan {
+		t.Error("plan mode should pass --plan to Kimi CLI")
+	}
+}
+
+// TestBuildArgs_DefaultModeHasNoExtraFlags verifies default mode only passes
+// the base flags and no mode-specific extras.
+func TestBuildArgs_DefaultModeHasNoExtraFlags(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", "/tmp/work", "kimi-k2", "default", "", nil, 0)
+	require.NoError(t, err)
+	defer ks.Close()
+
+	args := ks.buildArgs("hello")
+
+	// Must contain base flags
+	assertContainsArg(t, args, "--print")
+	assertContainsArg(t, args, "stream-json")
+	// Must NOT contain mode-specific flags
+	assertNotContainsArg(t, args, "--quiet")
+	assertNotContainsArg(t, args, "--plan")
+}
+
+// TestBuildArgs_ResumeSessionID checks that --resume is passed when a session ID exists.
+func TestBuildArgs_ResumeSessionID(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", "/tmp", "", "default", "session-abc", nil, 0)
+	require.NoError(t, err)
+	defer ks.Close()
+
+	args := ks.buildArgs("continue")
+
+	// Find --resume and its value
+	for i, arg := range args {
+		if arg == "--resume" && i+1 < len(args) {
+			if args[i+1] != "session-abc" {
+				t.Errorf("--resume value = %q, want %q", args[i+1], "session-abc")
+			}
+			return
+		}
+	}
+	t.Error("buildArgs should include --resume <session-id> when session ID is set")
+}
+
+func assertContainsArg(t *testing.T, args []string, want string) {
+	t.Helper()
+	for _, a := range args {
+		if a == want {
+			return
+		}
+	}
+	t.Errorf("args %v should contain %q", args, want)
+}
+
+func assertNotContainsArg(t *testing.T, args []string, unwanted string) {
+	t.Helper()
+	for _, a := range args {
+		if a == unwanted {
+			t.Errorf("args %v should NOT contain %q", args, unwanted)
+			return
+		}
+	}
+}
+
 func drainEvents(ch <-chan core.Event, max int) []core.Event {
 	var events []core.Event
 	timeout := time.After(500 * time.Millisecond)


### PR DESCRIPTION
## Problem

Closes #806.

Two linked bugs:

**Bug 1 — `--quiet` CLI error**
When a user sends `/mode quiet` and then any message, cc-connect passes `--quiet` to the Kimi CLI alongside `--output-format stream-json`. Kimi CLI does not support `--quiet` and immediately exits with:
```
Invalid value for --quiet: Quiet mode implies --output-format text
```
This is a Claude Code-specific flag; it was never valid for Kimi.

**Bug 2 — Session auto-reset (group chats)**
The `--quiet` crash causes Kimi to exit before printing `"To resume this session: kimi -r <uuid>"`. Without that line, `kimiSession.sessionID` is never updated, so the next turn starts without `--resume`, effectively creating a new session every time — the "auto-reset" symptom.

## Root Cause

`agent/kimi/session.go` had:
```go
case "quiet":
    args = append(args, "--quiet")  // ← Kimi CLI rejects this
```

## Fix

- Remove the `--quiet` CLI flag for Kimi quiet mode.
- Quiet behavior (show only final response) is already implemented by the existing `pendingMsgs` buffer: text accumulates during tool calls and is emitted as `EventText` only at the end via `flushPendingAsText()`. No CLI flag is needed.
- Extract args construction into a `buildArgs()` helper to make it unit-testable without a real CLI binary.
- Update the inaccurate doc-comment in `kimi.go`.

## Tests

4 new regression tests in `session_test.go`:
- `TestBuildArgs_QuietModeDoesNotPassQuietFlag` — primary regression test for #806
- `TestBuildArgs_PlanModePassesPlanFlag` — ensures plan mode still works
- `TestBuildArgs_DefaultModeHasNoExtraFlags` — baseline
- `TestBuildArgs_ResumeSessionID` — session continuity

All `./agent/kimi/...` tests pass (including existing tests).

## Impact

- Only affects `agent/kimi`; no changes to Claude Code, Cursor, Codex, or OpenCode agents.
- The "quiet" mode UX for Kimi users is preserved (intermediate tool output shown as thinking, final text only at end).

Made with [Cursor](https://cursor.com)