### PR TITLE
refactor(agent): centralize cmd/env option parsing into core with unified cmd field

### DIFF
--- a/agent/acp/agent.go
+++ b/agent/acp/agent.go
@@ -19,14 +19,15 @@ func init() {
 
 // Agent runs an ACP (Agent Client Protocol) agent subprocess over stdio JSON-RPC.
 type Agent struct {
-	workDir     string
-	command     string
-	args        []string
-	staticEnv   map[string]string
-	extraEnv    []string
-	sessionEnv  []string
-	authMethod  string // optional, e.g. "cursor_login" for Cursor CLI (see authenticate RPC)
-	displayName string // optional, for doctor (default "ACP")
+	workDir      string
+	cmd          string
+	cliExtraArgs []string // extra args from cmd, prepended before args
+	args         []string
+	staticEnv    map[string]string
+	extraEnv     []string
+	sessionEnv   []string
+	authMethod   string // optional, e.g. "cursor_login" for Cursor CLI (see authenticate RPC)
+	displayName  string // optional, for doctor (default "ACP")
 
 	// mode is the pending permission mode to apply to new sessions.
 	// When set, StartSession applies it via session/set_mode right after
@@ -72,10 +73,9 @@ func New(opts map[string]any) (core.Agent, error) {
 	if workDir == "" {
 		workDir = "."
 	}
-	cmdStr, _ := opts["command"].(string)
-	cmdStr = strings.TrimSpace(cmdStr)
+	cmdStr, cliExtraArgs := core.ParseCmdOpts(opts, "")
 	if cmdStr == "" {
-		return nil, fmt.Errorf("acp: agent option \"command\" is required (path or name of the ACP agent binary)")
+		return nil, fmt.Errorf("acp: agent option \"cmd\" or \"command\" is required (path or name of the ACP agent binary)")
 	}
 	if _, err := exec.LookPath(cmdStr); err != nil {
 		return nil, fmt.Errorf("acp: command %q not found in PATH: %w", cmdStr, err)
@@ -96,7 +96,8 @@ func New(opts map[string]any) (core.Agent, error) {
 
 	return &Agent{
 		workDir:     workDir,
-		command:     cmdStr,
+		cmd:          cmdStr,
+		cliExtraArgs: cliExtraArgs,
 		args:        args,
 		staticEnv:   staticEnv,
 		extraEnv:    extra,
@@ -194,7 +195,7 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	defer a.mu.RUnlock()
 
 	opts := map[string]any{
-		"command": a.command,
+		"cmd": a.cmd,
 	}
 	if len(a.args) > 0 {
 		opts["args"] = append([]string(nil), a.args...)
@@ -223,8 +224,8 @@ func (a *Agent) SetSessionEnv(env []string) {
 
 func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentSession, error) {
 	a.mu.RLock()
-	command := a.command
-	args := a.args
+	command := a.cmd
+	allArgs := append(append([]string{}, a.cliExtraArgs...), a.args...)
 	workDir := a.workDir
 	authMethod := a.authMethod
 	pendingMode := a.mode
@@ -234,7 +235,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 
 	return newACPSession(ctx, acpSessionConfig{
 		command:         command,
-		args:            args,
+		args:            allArgs,
 		extraEnv:        extra,
 		workDir:         workDir,
 		resumeSessionID: sessionID,
@@ -250,9 +251,8 @@ func (a *Agent) Stop() error { return nil }
 
 func (a *Agent) CLIBinaryName() string {
 	a.mu.RLock()
-	cmd := a.command
-	a.mu.RUnlock()
-	return filepath.Base(cmd)
+	defer a.mu.RUnlock()
+	return filepath.Base(a.cmd)
 }
 
 func (a *Agent) CLIDisplayName() string {

--- a/agent/acp/agent_test.go
+++ b/agent/acp/agent_test.go
@@ -52,8 +52,8 @@ func TestWorkspaceAgentOptions(t *testing.T) {
 	}
 	opts := snapshotter.WorkspaceAgentOptions()
 
-	if got, _ := opts["command"].(string); got != "true" {
-		t.Fatalf("command = %q, want true", got)
+	if got, _ := opts["cmd"].(string); got != "true" {
+		t.Fatalf("cmd = %q, want true", got)
 	}
 	gotArgs, _ := opts["args"].([]string)
 	if len(gotArgs) != 2 || gotArgs[0] != "--acp" || gotArgs[1] != "--stdio" {

--- a/agent/acp/list_sessions.go
+++ b/agent/acp/list_sessions.go
@@ -67,7 +67,8 @@ type acpSessionListEntry struct {
 // and starts its readLoop. The caller owns the returned `teardown`
 // func and must invoke it to reap the child process.
 func (a *Agent) probeSpawn(ctx context.Context, cwd string) (*transport, *bytes.Buffer, func(), error) {
-	cmd := exec.CommandContext(ctx, a.command, a.args...)
+	allArgs := append(append([]string{}, a.cliExtraArgs...), a.args...)
+	cmd := exec.CommandContext(ctx, a.cmd, allArgs...)
 	cmd.Dir = cwd
 	cmd.Env = core.MergeEnv(os.Environ(), a.extraEnv)
 
@@ -83,7 +84,7 @@ func (a *Agent) probeSpawn(ctx context.Context, cwd string) (*transport, *bytes.
 	cmd.Stderr = io.MultiWriter(&stderrBuf)
 
 	if err := cmd.Start(); err != nil {
-		return nil, nil, nil, fmt.Errorf("acp: probe start %s: %w", a.command, err)
+		return nil, nil, nil, fmt.Errorf("acp: probe start %s: %w", a.cmd, err)
 	}
 
 	// The server-request handler needs to reference `tr` itself in order
@@ -210,7 +211,7 @@ func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, erro
 		return nil, err
 	}
 	if len(init.AgentCapabilities.SessionCapabilities.List) == 0 {
-		slog.Info("acp: session/list unsupported by agent, caching for fast-path", "command", a.command)
+		slog.Info("acp: session/list unsupported by agent, caching for fast-path", "command", a.cmd)
 		a.listUnsupported.Store(true)
 		return nil, nil
 	}

--- a/agent/antigravity/antigravity.go
+++ b/agent/antigravity/antigravity.go
@@ -30,15 +30,17 @@ func init() {
 //   - "yolo":      auto-approve all tools (--dangerously-skip-permissions)
 //   - "plan":      read-only plan mode with terminal sandbox constraints (--sandbox)
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string
-	cmd        string // CLI binary name, default "agy"
-	timeout    time.Duration
-	providers  []core.ProviderConfig
-	activeIdx  int
-	sessionEnv []string
-	mu         sync.RWMutex
+	workDir      string
+	model        string
+	mode         string
+	cmd          string   // CLI binary name, default "agy"
+	cliExtraArgs []string // extra args from cmd after the binary name
+	configEnv    []string // env vars from [projects.agent.options.env]
+	timeout      time.Duration
+	providers    []core.ProviderConfig
+	activeIdx    int
+	sessionEnv   []string
+	mu           sync.RWMutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -49,10 +51,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	model, _ := opts["model"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
-	cmd, _ := opts["cmd"].(string)
-	if cmd == "" {
-		cmd = "agy"
-	}
+	cmd, extraArgs := core.ParseCmdOpts(opts, "agy")
 
 	var timeoutMins int64
 	switch v := opts["timeout_mins"].(type) {
@@ -77,12 +76,14 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 
 	return &Agent{
-		workDir:   workDir,
-		model:     model,
-		mode:      mode,
-		cmd:       cmd,
-		timeout:   timeout,
-		activeIdx: -1,
+		workDir:      workDir,
+		model:        model,
+		mode:         mode,
+		cmd:          cmd,
+		cliExtraArgs: extraArgs,
+		configEnv:    core.ParseConfigEnv(opts),
+		timeout:      timeout,
+		activeIdx:    -1,
 	}, nil
 }
 
@@ -206,9 +207,11 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	mode := a.mode
 	cmd := a.cmd
+	extraArgs := append([]string{}, a.cliExtraArgs...)
 	workDir := a.workDir
 	timeout := a.timeout
-	extraEnv := a.providerEnvLocked()
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
@@ -217,7 +220,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
-	return newAntigravitySession(ctx, cmd, workDir, model, mode, sessionID, extraEnv, timeout)
+	return newAntigravitySession(ctx, cmd, extraArgs, workDir, model, mode, sessionID, extraEnv, timeout)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/antigravity/session.go
+++ b/agent/antigravity/session.go
@@ -24,6 +24,7 @@ import (
 // antigravitySession manages multi-turn conversations with the Antigravity CLI (agy).
 type antigravitySession struct {
 	cmd       string
+	extraArgs []string // extra args from cmd, prepended before agy args
 	workDir   string
 	model     string
 	mode      string
@@ -43,19 +44,20 @@ type antigravitySession struct {
 
 var permissionPromptPattern = regexp.MustCompile(`(?is)(allow|approve|permission).{0,400}(\(y/n\)|\(y\/n\)|\(y\/N\)|\(Y\/n\)|\[y\/n\]|\[y\/N\]|\[Y\/n\]|yes\/no)`)
 
-func newAntigravitySession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*antigravitySession, error) {
+func newAntigravitySession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*antigravitySession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	as := &antigravitySession{
-		cmd:      cmd,
-		workDir:  workDir,
-		model:    model,
-		mode:     mode,
-		timeout:  timeout,
-		extraEnv: extraEnv,
-		events:   make(chan core.Event, 64),
-		ctx:      sessionCtx,
-		cancel:   cancel,
+		cmd:       cmd,
+		extraArgs: extraArgs,
+		workDir:   workDir,
+		model:     model,
+		mode:      mode,
+		timeout:   timeout,
+		extraEnv:  extraEnv,
+		events:    make(chan core.Event, 64),
+		ctx:       sessionCtx,
+		cancel:    cancel,
 	}
 	as.alive.Store(true)
 
@@ -139,7 +141,7 @@ func (as *antigravitySession) Send(prompt string, images []core.ImageAttachment,
 		}
 		fullPrompt += "\n\n[Attached files saved at: " + strings.Join(fileRefs, ", ") + "]"
 	}
-	args := buildAntigravityArgs(chatID, isResume, as.mode, fullPrompt)
+	args := as.buildAntigravityArgs(chatID, isResume, as.mode, fullPrompt)
 	if strings.TrimSpace(as.model) != "" {
 		slog.Warn("antigravitySession: model is configured but ignored because agy does not support --model yet", "model", as.model)
 	}
@@ -201,9 +203,10 @@ func (as *antigravitySession) Send(prompt string, images []core.ImageAttachment,
 	return nil
 }
 
-func buildAntigravityArgs(chatID string, isResume bool, mode, fullPrompt string) []string {
+func (as *antigravitySession) buildAntigravityArgs(chatID string, isResume bool, mode, fullPrompt string) []string {
+	// Prepend extra args from cmd so wrappers like "timeout 3600 agy" work.
 	// Keep "-p <prompt>" at the very end because agy consumes the immediate next arg.
-	args := make([]string, 0, 10)
+	args := append([]string{}, as.extraArgs...)
 	if isResume {
 		args = append(args, "--conversation", chatID)
 	}

--- a/agent/antigravity/session_test.go
+++ b/agent/antigravity/session_test.go
@@ -57,7 +57,7 @@ func TestNormalizeMode(t *testing.T) {
 }
 
 func TestSession_ContinueSessionTreatedAsFresh(t *testing.T) {
-	s, err := newAntigravitySession(context.Background(), "echo", "/tmp", "", "default", core.ContinueSession, nil, 0)
+	s, err := newAntigravitySession(context.Background(), "echo", nil, "/tmp", "", "default", core.ContinueSession, nil, 0)
 	if err != nil {
 		t.Fatalf("newAntigravitySession: %v", err)
 	}
@@ -69,7 +69,8 @@ func TestSession_ContinueSessionTreatedAsFresh(t *testing.T) {
 }
 
 func TestBuildAntigravityArgs_PromptAtEnd(t *testing.T) {
-	args := buildAntigravityArgs("sid-1", true, "plan", "What is 1+1?")
+	s, _ := newAntigravitySession(context.Background(), "echo", nil, "/tmp", "", "default", "", nil, 0)
+	args := s.buildAntigravityArgs("sid-1", true, "plan", "What is 1+1?")
 	if len(args) < 2 {
 		t.Fatalf("args too short: %v", args)
 	}
@@ -97,7 +98,7 @@ func TestUsesInteractivePermission(t *testing.T) {
 }
 
 func TestRespondPermission_WritesTerminalAnswer(t *testing.T) {
-	s, err := newAntigravitySession(context.Background(), "echo", "/tmp", "", "default", "", nil, 0)
+	s, err := newAntigravitySession(context.Background(), "echo", nil, "/tmp", "", "default", "", nil, 0)
 	if err != nil {
 		t.Fatalf("newAntigravitySession: %v", err)
 	}

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -812,7 +812,7 @@ func (a *Agent) GetRunAsEnv() []string {
 // must propagate to per-workspace agent instances created lazily by
 // core.Engine.getOrCreateWorkspaceAgent. Without this snapshot, the engine
 // constructs workspace agents from a fresh opts map and silently drops
-// every claudecode field except mode/model — so cli_path, allowed_tools,
+// every claudecode field except mode/model — so cmd, allowed_tools,
 // and friends would only take effect on the project-level agent.
 //
 // Runtime-only state (providers, sessionEnv, providerProxy, platformPrompt)

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -131,6 +131,13 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 	cmd, cliExtraArgs := core.ParseCmdOpts(opts, "claude")
 	cmdArgsFlag, _ := opts["cmd_args_flag"].(string)
+	if cmdArgsFlag == "" {
+		if v, ok := opts["cli_args_flag"].(string); ok && v != "" {
+			slog.Warn("DEPRECATED: 'cli_args_flag' is deprecated, use 'cmd_args_flag' instead",
+				"value", v)
+			cmdArgsFlag = v
+		}
+	}
 	model, _ := opts["model"].(string)
 	reasoningEffort, _ := opts["reasoning_effort"].(string)
 	mode, _ := opts["mode"].(string)

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -35,10 +35,10 @@ func init() {
 //   - "bypassPermissions": auto-approve everything (alias: yolo)
 type Agent struct {
 	workDir          string
-	cliBin           string   // CLI binary name or path (default: "claude")
-	cliExtraArgs     []string // extra args parsed from cli_path (e.g. ["code", "-t", "foo"])
+	cmd              string   // CLI binary name (default: "claude")
+	cliExtraArgs     []string // extra args parsed from cmd (e.g. ["code", "-t", "foo"])
 	configEnv        []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
-	cliArgsFlag      string   // if set, claude args are passed as a single string via this flag (e.g. "-a")
+	cmdArgsFlag      string   // if set, claude args are passed as a single string via this flag (e.g. "-a")
 	model            string
 	reasoningEffort  string // "low" | "medium" | "high" | "max"
 	mode             string // "default" | "acceptEdits" | "plan" | "auto" | "bypassPermissions" | "dontAsk"
@@ -129,18 +129,8 @@ func New(opts map[string]any) (core.Agent, error) {
 	if workDir == "" {
 		workDir = "."
 	}
-	cliBin := "claude"
-	var cliExtraArgs []string
-	if cliPath, _ := opts["cli_path"].(string); cliPath != "" {
-		// NOTE: paths containing spaces are not supported because Fields
-		// splits on whitespace. Use a symlink or wrapper script instead.
-		parts := strings.Fields(cliPath)
-		cliBin = parts[0]
-		if len(parts) > 1 {
-			cliExtraArgs = parts[1:]
-		}
-	}
-	cliArgsFlag, _ := opts["cli_args_flag"].(string)
+	cmd, cliExtraArgs := core.ParseCmdOpts(opts, "claude")
+	cmdArgsFlag, _ := opts["cmd_args_flag"].(string)
 	model, _ := opts["model"].(string)
 	reasoningEffort, _ := opts["reasoning_effort"].(string)
 	mode, _ := opts["mode"].(string)
@@ -216,8 +206,8 @@ func New(opts map[string]any) (core.Agent, error) {
 	// skip the supervisor-side LookPath check and let spawn fail loudly
 	// at runtime if the target doesn't have claude installed.
 	if !spawnOpts.IsolationMode() {
-		if _, err := exec.LookPath(cliBin); err != nil {
-			return nil, fmt.Errorf("claudecode: %q CLI not found in PATH, please install it first", cliBin)
+		if _, err := exec.LookPath(cmd); err != nil {
+			return nil, fmt.Errorf("claudecode: %q CLI not found in PATH, please install it first", cmd)
 		}
 	}
 
@@ -248,9 +238,9 @@ func New(opts map[string]any) (core.Agent, error) {
 
 	return &Agent{
 		workDir:          workDir,
-		cliBin:           cliBin,
+		cmd:              cmd,
 		cliExtraArgs:     cliExtraArgs,
-		cliArgsFlag:      cliArgsFlag,
+		cmdArgsFlag:      cmdArgsFlag,
 		model:            model,
 		reasoningEffort:  normalizeEffort(reasoningEffort),
 		mode:             mode,
@@ -308,7 +298,7 @@ func normalizePermissionMode(raw string) string {
 }
 
 func (a *Agent) Name() string           { return "claudecode" }
-func (a *Agent) CLIBinaryName() string  { return a.cliBin }
+func (a *Agent) CLIBinaryName() string  { return a.cmd }
 func (a *Agent) CLIDisplayName() string { return "Claude" }
 
 func (a *Agent) SetWorkDir(dir string) {
@@ -527,7 +517,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt, tools, disTools, pluginDirs, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok, a.ccDataDir)
+	return newClaudeSession(ctx, workDir, a.cmd, a.cliExtraArgs, a.cmdArgsFlag, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt, tools, disTools, pluginDirs, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok, a.ccDataDir)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {
@@ -842,11 +832,11 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 		}
 		opts["env"] = envMap
 	}
-	if cliPath := snapshotCLIPath(a.cliBin, a.cliExtraArgs); cliPath != "" {
-		opts["cli_path"] = cliPath
+	if cliPath := snapshotCmdPath(a.cmd, a.cliExtraArgs); cliPath != "" {
+		opts["cmd"] = cliPath
 	}
-	if a.cliArgsFlag != "" {
-		opts["cli_args_flag"] = a.cliArgsFlag
+	if a.cmdArgsFlag != "" {
+		opts["cmd_args_flag"] = a.cmdArgsFlag
 	}
 	if a.model != "" {
 		opts["model"] = a.model
@@ -875,22 +865,22 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	return opts
 }
 
-// snapshotCLIPath rebuilds the cli_path opts string from cliBin and the
+// snapshotCmdPath rebuilds the cmd opts string from cmd and the
 // extra-args tail captured at construction. Returns "" when only the
 // default "claude" binary is in use, so we don't pollute the workspace
 // opts with a redundant default.
-func snapshotCLIPath(cliBin string, cliExtraArgs []string) string {
+func snapshotCmdPath(cmd string, cliExtraArgs []string) string {
 	// Normalise empty to the default binary so we can reason about extra args.
-	if cliBin == "" {
-		cliBin = "claude"
+	if cmd == "" {
+		cmd = "claude"
 	}
-	if cliBin == "claude" && len(cliExtraArgs) == 0 {
+	if cmd == "claude" && len(cliExtraArgs) == 0 {
 		return "" // default binary, no extra args — no need to persist
 	}
 	if len(cliExtraArgs) == 0 {
-		return cliBin
+		return cmd
 	}
-	return cliBin + " " + strings.Join(cliExtraArgs, " ")
+	return cmd + " " + strings.Join(cliExtraArgs, " ")
 }
 
 // stringsToAny copies a []string into a fresh []any so it round-trips

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -134,6 +134,8 @@ func New(opts map[string]any) (core.Agent, error) {
 	if cmdArgsFlag == "" {
 		if v, ok := opts["cli_args_flag"].(string); ok && v != "" {
 			slog.Warn("DEPRECATED: 'cli_args_flag' is deprecated, use 'cmd_args_flag' instead",
+				"deprecated_key", "cli_args_flag",
+				"new_key", "cmd_args_flag",
 				"value", v)
 			cmdArgsFlag = v
 		}

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -262,12 +262,12 @@ func TestAgent_Name(t *testing.T) {
 }
 
 func TestAgent_CLIBinaryName(t *testing.T) {
-	a := &Agent{cliBin: "claude"}
+	a := &Agent{cmd: "claude"}
 	if got := a.CLIBinaryName(); got != "claude" {
 		t.Errorf("CLIBinaryName() = %q, want %q", got, "claude")
 	}
 
-	a2 := &Agent{cliBin: "my-cli"}
+	a2 := &Agent{cmd: "my-cli"}
 	if got := a2.CLIBinaryName(); got != "my-cli" {
 		t.Errorf("CLIBinaryName() = %q, want %q", got, "my-cli")
 	}
@@ -518,7 +518,7 @@ func TestFindProjectDir_ICloudPath(t *testing.T) {
 func TestSnapshotCLIPath(t *testing.T) {
 	cases := []struct {
 		name      string
-		cliBin    string
+		cmd       string
 		extraArgs []string
 		want      string
 	}{
@@ -530,9 +530,9 @@ func TestSnapshotCLIPath(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := snapshotCLIPath(tc.cliBin, tc.extraArgs)
+			got := snapshotCmdPath(tc.cmd, tc.extraArgs)
 			if got != tc.want {
-				t.Errorf("snapshotCLIPath(%q, %v) = %q, want %q", tc.cliBin, tc.extraArgs, got, tc.want)
+				t.Errorf("snapshotCmdPath(%q, %v) = %q, want %q", tc.cmd, tc.extraArgs, got, tc.want)
 			}
 		})
 	}
@@ -543,9 +543,9 @@ func TestWorkspaceAgentOptions_FullSnapshot(t *testing.T) {
 	// PATH. WorkspaceAgentOptions only reads fields that the production
 	// New() also writes; this just verifies the snapshot shape.
 	a := &Agent{
-		cliBin:           "my-cli",
+		cmd:           "my-cli",
 		cliExtraArgs:     []string{"--add-dir", "/parent"},
-		cliArgsFlag:      "-a",
+		cmdArgsFlag:      "-a",
 		model:            "claude-opus-4-7",
 		reasoningEffort:  "high",
 		mode:             "acceptEdits",
@@ -559,8 +559,8 @@ func TestWorkspaceAgentOptions_FullSnapshot(t *testing.T) {
 
 	want := map[string]any{
 		"mode":               "acceptEdits",
-		"cli_path":           "my-cli --add-dir /parent",
-		"cli_args_flag":      "-a",
+		"cmd":           "my-cli --add-dir /parent",
+		"cmd_args_flag":      "-a",
 		"model":              "claude-opus-4-7",
 		"reasoning_effort":   "high",
 		"allowed_tools":      []any{"Edit", "Read"},
@@ -585,9 +585,9 @@ func TestWorkspaceAgentOptions_FullSnapshot(t *testing.T) {
 }
 
 func TestWorkspaceAgentOptions_OmitsZeroValues(t *testing.T) {
-	// Default agent (only mode is always emitted, plus default cliBin
-	// "claude" should be skipped by snapshotCLIPath).
-	a := &Agent{cliBin: "claude", mode: "default"}
+	// Default agent (only mode is always emitted, plus default cmd
+	// "claude" should be skipped by snapshotCmdPath).
+	a := &Agent{cmd: "claude", mode: "default"}
 	got := a.WorkspaceAgentOptions()
 
 	if len(got) != 1 {
@@ -597,7 +597,7 @@ func TestWorkspaceAgentOptions_OmitsZeroValues(t *testing.T) {
 		t.Errorf("snapshot[mode] = %v, want %q", got["mode"], "default")
 	}
 	for _, k := range []string{
-		"cli_path", "cli_args_flag", "model", "reasoning_effort",
+		"cmd", "cmd_args_flag", "model", "reasoning_effort",
 		"allowed_tools", "disallowed_tools", "max_context_tokens",
 		"router_url", "router_api_key",
 	} {
@@ -621,9 +621,9 @@ func TestWorkspaceAgentOptions_RoundTripsThroughNew(t *testing.T) {
 		t.Skip("run_as_user-based LookPath bypass is Unix-only")
 	}
 	parent := &Agent{
-		cliBin:           "my-cli",
+		cmd:           "my-cli",
 		cliExtraArgs:     []string{"code", "--add-dir", "/parent"},
-		cliArgsFlag:      "-a",
+		cmdArgsFlag:      "-a",
 		model:            "claude-opus-4-7",
 		reasoningEffort:  "high",
 		mode:             "acceptEdits",
@@ -643,14 +643,14 @@ func TestWorkspaceAgentOptions_RoundTripsThroughNew(t *testing.T) {
 	}
 	child := a.(*Agent)
 
-	if child.cliBin != "my-cli" {
-		t.Errorf("cliBin = %q, want %q", child.cliBin, "my-cli")
+	if child.cmd != "my-cli" {
+		t.Errorf("cmd = %q, want %q", child.cmd, "my-cli")
 	}
 	if !reflect.DeepEqual(child.cliExtraArgs, []string{"code", "--add-dir", "/parent"}) {
 		t.Errorf("cliExtraArgs = %v, want [code --add-dir /parent]", child.cliExtraArgs)
 	}
-	if child.cliArgsFlag != "-a" {
-		t.Errorf("cliArgsFlag = %q, want -a", child.cliArgsFlag)
+	if child.cmdArgsFlag != "-a" {
+		t.Errorf("cmdArgsFlag = %q, want -a", child.cmdArgsFlag)
 	}
 	if child.model != "claude-opus-4-7" {
 		t.Errorf("model = %q, want claude-opus-4-7", child.model)

--- a/agent/claudecode/provider_integration_test.go
+++ b/agent/claudecode/provider_integration_test.go
@@ -160,7 +160,7 @@ func TestIntegration_ProviderSwitch_SessionStartModel(t *testing.T) {
 				providers: providers,
 				activeIdx: -1,
 				workDir:   workDir,
-				cliBin:    cliBin,
+				cmd:    cliBin,
 			}
 			a.SetActiveProvider(prov.Name)
 

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -204,7 +204,7 @@ func buildAppendSystemPrompt(agentPrompt, platformPrompt, userAppend string) str
 	return strings.Join(parts, "\n")
 }
 
-func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, pluginDirs []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int, ccDataDir string) (*claudeSession, error) {
+func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cmdArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, pluginDirs []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int, ccDataDir string) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	// Claude Code rejects bypassPermissions when running as root.
@@ -217,7 +217,7 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	}
 
 	// innerArgs are Claude Code CLI flags — when a wrapper is used with
-	// cliArgsFlag these get bundled into a single passthrough string.
+	// cmdArgsFlag these get bundled into a single passthrough string.
 	// outerArgs are flags the wrapper itself understands (e.g. --model).
 	innerArgs := []string{
 		"--output-format", "stream-json",
@@ -326,16 +326,16 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	}
 
 	// Build final argument list.
-	// When cliArgsFlag is set (e.g. "-a"), inner args are bundled into a
+	// When cmdArgsFlag is set (e.g. "-a"), inner args are bundled into a
 	// single passthrough string via that flag, while outer args (--model etc.)
 	// are appended directly so the wrapper can also interpret them.
 	// Args containing spaces/newlines are quoted so the wrapper's command-line
 	// parser (e.g. splitCommandLine) keeps them as single tokens.
 	// Result: my-cli code -t foo -a "--verbose --append-system-prompt 'long text'" --model x
 	var allArgs []string
-	if cliArgsFlag != "" {
+	if cmdArgsFlag != "" {
 		allArgs = append(allArgs, cliExtraArgs...)
-		allArgs = append(allArgs, cliArgsFlag, shellJoinArgs(innerArgs))
+		allArgs = append(allArgs, cmdArgsFlag, shellJoinArgs(innerArgs))
 		allArgs = append(allArgs, outerArgs...)
 	} else {
 		allArgs = append(allArgs, cliExtraArgs...)

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -99,7 +99,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		codexHome:       strings.TrimSpace(codexHome),
 		systemPrompt:    strings.TrimSpace(systemPrompt),
 		appendPrompt:    strings.TrimSpace(appendPrompt),
-		cmd:             cliBin,
+		cmd:             cmd,
 		cliExtraArgs:    cliExtraArgs,
 		configEnv:       configEnv,
 		activeIdx:       -1,

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -40,8 +40,8 @@ type Agent struct {
 	codexHome       string
 	systemPrompt    string
 	appendPrompt    string
-	cliBin          string   // CLI binary name, default "codex"
-	cliExtraArgs    []string // extra args parsed from cli_path after the binary
+	cmd             string   // CLI binary name, default "codex"
+	cliExtraArgs    []string // extra args parsed from cmd after the binary
 	providers       []core.ProviderConfig
 	activeIdx       int      // -1 = no provider set
 	configEnv       []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
@@ -66,19 +66,10 @@ func New(opts map[string]any) (core.Agent, error) {
 	backend = normalizeBackend(backend)
 	appServerURL = normalizeAppServerURL(appServerURL)
 
-	// cli_path allows overriding the binary, e.g. "omx" or "omx --flag val"
-	cliBin := "codex"
-	var cliExtraArgs []string
-	if cliPath, _ := opts["cli_path"].(string); strings.TrimSpace(cliPath) != "" {
-		parts := strings.Fields(cliPath)
-		cliBin = parts[0]
-		if len(parts) > 1 {
-			cliExtraArgs = parts[1:]
-		}
-	}
+	cmd, cliExtraArgs := core.ParseCmdOpts(opts, "codex")
 
-	if _, err := exec.LookPath(cliBin); err != nil {
-		return nil, fmt.Errorf("codex: %q CLI not found in PATH, install with: npm install -g @openai/codex", cliBin)
+	if _, err := exec.LookPath(cmd); err != nil {
+		return nil, fmt.Errorf("codex: %q CLI not found in PATH, install with: npm install -g @openai/codex", cmd)
 	}
 
 	// Parse project-level env from opts["env"] (set via [projects.agent.options.env] in config.toml).
@@ -108,7 +99,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		codexHome:       strings.TrimSpace(codexHome),
 		systemPrompt:    strings.TrimSpace(systemPrompt),
 		appendPrompt:    strings.TrimSpace(appendPrompt),
-		cliBin:          cliBin,
+		cmd:             cliBin,
 		cliExtraArgs:    cliExtraArgs,
 		configEnv:       configEnv,
 		activeIdx:       -1,
@@ -373,7 +364,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	codexHome := a.codexHome
 	systemPrompt := a.systemPrompt
 	appendPrompt := a.appendPrompt
-	cliBin := a.cliBin
+	cliBin := a.cmd
 	cliExtraArgs := a.cliExtraArgs
 	workDir := a.workDir
 	// Order matters for MergeEnv override semantics (later wins):

--- a/agent/codex/project_env_test.go
+++ b/agent/codex/project_env_test.go
@@ -16,7 +16,7 @@ func TestNew_ParsesProjectEnvFromOpts(t *testing.T) {
 	// to be installed on the test runner.
 	opts := map[string]any{
 		"work_dir": t.TempDir(),
-		"cli_path": "go",
+		"cmd": "go",
 		"env": map[string]string{
 			"HTTPS_PROXY": "http://127.0.0.1:10808",
 			"HTTP_PROXY":  "http://127.0.0.1:10808",
@@ -50,7 +50,7 @@ func TestNew_ParsesProjectEnvFromOpts(t *testing.T) {
 func TestNew_ParsesProjectEnvFromMapStringAny(t *testing.T) {
 	opts := map[string]any{
 		"work_dir": t.TempDir(),
-		"cli_path": "go",
+		"cmd": "go",
 		"env": map[string]any{
 			"OPENAI_BASE_URL": "https://api.example.com/v1",
 			"CUSTOM_FLAG":     "yes",
@@ -80,7 +80,7 @@ func TestNew_ParsesProjectEnvFromMapStringAny(t *testing.T) {
 func TestNew_NoEnvOpts(t *testing.T) {
 	opts := map[string]any{
 		"work_dir": t.TempDir(),
-		"cli_path": "go",
+		"cmd": "go",
 	}
 
 	a, err := New(opts)

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -30,8 +30,8 @@ type codexSession struct {
 	mode           string
 	baseURL        string   // provider base URL; passed as -c openai_base_url=<url>
 	modelProvider  string   // Codex model_provider name; passed as -c model_provider=<name>
-	cliBin         string   // CLI binary, default "codex"
-	cliExtraArgs   []string // extra args from cli_path, prepended before exec args
+	cmd            string   // CLI binary, default "codex"
+	cliExtraArgs   []string // extra args from cmd, prepended before exec args
 	extraEnv       []string
 	promptPreamble string
 	events         chan core.Event
@@ -97,7 +97,7 @@ func newCodexSession(ctx context.Context, cliBin string, cliExtraArgs []string, 
 		mode:           mode,
 		baseURL:        baseURL,
 		modelProvider:  modelProvider,
-		cliBin:         cliBin,
+		cmd:            cliBin,
 		cliExtraArgs:   cliExtraArgs,
 		extraEnv:       extraEnv,
 		promptPreamble: buildCodexPromptPreamble(systemPrompt, appendPrompt),
@@ -141,7 +141,7 @@ func (cs *codexSession) Send(prompt string, images []core.ImageAttachment, files
 		args = append(append([]string{}, cs.cliExtraArgs...), args...)
 	}
 
-	bin := cs.cliBin
+	bin := cs.cmd
 	if bin == "" {
 		bin = "codex"
 	}

--- a/agent/copilot/copilot.go
+++ b/agent/copilot/copilot.go
@@ -26,13 +26,15 @@ func init() {
 //   - "default":           every tool call requires user approval
 //   - "bypassPermissions": auto-approve everything (alias: yolo)
 type Agent struct {
-	workDir    string
-	cliBin     string // CLI binary name or path (default: "copilot")
-	model      string
-	mode       string // "default" | "bypassPermissions"
-	providers  []core.ProviderConfig
-	activeIdx  int // -1 = no provider set
-	sessionEnv []string
+	workDir      string
+	cmd          string   // CLI binary name (default: "copilot")
+	cliExtraArgs []string // extra args from cmd after the binary name
+	configEnv    []string // env vars from [projects.agent.options.env]
+	model        string
+	mode         string // "default" | "bypassPermissions"
+	providers    []core.ProviderConfig
+	activeIdx    int // -1 = no provider set
+	sessionEnv   []string
 
 	mu sync.RWMutex
 }
@@ -42,24 +44,23 @@ func New(opts map[string]any) (core.Agent, error) {
 	if workDir == "" {
 		workDir = "."
 	}
-	cliBin := "copilot"
-	if cliPath, _ := opts["cli_path"].(string); strings.TrimSpace(cliPath) != "" {
-		cliBin = strings.TrimSpace(cliPath)
-	}
+	cmd, extraArgs := core.ParseCmdOpts(opts, "copilot")
 	model, _ := opts["model"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
 
-	if _, err := exec.LookPath(cliBin); err != nil {
-		return nil, fmt.Errorf("copilot: %q CLI not found in PATH, please install it first", cliBin)
+	if _, err := exec.LookPath(cmd); err != nil {
+		return nil, fmt.Errorf("copilot: %q CLI not found in PATH, please install it first", cmd)
 	}
 
 	return &Agent{
-		workDir:   workDir,
-		cliBin:    cliBin,
-		model:     model,
-		mode:      mode,
-		activeIdx: -1,
+		workDir:      workDir,
+		cmd:          cmd,
+		cliExtraArgs: extraArgs,
+		configEnv:    core.ParseConfigEnv(opts),
+		model:        model,
+		mode:         mode,
+		activeIdx:    -1,
 	}, nil
 }
 
@@ -73,7 +74,7 @@ func normalizeMode(raw string) string {
 }
 
 func (a *Agent) Name() string           { return "copilot" }
-func (a *Agent) CLIBinaryName() string  { return a.cliBin }
+func (a *Agent) CLIBinaryName() string  { return a.cmd }
 func (a *Agent) CLIDisplayName() string { return "GitHub Copilot" }
 
 func (a *Agent) SetWorkDir(dir string) {
@@ -151,8 +152,10 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	mode := a.mode
 	workDir := a.workDir
-	cliBin := a.cliBin
-	extraEnv := a.providerEnvLocked()
+	cmd := a.cmd
+	extraArgs := append([]string{}, a.cliExtraArgs...)
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	provider := a.providerConfigLocked()
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
@@ -162,7 +165,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.RUnlock()
 
-	return newCopilotSession(ctx, workDir, cliBin, model, mode, sessionID, extraEnv, provider)
+	return newCopilotSession(ctx, workDir, cmd, extraArgs, model, mode, sessionID, extraEnv, provider)
 }
 
 // listSessionsProbeTimeout bounds how long we wait for a session.list probe.
@@ -195,7 +198,7 @@ type probeSession struct {
 }
 
 type probeSnapshot struct {
-	cliBin  string
+	cmd  string
 	workDir string
 	env     []string
 }
@@ -205,7 +208,7 @@ type probeSnapshot struct {
 func newProbeSession(ctx context.Context, snapshot probeSnapshot) (*probeSession, error) {
 	probeCtx, cancel := context.WithCancel(ctx)
 
-	cmd := exec.CommandContext(probeCtx, snapshot.cliBin, "--headless", "--stdio", "--no-auto-update")
+	cmd := exec.CommandContext(probeCtx, snapshot.cmd, "--headless", "--stdio", "--no-auto-update")
 	cmd.Dir = snapshot.workDir
 	cmd.Env = snapshot.env
 
@@ -277,7 +280,7 @@ func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, erro
 	snapshot := a.probeSnapshotLocked()
 	a.mu.RUnlock()
 
-	if _, err := exec.LookPath(snapshot.cliBin); err != nil {
+	if _, err := exec.LookPath(snapshot.cmd); err != nil {
 		return nil, nil
 	}
 
@@ -343,8 +346,8 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	if a.model != "" {
 		opts["model"] = a.model
 	}
-	if a.cliBin != "copilot" && a.cliBin != "" {
-		opts["cli_path"] = a.cliBin
+	if a.cmd != "copilot" && a.cmd != "" {
+		opts["cmd"] = a.cmd
 	}
 	return opts
 }
@@ -363,7 +366,7 @@ func (a *Agent) DeleteSession(ctx context.Context, sessionID string) error {
 	snapshot := a.probeSnapshotLocked()
 	a.mu.RUnlock()
 
-	if _, err := exec.LookPath(snapshot.cliBin); err != nil {
+	if _, err := exec.LookPath(snapshot.cmd); err != nil {
 		return nil
 	}
 
@@ -497,7 +500,7 @@ func (a *Agent) probeSnapshotLocked() probeSnapshot {
 	if len(a.sessionEnv) > 0 {
 		env = core.MergeEnv(env, a.sessionEnv)
 	}
-	return probeSnapshot{cliBin: a.cliBin, workDir: a.workDir, env: env}
+	return probeSnapshot{cmd: a.cmd, workDir: a.workDir, env: env}
 }
 
 func (a *Agent) providerConfigLocked() *copilotWireProviderConfig {

--- a/agent/copilot/copilot_test.go
+++ b/agent/copilot/copilot_test.go
@@ -229,7 +229,7 @@ func TestAgent_ListSessions(t *testing.T) {
 }
 
 func TestAgent_CLIBinaryName(t *testing.T) {
-	a := &Agent{cliBin: "copilot"}
+	a := &Agent{cmd: "copilot"}
 	if got := a.CLIBinaryName(); got != "copilot" {
 		t.Fatalf("CLIBinaryName() = %q, want copilot", got)
 	}
@@ -243,7 +243,7 @@ func TestAgent_CLIDisplayName(t *testing.T) {
 }
 
 func TestAgent_WorkspaceAgentOptions(t *testing.T) {
-	a := &Agent{mode: "bypassPermissions", model: "gpt-4o", cliBin: "copilot"}
+	a := &Agent{mode: "bypassPermissions", model: "gpt-4o", cmd: "copilot"}
 	opts := a.WorkspaceAgentOptions()
 	if opts["mode"] != "bypassPermissions" {
 		t.Fatalf("mode = %v, want bypassPermissions", opts["mode"])
@@ -252,15 +252,15 @@ func TestAgent_WorkspaceAgentOptions(t *testing.T) {
 		t.Fatalf("model = %v, want gpt-4o", opts["model"])
 	}
 	// cliBin is "copilot" (default) so cli_path should not be set
-	if _, ok := opts["cli_path"]; ok {
-		t.Fatal("cli_path should not be set for default binary name")
+	if _, ok := opts["cmd"]; ok {
+		t.Fatal("cmd should not be set for default binary name")
 	}
 
 	// Custom CLI path should be included
-	a2 := &Agent{mode: "default", cliBin: "/custom/copilot"}
+	a2 := &Agent{mode: "default", cmd: "/custom/copilot"}
 	opts2 := a2.WorkspaceAgentOptions()
-	if opts2["cli_path"] != "/custom/copilot" {
-		t.Fatalf("cli_path = %v, want /custom/copilot", opts2["cli_path"])
+	if opts2["cmd"] != "/custom/copilot" {
+		t.Fatalf("cmd = %v, want /custom/copilot", opts2["cmd"])
 	}
 }
 
@@ -270,7 +270,7 @@ func TestAgent_WorkspaceAgentOptions(t *testing.T) {
 
 // TestAgent_ListSessions_NoBinary verifies graceful nil return when binary is missing.
 func TestAgent_ListSessions_NoBinary(t *testing.T) {
-	a := &Agent{cliBin: "copilot-nonexistent-xyz", workDir: "."}
+	a := &Agent{cmd: "copilot-nonexistent-xyz", workDir: "."}
 	sessions, err := a.ListSessions(context.Background())
 	if err != nil {
 		t.Fatalf("ListSessions with missing binary returned error: %v", err)
@@ -282,7 +282,7 @@ func TestAgent_ListSessions_NoBinary(t *testing.T) {
 
 // TestAgent_DeleteSession_NoBinary verifies graceful nil return when binary is missing.
 func TestAgent_DeleteSession_NoBinary(t *testing.T) {
-	a := &Agent{cliBin: "copilot-nonexistent-xyz", workDir: "."}
+	a := &Agent{cmd: "copilot-nonexistent-xyz", workDir: "."}
 	if err := a.DeleteSession(context.Background(), "some-session-id"); err != nil {
 		t.Fatalf("DeleteSession with missing binary returned error: %v", err)
 	}
@@ -290,7 +290,7 @@ func TestAgent_DeleteSession_NoBinary(t *testing.T) {
 
 // TestAgent_DeleteSession_EmptyID verifies empty session ID returns nil immediately.
 func TestAgent_DeleteSession_EmptyID(t *testing.T) {
-	a := &Agent{cliBin: "copilot-nonexistent-xyz", workDir: "."}
+	a := &Agent{cmd: "copilot-nonexistent-xyz", workDir: "."}
 	if err := a.DeleteSession(context.Background(), ""); err != nil {
 		t.Fatalf("DeleteSession with empty ID returned error: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestAgent_ListSessions_RPC(t *testing.T) {
 
 	// Point agent at the test binary itself acting as a mock copilot
 	a := &Agent{
-		cliBin:  bin,
+		cmd:  bin,
 		workDir: ".",
 	}
 
@@ -341,7 +341,7 @@ func TestAgent_DeleteSession_RPC(t *testing.T) {
 	}
 
 	a := &Agent{
-		cliBin:  bin,
+		cmd:  bin,
 		workDir: ".",
 	}
 

--- a/agent/copilot/copilot_test.go
+++ b/agent/copilot/copilot_test.go
@@ -251,7 +251,7 @@ func TestAgent_WorkspaceAgentOptions(t *testing.T) {
 	if opts["model"] != "gpt-4o" {
 		t.Fatalf("model = %v, want gpt-4o", opts["model"])
 	}
-	// cliBin is "copilot" (default) so cli_path should not be set
+	// cmd is "copilot" (default) so cmd should not be set
 	if _, ok := opts["cmd"]; ok {
 		t.Fatal("cmd should not be set for default binary name")
 	}

--- a/agent/copilot/session.go
+++ b/agent/copilot/session.go
@@ -80,45 +80,45 @@ type copilotPermissionResult struct {
 	Rules []any  `json:"rules,omitempty"`
 }
 
-func newCopilotSession(ctx context.Context, workDir, cliBin, model, mode, resumeSessionID string, extraEnv []string, provider *copilotWireProviderConfig) (*copilotSession, error) {
+func newCopilotSession(ctx context.Context, workDir, cliBin string, extraArgs []string, model, mode, resumeSessionID string, extraEnv []string, provider *copilotWireProviderConfig) (*copilotSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
-	args := []string{"--headless", "--stdio", "--no-auto-update"}
+	args := append(append([]string{}, extraArgs...), "--headless", "--stdio", "--no-auto-update")
 
 	slog.Debug("copilotSession: starting", "bin", cliBin, "args", args, "dir", workDir)
 
-	cmd := exec.CommandContext(sessionCtx, cliBin, args...)
-	cmd.Dir = workDir
-	prepareCmdForKill(cmd)
+	child := exec.CommandContext(sessionCtx, cliBin, args...)
+	child.Dir = workDir
+	prepareCmdForKill(child)
 
 	env := os.Environ()
 	if len(extraEnv) > 0 {
 		env = core.MergeEnv(env, extraEnv)
 	}
-	cmd.Env = env
+	child.Env = env
 
-	stdin, err := cmd.StdinPipe()
+	stdin, err := child.StdinPipe()
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("copilotSession: stdin pipe: %w", err)
 	}
 
-	stdout, err := cmd.StdoutPipe()
+	stdout, err := child.StdoutPipe()
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("copilotSession: stdout pipe: %w", err)
 	}
 
 	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
+	child.Stderr = &stderrBuf
 
-	if err := cmd.Start(); err != nil {
+	if err := child.Start(); err != nil {
 		cancel()
 		return nil, fmt.Errorf("copilotSession: start: %w", err)
 	}
 
 	cs := &copilotSession{
-		cmd:                cmd,
+		cmd:                child,
 		rpc:                newRPCClient(stdin),
 		reader:             newLSPReader(stdout),
 		events:             make(chan core.Event, 64),

--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -31,14 +31,16 @@ func init() {
 //   - "plan":     --mode plan (read-only analysis)
 //   - "ask":      --mode ask (Q&A style, read-only)
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string
-	cmd        string // CLI binary name, default "agent"
-	providers  []core.ProviderConfig
-	activeIdx  int
-	sessionEnv []string
-	mu         sync.RWMutex
+	workDir      string
+	model        string
+	mode         string
+	cmd          string   // CLI binary name, default "agent"
+	cliExtraArgs []string // extra args from cmd after the binary name
+	configEnv    []string // env vars from [projects.agent.options.env]
+	providers    []core.ProviderConfig
+	activeIdx    int
+	sessionEnv   []string
+	mu           sync.RWMutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -49,20 +51,19 @@ func New(opts map[string]any) (core.Agent, error) {
 	model, _ := opts["model"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
-	cmd, _ := opts["cmd"].(string)
-	if cmd == "" {
-		cmd = "agent"
-	}
+	cmd, extraArgs := core.ParseCmdOpts(opts, "agent")
 	if _, err := exec.LookPath(cmd); err != nil {
 		return nil, fmt.Errorf("cursor: %q CLI not found in PATH, install with: npm i -g @anthropic-ai/cursor-agent (or from Cursor IDE settings)", cmd)
 	}
 
 	return &Agent{
-		workDir:   workDir,
-		model:     model,
-		mode:      mode,
-		cmd:       cmd,
-		activeIdx: -1,
+		workDir:      workDir,
+		model:        model,
+		mode:         mode,
+		cmd:          cmd,
+		cliExtraArgs: extraArgs,
+		configEnv:    core.ParseConfigEnv(opts),
+		activeIdx:    -1,
 	}, nil
 }
 
@@ -193,8 +194,10 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	mode := a.mode
 	cmd := a.cmd
+	extraArgs := append([]string{}, a.cliExtraArgs...)
 	workDir := a.workDir
-	extraEnv := a.providerEnvLocked()
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
@@ -203,7 +206,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.RUnlock()
 
-	return newCursorSession(ctx, cmd, workDir, model, mode, sessionID, extraEnv)
+	return newCursorSession(ctx, cmd, extraArgs, workDir, model, mode, sessionID, extraEnv)
 }
 
 // ListSessions reads sessions from Cursor Agent CLI chat storage.

--- a/agent/cursor/session.go
+++ b/agent/cursor/session.go
@@ -22,17 +22,18 @@ import (
 // cursorSession manages multi-turn conversations with the Cursor Agent CLI.
 // Each Send() launches a new `agent --print` process with --resume for continuity.
 type cursorSession struct {
-	cmd      string // CLI binary name
-	workDir  string
-	model    string
-	mode     string
-	extraEnv []string
-	events   chan core.Event
-	chatID   atomic.Value // stores string — Cursor chat/session ID
-	ctx      context.Context
-	cancel   context.CancelFunc
-	wg       sync.WaitGroup
-	alive    atomic.Bool
+	cmd       string   // CLI binary name
+	extraArgs []string // extra args from cmd, prepended before agent args
+	workDir   string
+	model     string
+	mode      string
+	extraEnv  []string
+	events    chan core.Event
+	chatID    atomic.Value // stores string — Cursor chat/session ID
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	alive     atomic.Bool
 
 	thinkingBuf strings.Builder // accumulate thinking deltas
 
@@ -51,18 +52,19 @@ type pendingInteractionQuery struct {
 	queryType string // e.g. "webFetchRequestQuery", "shellRequestQuery"
 }
 
-func newCursorSession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string) (*cursorSession, error) {
+func newCursorSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, resumeID string, extraEnv []string) (*cursorSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	cs := &cursorSession{
-		cmd:      cmd,
-		workDir:  workDir,
-		model:    model,
-		mode:     mode,
-		extraEnv: extraEnv,
-		events:   make(chan core.Event, 64),
-		ctx:      sessionCtx,
-		cancel:   cancel,
+		cmd:       cmd,
+		extraArgs: extraArgs,
+		workDir:   workDir,
+		model:     model,
+		mode:      mode,
+		extraEnv:  extraEnv,
+		events:    make(chan core.Event, 64),
+		ctx:       sessionCtx,
+		cancel:    cancel,
 	}
 	cs.alive.Store(true)
 
@@ -88,10 +90,10 @@ func (cs *cursorSession) Send(prompt string, images []core.ImageAttachment, file
 	chatID := cs.CurrentSessionID()
 	isResume := chatID != ""
 
-	args := []string{
+	args := append(append([]string{}, cs.extraArgs...),
 		"--print",
 		"--output-format", "stream-json",
-	}
+	)
 
 	switch cs.mode {
 	case "force":

--- a/agent/gemini/gemini.go
+++ b/agent/gemini/gemini.go
@@ -30,15 +30,17 @@ func init() {
 //   - "yolo":      auto-approve all tools (-y / --approval-mode yolo)
 //   - "plan":      read-only plan mode (--approval-mode plan)
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string
-	cmd        string // CLI binary name, default "gemini"
-	timeout    time.Duration
-	providers  []core.ProviderConfig
-	activeIdx  int
-	sessionEnv []string
-	mu         sync.RWMutex
+	workDir      string
+	model        string
+	mode         string
+	cmd          string   // CLI binary name, default "gemini"
+	cliExtraArgs []string // extra args from cmd after the binary name
+	configEnv    []string // env vars from [projects.agent.options.env]
+	timeout      time.Duration
+	providers    []core.ProviderConfig
+	activeIdx    int
+	sessionEnv   []string
+	mu           sync.RWMutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -49,10 +51,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	model, _ := opts["model"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
-	cmd, _ := opts["cmd"].(string)
-	if cmd == "" {
-		cmd = "gemini"
-	}
+	cmd, extraArgs := core.ParseCmdOpts(opts, "gemini")
 
 	var timeoutMins int64
 	switch v := opts["timeout_mins"].(type) {
@@ -77,12 +76,14 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 
 	return &Agent{
-		workDir:   workDir,
-		model:     model,
-		mode:      mode,
-		cmd:       cmd,
-		timeout:   timeout,
-		activeIdx: -1,
+		workDir:      workDir,
+		model:        model,
+		mode:         mode,
+		cmd:          cmd,
+		cliExtraArgs: extraArgs,
+		configEnv:    core.ParseConfigEnv(opts),
+		timeout:      timeout,
+		activeIdx:    -1,
 	}, nil
 }
 
@@ -209,9 +210,11 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	mode := a.mode
 	cmd := a.cmd
+	extraArgs := append([]string{}, a.cliExtraArgs...)
 	workDir := a.workDir
 	timeout := a.timeout
-	extraEnv := a.providerEnvLocked()
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
@@ -220,7 +223,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
-	return newGeminiSession(ctx, cmd, workDir, model, mode, sessionID, extraEnv, timeout)
+	return newGeminiSession(ctx, cmd, extraArgs, workDir, model, mode, sessionID, extraEnv, timeout)
 }
 
 // ListSessions reads sessions from ~/.gemini/tmp/<project_hash>/chats/.

--- a/agent/gemini/session.go
+++ b/agent/gemini/session.go
@@ -25,34 +25,36 @@ import (
 // with --resume for conversation continuity. The prompt is passed via stdin
 // (using -p - flag) to preserve newlines in multi-line messages.
 type geminiSession struct {
-	cmd      string
-	workDir  string
-	model    string
-	mode     string
-	timeout  time.Duration
-	extraEnv []string
-	events   chan core.Event
-	chatID   atomic.Value // stores string — Gemini session ID
-	ctx      context.Context
-	cancel   context.CancelFunc
-	wg       sync.WaitGroup
-	alive    atomic.Bool
+	cmd       string
+	extraArgs []string // extra args from cmd, prepended before gemini args
+	workDir   string
+	model     string
+	mode      string
+	timeout   time.Duration
+	extraEnv  []string
+	events    chan core.Event
+	chatID    atomic.Value // stores string — Gemini session ID
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	alive     atomic.Bool
 
 	pendingMsgs []string // buffered assistant messages awaiting classification
 }
 
-func newGeminiSession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*geminiSession, error) {
+func newGeminiSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*geminiSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	gs := &geminiSession{
-		cmd:      cmd,
-		workDir:  workDir,
-		model:    model,
-		mode:     mode,
-		timeout:  timeout,
-		extraEnv: extraEnv,
-		events:   make(chan core.Event, 64),
-		ctx:      sessionCtx,
+		cmd:       cmd,
+		extraArgs: extraArgs,
+		workDir:   workDir,
+		model:     model,
+		mode:      mode,
+		timeout:   timeout,
+		extraEnv:  extraEnv,
+		events:    make(chan core.Event, 64),
+		ctx:       sessionCtx,
 		cancel:   cancel,
 	}
 	gs.alive.Store(true)
@@ -112,9 +114,9 @@ func (gs *geminiSession) Send(prompt string, images []core.ImageAttachment, file
 	chatID := gs.CurrentSessionID()
 	isResume := chatID != ""
 
-	args := []string{
+	args := append(append([]string{}, gs.extraArgs...),
 		"--output-format", "stream-json",
-	}
+	)
 
 	switch gs.mode {
 	case "yolo":

--- a/agent/gemini/session_test.go
+++ b/agent/gemini/session_test.go
@@ -497,7 +497,7 @@ func TestComputeLineDiff(t *testing.T) {
 }
 
 func TestGeminiSession_ContinueSessionTreatedAsFresh(t *testing.T) {
-	s, err := newGeminiSession(context.Background(), "echo", "/tmp", "", "default", core.ContinueSession, nil, 0)
+	s, err := newGeminiSession(context.Background(), "echo", nil, "/tmp", "", "default", core.ContinueSession, nil, 0)
 	if err != nil {
 		t.Fatalf("newGeminiSession: %v", err)
 	}

--- a/agent/iflow/iflow.go
+++ b/agent/iflow/iflow.go
@@ -35,6 +35,8 @@ type Agent struct {
 	model          string
 	mode           string
 	cmd            string
+	cliExtraArgs   []string // extra args from cmd after the binary name
+	configEnv      []string // env vars from [projects.agent.options.env]
 	toolTimeoutSec int
 	providers      []core.ProviderConfig
 	activeIdx      int
@@ -50,10 +52,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	model, _ := opts["model"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
-	cmd, _ := opts["cmd"].(string)
-	if cmd == "" {
-		cmd = "iflow"
-	}
+	cmd, extraArgs := core.ParseCmdOpts(opts, "iflow")
 
 	if _, err := exec.LookPath(cmd); err != nil {
 		return nil, fmt.Errorf("iflow: %q CLI not found in PATH, install with: npm i -g @iflow-ai/iflow-cli", cmd)
@@ -74,6 +73,8 @@ func New(opts map[string]any) (core.Agent, error) {
 		model:          model,
 		mode:           mode,
 		cmd:            cmd,
+		cliExtraArgs:   extraArgs,
+		configEnv:      core.ParseConfigEnv(opts),
 		toolTimeoutSec: toolTimeoutSec,
 		activeIdx:      -1,
 	}, nil
@@ -148,9 +149,11 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	mode := a.mode
 	cmd := a.cmd
+	extraArgs := append([]string{}, a.cliExtraArgs...)
 	workDir := a.workDir
 	toolTimeoutSec := a.toolTimeoutSec
-	extraEnv := a.providerEnvLocked()
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
@@ -159,7 +162,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
-	return newIFlowSession(ctx, cmd, workDir, model, mode, sessionID, extraEnv, toolTimeoutSec)
+	return newIFlowSession(ctx, cmd, extraArgs, workDir, model, mode, sessionID, extraEnv, toolTimeoutSec)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/iflow/session.go
+++ b/agent/iflow/session.go
@@ -41,6 +41,7 @@ var iflowPendingToolTimeoutDefaultMode = 6 * time.Second
 // then tails the transcript JSONL to recover structured assistant/tool events.
 type iflowSession struct {
 	cmd            string
+	extraArgs      []string // extra args from cmd, prepended before iflow args
 	workDir        string
 	model          string
 	mode           string
@@ -92,11 +93,12 @@ type iflowToolResult struct {
 	Output string
 }
 
-func newIFlowSession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string, toolTimeoutSec int) (*iflowSession, error) {
+func newIFlowSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, resumeID string, extraEnv []string, toolTimeoutSec int) (*iflowSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	s := &iflowSession{
 		cmd:            cmd,
+		extraArgs:      extraArgs,
 		workDir:        workDir,
 		model:          model,
 		mode:           mode,
@@ -157,7 +159,7 @@ func (s *iflowSession) Send(prompt string, images []core.ImageAttachment, files 
 	}
 	turn.sessionDir = sessionDir
 
-	args := make([]string, 0, 16)
+	args := append([]string{}, s.extraArgs...)
 	if s.model != "" {
 		args = append(args, "-m", s.model)
 	}

--- a/agent/iflow/session_test.go
+++ b/agent/iflow/session_test.go
@@ -337,7 +337,7 @@ func TestIFlowTurnTimerResetsOnPartialToolCompletion(t *testing.T) {
 }
 
 func TestIFlowSessionCustomToolTimeout(t *testing.T) {
-	sess, err := newIFlowSession(context.Background(), "echo", "/tmp", "", "yolo", "", nil, 300)
+	sess, err := newIFlowSession(context.Background(), "echo", nil, "/tmp", "", "yolo", "", nil, 300)
 	if err != nil {
 		t.Fatalf("newIFlowSession: %v", err)
 	}
@@ -348,7 +348,7 @@ func TestIFlowSessionCustomToolTimeout(t *testing.T) {
 }
 
 func TestIFlowSessionDefaultToolTimeout(t *testing.T) {
-	sess, err := newIFlowSession(context.Background(), "echo", "/tmp", "", "yolo", "", nil, 0)
+	sess, err := newIFlowSession(context.Background(), "echo", nil, "/tmp", "", "yolo", "", nil, 0)
 	if err != nil {
 		t.Fatalf("newIFlowSession: %v", err)
 	}
@@ -394,7 +394,7 @@ while :; do sleep 1; done
 		t.Fatalf("WriteFile fake iflow: %v", err)
 	}
 
-	sess, err := newIFlowSession(context.Background(), cmdPath, workDir, "", "default", "", nil, 0)
+	sess, err := newIFlowSession(context.Background(), cmdPath, nil, workDir, "", "default", "", nil, 0)
 	if err != nil {
 		t.Fatalf("newIFlowSession: %v", err)
 	}
@@ -430,7 +430,7 @@ while :; do sleep 1; done
 }
 
 func TestIFlowSession_ContinueSessionTreatedAsFresh(t *testing.T) {
-	s, err := newIFlowSession(context.Background(), "echo", "/tmp", "", "default", core.ContinueSession, nil, 0)
+	s, err := newIFlowSession(context.Background(), "echo", nil, "/tmp", "", "default", core.ContinueSession, nil, 0)
 	if err != nil {
 		t.Fatalf("newIFlowSession: %v", err)
 	}

--- a/agent/kimi/kimi.go
+++ b/agent/kimi/kimi.go
@@ -30,15 +30,17 @@ func init() {
 //   - "plan":    read-only plan mode
 //   - "quiet":   alias for --quiet (print + text + final-message-only)
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string
-	cmd        string // CLI binary name, default "kimi"
-	timeout    time.Duration
-	providers  []core.ProviderConfig
-	activeIdx  int // -1 = no provider set
-	sessionEnv []string
-	mu         sync.RWMutex
+	workDir      string
+	model        string
+	mode         string
+	cmd          string   // CLI binary name, default "kimi"
+	cliExtraArgs []string // extra args from cmd after the binary name
+	configEnv    []string // env vars from [projects.agent.options.env]
+	timeout      time.Duration
+	providers    []core.ProviderConfig
+	activeIdx    int // -1 = no provider set
+	sessionEnv   []string
+	mu           sync.RWMutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -49,10 +51,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	model, _ := opts["model"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
-	cmd, _ := opts["cmd"].(string)
-	if cmd == "" {
-		cmd = "kimi"
-	}
+	cmd, extraArgs := core.ParseCmdOpts(opts, "kimi")
 
 	var timeoutMins int64
 	switch v := opts["timeout_mins"].(type) {
@@ -77,12 +76,14 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 
 	return &Agent{
-		workDir:   workDir,
-		model:     model,
-		mode:      mode,
-		cmd:       cmd,
-		timeout:   timeout,
-		activeIdx: -1,
+		workDir:      workDir,
+		model:        model,
+		mode:         mode,
+		cmd:          cmd,
+		cliExtraArgs: extraArgs,
+		configEnv:    core.ParseConfigEnv(opts),
+		timeout:      timeout,
+		activeIdx:    -1,
 	}, nil
 }
 
@@ -100,7 +101,7 @@ func normalizeMode(raw string) string {
 }
 
 func (a *Agent) Name() string           { return "kimi" }
-func (a *Agent) CLIBinaryName() string  { return "kimi" }
+func (a *Agent) CLIBinaryName() string  { return a.cmd }
 func (a *Agent) CLIDisplayName() string { return "Kimi" }
 
 func (a *Agent) SetWorkDir(dir string) {
@@ -158,9 +159,11 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	mode := a.mode
 	cmd := a.cmd
+	extraArgs := append([]string{}, a.cliExtraArgs...)
 	workDir := a.workDir
 	timeout := a.timeout
-	extraEnv := a.providerEnvLocked()
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
@@ -169,7 +172,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
-	return newKimiSession(ctx, cmd, workDir, model, mode, sessionID, extraEnv, timeout)
+	return newKimiSession(ctx, cmd, extraArgs, workDir, model, mode, sessionID, extraEnv, timeout)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -25,6 +25,7 @@ import (
 // with --resume for conversation continuity.
 type kimiSession struct {
 	cmd       string
+	extraArgs []string // extra args from cmd, prepended before kimi args
 	workDir   string
 	model     string
 	mode      string
@@ -40,19 +41,20 @@ type kimiSession struct {
 	pendingMsgs []string // buffered assistant text messages
 }
 
-func newKimiSession(ctx context.Context, cmd, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*kimiSession, error) {
+func newKimiSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*kimiSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	ks := &kimiSession{
-		cmd:      cmd,
-		workDir:  workDir,
-		model:    model,
-		mode:     mode,
-		timeout:  timeout,
-		extraEnv: extraEnv,
-		events:   make(chan core.Event, 64),
-		ctx:      sessionCtx,
-		cancel:   cancel,
+		cmd:       cmd,
+		extraArgs: extraArgs,
+		workDir:   workDir,
+		model:     model,
+		mode:      mode,
+		timeout:   timeout,
+	extraEnv:  extraEnv,
+		events:    make(chan core.Event, 64),
+		ctx:       sessionCtx,
+		cancel:    cancel,
 	}
 	ks.alive.Store(true)
 
@@ -122,10 +124,10 @@ func (ks *kimiSession) Send(prompt string, images []core.ImageAttachment, files 
 		fullPrompt += "\n\n[Attached files saved at: " + strings.Join(fileRefs, ", ") + "]"
 	}
 
-	args := []string{
+	args := append(append([]string{}, ks.extraArgs...),
 		"--print",
 		"--output-format", "stream-json",
-	}
+	)
 
 	switch ks.mode {
 	case "plan":

--- a/agent/kimi/session_test.go
+++ b/agent/kimi/session_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewKimiSession(t *testing.T) {
 	ctx := context.Background()
-	ks, err := newKimiSession(ctx, "kimi", "/tmp", "kimi-k2", "default", "resume-123", nil, 0)
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "kimi-k2", "default", "resume-123", nil, 0)
 	require.NoError(t, err)
 	require.NotNil(t, ks)
 	assert.True(t, ks.Alive())
@@ -41,7 +41,7 @@ func TestExtractResumeSessionID(t *testing.T) {
 
 func TestHandleAssistantWithText(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
 	defer ks.Close()
 
 	ks.handleEvent(map[string]any{
@@ -58,7 +58,7 @@ func TestHandleAssistantWithText(t *testing.T) {
 
 func TestHandleAssistantWithThink(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
 	defer ks.Close()
 
 	ks.handleEvent(map[string]any{
@@ -78,7 +78,7 @@ func TestHandleAssistantWithThink(t *testing.T) {
 
 func TestHandleAssistantWithToolCalls(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
 	defer ks.Close()
 
 	ks.handleEvent(map[string]any{
@@ -109,7 +109,7 @@ func TestHandleAssistantWithToolCalls(t *testing.T) {
 
 func TestHandleTool(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
 	defer ks.Close()
 
 	ks.handleEvent(map[string]any{
@@ -129,7 +129,7 @@ func TestHandleTool(t *testing.T) {
 
 func TestFlushPendingAsText(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
 	defer ks.Close()
 
 	ks.pendingMsgs = []string{"Hello", " ", "world"}
@@ -144,7 +144,7 @@ func TestFlushPendingAsText(t *testing.T) {
 
 func TestFlushPendingAsThinking(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
 	defer ks.Close()
 
 	ks.pendingMsgs = []string{"Thinking..."}

--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -32,7 +32,9 @@ type Agent struct {
 	workDir              string
 	model                string
 	mode                 string
-	cmd                  string // CLI binary name, default "opencode"
+	cmd                  string   // CLI binary name, default "opencode"
+	cliExtraArgs         []string // extra args from cmd after the binary name
+	configEnv            []string // env vars from [projects.agent.options.env]
 	agentName            string // passed as --agent to opencode (for plugin-defined agents)
 	providers            []core.ProviderConfig
 	activeIdx            int
@@ -67,10 +69,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	model, _ := opts["model"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
-	cmd, _ := opts["cmd"].(string)
-	if cmd == "" {
-		cmd = "opencode"
-	}
+	cmd, extraArgs := core.ParseCmdOpts(opts, "opencode")
 	agentName, _ := opts["agent"].(string) // --agent flag for plugin-defined agents (#1210)
 	ccDataDir, _ := opts["cc_data_dir"].(string)
 	ccProject, _ := opts["cc_project"].(string)
@@ -89,6 +88,8 @@ func New(opts map[string]any) (core.Agent, error) {
 		model:                model,
 		mode:                 mode,
 		cmd:                  cmd,
+		cliExtraArgs:         extraArgs,
+		configEnv:            core.ParseConfigEnv(opts),
 		agentName:            agentName,
 		activeIdx:            -1,
 		modelCachePath:       modelCachePath,
@@ -464,9 +465,11 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	model := a.model
 	mode := a.mode
 	cmd := a.cmd
+	extraArgs := append([]string{}, a.cliExtraArgs...)
 	workDir := a.workDir
 	agentName := a.agentName
-	extraEnv := a.providerEnvLocked()
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
@@ -475,7 +478,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
-	return newOpencodeSession(ctx, cmd, workDir, model, mode, agentName, sessionID, extraEnv)
+	return newOpencodeSession(ctx, cmd, extraArgs, workDir, model, mode, agentName, sessionID, extraEnv)
 }
 
 // ListSessions runs `opencode session list` and parses the JSON output.

--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -25,6 +25,7 @@ import (
 // with --session for conversation continuity.
 type opencodeSession struct {
 	cmd               string
+	extraArgs         []string // extra args from cmd, prepended before opencode args
 	workDir           string
 	model             string
 	mode              string
@@ -40,11 +41,12 @@ type opencodeSession struct {
 	resultSent        atomic.Bool // true when EventResult has been sent for this turn
 }
 
-func newOpencodeSession(ctx context.Context, cmd, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
+func newOpencodeSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	s := &opencodeSession{
 		cmd:       cmd,
+		extraArgs: extraArgs,
 		workDir:   workDir,
 		model:     model,
 		mode:      mode,
@@ -155,7 +157,7 @@ func opencodeImageExt(mimeType string) string {
 }
 
 func (s *opencodeSession) buildRunArgs(prompt string, imagePaths []string, chatID string) []string {
-	args := []string{"run", "--format", "json"}
+	args := append(append([]string{}, s.extraArgs...), "run", "--format", "json")
 
 	if chatID != "" {
 		args = append(args, "--session", chatID)

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -61,7 +61,7 @@ func TestOpencodeSessionEntry_Unmarshal(t *testing.T) {
 // the ContinueSession sentinel (__continue__) is not passed as a literal
 // session ID to the CLI. This was fixed in PR #249.
 func TestNewOpencodeSession_ContinueSessionTreatedAsFresh(t *testing.T) {
-	s, err := newOpencodeSession(context.Background(), "echo", "/tmp", "", "default", "", core.ContinueSession, nil)
+	s, err := newOpencodeSession(context.Background(), "echo", nil, "/tmp", "", "default", "", core.ContinueSession, nil)
 	if err != nil {
 		t.Fatalf("newOpencodeSession: %v", err)
 	}

--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -22,13 +22,15 @@ func init() {
 
 // Agent drives the pi coding agent CLI (`pi --mode json --no-input`).
 type Agent struct {
-	cmd        string // path to pi binary
-	workDir    string
-	model      string
-	mode       string // "default" | "yolo"
-	thinking   string // reasoning effort: off, minimal, low, medium, high, xhigh
-	sessionEnv []string
-	mu         sync.Mutex
+	cmd          string   // path to pi binary
+	cliExtraArgs []string // extra args from cmd after the binary name
+	configEnv    []string // env vars from [projects.agent.options.env]
+	workDir      string
+	model        string
+	mode         string // "default" | "yolo"
+	thinking     string // reasoning effort: off, minimal, low, medium, high, xhigh
+	sessionEnv   []string
+	mu           sync.Mutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -40,10 +42,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
 
-	cmd, _ := opts["cmd"].(string)
-	if cmd == "" {
-		cmd = "pi"
-	}
+	cmd, extraArgs := core.ParseCmdOpts(opts, "pi")
 
 	if _, err := exec.LookPath(cmd); err != nil {
 		return nil, fmt.Errorf("pi: '%s' not found in PATH, install with: npm install -g @mariozechner/pi-coding-agent", cmd)
@@ -57,10 +56,12 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 
 	return &Agent{
-		cmd:     cmd,
-		workDir: workDir,
-		model:   model,
-		mode:    mode,
+		cmd:          cmd,
+		cliExtraArgs: extraArgs,
+		configEnv:    core.ParseConfigEnv(opts),
+		workDir:      workDir,
+		model:        model,
+		mode:         mode,
 	}, nil
 }
 
@@ -74,7 +75,7 @@ func normalizeMode(raw string) string {
 }
 
 func (a *Agent) Name() string           { return "pi" }
-func (a *Agent) CLIBinaryName() string  { return "pi" }
+func (a *Agent) CLIBinaryName() string  { return a.cmd }
 func (a *Agent) CLIDisplayName() string { return "Pi" }
 
 func (a *Agent) SetModel(model string) {
@@ -110,9 +111,11 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	mode := a.mode
 	model := a.model
 	thinking := a.thinking
-	extraEnv := append([]string{}, a.sessionEnv...)
+	extraArgs := append([]string{}, a.cliExtraArgs...)
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.sessionEnv...)
 	a.mu.Unlock()
-	return newPiSession(ctx, a.cmd, a.workDir, model, mode, thinking, sessionID, extraEnv)
+	return newPiSession(ctx, a.cmd, extraArgs, a.workDir, model, mode, thinking, sessionID, extraEnv)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -121,7 +121,7 @@ func TestNew_DefaultCmd(t *testing.T) {
 // ── Agent interface methods ──────────────────────────────────
 
 func TestAgent_NameAndDisplay(t *testing.T) {
-	a := &Agent{}
+	a := &Agent{cmd: "pi"}
 	if a.Name() != "pi" {
 		t.Errorf("Name() = %q", a.Name())
 	}
@@ -645,11 +645,11 @@ func TestCleanAttachments_NonexistentDir(t *testing.T) {
 
 func TestPiSessionAttachmentDirsAreIsolated(t *testing.T) {
 	workDir := t.TempDir()
-	s1, err := newPiSession(context.Background(), "pi", workDir, "", "", "", "", nil)
+	s1, err := newPiSession(context.Background(), "pi", nil, workDir, "", "", "", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s2, err := newPiSession(context.Background(), "pi", workDir, "", "", "", "", nil)
+	s2, err := newPiSession(context.Background(), "pi", nil, workDir, "", "", "", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1186,7 +1186,7 @@ func TestHandleMessageEnd_UserRole(t *testing.T) {
 // ── piSession lifecycle ──────────────────────────────────────
 
 func TestPiSession_NewWithResumeID(t *testing.T) {
-	s, err := newPiSession(context.Background(), "echo", "/tmp", "model", "default", "", "resume-id", nil)
+	s, err := newPiSession(context.Background(), "echo", nil, "/tmp", "model", "default", "", "resume-id", nil)
 	if err != nil {
 		t.Fatalf("newPiSession: %v", err)
 	}
@@ -1202,7 +1202,7 @@ func TestPiSession_ContinueSessionTreatedAsFresh(t *testing.T) {
 	// Claude Code to pick up the latest CLI session via --continue. Agents that
 	// don't support --continue must treat it as "" (fresh session), otherwise
 	// they pass the literal "__continue__" as a session ID which always fails.
-	s, err := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", core.ContinueSession, nil)
+	s, err := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", core.ContinueSession, nil)
 	if err != nil {
 		t.Fatalf("newPiSession: %v", err)
 	}
@@ -1214,7 +1214,7 @@ func TestPiSession_ContinueSessionTreatedAsFresh(t *testing.T) {
 }
 
 func TestPiSession_NewWithoutResumeID(t *testing.T) {
-	s, err := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", "", nil)
+	s, err := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", "", nil)
 	if err != nil {
 		t.Fatalf("newPiSession: %v", err)
 	}
@@ -1226,7 +1226,7 @@ func TestPiSession_NewWithoutResumeID(t *testing.T) {
 }
 
 func TestPiSession_SendWhenClosed(t *testing.T) {
-	s, _ := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", "", nil)
+	s, _ := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", "", nil)
 	s.Close()
 
 	err := s.Send("hello", nil, nil)
@@ -1255,7 +1255,7 @@ func TestPiSession_Events(t *testing.T) {
 }
 
 func TestPiSession_Close(t *testing.T) {
-	s, _ := newPiSession(context.Background(), "echo", "/tmp", "", "default", "", "", nil)
+	s, _ := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", "", nil)
 
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
@@ -1363,7 +1363,7 @@ func TestPiSession_ReadLoopWithEcho(t *testing.T) {
 	line1, _ := json.Marshal(sessionEvent)
 	line2, _ := json.Marshal(textEvent)
 
-	s, err := newPiSession(context.Background(), "sh", "/tmp", "", "default", "", "", nil)
+	s, err := newPiSession(context.Background(), "sh", nil, "/tmp", "", "default", "", "", nil)
 	if err != nil {
 		t.Fatalf("newPiSession: %v", err)
 	}

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -25,6 +25,7 @@ import (
 // Subsequent turns use `--session <sessionID>` to resume.
 type piSession struct {
 	cmd       string
+	extraArgs []string // extra args from cmd, prepended before pi args
 	workDir   string
 	model     string
 	mode      string
@@ -52,16 +53,17 @@ type piSession struct {
 	lastUsage *core.ContextUsage
 }
 
-func newPiSession(ctx context.Context, cmd, workDir, model, mode, thinking, resumeID string, extraEnv []string) (*piSession, error) {
+func newPiSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, thinking, resumeID string, extraEnv []string) (*piSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	s := &piSession{
-		cmd:      cmd,
-		workDir:  workDir,
-		model:    model,
-		mode:     mode,
-		thinking: thinking,
-		extraEnv: extraEnv,
+		cmd:       cmd,
+		extraArgs: extraArgs,
+		workDir:   workDir,
+		model:     model,
+		mode:      mode,
+		thinking:  thinking,
+		extraEnv:  extraEnv,
 		attachDir: filepath.Join(workDir, ".cc-connect", "attachments",
 			fmt.Sprintf("pi_%d", time.Now().UnixNano())),
 		events:   make(chan core.Event, 64),
@@ -95,7 +97,7 @@ func (s *piSession) Send(prompt string, images []core.ImageAttachment, files []c
 		return fmt.Errorf("session is closed")
 	}
 
-	args := []string{"--mode", "json", "-p"}
+	args := append(append([]string{}, s.extraArgs...), "--mode", "json", "-p")
 
 	sid := s.CurrentSessionID()
 	if sid != "" {

--- a/agent/qoder/qoder.go
+++ b/agent/qoder/qoder.go
@@ -19,11 +19,14 @@ func init() {
 
 // Agent drives Qoder CLI using `qodercli -p <prompt> -f stream-json`.
 type Agent struct {
-	workDir    string
-	model      string
-	mode       string // "default" | "yolo"
-	sessionEnv []string
-	mu         sync.Mutex
+	workDir      string
+	cmd          string   // CLI binary name (default: "qodercli")
+	cliExtraArgs []string // extra args from cmd after the binary name
+	configEnv    []string // env vars from [projects.agent.options.env]
+	model        string
+	mode         string // "default" | "yolo"
+	sessionEnv   []string
+	mu           sync.Mutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -35,14 +38,18 @@ func New(opts map[string]any) (core.Agent, error) {
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
 
-	if _, err := exec.LookPath("qodercli"); err != nil {
-		return nil, fmt.Errorf("qoder: 'qodercli' not found in PATH, install with: curl -fsSL https://qoder.com/install | bash")
+	cmd, extraArgs := core.ParseCmdOpts(opts, "qodercli")
+	if _, err := exec.LookPath(cmd); err != nil {
+		return nil, fmt.Errorf("qoder: %q not found in PATH, install with: curl -fsSL https://qoder.com/install | bash", cmd)
 	}
 
 	return &Agent{
-		workDir: workDir,
-		model:   model,
-		mode:    mode,
+		workDir:      workDir,
+		cmd:          cmd,
+		cliExtraArgs: extraArgs,
+		configEnv:    core.ParseConfigEnv(opts),
+		model:        model,
+		mode:         mode,
 	}, nil
 }
 
@@ -56,7 +63,7 @@ func normalizeMode(raw string) string {
 }
 
 func (a *Agent) Name() string           { return "qoder" }
-func (a *Agent) CLIBinaryName() string  { return "qodercli" }
+func (a *Agent) CLIBinaryName() string  { return a.cmd }
 func (a *Agent) CLIDisplayName() string { return "Qoder" }
 
 func (a *Agent) SetWorkDir(dir string) {
@@ -105,11 +112,14 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	a.mu.Lock()
 	mode := a.mode
 	model := a.model
+	cmd := a.cmd
+	extraArgs := append([]string{}, a.cliExtraArgs...)
 	workDir := a.workDir
-	extraEnv := append([]string{}, a.sessionEnv...)
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.sessionEnv...)
 	a.mu.Unlock()
 
-	return newQoderSession(ctx, workDir, model, mode, sessionID, extraEnv)
+	return newQoderSession(ctx, cmd, extraArgs, workDir, model, mode, sessionID, extraEnv)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/qoder/qoder_test.go
+++ b/agent/qoder/qoder_test.go
@@ -133,7 +133,7 @@ func TestAgent_Name(t *testing.T) {
 }
 
 func TestAgent_CLIBinaryName(t *testing.T) {
-	a := &Agent{}
+	a := &Agent{cmd: "qodercli"}
 	if got := a.CLIBinaryName(); got != "qodercli" {
 		t.Errorf("CLIBinaryName() = %q, want %q", got, "qodercli")
 	}

--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -23,16 +23,18 @@ import (
 // Each Send() spawns `qodercli -p <prompt> -f stream-json -q`.
 // Subsequent turns use `-r <sessionID>` to resume the conversation.
 type qoderSession struct {
-	workDir        string
-	model          string
-	mode           string
-	extraEnv       []string
-	events         chan core.Event
-	sessionID      atomic.Value // stores string
-	ctx            context.Context
-	cancel         context.CancelFunc
-	wg             sync.WaitGroup
-	alive          atomic.Bool
+	cmd       string
+	extraArgs []string // extra args from cmd, prepended before qoder args
+	workDir   string
+	model     string
+	mode      string
+	extraEnv  []string
+	events    chan core.Event
+	sessionID atomic.Value // stores string
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	alive     atomic.Bool
 	startupWarning string
 
 	textMu             sync.Mutex
@@ -47,17 +49,19 @@ const maxAssistantTextCacheEntries = 1024
 // silently skipped under root).
 func (qs *qoderSession) StartupWarning() string { return qs.startupWarning }
 
-func newQoderSession(ctx context.Context, workDir, model, mode, resumeID string, extraEnv []string) (*qoderSession, error) {
+func newQoderSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, resumeID string, extraEnv []string) (*qoderSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	qs := &qoderSession{
-		workDir:  workDir,
-		model:    model,
-		mode:     mode,
-		extraEnv: extraEnv,
-		events:   make(chan core.Event, 64),
-		ctx:      sessionCtx,
-		cancel:   cancel,
+		cmd:       cmd,
+		extraArgs: extraArgs,
+		workDir:   workDir,
+		model:     model,
+		mode:      mode,
+		extraEnv:  extraEnv,
+		events:    make(chan core.Event, 64),
+		ctx:       sessionCtx,
+		cancel:    cancel,
 
 		assistantTextByID: make(map[string]string),
 	}
@@ -88,7 +92,7 @@ func (qs *qoderSession) Send(prompt string, images []core.ImageAttachment, files
 		return fmt.Errorf("session is closed")
 	}
 
-	args := []string{"-p", prompt, "-f", "stream-json", "-q", "-w", qs.workDir}
+	args := append(append([]string{}, qs.extraArgs...), "-p", prompt, "-f", "stream-json", "-q", "-w", qs.workDir)
 
 	sid := qs.CurrentSessionID()
 	if sid != "" {
@@ -109,7 +113,7 @@ func (qs *qoderSession) Send(prompt string, images []core.ImageAttachment, files
 
 	slog.Debug("qoderSession: launching", "resume", sid != "", "args_len", len(args))
 
-	cmd := exec.CommandContext(qs.ctx, "qodercli", args...)
+	cmd := exec.CommandContext(qs.ctx, qs.cmd, args...)
 	cmd.Dir = qs.workDir
 	if len(qs.extraEnv) > 0 {
 		cmd.Env = core.MergeEnv(os.Environ(), qs.extraEnv)

--- a/config.example.toml
+++ b/config.example.toml
@@ -1725,7 +1725,7 @@ app_secret = "your-feishu-app-secret"
 # # Optional: override only if the `devin` binary is at a non-standard path.
 # # Always use an absolute path when running under launchd / systemd where
 # # $PATH is minimal (e.g. ~/.local/bin may not be included).
-# # command = "/Users/me/.local/bin/devin"
+# # cmd = "/Users/me/.local/bin/devin"
 # #
 # # Optional: initial permission mode applied to new sessions via
 # # session/set_mode. Valid ids: normal, ask, plan, accept-edits, bypass.
@@ -1765,7 +1765,7 @@ app_secret = "your-feishu-app-secret"
 #
 # [projects.agent.options]
 # work_dir = "/path/to/project"
-# command = "agent"
+# cmd = "agent"
 # args = ["acp"]
 # auth_method = "cursor_login"
 # display_name = "Cursor ACP"
@@ -1793,7 +1793,7 @@ app_secret = "your-feishu-app-secret"
 #
 # [projects.agent.options]
 # work_dir = "/path/to/project"
-# command = "openclaw"
+# cmd = "openclaw"
 # args = ["acp"]
 # # Remote gateway (use token-file on shared hosts — avoid --token in argv):
 # # args = ["acp", "--url", "wss://gateway-host:18789", "--token-file", "/path/to/gateway.token"]
@@ -1811,7 +1811,7 @@ app_secret = "your-feishu-app-secret"
 #
 # [projects.agent.options]
 # work_dir = "/path/to/project"
-# command = "traecli"
+# cmd = "traecli"
 # args = ["acp", "serve"]
 # display_name = "Trae CLI ACP"
 
@@ -1824,7 +1824,7 @@ app_secret = "your-feishu-app-secret"
 #
 # [projects.agent.options]
 # work_dir = "/path/to/project"
-# command = "coco"
+# cmd = "coco"
 # args = ["acp", "serve"]
 # display_name = "COCO ACP"
 
@@ -1839,10 +1839,10 @@ app_secret = "your-feishu-app-secret"
 #
 # [projects.agent.options]
 # work_dir = "/path/to/project"
-# command = "copilot"
+# cmd = "copilot"
 # args = ["--acp", "--stdio"]
 # display_name = "Copilot ACP"
-# # command = "/absolute/path/to/copilot"   # if not on PATH (see COPILOT_CLI_PATH in GitHub docs)
+# # cmd = "/absolute/path/to/copilot"   # if not on PATH (see COPILOT_CLI_PATH in GitHub docs)
 
 # [[projects.platforms]]
 # type = "telegram"
@@ -1956,7 +1956,7 @@ app_secret = "your-feishu-app-secret"
 # work_dir = "/path/to/code"
 # model = "gpt-4.1"           # or claude-sonnet-4.6, o3-mini, etc.
 # mode = "default"            # "default" or "bypassPermissions" (yolo)
-# cli_path = "copilot"        # CLI binary name or path (default: "copilot")
+# cmd = "copilot"              # CLI binary name or path (default: "copilot")
 #
 # [[projects.platforms]]
 # type = "telegram"

--- a/core/cmdopts.go
+++ b/core/cmdopts.go
@@ -1,0 +1,76 @@
+package core
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// ParseCmdOpts extracts the command and extra args from agent options.
+//
+// Priority (first non-empty wins):
+//  1. "cmd" (canonical field, no warning)
+//  2. "cli_path" (deprecated — logs a warning)
+//  3. "command" (deprecated — logs a warning)
+//  4. defaultBin (fallback when nothing is configured)
+//
+// Examples:
+//
+//	"my-cli code -t foo" → cmd="my-cli", extraArgs=["code", "-t", "foo"]
+//	"claude"             → cmd="claude", extraArgs=nil
+//	"" (default "pi")    → cmd="pi", extraArgs=nil
+func ParseCmdOpts(opts map[string]any, defaultBin string) (cmd string, extraArgs []string) {
+	if v, ok := opts["cmd"].(string); ok && strings.TrimSpace(v) != "" {
+		parts := strings.Fields(v)
+		return parts[0], parts[1:]
+	}
+
+	if v, ok := opts["cli_path"].(string); ok && strings.TrimSpace(v) != "" {
+		slog.Warn("DEPRECATED: 'cli_path' is deprecated, use 'cmd' instead",
+			"value", v)
+		parts := strings.Fields(v)
+		return parts[0], parts[1:]
+	}
+
+	if v, ok := opts["command"].(string); ok && strings.TrimSpace(v) != "" {
+		slog.Warn("DEPRECATED: 'command' is deprecated, use 'cmd' instead",
+			"value", v)
+		parts := strings.Fields(v)
+		return parts[0], parts[1:]
+	}
+
+	return defaultBin, nil
+}
+
+// ParseConfigEnv parses opts["env"] (set via [projects.agent.options.env]
+// in config.toml) into a []string of KEY=VALUE pairs.
+//
+// Supports both map[string]string and map[string]any (from TOML parser).
+// Returns nil when no env is configured.
+//
+// The returned slice should be stored separately from sessionEnv so that
+// SetSessionEnv calls cannot overwrite static config env.
+func ParseConfigEnv(opts map[string]any) []string {
+	raw, ok := opts["env"]
+	if !ok || raw == nil {
+		return nil
+	}
+
+	switch m := raw.(type) {
+	case map[string]string:
+		env := make([]string, 0, len(m))
+		for k, v := range m {
+			env = append(env, k+"="+v)
+		}
+		return env
+	case map[string]any:
+		env := make([]string, 0, len(m))
+		for k, v := range m {
+			if s, ok := v.(string); ok {
+				env = append(env, k+"="+s)
+			}
+		}
+		return env
+	default:
+		return nil
+	}
+}

--- a/core/cmdopts.go
+++ b/core/cmdopts.go
@@ -26,6 +26,8 @@ func ParseCmdOpts(opts map[string]any, defaultBin string) (cmd string, extraArgs
 
 	if v, ok := opts["cli_path"].(string); ok && strings.TrimSpace(v) != "" {
 		slog.Warn("DEPRECATED: 'cli_path' is deprecated, use 'cmd' instead",
+			"deprecated_key", "cli_path",
+			"new_key", "cmd",
 			"value", v)
 		parts := strings.Fields(v)
 		return parts[0], parts[1:]
@@ -33,6 +35,8 @@ func ParseCmdOpts(opts map[string]any, defaultBin string) (cmd string, extraArgs
 
 	if v, ok := opts["command"].(string); ok && strings.TrimSpace(v) != "" {
 		slog.Warn("DEPRECATED: 'command' is deprecated, use 'cmd' instead",
+			"deprecated_key", "command",
+			"new_key", "cmd",
 			"value", v)
 		parts := strings.Fields(v)
 		return parts[0], parts[1:]

--- a/core/cmdopts_test.go
+++ b/core/cmdopts_test.go
@@ -1,0 +1,319 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"sort"
+	"testing"
+)
+
+// captureSlog redirects the default slog logger to a buffer for the duration
+// of a test, and returns the buffer plus a restore func.
+func captureSlog(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	prev := slog.Default()
+	buf := &bytes.Buffer{}
+	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	slog.SetDefault(slog.New(handler))
+	return buf, func() { slog.SetDefault(prev) }
+}
+
+func TestParseCmdOpts_CmdField(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       map[string]any
+		defaultBin string
+		wantCmd    string
+		wantArgs   []string
+	}{
+		{
+			name:       "cmd field with no args",
+			opts:       map[string]any{"cmd": "claude"},
+			defaultBin: "fallback",
+			wantCmd:    "claude",
+			wantArgs:   nil,
+		},
+		{
+			name:       "cmd field with extra args",
+			opts:       map[string]any{"cmd": "my-cli code -t foo"},
+			defaultBin: "fallback",
+			wantCmd:    "my-cli",
+			wantArgs:   []string{"code", "-t", "foo"},
+		},
+		{
+			name:       "cmd field with leading/trailing whitespace",
+			opts:       map[string]any{"cmd": "  claude  "},
+			defaultBin: "fallback",
+			wantCmd:    "claude",
+			wantArgs:   nil,
+		},
+		{
+			name:       "cmd field empty falls through to default",
+			opts:       map[string]any{"cmd": ""},
+			defaultBin: "fallback",
+			wantCmd:    "fallback",
+			wantArgs:   nil,
+		},
+		{
+			name:       "cmd field whitespace only falls through to default",
+			opts:       map[string]any{"cmd": "   \t  "},
+			defaultBin: "fallback",
+			wantCmd:    "fallback",
+			wantArgs:   nil,
+		},
+		{
+			name:       "cmd field non-string falls through to default",
+			opts:       map[string]any{"cmd": 12345},
+			defaultBin: "fallback",
+			wantCmd:    "fallback",
+			wantArgs:   nil,
+		},
+		{
+			name:       "no fields set returns default",
+			opts:       map[string]any{},
+			defaultBin: "pi",
+			wantCmd:    "pi",
+			wantArgs:   nil,
+		},
+		{
+			name:       "cmd with single extra arg",
+			opts:       map[string]any{"cmd": "gemini --model pro"},
+			defaultBin: "fallback",
+			wantCmd:    "gemini",
+			wantArgs:   []string{"--model", "pro"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf, restore := captureSlog(t)
+			defer restore()
+			gotCmd, gotArgs := ParseCmdOpts(tt.opts, tt.defaultBin)
+			if gotCmd != tt.wantCmd {
+				t.Errorf("cmd: got %q, want %q", gotCmd, tt.wantCmd)
+			}
+			if !equalStrings(gotArgs, tt.wantArgs) {
+				t.Errorf("extraArgs: got %v, want %v", gotArgs, tt.wantArgs)
+			}
+			if buf.Len() != 0 {
+				t.Errorf("expected no log output, got: %s", buf.String())
+			}
+		})
+	}
+}
+
+func TestParseCmdOpts_DeprecatedCliPath(t *testing.T) {
+	buf, restore := captureSlog(t)
+	defer restore()
+	cmd, extraArgs := ParseCmdOpts(map[string]any{"cli_path": "old-cli --flag"}, "fallback")
+	if cmd != "old-cli" {
+		t.Errorf("cmd: got %q, want %q", cmd, "old-cli")
+	}
+	if !equalStrings(extraArgs, []string{"--flag"}) {
+		t.Errorf("extraArgs: got %v, want %v", extraArgs, []string{"--flag"})
+	}
+	if buf.Len() == 0 {
+		t.Fatal("expected deprecation warning, got none")
+	}
+	var rec map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &rec); err != nil {
+		t.Fatalf("unmarshal log record: %v\nlog: %s", err, buf.String())
+	}
+	if rec["deprecated_key"] != "cli_path" {
+		t.Errorf("deprecated_key: got %v, want %q", rec["deprecated_key"], "cli_path")
+	}
+	if rec["new_key"] != "cmd" {
+		t.Errorf("new_key: got %v, want %q", rec["new_key"], "cmd")
+	}
+	if rec["value"] != "old-cli --flag" {
+		t.Errorf("value: got %v, want %q", rec["value"], "old-cli --flag")
+	}
+}
+
+func TestParseCmdOpts_DeprecatedCommand(t *testing.T) {
+	buf, restore := captureSlog(t)
+	defer restore()
+	cmd, extraArgs := ParseCmdOpts(map[string]any{"command": "legacy-cli sub"}, "fallback")
+	if cmd != "legacy-cli" {
+		t.Errorf("cmd: got %q, want %q", cmd, "legacy-cli")
+	}
+	if !equalStrings(extraArgs, []string{"sub"}) {
+		t.Errorf("extraArgs: got %v, want %v", extraArgs, []string{"sub"})
+	}
+	var rec map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &rec); err != nil {
+		t.Fatalf("unmarshal log record: %v\nlog: %s", err, buf.String())
+	}
+	if rec["deprecated_key"] != "command" {
+		t.Errorf("deprecated_key: got %v, want %q", rec["deprecated_key"], "command")
+	}
+	if rec["new_key"] != "cmd" {
+		t.Errorf("new_key: got %v, want %q", rec["new_key"], "cmd")
+	}
+}
+
+func TestParseCmdOpts_Priority(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    map[string]any
+		wantCmd string
+	}{
+		{
+			name:    "cmd wins over cli_path",
+			opts:    map[string]any{"cmd": "new-cli", "cli_path": "old-cli"},
+			wantCmd: "new-cli",
+		},
+		{
+			name:    "cmd wins over command",
+			opts:    map[string]any{"cmd": "new-cli", "command": "old-cli"},
+			wantCmd: "new-cli",
+		},
+		{
+			name:    "cli_path wins over command",
+			opts:    map[string]any{"cli_path": "mid-cli", "command": "old-cli"},
+			wantCmd: "mid-cli",
+		},
+		{
+			name:    "cli_path wins over default",
+			opts:    map[string]any{"cli_path": "mid-cli"},
+			wantCmd: "mid-cli",
+		},
+		{
+			name:    "command wins over default",
+			opts:    map[string]any{"command": "old-cli"},
+			wantCmd: "old-cli",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, restore := captureSlog(t)
+			defer restore()
+			cmd, _ := ParseCmdOpts(tt.opts, "fallback")
+			if cmd != tt.wantCmd {
+				t.Errorf("cmd: got %q, want %q", cmd, tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestParseCmdOpts_NoWarningForCanonical(t *testing.T) {
+	buf, restore := captureSlog(t)
+	defer restore()
+	ParseCmdOpts(map[string]any{"cmd": "claude"}, "fallback")
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output for 'cmd' field, got: %s", buf.String())
+	}
+}
+
+func TestParseCmdOpts_SlogRestoreNoLeak(t *testing.T) {
+	// Sanity check: the restore func actually reverts the default logger.
+	// We use a unique sentinel handler and verify it's gone after restore.
+	sentinel := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	prev := slog.Default()
+	slog.SetDefault(sentinel)
+	{
+		_, restore := captureSlog(t)
+		restore()
+	}
+	if slog.Default() != sentinel {
+		t.Errorf("expected default logger to be restored to sentinel")
+	}
+	slog.SetDefault(prev) // cleanup
+}
+
+func TestParseConfigEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		opts map[string]any
+		want []string
+	}{
+		{
+			name: "nil opts",
+			opts: nil,
+			want: nil,
+		},
+		{
+			name: "no env key",
+			opts: map[string]any{"cmd": "x"},
+			want: nil,
+		},
+		{
+			name: "env nil value",
+			opts: map[string]any{"env": nil},
+			want: nil,
+		},
+		{
+			name: "env map string string",
+			opts: map[string]any{"env": map[string]string{"FOO": "bar", "BAZ": "qux"}},
+			want: []string{"FOO=bar", "BAZ=qux"},
+		},
+		{
+			name: "env map any string values (TOML output)",
+			opts: map[string]any{"env": map[string]any{"FOO": "bar", "BAZ": "qux"}},
+			want: []string{"FOO=bar", "BAZ=qux"},
+		},
+		{
+			name: "env map any with non-string value is skipped",
+			opts: map[string]any{"env": map[string]any{"FOO": "bar", "NUM": 42}},
+			want: []string{"FOO=bar"},
+		},
+		{
+			name: "env empty map",
+			opts: map[string]any{"env": map[string]string{}},
+			want: []string{},
+		},
+		{
+			name: "env unsupported type returns nil",
+			opts: map[string]any{"env": []string{"FOO=bar"}},
+			want: nil,
+		},
+		{
+			name: "env value containing equals",
+			opts: map[string]any{"env": map[string]string{"URL": "https://x?a=1&b=2"}},
+			want: []string{"URL=https://x?a=1&b=2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseConfigEnv(tt.opts)
+			if !equalStrings(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConfigEnv_DoesNotMutateInput(t *testing.T) {
+	in := map[string]any{
+		"env": map[string]any{
+			"FOO": "bar",
+		},
+	}
+	_ = ParseConfigEnv(in)
+	// Mutate the input — the next call should still return correct data,
+	// proving we don't keep a reference to the inner map.
+	in["env"].(map[string]any)["FOO"] = "mutated"
+	in["env"].(map[string]any)["NEW"] = "added"
+	got := ParseConfigEnv(in)
+	if !equalStrings(got, []string{"FOO=mutated", "NEW=added"}) {
+		t.Errorf("expected fresh read on each call, got %v", got)
+	}
+}
+
+// equalStrings compares two string slices for unordered-set equality.
+// Order is not guaranteed for map-based inputs.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

以前 13 个 agent 对 CLI 二进制路径的配置用着 3 种不同的字段名（`command`、`cli_path`、`cmd`），各自的分词行为也不一致。同时只有 claudecode/codex/acp 支持通过 `[projects.agent.options.env]` 配置静态环境变量，其余 agent 完全不可配。

这个 PR 把两件事集中到了 `core/`：

### 1. `core.ParseCmdOpts()` — 统一 CLI 配置

所有 agent 的 `New()` 中获取二进制路径的逻辑统一替换为：

```go
cmd, extraArgs := core.ParseCmdOpts(opts, defaultBin)
```

- 规范字段名：统一使用 `cmd`（支持 `"binary arg1 arg2"` 格式）
- 向后兼容：`cli_path` 和 `command` 仍然可用，但会打印 deprecation warning
- 修复 bug：
  - **copilot** — 之前 `cli_path` 只用 `TrimSpace` 不分词，现在可以传额外参数
  - **acp** — `command` 之前不分词，现在拆出 `cliExtraArgs`
  - **qoder** — 硬编码 `qodercli` 且完全没有 `SetSessionEnv`，现在可配置二进制路径和 session env

### 2. `core.ParseConfigEnv()` — 统一环境变量配置

所有 agent 的 `New()` 中新增 `configEnv` 字段：

```go
configEnv: core.ParseConfigEnv(opts)
```

- 支持 `[projects.agent.options.env]` 配置，以 `[]string{"KEY=VALUE", ...}` 格式存储
- 独立于 `SetSessionEnv()`，不会被运行时 /env 命令覆盖
- 新增支持的 agent：antigravity, cursor, gemini, iflow, kimi, opencode, pi, qoder

### 3. 修正 env 合并顺序

在所有 agent 的 `StartSession()` 中统一 env 合并顺序（`MergeEnv` 后者优先）：

```
configEnv < providerEnv < sessionEnv
```

两个 agent（copilot、opencode）之前把 `configEnv` 放在 `providerEnv` 之后，导致配置文件中的 env 可能覆盖 provider 的 API key，已修复。

### 4. `cli_args_flag` → `cmd_args_flag`（claudecode）

claudecode 独有的 `cli_args_flag`（用于 wrapper 场景下将 inner args 打包传给外层 CLI）同步改名：

```go
// 优先读新 key
cmdArgsFlag, _ := opts["cmd_args_flag"].(string)
// 向后兼容
if cmdArgsFlag == "" {
    if v, ok := opts["cli_args_flag"].(string); ok && v != "" {
        slog.Warn("DEPRECATED: 'cli_args_flag' is deprecated, use 'cmd_args_flag' instead")
        cmdArgsFlag = v
    }
}
```

---

### 改动前后对比

| Agent | 之前配置字段 | 之后配置字段 | 之前支持 extra args | 之后支持 extra args | 之前支持 `[env]` | 之后支持 `[env]` |
|---|---|---|---|---|---|---|
| **claudecode** | `cli_path` | `cmd` | ✅ strings.Fields | ✅ ParseCmdOpts | ✅ 已有 | ✅ 不变 |
| **codex** | `cli_path` | `cmd` | ✅ strings.Fields | ✅ ParseCmdOpts | ✅ 已有 | ✅ 不变 |
| **copilot** | `cli_path` | `cmd` | ❌ 仅 TrimSpace | ✅ ParseCmdOpts (**修复**) | ❌ | ✅ 新增 |
| **acp** | `command` | `cmd` | ❌ | ✅ ParseCmdOpts (**修复**) | ✅ 已有 | ✅ 不变 |
| **devin** | `command`(委托 acp) | 委托 acp → 自动受益 | ❌ | ✅ 透传受益 | ✅ 委托 acp | ✅ 不变 |
| **antigravity** | `cmd` | `cmd` | ❌ | ✅ ParseCmdOpts | ❌ | ✅ 新增 |
| **cursor** | `cmd` | `cmd` | ❌ | ✅ ParseCmdOpts | ❌ | ✅ 新增 |
| **gemini** | `cmd` | `cmd` | ❌ | ✅ ParseCmdOpts | ❌ | ✅ 新增 |
| **iflow** | `cmd` | `cmd` | ❌ | ✅ ParseCmdOpts | ❌ | ✅ 新增 |
| **kimi** | `cmd` | `cmd` | ❌ | ✅ ParseCmdOpts | ❌ | ✅ 新增 |
| **opencode** | `cmd` | `cmd` | ❌ | ✅ ParseCmdOpts | ❌ | ✅ 新增 |
| **pi** | `cmd` | `cmd` | ❌ | ✅ ParseCmdOpts | ❌ | ✅ 新增 |
| **qoder** | 硬编码 `qodercli` | `cmd` | ❌ | ✅ ParseCmdOpts (**修复**) | ❌ 无 SetSessionEnv | ✅ 新增 + sessionEnv |
| **tmux** | N/A | N/A | N/A | N/A | N/A | N/A |

### 核心新文件

- `core/cmdopts.go` — `ParseCmdOpts()` + `ParseConfigEnv()`

## Tests

- [x] `go build ./...`
- [x] `go test ./...` — all 28 packages pass (pre-existing flaky `TempDir cleanup` in `engine_matrix` only)
- [x] `go vet ./...`