### PR TITLE
feat(send): configurable attachment size limit via max_attachment_size_mb

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ Notes:
 - `--image` and `--file` can both be repeated.
 - `--tts` sends synthesized speech when the user asks for a voice reply.
 - `attachment_send = "off"` disables only attachment send-back; ordinary text replies still work.
+- Attachments are capped at 50 MiB by default; configure with `max_attachment_size_mb` (or `CC_MAX_ATTACHMENT_SIZE_MB` env, same MiB unit).
 - This command is for generated attachments, not ordinary text replies.
 
 📖 **Full documentation:** [docs/usage.md](docs/usage.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -531,6 +531,7 @@ cc-connect send --tts "你好"
 - `--image` 和 `--file` 都可以重复传多个。
 - `--tts` 用当前 TTS provider 合成并发送语音，适合用户自然要求“发语音”的场景。
 - `attachment_send = "off"` 只会关闭附件回传，普通文本回复仍然正常。
+- 单个附件默认上限 50 MiB；可用 `max_attachment_size_mb` 配置（或环境变量 `CC_MAX_ATTACHMENT_SIZE_MB`，同样单位 MiB）。
 - 这个命令是给“生成后的附件回传”用的，不是给普通文本回复用的。
 
 📖 **完整文档：** [docs/usage.zh-CN.md](docs/usage.zh-CN.md)

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -28,6 +29,11 @@ var (
 	commit    = "none"
 	buildTime = "unknown"
 )
+
+// globalAPIServer holds the running API server so the config-reload path can
+// re-apply hot-reloadable settings (e.g. max attachment size) without threading
+// it through the engine's reload closure. nil when the API server is disabled.
+var globalAPIServer *core.APIServer
 
 // defaultResetOnIdleMins is applied when a project does not set
 // reset_on_idle_mins. After this many minutes of user inactivity, cc-connect
@@ -162,6 +168,27 @@ func preScanLogMaxBackupsFlag(args []string) string {
 		}
 	}
 	return ""
+}
+
+// resolveMaxAttachmentSize returns the per-attachment size limit in bytes for
+// the /send API. Priority: CC_MAX_ATTACHMENT_SIZE_MB env var (MiB) >
+// config max_attachment_size_mb > core.DefaultMaxAttachmentSize. The env var
+// intentionally uses the same MiB unit as the config field so the two knobs
+// cannot silently disagree by a factor of 1<<20. A malformed or non-positive
+// env value is ignored (falling through to config/default) rather than being
+// fatal — the same lenient posture as resolveLogMaxSize, which also warns so
+// a typo never silently downgrades the setting.
+func resolveMaxAttachmentSize(cfg *config.Config) int64 {
+	if v := strings.TrimSpace(os.Getenv("CC_MAX_ATTACHMENT_SIZE_MB")); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n << 20
+		}
+		fmt.Fprintf(os.Stderr, "warning: ignoring CC_MAX_ATTACHMENT_SIZE_MB=%q: must be a positive integer (MiB)\n", v)
+	}
+	if cfg != nil && cfg.MaxAttachmentSizeMB > 0 {
+		return int64(cfg.MaxAttachmentSizeMB) << 20
+	}
+	return core.DefaultMaxAttachmentSize
 }
 
 type initialModelRefreshStarter interface {
@@ -1235,6 +1262,9 @@ func main() {
 	if err != nil {
 		slog.Warn("api server unavailable", "error", err)
 	} else {
+		globalAPIServer = apiSrv
+		apiSrv.SetMaxAttachmentSize(resolveMaxAttachmentSize(cfg))
+
 		relayMgr := core.NewRelayManager(cfg.DataDir)
 		if cfg.Relay.TimeoutSecs != nil {
 			secs := *cfg.Relay.TimeoutSecs
@@ -1632,6 +1662,11 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 	}
 
 	result := &core.ConfigReloadResult{}
+
+	// Re-apply process-global hot-reloadable settings.
+	if globalAPIServer != nil {
+		globalAPIServer.SetMaxAttachmentSize(resolveMaxAttachmentSize(cfg))
+	}
 
 	// Find the matching project
 	var proj *config.ProjectConfig

--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/chenhg5/cc-connect/config"
 	"github.com/chenhg5/cc-connect/core"
 )
 
@@ -172,19 +173,21 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 		req.Message = strings.Join(positional, " ")
 	}
 
-	images, err := loadImageAttachments(imagePaths)
+	maxAtt := resolveMaxAttachmentSize(loadSendConfigBestEffort())
+
+	images, err := loadImageAttachments(imagePaths, maxAtt)
 	if err != nil {
 		return req, "", err
 	}
-	files, err := loadFileAttachments(filePaths)
+	files, err := loadFileAttachments(filePaths, maxAtt)
 	if err != nil {
 		return req, "", err
 	}
-	audioFiles, err := loadTypedFileAttachments(audioPaths, "audio")
+	audioFiles, err := loadTypedFileAttachments(audioPaths, "audio", maxAtt)
 	if err != nil {
 		return req, "", err
 	}
-	videoFiles, err := loadTypedFileAttachments(videoPaths, "video")
+	videoFiles, err := loadTypedFileAttachments(videoPaths, "video", maxAtt)
 	if err != nil {
 		return req, "", err
 	}
@@ -206,10 +209,10 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 	return req, dataDir, nil
 }
 
-func loadImageAttachments(paths []string) ([]core.ImageAttachment, error) {
+func loadImageAttachments(paths []string, maxSize int64) ([]core.ImageAttachment, error) {
 	images := make([]core.ImageAttachment, 0, len(paths))
 	for _, path := range paths {
-		data, fileName, mimeType, err := readAttachment(path)
+		data, fileName, mimeType, err := readAttachment(path, maxSize)
 		if err != nil {
 			return nil, err
 		}
@@ -221,10 +224,10 @@ func loadImageAttachments(paths []string) ([]core.ImageAttachment, error) {
 	return images, nil
 }
 
-func loadFileAttachments(paths []string) ([]core.FileAttachment, error) {
+func loadFileAttachments(paths []string, maxSize int64) ([]core.FileAttachment, error) {
 	files := make([]core.FileAttachment, 0, len(paths))
 	for _, path := range paths {
-		data, fileName, mimeType, err := readAttachment(path)
+		data, fileName, mimeType, err := readAttachment(path, maxSize)
 		if err != nil {
 			return nil, err
 		}
@@ -233,10 +236,10 @@ func loadFileAttachments(paths []string) ([]core.FileAttachment, error) {
 	return files, nil
 }
 
-func loadTypedFileAttachments(paths []string, mediaType string) ([]core.FileAttachment, error) {
+func loadTypedFileAttachments(paths []string, mediaType string, maxSize int64) ([]core.FileAttachment, error) {
 	files := make([]core.FileAttachment, 0, len(paths))
 	for _, path := range paths {
-		data, fileName, mimeType, err := readAttachment(path)
+		data, fileName, mimeType, err := readAttachment(path, maxSize)
 		if err != nil {
 			return nil, err
 		}
@@ -271,17 +274,32 @@ func attachmentMatchesMediaType(mimeType, fileName, mediaType string) bool {
 	return false
 }
 
-const maxAttachmentSize = 50 << 20 // 50 MB
+// loadSendConfigBestEffort loads config.toml — resolved the same way the
+// daemon resolves it — so the standalone `cc-connect send` subcommand (a
+// separate process that otherwise has no config) can honour
+// max_attachment_size_mb. Errors are ignored and nil is returned, so a missing
+// or invalid config never breaks sending; the caller then falls back to the
+// env var / default via resolveMaxAttachmentSize.
+func loadSendConfigBestEffort() *config.Config {
+	cfg, err := config.Load(resolveConfigPath(""))
+	if err != nil {
+		return nil
+	}
+	return cfg
+}
 
-func readAttachment(path string) ([]byte, string, string, error) {
+// readAttachment reads a single attachment file, rejecting anything larger than
+// maxSize bytes (resolved by the caller from config/env/default). The limit is
+// enforced before the file is read into memory.
+func readAttachment(path string, maxSize int64) ([]byte, string, string, error) {
 	cleaned := filepath.Clean(path)
 
 	info, err := os.Stat(cleaned)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("read attachment %s: %w", path, err)
 	}
-	if info.Size() > maxAttachmentSize {
-		return nil, "", "", fmt.Errorf("attachment %s exceeds size limit (%d MB)", path, maxAttachmentSize>>20)
+	if info.Size() > maxSize {
+		return nil, "", "", fmt.Errorf("attachment %s exceeds size limit (%d MB)", path, maxSize>>20)
 	}
 
 	data, err := os.ReadFile(cleaned)

--- a/cmd/cc-connect/send_test.go
+++ b/cmd/cc-connect/send_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chenhg5/cc-connect/config"
 	"github.com/chenhg5/cc-connect/core"
 )
 
@@ -207,12 +208,13 @@ func TestDetectAttachmentMimeType_UsesExtensionFallback(t *testing.T) {
 }
 
 func TestReadAttachment_SizeLimit(t *testing.T) {
+	const limit int64 = 100 // tiny limit keeps the test fast and deterministic
 	dir := t.TempDir()
 	small := filepath.Join(dir, "small.txt")
 	if err := os.WriteFile(small, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, err := readAttachment(small); err != nil {
+	if _, _, _, err := readAttachment(small, limit); err != nil {
 		t.Fatalf("small file should succeed: %v", err)
 	}
 
@@ -221,12 +223,12 @@ func TestReadAttachment_SizeLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := f.Truncate(maxAttachmentSize + 1); err != nil {
+	if err := f.Truncate(limit + 1); err != nil {
 		f.Close()
 		t.Fatal(err)
 	}
 	f.Close()
-	if _, _, _, err := readAttachment(big); err == nil {
+	if _, _, _, err := readAttachment(big, limit); err == nil {
 		t.Fatal("oversized file should be rejected")
 	}
 }
@@ -244,7 +246,7 @@ func TestReadAttachment_CleanPath(t *testing.T) {
 
 	// Path with ../ should still work after cleaning
 	dirty := filepath.Join(sub, "..", "sub", "test.txt")
-	data, name, _, err := readAttachment(dirty)
+	data, name, _, err := readAttachment(dirty, core.DefaultMaxAttachmentSize)
 	if err != nil {
 		t.Fatalf("readAttachment with dirty path: %v", err)
 	}
@@ -253,6 +255,39 @@ func TestReadAttachment_CleanPath(t *testing.T) {
 	}
 	if name != "test.txt" {
 		t.Errorf("unexpected filename: %q", name)
+	}
+}
+
+func TestResolveMaxAttachmentSize(t *testing.T) {
+	// Default when neither env nor config sets it.
+	t.Setenv("CC_MAX_ATTACHMENT_SIZE_MB", "")
+	if got := resolveMaxAttachmentSize(nil); got != core.DefaultMaxAttachmentSize {
+		t.Fatalf("default = %d, want %d", got, core.DefaultMaxAttachmentSize)
+	}
+
+	cfg := &config.Config{MaxAttachmentSizeMB: 100}
+
+	// Config value (MiB → bytes) honoured when env is unset.
+	if got, want := resolveMaxAttachmentSize(cfg), int64(100)<<20; got != want {
+		t.Fatalf("from config = %d, want %d", got, want)
+	}
+
+	// Env var is MiB (same unit as the config field) and takes precedence.
+	t.Setenv("CC_MAX_ATTACHMENT_SIZE_MB", "1024") // 1024 MiB = 1 GiB
+	if got, want := resolveMaxAttachmentSize(cfg), int64(1<<30); got != want {
+		t.Fatalf("env override = %d, want %d", got, want)
+	}
+
+	// Malformed env falls through to config rather than being fatal.
+	t.Setenv("CC_MAX_ATTACHMENT_SIZE_MB", "not-a-number")
+	if got, want := resolveMaxAttachmentSize(cfg), int64(100)<<20; got != want {
+		t.Fatalf("malformed env should fall through to config = %d, want %d", got, want)
+	}
+
+	// Non-positive env also falls through.
+	t.Setenv("CC_MAX_ATTACHMENT_SIZE_MB", "0")
+	if got, want := resolveMaxAttachmentSize(cfg), int64(100)<<20; got != want {
+		t.Fatalf("zero env should fall through to config = %d, want %d", got, want)
 	}
 }
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -47,6 +47,17 @@
 # 不带附件的 `cc-connect send --message` 不受影响。
 # attachment_send = "on"
 
+# Maximum size of a single attachment (in MiB) for `cc-connect send
+# --file/--image/--audio/--video` and the /send API. Default: 50 (i.e. 50 MiB).
+# Set 0 to keep the default. Raise it to send larger files; the /send request
+# body limit scales with this value to fit base64-encoded attachments.
+# Can also be overridden by the CC_MAX_ATTACHMENT_SIZE_MB env var (same MiB
+# unit; takes precedence over this option when set).
+# `cc-connect send` 单个附件的最大大小（单位 MiB）。默认 50（即 50 MiB），设 0 保持默认。
+# 调大可发送更大文件；/send 请求体上限会随之按 base64 膨胀自动放大。
+# 也可用环境变量 CC_MAX_ATTACHMENT_SIZE_MB 覆盖（同样单位 MiB；设置后优先级高于本配置项）。
+# max_attachment_size_mb = 50
+
 [log]
 level = "info" # debug, info, warn, error
 

--- a/config/config.go
+++ b/config/config.go
@@ -128,6 +128,12 @@ type Config struct {
 	// for sourcing shell profiles so that user-defined functions and aliases are
 	// available. Example: "source ~/.zshrc"
 	ShellProfile string `toml:"shell_profile,omitempty"`
+	// MaxAttachmentSizeMB is the per-file size limit, in MiB, for attachments
+	// sent through `cc-connect send --file/--image/--audio/--video` and the
+	// /send API. 0 (the default) means use core.DefaultMaxAttachmentSize
+	// (50 MiB). Raise it to send larger files; the request body limit on the
+	// API side scales with this value to account for base64 expansion.
+	MaxAttachmentSizeMB int `toml:"max_attachment_size_mb,omitempty"`
 }
 
 // CronConfig controls cron job behavior.

--- a/core/api.go
+++ b/core/api.go
@@ -15,6 +15,11 @@ import (
 	"time"
 )
 
+// DefaultMaxAttachmentSize is the default per-attachment size limit (50 MiB)
+// applied by the /send API and `cc-connect send` when max_attachment_size_mb
+// is unset. Exported so cmd/cc-connect can resolve the same default.
+const DefaultMaxAttachmentSize int64 = 50 << 20
+
 // APIServer exposes a local Unix socket API for external tools (e.g. cron jobs)
 // to send messages to active sessions.
 type APIServer struct {
@@ -26,7 +31,11 @@ type APIServer struct {
 	cron       *CronScheduler
 	timer      *TimerScheduler
 	relay      *RelayManager
-	mu         sync.RWMutex
+	// maxAttachmentBytes caps the raw size of a single attachment accepted by
+	// /send; the request body limit in handleSend is derived from it (base64
+	// expansion + envelope). Defaults to DefaultMaxAttachmentSize.
+	maxAttachmentBytes int64
+	mu                 sync.RWMutex
 }
 
 // SendRequest is the JSON body for POST /send.
@@ -72,10 +81,11 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 	}
 
 	s := &APIServer{
-		socketPath: sockPath,
-		listener:   listener,
-		mux:        http.NewServeMux(),
-		engines:    make(map[string]*Engine),
+		socketPath:         sockPath,
+		listener:           listener,
+		mux:                http.NewServeMux(),
+		engines:            make(map[string]*Engine),
+		maxAttachmentBytes: DefaultMaxAttachmentSize,
 	}
 	s.mux.HandleFunc("/send", s.handleSend)
 	s.mux.HandleFunc("/sessions", s.handleSessions)
@@ -126,6 +136,39 @@ func (s *APIServer) SetTimerScheduler(ts *TimerScheduler) {
 	s.timer = ts
 }
 
+// SetMaxAttachmentSize overrides the per-attachment size limit (bytes) used by
+// /send. Non-positive values are ignored so the default is retained. Safe to
+// call at any time, including from the config reload path: it is guarded by
+// s.mu because handleSend reads the limit concurrently.
+func (s *APIServer) SetMaxAttachmentSize(bytes int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if bytes > 0 {
+		s.maxAttachmentBytes = bytes
+	}
+}
+
+// sendBodyEnvelope is the slack added on top of the base64-expanded attachment
+// limit when sizing the /send request body: it covers the JSON envelope (field
+// names, message text, metadata) and a few sub-limit attachments.
+const sendBodyEnvelope int64 = 8 << 20 // 8 MiB
+
+// sendBodyLimit returns the maximum accepted /send request body size in bytes.
+// It is derived from the per-attachment limit to accommodate base64 expansion
+// (~4/3) plus envelope slack, falling back to DefaultMaxAttachmentSize when no
+// limit has been set (e.g. APIServer zero value in tests). Callers in hot paths
+// (handleSend) run concurrently with SetMaxAttachmentSize, so the read is
+// guarded by s.mu.
+func (s *APIServer) sendBodyLimit() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	limit := s.maxAttachmentBytes
+	if limit <= 0 {
+		limit = DefaultMaxAttachmentSize
+	}
+	return limit*4/3 + sendBodyEnvelope
+}
+
 func (s *APIServer) Start() {
 	s.server = &http.Server{Handler: s.mux}
 	go func() {
@@ -161,9 +204,14 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	const maxSendBody = 52 << 20 // 52 MB (slightly above max attachment to account for base64 overhead)
+	// Attachments travel base64-encoded inside the JSON body (~4/3 expansion)
+	// plus the request envelope, so size the reader to fit one max-size
+	// attachment with overhead to spare. The previous hard-coded 52 MB cap was
+	// smaller than a single 50 MB attachment after base64 encoding and would
+	// reject valid sends; deriving it from maxAttachmentBytes keeps the body
+	// limit in step with the configured attachment limit.
 	var req SendRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, maxSendBody)).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, s.sendBodyLimit())).Decode(&req); err != nil {
 		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -317,3 +317,48 @@ func TestHandleCronExec_ProjectMissingIsBadRequest(t *testing.T) {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 	}
 }
+
+func TestSendBodyLimit_DefaultAndOverride(t *testing.T) {
+	// Zero-value APIServer (no SetMaxAttachmentSize call) falls back to the
+	// default and sizes the body for one base64-expanded attachment + envelope.
+	got := (&APIServer{}).sendBodyLimit()
+	want := DefaultMaxAttachmentSize*4/3 + sendBodyEnvelope
+	if got != want {
+		t.Fatalf("default sendBodyLimit = %d, want %d", got, want)
+	}
+
+	// A configured limit scales the body limit proportionally.
+	api := &APIServer{}
+	api.SetMaxAttachmentSize(100 << 20) // 100 MiB
+	got = api.sendBodyLimit()
+	want = (100<<20)*4/3 + sendBodyEnvelope
+	if got != want {
+		t.Fatalf("overridden sendBodyLimit = %d, want %d", got, want)
+	}
+
+	// Non-positive values are a no-op: the previously configured limit is kept
+	// (callers always pass a positive, resolved value; this just guards typos).
+	api.SetMaxAttachmentSize(0)
+	if got, want := api.sendBodyLimit(), (100<<20)*4/3+sendBodyEnvelope; got != want {
+		t.Fatalf("sendBodyLimit after zero override = %d, want %d (100 MiB retained)", got, want)
+	}
+}
+
+// TestSetMaxAttachmentSize_ConcurrentSafe exercises the reload-vs-request race
+// window: SetMaxAttachmentSize (config reload goroutine) mutates the limit
+// while handleSend's sendBodyLimit reads it. Run with -race to catch the
+// unsynchronised access this guards against.
+func TestSetMaxAttachmentSize_ConcurrentSafe(t *testing.T) {
+	api := &APIServer{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 300; i++ {
+			api.SetMaxAttachmentSize(int64(50+i%10) << 20)
+		}
+	}()
+	for i := 0; i < 300; i++ {
+		_ = api.sendBodyLimit()
+	}
+	<-done
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -792,6 +792,7 @@ Notes:
 - `--image` and `--file` can both be repeated.
 - Absolute paths are recommended so the command does not depend on the agent's current working directory.
 - With `attachment_send = "off"`, image/file send-back is blocked but ordinary text replies still work.
+- Each attachment is capped at **50 MiB** by default. Configure it with `max_attachment_size_mb` (MiB) in config.toml, or override that value with the `CC_MAX_ATTACHMENT_SIZE_MB` env var (same MiB unit; takes precedence when set), e.g. `CC_MAX_ATTACHMENT_SIZE_MB=100 cc-connect send --file big.bin`.
 
 ### Typical use cases
 
@@ -805,7 +806,7 @@ Notes:
 - This command is for generated attachment and voice delivery, not ordinary text replies.
 - The files must exist on the local machine where the agent runs.
 - There must be an active session; otherwise the command fails because cc-connect has no chat context to deliver to.
-- Platform-specific file size and file type limits still apply.
+- The target platform also enforces its own file-size/type limit at delivery; the effective per-attachment ceiling is the smaller of that limit and `max_attachment_size_mb` (a file that passes cc-connect may still be rejected by the platform).
 
 ---
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -705,6 +705,7 @@ cc-connect send --tts "你好"
 - `--image` 和 `--file` 都可以重复多次。
 - 建议使用绝对路径，避免 Agent 当前工作目录变化导致找不到文件。
 - 如果设置了 `attachment_send = "off"`，图片/文件回传会被拒绝，但普通文本回复仍然正常。
+- 每个附件默认上限 **50 MiB**。可在 config.toml 用 `max_attachment_size_mb`（单位 MiB）调整，或用环境变量 `CC_MAX_ATTACHMENT_SIZE_MB` 覆盖该值（同样单位 MiB，设置后优先级更高），例如 `CC_MAX_ATTACHMENT_SIZE_MB=100 cc-connect send --file big.bin`。
 
 ### 典型场景
 
@@ -718,7 +719,7 @@ cc-connect send --tts "你好"
 - 这个命令是给“附件和语音回传”用的，不要拿它代替普通文本回复。
 - 只能发送本机上 Agent 可访问到的文件。
 - 必须存在活跃会话；如果当前项目没有活动聊天上下文，命令会失败。
-- 平台本身仍可能有文件大小或文件类型限制。
+- 目标平台在投递时还会校验自己的文件大小/类型上限；实际生效的是它与 `max_attachment_size_mb` 中**更小**的那个（通过了 cc-connect 的文件仍可能在投递时被平台拒绝）。
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a **configurable per-attachment size limit** for `cc-connect send --file/--image/--audio/--video` and the `/send` API. The default stays 50 MiB (no behavior change); it can be raised or lowered via `max_attachment_size_mb` (MiB) in `config.toml`, or overridden by the `CC_MAX_ATTACHMENT_SIZE_MB` env var (same MiB unit; takes precedence when set).

This also fixes a latent issue: the `/send` request body limit was hard-coded to 52 MB, but attachments are base64-encoded in the JSON body (~4/3 expansion), so a 50 MB attachment becomes ~67 MB and was silently rejected. The body limit is now derived from the attachment limit (`limit*4/3 + 8 MiB` envelope), which is what makes the configuration actually usable.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation only
- [ ] Internal refactor / chore

> Note: the body-limit correction is a supporting change that makes the new feature work, not a standalone issue-driven bug fix. The default (50 MiB) matches previous behavior, so this is not a breaking change.

## Testing

### Automated tests added in this PR

- `TestSendBodyLimit_DefaultAndOverride` (`core/api_test.go`) — asserts the default body limit, the `SetMaxAttachmentSize` override, and no-op on non-positive values; validates the base64-aware derivation.
- `TestSetMaxAttachmentSize_ConcurrentSafe` (`core/api_test.go`) — concurrent `SetMaxAttachmentSize` writes + `sendBodyLimit` reads, verified under `-race` (Rule 6 concurrency safety).
- `TestResolveMaxAttachmentSize` (`cmd/cc-connect/send_test.go`) — all resolution paths: env (MiB) / config / default / malformed / zero.
- `TestReadAttachment_SizeLimit` (`cmd/cc-connect/send_test.go`) — updated to a parameterized `maxSize` size guard.

### Critical User Journeys (CUJ) impact

- [x] No CUJ touched

This PR only changes the `/send` attachment **size limit** (a config knob + derived body limit). It does not touch session / permission / cron / config-switch CUJ flows, nor UI rendering.

> Note on a pre-existing flaky test: `TestCUJ_H2_TwoPlatformsConcurrentNoBleed` (`core`) can time out at its 30s deadline when the whole `core` package runs under `-race` on constrained CI hosts — its own comment calls this out, and it passes in ~1.4s in isolation. It exercises `ReceiveMessage` / session isolation, a path this PR does not touch.

### Verification

- `go build ./...` ✅
- `go test ./...` (36 packages) ✅
- `go test -race ./core/ -run 'TestSetMaxAttachmentSize_ConcurrentSafe|TestSendBodyLimit'` ✅
- `go vet ./...` ✅; `gofmt` clean

## Manual / user-visible behavior change

- Default behavior is **unchanged** (still 50 MiB).
- Users can set `max_attachment_size_mb` in `config.toml` (e.g. 100) to send larger attachments, or set `CC_MAX_ATTACHMENT_SIZE_MB` (MiB) in the invoking environment to override (takes precedence when set) — e.g. `CC_MAX_ATTACHMENT_SIZE_MB=100 cc-connect send --file big.bin`.
- The daemon applies the value at startup and on config hot-reload (SIGHUP). The `cc-connect send` subcommand (a separate process that does not load config) best-effort reads the same `config.toml` to stay consistent.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes (with `-race`, concurrency touched)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n: N/A — new strings are CLI/API error messages only (consistent with existing `send.go`/`api.go`; not IM user-facing text)
- [x] No secrets / credentials in source

## Related

- Issue: none (no linked issue)
- Related PR: none

---

**Implementation notes (for reviewers):**

| Location | Change |
|---|---|
| `config/config.go` | new `MaxAttachmentSizeMB` field |
| `core/api.go` | `DefaultMaxAttachmentSize` (50 MiB) const; `APIServer.SetMaxAttachmentSize` setter (guarded by `s.mu` for concurrency); `sendBodyLimit()` derives the body limit |
| `cmd/cc-connect/main.go` | `resolveMaxAttachmentSize` (env `CC_MAX_ATTACHMENT_SIZE_MB` (MiB) > config > default; warns on malformed env); applied at startup + reload; package-global `globalAPIServer` lets the reload closure re-apply it |
| `cmd/cc-connect/send.go` | send subcommand best-effort reads config; `readAttachment` takes a parameterized `maxSize`, enforced before reading the file into memory |
