### PR TITLE
fix(core): stop skill discovery from descending into skill directories

### DIFF
--- a/core/skill.go
+++ b/core/skill.go
@@ -97,37 +97,43 @@ func discoverSkillsInDir(scanRoot, currentDir string, seen, visited map[string]b
 		return nil
 	}
 
-	var result []*Skill
-	for _, entry := range entries {
-		fullPath := filepath.Join(currentDir, entry.Name())
-
-		if entry.Name() == "SKILL.md" {
-			skillDir := filepath.Dir(fullPath)
-			if sameFilePath(skillDir, scanRoot) {
+	// A directory containing SKILL.md is a skill. Register it and do NOT
+	// descend into its subdirectories: any deeper SKILL.md files are the
+	// skill's private reference assets (templates, style libraries, ...),
+	// not standalone skills. A SKILL.md directly at the scan root is
+	// ignored (the root is a container of skills, not a skill itself).
+	if !sameFilePath(currentDir, scanRoot) {
+		for _, entry := range entries {
+			if entry.IsDir() || entry.Name() != "SKILL.md" {
 				continue
 			}
 
-			skillName := filepath.Base(skillDir)
+			skillName := filepath.Base(currentDir)
 			if seen[strings.ToLower(skillName)] {
-				continue
+				return nil
 			}
 
-			data, err := os.ReadFile(fullPath)
+			data, err := os.ReadFile(filepath.Join(currentDir, entry.Name()))
 			if err != nil {
-				continue
+				return nil
 			}
 
-			skill := parseSkillMD(skillName, string(data), skillDir)
+			skill := parseSkillMD(skillName, string(data), currentDir)
 			if skill == nil {
-				continue
+				return nil
 			}
 
 			seen[strings.ToLower(skillName)] = true
-			result = append(result, skill)
-			slog.Debug("skill: discovered", "name", skillName, "dir", skillDir)
-			continue
+			slog.Debug("skill: discovered", "name", skillName, "dir", currentDir)
+			return []*Skill{skill}
 		}
+	}
 
+	// Not a skill directory itself — keep descending so grouped layouts
+	// (e.g. <root>/automation/<skill>/SKILL.md) are still discovered.
+	var result []*Skill
+	for _, entry := range entries {
+		fullPath := filepath.Join(currentDir, entry.Name())
 		if shouldDescendIntoSkillPath(fullPath, entry) {
 			result = append(result, discoverSkillsInDir(scanRoot, fullPath, seen, visited)...)
 		}

--- a/core/skill_test.go
+++ b/core/skill_test.go
@@ -124,6 +124,33 @@ func TestSkillRegistryListAll_IgnoresRootSkillFile(t *testing.T) {
 	}
 }
 
+func TestSkillRegistryListAll_IgnoresNestedSkillFilesInsideSkillDirectories(t *testing.T) {
+	root := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "frontend-design", "SKILL.md"), "Frontend design skill")
+	// Reference assets bundled inside the skill must not be registered as
+	// standalone skills (e.g. style template libraries).
+	writeSkillFile(t, filepath.Join(root, "frontend-design", "references", "styles", "finance-report", "SKILL.md"), "Finance report style template")
+	writeSkillFile(t, filepath.Join(root, "frontend-design", "references", "styles", "dcf-valuation", "SKILL.md"), "DCF valuation style template")
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 1 {
+		t.Fatalf("skills discovered = %d, want 1", len(skills))
+	}
+	if r.Resolve("frontend-design") == nil {
+		t.Fatalf("expected frontend-design skill to resolve")
+	}
+	if r.Resolve("finance-report") != nil {
+		t.Fatalf("nested reference template finance-report must not resolve as a skill")
+	}
+	if r.Resolve("dcf-valuation") != nil {
+		t.Fatalf("nested reference template dcf-valuation must not resolve as a skill")
+	}
+}
+
 func writeSkillFile(t *testing.T, path, description string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {


### PR DESCRIPTION
Fixes #1304

## Problem

`discoverSkillsInDir` recursively registers every `SKILL.md` it finds at any depth. Skills that bundle SKILL.md-formatted *reference templates* leak all of them as commands: e.g. a frontend-design skill shipping ~100 style recipes under `references/styles/<style>/SKILL.md` floods the Discord slash-command list with `finance-report`, `dcf-valuation`, 40+ `html-ppt-*`, etc. — commands the user never installed, which execute out-of-context template prompts when tapped. Claude Code itself treats anything below a skill directory as private assets.

## Fix

A directory containing `SKILL.md` is a skill — register it and **stop descending**: deeper `SKILL.md` files are that skill's internal assets, not standalone skills.

Grouped layouts keep working: descent only stops once a `SKILL.md` is found, and group folders (`<root>/automation/<skill>/SKILL.md`) have none, so all existing tests pass unchanged (grouping, symlinks, loop protection, dedupe, root SKILL.md ignore).

## Tests

- New regression test `TestSkillRegistryListAll_IgnoresNestedSkillFilesInsideSkillDirectories`: a skill with nested reference templates resolves only the skill itself; the templates do not resolve.
- All 5 pre-existing skill registry tests pass unchanged.
- Full `go test ./core/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)