### PR TITLE
feat(stream_preview): add stop_behavior config to freeze preview on /stop (#1295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+- **`[stream_preview] stop_behavior = "freeze"`**: when the user interrupts an agent turn with `/stop`, the partial streaming preview message is now optionally preserved on the IM side instead of being unconditionally deleted (#1295). Users can read the partial answer and quote it in their next instruction. Add `stop_behavior = "freeze"` under `[stream_preview]`; the default (`"discard"`) preserves the prior behavior. The frozen preview is detached from the streaming lifecycle so the next turn starts a fresh preview without conflict.
+
 ## v1.3.3 (2026-06-15)
 
 First stable release of the 1.3.3 series. Stabilizes the v1.3.3-beta.1 → v1.3.3-beta.5

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -595,6 +595,13 @@ func main() {
 			if cfg.StreamPreview.DisabledPlatforms != nil {
 				spcfg.DisabledPlatforms = cfg.StreamPreview.DisabledPlatforms
 			}
+			if cfg.StreamPreview.StopBehavior != nil {
+				if !core.StopBehaviorIsValid(*cfg.StreamPreview.StopBehavior) {
+					slog.Error("invalid [stream_preview] stop_behavior: must be \"discard\" or \"freeze\"", "value", *cfg.StreamPreview.StopBehavior)
+					os.Exit(1)
+				}
+				spcfg.StopBehavior = *cfg.StreamPreview.StopBehavior
+			}
 			engine.SetStreamPreviewCfg(spcfg)
 		}
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -210,10 +210,19 @@ level = "info" # debug, info, warn, error
 # 支持 Telegram、Discord 和飞书。消息会定期编辑，直到最终回复发送。
 
 # [stream_preview]
-# enabled = true            # Enable/disable streaming preview (default: true) / 启用/禁用流式预览（默认 true）
-# interval_ms = 1500        # Min ms between updates (default: 1500) / 更新最小间隔毫秒数（默认 1500）
-# min_delta_chars = 30      # Min new chars before sending update (default: 30) / 发送更新前最少新增字符数（默认 30）
-# max_chars = 2000          # Max preview length (default: 2000) / 预览最大长度（默认 2000）
+# enabled = true # Enable/disable streaming preview (default: true) / 启用/禁用流式预览（默认 true）
+# interval_ms =1500 # Min ms between updates (default:1500) / 更新最小间隔毫秒数（默认1500）
+# min_delta_chars =30 # Min new chars before sending update (default:30) / 发送更新前最少新增字符数（默认30）
+# max_chars =2000 # Max preview length (default:2000) / 预览最大长度（默认2000）
+# stop_behavior = "discard" # What to do with the preview when /stop interrupts the agent turn (#1295):
+# # "discard" (default) - delete the preview message on /stop
+# # "freeze" - keep the partial preview on /stop so the user can read and quote
+# # it when composing their next instruction. The preview is detached
+# # so the next turn can start a fresh preview without conflict.
+# # /stop 中断 agent turn 时如何处理 preview 消息（#1295）：
+# # "discard"（默认）- 删除 preview 消息（保持旧行为）
+# # "freeze" - 保留部分 preview，用户可在下一条指令中阅读或引用；
+# # 同时与 streaming lifecycle 解绑，下一轮的 preview 不会冲突
 
 # =============================================================================
 # Instant Reply / 即时确认回复

--- a/config.example.toml
+++ b/config.example.toml
@@ -210,10 +210,10 @@ level = "info" # debug, info, warn, error
 # 支持 Telegram、Discord 和飞书。消息会定期编辑，直到最终回复发送。
 
 # [stream_preview]
-# enabled = true # Enable/disable streaming preview (default: true) / 启用/禁用流式预览（默认 true）
-# interval_ms =1500 # Min ms between updates (default:1500) / 更新最小间隔毫秒数（默认1500）
-# min_delta_chars =30 # Min new chars before sending update (default:30) / 发送更新前最少新增字符数（默认30）
-# max_chars =2000 # Max preview length (default:2000) / 预览最大长度（默认2000）
+# enabled = true            # Enable/disable streaming preview (default: true) / 启用/禁用流式预览（默认 true）
+# interval_ms = 1500        # Min ms between updates (default: 1500) / 更新最小间隔毫秒数（默认 1500）
+# min_delta_chars = 30      # Min new chars before sending update (default: 30) / 发送更新前最少新增字符数（默认 30）
+# max_chars = 2000          # Max preview length (default: 2000) / 预览最大长度（默认 2000）
 # stop_behavior = "discard" # What to do with the preview when /stop interrupts the agent turn (#1295):
 # # "discard" (default) - delete the preview message on /stop
 # # "freeze" - keep the partial preview on /stop so the user can read and quote

--- a/config/config.go
+++ b/config/config.go
@@ -200,9 +200,9 @@ type DisplayConfig struct {
 type StreamPreviewConfig struct {
 	Enabled           *bool    `toml:"enabled"`                      // default true
 	DisabledPlatforms []string `toml:"disabled_platforms,omitempty"` // platforms where preview is disabled (e.g. ["feishu"])
-	IntervalMs        *int     `toml:"interval_ms"`                  // min ms between updates; default1500
-	MinDeltaChars     *int     `toml:"min_delta_chars"`              // min new chars before update; default30
-	MaxChars          *int     `toml:"max_chars"`                    // max preview length; default2000
+	IntervalMs        *int     `toml:"interval_ms"`                  // min ms between updates; default 1500
+	MinDeltaChars     *int     `toml:"min_delta_chars"`              // min new chars before update; default 30
+	MaxChars          *int     `toml:"max_chars"`                    // max preview length; default 2000
 	StopBehavior      *string  `toml:"stop_behavior,omitempty"`      // preview disposal on /stop: "" | "discard" (default) | "freeze" (#1295)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -200,9 +200,10 @@ type DisplayConfig struct {
 type StreamPreviewConfig struct {
 	Enabled           *bool    `toml:"enabled"`                      // default true
 	DisabledPlatforms []string `toml:"disabled_platforms,omitempty"` // platforms where preview is disabled (e.g. ["feishu"])
-	IntervalMs        *int     `toml:"interval_ms"`                  // min ms between updates; default 1500
-	MinDeltaChars     *int     `toml:"min_delta_chars"`              // min new chars before update; default 30
-	MaxChars          *int     `toml:"max_chars"`                    // max preview length; default 2000
+	IntervalMs        *int     `toml:"interval_ms"`                  // min ms between updates; default1500
+	MinDeltaChars     *int     `toml:"min_delta_chars"`              // min new chars before update; default30
+	MaxChars          *int     `toml:"max_chars"`                    // max preview length; default2000
+	StopBehavior      *string  `toml:"stop_behavior,omitempty"`      // preview disposal on /stop: "" | "discard" (default) | "freeze" (#1295)
 }
 
 // InstantReplyConfig controls the immediate confirmation reply sent when a message

--- a/core/engine.go
+++ b/core/engine.go
@@ -4380,7 +4380,18 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		select {
 		case <-stopCh:
-			sp.discard()
+			// /stop interrupts the agent turn. The streaming preview lifecycle
+			// can either drop or freeze the preview, controlled by
+			// [stream_preview] stop_behavior (default: discard). Freezing
+			// keeps the partial text on screen and detaches the handle so
+			// the next turn's SendPreviewStart does not collide with it
+			// (#1295).
+			if e.streamPreview.StopBehavior == StopBehaviorFreeze {
+				sp.freeze()
+				sp.detachPreview()
+			} else {
+				sp.discard()
+			}
 			return
 		case event, ok = <-events:
 			if !ok {

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -8,13 +8,38 @@ import (
 	"time"
 )
 
+// StopBehavior values control what happens to the streaming preview message
+// when the user interrupts an agent turn with /stop.
+const (
+	// StopBehaviorDiscard deletes the preview message on /stop. This is the
+	// default and preserves the prior behavior.
+	StopBehaviorDiscard = "discard"
+	// StopBehaviorFreeze keeps the preview message on /stop, freezes it at
+	// the last text, and detaches it from the streaming lifecycle so the
+	// next turn can send a fresh message without conflict. Users can read
+	// and quote the frozen preview when composing their next instruction.
+	StopBehaviorFreeze = "freeze"
+)
+
+// StopBehaviorIsValid reports whether v is a known stop_behavior value.
+// Empty string is treated as valid and resolves to the default (discard).
+func StopBehaviorIsValid(v string) bool {
+	switch v {
+	case "", StopBehaviorDiscard, StopBehaviorFreeze:
+		return true
+	default:
+		return false
+	}
+}
+
 // StreamPreviewCfg controls the streaming preview behavior.
 type StreamPreviewCfg struct {
 	Enabled           bool     // global toggle
 	DisabledPlatforms []string // platforms where streaming preview is disabled (e.g. "feishu")
-	IntervalMs        int      // minimum ms between updates (default 1500)
-	MinDeltaChars     int      // minimum new chars before sending an update (default 30)
-	MaxChars          int      // max preview length (default 2000)
+	IntervalMs        int      // minimum ms between updates (default1500)
+	MinDeltaChars     int      // minimum new chars before sending an update (default30)
+	MaxChars          int      // max preview length (default2000)
+	StopBehavior      string   // what to do with preview on /stop: "" | "discard" (default) | "freeze"
 }
 
 // DefaultStreamPreviewCfg returns sensible defaults.
@@ -25,6 +50,7 @@ func DefaultStreamPreviewCfg() StreamPreviewCfg {
 		IntervalMs:        1500,
 		MinDeltaChars:     30,
 		MaxChars:          2000,
+		StopBehavior:      StopBehaviorDiscard,
 	}
 }
 

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -36,9 +36,9 @@ func StopBehaviorIsValid(v string) bool {
 type StreamPreviewCfg struct {
 	Enabled           bool     // global toggle
 	DisabledPlatforms []string // platforms where streaming preview is disabled (e.g. "feishu")
-	IntervalMs        int      // minimum ms between updates (default1500)
-	MinDeltaChars     int      // minimum new chars before sending an update (default30)
-	MaxChars          int      // max preview length (default2000)
+	IntervalMs        int      // minimum ms between updates (default 1500)
+	MinDeltaChars     int      // minimum new chars before sending an update (default 30)
+	MaxChars          int      // max preview length (default 2000)
 	StopBehavior      string   // what to do with preview on /stop: "" | "discard" (default) | "freeze"
 }
 

--- a/core/streaming_test.go
+++ b/core/streaming_test.go
@@ -460,3 +460,156 @@ func TestStreamPreview_AppliesTransform(t *testing.T) {
 		t.Fatalf("final message = %q, want transformed final preview", got)
 	}
 }
+
+// TestStreamPreview_StopBehaviorFreeze_KeepsAndDetaches verifies the freeze
+// branch used by the engine when [stream_preview] stop_behavior = "freeze":
+// freeze() must push the final accumulated text to the platform and
+// detachPreview() must clear previewMsgID so a subsequent streamPreview
+// can send a fresh preview without colliding with the frozen one (#1295).
+func TestStreamPreview_StopBehaviorFreeze_KeepsAndDetaches(t *testing.T) {
+	mp := &mockCleanerPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 1,
+		MaxChars:      500,
+		StopBehavior:  StopBehaviorFreeze,
+	}
+
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+	sp.appendText("partial answer so far")
+	time.Sleep(80 * time.Millisecond)
+
+	// Simulate the engine.go /stop branch: freeze then detach.
+	sp.freeze()
+	sp.detachPreview()
+
+	mp.mu.Lock()
+	deletedCount := len(mp.deleted)
+	msgs := append([]string(nil), mp.messages...)
+	mp.mu.Unlock()
+
+	if deletedCount != 0 {
+		t.Fatalf("freeze must NOT delete preview; got %d delete calls", deletedCount)
+	}
+	last := ""
+	if len(msgs) > 0 {
+		last = msgs[len(msgs)-1]
+	}
+	if !strings.HasPrefix(last, "update:") {
+		t.Fatalf("final message = %q, want an update: prefix from freeze()", last)
+	}
+	if !strings.Contains(last, "partial answer so far") {
+		t.Fatalf("final message = %q, want to contain accumulated text", last)
+	}
+	if sp.previewMsgID != nil {
+		t.Fatalf("detachPreview should clear previewMsgID; got %#v", sp.previewMsgID)
+	}
+
+	// A second streamPreview in the next turn must be able to start a fresh
+	// preview without conflicting with the frozen one. detachPreview already
+	// cleared the handle so the prior preview is invisible to the lifecycle.
+	sp2 := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+	sp2.appendText("next turn first chunk")
+	time.Sleep(80 * time.Millisecond)
+
+	mp.mu.Lock()
+	startMsgs := []string{}
+	for _, m := range mp.messages {
+		if strings.HasPrefix(m, "start:") {
+			startMsgs = append(startMsgs, m)
+		}
+	}
+	mp.mu.Unlock()
+	if len(startMsgs) != 2 {
+		t.Fatalf("next-turn start count = %d, want2 (frozen + fresh); msgs=%v", len(startMsgs), startMsgs)
+	}
+}
+
+// TestStreamPreview_StopBehaviorDiscard_DefaultUnchanged verifies that the
+// default StopBehavior ("") resolves to discard, matching the prior
+// behavior where /stop removes the preview message entirely.
+func TestStreamPreview_StopBehaviorDiscard_DefaultUnchanged(t *testing.T) {
+	mp := &mockCleanerPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 1,
+		MaxChars:      500,
+		// StopBehavior left empty on purpose: defaults to discard.
+	}
+	if cfg.StopBehavior != "" {
+		t.Fatalf("test fixture broken: StopBehavior = %q, want empty", cfg.StopBehavior)
+	}
+
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+	sp.appendText("Hello World")
+	time.Sleep(80 * time.Millisecond)
+
+	// Simulate the engine.go /stop branch when StopBehavior is not "freeze":
+	// discard() should run, deleting the preview message.
+	if sp.cfg.StopBehavior == StopBehaviorFreeze {
+		t.Fatal("test premise broken: empty StopBehavior must not equal freeze")
+	}
+	sp.discard()
+
+	mp.mu.Lock()
+	deletedCount := len(mp.deleted)
+	mp.mu.Unlock()
+	if deletedCount != 1 {
+		t.Fatalf("default /stop should delete preview; got %d delete calls", deletedCount)
+	}
+}
+
+// TestStreamPreview_StopBehaviorDiscard_ExplicitString verifies that setting
+// StopBehavior = "discard" behaves identically to leaving it empty (both
+// call discard, neither freezes).
+func TestStreamPreview_StopBehaviorDiscard_ExplicitString(t *testing.T) {
+	mp := &mockCleanerPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 1,
+		MaxChars:      500,
+		StopBehavior:  StopBehaviorDiscard,
+	}
+
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+	sp.appendText("Hello World")
+	time.Sleep(80 * time.Millisecond)
+
+	if sp.cfg.StopBehavior == StopBehaviorFreeze {
+		t.Fatal("explicit discard must not be classified as freeze")
+	}
+	sp.discard()
+
+	mp.mu.Lock()
+	deletedCount := len(mp.deleted)
+	mp.mu.Unlock()
+	if deletedCount != 1 {
+		t.Fatalf("explicit discard should delete preview; got %d delete calls", deletedCount)
+	}
+}
+
+// TestStopBehaviorIsValid guards against typos in TOML config: any value
+// outside {"", "discard", "freeze"} should be rejected by the validator.
+func TestStopBehaviorIsValid(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"", true},
+		{StopBehaviorDiscard, true},
+		{StopBehaviorFreeze, true},
+		{"DISCARD", false},
+		{"Freeze", false},
+		{"drop", false},
+		{"keep", false},
+		{"true", false},
+	}
+	for _, c := range cases {
+		if got := StopBehaviorIsValid(c.value); got != c.want {
+			t.Errorf("StopBehaviorIsValid(%q) = %v, want %v", c.value, got, c.want)
+		}
+	}
+}

--- a/tests/release_local/config_matrix/config_matrix_test.go
+++ b/tests/release_local/config_matrix/config_matrix_test.go
@@ -128,6 +128,8 @@ disabled_platforms = ["feishu", "telegram"]
 interval_ms = 250
 min_delta_chars = 12
 max_chars = 777
+stop_behavior = "freeze"
+
 
 [[projects]]
 name = "release"
@@ -169,6 +171,9 @@ app_secret = "secret"
 	}
 	if cfg.StreamPreview.MaxChars == nil || *cfg.StreamPreview.MaxChars != 777 {
 		t.Fatalf("stream_preview.max_chars = %#v, want 777", cfg.StreamPreview.MaxChars)
+	}
+	if cfg.StreamPreview.StopBehavior == nil || *cfg.StreamPreview.StopBehavior != "freeze" {
+		t.Fatalf("stream_preview.stop_behavior = %#v, want \"freeze\"", cfg.StreamPreview.StopBehavior)
 	}
 
 	proj := &cfg.Projects[0]


### PR DESCRIPTION
Fixes #1295

## Problem

On , cc-connect unconditionally deletes the streaming preview message
(`sp.discard()`). The user cannot see or quote the partial agent output
when composing their next instruction.

## Solution

Add a new `[stream_preview] stop_behavior` option:

| Value | Effect on /stop |
|---|---|
| `"discard"` (default) | Delete the preview message (current behavior) |
| `"freeze"` | Keep the partial preview on screen; detach from streaming lifecycle so the next turn's preview starts fresh without conflict. |

## Changes

- `core/streaming.go` — add `StopBehavior` field + `StopBehaviorDiscard`/`StopBehaviorFreeze` constants + `StopBehaviorIsValid` validator.
- `core/engine.go` — `case <-stopCh:` branch is now conditional: freeze + detachPreview when stop_behavior == "freeze", otherwise discard.
- `config/config.go` — add `StopBehavior *string` with `toml:"stop_behavior,omitempty"` tag.
- `cmd/cc-connect/main.go` — plumb the new field through startup, with validation that fails fast on unknown values.
- `config.example.toml` — bilingual (en+zh) docs for the new option.
- `CHANGELOG.md` — Unreleased entry.

## Tests

4 new unit tests in `core/streaming_test.go`:
- `TestStreamPreview_StopBehaviorFreeze_KeepsAndDetaches` — freeze + detach, verify preview is NOT deleted, last text is in place, and a fresh second streamPreview starts cleanly (no conflict).
- `TestStreamPreview_StopBehaviorDiscard_DefaultUnchanged` — empty StopBehavior resolves to discard (existing behavior preserved).
- `TestStreamPreview_StopBehaviorDiscard_ExplicitString` — explicit `"discard"` behaves like the default.
- `TestStopBehaviorIsValid` — validator rejects typos (DISCARD, Freeze, drop, keep, true).

Also extended `tests/release_local/config_matrix/config_matrix_test.go` to parse and assert `stop_behavior = "freeze"`.

## Validation

- `go build ./core ./config` — clean
- `go vet ./core ./config` — clean
- `gofmt -l` — clean
- `go test ./core/` — full suite PASS (43.7s)
- `go test ./config/` — PASS
- `go test ./tests/release_local/config_matrix/` — PASS
- `go test ./tests/release_local/turn_contract/` (Streaming tests) — PASS

## Non-goals (unchanged)

- `freeze()` / `detachPreview()` internals — these already existed and are used by the thinking/permission paths; not modified.
- Other `/stop` behavior — only the preview disposal is affected.
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)