### PR TITLE
支持 send --cwd 指定工作目录

### DIFF
--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -97,6 +97,12 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 			}
 			i++
 			req.Message = args[i]
+		case "--cwd", "--work-dir":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("%s requires a value", args[i])
+			}
+			i++
+			req.WorkDir = args[i]
 		case "--tts":
 			if i+1 >= len(args) {
 				return req, "", fmt.Errorf("%s requires a value", args[i])
@@ -348,6 +354,8 @@ Send a message, attachment, or synthesized voice message to an active cc-connect
 
 Options:
   -m, --message <text>     Message to send (preferred over positional args)
+      --cwd <path>         Start a new session in this working directory
+      --work-dir <path>    Alias for --cwd
       --tts <text>         Synthesize text and send it as a voice/audio message
       --image <path>       Send an image attachment (repeatable)
       --file <path>        Send a file attachment (repeatable)

--- a/cmd/cc-connect/send_test.go
+++ b/cmd/cc-connect/send_test.go
@@ -76,6 +76,26 @@ func TestParseSendArgs_UsesSessionEnvFallback(t *testing.T) {
 	}
 }
 
+func TestParseSendArgs_WorkDirOption(t *testing.T) {
+	workDir := t.TempDir()
+
+	req, _, err := parseSendArgs([]string{"--cwd", workDir, "--message", "please check"})
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if got := req.WorkDir; got != workDir {
+		t.Fatalf("WorkDir = %q, want %q", got, workDir)
+	}
+
+	req, _, err = parseSendArgs([]string{"--work-dir", workDir, "please check"})
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error for --work-dir: %v", err)
+	}
+	if got := req.WorkDir; got != workDir {
+		t.Fatalf("WorkDir from --work-dir = %q, want %q", got, workDir)
+	}
+}
+
 // TestParseSendArgs_AudioPopulatesAudios is the regression for
 // t-20260615-cqjbk1: --audio and --video must NOT land in req.Files
 // (which would route them through SendFile and skip

--- a/core/api.go
+++ b/core/api.go
@@ -42,6 +42,8 @@ type SendRequest struct {
 	Project    string            `json:"project"`
 	SessionKey string            `json:"session_key"`
 	Message    string            `json:"message"`
+	WorkDir    string            `json:"work_dir,omitempty"`
+	CWD        string            `json:"cwd,omitempty"`
 	TTSText    string            `json:"tts_text,omitempty"`
 	Images     []ImageAttachment `json:"images,omitempty"`
 	Files      []FileAttachment  `json:"files,omitempty"`
@@ -198,8 +200,12 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	workDir := req.WorkDir
+	if workDir == "" {
+		workDir = req.CWD
+	}
 	if req.Message != "" || len(req.Images) > 0 || len(req.Files) > 0 {
-		if err := engine.SendToSessionWithAttachments(req.SessionKey, req.Message, req.Images, req.Files, req.AtUsers, req.AtAll); err != nil {
+		if err := engine.SendToSessionWithOptions(req.SessionKey, req.Message, req.Images, req.Files, SendOptions{WorkDir: workDir, AtUsers: req.AtUsers, AtAll: req.AtAll}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -173,6 +175,179 @@ func TestHandleSend_EmptyProjectMultipleEnginesRequiresName(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+type sendWorkDirAgent struct {
+	name    string
+	workDir string
+	session AgentSession
+}
+
+func (a *sendWorkDirAgent) Name() string { return a.name }
+func (a *sendWorkDirAgent) StartSession(_ context.Context, _ string) (AgentSession, error) {
+	return a.session, nil
+}
+func (a *sendWorkDirAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) {
+	return nil, nil
+}
+func (a *sendWorkDirAgent) Stop() error { return nil }
+func (a *sendWorkDirAgent) GetWorkDir() string {
+	return a.workDir
+}
+
+func TestHandleSend_WorkDirStartsSideSession(t *testing.T) {
+	agentName := "test-send-workdir-agent"
+	baseDir := t.TempDir()
+	targetDir := t.TempDir()
+	sessionKey := "test:user1"
+	var workspaceSession *resultAgentSession
+
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		workDir, _ := opts["work_dir"].(string)
+		workspaceSession = newResultAgentSession("agent result from " + workDir)
+		return &sendWorkDirAgent{
+			name:    agentName,
+			workDir: workDir,
+			session: workspaceSession,
+		}, nil
+	})
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "test"},
+	}
+	engine := NewEngine(
+		"test",
+		&sendWorkDirAgent{
+			name:    agentName,
+			workDir: baseDir,
+			session: newResultAgentSession("base result"),
+		},
+		[]Platform{platform},
+		filepath.Join(t.TempDir(), "sessions.json"),
+		LangEnglish,
+	)
+	api := &APIServer{engines: map[string]*Engine{"test": engine}}
+
+	body, err := json.Marshal(map[string]any{
+		"project":     "test",
+		"session_key": sessionKey,
+		"message":     "please ask this person",
+		"work_dir":    targetDir,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	sent := platform.getSent()
+	if len(sent) != 1 || sent[0] != "please ask this person" {
+		t.Fatalf("platform sent = %#v, want direct send of request content", sent)
+	}
+
+	_, sessions, err := engine.getOrCreateWorkspaceAgent(targetDir)
+	if err != nil {
+		t.Fatalf("get workspace agent: %v", err)
+	}
+	list := sessions.ListSessions(sessionKey)
+	if len(list) != 1 {
+		t.Fatalf("workspace sessions len = %d, want 1", len(list))
+	}
+	if got := list[0].GetName(); got != "send" {
+		t.Fatalf("side session name = %q, want send", got)
+	}
+
+	platform.clearSent()
+	engine.handleMessage(platform, &Message{
+		SessionKey: sessionKey,
+		Platform:   "test",
+		UserID:     "user1",
+		UserName:   "Target",
+		Content:    "human answer",
+		ReplyCtx:   "reply-ctx",
+	})
+	sent = waitForPlatformSend(&platform.stubPlatformEngine, 1, 3*time.Second)
+	if len(sent) == 0 || !strings.Contains(strings.Join(sent, "\n"), "agent result from "+targetDir) {
+		t.Fatalf("platform sent after reply = %#v, want agent result from target work dir", sent)
+	}
+	if workspaceSession == nil || len(workspaceSession.sentPrompts) != 1 || !strings.Contains(workspaceSession.sentPrompts[0], "human answer") {
+		t.Fatalf("workspace session prompts = %#v, want human reply prompt", workspaceSession)
+	}
+}
+
+func TestHandleSend_WorkDirFollowsDirectParticipantOnInboundSession(t *testing.T) {
+	agentName := "test-send-workdir-direct-agent"
+	baseDir := t.TempDir()
+	targetDir := t.TempDir()
+	syntheticKey := "test:d:proactive:user1"
+	realInboundKey := "test:d:real-conversation:user1"
+	var workspaceSession *resultAgentSession
+
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		workDir, _ := opts["work_dir"].(string)
+		workspaceSession = newResultAgentSession("agent result from " + workDir)
+		return &sendWorkDirAgent{
+			name:    agentName,
+			workDir: workDir,
+			session: workspaceSession,
+		}, nil
+	})
+
+	platform := &stubCronReplyTargetPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "test"},
+	}
+	engine := NewEngine(
+		"test",
+		&sendWorkDirAgent{
+			name:    agentName,
+			workDir: baseDir,
+			session: newResultAgentSession("base result"),
+		},
+		[]Platform{platform},
+		filepath.Join(t.TempDir(), "sessions.json"),
+		LangEnglish,
+	)
+	api := &APIServer{engines: map[string]*Engine{"test": engine}}
+
+	body, err := json.Marshal(map[string]any{
+		"project":     "test",
+		"session_key": syntheticKey,
+		"message":     "please ask this person",
+		"work_dir":    targetDir,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	platform.clearSent()
+	engine.handleMessage(platform, &Message{
+		SessionKey: realInboundKey,
+		Platform:   "test",
+		UserID:     "user1",
+		UserName:   "Target",
+		Content:    "human answer",
+		ReplyCtx:   "reply-ctx",
+	})
+	sent := waitForPlatformSend(&platform.stubPlatformEngine, 1, 3*time.Second)
+	if len(sent) == 0 || !strings.Contains(strings.Join(sent, "\n"), "agent result from "+targetDir) {
+		t.Fatalf("platform sent after reply = %#v, want agent result from target work dir", sent)
+	}
+	if workspaceSession == nil || len(workspaceSession.sentPrompts) != 1 || !strings.Contains(workspaceSession.sentPrompts[0], "human answer") {
+		t.Fatalf("workspace session prompts = %#v, want human reply prompt", workspaceSession)
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -270,8 +270,8 @@ type Engine struct {
 	filterExternalSessions bool
 
 	// Shell configuration for /shell, cron exec, hooks, webhook exec
-	shell       string // shell binary path (e.g. "sh", "/bin/zsh")
-	shellFlag   string // shell flag (e.g. "-c", "-Command", "/C")
+	shell        string // shell binary path (e.g. "sh", "/bin/zsh")
+	shellFlag    string // shell flag (e.g. "-c", "-Command", "/C")
 	shellProfile string // prepended to every command (e.g. "source ~/.zshrc;")
 
 	// Multi-workspace mode
@@ -283,6 +283,8 @@ type Engine struct {
 	workspacePool                *workspacePool
 	initFlows                    map[string]*workspaceInitFlow // workspace channel key → init state
 	initFlowsMu                  sync.Mutex
+	sendWorkDirMu                sync.RWMutex
+	sendWorkDirs                 map[string]string // sessionKey → work_dir assigned by send --cwd
 
 	// Terminal observation (--observe)
 	observeEnabled    bool
@@ -556,6 +558,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		skills:                NewSkillRegistry(),
 		aliases:               make(map[string]string),
 		interactiveStates:     make(map[string]*interactiveState),
+		sendWorkDirs:          make(map[string]string),
 		platformReady:         make(map[Platform]bool),
 		startedAt:             time.Now(),
 		streamPreview:         DefaultStreamPreviewCfg(),
@@ -2592,7 +2595,17 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	var wsAgent Agent
 	var wsSessions *SessionManager
 	var resolvedWorkspace string
-	if e.multiWorkspace {
+	if forcedWorkDir := e.sendWorkDirForSession(msg.SessionKey); forcedWorkDir != "" {
+		e.bindSendWorkDir(msg.SessionKey, forcedWorkDir)
+		var err error
+		wsAgent, wsSessions, err = e.getOrCreateWorkspaceAgent(forcedWorkDir)
+		if err != nil {
+			slog.Error("failed to create send work_dir agent", "work_dir", forcedWorkDir, "err", err)
+			e.reply(p, msg.ReplyCtx, fmt.Sprintf("Failed to initialize workspace: %v", err))
+			return
+		}
+		resolvedWorkspace = forcedWorkDir
+	} else if e.multiWorkspace {
 		channelID := effectiveChannelID(msg)
 		channelKey := effectiveWorkspaceChannelKey(msg)
 		workspace, channelName, err := e.resolveWorkspace(p, channelID)
@@ -2639,7 +2652,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	sessions := e.sessions
 	agent := e.agent
 	interactiveKey := msg.SessionKey
-	if e.multiWorkspace && wsSessions != nil {
+	if resolvedWorkspace != "" && wsSessions != nil {
 		sessions = wsSessions
 		agent = wsAgent
 		interactiveKey = resolvedWorkspace + ":" + msg.SessionKey
@@ -3509,10 +3522,14 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 // getOrCreateWorkspaceAgent returns (or creates) a per-workspace agent and session manager.
 // workspace must be a normalized path (from resolveWorkspace or normalizeWorkspacePath).
 func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionManager, error) {
+	e.interactiveMu.Lock()
 	if e.workspacePool == nil {
-		return nil, nil, fmt.Errorf("workspace pool not initialized (multi-workspace mode not enabled)")
+		e.workspacePool = newWorkspacePool(DefaultWorkspaceIdleTimeout)
 	}
-	ws := e.workspacePool.GetOrCreate(workspace)
+	pool := e.workspacePool
+	e.interactiveMu.Unlock()
+
+	ws := pool.GetOrCreate(workspace)
 	ws.mu.Lock()
 	defer ws.mu.Unlock()
 
@@ -10315,7 +10332,28 @@ func (e *Engine) SendToSession(sessionKey, message string) error {
 	return e.SendToSessionWithAttachments(sessionKey, message, nil, nil, nil, false)
 }
 
+// SendOptions controls optional behavior for external send callers.
+type SendOptions struct {
+	WorkDir string
+	AtUsers []string
+	AtAll   bool
+}
+
 func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images []ImageAttachment, files []FileAttachment, atUsers []string, atAll bool) error {
+	return e.SendToSessionWithOptions(sessionKey, message, images, files, SendOptions{AtUsers: atUsers, AtAll: atAll})
+}
+
+func (e *Engine) SendToSessionWithOptions(sessionKey, message string, images []ImageAttachment, files []FileAttachment, opts SendOptions) error {
+	if strings.TrimSpace(opts.WorkDir) != "" {
+		workDir, useWorkDirSession, err := e.resolveSendWorkDir(opts.WorkDir)
+		if err != nil {
+			return err
+		}
+		if useWorkDirSession {
+			return e.SendToSessionInWorkDir(sessionKey, message, images, files, workDir, opts.AtUsers, opts.AtAll)
+		}
+	}
+
 	state, p, replyCtx, err := e.resolveOutboundSessionTarget(sessionKey, len(images) > 0 || len(files) > 0)
 	if err != nil {
 		return err
@@ -10351,9 +10389,9 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 			return err
 		}
 		// Use AtMentionSender when @users specified and platform supports it
-		if len(atUsers) > 0 || atAll {
+		if len(opts.AtUsers) > 0 || opts.AtAll {
 			if atSender, ok := p.(AtMentionSender); ok {
-				if err := atSender.ReplyWithAt(e.ctx, replyCtx, message, atUsers, atAll); err != nil {
+				if err := atSender.ReplyWithAt(e.ctx, replyCtx, message, opts.AtUsers, opts.AtAll); err != nil {
 					return err
 				}
 			} else {
@@ -10389,6 +10427,257 @@ func (e *Engine) SendToSessionWithAttachments(sessionKey, message string, images
 		}
 	}
 	return nil
+}
+
+type sendTarget struct {
+	state      *interactiveState
+	platform   Platform
+	replyCtx   any
+	sessionKey string
+}
+
+func (e *Engine) SendToSessionInWorkDir(sessionKey, message string, images []ImageAttachment, files []FileAttachment, workDir string, atUsers []string, atAll bool) error {
+	if message == "" && len(images) == 0 && len(files) == 0 {
+		return fmt.Errorf("message or attachment is required")
+	}
+	if (len(images) > 0 || len(files) > 0) && !e.attachmentSendEnabled {
+		return ErrAttachmentSendDisabled
+	}
+
+	target, err := e.resolveSendTarget(sessionKey, len(images) > 0 || len(files) > 0)
+	if err != nil {
+		return err
+	}
+	if target.platform == nil {
+		return fmt.Errorf("no active session found (key=%q)", sessionKey)
+	}
+
+	_, sessions, err := e.getOrCreateWorkspaceAgent(workDir)
+	if err != nil {
+		return err
+	}
+	session := sessions.NewSession(target.sessionKey, "send")
+	if message != "" {
+		session.AddHistory("assistant", message)
+	}
+	sessions.Save()
+	e.bindSendWorkDir(target.sessionKey, workDir)
+
+	var imageSender ImageSender
+	if len(images) > 0 {
+		var ok bool
+		imageSender, ok = target.platform.(ImageSender)
+		if !ok {
+			return fmt.Errorf("platform %s: %w", target.platform.Name(), ErrNotSupported)
+		}
+	}
+
+	var fileSender FileSender
+	if len(files) > 0 {
+		var ok bool
+		fileSender, ok = target.platform.(FileSender)
+		if !ok {
+			return fmt.Errorf("platform %s: %w", target.platform.Name(), ErrNotSupported)
+		}
+	}
+
+	if message != "" {
+		if err := e.waitOutgoing(target.platform); err != nil {
+			return err
+		}
+		if len(atUsers) > 0 || atAll {
+			if atSender, ok := target.platform.(AtMentionSender); ok {
+				if err := atSender.ReplyWithAt(e.ctx, target.replyCtx, message, atUsers, atAll); err != nil {
+					return err
+				}
+			} else if err := target.platform.Send(e.ctx, target.replyCtx, message); err != nil {
+				return err
+			}
+		} else {
+			if err := target.platform.Send(e.ctx, target.replyCtx, message); err != nil {
+				return err
+			}
+		}
+		if target.state != nil {
+			target.state.mu.Lock()
+			target.state.sideText = strings.TrimSpace(message)
+			target.state.mu.Unlock()
+		}
+	}
+	for _, img := range images {
+		if err := e.waitOutgoing(target.platform); err != nil {
+			return err
+		}
+		if err := imageSender.SendImage(e.ctx, target.replyCtx, img); err != nil {
+			return err
+		}
+	}
+	for _, file := range files {
+		if err := e.waitOutgoing(target.platform); err != nil {
+			return err
+		}
+		if err := fileSender.SendFile(e.ctx, target.replyCtx, file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *Engine) resolveSendTarget(sessionKey string, attachments bool) (sendTarget, error) {
+	e.interactiveMu.Lock()
+
+	resolvedSessionKey := sessionKey
+	var state *interactiveState
+	if sessionKey != "" {
+		state = e.interactiveStates[sessionKey]
+		if state == nil && e.multiWorkspace {
+			if iKey := e.interactiveKeyForSessionKeyLocked(sessionKey); iKey != sessionKey {
+				state = e.interactiveStates[iKey]
+			}
+		}
+	} else if len(e.interactiveStates) == 1 {
+		for key, s := range e.interactiveStates {
+			resolvedSessionKey = key
+			state = s
+			break
+		}
+	} else if len(e.interactiveStates) > 1 && attachments {
+		e.interactiveMu.Unlock()
+		return sendTarget{}, fmt.Errorf("multiple active sessions; must specify --session to send attachments")
+	} else {
+		for key, s := range e.interactiveStates {
+			resolvedSessionKey = key
+			state = s
+			break
+		}
+	}
+	e.interactiveMu.Unlock()
+
+	var p Platform
+	var replyCtx any
+	if state != nil {
+		state.mu.Lock()
+		p = state.platform
+		replyCtx = state.replyCtx
+		state.mu.Unlock()
+	}
+
+	if p == nil && resolvedSessionKey != "" {
+		strippedKey := resolvedSessionKey
+		platformName := ""
+		if idx := strings.Index(strippedKey, ":"); idx > 0 {
+			platformName = strippedKey[:idx]
+		}
+		var targetPlatform Platform
+		for _, candidate := range e.platforms {
+			if candidate.Name() == platformName {
+				targetPlatform = candidate
+				break
+			}
+		}
+		if targetPlatform == nil {
+			for _, candidate := range e.platforms {
+				needle := ":" + candidate.Name() + ":"
+				if idx := strings.Index(strippedKey, needle); idx >= 0 {
+					targetPlatform = candidate
+					strippedKey = strippedKey[idx+1:]
+					break
+				}
+			}
+		}
+		if targetPlatform != nil {
+			rc, ok := targetPlatform.(ReplyContextReconstructor)
+			if !ok {
+				return sendTarget{}, fmt.Errorf("platform %q does not support proactive messaging", targetPlatform.Name())
+			}
+			reconstructed, err := rc.ReconstructReplyCtx(strippedKey)
+			if err != nil {
+				return sendTarget{}, fmt.Errorf("reconstruct reply context: %w", err)
+			}
+			p = targetPlatform
+			replyCtx = reconstructed
+			resolvedSessionKey = strippedKey
+		}
+	}
+
+	return sendTarget{
+		state:      state,
+		platform:   p,
+		replyCtx:   replyCtx,
+		sessionKey: resolvedSessionKey,
+	}, nil
+}
+
+func (e *Engine) resolveSendWorkDir(workDir string) (string, bool, error) {
+	current := e.currentSendWorkDir()
+	target, err := normalizeSendWorkDir(workDir, current)
+	if err != nil {
+		return "", false, err
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return "", false, fmt.Errorf("work_dir %q: %w", target, err)
+	}
+	if !info.IsDir() {
+		return "", false, fmt.Errorf("work_dir %q is not a directory", target)
+	}
+
+	if current != "" {
+		if normalizedCurrent, err := normalizeSendWorkDir(current, ""); err == nil && normalizedCurrent == target {
+			return target, false, nil
+		}
+	}
+	return target, true, nil
+}
+
+func (e *Engine) currentSendWorkDir() string {
+	if e.agent != nil {
+		if wd, ok := e.agent.(interface{ GetWorkDir() string }); ok {
+			if dir := strings.TrimSpace(wd.GetWorkDir()); dir != "" {
+				return dir
+			}
+		}
+	}
+	if strings.TrimSpace(e.baseWorkDir) != "" {
+		return strings.TrimSpace(e.baseWorkDir)
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		return cwd
+	}
+	return ""
+}
+
+func normalizeSendWorkDir(workDir, base string) (string, error) {
+	dir := strings.TrimSpace(workDir)
+	if dir == "" {
+		return "", fmt.Errorf("work_dir is required")
+	}
+	if dir == "~" || strings.HasPrefix(dir, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		if dir == "~" {
+			dir = home
+		} else {
+			dir = filepath.Join(home, strings.TrimPrefix(dir, "~/"))
+		}
+	}
+	if !filepath.IsAbs(dir) {
+		if strings.TrimSpace(base) == "" {
+			var err error
+			base, err = os.Getwd()
+			if err != nil {
+				return "", fmt.Errorf("resolve current directory: %w", err)
+			}
+		}
+		dir = filepath.Join(base, dir)
+	}
+	abs, err := filepath.Abs(filepath.Clean(dir))
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
 }
 
 // SendTTSToSession synthesizes and sends a voice message to an active session.
@@ -15336,6 +15625,11 @@ func (e *Engine) commandContextWithWorkspace(p Platform, msg *Message) (Agent, *
 // sessionContextForKey resolves the agent and session manager for a sessionKey.
 // It uses existing workspace bindings and falls back to global context if unresolved.
 func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager) {
+	if workspace := e.sendWorkDirForSession(sessionKey); workspace != "" {
+		if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(workspace); err == nil {
+			return wsAgent, wsSessions
+		}
+	}
 	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return e.agent, e.sessions
 	}
@@ -15361,6 +15655,54 @@ func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager
 	return e.agent, e.sessions
 }
 
+func (e *Engine) bindSendWorkDir(sessionKey, workDir string) {
+	if sessionKey == "" || workDir == "" {
+		return
+	}
+	keys := []string{sessionKey}
+	if participantKey := directParticipantKeyForSession(sessionKey); participantKey != "" {
+		keys = append(keys, participantKey)
+	}
+	e.sendWorkDirMu.Lock()
+	defer e.sendWorkDirMu.Unlock()
+	if e.sendWorkDirs == nil {
+		e.sendWorkDirs = make(map[string]string)
+	}
+	for _, key := range keys {
+		if key != "" {
+			e.sendWorkDirs[key] = workDir
+		}
+	}
+}
+
+func (e *Engine) sendWorkDirForSession(sessionKey string) string {
+	if sessionKey == "" {
+		return ""
+	}
+	participantKey := directParticipantKeyForSession(sessionKey)
+	e.sendWorkDirMu.RLock()
+	defer e.sendWorkDirMu.RUnlock()
+	if workDir := e.sendWorkDirs[sessionKey]; workDir != "" {
+		return workDir
+	}
+	if participantKey != "" {
+		return e.sendWorkDirs[participantKey]
+	}
+	return ""
+}
+
+func directParticipantKeyForSession(sessionKey string) string {
+	platformName := extractPlatformName(sessionKey)
+	if platformName == "" {
+		return ""
+	}
+	parts := strings.SplitN(sessionKey, ":", 5)
+	if len(parts) < 4 || parts[1] != "d" || strings.TrimSpace(parts[3]) == "" {
+		return ""
+	}
+	return platformName + ":direct-user:" + strings.TrimSpace(parts[3])
+}
+
 // workspaceFromLiveState extracts the workspace path embedded in a live
 // interactive state key for sessionKey, or "" if no live state references
 // this sessionKey. Used as a recovery path when channel-binding-derived
@@ -15383,6 +15725,9 @@ func (e *Engine) workspaceFromLiveState(sessionKey string) string {
 // interactiveKeyForSessionKey returns the interactive state key for a sessionKey.
 // In multi-workspace mode, it prefixes with the bound workspace path when available.
 func (e *Engine) interactiveKeyForSessionKey(sessionKey string) string {
+	if workspace := e.sendWorkDirForSession(sessionKey); workspace != "" {
+		return workspace + ":" + sessionKey
+	}
 	// Single-workspace fast path: no scan, no binding lookup, no lock.
 	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return sessionKey
@@ -15416,6 +15761,9 @@ func (e *Engine) interactiveKeyForSessionKey(sessionKey string) string {
 //     ID, so step 2 misses. The state map was keyed correctly at processing
 //     time, so we recover the workspace prefix from there.
 func (e *Engine) interactiveKeyForSessionKeyLocked(sessionKey string) string {
+	if workspace := e.sendWorkDirForSession(sessionKey); workspace != "" {
+		return workspace + ":" + sessionKey
+	}
 	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return sessionKey
 	}


### PR DESCRIPTION
Fixes #1379

## 概要

这个 PR 给外部 `cc-connect send` 流程增加工作目录选择能力。

调用方现在可以使用 `cc-connect send --cwd /path/to/repo ...`，也可以在本地 `/send` API 里传 `work_dir` 或 `cwd`。当目标目录不同于当前项目目录时，engine 会在该目录下创建一个侧会话，把主动消息发到目标聊天会话，并让后续来自该会话的回复继续路由到这个目录。

对于私聊 session key，后续绑定使用现有 typed session key 字段（`platform:d:<conversation>:<user>`）派生 direct participant key。这样可以保持 core 侧平台无关，也避免为了 DingTalk 私聊单独增加 alias hook。

## 逐文件说明

- `cmd/cc-connect/send.go`
  - 解析 `--cwd` 和 `--work-dir`。
  - 在 CLI help 中补充新参数，方便用户发现这个能力。
  - 不改变已有 message、attachment、TTS、at-mention 参数行为。

- `cmd/cc-connect/send_test.go`
  - 增加 `--cwd` 和 `--work-dir` 的回归测试。
  - 确认两个参数都会正确填充到发送请求的工作目录字段。

- `core/api.go`
  - 给 `SendRequest` 增加 `work_dir` 和 `cwd` JSON 字段。
  - 在 API 层统一两个字段，再传给 engine。
  - 将 message/image/file 的发送路径切到 `SendToSessionWithOptions`，让工作目录、at-users、at-all 一起传入，同时保留旧 wrapper API。

- `core/api_test.go`
  - 增加一个支持 workdir 的 stub agent，用来验证 `/send` 行为。
  - 验证 `/send` 携带 `work_dir` 时，会在目标目录创建名为 `send` 的侧会话。
  - 验证同一私聊参与人后续用真实 inbound direct session key 回复时，仍然进入目标目录，而不是回到基础 agent。

- `core/engine.go`
  - 增加 `SendOptions`，并保留 `SendToSessionWithAttachments` 作为兼容 wrapper。
  - 增加 `SendToSessionInWorkDir`，处理带工作目录的侧会话发送流程。
  - 懒初始化 workspace agent pool，让 `send --cwd` 在非 multi-workspace 模式下也能工作。
  - 按 session key 和派生 direct participant key 记录 send 指定的工作目录。
  - 在入站消息处理、session context 解析和 interactive key 计算时读取该绑定，确保后续回复继续落在选定目录。

## 验证

```sh
git diff --check
GOCACHE=/private/tmp/cc-connect-gocache GOMODCACHE=/private/tmp/cc-connect-gomodcache go test ./cmd/cc-connect ./core -run 'TestParseSendArgs_WorkDirOption|TestHandleSend_WorkDirStartsSideSession|TestHandleSend_WorkDirFollowsDirectParticipantOnInboundSession' -count=1
```

两个命令均已通过。
