### PR TITLE
feat(kiro): add Kiro CLI coding agent support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ go build -tags 'no_discord no_dingtalk no_qq no_qqbot no_line' ./cmd/cc-connect
 ```
 
 Available tags: `no_acp`, `no_claudecode`, `no_codex`, `no_copilot`, `no_cursor`, `no_gemini`,
-`no_iflow`, `no_opencode`, `no_qoder`, `no_feishu`, `no_telegram`,
+`no_iflow`, `no_kiro`, `no_opencode`, `no_qoder`, `no_feishu`, `no_telegram`,
 `no_discord`, `no_slack`, `no_dingtalk`, `no_wecom`, `no_weixin`, `no_qq`, `no_qqbot`,
 `no_line`, `no_weibo`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -86,6 +86,10 @@ npm install -g @iflow-ai/iflow-cli
 
 # Qoder CLI
 curl -fsSL https://qoder.com/install | bash
+
+# Kiro CLI
+# Follow Kiro's official installer, then authenticate with:
+kiro-cli login --use-device-flow
 ```
 
 For **Cursor Agent** and **OpenCode**, follow their official install docs:
@@ -101,6 +105,7 @@ gemini --version
 iflow --version
 opencode --version
 qodercli --version
+kiro-cli --version
 ```
 
 ## Step 3: Create config.toml
@@ -143,7 +148,7 @@ level = "info"  # debug, info, warn, error
 name = "my-project"
 
 [projects.agent]
-type = "claudecode"  # or "codex", "cursor", "gemini", "qoder", "opencode", "iflow"
+type = "claudecode"  # or "codex", "cursor", "gemini", "qoder", "kiro", "opencode", "iflow"
 
 [projects.agent.options]
 work_dir = "/absolute/path/to/your/project"
@@ -160,6 +165,13 @@ mode = "default"
 # --- Qoder CLI mode options ---
 # "default", "yolo"
 # model = "auto"  # "auto", "ultimate", "performance", "efficient", "lite"
+
+# --- Kiro CLI mode options ---
+# "default", "yolo" (passes --trust-all-tools)
+# model = "auto"  # optional: omit or set "auto" to use Kiro CLI's default
+# agent = "default"  # optional Kiro agent profile
+# agent_engine = "v2"  # optional: "v1", "v2", or "kas"
+# kas_mode = "vibe"  # optional when agent_engine = "kas": "vibe" or "spec"
 
 # --- iFlow CLI mode options ---
 # "default", "auto-edit", "plan", "yolo"
@@ -498,13 +510,14 @@ cc-connect supports scheduled tasks (cron jobs). You can always create them via 
 
 **Claude Code** handles this automatically via `--append-system-prompt` — no extra setup needed.
 
-**For Codex, Cursor Agent, Qoder CLI, Gemini CLI, OpenCode, or iFlow CLI**, add the following instructions to the agent's project-level instruction file in your project's `work_dir`:
+**For Codex, Cursor Agent, Qoder CLI, Kiro CLI, Gemini CLI, OpenCode, or iFlow CLI**, add the following instructions to the agent's project-level instruction file in your project's `work_dir`:
 
 | Agent | File to create/edit |
 |-------|-------------------|
 | Codex | `AGENTS.md` |
 | Cursor Agent | `.cursorrules` |
 | Qoder CLI | `AGENTS.md` |
+| Kiro CLI | `AGENTS.md` |
 | Gemini CLI | `GEMINI.md` |
 | OpenCode | `OPENCODE.md` |
 | iFlow CLI | `IFLOW.md` |
@@ -654,7 +667,26 @@ type = "telegram"
 [projects.platforms.options]
 token = "xxx"
 
-# Sixth project — using iFlow CLI
+# Sixth project — using Kiro CLI
+[[projects]]
+name = "my-kiro-project"
+
+[projects.agent]
+type = "kiro"
+
+[projects.agent.options]
+work_dir = "/path/to/kiro-project"
+mode = "default"    # "default" | "yolo"
+# model = "auto"
+# agent = "default"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+token = "xxx"
+
+# Seventh project — using iFlow CLI
 [[projects]]
 name = "my-iflow-project"
 
@@ -785,6 +817,7 @@ The following additional features are available:
 - **Cursor Agent**: Cursor Agent CLI integration (`agent --print --output-format stream-json`)
 - **Gemini CLI**: Google Gemini CLI integration (`gemini -p --output-format stream-json`)
 - **Qoder CLI**: Qoder CLI integration (`qodercli -p -f stream-json`)
+- **Kiro CLI**: Kiro CLI integration (`kiro-cli chat --no-interactive`)
 - **OpenCode**: OpenCode CLI integration (`opencode run --format json`)
 - **iFlow CLI**: iFlow CLI integration (`iflow -i -r -o`)
 - **Voice Messages (STT)**: Speech-to-text via Whisper API (OpenAI / Groq / SiliconFlow). Requires `ffmpeg` and `[speech]` config.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ PLATFORMS := \
 #   make build EXCLUDE=discord,dingtalk,qq,qqbot,line
 # ---------------------------------------------------------------------------
 
-ALL_AGENTS    := acp antigravity claudecode codex copilot cursor devin gemini iflow kimi opencode pi qoder tmux
+ALL_AGENTS    := acp antigravity claudecode codex copilot cursor devin gemini iflow kimi kiro opencode pi qoder tmux
 ALL_PLATFORMS := feishu telegram discord slack dingtalk wecom weixin qq qqbot line weibo max
 ALL_EXTRAS    := web
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ High-level view of what each **built-in platform** can do in cc-connect.
 ## ✨ Why cc-connect?
 
 ### 🤖 Universal Agent Support
-**10+ AI Agents** — Claude Code, Codex, Cursor Agent, Kimi CLI, Qoder CLI, Gemini CLI, OpenCode, iFlow CLI, Pi, Devin, Copilot — plus any agent that supports the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents). Use whichever fits your workflow, or all of them at once.
+**10+ AI Agents** — Claude Code, Codex, Cursor Agent, Kimi CLI, Kiro CLI, Qoder CLI, Gemini CLI, OpenCode, iFlow CLI, Pi, Devin, Copilot — plus any agent that supports the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents). Use whichever fits your workflow, or all of them at once.
 
 ### 📱 Platform Flexibility
 **12 Chat Platforms** — Feishu, WPS Xiezuo, DingTalk, Slack, Telegram, Discord, WeChat Work, Weibo, LINE, QQ, QQ Bot (Official), plus **Weixin (personal ilink)** for **personal WeChat**. Most platforms need **zero public IP**.
@@ -355,6 +355,7 @@ cc-connect update --pre     # Include pre-releases
 | Agent | Cursor Agent | ✅ Supported |
 | Agent | Gemini CLI (Google) | ✅ Supported |
 | Agent | Qoder CLI | ✅ Supported |
+| Agent | Kiro CLI | ✅ Supported |
 | Agent | OpenCode (Crush) | ✅ Supported |
 | Agent | iFlow CLI | ✅ Supported |
 | Agent | Kimi CLI (Moonshot) | ✅ Supported |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -224,7 +224,7 @@ MiniMax M3 突破 Coding 与 Agentic AI 前沿，基于 MiniMax Sparse Attention
 ## ✨ 为什么选择 cc-connect？
 
 ### 🤖 通用 Agent 支持
-**10+ 大 AI Agent** — Claude Code、Codex、Cursor Agent、Kimi CLI、Qoder CLI、Gemini CLI、OpenCode、iFlow CLI、Pi、Devin、Copilot，还可通过 [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents) 接入更多 Agent。按需选用，或同时使用全部。
+**10+ 大 AI Agent** — Claude Code、Codex、Cursor Agent、Kimi CLI、Kiro CLI、Qoder CLI、Gemini CLI、OpenCode、iFlow CLI、Pi、Devin、Copilot，还可通过 [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents) 接入更多 Agent。按需选用，或同时使用全部。
 
 ### 📱 平台灵活性
 **12 大聊天平台** — 飞书、WPS 协作、钉钉、Slack、Telegram、Discord、企业微信、微博、LINE、QQ、QQ 官方机器人，以及 **微信个人号（ilink）**。大部分平台**无需公网 IP**。
@@ -354,6 +354,7 @@ cc-connect update --pre     # 含预发布版本
 | Agent | Cursor Agent | ✅ 已支持 |
 | Agent | Gemini CLI (Google) | ✅ 已支持 |
 | Agent | Qoder CLI | ✅ 已支持 |
+| Agent | Kiro CLI | ✅ 已支持 |
 | Agent | OpenCode (Crush) | ✅ 已支持 |
 | Agent | iFlow CLI | ✅ 已支持 |
 | Agent | Kimi CLI (Moonshot) | ✅ 已支持 |

--- a/agent/kiro/kiro.go
+++ b/agent/kiro/kiro.go
@@ -1,0 +1,406 @@
+package kiro
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func init() {
+	core.RegisterAgent("kiro", New)
+}
+
+// Agent drives Kiro CLI using `kiro-cli chat <prompt> --no-interactive`.
+type Agent struct {
+	workDir      string
+	model        string
+	mode         string // "default" | "yolo"
+	cmd          string
+	agentProfile string
+	agentEngine  string
+	kasMode      string
+	trustTools   string
+	sessionEnv   []string
+	mu           sync.Mutex
+}
+
+func New(opts map[string]any) (core.Agent, error) {
+	workDir, _ := opts["work_dir"].(string)
+	if workDir == "" {
+		workDir = "."
+	}
+	model, _ := opts["model"].(string)
+	mode, _ := opts["mode"].(string)
+	mode = normalizeMode(mode)
+	cmd, _ := opts["cmd"].(string)
+	agentProfile, _ := opts["agent"].(string)
+	agentEngine, _ := opts["agent_engine"].(string)
+	kasMode, _ := opts["kas_mode"].(string)
+	trustTools, _ := opts["trust_tools"].(string)
+
+	resolvedCmd, err := resolveKiroCmd(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Agent{
+		workDir:      workDir,
+		model:        model,
+		mode:         mode,
+		cmd:          resolvedCmd,
+		agentProfile: agentProfile,
+		agentEngine:  agentEngine,
+		kasMode:      kasMode,
+		trustTools:   trustTools,
+	}, nil
+}
+
+func resolveKiroCmd(cmd string) (string, error) {
+	if strings.TrimSpace(cmd) == "" {
+		cmd = "kiro-cli"
+	}
+	if path, err := exec.LookPath(cmd); err == nil {
+		return path, nil
+	}
+	if cmd != "kiro-cli" {
+		return "", fmt.Errorf("kiro: %q CLI not found in PATH, install Kiro CLI and ensure it is executable", cmd)
+	}
+
+	var candidates []string
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, ".local", "bin", "kiro-cli"))
+	}
+	candidates = append(candidates, "/opt/homebrew/bin/kiro-cli", "/usr/local/bin/kiro-cli")
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("kiro: %q CLI not found in PATH or common install locations, install Kiro CLI and ensure it is executable", cmd)
+}
+
+func normalizeMode(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "yolo", "auto", "bypass", "trust", "trust-all", "trust_all", "trustall":
+		return "yolo"
+	default:
+		return "default"
+	}
+}
+
+func (a *Agent) Name() string           { return "kiro" }
+func (a *Agent) CLIBinaryName() string  { return a.cmdName() }
+func (a *Agent) CLIDisplayName() string { return "Kiro CLI" }
+
+func (a *Agent) cmdName() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cmd == "" {
+		return "kiro-cli"
+	}
+	return a.cmd
+}
+
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("kiro: work_dir changed", "work_dir", dir)
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+
+func (a *Agent) SetModel(model string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.model = model
+	slog.Info("kiro: model changed", "model", model)
+}
+
+func (a *Agent) GetModel() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.model
+}
+
+func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
+	models, err := a.listModels(ctx)
+	if err == nil && len(models) > 0 {
+		return models
+	}
+	return []core.ModelOption{
+		{Name: "auto", Desc: "Kiro CLI default model"},
+	}
+}
+
+func (a *Agent) SetSessionEnv(env []string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sessionEnv = env
+}
+
+func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentSession, error) {
+	a.mu.Lock()
+	cmd := a.cmd
+	if cmd == "" {
+		cmd = "kiro-cli"
+	}
+	workDir := a.workDir
+	model := a.model
+	mode := a.mode
+	agentProfile := a.agentProfile
+	agentEngine := a.agentEngine
+	kasMode := a.kasMode
+	trustTools := a.trustTools
+	extraEnv := append([]string{}, a.sessionEnv...)
+	a.mu.Unlock()
+
+	return newKiroSession(ctx, cmd, workDir, model, mode, agentProfile, agentEngine, kasMode, trustTools, sessionID, extraEnv)
+}
+
+func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {
+	a.mu.Lock()
+	cmdName := a.cmd
+	if cmdName == "" {
+		cmdName = "kiro-cli"
+	}
+	workDir := a.workDir
+	a.mu.Unlock()
+
+	cmd := exec.CommandContext(ctx, cmdName, "chat", "--list-sessions", "--format", "json")
+	cmd.Dir = workDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("kiro: list sessions: %w", err)
+	}
+	return parseSessionList(out), nil
+}
+
+func (a *Agent) DeleteSession(ctx context.Context, sessionID string) error {
+	if strings.TrimSpace(sessionID) == "" {
+		return nil
+	}
+	a.mu.Lock()
+	cmdName := a.cmd
+	if cmdName == "" {
+		cmdName = "kiro-cli"
+	}
+	workDir := a.workDir
+	a.mu.Unlock()
+
+	cmd := exec.CommandContext(ctx, cmdName, "chat", "--delete-session", sessionID)
+	cmd.Dir = workDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kiro: delete session: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func (a *Agent) Stop() error { return nil }
+
+func (a *Agent) SetMode(mode string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.mode = normalizeMode(mode)
+	slog.Info("kiro: mode changed", "mode", a.mode)
+}
+
+func (a *Agent) GetMode() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.mode
+}
+
+func (a *Agent) PermissionModes() []core.PermissionModeInfo {
+	return []core.PermissionModeInfo{
+		{Key: "default", Name: "Default", NameZh: "默认", Desc: "Kiro CLI default tool trust behavior", DescZh: "Kiro CLI 默认工具信任行为"},
+		{Key: "yolo", Name: "Trust All", NameZh: "信任全部工具", Desc: "Pass --trust-all-tools to Kiro CLI", DescZh: "向 Kiro CLI 传递 --trust-all-tools"},
+	}
+}
+
+func (a *Agent) SkillDirs() []string {
+	workDir := a.GetWorkDir()
+	absDir, err := filepath.Abs(workDir)
+	if err != nil {
+		absDir = workDir
+	}
+	dirs := []string{filepath.Join(absDir, ".kiro", "skills")}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".kiro", "skills"))
+	}
+	return dirs
+}
+
+func (a *Agent) ProjectMemoryFile() string {
+	workDir := a.GetWorkDir()
+	absDir, err := filepath.Abs(workDir)
+	if err != nil {
+		absDir = workDir
+	}
+	return filepath.Join(absDir, "AGENTS.md")
+}
+
+func (a *Agent) GlobalMemoryFile() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(homeDir, ".kiro", "AGENTS.md")
+}
+
+func (a *Agent) CompressCommand() string { return "/compact" }
+
+func (a *Agent) BaseOpts() map[string]any {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := map[string]any{
+		"cmd":          a.cmd,
+		"model":        a.model,
+		"mode":         a.mode,
+		"agent":        a.agentProfile,
+		"agent_engine": a.agentEngine,
+		"kas_mode":     a.kasMode,
+		"trust_tools":  a.trustTools,
+	}
+	for k, v := range out {
+		if s, ok := v.(string); ok && s == "" {
+			delete(out, k)
+		}
+	}
+	return out
+}
+
+func (a *Agent) listModels(ctx context.Context) ([]core.ModelOption, error) {
+	a.mu.Lock()
+	cmdName := a.cmd
+	if cmdName == "" {
+		cmdName = "kiro-cli"
+	}
+	workDir := a.workDir
+	a.mu.Unlock()
+
+	cmd := exec.CommandContext(ctx, cmdName, "chat", "--list-models", "--format", "json")
+	cmd.Dir = workDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseModelList(out), nil
+}
+
+func parseModelList(data []byte) []core.ModelOption {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	var models []core.ModelOption
+	walkJSON(raw, func(m map[string]any) {
+		name := firstString(m, "id", "name", "model", "model_id")
+		if name == "" {
+			return
+		}
+		desc := firstString(m, "display_name", "displayName", "description", "label")
+		models = append(models, core.ModelOption{Name: name, Desc: desc})
+	})
+	return dedupeModels(models)
+}
+
+func parseSessionList(data []byte) []core.AgentSessionInfo {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	var sessions []core.AgentSessionInfo
+	walkJSON(raw, func(m map[string]any) {
+		id := firstString(m, "id", "session_id", "sessionId", "sessionID")
+		if id == "" {
+			return
+		}
+		summary := firstString(m, "title", "name", "summary", "description")
+		updated := firstString(m, "updated_at", "updatedAt", "updated", "last_active_at", "lastActiveAt", "modified_at", "modifiedAt")
+		sessions = append(sessions, core.AgentSessionInfo{ID: id, Summary: summary, ModifiedAt: parseKiroTime(updated)})
+	})
+	return sessions
+}
+
+func parseKiroTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05", "2006-01-02T15:04:05"} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func walkJSON(v any, visit func(map[string]any)) {
+	switch x := v.(type) {
+	case []any:
+		for _, item := range x {
+			walkJSON(item, visit)
+		}
+	case map[string]any:
+		visit(x)
+		for _, item := range x {
+			walkJSON(item, visit)
+		}
+	}
+}
+
+func firstString(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			switch t := v.(type) {
+			case string:
+				if strings.TrimSpace(t) != "" {
+					return strings.TrimSpace(t)
+				}
+			case float64:
+				return fmt.Sprintf("%.0f", t)
+			}
+		}
+	}
+	return ""
+}
+
+func dedupeModels(in []core.ModelOption) []core.ModelOption {
+	seen := make(map[string]bool)
+	var out []core.ModelOption
+	for _, model := range in {
+		if model.Name == "" || seen[model.Name] {
+			continue
+		}
+		seen[model.Name] = true
+		out = append(out, model)
+	}
+	return out
+}
+
+var (
+	_ core.Agent              = (*Agent)(nil)
+	_ core.SessionDeleter     = (*Agent)(nil)
+	_ core.ModelSwitcher      = (*Agent)(nil)
+	_ core.ModeSwitcher       = (*Agent)(nil)
+	_ core.WorkDirSwitcher    = (*Agent)(nil)
+	_ core.MemoryFileProvider = (*Agent)(nil)
+	_ core.SkillProvider      = (*Agent)(nil)
+	_ core.ContextCompressor  = (*Agent)(nil)
+	_ core.AgentOptsProvider  = (*Agent)(nil)
+)

--- a/agent/kiro/kiro_test.go
+++ b/agent/kiro/kiro_test.go
@@ -1,0 +1,209 @@
+package kiro
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestNormalizeMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "default"},
+		{"default", "default"},
+		{"yolo", "yolo"},
+		{"AUTO", "yolo"},
+		{"trust-all", "yolo"},
+		{"unknown", "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := normalizeMode(tt.input); got != tt.want {
+				t.Fatalf("normalizeMode(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentBasics(t *testing.T) {
+	a := &Agent{cmd: "kiro-cli"}
+	if got := a.Name(); got != "kiro" {
+		t.Fatalf("Name() = %q, want kiro", got)
+	}
+	if got := a.CLIBinaryName(); got != "kiro-cli" {
+		t.Fatalf("CLIBinaryName() = %q, want kiro-cli", got)
+	}
+	if got := a.CLIDisplayName(); got != "Kiro CLI" {
+		t.Fatalf("CLIDisplayName() = %q, want Kiro CLI", got)
+	}
+	a.SetWorkDir("/tmp/project")
+	if got := a.GetWorkDir(); got != "/tmp/project" {
+		t.Fatalf("GetWorkDir() = %q", got)
+	}
+	a.SetModel("claude-sonnet-4.5")
+	if got := a.GetModel(); got != "claude-sonnet-4.5" {
+		t.Fatalf("GetModel() = %q", got)
+	}
+}
+
+func TestResolveKiroCmdExplicitPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kiro-cli")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveKiroCmd(path)
+	if err != nil {
+		t.Fatalf("resolveKiroCmd: %v", err)
+	}
+	if got != path {
+		t.Fatalf("resolveKiroCmd() = %q, want %q", got, path)
+	}
+}
+
+func TestAgentStartSessionWorkDirRace(t *testing.T) {
+	a := &Agent{cmd: "kiro-cli", workDir: "/initial"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			a.SetWorkDir(fmt.Sprintf("/path-%d", i))
+		}(i)
+		go func() {
+			defer wg.Done()
+			sess, err := a.StartSession(context.Background(), "")
+			if err != nil {
+				t.Errorf("StartSession: %v", err)
+				return
+			}
+			_ = sess.Close()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestBuildArgs(t *testing.T) {
+	ks, err := newKiroSession(context.Background(), "kiro-cli", "/tmp", "model-a", "yolo", "reviewer", "kas", "spec", "", "session-123", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ks.Close()
+
+	got := ks.buildArgs("hello")
+	want := []string{
+		"chat", "--no-interactive",
+		"--resume-id", "session-123",
+		"--trust-all-tools",
+		"--model", "model-a",
+		"--agent", "reviewer",
+		"--agent-engine", "kas",
+		"--mode", "spec",
+		"hello",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("args len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("arg[%d] = %q, want %q; args=%#v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestBuildArgsTrustTools(t *testing.T) {
+	ks, err := newKiroSession(context.Background(), "kiro-cli", "/tmp", "auto", "default", "", "", "", "fs_read,fs_write", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ks.Close()
+
+	got := ks.buildArgs("hello")
+	joined := fmt.Sprintf("%q", got)
+	if !containsArgPair(got, "--trust-tools", "fs_read,fs_write") {
+		t.Fatalf("args missing trust-tools: %s", joined)
+	}
+	if containsArg(got, "--model") {
+		t.Fatalf("auto model should not be passed: %s", joined)
+	}
+}
+
+func TestExtractSessionID(t *testing.T) {
+	tests := map[string]string{
+		"Session: abc-123":     "abc-123",
+		"Session ID: sess_001": "sess_001",
+		"no session here":      "",
+	}
+	for input, want := range tests {
+		if got := extractSessionID(input); got != want {
+			t.Fatalf("extractSessionID(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestCleanKiroOutput(t *testing.T) {
+	input := "\x1b[?25l\r▰▱▱ Opening browser... | Press (^) + C to cancel\nhello\n"
+	if got := cleanKiroOutput(input); got != "hello" {
+		t.Fatalf("cleanKiroOutput() = %q, want hello", got)
+	}
+}
+
+func TestParseModelList(t *testing.T) {
+	raw := []byte(`{"models":[{"id":"m1","displayName":"Model One"},{"name":"m2","description":"Model Two"}]}`)
+	got := parseModelList(raw)
+	if len(got) != 2 {
+		t.Fatalf("len(models) = %d, want 2: %#v", len(got), got)
+	}
+	if got[0].Name != "m1" || got[0].Desc != "Model One" {
+		t.Fatalf("first model = %#v", got[0])
+	}
+}
+
+func TestParseSessionList(t *testing.T) {
+	raw := []byte(`{"sessions":[{"id":"s1","title":"First","updated_at":"2026-06-10T12:00:00Z"}]}`)
+	got := parseSessionList(raw)
+	if len(got) != 1 {
+		t.Fatalf("len(sessions) = %d, want 1: %#v", len(got), got)
+	}
+	if got[0].ID != "s1" || got[0].Summary != "First" {
+		t.Fatalf("session = %#v", got[0])
+	}
+	if got[0].ModifiedAt.IsZero() || !got[0].ModifiedAt.Equal(time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("ModifiedAt = %v", got[0].ModifiedAt)
+	}
+}
+
+func containsArg(args []string, needle string) bool {
+	for _, arg := range args {
+		if arg == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArgPair(args []string, key, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == key && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	_ core.Agent          = (*Agent)(nil)
+	_ core.AgentSession   = (*kiroSession)(nil)
+	_ core.SessionDeleter = (*Agent)(nil)
+)

--- a/agent/kiro/session.go
+++ b/agent/kiro/session.go
@@ -1,0 +1,273 @@
+package kiro
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+var sessionIDPattern = regexp.MustCompile(`(?i)\bSession(?:\s+ID)?:\s*([A-Za-z0-9._:-]+)`)
+
+type kiroSession struct {
+	cmd          string
+	workDir      string
+	model        string
+	mode         string
+	agentProfile string
+	agentEngine  string
+	kasMode      string
+	trustTools   string
+	extraEnv     []string
+	events       chan core.Event
+	sessionID    atomic.Value // stores string
+	ctx          context.Context
+	cancel       context.CancelFunc
+	wg           sync.WaitGroup
+	alive        atomic.Bool
+}
+
+func newKiroSession(ctx context.Context, cmd, workDir, model, mode, agentProfile, agentEngine, kasMode, trustTools, resumeID string, extraEnv []string) (*kiroSession, error) {
+	sessionCtx, cancel := context.WithCancel(ctx)
+	ks := &kiroSession{
+		cmd:          cmd,
+		workDir:      workDir,
+		model:        model,
+		mode:         mode,
+		agentProfile: agentProfile,
+		agentEngine:  agentEngine,
+		kasMode:      kasMode,
+		trustTools:   trustTools,
+		extraEnv:     extraEnv,
+		events:       make(chan core.Event, 64),
+		ctx:          sessionCtx,
+		cancel:       cancel,
+	}
+	ks.alive.Store(true)
+	if resumeID != "" && resumeID != core.ContinueSession {
+		ks.sessionID.Store(resumeID)
+	}
+	return ks, nil
+}
+
+func (ks *kiroSession) Send(prompt string, images []core.ImageAttachment, files []core.FileAttachment) error {
+	if !ks.alive.Load() {
+		return fmt.Errorf("session is closed")
+	}
+
+	if len(images) > 0 || len(files) > 0 {
+		filePaths := core.SaveFilesToDisk(ks.workDir, files)
+		imagePaths := saveKiroImages(ks.workDir, images)
+		prompt = core.AppendFileRefs(prompt, append(imagePaths, filePaths...))
+	}
+
+	args := ks.buildArgs(prompt)
+	slog.Debug("kiroSession: launching", "resume", ks.CurrentSessionID() != "", "args", core.RedactArgs(args))
+
+	cmd := exec.CommandContext(ks.ctx, ks.cmd, args...)
+	cmd.Dir = ks.workDir
+	if len(ks.extraEnv) > 0 {
+		cmd.Env = core.MergeEnv(os.Environ(), ks.extraEnv)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("kiroSession: stdout pipe: %w", err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("kiroSession: start: %w", err)
+	}
+
+	ks.wg.Add(1)
+	go ks.readLoop(cmd, stdout, &stderrBuf)
+	return nil
+}
+
+func (ks *kiroSession) buildArgs(prompt string) []string {
+	args := []string{"chat", "--no-interactive"}
+	if sid := ks.CurrentSessionID(); sid != "" {
+		args = append(args, "--resume-id", sid)
+	}
+	if ks.mode == "yolo" {
+		args = append(args, "--trust-all-tools")
+	} else if ks.trustTools != "" {
+		args = append(args, "--trust-tools", ks.trustTools)
+	}
+	if ks.model != "" && ks.model != "auto" {
+		args = append(args, "--model", ks.model)
+	}
+	if ks.agentProfile != "" {
+		args = append(args, "--agent", ks.agentProfile)
+	}
+	if ks.agentEngine != "" {
+		args = append(args, "--agent-engine", ks.agentEngine)
+	}
+	if ks.kasMode != "" {
+		args = append(args, "--mode", ks.kasMode)
+	}
+	return append(args, prompt)
+}
+
+func (ks *kiroSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
+	defer ks.wg.Done()
+
+	var lines []string
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := stripANSI(scanner.Text())
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines = append(lines, line)
+		if sid := extractSessionID(line); sid != "" {
+			ks.sessionID.Store(sid)
+		}
+	}
+	scanErr := scanner.Err()
+	exitErr := cmd.Wait()
+
+	content := cleanKiroOutput(strings.Join(lines, "\n"))
+	if sid := extractSessionID(content); sid != "" {
+		ks.sessionID.Store(sid)
+	}
+
+	if scanErr != nil {
+		ks.send(core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", scanErr)})
+		return
+	}
+	if exitErr != nil {
+		stderrMsg := strings.TrimSpace(stripANSI(stderrBuf.String()))
+		if stderrMsg == "" {
+			stderrMsg = content
+		}
+		if stderrMsg == "" {
+			stderrMsg = exitErr.Error()
+		}
+		slog.Error("kiroSession: process failed", "error", exitErr, "stderr", truncStr(stderrMsg, 200))
+		ks.send(core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)})
+		return
+	}
+	if content != "" {
+		ks.send(core.Event{Type: core.EventResult, Content: content, SessionID: ks.CurrentSessionID(), Done: true})
+		return
+	}
+	ks.send(core.Event{Type: core.EventResult, SessionID: ks.CurrentSessionID(), Done: true})
+}
+
+func (ks *kiroSession) send(ev core.Event) {
+	select {
+	case ks.events <- ev:
+	case <-ks.ctx.Done():
+	}
+}
+
+func saveKiroImages(workDir string, images []core.ImageAttachment) []string {
+	if len(images) == 0 {
+		return nil
+	}
+	attachDir := filepath.Join(workDir, ".cc-connect", "attachments")
+	if err := os.MkdirAll(attachDir, 0o755); err != nil {
+		attachDir = os.TempDir()
+	}
+	var paths []string
+	for i, img := range images {
+		ext := ".png"
+		switch img.MimeType {
+		case "image/jpeg":
+			ext = ".jpg"
+		case "image/gif":
+			ext = ".gif"
+		case "image/webp":
+			ext = ".webp"
+		}
+		path := filepath.Join(attachDir, fmt.Sprintf("img_%d_%d%s", time.Now().UnixMilli(), i, ext))
+		if err := os.WriteFile(path, img.Data, 0o644); err != nil {
+			slog.Warn("kiroSession: failed to save image", "error", err)
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func extractSessionID(text string) string {
+	m := sessionIDPattern.FindStringSubmatch(text)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+func cleanKiroOutput(text string) string {
+	text = stripANSI(text)
+	lines := strings.Split(text, "\n")
+	out := lines[:0]
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "▰") || strings.Contains(trimmed, "Opening browser") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+
+func stripANSI(s string) string {
+	return ansiPattern.ReplaceAllString(s, "")
+}
+
+func truncStr(s string, maxRunes int) string {
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	return string([]rune(s)[:maxRunes]) + "..."
+}
+
+func (ks *kiroSession) RespondPermission(_ string, _ core.PermissionResult) error { return nil }
+func (ks *kiroSession) Events() <-chan core.Event                                 { return ks.events }
+
+func (ks *kiroSession) CurrentSessionID() string {
+	v, _ := ks.sessionID.Load().(string)
+	return v
+}
+
+func (ks *kiroSession) Alive() bool { return ks.alive.Load() }
+
+func (ks *kiroSession) Close() error {
+	ks.alive.Store(false)
+	ks.cancel()
+	done := make(chan struct{})
+	go func() {
+		ks.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		close(ks.events)
+	case <-time.After(8 * time.Second):
+		slog.Warn("kiroSession: close timed out, abandoning wg.Wait")
+	}
+	return nil
+}

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1420,7 +1420,7 @@ func printUsage() {
  \___\__|      \___\___/|_| |_|_| |_|\___|\___|\__|  %s%s
 
   Bridge your messaging platforms to local AI coding agents.
-  Supports: Claude Code, Codex, Cursor, Gemini CLI, Qoder CLI, OpenCode
+  Supports: Claude Code, Codex, Cursor, Gemini CLI, Kiro CLI, Qoder CLI, OpenCode
   Platforms: Feishu, Telegram, Slack, DingTalk, Discord, LINE, WeChat Work, Weixin, QQ, QQ Bot
 
   GitHub:  https://github.com/chenhg5/cc-connect

--- a/cmd/cc-connect/plugin_agent_kiro.go
+++ b/cmd/cc-connect/plugin_agent_kiro.go
@@ -1,0 +1,5 @@
+//go:build !no_kiro
+
+package main
+
+import _ "github.com/chenhg5/cc-connect/agent/kiro"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1543,6 +1543,47 @@ app_secret = "your-feishu-app-secret"
 # token = "your-telegram-bot-token"
 
 # =============================================================================
+# Project 6: Using Kiro CLI / 项目 6：使用 Kiro CLI (uncomment to enable / 取消注释以启用)
+# =============================================================================
+# Requires: install Kiro CLI, then authenticate with `kiro-cli login --use-device-flow`
+# 需要安装 Kiro CLI，然后运行 `kiro-cli login --use-device-flow` 完成认证
+# Kiro CLI uses `kiro-cli chat --no-interactive` under the hood.
+# Kiro CLI 底层使用 `kiro-cli chat --no-interactive` 命令。
+#
+# [[projects]]
+# name = "my-kiro-project"
+#
+# [projects.agent]
+# type = "kiro"
+#
+# [projects.agent.options]
+# work_dir = "/path/to/project"
+# mode = "default"  # "default" | "yolo"
+#
+# Mode options / 模式说明:
+# - "default": Kiro CLI default tool trust behavior / 使用 Kiro CLI 默认工具信任策略
+# - "yolo":    Trust all tools (--trust-all-tools) / 信任全部工具
+#
+# Optional: specify a model / 可选：指定模型
+# model = "auto"
+#
+# Optional: choose a Kiro agent profile / 可选：指定 Kiro agent profile
+# agent = "default"
+#
+# Optional: select Kiro agent engine / 可选：指定 Kiro agent engine
+# agent_engine = "v2"  # "v1" | "v2" | "kas"
+# kas_mode = "vibe"    # when agent_engine = "kas": "vibe" | "spec"
+#
+# Optional: trust only specific tools instead of all tools / 可选：只信任指定工具
+# trust_tools = "shell,read,write"
+#
+# [[projects.platforms]]
+# type = "telegram"
+#
+# [projects.platforms.options]
+# token = "your-telegram-bot-token"
+
+# =============================================================================
 # Project: Using tmux / 使用 tmux (uncomment to enable / 取消注释以启用)
 # =============================================================================
 # Requires: tmux — https://github.com/tmux/tmux
@@ -1589,7 +1630,7 @@ app_secret = "your-feishu-app-secret"
 # token = "your-telegram-bot-token"
 
 # =============================================================================
-# Project 6: Using OpenCode / 项目 6：使用 OpenCode (uncomment to enable / 取消注释以启用)
+# Project 7: Using OpenCode / 项目 7：使用 OpenCode (uncomment to enable / 取消注释以启用)
 # =============================================================================
 # Requires: OpenCode CLI — https://github.com/opencode-ai/opencode
 # 需要安装：OpenCode CLI
@@ -1779,7 +1820,7 @@ app_secret = "your-feishu-app-secret"
 # token = "your-telegram-bot-token"
 
 # =============================================================================
-# Project 7: Using iFlow CLI / 项目 7：使用 iFlow CLI (uncomment to enable / 取消注释以启用)
+# Project 8: Using iFlow CLI / 项目 8：使用 iFlow CLI (uncomment to enable / 取消注释以启用)
 # =============================================================================
 # Requires: npm install -g @iflow-ai/iflow-cli
 # 需要安装：npm install -g @iflow-ai/iflow-cli


### PR DESCRIPTION
## Summary

Add native support for [Kiro CLI](https://kiro.dev/) as a coding agent in cc-connect.

Reuses the existing agent/plugin registration, permission modes, and documentation template mechanisms.

## Changes

- New `agent/kiro/` package implementing `core.Agent` and `core.AgentSession` interfaces
- Plugin registration file `plugin_agent_kiro.go` with `no_kiro` build tag
- Added `kiro` to `ALL_AGENTS` in Makefile
- Config example in `config.example.toml`
- Unit tests for the kiro agent package

## Testing

- `go test ./agent/kiro/...`
- `go build -tags no_web ./cmd/cc-connect`

Co-authored-by: OmX <omx@oh-my-codex.dev>