### PR TITLE
fix(opencode): eliminate TempDir cleanup race in TestAvailableModels under -cover (#1118)

### DIFF
--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -40,6 +40,7 @@ type Agent struct {
 	modelCachePath       string
 	persistentModelCache *opencodePersistentModelCache
 	refreshingModelCache bool
+	refreshWg            sync.WaitGroup // tracks in-flight background model-cache refresh goroutines
 	mu                   sync.RWMutex
 }
 
@@ -344,9 +345,11 @@ func (a *Agent) startPersistentModelRefresh(snapshot opencodeModelDiscoverySnaps
 		return
 	}
 	a.refreshingModelCache = true
+	a.refreshWg.Add(1)
 	a.mu.Unlock()
 
 	go func() {
+		defer a.refreshWg.Done()
 		defer func() {
 			a.mu.Lock()
 			a.refreshingModelCache = false

--- a/agent/opencode/opencode_model_test.go
+++ b/agent/opencode/opencode_model_test.go
@@ -660,6 +660,14 @@ func TestAvailableModels_PrefersPersistentCacheOverDiscoveredModels(t *testing.T
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
+	a := agent.(*Agent)
+	// AvailableModels with a cached result launches a background refresh goroutine that
+	// writes into dataDir. Register cleanup BEFORE calling AvailableModels so that
+	// t.Cleanup runs in LIFO order: our Wait() fires first, then t.TempDir's RemoveAll.
+	// Without this, the goroutine can still be writing when RemoveAll runs, causing
+	// "TempDir RemoveAll cleanup: directory not empty" under -cover (see #1118).
+	t.Cleanup(func() { a.refreshWg.Wait() })
+
 	switcher, ok := agent.(core.ModelSwitcher)
 	if !ok {
 		t.Fatalf("New() agent does not implement core.ModelSwitcher")


### PR DESCRIPTION
## Problem

Fixes #1118.

`TestAvailableModels_PrefersPersistentCacheOverDiscoveredModels` intermittently fails under `-cover` with:

```
--- FAIL: TestAvailableModels_PrefersPersistentCacheOverDiscoveredModels (0.00s)
    testing.go:1369: TempDir RemoveAll cleanup: unlinkat /tmp/.../001: directory not empty
```

The test assertions pass — the failure is purely from Go's `t.TempDir()` cleanup hook running while a background goroutine is still writing into the directory.

## Root Cause

`AvailableModels()` with a warm persistent cache calls `startPersistentModelRefresh()`, which spawns a background goroutine that re-discovers models and writes the updated list to disk (`storePersistentModelCache` → `core.AtomicWriteFile`).

When the test function returns immediately after the assertion, `t.TempDir()` runs `os.RemoveAll` on the directory. The background goroutine may still be holding files open inside it. Under normal execution, the race window is too small to trigger; coverage instrumentation slows things down enough to make it reproducible.

## Fix (minimal, two-part)

**Production change** (`opencode.go`):
- Add `refreshWg sync.WaitGroup` to `Agent`.
- In `startPersistentModelRefresh`, call `a.refreshWg.Add(1)` before spawning the goroutine and `defer a.refreshWg.Done()` inside it.
- Zero production behaviour change — this is pure bookkeeping.

**Test change** (`opencode_model_test.go`):
- In `TestAvailableModels_PrefersPersistentCacheOverDiscoveredModels`, register `t.Cleanup(func() { a.refreshWg.Wait() })` immediately after the agent is created (and before `AvailableModels` is called).
- `t.Cleanup` functions run in LIFO order, so our `Wait()` fires **before** `t.TempDir()`'s `RemoveAll`, ensuring the background goroutine finishes writing before the directory is removed.

## Verification

```
$ for i in $(seq 1 10); do go test -count=1 -cover ./agent/opencode/...; done
ok  github.com/chenhg5/cc-connect/agent/opencode  0.228s  coverage: 53.1% of statements
ok  github.com/chenhg5/cc-connect/agent/opencode  0.225s  coverage: 53.1% of statements
ok  github.com/chenhg5/cc-connect/agent/opencode  0.212s  coverage: 53.1% of statements
ok  github.com/chenhg5/cc-connect/agent/opencode  0.211s  coverage: 53.1% of statements
ok  github.com/chenhg5/cc-connect/agent/opencode  0.212s  coverage: 53.1% of statements
ok  github.com/chenhg5/cc-connect/agent/opencode  0.210s  coverage: 53.1% of statements
ok  github.com/chenhg5/cc-connect/agent/opencode  0.211s  coverage: 53.1% of statements
ok  github.com/chenhg5/cc-connect/agent/opencode  0.207s  coverage: 53.1% of statements
ok  github.com/chenhg5/cc-connect/agent/opencode  0.221s  coverage: 53.1% of statements
ok  github.com/chenhg5/cc-connect/agent/opencode  0.240s  coverage: 53.1% of statements
```

**10/10 PASS** — no flakes.

## Scope

Changes are confined to `agent/opencode/` only. No other agents are affected.

Made with [Cursor](https://cursor.com)