### PR TITLE
fix(core): prevent concurrent message queue miss

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2755,6 +2755,12 @@ sessionLocked:
 	// reset_on_idle_mins is not defeated by heartbeats or unsolicited agent
 	// output running between user messages (#1115).
 	session.TouchUserActivity()
+
+	// Ensure an interactiveState entry exists before launching the async
+	// processor so messages arriving during session startup can be queued
+	// instead of dropped (issue #565). This is still needed after idle auto-
+	// reset because cleanupInteractiveState may remove the early placeholder.
+	e.ensureInteractiveStateForQueueing(interactiveKey, p, msg.ReplyCtx)
 	e.noteUserMessageAccepted(interactiveKey, msg.UserMessageTimeMs)
 	slog.Debug("user message accepted for processing",
 		"platform", msg.Platform,


### PR DESCRIPTION
## Summary
- create the interactive queue placeholder before taking the session lock
- keep the existing post-reset placeholder creation for idle cleanup cases
- fixes a race where a concurrent message could see the session as busy before queue state existed and be dropped

## Verification
- go test -race ./core -run '^TestCUJ_H2_TwoPlatformsConcurrentNoBleed$' -count=50\n\n## Context\nThis was found while checking PR #1328. The failing CI test also reproduces on current upstream/main, so this fix is kept in a separate branch and PR instead of being mixed into the antigravity permission bridge changes.