### PR TITLE
feat(slack): streaming preview + aggregated turn card

### DIFF
--- a/platform/slack/streaming.go
+++ b/platform/slack/streaming.go
@@ -1,0 +1,62 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chenhg5/cc-connect/core"
+
+	"github.com/slack-go/slack"
+)
+
+// slackPreviewHandle points at the in-flight streaming-preview message so
+// UpdateMessage can edit it in place via chat.update.
+type slackPreviewHandle struct {
+	channel   string
+	timestamp string
+}
+
+// SendPreviewStart posts the initial streaming-preview message (threaded like a
+// normal reply) and returns a handle for subsequent edits. Implements
+// core.PreviewStarter; together with UpdateMessage it lights up the engine's
+// real-time streaming preview for Slack (the engine throttles the edits, so we
+// stay within chat.update rate limits).
+func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content string) (any, error) {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return nil, fmt.Errorf("slack: invalid reply context type %T", rctx)
+	}
+	opts := []slack.MsgOption{
+		slack.MsgOptionText(core.MarkdownToSlackMrkdwn(content), false),
+	}
+	if rc.timestamp != "" {
+		opts = append(opts, slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{ThreadTimestamp: rc.timestamp}))
+	}
+	_, ts, err := p.client.PostMessageContext(ctx, rc.channel, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("slack: send preview: %w", err)
+	}
+	return &slackPreviewHandle{channel: rc.channel, timestamp: ts}, nil
+}
+
+// UpdateMessage edits the preview message in place. The engine passes the handle
+// returned by SendPreviewStart (not the reply context). Implements
+// core.MessageUpdater.
+func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content string) error {
+	h, ok := previewHandle.(*slackPreviewHandle)
+	if !ok {
+		return fmt.Errorf("slack: invalid preview handle type %T", previewHandle)
+	}
+	_, _, _, err := p.client.UpdateMessageContext(ctx, h.channel, h.timestamp,
+		slack.MsgOptionText(core.MarkdownToSlackMrkdwn(content), false),
+	)
+	if err != nil {
+		return fmt.Errorf("slack: update preview: %w", err)
+	}
+	return nil
+}
+
+var (
+	_ core.MessageUpdater = (*Platform)(nil)
+	_ core.PreviewStarter = (*Platform)(nil)
+)

--- a/platform/slack/streaming_card.go
+++ b/platform/slack/streaming_card.go
@@ -1,0 +1,105 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+
+	"github.com/slack-go/slack"
+)
+
+// cardUpdateMinInterval coalesces chat.update calls for the streaming card so we
+// stay within Slack's rate limits. The engine pushes an update per agent event;
+// we flush at most once per interval and always flush on Finalize.
+const cardUpdateMinInterval = 1200 * time.Millisecond
+
+// slackStreamingCard aggregates one agent turn (thinking + tool steps + answer)
+// into a single Slack message that updates in place — the cc-connect equivalent
+// of DingTalk's AI Card. Implements core.StreamingCard.
+type slackStreamingCard struct {
+	client  *slack.Client
+	channel string
+	ts      string
+
+	mu         sync.Mutex
+	failed     bool
+	lastUpdate time.Time
+	lastSent   string
+}
+
+// CreateStreamingCard posts the initial card message (threaded like a normal
+// reply) and returns it. Implements core.StreamingCardPlatform: when present,
+// the engine routes the whole turn through this card and skips the plain
+// streaming preview (they are mutually exclusive, so no double-post).
+func (p *Platform) CreateStreamingCard(ctx context.Context, rctx any) (core.StreamingCard, error) {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return nil, fmt.Errorf("slack: invalid reply context type %T", rctx)
+	}
+	opts := []slack.MsgOption{slack.MsgOptionText("…", false)}
+	if rc.timestamp != "" {
+		opts = append(opts, slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{ThreadTimestamp: rc.timestamp}))
+	}
+	_, ts, err := p.client.PostMessageContext(ctx, rc.channel, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("slack: create streaming card: %w", err)
+	}
+	return &slackStreamingCard{client: p.client, channel: rc.channel, ts: ts}, nil
+}
+
+// Update edits the card with the latest aggregated content, throttled. Transient
+// update errors are swallowed (a later Update / Finalize retries) so a blip
+// doesn't abort the turn; the engine still gets the final content via Finalize.
+func (c *slackStreamingCard) Update(ctx context.Context, content string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.failed || content == "" {
+		return nil
+	}
+	if time.Since(c.lastUpdate) < cardUpdateMinInterval {
+		return nil
+	}
+	rendered := core.MarkdownToSlackMrkdwn(content)
+	if rendered == "" || rendered == c.lastSent {
+		return nil
+	}
+	if _, _, _, err := c.client.UpdateMessageContext(ctx, c.channel, c.ts, slack.MsgOptionText(rendered, false)); err != nil {
+		return nil
+	}
+	c.lastUpdate = time.Now()
+	c.lastSent = rendered
+	return nil
+}
+
+// Finalize writes the final content unconditionally (no throttle). On error it
+// marks the card failed and returns the error so the engine falls back to a
+// normal message.
+func (c *slackStreamingCard) Finalize(ctx context.Context, content string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.failed {
+		return nil
+	}
+	rendered := core.MarkdownToSlackMrkdwn(content)
+	if rendered == "" || rendered == c.lastSent {
+		return nil
+	}
+	if _, _, _, err := c.client.UpdateMessageContext(ctx, c.channel, c.ts, slack.MsgOptionText(rendered, false)); err != nil {
+		c.failed = true
+		return fmt.Errorf("slack: finalize streaming card: %w", err)
+	}
+	c.lastSent = rendered
+	return nil
+}
+
+// Failed reports whether the card has entered a terminal failed state.
+func (c *slackStreamingCard) Failed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.failed
+}
+
+var _ core.StreamingCardPlatform = (*Platform)(nil)

--- a/platform/slack/streaming_card.go
+++ b/platform/slack/streaming_card.go
@@ -11,62 +11,77 @@ import (
 	"github.com/slack-go/slack"
 )
 
-// cardUpdateMinInterval coalesces chat.update calls for the streaming card so we
-// stay within Slack's rate limits. The engine pushes an update per agent event;
-// we flush at most once per interval and always flush on Finalize.
-const cardUpdateMinInterval = 1200 * time.Millisecond
+// cardUpdateMinInterval coalesces chat.update calls for the streaming card.
+// Slack recommends updating a streamed message at most once every ~3s; faster
+// risks chat.update rate limits.
+const cardUpdateMinInterval = 3 * time.Second
 
 // slackStreamingCard aggregates one agent turn (thinking + tool steps + answer)
 // into a single Slack message that updates in place — the cc-connect equivalent
-// of DingTalk's AI Card. Implements core.StreamingCard.
+// of DingTalk's AI Card. The message is posted LAZILY on the first non-empty
+// content, so the native "is thinking…" status (set in StartTyping) stays
+// visible until the bot actually has something to show. Implements
+// core.StreamingCard.
 type slackStreamingCard struct {
-	client  *slack.Client
-	channel string
-	ts      string
+	client   *slack.Client
+	channel  string
+	threadTS string
 
 	mu         sync.Mutex
+	ts         string // empty until the first post
 	failed     bool
 	lastUpdate time.Time
 	lastSent   string
 }
 
-// CreateStreamingCard posts the initial card message (threaded like a normal
-// reply) and returns it. Implements core.StreamingCardPlatform: when present,
-// the engine routes the whole turn through this card and skips the plain
-// streaming preview (they are mutually exclusive, so no double-post).
+// CreateStreamingCard prepares a lazy streaming card; the Slack message is not
+// posted until the first content arrives. Implements core.StreamingCardPlatform
+// — when present, the engine routes the whole turn through this card and skips
+// the plain streaming preview (mutually exclusive, so no double-post).
 func (p *Platform) CreateStreamingCard(ctx context.Context, rctx any) (core.StreamingCard, error) {
 	rc, ok := rctx.(replyContext)
 	if !ok {
 		return nil, fmt.Errorf("slack: invalid reply context type %T", rctx)
 	}
-	opts := []slack.MsgOption{slack.MsgOptionText("…", false)}
-	if rc.timestamp != "" {
-		opts = append(opts, slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{ThreadTimestamp: rc.timestamp}))
-	}
-	_, ts, err := p.client.PostMessageContext(ctx, rc.channel, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("slack: create streaming card: %w", err)
-	}
-	return &slackStreamingCard{client: p.client, channel: rc.channel, ts: ts}, nil
+	return &slackStreamingCard{client: p.client, channel: rc.channel, threadTS: rc.timestamp}, nil
 }
 
-// Update edits the card with the latest aggregated content, throttled. Transient
-// update errors are swallowed (a later Update / Finalize retries) so a blip
-// doesn't abort the turn; the engine still gets the final content via Finalize.
+// render posts the card on first use, then edits it in place thereafter.
+// Caller must hold c.mu.
+func (c *slackStreamingCard) render(ctx context.Context, rendered string) error {
+	if c.ts == "" {
+		opts := []slack.MsgOption{slack.MsgOptionText(rendered, false)}
+		if c.threadTS != "" {
+			opts = append(opts, slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{ThreadTimestamp: c.threadTS}))
+		}
+		_, ts, err := c.client.PostMessageContext(ctx, c.channel, opts...)
+		if err != nil {
+			return err
+		}
+		c.ts = ts
+		return nil
+	}
+	_, _, _, err := c.client.UpdateMessageContext(ctx, c.channel, c.ts, slack.MsgOptionText(rendered, false))
+	return err
+}
+
+// Update renders the latest aggregated content. The first post is immediate;
+// subsequent edits are coalesced to ~cardUpdateMinInterval. Transient errors are
+// swallowed (Finalize retries) so a blip doesn't abort the turn.
 func (c *slackStreamingCard) Update(ctx context.Context, content string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.failed || content == "" {
 		return nil
 	}
-	if time.Since(c.lastUpdate) < cardUpdateMinInterval {
+	if c.ts != "" && time.Since(c.lastUpdate) < cardUpdateMinInterval {
 		return nil
 	}
 	rendered := core.MarkdownToSlackMrkdwn(content)
 	if rendered == "" || rendered == c.lastSent {
 		return nil
 	}
-	if _, _, _, err := c.client.UpdateMessageContext(ctx, c.channel, c.ts, slack.MsgOptionText(rendered, false)); err != nil {
+	if err := c.render(ctx, rendered); err != nil {
 		return nil
 	}
 	c.lastUpdate = time.Now()
@@ -74,9 +89,9 @@ func (c *slackStreamingCard) Update(ctx context.Context, content string) error {
 	return nil
 }
 
-// Finalize writes the final content unconditionally (no throttle). On error it
-// marks the card failed and returns the error so the engine falls back to a
-// normal message.
+// Finalize writes the final content unconditionally (no throttle); it posts the
+// card if it was never posted. On error it marks the card failed and returns the
+// error so the engine falls back to a normal message.
 func (c *slackStreamingCard) Finalize(ctx context.Context, content string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -87,7 +102,7 @@ func (c *slackStreamingCard) Finalize(ctx context.Context, content string) error
 	if rendered == "" || rendered == c.lastSent {
 		return nil
 	}
-	if _, _, _, err := c.client.UpdateMessageContext(ctx, c.channel, c.ts, slack.MsgOptionText(rendered, false)); err != nil {
+	if err := c.render(ctx, rendered); err != nil {
 		c.failed = true
 		return fmt.Errorf("slack: finalize streaming card: %w", err)
 	}


### PR DESCRIPTION
## Problem

Slack is the only major platform that doesn't implement cc-connect's streaming-preview interfaces — `discord`, `feishu`, `telegram`, and `max` all do. So Slack replies arrive as a single message at the end of the turn, with no live "typing it out" feedback, even though the engine (`core/streaming.go`) and the `claudecode` agent (which already emits `EventText`/`EventThinking`/`EventToolUse`) are fully wired for it.

## What this adds

The two interfaces the engine needs, implemented for Slack in `platform/slack/streaming.go`:

- **`SendPreviewStart`** (`core.PreviewStarter`): posts the initial preview message — threaded exactly like a normal reply — and returns a `{channel, ts}` handle.
- **`UpdateMessage`** (`core.MessageUpdater`): edits that message in place via `chat.update` as the engine streams new content.

That's the same minimal pair `telegram` implements.

## Notes

- **No config needed** — `DefaultStreamPreviewCfg()` has `Enabled: true`; implementing the interfaces is sufficient to light it up. DMs and channels both benefit.
- **Rate limits** — the engine throttles edits (default 1500ms / 30 chars), keeping well within Slack's `chat.update` limits.
- **Footer preserved** — when no `StatusFooterUpdater` is implemented, the engine appends the per-turn status footer inline at finish, so the existing reply footer still shows.
- **No double-post** — the engine finalizes via the preview (`sp.finish()` → `UpdateMessage`) and only falls back to `Send` when the preview is inactive/failed (`core/engine.go` `else if sp.finish(...)`), so exactly one message is produced.

Optional follow-ups (not in this PR): `SetPreviewStatus` (`PreviewStatusUpdater`) for a thinking/working/done header, and token-level deltas via `--include-partial-messages` on the Claude Code spawn (currently the preview updates per completed text block).
