### PR TITLE
fix(daemon): remove duplicate CheckLinger stub blocking darwin/windows build (#1311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - **`cc-connect cron add --silent`**: expose the `--silent` flag on the cron add CLI so users can suppress the cron start notification when creating a job. The server already accepted `silent` on `/cron/add`; only the CLI side was missing (#858).
 - **QQ Bot inline keyboard**: add support for inline keyboard buttons and INTERACTION_CREATE events. Permission requests now render as clickable buttons instead of text replies. Requires enabling the INTERACTION capability (bit 26) in the QQ Open Platform bot settings.
 
+### Fixed
+- **macOS/Windows build failure from duplicate `CheckLinger`**: `daemon/linger_other.go` (`//go:build !linux`) redeclared `CheckLinger` together with the per-platform stubs in `daemon/launchd.go` (darwin), `daemon/windows.go` (windows), and `daemon/unsupported.go` (other), so `go build ./...` failed on every non-Linux platform. Deleted `daemon/linger_other.go`; per-platform stubs already cover darwin/windows/other, and `daemon/systemd.go` covers Linux. `make release-all` now succeeds on all target platforms (#1311).
+
 ### ⚠️ QQ Bot Intent Configuration Change
 The default intents for QQ Bot now include `INTERACTION_CREATE` (bit 26, value `1<<26`). If you previously set a custom `intents` value without this bit, inline keyboard buttons will not work — update your `intents` to include bit 26. If you use the default intents, no action is needed. See `config.example.toml` for the new `intents` option.
 

--- a/daemon/linger_other.go
+++ b/daemon/linger_other.go
@@ -1,8 +1,0 @@
-//go:build !linux
-
-package daemon
-
-// CheckLinger is only meaningful for user-level systemd services on Linux.
-func CheckLinger() (enabled bool, user string) {
-	return true, ""
-}


### PR DESCRIPTION
Fixes #1311

## What changed

Deleted `daemon/linger_other.go`. The file declared `//go:build !linux`
and defined `CheckLinger`, but the per-platform stubs already cover
every non-Linux target:

| GOOS    | CheckLinger provider  |
| ------- | --------------------- |
| linux   | daemon/systemd.go     |
| darwin  | daemon/launchd.go     |
| windows | daemon/windows.go     |
| other   | daemon/unsupported.go |

`linger_other.go` was therefore a duplicate that produced
`CheckLinger redeclared in this block` on darwin, windows, and
other (e.g. freebsd/openbsd), breaking `go build ./...` and
`make release-all` on every non-Linux platform.

## Why this fix is safe

- No test file references `CheckLinger` from `linger_other` (verified
  with ripgrep across the whole repo).
- `cmd/cc-connect/daemon.go:109` calls `daemon.CheckLinger()` — the
  call is package-qualified, so the provider file doesn't matter.
- `CheckLinger` semantics on each non-Linux platform are unchanged:
  - darwin (launchd): `return true, ""`
  - windows: `return false, ""`
  - other (unsupported): `return false, ""`

## Verification

- `GOOS=darwin  go build ./...`  exit=0
- `GOOS=windows go build ./...`  exit=0
- `GOOS=linux   go build ./...`  exit=0
- `GOOS=freebsd go build ./...`  exit=0 (unsupported.go path)
- `GOOS=darwin  go vet ./daemon/`   exit=0
- `GOOS=windows go vet ./daemon/`   exit=0
- `GOOS=freebsd go vet ./daemon/`   exit=0
- `go test -count=1 ./daemon/...` all PASS
- `golangci-lint` is not installed in this sandbox; the CI `lint` job
  on PR creation will catch any findings. The diff is a single file
  deletion + a CHANGELOG bullet, so `--new-from-rev origin/main`
  should report 0 issues.

## Files

- `daemon/linger_other.go` — deleted
- `CHANGELOG.md` — unreleased ### Fixed entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)