### PR TITLE
fix(core): defer session restart on /model until the in-flight turn completes

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3736,6 +3736,37 @@ func (e *Engine) cleanupInteractiveState(sessionKey string, expected ...*interac
 	e.interactiveMu.Unlock()
 }
 
+// settingsChangeIdleWaitCeiling bounds how long a deferred session restart
+// (e.g. after /model) waits for an in-flight turn to finish.
+const settingsChangeIdleWaitCeiling = 30 * time.Minute
+
+// restartInteractiveSessionWhenIdle closes the interactive agent session so
+// the next turn respawns with updated settings (e.g. a new model). Unlike
+// calling cleanupInteractiveState directly, an in-flight turn is not killed:
+// when the session is busy the restart is deferred to a background goroutine
+// that waits for the turn to finish first, so the in-flight response is
+// delivered normally and the new settings apply from the next turn onward.
+// Returns true when the restart was deferred.
+func (e *Engine) restartInteractiveSessionWhenIdle(sessions *SessionManager, sessionKey, interactiveKey string) bool {
+	session := sessions.GetOrCreateActive(sessionKey)
+	if session.TryLock() {
+		session.UnlockWithoutUpdate()
+		e.cleanupInteractiveState(interactiveKey)
+		return false
+	}
+
+	go func() {
+		// Wait for the in-flight turn to release the session lock. If the
+		// ceiling is hit the restart proceeds anyway — equivalent to the
+		// pre-deferral behavior, just much later.
+		if e.waitForSessionLock(session, settingsChangeIdleWaitCeiling) {
+			session.UnlockWithoutUpdate()
+		}
+		e.cleanupInteractiveState(interactiveKey)
+	}()
+	return true
+}
+
 func (e *Engine) closeAgentSessionAsync(sessionKey string, agentSession AgentSession) {
 	if agentSession == nil {
 		return
@@ -8857,13 +8888,17 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChangeFailed, err))
 		return
 	}
-	e.cleanupInteractiveState(interactiveKey)
+	deferred := e.restartInteractiveSessionWhenIdle(sessions, msg.SessionKey, interactiveKey)
 
 	// Keep the existing agent session ID so the next StartSession uses
 	// --resume <id> --model <new>, which lets the CLI agent restore context
 	// natively without replaying history (no extra token cost).
 	sessions.Save()
 
+	if deferred {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChangedDeferred, target))
+		return
+	}
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChanged, target))
 }
 
@@ -10800,7 +10835,7 @@ func (e *Engine) handleModelCardAction(args, sessionKey string) *Card {
 	}
 
 	resolved, err := e.switchModelOnAgent(agent, target, agent == e.agent)
-	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(sessionKey))
+	e.restartInteractiveSessionWhenIdle(sessions, sessionKey, e.interactiveKeyForSessionKey(sessionKey))
 	if err == nil {
 		sessions.Save()
 	}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -14326,3 +14326,63 @@ func TestHandlePendingPermission_StalePermissionCallback_Dropped(t *testing.T) {
 		}
 	})
 }
+
+// --- restartInteractiveSessionWhenIdle tests ---
+
+type closeTrackingAgentSession struct {
+	stubAgentSession
+	closed atomic.Bool
+}
+
+func (s *closeTrackingAgentSession) Close() error {
+	s.closed.Store(true)
+	return nil
+}
+
+func TestRestartInteractiveSessionWhenIdle_DefersWhileTurnInFlight(t *testing.T) {
+	e := newTestEngine()
+	sessionKey := "test:chat:user"
+	as := &closeTrackingAgentSession{}
+	e.interactiveStates[sessionKey] = &interactiveState{agentSession: as}
+
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	if !session.TryLock() {
+		t.Fatalf("expected to lock fresh session")
+	}
+
+	deferred := e.restartInteractiveSessionWhenIdle(e.sessions, sessionKey, sessionKey)
+	if !deferred {
+		t.Fatalf("expected restart to be deferred while turn is in flight")
+	}
+
+	// The in-flight turn must not be killed by the model switch.
+	time.Sleep(100 * time.Millisecond)
+	if as.closed.Load() {
+		t.Fatalf("agent session closed while turn was still in flight")
+	}
+
+	// Turn finishes — the deferred restart should now close the session.
+	session.Unlock()
+	deadline := time.Now().Add(5 * time.Second)
+	for !as.closed.Load() {
+		if time.Now().After(deadline) {
+			t.Fatalf("agent session was not closed after the turn finished")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestRestartInteractiveSessionWhenIdle_RestartsImmediatelyWhenIdle(t *testing.T) {
+	e := newTestEngine()
+	sessionKey := "test:chat:user"
+	as := &closeTrackingAgentSession{}
+	e.interactiveStates[sessionKey] = &interactiveState{agentSession: as}
+
+	deferred := e.restartInteractiveSessionWhenIdle(e.sessions, sessionKey, sessionKey)
+	if deferred {
+		t.Fatalf("expected immediate restart when no turn is in flight")
+	}
+	if !as.closed.Load() {
+		t.Fatalf("agent session should be closed immediately when idle")
+	}
+}

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -299,6 +299,7 @@ const (
 	MsgReplyFooterRemaining  MsgKey = "reply_footer_remaining"
 	MsgModelCurrent          MsgKey = "model_current"
 	MsgModelChanged          MsgKey = "model_changed"
+	MsgModelChangedDeferred  MsgKey = "model_changed_deferred"
 	MsgModelChangeFailed     MsgKey = "model_change_failed"
 	MsgModelCardSwitching    MsgKey = "model_card_switching"
 	MsgModelCardSwitched     MsgKey = "model_card_switched"
@@ -2207,6 +2208,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "模型已切換為 `%s`，新會話將使用此模型。",
 		LangJapanese:           "モデルを `%s` に切り替えました。新しいセッションで使用されます。",
 		LangSpanish:            "Modelo cambiado a `%s`. Las nuevas sesiones usarán este modelo.",
+	},
+	MsgModelChangedDeferred: {
+		LangEnglish:            "Model switched to `%s`. A turn is currently in progress — the current session will restart with the new model right after it finishes.",
+		LangChinese:            "模型已切换为 `%s`。当前有正在进行的回合 — 等它结束后会话将自动以新模型重启。",
+		LangTraditionalChinese: "模型已切換為 `%s`。目前有正在進行的回合 — 等它結束後會話將自動以新模型重啟。",
+		LangJapanese:           "モデルを `%s` に切り替えました。現在処理中のターンが完了した後、新しいモデルでセッションが再起動されます。",
+		LangSpanish:            "Modelo cambiado a `%s`. Hay un turno en curso — la sesión se reiniciará con el nuevo modelo justo después de que termine.",
 	},
 	MsgModelChangeFailed: {
 		LangEnglish:            "❌ Failed to change model: %v",


### PR DESCRIPTION
Fixes #1303

## Problem

Switching models (`/model`, or the model card action) called `cleanupInteractiveState` unconditionally, closing the agent session even while a turn was in flight. The agent had often already generated the reply (it is persisted in the CLI transcript), but the session was torn down before the turn-complete event was processed — the response silently never reached the user.

## Fix

New helper `restartInteractiveSessionWhenIdle`:

- **Idle session** → behavior unchanged: restart immediately.
- **Turn in flight** (detected via the session lock that turn processing already holds) → the restart is deferred to a background goroutine that waits for the lock to be released, so the in-flight reply is delivered normally and the new model applies from the next turn. A 30-minute ceiling guards against a stuck turn (then it falls back to the old behavior).

`cmdModel` replies with a dedicated i18n message in the deferred case (EN/ZH/ZH-TW/JA/ES added) so the user knows the switch takes effect after the current turn.

Applied to `cmdModel` and `handleModelCardAction`. The card-driven `executeCardAction` flow shares the same root issue but immediately re-creates interactive state for its progress card, so it is intentionally left unchanged here — happy to extend if you'd like.

## Tests

- `TestRestartInteractiveSessionWhenIdle_DefersWhileTurnInFlight` — locks the session, asserts the agent session is **not** closed while busy, then asserts it **is** closed after unlock.
- `TestRestartInteractiveSessionWhenIdle_RestartsImmediatelyWhenIdle` — idle path unchanged.
- Full `go test ./core/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)