### PR TITLE
fix(tts/minimax): drop status=2 trailer chunk to stop audio playing twice

### DIFF
--- a/core/tts.go
+++ b/core/tts.go
@@ -383,6 +383,13 @@ func (m *MiniMaxTTS) Synthesize(ctx context.Context, text string, opts TTSSynthe
 		if chunk.BaseResp.StatusCode != 0 {
 			return nil, "", fmt.Errorf("minimax tts API error %d: %s", chunk.BaseResp.StatusCode, chunk.BaseResp.StatusMsg)
 		}
+		// MiniMax T2A v2 stream protocol: status=1 carries incremental audio
+		// chunks; the final status=2 chunk re-sends the full audio as a
+		// trailer for non-stream clients. Appending the trailer doubles the
+		// audio length and makes the spoken text play twice, so skip it.
+		if chunk.Data.Status == 2 {
+			break
+		}
 		if chunk.Data.Audio != "" {
 			audioBytes, err := hex.DecodeString(chunk.Data.Audio)
 			if err != nil {

--- a/core/tts_test.go
+++ b/core/tts_test.go
@@ -263,6 +263,83 @@ func TestMiniMaxTTS_Success(t *testing.T) {
 	}
 }
 
+// TestMiniMaxTTS_FinalStatusChunkAudioIsDropped reproduces the doubled-audio
+// bug: MiniMax T2A v2 stream protocol sends incremental audio in status=1
+// chunks and re-emits the full audio in a final status=2 trailer chunk for
+// non-stream clients. Without dedup the resulting audio plays twice.
+func TestMiniMaxTTS_FinalStatusChunkAudioIsDropped(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Incremental status=1 chunks: "hello" hex-encoded across 3 chunks.
+		for _, hexAudio := range []string{"68", "656c6c", "6f"} {
+			chunk := map[string]any{
+				"data":      map[string]any{"audio": hexAudio, "status": 1},
+				"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
+			}
+			data, _ := json.Marshal(chunk)
+			fmt.Fprintf(w, "data:%s\n\n", data)
+		}
+		// Final status=2 chunk re-sends the full "hello" audio as trailer.
+		final := map[string]any{
+			"data":      map[string]any{"audio": "68656c6c6f", "status": 2},
+			"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
+		}
+		finalData, _ := json.Marshal(final)
+		fmt.Fprintf(w, "data:%s\n\n", finalData)
+	}))
+	defer apiServer.Close()
+
+	tts := NewMiniMaxTTS("test-key", apiServer.URL, "", nil)
+	audio, _, err := tts.Synthesize(context.Background(), "hello", TTSSynthesisOpts{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := string(audio), "hello"; got != want {
+		t.Errorf("audio = %q (len=%d), want %q (len=%d) — status=2 trailer was not deduplicated, audio plays twice",
+			got, len(got), want, len(want))
+	}
+}
+
+// TestMiniMaxTTS_StopsAfterFinalStatusChunk ensures any unexpected chunks
+// after status=2 are not appended (defence in depth against future server
+// changes).
+func TestMiniMaxTTS_StopsAfterFinalStatusChunk(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// status=1 with "hi" (6869)
+		chunk := map[string]any{
+			"data":      map[string]any{"audio": "6869", "status": 1},
+			"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
+		}
+		data, _ := json.Marshal(chunk)
+		fmt.Fprintf(w, "data:%s\n\n", data)
+		// status=2 trailer with full audio
+		final := map[string]any{
+			"data":      map[string]any{"audio": "6869", "status": 2},
+			"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
+		}
+		finalData, _ := json.Marshal(final)
+		fmt.Fprintf(w, "data:%s\n\n", finalData)
+		// Bogus extra chunk after final — must be ignored.
+		extra := map[string]any{
+			"data":      map[string]any{"audio": "deadbeef", "status": 1},
+			"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
+		}
+		extraData, _ := json.Marshal(extra)
+		fmt.Fprintf(w, "data:%s\n\n", extraData)
+	}))
+	defer apiServer.Close()
+
+	tts := NewMiniMaxTTS("test-key", apiServer.URL, "", nil)
+	audio, _, err := tts.Synthesize(context.Background(), "hi", TTSSynthesisOpts{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := string(audio), "hi"; got != want {
+		t.Errorf("audio = %q, want %q — trailing chunks after status=2 were not ignored", got, want)
+	}
+}
+
 func TestMiniMaxTTS_APIError(t *testing.T) {
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/core/tts_test.go
+++ b/core/tts_test.go
@@ -277,7 +277,9 @@ func TestMiniMaxTTS_FinalStatusChunkAudioIsDropped(t *testing.T) {
 				"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
 			}
 			data, _ := json.Marshal(chunk)
-			fmt.Fprintf(w, "data:%s\n\n", data)
+			if _, err := fmt.Fprintf(w, "data:%s\n\n", data); err != nil {
+				t.Errorf("write chunk: %v", err)
+			}
 		}
 		// Final status=2 chunk re-sends the full "hello" audio as trailer.
 		final := map[string]any{
@@ -285,7 +287,9 @@ func TestMiniMaxTTS_FinalStatusChunkAudioIsDropped(t *testing.T) {
 			"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
 		}
 		finalData, _ := json.Marshal(final)
-		fmt.Fprintf(w, "data:%s\n\n", finalData)
+		if _, err := fmt.Fprintf(w, "data:%s\n\n", finalData); err != nil {
+			t.Errorf("write final: %v", err)
+		}
 	}))
 	defer apiServer.Close()
 
@@ -312,21 +316,27 @@ func TestMiniMaxTTS_StopsAfterFinalStatusChunk(t *testing.T) {
 			"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
 		}
 		data, _ := json.Marshal(chunk)
-		fmt.Fprintf(w, "data:%s\n\n", data)
+		if _, err := fmt.Fprintf(w, "data:%s\n\n", data); err != nil {
+			t.Errorf("write chunk: %v", err)
+		}
 		// status=2 trailer with full audio
 		final := map[string]any{
 			"data":      map[string]any{"audio": "6869", "status": 2},
 			"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
 		}
 		finalData, _ := json.Marshal(final)
-		fmt.Fprintf(w, "data:%s\n\n", finalData)
+		if _, err := fmt.Fprintf(w, "data:%s\n\n", finalData); err != nil {
+			t.Errorf("write final: %v", err)
+		}
 		// Bogus extra chunk after final — must be ignored.
 		extra := map[string]any{
 			"data":      map[string]any{"audio": "deadbeef", "status": 1},
 			"base_resp": map[string]any{"status_code": 0, "status_msg": "success"},
 		}
 		extraData, _ := json.Marshal(extra)
-		fmt.Fprintf(w, "data:%s\n\n", extraData)
+		if _, err := fmt.Fprintf(w, "data:%s\n\n", extraData); err != nil {
+			t.Errorf("write extra: %v", err)
+		}
 	}))
 	defer apiServer.Close()
 


### PR DESCRIPTION
## Bug

When `[tts]` is enabled with `provider = "minimax"`, the synthesised voice message plays the full text **twice**. Reproduced 100% against MiniMax `speech-2.8-hd` end-to-end on Feishu (cc-connect beta.5).

## Root cause

MiniMax T2A v2 stream protocol (`/v1/t2a_v2` with `stream: true`) emits two kinds of SSE chunks:

- `status=1` chunks — incremental audio bytes.
- A single final `status=2` chunk — re-sends the **full audio as a trailer** for non-stream clients.

Previously `core/tts.go` appended every chunk whose `Data.Audio` was non-empty without inspecting `Status`, so both the streamed audio and the trailer were concatenated into the returned MP3, doubling its length.

## Evidence

Live capture (`text = "测试"`):

```
status=1: 4 chunks, 18 477 bytes total  ← single take of the audio
status=2: 1 chunk,  19 572 bytes        ← trailer = full audio again
cc-connect output: 38 049 bytes         ≈ 2× expected
```

End-to-end on Feishu (text `cc-connect beta 点 5 TTS 验证通过`) produced a 140 577 byte MP3 (~9 s) where 5 s of speech repeated.

## Fix

`break` out of the SSE read loop when a `status=2` chunk arrives and skip its audio. Comment in code documents the protocol so the next reader doesn't re-introduce the bug.

## Tests

`core/tts_test.go`:

- `TestMiniMaxTTS_FinalStatusChunkAudioIsDropped` — status=1 chunks deliver `"hello"`, status=2 trailer also carries `"hello"`. Asserts decoded audio is `"hello"` (5 bytes), not `"hellohello"` (10 bytes). Fails on `main`, passes with this fix.
- `TestMiniMaxTTS_StopsAfterFinalStatusChunk` — defence in depth: ignores any chunks that arrive after `status=2`.
- Existing `TestMiniMaxTTS_Success` / `_APIError` / `_BusinessError` / `_EmptyAudio` / `_ContextCancelled` all still pass.

Full `go test ./core/ -count=1` is green (43.3 s).

## Verification

Re-running the same `text = "测试"` capture against the patched `Synthesize` returns a single ~18 KB MP3 that plays the text once.

## Risk

Very low. Only affects the MiniMax TTS adapter; other providers (`qwen` / `openai` / `mimo` / `espeak` / `pico` / `edge`) are untouched. No behaviour change for users not using `[tts.minimax]`. The trailer was never used as authoritative audio in the previous code path — it was silently doubling output that users assumed was fine but actually was 2×.

## Suggested release lane

- Not a beta.5 blocker (released), but a clear UX/quality bug for anyone enabling MiniMax TTS.
- Safe to merge into `main` and ship in the next tag.


Made with [Cursor](https://cursor.com)