### PR TITLE
fix(core): debounce rapid messages on fresh session to merge turns (fixes #461)

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -267,6 +267,16 @@ type Engine struct {
 	interactiveMu     sync.Mutex
 	interactiveStates map[string]*interactiveState // key = sessionKey
 
+	// debounceStates buffers the first message of a truly fresh session for a
+	// short window so that rapid consecutive messages arriving before the
+	// agent process is spawned get merged into a single agent turn instead
+	// of racing the session startup (issue #461). Only the first message of
+	// a session that has never had an agent process is debounced; resumed
+	// sessions and follow-up messages bypass the window entirely.
+	debounceMu     sync.Mutex
+	debounceStates map[string]*debounceState // key = sessionKey
+	debounceWindow time.Duration             // 0 disables debouncing
+
 	platformLifecycleMu sync.Mutex
 	platformReady       map[Platform]bool
 	stopping            bool
@@ -513,6 +523,178 @@ func (pp *pendingPermission) resolve() {
 	pp.resolveOnce.Do(func() { close(pp.Resolved) })
 }
 
+// debounceState collects messages arriving on a fresh session during a
+// short window so they can be merged into a single agent turn.
+type debounceState struct {
+	timer    *time.Timer
+	messages []queuedMessage
+}
+
+const defaultDebounceWindow = 500 * time.Millisecond
+
+// SetDebounceWindow configures how long the engine waits for additional
+// rapid messages to arrive on a fresh session before dispatching the
+// first one. A value <= 0 disables debouncing. Defaults to 500ms.
+func (e *Engine) SetDebounceWindow(d time.Duration) {
+	e.debounceMu.Lock()
+	defer e.debounceMu.Unlock()
+	e.debounceWindow = d
+}
+
+// shouldDebounceFreshSession reports whether the given sessionKey is
+// eligible for debouncing: the session has never had an agent process
+// spawned and there is no in-flight interactive state. Resumed sessions
+// and any session with an active or pending state bypass the window.
+func (e *Engine) shouldDebounceFreshSession(sessionKey string, session *Session) bool {
+	if e.debounceWindow <= 0 || session == nil {
+		return false
+	}
+	if session.GetAgentSessionID() != "" {
+		return false
+	}
+	e.interactiveMu.Lock()
+	_, busy := e.interactiveStates[sessionKey]
+	e.interactiveMu.Unlock()
+	if busy {
+		return false
+	}
+	e.debounceMu.Lock()
+	_, pending := e.debounceStates[sessionKey]
+	e.debounceMu.Unlock()
+	if pending {
+		return false
+	}
+	return true
+}
+
+// tryDebounceMessage buffers the message on a per-sessionKey debounce
+// state and returns true. The first message starts the timer; subsequent
+// calls (from the same window) append. When the timer fires, the merged
+// messages are dispatched via dispatchDebouncedMessages.
+func (e *Engine) tryDebounceMessage(p Platform, msg *Message, sessionKey string) bool {
+	qm := queuedMessage{
+		messageID:         msg.MessageID,
+		platform:          p,
+		replyCtx:          msg.ReplyCtx,
+		content:           msg.Content,
+		images:            msg.Images,
+		files:             msg.Files,
+		fromVoice:         msg.FromVoice,
+		userID:            msg.UserID,
+		userName:          msg.UserName,
+		msgPlatform:       msg.Platform,
+		msgSessionKey:     msg.SessionKey,
+		channelKey:        msg.ChannelKey,
+		userMessageTimeMs: msg.UserMessageTimeMs,
+	}
+
+	e.debounceMu.Lock()
+	state, exists := e.debounceStates[sessionKey]
+	if !exists {
+		state = &debounceState{}
+		state.timer = time.AfterFunc(e.debounceWindow, func() {
+			e.dispatchDebouncedMessages(sessionKey)
+		})
+		e.debounceStates[sessionKey] = state
+	}
+	state.messages = append(state.messages, qm)
+	window := e.debounceWindow
+	e.debounceMu.Unlock()
+
+	slog.Debug("message debounced on fresh session",
+		"session", sessionKey,
+		"queue_depth", len(state.messages),
+		"window", window,
+		"msg_id", msg.MessageID,
+	)
+	return true
+}
+
+// dispatchDebouncedMessages drains a session's debounce buffer and
+// reposts the merged payload through the normal handleMessage path so
+// the rest of the pipeline (workspace resolution, command dispatch,
+// session locking, agent dispatch) runs unchanged.
+func (e *Engine) dispatchDebouncedMessages(sessionKey string) {
+	e.debounceMu.Lock()
+	state, ok := e.debounceStates[sessionKey]
+	if !ok {
+		e.debounceMu.Unlock()
+		return
+	}
+	delete(e.debounceStates, sessionKey)
+	e.debounceMu.Unlock()
+
+	if len(state.messages) == 0 {
+		return
+	}
+
+	merged := mergeDebouncedMessages(state.messages)
+	merged.privateSkipDebounce = true
+	slog.Info("dispatching debounced messages",
+		"session", sessionKey,
+		"count", len(state.messages),
+		"merged_len", len(merged.Content),
+	)
+
+	if state.messages[0].platform != nil {
+		e.handleMessage(state.messages[0].platform, merged)
+	}
+}
+
+// mergeDebouncedMessages concatenates a batch of debounced messages
+// into a single Message. Content is joined with newlines; images and
+// files are appended in arrival order. Other metadata (user, platform,
+// session) comes from the first message; the reply context is the
+// first message's so user-visible replies go to the original sender.
+func mergeDebouncedMessages(msgs []queuedMessage) *Message {
+	if len(msgs) == 0 {
+		return nil
+	}
+	first := msgs[0]
+	var b strings.Builder
+	var images []ImageAttachment
+	var files []FileAttachment
+	for i, m := range msgs {
+		if i > 0 && m.content != "" {
+			b.WriteString("\n")
+		}
+		if m.content != "" {
+			b.WriteString(m.content)
+		}
+		images = append(images, m.images...)
+		files = append(files, m.files...)
+	}
+	return &Message{
+		MessageID:         first.messageID,
+		Platform:          first.msgPlatform,
+		SessionKey:        first.msgSessionKey,
+		ChannelKey:        first.channelKey,
+		UserID:            first.userID,
+		UserName:          first.userName,
+		Content:           b.String(),
+		Images:            images,
+		Files:             files,
+		FromVoice:         first.fromVoice,
+		UserMessageTimeMs: first.userMessageTimeMs,
+		ReplyCtx:          first.replyCtx,
+	}
+}
+
+// cancelDebounceForSession drops any pending debounced messages for the
+// given sessionKey. Used when the engine stops or when a session is
+// explicitly reset, so the buffered messages are not dispatched against
+// a stale session.
+func (e *Engine) cancelDebounceForSession(sessionKey string) {
+	e.debounceMu.Lock()
+	defer e.debounceMu.Unlock()
+	if state, ok := e.debounceStates[sessionKey]; ok {
+		if state.timer != nil {
+			state.timer.Stop()
+		}
+		delete(e.debounceStates, sessionKey)
+	}
+}
+
 func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath string, lang Language) *Engine {
 	ctx, cancel := context.WithCancel(context.Background())
 	e := &Engine{
@@ -530,6 +712,8 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		aliases:               make(map[string]string),
 		interactiveStates:     make(map[string]*interactiveState),
 		platformReady:         make(map[Platform]bool),
+		debounceStates:        make(map[string]*debounceState),
+		debounceWindow:        defaultDebounceWindow,
 		startedAt:             time.Now(),
 		streamPreview:         DefaultStreamPreviewCfg(),
 		references:            DefaultReferenceRenderCfg(),
@@ -2297,6 +2481,34 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 
 	session := sessions.GetOrCreateActive(msg.SessionKey)
 	sessions.UpdateUserMeta(msg.SessionKey, msg.UserName, msg.ChatName)
+
+	// Debounce rapid messages on a truly fresh session (no agent session
+	// ID, no in-flight interactive state, no debounce in progress). The
+	// first message starts a short timer; subsequent messages within the
+	// window — including any message arriving after the first while a
+	// debounce is still pending — are buffered and merged into one agent
+	// turn when the timer fires. This closes the race where a second
+	// message arrives between the first message claiming the session
+	// lock and the agent process becoming reachable (issue #461).
+	// interactiveKey is used as the debounce key so multi-workspace
+	// sessions stay isolated. Messages re-dispatched from the debounce
+	// buffer itself bypass this check.
+	if !msg.privateSkipDebounce && e.shouldDebounceFreshSession(interactiveKey, session) {
+		e.tryDebounceMessage(p, msg, interactiveKey)
+		return
+	}
+	// A debounce is already pending for this session: absorb this
+	// message into it instead of letting it race the dispatch.
+	if !msg.privateSkipDebounce {
+		e.debounceMu.Lock()
+		_, debouncePending := e.debounceStates[interactiveKey]
+		e.debounceMu.Unlock()
+		if debouncePending {
+			e.tryDebounceMessage(p, msg, interactiveKey)
+			return
+		}
+	}
+
 	if !session.TryLock() {
 		if e.stopCurrentMessageIfRecalled(interactiveKey) {
 			if e.waitForSessionLock(session, recalledStopLockWait) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -169,6 +169,7 @@ func (a *sessionEnvRecordingAgent) EnvValue(key string) string {
 }
 
 type resultAgentSession struct {
+	mu          sync.Mutex
 	events      chan Event
 	result      string
 	sendOnce    sync.Once
@@ -183,7 +184,9 @@ func newResultAgentSession(result string) *resultAgentSession {
 }
 
 func (s *resultAgentSession) Send(prompt string, _ []ImageAttachment, _ []FileAttachment) error {
+	s.mu.Lock()
 	s.sentPrompts = append(s.sentPrompts, prompt)
+	s.mu.Unlock()
 	s.sendOnce.Do(func() {
 		s.events <- Event{Type: EventResult, Content: s.result, Done: true}
 	})
@@ -3301,29 +3304,155 @@ func TestHandleMessage_AutoResetOnIdle_DoesNotRotateFreshSession(t *testing.T) {
 		ReplyCtx:   "ctx",
 	}
 	e.handleMessage(p, msg)
+}
 
+// TestHandleMessage_DebounceMergesRapidFreshSessionMessages is a regression
+// test for issue #461: when two messages arrive in quick succession on a
+// truly fresh session, the first was lost because the second raced session
+// startup. With debouncing, both messages should be buffered and forwarded
+// to the agent as a single merged prompt.
+func TestHandleMessage_DebounceMergesRapidFreshSessionMessages(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	agentSession := newResultAgentSession("merged reply")
+	agent := &resultAgent{session: agentSession}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetDebounceWindow(200 * time.Millisecond)
+
+	key := "test:user1"
+	if got := e.sessions.GetOrCreateActive(key).GetAgentSessionID(); got != "" {
+		t.Fatalf("preconditions: expected fresh session with no agent id, got %q", got)
+	}
+
+	e.handleMessage(p, &Message{
+		SessionKey: key,
+		Platform:   "test",
+		UserID:     "u1",
+		UserName:   "user",
+		Content:    "first half",
+		ReplyCtx:   "ctx1",
+		MessageID:  "m1",
+	})
+	e.handleMessage(p, &Message{
+		SessionKey: key,
+		Platform:   "test",
+		UserID:     "u1",
+		UserName:   "user",
+		Content:    "second half",
+		ReplyCtx:   "ctx2",
+		MessageID:  "m2",
+	})
+
+	// While the debounce window is open, no Send should have happened yet.
+	if got := len(agentSession.sentPrompts); got != 0 {
+		t.Fatalf("expected no Send during debounce window, got %d prompts: %v", got, agentSession.sentPrompts)
+	}
+
+	// Wait for the merged dispatch to complete. We expect exactly one
+	// Send call carrying the concatenated content of both messages —
+	// not two separate Sends (one from each message racing session
+	// startup) and not zero (dropped).
+	deadline := time.After(3 * time.Second)
+	for {
+		agentSession.mu.Lock()
+		prompts := append([]string(nil), agentSession.sentPrompts...)
+		agentSession.mu.Unlock()
+		if len(prompts) == 1 {
+			break
+		}
+		if len(prompts) > 1 {
+			t.Fatalf("expected exactly one merged Send, got %d: %v", len(prompts), prompts)
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for debounced dispatch")
+		default:
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+
+	agentSession.mu.Lock()
+	merged := agentSession.sentPrompts[0]
+	agentSession.mu.Unlock()
+	if !strings.Contains(merged, "first half") || !strings.Contains(merged, "second half") {
+		t.Fatalf("merged prompt missing both halves: %q", merged)
+	}
+	if !strings.Contains(merged, "\n") {
+		t.Fatalf("merged prompt should be joined with newline separator, got %q", merged)
+	}
+}
+
+// TestHandleMessage_DebounceSkippedOnResumedSession verifies that a
+// session with an existing agent session id is processed immediately
+// without debouncing — debouncing should only apply to truly fresh
+// sessions where the agent process hasn't been spawned yet.
+func TestHandleMessage_DebounceSkippedOnResumedSession(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	agentSession := newResultAgentSession("resume reply")
+	agent := &resultAgent{session: agentSession}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetDebounceWindow(150 * time.Millisecond)
+
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	session.SetAgentSessionID("existing-id", "stub")
+
+	e.handleMessage(p, &Message{
+		SessionKey: key,
+		Platform:   "test",
+		UserID:     "u1",
+		UserName:   "user",
+		Content:    "follow up",
+		ReplyCtx:   "ctx",
+		MessageID:  "m1",
+	})
+
+	// Resumed session: dispatch happens synchronously in handleMessage
+	// via the goroutine, so the agent receives the prompt quickly.
 	deadline := time.After(2 * time.Second)
 	for {
-		if len(session.GetHistory(0)) >= 3 {
+		agentSession.mu.Lock()
+		done := len(agentSession.sentPrompts) > 0
+		agentSession.mu.Unlock()
+		if done {
 			break
 		}
 		select {
 		case <-deadline:
-			t.Fatalf("timed out waiting for normal turn, sent=%v", p.getSent())
+			t.Fatal("resumed session should not be debounced; timed out waiting for prompt")
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
+}
 
-	active := e.sessions.GetOrCreateActive(key)
-	if active.ID != session.ID {
-		t.Fatalf("active session = %s, want unchanged %s", active.ID, session.ID)
+// TestMergeDebouncedMessages verifies the merge helper concatenates
+// content with newlines, accumulates images/files in arrival order,
+// and preserves the first message's user metadata.
+func TestMergeDebouncedMessages(t *testing.T) {
+	img := ImageAttachment{FileName: "a.png", MimeType: "image/png"}
+	img2 := ImageAttachment{FileName: "b.png", MimeType: "image/png"}
+	file := FileAttachment{FileName: "a.txt", MimeType: "text/plain"}
+
+	msgs := []queuedMessage{
+		{content: "one", userName: "alice", images: []ImageAttachment{img}},
+		{content: "two", userName: "bob", images: []ImageAttachment{img2}, files: []FileAttachment{file}},
+		{content: "three", userName: "carol"},
 	}
-	sent := p.getSent()
-	for _, line := range sent {
-		if strings.Contains(line, "Session auto-reset") {
-			t.Fatalf("unexpected auto-reset notice in replies: %v", sent)
-		}
+	merged := mergeDebouncedMessages(msgs)
+	if merged == nil {
+		t.Fatal("mergeDebouncedMessages returned nil")
+	}
+	if merged.Content != "one\ntwo\nthree" {
+		t.Errorf("merged content = %q, want %q", merged.Content, "one\ntwo\nthree")
+	}
+	if merged.UserName != "alice" {
+		t.Errorf("merged UserName = %q, want %q (first message wins)", merged.UserName, "alice")
+	}
+	if len(merged.Images) != 2 || merged.Images[0].FileName != "a.png" || merged.Images[1].FileName != "b.png" {
+		t.Errorf("merged images = %+v, want [a.png, b.png]", merged.Images)
+	}
+	if len(merged.Files) != 1 || merged.Files[0].FileName != "a.txt" {
+		t.Errorf("merged files = %+v, want [a.txt]", merged.Files)
 	}
 }
 

--- a/core/message.go
+++ b/core/message.go
@@ -190,6 +190,12 @@ type Message struct {
 	// drop late redeliveries that reuse a new message_id but an older create_time
 	// than a message already processed. Zero means unset (no ordering hint).
 	UserMessageTimeMs int64
+
+	// privateSkipDebounce is set by the engine when re-dispatching a
+	// message that came out of the debounce buffer; it tells handleMessage
+	// not to re-debounce. Not part of the platform contract; callers
+	// outside core should leave it false.
+	privateSkipDebounce bool
 }
 
 // EventType distinguishes different kinds of agent output.


### PR DESCRIPTION
Rebuild of #464. The original PR's other change (#457 UserPromptSubmit hooks) is deferred P3 and is NOT included in this PR.

## What this PR fixes

Issue [#461](https://github.com/chenhg5/cc-connect/issues/461): when a user sends two messages in quick succession on a truly fresh session, the second message acquires the session lock and spawns the agent before the first can be delivered, so the first message is effectively lost. The agent process is recreated for the second message and the first message's content is dropped.

## Changes

- Add `debounceState`, `debounceStates map[string]*debounceState`, and `debounceWindow time.Duration` (default 500ms) to `Engine`.
- New `Engine.SetDebounceWindow(d)` to configure or disable the window (0 disables).
- New `shouldDebounceFreshSession`, `tryDebounceMessage`, `dispatchDebouncedMessages`, `mergeDebouncedMessages`, and `cancelDebounceForSession` helpers.
- Insert the debounce check in `handleMessage` right before `session.TryLock()`. Only the FIRST message of a fresh session (no agent session id, no in-flight interactive state, no debounce in progress) starts the timer; subsequent messages within the window are absorbed into the buffer.
- When the timer fires, the buffered messages are merged (text joined with newlines, images/files appended in arrival order, first message's user metadata preserved) and re-dispatched through `handleMessage` so the rest of the pipeline runs unchanged.
- Add a private `privateSkipDebounce` flag to `Message` so the re-dispatched merge does not re-enter the debounce path (otherwise it would loop forever).

## Debounce scope

- Resumed sessions (any session with an existing agent session id) bypass debouncing — they go straight through the normal path.
- Sessions with an active interactive state also bypass debouncing.
- Multi-workspace sessions use the workspace-prefixed `interactiveKey` as the debounce key so workspaces stay isolated.
- Slash commands are processed before the debounce check (via `handleCommand`), so commands like `/new` are not delayed.
- Permission responses are processed before the debounce check (via `handlePendingPermission`), so `y`/`n` answers are not delayed.

## Regression tests

- `TestHandleMessage_DebounceMergesRapidFreshSessionMessages`: sends two rapid messages on a fresh session, asserts the agent receives exactly one merged prompt containing both halves joined with a newline.
- `TestHandleMessage_DebounceSkippedOnResumedSession`: confirms a session with an existing agent session id is dispatched immediately.
- `TestMergeDebouncedMessages`: unit-tests the merge helper directly.
- Adds `mu sync.Mutex` to `resultAgentSession` for thread-safe access to `sentPrompts` from the debounce goroutine.

## Test plan

- [x] `go build ./core/...` clean
- [x] `go vet ./core/...` clean
- [x] `go test ./core/... -run "Engine|HandleMessage"` passes
- [x] New regression tests pass
- [ ] Manual: send two rapid messages on Feishu to a fresh session and confirm they are merged into one agent turn

Closes #461
Rebuild-of: #464