### PR TITLE
fix(codex): align suggest mode with description; replace deprecated --full-auto

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -22,10 +22,13 @@ func init() {
 
 // Agent drives OpenAI Codex CLI using `codex exec --json`.
 //
-// Modes (maps to codex exec flags):
-//   - "suggest":   default, no special flags (safe commands only)
-//   - "auto-edit": --full-auto (sandbox-protected auto execution)
-//   - "full-auto": --full-auto (sandbox-protected auto execution)
+// `codex exec` has no approval IPC, so approvals are not interactive on the
+// exec backend. To get interactive approvals, switch to backend="app_server".
+//
+// Modes on the exec backend (maps to codex exec flags):
+//   - "suggest":   --sandbox read-only       + approval_policy=never (no prompts)
+//   - "auto-edit": --sandbox workspace-write + approval_policy=never (alias of full-auto)
+//   - "full-auto": --sandbox workspace-write + approval_policy=never
 //   - "yolo":      --dangerously-bypass-approvals-and-sandbox
 type Agent struct {
 	workDir         string
@@ -674,11 +677,32 @@ func (a *Agent) activeProviderCodexConfig() (name string, apiKey string, wireAPI
 	return p.Name, p.APIKey, p.CodexWireAPI, p.CodexHTTPHeaders
 }
 
+// PermissionModes returns the supported codex permission modes.
+//
+// Behavior depends on backend:
+//   - exec backend (default): codex exec has no approval IPC, so all modes run
+//     with approval_policy=never. Sandbox tier is what controls access. The
+//     "suggest" label refers to the *intent* (read-only safety) — the CLI does
+//     not pop interactive approval prompts on this backend.
+//   - app_server backend: "suggest" enables real interactive approval requests
+//     (execCommandApproval / applyPatchApproval / permissionsApproval).
+//
+// Note: auto-edit and full-auto produce the same flags on the exec backend
+// (codex CLI has no separate "ask for shell only" mode); auto-edit is kept as
+// an alias for backward compatibility with existing user configs.
 func (a *Agent) PermissionModes() []core.PermissionModeInfo {
 	return []core.PermissionModeInfo{
-		{Key: "suggest", Name: "Suggest", NameZh: "建议", Desc: "Ask permission for every tool call", DescZh: "每次工具调用都需确认"},
-		{Key: "auto-edit", Name: "Auto Edit", NameZh: "自动编辑", Desc: "Auto-approve file edits, ask for shell commands", DescZh: "自动允许文件编辑，Shell 命令需确认"},
-		{Key: "full-auto", Name: "Full Auto", NameZh: "全自动", Desc: "Auto-approve with workspace sandbox", DescZh: "自动通过（工作区沙箱）"},
-		{Key: "yolo", Name: "YOLO", NameZh: "YOLO 模式", Desc: "Bypass all approvals and sandbox", DescZh: "跳过所有审批和沙箱"},
+		{Key: "suggest", Name: "Suggest", NameZh: "建议",
+			Desc:   "Read-only sandbox; on exec backend no prompts, on app_server backend asks for every tool call",
+			DescZh: "只读沙箱；exec 后端不弹审批，app_server 后端每次工具调用都会询问"},
+		{Key: "auto-edit", Name: "Auto Edit", NameZh: "自动编辑",
+			Desc:   "Workspace-write sandbox, no approval prompts (alias of Full Auto)",
+			DescZh: "工作区可写沙箱，不弹审批（等同于全自动）"},
+		{Key: "full-auto", Name: "Full Auto", NameZh: "全自动",
+			Desc:   "Workspace-write sandbox, no approval prompts",
+			DescZh: "工作区可写沙箱，不弹审批"},
+		{Key: "yolo", Name: "YOLO", NameZh: "YOLO 模式",
+			Desc:   "Bypass all approvals and sandbox (DANGEROUS)",
+			DescZh: "跳过所有审批和沙箱（危险）"},
 	}
 }

--- a/agent/codex/integration_test.go
+++ b/agent/codex/integration_test.go
@@ -88,7 +88,8 @@ func TestIntegration_CodexProviderFlow(t *testing.T) {
 		"--model", "openai/gpt-5.3-codex",
 		"-c", `model_provider="shengsuanyun-codex"`,
 		"-c", `openai_base_url="https://router.shengsuanyun.com/api/v1"`,
-		"--full-auto",
+		"--sandbox", "workspace-write",
+		"-c", `approval_policy="never"`,
 	)
 	cmd.Dir = workDir
 	cmd.Env = append(os.Environ(),

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -188,11 +188,25 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 		args = []string{"exec", "--skip-git-repo-check"}
 	}
 
+	// Mode → sandbox + approval mapping.
+	//
+	// `codex exec` (this backend) has no approval IPC, so approval_policy must
+	// always be "never" — otherwise the CLI blocks waiting for a TTY response
+	// that never arrives. Sandbox tier is what actually enforces safety here.
+	//
+	// As of codex-cli 0.137 `--full-auto` is no longer accepted; use the
+	// canonical `--sandbox <mode>` form together with `-c approval_policy=...`.
+	//
+	// For real interactive approvals (suggest semantics), users must opt into
+	// the `app_server` backend, which handles execCommandApproval /
+	// applyPatchApproval / permissionsApproval over JSON-RPC.
 	switch cs.mode {
 	case "auto-edit", "full-auto":
-		args = append(args, "--full-auto")
+		args = append(args, "--sandbox", "workspace-write", "-c", `approval_policy="never"`)
 	case "yolo":
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
+	default: // "suggest"
+		args = append(args, "--sandbox", "read-only", "-c", `approval_policy="never"`)
 	}
 
 	if cs.model != "" {

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -48,7 +48,10 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 	want := []string{
 		"exec",
 		"--skip-git-repo-check",
-		"--full-auto",
+		"--sandbox",
+		"workspace-write",
+		"-c",
+		`approval_policy="never"`,
 		"--model",
 		"o3",
 		"-c",
@@ -115,6 +118,65 @@ func TestBuildExecArgs_ResumeOmitsCdFlag(t *testing.T) {
 	// --json and stdin marker must still be present.
 	if !containsSequence(args, []string{"--json", "-"}) {
 		t.Fatalf("resume args missing --json + stdin marker: %v", args)
+	}
+}
+
+// TestBuildExecArgs_ModeMapping verifies each permission mode maps to the
+// correct codex CLI flags. Critical: codex exec has no approval IPC, so
+// approval_policy must always be "never" to avoid hanging on a TTY prompt
+// that this backend cannot answer.
+func TestBuildExecArgs_ModeMapping(t *testing.T) {
+	tests := []struct {
+		mode             string
+		wantSandbox      string // "" means no --sandbox flag (only yolo)
+		wantApproval     bool   // true means -c approval_policy="never" must be present
+		wantBypass       bool   // true means --dangerously-bypass-approvals-and-sandbox
+		wantNoFullAuto   bool   // always true: --full-auto is removed in codex 0.137+
+	}{
+		{mode: "suggest", wantSandbox: "read-only", wantApproval: true, wantNoFullAuto: true},
+		{mode: "auto-edit", wantSandbox: "workspace-write", wantApproval: true, wantNoFullAuto: true},
+		{mode: "full-auto", wantSandbox: "workspace-write", wantApproval: true, wantNoFullAuto: true},
+		{mode: "yolo", wantBypass: true, wantNoFullAuto: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.mode, func(t *testing.T) {
+			cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", tc.mode, "", "", nil, "")
+			if err != nil {
+				t.Fatalf("newCodexSession: %v", err)
+			}
+			args := cs.buildExecArgs("hi", nil)
+
+			if tc.wantSandbox != "" {
+				if !containsSequence(args, []string{"--sandbox", tc.wantSandbox}) {
+					t.Errorf("mode=%s missing --sandbox %s; args=%v", tc.mode, tc.wantSandbox, args)
+				}
+			}
+			if tc.wantApproval {
+				if !containsSequence(args, []string{"-c", `approval_policy="never"`}) {
+					t.Errorf("mode=%s missing approval_policy=never; args=%v", tc.mode, args)
+				}
+			}
+			if tc.wantBypass {
+				found := false
+				for _, a := range args {
+					if a == "--dangerously-bypass-approvals-and-sandbox" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("mode=%s missing --dangerously-bypass-approvals-and-sandbox; args=%v", tc.mode, args)
+				}
+			}
+			if tc.wantNoFullAuto {
+				for _, a := range args {
+					if a == "--full-auto" {
+						t.Errorf("mode=%s still emits deprecated --full-auto; args=%v", tc.mode, args)
+					}
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

Two long-standing inconsistencies on the **codex `exec` backend** (the default):

### 1. `suggest` mode silently hangs

The UI says "Ask permission for every tool call / 每次工具调用都需确认", but `codex exec` has **no approval IPC** — any approval prompt blocks waiting for a TTY response that never arrives. Users who pick `suggest` and run a tool see the agent freeze until 5-min timeout.

### 2. `--full-auto` was removed in codex-cli 0.137

Current `auto-edit` / `full-auto` modes pass `--full-auto`, which the new CLI rejects.

## What changes

### Mode → flag mapping on `exec` backend

| Mode | Before | After |
|---|---|---|
| `suggest` | (no flag) → hangs on first tool call | `--sandbox read-only -c approval_policy="never"` |
| `auto-edit` | `--full-auto` (deprecated) | `--sandbox workspace-write -c approval_policy="never"` |
| `full-auto` | `--full-auto` (deprecated) | `--sandbox workspace-write -c approval_policy="never"` |
| `yolo` | `--dangerously-bypass-approvals-and-sandbox` | unchanged |

### Documentation / UI text

`PermissionModes()` descriptions now state the real behavior on each backend:

- `suggest`: "Read-only sandbox; on exec backend no prompts, on app_server backend asks for every tool call"
- `auto-edit` / `full-auto`: "Workspace-write sandbox, no approval prompts" (auto-edit marked as alias)
- `yolo`: "Bypass all approvals and sandbox (DANGEROUS)"

The package-level doc now explicitly says: real interactive approvals require `backend = "app_server"`, which already wires `execCommandApproval` / `applyPatchApproval` / `permissionsApproval` / `requestUserInput` from codex JSON-RPC.

## Why no breaking change

- Mode keys (`suggest` / `auto-edit` / `full-auto` / `yolo`) **unchanged** — existing user configs run with the same effective sandbox tier.
- The behavioral change is `suggest` going from **"hangs"** to **"completes safely under read-only sandbox"** — strictly a bug fix.
- `--full-auto` → `--sandbox workspace-write` is functionally equivalent, just on the supported flag form.

## Tests

- New `TestBuildExecArgs_ModeMapping` covers all 4 modes:
  - asserts the right `--sandbox` tier
  - asserts `approval_policy="never"` is emitted (so exec backend can never hang on approval)
  - asserts `--full-auto` is **never** emitted
  - asserts `yolo` still uses `--dangerously-bypass-approvals-and-sandbox`
- Updated `TestBuildExecArgs_IncludesReasoningEffort` and `TestIntegration_CodexProviderFlow` to expect the new flag form.
- `go test -count=1 ./agent/codex/...` → PASS
- `golangci-lint run --new-from-rev=origin/main ./agent/codex/...` → 0 issues

## Out of scope (not in this PR)

- Abstracting modes into `access = read-only/workspace/full` (lark-coding-agent-bridge style) — would break existing configs, requires owner decision.
- Auto-detecting backend and switching `suggest` to interactive on `app_server` — already works today; this PR just clarifies it in docs.
- Promoting `app_server` backend or improving its documentation — separate task.

Refs internal task `t-20260614-st7ft2`.

Made with [Cursor](https://cursor.com)