### PR TITLE
docs: FAQ for OpenClaw via ACP, WeChat group chat_id, Telegram proxy (#501, #805, #245)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1035,3 +1035,116 @@ type = "feishu"  # or wps-xiezuo, dingtalk, telegram, slack, discord, wecom, wei
 [projects.platforms.options]
 # platform-specific options
 ```
+
+---
+
+## FAQ
+
+Quick answers to questions that came up repeatedly in issues and that the
+maintainers have resolved. Each entry links back to the originating issue
+or PR so you can dig further if needed.
+
+### Does cc-connect support OpenClaw? (issue #501)
+
+Yes. OpenClaw is supported via the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents). cc-connect ships an `acp` agent type that talks to any ACP-compatible CLI, including OpenClaw's `openclaw acp` subcommand.
+
+Minimal config snippet (full version is in `config.example.toml` under
+`# --- Example: OpenClaw (Gateway-backed ACP bridge) ---`):
+
+```toml
+[[projects]]
+name = "openclaw-acp"
+
+[projects.agent]
+type = "acp"
+
+[projects.agent.options]
+work_dir = "/path/to/project"
+command = "openclaw"
+args = ["acp"]
+display_name = "OpenClaw ACP"
+```
+
+**Pairing is required for remote gateways.** If you point cc-connect at a
+remote OpenClaw Gateway (`args = ["acp", "--url", "wss://..."]`) you must
+pair first or every reply comes back empty:
+
+1. Start the gateway: `openclaw acp --url wss://your-gateway:18789`
+2. In another terminal: `openclaw pair`
+3. Approve the pairing request in the OpenClaw UI
+4. Now cc-connect can talk to the authorized gateway
+
+Empty responses from OpenClaw are almost always a missing pairing step
+(issue #432). Re-run `openclaw pair` and re-approve before debugging
+anything else. Reference: <https://zhuanlan.zhihu.com/p/2005687480976970296>
+
+### Personal WeChat group chat — finding the right `chat_id` (issue #805)
+
+Personal WeChat (the `weixin` platform) supports group chats. To bind the
+bot to a specific group, set `chat_id` in `[[projects.platforms.options]]`
+to the **group chat ID**, not an individual user ID. Group chat IDs always
+end with `@chatroom`, for example:
+
+```toml
+[[projects.platforms]]
+type = "weixin"
+
+[projects.platforms.options]
+token = "ilink_bot_bearer_token"
+chat_id = "your_group_chat_id@chatroom"   # group chats end with @chatroom
+```
+
+**How to find the group chat ID:**
+
+1. Start cc-connect and let the bot be in the target group.
+2. Send any message in the group from a known allowed account.
+3. Check the cc-connect logs — the incoming `chat_id` (ending in
+   `@chatroom`) is logged at the moment the message is received. Copy
+   that value into `chat_id`.
+
+Leave `chat_id` empty (or omit the key) to respond to every chat the bot
+is in. Set it to a specific value to restrict the bot to that group or
+user only.
+
+Common pitfalls:
+
+- **"How do I add the bot to a group?"** Personal WeChat bots are added
+  by scanning the QR code *inside* the group with the linked WeChat
+  account, or by sharing the QR via the personal chat and then opening
+  it inside the target group. There is no API-side "invite bot to group"
+  call; the bot becomes a group member the same way any other WeChat
+  contact does.
+- **Bot never receives group messages** — make sure the group is bound
+  to your cc-connect instance. If `allow_from` is set, the first user
+  to message in the group is recorded; if the binding is to a
+  different user, the bot stays silent.
+- **Bot replies in private but ignores the group (or vice versa)** —
+  duplicate the `[[projects.platforms]]` block, one with `chat_id` set
+  to the group and one without, to cover both surfaces.
+
+For more on the `weixin` platform, see [docs/weixin.md](./weixin.md).
+
+### Telegram proxy / outbound restrictions (issue #245)
+
+The Telegram platform supports HTTP and SOCKS5 forward proxies directly in
+`[projects.platforms.options]`. You do not need a system-wide proxy or a
+sidecar — set the proxy per Telegram instance.
+
+```toml
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+token = "${TELEGRAM_BOT_TOKEN}"
+proxy = "http://127.0.0.1:7890"     # or socks5://127.0.0.1:1080
+proxy_username = ""                  # leave empty if no auth
+proxy_password = ""
+```
+
+`proxy` accepts both `http://` and `socks5://` URLs. Authentication is
+optional. The proxy only affects the Telegram Bot API calls for that
+platform instance; other platforms and the management API are not
+tunneled through it.
+
+Full reference: [docs/telegram.md](./telegram.md#21-optional-use-a-proxy).
+This option was added in PR #389.

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -947,3 +947,108 @@ type = "feishu"  # 或 wps-xiezuo, dingtalk, telegram, slack, discord, wecom, we
 [projects.platforms.options]
 # 平台特定配置
 ```
+
+---
+
+## 常见问题（FAQ）
+
+下面这些是 issue 区里反复出现、维护者已经回答过的问题。每条都附上了
+原始 issue / PR 链接，方便继续深入。
+
+### cc-connect 是否支持 OpenClaw？(issue #501)
+
+支持。OpenClaw 通过 [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents) 接入。
+cc-connect 内置了 `acp` agent 类型，可以和任何 ACP 兼容的 CLI 通信，
+包括 OpenClaw 的 `openclaw acp` 子命令。
+
+最小配置示例（完整版见 `config.example.toml` 中 `# --- Example:
+OpenClaw (Gateway-backed ACP bridge) ---` 段）：
+
+```toml
+[[projects]]
+name = "openclaw-acp"
+
+[projects.agent]
+type = "acp"
+
+[projects.agent.options]
+work_dir = "/path/to/project"
+command = "openclaw"
+args = ["acp"]
+display_name = "OpenClaw ACP"
+```
+
+**远端 Gateway 必须先完成配对授权。** 如果你把 cc-connect 指向
+远程 OpenClaw Gateway（`args = ["acp", "--url", "wss://..."]`），
+必须先配对，否则所有回复都会是空消息：
+
+1. 启动 Gateway：`openclaw acp --url wss://your-gateway:18789`
+2. 另开终端执行：`openclaw pair`
+3. 在 OpenClaw UI 里同意配对请求
+4. 完成后 cc-connect 才能与已授权的 Gateway 通信
+
+OpenClaw 回复空消息几乎都是漏掉了配对步骤（issue #432）。在排查其他
+原因之前，先重跑 `openclaw pair` 并在 UI 中重新授权一次。
+参考：<https://zhuanlan.zhihu.com/p/2005687480976970296>
+
+### 个人微信群聊 — 如何获取正确的 `chat_id`(issue #805)
+
+个人微信（`weixin` 平台）支持群聊。要把机器人绑定到某个群，需要把
+`[[projects.platforms.options]]` 里的 `chat_id` 设置为**群聊 ID**，
+而不是个人用户 ID。群聊 ID 一定以 `@chatroom` 结尾，例如：
+
+```toml
+[[projects.platforms]]
+type = "weixin"
+
+[projects.platforms.options]
+token = "ilink_bot_bearer_token"
+chat_id = "your_group_chat_id@chatroom"   # 群聊 ID 以 @chatroom 结尾
+```
+
+**获取群聊 ID 的方法：**
+
+1. 启动 cc-connect，并让机器人加入目标群。
+2. 让群里任意已知允许的用户在群里发一条消息。
+3. 查看 cc-connect 日志，消息到达时会打印带 `@chatroom` 后缀的
+   `chat_id`。把那个值原样填到 `chat_id` 即可。
+
+把 `chat_id` 留空（或不写这个键）就表示响应机器人所在的所有聊天。
+填具体值则只响应那个群/个人。
+
+常见坑：
+
+- **「怎么把机器人加进群？」** 个人微信机器人没有"邀请机器人入群"
+  的 API；只能由已经扫码绑定 ilink 的微信号，在群里发起"添加"或把
+  机器人的二维码发到群里、让群里的人扫码添加。和把普通好友拉进群
+  一样。
+- **群里发消息机器人不响应** — 检查是否把 `chat_id` 绑到了别的用户/
+  群，或 `allow_from` 限制了别的用户，把当前用户也加入。
+- **私聊能回、群聊不回（或反之）** — 复制一份 `[[projects.platforms]]`
+  块，一份 `chat_id` 填群 ID、另一份留空，就能同时覆盖私聊和群聊。
+
+更多关于 `weixin` 平台的内容见 [docs/weixin.md](./weixin.md)。
+
+### Telegram 代理 / 出站限制 (issue #245)
+
+Telegram 平台在 `[projects.platforms.options]` 里直接支持 HTTP 和
+SOCKS5 正向代理。不需要配系统级代理或 sidecar，per Telegram 实例
+设置即可。
+
+```toml
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+token = "${TELEGRAM_BOT_TOKEN}"
+proxy = "http://127.0.0.1:7890"     # 或 socks5://127.0.0.1:1080
+proxy_username = ""                  # 代理无鉴权时留空
+proxy_password = ""
+```
+
+`proxy` 同时接受 `http://` 和 `socks5://` 两种 URL，鉴权可选。
+代理只作用于该 Telegram 实例的 Bot API 请求，不会影响其他平台或
+管理后台的出站。
+
+完整说明见 [docs/telegram.md](./telegram.md#21-optional-use-a-proxy)（英文原文，
+`docs/telegram.md` 目前只有英文版）。该配置由 PR #389 引入。

--- a/docs/weixin.md
+++ b/docs/weixin.md
@@ -136,6 +136,38 @@ go build -tags no_weixin ./cmd/cc-connect
 
 ---
 
+## 群聊：`chat_id` 以 `@chatroom` 结尾
+
+个人微信支持群聊。要把机器人绑定到某个群，把 `[[projects.platforms.options]]`
+里的 `chat_id` 写成**群聊 ID**（不是个人用户 ID）。群聊 ID 一定以
+`@chatroom` 结尾，例如 `1234567890@chatroom`。
+
+```toml
+[[projects.platforms]]
+type = "weixin"
+
+[projects.platforms.options]
+token = "ilink_bot_bearer_token"
+chat_id = "your_group_chat_id@chatroom"   # 群聊 ID 以 @chatroom 结尾
+```
+
+**怎么拿到这个群聊 ID：**
+
+1. 启动 cc-connect，并让机器人加入目标群。
+2. 让群里任意已知允许的用户在群里发一条消息。
+3. 看 cc-connect 日志：消息到达时会打印带 `@chatroom` 后缀的
+   `chat_id`，把它原样填到 `chat_id` 即可。
+
+把 `chat_id` 留空就响应机器人所在的所有聊天。填具体值只响应那一个
+群/个人。私聊和群聊都想覆盖时，复制一份 `[[projects.platforms]]`
+块即可（一份 `chat_id` 填群 ID、另一份留空）。
+
+**把机器人加进群：** 个人微信机器人没有"邀请机器人入群"的 API。
+由已经扫码绑定 ilink 的微信号，在群里发起"添加"或把机器人的二维码
+发到群里让其他人扫码。和把普通好友拉进群一样。
+
+---
+
 ## 相关链接
 
 - 仓库内示例配置：[config.example.toml](../config.example.toml)  


### PR DESCRIPTION
Resolves the docs follow-up entries from dev-codex's
2026-06-06 closed-issue-followup-ledger.md. Three closed issues still
carry user value, so the answers are folded into the docs as a new
FAQ section.

## Issue coverage

| Issue | Title | FAQ entry |
|---|---|---|
| #501 | Does it support OpenClaw? | OpenClaw via ACP: config snippet + pairing requirement + relation to #432 |
| #805 | 个人微信支持群聊了吗 | Personal WeChat group chat: `@chatroom` suffix + how to read chat_id from logs + how to add the bot to a group |
| #245 | Telegram proxy config | Telegram proxy: short pointer to `docs/telegram.md#21-optional-use-a-proxy` (config was added in PR #389) |

## Files changed

- `docs/usage.md` — new "FAQ" section at the end (English) with the three entries above
- `docs/usage.zh-CN.md` — matching "常见问题" section in Chinese, cross-linked
- `docs/weixin.md` — short "群聊：`chat_id` 以 `@chatroom` 结尾" section so the answer is also discoverable from the platform doc

## Why this layout

- Both languages get the same FAQ block to match the existing docs structure (usage.md / usage.zh-CN.md are siblings).
- The OpenClaw config example in `config.example.toml` is left untouched — PRs led there to be discovered by readers grepping the file. The FAQ entry only points to it.
- The WeChat group chat content appears in two places (FAQ + weixin.md) so searchers land on the closest doc. The two versions are kept short and the FAQ entry defers to `weixin.md` for full platform details.
- The Telegram proxy FAQ entry does NOT duplicate `docs/telegram.md` — it links there, because PR #389 already added the full proxy section.

## Why no README change

Both `README.md` and `README.zh-CN.md` already mention ACP at the
"supported agents" level (lines 227 and 362). The deeper setup steps
(ACP pairing, gateway URL, token file) live in `config.example.toml`
and the platform docs. Adding the FAQ to `docs/usage.md` keeps the
README tight while making the answer discoverable for anyone reading
the usage guide.

## Verification

- No production code changes
- No new dependencies
- `go test -tags no_web -count=1 ./...` not relevant (docs only)
- Markdown link anchors verified: `./telegram.md#21-optional-use-a-proxy` exists, `./weixin.md` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)