### PR TITLE
fix(send): route --audio/--video to dedicated AudioSender/VideoSender path

### DIFF
--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -189,10 +189,17 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 		return req, "", err
 	}
 	req.Images = images
-	req.Files = append(files, audioFiles...)
-	req.Files = append(req.Files, videoFiles...)
+	// Keep audio / video clips on dedicated fields. Routing them through
+	// req.Files would force the engine to dispatch them via FileSender —
+	// that loses the native voice-bubble / video-bubble path on platforms
+	// that implement AudioSender / VideoSender (e.g. Feishu's ffmpeg
+	// transcode for mp3 → opus). See cc-connect internal task
+	// t-20260615-cqjbk1.
+	req.Files = files
+	req.Audios = audioFiles
+	req.Videos = videoFiles
 
-	if req.Message == "" && req.TTSText == "" && len(req.Images) == 0 && len(req.Files) == 0 {
+	if req.Message == "" && req.TTSText == "" && len(req.Images) == 0 && len(req.Files) == 0 && len(req.Audios) == 0 && len(req.Videos) == 0 {
 		return req, "", fmt.Errorf("message, tts text, or attachment is required")
 	}
 

--- a/cmd/cc-connect/send_test.go
+++ b/cmd/cc-connect/send_test.go
@@ -76,32 +76,88 @@ func TestParseSendArgs_UsesSessionEnvFallback(t *testing.T) {
 	}
 }
 
-func TestParseSendArgs_AudioAndVideoAttachments(t *testing.T) {
+// TestParseSendArgs_AudioPopulatesAudios is the regression for
+// t-20260615-cqjbk1: --audio and --video must NOT land in req.Files
+// (which would route them through SendFile and skip
+// AudioSender / VideoSender). They each get their own slice.
+func TestParseSendArgs_AudioPopulatesAudios(t *testing.T) {
 	dir := t.TempDir()
 	audioPath := filepath.Join(dir, "voice.opus")
-	videoPath := filepath.Join(dir, "demo.mp4")
 	if err := os.WriteFile(audioPath, []byte("opus"), 0o644); err != nil {
 		t.Fatalf("write audio: %v", err)
 	}
+
+	req, _, err := parseSendArgs([]string{"--audio", audioPath})
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if len(req.Files) != 0 {
+		t.Fatalf("req.Files len = %d, want 0 (audio must NOT be appended into Files)", len(req.Files))
+	}
+	if len(req.Audios) != 1 {
+		t.Fatalf("req.Audios len = %d, want 1", len(req.Audios))
+	}
+	if req.Audios[0].FileName != "voice.opus" {
+		t.Fatalf("audio filename = %q, want voice.opus", req.Audios[0].FileName)
+	}
+	if string(req.Audios[0].Data) != "opus" {
+		t.Fatalf("audio data = %q, want %q", req.Audios[0].Data, "opus")
+	}
+}
+
+func TestParseSendArgs_VideoPopulatesVideos(t *testing.T) {
+	dir := t.TempDir()
+	videoPath := filepath.Join(dir, "demo.mp4")
 	if err := os.WriteFile(videoPath, []byte("mp4"), 0o644); err != nil {
 		t.Fatalf("write video: %v", err)
 	}
 
-	req, _, err := parseSendArgs([]string{"--audio", audioPath, "--video", videoPath})
+	req, _, err := parseSendArgs([]string{"--video", videoPath})
 	if err != nil {
 		t.Fatalf("parseSendArgs returned error: %v", err)
 	}
-	if len(req.Images) != 0 {
-		t.Fatalf("images len = %d, want 0", len(req.Images))
+	if len(req.Files) != 0 {
+		t.Fatalf("req.Files len = %d, want 0 (video must NOT be appended into Files)", len(req.Files))
 	}
-	if len(req.Files) != 2 {
-		t.Fatalf("files len = %d, want 2", len(req.Files))
+	if len(req.Videos) != 1 {
+		t.Fatalf("req.Videos len = %d, want 1", len(req.Videos))
 	}
-	if req.Files[0].FileName != "voice.opus" {
-		t.Fatalf("audio filename = %q, want voice.opus", req.Files[0].FileName)
+	if req.Videos[0].FileName != "demo.mp4" {
+		t.Fatalf("video filename = %q, want demo.mp4", req.Videos[0].FileName)
 	}
-	if req.Files[1].FileName != "demo.mp4" {
-		t.Fatalf("video filename = %q, want demo.mp4", req.Files[1].FileName)
+}
+
+func TestParseSendArgs_AudioVideoFileMixed_StaySeparate(t *testing.T) {
+	dir := t.TempDir()
+	audioPath := filepath.Join(dir, "voice.opus")
+	videoPath := filepath.Join(dir, "demo.mp4")
+	docPath := filepath.Join(dir, "notes.md")
+	for _, f := range [][2]string{
+		{audioPath, "opus"},
+		{videoPath, "mp4"},
+		{docPath, "hello"},
+	} {
+		if err := os.WriteFile(f[0], []byte(f[1]), 0o644); err != nil {
+			t.Fatalf("write %s: %v", f[0], err)
+		}
+	}
+
+	req, _, err := parseSendArgs([]string{
+		"--audio", audioPath,
+		"--video", videoPath,
+		"--file", docPath,
+	})
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if len(req.Audios) != 1 || req.Audios[0].FileName != "voice.opus" {
+		t.Fatalf("req.Audios = %#v", req.Audios)
+	}
+	if len(req.Videos) != 1 || req.Videos[0].FileName != "demo.mp4" {
+		t.Fatalf("req.Videos = %#v", req.Videos)
+	}
+	if len(req.Files) != 1 || req.Files[0].FileName != "notes.md" {
+		t.Fatalf("req.Files = %#v (only the --file should land here)", req.Files)
 	}
 }
 

--- a/core/api.go
+++ b/core/api.go
@@ -30,6 +30,14 @@ type APIServer struct {
 }
 
 // SendRequest is the JSON body for POST /send.
+//
+// Audios and Videos are kept separate from Files so the engine can
+// dispatch them to AudioSender / VideoSender (native voice / video
+// bubble) instead of FileSender (generic file download). The fields
+// reuse FileAttachment as the wire format because audio/video clips
+// are byte blobs with a name + mime — the dedicated typing happens at
+// the dispatch layer in engine.go. See cc-connect internal task
+// t-20260615-cqjbk1.
 type SendRequest struct {
 	Project    string            `json:"project"`
 	SessionKey string            `json:"session_key"`
@@ -37,6 +45,8 @@ type SendRequest struct {
 	TTSText    string            `json:"tts_text,omitempty"`
 	Images     []ImageAttachment `json:"images,omitempty"`
 	Files      []FileAttachment  `json:"files,omitempty"`
+	Audios     []FileAttachment  `json:"audios,omitempty"`
+	Videos     []FileAttachment  `json:"videos,omitempty"`
 	AtUsers    []string          `json:"at_users,omitempty"`
 	AtAll      bool              `json:"at_all,omitempty"`
 }
@@ -157,7 +167,7 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	if req.Message == "" && strings.TrimSpace(req.TTSText) == "" && len(req.Images) == 0 && len(req.Files) == 0 {
+	if req.Message == "" && strings.TrimSpace(req.TTSText) == "" && len(req.Images) == 0 && len(req.Files) == 0 && len(req.Audios) == 0 && len(req.Videos) == 0 {
 		http.Error(w, "message, tts_text, or attachment is required", http.StatusBadRequest)
 		return
 	}
@@ -190,6 +200,20 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 
 	if req.Message != "" || len(req.Images) > 0 || len(req.Files) > 0 {
 		if err := engine.SendToSessionWithAttachments(req.SessionKey, req.Message, req.Images, req.Files, req.AtUsers, req.AtAll); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if len(req.Audios) > 0 {
+		if err := engine.SendAudiosToSession(req.SessionKey, req.Audios); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if len(req.Videos) > 0 {
+		if err := engine.SendVideosToSession(req.SessionKey, req.Videos); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/core/bridge.go
+++ b/core/bridge.go
@@ -311,6 +311,7 @@ var (
 	_ PreviewCleaner            = (*BridgePlatform)(nil)
 	_ TypingIndicator           = (*BridgePlatform)(nil)
 	_ AudioSender               = (*BridgePlatform)(nil)
+	_ VideoSender               = (*BridgePlatform)(nil)
 	_ ImageSender               = (*BridgePlatform)(nil)
 	_ FileSender                = (*BridgePlatform)(nil)
 	_ CardNavigable             = (*BridgePlatform)(nil)
@@ -621,6 +622,25 @@ func (bp *BridgePlatform) SendAudio(ctx context.Context, replyCtx any, audio []b
 		"reply_ctx":   rc.ReplyCtx,
 		"data":        base64.StdEncoding.EncodeToString(audio),
 		"format":      format,
+	})
+}
+
+func (bp *BridgePlatform) SendVideo(ctx context.Context, replyCtx any, video []byte, format string, fileName string) error {
+	rc, ok := replyCtx.(*bridgeReplyCtx)
+	if !ok {
+		return fmt.Errorf("bridge: invalid reply context")
+	}
+	a := bp.server.getAdapter(rc.Platform)
+	if a == nil || !a.capabilities["video"] {
+		return ErrNotSupported
+	}
+	return bp.server.sendToAdapter(rc.Platform, map[string]any{
+		"type":        "video",
+		"session_key": rc.SessionKey,
+		"reply_ctx":   rc.ReplyCtx,
+		"data":        base64.StdEncoding.EncodeToString(video),
+		"format":      format,
+		"file_name":   fileName,
 	})
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -10309,6 +10309,119 @@ func (e *Engine) SendTTSToSession(sessionKey, text string) error {
 	return e.synthesizeAndSendTTS(p, replyCtx, text)
 }
 
+// SendAudiosToSession routes outbound audio attachments to the
+// platform's AudioSender (native voice bubble + transcoding) when
+// supported, falling back to FileSender otherwise. Used by
+// `cc-connect send --audio`. Mirrors SendToSessionWithAttachments for
+// audio-typed clips so they don't get dispatched as generic files.
+func (e *Engine) SendAudiosToSession(sessionKey string, audios []FileAttachment) error {
+	if len(audios) == 0 {
+		return nil
+	}
+	_, p, replyCtx, err := e.resolveOutboundSessionTarget(sessionKey, true)
+	if err != nil {
+		return err
+	}
+	if !e.attachmentSendEnabled {
+		return ErrAttachmentSendDisabled
+	}
+
+	audioSender, audioOK := p.(AudioSender)
+	fileSender, fileOK := p.(FileSender)
+	if !audioOK && !fileOK {
+		return fmt.Errorf("platform %s: %w", p.Name(), ErrNotSupported)
+	}
+
+	for _, a := range audios {
+		if err := e.waitOutgoing(p); err != nil {
+			return err
+		}
+		format := audioFormatHint(a)
+		if audioOK {
+			if err := audioSender.SendAudio(e.ctx, replyCtx, a.Data, format); err != nil {
+				return err
+			}
+			continue
+		}
+		// Fallback: platform has no AudioSender. Send as a plain file so
+		// the user still receives the clip — but warn so operators know
+		// the native voice bubble was unavailable.
+		slog.Warn("send: platform has no AudioSender, falling back to SendFile",
+			"platform", p.Name(), "file_name", a.FileName, "format", format)
+		if err := fileSender.SendFile(e.ctx, replyCtx, a); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SendVideosToSession routes outbound video attachments to the
+// platform's VideoSender (native video bubble) when supported, falling
+// back to FileSender otherwise. Used by `cc-connect send --video`.
+func (e *Engine) SendVideosToSession(sessionKey string, videos []FileAttachment) error {
+	if len(videos) == 0 {
+		return nil
+	}
+	_, p, replyCtx, err := e.resolveOutboundSessionTarget(sessionKey, true)
+	if err != nil {
+		return err
+	}
+	if !e.attachmentSendEnabled {
+		return ErrAttachmentSendDisabled
+	}
+
+	videoSender, videoOK := p.(VideoSender)
+	fileSender, fileOK := p.(FileSender)
+	if !videoOK && !fileOK {
+		return fmt.Errorf("platform %s: %w", p.Name(), ErrNotSupported)
+	}
+
+	for _, v := range videos {
+		if err := e.waitOutgoing(p); err != nil {
+			return err
+		}
+		format := videoFormatHint(v)
+		if videoOK {
+			if err := videoSender.SendVideo(e.ctx, replyCtx, v.Data, format, v.FileName); err != nil {
+				return err
+			}
+			continue
+		}
+		slog.Warn("send: platform has no VideoSender, falling back to SendFile",
+			"platform", p.Name(), "file_name", v.FileName, "format", format)
+		if err := fileSender.SendFile(e.ctx, replyCtx, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// audioFormatHint extracts the short format hint (e.g. "mp3", "opus")
+// from a FileAttachment. Filename extension wins over MIME type because
+// the CLI-uploaded name is more reliable than detected MIME (raw
+// audio bytes often sniff to application/octet-stream).
+func audioFormatHint(a FileAttachment) string {
+	if ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(a.FileName), ".")); ext != "" {
+		return ext
+	}
+	if a.MimeType != "" {
+		// "audio/mpeg" -> "mpeg"; "audio/ogg; codecs=opus" -> "ogg"
+		mt := strings.ToLower(a.MimeType)
+		if i := strings.Index(mt, ";"); i >= 0 {
+			mt = mt[:i]
+		}
+		if i := strings.Index(mt, "/"); i >= 0 {
+			return strings.TrimSpace(mt[i+1:])
+		}
+	}
+	return ""
+}
+
+// videoFormatHint mirrors audioFormatHint for video clips.
+func videoFormatHint(v FileAttachment) string {
+	return audioFormatHint(v)
+}
+
 func (e *Engine) resolveOutboundSessionTarget(sessionKey string, hasAttachments bool) (*interactiveState, Platform, any, error) {
 	e.interactiveMu.Lock()
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -14660,3 +14660,202 @@ func TestHandlePendingPermission_ApproveAllWithMention(t *testing.T) {
 		t.Fatal("state.approveAll = false, want true (approve-all must persist for follow-up tools)")
 	}
 }
+
+// ─── Audio / Video routing (t-20260615-cqjbk1) ────────────────────────
+// `cc-connect send --audio` / `--video` must reach AudioSender /
+// VideoSender — NOT SendFile. PR #1202 made the CLI flags exist but
+// silently routed clips through SendFile, defeating the
+// transcoding-and-render-as-native-bubble pipeline.
+
+// audioVideoStubPlatform implements both AudioSender and VideoSender
+// alongside the file-fallback path so we can assert the engine picks
+// the dedicated method.
+type audioVideoStubPlatform struct {
+	stubMediaPlatform
+	mu     sync.Mutex
+	audios []audioCall
+	videos []videoCall
+}
+
+type audioCall struct {
+	data   []byte
+	format string
+}
+
+type videoCall struct {
+	data     []byte
+	format   string
+	fileName string
+}
+
+func (p *audioVideoStubPlatform) SendAudio(_ context.Context, _ any, audio []byte, format string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.audios = append(p.audios, audioCall{data: append([]byte(nil), audio...), format: format})
+	return nil
+}
+
+func (p *audioVideoStubPlatform) SendVideo(_ context.Context, _ any, video []byte, format string, fileName string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.videos = append(p.videos, videoCall{data: append([]byte(nil), video...), format: format, fileName: fileName})
+	return nil
+}
+
+func TestSendAudiosToSession_RoutesToSendAudio_NotSendFile(t *testing.T) {
+	p := &audioVideoStubPlatform{stubMediaPlatform: stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.interactiveStates["session-audio"] = &interactiveState{platform: p, replyCtx: "ctx"}
+
+	err := e.SendAudiosToSession("session-audio", []FileAttachment{
+		{MimeType: "audio/mpeg", Data: []byte("mp3-bytes"), FileName: "clip.mp3"},
+		{MimeType: "audio/ogg", Data: []byte("opus-bytes"), FileName: "voice.opus"},
+	})
+	if err != nil {
+		t.Fatalf("SendAudiosToSession returned error: %v", err)
+	}
+	if got := len(p.audios); got != 2 {
+		t.Fatalf("AudioSender.SendAudio called %d times, want 2", got)
+	}
+	if p.audios[0].format != "mp3" {
+		t.Errorf("audio[0].format = %q, want %q (filename ext wins)", p.audios[0].format, "mp3")
+	}
+	if p.audios[1].format != "opus" {
+		t.Errorf("audio[1].format = %q, want %q", p.audios[1].format, "opus")
+	}
+	if string(p.audios[0].data) != "mp3-bytes" {
+		t.Errorf("audio[0].data = %q, want %q", p.audios[0].data, "mp3-bytes")
+	}
+	// Crucial: must NOT have hit SendFile.
+	if len(p.files) != 0 {
+		t.Errorf("SendFile called %d times, want 0 (audio must not fall back when AudioSender exists)", len(p.files))
+	}
+}
+
+func TestSendAudiosToSession_PlatformWithoutAudioSender_FallsBackToFile(t *testing.T) {
+	// stubMediaPlatform implements ImageSender + FileSender but NOT AudioSender.
+	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "no-audio"}}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.interactiveStates["session-fallback"] = &interactiveState{platform: p, replyCtx: "ctx"}
+
+	err := e.SendAudiosToSession("session-fallback", []FileAttachment{
+		{MimeType: "audio/mpeg", Data: []byte("mp3-bytes"), FileName: "clip.mp3"},
+	})
+	if err != nil {
+		t.Fatalf("SendAudiosToSession returned error: %v", err)
+	}
+	if len(p.files) != 1 {
+		t.Fatalf("expected fallback SendFile call, got %d", len(p.files))
+	}
+	if p.files[0].FileName != "clip.mp3" {
+		t.Errorf("fallback file name = %q, want clip.mp3", p.files[0].FileName)
+	}
+}
+
+func TestSendAudiosToSession_PlatformWithNeitherSender_Errors(t *testing.T) {
+	p := &stubPlatformEngine{n: "text-only"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.interactiveStates["session-none"] = &interactiveState{platform: p, replyCtx: "ctx"}
+
+	err := e.SendAudiosToSession("session-none", []FileAttachment{
+		{MimeType: "audio/mpeg", Data: []byte("x"), FileName: "x.mp3"},
+	})
+	if err == nil {
+		t.Fatal("expected error when platform has neither AudioSender nor FileSender")
+	}
+	if !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("err = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestSendAudiosToSession_DisabledByConfig(t *testing.T) {
+	p := &audioVideoStubPlatform{stubMediaPlatform: stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetAttachmentSendEnabled(false)
+	e.interactiveStates["session-audio-off"] = &interactiveState{platform: p, replyCtx: "ctx"}
+
+	err := e.SendAudiosToSession("session-audio-off", []FileAttachment{
+		{MimeType: "audio/mpeg", Data: []byte("x"), FileName: "x.mp3"},
+	})
+	if !errors.Is(err, ErrAttachmentSendDisabled) {
+		t.Fatalf("err = %v, want ErrAttachmentSendDisabled", err)
+	}
+	if len(p.audios) != 0 {
+		t.Errorf("audios sent while disabled: %d, want 0", len(p.audios))
+	}
+}
+
+func TestSendVideosToSession_RoutesToSendVideo_NotSendFile(t *testing.T) {
+	p := &audioVideoStubPlatform{stubMediaPlatform: stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.interactiveStates["session-video"] = &interactiveState{platform: p, replyCtx: "ctx"}
+
+	err := e.SendVideosToSession("session-video", []FileAttachment{
+		{MimeType: "video/mp4", Data: []byte("mp4-bytes"), FileName: "demo.mp4"},
+	})
+	if err != nil {
+		t.Fatalf("SendVideosToSession returned error: %v", err)
+	}
+	if len(p.videos) != 1 {
+		t.Fatalf("VideoSender.SendVideo called %d times, want 1", len(p.videos))
+	}
+	if p.videos[0].format != "mp4" {
+		t.Errorf("video[0].format = %q, want mp4", p.videos[0].format)
+	}
+	if p.videos[0].fileName != "demo.mp4" {
+		t.Errorf("video[0].fileName = %q, want demo.mp4", p.videos[0].fileName)
+	}
+	if len(p.files) != 0 {
+		t.Errorf("SendFile called %d times, want 0 (video must not fall back when VideoSender exists)", len(p.files))
+	}
+}
+
+func TestSendVideosToSession_PlatformWithoutVideoSender_FallsBackToFile(t *testing.T) {
+	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "no-video"}}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.interactiveStates["session-vfb"] = &interactiveState{platform: p, replyCtx: "ctx"}
+
+	err := e.SendVideosToSession("session-vfb", []FileAttachment{
+		{MimeType: "video/mp4", Data: []byte("mp4"), FileName: "demo.mp4"},
+	})
+	if err != nil {
+		t.Fatalf("SendVideosToSession returned error: %v", err)
+	}
+	if len(p.files) != 1 {
+		t.Fatalf("expected fallback SendFile call, got %d", len(p.files))
+	}
+}
+
+func TestAudioFormatHint(t *testing.T) {
+	cases := []struct {
+		name string
+		in   FileAttachment
+		want string
+	}{
+		{"filename ext wins", FileAttachment{FileName: "voice.OPUS", MimeType: "application/octet-stream"}, "opus"},
+		{"mime fallback", FileAttachment{FileName: "blob", MimeType: "audio/mpeg"}, "mpeg"},
+		{"mime with codecs", FileAttachment{FileName: "blob", MimeType: "audio/ogg; codecs=opus"}, "ogg"},
+		{"empty", FileAttachment{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := audioFormatHint(tc.in); got != tc.want {
+				t.Errorf("audioFormatHint(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentSystemPrompt_DocumentsAudioVideoFlags(t *testing.T) {
+	prompt := AgentSystemPrompt()
+	for _, want := range []string{"send --audio", "send --video"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("AgentSystemPrompt missing %q", want)
+		}
+	}
+	// Make sure the surrounding guidance is also present so the agent
+	// doesn't silently downgrade --audio/--video to --file.
+	if !strings.Contains(prompt, "Do NOT downgrade") {
+		t.Error("AgentSystemPrompt missing the 'Do NOT downgrade' anti-regression line")
+	}
+}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -81,11 +81,18 @@ When you generate a local image or file that should be sent to the user, use:
 You may repeat --image / --file multiple times. Use this only for generated attachments that need to be delivered to the user.
 If you include --message, do not repeat the exact same sentence again in your normal reply, because your normal reply is also delivered automatically.
 
-When the user explicitly asks you to send a voice/audio reply, synthesize and send it with:
+When sending an audio (mp3/wav/m4a/ogg/opus) or video (mp4/mov/webm) clip that should render inline as a native voice bubble or video player — instead of as a generic file download — use the dedicated flags:
+
+  cc-connect send --audio /absolute/path/to/clip.mp3
+  cc-connect send --video /absolute/path/to/demo.mp4
+
+These render as native media on platforms that support it (e.g. Feishu voice bubbles, Telegram voice messages). cc-connect transparently transcodes audio to the platform's preferred codec (e.g. opus for Feishu). On platforms without dedicated audio/video support cc-connect automatically falls back to the file-attachment path so delivery is preserved. Do NOT downgrade the user's request to --file when they explicitly asked for audio or video.
+
+When the user explicitly asks you to synthesize speech from text, use:
 
   cc-connect send --tts "text to speak"
 
-After this command succeeds, reply only with NO_REPLY unless the user also asked for a visible text confirmation. This prevents sending an extra text message after the voice message.
+After cc-connect send --tts (or --audio) succeeds, reply only with NO_REPLY unless the user also asked for a visible text confirmation. This prevents sending an extra text message after the voice message.
 
 ### Scheduled tasks (cron)
 When the user asks you to do something on a schedule (e.g. "每天早上6点帮我总结GitHub trending"), use the Bash tool to run:

--- a/core/tts.go
+++ b/core/tts.go
@@ -61,8 +61,26 @@ func (c *TTSCfg) SetTTSMode(mode string) {
 }
 
 // AudioSender is implemented by platforms that support sending voice/audio messages.
+//
+// `format` is the lowercase short format hint extracted from the filename
+// extension or MIME type (e.g. "mp3", "ogg", "opus", "m4a"). Platforms
+// that need a specific codec (Feishu requires opus) are expected to
+// transcode internally; format is only an input hint.
 type AudioSender interface {
 	SendAudio(ctx context.Context, replyCtx any, audio []byte, format string) error
+}
+
+// VideoSender is implemented by platforms that can render a native
+// inline video bubble for an outbound clip rather than a generic file
+// download. Engine code falls back to FileSender when a platform does
+// not implement this interface.
+//
+// `format` is the lowercase short format hint (e.g. "mp4", "mov",
+// "webm"). Implementations are free to transcode to the platform's
+// preferred codec; on Feishu mp4/H.264 has the broadest playback
+// support so non-mp4 inputs may render with reduced compatibility.
+type VideoSender interface {
+	SendVideo(ctx context.Context, replyCtx any, video []byte, format string, fileName string) error
 }
 
 // ──────────────────────────────────────────────────────────────

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -4350,7 +4350,82 @@ func (p *Platform) SendAudio(ctx context.Context, rctx any, audio []byte, format
 		return fmt.Errorf("%s: build audio message: %w", p.tag(), err)
 	}
 
+	// Diagnostic for QA-reported intermittent "audio rendered as file" in
+	// P2P reply mode (see internal task t-20260615-cqjbk1). Tracking the
+	// API path lets operators correlate Feishu client renders to whether
+	// we used Reply (in-thread) or Create (new message) when issues
+	// recur. The Reply path has historically had narrower MsgType
+	// support on some Feishu desktop client versions.
+	if p.shouldUseThreadOrReplyAPI(rc) {
+		slog.Debug(p.tag()+": SendAudio using Reply API",
+			"file_key", fileKey, "msg_id", rc.messageID, "format", format)
+	} else {
+		slog.Debug(p.tag()+": SendAudio using Create API",
+			"file_key", fileKey, "chat_id", rc.chatID, "format", format)
+	}
+
 	return p.sendMediaMessage(ctx, rc, larkim.MsgTypeAudio, audioContent)
+}
+
+// SendVideo uploads video bytes to Feishu and sends a native video
+// (MsgTypeMedia) message. Implements core.VideoSender.
+//
+// Feishu's File API only recognises "mp4" as the video file_type, so
+// every input is uploaded under that label. Actual playback depends on
+// the Feishu client (mp4 H.264 has the broadest support); other
+// containers like webm / mkv typically still upload but may render as
+// a download tile on some clients. The fallback path to SendFile in
+// engine.go preserves at least delivery when this happens.
+func (p *Platform) SendVideo(ctx context.Context, rctx any, video []byte, format string, fileName string) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return fmt.Errorf("%s: SendVideo: invalid reply context type %T", p.tag(), rctx)
+	}
+	if fileName == "" {
+		if format != "" {
+			fileName = "video." + format
+		} else {
+			fileName = "video.mp4"
+		}
+	}
+
+	var uploadResp *larkim.CreateFileResp
+	if err := p.withTransientRetry(ctx, "upload video", func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, "upload video", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			req := larkim.NewCreateFileReqBuilder().
+				Body(larkim.NewCreateFileReqBodyBuilder().
+					FileType(larkim.FileTypeMp4).
+					FileName(fileName).
+					File(bytes.NewReader(video)).
+					Build()).
+				Build()
+			var err error
+			uploadResp, err = client.Im.File.Create(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: upload video: %w", p.tag(), err)
+			}
+			if !uploadResp.Success() {
+				return fmt.Errorf("%s: upload video code=%d msg=%s", p.tag(), uploadResp.Code, uploadResp.Msg)
+			}
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+	if uploadResp.Data == nil || uploadResp.Data.FileKey == nil {
+		return fmt.Errorf("%s: upload video: no file_key returned", p.tag())
+	}
+	fileKey := *uploadResp.Data.FileKey
+
+	slog.Debug(p.tag()+": video uploaded", "file_key", fileKey, "format", format, "size", len(video))
+
+	mediaMsg := larkim.MessageMedia{FileKey: fileKey}
+	mediaContent, err := mediaMsg.String()
+	if err != nil {
+		return fmt.Errorf("%s: build video message: %w", p.tag(), err)
+	}
+
+	return p.sendMediaMessage(ctx, rc, larkim.MsgTypeMedia, mediaContent)
 }
 
 type postElement struct {


### PR DESCRIPTION
## Summary

Fixes a regression in PR #1202 (`feat(feishu): send audio and video attachments as media`) where the new `cc-connect send --audio` / `--video` CLI flags landed but the actual feature was a no-op: the parser appended audio/video files into `req.Files`, so the engine dispatched them via `SendFile` — bypassing `AudioSender` (with its mp3→opus ffmpeg transcode) entirely.

User-visible symptom (QA-reproduced): `cc-connect send --audio sample.mp3` shows up in Feishu as a generic file download, not a voice bubble. The 258 lines of CLI plumbing were indistinguishable from `--file`.

## What changed

### Routing
- `core.SendRequest` gains dedicated `Audios` / `Videos []FileAttachment` fields (was: silently merged into `Files`).
- `cmd/cc-connect/send.go` populates them separately.
- New `core.VideoSender` interface (parallel to existing `AudioSender`).
- New `Engine.SendAudiosToSession` / `Engine.SendVideosToSession`: prefer `AudioSender` / `VideoSender`, automatic `SendFile` fallback + `slog.Warn` when the platform hasn't wired native media yet — preserves delivery on platforms that don't yet implement the dedicated interface.
- `platform/feishu`: implements `SendVideo` (FileTypeMp4 → MsgTypeMedia). `SendAudio` unchanged behaviour, plus diagnostic `slog.Debug` (Reply vs Create API path) for the QA-reported intermittent ""audio renders as file in P2P reply mode"" investigation.
- `core/bridge.BridgePlatform` advertises `VideoSender` capability.

### Agent prompt
- `core.AgentSystemPrompt` now documents `--audio` / `--video` AND explicitly tells the agent **not** to downgrade the user's request to `--file`. Previous prompt only listed `--image` / `--file` / `--tts`, so LLM-side robustness logic quietly substituted `--file` when users asked for `--audio` (subsumes the prompt-only sibling task).

## Tests added

- `TestParseSendArgs_AudioPopulatesAudios` / `_VideoPopulatesVideos` / `_AudioVideoFileMixed_StaySeparate` — CLI no longer leaks audio/video into `Files`.
- `TestSendAudiosToSession_RoutesToSendAudio_NotSendFile` + fallback (`_PlatformWithoutAudioSender_FallsBackToFile`) + neither sender (`_PlatformWithNeitherSender_Errors`) + `_DisabledByConfig`.
- `TestSendVideosToSession_RoutesToSendVideo_NotSendFile` + `_PlatformWithoutVideoSender_FallsBackToFile`.
- `TestAudioFormatHint` — filename ext wins over mime, codec hint stripped.
- `TestAgentSystemPrompt_DocumentsAudioVideoFlags` — pins both flags **and** the ""Do NOT downgrade"" anti-regression line so a future prompt rewrite cannot silently drop them again.

## Verification

\`\`\`
go test -count=1 ./core/... ./cmd/cc-connect/... ./platform/feishu/...
ok core ✓  ok cmd/cc-connect ✓  ok platform/feishu ✓
golangci-lint run --new-from-rev=origin/main ./core/... ./cmd/cc-connect/... ./platform/feishu/...
0 issues.
\`\`\`

## Known follow-ups (not in this PR)

QA reports that even routing `.opus` through Feishu's `SendAudio` may render as a file in some P2P **reply-mode** clients. New `slog.Debug` lines now surface whether the Reply or Create API was used so we can isolate that — most likely a Feishu desktop-client version issue rather than a cc-connect bug. If repro becomes deterministic, follow-up could force `MsgTypeAudio` through the Create path. Tracked separately.

## Refs

- Internal task: t-20260615-cqjbk1 (P1, supersedes t-20260614-nftm6b)
- Triage note: \`projects/cc-connect/agents/qa-cursor/release-gate/notes/2026-06-15-pr1202-incomplete-agent-prompt.md\`
- Original feature PR: #1202


Made with [Cursor](https://cursor.com)