### PR TITLE
feat(config): optional host bind address for bridge & management servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New Features
 - **`cc-connect cron add --silent`**: expose the `--silent` flag on the cron add CLI so users can suppress the cron start notification when creating a job. The server already accepted `silent` on `/cron/add`; only the CLI side was missing (#858).
 - **QQ Bot inline keyboard**: add support for inline keyboard buttons and INTERACTION_CREATE events. Permission requests now render as clickable buttons instead of text replies. Requires enabling the INTERACTION capability (bit 26) in the QQ Open Platform bot settings.
+- **`host` bind address**: new optional `host` field for `[bridge]` and `[management]` — bind the HTTP servers to a specific address (e.g. `127.0.0.1` or `::1`) instead of all interfaces. Empty (default) preserves the previous all-interfaces behavior. Useful when running behind a same-host reverse proxy (#1334).
 
 ### ⚠️ QQ Bot Intent Configuration Change
 The default intents for QQ Bot now include `INTERACTION_CREATE` (bit 26, value `1<<26`). If you previously set a custom `intents` value without this bit, inline keyboard buttons will not work — update your `intents` to include bit 26. If you use the default intents, no action is needed. See `config.example.toml` for the new `intents` option.

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -979,6 +979,7 @@ func main() {
 			slog.Error("bridge: failed to create server - token is required (or set insecure=true for local dev)")
 			os.Exit(1)
 		}
+		bridgeSrv.SetHost(cfg.Bridge.Host)
 		for i, e := range engines {
 			bp := bridgeSrv.NewPlatform(cfg.Projects[i].Name)
 			bridgeSrv.RegisterEngine(cfg.Projects[i].Name, e, bp)
@@ -1013,6 +1014,7 @@ func main() {
 			port = 9820
 		}
 		mgmtSrv = core.NewManagementServer(port, cfg.Management.Token, cfg.Management.CORSOrigins)
+		mgmtSrv.SetHost(cfg.Management.Host)
 		for i, e := range engines {
 			mgmtSrv.RegisterEngine(cfg.Projects[i].Name, e)
 		}

--- a/config.example.toml
+++ b/config.example.toml
@@ -351,6 +351,7 @@ level = "info" # debug, info, warn, error
 # [bridge]
 # enabled = true
 # port = 9810                         # WebSocket listen port (default: 9810) / 监听端口
+# host = "127.0.0.1"                  # Bind address; empty = all interfaces (default). Use "127.0.0.1" or "::1" to restrict to loopback when behind a reverse proxy / 绑定地址；留空=所有网卡（默认）。置于反向代理之后时可设为 "127.0.0.1" 或 "::1" 只监听本机
 # token = "your-bridge-secret"        # Auth token (required) / 认证密钥（必填）
 # path = "/bridge/ws"                 # URL path (default: "/bridge/ws") / URL 路径
 
@@ -366,6 +367,7 @@ level = "info" # debug, info, warn, error
 # [management]
 # enabled = true
 # port = 9820                           # HTTP listen port (default: 9820) / 监听端口
+# host = "127.0.0.1"                    # Bind address; empty = all interfaces (default). Use "127.0.0.1" or "::1" to restrict to loopback when behind a reverse proxy / 绑定地址；留空=所有网卡（默认）。置于反向代理之后时可设为 "127.0.0.1" 或 "::1" 只监听本机
 # token = "your-mgmt-secret"            # Auth token (required) / 认证密钥（必填）
 # cors_origins = ["http://localhost:3000"]  # Allowed CORS origins / 允许的 CORS 来源
 

--- a/config/config.go
+++ b/config/config.go
@@ -153,6 +153,7 @@ type WebhookConfig struct {
 type BridgeConfig struct {
 	Enabled     *bool    `toml:"enabled"`                // default false
 	Port        int      `toml:"port,omitempty"`         // listen port; default 9810
+	Host        string   `toml:"host,omitempty"`         // bind address; empty = all interfaces (e.g. "127.0.0.1" or "::1" to restrict to loopback)
 	Token       string   `toml:"token,omitempty"`        // shared secret for authentication; required unless insecure=true
 	Path        string   `toml:"path,omitempty"`         // URL path; default "/bridge/ws"
 	CORSOrigins []string `toml:"cors_origins,omitempty"` // allowed CORS origins; empty = no CORS
@@ -173,6 +174,7 @@ type HookConfig struct {
 type ManagementConfig struct {
 	Enabled     *bool    `toml:"enabled"`                // default false
 	Port        int      `toml:"port,omitempty"`         // listen port; default 9820
+	Host        string   `toml:"host,omitempty"`         // bind address; empty = all interfaces (e.g. "127.0.0.1" or "::1" to restrict to loopback)
 	Token       string   `toml:"token,omitempty"`        // shared secret for authentication; required
 	CORSOrigins []string `toml:"cors_origins,omitempty"` // allowed CORS origins; empty = no CORS
 }

--- a/core/bridge.go
+++ b/core/bridge.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -25,6 +26,7 @@ import (
 // lightweight BridgePlatform handle that delegates to this server.
 type BridgeServer struct {
 	port        int
+	host        string // bind address; empty = all interfaces
 	token       string
 	path        string
 	corsOrigins []string
@@ -194,6 +196,13 @@ func newBridgeServer(port int, token, path string, corsOrigins []string, insecur
 	}
 }
 
+// SetHost sets the bind address for the server. An empty string (the default)
+// binds to all interfaces, preserving the previous behavior. Must be called
+// before Start.
+func (bs *BridgeServer) SetHost(host string) {
+	bs.host = host
+}
+
 // NewPlatform creates a BridgePlatform for a specific project engine.
 func (bs *BridgeServer) NewPlatform(projectName string) *BridgePlatform {
 	return &BridgePlatform{server: bs, project: projectName}
@@ -219,7 +228,7 @@ func (bs *BridgeServer) Start() {
 	mux.HandleFunc("/bridge/sessions", bs.corsHTTP(bs.authHTTP(bs.handleSessions)))
 	mux.HandleFunc("/bridge/sessions/", bs.corsHTTP(bs.authHTTP(bs.handleSessionRoutes)))
 
-	addr := fmt.Sprintf(":%d", bs.port)
+	addr := net.JoinHostPort(bs.host, strconv.Itoa(bs.port))
 	bs.server = &http.Server{Addr: addr, Handler: mux}
 
 	go func() {

--- a/core/management.go
+++ b/core/management.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -36,6 +37,7 @@ type ProjectSettingsUpdate struct {
 // (web dashboards, TUI clients, GUI desktop apps, Mac tray apps, etc.).
 type ManagementServer struct {
 	port        int
+	host        string // bind address; empty = all interfaces
 	token       string
 	corsOrigins []string
 	server      *http.Server
@@ -81,6 +83,13 @@ func NewManagementServer(port int, token string, corsOrigins []string) *Manageme
 		engines:     make(map[string]*Engine),
 		startedAt:   time.Now(),
 	}
+}
+
+// SetHost sets the bind address for the server. An empty string (the default)
+// binds to all interfaces, preserving the previous behavior. Must be called
+// before Start.
+func (m *ManagementServer) SetHost(host string) {
+	m.host = host
 }
 
 func (m *ManagementServer) RegisterEngine(name string, e *Engine) {
@@ -200,7 +209,7 @@ func (m *ManagementServer) Start() {
 	handler := m.buildHandler(mux)
 
 	m.server = &http.Server{
-		Addr:    fmt.Sprintf(":%d", m.port),
+		Addr:    net.JoinHostPort(m.host, strconv.Itoa(m.port)),
 		Handler: handler,
 	}
 	go func() {

--- a/docs/bridge-protocol.md
+++ b/docs/bridge-protocol.md
@@ -55,9 +55,12 @@ The port and path are configured in `config.toml`:
 [bridge]
 enabled = true
 port = 9810
+host = "127.0.0.1"        # optional; empty = all interfaces. Set "127.0.0.1"/"::1" to restrict to loopback
 path = "/bridge/ws"       # optional, default "/bridge/ws"
 token = "your-secret"     # required for authentication
 ```
+
+`host` defaults to all interfaces (binding both IPv4 and IPv6 wildcard) for backward compatibility. When the bridge is only consumed by adapters on the same machine, set `host = "127.0.0.1"` (or `"::1"`) so the port is not reachable from other hosts.
 
 ### Authentication
 

--- a/docs/bridge-protocol.zh-CN.md
+++ b/docs/bridge-protocol.zh-CN.md
@@ -55,9 +55,12 @@ ws://<host>:<port>/bridge/ws
 [bridge]
 enabled = true
 port = 9810
+host = "127.0.0.1"        # 可选；留空监听所有网卡。设为 "127.0.0.1"/"::1" 可仅监听本机回环
 path = "/bridge/ws"       # 可选，默认 "/bridge/ws"
 token = "your-secret"     # 认证密钥，必填
 ```
+
+为保持向后兼容，`host` 默认监听所有网卡（同时绑定 IPv4 与 IPv6 通配地址）。当 Bridge 仅供本机适配器使用时，建议设为 `host = "127.0.0.1"`（或 `"::1"`），使该端口不被其他主机访问。
 
 ### 认证
 

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -57,6 +57,7 @@ Add the following to `config.toml`:
 [management]
 enabled = true
 port = 9820
+host = "127.0.0.1"
 token = "mgmt-secret"
 ```
 
@@ -64,9 +65,12 @@ token = "mgmt-secret"
 |----------|---------|-----------|--------------------------------------------------|
 | `enabled`| boolean | `false`   | Enable the Management API server                 |
 | `port`   | integer | `9820`    | TCP port to listen on                            |
+| `host`   | string  | `""`      | Bind address; empty binds all interfaces. Set `"127.0.0.1"` or `"::1"` to restrict to loopback |
 | `token`  | string  | (required)| Shared secret for authentication                 |
 
 When `enabled` is `false`, the Management API is not started. The token should be a strong, random string (e.g. 32+ characters).
+
+`host` defaults to all interfaces for backward compatibility. When cc-connect runs behind a reverse proxy on the same machine, set `host = "127.0.0.1"` (or `"::1"`) so the API is not reachable from other hosts even if a firewall rule is missing. Note that an empty `host` binds both IPv4 and IPv6 wildcard addresses.
 
 ### 2.2 Base URL
 

--- a/docs/management-api.zh-CN.md
+++ b/docs/management-api.zh-CN.md
@@ -57,6 +57,7 @@ cc-connect 管理 API 是基于 HTTP 的 REST API，供外部应用（Web 控制
 [management]
 enabled = true
 port = 9820
+host = "127.0.0.1"
 token = "mgmt-secret"
 ```
 
@@ -64,9 +65,12 @@ token = "mgmt-secret"
 |------------|---------|----------|-------------------------------------------|
 | `enabled`  | boolean | `false`  | 是否启用管理 API 服务                     |
 | `port`     | integer | `9820`   | 监听 TCP 端口                             |
+| `host`     | string  | `""`     | 绑定地址；留空监听所有网卡。设为 `"127.0.0.1"` 或 `"::1"` 可仅监听本机回环 |
 | `token`    | string  | (必填)   | 认证用共享密钥                            |
 
 当 `enabled` 为 `false` 时，管理 API 不会启动。令牌应为强随机字符串（建议 32 字符以上）。
+
+为保持向后兼容，`host` 默认监听所有网卡。当 cc-connect 与反向代理部署在同一台机器上时，建议设为 `host = "127.0.0.1"`（或 `"::1"`），这样即使防火墙规则缺失，该 API 也不会被其他主机访问到。注意：`host` 留空会同时绑定 IPv4 与 IPv6 通配地址。
 
 ### 2.2 基础 URL
 


### PR DESCRIPTION
Closes #1334.

## What

Adds an optional `host` field to the `[bridge]` and `[management]` config sections so the two built-in HTTP servers can bind to a specific address instead of always listening on all interfaces.

```toml
[bridge]
host = "127.0.0.1"   # optional; "" (default) = all interfaces

[management]
host = "::1"         # optional; "" (default) = all interfaces
```

## Why

Both servers listened on `:port`, which binds the IPv4 **and** IPv6 wildcard. On a single-host deployment behind a reverse proxy (Caddy/Nginx on the same box), these token-bearing, session-controlling endpoints never need to be reachable off-host — but today the only way to keep them private is external firewalling, and the IPv6 side is easy to forget. Binding to loopback makes "private" a property of the process rather than of a firewall rule that can drift.

## How

- `config.BridgeConfig` / `config.ManagementConfig` gain `Host string` (`toml:"host,omitempty"`).
- `BridgeServer` / `ManagementServer` gain a `host` field, set via a `SetHost` setter and wired in `cmd/cc-connect/main.go`. **Constructor signatures are unchanged**, so no existing call sites or tests are touched.
- The listen address is built with `net.JoinHostPort(host, strconv.Itoa(port))` rather than `fmt.Sprintf`.

## Notes on your three questions

1. **Validation** — agreed, trust Go's `net` package; no custom validator added.
2. **IPv6 loopback** — `"::1"` works out of the box. One correction to the approach: I used `net.JoinHostPort` instead of `fmt.Sprintf("%s:%d", host, port)`, because the `Sprintf` form produces `::1:9820` for an IPv6 host, which `net.Listen` cannot parse. `JoinHostPort` brackets it correctly → `[::1]:9820`, and `JoinHostPort("", port)` still yields `:port`, identical to the previous behavior — so the default path is unchanged.
3. **Docs** — handled in this same PR: `config.example.toml` plus `docs/management-api.md`, `docs/bridge-protocol.md` and their `.zh-CN` counterparts.

## Backward compatibility

Empty `host` (the default and the zero value) reproduces the old `:port` behavior exactly, including for any construction path that never calls `SetHost`.

## Testing

Manual reasoning + diff review only — I don't have a Go toolchain on the machine I drafted this on, so I have **not** run `go build`/`go test`/`gofmt` locally. The change is small and mechanical; please run CI/gofmt on your side, and I'm happy to amend for any formatting nits.
