### PR TITLE
fix(core): resolve thread parent for cron workspace binding in multi-workspace mode

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -1296,9 +1296,35 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		channelID := extractChannelID(sessionKey)
 		if channelID != "" {
 			workspace, _, err := e.resolveWorkspace(targetPlatform, channelID)
-			if err == nil && workspace != "" {
-				wsAgent, wsSessions, _, effectiveDir, err := e.workspaceContext(workspace, sessionKey)
-				if err == nil {
+			if err == nil && workspace == "" {
+				// The stored key may carry a thread ID (e.g. Discord with
+				// thread_isolation rewrites session keys to "discord:<threadID>")
+				// while workspace bindings are keyed by the parent channel.
+				// Ask the platform for the parent and retry the lookup.
+				if resolver, ok := targetPlatform.(ThreadParentResolver); ok {
+					parent, perr := resolver.ResolveThreadParent(channelID)
+					switch {
+					case perr != nil:
+						slog.Warn("cron: thread parent lookup failed",
+							"job", job.ID, "channel", channelID, "error", perr)
+					case parent != "" && parent != channelID:
+						workspace, _, err = e.resolveWorkspace(targetPlatform, parent)
+					}
+				}
+			}
+			switch {
+			case err != nil:
+				slog.Warn("cron: workspace resolution failed, using global agent",
+					"job", job.ID, "session_key", sessionKey, "error", err)
+			case workspace == "":
+				slog.Warn("cron: no workspace binding for channel, using global agent",
+					"job", job.ID, "session_key", sessionKey, "channel", channelID)
+			default:
+				wsAgent, wsSessions, _, effectiveDir, wcErr := e.workspaceContext(workspace, sessionKey)
+				if wcErr != nil {
+					slog.Warn("cron: workspace agent unavailable, using global agent",
+						"job", job.ID, "workspace", workspace, "error", wcErr)
+				} else {
 					agent = wsAgent
 					sessions = wsSessions
 					workspaceDir = effectiveDir

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -12320,6 +12320,146 @@ func TestExecuteCronJob_WorkspacePrefixedSessionKey(t *testing.T) {
 	}
 }
 
+// namedResultAgent is a resultAgent whose Name() matches a registered agent
+// factory, so getOrCreateWorkspaceAgent can spawn workspace instances of it.
+type namedResultAgent struct {
+	resultAgent
+	customName string
+}
+
+func (a *namedResultAgent) Name() string { return a.customName }
+
+// stubThreadParentPlatform implements ReplyContextReconstructor and
+// ThreadParentResolver on top of stubPlatformEngine.
+type stubThreadParentPlatform struct {
+	stubPlatformEngine
+	parents         map[string]string
+	resolvedThreads []string
+}
+
+func (p *stubThreadParentPlatform) ReconstructReplyCtx(sessionKey string) (any, error) {
+	return "thread-rctx", nil
+}
+
+func (p *stubThreadParentPlatform) ResolveThreadParent(channelID string) (string, error) {
+	p.resolvedThreads = append(p.resolvedThreads, channelID)
+	if parent, ok := p.parents[channelID]; ok {
+		return parent, nil
+	}
+	return channelID, nil
+}
+
+// Regression for cron jobs whose stored session key carries a Discord thread
+// ID (thread_isolation rewrites guild session keys to "discord:<threadID>"):
+// workspace bindings are keyed by the parent channel, so ExecuteCronJob must
+// consult ThreadParentResolver instead of silently falling back to the
+// global agent.
+func TestExecuteCronJob_ResolvesThreadParentForWorkspaceBinding(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewCronStore() error = %v", err)
+	}
+
+	baseDir := t.TempDir()
+	wsDir := filepath.Join(baseDir, "guanqizhu")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	agentName := "cron-thread-parent-agent"
+	wsSession := newResultAgentSession("workspace done")
+	var factoryWorkDirs []string
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		if wd, _ := opts["work_dir"].(string); wd != "" {
+			factoryWorkDirs = append(factoryWorkDirs, wd)
+		}
+		return &namedResultAgent{resultAgent{session: wsSession}, agentName}, nil
+	})
+
+	globalSession := newResultAgentSession("global done")
+	globalAgent := &namedResultAgent{resultAgent{session: globalSession}, agentName}
+
+	platform := &stubThreadParentPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+		parents:            map[string]string{"T-thread": "C-parent"},
+	}
+
+	// Session path must live in a temp dir: workspace session managers are
+	// created next to it, and "" would litter the package dir during tests.
+	e := NewEngine("test", globalAgent, []Platform{platform},
+		filepath.Join(t.TempDir(), "sessions.json"), LangEnglish)
+	defer e.cancel()
+	e.cronScheduler = NewCronScheduler(store)
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+	e.workspaceBindings.Bind("project:test", "discord:C-parent", "guanqizhu", wsDir)
+
+	job := &CronJob{
+		ID:         "job-thread",
+		SessionKey: "discord:T-thread",
+		Prompt:     "fix rejected ads",
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatalf("store.Add() error = %v", err)
+	}
+
+	if err := e.ExecuteCronJob(job); err != nil {
+		t.Fatalf("ExecuteCronJob() error = %v", err)
+	}
+
+	if len(platform.resolvedThreads) == 0 || platform.resolvedThreads[0] != "T-thread" {
+		t.Fatalf("ResolveThreadParent calls = %v, want [T-thread]", platform.resolvedThreads)
+	}
+	wantDir := normalizeWorkspacePath(wsDir)
+	if len(factoryWorkDirs) != 1 || factoryWorkDirs[0] != wantDir {
+		t.Fatalf("workspace agent work_dirs = %v, want [%s]", factoryWorkDirs, wantDir)
+	}
+	if len(wsSession.sentPrompts) != 1 || !strings.Contains(wsSession.sentPrompts[0], "fix rejected ads") {
+		t.Fatalf("workspace agent prompts = %#v, want the cron prompt", wsSession.sentPrompts)
+	}
+	if len(globalSession.sentPrompts) != 0 {
+		t.Fatalf("global agent prompts = %#v, want none (job must run on workspace agent)", globalSession.sentPrompts)
+	}
+}
+
+// When the thread parent has no binding either, the job must still run —
+// on the global agent — rather than fail.
+func TestExecuteCronJob_NoBindingFallsBackToGlobalAgent(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewCronStore() error = %v", err)
+	}
+
+	globalSession := newResultAgentSession("global done")
+	globalAgent := &namedResultAgent{resultAgent{session: globalSession}, "cron-no-binding-agent"}
+
+	platform := &stubThreadParentPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "discord"},
+	}
+
+	e := NewEngine("test", globalAgent, []Platform{platform},
+		filepath.Join(t.TempDir(), "sessions.json"), LangEnglish)
+	defer e.cancel()
+	e.cronScheduler = NewCronScheduler(store)
+	e.SetMultiWorkspace(t.TempDir(), filepath.Join(t.TempDir(), "bindings.json"))
+
+	job := &CronJob{
+		ID:         "job-unbound",
+		SessionKey: "discord:T-orphan",
+		Prompt:     "daily report",
+	}
+	if err := store.Add(job); err != nil {
+		t.Fatalf("store.Add() error = %v", err)
+	}
+
+	if err := e.ExecuteCronJob(job); err != nil {
+		t.Fatalf("ExecuteCronJob() error = %v", err)
+	}
+
+	if len(globalSession.sentPrompts) != 1 || !strings.Contains(globalSession.sentPrompts[0], "daily report") {
+		t.Fatalf("global agent prompts = %#v, want the cron prompt", globalSession.sentPrompts)
+	}
+}
+
 func TestExecuteCronJob_ExpandsSlashSkillPrompt(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -597,6 +597,17 @@ type ChannelNameResolver interface {
 	ResolveChannelName(channelID string) (string, error)
 }
 
+// ThreadParentResolver is an optional interface for platforms whose session
+// keys may carry a thread ID instead of a channel ID (e.g. Discord with
+// thread_isolation). Workspace bindings are keyed by the parent channel, so
+// sessionKey-only paths (such as cron jobs, whose stored key has no Message
+// context) need this to map a thread back to its bindable channel.
+type ThreadParentResolver interface {
+	// ResolveThreadParent returns the parent channel ID for a thread ID.
+	// A non-thread channel ID is returned unchanged.
+	ResolveThreadParent(channelID string) (string, error)
+}
+
 // StreamingCard represents an active streaming card that aggregates
 // an entire agent turn (tool calls, thinking, text) into a single
 // updatable message.

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -346,6 +346,21 @@ func resolveParentChannelID(channelID string, ops discordThreadOps) string {
 	return channelID
 }
 
+// resolveThreadParentID is the error-surfacing variant of
+// resolveParentChannelID, backing core.ThreadParentResolver: callers like
+// cron workspace resolution need to distinguish "not a thread" (ID returned
+// unchanged) from "lookup failed" (error) to log the fallback accurately.
+func resolveThreadParentID(channelID string, ops discordThreadOps) (string, error) {
+	ch, err := ops.ResolveChannel(channelID)
+	if err != nil {
+		return "", fmt.Errorf("discord: resolve channel %s: %w", channelID, err)
+	}
+	if isThreadChannelType(ch.Type) && ch.ParentID != "" {
+		return ch.ParentID, nil
+	}
+	return channelID, nil
+}
+
 // resolveThreadReplyContext routes a guild message into a Discord thread for
 // thread_isolation mode and returns the per-thread session key, the reply
 // context, and the parent channel ID.
@@ -1067,6 +1082,7 @@ func (p *progressPlatform) ProgressUpdateInterval() time.Duration {
 var _ core.ImageSender = (*Platform)(nil)
 var _ core.FileSender = (*Platform)(nil)
 var _ core.InlineButtonSender = (*Platform)(nil)
+var _ core.ThreadParentResolver = (*Platform)(nil)
 var _ core.ProgressStyleProvider = (*progressPlatform)(nil)
 var _ core.ProgressCardPayloadSupport = (*progressPlatform)(nil)
 var _ core.ProgressUpdateThrottler = (*progressPlatform)(nil)
@@ -1093,6 +1109,13 @@ func (p *Platform) ResolveCronReplyTarget(sessionKey string, title string) (stri
 		return "", nil, err
 	}
 	return resolvedSessionKey, rc, nil
+}
+
+// ResolveThreadParent implements core.ThreadParentResolver. Session keys
+// rewritten by thread_isolation carry a thread ID where workspace bindings
+// are keyed by the parent channel; this maps the thread back to that channel.
+func (p *Platform) ResolveThreadParent(channelID string) (string, error) {
+	return resolveThreadParentID(channelID, sessionThreadOps{session: p.session})
 }
 
 // discordPreviewHandle stores the IDs needed to edit or delete a preview message.

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -381,6 +381,41 @@ func TestResolveCronReplyTarget_ReusesExistingThreadKey(t *testing.T) {
 	}
 }
 
+func TestResolveThreadParentID(t *testing.T) {
+	ops := fakeThreadOps{
+		resolveChannel: func(channelID string) (*discordgo.Channel, error) {
+			switch channelID {
+			case "thread-1":
+				return &discordgo.Channel{ID: "thread-1", Type: discordgo.ChannelTypeGuildPublicThread, ParentID: "channel-1"}, nil
+			case "channel-1":
+				return &discordgo.Channel{ID: "channel-1", Type: discordgo.ChannelTypeGuildText}, nil
+			default:
+				return nil, fmt.Errorf("unknown channel %q", channelID)
+			}
+		},
+	}
+
+	parent, err := resolveThreadParentID("thread-1", ops)
+	if err != nil {
+		t.Fatalf("resolveThreadParentID(thread) error = %v", err)
+	}
+	if parent != "channel-1" {
+		t.Fatalf("parent = %q, want channel-1", parent)
+	}
+
+	same, err := resolveThreadParentID("channel-1", ops)
+	if err != nil {
+		t.Fatalf("resolveThreadParentID(channel) error = %v", err)
+	}
+	if same != "channel-1" {
+		t.Fatalf("non-thread channel = %q, want channel-1 unchanged", same)
+	}
+
+	if _, err := resolveThreadParentID("missing", ops); err == nil {
+		t.Fatal("resolveThreadParentID(missing) error = nil, want lookup error")
+	}
+}
+
 func TestSendWithButtons_UsesFollowupComponents(t *testing.T) {
 	requests := make([]string, 0, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Problem

In multi-workspace mode with Discord `thread_isolation = true`, cron jobs silently run in cc-connect's launch directory (global agent) instead of the channel's bound workspace.

Root cause: thread_isolation rewrites guild session keys to `discord:<threadID>`, and cron jobs persist that thread-keyed session key. At execution time `ExecuteCronJob` extracts the thread ID via `extractChannelID(sessionKey)`, but workspace bindings are keyed by the **parent channel** — the lookup misses and the code silently falls back to the global agent.

Message paths were already fixed by stamping `Message.ChannelKey` with the parent channel (the thread_isolation auto-bind fix), but cron has no `Message` context at execution time, so the same gap remained. The asymmetry is confusing to debug: `/workspace` in the thread correctly reports a binding while the cron job ignores it — with no log line explaining why.

## Fix

- **`core.ThreadParentResolver`** — new optional platform interface mapping a thread ID back to its bindable parent channel ID (non-thread IDs returned unchanged).
- **`ExecuteCronJob`** — when the direct binding lookup misses, consult `ThreadParentResolver` and retry with the parent channel before falling back. All three global-agent fallback branches (resolution error / no binding / workspace agent creation failure) now log `slog.Warn` instead of failing silently.
- **Discord** — implements `ResolveThreadParent` via channel `ParentID` lookup, with errors surfaced (unlike `resolveParentChannelID`, which swallows them) so the cron fallback log is accurate.

Existing thread-keyed cron jobs in `jobs.json` are fixed without recreation, including jobs created by agents via `cc-connect cron add` (whose `CC_SESSION_KEY` is thread-keyed).

## Tests

- `TestExecuteCronJob_ResolvesThreadParentForWorkspaceBinding` — thread-keyed job resolves the parent-channel binding; workspace agent receives the prompt with the bound `work_dir`, global agent receives nothing.
- `TestExecuteCronJob_NoBindingFallsBackToGlobalAgent` — unbound thread still runs on the global agent rather than failing.
- `TestResolveThreadParentID` (discord) — thread → parent, non-thread unchanged, lookup error surfaced.

`go build ./...`, `go test ./core/ ./platform/discord/` (incl. `-race`) pass. Verified on a live multi-workspace Discord deployment: cron job created inside an isolated thread now executes in the bound workspace directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)