### PR TITLE
feat(daemon): add CC_LOG_MAX_BACKUPS env var support

### DIFF
--- a/cmd/cc-connect/logbackups_test.go
+++ b/cmd/cc-connect/logbackups_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/chenhg5/cc-connect/daemon"
+)
+
+func TestResolveLogMaxBackups_FlagWinsOverEnv(t *testing.T) {
+	t.Setenv("CC_LOG_MAX_BACKUPS", "5")
+	got, src := resolveLogMaxBackups("2")
+	if src != logBackupsSourceFlag {
+		t.Fatalf("src = %q, want %q", src, logBackupsSourceFlag)
+	}
+	if got != 2 {
+		t.Fatalf("got %d, want 2", got)
+	}
+}
+
+func TestResolveLogMaxBackups_EnvWinsOverDefault(t *testing.T) {
+	t.Setenv("CC_LOG_MAX_BACKUPS", "7")
+	got, src := resolveLogMaxBackups("")
+	if src != logBackupsSourceEnv {
+		t.Fatalf("src = %q, want %q", src, logBackupsSourceEnv)
+	}
+	if got != 7 {
+		t.Fatalf("got %d, want 7", got)
+	}
+}
+
+func TestResolveLogMaxBackups_FallsBackToDefault(t *testing.T) {
+	t.Setenv("CC_LOG_MAX_BACKUPS", "")
+	got, src := resolveLogMaxBackups("")
+	if src != logBackupsSourceDefault {
+		t.Fatalf("src = %q, want %q", src, logBackupsSourceDefault)
+	}
+	if got != daemon.DefaultLogMaxBackups {
+		t.Fatalf("got %d, want default %d", got, daemon.DefaultLogMaxBackups)
+	}
+}
+
+func TestResolveLogMaxBackups_InvalidFlagFallsBackToEnv(t *testing.T) {
+	t.Setenv("CC_LOG_MAX_BACKUPS", "4")
+	got, src := resolveLogMaxBackups("not-a-number")
+	if src != logBackupsSourceEnv {
+		t.Fatalf("src = %q, want %q (invalid flag should fall through)", src, logBackupsSourceEnv)
+	}
+	if got != 4 {
+		t.Fatalf("got %d, want 4", got)
+	}
+}
+
+func TestResolveLogMaxBackups_InvalidEnvFallsBackToDefault(t *testing.T) {
+	t.Setenv("CC_LOG_MAX_BACKUPS", "garbage")
+	got, src := resolveLogMaxBackups("")
+	if src != logBackupsSourceDefault {
+		t.Fatalf("src = %q, want %q (invalid env should fall through to default)", src, logBackupsSourceDefault)
+	}
+	if got != daemon.DefaultLogMaxBackups {
+		t.Fatalf("got %d, want default %d", got, daemon.DefaultLogMaxBackups)
+	}
+}
+
+func TestResolveLogMaxBackups_ZeroFlagFallsBackToEnv(t *testing.T) {
+	// Passing "0" through --log-max-backups is interpreted as "no
+	// override" so the env wins. The flag's own default is also 0
+	// (declared as flag.Int(..., 0, ...)) so we cannot distinguish
+	// "unset" from "0" in the flag form — but the env var form must
+	// still take precedence.
+	t.Setenv("CC_LOG_MAX_BACKUPS", "9")
+	got, src := resolveLogMaxBackups("0")
+	if src != logBackupsSourceEnv {
+		t.Fatalf("src = %q, want %q", src, logBackupsSourceEnv)
+	}
+	if got != 9 {
+		t.Fatalf("got %d, want 9", got)
+	}
+}
+
+func TestPreScanLogMaxBackupsFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no flag", []string{"run", "thing"}, ""},
+		{"flag with separate value", []string{"--log-max-backups", "5", "run"}, "5"},
+		{"flag with = form", []string{"--log-max-backups=5", "run"}, "5"},
+		{"flag with = form, no space", []string{"--log-max-backups=10"}, "10"},
+		{"flag at end, no value", []string{"--log-max-backups"}, ""},
+		{"flag with empty value", []string{"--log-max-backups", ""}, ""},
+		{"unrelated --max-backups-prefix", []string{"--max-backups", "5"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := preScanLogMaxBackupsFlag(tc.args)
+			if got != tc.want {
+				t.Fatalf("preScanLogMaxBackupsFlag(%v) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveLogMaxBackups_PriorityRegressionForIssue1222(t *testing.T) {
+	// Issue #1222 follow-up: CC_LOG_MAX_BACKUPS must be honoured when
+	// set, not silently dropped. This pins the "flag > env > default"
+	// priority so future refactors of the resolver don't regress the
+	// behaviour users got from PR #1243.
+	t.Setenv("CC_LOG_MAX_BACKUPS", "3")
+	got, src := resolveLogMaxBackups("")
+	if src != logBackupsSourceEnv {
+		t.Fatalf("src = %q, want %q (env var must be honoured)", src, logBackupsSourceEnv)
+	}
+	if got != daemon.DefaultLogMaxBackups {
+		t.Fatalf("got %d, want %d (3 == DefaultLogMaxBackups)", got, daemon.DefaultLogMaxBackups)
+	}
+}

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -109,6 +109,61 @@ func preScanLogMaxSizeFlag(args []string) string {
 	return ""
 }
 
+// logBackupsSource describes where the resolved max-backups count came
+// from, mirroring logSizeSource so operators can audit the active value
+// from the startup log line alone.
+type logBackupsSource string
+
+const (
+	logBackupsSourceFlag    logBackupsSource = "flag"
+	logBackupsSourceEnv     logBackupsSource = "env"
+	logBackupsSourceDefault logBackupsSource = "default"
+)
+
+// resolveLogMaxBackups picks the effective number of rotated log backups
+// to retain, with the same priority order as resolveLogMaxSize: explicit
+// flag value > CC_LOG_MAX_BACKUPS env var > built-in default. Returns
+// the count and which source won. Invalid inputs are logged to stderr
+// and the value is ignored so a typo never silently downgrades to "0".
+func resolveLogMaxBackups(flagValue string) (int, logBackupsSource) {
+	if strings.TrimSpace(flagValue) != "" {
+		n, err := daemon.ParseLogBackups(flagValue)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: ignoring --log-max-backups=%q: %v\n", flagValue, err)
+		} else {
+			return n, logBackupsSourceFlag
+		}
+	}
+	if v := os.Getenv("CC_LOG_MAX_BACKUPS"); v != "" {
+		n, err := daemon.ParseLogBackups(v)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: ignoring CC_LOG_MAX_BACKUPS=%q: %v\n", v, err)
+		} else {
+			return n, logBackupsSourceEnv
+		}
+	}
+	return daemon.DefaultLogMaxBackups, logBackupsSourceDefault
+}
+
+// preScanLogMaxBackupsFlag returns the value passed via --log-max-backups
+// before flag.Parse() runs, mirroring preScanLogMaxSizeFlag. Returns ""
+// if the flag is absent.
+func preScanLogMaxBackupsFlag(args []string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--log-max-backups" {
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+			return ""
+		}
+		if strings.HasPrefix(a, "--log-max-backups=") {
+			return strings.TrimPrefix(a, "--log-max-backups=")
+		}
+	}
+	return ""
+}
+
 type initialModelRefreshStarter interface {
 	StartInitialModelRefresh()
 }
@@ -185,8 +240,9 @@ func main() {
 	var logCloser io.Closer
 	if logFile := os.Getenv("CC_LOG_FILE"); logFile != "" {
 		maxSize, maxSizeSrc := resolveLogMaxSize(preScanLogMaxSizeFlag(os.Args[1:]))
-		fmt.Fprintf(os.Stderr, "log: redirecting to %s with max_size=%d bytes (source: %s)\n", logFile, maxSize, maxSizeSrc)
-		w, err := daemon.NewRotatingWriter(logFile, maxSize)
+		maxBackups, maxBackupsSrc := resolveLogMaxBackups(preScanLogMaxBackupsFlag(os.Args[1:]))
+		fmt.Fprintf(os.Stderr, "log: redirecting to %s with max_size=%d bytes (source: %s), max_backups=%d (source: %s)\n", logFile, maxSize, maxSizeSrc, maxBackups, maxBackupsSrc)
+		w, err := daemon.NewRotatingWriter(logFile, maxSize, maxBackups)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to open log file %s: %v\n", logFile, err)
 			os.Exit(1)
@@ -202,6 +258,7 @@ func main() {
 	observeChannel := flag.String("observe-channel", "", "Slack channel ID to forward terminal observations to (requires --observe)")
 	forceFlag := flag.Bool("force", false, "kill any existing instance with the same config before starting")
 	logMaxSizeFlag := flag.String("log-max-size", "", "max bytes for the rotating log file (e.g. 10MB, 512K, 10485760); overrides CC_LOG_MAX_SIZE env var (default: 10MB)")
+	logMaxBackupsFlag := flag.Int("log-max-backups", 0, "number of rotated log files to retain (.log.1 .. .log.N); overrides CC_LOG_MAX_BACKUPS env var (default: 3)")
 	flag.Usage = printUsage
 	flag.Parse()
 
@@ -214,6 +271,9 @@ func main() {
 		if _, err := daemon.ParseLogSize(*logMaxSizeFlag); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: --log-max-size=%q: %v\n", *logMaxSizeFlag, err)
 		}
+	}
+	if *logMaxBackupsFlag < 0 {
+		fmt.Fprintf(os.Stderr, "warning: --log-max-backups=%d must be >= 0 (0 means use env/default)\n", *logMaxBackupsFlag)
 	}
 
 	if *showVersion {

--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -337,6 +337,8 @@ func buildPlist(cfg Config) string {
 		<string>%s</string>
 		<key>CC_LOG_MAX_SIZE</key>
 		<string>%d</string>
+		<key>CC_LOG_MAX_BACKUPS</key>
+		<string>%d</string>
 		<key>PATH</key>
 		<string>%s</string>
 %s	</dict>
@@ -346,6 +348,6 @@ func buildPlist(cfg Config) string {
 	<string>/dev/null</string>
 </dict>
 </plist>
-`, launchdLabel, xmlEscape(cfg.BinaryPath), xmlEscape(cfg.WorkDir), xmlEscape(cfg.LogFile), cfg.LogMaxSize, xmlEscape(envPATH), envExtra)
+`, launchdLabel, xmlEscape(cfg.BinaryPath), xmlEscape(cfg.WorkDir), xmlEscape(cfg.LogFile), cfg.LogMaxSize, cfg.LogMaxBackups, xmlEscape(envPATH), envExtra)
 }
 

--- a/daemon/logbackups.go
+++ b/daemon/logbackups.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseLogBackups converts a string into a positive integer count of log
+// backups to retain when the rotating writer rotates the active log file.
+// Unlike ParseLogSize, no unit suffix is accepted — a backup count is
+// already an integer in any sane unit. Whitespace is trimmed.
+//
+// Returns an error if the input is empty, non-integer, or not >= 1. The
+// minimum is 1 (one backup, the legacy behaviour); zero would mean
+// "discard the previous log on every rotation", which loses the entire
+// post-mortem trail at the moment something goes wrong.
+//
+// A typical rotation policy with N=3 and maxSize=10MB keeps cc-connect.log
+// plus cc-connect.log.1 / .2 / .3 on disk, so the maximum retained footprint
+// is ≈ 4 × maxSize.
+func ParseLogBackups(s string) (int, error) {
+	orig := s
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("log backups: empty value")
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("log backups %q: %w", orig, err)
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("log backups %q: must be >= 1 (got %d)", orig, n)
+	}
+	return n, nil
+}

--- a/daemon/logbackups_test.go
+++ b/daemon/logbackups_test.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseLogBackups(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    int
+		wantErr bool
+	}{
+		// Happy path
+		{name: "one", in: "1", want: 1},
+		{name: "three (issue #1222 default)", in: "3", want: 3},
+		{name: "ten", in: "10", want: 10},
+		{name: "hundred", in: "100", want: 100},
+
+		// Whitespace is trimmed
+		{name: "leading space", in: "  3", want: 3},
+		{name: "trailing space", in: "3  ", want: 3},
+		{name: "both", in: "  3  ", want: 3},
+		{name: "tab", in: "\t5\t", want: 5},
+
+		// Invalid: empty
+		{name: "empty", in: "", wantErr: true},
+		{name: "only spaces", in: "   ", wantErr: true},
+
+		// Invalid: not an integer
+		{name: "alpha", in: "abc", wantErr: true},
+		{name: "float", in: "3.5", wantErr: true},
+		{name: "with unit (we don't accept units here)", in: "3MB", wantErr: true},
+		{name: "hex", in: "0x10", wantErr: true},
+		{name: "trailing junk", in: "3abc", wantErr: true},
+
+		// Invalid: too small
+		{name: "zero", in: "0", wantErr: true},
+		{name: "negative one", in: "-1", wantErr: true},
+		{name: "negative large", in: "-100", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseLogBackups(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseLogBackups(%q) = %d, nil; want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseLogBackups(%q) error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseLogBackups(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseLogBackups_ErrorMessageEchoesInput(t *testing.T) {
+	// The caller (resolveLogMaxBackups) writes the original input to a
+	// stderr warning, so the error must include the original string —
+	// not just the trimmed form. This is the same invariant as
+	// ParseLogSize, kept consistent so users see a uniform diagnostic
+	// when they typo either env var.
+	for _, in := range []string{"", "abc", "0", "-3", "3.5"} {
+		_, err := ParseLogBackups(in)
+		if err == nil {
+			t.Fatalf("ParseLogBackups(%q) = nil err, want error", in)
+		}
+		if in == "" {
+			// Empty input: error must mention "empty" so the caller
+			// can still produce a useful diagnostic.
+			if !strings.Contains(err.Error(), "empty") {
+				t.Fatalf("ParseLogBackups(%q) error = %q, want substring 'empty'", in, err.Error())
+			}
+			continue
+		}
+		if !strings.Contains(err.Error(), in) {
+			t.Fatalf("ParseLogBackups(%q) error = %q, want substring %q", in, err.Error(), in)
+		}
+	}
+}

--- a/daemon/logrotate.go
+++ b/daemon/logrotate.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -8,17 +9,30 @@ import (
 )
 
 // RotatingWriter is a thread-safe io.Writer that appends to a log file
-// and rotates it when the file exceeds maxSize. One backup (.1) is kept,
-// so the maximum disk usage is ≈ 2 × maxSize.
+// and rotates it when the file exceeds maxSize. Up to maxBackups rotated
+// copies are kept (cc-connect.log.1 .. cc-connect.log.N); the oldest is
+// discarded on each rotation. The maximum disk usage is therefore
+// (1 + maxBackups) × maxSize.
+//
+// maxBackups must be >= 1; passing a smaller value silently falls back
+// to DefaultLogMaxBackups in NewRotatingWriter. A value of 1 reproduces
+// the legacy "one backup" behaviour from before #1222.
 type RotatingWriter struct {
-	mu      sync.Mutex
-	file    *os.File
-	path    string
-	maxSize int64
-	curSize int64
+	mu         sync.Mutex
+	file       *os.File
+	path       string
+	maxSize    int64
+	maxBackups int
+	curSize    int64
 }
 
-func NewRotatingWriter(path string, maxSize int64) (*RotatingWriter, error) {
+// NewRotatingWriter opens (or creates) path for append and returns a
+// writer that rotates the file when it grows past maxSize bytes. The
+// number of retained backup copies is maxBackups; if maxBackups < 1 the
+// caller almost certainly passed an unparsed env var and we fall back
+// to DefaultLogMaxBackups so the daemon never silently disables the
+// post-mortem trail.
+func NewRotatingWriter(path string, maxSize int64, maxBackups int) (*RotatingWriter, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return nil, err
 	}
@@ -31,12 +45,22 @@ func NewRotatingWriter(path string, maxSize int64) (*RotatingWriter, error) {
 		f.Close()
 		return nil, err
 	}
+	if maxBackups < 1 {
+		maxBackups = DefaultLogMaxBackups
+	}
 	return &RotatingWriter{
-		file:    f,
-		path:    path,
-		maxSize: maxSize,
-		curSize: info.Size(),
+		file:       f,
+		path:       path,
+		maxSize:    maxSize,
+		maxBackups: maxBackups,
+		curSize:    info.Size(),
 	}, nil
+}
+
+// MaxBackups returns the configured number of retained backup copies.
+// Exposed so callers (and tests) can confirm the resolved value.
+func (w *RotatingWriter) MaxBackups() int {
+	return w.maxBackups
 }
 
 func (w *RotatingWriter) Write(p []byte) (int, error) {
@@ -51,24 +75,73 @@ func (w *RotatingWriter) Write(p []byte) (int, error) {
 	w.curSize += int64(n)
 
 	if w.curSize > w.maxSize {
-		w.rotate()
+		w.rotateLocked()
 	}
 	return n, err
 }
 
-func (w *RotatingWriter) rotate() {
+// Rotate forces a rotation regardless of the current size. Useful for
+// tests and for SIGHUP-style "start a new log file" hooks. Errors are
+// logged via slog but never returned, because Write cannot surface
+// rotation errors to its caller and the alternative (dropping log
+// data) is worse than a missed rotation.
+func (w *RotatingWriter) Rotate() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		return os.ErrClosed
+	}
+	w.rotateLocked()
+	if w.file == nil {
+		return fmt.Errorf("logrotate: reopen after rotation failed for %s", w.path)
+	}
+	return nil
+}
+
+// backupPath returns the rotated-file name for the i-th backup.
+// .1 is the most recent, .N is the oldest.
+func (w *RotatingWriter) backupPath(i int) string {
+	return fmt.Sprintf("%s.%d", w.path, i)
+}
+
+// rotateLocked performs the chain rotation: delete the oldest (.N),
+// shift .(N-1) -> .N, ... .1 -> .2, rename active -> .1, reopen.
+//
+// Caller must hold w.mu.
+func (w *RotatingWriter) rotateLocked() {
 	w.file.Close()
 
-	backup := w.path + ".1"
-	os.Remove(backup)
+	// 1. Delete the oldest, if it exists. If this fails it is not fatal —
+	//    the next rename below will overwrite an empty slot.
+	oldest := w.backupPath(w.maxBackups)
+	if err := os.Remove(oldest); err != nil && !os.IsNotExist(err) {
+		slog.Warn("logrotate: remove oldest failed", "error", err, "path", oldest)
+	}
+
+	// 2. Walk the chain from oldest toward newest, shifting each .i -> .(i+1).
+	//    We iterate from N-1 down to 1 because each rename frees the source
+	//    slot for the previous iteration.
+	for i := w.maxBackups - 1; i >= 1; i-- {
+		src := w.backupPath(i)
+		dst := w.backupPath(i + 1)
+		if err := os.Rename(src, dst); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			slog.Warn("logrotate: shift failed", "error", err, "src", src, "dst", dst)
+		}
+	}
+
+	// 3. Move the active log to .1.
+	backup := w.backupPath(1)
 	if err := os.Rename(w.path, backup); err != nil {
 		slog.Warn("logrotate: rename failed", "error", err, "path", w.path, "backup", backup)
 	}
 
+	// 4. Reopen a fresh active log. If this fails w.file becomes nil and
+	//    Write() returns os.ErrClosed instead of panicking.
 	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		// If we cannot open the new log file, w.file will be nil.
-		// Write() checks for nil and returns os.ErrClosed instead of panicking.
 		w.file = nil
 		w.curSize = 0
 		return

--- a/daemon/logrotate_test.go
+++ b/daemon/logrotate_test.go
@@ -88,7 +88,7 @@ func TestRotatingWriter_BackupRotation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRotatingWriter: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	chunk := strings.Repeat("x", 250) // each write forces a rotation
 	for i := 0; i < 5; i++ {
@@ -123,7 +123,7 @@ func TestRotatingWriter_BackupDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRotatingWriter: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	chunk := strings.Repeat("y", 200)
 	for i := 0; i < 4; i++ {
@@ -152,7 +152,7 @@ func TestRotatingWriter_FallbackForInvalidMaxBackups(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRotatingWriter: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 	if w.MaxBackups() != DefaultLogMaxBackups {
 		t.Fatalf("MaxBackups() = %d, want %d", w.MaxBackups(), DefaultLogMaxBackups)
 	}
@@ -172,7 +172,7 @@ func TestIssue1222_BackupRetention(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRotatingWriter: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	// Write 6 chunks, each > maxSize so each forces a rotation. With
 	// maxBackups=3 the disk should hold active + .1 + .2 + .3 and no

--- a/daemon/logrotate_test.go
+++ b/daemon/logrotate_test.go
@@ -12,7 +12,7 @@ func TestRotatingWriter(t *testing.T) {
 	logPath := filepath.Join(dir, "test.log")
 
 	maxSize := int64(500) // 500 bytes
-	w, err := NewRotatingWriter(logPath, maxSize)
+	w, err := NewRotatingWriter(logPath, maxSize, 1)
 	if err != nil {
 		t.Fatalf("NewRotatingWriter: %v", err)
 	}
@@ -50,11 +50,12 @@ func TestMetaSaveLoad(t *testing.T) {
 	defer os.Setenv("HOME", origHome)
 
 	m := &Meta{
-		LogFile:     "/tmp/test.log",
-		LogMaxSize:  1024,
-		WorkDir:     "/tmp",
-		BinaryPath:  "/usr/local/bin/cc-connect",
-		InstalledAt: NowISO(),
+		LogFile:       "/tmp/test.log",
+		LogMaxSize:    1024,
+		LogMaxBackups: 3,
+		WorkDir:       "/tmp",
+		BinaryPath:    "/usr/local/bin/cc-connect",
+		InstalledAt:  NowISO(),
 	}
 
 	if err := SaveMeta(m); err != nil {
@@ -72,4 +73,151 @@ func TestMetaSaveLoad(t *testing.T) {
 	if loaded.WorkDir != m.WorkDir {
 		t.Errorf("WorkDir mismatch: %s != %s", loaded.WorkDir, m.WorkDir)
 	}
+}
+
+// TestRotatingWriter_BackupRotation exercises the chain: writing past
+// maxSize N times should produce .log.1 .. .log.N, and the oldest
+// (N+1th write) should be discarded.
+func TestRotatingWriter_BackupRotation(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "chain.log")
+
+	maxSize := int64(200)
+	maxBackups := 3
+	w, err := NewRotatingWriter(logPath, maxSize, maxBackups)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	chunk := strings.Repeat("x", 250) // each write forces a rotation
+	for i := 0; i < 5; i++ {
+		if _, err := w.Write([]byte(chunk)); err != nil {
+			t.Fatalf("Write #%d: %v", i, err)
+		}
+	}
+
+	// After 5 rotations with maxBackups=3, the active log is fresh and
+	// .log.1 / .log.2 / .log.3 must exist; .log.4 must NOT exist (it
+	// was the oldest and was discarded).
+	for i := 1; i <= maxBackups; i++ {
+		p := logPath + "." + itoa(i)
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("backup %s missing: %v", p, err)
+		}
+	}
+	if _, err := os.Stat(logPath + ".4"); !os.IsNotExist(err) {
+		t.Errorf(".log.4 should have been discarded, err=%v", err)
+	}
+}
+
+// TestRotatingWriter_BackupDisabled pins the legacy single-backup
+// behaviour: with maxBackups=1 only .log.1 is ever produced, and the
+// active log is always fresh.
+func TestRotatingWriter_BackupDisabled(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "single.log")
+
+	maxSize := int64(100)
+	w, err := NewRotatingWriter(logPath, maxSize, 1)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	chunk := strings.Repeat("y", 200)
+	for i := 0; i < 4; i++ {
+		if _, err := w.Write([]byte(chunk)); err != nil {
+			t.Fatalf("Write #%d: %v", i, err)
+		}
+	}
+
+	if _, err := os.Stat(logPath + ".1"); err != nil {
+		t.Errorf(".log.1 should exist: %v", err)
+	}
+	if _, err := os.Stat(logPath + ".2"); !os.IsNotExist(err) {
+		t.Errorf(".log.2 should NOT exist with maxBackups=1, err=%v", err)
+	}
+}
+
+// TestRotatingWriter_FallbackForInvalidMaxBackups verifies that passing
+// a non-positive maxBackups falls back to DefaultLogMaxBackups (3)
+// rather than silently disabling the post-mortem trail. This is the
+// safety net for an unparsed env var or a typo'd flag.
+func TestRotatingWriter_FallbackForInvalidMaxBackups(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "fallback.log")
+
+	w, err := NewRotatingWriter(logPath, 100, 0)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+	if w.MaxBackups() != DefaultLogMaxBackups {
+		t.Fatalf("MaxBackups() = %d, want %d", w.MaxBackups(), DefaultLogMaxBackups)
+	}
+}
+
+// TestIssue1222_BackupRetention is the regression test pinning the
+// follow-up to issue #1222: PR #1243 added CC_LOG_MAX_SIZE but only
+// kept a single backup, which still loses any post-mortem context
+// older than one rotation. With the new env var (and its flag
+// counterpart) we retain the configured number of backups.
+func TestIssue1222_BackupRetention(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "issue1222.log")
+
+	maxSize := int64(150)
+	w, err := NewRotatingWriter(logPath, maxSize, 3)
+	if err != nil {
+		t.Fatalf("NewRotatingWriter: %v", err)
+	}
+	defer w.Close()
+
+	// Write 6 chunks, each > maxSize so each forces a rotation. With
+	// maxBackups=3 the disk should hold active + .1 + .2 + .3 and no
+	// more — the 4 oldest chunks get shifted off.
+	chunk := []byte(strings.Repeat("z", 200))
+	for i := 0; i < 6; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("Write #%d: %v", i, err)
+		}
+	}
+
+	for i := 1; i <= 3; i++ {
+		p := logPath + "." + itoa(i)
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("backup %s missing: %v", p, err)
+		}
+		if info.Size() == 0 {
+			t.Errorf("backup %s is empty", p)
+		}
+	}
+	if _, err := os.Stat(logPath + ".4"); !os.IsNotExist(err) {
+		t.Errorf(".log.4 should have been discarded, err=%v", err)
+	}
+}
+
+// itoa avoids importing strconv just for these tests; small and local.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
 }

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -15,17 +15,19 @@ import (
 )
 
 const (
-	DefaultLogMaxSize = 10 * 1024 * 1024 // 10 MB
-	ServiceName       = "cc-connect"
+	DefaultLogMaxSize    = 10 * 1024 * 1024 // 10 MB
+	DefaultLogMaxBackups = 3                // active + .1 + .2 + .3
+	ServiceName          = "cc-connect"
 )
 
 type Config struct {
-	BinaryPath string
-	WorkDir    string
-	LogFile    string
-	LogMaxSize int64
-	EnvPATH    string            // capture user's PATH so agents are accessible
-	EnvExtra   map[string]string // selected environment variables needed by the service runtime
+	BinaryPath        string
+	WorkDir           string
+	LogFile           string
+	LogMaxSize        int64
+	LogMaxBackups     int
+	EnvPATH           string            // capture user's PATH so agents are accessible
+	EnvExtra          map[string]string // selected environment variables needed by the service runtime
 	// NoCaptureSecrets, when true, restricts the install-time env capture
 	// to proxy-related variables only and skips both the config.toml ${ENV}
 	// placeholder scan and any extension discoverers registered via
@@ -72,11 +74,12 @@ func DefaultDataDir() string {
 // etc. can locate the log file without parsing service definitions.
 
 type Meta struct {
-	LogFile     string `json:"log_file"`
-	LogMaxSize  int64  `json:"log_max_size"`
-	WorkDir     string `json:"work_dir"`
-	BinaryPath  string `json:"binary_path"`
-	InstalledAt string `json:"installed_at"`
+	LogFile      string `json:"log_file"`
+	LogMaxSize   int64  `json:"log_max_size"`
+	LogMaxBackups int   `json:"log_max_backups"`
+	WorkDir      string `json:"work_dir"`
+	BinaryPath   string `json:"binary_path"`
+	InstalledAt  string `json:"installed_at"`
 }
 
 func metaPath() string {
@@ -138,6 +141,9 @@ func Resolve(cfg *Config) error {
 	}
 	if cfg.LogMaxSize <= 0 {
 		cfg.LogMaxSize = DefaultLogMaxSize
+	}
+	if cfg.LogMaxBackups < 1 {
+		cfg.LogMaxBackups = DefaultLogMaxBackups
 	}
 	if cfg.EnvPATH == "" {
 		cfg.EnvPATH = os.Getenv("PATH")

--- a/daemon/systemd.go
+++ b/daemon/systemd.go
@@ -184,6 +184,7 @@ func (m *systemdManager) buildUnit(cfg Config) string {
 	sb.WriteString("RestartSec=10\n")
 	fmt.Fprintf(&sb, "Environment=\"CC_LOG_FILE=%s\"\n", cfg.LogFile)
 	fmt.Fprintf(&sb, "Environment=\"CC_LOG_MAX_SIZE=%d\"\n", cfg.LogMaxSize)
+	fmt.Fprintf(&sb, "Environment=\"CC_LOG_MAX_BACKUPS=%d\"\n", cfg.LogMaxBackups)
 	if cfg.EnvPATH != "" {
 		fmt.Fprintf(&sb, "Environment=\"PATH=%s\"\n", cfg.EnvPATH)
 	}

--- a/daemon/windows.go
+++ b/daemon/windows.go
@@ -181,6 +181,7 @@ func buildWindowsTaskScript(cfg Config) string {
 	sb.WriteString("$ErrorActionPreference = 'Stop'\r\n")
 	writePowerShellEnv(&sb, "CC_LOG_FILE", cfg.LogFile)
 	writePowerShellEnv(&sb, "CC_LOG_MAX_SIZE", strconv.FormatInt(cfg.LogMaxSize, 10))
+	writePowerShellEnv(&sb, "CC_LOG_MAX_BACKUPS", strconv.Itoa(cfg.LogMaxBackups))
 	if cfg.EnvPATH != "" {
 		writePowerShellEnv(&sb, "PATH", cfg.EnvPATH)
 	}


### PR DESCRIPTION
Fixes #1222 (follow-up to #1243)

## 背景

PR #1243 修了 `CC_LOG_MAX_SIZE` 的解析,但保留的备份数量仍然是
硬编码的 1(只留 `.log.1`)。这意味着在最坏情况下,用户只保留一份
rotation 之前的日志,后面那一段还是会丢,问题 #1222 报告的"现场
缺失"并没有真正解决。

这次改动把备份数量做成和 size 一样的可配置项,沿用 `flag > env >
default` 的优先级。

## 变更

- `daemon/logbackups.go` (新): `ParseLogBackups(s) (int, error)`,>=1,
  不接受单位后缀,错误回显原输入。和 `ParseLogSize` 行为保持一致。
- `daemon/manager.go`: `Config` 和 `Meta` 新增 `LogMaxBackups int`;
  `Resolve()` 在 < 1 时回退到 `DefaultLogMaxBackups = 3`。
- `daemon/logrotate.go`: `RotatingWriter` 新增 `maxBackups` 字段,
  链式 rotation 算法:
  1. 删除最旧的 `.log.N`
  2. 从 `N-1` 走到 `1`,把 `.log.i` 重命名为 `.log.(i+1)`
  3. 把活动日志重命名为 `.log.1`
  4. 重新打开新的活动日志
  新增 `Rotate()` 方法供测试和 SIGHUP 风格的"换新日志"使用。
  `maxBackups < 1` 时回退到默认值,而不是悄悄关掉备份。
- `cmd/cc-connect/main.go`: 新增 `resolveLogMaxBackups`、
  `preScanLogMaxBackupsFlag`、`--log-max-backups` flag。启动日志
  现在同时输出 `max_size` 和 `max_backups` 以及各自来源。预扫描
  模式保证在 `flag.Parse()` 之前的 rotating-writer 初始化阶段也
  能拿到 flag 值。
- `daemon/launchd.go` / `daemon/systemd.go` / `daemon/windows.go`:
  服务模板增加 `CC_LOG_MAX_BACKUPS` env var 的写入,保证全新安装
  时自动带上。

## 测试

- `TestParseLogBackups`: 19 个子用例,覆盖有效/空白/非整数/小于 1/
  负数/带单位/`3MB` 拒绝(数量没有单位)。
- `TestParseLogBackups_ErrorMessageEchoesInput`: 错误信息包含原
  始输入(便于 systemd 单元里 grep)。
- `TestRotatingWriter_BackupRotation`: 写入超过 N 次,验证只存在
  `.log.1 .. .log.N`,最旧的被丢弃。
- `TestRotatingWriter_BackupDisabled`: `maxBackups=1` 时只有
  `.log.1`,和 legacy 行为一致。
- `TestRotatingWriter_FallbackForInvalidMaxBackups`: 传 `< 1` 触发
  `DefaultLogMaxBackups` 兜底。
- `TestIssue1222_BackupRetention`: 6 次强制 rotation 后只留
  `.log.1 .. .log.3`,把问题 #1222 的"备份保留"语义钉死。
- `cmd/cc-connect/logbackups_test.go`: flag>env>default 优先级、
  非法值回退、预扫描 7 个子用例。

所有测试:
```
go test -count=1 -tags no_web ./daemon/ ./cmd/cc-connect/
ok  	github.com/chenhg5/cc-connect/daemon	0.006s
ok  	github.com/chenhg5/cc-connect/cmd/cc-connect	0.025s
```

## 与 PR #1243 的关系

完全独立:不动 `ParseLogSize`,不动 `DefaultLogMaxSize`,不动
`log-max-size` flag。沿用同一套 `flag > env > default` 优先级和
同一组预扫描/启动日志模式,只新增 backups 一条对应的链路。

## 验收

- [x] `CC_LOG_MAX_BACKUPS=3`(默认)与现有行为兼容 — `daemon` package
  默认 3,服务模板写入 3。
- [x] `CC_LOG_MAX_BACKUPS=0` 或非法值回退到默认(不会把 rotation
  静默关掉)。
- [x] `CC_LOG_MAX_BACKUPS=1` 复现 legacy 单备份行为。
- [x] `--log-max-backups` flag 覆盖 env var。
- [x] 启动日志输出 `max_backups=N (source: flag|env|default)`。
- [x] launchd plist / systemd unit / Windows task 三套模板同步。