### PR TITLE
fix(codex): use -c sandbox_mode override on exec resume (P1, fixes silent resume failure)

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -197,16 +197,32 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 	// As of codex-cli 0.137 `--full-auto` is no longer accepted; use the
 	// canonical `--sandbox <mode>` form together with `-c approval_policy=...`.
 	//
+	// CAVEAT: `codex exec resume` does NOT accept the `--sandbox <mode>` flag
+	// (only `codex exec` does). Both subcommands accept `-c key=value` config
+	// overrides though, so on resume we express sandbox via `-c sandbox_mode=...`
+	// instead. Without this, every resume would fail with:
+	//   error: unexpected argument '--sandbox' found
+	// — and the user would silently lose their session on every cc-connect
+	// restart / idle reset.
+	//
 	// For real interactive approvals (suggest semantics), users must opt into
 	// the `app_server` backend, which handles execCommandApproval /
 	// applyPatchApproval / permissionsApproval over JSON-RPC.
 	switch cs.mode {
 	case "auto-edit", "full-auto":
-		args = append(args, "--sandbox", "workspace-write", "-c", `approval_policy="never"`)
+		if isResume {
+			args = append(args, "-c", `sandbox_mode="workspace-write"`, "-c", `approval_policy="never"`)
+		} else {
+			args = append(args, "--sandbox", "workspace-write", "-c", `approval_policy="never"`)
+		}
 	case "yolo":
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 	default: // "suggest"
-		args = append(args, "--sandbox", "read-only", "-c", `approval_policy="never"`)
+		if isResume {
+			args = append(args, "-c", `sandbox_mode="read-only"`, "-c", `approval_policy="never"`)
+		} else {
+			args = append(args, "--sandbox", "read-only", "-c", `approval_policy="never"`)
+		}
 	}
 
 	if cs.model != "" {

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -180,6 +180,77 @@ func TestBuildExecArgs_ModeMapping(t *testing.T) {
 	}
 }
 
+// TestBuildExecArgs_ResumeUsesSandboxModeConfigOverride is the regression test
+// for the "codex exec resume" sandbox flag bug.
+//
+// codex CLI 0.137 limitation: `codex exec resume` does NOT accept the
+// `--sandbox <mode>` flag (only `codex exec` does). Both subcommands accept
+// `-c key=value` config overrides, so resume must express sandbox via
+// `-c sandbox_mode="..."` instead. Without this, every resume fails with:
+//
+//	error: unexpected argument '--sandbox' found
+//
+// silently destroying the user's session on cc-connect restart / idle reset.
+func TestBuildExecArgs_ResumeUsesSandboxModeConfigOverride(t *testing.T) {
+	tests := []struct {
+		mode            string
+		wantSandboxMode string // "" means no sandbox_mode override expected (yolo)
+		wantBypass      bool
+	}{
+		{mode: "suggest", wantSandboxMode: "read-only"},
+		{mode: "auto-edit", wantSandboxMode: "workspace-write"},
+		{mode: "full-auto", wantSandboxMode: "workspace-write"},
+		{mode: "yolo", wantBypass: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.mode, func(t *testing.T) {
+			cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", tc.mode, "thread-abc", "", nil, "")
+			if err != nil {
+				t.Fatalf("newCodexSession: %v", err)
+			}
+			args := cs.buildExecArgs("hi", nil)
+
+			// Sanity: this is a resume invocation.
+			if !containsSequence(args, []string{"exec", "resume", "--skip-git-repo-check"}) {
+				t.Fatalf("expected resume invocation, got: %v", args)
+			}
+
+			// Regression: --sandbox flag must NEVER appear in resume args.
+			// codex exec resume rejects it with: "unexpected argument '--sandbox' found".
+			for i, a := range args {
+				if a == "--sandbox" {
+					t.Errorf("mode=%s: resume args must not contain --sandbox (codex exec resume rejects it), but found at index %d: %v", tc.mode, i, args)
+				}
+			}
+
+			if tc.wantSandboxMode != "" {
+				want := `sandbox_mode="` + tc.wantSandboxMode + `"`
+				if !containsSequence(args, []string{"-c", want}) {
+					t.Errorf("mode=%s: resume args missing -c %s; args=%v", tc.mode, want, args)
+				}
+				// approval_policy must still be never for exec backend (no IPC).
+				if !containsSequence(args, []string{"-c", `approval_policy="never"`}) {
+					t.Errorf("mode=%s: resume args missing approval_policy=never; args=%v", tc.mode, args)
+				}
+			}
+
+			if tc.wantBypass {
+				found := false
+				for _, a := range args {
+					if a == "--dangerously-bypass-approvals-and-sandbox" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("mode=%s: resume args missing --dangerously-bypass-approvals-and-sandbox; args=%v", tc.mode, args)
+				}
+			}
+		})
+	}
+}
+
 func TestGetModelAndReasoningEffort_FromRuntimeConfigWhenUnset(t *testing.T) {
 	workDir := t.TempDir()
 	binDir := filepath.Join(workDir, "bin")


### PR DESCRIPTION
## TL;DR

`codex exec resume` does NOT accept the `--sandbox <mode>` flag (only `codex exec` does). PR #1351 generalized sandbox+approval flags across both paths, which silently broke every codex `exec` backend resume.

Fix: on resume, express sandbox via `-c sandbox_mode=\"...\"` config override instead of the `--sandbox` flag. Both `codex exec` and `codex exec resume` accept `-c`, so this is the canonical fix that doesn't regress the first-turn path.

## Why

Found while QA'ing beta.5 release. After PR #1351, every codex exec resume launched as:

\`\`\`
codex exec resume --skip-git-repo-check --sandbox workspace-write -c approval_policy=\"never\" <thread_id> --json -
\`\`\`

and failed immediately with:

\`\`\`
error: unexpected argument '--sandbox' found

  tip: to pass '--sandbox' as a value, use '-- --sandbox'

Usage: codex exec resume --skip-git-repo-check [SESSION_ID] [PROMPT]
\`\`\`

Impact:
- **Triggered by**: any cc-connect process restart, idle-reset, or anything else that causes the engine to resume an existing codex session
- **Affected backend**: `exec` (default) — every mode except `yolo`
- **Not affected**: `app_server` backend (uses JSON-RPC, doesn't go through `buildExecArgs`); `yolo` mode (uses `--dangerously-bypass-approvals-and-sandbox` which both subcommands accept)

User-visible symptom: the bot looks broken on the very next message after restart, with no obvious recovery path other than \`/new\`.

## What changed

\`agent/codex/session.go::buildExecArgs\`:

| mode | first turn (\`codex exec\`) | resume (\`codex exec resume\`) |
| - | - | - |
| suggest | \`--sandbox read-only -c approval_policy=\"never\"\` | **NEW:** \`-c sandbox_mode=\"read-only\" -c approval_policy=\"never\"\` |
| auto-edit / full-auto | \`--sandbox workspace-write -c approval_policy=\"never\"\` | **NEW:** \`-c sandbox_mode=\"workspace-write\" -c approval_policy=\"never\"\` |
| yolo | \`--dangerously-bypass-approvals-and-sandbox\` | unchanged (resume accepts it) |

The first-turn path is unchanged. Only the resume path swaps \`--sandbox <mode>\` for \`-c sandbox_mode=\"<mode>\"\`.

## Tests

- **New** \`TestBuildExecArgs_ResumeUsesSandboxModeConfigOverride\` (subtests: suggest / auto-edit / full-auto / yolo) — asserts for every mode that:
  - The resume invocation never contains a bare \`--sandbox\` flag (regression guard for this exact bug)
  - Sandbox is correctly expressed via \`-c sandbox_mode=\"...\"\` (or the bypass flag for yolo)
  - \`approval_policy=\"never\"\` is still enforced (exec backend has no IPC)
- Existing \`TestBuildExecArgs_ModeMapping\` unchanged — still covers the first-turn \`codex exec\` path with \`--sandbox <mode>\`.
- Manually verified \`codex exec resume --skip-git-repo-check -c sandbox_mode=\"read-only\" -c approval_policy=\"never\" --json --last\` against codex-cli 0.137 — no flag error.

\`go test ./agent/codex/...\` passes locally.

## Release notes for PR description

> Fix: codex agent in default \`exec\` backend would silently fail to resume any session after cc-connect restart or idle reset, due to a mismatch with codex-cli 0.137's \`codex exec resume\` not accepting the \`--sandbox\` flag. Resume now uses \`-c sandbox_mode=\"...\"\` config override, which both \`codex exec\` and \`codex exec resume\` accept.

## QA context (qa-cursor)

Bug + matrix documented in:
- \`projects/cc-connect/agents/qa-cursor/release-gate/CODEX-PERMISSION-MATRIX.md\` (CODEX-RESUME-01 + Known bug 1)
- \`projects/cc-connect/agents/qa-cursor/release-gate/notes/2026-06-15-beta5-followup-test-plan.md\` (A6 section)

Not blocking beta.5 in practice (app_server backend works fully; exec backend works on the first turn) but every subsequent message after restart breaks for default-configured users. Target: beta.6.

Made with [Cursor](https://cursor.com)