### PR TITLE
fix(skill): scan only depth-1 SKILL.md, ignore nested files (#1304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Skill discovery depth-1 only**: skill scanning no longer recurses into subdirectories. Only `<skill_dir>/<name>/SKILL.md` is registered; nested SKILL.md files (e.g. inside `<name>/references/...`) are treated as skill assets and ignored, matching the Claude Code CLI convention. Previously, nested SKILL.md files leaked into platform command menus as phantom slash commands (101 leaked commands from `frontend-design` skill alone) (#1304).
+
 ## v1.3.3 (2026-06-15)
 
 First stable release of the 1.3.3 series. Stabilizes the v1.3.3-beta.1 → v1.3.3-beta.5

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -560,9 +560,14 @@ type CommandProvider interface {
 }
 
 // SkillProvider is an optional interface for agents that expose skills via
-// local directories (e.g. .claude/skills/<name>/SKILL.md). Each subdirectory
-// containing a SKILL.md is treated as a skill. Skills are project-level and
-// agent-specific — they are NOT shared across different agent types.
+// local directories (e.g. .claude/skills/<name>/SKILL.md). Only the depth-1
+// layout is recognised: each immediate subdirectory of the returned dirs
+// that contains a SKILL.md is registered as a skill. Nested SKILL.md files
+// (e.g. inside `<name>/references/...`) are treated as skill assets and
+// ignored — they match the Claude Code CLI convention (issue #1304) and
+// prevent phantom slash commands from leaking into platform command menus.
+// Skills are project-level and agent-specific — they are NOT shared across
+// different agent types.
 type SkillProvider interface {
 	SkillDirs() []string
 }

--- a/core/skill.go
+++ b/core/skill.go
@@ -78,84 +78,74 @@ func (r *SkillRegistry) ListAll() []*Skill {
 	seen := make(map[string]bool)
 
 	for _, dir := range r.dirs {
-		result = append(result, discoverSkillsInDir(dir, dir, seen, make(map[string]bool))...)
+		result = append(result, discoverSkillsInDir(dir, seen)...)
 	}
 
 	r.cache = result
 	return result
 }
 
-func discoverSkillsInDir(scanRoot, currentDir string, seen, visited map[string]bool) []*Skill {
-	realDir := realPath(currentDir)
-	if visited[realDir] {
-		return nil
-	}
-	visited[realDir] = true
-
-	entries, err := os.ReadDir(currentDir)
+// discoverSkillsInDir scans a single skill root directory for immediate
+// subdirectories that contain a SKILL.md file. Per the Claude Code CLI
+// convention (issue #1304), only depth-1 layout is recognised:
+//
+//	<root>/<skill-name>/SKILL.md        — registered
+//	<root>/<skill-name>/references/...  — asset, NOT registered
+//
+// Nested SKILL.md files inside a skill (e.g. example templates shipped
+// alongside the real one) are treated as skill assets and ignored, so they
+// cannot leak into platform command menus as phantom slash commands.
+func discoverSkillsInDir(scanRoot string, seen map[string]bool) []*Skill {
+	entries, err := os.ReadDir(scanRoot)
 	if err != nil {
 		return nil
 	}
 
 	var result []*Skill
 	for _, entry := range entries {
-		fullPath := filepath.Join(currentDir, entry.Name())
-
-		if entry.Name() == "SKILL.md" {
-			skillDir := filepath.Dir(fullPath)
-			if sameFilePath(skillDir, scanRoot) {
-				continue
-			}
-
-			skillName := filepath.Base(skillDir)
-			if seen[strings.ToLower(skillName)] {
-				continue
-			}
-
-			data, err := os.ReadFile(fullPath)
-			if err != nil {
-				continue
-			}
-
-			skill := parseSkillMD(skillName, string(data), skillDir)
-			if skill == nil {
-				continue
-			}
-
-			seen[strings.ToLower(skillName)] = true
-			result = append(result, skill)
-			slog.Debug("skill: discovered", "name", skillName, "dir", skillDir)
+		if !isDiscoverableSubdir(scanRoot, entry) {
 			continue
 		}
 
-		if shouldDescendIntoSkillPath(fullPath, entry) {
-			result = append(result, discoverSkillsInDir(scanRoot, fullPath, seen, visited)...)
+		skillName := entry.Name()
+		if seen[strings.ToLower(skillName)] {
+			continue
 		}
+
+		skillDir := filepath.Join(scanRoot, skillName)
+		skillFile := filepath.Join(skillDir, "SKILL.md")
+		data, err := os.ReadFile(skillFile)
+		if err != nil {
+			// No SKILL.md at the top of this subdir — and we deliberately
+			// do NOT recurse, matching the Claude Code CLI rule.
+			continue
+		}
+
+		skill := parseSkillMD(skillName, string(data), skillDir)
+		if skill == nil {
+			continue
+		}
+
+		seen[strings.ToLower(skillName)] = true
+		result = append(result, skill)
+		slog.Debug("skill: discovered", "name", skillName, "dir", skillDir)
 	}
 
 	return result
 }
 
-func shouldDescendIntoSkillPath(path string, entry os.DirEntry) bool {
+// isDiscoverableSubdir reports whether entry should be considered as a
+// potential skill subdirectory of parentDir. Accepts real directories and
+// symlinks that resolve to directories.
+func isDiscoverableSubdir(parentDir string, entry os.DirEntry) bool {
 	if entry.IsDir() {
 		return true
 	}
 	if entry.Type()&os.ModeSymlink == 0 {
 		return false
 	}
-	info, err := os.Stat(path)
+	info, err := os.Stat(filepath.Join(parentDir, entry.Name()))
 	return err == nil && info.IsDir()
-}
-
-func sameFilePath(a, b string) bool {
-	return realPath(a) == realPath(b)
-}
-
-func realPath(path string) string {
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		return filepath.Clean(resolved)
-	}
-	return filepath.Clean(path)
 }
 
 // Dirs returns the configured skill directories.
@@ -165,7 +155,7 @@ func (r *SkillRegistry) Dirs() []string {
 	return append([]string(nil), r.dirs...)
 }
 
-// Invalidate clears the cache so skills are re-scanned on next access.
+// Invalidate clears the cache so skills will be re-scanned on next access.
 func (r *SkillRegistry) Invalidate() {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/core/skill_test.go
+++ b/core/skill_test.go
@@ -7,11 +7,15 @@ import (
 	"testing"
 )
 
-func TestSkillRegistryListAll_RecursesIntoGroupedDirectories(t *testing.T) {
+// Per the Claude Code CLI convention (issue #1304), only the depth-1 layout
+// `skills/<name>/SKILL.md` is registered. Nested SKILL.md files are assets,
+// not installable skills.
+
+func TestSkillRegistryListAll_FindsDepth1Skills(t *testing.T) {
 	root := t.TempDir()
-	writeSkillFile(t, filepath.Join(root, "automation", "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
-	writeSkillFile(t, filepath.Join(root, "productivity", "doc", "SKILL.md"), "Doc skill")
-	writeSkillFile(t, filepath.Join(root, ".system", "skill-installer", "SKILL.md"), "System skill")
+	writeSkillFile(t, filepath.Join(root, "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
+	writeSkillFile(t, filepath.Join(root, "doc", "SKILL.md"), "Doc skill")
+	writeSkillFile(t, filepath.Join(root, "skill-installer", "SKILL.md"), "System skill")
 
 	r := NewSkillRegistry()
 	r.SetDirs([]string{root})
@@ -22,13 +26,75 @@ func TestSkillRegistryListAll_RecursesIntoGroupedDirectories(t *testing.T) {
 		t.Fatalf("skills discovered = %d, want 3", len(skills))
 	}
 	if r.Resolve("telegram-codex-bot") == nil {
-		t.Fatalf("expected grouped skill to resolve")
+		t.Fatalf("expected telegram-codex-bot to resolve")
 	}
 	if r.Resolve("doc") == nil {
-		t.Fatalf("expected nested productivity skill to resolve")
+		t.Fatalf("expected doc to resolve")
 	}
 	if r.Resolve("skill-installer") == nil {
-		t.Fatalf("expected .system skill to resolve")
+		t.Fatalf("expected skill-installer to resolve")
+	}
+}
+
+func TestSkillRegistryListAll_IgnoresNestedSkillFiles(t *testing.T) {
+	root := t.TempDir()
+	// Depth-1 skill — should be registered.
+	writeSkillFile(t, filepath.Join(root, "frontend-design", "SKILL.md"), "Frontend design skill")
+	// Nested SKILL.md files inside the skill — should NOT be registered.
+	// This is the exact layout from issue #1304 that leaked 101 phantom
+	// slash commands into Discord's command menu.
+	writeSkillFile(t, filepath.Join(root, "frontend-design", "references", "finance-report", "SKILL.md"), "Finance report template")
+	writeSkillFile(t, filepath.Join(root, "frontend-design", "references", "html-ppt-knowledge-arch-blueprint", "SKILL.md"), "PPT knowledge template")
+	// Nested SKILL.md at arbitrary depth — also ignored.
+	writeSkillFile(t, filepath.Join(root, "frontend-design", "references", "deep", "deeper", "SKILL.md"), "Deeply nested")
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 1 {
+		names := make([]string, 0, len(skills))
+		for _, s := range skills {
+			names = append(names, s.Name)
+		}
+		t.Fatalf("skills discovered = %d (%v), want 1", len(skills), names)
+	}
+	if skills[0].Name != "frontend-design" {
+		t.Fatalf("skill name = %q, want frontend-design", skills[0].Name)
+	}
+	if r.Resolve("finance-report") != nil {
+		t.Fatalf("nested SKILL.md must not resolve as a skill")
+	}
+	if r.Resolve("html-ppt-knowledge-arch-blueprint") != nil {
+		t.Fatalf("nested SKILL.md must not resolve as a skill")
+	}
+	if r.Resolve("deeper") != nil {
+		t.Fatalf("nested SKILL.md at any depth must not resolve as a skill")
+	}
+}
+
+func TestSkillRegistryListAll_IgnoresSubdirWithoutSkillFile(t *testing.T) {
+	root := t.TempDir()
+	// Has SKILL.md — registered.
+	writeSkillFile(t, filepath.Join(root, "real-skill", "SKILL.md"), "Real skill")
+	// Missing SKILL.md — silently skipped (and we don't recurse to look for one).
+	if err := os.MkdirAll(filepath.Join(root, "no-skill-file", "references"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Has SKILL.md but at depth-2 — also skipped (no recursion).
+	writeSkillFile(t, filepath.Join(root, "real-skill", "references", "SKILL.md"), "Asset")
+
+	r := NewSkillRegistry()
+	r.SetDirs([]string{root})
+
+	skills := r.ListAll()
+
+	if len(skills) != 1 {
+		t.Fatalf("skills discovered = %d, want 1", len(skills))
+	}
+	if skills[0].Name != "real-skill" {
+		t.Fatalf("skill name = %q, want real-skill", skills[0].Name)
 	}
 }
 
@@ -38,14 +104,15 @@ func TestSkillRegistryListAll_FollowsDirectorySymlinks(t *testing.T) {
 	}
 	root := t.TempDir()
 	targetRoot := t.TempDir()
-	writeSkillFile(t, filepath.Join(targetRoot, "automation", "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
-	writeSkillFile(t, filepath.Join(targetRoot, "research", "hf-papers", "SKILL.md"), "HF papers skill")
+	writeSkillFile(t, filepath.Join(targetRoot, "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
+	writeSkillFile(t, filepath.Join(targetRoot, "hf-papers", "SKILL.md"), "HF papers skill")
 
-	if err := os.Symlink(filepath.Join(targetRoot, "automation"), filepath.Join(root, "automation")); err != nil {
-		t.Fatalf("symlink automation: %v", err)
+	// Symlink each individual skill directory at depth-1.
+	if err := os.Symlink(filepath.Join(targetRoot, "telegram-codex-bot"), filepath.Join(root, "telegram-codex-bot")); err != nil {
+		t.Fatalf("symlink telegram-codex-bot: %v", err)
 	}
-	if err := os.Symlink(filepath.Join(targetRoot, "research"), filepath.Join(root, "research")); err != nil {
-		t.Fatalf("symlink research: %v", err)
+	if err := os.Symlink(filepath.Join(targetRoot, "hf-papers"), filepath.Join(root, "hf-papers")); err != nil {
+		t.Fatalf("symlink hf-papers: %v", err)
 	}
 
 	r := NewSkillRegistry()
@@ -57,10 +124,10 @@ func TestSkillRegistryListAll_FollowsDirectorySymlinks(t *testing.T) {
 		t.Fatalf("skills discovered = %d, want 2", len(skills))
 	}
 	if r.Resolve("telegram-codex-bot") == nil {
-		t.Fatalf("expected symlinked automation skill to resolve")
+		t.Fatalf("expected symlinked depth-1 skill to resolve")
 	}
 	if r.Resolve("hf-papers") == nil {
-		t.Fatalf("expected symlinked research skill to resolve")
+		t.Fatalf("expected symlinked depth-1 skill to resolve")
 	}
 }
 
@@ -69,10 +136,13 @@ func TestSkillRegistryListAll_DoesNotLoopOnDirectorySymlinks(t *testing.T) {
 		t.Skip("symlink creation requires administrator on Windows")
 	}
 	root := t.TempDir()
-	writeSkillFile(t, filepath.Join(root, "automation", "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
-
-	if err := os.Symlink(filepath.Join(root, "automation"), filepath.Join(root, "automation", "again")); err != nil {
-		t.Fatalf("symlink loop: %v", err)
+	writeSkillFile(t, filepath.Join(root, "telegram-codex-bot", "SKILL.md"), "Telegram bot skill")
+	// Self-referential depth-1 symlink: `self-loop` points back at itself.
+	// Discovery must not hang (no recursion past depth-1, so this is the
+	// natural safety — but we still verify the registry returns and the
+	// legitimate skill is registered).
+	if err := os.Symlink(filepath.Join(root, "self-loop"), filepath.Join(root, "self-loop")); err != nil {
+		t.Skipf("filesystem does not permit self-referential symlink: %v", err)
 	}
 
 	r := NewSkillRegistry()
@@ -84,17 +154,21 @@ func TestSkillRegistryListAll_DoesNotLoopOnDirectorySymlinks(t *testing.T) {
 		t.Fatalf("skills discovered = %d, want 1", len(skills))
 	}
 	if r.Resolve("telegram-codex-bot") == nil {
-		t.Fatalf("expected looping symlink tree to still resolve skill")
+		t.Fatalf("expected legitimate skill to still resolve alongside symlink loop")
 	}
 }
 
 func TestSkillRegistryListAll_DedupesByLeafDirectoryName(t *testing.T) {
 	root := t.TempDir()
-	writeSkillFile(t, filepath.Join(root, "apple", "helper", "SKILL.md"), "Apple helper")
-	writeSkillFile(t, filepath.Join(root, "automation", "helper", "SKILL.md"), "Automation helper")
+	// Two different depth-1 skills happen to share a lower-case name with the
+	// same normalised key — dedupe by lower-cased name across all configured
+	// directories.
+	otherRoot := t.TempDir()
+	writeSkillFile(t, filepath.Join(root, "helper", "SKILL.md"), "Root helper")
+	writeSkillFile(t, filepath.Join(otherRoot, "helper", "SKILL.md"), "Other helper")
 
 	r := NewSkillRegistry()
-	r.SetDirs([]string{root})
+	r.SetDirs([]string{root, otherRoot})
 
 	skills := r.ListAll()
 
@@ -108,8 +182,10 @@ func TestSkillRegistryListAll_DedupesByLeafDirectoryName(t *testing.T) {
 
 func TestSkillRegistryListAll_IgnoresRootSkillFile(t *testing.T) {
 	root := t.TempDir()
+	// A SKILL.md placed directly at the scan root must be ignored — only
+	// subdirectories count as skill candidates.
 	writeSkillFile(t, filepath.Join(root, "SKILL.md"), "Root skill should be ignored")
-	writeSkillFile(t, filepath.Join(root, "group", "visible-skill", "SKILL.md"), "Visible skill")
+	writeSkillFile(t, filepath.Join(root, "visible-skill", "SKILL.md"), "Visible skill")
 
 	r := NewSkillRegistry()
 	r.SetDirs([]string{root})


### PR DESCRIPTION
## Summary

cc-connect's `SkillRegistry.discoverSkillsInDir` recursed into every
subdirectory looking for SKILL.md files. This caused nested SKILL.md
files inside a skill's own asset tree (e.g.
`frontend-design/references/finance-report/SKILL.md`) to be registered
as sibling skills, leaking them as phantom slash commands into platform
command menus. Issue #1304 reports 101 leaked commands from one skill
(`frontend-design`) alone.

This change switches the scan to depth-1 only, matching the Claude Code
CLI convention:

```
<skill_dir>/<skill-name>/SKILL.md        — registered
<skill_dir>/<skill-name>/references/...  — asset, NOT registered
```

## Changes

- `core/skill.go`: `discoverSkillsInDir` now scans immediate subdirectories
  only. The `visited` recursion-safety map and `shouldDescendIntoSkillPath`
  helper are gone. `sameFilePath`/`realPath` (only used by the removed
  recursion guard) are also removed. `isDiscoverableSubdir` keeps the same
  dir/symlink semantics for the depth-1 entry check.
- `core/skill_test.go`: 4 existing tests rewrote to use depth-1 layouts,
  added `TestSkillRegistryListAll_IgnoresNestedSkillFiles` (exact #1304
  scenario) and `TestSkillRegistryListAll_IgnoresSubdirWithoutSkillFile`.
- `core/interfaces.go`: `SkillProvider` docstring updated to describe the
  depth-1 rule.
- `CHANGELOG.md`: unreleased `Fixed` entry.

## Test plan

- [x] `go test ./core/` — all 7 skill tests pass; full core suite passes.
- [x] `go test ./config/ ./daemon/` — pass.
- [x] `go vet ./core/... ./agent/... ./config/... ./cmd/... ./daemon/... ./platform/...` — clean.
- [x] `gofmt -l core/skill.go core/skill_test.go` — clean.
- [x] `golangci-lint v2.11.4 run --new-from-rev origin/main ./core/` — 0 issues.

The fix is API-compatible: only the internal discovery walker changes.
`Skill`, `SkillRegistry`, `Engine.ListSkills`, and the management API
are unchanged.

Fixes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)