### PR TITLE
fix(dingtalk): handle msgtype=file inbound (route to FileAttachment) — closes #981 file half

### DIFF
--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -315,6 +315,14 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 		return
 	}
 
+	// Handle file messages (PDF, txt, docx, …). Same downloadCode mechanism as
+	// images, but the payload also carries fileName / fileSize that we surface
+	// to the agent via core.FileAttachment.FileName.
+	if data.Msgtype == "file" {
+		p.handleFileMessage(data, sessionKey)
+		return
+	}
+
 	// Extract message content, recovering quoted/reply info from richText.
 	messageContent := data.Text.Content
 	if richText != nil && richText.IsReplyMsg && richText.RepliedMsg != nil {
@@ -530,6 +538,90 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 		Images: []core.ImageAttachment{{
 			MimeType: mimeType,
 			Data:     imgBytes,
+		}},
+	}
+
+	p.handler(p, msg)
+}
+
+// handleFileMessage downloads a file attachment (msgtype=file) and dispatches
+// it to the engine as a core.FileAttachment so the agent can read its contents.
+// Mirrors handleImageMessage but uses a larger size cap (50 MiB) and preserves
+// the file name reported by DingTalk.
+func (p *Platform) handleFileMessage(data *chatbot.BotCallbackDataModel, sessionKey string) {
+	slog.Debug("dingtalk: file message received", "user", data.SenderNick)
+
+	fileData, ok := data.Content.(map[string]interface{})
+	if !ok {
+		slog.Error("dingtalk: invalid file content type", "type", fmt.Sprintf("%T", data.Content))
+		return
+	}
+
+	downloadCode, _ := fileData["downloadCode"].(string)
+	if downloadCode == "" {
+		slog.Error("dingtalk: file message missing downloadCode")
+		return
+	}
+
+	fileName, _ := fileData["fileName"].(string)
+
+	downloadURL, err := p.getDownloadURL(downloadCode)
+	if err != nil {
+		slog.Error("dingtalk: failed to get file download URL", "error", err)
+		return
+	}
+
+	resp, err := p.httpClient.Get(downloadURL)
+	if err != nil {
+		slog.Error("dingtalk: failed to download file", "error", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Error("dingtalk: file download returned status", "status", resp.StatusCode)
+		return
+	}
+
+	// DingTalk caps single file at 100 MiB; 50 MiB is plenty for agent inputs
+	// and matches what other platforms accept without OOM risk.
+	const maxFileBytes = 50 * 1024 * 1024
+	fileBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxFileBytes+1))
+	if err != nil {
+		slog.Error("dingtalk: failed to read file data", "error", err)
+		return
+	}
+	if len(fileBytes) > maxFileBytes {
+		slog.Error("dingtalk: file too large, dropping", "size", len(fileBytes), "limit", maxFileBytes, "file_name", fileName)
+		return
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
+	slog.Info("dingtalk: file downloaded successfully", "size", len(fileBytes), "mime", mimeType, "file_name", fileName)
+
+	msg := &core.Message{
+		SessionKey: sessionKey,
+		Platform:   "dingtalk",
+		UserID:     data.SenderStaffId,
+		UserName:   data.SenderNick,
+		ChatName:   data.ConversationTitle,
+		MessageID:  data.MsgId,
+		ChannelKey: data.ConversationId,
+		ReplyCtx: replyContext{
+			sessionWebhook: data.SessionWebhook,
+			conversationId: data.ConversationId,
+			senderStaffId:  data.SenderStaffId,
+			messageID:      data.MsgId,
+			isGroup:        data.ConversationType == "2",
+		},
+		Files: []core.FileAttachment{{
+			MimeType: mimeType,
+			Data:     fileBytes,
+			FileName: fileName,
 		}},
 	}
 

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -3,6 +3,7 @@ package dingtalk
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -973,6 +974,139 @@ func TestOnRawMessage_PictureMsgTypeNotDroppedAsEmptyText(t *testing.T) {
 	if handlerCalledWithEmptyContent {
 		t.Error("msgtype=picture: handler called with empty content (image was silently dropped as text)")
 	}
+}
+
+func TestOnRawMessage_FileMsgTypeNotDroppedAsEmptyText(t *testing.T) {
+	// Regression test for #981 (file branch): DingTalk sends msgtype="file" for
+	// PDF/txt/doc attachments. Before this fix the message fell through to the
+	// text handler with empty Content and no Files attached, so the engine
+	// silently dropped the user message — agent would later reply "I did not
+	// receive a file". After the fix the message is routed to
+	// handleFileMessage, which downloads via the same messageFiles/download
+	// endpoint as images and produces a core.FileAttachment.
+	var handlerCalledWithEmptyContent bool
+
+	func() {
+		defer func() { recover() }() // handleFileMessage panics on nil httpClient — that's OK
+		p := &Platform{
+			handler: func(_ core.Platform, msg *core.Message) {
+				if msg.Content == "" && len(msg.Files) == 0 && len(msg.Images) == 0 {
+					handlerCalledWithEmptyContent = true
+				}
+			},
+		}
+		p.onRawMessage(`{
+			"msgtype": "file",
+			"msgId": "msg-file-1",
+			"conversationType": "1",
+			"conversationId": "conv-1",
+			"conversationTitle": "test",
+			"senderStaffId": "user-1",
+			"senderNick": "Alice",
+			"sessionWebhook": "https://example.invalid/webhook",
+			"content": {"downloadCode": "some-code", "fileName": "report.txt", "fileSize": 1234}
+		}`)
+	}()
+
+	if handlerCalledWithEmptyContent {
+		t.Error("msgtype=file: handler called with empty content + no files (file was silently dropped as text)")
+	}
+}
+
+func TestHandleFileMessage_BuildsFileAttachmentWithName(t *testing.T) {
+	// Mocks the messageFiles/download flow end-to-end and asserts:
+	//   1. handleFileMessage parses downloadCode + fileName from content
+	//   2. it issues the access-token + download-URL + GET file chain
+	//   3. the dispatched core.Message carries Files[0] with name + bytes
+	const fileBody = "hello dingtalk file"
+	const fileName = "spec.md"
+
+	// Mock the file's actual content download (separate HTTP server).
+	fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown")
+		_, _ = w.Write([]byte(fileBody))
+	}))
+	defer fileSrv.Close()
+
+	rt := &dingtalkFileDownloadRT{
+		accessToken: "tok-files",
+		downloadURL: fileSrv.URL,
+	}
+
+	captured := make(chan *core.Message, 1)
+	p := &Platform{
+		clientID:     "cid",
+		clientSecret: "csec",
+		robotCode:    "robot-1",
+		httpClient:   &http.Client{Transport: rt},
+		handler: func(_ core.Platform, msg *core.Message) {
+			captured <- msg
+		},
+	}
+
+	p.onRawMessage(`{
+		"msgtype": "file",
+		"msgId": "msg-file-2",
+		"conversationType": "1",
+		"conversationId": "conv-1",
+		"conversationTitle": "test",
+		"senderStaffId": "user-1",
+		"senderNick": "Alice",
+		"sessionWebhook": "https://example.invalid/webhook",
+		"content": {"downloadCode": "dc-xyz", "fileName": "` + fileName + `", "fileSize": 19}
+	}`)
+
+	select {
+	case msg := <-captured:
+		if len(msg.Files) != 1 {
+			t.Fatalf("Files len = %d, want 1", len(msg.Files))
+		}
+		f := msg.Files[0]
+		if f.FileName != fileName {
+			t.Errorf("FileName = %q, want %q", f.FileName, fileName)
+		}
+		if string(f.Data) != fileBody {
+			t.Errorf("file bytes = %q, want %q", f.Data, fileBody)
+		}
+		if f.MimeType != "text/markdown" {
+			t.Errorf("MimeType = %q, want %q", f.MimeType, "text/markdown")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never invoked with file message")
+	}
+}
+
+// dingtalkFileDownloadRT mocks /v1.0/oauth2/accessToken and
+// /v1.0/robot/messageFiles/download. The latter returns downloadURL pointing
+// to a test server that serves the actual file body. Used by
+// TestHandleFileMessage_BuildsFileAttachmentWithName.
+type dingtalkFileDownloadRT struct {
+	accessToken string
+	downloadURL string
+}
+
+func (f *dingtalkFileDownloadRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	switch req.URL.Path {
+	case "/v1.0/oauth2/accessToken":
+		body := fmt.Sprintf(`{"accessToken":%q,"expireIn":7200}`, f.accessToken)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	case "/v1.0/robot/messageFiles/download":
+		body := fmt.Sprintf(`{"downloadUrl":%q}`, f.downloadURL)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}
+	// Forward non-DingTalk-API requests to the default transport so the test
+	// can serve actual file bytes from an httptest.Server.
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 func TestGetAccessToken_ZeroExpireIn_FallsBackToDefault(t *testing.T) {

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -987,7 +987,7 @@ func TestOnRawMessage_FileMsgTypeNotDroppedAsEmptyText(t *testing.T) {
 	var handlerCalledWithEmptyContent bool
 
 	func() {
-		defer func() { recover() }() // handleFileMessage panics on nil httpClient — that's OK
+		defer func() { _ = recover() }() // handleFileMessage panics on nil httpClient — that's OK
 		p := &Platform{
 			handler: func(_ core.Platform, msg *core.Message) {
 				if msg.Content == "" && len(msg.Files) == 0 && len(msg.Images) == 0 {


### PR DESCRIPTION
## Summary

DingTalk delivers user-uploaded files (PDF / txt / docx / …) via `msgtype="file"` callbacks that carry a `downloadCode` + `fileName` in the content payload. cc-connect previously had **no branch for this** in `onRawMessage`'s dispatcher: the message fell through to the default text handler with empty `Content` and no `Files` attached, so the engine silently dropped the user message and the agent later replied "I did not receive a file" — extremely confusing UX.

This is the **file half** of the same #981 family that PR #1128 already fixed for `image`/`picture` msgtypes.

## Changes

- Route `msgtype="file"` to new `handleFileMessage` in `platform/dingtalk/dingtalk.go`
- `handleFileMessage` mirrors `handleImageMessage`:
  - parse `downloadCode` + `fileName` from `data.Content`
  - reuse existing `getDownloadURL` / HTTP download chain
  - cap at 50 MiB (DingTalk's per-file limit is 100 MiB; 50 is plenty for agent inputs without OOM risk)
  - dispatch as `core.Message{Files: []core.FileAttachment{...}}` preserving original `FileName`

## Tests

| Test | Type | Purpose |
| ---- | ---- | ------- |
| `TestOnRawMessage_FileMsgTypeNotDroppedAsEmptyText` | regression | handler must never see empty file inbound |
| `TestHandleFileMessage_BuildsFileAttachmentWithName` | positive | mocks accessToken + download URL + file body, asserts dispatched `Message` carries a `FileAttachment` with correct name, bytes, mime |
| `TestOnRawMessage_PictureMsgTypeNotDroppedAsEmptyText` | unchanged | image branch still passes |

```
ok  github.com/chenhg5/cc-connect/platform/dingtalk  0.019s
```

## Manual verification (release-test environment)

Sent `.txt` + "read this file" to DingTalk private chat with the release-test cc-connect binary built from this branch.

| Before | After |
| ------ | ----- |
| `msgtype=file content_len=0 has_files=false` → engine drops msg → agent replies "I did not receive a file" | `dingtalk: file downloaded successfully size=N file_name=xxx.txt` → agent correctly describes file contents |

## How this was found

`qa-cursor` was running release-gate `UI-P0-19`, a test case explicitly designed as a "known-gap" expected-fail. Repro confirmed the gap in the live binary, then we built the fix on top of `main` and re-tested in the same session.

## Test plan for reviewer

- [ ] `go test ./platform/dingtalk/...`
- [ ] Send a small `.txt` file to a DingTalk bot in private chat with caption "read this"; agent should be able to read the contents
- [ ] Send a small `.pdf`; same expectation
- [ ] Send a >50 MiB file; should be rejected with `dingtalk: file too large` log (no crash)
- [ ] Send an image (unchanged path); should still be processed via `handleImageMessage`

Made with [Cursor](https://cursor.com)