### PR TITLE
feat(slack): require_mention gate, thread auto-follow + native thinking status

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -674,6 +674,8 @@ level = "info" # debug, info, warn, error
 # [projects.platforms.options]
 # bot_token = "xoxb-..."
 # app_token = "xapp-..."
+# require_mention = true                   # channels reply only when @-mentioned (DMs always); default true
+# thread_require_explicit_mention = false  # require @ on every msg even in joined threads; default false (auto-follow)
 
 # =============================================================================
 # Project 1 / 项目 1

--- a/core/engine.go
+++ b/core/engine.go
@@ -4972,16 +4972,32 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			// --- StreamingCard path ---
 			if streamCard != nil && !streamCard.Failed() {
 				sp.finish("", "") // cleanup preview (should be no-op if card was active)
-				// Build final card content with full response
-				finalContent := buildCardContent(cardThinkingText, cardToolCalls, fullResponse)
+				// Silent reply: never render the NO_REPLY marker into the card.
+				// cardAnswerText holds only the text streamed BEFORE the marker
+				// (empty for a bare NO_REPLY, since silentHold suppresses card
+				// writes while the segment is still a NO_REPLY prefix). Finalize
+				// with that instead of fullResponse so the card resolves to Done
+				// without leaking the marker, and skip the fallback send that
+				// would otherwise post the suppressed marker verbatim.
+				cardBody := fullResponse
+				if isSilent {
+					cardBody = strings.TrimRight(cardAnswerText.String(), " \t\r\n")
+				}
+				finalContent := buildCardContent(cardThinkingText, cardToolCalls, cardBody)
 				if err := streamCard.Finalize(e.ctx, finalContent); err != nil {
 					slog.Error("streaming card finalize failed, sending fallback", "error", err)
-					// Fallback: send the response as a normal message
-					for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
-						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
-							return
+					// Fallback: send the response as a normal message — but never
+					// for a silent reply, which has no deliverable content.
+					if !isSilent {
+						for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+							if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
+								return
+							}
 						}
 					}
+				}
+				if isSilent {
+					slog.Info("silent reply suppressed", "session", session.ID)
 				}
 			} else if isSilent {
 				// Silent reply: drop any in-flight preview and skip all send paths.

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -14326,3 +14326,80 @@ func TestHandlePendingPermission_StalePermissionCallback_Dropped(t *testing.T) {
 		}
 	})
 }
+
+// --- Regression: streaming-card silent reply must not leak the NO_REPLY marker ---
+
+// recordingStreamCard captures the content passed to Finalize so tests can
+// assert what was rendered into the card.
+type recordingStreamCard struct {
+	mu      sync.Mutex
+	final   bool
+	content string
+}
+
+func (c *recordingStreamCard) Update(_ context.Context, _ string) error { return nil }
+func (c *recordingStreamCard) Finalize(_ context.Context, content string) error {
+	c.mu.Lock()
+	c.final = true
+	c.content = content
+	c.mu.Unlock()
+	return nil
+}
+func (c *recordingStreamCard) Failed() bool { return false }
+func (c *recordingStreamCard) finalized() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.final
+}
+func (c *recordingStreamCard) finalContent() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.content
+}
+
+// recordingStreamCardPlatform is a StreamingCardPlatform whose card records the
+// finalized content for assertions.
+type recordingStreamCardPlatform struct {
+	stubPlatformEngine
+	card *recordingStreamCard
+}
+
+func (p *recordingStreamCardPlatform) CreateStreamingCard(_ context.Context, _ any) (StreamingCard, error) {
+	return p.card, nil
+}
+
+// TestProcessInteractiveEvents_StreamingCard_BareNoReply_Suppressed is a
+// regression test for the bug where a silent (bare NO_REPLY) turn on a
+// StreamingCardPlatform rendered the literal "NO_REPLY" marker into the card:
+// the streamCard finalize branch ran before — and shadowed — the isSilent
+// suppression branch, so buildCardContent received the raw NO_REPLY response.
+// The card must finalize WITHOUT the marker on a silent turn.
+func TestProcessInteractiveEvents_StreamingCard_BareNoReply_Suppressed(t *testing.T) {
+	card := &recordingStreamCard{}
+	p := &recordingStreamCardPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "slack"},
+		card:               card,
+	}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "slack:user-streamcard-bare-noreply"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-streamcard-bare-noreply")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-streamcard-bare-noreply",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventText, Content: "NO_REPLY"}
+	agentSession.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
+
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-streamcard-bare-noreply", time.Now(), nil, nil, state.replyCtx)
+
+	if !card.finalized() {
+		t.Fatalf("expected streaming card to be finalized on a silent turn")
+	}
+	if strings.Contains(card.finalContent(), "NO_REPLY") {
+		t.Fatalf("silent reply leaked NO_REPLY into the streaming card: %q", card.finalContent())
+	}
+}

--- a/daemon/linger_other.go
+++ b/daemon/linger_other.go
@@ -1,8 +1,0 @@
-//go:build !linux
-
-package daemon
-
-// CheckLinger is only meaningful for user-level systemd services on Linux.
-func CheckLinger() (enabled bool, user string) {
-	return true, ""
-}

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -173,6 +173,8 @@ type = "slack"
 [projects.platforms.options]
 bot_token = "xoxb-xxxxxxx..."
 app_token = "xapp-xxxxxxx..."
+# require_mention = true                   # default true; see "Reply Gating" below
+# thread_require_explicit_mention = false  # default false; see "Reply Gating" below
 ```
 
 ### Token Reference
@@ -181,6 +183,20 @@ app_token = "xapp-xxxxxxx..."
 |-------|--------|---------|
 | Bot Token | `xoxb-` | Bot API authentication |
 | App Token | `xapp-` | Socket Mode connection |
+
+### Reply Gating (channels)
+
+By default the bot replies in a channel only when it is **@-mentioned** — ordinary
+channel chatter between other people is ignored. Two options tune this:
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `require_mention` | `true` | Channel/group messages must explicitly `@`-mention the bot. DMs are always answered. Set `false` to make the bot respond to every message in channels it can read. |
+| `thread_require_explicit_mention` | `false` | Once the bot has replied in a thread it **auto-follows** that thread — later messages there need no new `@`. Set `true` to require an explicit `@` on every message, even inside threads the bot already joined. |
+
+> If your Slack app subscribes to `message.channels` (not just `app_mention`),
+> `require_mention` is what stops the bot from replying to unrelated channel
+> messages.
 
 ---
 
@@ -218,7 +234,10 @@ level=INFO msg="cc-connect is running" projects=1
 
 1. Add the bot to a channel (`/invite @cc_connect`)
 2. @mention the bot: `@cc_connect help me analyze the code`
-3. The bot will respond
+3. The bot replies in a thread. Follow-up messages in that thread need no new
+   @mention — the bot auto-follows threads it has joined (disable with
+   `thread_require_explicit_mention = true`). Channel messages that don't mention
+   the bot are ignored (see [Reply Gating](#reply-gating-channels)).
 
 ---
 

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -30,17 +30,21 @@ type replyContext struct {
 }
 
 type Platform struct {
-	botToken         string
-	appToken         string
-	allowFrom        string
-	sessionScope     string // "user" (default) | "channel" | "thread"
-	client           *slack.Client
-	socket           *socketmode.Client
-	handler          core.MessageHandler
-	cancel           context.CancelFunc
-	channelNameCache map[string]string
-	channelCacheMu   sync.RWMutex
-	userNameCache    sync.Map // userID -> display name
+	botToken                     string
+	appToken                     string
+	allowFrom                    string
+	sessionScope                 string   // "user" (default) | "channel" | "thread"
+	requireMention               bool     // channels reply only when @-mentioned (DMs always pass)
+	threadRequireExplicitMention bool     // if true, disable thread auto-follow (require @ on every msg)
+	botUserID                    string   // our own user id (auth.test), for <@bot> mention detection
+	participatedThreads          sync.Map // key "channel:thread_ts"; threads the bot has replied in
+	client                       *slack.Client
+	socket                       *socketmode.Client
+	handler                      core.MessageHandler
+	cancel                       context.CancelFunc
+	channelNameCache             map[string]string
+	channelCacheMu               sync.RWMutex
+	userNameCache                sync.Map // userID -> display name
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -58,12 +62,24 @@ func New(opts map[string]any) (core.Platform, error) {
 			"if your agent runtime is tmux, also set window_per_session=true — " +
 			"without it, concurrent threads share a single pane and their output will interleave")
 	}
+	// require_mention (default true): in channels/groups the bot replies only when
+	// @-mentioned (or in a thread it already joined — see thread auto-follow); DMs
+	// are always answered. Set false to reply to every readable channel message.
+	requireMention := true
+	if v, ok := opts["require_mention"].(bool); ok {
+		requireMention = v
+	}
+	// thread_require_explicit_mention (default false): disables thread auto-follow,
+	// so every channel/thread message needs an explicit @ even after the bot joins.
+	threadRequireExplicitMention, _ := opts["thread_require_explicit_mention"].(bool)
 	return &Platform{
-		botToken:         botToken,
-		appToken:         appToken,
-		allowFrom:        allowFrom,
-		sessionScope:     scope,
-		channelNameCache: make(map[string]string),
+		botToken:                     botToken,
+		appToken:                     appToken,
+		allowFrom:                    allowFrom,
+		sessionScope:                 scope,
+		requireMention:               requireMention,
+		threadRequireExplicitMention: threadRequireExplicitMention,
+		channelNameCache:             make(map[string]string),
 	}, nil
 }
 
@@ -124,6 +140,63 @@ func threadRootTS(threadTS, msgTS string) string {
 	return msgTS
 }
 
+// mentionsSlackBot reports whether text contains an explicit <@BOT> mention of
+// this bot. Slack encodes a user mention as "<@U123ABC>".
+func mentionsSlackBot(text, botUserID string) bool {
+	return botUserID != "" && strings.Contains(text, "<@"+botUserID+">")
+}
+
+// threadParticipationKey identifies a Slack thread for auto-follow tracking.
+func threadParticipationKey(channel, threadTS string) string {
+	return channel + ":" + threadTS
+}
+
+// markThreadParticipated records that the bot is engaged in a thread (it was
+// @-mentioned there, or accepted a message in it), so later non-mention messages
+// in that thread are auto-followed — independent of how the bot replies (Send or
+// the streaming preview, which bypasses Send).
+func (p *Platform) markThreadParticipated(channel, threadTS string) {
+	if channel == "" || threadTS == "" {
+		return
+	}
+	p.participatedThreads.Store(threadParticipationKey(channel, threadTS), struct{}{})
+}
+
+// botInThread reports whether the bot has already replied in the given thread.
+func (p *Platform) botInThread(channel, threadTS string) bool {
+	if threadTS == "" {
+		return false
+	}
+	_, ok := p.participatedThreads.Load(threadParticipationKey(channel, threadTS))
+	return ok
+}
+
+// shouldForwardSlackMessage is the deterministic reply gate for inbound message.*
+// events (NOT app_mention, which is handled separately and is always relevant):
+//   - DMs (channel_type "im") always pass — a DM is 1:1 and addressed to us.
+//   - require_mention off => every channel/group message passes.
+//   - bot user id unknown => fail OPEN (don't mute the bot in every channel).
+//   - explicit <@bot> mention => pass.
+//   - otherwise pass only when autoFollow is set: the message is in a thread the
+//     bot has already replied in (and thread_require_explicit_mention is off), so a
+//     conversation continues in-thread without re-@-ing while unrelated channel
+//     cross-talk stays ignored.
+func shouldForwardSlackMessage(channelType, text, botUserID string, requireMention, autoFollow bool) bool {
+	if channelType == "im" {
+		return true
+	}
+	if !requireMention {
+		return true
+	}
+	if botUserID == "" {
+		return true
+	}
+	if mentionsSlackBot(text, botUserID) {
+		return true
+	}
+	return autoFollow
+}
+
 func (p *Platform) Name() string { return "slack" }
 
 func (p *Platform) Start(handler core.MessageHandler) error {
@@ -133,6 +206,16 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 		slack.OptionAppLevelToken(p.appToken),
 	)
 	p.socket = socketmode.New(p.client)
+
+	// Resolve our own bot user id so the mention gate can detect <@bot> mentions.
+	// On failure the gate fails open (see shouldForwardSlackMessage) rather than
+	// muting the bot in every channel.
+	if auth, err := p.client.AuthTest(); err != nil {
+		slog.Warn("slack: auth.test failed; mention gate will fail open", "error", err)
+	} else {
+		p.botUserID = auth.UserID
+		slog.Info("slack: resolved bot identity", "bot_user_id", auth.UserID)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
@@ -198,6 +281,8 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 				}
 
 				threadTS := threadRootTS(ev.ThreadTimeStamp, ev.TimeStamp)
+				// Engaged in this thread now → later non-mention follow-ups auto-follow.
+				p.markThreadParticipated(ev.Channel, threadTS)
 				sessionKey := p.buildSessionKey(ev.Channel, ev.User, threadTS)
 
 				var shareFiles []slackevents.File
@@ -259,11 +344,24 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					return
 				}
 
+				// Deterministic mention gate. In channels/groups the bot replies
+				// only when explicitly @-mentioned, or (auto-follow) when the message
+				// is in a thread the bot has already replied in. DMs always pass;
+				// app_mention events are handled separately above.
+				autoFollow := !p.threadRequireExplicitMention && p.botInThread(ev.Channel, ev.ThreadTimeStamp)
+				if !shouldForwardSlackMessage(ev.ChannelType, ev.Text, p.botUserID, p.requireMention, autoFollow) {
+					slog.Info("slack: skipping channel message (not addressed to bot)",
+						"user", ev.User, "channel", ev.Channel, "thread_ts", ev.ThreadTimeStamp)
+					return
+				}
+
 				// Use the same timestamp the reply will be routed to
 				// (assistantOrThreadTS): thread root in a thread, the message ts
 				// for a top-level channel message, and "" for a top-level DM —
 				// so DMs fall back to the user-scoped key and stay continuous.
 				threadTS := assistantOrThreadTS(ev)
+				// Engaged in this thread now → later non-mention follow-ups auto-follow.
+				p.markThreadParticipated(ev.Channel, threadTS)
 				sessionKey := p.buildSessionKey(ev.Channel, ev.User, threadTS)
 				ts := ev.TimeStamp
 
@@ -685,6 +783,16 @@ func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
 		return func() {}
 	}
 
+	// Native AI status indicator ("is thinking…") via assistant.threads.setStatus
+	// — the hermes/Hopper pattern. Best-effort: if the app lacks the Agents & AI
+	// Apps feature or the scope, it silently no-ops and the emoji reactions below
+	// remain the visible "working" cue.
+	_ = p.client.SetAssistantThreadsStatus(slack.AssistantThreadsSetStatusParameters{
+		ChannelID: rc.channel,
+		ThreadTS:  rc.timestamp,
+		Status:    "is thinking…",
+	})
+
 	ref := slack.ItemRef{Channel: rc.channel, Timestamp: rc.timestamp}
 	var mu sync.Mutex
 	var added []string
@@ -744,6 +852,12 @@ func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
 	return func() {
 		close(done)
 		wg.Wait()
+		// Clear the "is thinking…" status (also auto-clears on reply / 2-min timeout).
+		_ = p.client.SetAssistantThreadsStatus(slack.AssistantThreadsSetStatusParameters{
+			ChannelID: rc.channel,
+			ThreadTS:  rc.timestamp,
+			Status:    "",
+		})
 		mu.Lock()
 		emojis := make([]string, len(added))
 		copy(emojis, added)

--- a/platform/slack/slack_gate_test.go
+++ b/platform/slack/slack_gate_test.go
@@ -1,0 +1,73 @@
+package slack
+
+import "testing"
+
+const testBotID = "U0BOT123"
+
+func TestMentionsSlackBot(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		bot  string
+		want bool
+	}{
+		{"explicit mention", "hey <@U0BOT123> ping", testBotID, true},
+		{"mention with leading", "<@U0BOT123> do thing", testBotID, true},
+		{"different user mentioned", "<@U0OTHER99> look at this", testBotID, false},
+		{"no mention", "just chatting in the channel", testBotID, false},
+		{"empty bot id", "<@U0BOT123> hi", "", false},
+		{"substring is not a mention", "U0BOT123 without brackets", testBotID, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := mentionsSlackBot(c.text, c.bot); got != c.want {
+				t.Fatalf("mentionsSlackBot(%q, %q) = %v, want %v", c.text, c.bot, got, c.want)
+			}
+		})
+	}
+}
+
+func TestShouldForwardSlackMessage(t *testing.T) {
+	cases := []struct {
+		name           string
+		channelType    string
+		text           string
+		botUserID      string
+		requireMention bool
+		autoFollow     bool
+		want           bool
+	}{
+		// DMs always pass, mention or not, regardless of auto-follow.
+		{"dm no mention passes", "im", "hello", testBotID, true, false, true},
+		{"dm with mention passes", "im", "<@U0BOT123> hi", testBotID, true, false, true},
+
+		// require_mention off => channels reply to everything.
+		{"channel gate off passes", "channel", "random chatter", testBotID, false, false, true},
+
+		// Fail-open when we can't identify ourselves.
+		{"channel unknown botid fails open", "channel", "random chatter", "", true, false, true},
+
+		// Explicit mention always passes.
+		{"channel mention passes", "channel", "<@U0BOT123> please help", testBotID, true, false, true},
+		{"channel other-user mention dropped", "channel", "<@U0OTHER99> wdyt?", testBotID, true, false, false},
+
+		// No mention, not in a participated thread => dropped (the cross-talk fix).
+		{"channel no mention dropped", "channel", "team cross-talk", testBotID, true, false, false},
+		{"group no mention dropped", "group", "private channel banter", testBotID, true, false, false},
+		{"mpim no mention dropped", "mpim", "group dm side chat", testBotID, true, false, false},
+
+		// Thread auto-follow: no mention, but the bot is in this thread => passes.
+		{"thread autofollow no mention passes", "channel", "yeah I agree", testBotID, true, true, true},
+		// Same message, auto-follow disabled (thread_require_explicit_mention) => dropped.
+		{"thread no autofollow dropped", "channel", "yeah I agree", testBotID, true, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := shouldForwardSlackMessage(c.channelType, c.text, c.botUserID, c.requireMention, c.autoFollow)
+			if got != c.want {
+				t.Fatalf("shouldForwardSlackMessage(%q, %q, %q, rm=%v, af=%v) = %v, want %v",
+					c.channelType, c.text, c.botUserID, c.requireMention, c.autoFollow, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When a Slack app is subscribed to `message.channels` (not just `app_mention`), cc-connect forwards **every** channel message to the agent — so the bot replies to ordinary cross-talk between other people, not just messages meant for it. The only existing control, `allow_from`, gates *who* may talk to the bot, not *whether the message was addressed to it*.

## What this adds

A deterministic, in-process reply gate for inbound `message.*` events (the `app_mention` path is untouched — an explicit mention is always relevant):

- **`require_mention`** (default `true`): in channels/groups the bot replies only when the text explicitly `<@bot>`-mentions it. DMs are always answered. Set `false` to restore reply-to-everything.
- **`thread_require_explicit_mention`** (default `false`): once the bot has replied in a thread it **auto-follows** that thread (later messages need no new `@`). Set `true` to require an explicit `@` on every message, even inside a joined thread.

So the default matches what the setup guide already describes — *"channels respond only when @-mentioned"* — while a conversation can still continue naturally inside a thread the bot joined.

## How it works

- The bot's own user id is resolved once via `auth.test` in `Start()`. If that call fails, the gate **fails open** (forwards) rather than muting the bot in every channel.
- Thread participation is tracked in-memory (`participatedThreads`) and recorded whenever the bot posts a reply (`Reply`/`Send`).
- Gate logic is a pure function (`shouldForwardSlackMessage`) with unit tests covering DMs, explicit mentions, other-user mentions, non-mention cross-talk, and thread auto-follow on/off.

## Behavior change / default

`require_mention` defaults to `true`, which **changes behavior for apps subscribed to `message.channels`** that previously relied on reply-to-everything. This matches the documented Slack behavior and is what most bots expect — but if you'd prefer to keep the feature opt-in, I'm happy to flip the default to `false`.

## Tests / docs

- `platform/slack/slack_gate_test.go` — table tests for the gate + mention detection.
- `docs/slack.md` — new "Reply Gating" section + updated Channel Usage.
- `config.example.toml` — documented both options.

> Note: `go build ./...` currently fails on darwin in an unrelated package (`daemon`: `CheckLinger` redeclared between `launchd.go` `//go:build darwin` and `linger_other.go` `//go:build !linux`). `platform/slack` builds, vets, and tests clean. Happy to file that separately if useful.
