### PR TITLE
docs(security): release note + migration hint for v1.4.0 allow_from fail-closed (companion to #1164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Security
+- **BREAKING: `allow_from` default changed from allow-all to fail-closed.** The legacy behavior treated an empty `allow_from` as “permit every user” (or any `*` wildcard as the same). Starting with v1.4.0, `allow_from` (and the platform-level `allow_chat`) **default to deny-all when empty**. Users upgrading from <v1.4.0 MUST explicitly set `allow_from` in `[[projects]]` (or `[platform.<name>.options]`) to grant access — otherwise the platform will reject every incoming message and log a clear `WARN` with the platform name and a hint to set `allow_from`. The wildcard `allow_from = "*"` is still supported and reproduces the old behavior; it should be used only as a temporary migration step and replaced with an explicit user list before going to production. Same rule applies to `allow_chat` for chat/group allow-listing. See the “Security defaults” callout at the top of `config.example.toml` for the migration recipe.
+
 ## v1.3.3-beta.4 (2026-05-28)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -443,6 +443,29 @@ start if any gate fails or if the probe detects a cross-user leak.
 
 ---
 
+### 🛡️ Security Defaults (v1.4.0+)
+
+From **v1.4.0** onwards, `allow_from` and the platform-level `allow_chat` default
+to **fail-closed** (deny-all) when left empty. In v1.3.x and earlier the same
+empty value meant "permit every user" — that legacy behavior is now opt-in via
+the explicit wildcard `allow_from = "*"`. If you upgrade without setting
+`allow_from` explicitly, every incoming message will be rejected and a `WARN`
+log will be emitted.
+
+```toml
+# Per-platform migration example / 平台级迁移示例
+[platform.telegram.options]
+token = "${TELEGRAM_BOT_TOKEN}"
+allow_from = ["*"]                       # 旧行为,临时开 / legacy behavior, temporary
+# allow_from = ["alice", "bob", "carol"]  # 生产前改成显式列表 / explicit list before production
+```
+
+See the **Unreleased** entry in [`CHANGELOG.md`](./CHANGELOG.md) and the
+"Security defaults" callout at the top of
+[`config.example.toml`](./config.example.toml) for the full migration recipe.
+
+---
+
 ### 🔐 Permission Modes
 
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -432,6 +432,26 @@ cc-connect doctor user-isolation
 
 ---
 
+### 🛡️ 安全默认值（v1.4.0+）
+
+从 **v1.4.0** 起,`allow_from` 以及平台级 `allow_chat` 在留空时默认为**失败
+关闭**(deny-all)。在 v1.3.x 及更早版本中,空值等价于"允许所有用户"——这一
+旧行为需要通过显式通配符 `allow_from = "*"` 才能恢复。如果升级时未显式设置
+`allow_from`,所有收到的消息都会被拒绝,并打印一条 `WARN` 日志。
+
+```toml
+# 平台级迁移示例
+[platform.telegram.options]
+token = "${TELEGRAM_BOT_TOKEN}"
+allow_from = ["*"]                       # 旧行为,临时开启
+# allow_from = ["alice", "bob", "carol"]  # 生产前改为显式白名单
+```
+
+完整迁移说明见 [`CHANGELOG.md`](./CHANGELOG.md) 的 **Unreleased** 段,以及
+[`config.example.toml`](./config.example.toml) 顶部的"Security defaults"提示块。
+
+---
+
 ### 🔐 权限模式
 
 ```

--- a/config.example.toml
+++ b/config.example.toml
@@ -14,6 +14,42 @@
 # 单个 cc-connect 进程可以同时管理多个项目。
 
 # =============================================================================
+# ⚠️  v1.4.0 BREAKING: allow_from now defaults to deny-all / allow_from 现在默认为全部拒绝
+# =============================================================================
+# In v1.3.x and earlier, an empty `allow_from` was treated as "permit every user"
+# (or any `*` wildcard as the same). Starting with v1.4.0, `allow_from` and the
+# platform-level `allow_chat` **default to deny-all when empty**. Without an
+# explicit value, the platform will reject every incoming message and emit a
+# clear `WARN` log. The wildcard `allow_from = "*"` still reproduces the old
+# behavior — use it as a TEMPORARY migration step only, and replace with an
+# explicit user list before going to production.
+#
+# 在 v1.3.x 及更早版本中,空的 `allow_from` 会被视为 "允许所有用户"(`*` 通配符
+# 行为相同)。从 v1.4.0 开始,`allow_from` 以及平台级 `allow_chat` **在留空时
+# 默认为全部拒绝**。如果未显式配置,平台会拒绝所有收到的消息,并打印一条清晰
+# 的 `WARN` 日志。通配符 `allow_from = "*"` 仍可复现旧行为 — 请仅作为临时
+# 迁移步骤使用,并在上生产前替换为显式用户列表。
+#
+# --- Migration example / 迁移示例 ---
+#
+#   [platform.telegram.options]
+#   token = "${TELEGRAM_BOT_TOKEN}"
+#   allow_from = ["*"]                       # 旧行为,临时开启,生产前改成显式列表
+#   # allow_from = ["alice", "bob", "carol"]  # 推荐的显式白名单形式
+#
+# Or, on a per-project basis / 也可以在 [[projects]] 级别配置:
+#
+#   [[projects]]
+#   name = "mybot"
+#   allow_from = ["*"]                       # 旧行为,临时开启
+#   [[projects.platforms]]
+#   type = "telegram"
+#   # ...
+#
+# See CHANGELOG.md "Unreleased" for the full release note.
+# 完整变更说明见 CHANGELOG.md 的 "Unreleased" 段。
+
+# =============================================================================
 # Global Settings / 全局设置
 # =============================================================================
 

--- a/core/command_test.go
+++ b/core/command_test.go
@@ -253,7 +253,7 @@ func TestAllowList(t *testing.T) {
 		user   string
 		expect bool
 	}{
-		{"", "anyone", true},
+		{"", "anyone", false},
 		{"*", "anyone", true},
 		{"user1", "user1", true},
 		{"user1", "USER1", true},

--- a/core/message.go
+++ b/core/message.go
@@ -29,18 +29,17 @@ func MergeEnv(base, extra []string) []string {
 	return append(merged, extra...)
 }
 
-// CheckAllowFrom logs a security warning at startup when allow_from is not
-// configured (defaults to permit-all). Platforms should call this during init.
 // CheckAllowFrom logs a startup message about the allow_from policy.
 // When allow_from is empty, access is denied for all users (fail-closed).
 // Users must explicitly set allow_from = "*" to permit everyone.
 func CheckAllowFrom(platform, allowFrom string) {
 	allowFrom = strings.TrimSpace(allowFrom)
-	if allowFrom == "" {
+	switch allowFrom {
+	case "":
 		slog.Warn("allow_from is not set — all users are DENIED (fail-closed). "+
 			"Set allow_from = \"*\" to permit everyone, or list specific user IDs.",
 			"platform", platform)
-	} else if allowFrom == "*" {
+	case "*":
 		slog.Warn("allow_from = \"*\" — all users are permitted. "+
 			"Consider restricting to specific user IDs.",
 			"platform", platform)

--- a/core/message.go
+++ b/core/message.go
@@ -31,10 +31,18 @@ func MergeEnv(base, extra []string) []string {
 
 // CheckAllowFrom logs a security warning at startup when allow_from is not
 // configured (defaults to permit-all). Platforms should call this during init.
+// CheckAllowFrom logs a startup message about the allow_from policy.
+// When allow_from is empty, access is denied for all users (fail-closed).
+// Users must explicitly set allow_from = "*" to permit everyone.
 func CheckAllowFrom(platform, allowFrom string) {
-	if strings.TrimSpace(allowFrom) == "" {
-		slog.Warn("allow_from is not set — all users are permitted. "+
-			"Set allow_from in config to restrict access.",
+	allowFrom = strings.TrimSpace(allowFrom)
+	if allowFrom == "" {
+		slog.Warn("allow_from is not set — all users are DENIED (fail-closed). "+
+			"Set allow_from = \"*\" to permit everyone, or list specific user IDs.",
+			"platform", platform)
+	} else if allowFrom == "*" {
+		slog.Warn("allow_from = \"*\" — all users are permitted. "+
+			"Consider restricting to specific user IDs.",
 			"platform", platform)
 	}
 }
@@ -49,12 +57,16 @@ func RedactToken(text, token string) string {
 }
 
 // AllowList checks whether a user ID is permitted based on a comma-separated
-// allow_from string. Returns true if allowFrom is empty or "*" (allow all),
-// or if the userID is in the list. Comparison is case-insensitive.
+// allow_from string. Returns true if allowFrom is "*" (allow all), or if the
+// userID is in the list. Empty allowFrom denies all (fail-closed).
+// Comparison is case-insensitive.
 func AllowList(allowFrom, userID string) bool {
 	allowFrom = strings.TrimSpace(allowFrom)
-	if allowFrom == "" || allowFrom == "*" {
+	if allowFrom == "*" {
 		return true
+	}
+	if allowFrom == "" {
+		return false
 	}
 	for _, id := range strings.Split(allowFrom, ",") {
 		if strings.EqualFold(strings.TrimSpace(id), userID) {

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -21,6 +21,7 @@ func TestGetAccessToken_ConcurrentAccess(t *testing.T) {
 	// with a pre-cached token are properly synchronized by the mutex
 
 	p := &Platform{
+		allowFrom: "*",
 		clientID:     "test_client",
 		clientSecret: "test_secret",
 		httpClient:   &http.Client{}, // Valid HTTP client
@@ -60,6 +61,7 @@ func TestGetAccessToken_ConcurrentAccess(t *testing.T) {
 func TestGetAccessToken_MutexExists(t *testing.T) {
 	// Verify that the tokenMu mutex field exists and works
 	p := &Platform{
+		allowFrom: "*",
 		clientID:     "test_client",
 		clientSecret: "test_secret",
 	}
@@ -79,6 +81,7 @@ func TestGetAccessToken_MutexExists(t *testing.T) {
 func TestGetAccessToken_CachedTokenAccess(t *testing.T) {
 	// Test that cached token access is thread-safe
 	p := &Platform{
+		allowFrom: "*",
 		clientID:     "test_client",
 		clientSecret: "test_secret",
 		accessToken:  "cached_token",
@@ -114,7 +117,7 @@ func TestGetAccessToken_CachedTokenAccess(t *testing.T) {
 
 func TestPlatform_MutexFieldExists(t *testing.T) {
 	// Verify the Platform struct has the tokenMu field
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 
 	// Verify no panic under lock (test will fail to compile if tokenMu doesn't exist)
 	p.tokenMu.Lock()
@@ -126,7 +129,7 @@ func TestPlatform_MutexFieldExists(t *testing.T) {
 
 func TestPlatform_AccessTokenFieldsExist(t *testing.T) {
 	// Verify the Platform struct has the token caching fields
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 
 	// Set the fields
 	p.accessToken = "test_token"
@@ -145,7 +148,7 @@ func TestPlatform_AccessTokenFieldsExist(t *testing.T) {
 // ──────────────────────────────────────────────────────────────
 
 func TestReconstructReplyCtx_GroupSharedSession(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	rctx, err := p.ReconstructReplyCtx("dingtalk:g:conv123")
 	if err != nil {
 		t.Fatalf("ReconstructReplyCtx() error = %v", err)
@@ -166,7 +169,7 @@ func TestReconstructReplyCtx_GroupSharedSession(t *testing.T) {
 }
 
 func TestReconstructReplyCtx_GroupPerUserSession(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	rctx, err := p.ReconstructReplyCtx("dingtalk:g:conv123:user456")
 	if err != nil {
 		t.Fatalf("ReconstructReplyCtx() error = %v", err)
@@ -184,7 +187,7 @@ func TestReconstructReplyCtx_GroupPerUserSession(t *testing.T) {
 }
 
 func TestReconstructReplyCtx_DirectSession(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	rctx, err := p.ReconstructReplyCtx("dingtalk:d:conv789:user111")
 	if err != nil {
 		t.Fatalf("ReconstructReplyCtx() error = %v", err)
@@ -205,7 +208,7 @@ func TestReconstructReplyCtx_DirectSession(t *testing.T) {
 }
 
 func TestReconstructReplyCtx_InvalidPrefix(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	_, err := p.ReconstructReplyCtx("telegram:g:conv123")
 	if err == nil {
 		t.Fatal("expected error for non-dingtalk prefix")
@@ -213,7 +216,7 @@ func TestReconstructReplyCtx_InvalidPrefix(t *testing.T) {
 }
 
 func TestReconstructReplyCtx_InvalidConvType(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	_, err := p.ReconstructReplyCtx("dingtalk:x:conv123")
 	if err == nil {
 		t.Fatal("expected error for invalid conversation type")
@@ -221,7 +224,7 @@ func TestReconstructReplyCtx_InvalidConvType(t *testing.T) {
 }
 
 func TestReconstructReplyCtx_EmptyConversationId(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	_, err := p.ReconstructReplyCtx("dingtalk:g:")
 	if err == nil {
 		t.Fatal("expected error for empty conversationId")
@@ -229,7 +232,7 @@ func TestReconstructReplyCtx_EmptyConversationId(t *testing.T) {
 }
 
 func TestReconstructReplyCtx_TooFewParts(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	_, err := p.ReconstructReplyCtx("dingtalk:")
 	if err == nil {
 		t.Fatal("expected error for too few parts")
@@ -241,7 +244,7 @@ func TestReconstructReplyCtx_TooFewParts(t *testing.T) {
 // ──────────────────────────────────────────────────────────────
 
 func TestFormatReplyContent_WithQuotedText(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	repliedContent, _ := json.Marshal(repliedTextContent{Text: "original message"})
 	richText := &richTextContent{
 		Content:    "user reply",
@@ -259,7 +262,7 @@ func TestFormatReplyContent_WithQuotedText(t *testing.T) {
 }
 
 func TestFormatReplyContent_EmptyContent_UsesFallback(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	repliedContent, _ := json.Marshal(repliedTextContent{Text: "quoted"})
 	richText := &richTextContent{
 		Content:    "",
@@ -277,7 +280,7 @@ func TestFormatReplyContent_EmptyContent_UsesFallback(t *testing.T) {
 }
 
 func TestFormatReplyContent_TextQuotePreservesWhitespace(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	repliedContent, _ := json.Marshal(repliedTextContent{Text: "  original message  "})
 	richText := &richTextContent{
 		Content:    "user reply",
@@ -295,7 +298,7 @@ func TestFormatReplyContent_TextQuotePreservesWhitespace(t *testing.T) {
 }
 
 func TestFormatReplyContent_NilRepliedMsg(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	richText := &richTextContent{
 		Content:    "just a message",
 		IsReplyMsg: true,
@@ -308,7 +311,7 @@ func TestFormatReplyContent_NilRepliedMsg(t *testing.T) {
 }
 
 func TestFormatReplyContent_NonTextMsgType(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	richText := &richTextContent{
 		Content:    "user reply",
 		IsReplyMsg: true,
@@ -324,7 +327,7 @@ func TestFormatReplyContent_NonTextMsgType(t *testing.T) {
 }
 
 func TestFormatReplyContent_WithQuotedInteractiveCardContent(t *testing.T) {
-	p := &Platform{cardTemplateKey: "content"}
+	p := &Platform{allowFrom: "*", cardTemplateKey: "content"}
 	richText := &richTextContent{
 		Content:    "user reply",
 		IsReplyMsg: true,
@@ -349,7 +352,7 @@ func TestFormatReplyContent_WithQuotedInteractiveCardContent(t *testing.T) {
 }
 
 func TestFormatReplyContent_WithQuotedInteractiveCardCustomTemplateKey(t *testing.T) {
-	p := &Platform{cardTemplateKey: "body"}
+	p := &Platform{allowFrom: "*", cardTemplateKey: "body"}
 	richText := &richTextContent{
 		Content:    "next question",
 		IsReplyMsg: true,
@@ -374,7 +377,7 @@ func TestFormatReplyContent_WithQuotedInteractiveCardCustomTemplateKey(t *testin
 }
 
 func TestFormatReplyContent_WithQuotedInteractiveCardNestedJSONEnvelope(t *testing.T) {
-	p := &Platform{cardTemplateKey: "content"}
+	p := &Platform{allowFrom: "*", cardTemplateKey: "content"}
 	richText := &richTextContent{
 		Content:    "continue",
 		IsReplyMsg: true,
@@ -394,7 +397,7 @@ func TestFormatReplyContent_WithQuotedInteractiveCardNestedJSONEnvelope(t *testi
 }
 
 func TestFormatReplyContent_WithQuotedInteractiveCardTopLevelFallback(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	richText := &richTextContent{
 		Content:    "what next?",
 		IsReplyMsg: true,
@@ -415,7 +418,7 @@ func TestFormatReplyContent_WithQuotedInteractiveCardTopLevelFallback(t *testing
 }
 
 func TestFormatReplyContent_InteractiveCardPreservesVisibleJSONContent(t *testing.T) {
-	p := &Platform{cardTemplateKey: "content"}
+	p := &Platform{allowFrom: "*", cardTemplateKey: "content"}
 	richText := &richTextContent{
 		Content:    "follow up",
 		IsReplyMsg: true,
@@ -440,7 +443,7 @@ func TestFormatReplyContent_InteractiveCardPreservesVisibleJSONContent(t *testin
 }
 
 func TestFormatReplyContent_InteractiveCardTopLevelFallbackIgnoresCustomKey(t *testing.T) {
-	p := &Platform{cardTemplateKey: "body"}
+	p := &Platform{allowFrom: "*", cardTemplateKey: "body"}
 	richText := &richTextContent{
 		Content:    "follow up",
 		IsReplyMsg: true,
@@ -461,7 +464,7 @@ func TestFormatReplyContent_InteractiveCardTopLevelFallbackIgnoresCustomKey(t *t
 }
 
 func TestFormatReplyContent_TruncatesLongQuotedInteractiveCardContent(t *testing.T) {
-	p := &Platform{cardTemplateKey: "content"}
+	p := &Platform{allowFrom: "*", cardTemplateKey: "content"}
 	longText := strings.Repeat("x", maxQuotedMessageRunes+1)
 	cardContent, err := json.Marshal(map[string]any{
 		"cardData": map[string]any{
@@ -492,6 +495,7 @@ func TestFormatReplyContent_TruncatesLongQuotedInteractiveCardContent(t *testing
 func TestOnRawMessage_QuotedInteractiveCardEnrichesMessageContent(t *testing.T) {
 	var got *core.Message
 	p := &Platform{
+		allowFrom:       "*",
 		cardTemplateKey: "content",
 		handler: func(_ core.Platform, msg *core.Message) {
 			got = msg
@@ -533,7 +537,7 @@ func TestOnRawMessage_QuotedInteractiveCardEnrichesMessageContent(t *testing.T) 
 }
 
 func TestFormatReplyContent_EmptyQuotedText(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	repliedContent, _ := json.Marshal(repliedTextContent{Text: ""})
 	richText := &richTextContent{
 		Content:    "user reply",
@@ -556,7 +560,7 @@ func TestFormatReplyContent_EmptyQuotedText(t *testing.T) {
 func TestProactiveRouting_GroupSessionUsesGroupAPI(t *testing.T) {
 	// Verify that a group session key produces a replyContext with isGroup=true,
 	// which sendProactiveMessage would route to groupMessages/send.
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	rctx, err := p.ReconstructReplyCtx("dingtalk:g:conv123:user456")
 	if err != nil {
 		t.Fatalf("ReconstructReplyCtx() error = %v", err)
@@ -570,7 +574,7 @@ func TestProactiveRouting_GroupSessionUsesGroupAPI(t *testing.T) {
 func TestProactiveRouting_DirectSessionUsesDirectAPI(t *testing.T) {
 	// Verify that a direct session key produces a replyContext with isGroup=false,
 	// which sendProactiveMessage would route to oToMessages/batchSend.
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	rctx, err := p.ReconstructReplyCtx("dingtalk:d:conv789:user111")
 	if err != nil {
 		t.Fatalf("ReconstructReplyCtx() error = %v", err)
@@ -704,6 +708,7 @@ func TestOnRawMessage_PictureMsgTypeNotDroppedAsEmptyText(t *testing.T) {
 	func() {
 		defer func() { recover() }() // handleImageMessage panics on nil httpClient — that's OK
 		p := &Platform{
+			allowFrom: "*",
 			handler: func(_ core.Platform, msg *core.Message) {
 				if msg.Content == "" && len(msg.Images) == 0 {
 					handlerCalledWithEmptyContent = true
@@ -732,6 +737,7 @@ func TestOnRawMessage_PictureMsgTypeNotDroppedAsEmptyText(t *testing.T) {
 
 func TestGetAccessToken_ZeroExpireIn_FallsBackToDefault(t *testing.T) {
 	p := &Platform{
+		allowFrom: "*",
 		clientID:     "test_client",
 		clientSecret: "test_secret",
 		httpClient: &http.Client{
@@ -759,6 +765,7 @@ func TestGetAccessToken_ZeroExpireIn_FallsBackToDefault(t *testing.T) {
 
 func TestGetAccessToken_NegativeExpireIn_FallsBackToDefault(t *testing.T) {
 	p := &Platform{
+		allowFrom: "*",
 		clientID:     "test_client",
 		clientSecret: "test_secret",
 		httpClient: &http.Client{
@@ -777,6 +784,7 @@ func TestGetAccessToken_NegativeExpireIn_FallsBackToDefault(t *testing.T) {
 
 func TestGetAccessToken_NormalExpireIn_AppliesBuffer(t *testing.T) {
 	p := &Platform{
+		allowFrom: "*",
 		clientID:     "test_client",
 		clientSecret: "test_secret",
 		httpClient: &http.Client{

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -18,6 +18,8 @@ func TestOnMessageRecalledDispatchesCoreRecallMessage(t *testing.T) {
 	got := make(chan *core.Message, 1)
 	p := &Platform{
 		platformName: "feishu",
+		allowFrom:    "*",
+		allowChat:    "*",
 		handler: func(_ core.Platform, msg *core.Message) {
 			got <- msg
 		},
@@ -1011,6 +1013,8 @@ func TestOnMessageThreadIsolationAdmitsAttachmentWithoutMention(t *testing.T) {
 		appID:           appID,
 		appSecret:       appSecret,
 		botOpenID:       botOpenID,
+		allowFrom:       "*",
+		allowChat:       "*",
 		threadIsolation: true,
 		dedup:           &core.MessageDedup{},
 		client: lark.NewClient(appID, appSecret,

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -571,6 +571,7 @@ func TestNewFeishu_InvalidCustomDomain(t *testing.T) {
 func TestLark_SessionKeyPrefix(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
+		"allow_from": "*", "allow_chat": "*",
 	})
 	if err != nil {
 		t.Fatalf("newPlatform(lark) error = %v", err)
@@ -626,6 +627,7 @@ func TestLark_SessionKeyPrefix(t *testing.T) {
 func TestLark_ThreadIsolationUsesRootSessionKey(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+		"allow_from": "*", "allow_chat": "*",
 	})
 	if err != nil {
 		t.Fatalf("newPlatform(lark) error = %v", err)
@@ -688,6 +690,7 @@ func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
 		"group_reply_all": true, "thread_isolation": true,
+		"allow_from": "*", "allow_chat": "*",
 	})
 	if err != nil {
 		t.Fatalf("newPlatform(lark) error = %v", err)

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -117,7 +117,7 @@ func TestNew_ProgressStyleRejectsInvalidValue(t *testing.T) {
 }
 
 func TestInteractivePlatform_OnMessagePassesCardSenderToHandler(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -181,7 +181,7 @@ func TestInteractivePlatform_OnMessagePassesCardSenderToHandler(t *testing.T) {
 }
 
 func TestInteractivePlatform_CardActionPassesCardSenderToHandler(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -235,7 +235,7 @@ func TestInteractivePlatform_CardActionPassesCardSenderToHandler(t *testing.T) {
 }
 
 func TestInteractivePlatform_CardActionActWithoutCardResponseDoesNotWarn(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -276,7 +276,7 @@ func TestInteractivePlatform_CardActionActWithoutCardResponseDoesNotWarn(t *test
 }
 
 func TestInteractivePlatform_CardActionFormSubmitPassesSelectedIDs(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -321,7 +321,7 @@ func TestInteractivePlatform_CardActionFormSubmitPassesSelectedIDs(t *testing.T)
 }
 
 func TestInteractivePlatform_CardActionFormSubmitUsesActionNameFallback(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -365,7 +365,7 @@ func TestInteractivePlatform_CardActionFormSubmitUsesActionNameFallback(t *testi
 }
 
 func TestInteractivePlatform_CardActionFormCancelUsesActionNameFallback(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -405,7 +405,7 @@ func TestInteractivePlatform_CardActionFormCancelUsesActionNameFallback(t *testi
 }
 
 func TestInteractivePlatform_CardActionUsesCallbackSessionKey(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*", "thread_isolation": true})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -445,7 +445,7 @@ func TestInteractivePlatform_CardActionUsesCallbackSessionKey(t *testing.T) {
 }
 
 func TestInteractivePlatform_ModelCardActionReturnsCardUpdate(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1056,7 +1056,7 @@ func TestAllowChat_FiltersGroupMessages(t *testing.T) {
 		chatType  string
 		wantPass  bool
 	}{
-		{"empty allow_chat permits all groups", "", "oc_abc", "group", true},
+		{"empty allow_chat denies all groups (fail-closed)", "", "oc_abc", "group", false},
 		{"wildcard permits all groups", "*", "oc_abc", "group", true},
 		{"matching chat_id passes", "oc_abc", "oc_abc", "group", true},
 		{"non-matching chat_id blocked", "oc_abc", "oc_xyz", "group", false},
@@ -1070,6 +1070,7 @@ func TestAllowChat_FiltersGroupMessages(t *testing.T) {
 			p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
 				"app_id": "cli_xxx", "app_secret": "secret",
 				"enable_feishu_card": true,
+				"allow_from":        "*",
 				"group_reply_all":    true,
 				"allow_chat":         tt.allowChat,
 			})
@@ -1256,7 +1257,7 @@ func (m *mockRefreshPlatform) RefreshCard(ctx context.Context, sessionKey string
 }
 
 func TestCardAction_NavFast_ReturnsCard(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1291,7 +1292,7 @@ func TestCardAction_NavFast_ReturnsCard(t *testing.T) {
 }
 
 func TestCardAction_NavSlow_ReturnsToastThenRefreshes(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -1342,7 +1343,7 @@ func TestCardAction_NavSlow_ReturnsToastThenRefreshes(t *testing.T) {
 }
 
 func TestCardAction_NavSlow_NilCard_NoRefresh(t *testing.T) {
-	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "allow_from": "*", "allow_chat": "*"})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}

--- a/platform/max/max_test.go
+++ b/platform/max/max_test.go
@@ -120,7 +120,7 @@ func TestDefaultFilename(t *testing.T) {
 }
 
 func TestReconstructReplyCtx(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	cases := []struct {
 		key     string
 		chatID  string
@@ -310,8 +310,9 @@ func (m *mockAPI) handleCDN(w http.ResponseWriter, r *http.Request) {
 func newTestPlatform(t *testing.T, apiBase string) *Platform {
 	t.Helper()
 	p, err := New(map[string]any{
-		"token":    "test-token",
-		"api_base": apiBase,
+		"token":      "test-token",
+		"api_base":   apiBase,
+		"allow_from": "*",
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/platform/slack/slack_test.go
+++ b/platform/slack/slack_test.go
@@ -51,7 +51,7 @@ func TestDownloadSlackFile_HTMLDetection(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	p := &Platform{botToken: "xoxb-test-token"}
+	p := &Platform{allowFrom: "*", botToken: "xoxb-test-token"}
 	_, err := p.downloadSlackFile(ts.URL)
 	if err == nil {
 		t.Fatal("expected error for HTML response, got nil")
@@ -70,7 +70,7 @@ func TestDownloadSlackFile_MissingAuth(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	p := &Platform{botToken: "xoxb-test-token"}
+	p := &Platform{allowFrom: "*", botToken: "xoxb-test-token"}
 	_, err := p.downloadSlackFile(ts.URL)
 	if err == nil {
 		t.Fatal("expected error for 401 response, got nil")
@@ -91,7 +91,7 @@ func TestDownloadSlackFile_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	p := &Platform{botToken: "xoxb-test-token"}
+	p := &Platform{allowFrom: "*", botToken: "xoxb-test-token"}
 	data, err := p.downloadSlackFile(ts.URL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -102,7 +102,7 @@ func TestDownloadSlackFile_Success(t *testing.T) {
 }
 
 func TestDownloadSlackFile_EmptyURL(t *testing.T) {
-	p := &Platform{botToken: "xoxb-test-token"}
+	p := &Platform{allowFrom: "*", botToken: "xoxb-test-token"}
 	_, err := p.downloadSlackFile("")
 	if err == nil {
 		t.Fatal("expected error for empty URL, got nil")
@@ -127,7 +127,7 @@ func TestProcessSlackFileShares_GenericFile(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	p := &Platform{botToken: "xoxb-test"}
+	p := &Platform{allowFrom: "*", botToken: "xoxb-test"}
 	images, audio, docs := p.processSlackFileShares([]slackevents.File{
 		{
 			ID:                 "Fpdf",
@@ -162,7 +162,7 @@ func TestProcessSlackFileShares_ImageVsDoc(t *testing.T) {
 	}))
 	defer txtSrv.Close()
 
-	p := &Platform{botToken: "xoxb-test"}
+	p := &Platform{allowFrom: "*", botToken: "xoxb-test"}
 	images, audio, docs := p.processSlackFileShares([]slackevents.File{
 		{ID: "1", Name: "x.png", Mimetype: "image/png", URLPrivateDownload: imgSrv.URL},
 		{ID: "2", Name: "n.txt", Mimetype: "text/plain", URLPrivateDownload: txtSrv.URL},
@@ -188,7 +188,7 @@ func TestProcessSlackFileShares_EmptyMimeBecomesOctetStream(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	p := &Platform{botToken: "xoxb-test"}
+	p := &Platform{allowFrom: "*", botToken: "xoxb-test"}
 	_, _, docs := p.processSlackFileShares([]slackevents.File{
 		{ID: "z", Name: "blob.bin", Mimetype: "", URLPrivateDownload: ts.URL},
 	})

--- a/platform/telegram/telegram_test.go
+++ b/platform/telegram/telegram_test.go
@@ -237,6 +237,7 @@ func TestPlatformStart_RetriesInBackgroundUntilConnected(t *testing.T) {
 	me := &models.User{ID: 42, Username: "mybot"}
 
 	p := &Platform{
+		allowFrom: "*",
 		token:      "token",
 		httpClient: &http.Client{},
 		newBot: func(_ string, _ func(context.Context, *models.Update), _ *http.Client) (telegramBot, *models.User, func(context.Context), error) {
@@ -281,6 +282,7 @@ func TestPlatformStart_InitialConnectFailureEmitsUnavailableOnceBeforeReady(t *t
 	me := &models.User{ID: 42, Username: "mybot"}
 
 	p := &Platform{
+		allowFrom: "*",
 		token:      "token",
 		httpClient: &http.Client{},
 		newBot: func(_ string, _ func(context.Context, *models.Update), _ *http.Client) (telegramBot, *models.User, func(context.Context), error) {
@@ -321,7 +323,7 @@ func TestPlatformStart_InitialConnectFailureEmitsUnavailableOnceBeforeReady(t *t
 }
 
 func TestPlatformDisconnectedSendPathsReturnNotConnected(t *testing.T) {
-	p := &Platform{token: "token", httpClient: &http.Client{}}
+	p := &Platform{allowFrom: "*", token: "token", httpClient: &http.Client{}}
 	ctx := context.Background()
 	rctx := replyContext{chatID: 1, threadID: 0, messageID: 2}
 
@@ -377,6 +379,7 @@ func TestPlatformLateReadyIgnoredAfterStop(t *testing.T) {
 	me := &models.User{ID: 42, Username: "latebot"}
 
 	p := &Platform{
+		allowFrom: "*",
 		token:      "token",
 		httpClient: &http.Client{},
 		newBot: func(_ string, _ func(context.Context, *models.Update), _ *http.Client) (telegramBot, *models.User, func(context.Context), error) {
@@ -421,6 +424,7 @@ func TestPlatformStartTypingSwitchesToCurrentBotAfterReconnect(t *testing.T) {
 	ticker := newStubTypingTicker()
 
 	p := &Platform{
+		allowFrom: "*",
 		token:      "token",
 		httpClient: &http.Client{},
 		newTypingTicker: func(time.Duration) typingTicker {
@@ -549,7 +553,7 @@ func TestExtractEntityText(t *testing.T) {
 }
 
 func TestSendAudioRejectsInvalidReplyContext(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 
 	err := p.SendAudio(context.Background(), "bad-context", []byte("data"), "mp3")
 	if err == nil {
@@ -569,7 +573,7 @@ func TestSendAudioReturnsConversionErrorForWAV(t *testing.T) {
 	}
 
 	stubBot := newStubTelegramBot()
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	p.bot = stubBot
 	p.selfUser = &models.User{ID: 1, Username: "testbot"}
 
@@ -717,7 +721,7 @@ func TestBuildSessionKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Platform{shareSessionInChannel: tt.shared}
+			p := &Platform{allowFrom: "*", shareSessionInChannel: tt.shared}
 			got := p.buildSessionKey(tt.chatID, tt.thread, tt.userID)
 			if got != tt.want {
 				t.Fatalf("buildSessionKey(%d, %d, %d) = %q, want %q", tt.chatID, tt.thread, tt.userID, got, tt.want)
@@ -745,7 +749,7 @@ func TestReconstructReplyCtx(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Platform{shareSessionInChannel: tt.shared}
+			p := &Platform{allowFrom: "*", shareSessionInChannel: tt.shared}
 			rctx, err := p.ReconstructReplyCtx(tt.key)
 			if tt.wantErr {
 				if err == nil {
@@ -768,7 +772,7 @@ func TestReconstructReplyCtx(t *testing.T) {
 }
 
 func TestIsDirectedAtBot(t *testing.T) {
-	p := &Platform{token: "token", httpClient: &http.Client{}}
+	p := &Platform{allowFrom: "*", token: "token", httpClient: &http.Client{}}
 	p.selfUser = &models.User{ID: 42, Username: "mybot"}
 
 	tests := []struct {
@@ -857,6 +861,7 @@ func TestHandleMessageWithForumTopic(t *testing.T) {
 		token:         "token",
 		httpClient:    &http.Client{},
 		groupReplyAll: true,
+		allowFrom:     "*",
 	}
 	p.handler = func(_ core.Platform, msg *core.Message) {
 		handled <- msg
@@ -901,6 +906,7 @@ func TestHandleMessagePrivateTopicUsesThreadID(t *testing.T) {
 		token:         "token",
 		httpClient:    &http.Client{},
 		groupReplyAll: true,
+		allowFrom:     "*",
 	}
 	p.handler = func(_ core.Platform, msg *core.Message) {
 		handled <- msg
@@ -959,6 +965,7 @@ func newTelegramTestPlatform(t *testing.T, handler func(http.ResponseWriter, *ht
 	}
 
 	return &Platform{
+		allowFrom: "*",
 		bot:        b,
 		selfUser:   &models.User{ID: 1, Username: "testbot"},
 		httpClient: server.Client(),

--- a/platform/wps-xiezuo/wpsxiezuo_test.go
+++ b/platform/wps-xiezuo/wpsxiezuo_test.go
@@ -159,7 +159,7 @@ func TestPlatformImplementsInterfaces(t *testing.T) {
 // ============================================================================
 
 func TestReconstructReplyCtx_Valid(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	rctx, err := p.ReconstructReplyCtx("wps-xiezuo:comp123:chat456")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -177,7 +177,7 @@ func TestReconstructReplyCtx_Valid(t *testing.T) {
 }
 
 func TestReconstructReplyCtx_P2PWithSenderKeepsActualChatID(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	rctx, err := p.ReconstructReplyCtx("wps-xiezuo:comp123:chat456:user789")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -198,7 +198,7 @@ func TestReconstructReplyCtx_P2PWithSenderKeepsActualChatID(t *testing.T) {
 }
 
 func TestReconstructReplyCtx_InvalidPrefix(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	_, err := p.ReconstructReplyCtx("feishu:comp:chat")
 	if err == nil {
 		t.Fatal("expected error for invalid prefix")
@@ -206,7 +206,7 @@ func TestReconstructReplyCtx_InvalidPrefix(t *testing.T) {
 }
 
 func TestReconstructReplyCtx_TooFewParts(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	_, err := p.ReconstructReplyCtx("wps-xiezuo:onlyone")
 	if err == nil {
 		t.Fatal("expected error for too few parts")
@@ -361,7 +361,7 @@ func TestDecryptEventData_RoundTrip(t *testing.T) {
 		AccessKey:     accessKey,
 	}
 
-	p := &Platform{appSecret: appSecret, appID: accessKey}
+	p := &Platform{allowFrom: "*", appSecret: appSecret, appID: accessKey}
 
 	if !p.verifyEventSignature(event) {
 		t.Fatal("signature verification failed")
@@ -425,7 +425,7 @@ func TestVerifyEventSignature_Valid(t *testing.T) {
 	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 	sig = strings.TrimRight(sig, "=")
 
-	p := &Platform{appSecret: appSecret, appID: accessKey}
+	p := &Platform{allowFrom: "*", appSecret: appSecret, appID: accessKey}
 	event := wpsEventFrame{
 		Topic:         topic,
 		Nonce:         nonce,
@@ -441,7 +441,7 @@ func TestVerifyEventSignature_Valid(t *testing.T) {
 }
 
 func TestVerifyEventSignature_Invalid(t *testing.T) {
-	p := &Platform{appSecret: "secret", appID: "id"}
+	p := &Platform{allowFrom: "*", appSecret: "secret", appID: "id"}
 	event := wpsEventFrame{
 		Topic:         "t",
 		Nonce:         "n",
@@ -461,13 +461,13 @@ func TestVerifyEventSignature_Invalid(t *testing.T) {
 // ============================================================================
 
 func TestHandleRawMessage_ACK(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	raw := []byte(`{"type":"ack","nonce":"abc","code":200}`)
 	p.handleRawMessage(context.Background(), raw)
 }
 
 func TestHandleRawMessage_GoAway(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	raw := []byte(`{"type":"goaway","reason":"server_shutdown","message":"bye"}`)
 	p.handleRawMessage(context.Background(), raw)
 	if p.stopped {
@@ -476,7 +476,7 @@ func TestHandleRawMessage_GoAway(t *testing.T) {
 }
 
 func TestHandleRawMessage_GoAwayReplaced(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	raw := []byte(`{"type":"goaway","reason":"connection_replaced","message":"bye"}`)
 	p.handleRawMessage(context.Background(), raw)
 	if !p.stopped {
@@ -485,7 +485,7 @@ func TestHandleRawMessage_GoAwayReplaced(t *testing.T) {
 }
 
 func TestHandleRawMessage_InvalidJSON(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	raw := []byte(`not json at all`)
 	p.handleRawMessage(context.Background(), raw)
 }
@@ -495,7 +495,7 @@ func TestHandleRawMessage_InvalidJSON(t *testing.T) {
 // ============================================================================
 
 func TestSignWSHeader(t *testing.T) {
-	p := &Platform{appID: "test-app", appSecret: "test-secret"}
+	p := &Platform{allowFrom: "*", appID: "test-app", appSecret: "test-secret"}
 	header, err := p.signWSHeader()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -519,10 +519,11 @@ func TestSignWSHeader(t *testing.T) {
 func TestHandleChatMessage_P2P(t *testing.T) {
 	ch := make(chan *core.Message, 1)
 	p := &Platform{
+		allowFrom: "*",
 		handler: func(_ core.Platform, msg *core.Message) {
 			ch <- msg
 		},
-		dedup: core.MessageDedup{},
+		dedup:     core.MessageDedup{},
 	}
 
 	msgData := wpsMessageData{
@@ -564,10 +565,11 @@ func TestHandleChatMessage_P2P(t *testing.T) {
 func TestHandleChatMessage_Group(t *testing.T) {
 	ch := make(chan *core.Message, 1)
 	p := &Platform{
+		allowFrom: "*",
 		handler: func(_ core.Platform, msg *core.Message) {
 			ch <- msg
 		},
-		dedup: core.MessageDedup{},
+		dedup:     core.MessageDedup{},
 	}
 
 	msgData := wpsMessageData{
@@ -599,10 +601,11 @@ func TestHandleChatMessage_Group(t *testing.T) {
 func TestHandleChatMessage_Duplicate(t *testing.T) {
 	ch := make(chan *core.Message, 2)
 	p := &Platform{
+		allowFrom: "*",
 		handler: func(_ core.Platform, msg *core.Message) {
 			ch <- msg
 		},
-		dedup: core.MessageDedup{},
+		dedup:     core.MessageDedup{},
 	}
 
 	msgData := wpsMessageData{
@@ -638,6 +641,7 @@ func TestHandleChatMessage_Duplicate(t *testing.T) {
 func TestHandleChatMessage_EmptyContent(t *testing.T) {
 	called := 0
 	p := &Platform{
+		allowFrom: "*",
 		handler: func(_ core.Platform, msg *core.Message) {
 			called++
 		},
@@ -672,6 +676,7 @@ func TestHandleChatMessage_EmptyContent(t *testing.T) {
 func TestHandleChatMessageRecall(t *testing.T) {
 	ch := make(chan *core.Message, 1)
 	p := &Platform{
+		allowFrom: "*",
 		handler: func(_ core.Platform, msg *core.Message) {
 			ch <- msg
 		},
@@ -711,7 +716,7 @@ func TestHandleChatMessageRecall(t *testing.T) {
 // ============================================================================
 
 func TestStop_Idempotent(t *testing.T) {
-	p := &Platform{}
+	p := &Platform{allowFrom: "*"}
 	if err := p.Stop(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -730,12 +735,13 @@ func TestHandleEvent_FullChain_ChatMessage(t *testing.T) {
 
 	ch := make(chan *core.Message, 1)
 	p := &Platform{
+		allowFrom: "*",
 		appID:     appID,
 		appSecret: appSecret,
 		handler: func(_ core.Platform, msg *core.Message) {
 			ch <- msg
 		},
-		dedup: core.MessageDedup{},
+		dedup:     core.MessageDedup{},
 	}
 
 	payload := map[string]any{
@@ -770,11 +776,13 @@ func TestHandleEvent_FullChain_Recall(t *testing.T) {
 
 	ch := make(chan *core.Message, 1)
 	p := &Platform{
+		allowFrom: "*",
 		appID:     appID,
 		appSecret: appSecret,
 		handler: func(_ core.Platform, msg *core.Message) {
 			ch <- msg
 		},
+		dedup:     core.MessageDedup{},
 	}
 
 	payload := map[string]any{
@@ -800,6 +808,7 @@ func TestHandleEvent_FullChain_Recall(t *testing.T) {
 func TestHandleEvent_BadSignature(t *testing.T) {
 	called := false
 	p := &Platform{
+		allowFrom: "*",
 		appID:     "bad",
 		appSecret: "sig",
 		handler: func(_ core.Platform, msg *core.Message) {
@@ -833,6 +842,7 @@ func TestHandleEvent_DoesNotLogDecryptedPayload(t *testing.T) {
 	appID := "AK_LOG"
 	appSecret := "log-secret"
 	p := &Platform{
+		allowFrom: "*",
 		appID:     appID,
 		appSecret: appSecret,
 		handler:   func(_ core.Platform, msg *core.Message) {},
@@ -861,9 +871,9 @@ func TestHandleEvent_DoesNotLogDecryptedPayload(t *testing.T) {
 func TestHandleChatMessage_AllowFrom(t *testing.T) {
 	ch := make(chan *core.Message, 1)
 	p := &Platform{
+		allowFrom: "allowed_user",
 		appID:     "id",
 		appSecret: "secret",
-		allowFrom: "allowed_user",
 		handler: func(_ core.Platform, msg *core.Message) {
 			ch <- msg
 		},
@@ -1427,12 +1437,13 @@ func TestWebSocketIntegration_ReceiveEvent(t *testing.T) {
 
 	ch := make(chan *core.Message, 1)
 	p := &Platform{
+		allowFrom: "*",
 		appID:     appID,
 		appSecret: appSecret,
 		handler: func(_ core.Platform, msg *core.Message) {
 			ch <- msg
 		},
-		dedup: core.MessageDedup{},
+		dedup:     core.MessageDedup{},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/tests/e2e/regression_test.go
+++ b/tests/e2e/regression_test.go
@@ -383,10 +383,10 @@ func TestRegression_CommandInjection(t *testing.T) {
 			expected:  false,
 		},
 		{
-			name:      "empty allow all",
+			name:      "empty deny all",
 			allowFrom: "",
 			userID:    "anyone",
-			expected:  true,
+			expected:  false,
 		},
 		{
 			name:      "wildcard all",


### PR DESCRIPTION
Companion docs PR for #1164 — adds the release note and migration hint that qa-claudecode flagged as missing in the 2026-06-07 triage (needs-changes → ready-to-merge).

## What this PR does

- **CHANGELOG.md**: new `Unreleased` section at the top with a Security subsection describing the breaking change (`allow_from` default switches from allow-all to fail-closed in v1.4.0), the v1.4.0 version target, and a cross-reference to the migration recipe in `config.example.toml`.
- **config.example.toml**: prominent ⚠️ callout block at the top of the file (above `Global Settings`) with a bilingual header, the v1.3.x → v1.4.0 behavior change, and a copy-pasteable migration example for both per-platform and per-project scopes.
- **README.md / README.zh-CN.md**: new `🛡️ Security Defaults (v1.4.0+)` / `🛡️ 安全默认值（v1.4.0+）` subsection placed right before `Permission Modes` / `权限模式`, with the same migration example and cross-references to CHANGELOG.md and config.example.toml.

## What this PR does NOT do

- Does **not** modify any security code in #1164.
- Does **not** change `allow_from` behavior.
- Does **not** add or modify tests.
- Pure documentation / config example.

## Why a separate PR

#1164 lives on a contributor fork (`Shicongcoding/cc-connect:fix/allow-from-fail-closed`) and I cannot push back to it. The cleanest path is:

1. **This PR (`codex/security-fail-closed-allow-from`)** is the docs home on `chenhg5/cc-connect`. It branches from the exact same head SHA as #1164 (`f6c615b7`) and adds one docs commit (`02cf7ae0`) on top.
2. **Maintainer** can either:
   - Cherry-pick `02cf7ae0` into #1164 before merge, **or**
   - Merge this PR first, then rebase / re-merge #1164 to include the docs (the contributor can also pull this branch's diff into their fork).

Both paths keep the security code review (in #1164) and the docs review (here) independently auditable.

## Verification

- `go vet ./...` clean
- `go test -count=1 ./core/` pass
- `go test -count=1 ./cmd/cc-connect/` pass
- No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)