### PR TITLE
feat(agent/antigravity): bridge tool permissions to chat

### DIFF
--- a/agent/antigravity/antigravity.go
+++ b/agent/antigravity/antigravity.go
@@ -26,7 +26,7 @@ func init() {
 // Agent drives the Antigravity CLI (agy) in headless mode.
 //
 // Modes (maps to agy approval and sandbox flags):
-//   - "default":   agy print-mode default permission policy
+//   - "default":   ask for each tool through the cc-connect permission bridge
 //   - "yolo":      auto-approve all tools (--dangerously-skip-permissions)
 //   - "plan":      read-only plan mode with terminal sandbox constraints (--sandbox)
 type Agent struct {
@@ -284,7 +284,7 @@ func (a *Agent) GetMode() string {
 
 func (a *Agent) PermissionModes() []core.PermissionModeInfo {
 	return []core.PermissionModeInfo{
-		{Key: "default", Name: "Default", NameZh: "默认", Desc: "Use Agy's default non-interactive print policy", DescZh: "使用 Agy 默认的非交互打印模式权限策略"},
+		{Key: "default", Name: "Default", NameZh: "默认", Desc: "Ask for approval through cc-connect on each tool use", DescZh: "每次工具调用都通过 cc-connect 请求确认"},
 		{Key: "yolo", Name: "YOLO", NameZh: "全自动", Desc: "Auto-approve all tool calls", DescZh: "自动批准所有工具调用"},
 		{Key: "plan", Name: "Plan", NameZh: "规划模式", Desc: "Read-only plan mode in sandbox", DescZh: "只读沙箱规划模式"},
 	}

--- a/agent/antigravity/antigravity.go
+++ b/agent/antigravity/antigravity.go
@@ -26,7 +26,7 @@ func init() {
 // Agent drives the Antigravity CLI (agy) in headless mode.
 //
 // Modes (maps to agy approval and sandbox flags):
-//   - "default":   standard approval mode (prompt for each tool use)
+//   - "default":   agy print-mode default permission policy
 //   - "yolo":      auto-approve all tools (--dangerously-skip-permissions)
 //   - "plan":      read-only plan mode with terminal sandbox constraints (--sandbox)
 type Agent struct {
@@ -284,7 +284,7 @@ func (a *Agent) GetMode() string {
 
 func (a *Agent) PermissionModes() []core.PermissionModeInfo {
 	return []core.PermissionModeInfo{
-		{Key: "default", Name: "Default", NameZh: "默认", Desc: "Prompt for approval on each tool use", DescZh: "每次工具调用都需要确认"},
+		{Key: "default", Name: "Default", NameZh: "默认", Desc: "Use Agy's default non-interactive print policy", DescZh: "使用 Agy 默认的非交互打印模式权限策略"},
 		{Key: "yolo", Name: "YOLO", NameZh: "全自动", Desc: "Auto-approve all tool calls", DescZh: "自动批准所有工具调用"},
 		{Key: "plan", Name: "Plan", NameZh: "规划模式", Desc: "Read-only plan mode in sandbox", DescZh: "只读沙箱规划模式"},
 	}

--- a/agent/antigravity/permission_bridge.go
+++ b/agent/antigravity/permission_bridge.go
@@ -1,0 +1,328 @@
+package antigravity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/chenhg5/cc-connect/agent/antigravityhook"
+	"github.com/chenhg5/cc-connect/core"
+)
+
+const agyPermissionHookName = "cc-connect-permission-bridge"
+
+type agyHookInput struct {
+	ConversationID string `json:"conversationId"`
+	StepIndex      int    `json:"stepIdx"`
+	ToolCall       struct {
+		Name string         `json:"name"`
+		Args map[string]any `json:"args"`
+	} `json:"toolCall"`
+}
+
+type agyPermissionBridge struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	listener  net.Listener
+	address   string
+	token     string
+	rootDir   string
+	configDir string
+	events    chan<- core.Event
+
+	nextID    atomic.Uint64
+	pendingMu sync.Mutex
+	pending   map[string]chan core.PermissionResult
+	closeOnce sync.Once
+	wg        sync.WaitGroup
+}
+
+func newAgyPermissionBridge(ctx context.Context, events chan<- core.Event) (*agyPermissionBridge, error) {
+	bridgeCtx, cancel := context.WithCancel(ctx)
+	rootDir, err := os.MkdirTemp("", "cc-connect-agy-permission-")
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("create permission bridge directory: %w", err)
+	}
+
+	configDir, err := createAgyConfigOverlay(rootDir)
+	if err != nil {
+		cancel()
+		_ = os.RemoveAll(rootDir)
+		return nil, err
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		cancel()
+		_ = os.RemoveAll(rootDir)
+		return nil, fmt.Errorf("listen for Agy permission hooks: %w", err)
+	}
+
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		cancel()
+		_ = listener.Close()
+		_ = os.RemoveAll(rootDir)
+		return nil, fmt.Errorf("generate permission bridge token: %w", err)
+	}
+
+	bridge := &agyPermissionBridge{
+		ctx:       bridgeCtx,
+		cancel:    cancel,
+		listener:  listener,
+		address:   listener.Addr().String(),
+		token:     base64.RawURLEncoding.EncodeToString(tokenBytes),
+		rootDir:   rootDir,
+		configDir: configDir,
+		events:    events,
+		pending:   make(map[string]chan core.PermissionResult),
+	}
+	bridge.wg.Add(1)
+	go bridge.acceptLoop()
+	return bridge, nil
+}
+
+func createAgyConfigOverlay(rootDir string) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for Agy permission bridge: %w", err)
+	}
+	// Antigravity currently stores its CLI state under .gemini and exposes it
+	// through the --gemini_dir compatibility flag.
+	realConfigRoot := filepath.Join(homeDir, ".gemini")
+	overlayConfigRoot := filepath.Join(rootDir, "agy-config")
+	overlayConfigDir := filepath.Join(overlayConfigRoot, "config")
+	if err := os.MkdirAll(overlayConfigDir, 0o700); err != nil {
+		return "", fmt.Errorf("create Agy permission overlay: %w", err)
+	}
+
+	if err := mirrorDirectoryEntries(realConfigRoot, overlayConfigRoot, map[string]bool{"config": true}); err != nil {
+		return "", err
+	}
+	realConfigDir := filepath.Join(realConfigRoot, "config")
+	if err := mirrorDirectoryEntries(realConfigDir, overlayConfigDir, map[string]bool{"hooks.json": true}); err != nil {
+		return "", err
+	}
+
+	hooks := make(map[string]json.RawMessage)
+	hooksPath := filepath.Join(realConfigDir, "hooks.json")
+	if data, err := os.ReadFile(hooksPath); err == nil {
+		if err := json.Unmarshal(data, &hooks); err != nil {
+			return "", fmt.Errorf("parse existing Agy hooks %s: %w", hooksPath, err)
+		}
+		if hooks == nil {
+			hooks = make(map[string]json.RawMessage)
+		}
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("read existing Agy hooks %s: %w", hooksPath, err)
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve cc-connect executable for Agy hook: %w", err)
+	}
+	bridgeHook, err := json.Marshal(map[string]any{
+		"PreToolUse": []any{
+			map[string]any{
+				"matcher": "*",
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": shellQuote(executable) + " _agy-permission-hook",
+						"timeout": 86400,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal Agy permission hook: %w", err)
+	}
+	hooks[agyPermissionHookName] = bridgeHook
+
+	data, err := json.MarshalIndent(hooks, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal Agy hooks overlay: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(overlayConfigDir, "hooks.json"), data, 0o600); err != nil {
+		return "", fmt.Errorf("write Agy hooks overlay: %w", err)
+	}
+	return overlayConfigRoot, nil
+}
+
+func mirrorDirectoryEntries(sourceDir, targetDir string, skip map[string]bool) error {
+	entries, err := os.ReadDir(sourceDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read Agy config directory %s: %w", sourceDir, err)
+	}
+	for _, entry := range entries {
+		if skip[entry.Name()] {
+			continue
+		}
+		source := filepath.Join(sourceDir, entry.Name())
+		target := filepath.Join(targetDir, entry.Name())
+		if err := os.Symlink(source, target); err != nil {
+			return fmt.Errorf("link Agy config %s: %w", source, err)
+		}
+	}
+	return nil
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func (b *agyPermissionBridge) Env() []string {
+	return []string{
+		antigravityhook.EnvAddress + "=" + b.address,
+		antigravityhook.EnvToken + "=" + b.token,
+	}
+}
+
+func (b *agyPermissionBridge) AgyConfigDir() string { return b.configDir }
+
+func (b *agyPermissionBridge) acceptLoop() {
+	defer b.wg.Done()
+	for {
+		conn, err := b.listener.Accept()
+		if err != nil {
+			if b.ctx.Err() == nil {
+				select {
+				case b.events <- core.Event{Type: core.EventError, Error: fmt.Errorf("antigravity permission bridge: %w", err)}:
+				case <-b.ctx.Done():
+				}
+			}
+			return
+		}
+		b.wg.Add(1)
+		go b.handleConnection(conn)
+	}
+}
+
+func (b *agyPermissionBridge) handleConnection(conn net.Conn) {
+	defer b.wg.Done()
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+
+	var request antigravityhook.BridgeRequest
+	if err := json.NewDecoder(io.LimitReader(conn, 4<<20)).Decode(&request); err != nil {
+		b.writeResponse(conn, antigravityhook.BridgeResponse{Decision: "deny", Reason: "invalid cc-connect permission bridge request"})
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(request.Token), []byte(b.token)) != 1 {
+		b.writeResponse(conn, antigravityhook.BridgeResponse{Decision: "deny", Reason: "cc-connect permission bridge authentication failed"})
+		return
+	}
+	_ = conn.SetDeadline(time.Time{})
+
+	var input agyHookInput
+	if err := json.Unmarshal(request.HookInput, &input); err != nil || strings.TrimSpace(input.ToolCall.Name) == "" {
+		b.writeResponse(conn, antigravityhook.BridgeResponse{Decision: "deny", Reason: "invalid Agy tool permission request"})
+		return
+	}
+	if input.ToolCall.Args == nil {
+		input.ToolCall.Args = make(map[string]any)
+	}
+
+	requestID := fmt.Sprintf("agy-perm-%d", b.nextID.Add(1))
+	resultCh := make(chan core.PermissionResult, 1)
+	b.pendingMu.Lock()
+	b.pending[requestID] = resultCh
+	b.pendingMu.Unlock()
+	defer func() {
+		b.pendingMu.Lock()
+		delete(b.pending, requestID)
+		b.pendingMu.Unlock()
+	}()
+
+	preview := formatAgyToolInput(input.ToolCall.Args)
+	event := core.Event{
+		Type:         core.EventPermissionRequest,
+		RequestID:    requestID,
+		ToolName:     input.ToolCall.Name,
+		ToolInput:    preview,
+		ToolInputRaw: input.ToolCall.Args,
+	}
+	select {
+	case b.events <- event:
+	case <-b.ctx.Done():
+		b.writeResponse(conn, antigravityhook.BridgeResponse{Decision: "deny", Reason: "cc-connect session closed"})
+		return
+	}
+
+	select {
+	case result := <-resultCh:
+		response := antigravityhook.BridgeResponse{Decision: "allow"}
+		if strings.EqualFold(strings.TrimSpace(result.Behavior), "deny") {
+			response.Decision = "deny"
+			response.Reason = strings.TrimSpace(result.Message)
+			if response.Reason == "" {
+				response.Reason = "User denied this tool use."
+			}
+		}
+		b.writeResponse(conn, response)
+	case <-b.ctx.Done():
+		b.writeResponse(conn, antigravityhook.BridgeResponse{Decision: "deny", Reason: "cc-connect session closed"})
+	}
+}
+
+func formatAgyToolInput(input map[string]any) string {
+	if command, _ := input["CommandLine"].(string); strings.TrimSpace(command) != "" {
+		return command
+	}
+	data, err := json.MarshalIndent(input, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%v", input)
+	}
+	return string(data)
+}
+
+func (b *agyPermissionBridge) writeResponse(conn net.Conn, response antigravityhook.BridgeResponse) {
+	_ = json.NewEncoder(conn).Encode(response)
+}
+
+func (b *agyPermissionBridge) RespondPermission(requestID string, result core.PermissionResult) error {
+	behavior := strings.ToLower(strings.TrimSpace(result.Behavior))
+	if behavior != "allow" && behavior != "deny" {
+		return fmt.Errorf("antigravity: invalid permission behavior %q", result.Behavior)
+	}
+	result.Behavior = behavior
+
+	b.pendingMu.Lock()
+	ch := b.pending[requestID]
+	b.pendingMu.Unlock()
+	if ch == nil {
+		return fmt.Errorf("antigravity: unknown permission request %q", requestID)
+	}
+	select {
+	case ch <- result:
+		return nil
+	default:
+		return fmt.Errorf("antigravity: permission request %q is already resolved", requestID)
+	}
+}
+
+func (b *agyPermissionBridge) Close() {
+	b.closeOnce.Do(func() {
+		b.cancel()
+		_ = b.listener.Close()
+		b.wg.Wait()
+		_ = os.RemoveAll(b.rootDir)
+	})
+}

--- a/agent/antigravity/permission_bridge.go
+++ b/agent/antigravity/permission_bridge.go
@@ -188,6 +188,13 @@ func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
+func bridgeTokenEqual(got, want string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
 func (b *agyPermissionBridge) Env() []string {
 	return []string{
 		antigravityhook.EnvAddress + "=" + b.address,
@@ -225,7 +232,7 @@ func (b *agyPermissionBridge) handleConnection(conn net.Conn) {
 		b.writeResponse(conn, antigravityhook.BridgeResponse{Decision: "deny", Reason: "invalid cc-connect permission bridge request"})
 		return
 	}
-	if subtle.ConstantTimeCompare([]byte(request.Token), []byte(b.token)) != 1 {
+	if !bridgeTokenEqual(request.Token, b.token) {
 		b.writeResponse(conn, antigravityhook.BridgeResponse{Decision: "deny", Reason: "cc-connect permission bridge authentication failed"})
 		return
 	}

--- a/agent/antigravity/permission_bridge_test.go
+++ b/agent/antigravity/permission_bridge_test.go
@@ -1,0 +1,138 @@
+package antigravity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/agent/antigravityhook"
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestAgyPermissionBridgePreservesHooksAndRelaysDecisions(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	realConfigDir := filepath.Join(homeDir, ".gemini", "config")
+	if err := os.MkdirAll(realConfigDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll config: %v", err)
+	}
+	originalHooks := []byte(`{
+  "existing-hook": {
+    "PreToolUse": [{"matcher": "read_file", "hooks": [{"type": "command", "command": "existing"}]}]
+  }
+}`)
+	realHooksPath := filepath.Join(realConfigDir, "hooks.json")
+	if err := os.WriteFile(realHooksPath, originalHooks, 0o600); err != nil {
+		t.Fatalf("WriteFile hooks: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realConfigDir, "keep.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile keep config: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := make(chan core.Event, 4)
+	bridge, err := newAgyPermissionBridge(ctx, events)
+	if err != nil {
+		t.Fatalf("newAgyPermissionBridge: %v", err)
+	}
+	defer bridge.Close()
+
+	gotOriginal, err := os.ReadFile(realHooksPath)
+	if err != nil {
+		t.Fatalf("ReadFile original hooks: %v", err)
+	}
+	if !bytes.Equal(gotOriginal, originalHooks) {
+		t.Fatalf("real hooks changed:\n%s", gotOriginal)
+	}
+	if target, err := os.Readlink(filepath.Join(bridge.AgyConfigDir(), "config", "keep.json")); err != nil {
+		t.Fatalf("Readlink preserved config: %v", err)
+	} else if target != filepath.Join(realConfigDir, "keep.json") {
+		t.Fatalf("preserved config target = %q", target)
+	}
+
+	var overlayHooks map[string]json.RawMessage
+	overlayData, err := os.ReadFile(filepath.Join(bridge.AgyConfigDir(), "config", "hooks.json"))
+	if err != nil {
+		t.Fatalf("ReadFile overlay hooks: %v", err)
+	}
+	if err := json.Unmarshal(overlayData, &overlayHooks); err != nil {
+		t.Fatalf("Unmarshal overlay hooks: %v", err)
+	}
+	if _, ok := overlayHooks["existing-hook"]; !ok {
+		t.Fatal("overlay does not preserve existing hook")
+	}
+	if _, ok := overlayHooks[agyPermissionHookName]; !ok {
+		t.Fatal("overlay does not contain cc-connect permission hook")
+	}
+
+	testBridgeDecision(t, bridge, events, "allow", "", "allow", "")
+	testBridgeDecision(t, bridge, events, "deny", "not now", "deny", "not now")
+}
+
+func testBridgeDecision(t *testing.T, bridge *agyPermissionBridge, events <-chan core.Event, behavior, message, wantDecision, wantReason string) {
+	t.Helper()
+
+	hookInput := `{
+  "conversationId": "conversation-1",
+  "stepIdx": 3,
+  "toolCall": {
+    "name": "run_command",
+    "args": {"CommandLine": "touch /tmp/permission-test", "Cwd": "/tmp"}
+  }
+}`
+	var output bytes.Buffer
+	relayDone := make(chan error, 1)
+	go func() {
+		relayDone <- antigravityhook.Relay(strings.NewReader(hookInput), &output, bridge.address, bridge.token)
+	}()
+
+	var event core.Event
+	select {
+	case event = <-events:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for permission event")
+	}
+	if event.Type != core.EventPermissionRequest {
+		t.Fatalf("event type = %q, want permission_request", event.Type)
+	}
+	if event.RequestID == "" || event.ToolName != "run_command" {
+		t.Fatalf("event = %#v, want run_command permission request", event)
+	}
+	if event.ToolInput != "touch /tmp/permission-test" {
+		t.Fatalf("ToolInput = %q", event.ToolInput)
+	}
+
+	if err := bridge.RespondPermission(event.RequestID, core.PermissionResult{Behavior: behavior, Message: message}); err != nil {
+		t.Fatalf("RespondPermission: %v", err)
+	}
+	select {
+	case err := <-relayDone:
+		if err != nil {
+			t.Fatalf("Relay: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for hook response")
+	}
+
+	var response antigravityhook.BridgeResponse
+	if err := json.Unmarshal(output.Bytes(), &response); err != nil {
+		t.Fatalf("Unmarshal hook response %q: %v", output.String(), err)
+	}
+	if response.Decision != wantDecision || response.Reason != wantReason {
+		t.Fatalf("response = %#v, want decision=%q reason=%q", response, wantDecision, wantReason)
+	}
+}
+
+func TestAgyPermissionBridgeRejectsInvalidBehavior(t *testing.T) {
+	bridge := &agyPermissionBridge{pending: make(map[string]chan core.PermissionResult)}
+	if err := bridge.RespondPermission("request-1", core.PermissionResult{Behavior: "maybe"}); err == nil {
+		t.Fatal("RespondPermission() error = nil, want invalid behavior error")
+	}
+}

--- a/agent/antigravity/permission_bridge_test.go
+++ b/agent/antigravity/permission_bridge_test.go
@@ -136,3 +136,15 @@ func TestAgyPermissionBridgeRejectsInvalidBehavior(t *testing.T) {
 		t.Fatal("RespondPermission() error = nil, want invalid behavior error")
 	}
 }
+
+func TestBridgeTokenEqualRequiresMatchingLength(t *testing.T) {
+	if !bridgeTokenEqual("same-length-token", "same-length-token") {
+		t.Fatal("bridgeTokenEqual() = false, want true")
+	}
+	if bridgeTokenEqual("short", "same-length-token") {
+		t.Fatal("bridgeTokenEqual() = true for length mismatch, want false")
+	}
+	if bridgeTokenEqual("same-length-tokem", "same-length-token") {
+		t.Fatal("bridgeTokenEqual() = true for same-length mismatch, want false")
+	}
+}

--- a/agent/antigravity/session.go
+++ b/agent/antigravity/session.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -23,26 +22,22 @@ import (
 
 // antigravitySession manages multi-turn conversations with the Antigravity CLI (agy).
 type antigravitySession struct {
-	cmd       string
-	extraArgs []string // extra args from cmd, prepended before agy args
-	workDir   string
-	model     string
-	mode      string
-	timeout   time.Duration
-	extraEnv  []string
-	events    chan core.Event
-	stdin     io.WriteCloser
-	stdinMu   sync.Mutex
-	closeOnce sync.Once
-	permReqID atomic.Value // stores string
-	chatID    atomic.Value // stores string
-	ctx       context.Context
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
-	alive     atomic.Bool
+	cmd              string
+	extraArgs        []string // extra args from cmd, prepended before agy args
+	workDir          string
+	model            string
+	mode             string
+	timeout          time.Duration
+	extraEnv         []string
+	events           chan core.Event
+	closeOnce        sync.Once
+	chatID           atomic.Value // stores string
+	ctx              context.Context
+	cancel           context.CancelFunc
+	wg               sync.WaitGroup
+	alive            atomic.Bool
+	permissionBridge *agyPermissionBridge
 }
-
-var permissionPromptPattern = regexp.MustCompile(`(?is)(allow|approve|permission).{0,400}(\(y/n\)|\(y\/n\)|\(y\/N\)|\(Y\/n\)|\[y\/n\]|\[y\/N\]|\[Y\/n\]|yes\/no)`)
 
 func newAntigravitySession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*antigravitySession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
@@ -60,6 +55,15 @@ func newAntigravitySession(ctx context.Context, cmd string, extraArgs []string, 
 		cancel:    cancel,
 	}
 	as.alive.Store(true)
+
+	if mode == "default" {
+		bridge, err := newAgyPermissionBridge(sessionCtx, as.events)
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("antigravity: initialize permission bridge: %w", err)
+		}
+		as.permissionBridge = bridge
+	}
 
 	if resumeID != "" && resumeID != core.ContinueSession {
 		as.chatID.Store(resumeID)
@@ -141,7 +145,11 @@ func (as *antigravitySession) Send(prompt string, messageID string, images []cor
 		}
 		fullPrompt += "\n\n[Attached files saved at: " + strings.Join(fileRefs, ", ") + "]"
 	}
-	args := as.buildAntigravityArgs(chatID, isResume, as.mode, fullPrompt)
+	agyConfigDir := ""
+	if as.permissionBridge != nil {
+		agyConfigDir = as.permissionBridge.AgyConfigDir()
+	}
+	args := as.buildAntigravityArgs(chatID, isResume, as.mode, agyConfigDir, fullPrompt)
 	if strings.TrimSpace(as.model) != "" {
 		slog.Warn("antigravitySession: model is configured but ignored because agy does not support --model yet", "model", as.model)
 	}
@@ -169,18 +177,16 @@ func (as *antigravitySession) Send(prompt string, messageID string, images []cor
 	if len(as.extraEnv) > 0 {
 		env = core.MergeEnv(env, as.extraEnv)
 	}
+	if as.permissionBridge != nil {
+		env = core.MergeEnv(env, as.permissionBridge.Env())
+	}
 	cmd.Env = env
 
+	// Keep stdin disconnected: agy --print consumes piped stdin to EOF before
+	// processing the prompt, so an open pipe would deadlock the turn.
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("antigravitySession: stdout pipe: %w", err)
-	}
-	var stdin io.WriteCloser
-	if usesInteractivePermission(as.mode) {
-		stdin, err = cmd.StdinPipe()
-		if err != nil {
-			return fmt.Errorf("antigravitySession: stdin pipe: %w", err)
-		}
 	}
 
 	var stderrBuf bytes.Buffer
@@ -189,9 +195,6 @@ func (as *antigravitySession) Send(prompt string, messageID string, images []cor
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("antigravitySession: start: %w", err)
 	}
-	as.stdinMu.Lock()
-	as.stdin = stdin
-	as.stdinMu.Unlock()
 
 	started = true
 	as.wg.Add(1)
@@ -203,10 +206,14 @@ func (as *antigravitySession) Send(prompt string, messageID string, images []cor
 	return nil
 }
 
-func (as *antigravitySession) buildAntigravityArgs(chatID string, isResume bool, mode, fullPrompt string) []string {
+func (as *antigravitySession) buildAntigravityArgs(chatID string, isResume bool, mode, agyConfigDir, fullPrompt string) []string {
 	// Prepend extra args from cmd so wrappers like "timeout 3600 agy" work.
 	// Keep "-p <prompt>" at the very end because agy consumes the immediate next arg.
 	args := append([]string{}, as.extraArgs...)
+	if agyConfigDir != "" {
+		// Antigravity currently names this compatibility flag --gemini_dir.
+		args = append(args, "--gemini_dir="+agyConfigDir, "--print-timeout=24h")
+	}
 	if isResume {
 		args = append(args, "--conversation", chatID)
 	}
@@ -218,10 +225,6 @@ func (as *antigravitySession) buildAntigravityArgs(chatID string, isResume bool,
 	}
 	args = append(args, "-p", fullPrompt)
 	return args
-}
-
-func usesInteractivePermission(mode string) bool {
-	return strings.EqualFold(strings.TrimSpace(mode), "default")
 }
 
 func (as *antigravitySession) readLoop(ctx context.Context, cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer, tempFiles []string, preEntries map[string]bool, sendStartedAt time.Time) {
@@ -282,33 +285,11 @@ func (as *antigravitySession) readLoop(ctx context.Context, cmd *exec.Cmd, stdou
 
 	reader := bufio.NewReader(stdout)
 	buf := make([]byte, 1024)
-	permWindow := ""
 
 	for {
 		n, err := reader.Read(buf)
 		if n > 0 {
 			text := string(buf[:n])
-			permWindow += text
-			if len(permWindow) > 4096 {
-				permWindow = permWindow[len(permWindow)-4096:]
-			}
-			if pending, _ := as.permReqID.Load().(string); pending == "" {
-				if prompt, ok := extractPermissionPrompt(permWindow); ok {
-					requestID := fmt.Sprintf("agy-perm-%d", time.Now().UnixNano())
-					as.permReqID.Store(requestID)
-					select {
-					case as.events <- core.Event{
-						Type:         core.EventPermissionRequest,
-						RequestID:    requestID,
-						ToolName:     "terminal_permission",
-						ToolInput:    prompt,
-						ToolInputRaw: map[string]any{"prompt": prompt},
-					}:
-					case <-as.ctx.Done():
-						return
-					}
-				}
-			}
 			select {
 			case as.events <- core.Event{Type: core.EventText, Content: text}:
 			case <-as.ctx.Done():
@@ -404,42 +385,14 @@ func (as *antigravitySession) detectNewSessionID(preEntries map[string]bool, sen
 	return candidates[0].sessionID
 }
 
-func extractPermissionPrompt(text string) (string, bool) {
-	loc := permissionPromptPattern.FindStringIndex(text)
-	if loc == nil {
-		return "", false
-	}
-	prompt := strings.TrimSpace(text[loc[0]:loc[1]])
-	if prompt == "" {
-		return "", false
-	}
-	return prompt, true
-}
-
 func (as *antigravitySession) RespondPermission(requestID string, result core.PermissionResult) error {
 	if !as.alive.Load() {
 		return fmt.Errorf("session is closed")
 	}
-	if pending, _ := as.permReqID.Load().(string); pending != "" && requestID != "" && requestID != pending {
-		return fmt.Errorf("permission request mismatch: got %q, pending %q", requestID, pending)
+	if as.permissionBridge == nil {
+		return fmt.Errorf("antigravity: permission responses are only available in default mode")
 	}
-	as.stdinMu.Lock()
-	defer as.stdinMu.Unlock()
-	if as.stdin == nil {
-		return fmt.Errorf("stdin is not available")
-	}
-	// agy permission prompts accept terminal-style responses.
-	// Keep this conservative until agy exposes a structured permission protocol.
-	reply := "y\n"
-	if strings.EqualFold(result.Behavior, "deny") {
-		reply = "n\n"
-	}
-	_, err := io.WriteString(as.stdin, reply)
-	if err != nil {
-		return fmt.Errorf("write permission response: %w", err)
-	}
-	as.permReqID.Store("")
-	return nil
+	return as.permissionBridge.RespondPermission(requestID, result)
 }
 
 func (as *antigravitySession) Events() <-chan core.Event {
@@ -458,12 +411,9 @@ func (as *antigravitySession) Alive() bool {
 func (as *antigravitySession) Close() error {
 	as.alive.Store(false)
 	as.cancel()
-	as.stdinMu.Lock()
-	if as.stdin != nil {
-		_ = as.stdin.Close()
-		as.stdin = nil
+	if as.permissionBridge != nil {
+		as.permissionBridge.Close()
 	}
-	as.stdinMu.Unlock()
 	done := make(chan struct{})
 	go func() {
 		as.wg.Wait()

--- a/agent/antigravity/session_test.go
+++ b/agent/antigravity/session_test.go
@@ -228,7 +228,7 @@ func TestSendDoesNotHoldStdinOpen(t *testing.T) {
 	}
 	defer func() { _ = s.Close() }()
 
-	if err := s.Send("hello", nil, nil); err != nil {
+	if err := s.Send("hello", "", nil, nil); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 

--- a/agent/antigravity/session_test.go
+++ b/agent/antigravity/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -58,6 +59,8 @@ func TestNormalizeMode(t *testing.T) {
 }
 
 func TestSession_ContinueSessionTreatedAsFresh(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	s, err := newAntigravitySession(context.Background(), "echo", nil, "/tmp", "", "default", core.ContinueSession, nil, 0)
 	if err != nil {
 		t.Fatalf("newAntigravitySession: %v", err)
@@ -70,8 +73,8 @@ func TestSession_ContinueSessionTreatedAsFresh(t *testing.T) {
 }
 
 func TestBuildAntigravityArgs_PromptAtEnd(t *testing.T) {
-	s, _ := newAntigravitySession(context.Background(), "echo", nil, "/tmp", "", "default", "", nil, 0)
-	args := s.buildAntigravityArgs("sid-1", true, "plan", "What is 1+1?")
+	s, _ := newAntigravitySession(context.Background(), "echo", []string{"--verbose"}, "/tmp", "", "default", "", nil, 0)
+	args := s.buildAntigravityArgs("sid-1", true, "plan", "/tmp/agy-config", "What is 1+1?")
 	if len(args) < 2 {
 		t.Fatalf("args too short: %v", args)
 	}
@@ -80,6 +83,12 @@ func TestBuildAntigravityArgs_PromptAtEnd(t *testing.T) {
 	}
 	if !contains(args, "--sandbox") {
 		t.Fatalf("expected --sandbox in args, got: %v", args)
+	}
+	if !contains(args, "--gemini_dir=/tmp/agy-config") || !contains(args, "--print-timeout=24h") {
+		t.Fatalf("expected isolated Agy config and extended print timeout, got: %v", args)
+	}
+	if !contains(args, "--verbose") {
+		t.Fatalf("expected configured extra args, got: %v", args)
 	}
 	if contains(args, "-m") || contains(args, "--model") {
 		t.Fatalf("did not expect model flags in args, got: %v", args)
@@ -154,76 +163,94 @@ func TestAntigravitySession_ResumePassesConversationID(t *testing.T) {
 	}
 }
 
-func TestUsesInteractivePermission(t *testing.T) {
-	if !usesInteractivePermission("default") {
-		t.Fatal("default mode should use interactive permission stdin")
-	}
-	if usesInteractivePermission("yolo") {
-		t.Fatal("yolo mode should not use interactive permission stdin")
-	}
-	if usesInteractivePermission("plan") {
-		t.Fatal("plan mode should not use interactive permission stdin")
-	}
-}
+func TestDefaultModeCreatesPermissionBridge(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 
-func TestRespondPermission_WritesTerminalAnswer(t *testing.T) {
 	s, err := newAntigravitySession(context.Background(), "echo", nil, "/tmp", "", "default", "", nil, 0)
 	if err != nil {
 		t.Fatalf("newAntigravitySession: %v", err)
 	}
 	defer func() { _ = s.Close() }()
 
-	r, w, err := os.Pipe()
+	if s.permissionBridge == nil {
+		t.Fatal("permissionBridge = nil, want default-mode permission bridge")
+	}
+	if _, err := os.Stat(filepath.Join(s.permissionBridge.AgyConfigDir(), "config", "hooks.json")); err != nil {
+		t.Fatalf("stat Agy hook overlay: %v", err)
+	}
+}
+
+func TestNonDefaultModesDoNotCreatePermissionBridge(t *testing.T) {
+	for _, mode := range []string{"yolo", "plan"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
+			s, err := newAntigravitySession(context.Background(), "echo", nil, "/tmp", "", mode, "", nil, 0)
+			if err != nil {
+				t.Fatalf("newAntigravitySession: %v", err)
+			}
+			defer func() { _ = s.Close() }()
+
+			if s.permissionBridge != nil {
+				t.Fatalf("permissionBridge = %v, want nil", s.permissionBridge)
+			}
+		})
+	}
+}
+
+func TestRespondPermissionRequiresDefaultMode(t *testing.T) {
+	s, err := newAntigravitySession(context.Background(), "echo", nil, "/tmp", "", "plan", "", nil, 0)
 	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
+		t.Fatalf("newAntigravitySession: %v", err)
 	}
-	defer func() { _ = r.Close() }()
-	defer func() { _ = w.Close() }()
-	s.stdin = w
+	defer func() { _ = s.Close() }()
 
-	s.permReqID.Store("req")
-	if err := s.RespondPermission("req", core.PermissionResult{Behavior: "allow"}); err != nil {
-		t.Fatalf("RespondPermission allow: %v", err)
-	}
-	buf := make([]byte, 8)
-	n, err := r.Read(buf)
-	if err != nil && err != io.EOF {
-		t.Fatalf("read allow response: %v", err)
-	}
-	if got := string(buf[:n]); got != "y\n" {
-		t.Fatalf("allow response = %q, want %q", got, "y\n")
-	}
-
-	s.permReqID.Store("req")
-	if err := s.RespondPermission("req", core.PermissionResult{Behavior: "deny"}); err != nil {
-		t.Fatalf("RespondPermission deny: %v", err)
-	}
-	n, err = r.Read(buf)
-	if err != nil && err != io.EOF {
-		t.Fatalf("read deny response: %v", err)
-	}
-	if got := string(buf[:n]); got != "n\n" {
-		t.Fatalf("deny response = %q, want %q", got, "n\n")
+	err = s.RespondPermission("req", core.PermissionResult{Behavior: "allow"})
+	if err == nil || !strings.Contains(err.Error(), "only available in default mode") {
+		t.Fatalf("RespondPermission() error = %v, want default-mode error", err)
 	}
 }
 
-func TestExtractPermissionPrompt(t *testing.T) {
-	text := "Tool wants to run command. Allow this action? (y/N)"
-	got, ok := extractPermissionPrompt(text)
-	if !ok {
-		t.Fatalf("expected permission prompt to be detected")
-	}
-	if got == "" {
-		t.Fatalf("detected prompt should not be empty")
-	}
-}
+func TestSendDoesNotHoldStdinOpen(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
 
-func TestExtractPermissionPrompt_SplitChunksDetectedInWindow(t *testing.T) {
-	part1 := "Tool wants to run command. Allow this"
-	part2 := " action? (y/N)"
-	got, ok := extractPermissionPrompt(part1 + part2)
-	if !ok || got == "" {
-		t.Fatalf("expected split prompt to be detected, got ok=%v prompt=%q", ok, got)
+	workDir := t.TempDir()
+	cmdPath := filepath.Join(t.TempDir(), "fake-agy.sh")
+	script := "#!/bin/sh\ncat >/dev/null\nprintf 'done\\n'\n"
+	if err := os.WriteFile(cmdPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile fake agy: %v", err)
+	}
+
+	s, err := newAntigravitySession(context.Background(), cmdPath, nil, workDir, "", "default", "", nil, 2*time.Second)
+	if err != nil {
+		t.Fatalf("newAntigravitySession: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if err := s.Send("hello", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	deadline := time.After(3 * time.Second)
+	var text strings.Builder
+	for {
+		select {
+		case ev := <-s.Events():
+			switch ev.Type {
+			case core.EventPermissionRequest:
+				t.Fatal("unexpected permission request from unstructured stdout")
+			case core.EventText:
+				text.WriteString(ev.Content)
+			case core.EventResult:
+				if !strings.Contains(text.String(), "done") {
+					t.Fatalf("text = %q, want done", text.String())
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for agy process to receive stdin EOF")
+		}
 	}
 }
 

--- a/agent/antigravityhook/protocol.go
+++ b/agent/antigravityhook/protocol.go
@@ -13,7 +13,9 @@ const (
 	EnvAddress = "CC_CONNECT_AGY_PERMISSION_ADDR"
 	EnvToken   = "CC_CONNECT_AGY_PERMISSION_TOKEN"
 
-	maxHookInput = 4 << 20
+	maxHookInput          = 4 << 20
+	bridgeDialTimeout     = 5 * time.Second
+	bridgeResponseTimeout = 24 * time.Hour
 )
 
 type BridgeRequest struct {
@@ -43,12 +45,14 @@ func Relay(in io.Reader, out io.Writer, address, token string) error {
 		return fmt.Errorf("hook input is not valid JSON")
 	}
 
-	conn, err := net.DialTimeout("tcp", address, 5*time.Second)
+	conn, err := net.DialTimeout("tcp", address, bridgeDialTimeout)
 	if err != nil {
 		return fmt.Errorf("connect permission bridge: %w", err)
 	}
 	defer func() { _ = conn.Close() }()
-	_ = conn.SetDeadline(time.Now().Add(24 * time.Hour))
+	// The listener is started before agy runs this hook, so dial failures should
+	// fail closed quickly. After connect, wait much longer for a human response.
+	_ = conn.SetDeadline(time.Now().Add(bridgeResponseTimeout))
 
 	if err := json.NewEncoder(conn).Encode(BridgeRequest{Token: token, HookInput: input}); err != nil {
 		return fmt.Errorf("send permission request: %w", err)

--- a/agent/antigravityhook/protocol.go
+++ b/agent/antigravityhook/protocol.go
@@ -1,0 +1,71 @@
+package antigravityhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+)
+
+const (
+	EnvAddress = "CC_CONNECT_AGY_PERMISSION_ADDR"
+	EnvToken   = "CC_CONNECT_AGY_PERMISSION_TOKEN"
+
+	maxHookInput = 4 << 20
+)
+
+type BridgeRequest struct {
+	Token     string          `json:"token"`
+	HookInput json.RawMessage `json:"hook_input"`
+}
+
+type BridgeResponse struct {
+	Decision string `json:"decision"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// Relay forwards one Agy hook invocation to the owning cc-connect session.
+func Relay(in io.Reader, out io.Writer, address, token string) error {
+	if strings.TrimSpace(address) == "" || strings.TrimSpace(token) == "" {
+		return fmt.Errorf("permission bridge environment is missing")
+	}
+
+	input, err := io.ReadAll(io.LimitReader(in, maxHookInput+1))
+	if err != nil {
+		return fmt.Errorf("read hook input: %w", err)
+	}
+	if len(input) > maxHookInput {
+		return fmt.Errorf("hook input exceeds %d bytes", maxHookInput)
+	}
+	if !json.Valid(input) {
+		return fmt.Errorf("hook input is not valid JSON")
+	}
+
+	conn, err := net.DialTimeout("tcp", address, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("connect permission bridge: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(24 * time.Hour))
+
+	if err := json.NewEncoder(conn).Encode(BridgeRequest{Token: token, HookInput: input}); err != nil {
+		return fmt.Errorf("send permission request: %w", err)
+	}
+
+	var response BridgeResponse
+	if err := json.NewDecoder(io.LimitReader(conn, 64<<10)).Decode(&response); err != nil {
+		return fmt.Errorf("read permission response: %w", err)
+	}
+	switch response.Decision {
+	case "allow", "deny":
+	default:
+		return fmt.Errorf("invalid permission decision %q", response.Decision)
+	}
+
+	if err := json.NewEncoder(out).Encode(response); err != nil {
+		return fmt.Errorf("write hook response: %w", err)
+	}
+	return nil
+}

--- a/agent/antigravityhook/protocol_test.go
+++ b/agent/antigravityhook/protocol_test.go
@@ -1,0 +1,25 @@
+package antigravityhook
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRelayRejectsInvalidInputBeforeConnecting(t *testing.T) {
+	var output bytes.Buffer
+	err := Relay(strings.NewReader("not-json"), &output, "127.0.0.1:1", "token")
+	if err == nil || !strings.Contains(err.Error(), "not valid JSON") {
+		t.Fatalf("Relay() error = %v, want invalid JSON error", err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("output = %q, want empty", output.String())
+	}
+}
+
+func TestRelayRequiresBridgeEnvironment(t *testing.T) {
+	err := Relay(strings.NewReader("{}"), &bytes.Buffer{}, "", "")
+	if err == nil || !strings.Contains(err.Error(), "environment is missing") {
+		t.Fatalf("Relay() error = %v, want missing environment error", err)
+	}
+}

--- a/cmd/cc-connect/antigravity_hook.go
+++ b/cmd/cc-connect/antigravity_hook.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/chenhg5/cc-connect/agent/antigravityhook"
+)
+
+func runAntigravityPermissionHook() {
+	err := antigravityhook.Relay(
+		os.Stdin,
+		os.Stdout,
+		os.Getenv(antigravityhook.EnvAddress),
+		os.Getenv(antigravityhook.EnvToken),
+	)
+	if err == nil {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "cc-connect Agy permission hook: %v\n", err)
+	_ = json.NewEncoder(os.Stdout).Encode(antigravityhook.BridgeResponse{
+		Decision: "deny",
+		Reason:   "cc-connect permission bridge is unavailable",
+	})
+}

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -202,6 +202,13 @@ type providerWiringResult struct {
 }
 
 func main() {
+	// Agy hooks require stdout to contain only the final JSON decision. Handle
+	// this internal command before update checks, logging, or normal CLI setup.
+	if len(os.Args) > 1 && os.Args[1] == "_agy-permission-hook" {
+		runAntigravityPermissionHook()
+		return
+	}
+
 	checkUpdateAsync()
 
 	// Handle subcommands before flag parsing

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -47,7 +47,7 @@ type progressPlatform struct {
 type Platform struct {
 	token                      string
 	allowFrom                  string
-	guildID                    string   // optional: per-guild registration (instant) vs global (up to 1h propagation)
+	guildID                    string // optional: per-guild registration (instant) vs global (up to 1h propagation)
 	progressStyle              string
 	groupReplyAllGuilds        []string // guild IDs where groupReplyAll is active; "*" = all guilds
 	shareSessionInChannel      bool
@@ -848,7 +848,7 @@ func (p *Platform) handleInteraction(s *discordgo.Session, i *discordgo.Interact
 		MessageID: i.ID,
 		ChannelID: i.ChannelID,
 		UserID:    userID, UserName: userName,
-		Content:  cmdText, ReplyCtx: rctx,
+		Content: cmdText, ReplyCtx: rctx,
 	}
 	msg.ChatName, _ = p.ResolveChannelName(channelID)
 	p.dispatchMessage(msg)
@@ -888,12 +888,12 @@ func reconstructCommand(data discordgo.ApplicationCommandInteractionData) string
 
 func (p *Platform) handleComponentInteraction(s *discordgo.Session, i *discordgo.InteractionCreate, userID, userName string) {
 	data := i.MessageComponentData()
-	if !strings.HasPrefix(data.CustomID, "cmd:") {
+	command, isPermissionResponse, ok := discordComponentCommand(data.CustomID)
+	if !ok {
 		slog.Debug("discord: unknown component interaction", "custom_id", data.CustomID)
 		return
 	}
 
-	command := strings.TrimPrefix(data.CustomID, "cmd:")
 	origText := ""
 	if i.Message != nil {
 		origText = i.Message.Content
@@ -922,16 +922,32 @@ func (p *Platform) handleComponentInteraction(s *discordgo.Session, i *discordgo
 	}
 	chatName, _ := p.ResolveChannelName(channelID)
 	p.dispatchMessage(&core.Message{
-		SessionKey: sessionKey,
-		ChannelKey: channelKey,
-		Platform:   "discord",
-		MessageID:  i.ID,
-		UserID:     userID,
-		UserName:   userName,
-		Content:    command,
-		ChatName:   chatName,
-		ReplyCtx:   rc,
+		SessionKey:           sessionKey,
+		ChannelKey:           channelKey,
+		Platform:             "discord",
+		MessageID:            i.ID,
+		UserID:               userID,
+		UserName:             userName,
+		Content:              command,
+		ChatName:             chatName,
+		ReplyCtx:             rc,
+		IsPermissionResponse: isPermissionResponse,
 	})
+}
+
+func discordComponentCommand(customID string) (command string, isPermissionResponse bool, ok bool) {
+	if command, found := strings.CutPrefix(customID, "cmd:"); found && command != "" {
+		return command, false, true
+	}
+	if action, found := strings.CutPrefix(customID, "perm:"); found {
+		switch action {
+		case "allow", "deny":
+			return action, true, true
+		case "allow_all":
+			return "allow all", true, true
+		}
+	}
+	return "", false, false
 }
 
 func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
@@ -1160,10 +1176,6 @@ func buildDiscordActionRows(rows [][]core.ButtonOption) []discordgo.MessageCompo
 }
 
 func (p *Platform) SendWithButtons(ctx context.Context, rctx any, content string, buttons [][]core.ButtonOption) error {
-	rc, ok := rctx.(*interactionReplyCtx)
-	if !ok {
-		return core.ErrNotSupported
-	}
 	if len(buttons) == 0 {
 		return fmt.Errorf("discord: no buttons provided")
 	}
@@ -1171,17 +1183,32 @@ func (p *Platform) SendWithButtons(ctx context.Context, rctx any, content string
 	if len(components) == 0 {
 		return fmt.Errorf("discord: no buttons provided")
 	}
-	if err := p.sendInteraction(rc, content); err != nil {
-		return err
+
+	switch rc := rctx.(type) {
+	case *interactionReplyCtx:
+		if err := p.sendInteraction(rc, content); err != nil {
+			return err
+		}
+		_, err := p.session.FollowupMessageCreate(rc.interaction, true, &discordgo.WebhookParams{
+			Content:    content,
+			Components: components,
+		})
+		if err != nil {
+			return fmt.Errorf("discord: send button followup: %w", err)
+		}
+		return nil
+	case replyContext:
+		_, err := p.session.ChannelMessageSendComplex(rc.targetChannelID(), &discordgo.MessageSend{
+			Content:    content,
+			Components: components,
+		})
+		if err != nil {
+			return fmt.Errorf("discord: send channel buttons: %w", err)
+		}
+		return nil
+	default:
+		return core.ErrNotSupported
 	}
-	_, err := p.session.FollowupMessageCreate(rc.interaction, true, &discordgo.WebhookParams{
-		Content:    content,
-		Components: components,
-	})
-	if err != nil {
-		return fmt.Errorf("discord: send button followup: %w", err)
-	}
-	return nil
 }
 
 func (p *progressPlatform) ProgressUpdateInterval() time.Duration {

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -512,6 +512,86 @@ func TestSendWithButtons_PreservesMultipleRows(t *testing.T) {
 	}
 }
 
+func TestSendWithButtons_UsesChannelComponents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/channels/ch-1/messages") {
+			t.Fatalf("request path = %q, want channel message", r.URL.Path)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload["content"] != "approve tool?" {
+			t.Fatalf("content = %#v, want approve tool?", payload["content"])
+		}
+		components, ok := payload["components"].([]any)
+		if !ok || len(components) != 1 {
+			t.Fatalf("components = %#v, want one row", payload["components"])
+		}
+		row := components[0].(map[string]any)["components"].([]any)
+		if row[0].(map[string]any)["custom_id"] != "perm:allow" {
+			t.Fatalf("button = %#v, want perm:allow", row[0])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg-1","channel_id":"ch-1"}`)
+	}))
+	defer server.Close()
+
+	p := &Platform{session: newTestDiscordSession(t, server)}
+	err := p.SendWithButtons(context.Background(), replyContext{channelID: "ch-1"}, "approve tool?", [][]core.ButtonOption{{
+		{Text: "Allow", Data: "perm:allow"},
+		{Text: "Deny", Data: "perm:deny"},
+	}})
+	if err != nil {
+		t.Fatalf("SendWithButtons() error = %v", err)
+	}
+}
+
+func TestHandleComponentInteraction_DispatchesPermissionResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{}`)
+	}))
+	defer server.Close()
+
+	var got *core.Message
+	p := &Platform{
+		session: newTestDiscordSession(t, server),
+		handler: func(_ core.Platform, msg *core.Message) {
+			got = msg
+		},
+	}
+	interaction := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		ID:        "interaction-1",
+		Token:     "token-1",
+		Type:      discordgo.InteractionMessageComponent,
+		ChannelID: "channel-1",
+		Message:   &discordgo.Message{ID: "message-1", Content: "approve tool?"},
+		Data:      discordgo.MessageComponentInteractionData{CustomID: "perm:allow"},
+	}}
+
+	p.handleComponentInteraction(p.session, interaction, "user-1", "user")
+
+	if got == nil {
+		t.Fatal("permission button did not dispatch a message")
+	}
+	if got.Content != "allow" || !got.IsPermissionResponse {
+		t.Fatalf("message = %#v, want allow permission response", got)
+	}
+	if got.SessionKey != "discord:channel-1:user-1" {
+		t.Fatalf("SessionKey = %q", got.SessionKey)
+	}
+}
+
+func TestDiscordComponentCommandRejectsUnknownPermissionAction(t *testing.T) {
+	if command, isPermission, ok := discordComponentCommand("perm:allow_all"); !ok || !isPermission || command != "allow all" {
+		t.Fatalf("allow-all component = (%q, %v, %v), want (allow all, true, true)", command, isPermission, ok)
+	}
+	if _, _, ok := discordComponentCommand("perm:maybe"); ok {
+		t.Fatal("discordComponentCommand accepted unknown permission action")
+	}
+}
+
 func TestSendFile_SendsChannelAttachment(t *testing.T) {
 	var contentType string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- bridge Antigravity `PreToolUse` hooks to cc-connect permission requests
- make Antigravity `default` mode support chat approval buttons and text responses
- keep `agy --print` stdin disconnected to avoid the print-mode startup deadlock
- support Discord permission buttons in normal channel messages and correctly route allow, deny, and allow-all callbacks

## Implementation

- create a per-session isolated Antigravity config overlay that preserves existing CLI state and hooks while injecting the cc-connect permission hook
- relay structured hook requests over a token-authenticated loopback connection to the owning agent session
- reuse the existing `EventPermissionRequest` and `RespondPermission` flow, so supported chat platforms use their existing button/text handling
- fail closed when the bridge is unavailable without modifying the user real `hooks.json`

Antigravity currently exposes the config override using its compatibility flag name, `--gemini_dir`; this PR only uses that native flag/path naming and does not add a Gemini agent dependency.

## Testing

- `go test ./...`
- `go build ./...`
- `go test -race ./agent/antigravity ./agent/antigravityhook ./platform/discord ./cmd/cc-connect`
- live verified with Antigravity CLI 1.0.7 on Linux and Discord: default-mode permission request and approval complete successfully
- live verified an actual Agy `PreToolUse` allow decision executes the requested tool

## Compatibility note

The runtime implementation has been verified on Linux. The isolated overlay uses filesystem symlinks and Unix shell quoting; Windows runtime behavior has not been verified.