### PR TITLE
feat(codex): support custom system_prompt / append_system_prompt config

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -141,15 +141,16 @@ type appServerRequestUserInputAnswer struct {
 }
 
 type appServerSession struct {
-	url           string
-	workDir       string
-	model         string
-	effort        string
-	mode          string
-	baseURL       string
-	modelProvider string
-	extraEnv      []string
-	codexHome     string
+	url            string
+	workDir        string
+	model          string
+	effort         string
+	mode           string
+	baseURL        string
+	modelProvider  string
+	extraEnv       []string
+	codexHome      string
+	promptPreamble string
 
 	events chan core.Event
 
@@ -175,9 +176,10 @@ type appServerSession struct {
 	closeOnce sync.Once
 	wg        sync.WaitGroup
 
-	stateMu     sync.Mutex
-	pendingMsgs []string
-	currentTurn string
+	stateMu      sync.Mutex
+	pendingMsgs  []string
+	currentTurn  string
+	preambleSent bool
 
 	runtimeMu sync.RWMutex
 	usage     *core.UsageReport
@@ -189,7 +191,7 @@ const (
 	appServerUsageRefreshTimeout = 1500 * time.Millisecond
 )
 
-func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string) (*appServerSession, error) {
+func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string, systemPrompt string, appendPrompt string) (*appServerSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 	s := &appServerSession{
 		url:              url,
@@ -201,11 +203,13 @@ func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode,
 		modelProvider:    modelProvider,
 		extraEnv:         append([]string(nil), extraEnv...),
 		codexHome:        strings.TrimSpace(codexHome),
+		promptPreamble:   buildCodexPromptPreamble(systemPrompt, appendPrompt),
 		events:           make(chan core.Event, 128),
 		ctx:              sessionCtx,
 		cancel:           cancel,
 		pending:          make(map[int64]chan rpcResponseEnvelope),
 		pendingApprovals: make(map[string]chan core.PermissionResult),
+		preambleSent:     resumeID != "" && resumeID != core.ContinueSession,
 	}
 	s.alive.Store(true)
 
@@ -451,6 +455,13 @@ func (s *appServerSession) Send(prompt string, images []core.ImageAttachment, fi
 	if err != nil {
 		return err
 	}
+
+	s.stateMu.Lock()
+	if !s.preambleSent {
+		prompt = prependCodexPromptPreamble(prompt, s.promptPreamble)
+		s.preambleSent = true
+	}
+	s.stateMu.Unlock()
 
 	threadID := s.CurrentSessionID()
 	if threadID == "" {

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -38,10 +38,12 @@ type Agent struct {
 	backend         string // "exec" | "app_server"
 	appServerURL    string
 	codexHome       string
+	systemPrompt    string
+	appendPrompt    string
 	cliBin          string   // CLI binary name, default "codex"
 	cliExtraArgs    []string // extra args parsed from cli_path after the binary
 	providers       []core.ProviderConfig
-	activeIdx       int // -1 = no provider set
+	activeIdx       int      // -1 = no provider set
 	configEnv       []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
 	sessionEnv      []string
 	mu              sync.RWMutex
@@ -58,6 +60,8 @@ func New(opts map[string]any) (core.Agent, error) {
 	backend, _ := opts["backend"].(string)
 	appServerURL, _ := opts["app_server_url"].(string)
 	codexHome, _ := opts["codex_home"].(string)
+	systemPrompt, _ := opts["system_prompt"].(string)
+	appendPrompt, _ := opts["append_system_prompt"].(string)
 	mode = normalizeMode(mode)
 	backend = normalizeBackend(backend)
 	appServerURL = normalizeAppServerURL(appServerURL)
@@ -102,6 +106,8 @@ func New(opts map[string]any) (core.Agent, error) {
 		backend:         backend,
 		appServerURL:    appServerURL,
 		codexHome:       strings.TrimSpace(codexHome),
+		systemPrompt:    strings.TrimSpace(systemPrompt),
+		appendPrompt:    strings.TrimSpace(appendPrompt),
 		cliBin:          cliBin,
 		cliExtraArgs:    cliExtraArgs,
 		configEnv:       configEnv,
@@ -365,6 +371,8 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	backend := a.backend
 	appServerURL := a.appServerURL
 	codexHome := a.codexHome
+	systemPrompt := a.systemPrompt
+	appendPrompt := a.appendPrompt
 	cliBin := a.cliBin
 	cliExtraArgs := a.cliExtraArgs
 	workDir := a.workDir
@@ -395,13 +403,13 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 
 	if backend == "app_server" {
-		return newAppServerSession(ctx, appServerURL, workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome)
+		return newAppServerSession(ctx, appServerURL, workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome, systemPrompt, appendPrompt)
 	}
 	if codexHome != "" {
 		extraEnv = append(extraEnv, "CODEX_HOME="+codexHome)
 	}
 
-	return newCodexSession(ctx, cliBin, cliExtraArgs, workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv, provName)
+	return newCodexSession(ctx, cliBin, cliExtraArgs, workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv, provName, systemPrompt, appendPrompt)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/codex/codex_cache_test.go
+++ b/agent/codex/codex_cache_test.go
@@ -40,4 +40,3 @@ func TestAvailableModels_FallbackToModelsCache(t *testing.T) {
 		t.Fatalf("models = %v, want [gpt-5.4 gpt-5.3-codex]", models)
 	}
 }
-

--- a/agent/codex/project_env_test.go
+++ b/agent/codex/project_env_test.go
@@ -96,3 +96,28 @@ func TestNew_NoEnvOpts(t *testing.T) {
 		t.Fatalf("expected 0 env vars, got %d: %v", len(agent.configEnv), agent.configEnv)
 	}
 }
+
+func TestNew_ParsesProjectPromptsFromOpts(t *testing.T) {
+	opts := map[string]any{
+		"work_dir":             t.TempDir(),
+		"cli_path":             "go",
+		"system_prompt":        "You are Linear Reporter.",
+		"append_system_prompt": "Always use linear-bug-intake.",
+	}
+
+	a, err := New(opts)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	agent := a.(*Agent)
+	agent.mu.RLock()
+	defer agent.mu.RUnlock()
+
+	if agent.systemPrompt != "You are Linear Reporter." {
+		t.Fatalf("systemPrompt = %q", agent.systemPrompt)
+	}
+	if agent.appendPrompt != "Always use linear-bug-intake." {
+		t.Fatalf("appendPrompt = %q", agent.appendPrompt)
+	}
+}

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -24,24 +24,25 @@ import (
 // codexSession manages a multi-turn Codex conversation.
 // First Send() uses `codex exec`, subsequent ones use `codex exec resume <threadID>`.
 type codexSession struct {
-	workDir       string
-	model         string
-	effort        string
-	mode          string
-	baseURL       string // provider base URL; passed as -c openai_base_url=<url>
-	modelProvider string // Codex model_provider name; passed as -c model_provider=<name>
-	cliBin        string   // CLI binary, default "codex"
-	cliExtraArgs  []string // extra args from cli_path, prepended before exec args
-	extraEnv      []string
-	events        chan core.Event
-	threadID  atomic.Value // stores string — Codex thread_id
-	ctx       context.Context
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
-	alive     atomic.Bool
-	closeOnce sync.Once
-	cmdMu     sync.Mutex
-	cmds      map[*exec.Cmd]struct{}
+	workDir        string
+	model          string
+	effort         string
+	mode           string
+	baseURL        string   // provider base URL; passed as -c openai_base_url=<url>
+	modelProvider  string   // Codex model_provider name; passed as -c model_provider=<name>
+	cliBin         string   // CLI binary, default "codex"
+	cliExtraArgs   []string // extra args from cli_path, prepended before exec args
+	extraEnv       []string
+	promptPreamble string
+	events         chan core.Event
+	threadID       atomic.Value // stores string — Codex thread_id
+	ctx            context.Context
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+	alive          atomic.Bool
+	closeOnce      sync.Once
+	cmdMu          sync.Mutex
+	cmds           map[*exec.Cmd]struct{}
 
 	pendingMsgs []string // buffered agent_message texts awaiting classification
 
@@ -63,23 +64,47 @@ var codexRuntimeConfigTimeout = 1500 * time.Millisecond
 var codexContextUsageRetryDelay = 50 * time.Millisecond
 var codexContextUsageRetryCount = 4
 
-func newCodexSession(ctx context.Context, cliBin string, cliExtraArgs []string, workDir, model, effort, mode, resumeID, baseURL string, extraEnv []string, modelProvider string) (*codexSession, error) {
+func buildCodexPromptPreamble(systemPrompt string, appendPrompt string) string {
+	var sections []string
+	if systemPrompt = strings.TrimSpace(systemPrompt); systemPrompt != "" {
+		sections = append(sections, "Project system prompt:\n"+systemPrompt)
+	}
+	if appendPrompt = strings.TrimSpace(appendPrompt); appendPrompt != "" {
+		sections = append(sections, "Additional project instructions:\n"+appendPrompt)
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+func prependCodexPromptPreamble(prompt string, preamble string) string {
+	preamble = strings.TrimSpace(preamble)
+	if preamble == "" {
+		return prompt
+	}
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return "Before answering, follow these project-level instructions for this cc-connect session. They are not user content.\n\n" + preamble
+	}
+	return "Before answering, follow these project-level instructions for this cc-connect session. They are not user content.\n\n" + preamble + "\n\n---\n\nUser message:\n" + prompt
+}
+
+func newCodexSession(ctx context.Context, cliBin string, cliExtraArgs []string, workDir, model, effort, mode, resumeID, baseURL string, extraEnv []string, modelProvider string, systemPrompt string, appendPrompt string) (*codexSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	cs := &codexSession{
-		workDir:       workDir,
-		model:         model,
-		effort:        effort,
-		mode:          mode,
-		baseURL:       baseURL,
-		modelProvider: modelProvider,
-		cliBin:        cliBin,
-		cliExtraArgs:  cliExtraArgs,
-		extraEnv:      extraEnv,
-		events:        make(chan core.Event, 64),
-		ctx:           sessionCtx,
-		cancel:        cancel,
-		cmds:          make(map[*exec.Cmd]struct{}),
+		workDir:        workDir,
+		model:          model,
+		effort:         effort,
+		mode:           mode,
+		baseURL:        baseURL,
+		modelProvider:  modelProvider,
+		cliBin:         cliBin,
+		cliExtraArgs:   cliExtraArgs,
+		extraEnv:       extraEnv,
+		promptPreamble: buildCodexPromptPreamble(systemPrompt, appendPrompt),
+		events:         make(chan core.Event, 64),
+		ctx:            sessionCtx,
+		cancel:         cancel,
+		cmds:           make(map[*exec.Cmd]struct{}),
 	}
 	cs.alive.Store(true)
 
@@ -108,6 +133,9 @@ func (cs *codexSession) Send(prompt string, images []core.ImageAttachment, files
 	}
 
 	isResume := cs.CurrentSessionID() != ""
+	if !isResume {
+		prompt = prependCodexPromptPreamble(prompt, cs.promptPreamble)
+	}
 	args := cs.buildExecArgs(prompt, imagePaths)
 	if len(cs.cliExtraArgs) > 0 {
 		args = append(append([]string{}, cs.cliExtraArgs...), args...)

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -557,7 +557,7 @@ func TestSend_PrependsProjectPromptOnFreshSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	if err := cs.Send("Create a Chat issue.", nil, nil); err != nil {
 		t.Fatalf("Send: %v", err)

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -38,7 +38,7 @@ func TestAvailableReasoningEfforts_ExcludesMinimal(t *testing.T) {
 }
 
 func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
-	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "o3", "high", "full-auto", "", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "o3", "high", "full-auto", "", "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 }
 
 func TestBuildExecArgs_IncludesBaseURL(t *testing.T) {
-	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "o3", "high", "full-auto", "", "https://custom.api.example.com", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "o3", "high", "full-auto", "", "https://custom.api.example.com", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestBuildExecArgs_IncludesBaseURL(t *testing.T) {
 }
 
 func TestBuildExecArgs_IncludesModelProvider(t *testing.T) {
-	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "openai/gpt-5.3-codex", "", "full-auto", "", "https://router.example.com/api/v1", nil, "shengsuanyun")
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "openai/gpt-5.3-codex", "", "full-auto", "", "https://router.example.com/api/v1", nil, "shengsuanyun", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestBuildExecArgs_IncludesModelProvider(t *testing.T) {
 }
 
 func TestBuildExecArgs_ResumeOmitsCdFlag(t *testing.T) {
-	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "full-auto", "thread-abc", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "full-auto", "thread-abc", "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -127,11 +127,11 @@ func TestBuildExecArgs_ResumeOmitsCdFlag(t *testing.T) {
 // that this backend cannot answer.
 func TestBuildExecArgs_ModeMapping(t *testing.T) {
 	tests := []struct {
-		mode             string
-		wantSandbox      string // "" means no --sandbox flag (only yolo)
-		wantApproval     bool   // true means -c approval_policy="never" must be present
-		wantBypass       bool   // true means --dangerously-bypass-approvals-and-sandbox
-		wantNoFullAuto   bool   // always true: --full-auto is removed in codex 0.137+
+		mode           string
+		wantSandbox    string // "" means no --sandbox flag (only yolo)
+		wantApproval   bool   // true means -c approval_policy="never" must be present
+		wantBypass     bool   // true means --dangerously-bypass-approvals-and-sandbox
+		wantNoFullAuto bool   // always true: --full-auto is removed in codex 0.137+
 	}{
 		{mode: "suggest", wantSandbox: "read-only", wantApproval: true, wantNoFullAuto: true},
 		{mode: "auto-edit", wantSandbox: "workspace-write", wantApproval: true, wantNoFullAuto: true},
@@ -141,7 +141,7 @@ func TestBuildExecArgs_ModeMapping(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.mode, func(t *testing.T) {
-			cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", tc.mode, "", "", nil, "")
+			cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", tc.mode, "", "", nil, "", "", "")
 			if err != nil {
 				t.Fatalf("newCodexSession: %v", err)
 			}
@@ -205,7 +205,7 @@ func TestBuildExecArgs_ResumeUsesSandboxModeConfigOverride(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.mode, func(t *testing.T) {
-			cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", tc.mode, "thread-abc", "", nil, "")
+			cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", tc.mode, "thread-abc", "", nil, "", "", "")
 			if err != nil {
 				t.Fatalf("newCodexSession: %v", err)
 			}
@@ -251,6 +251,33 @@ func TestBuildExecArgs_ResumeUsesSandboxModeConfigOverride(t *testing.T) {
 	}
 }
 
+func TestCodexPromptPreamble_PrependsProjectPrompts(t *testing.T) {
+	preamble := buildCodexPromptPreamble(
+		"You are Linear Reporter.",
+		"Always invoke linear-bug-intake.",
+	)
+
+	got := prependCodexPromptPreamble("Create a Chat issue.", preamble)
+
+	for _, want := range []string{
+		"Before answering, follow these project-level instructions",
+		"Project system prompt:\nYou are Linear Reporter.",
+		"Additional project instructions:\nAlways invoke linear-bug-intake.",
+		"User message:\nCreate a Chat issue.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("prompt preamble missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestCodexPromptPreamble_EmptyIsNoop(t *testing.T) {
+	const prompt = "Hello"
+	if got := prependCodexPromptPreamble(prompt, ""); got != prompt {
+		t.Fatalf("empty preamble changed prompt: %q", got)
+	}
+}
+
 func TestGetModelAndReasoningEffort_FromRuntimeConfigWhenUnset(t *testing.T) {
 	workDir := t.TempDir()
 	binDir := filepath.Join(workDir, "bin")
@@ -284,7 +311,7 @@ while (($line = [Console]::In.ReadLine()) -ne $null) {
 
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -318,7 +345,7 @@ func TestRefreshContextUsageFromRollout_UsesLastTokenCount(t *testing.T) {
 		t.Fatalf("write rollout: %v", err)
 	}
 
-	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", sessionID, "", []string{"CODEX_HOME=" + codexHome}, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", sessionID, "", []string{"CODEX_HOME=" + codexHome}, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -369,7 +396,7 @@ func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 	t.Setenv("CODEX_ARGS_FILE", argsFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -430,7 +457,7 @@ func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
 	t.Setenv("CODEX_ARGS_FILE", argsFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "thread-123", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "thread-123", "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -483,7 +510,7 @@ func TestSend_UsesStdinForMultilinePrompt(t *testing.T) {
 	t.Setenv("CODEX_STDIN_FILE", stdinFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "thread-stdin", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "thread-stdin", "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -502,6 +529,48 @@ func TestSend_UsesStdinForMultilinePrompt(t *testing.T) {
 	// cat > file creates the path before stdin is fully read; polling until
 	// content matches avoids racing an empty read (flaky under -cover / CI).
 	waitForFileEquals(t, stdinFile, prompt)
+}
+
+func TestSend_PrependsProjectPromptOnFreshSession(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	stdinFile := filepath.Join(workDir, "stdin.txt")
+	script := "#!/bin/sh\n" +
+		"cat > \"$CODEX_STDIN_FILE\"\n" +
+		"printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"thread-preamble\"}'\n" +
+		"printf '%s\\n' '{\"type\":\"turn.completed\"}'\n"
+	powershellScript := `
+[IO.File]::WriteAllText($env:CODEX_STDIN_FILE, [Console]::In.ReadToEnd())
+[Console]::Out.WriteLine('{"type":"thread.started","thread_id":"thread-preamble"}')
+[Console]::Out.WriteLine('{"type":"turn.completed"}')
+`
+	writeFakeCodexScript(t, binDir, script, powershellScript)
+
+	t.Setenv("CODEX_STDIN_FILE", stdinFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "", "You are Linear Reporter.", "Always invoke linear-bug-intake.")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer cs.Close()
+
+	if err := cs.Send("Create a Chat issue.", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	wantParts := []string{
+		"Project system prompt:\nYou are Linear Reporter.",
+		"Additional project instructions:\nAlways invoke linear-bug-intake.",
+		"User message:\nCreate a Chat issue.",
+	}
+	for _, want := range wantParts {
+		waitForFileContains(t, stdinFile, want)
+	}
 }
 
 func TestSend_HandlesLargeJSONLines(t *testing.T) {
@@ -536,7 +605,7 @@ func TestSend_HandlesLargeJSONLines(t *testing.T) {
 	t.Setenv("CODEX_PAYLOAD_FILE", payloadFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -704,6 +773,20 @@ func waitForFileEquals(t *testing.T, path, want string) {
 	t.Fatalf("stdin file %s: got %q, want %q", path, string(data), want)
 }
 
+func waitForFileContains(t *testing.T, path, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil && strings.Contains(string(data), want) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	data, _ := os.ReadFile(path)
+	t.Fatalf("file %s: got %q, want substring %q", path, string(data), want)
+}
+
 func containsSequence(args, want []string) bool {
 	if len(want) == 0 {
 		return true
@@ -742,7 +825,7 @@ func indexOf(args []string, target string) int {
 }
 
 func TestCodexSession_ContinueSessionTreatedAsFresh(t *testing.T) {
-	s, err := newCodexSession(context.Background(), "codex", nil, "/tmp", "", "", "full-auto", core.ContinueSession, "", nil, "")
+	s, err := newCodexSession(context.Background(), "codex", nil, "/tmp", "", "", "full-auto", core.ContinueSession, "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -784,7 +867,7 @@ func TestClose_ForceKillsProcessGroupAfterGracefulTimeout(t *testing.T) {
 		codexSessionForceKillWait = oldForceKillWait
 	})
 
-	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
@@ -851,7 +934,7 @@ func TestClose_ForceKillsAllTrackedProcessesAfterCmdOverwrite(t *testing.T) {
 		codexSessionForceKillWait = oldForceKillWait
 	})
 
-	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "")
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}

--- a/config.example.toml
+++ b/config.example.toml
@@ -1463,6 +1463,21 @@ app_secret = "your-feishu-app-secret"
 # Optional: specify Codex reasoning effort / 可选：指定 Codex 推理强度
 # reasoning_effort = "high"  # "minimal" | "low" | "medium" | "high" | "xhigh"
 #
+# Optional: project system prompt / 可选：项目系统提示
+# Codex has no native system-prompt flag, so cc-connect injects this as a
+# preamble prepended to your first message of each new session (resumed
+# sessions are not re-injected).
+# Codex 没有原生的系统提示参数，cc-connect 会将其作为前导内容注入到每个新
+# 会话的第一条消息之前（恢复的会话不会重复注入）。
+# system_prompt = "You are a helpful AI assistant that specializes in Python development."
+#
+# Optional: additional project instructions / 可选：追加的项目指令
+# Appended after system_prompt in the same injected preamble. Can be used
+# alone or combined with system_prompt.
+# 追加在 system_prompt 之后，包含在同一段注入的前导内容中。可单独使用，也可与
+# system_prompt 同时使用。
+# append_system_prompt = "Always respond in Chinese and prefer concise answers."
+#
 # # Active provider / 当前激活的 provider
 # # provider = "openai"
 #


### PR DESCRIPTION
## What

Adds `system_prompt` and `append_system_prompt` agent options to the **Codex** agent, mirroring the existing claudecode support (#1175).

## Why

Codex projects could not set a custom system prompt the way Claude Code projects can. Codex's CLI has no native `--system-prompt` flag, so these options are synthesized into a project preamble and **prepended to the first message of each new session**.

## How

- `buildCodexPromptPreamble` / `prependCodexPromptPreamble` build the preamble from `system_prompt` + `append_system_prompt`.
- Injected once per session; resumed sessions skip injection (`preambleSent` is preset when resuming a non-`ContinueSession` thread).
- Wired through both backends: `exec` (`session.go`) and `app_server` (`appserver_session.go`).
- Empty options are a no-op — prompts pass through unchanged.
- Adds `config.example.toml` documentation (bilingual) for the two new options, noting the preamble-injection semantics.

## Tests

New unit tests (all passing):
- `TestNew_ParsesProjectPromptsFromOpts`
- `TestCodexPromptPreamble_PrependsProjectPrompts`
- `TestCodexPromptPreamble_EmptyIsNoop`
- `TestSend_PrependsProjectPromptOnFreshSession`

`go build`, `gofmt`, `go vet`, and `go test ./agent/codex/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1346
