### PR TITLE
feat(send): generate video and music via providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,10 +517,10 @@ This refreshes the cc-connect instructions in the project memory file so the age
 You can control this feature globally in `config.toml`:
 
 ```toml
-attachment_send = "on"  # default: "on"; set to "off" to block image/file send-back
+attachment_send = "on"  # default: "on"; set to "off" to block image/file/generated-media send-back
 ```
 
-This switch is independent from the agent's `/mode`. It only controls `cc-connect send --image/--file`. Voice send-back uses the TTS config instead.
+This switch is independent from the agent's `/mode`. It controls `cc-connect send --image/--file` and generated media delivery from `--generate-video/--generate-music`. Voice send-back uses the TTS config instead.
 
 Examples:
 
@@ -529,13 +529,16 @@ cc-connect send --image /absolute/path/to/chart.png
 cc-connect send --file /absolute/path/to/report.pdf
 cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
 cc-connect send --tts "Hello from cc-connect"
+cc-connect send --generate-video "A cinematic sunrise over Hangzhou, 6 seconds"
+cc-connect send --generate-music "Ambient synthwave, night drive" --music-instrumental
 ```
 
 Notes:
 - Absolute paths are the safest option.
 - `--image` and `--file` can both be repeated.
 - `--tts` sends synthesized speech when the user asks for a voice reply.
-- `attachment_send = "off"` disables only attachment send-back; ordinary text replies still work.
+- `--generate-video` and `--generate-music` use configured `[video]` / `[music]` providers, currently MiniMax.
+- `attachment_send = "off"` disables attachment and generated-media send-back; ordinary text replies still work.
 - This command is for generated attachments, not ordinary text replies.
 
 📖 **Full documentation:** [docs/usage.md](docs/usage.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -505,10 +505,10 @@ cc-connect doctor user-isolation
 你也可以在 `config.toml` 里全局控制这项能力：
 
 ```toml
-attachment_send = "on"  # 默认 "on"；设为 "off" 会禁用图片/文件回传
+attachment_send = "on"  # 默认 "on"；设为 "off" 会禁用图片/文件/生成媒体回传
 ```
 
-这个开关与 agent 的 `/mode` 独立，只控制 `cc-connect send --image/--file` 这条附件回传路径。语音回传走 TTS 配置。
+这个开关与 agent 的 `/mode` 独立，控制 `cc-connect send --image/--file` 以及 `--generate-video/--generate-music` 生成媒体回传。语音回传走 TTS 配置。
 
 回传方式：
 
@@ -517,13 +517,16 @@ cc-connect send --image /absolute/path/to/chart.png
 cc-connect send --file /absolute/path/to/report.pdf
 cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
 cc-connect send --tts "你好"
+cc-connect send --generate-video "杭州日出的电影感镜头，6 秒"
+cc-connect send --generate-music "夜间驾驶氛围 synthwave" --music-instrumental
 ```
 
 要点：
 - 使用绝对路径最稳妥。
 - `--image` 和 `--file` 都可以重复传多个。
 - `--tts` 用当前 TTS provider 合成并发送语音，适合用户自然要求“发语音”的场景。
-- `attachment_send = "off"` 只会关闭附件回传，普通文本回复仍然正常。
+- `--generate-video` 和 `--generate-music` 使用已配置的 `[video]` / `[music]` provider，目前支持 MiniMax。
+- `attachment_send = "off"` 会关闭附件和生成媒体回传，普通文本回复仍然正常。
 - 这个命令是给“生成后的附件回传”用的，不是给普通文本回复用的。
 
 📖 **完整文档：** [docs/usage.zh-CN.md](docs/usage.zh-CN.md)

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -52,6 +52,26 @@ func resolveResetOnIdle(configured *int) (time.Duration, bool) {
 	return time.Duration(defaultResetOnIdleMins) * time.Minute, true
 }
 
+func resolveMiniMaxMediaAuth(dataDir, apiKey, baseURL, configFile, logPrefix string) (string, string) {
+	if strings.TrimSpace(apiKey) != "" {
+		return apiKey, baseURL
+	}
+	localCfg, err := config.LoadMiniMaxLocalConfig(dataDir, configFile)
+	if err != nil {
+		slog.Warn(logPrefix+": failed to load minimax local config", "error", err)
+		return "", baseURL
+	}
+	apiKey = localCfg.APIKey
+	if strings.TrimSpace(baseURL) == "" {
+		if localCfg.BaseURL != "" {
+			baseURL = localCfg.BaseURL
+		} else if localCfg.APIHost != "" {
+			baseURL = localCfg.APIHost
+		}
+	}
+	return apiKey, baseURL
+}
+
 // logSizeSource describes where the resolved log size came from, so the
 // caller can log it and operators can audit the active setting without
 // grepping systemd/launchd definitions.
@@ -794,6 +814,69 @@ func main() {
 					return config.SaveTTSMode(mode)
 				})
 				slog.Info("tts: enabled", "provider", ttsCfg.Provider, "voice", ttsCfg.Voice, "mode", initMode)
+			}
+		}
+
+		// Wire text-to-video generation if enabled
+		if cfg.Video.Enabled {
+			videoCfg := &core.VideoGenerationCfg{
+				Enabled:      true,
+				MaxPromptLen: cfg.Video.MaxPromptLen,
+			}
+			switch strings.TrimSpace(cfg.Video.Provider) {
+			case "", "minimax":
+				apiKey, baseURL := resolveMiniMaxMediaAuth(cfg.DataDir, cfg.Video.MiniMax.APIKey, cfg.Video.MiniMax.BaseURL, cfg.Video.MiniMax.ConfigFile, "video")
+				if apiKey != "" {
+					gen := core.NewMiniMaxVideoGenerator(apiKey, baseURL, cfg.Video.MiniMax.Model, nil)
+					gen.Duration = cfg.Video.MiniMax.Duration
+					gen.Resolution = cfg.Video.MiniMax.Resolution
+					if cfg.Video.MiniMax.PollIntervalSecs > 0 {
+						gen.PollInterval = time.Duration(cfg.Video.MiniMax.PollIntervalSecs) * time.Second
+					}
+					if cfg.Video.MiniMax.TimeoutSecs > 0 {
+						gen.Timeout = time.Duration(cfg.Video.MiniMax.TimeoutSecs) * time.Second
+					}
+					videoCfg.Provider = "minimax"
+					videoCfg.Generator = gen
+				} else {
+					slog.Warn("video: minimax provider enabled but api_key is empty")
+				}
+			default:
+				slog.Warn("video: unsupported provider", "provider", cfg.Video.Provider)
+			}
+			if videoCfg.Generator != nil {
+				engine.SetVideoGenerationConfig(videoCfg)
+				slog.Info("video: enabled", "provider", videoCfg.Provider)
+			}
+		}
+
+		// Wire text-to-music generation if enabled
+		if cfg.Music.Enabled {
+			musicCfg := &core.MusicGenerationCfg{
+				Enabled:         true,
+				MaxPromptLen:    cfg.Music.MaxPromptLen,
+				LyricsOptimizer: cfg.Music.MiniMax.LyricsOptimizer,
+				Instrumental:    cfg.Music.MiniMax.Instrumental,
+			}
+			switch strings.TrimSpace(cfg.Music.Provider) {
+			case "", "minimax":
+				apiKey, baseURL := resolveMiniMaxMediaAuth(cfg.DataDir, cfg.Music.MiniMax.APIKey, cfg.Music.MiniMax.BaseURL, cfg.Music.MiniMax.ConfigFile, "music")
+				if apiKey != "" {
+					gen := core.NewMiniMaxMusicGenerator(apiKey, baseURL, cfg.Music.MiniMax.Model, nil)
+					gen.SampleRate = cfg.Music.MiniMax.SampleRate
+					gen.Bitrate = cfg.Music.MiniMax.Bitrate
+					gen.Format = cfg.Music.MiniMax.Format
+					musicCfg.Provider = "minimax"
+					musicCfg.Generator = gen
+				} else {
+					slog.Warn("music: minimax provider enabled but api_key is empty")
+				}
+			default:
+				slog.Warn("music: unsupported provider", "provider", cfg.Music.Provider)
+			}
+			if musicCfg.Generator != nil {
+				engine.SetMusicGenerationConfig(musicCfg)
+				slog.Info("music: enabled", "provider", musicCfg.Provider)
 			}
 		}
 

--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -103,6 +103,28 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 			}
 			i++
 			req.TTSText = args[i]
+		case "--generate-video":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--generate-video requires a prompt")
+			}
+			i++
+			req.VideoPrompt = args[i]
+		case "--generate-music":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--generate-music requires a prompt")
+			}
+			i++
+			req.MusicPrompt = args[i]
+		case "--music-lyrics":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--music-lyrics requires a value")
+			}
+			i++
+			req.MusicLyrics = args[i]
+		case "--music-instrumental":
+			req.MusicInstrumental = true
+		case "--music-lyrics-optimizer":
+			req.MusicLyricsOptimizer = true
 		case "--image":
 			if i+1 >= len(args) {
 				return req, "", fmt.Errorf("--image requires a path")
@@ -192,8 +214,8 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 	req.Files = append(files, audioFiles...)
 	req.Files = append(req.Files, videoFiles...)
 
-	if req.Message == "" && req.TTSText == "" && len(req.Images) == 0 && len(req.Files) == 0 {
-		return req, "", fmt.Errorf("message, tts text, or attachment is required")
+	if req.Message == "" && req.TTSText == "" && req.VideoPrompt == "" && req.MusicPrompt == "" && len(req.Images) == 0 && len(req.Files) == 0 {
+		return req, "", fmt.Errorf("message, tts text, generated media prompt, or attachment is required")
 	}
 
 	return req, dataDir, nil
@@ -335,9 +357,11 @@ func printSendUsage() {
        cc-connect send [options] --audio <path>
        cc-connect send [options] --video <path>
        cc-connect send [options] --tts <text>
+       cc-connect send [options] --generate-video <prompt>
+       cc-connect send [options] --generate-music <prompt>
        echo "msg" | cc-connect send [options] --stdin
 
-Send a message, attachment, or synthesized voice message to an active cc-connect session.
+Send a message, attachment, synthesized voice message, or generated media to an active cc-connect session.
 
 Options:
   -m, --message <text>     Message to send (preferred over positional args)
@@ -347,6 +371,12 @@ Options:
       --audio <path>       Send an audio attachment (repeatable)
       --video <path>       Send a video attachment (repeatable)
       --stdin              Read message from stdin (best for long/special-char messages)
+      --generate-video <p> Generate a video via configured [video] provider and send it
+      --generate-music <p> Generate music via configured [music] provider and send it
+      --music-lyrics <txt> Lyrics for --generate-music
+      --music-instrumental Generate instrumental music
+      --music-lyrics-optimizer
+                           Let provider generate lyrics from the music prompt
       --at-users <ids>     @ user IDs, comma-separated (DingTalk)
       --at-all             @ everyone (DingTalk)
   -p, --project <name>     Target project (optional if only one project)
@@ -362,6 +392,8 @@ Examples:
   cc-connect send --video /tmp/demo.mp4
   cc-connect send --audio /tmp/voice.opus
   cc-connect send --tts "Hello from cc-connect"
+  cc-connect send --generate-video "A cinematic sunrise over Hangzhou, 6 seconds"
+  cc-connect send --generate-music "Ambient synthwave, night drive" --music-instrumental
   cc-connect send --stdin <<'EOF'
     Long message with "special" chars, $variables, and newlines
   EOF`)

--- a/cmd/cc-connect/send_test.go
+++ b/cmd/cc-connect/send_test.go
@@ -127,6 +127,28 @@ func TestParseSendArgs_TTSOnly(t *testing.T) {
 	}
 }
 
+func TestParseSendArgs_GeneratedMediaPrompts(t *testing.T) {
+	req, _, err := parseSendArgs([]string{
+		"--generate-video", "cinematic sunset",
+		"--generate-music", "ambient synthwave",
+		"--music-lyrics", "[Verse]\nhello",
+		"--music-instrumental",
+		"--music-lyrics-optimizer",
+	})
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if req.VideoPrompt != "cinematic sunset" {
+		t.Fatalf("video prompt = %q", req.VideoPrompt)
+	}
+	if req.MusicPrompt != "ambient synthwave" || req.MusicLyrics != "[Verse]\nhello" {
+		t.Fatalf("music prompt/lyrics = %q/%q", req.MusicPrompt, req.MusicLyrics)
+	}
+	if !req.MusicInstrumental || !req.MusicLyricsOptimizer {
+		t.Fatalf("music flags = instrumental:%v optimizer:%v", req.MusicInstrumental, req.MusicLyricsOptimizer)
+	}
+}
+
 func TestParseSendArgs_AudioRejectsNonAudio(t *testing.T) {
 	dir := t.TempDir()
 	docPath := filepath.Join(dir, "report.txt")

--- a/config.example.toml
+++ b/config.example.toml
@@ -39,10 +39,12 @@
 # 会话数据存储目录（默认 ~/.cc-connect），以 JSON 文件保存对话历史和会话状态。
 # data_dir = "/path/to/custom/dir"
 
-# Attachment send-back switch for `cc-connect send --image/--file`.
+# Attachment send-back switch for `cc-connect send --image/--file`
+# and generated media sent by `--generate-video/--generate-music`.
 # Independent from the agent's /mode. Set to "off" to block IM image/file send-back.
 # `cc-connect send --message` without attachments is unaffected.
-# 附件回传开关，用于控制 `cc-connect send --image/--file`。
+# 附件回传开关，用于控制 `cc-connect send --image/--file`
+# 以及 `--generate-video/--generate-music` 生成后的媒体附件回传。
 # 它与 agent 的 /mode 独立；设为 "off" 会禁用通过 IM 回传图片/文件。
 # 不带附件的 `cc-connect send --message` 不受影响。
 # attachment_send = "on"
@@ -507,6 +509,48 @@ level = "info" # debug, info, warn, error
 # base_url = ""              # optional: default "https://api.xiaomimimo.com/v1" / 留空使用默认地址
 #                            # Token Plan 国内地址：https://token-plan-cn.xiaomimimo.com/v1
 # model    = "mimo-v2.5-tts" # "mimo-v2.5-tts" | "mimo-v2.5-tts-voicedesign" | "mimo-v2.5-tts-voiceclone"
+
+# =============================================================================
+# Generated Video and Music Send-Back / 视频与音乐生成回传
+# =============================================================================
+# Enable these sections to let agents call `cc-connect send --generate-video`
+# or `cc-connect send --generate-music` directly through configured providers.
+# The generated media is sent back as a file attachment, so `attachment_send = "off"`
+# blocks delivery before provider generation starts.
+# 启用后，Agent 可以直接调用 `cc-connect send --generate-video` 或
+# `cc-connect send --generate-music`，不需要额外 CLI/skill。生成结果作为文件附件回传，
+# 因此 `attachment_send = "off"` 会在调用 provider 前直接拒绝。
+
+# [video]
+# enabled = false
+# provider = "minimax"
+# max_prompt_len = 0          # max rune count before rejecting generation; 0 = no limit
+#
+# [video.minimax]
+# api_key = "your-minimax-api-key" # optional: if empty, cc-connect reads ~/.cc-connect/config/minimax.json
+# base_url = ""                    # optional: default "https://api.minimaxi.com"
+# model = "MiniMax-Hailuo-2.3"
+# config_file = ""                 # optional MiniMax JSON config path; default data_dir/config/minimax.json
+# duration = 6                     # seconds; 0 = provider default
+# resolution = "1080P"             # empty = provider default
+# poll_interval_secs = 10
+# timeout_secs = 600
+#
+# [music]
+# enabled = false
+# provider = "minimax"
+# max_prompt_len = 0          # max rune count before rejecting generation; 0 = no limit
+#
+# [music.minimax]
+# api_key = "your-minimax-api-key" # optional: if empty, cc-connect reads ~/.cc-connect/config/minimax.json
+# base_url = ""                    # optional: default "https://api.minimaxi.com"
+# model = "music-2.6"
+# config_file = ""                 # optional MiniMax JSON config path; default data_dir/config/minimax.json
+# sample_rate = 44100
+# bitrate = 256000
+# format = "mp3"
+# lyrics_optimizer = true          # useful for prompt-only lyric songs
+# instrumental = false
 
 # =============================================================================
 # Daemon Mode / 守护进程模式

--- a/config/config.go
+++ b/config/config.go
@@ -99,6 +99,8 @@ type Config struct {
 	Language           string                  `toml:"language"` // "en" or "zh", default is "en"
 	Speech             SpeechConfig            `toml:"speech"`
 	TTS                TTSConfig               `toml:"tts"`
+	Video              VideoConfig             `toml:"video"`
+	Music              MusicConfig             `toml:"music"`
 	Display            DisplayConfig           `toml:"display"`
 	StreamPreview      StreamPreviewConfig     `toml:"stream_preview"`      // real-time streaming preview
 	InstantReply       InstantReplyConfig      `toml:"instant_reply"`       // immediate confirmation reply
@@ -309,6 +311,41 @@ type TTSConfig struct {
 		BaseURL string `toml:"base_url"`
 		Model   string `toml:"model"`
 	} `toml:"mimo"`
+}
+
+// VideoConfig configures direct text-to-video generation for cc-connect send.
+type VideoConfig struct {
+	Enabled      bool   `toml:"enabled"`
+	Provider     string `toml:"provider"`       // currently "minimax"
+	MaxPromptLen int    `toml:"max_prompt_len"` // max rune count before rejecting generation; 0 = no limit
+	MiniMax      struct {
+		APIKey           string `toml:"api_key"`
+		BaseURL          string `toml:"base_url"`
+		Model            string `toml:"model"`
+		ConfigFile       string `toml:"config_file"`        // optional JSON auth file; default data_dir/config/minimax.json when api_key is empty
+		Duration         int    `toml:"duration"`           // seconds; provider default when 0
+		Resolution       string `toml:"resolution"`         // e.g. "1080P"; provider default when empty
+		PollIntervalSecs int    `toml:"poll_interval_secs"` // default 10
+		TimeoutSecs      int    `toml:"timeout_secs"`       // default 600
+	} `toml:"minimax"`
+}
+
+// MusicConfig configures direct text-to-music generation for cc-connect send.
+type MusicConfig struct {
+	Enabled      bool   `toml:"enabled"`
+	Provider     string `toml:"provider"`       // currently "minimax"
+	MaxPromptLen int    `toml:"max_prompt_len"` // max rune count before rejecting generation; 0 = no limit
+	MiniMax      struct {
+		APIKey          string `toml:"api_key"`
+		BaseURL         string `toml:"base_url"`
+		Model           string `toml:"model"`
+		ConfigFile      string `toml:"config_file"` // optional JSON auth file; default data_dir/config/minimax.json when api_key is empty
+		SampleRate      int    `toml:"sample_rate"` // default 44100
+		Bitrate         int    `toml:"bitrate"`     // default 256000
+		Format          string `toml:"format"`      // default "mp3"
+		LyricsOptimizer bool   `toml:"lyrics_optimizer"`
+		Instrumental    bool   `toml:"instrumental"`
+	} `toml:"minimax"`
 }
 
 // TTSAgentConfig overrides global [tts] synthesis parameters for one project.

--- a/core/api.go
+++ b/core/api.go
@@ -31,14 +31,19 @@ type APIServer struct {
 
 // SendRequest is the JSON body for POST /send.
 type SendRequest struct {
-	Project    string            `json:"project"`
-	SessionKey string            `json:"session_key"`
-	Message    string            `json:"message"`
-	TTSText    string            `json:"tts_text,omitempty"`
-	Images     []ImageAttachment `json:"images,omitempty"`
-	Files      []FileAttachment  `json:"files,omitempty"`
-	AtUsers    []string          `json:"at_users,omitempty"`
-	AtAll      bool              `json:"at_all,omitempty"`
+	Project              string            `json:"project"`
+	SessionKey           string            `json:"session_key"`
+	Message              string            `json:"message"`
+	TTSText              string            `json:"tts_text,omitempty"`
+	VideoPrompt          string            `json:"video_prompt,omitempty"`
+	MusicPrompt          string            `json:"music_prompt,omitempty"`
+	MusicLyrics          string            `json:"music_lyrics,omitempty"`
+	MusicInstrumental    bool              `json:"music_instrumental,omitempty"`
+	MusicLyricsOptimizer bool              `json:"music_lyrics_optimizer,omitempty"`
+	Images               []ImageAttachment `json:"images,omitempty"`
+	Files                []FileAttachment  `json:"files,omitempty"`
+	AtUsers              []string          `json:"at_users,omitempty"`
+	AtAll                bool              `json:"at_all,omitempty"`
 }
 
 // NewAPIServer creates an API server on a Unix socket.
@@ -157,8 +162,8 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	if req.Message == "" && strings.TrimSpace(req.TTSText) == "" && len(req.Images) == 0 && len(req.Files) == 0 {
-		http.Error(w, "message, tts_text, or attachment is required", http.StatusBadRequest)
+	if req.Message == "" && strings.TrimSpace(req.TTSText) == "" && strings.TrimSpace(req.VideoPrompt) == "" && strings.TrimSpace(req.MusicPrompt) == "" && len(req.Images) == 0 && len(req.Files) == 0 {
+		http.Error(w, "message, tts_text, video_prompt, music_prompt, or attachment is required", http.StatusBadRequest)
 		return
 	}
 
@@ -197,6 +202,20 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 
 	if strings.TrimSpace(req.TTSText) != "" {
 		if err := engine.SendTTSToSession(req.SessionKey, req.TTSText); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if strings.TrimSpace(req.VideoPrompt) != "" {
+		if err := engine.SendGeneratedVideoToSession(req.SessionKey, req.VideoPrompt); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if strings.TrimSpace(req.MusicPrompt) != "" {
+		if err := engine.SendGeneratedMusicToSession(req.SessionKey, req.MusicPrompt, req.MusicLyrics, req.MusicInstrumental, req.MusicLyricsOptimizer); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -86,6 +87,83 @@ func TestHandleSend_AllowsTTSTextOnly(t *testing.T) {
 	}
 	if _, format, audioCalls := platform.audioSnapshot(); audioCalls != 1 || format != "mp3" {
 		t.Fatalf("audio calls/format = %d/%q", audioCalls, format)
+	}
+}
+
+type recordingVideoGenerator struct {
+	prompt string
+	calls  int
+}
+
+func (g *recordingVideoGenerator) GenerateVideo(_ context.Context, prompt string) ([]byte, string, error) {
+	g.prompt = prompt
+	g.calls++
+	return []byte("video-bytes"), "mp4", nil
+}
+
+type recordingMusicGenerator struct {
+	prompt string
+	opts   MusicGenerationOpts
+	calls  int
+}
+
+func (g *recordingMusicGenerator) GenerateMusic(_ context.Context, prompt string, opts MusicGenerationOpts) ([]byte, string, error) {
+	g.prompt = prompt
+	g.opts = opts
+	g.calls++
+	return []byte("music-bytes"), "mp3", nil
+}
+
+func TestHandleSend_AllowsGeneratedVideoAndMusic(t *testing.T) {
+	video := &recordingVideoGenerator{}
+	music := &recordingMusicGenerator{}
+	platform := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	engine := NewEngine("test", &stubAgent{}, []Platform{platform}, "", LangEnglish)
+	engine.SetVideoGenerationConfig(&VideoGenerationCfg{Enabled: true, Provider: "minimax", Generator: video})
+	engine.SetMusicGenerationConfig(&MusicGenerationCfg{Enabled: true, Provider: "minimax", Generator: music})
+	engine.interactiveStates["session-1"] = &interactiveState{
+		platform: platform,
+		replyCtx: "reply-ctx",
+	}
+
+	api := &APIServer{engines: map[string]*Engine{"test": engine}}
+	body, err := json.Marshal(SendRequest{
+		Project:              "test",
+		SessionKey:           "session-1",
+		VideoPrompt:          "cinematic sunset",
+		MusicPrompt:          "ambient synthwave",
+		MusicLyrics:          "[Verse]\nhello",
+		MusicInstrumental:    true,
+		MusicLyricsOptimizer: true,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if video.calls != 1 || video.prompt != "cinematic sunset" {
+		t.Fatalf("video calls/prompt = %d/%q", video.calls, video.prompt)
+	}
+	if music.calls != 1 || music.prompt != "ambient synthwave" {
+		t.Fatalf("music calls/prompt = %d/%q", music.calls, music.prompt)
+	}
+	if music.opts.Lyrics != "[Verse]\nhello" || !music.opts.Instrumental || !music.opts.LyricsOptimizer {
+		t.Fatalf("music opts = %#v", music.opts)
+	}
+	if len(platform.files) != 2 {
+		t.Fatalf("sent files = %d, want 2", len(platform.files))
+	}
+	if platform.files[0].MimeType != "video/mp4" || string(platform.files[0].Data) != "video-bytes" {
+		t.Fatalf("video file = %#v", platform.files[0])
+	}
+	if platform.files[1].MimeType != "audio/mpeg" || string(platform.files[1].Data) != "music-bytes" {
+		t.Fatalf("music file = %#v", platform.files[1])
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -173,6 +173,8 @@ type Engine struct {
 	i18n                  *I18n
 	speech                SpeechCfg
 	tts                   *TTSCfg
+	video                 *VideoGenerationCfg
+	music                 *MusicGenerationCfg
 	display               DisplayCfg
 	injectSender          bool
 	attachmentSendEnabled bool
@@ -249,8 +251,8 @@ type Engine struct {
 	filterExternalSessions bool
 
 	// Shell configuration for /shell, cron exec, hooks, webhook exec
-	shell       string // shell binary path (e.g. "sh", "/bin/zsh")
-	shellFlag   string // shell flag (e.g. "-c", "-Command", "/C")
+	shell        string // shell binary path (e.g. "sh", "/bin/zsh")
+	shellFlag    string // shell flag (e.g. "-c", "-Command", "/C")
 	shellProfile string // prepended to every command (e.g. "source ~/.zshrc;")
 
 	// Multi-workspace mode
@@ -660,6 +662,16 @@ func (e *Engine) SetSpeechConfig(cfg SpeechCfg) {
 // SetTTSConfig configures the text-to-speech subsystem.
 func (e *Engine) SetTTSConfig(cfg *TTSCfg) {
 	e.tts = cfg
+}
+
+// SetVideoGenerationConfig configures direct video generation for the send API.
+func (e *Engine) SetVideoGenerationConfig(cfg *VideoGenerationCfg) {
+	e.video = cfg
+}
+
+// SetMusicGenerationConfig configures direct music generation for the send API.
+func (e *Engine) SetMusicGenerationConfig(cfg *MusicGenerationCfg) {
+	e.music = cfg
 }
 
 // SetTTSSaveFunc registers a callback that persists TTS mode changes.
@@ -10181,6 +10193,83 @@ func (e *Engine) SendTTSToSession(sessionKey, text string) error {
 		return err
 	}
 	return e.synthesizeAndSendTTS(p, replyCtx, text)
+}
+
+// SendGeneratedVideoToSession generates a video with the configured provider
+// and sends it as a file attachment to an active session.
+func (e *Engine) SendGeneratedVideoToSession(sessionKey, prompt string) error {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return fmt.Errorf("video prompt is required")
+	}
+	if e.video == nil || !e.video.Enabled {
+		return fmt.Errorf("video generation is not configured")
+	}
+	if e.video.Generator == nil {
+		return fmt.Errorf("video generation provider is not configured")
+	}
+	if e.video.MaxPromptLen > 0 && utf8.RuneCountInString(prompt) > e.video.MaxPromptLen {
+		return fmt.Errorf("video prompt exceeds max_prompt_len (%d > %d)", utf8.RuneCountInString(prompt), e.video.MaxPromptLen)
+	}
+	if !e.attachmentSendEnabled {
+		return ErrAttachmentSendDisabled
+	}
+	slog.Info("video: starting generation", "provider", e.video.Provider, "prompt_len", len(prompt))
+	data, format, err := e.video.Generator.GenerateVideo(e.ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("generate video: %w", err)
+	}
+	file := FileAttachment{
+		MimeType: generatedMediaMime("video", format),
+		Data:     data,
+		FileName: generatedMediaFileName("video", format),
+	}
+	if err := e.SendToSessionWithAttachments(sessionKey, "", nil, []FileAttachment{file}, nil, false); err != nil {
+		return fmt.Errorf("send video: %w", err)
+	}
+	slog.Info("video: generated file sent", "provider", e.video.Provider, "format", format, "size", len(data))
+	return nil
+}
+
+// SendGeneratedMusicToSession generates music with the configured provider
+// and sends it as an audio file attachment to an active session.
+func (e *Engine) SendGeneratedMusicToSession(sessionKey, prompt, lyrics string, instrumental bool, lyricsOptimizer bool) error {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return fmt.Errorf("music prompt is required")
+	}
+	if e.music == nil || !e.music.Enabled {
+		return fmt.Errorf("music generation is not configured")
+	}
+	if e.music.Generator == nil {
+		return fmt.Errorf("music generation provider is not configured")
+	}
+	if e.music.MaxPromptLen > 0 && utf8.RuneCountInString(prompt) > e.music.MaxPromptLen {
+		return fmt.Errorf("music prompt exceeds max_prompt_len (%d > %d)", utf8.RuneCountInString(prompt), e.music.MaxPromptLen)
+	}
+	if !e.attachmentSendEnabled {
+		return ErrAttachmentSendDisabled
+	}
+	opts := MusicGenerationOpts{
+		Lyrics:          lyrics,
+		Instrumental:    instrumental || e.music.Instrumental,
+		LyricsOptimizer: lyricsOptimizer || e.music.LyricsOptimizer,
+	}
+	slog.Info("music: starting generation", "provider", e.music.Provider, "prompt_len", len(prompt), "instrumental", opts.Instrumental, "lyrics_optimizer", opts.LyricsOptimizer)
+	data, format, err := e.music.Generator.GenerateMusic(e.ctx, prompt, opts)
+	if err != nil {
+		return fmt.Errorf("generate music: %w", err)
+	}
+	file := FileAttachment{
+		MimeType: generatedMediaMime("music", format),
+		Data:     data,
+		FileName: generatedMediaFileName("music", format),
+	}
+	if err := e.SendToSessionWithAttachments(sessionKey, "", nil, []FileAttachment{file}, nil, false); err != nil {
+		return fmt.Errorf("send music: %w", err)
+	}
+	slog.Info("music: generated file sent", "provider", e.music.Provider, "format", format, "size", len(data))
+	return nil
 }
 
 func (e *Engine) resolveOutboundSessionTarget(sessionKey string, hasAttachments bool) (*interactiveState, Platform, any, error) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -796,6 +796,30 @@ func TestEngineSendToSessionWithAttachments_DisabledByConfig(t *testing.T) {
 	}
 }
 
+func TestEngineSendGeneratedMedia_DisabledByConfigSkipsProviders(t *testing.T) {
+	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetAttachmentSendEnabled(false)
+	video := &recordingVideoGenerator{}
+	music := &recordingMusicGenerator{}
+	e.SetVideoGenerationConfig(&VideoGenerationCfg{Enabled: true, Provider: "minimax", Generator: video})
+	e.SetMusicGenerationConfig(&MusicGenerationCfg{Enabled: true, Provider: "minimax", Generator: music})
+	e.interactiveStates["session-1"] = &interactiveState{
+		platform: p,
+		replyCtx: "ctx-1",
+	}
+
+	if err := e.SendGeneratedVideoToSession("session-1", "cinematic sunset"); !errors.Is(err, ErrAttachmentSendDisabled) {
+		t.Fatalf("video err = %v, want ErrAttachmentSendDisabled", err)
+	}
+	if err := e.SendGeneratedMusicToSession("session-1", "ambient synthwave", "", false, false); !errors.Is(err, ErrAttachmentSendDisabled) {
+		t.Fatalf("music err = %v, want ErrAttachmentSendDisabled", err)
+	}
+	if video.calls != 0 || music.calls != 0 {
+		t.Fatalf("provider calls = video:%d music:%d, want both 0", video.calls, music.calls)
+	}
+}
+
 func TestEngineSendToSessionWithAttachments_MultiWorkspaceRawSessionKey(t *testing.T) {
 	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
@@ -2195,6 +2219,12 @@ func TestAgentSystemPrompt_MentionsAttachmentSend(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "cc-connect send --tts") {
 		t.Fatalf("prompt missing tts send instructions: %q", prompt)
+	}
+	if !strings.Contains(prompt, "cc-connect send --generate-video") {
+		t.Fatalf("prompt missing generated video instructions: %q", prompt)
+	}
+	if !strings.Contains(prompt, "cc-connect send --generate-music") {
+		t.Fatalf("prompt missing generated music instructions: %q", prompt)
 	}
 	if !strings.Contains(prompt, "NO_REPLY") {
 		t.Fatalf("prompt missing silent reply guidance for voice tool: %q", prompt)
@@ -7237,6 +7267,9 @@ func TestSetupMemoryFile_RefreshesLegacyInstructions(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "cc-connect send --image") {
 		t.Fatalf("expected refreshed attachment instructions, got %q", string(content))
+	}
+	if !strings.Contains(string(content), "cc-connect send --generate-video") {
+		t.Fatalf("expected refreshed generated media instructions, got %q", string(content))
 	}
 }
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -71,7 +71,7 @@ Your normal text responses are automatically delivered to the user — just repl
 
 ## Available tools
 
-### Send generated images, files, or voice messages back to the user
+### Send generated images, files, media, or voice messages back to the user
 When you generate a local image or file that should be sent to the user, use:
 
   cc-connect send --image /absolute/path/to/image.png
@@ -80,6 +80,13 @@ When you generate a local image or file that should be sent to the user, use:
 
 You may repeat --image / --file multiple times. Use this only for generated attachments that need to be delivered to the user.
 If you include --message, do not repeat the exact same sentence again in your normal reply, because your normal reply is also delivered automatically.
+
+When the user asks you to generate a video or music and cc-connect has a matching provider configured, generate and send it directly with:
+
+  cc-connect send --generate-video "video prompt"
+  cc-connect send --generate-music "music prompt" --music-instrumental
+
+Use --music-lyrics for explicit lyrics, or --music-lyrics-optimizer to let the provider create lyrics from the prompt.
 
 When the user explicitly asks you to send a voice/audio reply, synthesize and send it with:
 

--- a/core/media_generation.go
+++ b/core/media_generation.go
@@ -1,0 +1,434 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// VideoGenerator generates a video attachment from a text prompt.
+type VideoGenerator interface {
+	GenerateVideo(ctx context.Context, prompt string) (data []byte, format string, err error)
+}
+
+// MusicGenerator generates an audio/music attachment from a prompt and options.
+type MusicGenerator interface {
+	GenerateMusic(ctx context.Context, prompt string, opts MusicGenerationOpts) (data []byte, format string, err error)
+}
+
+// VideoGenerationCfg holds video generation configuration for the engine.
+type VideoGenerationCfg struct {
+	Enabled      bool
+	Provider     string
+	Generator    VideoGenerator
+	MaxPromptLen int
+}
+
+// MusicGenerationCfg holds music generation configuration for the engine.
+type MusicGenerationCfg struct {
+	Enabled         bool
+	Provider        string
+	Generator       MusicGenerator
+	MaxPromptLen    int
+	LyricsOptimizer bool
+	Instrumental    bool
+}
+
+// MusicGenerationOpts carries per-request music generation controls.
+type MusicGenerationOpts struct {
+	Lyrics          string
+	LyricsOptimizer bool
+	Instrumental    bool
+}
+
+// MiniMaxVideoGenerator implements MiniMax asynchronous video generation.
+type MiniMaxVideoGenerator struct {
+	APIKey         string
+	BaseURL        string
+	Model          string
+	Duration       int
+	Resolution     string
+	PollInterval   time.Duration
+	Timeout        time.Duration
+	Client         *http.Client
+	DownloadClient *http.Client
+}
+
+func NewMiniMaxVideoGenerator(apiKey, baseURL, model string, client *http.Client) *MiniMaxVideoGenerator {
+	if baseURL == "" {
+		baseURL = "https://api.minimaxi.com"
+	}
+	if model == "" {
+		model = "MiniMax-Hailuo-2.3"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &MiniMaxVideoGenerator{
+		APIKey:         apiKey,
+		BaseURL:        strings.TrimRight(baseURL, "/"),
+		Model:          model,
+		PollInterval:   10 * time.Second,
+		Timeout:        10 * time.Minute,
+		Client:         client,
+		DownloadClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func (m *MiniMaxVideoGenerator) GenerateVideo(ctx context.Context, prompt string) ([]byte, string, error) {
+	if strings.TrimSpace(prompt) == "" {
+		return nil, "", fmt.Errorf("video prompt is required")
+	}
+	timeout := m.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	taskID, err := m.createVideoTask(ctx, prompt)
+	if err != nil {
+		return nil, "", err
+	}
+	fileID, err := m.pollVideoTask(ctx, taskID)
+	if err != nil {
+		return nil, "", err
+	}
+	downloadURL, err := m.retrieveFileURL(ctx, fileID)
+	if err != nil {
+		return nil, "", err
+	}
+	data, err := m.downloadFile(ctx, downloadURL)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, "mp4", nil
+}
+
+func (m *MiniMaxVideoGenerator) createVideoTask(ctx context.Context, prompt string) (string, error) {
+	body := map[string]any{
+		"prompt": prompt,
+		"model":  m.Model,
+	}
+	if m.Duration > 0 {
+		body["duration"] = m.Duration
+	}
+	if strings.TrimSpace(m.Resolution) != "" {
+		body["resolution"] = strings.TrimSpace(m.Resolution)
+	}
+	var resp struct {
+		TaskID   string `json:"task_id"`
+		BaseResp struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	if err := m.doJSON(ctx, http.MethodPost, "/v1/video_generation", nil, body, &resp); err != nil {
+		return "", fmt.Errorf("minimax video: create task: %w", err)
+	}
+	if resp.BaseResp.StatusCode != 0 {
+		return "", fmt.Errorf("minimax video API error %d: %s", resp.BaseResp.StatusCode, resp.BaseResp.StatusMsg)
+	}
+	if strings.TrimSpace(resp.TaskID) == "" {
+		return "", fmt.Errorf("minimax video: empty task_id")
+	}
+	return resp.TaskID, nil
+}
+
+func (m *MiniMaxVideoGenerator) pollVideoTask(ctx context.Context, taskID string) (string, error) {
+	interval := m.PollInterval
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("minimax video: polling task %s: %w", taskID, ctx.Err())
+		case <-timer.C:
+		}
+		var resp struct {
+			Status       string `json:"status"`
+			FileID       string `json:"file_id"`
+			ErrorMessage string `json:"error_message"`
+			BaseResp     struct {
+				StatusCode int    `json:"status_code"`
+				StatusMsg  string `json:"status_msg"`
+			} `json:"base_resp"`
+		}
+		q := url.Values{"task_id": []string{taskID}}
+		if err := m.doJSON(ctx, http.MethodGet, "/v1/query/video_generation", q, nil, &resp); err != nil {
+			return "", fmt.Errorf("minimax video: query task: %w", err)
+		}
+		if resp.BaseResp.StatusCode != 0 {
+			return "", fmt.Errorf("minimax video query API error %d: %s", resp.BaseResp.StatusCode, resp.BaseResp.StatusMsg)
+		}
+		status := strings.ToLower(strings.TrimSpace(resp.Status))
+		switch status {
+		case "success", "completed", "succeeded":
+			if strings.TrimSpace(resp.FileID) == "" {
+				return "", fmt.Errorf("minimax video: task succeeded without file_id")
+			}
+			return resp.FileID, nil
+		case "fail", "failed", "error":
+			if resp.ErrorMessage == "" {
+				resp.ErrorMessage = resp.BaseResp.StatusMsg
+			}
+			return "", fmt.Errorf("minimax video task failed: %s", resp.ErrorMessage)
+		}
+		timer.Reset(interval)
+	}
+}
+
+func (m *MiniMaxVideoGenerator) retrieveFileURL(ctx context.Context, fileID string) (string, error) {
+	var resp struct {
+		File struct {
+			DownloadURL string `json:"download_url"`
+		} `json:"file"`
+		BaseResp struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	q := url.Values{"file_id": []string{fileID}}
+	if err := m.doJSON(ctx, http.MethodGet, "/v1/files/retrieve", q, nil, &resp); err != nil {
+		return "", fmt.Errorf("minimax video: retrieve file: %w", err)
+	}
+	if resp.BaseResp.StatusCode != 0 {
+		return "", fmt.Errorf("minimax video retrieve API error %d: %s", resp.BaseResp.StatusCode, resp.BaseResp.StatusMsg)
+	}
+	if strings.TrimSpace(resp.File.DownloadURL) == "" {
+		return "", fmt.Errorf("minimax video: empty download_url")
+	}
+	return resp.File.DownloadURL, nil
+}
+
+func (m *MiniMaxVideoGenerator) downloadFile(ctx context.Context, downloadURL string) ([]byte, error) {
+	client := m.DownloadClient
+	if client == nil {
+		client = m.Client
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create download request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read download: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download API %d: %s", resp.StatusCode, trimForError(data))
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("download returned empty file")
+	}
+	return data, nil
+}
+
+func (m *MiniMaxVideoGenerator) doJSON(ctx context.Context, method, path string, q url.Values, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+	u := strings.TrimRight(m.BaseURL, "/") + path
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, reader)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.APIKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := m.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("API %d: %s", resp.StatusCode, trimForError(data))
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	return nil
+}
+
+// MiniMaxMusicGenerator implements MiniMax music generation.
+type MiniMaxMusicGenerator struct {
+	APIKey     string
+	BaseURL    string
+	Model      string
+	SampleRate int
+	Bitrate    int
+	Format     string
+	Client     *http.Client
+}
+
+func NewMiniMaxMusicGenerator(apiKey, baseURL, model string, client *http.Client) *MiniMaxMusicGenerator {
+	if baseURL == "" {
+		baseURL = "https://api.minimaxi.com"
+	}
+	if model == "" {
+		model = "music-2.6"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Minute}
+	}
+	return &MiniMaxMusicGenerator{
+		APIKey:     apiKey,
+		BaseURL:    strings.TrimRight(baseURL, "/"),
+		Model:      model,
+		SampleRate: 44100,
+		Bitrate:    256000,
+		Format:     "mp3",
+		Client:     client,
+	}
+}
+
+func (m *MiniMaxMusicGenerator) GenerateMusic(ctx context.Context, prompt string, opts MusicGenerationOpts) ([]byte, string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil, "", fmt.Errorf("music prompt is required")
+	}
+	format := strings.TrimSpace(m.Format)
+	if format == "" {
+		format = "mp3"
+	}
+	sampleRate := m.SampleRate
+	if sampleRate <= 0 {
+		sampleRate = 44100
+	}
+	bitrate := m.Bitrate
+	if bitrate <= 0 {
+		bitrate = 256000
+	}
+	body := map[string]any{
+		"model":         m.Model,
+		"prompt":        prompt,
+		"output_format": "hex",
+		"audio_setting": map[string]any{
+			"sample_rate": sampleRate,
+			"bitrate":     bitrate,
+			"format":      format,
+		},
+	}
+	if opts.Instrumental {
+		body["is_instrumental"] = true
+	} else {
+		if strings.TrimSpace(opts.Lyrics) != "" {
+			body["lyrics"] = opts.Lyrics
+		}
+		if opts.LyricsOptimizer || strings.TrimSpace(opts.Lyrics) == "" {
+			body["lyrics_optimizer"] = true
+		}
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(m.BaseURL, "/")+"/v1/music_generation", bytes.NewReader(payload))
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := m.Client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("minimax music API %d: %s", resp.StatusCode, trimForError(data))
+	}
+	var result struct {
+		Data struct {
+			Audio    string `json:"audio"`
+			AudioURL string `json:"audio_url"`
+			Status   int    `json:"status"`
+		} `json:"data"`
+		BaseResp struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, "", fmt.Errorf("minimax music: parse response: %w", err)
+	}
+	if result.BaseResp.StatusCode != 0 {
+		return nil, "", fmt.Errorf("minimax music API error %d: %s", result.BaseResp.StatusCode, result.BaseResp.StatusMsg)
+	}
+	if strings.TrimSpace(result.Data.Audio) == "" {
+		return nil, "", fmt.Errorf("minimax music: empty audio data")
+	}
+	audio, err := hex.DecodeString(result.Data.Audio)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: decode audio hex: %w", err)
+	}
+	if len(audio) == 0 {
+		return nil, "", fmt.Errorf("minimax music: decoded empty audio")
+	}
+	return audio, format, nil
+}
+
+func generatedMediaFileName(kind, format string) string {
+	ext := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(format)), ".")
+	if ext == "" {
+		ext = "bin"
+	}
+	return fmt.Sprintf("generated-%s-%d.%s", kind, time.Now().UnixMilli(), ext)
+}
+
+func generatedMediaMime(kind, format string) string {
+	ext := "." + strings.TrimPrefix(strings.ToLower(strings.TrimSpace(format)), ".")
+	if mt := mime.TypeByExtension(ext); mt != "" {
+		return mt
+	}
+	switch kind {
+	case "video":
+		return "video/" + strings.TrimPrefix(ext, ".")
+	case "music":
+		if ext == ".mp3" {
+			return "audio/mpeg"
+		}
+		return "audio/" + strings.TrimPrefix(ext, ".")
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func trimForError(data []byte) string {
+	s := strings.TrimSpace(string(data))
+	if len(s) > 2048 {
+		s = s[:2048] + "..."
+	}
+	return s
+}

--- a/core/media_generation_test.go
+++ b/core/media_generation_test.go
@@ -1,0 +1,145 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMiniMaxMusicGenerator_GenerateHexAudio(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"audio":  "6d7033",
+				"status": 2,
+			},
+			"base_resp": map[string]any{
+				"status_code": 0,
+				"status_msg":  "success",
+			},
+		})
+	}))
+	defer ts.Close()
+
+	gen := NewMiniMaxMusicGenerator("sk-test", ts.URL, "music-2.6-free", ts.Client())
+	audio, format, err := gen.GenerateMusic(context.Background(), "ambient piano", MusicGenerationOpts{
+		LyricsOptimizer: true,
+		Instrumental:    true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateMusic() error = %v", err)
+	}
+	if string(audio) != "mp3" || format != "mp3" {
+		t.Fatalf("audio/format = %q/%q, want mp3/mp3", audio, format)
+	}
+	if gotPath != "/v1/music_generation" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer sk-test" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotBody["model"] != "music-2.6-free" || gotBody["prompt"] != "ambient piano" {
+		t.Fatalf("body = %#v", gotBody)
+	}
+	if gotBody["is_instrumental"] != true {
+		t.Fatalf("music flags not sent: %#v", gotBody)
+	}
+	if gotBody["lyrics_optimizer"] != nil {
+		t.Fatalf("lyrics_optimizer should not be sent for instrumental music: %#v", gotBody)
+	}
+}
+
+func TestMiniMaxMusicGenerator_PromptOnlyEnablesLyricsOptimizer(t *testing.T) {
+	var gotBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"audio":  "6d7033",
+				"status": 2,
+			},
+			"base_resp": map[string]any{
+				"status_code": 0,
+				"status_msg":  "success",
+			},
+		})
+	}))
+	defer ts.Close()
+
+	gen := NewMiniMaxMusicGenerator("sk-test", ts.URL, "", ts.Client())
+	if _, _, err := gen.GenerateMusic(context.Background(), "upbeat pop chorus", MusicGenerationOpts{}); err != nil {
+		t.Fatalf("GenerateMusic() error = %v", err)
+	}
+	if gotBody["lyrics_optimizer"] != true {
+		t.Fatalf("lyrics_optimizer not auto-enabled for prompt-only song: %#v", gotBody)
+	}
+	if gotBody["is_instrumental"] != nil {
+		t.Fatalf("is_instrumental should not be sent by default: %#v", gotBody)
+	}
+}
+
+func TestMiniMaxVideoGenerator_GeneratePollsAndDownloads(t *testing.T) {
+	var requested []string
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.Method+" "+r.URL.String())
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/video_generation":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode create: %v", err)
+			}
+			if body["prompt"] != "cinematic sunset" || body["model"] != "MiniMax-Hailuo-2.3" {
+				t.Fatalf("create body = %#v", body)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"task_id": "task-1", "base_resp": map[string]any{"status_code": 0}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/query/video_generation":
+			if r.URL.Query().Get("task_id") != "task-1" {
+				t.Fatalf("task_id = %q", r.URL.Query().Get("task_id"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "Success", "file_id": "file-1", "base_resp": map[string]any{"status_code": 0}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/files/retrieve":
+			if r.URL.Query().Get("file_id") != "file-1" {
+				t.Fatalf("file_id = %q", r.URL.Query().Get("file_id"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"file": map[string]any{"download_url": ts.URL + "/download.mp4"}, "base_resp": map[string]any{"status_code": 0}})
+		case r.Method == http.MethodGet && r.URL.Path == "/download.mp4":
+			_, _ = w.Write([]byte("video-bytes"))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ts.Close()
+
+	gen := NewMiniMaxVideoGenerator("sk-test", ts.URL, "", ts.Client())
+	gen.PollInterval = time.Millisecond
+	gen.Timeout = time.Second
+	gen.DownloadClient = ts.Client()
+
+	video, format, err := gen.GenerateVideo(context.Background(), "cinematic sunset")
+	if err != nil {
+		t.Fatalf("GenerateVideo() error = %v", err)
+	}
+	if string(video) != "video-bytes" || format != "mp4" {
+		t.Fatalf("video/format = %q/%q", video, format)
+	}
+	got := strings.Join(requested, "\n")
+	for _, want := range []string{"POST /v1/video_generation", "GET /v1/query/video_generation?task_id=task-1", "GET /v1/files/retrieve?file_id=file-1", "GET /download.mp4"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("requests =\n%s\nmissing %s", got, want)
+		}
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -736,9 +736,9 @@ Switch: `/tts always` or `/tts voice_only`
 
 ---
 
-## Image, File, and Voice Send-Back
+## Image, File, Voice, and Generated Media Send-Back
 
-When an agent generates a local image, PDF, report, bundle, or other file and needs to deliver it directly to the current chat, use attachment mode in `cc-connect send`. When the user explicitly asks for a voice message, the agent can also send synthesized speech through the same CLI.
+When an agent generates a local image, PDF, report, bundle, or other file and needs to deliver it directly to the current chat, use attachment mode in `cc-connect send`. When the user explicitly asks for a voice message, the agent can also send synthesized speech through the same CLI. If `[video]` or `[music]` is configured, the agent can generate video/music directly through the provider and send the result back as an attachment.
 
 **Currently supported platforms:**
 - Feishu
@@ -762,6 +762,7 @@ These two commands write the same cc-connect instructions. Either one is enough.
 - normal text replies should be returned normally
 - generated attachments should be sent back with `cc-connect send --image/--file`
 - requested voice messages should be sent with `cc-connect send --tts`
+- generated video/music should be sent with `cc-connect send --generate-video` or `--generate-music`
 
 If you have run setup before, run it again after upgrading so the instructions are refreshed to the latest version.
 
@@ -773,7 +774,40 @@ Add this to `config.toml` if you want to disable agent-driven attachment send-ba
 attachment_send = "off"
 ```
 
-The default is `on`. This switch is independent from the agent's `/mode` and only affects `cc-connect send --image/--file`. Synthesized voice send-back uses the `[tts]` provider config and is controlled by TTS availability instead.
+The default is `on`. This switch is independent from the agent's `/mode` and affects `cc-connect send --image/--file` plus generated media delivery from `--generate-video/--generate-music`. Synthesized voice send-back uses the `[tts]` provider config and is controlled by TTS availability instead.
+
+### Generated video/music providers
+
+Generated media uses provider settings in `config.toml`. MiniMax is currently supported; if `api_key` is empty, cc-connect reads the same MiniMax JSON config path used by TTS (`data_dir/config/minimax.json` by default).
+
+```toml
+[video]
+enabled = true
+provider = "minimax"
+
+[video.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # default: https://api.minimaxi.com
+model = "MiniMax-Hailuo-2.3"
+duration = 6
+resolution = "1080P"
+poll_interval_secs = 10
+timeout_secs = 600
+
+[music]
+enabled = true
+provider = "minimax"
+
+[music.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # default: https://api.minimaxi.com
+model = "music-2.6"
+sample_rate = 44100
+bitrate = 256000
+format = "mp3"
+lyrics_optimizer = true
+instrumental = false
+```
 
 ### CLI examples
 
@@ -782,16 +816,21 @@ cc-connect send --image /absolute/path/to/chart.png
 cc-connect send --file /absolute/path/to/report.pdf
 cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
 cc-connect send --tts "Hello from cc-connect"
+cc-connect send --generate-video "A cinematic sunrise over Hangzhou, 6 seconds"
+cc-connect send --generate-music "Ambient synthwave, night drive" --music-instrumental
+cc-connect send --generate-music "Upbeat pop chorus about shipping code" --music-lyrics-optimizer
 ```
 
 Notes:
 - `--image` is for image attachments.
 - `--file` is for any file attachment.
 - `--tts` synthesizes text and sends the generated audio through the active TTS provider.
+- `--generate-video` and `--generate-music` use configured providers and send the generated media as file attachments.
+- `--music-lyrics` provides explicit lyrics; `--music-lyrics-optimizer` lets the provider generate lyrics from the music prompt.
 - `--message` is optional and sends a text note before the attachments.
 - `--image` and `--file` can both be repeated.
 - Absolute paths are recommended so the command does not depend on the agent's current working directory.
-- With `attachment_send = "off"`, image/file send-back is blocked but ordinary text replies still work.
+- With `attachment_send = "off"`, image/file/generated-media send-back is blocked but ordinary text replies still work.
 
 ### Typical use cases
 
@@ -799,6 +838,7 @@ Notes:
 2. The agent generates a PDF, Markdown export, log bundle, or patch file that should be delivered as an attachment.
 3. The agent wants to send a short status message together with one or more generated files.
 4. The user asks the agent to "send this as voice" without typing a slash command.
+5. The user asks the agent to generate a short video or piece of music and the matching provider is configured.
 
 ### Important notes
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -649,9 +649,9 @@ speed = 0.96
 
 ---
 
-## 图片、文件与语音回传
+## 图片、文件、语音和生成媒体回传
 
-当 Agent 在本地生成了图片、PDF、日志包、报表等文件，需要把结果直接发回当前聊天时，可以使用 `cc-connect send` 的附件模式。用户明确要求“发语音”时，Agent 也可以用同一个 CLI 走 TTS 合成并发送语音。
+当 Agent 在本地生成了图片、PDF、日志包、报表等文件，需要把结果直接发回当前聊天时，可以使用 `cc-connect send` 的附件模式。用户明确要求“发语音”时，Agent 也可以用同一个 CLI 走 TTS 合成并发送语音。如果配置了 `[video]` 或 `[music]`，Agent 还可以直接通过 provider 生成视频/音乐，并把结果作为附件回传。
 
 **当前支持平台：**
 - 飞书
@@ -675,6 +675,7 @@ speed = 0.96
 - 普通文本回复直接正常输出
 - 生成附件后用 `cc-connect send --image/--file` 回传
 - 用户要求语音时用 `cc-connect send --tts` 回传
+- 生成视频/音乐时用 `cc-connect send --generate-video` 或 `--generate-music` 回传
 
 如果你以前已经执行过 setup，也建议升级后重新执行一次，以刷新到最新指令。
 
@@ -686,7 +687,40 @@ speed = 0.96
 attachment_send = "off"
 ```
 
-默认值是 `on`。这个开关与 agent 的 `/mode` 独立，只影响 `cc-connect send --image/--file` 这条图片/文件回传路径。TTS 语音回传走 `[tts]` provider 配置，由 TTS 是否可用决定。
+默认值是 `on`。这个开关与 agent 的 `/mode` 独立，影响 `cc-connect send --image/--file` 以及 `--generate-video/--generate-music` 生成媒体回传。TTS 语音回传走 `[tts]` provider 配置，由 TTS 是否可用决定。
+
+### 生成视频/音乐 provider
+
+生成媒体使用 `config.toml` 里的 provider 配置。目前支持 MiniMax；如果 `api_key` 留空，cc-connect 会读取与 TTS 相同的 MiniMax JSON 配置路径（默认 `data_dir/config/minimax.json`）。
+
+```toml
+[video]
+enabled = true
+provider = "minimax"
+
+[video.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # 默认：https://api.minimaxi.com
+model = "MiniMax-Hailuo-2.3"
+duration = 6
+resolution = "1080P"
+poll_interval_secs = 10
+timeout_secs = 600
+
+[music]
+enabled = true
+provider = "minimax"
+
+[music.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # 默认：https://api.minimaxi.com
+model = "music-2.6"
+sample_rate = 44100
+bitrate = 256000
+format = "mp3"
+lyrics_optimizer = true
+instrumental = false
+```
 
 ### CLI 用法
 
@@ -695,16 +729,21 @@ cc-connect send --image /absolute/path/to/chart.png
 cc-connect send --file /absolute/path/to/report.pdf
 cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
 cc-connect send --tts "你好"
+cc-connect send --generate-video "杭州日出的电影感镜头，6 秒"
+cc-connect send --generate-music "夜间驾驶氛围 synthwave" --music-instrumental
+cc-connect send --generate-music "关于发布代码的轻快流行副歌" --music-lyrics-optimizer
 ```
 
 说明：
 - `--image` 用于图片附件。
 - `--file` 用于任意文件附件。
 - `--tts` 会合成文本并通过当前 TTS provider 发送语音。
+- `--generate-video` 和 `--generate-music` 使用已配置 provider 生成媒体，并以文件附件回传。
+- `--music-lyrics` 提供明确歌词；`--music-lyrics-optimizer` 让 provider 根据音乐 prompt 生成歌词。
 - `--message` 可选，用于先发一段说明文字，再发附件。
 - `--image` 和 `--file` 都可以重复多次。
 - 建议使用绝对路径，避免 Agent 当前工作目录变化导致找不到文件。
-- 如果设置了 `attachment_send = "off"`，图片/文件回传会被拒绝，但普通文本回复仍然正常。
+- 如果设置了 `attachment_send = "off"`，图片/文件/生成媒体回传会被拒绝，但普通文本回复仍然正常。
 
 ### 典型场景
 
@@ -712,10 +751,11 @@ cc-connect send --tts "你好"
 2. Agent 生成了 PDF、Markdown 导出、日志包或补丁文件，需要作为附件交付。
 3. Agent 想告诉用户“结果已生成”，同时附上一个或多个文件。
 4. 用户自然说“发句 xx 的语音”，不想手输 slash 命令。
+5. 用户要求生成一段短视频或音乐，且对应 provider 已配置。
 
 ### 注意事项
 
-- 这个命令是给“附件和语音回传”用的，不要拿它代替普通文本回复。
+- 这个命令是给“附件、生成媒体和语音回传”用的，不要拿它代替普通文本回复。
 - 只能发送本机上 Agent 可访问到的文件。
 - 必须存在活跃会话；如果当前项目没有活动聊天上下文，命令会失败。
 - 平台本身仍可能有文件大小或文件类型限制。


### PR DESCRIPTION
## Summary
- add configurable `[video]` and `[music]` provider blocks for direct media generation from `cc-connect send`
- implement MiniMax text-to-video and text-to-music generators, including async video polling/download and hex audio decoding
- add `cc-connect send --generate-video`, `--generate-music`, `--music-lyrics`, `--music-instrumental`, and `--music-lyrics-optimizer`
- refresh setup prompt/docs/config examples so agents can use generated media without extra CLIs or skills

## Notes
- Generated video/music is delivered as file attachments, so `attachment_send = "off"` rejects before provider generation starts.
- If MiniMax `api_key` is empty, the generator reuses the local MiniMax JSON config path used by TTS.
- Prompt-only lyric music requests auto-enable MiniMax lyrics optimization unless instrumental mode is requested.

## Tests
- `go test ./core ./cmd/cc-connect ./config`
- `git diff --check`

## Full test sweep
`go test ./...` was run and failed in packages outside this change path:
- `agent/codex`: `TestGetModelAndReasoningEffort_FromRuntimeConfigWhenUnset` got empty model, expected `gpt-5.4`
- `daemon`: `TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable` got `Running = false`, expected true
