### PR TITLE
fix(acp): add AgentSessionCanceller interface for graceful /stop

### DIFF
--- a/agent/acp/rpc.go
+++ b/agent/acp/rpc.go
@@ -202,6 +202,14 @@ func (t *transport) call(ctx context.Context, method string, params any) (json.R
 	}
 }
 
+func (t *transport) sendNotification(method string, params any) error {
+	return t.writeJSON(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"params":  params,
+	})
+}
+
 func (t *transport) writeJSON(v any) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/agent/acp/session.go
+++ b/agent/acp/session.go
@@ -698,6 +698,24 @@ func (s *acpSession) CurrentSessionID() string {
 	return s.currentACPSessionID()
 }
 
+// CancelTurn sends an ACP session/cancel notification to abort the current
+// turn while keeping the session alive. The agent should cancel the active
+// LLM request and persist state, then wait for the next user message on the
+// same connection. This is used by /stop instead of Close().
+func (s *acpSession) CancelTurn() error {
+	sid := s.currentACPSessionID()
+	if sid == "" {
+		return fmt.Errorf("acp: no active session to cancel")
+	}
+	if s.tr == nil {
+		return fmt.Errorf("acp: transport not available")
+	}
+	slog.Debug("acp: cancelling current turn", "session_id", sid)
+	return s.tr.sendNotification("session/cancel", map[string]any{
+		"sessionId": sid,
+	})
+}
+
 func (s *acpSession) Alive() bool {
 	return s.alive.Load()
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -8638,6 +8638,52 @@ func (e *Engine) stopInteractiveSessionWithOptions(sessionKey string, notifyQueu
 	agentSession := state.agentSession
 	state.mu.Unlock()
 
+	// If the agent session supports graceful turn cancellation (e.g. ACP),
+	// send a cancel notification and keep the session alive for the next
+	// user message, rather than killing the process and destroying state.
+	if canceller, ok := agentSession.(AgentSessionCanceller); ok && agentSession != nil {
+		// Keep the state in the map so the next message reuses this session.
+		// Don't markStopped — the session is still usable.
+		// Don't delete from interactiveStates — keep it alive.
+		e.interactiveMu.Unlock()
+
+		if pending != nil {
+			pending.resolve()
+		}
+		if notifyQueued {
+			e.notifyDroppedQueuedMessages(state, fmt.Errorf("session cancelled"))
+		} else {
+			state.mu.Lock()
+			state.pendingMessages = nil
+			state.mu.Unlock()
+		}
+
+		// Mark eventsNeedResync so the next turn drains stale events from
+		// the cancelled turn before processing fresh input.
+		state.mu.Lock()
+		state.eventsNeedResync = true
+		state.mu.Unlock()
+
+		cancelErr := canceller.CancelTurn()
+		if cancelErr != nil {
+			slog.Warn("agent session CancelTurn failed, falling back to Close",
+				"session_key", sessionKey, "error", cancelErr)
+			// Fall through to normal cleanup below.
+			goto normalCleanup
+		}
+
+		slog.Info("agent session turn cancelled, session kept alive",
+			"session_key", sessionKey)
+
+		e.hooks.Emit(HookEvent{
+			Event:      HookEventSessionEnded,
+			SessionKey: sessionKey,
+		})
+
+		return true
+	}
+
+normalCleanup:
 	state.markStopped()
 	delete(e.interactiveStates, sessionKey)
 	e.interactiveMu.Unlock()

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -473,6 +473,14 @@ type ContextCompressor interface {
 	CompressCommand() string
 }
 
+// AgentSessionCanceller is an optional interface for agent sessions that support
+// cancelling the current turn without terminating the session or its underlying
+// process. When implemented, the engine calls CancelTurn instead of Close() for
+// /stop, allowing the session to remain alive for the next user message.
+type AgentSessionCanceller interface {
+	CancelTurn() error
+}
+
 // CommandProvider is an optional interface for agents that expose custom slash
 // commands via local files (e.g. .claude/commands/*.md). The engine scans the
 // returned directories for *.md files and registers them as slash commands.


### PR DESCRIPTION
## Problem

When `/stop` is issued against an ACP session (e.g. OpenCode via ACP), the engine kills the entire subprocess via `Process.Kill()`. Unlike Claude Code where each turn spawns a new process, ACP agents use a single long-lived server. Killing it destroys the session - the next user message starts a new conversation instead of resuming.

## Solution

Introduces an optional `AgentSessionCanceller` interface that agent sessions can implement to opt into graceful turn cancellation.

## Files changed

- **core/interfaces.go** - Adds AgentSessionCanceller interface with CancelTurn() method
- **agent/acp/session.go** - Implements CancelTurn() on acpSession (sends session/cancel notification)
- **core/engine.go** - Modifies stopInteractiveSessionWithOptions to check for AgentSessionCanceller
- **agent/acp/rpc.go** - Adds transport.sendNotification() for JSON-RPC 2.0 notifications

## Behavior

- /stop on ACP session: sends session/cancel, keeps process alive
- /stop on Claude Code: unchanged (no AgentSessionCanceller)
- Fallback: if CancelTurn() fails, engine falls through to Close()