### PR TITLE
fix(qoder): emit streaming text without dropping final result

### DIFF
--- a/agent/qoder/qoder_test.go
+++ b/agent/qoder/qoder_test.go
@@ -252,25 +252,112 @@ func TestHandleAssistant_ToolUseStopReason(t *testing.T) {
 	}
 }
 
-func TestHandleAssistant_SkipsNonFinished(t *testing.T) {
+func TestHandleAssistant_EmitsNonFinishedText(t *testing.T) {
 	qs := newTestSession()
 	defer qs.cancel()
 
-	// Neither status="finished" nor stop_reason set — should be skipped
+	// Newer qodercli stream-json can emit partial text before the final frame.
 	ev := &streamEvent{
 		Type: "assistant",
 		Message: &streamMessage{
-			Status:  "tool_calling",
-			Content: []byte(`[{"type":"text","text":"should be skipped"}]`),
+			ID:      "msg-partial",
+			Status:  "streaming",
+			Content: []byte(`[{"type":"text","text":"partial"}]`),
 		},
 	}
 	qs.handleEvent(ev)
 
 	select {
 	case got := <-qs.events:
-		t.Errorf("expected no event, got type=%s content=%q", got.Type, got.Content)
+		if got.Type != core.EventText || got.Content != "partial" {
+			t.Errorf("got type=%s content=%q, want EventText/partial", got.Type, got.Content)
+		}
 	default:
-		// ok
+		t.Error("expected a text event but channel was empty")
+	}
+}
+
+func TestHandleAssistant_SkipsThinkingWithoutBlockingSameMessageText(t *testing.T) {
+	qs := newTestSession()
+	defer qs.cancel()
+
+	thinking := &streamEvent{
+		Type: "assistant",
+		Message: &streamMessage{
+			ID:      "msg-same-id",
+			Content: []byte(`[{"type":"thinking","thinking":"hidden"},{"type":"redacted_thinking","data":"secret"}]`),
+		},
+	}
+	text := &streamEvent{
+		Type: "assistant",
+		Message: &streamMessage{
+			ID:         "msg-same-id",
+			StopReason: "end_turn",
+			Content:    []byte(`[{"type":"text","text":"visible answer"}]`),
+		},
+	}
+
+	qs.handleEvent(thinking)
+	select {
+	case got := <-qs.events:
+		t.Fatalf("expected thinking frames to be skipped, got type=%s content=%q", got.Type, got.Content)
+	default:
+	}
+
+	qs.handleEvent(text)
+	select {
+	case got := <-qs.events:
+		if got.Type != core.EventText || got.Content != "visible answer" {
+			t.Errorf("got type=%s content=%q, want EventText/visible answer", got.Type, got.Content)
+		}
+	default:
+		t.Error("expected text after thinking frames")
+	}
+}
+
+func TestHandleAssistant_DeduplicatesCumulativeTextForSameMessageID(t *testing.T) {
+	qs := newTestSession()
+	defer qs.cancel()
+
+	events := []*streamEvent{
+		{
+			Type: "assistant",
+			Message: &streamMessage{
+				ID:      "msg-cumulative",
+				Status:  "streaming",
+				Content: []byte(`[{"type":"text","text":"Hello"}]`),
+			},
+		},
+		{
+			Type: "assistant",
+			Message: &streamMessage{
+				ID:      "msg-cumulative",
+				Status:  "streaming",
+				Content: []byte(`[{"type":"text","text":"Hello world"}]`),
+			},
+		},
+		{
+			Type: "assistant",
+			Message: &streamMessage{
+				ID:         "msg-cumulative",
+				StopReason: "end_turn",
+				Content:    []byte(`[{"type":"text","text":"Hello world"}]`),
+			},
+		},
+	}
+	for _, ev := range events {
+		qs.handleEvent(ev)
+	}
+
+	got := drainQoderEvents(qs)
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2: %#v", len(got), got)
+	}
+	if got[0].Type != core.EventText || got[0].Content != "Hello" {
+		t.Errorf("event 0 = %s %q, want EventText Hello", got[0].Type, got[0].Content)
+	}
+	if got[1].Type != core.EventText || got[1].Content != " world" {
+		t.Errorf("event 1 = %s %q, want EventText ' world'", got[1].Type, got[1].Content)
 	}
 }
 
@@ -340,5 +427,17 @@ func TestHandleResult_OldFormatTakesPriority(t *testing.T) {
 		}
 	default:
 		t.Error("expected a result event but channel was empty")
+	}
+}
+
+func drainQoderEvents(qs *qoderSession) []core.Event {
+	var events []core.Event
+	for {
+		select {
+		case ev := <-qs.events:
+			events = append(events, ev)
+		default:
+			return events
+		}
 	}
 }

--- a/agent/qoder/qoder_test.go
+++ b/agent/qoder/qoder_test.go
@@ -277,7 +277,7 @@ func TestHandleAssistant_EmitsNonFinishedText(t *testing.T) {
 	}
 }
 
-func TestHandleAssistant_SkipsThinkingWithoutBlockingSameMessageText(t *testing.T) {
+func TestHandleAssistant_ThinkingDoesNotBlockTextOnSameID(t *testing.T) {
 	qs := newTestSession()
 	defer qs.cancel()
 
@@ -358,6 +358,34 @@ func TestHandleAssistant_DeduplicatesCumulativeTextForSameMessageID(t *testing.T
 	}
 	if got[1].Type != core.EventText || got[1].Content != " world" {
 		t.Errorf("event 1 = %s %q, want EventText ' world'", got[1].Type, got[1].Content)
+	}
+}
+
+func TestEmitAssistantTextBoundsDedupCache(t *testing.T) {
+	qs := newTestSession()
+	defer qs.cancel()
+
+	for i := 0; i < maxAssistantTextCacheEntries+1; i++ {
+		if !qs.emitAssistantText(fmt.Sprintf("msg-%d", i), "chunk") {
+			t.Fatalf("emitAssistantText(%d) returned false", i)
+		}
+		select {
+		case <-qs.events:
+		default:
+			t.Fatalf("expected emitted chunk for message %d", i)
+		}
+	}
+
+	qs.textMu.Lock()
+	defer qs.textMu.Unlock()
+	if got := len(qs.assistantTextByID); got != maxAssistantTextCacheEntries {
+		t.Fatalf("assistantTextByID len = %d, want %d", got, maxAssistantTextCacheEntries)
+	}
+	if _, ok := qs.assistantTextByID["msg-0"]; ok {
+		t.Fatal("oldest cached message id was not evicted")
+	}
+	if _, ok := qs.assistantTextByID[fmt.Sprintf("msg-%d", maxAssistantTextCacheEntries)]; !ok {
+		t.Fatal("newest cached message id was not retained")
 	}
 }
 

--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -35,9 +35,12 @@ type qoderSession struct {
 	alive          atomic.Bool
 	startupWarning string
 
-	textMu            sync.Mutex
-	assistantTextByID map[string]string
+	textMu             sync.Mutex
+	assistantTextByID  map[string]string
+	assistantTextOrder []string
 }
+
+const maxAssistantTextCacheEntries = 1024
 
 // StartupWarning implements core.StartupWarner. Returns a non-empty string
 // when the session was started under degraded conditions (e.g. yolo mode
@@ -324,11 +327,13 @@ func (qs *qoderSession) emitAssistantText(messageID, text string) bool {
 			return true
 		case prev != "" && strings.HasPrefix(text, prev):
 			chunk = strings.TrimPrefix(text, prev)
-			qs.assistantTextByID[messageID] = text
+			qs.setAssistantTextLocked(messageID, text)
 		case prev != "":
-			qs.assistantTextByID[messageID] = prev + text
+			// qoder occasionally sends a standalone fragment after cumulative
+			// frames; emit only the new fragment and remember the joined text.
+			qs.setAssistantTextLocked(messageID, prev+text)
 		default:
-			qs.assistantTextByID[messageID] = text
+			qs.setAssistantTextLocked(messageID, text)
 		}
 		qs.textMu.Unlock()
 	}
@@ -343,6 +348,19 @@ func (qs *qoderSession) emitAssistantText(messageID, text string) bool {
 	case <-qs.ctx.Done():
 		return false
 	}
+}
+
+func (qs *qoderSession) setAssistantTextLocked(messageID, text string) {
+	if _, ok := qs.assistantTextByID[messageID]; !ok {
+		qs.assistantTextOrder = append(qs.assistantTextOrder, messageID)
+		if len(qs.assistantTextOrder) > maxAssistantTextCacheEntries {
+			evictID := qs.assistantTextOrder[0]
+			copy(qs.assistantTextOrder, qs.assistantTextOrder[1:])
+			qs.assistantTextOrder = qs.assistantTextOrder[:len(qs.assistantTextOrder)-1]
+			delete(qs.assistantTextByID, evictID)
+		}
+	}
+	qs.assistantTextByID[messageID] = text
 }
 
 func (qs *qoderSession) handleResult(ev *streamEvent) {

--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -34,6 +34,9 @@ type qoderSession struct {
 	wg             sync.WaitGroup
 	alive          atomic.Bool
 	startupWarning string
+
+	textMu            sync.Mutex
+	assistantTextByID map[string]string
 }
 
 // StartupWarning implements core.StartupWarner. Returns a non-empty string
@@ -52,6 +55,8 @@ func newQoderSession(ctx context.Context, workDir, model, mode, resumeID string,
 		events:   make(chan core.Event, 64),
 		ctx:      sessionCtx,
 		cancel:   cancel,
+
+		assistantTextByID: make(map[string]string),
 	}
 	qs.alive.Store(true)
 
@@ -267,33 +272,29 @@ func (qs *qoderSession) handleAssistant(ev *streamEvent) {
 		return
 	}
 
-	// qodercli <0.2: uses Status="finished" to indicate final message
-	// qodercli 0.2.x: Status is empty/null, uses StopReason="end_turn"/"tool_use"
-	isFinished := ev.Message.Status == "finished" ||
-		ev.Message.StopReason == "end_turn" ||
-		ev.Message.StopReason == "tool_use"
-	if !isFinished {
-		return
-	}
-
 	var items []contentItem
 	if err := json.Unmarshal(ev.Message.Content, &items); err != nil {
 		return
 	}
 
+	// qodercli <0.2 uses Status="finished" for final messages.
+	// Newer stream-json output can reuse the same message id for thinking,
+	// redacted thinking, partial text, and final text frames.
+	isFinished := ev.Message.Status == "finished" ||
+		ev.Message.StopReason == "end_turn" ||
+		ev.Message.StopReason == "tool_use"
+
 	for _, item := range items {
 		switch item.Type {
 		case "text":
-			if item.Text != "" {
-				evt := core.Event{Type: core.EventText, Content: item.Text}
-				select {
-				case qs.events <- evt:
-				case <-qs.ctx.Done():
-					return
-				}
+			if !qs.emitAssistantText(ev.Message.ID, item.Text) {
+				return
 			}
 
 		case "function":
+			if !isFinished {
+				continue
+			}
 			inputPreview := extractToolPreview(item.Input)
 			evt := core.Event{Type: core.EventToolUse, ToolName: item.Name, ToolInput: inputPreview}
 			select {
@@ -302,6 +303,45 @@ func (qs *qoderSession) handleAssistant(ev *streamEvent) {
 				return
 			}
 		}
+	}
+}
+
+func (qs *qoderSession) emitAssistantText(messageID, text string) bool {
+	if text == "" {
+		return true
+	}
+
+	chunk := text
+	if messageID != "" {
+		qs.textMu.Lock()
+		if qs.assistantTextByID == nil {
+			qs.assistantTextByID = make(map[string]string)
+		}
+		prev := qs.assistantTextByID[messageID]
+		switch {
+		case text == prev:
+			qs.textMu.Unlock()
+			return true
+		case prev != "" && strings.HasPrefix(text, prev):
+			chunk = strings.TrimPrefix(text, prev)
+			qs.assistantTextByID[messageID] = text
+		case prev != "":
+			qs.assistantTextByID[messageID] = prev + text
+		default:
+			qs.assistantTextByID[messageID] = text
+		}
+		qs.textMu.Unlock()
+	}
+
+	if chunk == "" {
+		return true
+	}
+	evt := core.Event{Type: core.EventText, Content: chunk}
+	select {
+	case qs.events <- evt:
+		return true
+	case <-qs.ctx.Done():
+		return false
 	}
 }
 


### PR DESCRIPTION
## Summary
- parse Qoder assistant text frames even before the final finished/end_turn marker so streaming cards receive progressive text
- skip thinking/redacted_thinking frames without letting them occupy message-id de-duplication state
- de-duplicate cumulative text for shared assistant message ids while keeping the top-level result event as the authoritative final answer

Fixes #1270.
Fixes #1279.

## Tests
- go test ./agent/qoder
- go test ./agent/qoder ./core ./config
- git diff --check

## Notes
- go test -tags no_web ./... was also attempted locally and still hits existing environment/flaky failures outside this patch path: agent/codex mock CLI/runtime-config timeouts, agent/iflow pending-tool timeout, and daemon launchd status on macOS.