### PR TITLE
fix(gemini): parse map-shaped content and sync history on /switch (fixes #441)

### DIFF
--- a/agent/gemini/gemini.go
+++ b/agent/gemini/gemini.go
@@ -475,6 +475,10 @@ type sessionMessage struct {
 }
 
 // textContent extracts text from the flexible content field.
+// Gemini CLI can serialize content as a plain string, an array of
+// typed {text: "..."} parts, or an array of generic objects with a
+// "text" field. The third shape is what newer Gemini CLI versions
+// emit (see issue #441), so all three must be tried in order.
 func (m *sessionMessage) textContent() string {
 	if len(m.RawContent) == 0 {
 		return ""
@@ -484,7 +488,20 @@ func (m *sessionMessage) textContent() string {
 	if json.Unmarshal(m.RawContent, &s) == nil {
 		return s
 	}
-	// Try as array of {text: "..."} parts
+	// Try as array of generic {"text": "..."} objects
+	var rawParts []map[string]any
+	if json.Unmarshal(m.RawContent, &rawParts) == nil {
+		var texts []string
+		for _, p := range rawParts {
+			if txt, ok := p["text"].(string); ok && txt != "" {
+				texts = append(texts, txt)
+			}
+		}
+		if len(texts) > 0 {
+			return strings.Join(texts, "\n")
+		}
+	}
+	// Fallback: typed array of struct{Text string}
 	var parts []struct {
 		Text string `json:"text"`
 	}
@@ -601,4 +618,73 @@ func extractSessionSummary(sf *sessionFile) string {
 		return sf.SessionID[:12] + "..."
 	}
 	return sf.SessionID
+}
+
+// GetSessionHistory implements core.HistoryProvider so the engine's
+// /switch command can auto-sync the most recent history entries
+// from the Gemini CLI session file. Returns nil, nil when the
+// session file does not exist (e.g. a freshly created session that
+// has not been written to disk yet).
+func (a *Agent) GetSessionHistory(ctx context.Context, sessionID string, limit int) ([]core.HistoryEntry, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("gemini: cannot determine home dir: %w", err)
+	}
+
+	slug := geminiProjectSlug(a.workDir)
+	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", slug, "chats")
+
+	entries, err := os.ReadDir(chatsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("gemini: read chats dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(chatsDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+
+		var sf sessionFile
+		if json.Unmarshal(data, &sf) != nil || sf.SessionID != sessionID {
+			continue
+		}
+
+		// Subagent sessions reuse the same on-disk layout but are
+		// not interactive conversations we want to sync.
+		if sf.Kind == "subagent" {
+			continue
+		}
+
+		var history []core.HistoryEntry
+		for _, msg := range sf.Messages {
+			text := strings.TrimSpace(msg.textContent())
+			if text == "" {
+				continue
+			}
+			role := "assistant"
+			if msg.Type == "user" {
+				role = "user"
+			}
+			history = append(history, core.HistoryEntry{
+				Role:    role,
+				Content: text,
+			})
+		}
+
+		if limit > 0 && len(history) > limit {
+			history = history[len(history)-limit:]
+		}
+
+		return history, nil
+	}
+
+	return nil, fmt.Errorf("gemini: session not found: %s", sessionID)
 }

--- a/agent/gemini/session_test.go
+++ b/agent/gemini/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -441,6 +442,14 @@ func TestSessionMessage_TextContent(t *testing.T) {
 	if got := m3.textContent(); got != "" {
 		t.Errorf("nil content: got %q, want empty", got)
 	}
+
+	// Issue #441: newer Gemini CLI serializes content as an array of
+	// generic {"text": "..."} objects, not the typed struct shape
+	// above. The map[string]any fallback must extract the text.
+	m4 := sessionMessage{Type: "user", RawContent: json.RawMessage(`[{"type":"text","text":"from map"},{"text":"second"}]`)}
+	if got := m4.textContent(); got != "from map\nsecond" {
+		t.Errorf("map[string]any content: got %q, want %q", got, "from map\nsecond")
+	}
 }
 
 func TestComputeLineDiff(t *testing.T) {
@@ -505,5 +514,82 @@ func TestGeminiSession_ContinueSessionTreatedAsFresh(t *testing.T) {
 
 	if got := s.CurrentSessionID(); got != "" {
 		t.Errorf("ContinueSession should be treated as fresh: chatID = %q, want empty", got)
+	}
+}
+
+// TestAgent_GetSessionHistory is a regression test for issue #441:
+// GetSessionHistory must locate the correct session file under
+// ~/.gemini/tmp/<slug>/chats/ and decode both the plain-string and
+// map[string]any content shapes.
+func TestAgent_GetSessionHistory(t *testing.T) {
+	// Build a temporary home directory layout.
+	home := t.TempDir()
+	workDir := "/fake/workdir"
+	slug := geminiProjectSlug(workDir)
+	chatsDir := filepath.Join(home, ".gemini", "tmp", slug, "chats")
+	if err := os.MkdirAll(chatsDir, 0o755); err != nil {
+		t.Fatalf("mkdir chats dir: %v", err)
+	}
+
+	// Session file 1 — matching sessionID, with a mix of content
+	// shapes (plain string + map[string]any array).
+	const targetID = "session-target"
+	mustWrite := func(name, content string) {
+		path := filepath.Join(chatsDir, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	mustWrite("session-target.json", `{
+		"sessionId": "`+targetID+`",
+		"kind": "session",
+		"messages": [
+			{"type": "user", "content": "hi"},
+			{"type": "assistant", "content": [{"text": "hello there"}]},
+			{"type": "user", "content": [{"type": "text", "text": "from map shape"}]}
+		]
+	}`)
+	// Decoy session file with a different ID — must be skipped.
+	mustWrite("session-other.json", `{
+		"sessionId": "other",
+		"kind": "session",
+		"messages": [{"type": "user", "content": "ignored"}]
+	}`)
+
+	// Override $HOME so os.UserHomeDir returns our temp dir.
+	t.Setenv("HOME", home)
+	// UserHomeDir on Windows checks USERPROFILE/HOMEDRIVE; for tests
+	// on Linux/macOS HOME is sufficient. Skip if it didn't take.
+	if got, _ := os.UserHomeDir(); got != home {
+		t.Skipf("os.UserHomeDir did not honor HOME override (got %q); skipping", got)
+	}
+
+	agent := &Agent{workDir: workDir}
+	history, err := agent.GetSessionHistory(context.Background(), targetID, 0)
+	if err != nil {
+		t.Fatalf("GetSessionHistory: %v", err)
+	}
+	if len(history) != 3 {
+		t.Fatalf("history length = %d, want 3; got %+v", len(history), history)
+	}
+	want := []core.HistoryEntry{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "hello there"},
+		{Role: "user", Content: "from map shape"},
+	}
+	for i, h := range history {
+		if h.Role != want[i].Role || h.Content != want[i].Content {
+			t.Errorf("history[%d] = %+v, want %+v", i, h, want[i])
+		}
+	}
+
+	// Limit applies to the tail.
+	if limited, _ := agent.GetSessionHistory(context.Background(), targetID, 2); len(limited) != 2 || limited[0].Content != "hello there" {
+		t.Errorf("limit=2 should return last 2 entries; got %+v", limited)
+	}
+
+	// Unknown session ID surfaces an error.
+	if _, err := agent.GetSessionHistory(context.Background(), "no-such-id", 0); err == nil {
+		t.Errorf("expected error for unknown session ID")
 	}
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -5881,6 +5881,25 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 	session := sessions.SwitchToAgentSession(msg.SessionKey, matched.ID, agent.Name(), matched.Summary)
 	session.ClearHistory()
 
+	// Auto-sync recent history from the agent's backend session file
+	// so /current and /history are useful immediately after /switch
+	// (issue #441). This is best-effort: agents that don't implement
+	// HistoryProvider simply skip this step.
+	if hp, ok := agent.(HistoryProvider); ok {
+		if history, err := hp.GetSessionHistory(e.ctx, matched.ID, 10); err == nil && len(history) > 0 {
+			for _, h := range history {
+				session.AddHistory(h.Role, h.Content)
+			}
+			// Persist immediately so the sync survives a daemon
+			// restart. SwitchToAgentSession already calls
+			// saveLocked, but we add history after that point.
+			sessions.Save()
+			slog.Debug("cmdSwitch: synced history from agent",
+				"session_key", msg.SessionKey,
+				"entries", len(history))
+		}
+	}
+
 	shortID := matched.ID
 	if len(shortID) > 12 {
 		shortID = shortID[:12]


### PR DESCRIPTION
## Summary

Rebuild of #443 against current `main`. The original PR was
CONFLICTING (it modified `core/engine.go:cmdSwitch` which has
moved significantly since March 2026).

Three coordinated changes for issue #441:

1. **`agent/gemini/gemini.go` — `textContent` map fallback.**
   Newer Gemini CLI serializes content as an array of generic
   `{text: "..."}` objects, not the typed `struct{Text string}`
   shape. The new `[]map[string]any` fallback extracts the text
   field and joins with newlines. Plain-string and struct[] still
   work.

2. **`agent/gemini/gemini.go` — `GetSessionHistory`.**
   Implements `core.HistoryProvider` so `/switch` can pull the
   most recent entries from
   `~/.gemini/tmp/<slug>/chats/<id>.json`. Skips subagent sessions.

3. **`core/engine.go` — `cmdSwitch` history sync.**
   After `SwitchToAgentSession` + `ClearHistory`, if the agent
   implements `HistoryProvider`, pull the last 10 entries and
   `sessions.Save()` so the sync survives daemon restart (this
   addresses the QA P2 concern about persistence from the old
   PR review).

## Regression tests

- `TestSessionMessage_TextContent` now covers the
  `[]map[string]any` shape.
- `TestAgent_GetSessionHistory` writes a synthetic session file
  under `t.TempDir()` (used as `$HOME`), verifies extraction,
  limit, and unknown-id error.

## Why not just rebase the old branch?

The old branch `fix/gemini-session-history-issue-441` was
authored against a much smaller `core/engine.go`. A clean rebuild
is less risky than chasing multiple hunk conflicts.

## Test plan

- `go vet ./core/ ./agent/gemini/` clean
- `go test -count=1 -run 'TestAgent_GetSessionHistory|TestSessionMessage_TextContent' ./agent/gemini/` — 2/2 PASS
- `go test -count=1 ./core/ ./agent/gemini/` — full suite, all PASS

Fixes #441
Rebuild-of: #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)