### PR TITLE
fix(feishu): remove text_color from markdown element, keep on plain_text

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -5912,7 +5912,7 @@ func buildRichCardJSONBytes(status core.CardStatus, steps []core.ToolStep, markd
 				"tag":        "markdown",
 				"content":    sanitizeCardMarkdownForCard(line),
 				"text_size":  "notation",
-				"text_color": "grey",
+
 			})
 		}
 	}


### PR DESCRIPTION
text_color is valid per Feishu docs only for plain_text elements. The upstream PR #1204 incorrectly added it to a markdown (lark_md) element, causing Feishu to reject the card JSON with error:
  unknown property text_color, path: ...(tag: markdown)

Keep text_color on all plain_text elements where it is correct per Feishu card API documentation.