### PR TITLE
fix(claudecode): pass system prompts via files to avoid Windows cmd.e…

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -64,6 +64,12 @@ type claudeSession struct {
 	// startupWarning holds a one-time message to surface to the IM user at
 	// session start (e.g. when a permission mode was silently downgraded).
 	startupWarning string
+
+	// promptFiles are temp files holding the (possibly huge) system / append
+	// system prompts. On Windows the prompts are passed via --system-prompt-file
+	// / --append-system-prompt-file to avoid the cmd.exe ~8KB command-line limit.
+	// They are removed in Close().
+	promptFiles []string
 }
 
 // StartupWarning implements core.StartupWarner. Returns a non-empty string
@@ -88,6 +94,28 @@ func buildAppendSystemPrompt(agentPrompt, platformPrompt, userAppend string) str
 		parts = append(parts, userAppend)
 	}
 	return strings.Join(parts, "\n")
+}
+
+// writeSystemPromptToFile writes a system-prompt string to a temp file and
+// returns its path. Used so that large prompts are passed to Claude via the
+// --system-prompt-file / --append-system-prompt-file flags instead of inline
+// command-line arguments, which on Windows would exceed cmd.exe's ~8KB limit.
+// The returned path is tracked on the claudeSession and removed in Close().
+func writeSystemPromptToFile(content string) (string, error) {
+	f, err := os.CreateTemp("", "cc-connect-sysprompt-*.txt")
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
 }
 
 func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cliArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int) (*claudeSession, error) {
@@ -115,6 +143,23 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		innerArgs = append(innerArgs, "--verbose")
 	}
 
+	// promptFiles tracks temp files created for --system-prompt-file /
+	// --append-system-prompt-file so they can be cleaned up in Close().
+	var promptFiles []string
+	cleanupPromptFiles := func() {
+		for _, p := range promptFiles {
+			_ = os.Remove(p)
+		}
+	}
+	// If we fail before the session takes ownership of these temp files,
+	// remove them on the way out. Set to true once handed off to cs.
+	promptFilesHandedOff := false
+	defer func() {
+		if !promptFilesHandedOff {
+			cleanupPromptFiles()
+		}
+	}()
+
 	if mode != "" && mode != "default" {
 		innerArgs = append(innerArgs, "--permission-mode", mode)
 	}
@@ -134,8 +179,17 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	}
 
 	// Handle custom system prompt (replaces Claude's default system prompt).
+	// Pass via a temp file (--system-prompt-file) so large prompts do not blow
+	// past the Windows cmd.exe command-line length limit.
 	if systemPrompt != "" {
-		innerArgs = append(innerArgs, "--system-prompt", systemPrompt)
+		pf, err := writeSystemPromptToFile(systemPrompt)
+		if err != nil {
+			cleanupPromptFiles()
+			cancel()
+			return nil, fmt.Errorf("claudeSession: write system prompt file: %w", err)
+		}
+		promptFiles = append(promptFiles, pf)
+		innerArgs = append(innerArgs, "--system-prompt-file", pf)
 	}
 
 	// Append the cc-connect functionality prompt, platform formatting hints,
@@ -143,7 +197,14 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	// --append-system-prompt only honors its last occurrence, so the pieces
 	// must be concatenated here rather than passed as repeated flags.
 	if appended := buildAppendSystemPrompt(core.AgentSystemPrompt(), platformPrompt, appendSystemPrompt); appended != "" {
-		innerArgs = append(innerArgs, "--append-system-prompt", appended)
+		pf, err := writeSystemPromptToFile(appended)
+		if err != nil {
+			cleanupPromptFiles()
+			cancel()
+			return nil, fmt.Errorf("claudeSession: write append system prompt file: %w", err)
+		}
+		promptFiles = append(promptFiles, pf)
+		innerArgs = append(innerArgs, "--append-system-prompt-file", pf)
 	}
 
 	if effort != "" {
@@ -266,7 +327,9 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 		gracefulStopTimeout: 120 * time.Second,
 		ccHooks:             newCCPermissionHookRunner(workDir),
 		startupWarning:      rootDowngradeWarning,
+		promptFiles:         promptFiles,
 	}
+	promptFilesHandedOff = true
 	cs.setPermissionMode(mode)
 	cs.sessionID.Store(sessionID)
 	cs.alive.Store(true)
@@ -931,6 +994,7 @@ func (cs *claudeSession) Close() error {
 	select {
 	case <-cs.done:
 		slog.Info("claudeSession: exited cleanly after stdin close")
+		cs.removePromptFiles()
 		return nil
 	case <-time.After(graceful):
 		slog.Warn("claudeSession: graceful stop timed out, sending SIGTERM",
@@ -947,6 +1011,7 @@ func (cs *claudeSession) Close() error {
 	select {
 	case <-cs.done:
 		slog.Info("claudeSession: exited after SIGTERM")
+		cs.removePromptFiles()
 		return nil
 	case <-time.After(5 * time.Second):
 		slog.Warn("claudeSession: SIGTERM timed out, sending SIGKILL")
@@ -961,7 +1026,17 @@ func (cs *claudeSession) Close() error {
 		slog.Warn("claudeSession: force kill", "error", err)
 	}
 	<-cs.done
+	cs.removePromptFiles()
 	return nil
+}
+
+// removePromptFiles deletes the temp system-prompt files created for this
+// session (see writeSystemPromptToFile). Safe to call multiple times.
+func (cs *claudeSession) removePromptFiles() {
+	for _, p := range cs.promptFiles {
+		_ = os.Remove(p)
+	}
+	cs.promptFiles = nil
 }
 
 // shellJoinArgs joins args into a single string, quoting any arg that


### PR DESCRIPTION
…xe length limit

On Windows, launching Claude Code fails with "command line too long" (exit status 1) because the ~9KB cc-connect system prompt from AgentSystemPrompt() is passed as a single inline --append-system-prompt argument, exceeding cmd.exe's ~8191-character command-line limit. The WeCom/WeChat bot then receives messages but can never reply.

Write the (potentially huge) system prompt and append-system-prompt strings to temp files and pass them via Claude's --system-prompt-file / --append-system-prompt-file flags instead of inline arguments. This keeps the command line short on all platforms. Temp files are tracked on the claudeSession and removed in Close() (with a defer-guard cleanup if session construction fails before handoff).

Verified on Windows 11 with claude 2.1.174: the bot now replies normally, no more "exit status 1", and an 8918-byte cc-connect-sysprompt-*.txt is created and passed via --append-system-prompt-file.

<!--
Thanks for contributing! Please fill in the sections below.
The reviewer will use the checklist at the bottom to gate merge.
-->

## Summary

<!-- 1-3 sentences explaining WHAT this PR does and WHY. -->

## Type of change

<!-- Mark all that apply: -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

<!-- Explain how you verified the change. Be specific. -->

### Automated tests added in this PR

<!-- List the test functions you added or modified. -->

- `TestX_Y_Z` in `path/to/file_test.go` — what it asserts

### For bug fixes only — regression test

<!-- A bug fix PR MUST include a regression test that:
     (1) fails on the pre-fix code, and
     (2) passes on the fixed code.
     Name it so the bug is searchable later. -->

- Regression test name: `Test...`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

<!-- See AGENTS.md → "Critical User Journeys (CUJ)" and the inventory in
     projects/cc-connect/agents/qa-cursor/release-gate/CUJ-INVENTORY.md.
     Mark which CUJ groups this PR touches: -->

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

<!-- Describe what a user will see or do differently after this PR.
     If none, write "None". -->

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [ ] No new hardcoded platform/agent names in `core/`
- [ ] i18n strings have all-language translations (if any new user-facing text)
- [ ] No secrets / credentials in source

## Related

<!-- Link to issue, RFC, design doc, prior PR, etc. -->

- Issue:
- Related PR:
