### PR TITLE
fix(weixin): typing ticket 获取失败 — getConfigReq JSON 字段名错误

### DIFF
--- a/platform/weixin/types.go
+++ b/platform/weixin/types.go
@@ -145,7 +145,7 @@ type sendTypingReq struct {
 }
 
 type getConfigReq struct {
-	UserID       string   `json:"user_id"`
+	UserID       string   `json:"ilink_user_id"`
 	ContextToken string   `json:"context_token,omitempty"`
 	BaseInfo     baseInfo `json:"base_info"`
 }

--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -184,6 +185,20 @@ func TestGetConfig_RejectsNonZeroRet(t *testing.T) {
 	}
 	if out.Ret != -1 {
 		t.Fatalf("expected ret -1, got %d", out.Ret)
+	}
+}
+
+func TestGetConfigReq_JSONFieldName(t *testing.T) {
+	req := getConfigReq{
+		UserID:   "test_user",
+		BaseInfo: baseInfo{ChannelVersion: "1.0"},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"ilink_user_id"`) {
+		t.Fatalf("expected ilink_user_id in JSON, got: %s", string(data))
 	}
 }
 


### PR DESCRIPTION
## 问题

微信 typing 指示器无法工作，debug 日志显示：
```
weixin: getConfig for typing ticket failed error="weixin: getConfig ret=-2 errcode=0 errmsg=ilink_user_id required"
```

## 原因

`getConfigReq` 的 JSON tag 为 `user_id`，但 ilink API 要求 `ilink_user_id`。

对比 `sendTypingReq`（正确）和 `getConfigReq`（错误）：

| 结构体 | JSON tag |
|---|---|
| `sendTypingReq` | `json:"ilink_user_id"` ✅ |
| `getConfigReq` | `json:"user_id"` ❌ |

## 修复

将 `getConfigReq.UserID` 的 JSON tag 从 `user_id` 改为 `ilink_user_id`，并添加回归测试。

## 验证

本地构建测试通过，微信端 typing 指示器正常显示。