### PR TITLE
fix(engine): keep workspace binding when supervisor cannot stat it under run_as_user

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3384,10 +3384,8 @@ func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionMan
 	// already decorated. See cc-connect#496 and the cc-connect/core/runas.go
 	// preamble for why run_as_user has to survive this copy.
 	if _, ok := opts["run_as_user"]; !ok {
-		if ma, ok := e.agent.(interface{ GetRunAsUser() string }); ok {
-			if u := ma.GetRunAsUser(); u != "" {
-				opts["run_as_user"] = u
-			}
+		if u := e.runAsUser(); u != "" {
+			opts["run_as_user"] = u
 		}
 	}
 	if _, ok := opts["run_as_env"]; !ok {
@@ -15152,7 +15150,28 @@ func (e *Engine) lookupEffectiveWorkspaceBinding(channelKey string) (*WorkspaceB
 		return nil, "", false
 	}
 
+	// When run_as_user isolation is active, the workspace lives in the target
+	// user's space (typically under their HOME, set to mode 0700 by `sudo -i`).
+	// The supervisor process runs as a different user, so os.Stat here would
+	// hit EACCES on the target user's private path and we'd wrongly conclude
+	// the directory is "missing" — then Unbind() it, permanently dropping a
+	// perfectly valid binding. The agent that actually uses the workspace runs
+	// as the target user and can access it fine, so skip the supervisor-side
+	// existence check entirely under isolation and trust the binding.
+	if e.runAsUser() != "" {
+		return b, bindingKey, true
+	}
+
 	if _, err := os.Stat(b.Workspace); err != nil {
+		// Only a genuine "does not exist" justifies dropping the binding. A
+		// permission error (or any other transient stat failure) must NOT
+		// unbind: the directory may well exist but be inaccessible to the
+		// supervisor. Treating those as "missing" silently loses user bindings.
+		if !os.IsNotExist(err) {
+			slog.Warn("bound workspace stat failed; keeping binding (not treating as missing)",
+				"workspace", b.Workspace, "channel_key", channelKey, "binding_scope", bindingKey, "err", err)
+			return b, bindingKey, true
+		}
 		slog.Warn("bound workspace directory missing",
 			"workspace", b.Workspace, "channel_key", channelKey, "binding_scope", bindingKey)
 		if bindingKey != sharedWorkspaceBindingsKey {
@@ -15162,6 +15181,16 @@ func (e *Engine) lookupEffectiveWorkspaceBinding(channelKey string) (*WorkspaceB
 	}
 
 	return b, bindingKey, true
+}
+
+// runAsUser returns the configured run_as_user for the engine's agent, or ""
+// if OS-level user isolation is not active. Mirrors the capability probe used
+// when copying isolation settings to per-workspace agents (getOrCreateWorkspaceAgent).
+func (e *Engine) runAsUser() string {
+	if ma, ok := e.agent.(interface{ GetRunAsUser() string }); ok {
+		return ma.GetRunAsUser()
+	}
+	return ""
 }
 
 // resolveWorkspace resolves a channel to a workspace directory.

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -704,3 +704,78 @@ func TestCommandContextWithWorkspace_UnboundChannelFallsBack(t *testing.T) {
 		t.Errorf("expected interactiveKey to equal sessionKey when unbound, got %q want %q", interactiveKey, msg.SessionKey)
 	}
 }
+
+// newTestEngineWithMultiWorkspaceRunAsAgent builds a multi-workspace engine
+// whose agent reports a run_as_user, exercising the OS-isolation code paths.
+func newTestEngineWithMultiWorkspaceRunAsAgent(t *testing.T, baseDir, runAsUser string) *Engine {
+	t.Helper()
+	tmpDir := t.TempDir()
+	bindingPath := filepath.Join(tmpDir, "bindings.json")
+	sessionPath := filepath.Join(tmpDir, "sessions.json")
+	agent := &runAsTestAgent{namedTestAgent: &namedTestAgent{name: "runas-lookup-agent"}, runAsUser: runAsUser}
+	e := NewEngine("test", agent, nil, sessionPath, LangEnglish)
+	e.SetMultiWorkspace(baseDir, bindingPath)
+	return e
+}
+
+// TestLookupEffectiveBinding_RunAsUserKeepsInaccessibleWorkspace is a
+// regression guard for the bug where a bound workspace was silently dropped
+// under run_as_user. The supervisor process runs as a different user than the
+// agent, so os.Stat on the target user's private workspace returns EACCES (or,
+// here, the directory simply isn't visible to the supervisor). The old code
+// treated any stat error as "directory missing" and called Unbind(),
+// permanently losing the user's /ws binding even though the agent — running as
+// the target user — could access the workspace fine.
+//
+// With isolation active, lookupEffectiveWorkspaceBinding must skip the
+// supervisor-side existence check entirely: the binding stays usable and is
+// never unbound.
+func TestLookupEffectiveBinding_RunAsUserKeepsInaccessibleWorkspace(t *testing.T) {
+	baseDir := t.TempDir()
+	// Deliberately point at a path the supervisor can't stat as existing.
+	// Under real run_as_user this is the target user's private home; here a
+	// non-existent path stands in for "stat fails from the supervisor".
+	workspace := normalizeWorkspacePath(filepath.Join(baseDir, "private", "loader"))
+
+	e := newTestEngineWithMultiWorkspaceRunAsAgent(t, baseDir, "deploybot")
+	channelID := "C-isolated"
+	channelKey := workspaceChannelKey("test", channelID)
+	e.workspaceBindings.Bind("project:test", channelKey, "loader", workspace)
+
+	b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey)
+	if b == nil {
+		t.Fatal("binding was dropped under run_as_user; expected it to survive")
+	}
+	if !usable {
+		t.Errorf("expected binding to be usable under run_as_user despite supervisor-side stat failure")
+	}
+	if b.Workspace != workspace {
+		t.Errorf("workspace = %q, want %q", b.Workspace, workspace)
+	}
+
+	// The binding must still be persisted — not Unbind()'d.
+	if got := e.workspaceBindings.Lookup("project:test", channelKey); got == nil {
+		t.Fatal("binding was unbound under run_as_user; it must be preserved")
+	}
+}
+
+// TestLookupEffectiveBinding_NoIsolationUnbindsMissing preserves the original
+// behavior when isolation is NOT active: a genuinely missing workspace
+// directory is unbound so stale bindings don't linger.
+func TestLookupEffectiveBinding_NoIsolationUnbindsMissing(t *testing.T) {
+	baseDir := t.TempDir()
+	missing := normalizeWorkspacePath(filepath.Join(baseDir, "gone"))
+
+	e := newTestEngineWithMultiWorkspaceAgent(t, baseDir) // namedTestAgent: no run_as_user
+	channelID := "C-missing"
+	channelKey := workspaceChannelKey("test", channelID)
+	e.workspaceBindings.Bind("project:test", channelKey, "gone", missing)
+
+	_, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey)
+	if usable {
+		t.Errorf("expected missing workspace to be unusable without isolation")
+	}
+	if got := e.workspaceBindings.Lookup("project:test", channelKey); got != nil {
+		t.Errorf("expected missing workspace binding to be unbound without isolation, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary
Under `run_as_user` the workspace may live in the target user's private space, so the supervisor's `os.Stat` hits EACCES. The old code treated any stat error as "directory missing" and `Unbind()`'d, permanently dropping a valid binding.

Skip the supervisor-side existence check under isolation (the agent, running as the target user, can access it fine); for the non-isolation path only treat `os.IsNotExist` as missing.

## Test plan
- Added `TestLookupEffectiveBinding_RunAsUserKeepsInaccessibleWorkspace`; `go test ./core/` passes.

Fixes #1313
Related: #1312