### PR TITLE
fix(codex): kill app-server process groups on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### ⚠️ QQ Bot Intent Configuration Change
 The default intents for QQ Bot now include `INTERACTION_CREATE` (bit 26, value `1<<26`). If you previously set a custom `intents` value without this bit, inline keyboard buttons will not work — update your `intents` to include bit 26. If you use the default intents, no action is needed. See `config.example.toml` for the new `intents` option.
 
+### Fixed
+- **Codex app-server process leak on close**: `appServerSession.Close()` now starts the codex process in its own process group and force-kills the group, so child codex processes and helpers no longer survive after a session is closed (#1318).
+
 ## v1.3.3-beta.4 (2026-05-28)
 
 ### New Features

--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -249,6 +249,7 @@ func (s *appServerSession) connect() error {
 	}
 	cmd := exec.CommandContext(s.ctx, "codex", args...)
 	cmd.Dir = s.workDir
+	prepareCmdForKill(cmd)
 	env := append([]string(nil), s.extraEnv...)
 	if s.codexHome != "" {
 		env = append(env, "CODEX_HOME="+s.codexHome)
@@ -936,7 +937,10 @@ func (s *appServerSession) Close() error {
 		s.stdin = nil
 	}
 	if s.cmd != nil && s.cmd.Process != nil {
-		_ = s.cmd.Process.Kill()
+		if err := forceKillCmd(s.cmd); err != nil {
+			slog.Debug("codex app-server: force kill failed", "error", err)
+		}
+		s.cmd = nil
 	}
 	s.procMu.Unlock()
 

--- a/agent/codex/appserver_session_unix_test.go
+++ b/agent/codex/appserver_session_unix_test.go
@@ -1,0 +1,174 @@
+//go:build unix
+
+package codex
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestAppServerSession_CloseKillsProcessGroup(t *testing.T) {
+	if os.Getenv("CC_CONNECT_CODEX_HELPER") == "1" {
+		runFakeCodexAppServer(t)
+		return
+	}
+
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	childPIDFile := filepath.Join(workDir, "child.pid")
+	script := `#!/bin/sh
+exec "$CC_CONNECT_CODEX_HELPER_BIN" -test.run TestAppServerSession_CloseKillsProcessGroup --
+`
+	scriptPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	t.Setenv("CHILD_PID_FILE", childPIDFile)
+	t.Setenv("CC_CONNECT_CODEX_HELPER", "1")
+	t.Setenv("CC_CONNECT_CODEX_HELPER_BIN", os.Args[0])
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s, err := newAppServerSession(context.Background(), "stdio://", workDir, "", "", "", "", "", "", nil, "")
+	if err != nil {
+		t.Fatalf("newAppServerSession: %v", err)
+	}
+
+	childPID := waitForPIDFile(t, childPIDFile)
+	t.Cleanup(func() {
+		if processRunning(childPID) {
+			_ = syscall.Kill(childPID, syscall.SIGKILL)
+		}
+	})
+
+	parentPID := appServerProcessPID(t, s)
+	assertSameProcessGroup(t, parentPID, childPID)
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if !processRunning(childPID) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("child process %d still alive after app-server Close", childPID)
+}
+
+func runFakeCodexAppServer(t *testing.T) {
+	t.Helper()
+
+	child := exec.Command("sleep", "30")
+	if err := child.Start(); err != nil {
+		t.Fatalf("start child sleep: %v", err)
+	}
+	if err := os.WriteFile(os.Getenv("CHILD_PID_FILE"), []byte(strconv.Itoa(child.Process.Pid)+"\n"), 0o644); err != nil {
+		_ = child.Process.Kill()
+		t.Fatalf("write child pid file: %v", err)
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.Contains(line, `"method":"initialize"`):
+			fmt.Println(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"test"}}`)
+		case strings.Contains(line, `"method":"thread/start"`):
+			fmt.Println(`{"jsonrpc":"2.0","id":2,"result":{"cwd":"/tmp","model":"test-model","reasoningEffort":"xhigh","thread":{"id":"thread-close"}}}`)
+		case strings.Contains(line, `"method":"account/rateLimits/read"`):
+			fmt.Println(`{"jsonrpc":"2.0","id":3,"result":{"rateLimits":{}}}`)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("read stdin: %v", err)
+	}
+	_, _ = child.Process.Wait()
+}
+
+func appServerProcessPID(t *testing.T, s *appServerSession) int {
+	t.Helper()
+
+	s.procMu.Lock()
+	defer s.procMu.Unlock()
+	if s.cmd == nil || s.cmd.Process == nil {
+		t.Fatal("app-server process is not available")
+	}
+	return s.cmd.Process.Pid
+}
+
+func assertSameProcessGroup(t *testing.T, parentPID, childPID int) {
+	t.Helper()
+
+	parentPGID, err := syscall.Getpgid(parentPID)
+	if err != nil {
+		t.Fatalf("Getpgid(parent %d): %v", parentPID, err)
+	}
+	childPGID, err := syscall.Getpgid(childPID)
+	if err != nil {
+		t.Fatalf("Getpgid(child %d): %v", childPID, err)
+	}
+	if childPGID != parentPGID {
+		t.Fatalf("test child process group = %d, app-server process group = %d; fixture child escaped the process group", childPGID, parentPGID)
+	}
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr != nil {
+				t.Fatalf("parse pid file: %v", parseErr)
+			}
+			return pid
+		}
+		lastErr = err
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for pid file %s: %v", path, lastErr)
+	return 0
+}
+
+func processRunning(pid int) bool {
+	// Linux, including WSL2, can leave a killed child visible as a zombie until
+	// its parent is reaped. A zombie is no longer running, so it should not fail
+	// a process-group kill test.
+	if state, ok := linuxProcessState(pid); ok && state == 'Z' {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func linuxProcessState(pid int) (byte, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, false
+	}
+	idx := bytes.LastIndex(data, []byte(") "))
+	if idx < 0 || idx+2 >= len(data) {
+		return 0, false
+	}
+	return data[idx+2], true
+}


### PR DESCRIPTION
## Summary

- start Codex app-server sessions in their own process group and force-kill the group on close
- add a unix regression test that proves app-server child processes do not survive `Close()`
- restore macOS daemon testability by removing the duplicate non-linux linger stub and seeding the launchd status test plist

## Root cause

`appServerSession.Close()` only called `Process.Kill()` on the `codex` process. With the npm shim, that can leave the vendor `codex app-server` child process and its spawned helpers alive. Timed-out or completed app-server sessions can therefore accumulate under a long-running cc-connect daemon, leaving stale Codex processes around for later cron/message turns.

The classic Codex session path already used process-group handling; app-server sessions were missing the same lifecycle behavior.

## Tests

- `go test ./agent/codex -run TestAppServerSession_CloseKillsProcessGroup -count=1 -v`
- `go test ./agent/codex`
- `go test ./...`
