### PR TITLE
feat(cli): expose --silent flag for cron add (#858)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### New Features
+- **`cc-connect cron add --silent`**: expose the `--silent` flag on the cron add CLI so users can suppress the cron start notification when creating a job. The server already accepted `silent` on `/cron/add`; only the CLI side was missing (#858).
 - **QQ Bot inline keyboard**: add support for inline keyboard buttons and INTERACTION_CREATE events. Permission requests now render as clickable buttons instead of text replies. Requires enabling the INTERACTION capability (bit 26) in the QQ Open Platform bot settings.
 
 ### ⚠️ QQ Bot Intent Configuration Change

--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -59,6 +59,7 @@ func closeCronResponseBody(body io.Closer) {
 func runCronAdd(args []string) {
 	var project, sessionKey, cronExpr, prompt, execCmd, desc, dataDir, sessionMode string
 	var timeoutMins *int
+	var silent bool
 
 	var positional []string
 	for i := 0; i < len(args); i++ {
@@ -113,6 +114,8 @@ func runCronAdd(args []string) {
 				}
 				timeoutMins = &n
 			}
+		case "--silent":
+			silent = true
 		case "--help", "-h":
 			printCronAddUsage()
 			return
@@ -162,6 +165,9 @@ func runCronAdd(args []string) {
 		"prompt":      prompt,
 		"exec":        execCmd,
 		"description": desc,
+	}
+	if silent {
+		body["silent"] = true
 	}
 	if sessionMode != "" {
 		body["session_mode"] = sessionMode
@@ -622,12 +628,14 @@ Options:
       --desc <text>          Short description
       --session-mode <mode>  reuse (default) or new-per-run — fresh agent session each run
       --timeout-mins <n>     Max minutes to wait per run (0 = no limit; default 30 if omitted)
+      --silent               Suppress cron start notification
       --data-dir <path>      Data directory (default: ~/.cc-connect)
   -h, --help                 Show this help
 
 Examples:
   cc-connect cron add --cron "0 6 * * *" --prompt "Collect GitHub trending data" --desc "Daily Trending"
   cc-connect cron add --cron "*/30 * * * *" --exec "df -h" --desc "Disk usage check"
+  cc-connect cron add --cron "0 9 * * *" --prompt "Daily standup reminder" --silent
   cc-connect cron add 0 6 * * * Collect GitHub trending data and send me a summary`)
 }
 

--- a/cmd/cc-connect/cron_add_test.go
+++ b/cmd/cc-connect/cron_add_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPrintCronAddUsage_DocumentsSilent is a help-text guard for the
+// `cc-connect cron add --silent` flag. The flag is parsed in runCronAdd
+// (cmd/cc-connect/cron.go) and sets body["silent"] = true on the /cron/add
+// request; if printCronAddUsage ever drifts and stops mentioning it, users
+// who run `cc-connect cron add --help` will not discover the feature even
+// though it still works.
+//
+// This complements TestParseCronEditValue (cron_edit_test.go), which guards
+// the symmetric `cron edit <id> silent` path. The behavioural round-trip
+// (CLI flag → request body → server → CronJob.Silent) is covered by the
+// CronAddRequest / CronJob tests in core/api_test.go and core/cron_test.go.
+func TestPrintCronAddUsage_DocumentsSilent(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	printCronAddUsage()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	help := string(out)
+
+	if !strings.Contains(help, "--silent") {
+		t.Errorf("printCronAddUsage does not document --silent; got:\n%s", help)
+	}
+	if !strings.Contains(help, "Suppress cron start notification") {
+		t.Errorf("printCronAddUsage does not describe --silent; got:\n%s", help)
+	}
+	if !strings.Contains(help, "cc-connect cron add --cron \"0 9 * * *\" --prompt \"Daily standup reminder\" --silent") {
+		t.Errorf("printCronAddUsage does not include --silent example; got:\n%s", help)
+	}
+}


### PR DESCRIPTION
## Summary

Expose `--silent` on `cc-connect cron add` so users can suppress the cron start notification when creating a job. The `--silent` flag maps to `body["silent"] = true` on the `/cron/add` request and the server already accepts it (`core/api.go: CronAddRequest.Silent`, `core/cron.go: CronJob.Silent`).

## Context

- Issue #858 requests `cc-connect cron add --silent` and `cc-connect cron edit <id> silent true/false`.
- PR #875 (4ebcb7a5) covered both, but is now stale (1 year old, conflicts).
- PR #915 (7055ecd9) merged the `cron edit` side via `parseCronEditValue` + `cron_edit_test.go` regression test.
- PR #867 (be60d9e6) already merged related cron delivery behavior.

Only the `cron add` side remains.

## Changes

```diff
 func runCronAdd(args []string) {
   var timeoutMins *int
+  var silent bool
   ...
+    case "--silent":
+      silent = true
   ...
   if sessionMode != "" { ... }
+  if silent {
+    body["silent"] = true
+  }
```

`printCronAddUsage` updated to document `--silent` option and an example.

`cron_add_test.go` (new) verifies the help text continues to mention `--silent`, complementing `cron_edit_test.go`.

## Test plan

- [x] `go build -tags no_web ./cmd/cc-connect` passes
- [x] `go test ./cmd/cc-connect -count=1` passes (including new `TestPrintCronAddUsage_DocumentsSilent`)
- [x] `go test ./core -run Cron` passes (cron model + scheduler unchanged)
- [x] Manual: `cc-connect cron add --help` now lists `--silent` and the example
- [x] Manual: `cc-connect cron add --cron "*/5 * * * *" --exec "date" --silent` parses (fails at socket check as expected when daemon not running)

## Notes

- Out of scope for this PR: refactoring `runCronAdd` body-building into a unit-testable helper (matches the `parseCronEditValue` precedent, but kept minimal here per PR #875's style).
- Edit-side is already covered by `cron_edit_test.go` and PR #915.

Fixes #858

Refs #875