### PR TITLE
fix(slack): suppress NO_REPLY marker on streaming-card silent replies

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -5174,16 +5174,32 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			// --- StreamingCard path ---
 			if streamCard != nil && !streamCard.Failed() {
 				sp.finish("", "") // cleanup preview (should be no-op if card was active)
-				// Build final card content with full response
-				finalContent := buildCardContent(cardThinkingText, cardToolCalls, fullResponse)
+				// Silent reply: never render the NO_REPLY marker into the card.
+				// cardAnswerText holds only the text streamed BEFORE the marker
+				// (empty for a bare NO_REPLY, since silentHold suppresses card
+				// writes while the segment is still a NO_REPLY prefix). Finalize
+				// with that instead of fullResponse so the card resolves to Done
+				// without leaking the marker, and skip the fallback send that
+				// would otherwise post the suppressed marker verbatim.
+				cardBody := fullResponse
+				if isSilent {
+					cardBody = strings.TrimRight(cardAnswerText.String(), " \t\r\n")
+				}
+				finalContent := buildCardContent(cardThinkingText, cardToolCalls, cardBody)
 				if err := streamCard.Finalize(e.ctx, finalContent); err != nil {
 					slog.Error("streaming card finalize failed, sending fallback", "error", err)
-					// Fallback: send the response as a normal message
-					for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
-						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
-							return
+					// Fallback: send the response as a normal message — but never
+					// for a silent reply, which has no deliverable content.
+					if !isSilent {
+						for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+							if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
+								return
+							}
 						}
 					}
+				}
+				if isSilent {
+					slog.Info("silent reply suppressed", "session", session.ID)
 				}
 			} else if isSilent {
 				// Silent reply: drop any in-flight preview and skip all send paths.

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -15148,3 +15148,80 @@ func TestAgentSystemPrompt_DocumentsAudioVideoFlags(t *testing.T) {
 		t.Error("AgentSystemPrompt missing the 'Do NOT downgrade' anti-regression line")
 	}
 }
+
+// --- Regression: streaming-card silent reply must not leak the NO_REPLY marker ---
+
+// recordingStreamCard captures the content passed to Finalize so tests can
+// assert what was rendered into the card.
+type recordingStreamCard struct {
+	mu      sync.Mutex
+	final   bool
+	content string
+}
+
+func (c *recordingStreamCard) Update(_ context.Context, _ string) error { return nil }
+func (c *recordingStreamCard) Finalize(_ context.Context, content string) error {
+	c.mu.Lock()
+	c.final = true
+	c.content = content
+	c.mu.Unlock()
+	return nil
+}
+func (c *recordingStreamCard) Failed() bool { return false }
+func (c *recordingStreamCard) finalized() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.final
+}
+func (c *recordingStreamCard) finalContent() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.content
+}
+
+// recordingStreamCardPlatform is a StreamingCardPlatform whose card records the
+// finalized content for assertions.
+type recordingStreamCardPlatform struct {
+	stubPlatformEngine
+	card *recordingStreamCard
+}
+
+func (p *recordingStreamCardPlatform) CreateStreamingCard(_ context.Context, _ any) (StreamingCard, error) {
+	return p.card, nil
+}
+
+// TestProcessInteractiveEvents_StreamingCard_BareNoReply_Suppressed is a
+// regression test for the bug where a silent (bare NO_REPLY) turn on a
+// StreamingCardPlatform rendered the literal "NO_REPLY" marker into the card:
+// the streamCard finalize branch ran before — and shadowed — the isSilent
+// suppression branch, so buildCardContent received the raw NO_REPLY response.
+// The card must finalize WITHOUT the marker on a silent turn.
+func TestProcessInteractiveEvents_StreamingCard_BareNoReply_Suppressed(t *testing.T) {
+	card := &recordingStreamCard{}
+	p := &recordingStreamCardPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "slack"},
+		card:               card,
+	}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "slack:user-streamcard-bare-noreply"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-streamcard-bare-noreply")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-streamcard-bare-noreply",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventText, Content: "NO_REPLY"}
+	agentSession.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
+
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-streamcard-bare-noreply", time.Now(), nil, nil, state.replyCtx)
+
+	if !card.finalized() {
+		t.Fatalf("expected streaming card to be finalized on a silent turn")
+	}
+	if strings.Contains(card.finalContent(), "NO_REPLY") {
+		t.Fatalf("silent reply leaked NO_REPLY into the streaming card: %q", card.finalContent())
+	}
+}


### PR DESCRIPTION
## Summary

A turn that resolves to a bare `NO_REPLY` (the silent-reply marker documented in `core/interfaces.go`) is rendered into the chat as the **literal text "NO_REPLY"** on `StreamingCardPlatform`s (Slack today) instead of staying silent.

Root cause: in `processInteractiveEvents`, the `if streamCard != nil && !streamCard.Failed()` finalize branch runs **before** — and shadows — the `else if isSilent` suppression branch. It finalizes the card with `buildCardContent(..., fullResponse)`, and `fullResponse` is the unstripped `NO_REPLY` marker (the strip at the top of the block is gated on `!isSilent`). `silentHold`/`couldBeSilentPrefix` only guard the in-progress streaming `Update` path; the finalize path had no `isSilent` guard.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

`go build ./core/` clean. Ran the new regression test (passes), then reverted the `engine.go` guard locally and re-ran — it fails with `silent reply leaked NO_REPLY into the streaming card: "NO_REPLY"`, confirming it catches the bug.

### Automated tests added in this PR

- `TestProcessInteractiveEvents_StreamingCard_BareNoReply_Suppressed` in `core/engine_test.go` — drives a bare `NO_REPLY` turn through a `StreamingCardPlatform` stub and asserts the finalized card content does **not** contain the marker (and that the card is still finalized to Done).

### For bug fixes only — regression test

- Regression test name: `TestProcessInteractiveEvents_StreamingCard_BareNoReply_Suppressed`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

- [x] I — UI rendering correctness (cards, streaming, display modes)

Note: the silent/streaming-card tests pass (`go test ./core/ -run 'Silent|NoReply|StreamingCard'`). `TestCUJ_A3_ImageReachesAgent` fails on a clean checkout of `main` independent of this change (image-attachment path, unrelated), and `TestCUJ_H2_TwoPlatformsConcurrentNoBleed` is a pre-existing parallel flake (passes in isolation) — neither is touched by this fix.

## Manual / user-visible behavior change

- **Before:** a turn whose full response is a bare `NO_REPLY` posts the literal string "NO_REPLY" into the channel.
- **After:** the turn stays silent — the card finalizes to Done with the pre-marker streamed text (empty for a bare `NO_REPLY`), and the fallback send is skipped. Matches the `NO_REPLY` contract documented in `core/interfaces.go`.

## Checklist (reviewer will verify)

- [x] `go build ./core/` passes (full `go build ./...` requires `make web` to populate `web/dist` first — unrelated to this change)
- [x] Relevant `go test ./core/` (silent/streaming + the new regression test) passes
- [x] No new hardcoded platform/agent names in `core/` (uses the existing `isSilent` flag + `StreamingCard` interface)
- [x] No new user-facing strings (no i18n changes)
- [x] No secrets / credentials in source

## Related

- Closes #1398
- Surfaces on the streaming card added in #1333; this guards the finalize path that #1333's `silentHold` (streaming `Update` only) does not cover.
