### PR TITLE
relay: post visibility messages into the caller's thread when in one

### DIFF
--- a/core/relay.go
+++ b/core/relay.go
@@ -241,7 +241,12 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 	}
 
 	// Post the forwarded message to the group chat for visibility.
+	// When the caller is in a thread, post visibility messages into the
+	// same thread so group members see the relay exchange in-context.
 	groupSessionKey := platform + ":" + chatID + ":relay"
+	if threadTail, ok := relayThreadRoot(req.SessionKey); ok {
+		groupSessionKey = platform + ":" + chatID + ":" + threadTail
+	}
 	if sourceEngine != nil && visibility != RelayVisibilityNone {
 		label := relayVisibilityRequestLabel(visibility, fromName, toName, req.Message)
 		rm.sendToGroup(ctx, sourceEngine, platform, groupSessionKey, label)
@@ -346,6 +351,24 @@ func parseSessionKeyParts(sessionKey string) (platform, chatID string, err error
 		return parts[0], parts[2], nil
 	}
 	return parts[0], parts[1], nil
+}
+
+// relayThreadRoot extracts the thread root segment from a session key's third
+// part when it carries a "root:" or "thread:" prefix (as used by the feishu and
+// slack platforms).  Returns (tail, true) when the key targets a thread, or
+// ("", false) when it targets a top-level channel.
+func relayThreadRoot(sessionKey string) (tail string, ok bool) {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) < 3 {
+		return "", false
+	}
+	third := parts[2]
+	for _, pfx := range []string{"root:", "thread:"} {
+		if after, match := strings.CutPrefix(third, pfx); match && after != "" {
+			return third, true
+		}
+	}
+	return "", false
 }
 
 // ── Persistence ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When a user invokes `cc-connect relay send` from within a feishu thread (session key carries `root:om_xxx`), the relay request/response visibility messages now land in the **same thread** instead of the group chat main channel. This keeps the relay exchange visually grouped with the conversation that triggered it.
- When the caller is **not** in a thread (session key third part is a plain user ID, e.g. `ou_xxx`), `:relay` is kept as before — fully backward-compatible.

## How it works

A new helper `relayThreadRoot()` checks whether the session key's third segment carries a `root:` or `thread:` prefix. If so, the visibility `groupSessionKey` uses that thread root instead of the hardcoded `:relay`.

```
feishu:oc_xxx:root:om_456  →  groupSessionKey = feishu:oc_xxx:root:om_456    (thread)
feishu:oc_xxx:ou_789       →  groupSessionKey = feishu:oc_xxx:relay           (channel, unchanged)
```

## Test plan

- [x] Thread relay: visibility messages land in thread (`session_key` with `root:om_xxx`)
- [x] Channel relay: visibility messages land in channel (`session_key` with `ou_xxx`, `:relay` fallback)
- [x] Existing relay tests pass

## Diff

```
 core/relay.go | 23 insertions(+)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)