### PR TITLE
fix(claudecode): normalize work_dir so cc-connect and desktop CC share sessions

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -117,6 +117,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	if workDir == "" {
 		workDir = "."
 	}
+	workDir = normalizeWorkDir(workDir)
 	cliBin := "claude"
 	var cliExtraArgs []string
 	if cliPath, _ := opts["cli_path"].(string); cliPath != "" {
@@ -273,6 +274,7 @@ func (a *Agent) CLIBinaryName() string  { return a.cliBin }
 func (a *Agent) CLIDisplayName() string { return "Claude" }
 
 func (a *Agent) SetWorkDir(dir string) {
+	dir = normalizeWorkDir(dir)
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.workDir = dir

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -285,6 +286,108 @@ func TestAgent_SetWorkDir(t *testing.T) {
 	a.SetWorkDir("/tmp/test")
 	if got := a.GetWorkDir(); got != "/tmp/test" {
 		t.Errorf("GetWorkDir() = %q, want %q", got, "/tmp/test")
+	}
+}
+
+func TestNormalizeWorkDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty path is unchanged",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "trailing forward slash is stripped",
+			input:    "/home/user/project/",
+			expected: "/home/user/project",
+		},
+		{
+			name:     "trailing backslash is stripped (Windows path)",
+			input:    `D:\foo\bar\`,
+			expected: `D:\foo\bar`,
+		},
+		{
+			name:     "lowercase Windows drive letter is uppercased",
+			input:    `d:\foo\bar`,
+			expected: `D:\foo\bar`,
+		},
+		{
+			name:     "uppercase Windows drive letter is preserved",
+			input:    `D:\foo\bar`,
+			expected: `D:\foo\bar`,
+		},
+		{
+			name:     "drive letter case plus trailing slash",
+			input:    `d:\foo\bar\`,
+			expected: `D:\foo\bar`,
+		},
+		{
+			name:     "dot segments are collapsed",
+			input:    "/home/user/./project/../project",
+			expected: "/home/user/project",
+		},
+		{
+			name:     "Unix path with mixed trailing separators",
+			input:    "/home/user/project///",
+			expected: "/home/user/project",
+		},
+		{
+			name:     "NFC Unicode path is unchanged",
+			input:    "/home/user/Documents/项目文件夹",
+			expected: "/home/user/Documents/项目文件夹",
+		},
+		{
+			name:     "NFD Unicode path is normalized to NFC",
+			input:    "/home/user/Documents/ünicode", // u + combining diaeresis = NFD
+			expected: "/home/user/Documents/ünicode",      // precomposed ü = NFC
+		},
+		{
+			name:     "root path is preserved",
+			input:    "/",
+			expected: string(filepath.Separator) + "",
+		},
+		{
+			name:     "drive-only root is uppercased but kept",
+			input:    "d:",
+			expected: "D:",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeWorkDir(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeWorkDir(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestNormalizeWorkDir_DriveLetterEncodesToSameKey verifies that
+// d:\Foo\bar\ and D:\Foo\bar\ both encode to the same Claude Code project
+// key, which is the root cause described in issue #1040.
+func TestNormalizeWorkDir_DriveLetterEncodesToSameKey(t *testing.T) {
+	upperKey := encodeClaudeProjectKey(normalizeWorkDir(`D:\Foo\bar`))
+	lowerKey := encodeClaudeProjectKey(normalizeWorkDir(`d:\Foo\bar\`))
+	if upperKey != lowerKey {
+		t.Errorf("drive-letter case produced different project keys: %q vs %q", upperKey, lowerKey)
+	}
+}
+
+// TestNormalizeWorkDir_TrailingSlashEncodesToSameKey verifies that
+// D:\Foo\bar and D:\Foo\bar\ both encode to the same Claude Code project
+// key (no trailing dash), as expected by desktop Claude Code.
+func TestNormalizeWorkDir_TrailingSlashEncodesToSameKey(t *testing.T) {
+	noSlashKey := encodeClaudeProjectKey(normalizeWorkDir(`D:\Foo\bar`))
+	withSlashKey := encodeClaudeProjectKey(normalizeWorkDir(`D:\Foo\bar\`))
+	if noSlashKey != withSlashKey {
+		t.Errorf("trailing-slash variants produced different project keys: %q vs %q", noSlashKey, withSlashKey)
+	}
+	if strings.HasSuffix(noSlashKey, "-") {
+		t.Errorf("normalized key %q has trailing dash, expected none", noSlashKey)
 	}
 }
 

--- a/agent/claudecode/workdir_normalize.go
+++ b/agent/claudecode/workdir_normalize.go
@@ -51,7 +51,7 @@ func normalizeWindowsDriveLetter(path string) string {
 		return path
 	}
 	c := path[0]
-	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+	if c < 'A' || (c > 'Z' && c < 'a') || c > 'z' {
 		return path
 	}
 	if c >= 'a' && c <= 'z' {

--- a/agent/claudecode/workdir_normalize.go
+++ b/agent/claudecode/workdir_normalize.go
@@ -1,0 +1,61 @@
+package claudecode
+
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// normalizeWorkDir canonicalizes a Claude Code working directory path so that
+// the same logical directory always produces the same ~/.claude/projects/<key>
+// directory name, regardless of how the user typed it. Without this, cc-connect
+// and the desktop Claude Code CLI can encode the same directory into two
+// different project directories, making sessions invisible to /resume on the
+// other side (issue #1040).
+//
+// Normalization rules:
+//  1. filepath.Clean collapses ".", "..", and trailing path separators
+//     (per-platform: backslash on Windows, forward slash on Unix).
+//  2. Windows drive letters are upper-cased (e.g. "d:\\foo" → "D:\\foo") so
+//     that "d:\\foo" and "D:\\foo" encode to the same project key. Windows
+//     filesystems are case-insensitive at the volume level, so this matches
+//     what the desktop CLI does.
+//  3. Unicode is normalized to NFC. macOS HFS+ historically stored paths in
+//     NFD; APFS and most Linux filesystems use NFC. Without canonicalization,
+//     a user-typed NFD path produces a different encoded key than an
+//     NFC-typed path even when they refer to the same directory.
+func normalizeWorkDir(path string) string {
+	if path == "" {
+		return path
+	}
+	cleaned := filepath.Clean(path)
+	cleaned = strings.TrimRight(cleaned, `/\`)
+	if cleaned == "" {
+		// filepath.Clean on "/" or "\" returns the separator itself; if we
+		// trimmed the only character, restore the root marker.
+		cleaned = string(filepath.Separator)
+	}
+	cleaned = normalizeWindowsDriveLetter(cleaned)
+	cleaned = norm.NFC.String(cleaned)
+	return cleaned
+}
+
+// normalizeWindowsDriveLetter uppercases the leading single-letter volume
+// specifier on Windows-style absolute paths (e.g. "d:\\foo" → "D:\\foo").
+// We do this on every platform so that Linux-side encodings match what
+// desktop Claude Code produces on Windows. The function is a no-op for
+// paths that don't look like a drive-letter-rooted Windows path.
+func normalizeWindowsDriveLetter(path string) string {
+	if len(path) < 2 || path[1] != ':' {
+		return path
+	}
+	c := path[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+		return path
+	}
+	if c >= 'a' && c <= 'z' {
+		return string(c-('a'-'A')) + path[1:]
+	}
+	return path
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/slack-go/slack v0.16.0
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/text v0.34.0
 	modernc.org/sqlite v1.49.1
 	rsc.io/qr v0.2.0
 )
@@ -52,7 +53,6 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
-	golang.org/x/text v0.34.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect


### PR DESCRIPTION
Fixes #1040

## Problem

`/list` on cc-connect could see sessions created by the desktop Claude Code
CLI, but `/resume` on the desktop CLI could not see sessions created by
cc-connect — even when both pointed at the same directory. Evidence from
`~/.claude/projects/`:

```
d--LongYinHaHa-----------/   ← cc-connect (lowercase d, 11 dashes)
D--LongYinHaHa----------/    ← desktop CC (uppercase D, 10 dashes)
```

Two different project directories for what the user perceives as the same
working directory.

## Scope vs PR #1055

PR #1055 fixed `.` and `@` encoding (#1046) but did not address #1040.
#1040's root causes are path-level, not character-level:

1. **Drive letter case** — `d:\Foo\bar` and `D:\Foo\bar` differ by one
   character in the encoded key. Windows filesystems are case-insensitive
   at the volume level, but the encoded project key is a literal string
   comparison.
2. **Trailing slashes** — `D:\Foo\bar\` encodes to `D--Foo-bar-` (with
   trailing dash), while `D:\Foo\bar` encodes to `D--Foo-bar`. Claude Code's
   internal encoding drops the trailing separator.
3. **Unicode form** — paths typed as NFD (e.g. from macOS HFS+ or some
   IM-platform inputs) produce different keys than the NFC form Claude Code
   uses internally.

## Fix

`agent/claudecode/workdir_normalize.go` adds `normalizeWorkDir()` and
`agent/claudecode/claudecode.go` applies it in `New()` and `SetWorkDir()`
so the same path string always reaches both `cmd.Dir` and
`encodeClaudeProjectKey`. Rules:

1. `filepath.Clean` collapses `..`/`.` and strips trailing separators.
2. `normalizeWindowsDriveLetter` uppercases a leading `x:` to `X:`.
3. `norm.NFC.String` canonicalizes Unicode to NFC.

`go.mod` is updated to make `golang.org/x/text` a direct dependency
(it was already an indirect one before).

## Tests

`agent/claudecode/claudecode_test.go` gains:

- `TestNormalizeWorkDir` — 12 sub-cases covering empty input, trailing
  forward slash, trailing backslash, lowercase/uppercase drive letters,
  drive letter + trailing slash, dot segments, mixed trailing separators,
  NFC pass-through, NFD → NFC, root path, and drive-only root.
- `TestNormalizeWorkDir_DriveLetterEncodesToSameKey` — verifies
  `d:\Foo\bar\` and `D:\Foo\bar` produce identical project keys.
- `TestNormalizeWorkDir_TrailingSlashEncodesToSameKey` — verifies the
  normalized key has no trailing dash.

## Non-goals

- Session UI is untouched. Only the path string stored in
  `a.workDir` is normalized.
- `encodeClaudeProjectKey` itself is unchanged. Normalization happens at
  the input boundary, so the existing encoding logic (and its many
  fallback candidates) keeps working as before.

## Verification

- `go vet ./agent/claudecode/...` clean
- `go test ./agent/claudecode/...` (0.280s) all pass, including the new
  tests and all pre-existing `TestEncodeClaudeProjectKey` /
  `TestFindProjectDir_*` cases.
- `go build ./agent/claudecode/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)