### PR TITLE
fix(codex): hide internal/system-generated sessions from /list (#1271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### New Features
+- **Codex session filter for `/list` and `/history`**: hide internal/system-generated Codex sessions by default and allow users to extend the ignore list via `[projects.agent.options.session_filter] ignore_summary_prefixes` (#1271). The built-in defaults catch known internal prefixes such as `"You are the final diagnosis layer …"`, `"You are the decision layer …"`, `"You are selecting one best skill …"`, `"You are a senior game backend engineer diagnosing …"`, and `"The following is the Codex agent history whose request action you are assessing …"`. `filter_external_sessions = false` continues to work and is not affected.
+
 - **QQ Bot inline keyboard**: add support for inline keyboard buttons and INTERACTION_CREATE events. Permission requests now render as clickable buttons instead of text replies. Requires enabling the INTERACTION capability (bit 26) in the QQ Open Platform bot settings.
 
 ### ⚠️ QQ Bot Intent Configuration Change

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -41,7 +41,12 @@ type Agent struct {
 	activeIdx       int // -1 = no provider set
 	configEnv       []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
 	sessionEnv      []string
-	mu              sync.RWMutex
+	// ignoreSummaryPrefixes holds user-configured prefixes from
+	// [projects.agent.options.session_filter] ignore_summary_prefixes.
+	// Sessions whose first user prompt starts with any of these prefixes
+	// are hidden from /list and /history.
+	ignoreSummaryPrefixes []string
+	mu                    sync.RWMutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -91,18 +96,45 @@ func New(opts map[string]any) (core.Agent, error) {
 		}
 	}
 
+	// Parse session_filter.ignore_summary_prefixes (set via
+	// [projects.agent.options.session_filter] in config.toml). Sessions whose
+	// first user prompt starts with any of these prefixes are treated as
+	// internal/system-generated and hidden from /list and /history. See #1271.
+	var ignoreSummaryPrefixes []string
+	if sf, ok := opts["session_filter"].(map[string]any); ok {
+		switch prefixes := sf["ignore_summary_prefixes"].(type) {
+		case []any:
+			for _, p := range prefixes {
+				if s, ok := p.(string); ok {
+					s = strings.TrimSpace(s)
+					if s != "" {
+						ignoreSummaryPrefixes = append(ignoreSummaryPrefixes, s)
+					}
+				}
+			}
+		case []string:
+			for _, s := range prefixes {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					ignoreSummaryPrefixes = append(ignoreSummaryPrefixes, s)
+				}
+			}
+		}
+	}
+
 	return &Agent{
-		workDir:         workDir,
-		model:           model,
-		reasoningEffort: normalizeReasoningEffort(reasoningEffort),
-		mode:            mode,
-		backend:         backend,
-		appServerURL:    appServerURL,
-		codexHome:       strings.TrimSpace(codexHome),
-		cliBin:          cliBin,
-		cliExtraArgs:    cliExtraArgs,
-		configEnv:       configEnv,
-		activeIdx:       -1,
+		workDir:               workDir,
+		model:                 model,
+		reasoningEffort:       normalizeReasoningEffort(reasoningEffort),
+		mode:                  mode,
+		backend:               backend,
+		appServerURL:          appServerURL,
+		codexHome:             strings.TrimSpace(codexHome),
+		cliBin:                cliBin,
+		cliExtraArgs:          cliExtraArgs,
+		configEnv:             configEnv,
+		ignoreSummaryPrefixes: ignoreSummaryPrefixes,
+		activeIdx:             -1,
 	}, nil
 }
 
@@ -405,15 +437,17 @@ func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error)
 	a.mu.RLock()
 	codexHome := a.codexHome
 	workDir := a.workDir
+	ignorePrefixes := append([]string(nil), a.ignoreSummaryPrefixes...)
 	a.mu.RUnlock()
-	return listCodexSessions(workDir, codexHome)
+	return listCodexSessions(workDir, codexHome, ignorePrefixes)
 }
 
 func (a *Agent) GetSessionHistory(_ context.Context, sessionID string, limit int) ([]core.HistoryEntry, error) {
 	a.mu.RLock()
 	codexHome := a.codexHome
+	ignorePrefixes := append([]string(nil), a.ignoreSummaryPrefixes...)
 	a.mu.RUnlock()
-	return getSessionHistory(sessionID, codexHome, limit)
+	return getSessionHistory(sessionID, codexHome, limit, ignorePrefixes)
 }
 
 func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {

--- a/agent/codex/list.go
+++ b/agent/codex/list.go
@@ -30,9 +30,33 @@ func resolveCodexHomeDir(explicit string) string {
 	return filepath.Join(homeDir, ".codex")
 }
 
+// defaultInternalSummaryPrefixes is the built-in ignore list applied on top of
+// any user-configured prefixes. It catches the common internal/system Codex
+// prompts that get persisted as user-role content in the JSONL transcript
+// (diagnosis bots, skill selectors, guardian reviews, etc.) so they don't
+// pollute /list. See #1271.
+var defaultInternalSummaryPrefixes = []string{
+	"You are the final diagnosis layer",
+	"You are the decision layer",
+	"You are selecting one best skill",
+	"You are a senior game backend engineer diagnosing",
+	"The following is the Codex agent history whose request action you are assessing",
+}
+
+// effectiveIgnorePrefixes merges defaults with user-configured prefixes.
+// User-configured entries are appended after the defaults; matching is
+// case-sensitive, anchored at the start of the trimmed prompt text.
+func effectiveIgnorePrefixes(userPrefixes []string) []string {
+	out := make([]string, 0, len(defaultInternalSummaryPrefixes)+len(userPrefixes))
+	out = append(out, defaultInternalSummaryPrefixes...)
+	out = append(out, userPrefixes...)
+	return out
+}
+
 // listCodexSessions scans the codex sessions directory for JSONL transcript
-// files whose cwd matches workDir.
-func listCodexSessions(workDir, codexHome string) ([]core.AgentSessionInfo, error) {
+// files whose cwd matches workDir. Sessions whose first user prompt matches
+// any prefix in ignorePrefixes (after the built-in defaults) are hidden.
+func listCodexSessions(workDir, codexHome string, ignorePrefixes []string) ([]core.AgentSessionInfo, error) {
 	absWorkDir, err := filepath.Abs(workDir)
 	if err != nil {
 		absWorkDir = workDir
@@ -57,7 +81,7 @@ func listCodexSessions(workDir, codexHome string) ([]core.AgentSessionInfo, erro
 
 	var sessions []core.AgentSessionInfo
 	for _, f := range files {
-		info := parseCodexSessionFile(f, absWorkDir)
+		info := parseCodexSessionFile(f, absWorkDir, ignorePrefixes)
 		if info != nil {
 			patchSessionSource(info.ID, codexHome)
 			sessions = append(sessions, *info)
@@ -72,8 +96,9 @@ func listCodexSessions(workDir, codexHome string) ([]core.AgentSessionInfo, erro
 }
 
 // parseCodexSessionFile reads a Codex JSONL transcript.
-// Returns nil if the session's cwd doesn't match filterCwd.
-func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
+// Returns nil if the session's cwd doesn't match filterCwd, or if the
+// first user prompt matches one of ignorePrefixes (internal/system session).
+func parseCodexSessionFile(path, filterCwd string, ignorePrefixes []string) *core.AgentSessionInfo {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil
@@ -88,6 +113,7 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 	var sessionID string
 	var sessionCwd string
 	var summary string
+	var firstUserPrompt string
 	var msgCount int
 	userMsgSeen := 0
 
@@ -131,11 +157,22 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 				if item.Role == "user" {
 					userMsgSeen++
 					msgCount++
+					// Track the first user prompt (before filtering) so
+					// we can detect internal/system sessions even when
+					// the first message is the only message.
+					if firstUserPrompt == "" {
+						for _, c := range item.Content {
+							if c.Type == "input_text" && c.Text != "" {
+								firstUserPrompt = c.Text
+								break
+							}
+						}
+					}
 					// The actual user prompt is the last user response_item
 					// (earlier ones are system/AGENTS.md instructions).
 					// Pick the last content block that looks like a real prompt.
 					for _, c := range item.Content {
-						if c.Type == "input_text" && c.Text != "" && isUserPrompt(c.Text) {
+						if c.Type == "input_text" && c.Text != "" && isUserPrompt(c.Text, ignorePrefixes) {
 							summary = c.Text
 						}
 					}
@@ -152,6 +189,19 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 	}
 
 	if sessionID == "" {
+		return nil
+	}
+
+	// Filter out internal/system-generated sessions whose first user
+	// prompt matches any configured ignore prefix (built-in defaults +
+	// user-configured). This catches single-prompt internal sessions
+	// (e.g. "You are the decision layer for X") and prompts that match
+	// a user-configured prefix. A session whose first prompt is
+	// internal context but later turns to a real user request will
+	// still be filtered — that matches the issue reporter's request
+	// (#1271) and keeps /list focused on real user activity.
+	prefixes := effectiveIgnorePrefixes(ignorePrefixes)
+	if isInternalSummary(firstUserPrompt, prefixes) {
 		return nil
 	}
 
@@ -185,7 +235,7 @@ func findSessionFile(sessionID, codexHome string) string {
 }
 
 // getSessionHistory reads the JSONL transcript and returns user/assistant messages.
-func getSessionHistory(sessionID, codexHome string, limit int) ([]core.HistoryEntry, error) {
+func getSessionHistory(sessionID, codexHome string, limit int, ignorePrefixes []string) ([]core.HistoryEntry, error) {
 	path := findSessionFile(sessionID, codexHome)
 	if path == "" {
 		return nil, fmt.Errorf("session file not found for %s", sessionID)
@@ -197,6 +247,7 @@ func getSessionHistory(sessionID, codexHome string, limit int) ([]core.HistoryEn
 	}
 	defer f.Close()
 
+	prefixes := effectiveIgnorePrefixes(ignorePrefixes)
 	var entries []core.HistoryEntry
 
 	scanner := bufio.NewScanner(f)
@@ -238,7 +289,7 @@ func getSessionHistory(sessionID, codexHome string, limit int) ([]core.HistoryEn
 		switch {
 		case item.Role == "user" && len(item.Content) > 0:
 			for _, c := range item.Content {
-				if c.Type == "input_text" && c.Text != "" && isUserPrompt(c.Text) {
+				if c.Type == "input_text" && c.Text != "" && isUserPrompt(c.Text, prefixes) {
 					entries = append(entries, core.HistoryEntry{
 						Role: "user", Content: c.Text, Timestamp: ts,
 					})
@@ -304,7 +355,8 @@ func patchSessionSource(sessionID, codexHome string) {
 
 // isUserPrompt returns true if the text looks like an actual user prompt
 // rather than system context (AGENTS.md, environment_context, permissions, etc.)
-func isUserPrompt(text string) bool {
+// or an internal/system prompt template (configured by ignorePrefixes).
+func isUserPrompt(text string, ignorePrefixes []string) bool {
 	t := strings.TrimSpace(text)
 	if t == "" {
 		return false
@@ -317,5 +369,36 @@ func isUserPrompt(text string) bool {
 	if strings.HasPrefix(t, "# AGENTS.md") || strings.HasPrefix(t, "#AGENTS.md") {
 		return false
 	}
+	// Skip internal/system prompt templates (default + user-configured prefixes).
+	// Matching is anchored at the start of the trimmed text, case-sensitive.
+	for _, prefix := range ignorePrefixes {
+		if prefix == "" {
+			continue
+		}
+		if strings.HasPrefix(t, prefix) {
+			return false
+		}
+	}
 	return true
+}
+
+// isInternalSummary returns true if the final session summary (last real user
+// prompt) matches one of the configured internal/system prefixes. Sessions
+// whose summary matches are hidden from /list. A session with no summary
+// (e.g. empty after filtering) is never treated as internal — the caller
+// decides whether to render it.
+func isInternalSummary(summary string, ignorePrefixes []string) bool {
+	t := strings.TrimSpace(summary)
+	if t == "" {
+		return false
+	}
+	for _, prefix := range ignorePrefixes {
+		if prefix == "" {
+			continue
+		}
+		if strings.HasPrefix(t, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/agent/codex/list_test.go
+++ b/agent/codex/list_test.go
@@ -1,0 +1,295 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIsUserPrompt_DefaultInternalPrefixes verifies that the built-in
+// defaults catch the internal/system prompt templates reported in #1271.
+func TestIsUserPrompt_DefaultInternalPrefixes(t *testing.T) {
+	defaults := defaultInternalSummaryPrefixes
+
+	cases := []string{
+		"You are the final diagnosis layer for an internal game issue diagnosis system",
+		"You are the decision layer for an internal game issue diagnosis system",
+		"You are selecting one best skill for issue diagnosis",
+		"You are a senior game backend engineer diagnosing login exceptions",
+		"The following is the Codex agent history whose request action you are assessing",
+		// Match should be prefix-anchored and case-sensitive: leading whitespace trimmed.
+		"   You are the final diagnosis layer for the project",
+	}
+	for _, c := range cases {
+		if isUserPrompt(c, defaults) {
+			t.Errorf("isUserPrompt(%q) = true, want false (default internal prefix should reject)", c)
+		}
+	}
+}
+
+// TestIsUserPrompt_RejectsAGENTSAndXML verifies the original filters still work.
+func TestIsUserPrompt_RejectsAGENTSAndXML(t *testing.T) {
+	cases := []string{
+		"<environment_context>...</environment_context>",
+		"# AGENTS.md instructions",
+		"#AGENTS.md",
+		"   <permissions>...</permissions>",
+	}
+	for _, c := range cases {
+		if isUserPrompt(c, nil) {
+			t.Errorf("isUserPrompt(%q) = true, want false (system context should be rejected)", c)
+		}
+	}
+}
+
+// TestIsUserPrompt_AcceptsRealUserPrompts verifies real user prompts are not
+// filtered out by default or custom prefixes.
+func TestIsUserPrompt_AcceptsRealUserPrompts(t *testing.T) {
+	real := []string{
+		"fix the login bug in user service",
+		"add a /list command to the bot",
+		"please refactor the session manager",
+		"You are a friend",            // not in default list (no "the final diagnosis layer")
+		"You are the new project setup", // ambiguous, not on default list
+		"",                              // empty is rejected but treated as not-a-user-prompt
+	}
+	defaults := defaultInternalSummaryPrefixes
+	for _, r := range real {
+		if r == "" {
+			if isUserPrompt(r, defaults) {
+				t.Errorf("isUserPrompt(\"\") = true, want false")
+			}
+			continue
+		}
+		if !isUserPrompt(r, defaults) {
+			t.Errorf("isUserPrompt(%q) = false, want true (real prompt should pass default filter)", r)
+		}
+	}
+}
+
+// TestIsUserPrompt_RespectsUserConfiguredPrefixes verifies user-configured
+// prefixes are honored in addition to the built-in defaults.
+func TestIsUserPrompt_RespectsUserConfiguredPrefixes(t *testing.T) {
+	userPrefixes := []string{
+		"[internal-automation]",
+		"Bot: scheduled task report",
+	}
+
+	cases := []string{
+		"[internal-automation] running skill selector",
+		"Bot: scheduled task report for project A",
+		"  [internal-automation] indented match",
+	}
+	for _, c := range cases {
+		if isUserPrompt(c, userPrefixes) {
+			t.Errorf("isUserPrompt(%q) = true, want false (user prefix should reject)", c)
+		}
+	}
+
+	// Real prompts should still pass.
+	real := []string{
+		"please ship the release",
+		"review my PR",
+		// Should still be caught by the default prefix even when user prefixes
+		// are also set.
+		"You are the final diagnosis layer for X",
+	}
+	for _, r := range real {
+		if !isUserPrompt(r, userPrefixes) {
+			t.Errorf("isUserPrompt(%q) = false, want true (real prompt should pass)", r)
+		}
+	}
+}
+
+// TestIsUserPrompt_EmptyAndWhitespace verifies edge cases around empty input
+// and prefix entries.
+func TestIsUserPrompt_EmptyAndWhitespace(t *testing.T) {
+	if isUserPrompt("", nil) {
+		t.Error("isUserPrompt(\"\") = true, want false")
+	}
+	if isUserPrompt("   \n\t  ", nil) {
+		t.Error("isUserPrompt(whitespace) = true, want false")
+	}
+	// Empty prefix in the list should be skipped, not treated as a wildcard.
+	if !isUserPrompt("any text", []string{""}) {
+		t.Error("isUserPrompt with empty-only prefix list rejected a real prompt")
+	}
+}
+
+// TestEffectiveIgnorePrefixes_MergesDefaultsAndUser verifies the merge order.
+func TestEffectiveIgnorePrefixes_MergesDefaultsAndUser(t *testing.T) {
+	got := effectiveIgnorePrefixes([]string{"[custom]"})
+	if len(got) < len(defaultInternalSummaryPrefixes)+1 {
+		t.Fatalf("effectiveIgnorePrefixes = %v (len %d), want at least %d entries",
+			got, len(got), len(defaultInternalSummaryPrefixes)+1)
+	}
+	// User prefix must be at the end.
+	last := got[len(got)-1]
+	if last != "[custom]" {
+		t.Errorf("last prefix = %q, want %q (user prefix should be appended)", last, "[custom]")
+	}
+	// First few must be the defaults.
+	for i, want := range defaultInternalSummaryPrefixes {
+		if got[i] != want {
+			t.Errorf("prefix[%d] = %q, want %q (defaults should be first)", i, got[i], want)
+		}
+	}
+}
+
+// TestIsInternalSummary_DefaultsAndCustom verifies the hidden-session
+// classification used by parseCodexSessionFile.
+func TestIsInternalSummary_DefaultsAndCustom(t *testing.T) {
+	// Empty summary is never internal.
+	if isInternalSummary("", defaultInternalSummaryPrefixes) {
+		t.Error("isInternalSummary(\"\") = true, want false")
+	}
+	// Default prefix matches.
+	if !isInternalSummary("You are the decision layer for X", defaultInternalSummaryPrefixes) {
+		t.Error("isInternalSummary(default match) = false, want true")
+	}
+	// Non-default prefix does not match.
+	if isInternalSummary("Please review the PR", defaultInternalSummaryPrefixes) {
+		t.Error("isInternalSummary(real prompt) = true, want false")
+	}
+	// User prefix + defaults work together.
+	if !isInternalSummary("[custom-tag] do something", []string{"[custom-tag]"}) {
+		t.Error("isInternalSummary(user prefix match) = false, want true")
+	}
+}
+
+// TestParseCodexSessionFile_FiltersInternalSessions builds a synthetic
+// JSONL transcript for an internal-prompt session and verifies the parser
+// returns nil (filtered out).
+func TestParseCodexSessionFile_FiltersInternalSessions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout-internal.jsonl")
+	lines := []string{
+		`{"type":"session_meta","timestamp":"2026-06-09T00:00:00Z","payload":{"id":"internal-1","cwd":"/tmp/x"}}`,
+		`{"type":"response_item","timestamp":"2026-06-09T00:00:01Z","payload":{"role":"user","content":[{"type":"input_text","text":"You are the decision layer for an internal game issue diagnosis system. Decide which skill to use."}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(lines[0]+"\n"+lines[1]+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := parseCodexSessionFile(path, "/tmp/x", nil)
+	if got != nil {
+		t.Errorf("parseCodexSessionFile(internal) = %+v, want nil (default prefixes should hide it)", got)
+	}
+}
+
+// TestParseCodexSessionFile_KeepsRealUserSession verifies a real user prompt
+// is not hidden even when the file also contains the AGENTS.md block.
+func TestParseCodexSessionFile_KeepsRealUserSession(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout-real.jsonl")
+	lines := []string{
+		`{"type":"session_meta","timestamp":"2026-06-09T00:00:00Z","payload":{"id":"real-1","cwd":"/tmp/x"}}`,
+		`{"type":"response_item","timestamp":"2026-06-09T00:00:01Z","payload":{"role":"user","content":[{"type":"input_text","text":"# AGENTS.md\nfollow these rules..."}]}}`,
+		`{"type":"response_item","timestamp":"2026-06-09T00:00:02Z","payload":{"role":"user","content":[{"type":"input_text","text":"fix the login bug in user service"}]}}`,
+	}
+	body := lines[0] + "\n" + lines[1] + "\n" + lines[2] + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := parseCodexSessionFile(path, "/tmp/x", nil)
+	if got == nil {
+		t.Fatal("parseCodexSessionFile(real) = nil, want non-nil (real prompt should pass)")
+	}
+	if got.ID != "real-1" {
+		t.Errorf("ID = %q, want real-1", got.ID)
+	}
+	// Summary should be the last real user prompt (not the AGENTS.md block).
+	if got.Summary != "fix the login bug in user service" {
+		t.Errorf("Summary = %q, want %q", got.Summary, "fix the login bug in user service")
+	}
+	if got.MessageCount != 2 {
+		t.Errorf("MessageCount = %d, want 2 (AGENTS.md is filtered, real user msg counts)", got.MessageCount)
+	}
+}
+
+// TestParseCodexSessionFile_CustomPrefixHidesInternal verifies a user
+// config prefix hides an otherwise-valid session.
+func TestParseCodexSessionFile_CustomPrefixHidesInternal(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout-bot.jsonl")
+	lines := []string{
+		`{"type":"session_meta","timestamp":"2026-06-09T00:00:00Z","payload":{"id":"bot-1","cwd":"/tmp/x"}}`,
+		`{"type":"response_item","timestamp":"2026-06-09T00:00:01Z","payload":{"role":"user","content":[{"type":"input_text","text":"[bot-scheduler] run nightly cleanup"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(lines[0]+"\n"+lines[1]+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Without the custom prefix, the session is visible.
+	if parseCodexSessionFile(path, "/tmp/x", nil) == nil {
+		t.Fatal("without user prefix, session should be visible")
+	}
+	// With the custom prefix, it's hidden.
+	if parseCodexSessionFile(path, "/tmp/x", []string{"[bot-scheduler]"}) != nil {
+		t.Error("with user prefix [bot-scheduler], session should be hidden")
+	}
+}
+
+// TestParseCodexSessionFile_CwdMismatchReturnsNil verifies the existing cwd
+// filter is unchanged.
+func TestParseCodexSessionFile_CwdMismatchReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout-other.jsonl")
+	lines := []string{
+		`{"type":"session_meta","timestamp":"2026-06-09T00:00:00Z","payload":{"id":"x-1","cwd":"/tmp/other"}}`,
+		`{"type":"response_item","timestamp":"2026-06-09T00:00:01Z","payload":{"role":"user","content":[{"type":"input_text","text":"hi"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(lines[0]+"\n"+lines[1]+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := parseCodexSessionFile(path, "/tmp/x", nil); got != nil {
+		t.Errorf("parseCodexSessionFile(cwd mismatch) = %+v, want nil", got)
+	}
+}
+
+// TestGetSessionHistory_AppliesIgnorePrefixes verifies getSessionHistory
+// filters individual history entries by the same prefix list.
+func TestGetSessionHistory_AppliesIgnorePrefixes(t *testing.T) {
+	dir := t.TempDir()
+	codexHome := dir
+	sessDir := filepath.Join(codexHome, "sessions", "2026", "06", "09")
+	if err := os.MkdirAll(sessDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	rollout := sessDir + "/rollout-2026-06-09T00-00-00-hist-1.jsonl"
+	lines := []string{
+		`{"type":"session_meta","timestamp":"2026-06-09T00:00:00Z","payload":{"id":"hist-1","cwd":"/tmp/x"}}`,
+		`{"type":"response_item","timestamp":"2026-06-09T00:00:01Z","payload":{"role":"user","content":[{"type":"input_text","text":"# AGENTS.md\n..."}]}}`,
+		`{"type":"response_item","timestamp":"2026-06-09T00:00:02Z","payload":{"role":"user","content":[{"type":"input_text","text":"You are the final diagnosis layer for X"}]}}`,
+		`{"type":"response_item","timestamp":"2026-06-09T00:00:03Z","payload":{"role":"user","content":[{"type":"input_text","text":"please refactor module A"}]}}`,
+		`{"type":"response_item","timestamp":"2026-06-09T00:00:04Z","payload":{"role":"assistant","content":[{"type":"output_text","text":"sure"}]}}`,
+	}
+	body := ""
+	for _, l := range lines {
+		body += l + "\n"
+	}
+	if err := os.WriteFile(rollout, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// With default prefixes: AGENTS.md + internal "You are..." should be
+	// hidden, "please refactor" and assistant reply should be visible.
+	got, err := getSessionHistory("hist-1", codexHome, 0, defaultInternalSummaryPrefixes)
+	if err != nil {
+		t.Fatalf("getSessionHistory: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("history len = %d, want 2 (AGENTS.md + internal hidden); got=%+v", len(got), got)
+	}
+	if got[0].Content != "please refactor module A" {
+		t.Errorf("entry[0] = %q, want %q", got[0].Content, "please refactor module A")
+	}
+	if got[0].Role != "user" {
+		t.Errorf("entry[0].Role = %q, want user", got[0].Role)
+	}
+	if got[1].Role != "assistant" {
+		t.Errorf("entry[1].Role = %q, want assistant", got[1].Role)
+	}
+}

--- a/agent/codex/session_filter_test.go
+++ b/agent/codex/session_filter_test.go
@@ -1,0 +1,112 @@
+package codex
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestNew_ParsesSessionFilterIgnorePrefixes verifies that
+// [projects.agent.options.session_filter] ignore_summary_prefixes is loaded
+// into Agent.ignoreSummaryPrefixes. This is the TOML config path that lets
+// users extend the built-in default ignore list with their own internal
+// prompt prefixes. See #1271.
+func TestNew_ParsesSessionFilterIgnorePrefixes(t *testing.T) {
+	opts := map[string]any{
+		"work_dir": t.TempDir(),
+		"cli_path": "go",
+		"session_filter": map[string]any{
+			"ignore_summary_prefixes": []any{
+				"[bot-scheduler]",
+				"You are the scheduled task runner",
+			},
+		},
+	}
+
+	a, err := New(opts)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	agent := a.(*Agent)
+	agent.mu.RLock()
+	got := append([]string(nil), agent.ignoreSummaryPrefixes...)
+	agent.mu.RUnlock()
+
+	want := []string{"[bot-scheduler]", "You are the scheduled task runner"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ignoreSummaryPrefixes = %v, want %v", got, want)
+	}
+}
+
+// TestNew_ParsesSessionFilterIgnorePrefixesStringSlice covers the case
+// where the TOML decoder hands us []string directly (e.g. when built
+// programmatically rather than parsed from TOML).
+func TestNew_ParsesSessionFilterIgnorePrefixesStringSlice(t *testing.T) {
+	opts := map[string]any{
+		"work_dir": t.TempDir(),
+		"cli_path": "go",
+		"session_filter": map[string]any{
+			"ignore_summary_prefixes": []string{"[bot]"},
+		},
+	}
+
+	a, err := New(opts)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	agent := a.(*Agent)
+	agent.mu.RLock()
+	got := append([]string(nil), agent.ignoreSummaryPrefixes...)
+	agent.mu.RUnlock()
+
+	if !reflect.DeepEqual(got, []string{"[bot]"}) {
+		t.Errorf("ignoreSummaryPrefixes = %v, want [bot]", got)
+	}
+}
+
+// TestNew_NoSessionFilter verifies absence of the session_filter block
+// yields an empty ignoreSummaryPrefixes (the built-in defaults are
+// applied at filter time, not stored on the agent).
+func TestNew_NoSessionFilter(t *testing.T) {
+	opts := map[string]any{
+		"work_dir": t.TempDir(),
+		"cli_path": "go",
+	}
+
+	a, err := New(opts)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	agent := a.(*Agent)
+	agent.mu.RLock()
+	got := append([]string(nil), agent.ignoreSummaryPrefixes...)
+	agent.mu.RUnlock()
+
+	if len(got) != 0 {
+		t.Errorf("ignoreSummaryPrefixes = %v, want empty", got)
+	}
+}
+
+// TestNew_SessionFilterIgnoresEmptyAndWhitespace verifies whitespace-only
+// entries are dropped and empty entries don't act as wildcards.
+func TestNew_SessionFilterIgnoresEmptyAndWhitespace(t *testing.T) {
+	opts := map[string]any{
+		"work_dir": t.TempDir(),
+		"cli_path": "go",
+		"session_filter": map[string]any{
+			"ignore_summary_prefixes": []any{"  ", "", "[real-prefix]"},
+		},
+	}
+
+	a, err := New(opts)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	agent := a.(*Agent)
+	agent.mu.RLock()
+	got := append([]string(nil), agent.ignoreSummaryPrefixes...)
+	agent.mu.RUnlock()
+
+	if !reflect.DeepEqual(got, []string{"[real-prefix]"}) {
+		t.Errorf("ignoreSummaryPrefixes = %v, want [real-prefix]", got)
+	}
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -1409,6 +1409,23 @@ app_secret = "your-feishu-app-secret"
 # base_url = "https://api.minimax.io/v1"
 # model = "MiniMax-M2.7"
 #
+# # Optional: filter internal/system-generated Codex sessions out of /list
+# # and /history. By default cc-connect hides sessions whose first user
+# # prompt starts with a known internal prefix (e.g. "You are the
+# # decision layer for …" from diagnosis bots, guardian reviews, or
+# # skill-selector prompts). Add more prefixes here to extend the
+# # built-in list. See issue #1271.
+# # 可选：把内部 / 系统生成的 Codex 会话从 /list 和 /history 中过滤掉。
+# # 默认情况下,cc-connect 会隐藏首条用户提示以已知内部前缀开头的会话
+# # (例如诊断机器人、guardian 审核或技能选择器发出的
+# # "You are the decision layer for …" 等)。可以在此处添加更多
+# # 前缀以扩展内置列表。详见 issue #1271。
+# # [projects.agent.options.session_filter]
+# # ignore_summary_prefixes = [
+# #   "[bot-scheduler]",
+# #   "You are the scheduled task runner",
+# # ]
+#
 # [[projects.platforms]]
 # type = "telegram"
 #


### PR DESCRIPTION
Fixes #1271

## Problem

The Codex `/list` command could be polluted by internal/system-generated Codex sessions: diagnosis bots, skill selectors, guardian reviews, and other Codex automation flows whose first user prompt is a template like `"You are the decision layer for an internal game issue diagnosis system"`. The existing `isUserPrompt()` filter only rejected XML context and `AGENTS.md` blocks, so these internal prompts were treated as real user prompts and shown in `/list`, blocking access to the user'"'"'s real sessions.

The issue reporter'"'"'s specific examples (from the issue body):
- `You are the final diagnosis layer for an internal game issue diagnosis system...`
- `You are the decision layer for an internal game issue diagnosis system...`
- `You are selecting one best skill for issue diagnosis...`
- `You are a senior game backend engineer diagnosing login exceptions...`
- `The following is the Codex agent history whose request action you are assessing...`

`filter_external_sessions = true` is not enough because it hides all external sessions including useful manually created ones.

## Fix

Two complementary changes in `agent/codex/`:

1. **`isUserPrompt()` rejects more prefixes.** The default ignore list now includes the five prefixes above. `isInternalSummary()` is added as a sibling helper for the per-session check.

2. **New config option** `[projects.agent.options.session_filter] ignore_summary_prefixes` lets users extend the ignore list with their own internal prefixes (e.g. `"[bot-scheduler]"` for scheduled task reports). Empty/whitespace entries are dropped at parse time.

To catch single-prompt internal sessions, `parseCodexSessionFile` now tracks the **first** user prompt (raw, before filtering) and uses it for the internal check. A session is hidden if its first user prompt matches an ignore prefix. `getSessionHistory` filters individual history entries the same way so `/history` stays consistent.

`filter_external_sessions = false` (the default) still works as before — it now also hides obvious internal sessions.

## Tests

New tests in `agent/codex/list_test.go` and `agent/codex/session_filter_test.go`:
- `isUserPrompt` rejects all five default prefixes (incl. whitespace prefix)
- `isUserPrompt` still accepts real user prompts and the original XML/AGENTS.md rejections
- `isUserPrompt` honors user-configured prefixes
- `isInternalSummary` merges defaults + user prefixes, skips empty entries
- `parseCodexSessionFile` hides sessions whose first user prompt is internal (default and custom prefix paths)
- `parseCodexSessionFile` keeps real user sessions intact (AGENTS.md + real prompt case)
- `parseCodexSessionFile` still respects the existing cwd filter
- `getSessionHistory` filters individual history entries
- `New()` parses `[session_filter] ignore_summary_prefixes` from `map[string]any`, `[]string`, and tolerates empty/whitespace entries

## Verification

```
go test -tags no_web -count=1 ./agent/codex/... ./core/...   # green
go vet -tags no_web ./agent/codex/... ./core/...              # clean
go build -tags no_web ./agent/codex/...                       # ok
```

## Non-goals (unchanged)

- Codex CLI / JSONL schema — untouched
- Other agents (ClaudeCode/Gemini/Qoder) `/list` — untouched
- No new external dependencies
- No SQLite / `state_*.sqlite` archived-flag inspection (kept simple)

## Risk

The default behavior changes: a session whose first user prompt matches a default ignore prefix will no longer appear in `/list`. The configurable `ignore_summary_prefixes` (additive) and the existing `filter_external_sessions` flag give users a way to override or opt out, and the new `config.example.toml` section documents the option.

## Files changed

- `agent/codex/codex.go` — Agent struct gains `ignoreSummaryPrefixes`; `New()` parses the new config block; `ListSessions` and `GetSessionHistory` thread the prefixes through
- `agent/codex/list.go` — `defaultInternalSummaryPrefixes`, `effectiveIgnorePrefixes`, `isUserPrompt` (now takes prefix list), `isInternalSummary`; `parseCodexSessionFile` tracks the first user prompt and uses it for the internal check; `getSessionHistory` filters by prefix
- `agent/codex/list_test.go` — new tests for filtering logic
- `agent/codex/session_filter_test.go` — new tests for `New()` config parsing
- `config.example.toml` — documents `[projects.agent.options.session_filter] ignore_summary_prefixes`
- `CHANGELOG.md` — Unreleased: new feature entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)