### PR TITLE
feat(feishu): support after_click card replacement for cmd: actions

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -737,7 +737,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		}, nil
 	}
 
-	// cmd: — async command dispatch
+	// cmd: — async command dispatch, with optional in-place card replacement
 	if strings.HasPrefix(actionVal, "cmd:") {
 		cmdText := strings.TrimPrefix(actionVal, "cmd:")
 		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
@@ -754,6 +754,30 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 			Content:    cmdText,
 			ReplyCtx:   rctx,
 		})
+
+		if ac, ok := event.Event.Action.Value["after_click"].(map[string]any); ok {
+			if title, _ := ac["title"].(string); title != "" {
+				color, _ := ac["color"].(string)
+				if color == "" {
+					color = "green"
+				}
+				cb := core.NewCard().Title(title, color)
+				if md, _ := ac["markdown"].(string); md != "" {
+					cb.Markdown(md)
+				}
+				if linkText, _ := ac["link_text"].(string); linkText != "" {
+					if linkURL, _ := ac["link_url"].(string); linkURL != "" {
+						cb.Divider().Markdown("[" + linkText + "](" + linkURL + ")")
+					}
+				}
+				return &callback.CardActionTriggerResponse{
+					Card: &callback.Card{
+						Type: "raw",
+						Data: renderCardMap(cb.Build(), sessionKey),
+					},
+				}, nil
+			}
+		}
 	}
 
 	return nil, nil

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -2181,3 +2181,147 @@ func TestOnMessage_GracePeriodMessageIsProcessed(t *testing.T) {
 		t.Error("handler should be called for message within the 2s grace window")
 	}
 }
+
+func TestCmdAction_WithoutAfterClick_DispatchesAndReturnsNil(t *testing.T) {
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip, ok := platformAny.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *interactivePlatform", platformAny)
+	}
+
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) { msgCh <- msg }
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_user1"},
+			Action:   &callback.CallBackAction{Value: map[string]any{"action": "cmd:/verify F9F-162"}},
+			Context:  &callback.Context{OpenChatID: "oc_chat1", OpenMessageID: "om_msg1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response without after_click, got %#v", resp)
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "/verify F9F-162" {
+			t.Fatalf("dispatched content = %q, want /verify F9F-162", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected command to be dispatched")
+	}
+}
+
+func TestCmdAction_WithAfterClick_DispatchesAndReturnsCard(t *testing.T) {
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip, ok := platformAny.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *interactivePlatform", platformAny)
+	}
+
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) { msgCh <- msg }
+
+	afterClick := map[string]any{
+		"title":     "✅ Done",
+		"color":     "green",
+		"markdown":  "Command recorded.",
+		"link_text": "↗ Open",
+		"link_url":  "https://example.com/task/123",
+	}
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_user1"},
+			Action: &callback.CallBackAction{Value: map[string]any{
+				"action":      "cmd:/run-task 123",
+				"after_click": afterClick,
+			}},
+			Context: &callback.Context{OpenChatID: "oc_chat1", OpenMessageID: "om_msg1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp == nil || resp.Card == nil {
+		t.Fatalf("expected card response with after_click, got %#v", resp)
+	}
+	if resp.Card.Type != "raw" {
+		t.Fatalf("card type = %q, want raw", resp.Card.Type)
+	}
+	cardData, ok := resp.Card.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("card data type = %T, want map[string]any", resp.Card.Data)
+	}
+	header, ok := cardData["header"].(map[string]any)
+	if !ok {
+		t.Fatalf("card header type = %T, want map[string]any", cardData["header"])
+	}
+	if header["template"] != "green" {
+		t.Fatalf("card color = %q, want green", header["template"])
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "/run-task 123" {
+			t.Fatalf("dispatched content = %q, want /run-task 123", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected command to be dispatched")
+	}
+}
+
+func TestCmdAction_WithAfterClick_SessionKeyRoutes(t *testing.T) {
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip, ok := platformAny.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *interactivePlatform", platformAny)
+	}
+
+	const wantSessionKey = "custom-session-abc"
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) { msgCh <- msg }
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_user1"},
+			Action: &callback.CallBackAction{Value: map[string]any{
+				"action":      "cmd:/hello",
+				"session_key": wantSessionKey,
+				"after_click": map[string]any{"title": "✅ Sent"},
+			}},
+			Context: &callback.Context{OpenChatID: "oc_chat1", OpenMessageID: "om_msg1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp == nil || resp.Card == nil {
+		t.Fatalf("expected card response, got %#v", resp)
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.SessionKey != wantSessionKey {
+			t.Fatalf("session key = %q, want %q", msg.SessionKey, wantSessionKey)
+		}
+		if msg.Content != "/hello" {
+			t.Fatalf("content = %q, want /hello", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected command to be dispatched with correct session key")
+	}
+}


### PR DESCRIPTION
## Summary

- `cmd:` button actions now support an optional `after_click` object in the button value. When present with a non-empty `title`, `onCardAction` returns a `CardActionTriggerResponse` that replaces the original card in-place — while still dispatching the command to the agent asynchronously, exactly as before.
- If `after_click` is absent or has no `title`, behavior is **unchanged** (returns `nil`).
- The feature is generic — no platform-specific or domain-specific logic.

**Button value shape:**
```json
{
  "action": "cmd:<prompt>",
  "session_key": "...",
  "after_click": {
    "title": "✅ Done",
    "color": "green",
    "markdown": "Body text here.",
    "link_text": "↗ Open",
    "link_url": "https://example.com/..."
  }
}
```

**`after_click` fields:**
| Field | Required | Default | Description |
|---|---|---|---|
| `title` | yes | — | Card header text; if empty, feature is skipped |
| `color` | no | `"green"` | Header template color |
| `markdown` | no | — | Body markdown content |
| `link_text` + `link_url` | no | — | Appended as a markdown link after a divider |

## Test plan

- [x] `TestCmdAction_WithoutAfterClick_DispatchesAndReturnsNil` — no `after_click` → dispatches command, returns `nil`
- [x] `TestCmdAction_WithAfterClick_DispatchesAndReturnsCard` — with `after_click` → dispatches command **and** returns replacement card with correct header color
- [x] `TestCmdAction_WithAfterClick_SessionKeyRoutes` — `session_key` in button value still routes the dispatched message to the correct session
- [x] Full `./platform/feishu` test suite passes (`go test ./platform/feishu`)

Related: https://github.com/chenhg5/cc-connect/issues/871
Related: https://github.com/chenhg5/cc-connect/issues/936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1347
