### PR TITLE
fix(display): enforce quiet-mode "final message only" (#1302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Quiet mode "final message only" enforced**: when `[display].mode = "quiet"` (or legacy `[projects.X].quiet = true`), the engine now slices the accumulated assistant text at the last `tool_use` boundary and delivers only the text block emitted AFTER the last tool call. Previously, the pre-tool "lead-in" (e.g. "Let me check that for you...") was concatenated with the post-tool answer, glued together with no separator in most cases — clashing with the inline doc that promised "final message only" and producing visibly malformed replies. New opt-in `[display].prepend_pre_tool_text = true` restores the old "all text in one card" rendering for users who relied on it. Has no effect in `full` / `compact` mode. The fix lives in the platform-agnostic `processInteractiveEvents` finalization path, so all platforms (Slack, Discord, Feishu, Telegram, DingTalk, WeChat, QQ, LINE, ...) inherit the corrected behaviour uniformly (#1302).
+
 ## v1.3.3 (2026-06-15)
 
 First stable release of the 1.3.3 series. Stabilizes the v1.3.3-beta.1 → v1.3.3-beta.5

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -407,7 +407,7 @@ func main() {
 		engine := core.NewEngine(proj.Name, agent, platforms, sessionFile, lang)
 		// Wire display settings including show_context_indicator and reply_footer
 		// Global [display] config can be overridden by project-level settings
-		_, _, _, _, _, showCtx, showFooter := config.EffectiveDisplay(cfg, &proj)
+		_, _, _, _, _, showCtx, showFooter, _ := config.EffectiveDisplay(cfg, &proj)
 		engine.SetShowContextIndicator(showCtx)
 		showWorkdir := true
 		if proj.ShowWorkdirIndicator != nil {
@@ -537,14 +537,15 @@ func main() {
 
 		// Wire display truncation settings (includes legacy quiet → display mapping)
 		{
-			mode, tm, tool, tmlen, toollen, _, _ := config.EffectiveDisplay(cfg, &proj)
+			mode, tm, tool, tmlen, toollen, _, _, prepend := config.EffectiveDisplay(cfg, &proj)
 			engine.SetDisplayConfig(core.DisplayCfg{
-				Mode:             mode,
-				CardMode:         config.EffectiveCardMode(cfg, &proj),
-				ThinkingMessages: tm,
-				ThinkingMaxLen:   tmlen,
-				ToolMaxLen:       toollen,
-				ToolMessages:     tool,
+				Mode:               mode,
+				CardMode:           config.EffectiveCardMode(cfg, &proj),
+				ThinkingMessages:   tm,
+				ThinkingMaxLen:     tmlen,
+				ToolMaxLen:         toollen,
+				ToolMessages:       tool,
+				PrependPreToolText: prepend,
 			})
 		}
 
@@ -1646,14 +1647,15 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 	}
 
 	// Reload display config (includes legacy quiet → display mapping)
-	mode, tm, tool, tmlen, toollen, showCtx, showFooter := config.EffectiveDisplay(cfg, proj)
+	mode, tm, tool, tmlen, toollen, showCtx, showFooter, prepend := config.EffectiveDisplay(cfg, proj)
 	engine.SetDisplayConfig(core.DisplayCfg{
-		Mode:             mode,
-		CardMode:         config.EffectiveCardMode(cfg, proj),
-		ThinkingMessages: tm,
-		ThinkingMaxLen:   tmlen,
-		ToolMaxLen:       toollen,
-		ToolMessages:     tool,
+		Mode:               mode,
+		CardMode:           config.EffectiveCardMode(cfg, proj),
+		ThinkingMessages:   tm,
+		ThinkingMaxLen:     tmlen,
+		ToolMaxLen:         toollen,
+		ToolMessages:       tool,
+		PrependPreToolText: prepend,
 	})
 	result.DisplayUpdated = true
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -103,8 +103,13 @@ level = "info" # debug, info, warn, error
 #                           #       显示思考和工具消息，每条单独发送
 #                           # compact: hide thinking/tool, each text segment sent separately
 #                           #          隐藏思考和工具消息，每段文本独立发送
-#                           # quiet: hide thinking/tool, all text in one card, done emoji at end
-#                           #        隐藏思考和工具消息，所有文本合并到同一张卡片，完成后发送 done emoji
+#                           # quiet: hide thinking/tool, deliver only the final text block
+#                           #        (the text emitted after the LAST tool_use). The
+#                           #        pre-tool "lead-in" is dropped by default. See
+#                           #        prepend_pre_tool_text below to opt back in.
+#                           #        静默模式（仅最终消息）：隐藏思考和工具消息，只投递最后一个
+#                           #        tool_use 之后的文本块；默认丢弃 tool_use 之前的"开场白"。
+#                           #        如需保留开场白，请见下面的 prepend_pre_tool_text。
 # thinking_messages = true  # Show/hide thinking messages (default: true) / 是否显示思考消息（默认 true）
 # thinking_max_len = 300    # Max chars for thinking messages (default: 300) / 思考消息最大字符数（默认 300）
 # tool_max_len = 500        # Max chars for tool use messages (default: 500) / 工具调用消息最大字符数（默认 500）
@@ -113,6 +118,13 @@ level = "info" # debug, info, warn, error
 #                                # 在助手回复末尾显示「[ctx: ~N%]」上下文占用提示（默认 true 显示）
 # reply_footer = true            # Show Codex-like footer on assistant replies (default: true)
 #                                # 在助手回复底部显示类似 Codex 的状态行（默认 true 显示）
+# prepend_pre_tool_text = false  # Quiet-mode-only: when mode = "quiet", keep the pre-tool
+#                                # "lead-in" (e.g. "Let me check that for you...") and
+#                                # concatenate it with the final text. Default false delivers
+#                                # only the post-tool text. Has no effect in full/compact mode.
+#                                # 仅对静默模式生效：true 时保留 tool_use 前的"开场白"并与最终文本
+#                                # 拼接后一起投递（恢复旧行为）；默认 false 仅投递 tool_use 之后的
+#                                # 文本。对 full/compact 模式无影响。
 
 # Per-project override: each [[projects]] entry may have its own [projects.display]
 # block that overrides individual fields of the global [display] block above.

--- a/config/config.go
+++ b/config/config.go
@@ -181,7 +181,12 @@ type ManagementConfig struct {
 const (
 	DisplayModeFull    = "full"    // show thinking + tool messages as separate messages (default)
 	DisplayModeCompact = "compact" // hide thinking/tool, each text segment is a separate card
-	DisplayModeQuiet   = "quiet"   // hide thinking/tool, all text appends to one card
+	// DisplayModeQuiet (final message only): hide thinking/tool, only the text
+	// emitted AFTER the last tool_use is delivered as the final reply. The
+	// pre-tool "lead-in" (e.g. "Let me check that for you...") is dropped by
+	// default. Set DisplayConfig.PrependPreToolText = true to opt in to the
+	// pre-tool text and get the old "all text in one card" behaviour.
+	DisplayModeQuiet = "quiet"
 )
 
 // DisplayConfig controls how intermediate messages (thinking, tool output) are shown.
@@ -194,6 +199,13 @@ type DisplayConfig struct {
 	ToolMessages         *bool   `toml:"tool_messages"`          // whether tool progress messages are shown; default true
 	ShowContextIndicator *bool   `toml:"show_context_indicator"` // whether [ctx: ~N%] suffix is shown; default true
 	ReplyFooter          *bool   `toml:"reply_footer"`           // whether Codex-like footer is shown; default true
+	// PrependPreToolText is a quiet-mode-only knob. When mode = "quiet" and
+	// this is false (the default), the engine slices the accumulated text at
+	// the last tool_use boundary and only delivers the text block that
+	// follows it. Set this to true to keep the pre-tool "lead-in" and get
+	// the legacy "all text in one card" rendering (#1302). Has no effect in
+	// full / compact mode.
+	PrependPreToolText *bool `toml:"prepend_pre_tool_text"`
 }
 
 // StreamPreviewConfig controls real-time streaming preview in IM.
@@ -808,7 +820,7 @@ func projectQuietEffective(cfg *Config, proj *ProjectConfig) bool {
 //  1. project-level [projects.display].<field> (highest precedence)
 //  2. global [display].<field>
 //  3. mode-derived default (compact/quiet → false, full → true)
-func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMessages, toolMessages bool, thinkingMaxLen, toolMaxLen int, showContextIndicator, replyFooter bool) {
+func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMessages, toolMessages bool, thinkingMaxLen, toolMaxLen int, showContextIndicator, replyFooter, prependPreToolText bool) {
 	var projDisp *DisplayConfig
 	if proj != nil {
 		projDisp = proj.Display
@@ -904,6 +916,14 @@ func EffectiveDisplay(cfg *Config, proj *ProjectConfig) (mode string, thinkingMe
 		replyFooter = *cfg.Display.ReplyFooter
 	} else {
 		replyFooter = true
+	}
+
+	// PrependPreToolText precedence: proj.Display.PrependPreToolText > cfg.Display.PrependPreToolText > default false.
+	// Only meaningful when mode = "quiet"; the engine ignores the field otherwise (#1302).
+	if projDisp != nil && projDisp.PrependPreToolText != nil {
+		prependPreToolText = *projDisp.PrependPreToolText
+	} else if cfg.Display.PrependPreToolText != nil {
+		prependPreToolText = *cfg.Display.PrependPreToolText
 	}
 
 	return

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -299,7 +299,7 @@ func TestEffectiveDisplayQuiet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mode, tm, tool, _, _, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
+			mode, tm, tool, _, _, _, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
 			if mode != tt.wantMode {
 				t.Fatalf("Mode = %q, want %q", mode, tt.wantMode)
 			}
@@ -308,6 +308,50 @@ func TestEffectiveDisplayQuiet(t *testing.T) {
 			}
 			if tool != tt.wantTool {
 				t.Fatalf("ToolMessages = %v, want %v", tool, tt.wantTool)
+			}
+		})
+	}
+}
+
+func TestEffectiveDisplay_PrependPreToolText(t *testing.T) {
+	tru, fal := true, false
+	quiet := DisplayModeQuiet
+	tests := []struct {
+		name string
+		cfg  Config
+		proj ProjectConfig
+		want bool
+	}{
+		{
+			name: "default false when unset",
+			cfg:  Config{Display: DisplayConfig{Mode: &quiet}},
+			proj: ProjectConfig{},
+			want: false,
+		},
+		{
+			name: "global true wins when project unset",
+			cfg:  Config{Display: DisplayConfig{Mode: &quiet, PrependPreToolText: &tru}},
+			proj: ProjectConfig{},
+			want: true,
+		},
+		{
+			name: "project true wins over global false",
+			cfg:  Config{Display: DisplayConfig{PrependPreToolText: &fal}},
+			proj: ProjectConfig{Display: &DisplayConfig{PrependPreToolText: &tru}},
+			want: true,
+		},
+		{
+			name: "project false wins over global true",
+			cfg:  Config{Display: DisplayConfig{PrependPreToolText: &tru}},
+			proj: ProjectConfig{Display: &DisplayConfig{PrependPreToolText: &fal}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, _, _, _, _, got := EffectiveDisplay(&tt.cfg, &tt.proj)
+			if got != tt.want {
+				t.Errorf("PrependPreToolText = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -412,7 +456,7 @@ func TestEffectiveDisplay_ProjectOverride(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, tm, tool, thinkLen, toolMaxLen, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
+			_, tm, tool, thinkLen, toolMaxLen, _, _, _ := EffectiveDisplay(&tt.cfg, &tt.proj)
 			if tm != tt.wantTM {
 				t.Errorf("ThinkingMessages = %v, want %v", tm, tt.wantTM)
 			}

--- a/core/engine.go
+++ b/core/engine.go
@@ -168,6 +168,13 @@ type DisplayCfg struct {
 	ThinkingMaxLen   int // max runes for thinking preview; 0 = no truncation
 	ToolMaxLen       int // max runes for tool use preview; 0 = no truncation
 	ToolMessages     bool
+	// PrependPreToolText is a quiet-mode-only knob (#1302). When Mode == "quiet"
+	// and this is false (the default), the engine slices the accumulated
+	// assistant text at the last tool_use boundary and only delivers the
+	// text block that follows. Set this to true to keep the pre-tool
+	// "lead-in" and restore the legacy "all text in one card" rendering.
+	// Ignored outside quiet mode.
+	PrependPreToolText bool
 }
 
 // InstantReplyCfg controls the immediate confirmation reply sent when a message
@@ -270,8 +277,8 @@ type Engine struct {
 	filterExternalSessions bool
 
 	// Shell configuration for /shell, cron exec, hooks, webhook exec
-	shell       string // shell binary path (e.g. "sh", "/bin/zsh")
-	shellFlag   string // shell flag (e.g. "-c", "-Command", "/C")
+	shell        string // shell binary path (e.g. "sh", "/bin/zsh")
+	shellFlag    string // shell flag (e.g. "-c", "-Command", "/C")
 	shellProfile string // prepended to every command (e.g. "source ~/.zshrc;")
 
 	// Multi-workspace mode
@@ -4282,7 +4289,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 	var textParts []string
 	var segmentStart int // index into textParts: text before this has been sent/displayed
-	silentHold := false  // true while accumulated segment text could still resolve to a bare NO_REPLY marker
+	// postLastToolStart is the index in textParts where the text block emitted
+	// after the LAST tool_use begins. It stays 0 if no tool_use was observed.
+	// In quiet mode with PrependPreToolText=false (#1302), the EventResult
+	// handler uses textParts[postLastToolStart:] as the final reply so the
+	// user only sees the text emitted AFTER the last tool call, not the
+	// pre-tool "lead-in" (e.g. "Let me check that for you...").
+	postLastToolStart := 0
+	silentHold := false // true while accumulated segment text could still resolve to a bare NO_REPLY marker
 	toolCount := 0
 	waitStart := time.Now()
 	firstEventLogged := false
@@ -4647,13 +4661,23 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				break
 			}
 			// When tool messages are hidden, behavior depends on display mode:
-			//   quiet:   append separator to keep all text in one card
+			//   quiet:   append separator to keep all text in one card (legacy
+			//            behaviour when PrependPreToolText=true; when false, the
+			//            pre-tool slice is dropped at EventResult time — see #1302)
 			//   compact: freeze+detach to split text into separate cards
 			if !e.display.ToolMessages && len(textParts) > segmentStart {
 				if e.display.Mode == "quiet" {
 					if sp.canPreview() && sp.appendSeparator("\n\n") {
 						textParts = append(textParts, "\n\n")
 					}
+					// Mark the post-tool boundary (#1302): the next EventText
+					// chunk starts here. With PrependPreToolText=false (the
+					// default), EventResult slices textParts[postLastToolStart:]
+					// so the pre-tool "lead-in" is dropped from the final
+					// reply. The separator we just appended lives in the
+					// pre-tool segment and is dropped with it — fine, because
+					// nothing in the kept slice ever references it.
+					postLastToolStart = len(textParts)
 				} else {
 					if sp.canPreview() {
 						sp.freeze()
@@ -5041,7 +5065,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			// contains ALL text across tool boundaries. Prefer the full accumulated
 			// text over event.Content which only contains the last assistant segment.
 			if len(textParts) > 0 && segmentStart == 0 && !e.display.ToolMessages {
-				fullResponse = strings.Join(textParts, "")
+				// Quiet mode slices off the pre-tool "lead-in" so the user only
+				// sees the text emitted after the last tool_use (#1302). Other
+				// modes keep the full accumulated text as before.
+				textSource := textParts
+				if e.display.Mode == "quiet" && !e.display.PrependPreToolText {
+					textSource = textParts[postLastToolStart:]
+				}
+				fullResponse = strings.Join(textSource, "")
 			} else if fullResponse == "" && len(textParts) > 0 {
 				fullResponse = strings.Join(textParts, "")
 			}

--- a/core/engine_quiet_test.go
+++ b/core/engine_quiet_test.go
@@ -1,0 +1,224 @@
+package core
+
+// Tests for issue #1302 — quiet mode "final message only" behaviour.
+//
+// Quiet mode's inline doc promised "final message only" but the
+// implementation concatenated the pre-tool "lead-in" (e.g. "Let me check
+// that for you...") directly with the post-tool answer, with no
+// separator. The fix slices the accumulated text at the last tool_use
+// boundary when mode == "quiet" and DisplayCfg.PrependPreToolText is
+// false (the default). The pre-tool text and the "\n\n" separator
+// between pre and post are dropped from the final reply.
+//
+// These tests run the same end-to-end event loop the production
+// code uses (processInteractiveEvents), so they exercise all
+// platform-agnostic finalization paths in one go: stream preview,
+// sendChunksWithStatusFooter, the !isSilent branch, and the
+// accumulated-textParts slice point in EventResult.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// runQuietTurn drives one full turn with the given display config and
+// the given event sequence. It returns whatever the platform captured
+// via Reply / Send. The test framework is the same
+// processInteractiveEvents + controllableAgentSession path used by the
+// rest of the engine tests.
+func runQuietTurn(t *testing.T, cfg DisplayCfg, events []Event) []string {
+	t.Helper()
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(cfg)
+	e.SetReplyFooterEnabled(false) // keep final text predictable across tests
+
+	sessionKey := "test:quiet-u1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	sess := newControllableSession("s-quiet")
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx-quiet",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	for _, ev := range events {
+		sess.events <- ev
+	}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-quiet", time.Now(), nil, nil, state.replyCtx)
+	return p.getSent()
+}
+
+// TestQuiet_Default_DropsPreToolLeadIn is the primary regression test
+// for #1302. With mode = "quiet" and PrependPreToolText = false (the
+// default), the user only sees the text emitted after the LAST
+// tool_use. The pre-tool "Let me check that for you..." lead-in and
+// the "\n\n" separator that used to glue it to the answer are both
+// dropped.
+func TestQuiet_Default_DropsPreToolLeadIn(t *testing.T) {
+	cfg := DisplayCfg{
+		Mode:               "quiet",
+		ThinkingMessages:   false,
+		ToolMessages:       false,
+		PrependPreToolText: false,
+	}
+	sent := runQuietTurn(t, cfg, []Event{
+		{Type: EventText, Content: "Let me check that for you."},
+		{Type: EventToolUse, ToolName: "Bash", ToolInput: "pwd"},
+		{Type: EventText, Content: "Here is the answer: /home/user."},
+		{Type: EventResult, Content: "Here is the answer: /home/user.", Done: true},
+	})
+	if len(sent) == 0 {
+		t.Fatal("sent = nil, want at least one final reply")
+	}
+	// All sent messages should be the same final text (one card).
+	// We just check the final text — pre-tool content must not appear.
+	final := sent[len(sent)-1]
+	if strings.Contains(final, "Let me check that for you") {
+		t.Errorf("pre-tool lead-in leaked into final reply: %q", final)
+	}
+	if !strings.Contains(final, "Here is the answer: /home/user.") {
+		t.Errorf("post-tool answer missing from final reply: %q", final)
+	}
+	if strings.Contains(final, "\n\n") {
+		// The legacy bug glued the pre-tool text and post-tool text with
+		// "\n\n". With the fix in place the pre-tool slice (including
+		// the separator) is dropped, so the only "\n\n" we could see
+		// would be inside the post-tool text itself.
+		t.Errorf("unexpected \"\\n\\n\" in final reply (separator should be dropped): %q", final)
+	}
+}
+
+// TestQuiet_Default_NoTool_KeepsAllText covers the no-tool case: there
+// is no tool_use to mark a boundary, so the entire text is the
+// "final message" and must be delivered verbatim. This guards against
+// the fix accidentally regressing the common "user asks a question,
+// agent answers directly" path.
+func TestQuiet_Default_NoTool_KeepsAllText(t *testing.T) {
+	cfg := DisplayCfg{
+		Mode:               "quiet",
+		ThinkingMessages:   false,
+		ToolMessages:       false,
+		PrependPreToolText: false,
+	}
+	sent := runQuietTurn(t, cfg, []Event{
+		{Type: EventText, Content: "Just a direct answer."},
+		{Type: EventResult, Content: "Just a direct answer.", Done: true},
+	})
+	if len(sent) == 0 {
+		t.Fatal("sent = nil, want at least one final reply")
+	}
+	final := sent[len(sent)-1]
+	if !strings.Contains(final, "Just a direct answer.") {
+		t.Errorf("direct answer missing from final reply: %q", final)
+	}
+}
+
+// TestQuiet_PrependOptIn_KeepsPreToolLeadIn verifies the opt-in path:
+// with PrependPreToolText = true, the user gets the legacy
+// "pre-tool + post-tool" concatenation. This is what existing
+// quiet-mode users who relied on the old behaviour should set in
+// their config to keep the lead-in.
+//
+// Note: the legacy code only inserted a "\n\n" separator between the
+// pre- and post-tool slices when the platform's stream preview was
+// active (`sp.canPreview()` returns true). The stub platform in this
+// test does not implement stream preview, so we don't assert on the
+// separator here — only that both halves of the text are present in
+// the final reply, which is the user-visible behaviour the opt-in
+// knob controls.
+func TestQuiet_PrependOptIn_KeepsPreToolLeadIn(t *testing.T) {
+	cfg := DisplayCfg{
+		Mode:               "quiet",
+		ThinkingMessages:   false,
+		ToolMessages:       false,
+		PrependPreToolText: true,
+	}
+	sent := runQuietTurn(t, cfg, []Event{
+		{Type: EventText, Content: "Let me check that for you."},
+		{Type: EventToolUse, ToolName: "Bash", ToolInput: "pwd"},
+		{Type: EventText, Content: "Here is the answer: /home/user."},
+		{Type: EventResult, Content: "Here is the answer: /home/user.", Done: true},
+	})
+	if len(sent) == 0 {
+		t.Fatal("sent = nil, want at least one final reply")
+	}
+	final := sent[len(sent)-1]
+	if !strings.Contains(final, "Let me check that for you") {
+		t.Errorf("pre-tool lead-in missing with PrependPreToolText=true: %q", final)
+	}
+	if !strings.Contains(final, "Here is the answer: /home/user.") {
+		t.Errorf("post-tool answer missing with PrependPreToolText=true: %q", final)
+	}
+}
+
+// TestQuiet_Default_OnlyLastToolSurfaces verifies that when multiple
+// tool_uses happen, the user still only sees the text after the LAST
+// one. An intermediate text block followed by another tool_use should
+// also be treated as pre-tool lead-in (and dropped), because the
+// final reply is anchored on the most recent tool_use.
+func TestQuiet_Default_OnlyLastToolSurfaces(t *testing.T) {
+	cfg := DisplayCfg{
+		Mode:               "quiet",
+		ThinkingMessages:   false,
+		ToolMessages:       false,
+		PrependPreToolText: false,
+	}
+	sent := runQuietTurn(t, cfg, []Event{
+		{Type: EventText, Content: "First lead-in (drop me)."},
+		{Type: EventToolUse, ToolName: "Bash", ToolInput: "ls"},
+		{Type: EventText, Content: "Intermediate result (drop me too)."},
+		{Type: EventToolUse, ToolName: "Bash", ToolInput: "pwd"},
+		{Type: EventText, Content: "Final answer: /home/user."},
+		{Type: EventResult, Content: "Final answer: /home/user.", Done: true},
+	})
+	if len(sent) == 0 {
+		t.Fatal("sent = nil, want at least one final reply")
+	}
+	final := sent[len(sent)-1]
+	if strings.Contains(final, "First lead-in") {
+		t.Errorf("first pre-tool lead-in leaked: %q", final)
+	}
+	if strings.Contains(final, "Intermediate result") {
+		t.Errorf("intermediate text (between two tool_uses) leaked: %q", final)
+	}
+	if !strings.Contains(final, "Final answer: /home/user.") {
+		t.Errorf("final answer missing: %q", final)
+	}
+}
+
+// TestCompact_NotAffectedByQuietFix guards the other display modes
+// against the new quiet-mode slicing. The bug only exists in quiet
+// mode; compact and full mode must continue to deliver the full
+// accumulated textParts in their existing forms.
+func TestCompact_NotAffectedByQuietFix(t *testing.T) {
+	cfg := DisplayCfg{
+		Mode:               "compact",
+		ThinkingMessages:   false,
+		ToolMessages:       false,
+		PrependPreToolText: false,
+	}
+	sent := runQuietTurn(t, cfg, []Event{
+		{Type: EventText, Content: "Pre-tool lead-in."},
+		{Type: EventToolUse, ToolName: "Bash", ToolInput: "pwd"},
+		{Type: EventText, Content: "Post-tool answer."},
+		{Type: EventResult, Content: "Post-tool answer.", Done: true},
+	})
+	// Compact mode flushes each text segment as a separate card. We
+	// don't assert exact message count (it's governed by compact-mode
+	// segment flushing rules) — only that the pre-tool lead-in
+	// appears in some sent message. The point is: the quiet-mode
+	// slicing must NOT bleed into compact mode.
+	found := false
+	for _, s := range sent {
+		if strings.Contains(s, "Pre-tool lead-in.") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("compact mode unexpectedly dropped pre-tool text: sent = %v", sent)
+	}
+}

--- a/tests/release_local/config_matrix/config_matrix_test.go
+++ b/tests/release_local/config_matrix/config_matrix_test.go
@@ -84,7 +84,7 @@ app_secret = "secret"
 		t.Fatalf("ResetOnIdleMins = %#v, want explicit 0", proj.ResetOnIdleMins)
 	}
 
-	mode, thinking, tools, thinkingMax, toolMax, _, _ := config.EffectiveDisplay(cfg, proj)
+	mode, thinking, tools, thinkingMax, toolMax, _, _, _ := config.EffectiveDisplay(cfg, proj)
 	if mode != config.DisplayModeFull {
 		t.Fatalf("mode = %q, want project full override", mode)
 	}
@@ -111,7 +111,7 @@ func TestReleaseConfig_DefaultsKeepAttachmentsAndFullDisplayEnabled(t *testing.T
 	if cfg.AttachmentSend != "on" {
 		t.Fatalf("AttachmentSend = %q, want default on", cfg.AttachmentSend)
 	}
-	mode, thinking, tools, _, _, _, _ := config.EffectiveDisplay(cfg, &cfg.Projects[0])
+	mode, thinking, tools, _, _, _, _, _ := config.EffectiveDisplay(cfg, &cfg.Projects[0])
 	if mode != config.DisplayModeFull || !thinking || !tools {
 		t.Fatalf("display = mode:%s thinking:%v tools:%v, want full/true/true", mode, thinking, tools)
 	}
@@ -181,7 +181,7 @@ app_secret = "secret"
 	if strings.Join(proj.DisabledCommands, ",") != "restart,shell" {
 		t.Fatalf("disabled_commands = %#v", proj.DisabledCommands)
 	}
-	mode, thinking, tools, _, _, _, _ := config.EffectiveDisplay(cfg, proj)
+	mode, thinking, tools, _, _, _, _, _ := config.EffectiveDisplay(cfg, proj)
 	if mode != config.DisplayModeQuiet || thinking || tools {
 		t.Fatalf("display = mode:%s thinking:%v tools:%v, want quiet/false/false", mode, thinking, tools)
 	}


### PR DESCRIPTION
Fixes #1302

## What changed

Quiet mode's inline doc promised "final message only" but the engine
concatenated the assistant text block emitted **before** `tool_use`
directly to the post-tool answer, with no separator. The "\n\n" glue
that *did* exist was gated behind `sp.canPreview()`, so on platforms
without stream preview (Slack/Discord/Feishu/Telegram/DingTalk/...) the
two halves were mashed together. Reported by @vuyiv on Slack with
Claude Code in v1.3.3-beta.4.

## Fix

Track a `postLastToolStart` index on every `tool_use` event in quiet
mode, and at `EventResult` time slice `textParts` at that boundary.
This drops the pre-tool "lead-in" (and any platform-glue separator)
from the final reply while preserving the post-tool answer verbatim.

The change lives in `processInteractiveEvents` (platform-agnostic), so
all IM platforms benefit — Slack, Discord, Feishu, Telegram, DingTalk,
WeChat, QQ, LINE, etc.

## Opt-in for legacy behavior

Added `display.prepend_pre_tool_text` (default `false`). Set to `true`
to restore the legacy "all text in one card" behavior for users who
relied on the old concatenation.

## Doc unification

Updated `DisplayModeQuiet` doc to "Quiet mode (final message only)".
Added bilingual comment in `config.example.toml`.

## Tests

New `core/engine_quiet_test.go` (5 cases, drives the full
`processInteractiveEvents` loop with `controllableAgentSession`):

- `TestQuiet_Default_DropsPreToolLeadIn` — primary regression test
- `TestQuiet_Default_NoTool_KeepsAllText` — guards no-tool path
- `TestQuiet_PrependOptIn_KeepsPreToolLeadIn` — verifies opt-in
- `TestQuiet_Default_OnlyLastToolSurfaces` — multiple tool_uses
- `TestCompact_NotAffectedByQuietFix` — guards other display modes

New `TestEffectiveDisplay_PrependPreToolText` (4 subtests) in
`config/config_test.go`: default false, global true, project true,
project false.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test -count=1 -timeout 180s ./core/ ./config/ ./daemon/` all PASS
- `gofmt` clean on all modified Go files

## Non-goals (per task)

- Did not change thinking/tool suppression logic
- Did not change compact/normal/verbose modes
- Did not change raw Claude Code behavior
- Did not auto-merge / release

## Files

- `core/engine.go` — quiet-mode slicing in `processInteractiveEvents`
- `core/engine_quiet_test.go` — new
- `config/config.go` — `PrependPreToolText` field + resolution
- `config/config_test.go` — new subtests + signature update
- `config.example.toml` — bilingual doc
- `cmd/cc-connect/main.go` — wire 8th return value, 3 callers
- `tests/release_local/config_matrix/config_matrix_test.go` — wire
- `CHANGELOG.md` — unreleased Fixed entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)