### PR TITLE
fix(core): apply tool_max_len to tool input in progress_style=card

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -4153,7 +4153,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 				}
 				toolMsg := fmt.Sprintf(e.i18n.T(MsgTool), toolCount, event.ToolName, formattedInput)
-				if !cp.AppendEvent(ProgressEntryToolUse, toolInput, event.ToolName, toolMsg) {
+				// Truncate the tool input that goes into the progress card payload so
+				// tool_max_len applies uniformly to progress_style=card, matching
+				// the rich-card path. event.ToolInput itself is left untouched.
+				cardToolInput := truncateIf(toolInput, e.display.ToolMaxLen)
+				if !cp.AppendEvent(ProgressEntryToolUse, cardToolInput, event.ToolName, toolMsg) {
 					for _, chunk := range SplitMessageCodeFenceAware(toolMsg, maxPlatformMessageLen) {
 						sendWorkspace(p, replyCtx, chunk)
 					}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1752,6 +1752,74 @@ func TestProcessInteractiveEvents_CardProgressUsesStructuredPayloadWhenSupported
 	}
 }
 
+// TestProcessInteractiveEvents_CardProgressTruncatesToolInputByToolMaxLen verifies
+// that when progress_style=card is used (e.g. Feishu), a long tool input is
+// truncated to display.ToolMaxLen in the structured card payload. The original
+// event.ToolInput must remain unmutated.
+func TestProcessInteractiveEvents_CardProgressTruncatesToolInputByToolMaxLen(t *testing.T) {
+	p := &stubCompactProgressPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		style:              "card",
+		supportPayload:     true,
+	}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{
+		ThinkingMessages: true,
+		ThinkingMaxLen:   300,
+		ToolMaxLen:       50,
+		ToolMessages:     true,
+		Mode:             "full",
+	})
+	sessionKey := "feishu:user-card-truncate"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-card-truncate")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-card-truncate",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	longInput := strings.Repeat("abcdefghij", 12) // 120 chars
+	agentSession.events <- Event{Type: EventThinking, Content: "Plan"}
+	toolEvt := Event{Type: EventToolUse, ToolName: "Bash", ToolInput: longInput}
+	agentSession.events <- toolEvt
+	agentSession.events <- Event{Type: EventText, Content: "done"}
+	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
+
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-card-truncate", time.Now(), nil, nil, state.replyCtx)
+
+	if toolEvt.ToolInput != longInput {
+		t.Fatalf("event.ToolInput was mutated: got len=%d, want len=%d", len(toolEvt.ToolInput), len(longInput))
+	}
+
+	edits := p.getPreviewEdits()
+	var toolUseText string
+	for _, edit := range edits {
+		payload, ok := ParseProgressCardPayload(edit)
+		if !ok {
+			continue
+		}
+		for _, item := range payload.Items {
+			if item.Kind == ProgressEntryToolUse {
+				toolUseText = item.Text
+			}
+		}
+	}
+	if toolUseText == "" {
+		t.Fatalf("no ProgressEntryToolUse found in any card edit; edits=%v", edits)
+	}
+	if utf8.RuneCountInString(toolUseText) > 50+len("...") {
+		t.Fatalf("card tool input not truncated: runeCount=%d, content=%q", utf8.RuneCountInString(toolUseText), toolUseText)
+	}
+	if !strings.HasSuffix(toolUseText, "...") {
+		t.Fatalf("expected truncated tool input to end with '...', got %q", toolUseText)
+	}
+	if !strings.HasPrefix(toolUseText, "abcdefghij") {
+		t.Fatalf("expected truncated tool input to start with original prefix, got %q", toolUseText)
+	}
+}
+
 func TestProcessInteractiveEvents_RichCardShowsThinkingContent(t *testing.T) {
 	p := &stubCompactProgressPlatform{
 		stubPlatformEngine: stubPlatformEngine{n: "feishu"},


### PR DESCRIPTION
Fixes #1233

## Problem

When `progress_style=card` is enabled (e.g. Feishu with the structured card
payload), a long tool input (e.g. a long `Bash` command) is rendered at its
full length in the progress card, bypassing `display.tool_max_len`. The
rich-card path (`mode = "rich"`) and the `EventToolResult` path already apply
this limit, but the compact progress writer did not, so users on Feishu and
similar card-style platforms could not control how much of a tool call is
shown.

## Fix

`core/engine.go:4156` (the `cp.AppendEvent(ProgressEntryToolUse, ...)` call in
`processInteractiveEvents`) now passes `truncateIf(toolInput, e.display.ToolMaxLen)`
as the typed event text. `event.ToolInput` itself is **not** mutated, and the
legacy fallback `toolMsg` keeps its full formatted input — so text-mode
behavior is unchanged and the truncation is applied only at the card rendering
entry, exactly as requested.

This uses the same `truncateIf` helper already used by the rich-card path
(`Summary: truncateIf(event.ToolInput, e.display.ToolMaxLen)`) and by the
`EventToolResult` path, so behavior is now uniform across all card-style
rendering paths.

## Test

`TestProcessInteractiveEvents_CardProgressTruncatesToolInputByToolMaxLen`
asserts that with `progress_style=card` + `ToolMaxLen=50`:
- A 120-char `Bash` input produces a card payload item whose `Text` is
  truncated to 50 runes + `"..."`.
- `event.ToolInput` is left unmutated (verifies "truncate at render entry").
- The structured payload (Feishu-style) is used.

## Verification

- `go vet ./core/...` clean
- `go test ./core/...` (42.178s) all pass
- `go test ./platform/feishu/...` (25.794s) all pass
- `go test ./agent/...` all pass

## Non-goals

- Text-mode truncation behavior is unchanged (legacy `toolMsg` is still full).
- `display.tool_messages` semantics are unchanged.
- The `StreamingCard` (separate opt-in streaming card interface) path is
  untouched — issue #1233 is specifically about `progress_style=card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)