### PR TITLE
fix(core): strip @mentions from permission response matching (fixes #476)

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2761,7 +2761,31 @@ func buildAskQuestionResponse(originalInput map[string]any, questions []UserQues
 	return result
 }
 
+// mentionRe matches an @mention token preceded by start-of-string or
+// whitespace: '@' followed by a Unicode letter/digit/underscore and then
+// more word characters (including dots and dashes for ASCII bot names).
+// The preceding (^|\s) anchor keeps regular emails (e.g. user@example.com)
+// intact — only @-tokens that look like standalone mentions are stripped.
+// Used to strip platform-injected @-mentions from permission responses
+// in group chats (e.g. WeChat Work "允许 @群机器人"), where the mention
+// is appended to the user's response and would otherwise fail the
+// exact-match comparison in isAllowResponse / isDenyResponse /
+// isApproveAllResponse.
+var mentionRe = regexp.MustCompile(`(?:^|\s)@[\p{L}\p{N}_][\p{L}\p{N}_\-.]*`)
+
+// stripMentions removes @mention tokens from s and returns the result
+// with surrounding whitespace trimmed and internal whitespace
+// normalized. Supports CJK mention names (e.g. "@群机器人") as well as
+// ASCII names with dots/dashes/underscores (e.g. "@bot.example-1").
+// Regular emails (e.g. "user@example.com") are preserved because the
+// '@' is not at the start of a token.
+func stripMentions(s string) string {
+	stripped := mentionRe.ReplaceAllString(s, "")
+	return strings.TrimSpace(stripped)
+}
+
 func isApproveAllResponse(s string) bool {
+	s = stripMentions(s)
 	for _, w := range []string{
 		"allow all", "allowall", "approve all", "yes all",
 		"允许所有", "允许全部", "全部允许", "所有允许", "都允许", "全部同意",
@@ -2774,6 +2798,7 @@ func isApproveAllResponse(s string) bool {
 }
 
 func isAllowResponse(s string) bool {
+	s = stripMentions(s)
 	for _, w := range []string{"allow", "yes", "y", "ok", "允许", "同意", "可以", "好", "好的", "是", "确认", "approve"} {
 		if s == w {
 			return true
@@ -2783,6 +2808,7 @@ func isAllowResponse(s string) bool {
 }
 
 func isDenyResponse(s string) bool {
+	s = stripMentions(s)
 	for _, w := range []string{"deny", "no", "n", "reject", "拒绝", "不允许", "不行", "不", "否", "取消", "cancel"} {
 		if s == w {
 			return true

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -14120,3 +14120,81 @@ func TestMaybeAutoResetSessionOnIdle_NotFiredWhenUserActivityRecent(t *testing.T
 		t.Fatal("expected no idle reset because LastUserActivity is only 5min ago")
 	}
 }
+
+// TestStripMentions is a regression test for issue #476: in WeChat Work
+// (and other) group chats, platform-injected @-mentions get appended to
+// user responses like "允许 @群机器人". The exact-match permission
+// response checkers (isAllowResponse, isDenyResponse, isApproveAllResponse)
+// then fail because the comparison string is no longer exact. stripMentions
+// must remove @-mention tokens regardless of position.
+func TestStripMentions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no_mention", "允许", "允许"},
+		{"mention_suffix_cjk", "允许 @群机器人", "允许"},
+		{"mention_prefix_cjk", "@群机器人 允许", "允许"},
+		{"mention_between", "允许 @群机器人 全部同意", "允许 全部同意"},
+		{"multiple_mentions_prefix", "@bot1 @bot2 同意", "同意"},
+		{"multiple_mentions_middle", "允许 @bot1 @bot2 全部同意", "允许 全部同意"},
+		{"mention_with_ascii", "yes @user.name_1", "yes"},
+		{"mention_with_dash", "deny @some-bot-2", "deny"},
+		{"mention_alone", "@群机器人", ""},
+		{"surrounding_whitespace", "  允许  @群机器人  ", "允许"},
+		{"email_like_not_stripped", "user@example.com", "user@example.com"},
+		{"at_sign_alone", "@", "@"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripMentions(tt.in); got != tt.want {
+				t.Errorf("stripMentions(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPermissionResponseMatchersWithMentions covers the integration of
+// stripMentions with the three permission response matchers used to
+// detect "allow / deny / allow-all" replies to pending permission
+// requests in group chats.
+func TestPermissionResponseMatchersWithMentions(t *testing.T) {
+	cases := []struct {
+		input      string
+		allow      bool
+		deny       bool
+		allowAll   bool
+		desc       string
+	}{
+		// issue #476 exact failure mode
+		{"允许 @群机器人", true, false, false, "wecom allow + mention"},
+		{"拒绝 @群机器人", false, true, false, "wecom deny + mention"},
+		{"全部允许 @群机器人", false, false, true, "wecom allow-all + mention"},
+		// mention prefix
+		{"@群机器人 允许", true, false, false, "wecom mention then allow"},
+		{"@群机器人 拒绝", false, true, false, "wecom mention then deny"},
+		// plain positive control
+		{"允许", true, false, false, "plain allow"},
+		{"拒绝", false, true, false, "plain deny"},
+		// english
+		{"yes @bot", true, false, false, "english yes + mention"},
+		{"no @bot", false, true, false, "english no + mention"},
+		// not a permission response at all
+		{"hello world", false, false, false, "non-permission text"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := isAllowResponse(tc.input); got != tc.allow {
+				t.Errorf("isAllowResponse(%q) = %v, want %v", tc.input, got, tc.allow)
+			}
+			if got := isDenyResponse(tc.input); got != tc.deny {
+				t.Errorf("isDenyResponse(%q) = %v, want %v", tc.input, got, tc.deny)
+			}
+			if got := isApproveAllResponse(tc.input); got != tc.allowAll {
+				t.Errorf("isApproveAllResponse(%q) = %v, want %v", tc.input, got, tc.allowAll)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Rebuild of #482. The original PR was already minimal; this rebuild preserves the same logic and uses Unicode-aware character classes so CJK mention names match.

## What this PR fixes

Issue [#476](https://github.com/chenhg5/cc-connect/issues/476): in WeChat Work (企业微信) and other group-chat platforms, permission responses like "允许 @群机器人" carry a trailing platform-injected @-mention. The exact-match permission response checkers (`isApproveAllResponse`, `isAllowResponse`, `isDenyResponse`) then fail because the comparison string is no longer exact, leaving the permission request hanging until the user retries without the mention.

## Changes

- Add `mentionRe` regex (a `@` followed by a Unicode letter/digit/underscore and more word/dot/dash characters, preceded by start-of-string or whitespace) and `stripMentions(s string) string` helper.
- Apply `stripMentions` at the top of each permission response matcher so the comparison is done against the mention-stripped string.
- The `(^|\s)` anchor keeps regular emails (e.g. `user@example.com`) intact — only standalone @-tokens are stripped.

## Regression tests

- `TestStripMentions`: table-driven, covers prefix/suffix/middle mention positions, multiple mentions, CJK names (e.g. "@群机器人"), ASCII names with dots and dashes, surrounding whitespace, and a negative case for emails.
- `TestPermissionResponseMatchersWithMentions`: integration cases for all three matchers covering the issue #476 failure modes (mention suffix, mention prefix, plain positive control, English variants, non-permission text).

## Test plan

- [x] `go build ./core/...` clean
- [x] `go vet ./core/...` clean
- [x] `go test ./core/...` passes
- [x] New regression tests pass
- [ ] Manual: in a WeChat Work group, reply "允许 @群机器人" to a permission request and confirm it is recognized

Closes #476
Rebuild-of: #482