### PR TITLE
test(core): restore 9 PR #603 coverage unit tests

### DIFF
--- a/core/session_test.go
+++ b/core/session_test.go
@@ -897,3 +897,187 @@ func TestPruneDuplicateSessions_Persistence(t *testing.T) {
 		t.Errorf("merged history after reload = %d, want 2", len(history))
 	}
 }
+
+// TestSwitchToAgentSession_PreservesOldSession locks down that switching the
+// active session to a different agent_session_id keeps the previous ID in
+// KnownAgentSessionIDs so it stays visible to /list, /switch, and
+// filterOwnedSessions. Regression test for #603 / issue #600.
+func TestSwitchToAgentSession_PreservesOldSession(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSessionManager(dir + "/sessions.json")
+	userKey := "user:alice"
+
+	s1 := sm.GetOrCreateActive(userKey)
+	s1.SetAgentInfo("agent-A", "claude", "session A")
+
+	known := sm.KnownAgentSessionIDs()
+	if _, ok := known["agent-A"]; !ok {
+		t.Fatal("agent-A should be in KnownAgentSessionIDs before switch")
+	}
+
+	s2 := sm.SwitchToAgentSession(userKey, "agent-B", "claude", "session B")
+	if s2.GetAgentSessionID() != "agent-B" {
+		t.Fatalf("switched session AgentSessionID = %q, want agent-B", s2.GetAgentSessionID())
+	}
+
+	known = sm.KnownAgentSessionIDs()
+	if _, ok := known["agent-A"]; !ok {
+		t.Fatal("agent-A should still be in KnownAgentSessionIDs after switch")
+	}
+	if _, ok := known["agent-B"]; !ok {
+		t.Fatal("agent-B should be in KnownAgentSessionIDs after switch")
+	}
+}
+
+func TestSwitchToAgentSession_ReusesExisting(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSessionManager(dir + "/sessions.json")
+	userKey := "user:bob"
+
+	s1 := sm.GetOrCreateActive(userKey)
+	s1.SetAgentInfo("agent-A", "claude", "session A")
+
+	sm.SwitchToAgentSession(userKey, "agent-B", "claude", "session B")
+
+	s3 := sm.SwitchToAgentSession(userKey, "agent-A", "claude", "session A")
+	if s3.ID != s1.ID {
+		t.Fatalf("switching back to agent-A should reuse session %s, got %s", s1.ID, s3.ID)
+	}
+}
+
+func TestPastAgentSessionIDs_ClearPreservesHistory(t *testing.T) {
+	s := &Session{}
+	s.SetAgentSessionID("thread-1", "codex")
+	s.SetAgentSessionID("", "")
+
+	if len(s.PastAgentSessionIDs) != 1 || s.PastAgentSessionIDs[0] != "thread-1" {
+		t.Fatalf("PastAgentSessionIDs = %v, want [thread-1]", s.PastAgentSessionIDs)
+	}
+}
+
+func TestPastAgentSessionIDs_ReplacePreservesHistory(t *testing.T) {
+	s := &Session{}
+	s.SetAgentSessionID("thread-1", "codex")
+	s.SetAgentSessionID("thread-2", "codex")
+
+	if len(s.PastAgentSessionIDs) != 1 || s.PastAgentSessionIDs[0] != "thread-1" {
+		t.Fatalf("PastAgentSessionIDs = %v, want [thread-1]", s.PastAgentSessionIDs)
+	}
+	if s.AgentSessionID != "thread-2" {
+		t.Fatalf("AgentSessionID = %q, want thread-2", s.AgentSessionID)
+	}
+}
+
+func TestPastAgentSessionIDs_NoDuplicates(t *testing.T) {
+	s := &Session{}
+	s.SetAgentSessionID("thread-1", "codex")
+	s.SetAgentSessionID("", "")
+	s.SetAgentSessionID("thread-1", "codex")
+	s.SetAgentSessionID("", "")
+
+	if len(s.PastAgentSessionIDs) != 1 {
+		t.Fatalf("PastAgentSessionIDs has duplicates: %v", s.PastAgentSessionIDs)
+	}
+}
+
+func TestPastAgentSessionIDs_ContinueSentinelNotRecorded(t *testing.T) {
+	s := &Session{}
+	s.SetAgentSessionID(ContinueSession, "codex")
+	s.SetAgentSessionID("real-id", "codex")
+	s.SetAgentSessionID("", "")
+
+	for _, past := range s.PastAgentSessionIDs {
+		if past == ContinueSession {
+			t.Fatal("ContinueSession sentinel should not be in PastAgentSessionIDs")
+		}
+	}
+	if len(s.PastAgentSessionIDs) != 1 || s.PastAgentSessionIDs[0] != "real-id" {
+		t.Fatalf("PastAgentSessionIDs = %v, want [real-id]", s.PastAgentSessionIDs)
+	}
+}
+
+func TestKnownAgentSessionIDs_IncludesPast(t *testing.T) {
+	sm := NewSessionManager("")
+	s1 := sm.NewSession("user1", "a")
+	s1.SetAgentSessionID("thread-aaa", "codex")
+	s1.SetAgentSessionID("", "")
+
+	s2 := sm.NewSession("user1", "b")
+	s2.SetAgentSessionID("thread-bbb", "codex")
+
+	known := sm.KnownAgentSessionIDs()
+	if _, ok := known["thread-aaa"]; !ok {
+		t.Fatal("expected thread-aaa (past ID) in known set")
+	}
+	if _, ok := known["thread-bbb"]; !ok {
+		t.Fatal("expected thread-bbb (current ID) in known set")
+	}
+}
+
+// TestKnownAgentSessionIDs_ReproducesNewCommandBug simulates the exact user
+// reproduction steps: repeated /new commands progressively clear AgentSessionIDs.
+// Before the PastAgentSessionIDs fix, only the latest session would remain visible.
+func TestKnownAgentSessionIDs_ReproducesNewCommandBug(t *testing.T) {
+	sm := NewSessionManager("")
+	userKey := "user:test"
+
+	agentSessions := []AgentSessionInfo{
+		{ID: "codex-thread-1"},
+		{ID: "codex-thread-2"},
+		{ID: "codex-thread-3"},
+	}
+
+	s1 := sm.GetOrCreateActive(userKey)
+	s1.SetAgentSessionID("codex-thread-1", "codex")
+
+	s1.SetAgentSessionID("", "")
+	s2 := sm.NewSession(userKey, "session 2")
+	s2.SetAgentSessionID("codex-thread-2", "codex")
+
+	s2.SetAgentSessionID("", "")
+	s3 := sm.NewSession(userKey, "session 3")
+	s3.SetAgentSessionID("codex-thread-3", "codex")
+
+	known := sm.KnownAgentSessionIDs()
+	filtered := filterOwnedSessions(agentSessions, known)
+
+	if len(filtered) != 3 {
+		t.Fatalf("filterOwnedSessions returned %d sessions, want 3 (all should be visible)\nknown IDs: %v",
+			len(filtered), known)
+	}
+}
+
+// TestKnownAgentSessionIDs_ResetAllSessionsBug simulates resetAllSessions
+// clearing all IDs (management API provider switch). Past IDs should keep
+// all sessions visible.
+func TestKnownAgentSessionIDs_ResetAllSessionsBug(t *testing.T) {
+	sm := NewSessionManager("")
+	userKey := "user:test"
+
+	s1 := sm.NewSession(userKey, "a")
+	s1.SetAgentSessionID("thread-1", "codex")
+	s2 := sm.NewSession(userKey, "b")
+	s2.SetAgentSessionID("thread-2", "codex")
+	s3 := sm.NewSession(userKey, "c")
+	s3.SetAgentSessionID("thread-3", "codex")
+
+	for _, s := range sm.AllSessions() {
+		s.SetAgentSessionID("", "")
+	}
+
+	known := sm.KnownAgentSessionIDs()
+	for _, id := range []string{"thread-1", "thread-2", "thread-3"} {
+		if _, ok := known[id]; !ok {
+			t.Fatalf("expected %s in known set after resetAllSessions, known = %v", id, known)
+		}
+	}
+
+	agentSessions := []AgentSessionInfo{
+		{ID: "thread-1"}, {ID: "thread-2"}, {ID: "thread-3"},
+	}
+	filtered := filterOwnedSessions(agentSessions, known)
+	if len(filtered) != 3 {
+		t.Fatalf("filterOwnedSessions returned %d, want 3", len(filtered))
+	}
+}
+


### PR DESCRIPTION
## Summary

PR #603 (cafc802a, "feat(core): add session prune command to remove duplicate sessions") was merged but accidentally lost 9 unit tests targeting `SwitchToAgentSession`, `recordPastAgentSessionID`, and `KnownAgentSessionIDs` — production functions the PR kept. The production code never lost those behaviors, but the test coverage dropped by 9.

PR #603's branch already restored the 9 tests at commit 3392323b, but that commit lived on the merged branch and never made it onto main. This PR re-applies the same 9-test diff onto current main via cherry-pick so coverage restoration can land via a separate review path while the original PR #603 stays merged.

## Background

- Issue #600: legacy-session-preservation invariant
- PR #603 (cafc802a, merged): S1011 fix + `/prune` subcommand + `--empty`/`--merge` flags + 7 new `TestPruneDuplicateSessions_*` tests — but accidentally removed 9 pre-existing tests
- PR #603 branch commit 3392323b: restored the 9 tests byte-for-byte from `4e61c8f5:core/session_test.go` (the pre-rebase base)
- PM msg-20260609-kk5fl6: per lvsgh4 scope rule, route this via a new PR instead of reopening PR #603

## Changes

Cherry-pick of `3392323b` onto current main (5e2f3b9e). Single commit, +184 lines in `core/session_test.go`. **0 production code touched.**

The 9 restored tests:
- `TestSwitchToAgentSession_PreservesOldSession`
- `TestSwitchToAgentSession_ReusesExisting`
- `TestPastAgentSessionIDs_ClearPreservesHistory`
- `TestPastAgentSessionIDs_ReplacePreservesHistory`
- `TestPastAgentSessionIDs_NoDuplicates`
- `TestPastAgentSessionIDs_ContinueSentinelNotRecorded`
- `TestKnownAgentSessionIDs_IncludesPast`
- `TestKnownAgentSessionIDs_ReproducesNewCommandBug`
- `TestKnownAgentSessionIDs_ResetAllSessionsBug`

## Lineage

```
4e61c8f5  (had the 9 tests on PR #603 pre-rebase base)
  ↓
cafc802a  (PR #603 merge → accidentally dropped the 9 tests)
  ↓
3392323b  (restored the 9 tests on PR #603 branch — not landed)
  ↓ (this PR)
5e2f3b9e +9 tests back on main  ← here
```

## Test plan

- [x] `go test -count=1 -tags no_web ./core/` → ok 42.245s
  - All 48 `core/session_test.go` tests pass (39 existing + 9 restored)
  - All 1241 sub-test runs across `./core/` green
- [x] `go test -count=1 -tags no_web -v -run 'TestSwitchToAgentSession|TestPastAgentSessionIDs|TestKnownAgentSessionIDs_IncludesPast|TestKnownAgentSessionIDs_ReproducesNewCommandBug|TestKnownAgentSessionIDs_ResetAllSessionsBug' ./core/` → 9/9 PASS
- [x] `go vet -tags no_web ./core/...` → clean
- [x] Co-existence: 9 new tests live alongside existing `TestPruneDuplicateSessions_*` in same file, no namespace pollution
- [x] S1011 fix at `core/session.go:878` (`keep.History = append(keep.History, old.History...)`) and `:879` (`sort.SliceStable`) intact

## Cherry-pick attribution

This is a verbatim cherry-pick of `3392323b` from PR #603's branch. The 9 tests themselves are byte-for-byte identical to those in `4e61c8f5:core/session_test.go` (verified by QA in msg-20260609-odbt9x using awk next-func body + `diff -q` clean). No production code change.

Refs #600, #603