### PR TITLE
feat: add plugin_dir option to load Claude Code plugins

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -51,6 +51,7 @@ type Agent struct {
 	routerURL        string // Claude Code Router URL (e.g., "http://127.0.0.1:3456")
 	routerAPIKey     string // Claude Code Router API key (optional)
 	systemPrompt     string // Custom system prompt to pass to Claude CLI
+	pluginDirs       []string // Plugin directories to load via --plugin-dir (repeatable)
 
 	appendSystemPrompt string // Custom text appended to the system prompt (keeps Claude's default)
 
@@ -138,6 +139,17 @@ func New(opts map[string]any) (core.Agent, error) {
 	systemPrompt, _ := opts["system_prompt"].(string)
 	appendSystemPrompt, _ := opts["append_system_prompt"].(string)
 
+	var pluginDirs []string
+	if dir, ok := opts["plugin_dir"].(string); ok && dir != "" {
+		pluginDirs = []string{dir}
+	} else if dirs, ok := opts["plugin_dir"].([]any); ok {
+		for _, d := range dirs {
+			if s, ok := d.(string); ok && s != "" {
+				pluginDirs = append(pluginDirs, s)
+			}
+		}
+	}
+
 	var allowedTools []string
 	if tools, ok := opts["allowed_tools"].([]any); ok {
 		for _, t := range tools {
@@ -223,6 +235,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		reasoningEffort:  normalizeEffort(reasoningEffort),
 		mode:             mode,
 		systemPrompt:     systemPrompt,
+		pluginDirs:       pluginDirs,
 		allowedTools:     allowedTools,
 		disallowedTools:  disallowedTools,
 		maxContextTokens: maxContextTokens,
@@ -467,6 +480,8 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	effort := a.reasoningEffort
 	workDir := a.workDir
 	mode := a.mode
+	pluginDirs := make([]string, len(a.pluginDirs))
+	copy(pluginDirs, a.pluginDirs)
 	extraEnv := a.runtimeEnvLocked()
 
 	activeIdx := a.activeIdx
@@ -491,7 +506,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
+	return newClaudeSession(ctx, workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt, tools, disTools, pluginDirs, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {
@@ -832,6 +847,9 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	}
 	if a.routerAPIKey != "" {
 		opts["router_api_key"] = a.routerAPIKey
+	}
+	if len(a.pluginDirs) > 0 {
+		opts["plugin_dir"] = stringsToAny(a.pluginDirs)
 	}
 	return opts
 }

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -90,7 +90,7 @@ func buildAppendSystemPrompt(agentPrompt, platformPrompt, userAppend string) str
 	return strings.Join(parts, "\n")
 }
 
-func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
+func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, pluginDirs []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	// Claude Code rejects bypassPermissions when running as root.
@@ -131,6 +131,11 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	}
 	if len(disallowedTools) > 0 {
 		innerArgs = append(innerArgs, "--disallowedTools", strings.Join(disallowedTools, ","))
+	}
+
+	// Load plugins from specified directories.
+	for _, dir := range pluginDirs {
+		innerArgs = append(innerArgs, "--plugin-dir", dir)
 	}
 
 	// Handle custom system prompt (replaces Claude's default system prompt).


### PR DESCRIPTION
## Summary

Adds `plugin_dir` support to `agent.options` in config.toml, so cc-connect can pass `--plugin-dir` flags to Claude Code when spawning sessions. This enables installed plugins (like superpowers, last30days) to be loaded in IM-bridged sessions, closing the gap where skills work through cc-connect but plugins don't.

## Problem

When using Claude Code through cc-connect, installed plugins are not available. Skills (~/.claude/skills/) work fine, but plugins (~/.claude/plugins/) are not loaded because cc-connect does not pass `--plugin-dir` to the Claude Code subprocess. See #1324.

## Changes

- **`agent/claudecode/claudecode.go`**: Add `pluginDirs []string` field to Agent struct. Parse `plugin_dir` from opts map (supports both single string and array). Pass `pluginDirs` through `StartSession()` to `newClaudeSession()`. Include in `WorkspaceAgentOptions()` for multi-workspace propagation.
- **`agent/claudecode/session.go`**: Add `pluginDirs []string` parameter to `newClaudeSession()`. Iterate and append `--plugin-dir <dir>` for each entry to `innerArgs`.

## Configuration Example

```toml
[projects.agent.options]
mode = "bypassPermissions"
model = "sonnet"
# Single plugin directory
plugin_dir = "/Users/byctor/.claude/plugins/cache/claude-plugins-official"
# OR multiple directories
plugin_dir = [
  "/Users/byctor/.claude/plugins/cache/claude-plugins-official",
  "/Users/byctor/.claude/plugins/cache/last30days-skill"
]
```

## Test Plan

- [ ] Configure `plugin_dir` with a single string value and verify `--plugin-dir` appears in the spawned Claude Code process args
- [ ] Configure `plugin_dir` as an array and verify multiple `--plugin-dir` flags appear
- [ ] Leave `plugin_dir` unset and verify no `--plugin-dir` flag is added (no regression)
- [ ] Verify multi-workspace mode inherits `plugin_dir` from parent agent
- [ ] Verify plugins become accessible via slash commands in cc-connect sessions

Closes #1324