### PR TITLE
fix(claudecode): emit EventToolResult so tool output reaches progress card

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -740,9 +740,39 @@ func (cs *claudeSession) handleUser(raw map[string]any) {
 		contentType, _ := item["type"].(string)
 		if contentType == "tool_result" {
 			isError, _ := item["is_error"].(bool)
+			var result string
+			switch c := item["content"].(type) {
+			case string:
+				result = c
+			case []any:
+				var parts []string
+				for _, elem := range c {
+					if m, ok := elem.(map[string]any); ok {
+						if t, _ := m["text"].(string); t != "" {
+							parts = append(parts, t)
+						}
+					}
+				}
+				result = strings.Join(parts, "\n")
+			}
 			if isError {
-				result, _ := item["content"].(string)
 				slog.Debug("claudeSession: tool error", "content", result)
+			}
+			success := !isError
+			code := 0
+			if isError {
+				code = 1
+			}
+			evt := core.Event{
+				Type:         core.EventToolResult,
+				ToolResult:   truncateStr(strings.TrimSpace(result), 500),
+				ToolExitCode: &code,
+				ToolSuccess:  &success,
+			}
+			select {
+			case cs.events <- evt:
+			case <-cs.ctx.Done():
+				return
 			}
 		}
 	}

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -582,6 +582,129 @@ func makeFiller(n int) string {
 	return string(b)
 }
 
+// TestHandleUserEmitsToolResult is a regression test for the bug where
+// claudeSession.handleUser silently dropped tool_result content blocks
+// (only logging when is_error=true) instead of emitting EventToolResult.
+// Without this event, engine never sees tool output and the Feishu/Slack/
+// Discord progress card never renders tool results — only the final
+// assistant text reaches the user.
+//
+// Cases covered:
+//  - string content (plain text result)
+//  - array content (Anthropic SDK multi-block: [{type:"text", text:"..."}])
+//  - is_error=true (exit code 1, success=false)
+func TestHandleUserEmitsToolResult(t *testing.T) {
+	cases := []struct {
+		name        string
+		raw         map[string]any
+		wantResult  string
+		wantCode    int
+		wantSuccess bool
+	}{
+		{
+			name: "string content",
+			raw: map[string]any{
+				"type": "user",
+				"message": map[string]any{
+					"content": []any{
+						map[string]any{
+							"type":          "tool_result",
+							"tool_use_id":   "toolu_abc",
+							"is_error":      false,
+							"content":       "command output here",
+						},
+					},
+				},
+			},
+			wantResult:  "command output here",
+			wantCode:    0,
+			wantSuccess: true,
+		},
+		{
+			name: "array content",
+			raw: map[string]any{
+				"type": "user",
+				"message": map[string]any{
+					"content": []any{
+						map[string]any{
+							"type":        "tool_result",
+							"tool_use_id": "toolu_def",
+							"is_error":    false,
+							"content": []any{
+								map[string]any{"type": "text", "text": "line one"},
+								map[string]any{"type": "text", "text": "line two"},
+							},
+						},
+					},
+				},
+			},
+			wantResult:  "line one\nline two",
+			wantCode:    0,
+			wantSuccess: true,
+		},
+		{
+			name: "error result",
+			raw: map[string]any{
+				"type": "user",
+				"message": map[string]any{
+					"content": []any{
+						map[string]any{
+							"type":        "tool_result",
+							"tool_use_id": "toolu_err",
+							"is_error":    true,
+							"content":     "boom",
+						},
+					},
+				},
+			},
+			wantResult:  "boom",
+			wantCode:    1,
+			wantSuccess: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cs := &claudeSession{
+				events: make(chan core.Event, 4),
+				ctx:    ctx,
+			}
+			cs.alive.Store(true)
+
+			cs.handleUser(tc.raw)
+
+			select {
+			case evt := <-cs.events:
+				if evt.Type != core.EventToolResult {
+					t.Fatalf("event type = %q, want %q", evt.Type, core.EventToolResult)
+				}
+				if evt.ToolResult != tc.wantResult {
+					t.Errorf("ToolResult = %q, want %q", evt.ToolResult, tc.wantResult)
+				}
+				if evt.ToolExitCode == nil || *evt.ToolExitCode != tc.wantCode {
+					got := -1
+					if evt.ToolExitCode != nil {
+						got = *evt.ToolExitCode
+					}
+					t.Errorf("ToolExitCode = %d, want %d", got, tc.wantCode)
+				}
+				if evt.ToolSuccess == nil || *evt.ToolSuccess != tc.wantSuccess {
+					got := false
+					if evt.ToolSuccess != nil {
+						got = *evt.ToolSuccess
+					}
+					t.Errorf("ToolSuccess = %v, want %v", got, tc.wantSuccess)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for EventToolResult — handleUser dropped the tool_result")
+			}
+		})
+	}
+}
+
 func helperCommand(ctx context.Context, mode string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess", "--", mode)
 	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")


### PR DESCRIPTION
## Summary

`claudeSession.handleUser` silently dropped `tool_result` content blocks — only logging when `is_error=true` and never emitting an event. As a result the engine never learned when a tool finished (or what it returned), so the Feishu / Slack / Discord / etc. progress card never rendered tool output. Only the final assistant text reached the user.

This PR adds an `EventToolResult` emit on every `tool_result` block, mirroring how `agent/codex/session.go` already emits on `command_execution` completion.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only
- [ ] Internal refactor / chore

## Testing

### Automated tests added in this PR

- `TestHandleUserEmitsToolResult` in `agent/claudecode/session_test.go` — asserts that `handleUser` emits an `EventToolResult` with correct `ToolResult` / `ToolExitCode` / `ToolSuccess` for three cases: string content, array content (`[{type:"text",text:"..."}]`), and `is_error=true`.

### For bug fixes only — regression test

- Regression test name: `TestHandleUserEmitsToolResult`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally (`git show origin/main:agent/claudecode/session.go > agent/claudecode/session.go`); the regression test failed as expected — all 3 subcases timed out waiting for `EventToolResult`. Restored the fix; all 3 subcases pass.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched
- [ ] A — basic conversation
- [ ] B — session lifecycle
- [ ] C — agent execution control
- [ ] D — security & permissions
- [ ] E — scheduled tasks
- [ ] F — config switching
- [ ] G — error handling & robustness
- [x] I — UI rendering correctness (cards, streaming, display modes)

`go test ./core/ -run TestCUJ` not run (the change is confined to `agent/claudecode/` event extraction; no `core/` behavior touched).

## Manual / user-visible behavior change

**Before:** In any progress-card-capable platform (Feishu card mode, Slack streaming card, etc.), a Claude Code session that called tools would show only the final assistant text reply. Tool input panels (when configured) appeared, but tool **result** panels were missing entirely. Codex sessions on the same platform rendered both panels correctly.

**After:** Claude Code sessions now render tool **result** panels in the progress card just like Codex sessions do. No change to non-tool events.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./agent/claudecode/ -run TestHandleUserEmitsToolResult` passes (3 subcases)
- [x] `go test ./agent/claudecode/` passes (full package, existing tests unaffected)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (no new user-facing text)
- [x] No secrets / credentials in source

## Implementation notes

- `ToolName` is intentionally left empty. Anthropic's `tool_result` block carries only `tool_use_id`, not the tool name; reverse-mapping id→name would require caching every prior `tool_use` block and is fragile (compaction, multi-turn, cache eviction). Visual ordering in the card already lets the user pair the result with the preceding tool-input panel. `humanizeToolName("")` falls back to `"Tool"` in the renderer, so the panel title is sane.
- `content` field is handled in both forms Anthropic emits: plain `string` and `[]any` of `{type:"text", text:"..."}` blocks (text parts joined with `\n`).
- `exit_code` is derived from `is_error` (1 / 0); `success` is `!is_error`. This matches how `agent/codex/session.go:522` constructs the equivalent event.
- Reuses the package-local `truncateStr` helper to cap output at 500 chars, matching codex's truncation length.

## Related

- Pattern mirrored from: `agent/codex/session.go:522` (`case "command_execution":` → emits `EventToolResult`)
- Consumed by: `core/engine.go:4745` `case EventToolResult:` (progress card render path) and `core/progress_compact.go` `AppendEvent`.