### PR TITLE
fix(agents): replace bufio.Scanner with core.ReadLineLoop to fix "token too long" on large single-line output (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Fixed
+- **Agent bridge "bufio.Scanner: token too long"**: when an agent subprocess emitted a single newline-delimited line larger than the scanner buffer (e.g. a multi-MB MCP tool result), the bridge aborted the session with `bufio.ErrTooLong`. All line-oriented agent adapters (claudecode, codex app-server, cursor, gemini, kimi, opencode, pi, qoder) now read stdout via the shared `core.ReadLineLoop` helper, which uses `bufio.Reader.ReadBytes('\n')` with a 10MB cap. Lines over the cap are logged and dropped instead of killing the loop, so subsequent valid lines still reach the engine (#189).
+
 ### New Features
 - **`cc-connect cron add --silent`**: expose the `--silent` flag on the cron add CLI so users can suppress the cron start notification when creating a job. The server already accepted `silent` on `/cron/add`; only the CLI side was missing (#858).
 - **QQ Bot inline keyboard**: add support for inline keyboard buttons and INTERACTION_CREATE events. Permission requests now render as clickable buttons instead of text replies. Requires enabling the INTERACTION capability (bit 26) in the QQ Open Platform bot settings.

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -1,7 +1,6 @@
 package claudecode
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -280,13 +279,12 @@ func (cs *claudeSession) readLoop(stdout io.ReadCloser, stderrBuf *bytes.Buffer)
 	waitErrCh, waitDone := cs.startReadLoopWait(stdout)
 	defer cs.finishReadLoop(waitErrCh, stderrBuf)
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-	for scanner.Scan() {
-		cs.handleReadLoopLine(scanner.Text())
-	}
+	err := core.ReadLineLoop(stdout, func(line []byte) error {
+		cs.handleReadLoopLine(string(line))
+		return nil
+	})
 
-	cs.handleReadLoopScanErr(scanner.Err(), waitDone)
+	cs.handleReadLoopScanErr(err, waitDone)
 }
 
 func (cs *claudeSession) startReadLoopWait(stdout io.ReadCloser) (<-chan error, <-chan struct{}) {
@@ -359,7 +357,7 @@ func (cs *claudeSession) handleReadLoopScanErr(err error, waitDone <-chan struct
 	default:
 	}
 
-	slog.Error("claudeSession: scanner error", "error", err)
+	slog.Error("claudeSession: readLoop error", "error", err)
 	evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
 	select {
 	case cs.events <- evt:
@@ -941,8 +939,8 @@ func (cs *claudeSession) Close() error {
 	// descendants (e.g. MCP server bridges) a second chance to run cleanup
 	// handlers that respond to signals but not stdin EOF.
 	if err := signalProcessGroup(cs.cmd, syscall.SIGTERM); err != nil {
-			slog.Warn("claudeSession: signal SIGTERM", "error", err)
-		}
+		slog.Warn("claudeSession: signal SIGTERM", "error", err)
+	}
 
 	select {
 	case <-cs.done:

--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -1,7 +1,6 @@
 package codex
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -959,24 +958,17 @@ func (s *appServerSession) Close() error {
 
 func (s *appServerSession) readLoop(r io.Reader) {
 	defer s.wg.Done()
-	scanner := bufio.NewScanner(r)
-	scanBuf := make([]byte, 0, 64*1024)
-	const maxLineSize = 10 * 1024 * 1024 // 10MB
-	scanner.Buffer(scanBuf, maxLineSize)
-
-	for scanner.Scan() {
+	err := core.ReadLineLoop(r, func(data []byte) error {
 		select {
 		case <-s.ctx.Done():
-			return
+			return io.EOF
 		default:
 		}
-
-		data := scanner.Bytes()
 
 		var probe map[string]json.RawMessage
 		if err := json.Unmarshal(data, &probe); err != nil {
 			slog.Debug("codex app-server: invalid JSON", "error", err)
-			continue
+			return nil
 		}
 
 		_, hasID := probe["id"]
@@ -988,7 +980,7 @@ func (s *appServerSession) readLoop(r io.Reader) {
 			var resp rpcResponseEnvelope
 			if err := json.Unmarshal(data, &resp); err != nil {
 				slog.Debug("codex app-server: bad response envelope", "error", err)
-				continue
+				return nil
 			}
 			s.handleResponse(resp)
 
@@ -1001,21 +993,17 @@ func (s *appServerSession) readLoop(r io.Reader) {
 			var notif rpcNotificationEnvelope
 			if err := json.Unmarshal(data, &notif); err != nil {
 				slog.Debug("codex app-server: bad notification envelope", "error", err)
-				continue
+				return nil
 			}
 			s.handleNotification(notif.Method, notif.Params)
 		}
-	}
+		return nil
+	})
 
-	err := scanner.Err()
 	if err != nil {
 		if s.ctx.Err() == nil && !errors.Is(err, io.EOF) {
 			slog.Warn("codex app-server read failed", "error", err)
-			if errors.Is(err, bufio.ErrTooLong) {
-				s.emitError(fmt.Errorf("codex app-server line exceeds max size (%d bytes): %w", maxLineSize, err))
-			} else {
-				s.emitError(fmt.Errorf("codex app-server connection closed: %w", err))
-			}
+			s.emitError(fmt.Errorf("codex app-server connection closed: %w", err))
 		}
 		s.alive.Store(false)
 		s.rejectPending(err)
@@ -1030,17 +1018,15 @@ func (s *appServerSession) readLoop(r io.Reader) {
 
 func (s *appServerSession) stderrLoop(r io.Reader) {
 	defer s.wg.Done()
-	scanner := bufio.NewScanner(r)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+	err := core.ReadLineLoopWithLimit(r, 1024*1024, func(data []byte) error {
+		line := strings.TrimSpace(string(data))
 		if line == "" {
-			continue
+			return nil
 		}
 		slog.Debug("codex app-server stderr", "line", line)
-	}
-	if err := scanner.Err(); err != nil && s.ctx.Err() == nil {
+		return nil
+	})
+	if err != nil && s.ctx.Err() == nil {
 		slog.Debug("codex app-server stderr read failed", "error", err)
 	}
 }

--- a/agent/cursor/session.go
+++ b/agent/cursor/session.go
@@ -1,7 +1,6 @@
 package cursor
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -38,8 +37,8 @@ type cursorSession struct {
 
 	// Permission handling: each Send() creates a new process whose stdin is used
 	// to respond to interaction_query permission requests.
-	stdinMu  sync.Mutex
-	stdin    io.WriteCloser // current process stdin; nil when no process is running
+	stdinMu sync.Mutex
+	stdin   io.WriteCloser // current process stdin; nil when no process is running
 
 	pendingMu sync.Mutex
 	pending   *pendingInteractionQuery // most recent unresolved interaction_query/request
@@ -176,28 +175,21 @@ func (cs *cursorSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf
 		}
 	}()
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
-		slog.Debug("cursorSession: raw", "line", truncateStr(line, 500))
+	err := core.ReadLineLoop(stdout, func(line []byte) error {
+		slog.Debug("cursorSession: raw", "line", truncateStr(string(line), 500))
 
 		var raw map[string]any
-		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			slog.Debug("cursorSession: non-JSON line", "line", line)
-			continue
+		if err := json.Unmarshal(line, &raw); err != nil {
+			slog.Debug("cursorSession: non-JSON line", "line", string(line))
+			return nil
 		}
 
 		cs.handleEvent(raw)
-	}
+		return nil
+	})
 
-	if err := scanner.Err(); err != nil {
-		slog.Error("cursorSession: scanner error", "error", err)
+	if err != nil {
+		slog.Error("cursorSession: readLoop error", "error", err)
 		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
 		select {
 		case cs.events <- evt:

--- a/agent/gemini/session.go
+++ b/agent/gemini/session.go
@@ -1,7 +1,6 @@
 package gemini
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -229,28 +228,21 @@ func (gs *geminiSession) readLoop(ctx context.Context, cmd *exec.Cmd, stdout io.
 		stdout.Close()
 	}()
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
-		slog.Debug("geminiSession: raw", "line", truncate(line, 500))
+	err := core.ReadLineLoop(stdout, func(line []byte) error {
+		slog.Debug("geminiSession: raw", "line", truncate(string(line), 500))
 
 		var raw map[string]any
-		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			slog.Debug("geminiSession: non-JSON line", "line", line)
-			continue
+		if err := json.Unmarshal(line, &raw); err != nil {
+			slog.Debug("geminiSession: non-JSON line", "line", string(line))
+			return nil
 		}
 
 		gs.handleEvent(raw)
-	}
+		return nil
+	})
 
-	if err := scanner.Err(); err != nil {
-		slog.Error("geminiSession: scanner error", "error", err)
+	if err != nil {
+		slog.Error("geminiSession: readLoop error", "error", err)
 		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
 		select {
 		case gs.events <- evt:

--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -1,7 +1,6 @@
 package kimi
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -207,36 +206,27 @@ func (ks *kimiSession) readLoop(ctx context.Context, cmd *exec.Cmd, stdout io.Re
 		stdout.Close()
 	}()
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
-	var scanErr error
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
-		slog.Debug("kimiSession: raw", "line", truncate(line, 500))
+	scanErr := core.ReadLineLoop(stdout, func(line []byte) error {
+		slog.Debug("kimiSession: raw", "line", truncate(string(line), 500))
 
 		// Kimi prints a non-JSON line at the end: "To resume this session: kimi -r <id>"
-		if strings.HasPrefix(line, "To resume this session:") {
-			if id := extractResumeSessionID(line); id != "" {
+		if bytes.HasPrefix(line, []byte("To resume this session:")) {
+			if id := extractResumeSessionID(string(line)); id != "" {
 				ks.sessionID.Store(id)
 				slog.Debug("kimiSession: session id updated", "session_id", id)
 			}
-			continue
+			return nil
 		}
 
 		var raw map[string]any
-		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			slog.Debug("kimiSession: non-JSON line", "line", line)
-			continue
+		if err := json.Unmarshal(line, &raw); err != nil {
+			slog.Debug("kimiSession: non-JSON line", "line", string(line))
+			return nil
 		}
 
 		ks.handleEvent(raw)
-	}
-	scanErr = scanner.Err()
+		return nil
+	})
 
 	// Wait for process exit before sending any terminal event so the engine
 	// never sees EventError after EventResult from the same turn.
@@ -256,7 +246,7 @@ func (ks *kimiSession) readLoop(ctx context.Context, cmd *exec.Cmd, stdout io.Re
 	}
 
 	if scanErr != nil {
-		slog.Error("kimiSession: scanner error", "error", scanErr)
+		slog.Error("kimiSession: readLoop error", "error", scanErr)
 		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", scanErr)}
 		select {
 		case ks.events <- evt:

--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -1,7 +1,6 @@
 package opencode
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -193,26 +192,19 @@ func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBu
 	defer s.wg.Done()
 	defer func() { _ = cmd.Wait() }()
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
+	err := core.ReadLineLoop(stdout, func(line []byte) error {
 		var raw map[string]any
-		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			slog.Debug("opencodeSession: non-JSON line", "line", line)
-			continue
+		if err := json.Unmarshal(line, &raw); err != nil {
+			slog.Debug("opencodeSession: non-JSON line", "line", string(line))
+			return nil
 		}
 
 		s.handleEvent(raw)
-	}
+		return nil
+	})
 
-	if err := scanner.Err(); err != nil {
-		slog.Error("opencodeSession: scanner error", "error", err)
+	if err != nil {
+		slog.Error("opencodeSession: readLoop error", "error", err)
 		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
 		select {
 		case s.events <- evt:

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -1,7 +1,6 @@
 package pi
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -168,29 +167,19 @@ func (s *piSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *byt
 		}
 	}()
 
-	// Pi's JSON events are small (typically <1KB each). A 10MB Scanner buffer
-	// is more than sufficient — no need for the bufio.Reader approach used by
-	// adapters that may receive very large single-line responses.
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
+	err := core.ReadLineLoop(stdout, func(line []byte) error {
 		var raw map[string]any
-		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			slog.Debug("piSession: non-JSON line", "line", truncStr(line, 100))
-			continue
+		if err := json.Unmarshal(line, &raw); err != nil {
+			slog.Debug("piSession: non-JSON line", "line", truncStr(string(line), 100))
+			return nil
 		}
 
 		s.handleEvent(raw)
-	}
+		return nil
+	})
 
-	if err := scanner.Err(); err != nil {
-		slog.Error("piSession: scanner error", "error", err)
+	if err != nil {
+		slog.Error("piSession: readLoop error", "error", err)
 		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
 		select {
 		case s.events <- evt:

--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -1,7 +1,6 @@
 package qoder
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -131,29 +130,20 @@ func (qs *qoderSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf 
 	var gotResult bool
 	var nonJSONLines []string
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
+	scanErr := core.ReadLineLoop(stdout, func(line []byte) error {
 		var raw streamEvent
-		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			slog.Debug("qoderSession: non-JSON line", "line", truncStr(line, 100))
-			nonJSONLines = append(nonJSONLines, line)
-			continue
+		if err := json.Unmarshal(line, &raw); err != nil {
+			slog.Debug("qoderSession: non-JSON line", "line", truncStr(string(line), 100))
+			nonJSONLines = append(nonJSONLines, string(line))
+			return nil
 		}
 
 		if raw.Type == "result" {
 			gotResult = true
 		}
 		qs.handleEvent(&raw)
-	}
-
-	scanErr := scanner.Err()
+		return nil
+	})
 	if scanErr != nil {
 		slog.Error("qoderSession: scanner error", "error", scanErr)
 	}

--- a/core/agent_shared.go
+++ b/core/agent_shared.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+)
+
+// DefaultMaxLineSize is the default cap on a single line read by ReadLineLoop.
+// Lines longer than this are logged and dropped, preventing the read loop from
+// crashing on malformed or unexpectedly large input (MCP tool results, paste
+// payloads, etc.).
+const DefaultMaxLineSize = 10 * 1024 * 1024 // 10MB
+
+// ReadLineLoop reads newline-delimited lines from r, invoking handle for each
+// non-empty line. Lines longer than DefaultMaxLineSize are dropped with an
+// error log so the loop can keep reading subsequent lines. The handle callback
+// receives the line bytes with any trailing \r\n stripped.
+//
+// ReadLineLoop is the replacement for the bufio.Scanner pattern previously
+// used by agent adapters. bufio.Scanner terminates the read loop on overflow
+// (err = bufio.ErrTooLong), which kills the session; this helper logs and
+// continues so a single oversized line does not abort the bridge.
+//
+// Returns nil on clean EOF, the underlying reader error (non-EOF), or any
+// error returned by handle.
+func ReadLineLoop(r io.Reader, handle func(line []byte) error) error {
+	return ReadLineLoopWithLimit(r, DefaultMaxLineSize, handle)
+}
+
+// ReadLineLoopWithLimit is ReadLineLoop with a caller-specified max line size.
+// maxLineSize <= 0 falls back to DefaultMaxLineSize.
+func ReadLineLoopWithLimit(r io.Reader, maxLineSize int, handle func(line []byte) error) error {
+	if maxLineSize <= 0 {
+		maxLineSize = DefaultMaxLineSize
+	}
+	reader := bufio.NewReader(r)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			if len(line) > maxLineSize {
+				slog.Error("ReadLineLoop: line exceeds max size, dropping",
+					"size", len(line), "max", maxLineSize)
+				// bufio.Reader.ReadBytes keeps reading until the next '\n'
+				// or EOF, so the next iteration resumes after this oversized
+				// line and processes whatever valid data follows.
+			} else {
+				trimmed := bytes.TrimRight(line, "\r\n")
+				if len(trimmed) > 0 {
+					if herr := handle(trimmed); herr != nil {
+						return herr
+					}
+				}
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}

--- a/core/agent_shared_test.go
+++ b/core/agent_shared_test.go
@@ -1,0 +1,296 @@
+package core
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadLineLoop_BasicLines(t *testing.T) {
+	var got []string
+	err := ReadLineLoop(strings.NewReader("a\nb\nc\n"), func(line []byte) error {
+		got = append(got, string(line))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadLineLoop_StripsCRLF(t *testing.T) {
+	var got []string
+	err := ReadLineLoop(strings.NewReader("hello\r\nworld\r\n"), func(line []byte) error {
+		got = append(got, string(line))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0] != "hello" || got[1] != "world" {
+		t.Fatalf("CRLF not stripped: %q", got)
+	}
+}
+
+func TestReadLineLoop_SkipsEmptyLines(t *testing.T) {
+	var got []string
+	err := ReadLineLoop(strings.NewReader("\n\n\nfoo\n\nbar\n\n"), func(line []byte) error {
+		got = append(got, string(line))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0] != "foo" || got[1] != "bar" {
+		t.Fatalf("empty lines not skipped: %q", got)
+	}
+}
+
+func TestReadLineLoop_TrailingLineNoNewline(t *testing.T) {
+	var got []string
+	err := ReadLineLoop(strings.NewReader("a\nb\nc"), func(line []byte) error {
+		got = append(got, string(line))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadLineLoop_HandleError(t *testing.T) {
+	want := errors.New("boom")
+	err := ReadLineLoop(strings.NewReader("a\nb\nc\n"), func(line []byte) error {
+		if string(line) == "b" {
+			return want
+		}
+		return nil
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}
+
+func TestReadLineLoop_ReaderError(t *testing.T) {
+	r := &errReader{err: io.ErrUnexpectedEOF, after: 3}
+	err := ReadLineLoop(r, func(line []byte) error { return nil })
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("got %v, want %v", err, io.ErrUnexpectedEOF)
+	}
+}
+
+func TestReadLineLoop_Empty(t *testing.T) {
+	count := 0
+	err := ReadLineLoop(strings.NewReader(""), func(line []byte) error {
+		count++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("got %d lines, want 0", count)
+	}
+}
+
+// TestReadLineLoop_LargeJSONL exercises a 100KB single line plus a normal
+// line to confirm the reader doesn't drop or split data on large JSONL
+// payloads (the bug from issue #189 was bufio.Scanner terminating on
+// >64KB lines; this should now succeed cleanly).
+func TestReadLineLoop_LargeJSONL(t *testing.T) {
+	const big = 100 * 1024 // 100KB
+	prefix := `{"data":"`  // 9 chars
+	suffix := `"}`         // 2 chars
+	wantBig := len(prefix) + big + len(suffix)
+
+	payload := make([]byte, 0, wantBig+len(`{"data":"small"}\n`)+8)
+	payload = append(payload, prefix...)
+	payload = append(payload, bytes.Repeat([]byte("x"), big)...)
+	payload = append(payload, suffix...)
+	payload = append(payload, '\n')
+	payload = append(payload, `{"data":"small"}`...)
+	payload = append(payload, '\n')
+
+	var got [][]byte
+	err := ReadLineLoop(bytes.NewReader(payload), func(line []byte) error {
+		buf := make([]byte, len(line))
+		copy(buf, line)
+		got = append(got, buf)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d lines, want 2", len(got))
+	}
+	if len(got[0]) != wantBig {
+		t.Fatalf("line 0 size = %d, want %d", len(got[0]), wantBig)
+	}
+	if string(got[1]) != `{"data":"small"}` {
+		t.Fatalf("line 1 = %q, want %q", got[1], `{"data":"small"}`)
+	}
+}
+
+// TestReadLineLoop_OneMegabyteLine covers the boundary between typical
+// and large single-line payloads (e.g. one MCP tool result).
+func TestReadLineLoop_OneMegabyteLine(t *testing.T) {
+	const big = 1 * 1024 * 1024      // 1MB
+	prefix := `{"v":"`               // 6 chars
+	wantBig := len(prefix) + big + 1 // closing '"'
+
+	payload := append([]byte(prefix), bytes.Repeat([]byte("a"), big)...)
+	payload = append(payload, '"', '\n')
+
+	var got []byte
+	err := ReadLineLoop(bytes.NewReader(payload), func(line []byte) error {
+		got = append(got, line...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != wantBig {
+		t.Fatalf("got %d bytes, want %d", len(got), wantBig)
+	}
+}
+
+// TestReadLineLoop_TenMegabyteLine covers a single-line payload at the
+// default cap (10MB). The line should be passed through to handle without
+// being dropped.
+func TestReadLineLoop_TenMegabyteLine(t *testing.T) {
+	// Pick big so that the wrapped line fits exactly at the cap.
+	// Wrapper is `{"v":"` + <big bs> + `"` + `\n` = len(prefix)+big+2 bytes.
+	// After trimming the trailing `\n`, handle receives big+len(prefix)+1 bytes.
+	prefix := `{"v":"`
+	big := DefaultMaxLineSize - len(prefix) - 2
+
+	payload := append([]byte(prefix), bytes.Repeat([]byte("b"), big)...)
+	payload = append(payload, '"', '\n')
+
+	var got []byte
+	err := ReadLineLoop(bytes.NewReader(payload), func(line []byte) error {
+		got = append(got, line...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := big + len(prefix) + 1
+	if len(got) != want {
+		t.Fatalf("got %d bytes, want %d", len(got), want)
+	}
+}
+
+// TestReadLineLoop_OverflowLineDropped verifies that a line larger than
+// the cap is logged and dropped, while the next valid line is still
+// delivered to handle. This is the OOM-protection behavior.
+func TestReadLineLoop_OverflowLineDropped(t *testing.T) {
+	const cap = 1024
+	const huge = cap * 4
+	var payload bytes.Buffer
+	payload.WriteString(`{"v":"`)
+	payload.Write(bytes.Repeat([]byte("c"), huge))
+	payload.WriteString(`"}`)
+	payload.WriteByte('\n')
+	payload.WriteString(`{"v":"ok"}`)
+	payload.WriteByte('\n')
+
+	var got []string
+	err := ReadLineLoopWithLimit(&payload, cap, func(line []byte) error {
+		got = append(got, string(line))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != `{"v":"ok"}` {
+		t.Fatalf("got %v, want only [%q]", got, `{"v":"ok"}`)
+	}
+}
+
+// TestReadLineLoop_OverflowMidStreamDropsAndContinues stresses the
+// "drop and continue" contract: a 4x oversize line in the middle of a
+// stream must not abort later lines.
+func TestReadLineLoop_OverflowMidStreamDropsAndContinues(t *testing.T) {
+	const cap = 512
+	var payload bytes.Buffer
+	for i := 0; i < 5; i++ {
+		payload.WriteString(`"`)
+		payload.Write(bytes.Repeat([]byte("z"), cap*4))
+		payload.WriteString(`"`)
+		payload.WriteByte('\n')
+		payload.WriteString(`{"small":true}`)
+		payload.WriteByte('\n')
+	}
+
+	var smallCount int
+	err := ReadLineLoopWithLimit(&payload, cap, func(line []byte) error {
+		if string(line) == `{"small":true}` {
+			smallCount++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if smallCount != 5 {
+		t.Fatalf("got %d small lines, want 5", smallCount)
+	}
+}
+
+// TestReadLineLoopWithLimit_ZeroOrNegativeDefaults verifies that
+// maxLineSize <= 0 falls back to DefaultMaxLineSize.
+func TestReadLineLoopWithLimit_ZeroOrNegativeDefaults(t *testing.T) {
+	prefix := `{"v":"`
+	big := DefaultMaxLineSize - len(prefix) - 2
+
+	payload := append([]byte(prefix), bytes.Repeat([]byte("d"), big)...)
+	payload = append(payload, '"', '\n')
+
+	got := 0
+	err := ReadLineLoopWithLimit(bytes.NewReader(payload), 0, func(line []byte) error {
+		got = len(line)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := big + len(prefix) + 1
+	if got != want {
+		t.Fatalf("got %d bytes, want %d", got, want)
+	}
+}
+
+type errReader struct {
+	err   error
+	after int
+	n     int
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.n >= r.after {
+		return 0, r.err
+	}
+	n := copy(p, []byte("partial"))
+	r.n += n
+	return n, nil
+}


### PR DESCRIPTION
Fixes #189

## 问题
当 agent 子进程输出超过 64KB 的单行内容(单行 JSON / JSONL,如 MCP 工具大结果、粘贴大块文本)时,cc-connect 的 stdout 读循环会因为 `bufio.Scanner` 默认 64KB 上限而报 `bufio.ErrTooLong`,整个会话被打断。

## 方案
新增 `core.ReadLineLoop` / `core.ReadLineLoopWithLimit` 助手,基于 `bufio.Reader.ReadBytes('\n')` 读取,默认 10MB 上限。**超过上限的单行被记录 error 日志并丢弃**,后续有效行继续处理 — 与 `bufio.Scanner` 在 overflow 时终止 loop 的行为形成对比,后者会让整个会话崩溃。

## 改动
- `core/agent_shared.go`:新增 `ReadLineLoop` / `ReadLineLoopWithLimit`,`DefaultMaxLineSize = 10 * 1024 * 1024`
- `core/agent_shared_test.go`:13 个测试,覆盖基础行、CRLF 剥离、空行、无尾换行、100KB/1MB/10MB 单行、mid-stream overflow drop-and-continue、`<= 0` 限制回退默认值
- 迁移以下 adapter 的 stdout readLoop:`claudecode`、`codex/appserver_session.go`(stdout + stderr)、`cursor`、`gemini`、`kimi`、`opencode`、`pi`、`qoder`
- `codex/session.go` 现有的 `readJSONLines`(PR #127)按任务范围要求保持不动
- `CHANGELOG.md`:新增 ### Fixed 段

## 验证
- `go test ./core` 全部通过(43s,含新加的 13 个 ReadLineLoop 测试)
- `go test ./agent/{claudecode,codex,cursor,gemini,kimi,opencode,pi,qoder}` 全部通过
- `go vet ./core ./agent/...` 干净
- `gofmt` 干净

## 未覆盖风险
- `core.ReadLineLoop` 用 `bufio.Reader.ReadBytes`,遇到远超 10MB 的单行会先在内部 buffer 累积到该行结束,然后才丢弃。理论上一次 OOM 仍可能发生,但比 `bufio.Scanner` 不区分场景的硬崩溃更可控,且概率远低于「单行 >10MB」的合理输入范围。
- Antigravity (chunk-based)、acp/copilot(已用 bufio.Reader/LSP framing)、iflow(PTY)按设计保持不动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)