### PR TITLE
fix(daemon): remove redundant linger_other.go that breaks non-linux builds

### DIFF
--- a/daemon/linger_other.go
+++ b/daemon/linger_other.go
@@ -1,8 +1,0 @@
-//go:build !linux
-
-package daemon
-
-// CheckLinger is only meaningful for user-level systemd services on Linux.
-func CheckLinger() (enabled bool, user string) {
-	return true, ""
-}


### PR DESCRIPTION
## Summary
`daemon/linger_other.go` (`//go:build !linux`) duplicates `CheckLinger`, which is already defined by `launchd.go` (darwin), `windows.go` (windows) and `unsupported.go` (other). It is therefore redeclared on every non-Linux platform, so `make build` / `go build ./...` fails on macOS and Windows. Linux is unaffected (`systemd.go` provides it). The file is dead code — remove it.

## Test plan
- `go build ./...` / `make build` on macOS now succeeds.
- Linux build unchanged (`linger_other.go` was already excluded there).

Fixes #1311