### PR TITLE
fix(feishu): extract hr element as standalone '---' in quoted posts (fixes #508)

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1877,6 +1877,18 @@ func extractPostPlainText(content string) string {
 					lang := elem.Language
 					line = append(line, "```"+lang+"\n"+elem.Text+"\n```")
 				}
+			case "hr":
+				// Lark posts render an `hr` element as a horizontal rule;
+				// map it to a standalone markdown separator on its own line
+				// so the agent (and downstream markdown renderers) can
+				// recognize the boundary. We flush any pending line text
+				// first so the rule is not glued to surrounding text
+				// (issue #508; related #470/#472).
+				if len(line) > 0 {
+					parts = append(parts, strings.Join(line, ""))
+					line = line[:0]
+				}
+				parts = append(parts, "---")
 			}
 		}
 		if len(line) > 0 {

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -888,6 +888,42 @@ func TestExtractPostPlainText_CodeBlock(t *testing.T) {
 	}
 }
 
+// TestExtractPostPlainText_HrTag is a regression test for issue #508
+// (related #470/#472). Lark posts use the `hr` element to mark a
+// horizontal rule boundary between sections of a quoted post; the
+// extractor must surface it as a standalone `---` so the agent
+// understands the section break instead of silently dropping it.
+func TestExtractPostPlainText_HrTag(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "hr_alone",
+			content: `{"content":[[{"tag":"hr"}]]}`,
+			want:    "---",
+		},
+		{
+			name:    "hr_after_text",
+			content: `{"content":[[{"tag":"text","text":"before"},{"tag":"hr"},{"tag":"text","text":"after"}]]}`,
+			want:    "before\n---\nafter",
+		},
+		{
+			name:    "hr_between_paragraphs",
+			content: `{"content":[[{"tag":"text","text":"first"}],[{"tag":"hr"}],[{"tag":"text","text":"second"}]]}`,
+			want:    "first\n---\nsecond",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractPostPlainText(tc.content); got != tc.want {
+				t.Errorf("extractPostPlainText(%q) = %q, want %q", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
 func strPtr(s string) *string { return &s }
 
 func TestStripMentions(t *testing.T) {


### PR DESCRIPTION
Rebuild of #508. The original PR also touched the `code_block` (skip empty language prefix) and `a` (extract link text) cases; both improvements are already in main from prior merges, so this rebuild only carries the missing `hr` handling and its test.

## What this PR fixes

Issue [#508](https://github.com/chenhg5/cc-connect/pull/508) (related #470/#472): Lark posts use the `hr` element to draw a horizontal rule between sections of a quoted post. `extractPostPlainText` (the path that converts rich-text post content into the plain text forwarded to the agent when a quoted post is part of a forwarded message) silently dropped the element, so the agent had no way to see the section break.

## Changes

- Add a `case "hr"` branch in `extractPostPlainText` that flushes any pending inline text from the current paragraph and appends `"---"` as its own part. The convention matches `extractInteractiveCardText`, which already emits `"---"` for `hr` in interactive cards.

## Regression tests

- `TestExtractPostPlainText_HrTag` with three scenarios:
  - `hr_alone`: a paragraph that contains only `hr` yields exactly `"---"`.
  - `hr_after_text`: `before` + `hr` + `after` in the same paragraph yields `"before\n---\nafter"`.
  - `hr_between_paragraphs`: separate paragraphs around an `hr` yield `"first\n---\nsecond"`.

## Test plan

- [x] `go build ./platform/feishu/...` clean
- [x] `go vet ./platform/feishu/...` clean
- [x] `go test ./platform/feishu/... -run TestExtractPostPlainText` passes
- [x] New regression test passes
- [ ] Manual: forward a Feishu quoted post with an `hr` and confirm the agent sees `---`

Closes #508 (PR-equivalent fix)
Rebuild-of: #508