### PR TITLE
fix: persist workspace model selections

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3503,6 +3503,12 @@ func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionMan
 	// workspace-specific overrides always win
 	opts["work_dir"] = workspace
 
+	if e.projectState != nil {
+		if m := e.projectState.WorkspaceModelOverride(workspace); m != "" {
+			opts["model"] = m
+		}
+	}
+
 	// Copy model from original agent if possible
 	if _, ok := opts["model"]; !ok {
 		if ma, ok := e.agent.(interface{ GetModel() string }); ok {
@@ -9029,6 +9035,7 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChangeFailed, err))
 		return
 	}
+	e.persistWorkspaceModelOverride(interactiveKey, msg.SessionKey, agent, target)
 	e.cleanupInteractiveState(interactiveKey)
 
 	// Keep the existing agent session ID so the next StartSession uses
@@ -9111,7 +9118,7 @@ func (e *Engine) switchModelOnAgent(agent Agent, target string, persistConfig bo
 
 	providerSwitcher, ok := agent.(ProviderSwitcher)
 	if !ok {
-		if e.modelSaveFunc != nil {
+		if persistConfig && e.modelSaveFunc != nil {
 			if err := e.modelSaveFunc(target); err != nil {
 				return "", fmt.Errorf("save model: %w", err)
 			}
@@ -9121,7 +9128,7 @@ func (e *Engine) switchModelOnAgent(agent Agent, target string, persistConfig bo
 	}
 	active := providerSwitcher.GetActiveProvider()
 	if active == nil {
-		if e.modelSaveFunc != nil {
+		if persistConfig && e.modelSaveFunc != nil {
 			if err := e.modelSaveFunc(target); err != nil {
 				return "", fmt.Errorf("save model: %w", err)
 			}
@@ -11093,12 +11100,51 @@ func (e *Engine) handleModelCardAction(args, sessionKey string) *Card {
 	}
 
 	resolved, err := e.switchModelOnAgent(agent, target, agent == e.agent)
-	e.cleanupInteractiveState(e.interactiveKeyForSessionKey(sessionKey))
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+	if err == nil {
+		e.persistWorkspaceModelOverride(interactiveKey, sessionKey, agent, resolved)
+	}
+	e.cleanupInteractiveState(interactiveKey)
 	if err == nil {
 		sessions.Save()
 	}
 
 	return e.renderModelSwitchResultCard(resolved, err)
+}
+
+func (e *Engine) persistWorkspaceModelOverride(interactiveKey, sessionKey string, agent Agent, model string) {
+	if e.projectState == nil || !e.multiWorkspace || model == "" {
+		return
+	}
+	if agent == e.agent {
+		return
+	}
+	workspace := workspaceModelOverrideKey(interactiveKey, sessionKey, agent)
+	if workspace == "" {
+		return
+	}
+	e.projectState.SetWorkspaceModelOverride(workspace, model)
+	e.projectState.Save()
+}
+
+func workspaceModelOverrideKey(interactiveKey, sessionKey string, agent Agent) string {
+	if wd, ok := agent.(interface{ GetWorkDir() string }); ok {
+		if dir := strings.TrimSpace(wd.GetWorkDir()); dir != "" {
+			return normalizeWorkspacePath(dir)
+		}
+	}
+	return workspaceFromInteractiveKey(interactiveKey, sessionKey)
+}
+
+func workspaceFromInteractiveKey(interactiveKey, sessionKey string) string {
+	if interactiveKey == "" || sessionKey == "" || interactiveKey == sessionKey {
+		return ""
+	}
+	suffix := ":" + sessionKey
+	if !strings.HasSuffix(interactiveKey, suffix) {
+		return ""
+	}
+	return strings.TrimSuffix(interactiveKey, suffix)
 }
 
 // executeCardAction performs the side-effect for act: prefixed actions
@@ -11667,6 +11713,8 @@ func (e *Engine) pushDeleteModeResultCard(sessionKey string) {
 func (e *Engine) performModelSwitchAsync(sessionKey string, state *interactiveState, agent Agent, sessions *SessionManager, target string) {
 	resolved, err := e.switchModelOnAgent(agent, target, agent == e.agent)
 	if err == nil {
+		interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+		e.persistWorkspaceModelOverride(interactiveKey, sessionKey, agent, resolved)
 		sessions.Save()
 	}
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -4555,6 +4555,73 @@ func TestCmdModel_MultiWorkspaceSwitchDoesNotMutateProviderModel(t *testing.T) {
 	}
 }
 
+func TestCmdModel_MultiWorkspacePersistsWorkspaceModelForRecreatedAgent(t *testing.T) {
+	agentName := "test-workspace-model-override"
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		agent := &namedStubModelModeAgent{name: agentName}
+		if model, ok := opts["model"].(string); ok {
+			agent.model = model
+		}
+		if mode, ok := opts["mode"].(string); ok {
+			agent.mode = mode
+		}
+		return agent, nil
+	})
+
+	p := &stubPlatformEngine{n: "plain"}
+	globalAgent := &namedStubModelModeAgent{
+		name: agentName,
+		stubModelModeAgent: stubModelModeAgent{
+			model: "global-old",
+			mode:  "default",
+		},
+	}
+	e := NewEngine("test", globalAgent, []Platform{p}, "", LangEnglish)
+	e.SetProjectStateStore(NewProjectStateStore(filepath.Join(t.TempDir(), "projects", "test.state.json")))
+	e.SetMultiWorkspace(t.TempDir(), filepath.Join(t.TempDir(), "bindings.json"))
+
+	var savedModel string
+	e.SetModelSaveFunc(func(model string) error {
+		savedModel = model
+		return nil
+	})
+
+	wsDir := normalizeWorkspacePath(t.TempDir())
+	channelID := "C-model-override"
+	e.workspaceBindings.Bind("project:test", channelID, "chan", wsDir)
+	msg := &Message{SessionKey: "feishu:" + channelID + ":u1", ReplyCtx: "ctx"}
+
+	e.cmdModel(p, msg, []string{"switch", "gpt"})
+
+	if savedModel != "" {
+		t.Fatalf("global model save called with %q, want no config save for workspace switch", savedModel)
+	}
+	if globalAgent.model != "global-old" {
+		t.Fatalf("global agent model = %q, want unchanged", globalAgent.model)
+	}
+	if got := e.projectState.WorkspaceModelOverride(wsDir); got != "gpt-4.1" {
+		t.Fatalf("WorkspaceModelOverride(%q) = %q, want gpt-4.1", wsDir, got)
+	}
+
+	ws := e.workspacePool.GetOrCreate(wsDir)
+	ws.mu.Lock()
+	ws.agent = nil
+	ws.sessions = nil
+	ws.mu.Unlock()
+
+	recreatedRaw, _, err := e.getOrCreateWorkspaceAgent(wsDir)
+	if err != nil {
+		t.Fatalf("getOrCreateWorkspaceAgent returned error: %v", err)
+	}
+	recreated, ok := recreatedRaw.(*namedStubModelModeAgent)
+	if !ok {
+		t.Fatalf("workspace agent type = %T, want *namedStubModelModeAgent", recreatedRaw)
+	}
+	if recreated.model != "gpt-4.1" {
+		t.Fatalf("recreated workspace model = %q, want persisted workspace model gpt-4.1", recreated.model)
+	}
+}
+
 func TestCmdModel_KeepHistoryPreservesSessionID(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	agent := &stubModelModeAgent{

--- a/core/projectstate.go
+++ b/core/projectstate.go
@@ -9,8 +9,9 @@ import (
 )
 
 type projectStateData struct {
-	WorkDirOverride       string            `json:"work_dir_override,omitempty"`
-	WorkspaceDirOverrides map[string]string `json:"workspace_dir_overrides,omitempty"`
+	WorkDirOverride         string            `json:"work_dir_override,omitempty"`
+	WorkspaceDirOverrides   map[string]string `json:"workspace_dir_overrides,omitempty"`
+	WorkspaceModelOverrides map[string]string `json:"workspace_model_overrides,omitempty"`
 }
 
 // ProjectStateStore persists lightweight runtime state for one project.
@@ -67,6 +68,40 @@ func (ps *ProjectStateStore) ClearWorkspaceDirOverride(workspace string) {
 	delete(ps.state.WorkspaceDirOverrides, workspace)
 	if len(ps.state.WorkspaceDirOverrides) == 0 {
 		ps.state.WorkspaceDirOverrides = nil
+	}
+}
+
+func (ps *ProjectStateStore) WorkspaceModelOverride(workspace string) string {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	if ps.state.WorkspaceModelOverrides == nil {
+		return ""
+	}
+	return ps.state.WorkspaceModelOverrides[workspace]
+}
+
+func (ps *ProjectStateStore) SetWorkspaceModelOverride(workspace, model string) {
+	if model == "" {
+		ps.ClearWorkspaceModelOverride(workspace)
+		return
+	}
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.state.WorkspaceModelOverrides == nil {
+		ps.state.WorkspaceModelOverrides = make(map[string]string)
+	}
+	ps.state.WorkspaceModelOverrides[workspace] = model
+}
+
+func (ps *ProjectStateStore) ClearWorkspaceModelOverride(workspace string) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.state.WorkspaceModelOverrides == nil {
+		return
+	}
+	delete(ps.state.WorkspaceModelOverrides, workspace)
+	if len(ps.state.WorkspaceModelOverrides) == 0 {
+		ps.state.WorkspaceModelOverrides = nil
 	}
 }
 

--- a/core/projectstate_test.go
+++ b/core/projectstate_test.go
@@ -65,3 +65,33 @@ func TestWorkspaceDirOverride(t *testing.T) {
 		t.Fatalf("WorkspaceDirOverride(%q) after clearing other workspace = %q, want %q", workspaceB, got, "/tmp/workspace-b/override")
 	}
 }
+
+func TestWorkspaceModelOverride(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "projects", "demo.state.json")
+	workspaceA := "/tmp/workspace-a"
+	workspaceB := "/tmp/workspace-b"
+
+	store := NewProjectStateStore(statePath)
+	store.SetWorkspaceModelOverride(workspaceA, "opus")
+	store.SetWorkspaceModelOverride(workspaceB, "sonnet")
+	store.Save()
+
+	reloaded := NewProjectStateStore(statePath)
+	if got := reloaded.WorkspaceModelOverride(workspaceA); got != "opus" {
+		t.Fatalf("WorkspaceModelOverride(%q) = %q, want %q", workspaceA, got, "opus")
+	}
+	if got := reloaded.WorkspaceModelOverride(workspaceB); got != "sonnet" {
+		t.Fatalf("WorkspaceModelOverride(%q) = %q, want %q", workspaceB, got, "sonnet")
+	}
+
+	reloaded.ClearWorkspaceModelOverride(workspaceA)
+	reloaded.Save()
+
+	cleared := NewProjectStateStore(statePath)
+	if got := cleared.WorkspaceModelOverride(workspaceA); got != "" {
+		t.Fatalf("WorkspaceModelOverride(%q) after clear = %q, want empty", workspaceA, got)
+	}
+	if got := cleared.WorkspaceModelOverride(workspaceB); got != "sonnet" {
+		t.Fatalf("WorkspaceModelOverride(%q) after clearing other workspace = %q, want %q", workspaceB, got, "sonnet")
+	}
+}


### PR DESCRIPTION
## Summary
- persist per-workspace model selections in project state
- restore saved workspace model overrides when recreating workspace agents
- avoid writing global project config when switching models on workspace-scoped agents

## Tests
- go test ./core -run 'TestWorkspaceModelOverride' -count=1\n- go test ./core -run 'TestCmdModel_MultiWorkspacePersistsWorkspaceModelForRecreatedAgent' -count=1\n- go test ./core -count=1\n- go test ./...\n\n## Notes\nA fresh worktree based on origin/main was used for this branch.