### PR TITLE
fix(telegram,discord): default progress_style to compact for streaming edits

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1085,6 +1085,10 @@ app_secret = "your-feishu-app-secret"
 # group_reply_all = false  # If true, respond to ALL group messages without @mention / 设为 true 群聊无需 @ 也响应
 # share_session_in_channel = false  # If true, all users in a group share one agent session / 群聊共享会话
 # enable_reactions = false  # If true, add ⚡ reaction to incoming messages / 设为 true 收到消息时添加 ⚡ 表情
+# progress_style = "compact"  # Progress rendering: legacy | compact (default). Telegram has no rich card UI,
+#                             # so "card" is normalized to "compact". Set "legacy" to disable streaming edits.
+#                             # 进度展示：legacy | compact（默认）。Telegram 不支持富卡片，"card" 会被规整为 "compact"。
+#                             # 设为 "legacy" 可关闭流式 edit。
 
 # MAX messenger (uncomment to enable / 取消注释以启用)
 # 1. Create a bot via @MasterBot in MAX, get the access token

--- a/platform/discord/discord.go
+++ b/platform/discord/discord.go
@@ -87,10 +87,15 @@ func New(opts map[string]any) (core.Platform, error) {
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
-	progressStyle := "legacy"
+	// Default to "compact" so streaming edits work out of the box (Discord
+	// supports MessageUpdater.UpdateMessage). Users can opt back into the old
+	// "send entire reply at once" behavior with progress_style = "legacy".
+	progressStyle := "compact"
 	if v, ok := opts["progress_style"].(string); ok {
 		switch strings.ToLower(strings.TrimSpace(v)) {
-		case "", "legacy":
+		case "":
+			// keep default
+		case "legacy":
 			progressStyle = "legacy"
 		case "compact", "card":
 			progressStyle = strings.ToLower(strings.TrimSpace(v))

--- a/platform/discord/discord_test.go
+++ b/platform/discord/discord_test.go
@@ -650,7 +650,8 @@ func TestNew_ProgressStyleRejectsInvalidValue(t *testing.T) {
 
 func TestNew_LegacyProgressStyleDoesNotEnableProgressInterfaces(t *testing.T) {
 	pAny, err := New(map[string]any{
-		"token": "discord-token",
+		"token":          "discord-token",
+		"progress_style": "legacy",
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -660,6 +661,27 @@ func TestNew_LegacyProgressStyleDoesNotEnableProgressInterfaces(t *testing.T) {
 	}
 	if _, ok := pAny.(core.ProgressCardPayloadSupport); ok {
 		t.Fatalf("legacy discord platform should not implement ProgressCardPayloadSupport, got %T", pAny)
+	}
+}
+
+// TestNew_DefaultProgressStyleIsCompact verifies that omitting progress_style
+// opts in to streaming edits (compact). Before this change, the default was
+// "legacy" which meant Discord would silently fall through to one big final
+// p.Send for long replies — see release-gate note 2026-06-14 §"Telegram 同样
+// 无默认流式". Discord behaves identically to Telegram on this code path.
+func TestNew_DefaultProgressStyleIsCompact(t *testing.T) {
+	pAny, err := New(map[string]any{
+		"token": "discord-token",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	sp, ok := pAny.(core.ProgressStyleProvider)
+	if !ok {
+		t.Fatalf("default discord platform should implement ProgressStyleProvider, got %T", pAny)
+	}
+	if got := sp.ProgressStyle(); got != "compact" {
+		t.Fatalf("default ProgressStyle() = %q, want %q", got, "compact")
 	}
 }
 
@@ -701,7 +723,8 @@ func TestDispatchMessage_UsesWrappedProgressPlatformForHandler(t *testing.T) {
 
 func TestDispatchMessage_LegacyPlatformFallsBackToBasePlatform(t *testing.T) {
 	pAny, err := New(map[string]any{
-		"token": "discord-token",
+		"token":          "discord-token",
+		"progress_style": "legacy",
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -110,6 +110,7 @@ type Platform struct {
 	groupReplyAll         bool
 	shareSessionInChannel bool
 	enableReactions       bool
+	progressStyle         string // "legacy" | "compact" — telegram has no rich card, so "card" is mapped to "compact"
 	httpClient            *http.Client
 
 	mu                  sync.RWMutex
@@ -162,10 +163,54 @@ func New(opts map[string]any) (core.Platform, error) {
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	enableReactions, _ := opts["enable_reactions"].(bool)
-	return &Platform{token: token, allowFrom: allowFrom, groupReplyAll: groupReplyAll, shareSessionInChannel: shareSessionInChannel, enableReactions: enableReactions, httpClient: httpClient}, nil
+
+	// Default to "compact" so streaming edits work out of the box. Telegram has
+	// no rich card UI, so "card" is normalized to "compact". Users can opt out
+	// via progress_style = "legacy" to restore the old "send full text once"
+	// behavior.
+	progressStyle := "compact"
+	if v, ok := opts["progress_style"].(string); ok {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "":
+			// keep default
+		case "legacy":
+			progressStyle = "legacy"
+		case "compact", "card":
+			progressStyle = "compact"
+		default:
+			return nil, fmt.Errorf("telegram: invalid progress_style %q (want legacy, compact, or card)", v)
+		}
+	}
+
+	return &Platform{
+		token:                 token,
+		allowFrom:             allowFrom,
+		groupReplyAll:         groupReplyAll,
+		shareSessionInChannel: shareSessionInChannel,
+		enableReactions:       enableReactions,
+		progressStyle:         progressStyle,
+		httpClient:            httpClient,
+	}, nil
 }
 
 func (p *Platform) Name() string { return "telegram" }
+
+// ProgressStyle reports the streaming-progress style for this platform.
+//
+// Telegram supports MessageUpdater.UpdateMessage, so we default to "compact"
+// to enable progressive edits of long agent responses. Without this, the
+// engine falls back to legacy mode and sends the entire reply (which can be
+// 30k+ characters) in one final p.Send — users perceive it as "spinner spins
+// for minutes, then a wall of text appears".
+//
+// To restore the old single-send behavior set progress_style = "legacy" in
+// the platform options.
+func (p *Platform) ProgressStyle() string {
+	if p == nil || p.progressStyle == "" {
+		return "compact"
+	}
+	return p.progressStyle
+}
 
 func (p *Platform) Start(handler core.MessageHandler) error {
 	p.mu.Lock()

--- a/platform/telegram/telegram_test.go
+++ b/platform/telegram/telegram_test.go
@@ -964,3 +964,75 @@ func newTelegramTestPlatform(t *testing.T, handler func(http.ResponseWriter, *ht
 		httpClient: server.Client(),
 	}
 }
+
+func TestNewProgressStyleDefault(t *testing.T) {
+	p, err := New(map[string]any{"token": "test-token"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	tg, ok := p.(*Platform)
+	if !ok {
+		t.Fatalf("expected *Platform, got %T", p)
+	}
+	if got := tg.ProgressStyle(); got != "compact" {
+		t.Fatalf("default ProgressStyle() = %q, want %q", got, "compact")
+	}
+}
+
+func TestNewProgressStyleOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		wantErr  bool
+		wantMode string
+	}{
+		{name: "explicit compact", input: "compact", wantMode: "compact"},
+		{name: "explicit legacy", input: "legacy", wantMode: "legacy"},
+		{name: "card normalized to compact", input: "card", wantMode: "compact"},
+		{name: "uppercase tolerated", input: "COMPACT", wantMode: "compact"},
+		{name: "whitespace tolerated", input: "  legacy  ", wantMode: "legacy"},
+		{name: "empty string keeps default", input: "", wantMode: "compact"},
+		{name: "invalid value rejected", input: "fancy", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := New(map[string]any{
+				"token":          "test-token",
+				"progress_style": tc.input,
+			})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %v, got nil", tc.input)
+				}
+				if !strings.Contains(err.Error(), "invalid progress_style") {
+					t.Fatalf("error = %q, want substring 'invalid progress_style'", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			tg := p.(*Platform)
+			if got := tg.ProgressStyle(); got != tc.wantMode {
+				t.Fatalf("ProgressStyle() = %q, want %q", got, tc.wantMode)
+			}
+		})
+	}
+}
+
+// TestProgressStyleProviderInterface verifies *Platform satisfies the
+// core.ProgressStyleProvider interface so the engine's
+// progressStyleForPlatform() picks up our implementation rather than
+// falling back to legacy.
+func TestProgressStyleProviderInterface(t *testing.T) {
+	var p core.Platform = &Platform{progressStyle: "compact"}
+	provider, ok := p.(interface{ ProgressStyle() string })
+	if !ok {
+		t.Fatalf("*Platform does not satisfy ProgressStyle() interface")
+	}
+	if got := provider.ProgressStyle(); got != "compact" {
+		t.Fatalf("ProgressStyle() = %q, want compact", got)
+	}
+}
+


### PR DESCRIPTION
## Why

Both Telegram and Discord implement `MessageUpdater.UpdateMessage`, so the engine **can** stream partial agent output by editing one message in place. But they were silently falling back to legacy mode:

- **Telegram** never declared `ProgressStyle()`, so `progressStyleForPlatform()` returned `legacy`. QA observed a 33,323-char reply being sent as one final `p.Send` after the agent thought for 2m52s — users perceive it as "spinner spins forever, then a wall of text appears".
- **Discord** declared `progress_style` parsing but defaulted to `legacy`, with the same symptom on long replies.

QA evidence (release-gate note, 2026-06-14):

```
progress writer disabled: unsupported style platform=telegram style=legacy
stream preview finish: no active preview hasHandle=false degraded=true
EventResult: sending via p.Send (preview inactive or failed) response_len=33323
slow agent send elapsed=2m52.925732829s
```

## What changes

### Telegram (`platform/telegram/telegram.go`)

- Add `progressStyle` field on `*Platform`.
- Parse `options.progress_style`: accepts `legacy`, `compact`, `card` (normalized to `compact` — Telegram has no rich card UI). Invalid values are rejected with a clear error.
- Add `ProgressStyle() string` method (default `compact`).

### Discord (`platform/discord/discord.go`)

- Change default from `legacy` to `compact`.
- Existing `progress_style` parsing is unchanged.

### Behavior matrix

| Platform | Before (default) | After (default) | Opt-out path |
|---|---|---|---|
| Telegram | `legacy` (silent — never declared) | `compact` | `progress_style = "legacy"` |
| Discord | `legacy` (default explicit) | `compact` | `progress_style = "legacy"` |
| Slack | n/a (no UpdateMessage) | unchanged | unchanged |
| Feishu/Lark | `legacy` (intentional — see below) | unchanged | n/a |

## Why no breaking change for users who want the old behavior

Old behavior (single final `p.Send`) is fully preserved by setting `progress_style = "legacy"` in the platform options. The only effective change is that **users who never set this option** now get streaming edits — which is a strict UX improvement and matches what the engine is already capable of doing.

## Out of scope (suggested follow-ups, not in this PR)

1. **Capability-driven default for all platforms.** `core/bridge.go:bridgeProgressStyleForAdapter` already infers `compact`/`card` from declared capabilities, but only on the bridge code path. A future PR can extract that into a shared helper so any platform implementing `MessageUpdater` gets a sensible default automatically without each platform repeating the field/parser.
2. **Feishu/Lark default.** The right default is `card` (rich), which is a meaningfully bigger UX change. QA's release-gate note (TODO-2) says base config + `02-gen-config.sh` should inject `progress_style = "card"` for Feishu/Lark instead. Out of this PR.
3. **Slack.** Does not implement `UpdateMessage`, so streaming edit is structurally unavailable until that is added separately.

## Tests

- `platform/telegram/telegram_test.go`:
  - `TestNewProgressStyleDefault` — default is `compact`.
  - `TestNewProgressStyleOptions` — covers `compact` / `legacy` / `card`→`compact` / uppercase / whitespace / empty / invalid (rejected with `invalid progress_style` error).
  - `TestProgressStyleProviderInterface` — `*Platform` satisfies `core.ProgressStyleProvider` so `progressStyleForPlatform()` won't fall back to legacy.
- `platform/discord/discord_test.go`:
  - `TestNew_DefaultProgressStyleIsCompact` — new default behavior.
  - `TestDispatchMessage_LegacyPlatformFallsBackToBasePlatform` and `TestNew_LegacyProgressStyleDoesNotEnableProgressInterfaces` updated to pass `progress_style = "legacy"` explicitly (their intent is to verify the legacy code path, not the default; previously they relied on omitting the option).
- `go test -count=1 ./platform/telegram/... ./platform/discord/... ./core/...` → all PASS
- `golangci-lint run --new-from-rev=origin/main ./platform/telegram/... ./platform/discord/...` → 0 issues

Refs internal task `t-20260614-y6xjnz`. QA evidence:
`projects/cc-connect/agents/qa-cursor/release-gate/notes/2026-06-14-streaming-investigation.md`

Made with [Cursor](https://cursor.com)