### PR TITLE
Revert "feat: add plugin_dir option to load Claude Code plugins via -…

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -51,7 +51,6 @@ type Agent struct {
 	routerURL        string // Claude Code Router URL (e.g., "http://127.0.0.1:3456")
 	routerAPIKey     string // Claude Code Router API key (optional)
 	systemPrompt     string // Custom system prompt to pass to Claude CLI
-	pluginDirs       []string // Plugin directories to load via --plugin-dir (repeatable)
 
 	appendSystemPrompt string // Custom text appended to the system prompt (keeps Claude's default)
 
@@ -139,17 +138,6 @@ func New(opts map[string]any) (core.Agent, error) {
 	systemPrompt, _ := opts["system_prompt"].(string)
 	appendSystemPrompt, _ := opts["append_system_prompt"].(string)
 
-	var pluginDirs []string
-	if dir, ok := opts["plugin_dir"].(string); ok && dir != "" {
-		pluginDirs = []string{dir}
-	} else if dirs, ok := opts["plugin_dir"].([]any); ok {
-		for _, d := range dirs {
-			if s, ok := d.(string); ok && s != "" {
-				pluginDirs = append(pluginDirs, s)
-			}
-		}
-	}
-
 	var allowedTools []string
 	if tools, ok := opts["allowed_tools"].([]any); ok {
 		for _, t := range tools {
@@ -235,7 +223,6 @@ func New(opts map[string]any) (core.Agent, error) {
 		reasoningEffort:  normalizeEffort(reasoningEffort),
 		mode:             mode,
 		systemPrompt:     systemPrompt,
-		pluginDirs:       pluginDirs,
 		allowedTools:     allowedTools,
 		disallowedTools:  disallowedTools,
 		maxContextTokens: maxContextTokens,
@@ -480,8 +467,6 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	effort := a.reasoningEffort
 	workDir := a.workDir
 	mode := a.mode
-	pluginDirs := make([]string, len(a.pluginDirs))
-	copy(pluginDirs, a.pluginDirs)
 	extraEnv := a.runtimeEnvLocked()
 
 	activeIdx := a.activeIdx
@@ -506,7 +491,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt, tools, disTools, pluginDirs, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
+	return newClaudeSession(ctx, workDir, a.cliBin, a.cliExtraArgs, a.cliArgsFlag, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt, tools, disTools, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {
@@ -847,9 +832,6 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	}
 	if a.routerAPIKey != "" {
 		opts["router_api_key"] = a.routerAPIKey
-	}
-	if len(a.pluginDirs) > 0 {
-		opts["plugin_dir"] = stringsToAny(a.pluginDirs)
 	}
 	return opts
 }

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -90,7 +90,7 @@ func buildAppendSystemPrompt(agentPrompt, platformPrompt, userAppend string) str
 	return strings.Join(parts, "\n")
 }
 
-func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, pluginDirs []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
+func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	// Claude Code rejects bypassPermissions when running as root.
@@ -131,11 +131,6 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	}
 	if len(disallowedTools) > 0 {
 		innerArgs = append(innerArgs, "--disallowedTools", strings.Join(disallowedTools, ","))
-	}
-
-	// Load plugins from specified directories.
-	for _, dir := range pluginDirs {
-		innerArgs = append(innerArgs, "--plugin-dir", dir)
 	}
 
 	// Handle custom system prompt (replaces Claude's default system prompt).


### PR DESCRIPTION
…-plugin-…"

This reverts commit 2548b66c4666b4f371265d309f48d00a82ed7ffd.

<!--
Thanks for contributing! Please fill in the sections below.
The reviewer will use the checklist at the bottom to gate merge.
-->

## Summary

<!-- 1-3 sentences explaining WHAT this PR does and WHY. -->

## Type of change

<!-- Mark all that apply: -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

<!-- Explain how you verified the change. Be specific. -->

### Automated tests added in this PR

<!-- List the test functions you added or modified. -->

- `TestX_Y_Z` in `path/to/file_test.go` — what it asserts

### For bug fixes only — regression test

<!-- A bug fix PR MUST include a regression test that:
     (1) fails on the pre-fix code, and
     (2) passes on the fixed code.
     Name it so the bug is searchable later. -->

- Regression test name: `Test...`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

<!-- See AGENTS.md → "Critical User Journeys (CUJ)" and the inventory in
     projects/cc-connect/agents/qa-cursor/release-gate/CUJ-INVENTORY.md.
     Mark which CUJ groups this PR touches: -->

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

<!-- Describe what a user will see or do differently after this PR.
     If none, write "None". -->

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [ ] No new hardcoded platform/agent names in `core/`
- [ ] i18n strings have all-language translations (if any new user-facing text)
- [ ] No secrets / credentials in source

## Related

<!-- Link to issue, RFC, design doc, prior PR, etc. -->

- Issue:
- Related PR:
