### PR TITLE
fix(i18n): clarify /model switch applies to current and future sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **/model switch confirmation copy**: `MsgModelChanged` now explicitly states the
+  new model applies to the current session and all future sessions, removing the
+  misleading "new sessions" wording that made users think they needed `/new` to
+  see the change take effect (#1368).
+
 ## v1.3.3 (2026-06-15)
 
 First stable release of the 1.3.3 series. Stabilizes the v1.3.3-beta.1 → v1.3.3-beta.5

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -2202,11 +2202,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Modelo actual: %s",
 	},
 	MsgModelChanged: {
-		LangEnglish:            "Model switched to `%s`. New sessions will use this model.",
-		LangChinese:            "模型已切换为 `%s`，新会话将使用此模型。",
-		LangTraditionalChinese: "模型已切換為 `%s`，新會話將使用此模型。",
-		LangJapanese:           "モデルを `%s` に切り替えました。新しいセッションで使用されます。",
-		LangSpanish:            "Modelo cambiado a `%s`. Las nuevas sesiones usarán este modelo.",
+		LangEnglish:            "Model switched to `%s`. This session and all future sessions will use it.",
+		LangChinese:            "模型已切换为 `%s`，当前会话与后续会话均使用此模型。",
+		LangTraditionalChinese: "模型已切換為 `%s`，當前會話與後續會話均使用此模型。",
+		LangJapanese:           "モデルを `%s` に切り替えました。このセッションと今後のセッションで使用されます。",
+		LangSpanish:            "Modelo cambiado a `%s`. Esta sesión y las futuras usarán este modelo.",
 	},
 	MsgModelChangeFailed: {
 		LangEnglish:            "❌ Failed to change model: %v",


### PR DESCRIPTION
Fixes #1368

## Problem
The `/model` confirmation copy (`MsgModelChanged`) used wording like
"New sessions will use this model" / "新会话将使用此模型". Users read this
as "the current session still uses the old model" and assumed they had to
`/new` to see the new model take effect.

## Root cause
That worry is unfounded: `cmdModel` (in `core/engine.go`) keeps the agent
session id and re-invokes the runtime with `--resume <id> --model <new>`,
so the new model is live immediately for the current turn and persists
for every subsequent session created from this workspace. The copy was
just misleading.

## Change
- `core/i18n.go`: rewrote `MsgModelChanged` in all 5 supported languages
  (en, zh-CN, zh-TW, ja, es) to explicitly say "this session AND all
  future sessions will use it" / 当前会话与后续会话均使用此模型 / etc.
- `CHANGELOG.md`: added `Fixed` entry under a new `Unreleased` section
  (user-visible copy change).

No runtime logic touched. `cmdModel` was reviewed (line ~9034) and the
`--resume` behavior is already correct — only the user-facing text was
wrong.

## Tests
- `go test ./core/ -run 'TestCmdModel'` — 11/11 PASS
- `go test ./core/ -run 'TestI18n'` — 7/7 PASS
- `go build ./...` — clean
- Pre-commit lint (golangci-lint) — clean for changed files (no new
  findings beyond the pre-existing formatting issues on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)