### PR TITLE
fix(feishu): coalesce batch images into single multi-image dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - **Skill discovery depth-1 only**: skill scanning no longer recurses into subdirectories. Only `<skill_dir>/<name>/SKILL.md` is registered; nested SKILL.md files (e.g. inside `<name>/references/...`) are treated as skill assets and ignored, matching the Claude Code CLI convention. Previously, nested SKILL.md files leaked into platform command menus as phantom slash commands (101 leaked commands from `frontend-design` skill alone) (#1304).
+- **feishu**: coalesce consecutive image messages from the same session into a single multi-image dispatch to fix first-image drop on batch sends (#1395). When the Feishu mobile client sends N images in quick succession, each image arrives as a separate `image` event with very close `create_time` values. Dispatching each immediately caused core/engine's `create_time` watermark (PR #1168) to drop the oldest image, so the agent only saw N-1 images. A per-session image buffer with a 150ms quiet window now merges the burst into one `core.Message` carrying all images, in send order. Single-image sends and quoted-image replies are unaffected.
 
 ## v1.3.3 (2026-06-15)
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -173,6 +173,41 @@ type Platform struct {
 	richCardImagePending    map[string]*richCardImageUpload
 	richCardImageFailed     map[string]struct{}
 	richCardImageUploadFunc func(context.Context, string) (string, error)
+
+	// imageBatch coalesces consecutive image messages from the same session
+	// arriving within imageBatchWindow. Without this, sending N images in rapid
+	// succession from the Feishu mobile client (which posts each as a separate
+	// message) caused the first (oldest create_time) image to be dropped by
+	// core/engine's create_time watermark (PR #1168), so only N-1 images were
+	// ever delivered to the agent (issue #1395).
+	imageBatchMu sync.Mutex
+	imageBatch   map[string]*imageBatchEntry
+}
+
+// imageBatchWindow is the quiet period after the last image in a session
+// before the buffered batch is dispatched as a single multi-image message.
+// 150ms comfortably covers Feishu mobile's batch-send timing (typically
+// <100ms between images) while staying responsive for sequential single
+// image sends.
+const imageBatchWindow = 150 * time.Millisecond
+
+// imageBatchEntry holds image data accumulated for one session while we wait
+// to see if more images are coming. timer is stopped and replaced on every
+// new image to coalesce the window; the pointer is captured by the timer
+// callback so an in-flight (or stale) timer can detect that its entry has
+// been superseded and exit without dispatching.
+type imageBatchEntry struct {
+	sessionKey   string
+	userID       string
+	userName     string
+	chatName     string
+	rctx         replyContext
+	quoted       quotedMessage
+	images       []core.ImageAttachment
+	messageIDs   []string
+	createTimeMs int64
+	parentID     string
+	timer        *time.Timer
 }
 
 type interactivePlatform struct {
@@ -304,6 +339,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		callbackPath:               callbackPath,
 		encryptKey:                 encryptKey,
 		peerBots:                   peerBots,
+		imageBatch:                 make(map[string]*imageBatchEntry),
 	}
 	if !useInteractiveCard {
 		base.self = base
@@ -990,6 +1026,135 @@ func (p *Platform) dispatchCoreMessage(msg *core.Message) {
 	h(p.dispatchPlatform(), msg)
 }
 
+// bufferImage adds a freshly-downloaded image to the per-session batch buffer.
+// Consecutive image-only messages from the same session (same chatID + userID
+// + parentID) coalesce into a single multi-image dispatch after imageBatchWindow
+// of quiet time. A context mismatch (different parentID or userID) flushes the
+// existing batch immediately before the new one starts.
+//
+// The timer callback captures the entry pointer; flushImageBatchByRef verifies
+// the entry hasn't been superseded before dispatching, so a stale timer firing
+// after a replace or Stop will be a safe no-op.
+func (p *Platform) bufferImage(sessionKey string, entry *imageBatchEntry) {
+	p.imageBatchMu.Lock()
+	if p.imageBatch == nil {
+		// Lazy-init so tests that construct &Platform{} directly can still
+		// exercise the image path without remembering to allocate the map.
+		p.imageBatch = make(map[string]*imageBatchEntry)
+	}
+
+	// If a batch for this session exists with different context (parentID or
+	// userID), flush it first so we never mix unrelated batches.
+	var toFlush *imageBatchEntry
+	if existing, ok := p.imageBatch[sessionKey]; ok {
+		if existing.parentID != entry.parentID || existing.userID != entry.userID {
+			if existing.timer != nil {
+				existing.timer.Stop()
+			}
+			delete(p.imageBatch, sessionKey)
+			toFlush = existing
+		}
+	}
+
+	if existing, ok := p.imageBatch[sessionKey]; ok {
+		// Append into the existing batch and reset its timer.
+		if existing.timer != nil {
+			existing.timer.Stop()
+		}
+		existing.images = append(existing.images, entry.images...)
+		existing.messageIDs = append(existing.messageIDs, entry.messageIDs...)
+		if entry.createTimeMs > existing.createTimeMs {
+			existing.createTimeMs = entry.createTimeMs
+		}
+		ref := existing
+		existing.timer = time.AfterFunc(imageBatchWindow, func() {
+			p.flushImageBatchByRef(sessionKey, ref)
+		})
+	} else {
+		// Start a fresh batch with its own timer.
+		ref := entry
+		entry.timer = time.AfterFunc(imageBatchWindow, func() {
+			p.flushImageBatchByRef(sessionKey, ref)
+		})
+		p.imageBatch[sessionKey] = entry
+	}
+
+	p.imageBatchMu.Unlock()
+
+	if toFlush != nil {
+		p.dispatchImageBatchEntry(toFlush)
+	}
+}
+
+// flushImageBatchByRef dispatches the batch iff the map still points at the
+// same entry pointer (i.e. the timer wasn't superseded). Called by the
+// AfterFunc timer callback.
+func (p *Platform) flushImageBatchByRef(sessionKey string, ref *imageBatchEntry) {
+	p.imageBatchMu.Lock()
+	current, ok := p.imageBatch[sessionKey]
+	if !ok || current != ref {
+		p.imageBatchMu.Unlock()
+		return
+	}
+	if current.timer != nil {
+		current.timer.Stop()
+	}
+	delete(p.imageBatch, sessionKey)
+	p.imageBatchMu.Unlock()
+
+	p.dispatchImageBatchEntry(current)
+}
+
+// flushImageBatches synchronously dispatches any pending image batches.
+// Intended to be called from Stop() so buffered images aren't lost when
+// cc-connect shuts down.
+func (p *Platform) flushImageBatches() {
+	p.imageBatchMu.Lock()
+	pending := p.imageBatch
+	p.imageBatch = make(map[string]*imageBatchEntry)
+	p.imageBatchMu.Unlock()
+
+	for _, entry := range pending {
+		if entry.timer != nil {
+			entry.timer.Stop()
+		}
+		p.dispatchImageBatchEntry(entry)
+	}
+}
+
+// dispatchImageBatchEntry emits a single core.Message carrying all images
+// that were buffered into this batch entry. The newest create_time is used
+// as UserMessageTimeMs so the merged message preserves the user's intended
+// ordering, and the newest message_id is used as the canonical id.
+func (p *Platform) dispatchImageBatchEntry(entry *imageBatchEntry) {
+	if len(entry.images) == 0 {
+		return
+	}
+	lastIdx := len(entry.messageIDs) - 1
+	canonicalID := entry.messageIDs[lastIdx]
+	for _, mid := range entry.messageIDs {
+		if p.isMessageRecalled(mid) {
+			slog.Debug(p.tag()+": recalled image batch member dropped",
+				"message_id", mid, "batch_size", len(entry.images))
+		}
+	}
+	slog.Info(p.tag()+": dispatched image batch",
+		"session_key", entry.sessionKey,
+		"image_count", len(entry.images),
+		"message_ids", entry.messageIDs,
+	)
+	p.dispatchCoreMessage(&core.Message{
+		SessionKey: entry.sessionKey, Platform: p.platformName,
+		MessageID: canonicalID,
+		UserID:    entry.userID, UserName: entry.userName, ChatName: entry.chatName,
+		Content:           "",
+		ExtraContent:      entry.quoted.text,
+		Images:            append(entry.quoted.images, entry.images...),
+		ReplyCtx:          entry.rctx,
+		UserMessageTimeMs: entry.createTimeMs,
+	})
+}
+
 func (p *Platform) onMessageRecalled(_ context.Context, event *larkim.P2MessageRecalledV1) error {
 	if event == nil || event.Event == nil {
 		return nil
@@ -1237,11 +1402,34 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			}
 			return
 		}
+		// Batch consecutive image-only messages from the same session into a
+		// single multi-image dispatch. Feishu mobile sends N batch-selected
+		// images as N separate events with very close create_time values;
+		// dispatching each immediately causes core/engine's create_time
+		// watermark (PR #1168) to drop the oldest image (issue #1395).
+		// We only coalesce plain image messages (no quoted context) because
+		// quoted images are usually a single image replying to a prior text.
+		if parentID == "" {
+			p.bufferImage(sessionKey, &imageBatchEntry{
+				sessionKey:   sessionKey,
+				userID:       userID,
+				userName:     userName,
+				chatName:     chatName,
+				rctx:         rctx,
+				images:       []core.ImageAttachment{{MimeType: mimeType, Data: imgData}},
+				messageIDs:   []string{messageID},
+				createTimeMs: createTimeMs,
+				parentID:     parentID,
+			})
+			return
+		}
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Images:            []core.ImageAttachment{{MimeType: mimeType, Data: imgData}},
+			Content:           "",
+			ExtraContent:      quoted.text,
+			Images:            append(quoted.images, core.ImageAttachment{MimeType: mimeType, Data: imgData}),
 			ReplyCtx:          rctx,
 			UserMessageTimeMs: createTimeMs,
 		})
@@ -4288,6 +4476,8 @@ func (p *Platform) Stop() error {
 			slog.Error(p.tag()+": webhook server shutdown error", "error", err)
 		}
 	}
+	// Flush any pending image batches so buffered images aren't lost on shutdown.
+	p.flushImageBatches()
 	return nil
 }
 

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -1265,3 +1265,410 @@ func TestNewPlatform_RequireMentionTrueDoesNotForceGroupReplyAll(t *testing.T) {
 		t.Error("require_mention=true should leave groupReplyAll=false, but it is true")
 	}
 }
+
+// TestDispatchMessageCoalescesImageBatch covers issue #1395: when the Feishu
+// mobile client sends N images in quick succession, each image arrives as a
+// separate message event with very close create_time values. Dispatching each
+// immediately caused core/engine's create_time watermark (PR #1168) to drop
+// the oldest image, so the agent only saw N-1 images. After the fix, all N
+// images within imageBatchWindow should be coalesced into ONE dispatched
+// core.Message with N image attachments.
+func TestDispatchMessageCoalescesImageBatch(t *testing.T) {
+	const appID = "cli_batch_img"
+	const appSecret = "secret-batch-img"
+	const chatID = "oc_batch"
+	const userID = "ou_user"
+
+	tests := []struct {
+		name      string
+		imageKeys []string
+		wantCount int
+		wantMsgs  int
+	}{
+		{name: "2 images", imageKeys: []string{"img_1", "img_2"}, wantCount: 2, wantMsgs: 1},
+		{name: "3 images", imageKeys: []string{"img_a", "img_b", "img_c"}, wantCount: 3, wantMsgs: 1},
+		{name: "4 images", imageKeys: []string{"i1", "i2", "i3", "i4"}, wantCount: 4, wantMsgs: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Per-image payload bytes so we can verify order preservation.
+			imageBytes := map[string][]byte{}
+			for i, k := range tc.imageKeys {
+				imageBytes[k] = []byte{0x89, 'P', 'N', 'G', byte(i + 1), '\r', '\n', 0x1a, '\n'}
+			}
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+					w.Header().Set("Content-Type", "application/json")
+					writeJSON(t, w, map[string]any{
+						"code":                0,
+						"msg":                 "success",
+						"expire":              7200,
+						"tenant_access_token": "tenant-token",
+					})
+				case strings.Contains(r.URL.Path, "/resources/"):
+					key := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+					data, ok := imageBytes[key]
+					if !ok {
+						t.Fatalf("unexpected image key %q", key)
+					}
+					w.Header().Set("Content-Type", "image/png")
+					if _, err := w.Write(data); err != nil {
+						t.Fatalf("write image: %v", err)
+					}
+				default:
+					w.Header().Set("Content-Type", "application/json")
+					writeJSON(t, w, map[string]any{"code": 0, "msg": "success", "data": map[string]any{}})
+				}
+			}))
+			defer srv.Close()
+
+			received := make(chan *core.Message, tc.wantCount+1)
+			p := &Platform{
+				platformName: "feishu",
+				domain:       srv.URL,
+				appID:        appID,
+				appSecret:    appSecret,
+				dedup:        &core.MessageDedup{},
+				client: lark.NewClient(appID, appSecret,
+					lark.WithOpenBaseUrl(srv.URL),
+					lark.WithHttpClient(srv.Client()),
+				),
+				handler: func(_ core.Platform, msg *core.Message) {
+					received <- msg
+				},
+				imageBatch: make(map[string]*imageBatchEntry),
+			}
+
+			sessionKey := "feishu:" + chatID + ":" + userID
+			for i, key := range tc.imageKeys {
+				msgID := "om_img_" + strconv.Itoa(i)
+				content := `{"image_key":"` + key + `"}`
+				p.dispatchMessage(
+					context.Background(),
+					"image",
+					content,
+					nil,
+					msgID,
+					sessionKey,
+					userID,
+					chatID,
+					replyContext{messageID: msgID, chatID: chatID, sessionKey: sessionKey},
+					"", // no parentID so we exercise the batch path
+					int64(1710000000000+i),
+				)
+			}
+
+			// Collect dispatched messages with a generous timeout that comfortably
+			// exceeds imageBatchWindow (150ms) but still finishes the test quickly.
+			var dispatched []*core.Message
+			deadline := time.After(2 * time.Second)
+			for len(dispatched) < tc.wantMsgs {
+				select {
+				case msg := <-received:
+					dispatched = append(dispatched, msg)
+				case <-deadline:
+					t.Fatalf("got %d messages, want %d (timeout)", len(dispatched), tc.wantMsgs)
+				}
+			}
+
+			// Allow late stragglers to surface so we can fail loudly if batching
+			// leaked more than one dispatch.
+			select {
+			case extra := <-received:
+				t.Fatalf("unexpected extra dispatched message %q with %d images", extra.MessageID, len(extra.Images))
+			case <-time.After(imageBatchWindow + 100*time.Millisecond):
+			}
+
+			if len(dispatched) != 1 {
+				t.Fatalf("dispatched %d messages, want exactly 1 (batch should coalesce)", len(dispatched))
+			}
+			msg := dispatched[0]
+			if len(msg.Images) != tc.wantCount {
+				t.Fatalf("merged message has %d images, want %d", len(msg.Images), tc.wantCount)
+			}
+			for i, img := range msg.Images {
+				want := imageBytes[tc.imageKeys[i]]
+				if string(img.Data) != string(want) {
+					t.Errorf("image[%d] data = %x, want %x (order must match send order)", i, img.Data, want)
+				}
+			}
+		})
+	}
+}
+
+// TestDispatchMessageSingleImageRegression ensures the single-image path still
+// works after introducing the image-batch buffer (issue #1395). A single image
+// must still produce one dispatched core.Message.
+func TestDispatchMessageSingleImageRegression(t *testing.T) {
+	const appID = "cli_single_img"
+	const appSecret = "secret-single-img"
+	const imageKey = "img_single"
+
+	imageBytes := []byte{0x89, 'P', 'N', 'G', 'S', '\r', '\n', 0x1a, '\n'}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/resources/"+imageKey):
+			w.Header().Set("Content-Type", "image/png")
+			if _, err := w.Write(imageBytes); err != nil {
+				t.Fatalf("write image: %v", err)
+			}
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success", "data": map[string]any{}})
+		}
+	}))
+	defer srv.Close()
+
+	got := make(chan *core.Message, 1)
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		dedup:        &core.MessageDedup{},
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			got <- msg
+		},
+		imageBatch: make(map[string]*imageBatchEntry),
+	}
+
+	p.dispatchMessage(
+		context.Background(),
+		"image",
+		`{"image_key":"`+imageKey+`"}`,
+		nil,
+		"om_single",
+		"feishu:oc_single:ou_user",
+		"ou_user",
+		"oc_single",
+		replyContext{messageID: "om_single", chatID: "oc_single", sessionKey: "feishu:oc_single:ou_user"},
+		"", 0,
+	)
+
+	select {
+	case msg := <-got:
+		if msg.MessageID != "om_single" {
+			t.Errorf("MessageID = %q, want om_single", msg.MessageID)
+		}
+		if len(msg.Images) != 1 {
+			t.Fatalf("len(Images) = %d, want 1", len(msg.Images))
+		}
+		if string(msg.Images[0].Data) != string(imageBytes) {
+			t.Fatal("image data did not match downloaded resource")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for single image to dispatch")
+	}
+}
+
+// TestDispatchMessageQuotedImageNotBatched ensures that quoted (parentID != "")
+// images still follow the legacy synchronous path: one dispatched message per
+// image, with quoted context attached. Batching must not affect this code path.
+func TestDispatchMessageQuotedImageNotBatched(t *testing.T) {
+	const appID = "cli_quoted_img"
+	const appSecret = "secret-quoted-img"
+	const parentMessageID = "om_parent_quoted"
+	const imageKey = "img_quoted"
+
+	imageData := []byte{0x89, 'P', 'N', 'G', 'Q', '\r', '\n', 0x1a, '\n'}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID:
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"items": []map[string]any{
+						{
+							"msg_type":  "text",
+							"parent_id": "",
+							"sender":    map[string]any{"id": "", "sender_type": "user"},
+							"body":      map[string]any{"content": `{"text":"请看图"}`},
+						},
+					},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/resources/"+imageKey):
+			w.Header().Set("Content-Type", "image/png")
+			if _, err := w.Write(imageData); err != nil {
+				t.Fatalf("write image: %v", err)
+			}
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success", "data": map[string]any{}})
+		}
+	}))
+	defer srv.Close()
+
+	got := make(chan *core.Message, 1)
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			got <- msg
+		},
+		imageBatch: make(map[string]*imageBatchEntry),
+	}
+
+	p.dispatchMessage(
+		context.Background(),
+		"image",
+		`{"image_key":"`+imageKey+`"}`,
+		nil,
+		"om_quoted_child",
+		"feishu:oc_chat:ou_user",
+		"ou_user",
+		"oc_chat",
+		replyContext{messageID: "om_quoted_child", chatID: "oc_chat", sessionKey: "feishu:oc_chat:ou_user"},
+		parentMessageID, 0,
+	)
+
+	select {
+	case msg := <-got:
+		if len(msg.Images) != 1 {
+			t.Fatalf("quoted image path: len(Images) = %d, want 1 (no batching)", len(msg.Images))
+		}
+		if !strings.Contains(msg.ExtraContent, "请看图") {
+			t.Fatalf("ExtraContent = %q, want quoted text context", msg.ExtraContent)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for quoted image to dispatch")
+	}
+}
+
+// TestFlushImageBatchesStopsPendingTimers ensures Stop()-style flush
+// synchronously dispatches all buffered images without losing any.
+func TestFlushImageBatchesStopsPendingTimers(t *testing.T) {
+	const appID = "cli_flush"
+	const appSecret = "secret-flush"
+	const imageKey = "img_flush"
+
+	imageBytes := []byte{0x89, 'P', 'N', 'G', 'F', '\r', '\n', 0x1a, '\n'}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/resources/"+imageKey):
+			w.Header().Set("Content-Type", "image/png")
+			if _, err := w.Write(imageBytes); err != nil {
+				t.Fatalf("write image: %v", err)
+			}
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success", "data": map[string]any{}})
+		}
+	}))
+	defer srv.Close()
+
+	received := make(chan *core.Message, 2)
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		dedup:        &core.MessageDedup{},
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			received <- msg
+		},
+		imageBatch: make(map[string]*imageBatchEntry),
+	}
+
+	// Buffer a single image but DON'T wait for the timer — instead flush manually.
+	p.bufferImage("feishu:oc_flush:ou_user", &imageBatchEntry{
+		sessionKey:   "feishu:oc_flush:ou_user",
+		userID:       "ou_user",
+		chatName:     "oc_flush",
+		rctx:         replyContext{messageID: "om_flush", chatID: "oc_flush", sessionKey: "feishu:oc_flush:ou_user"},
+		images:       []core.ImageAttachment{{MimeType: "image/png", Data: imageBytes}},
+		messageIDs:   []string{"om_flush"},
+		createTimeMs: 1710000000000,
+	})
+
+	// Confirm the buffer is populated and the timer is pending.
+	p.imageBatchMu.Lock()
+	if len(p.imageBatch) != 1 {
+		p.imageBatchMu.Unlock()
+		t.Fatalf("imageBatch size = %d, want 1 before flush", len(p.imageBatch))
+	}
+	p.imageBatchMu.Unlock()
+
+	p.flushImageBatches()
+
+	// After flush, the map must be empty AND no timer should be left pending.
+	p.imageBatchMu.Lock()
+	batchSize := len(p.imageBatch)
+	p.imageBatchMu.Unlock()
+	if batchSize != 0 {
+		t.Fatalf("imageBatch size = %d after flushImageBatches, want 0", batchSize)
+	}
+
+	select {
+	case msg := <-received:
+		if len(msg.Images) != 1 {
+			t.Fatalf("flushed message has %d images, want 1", len(msg.Images))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for flushed batch to dispatch")
+	}
+
+	// No additional dispatches after flush.
+	select {
+	case extra := <-received:
+		t.Fatalf("unexpected extra message after flush: %+v", extra)
+	case <-time.After(imageBatchWindow + 100*time.Millisecond):
+	}
+}
+
+// TestFlushImageBatchesEmptySafe ensures flushImageBatches is a safe no-op
+// when nothing is buffered (e.g. Stop() called on an idle platform).
+func TestFlushImageBatchesEmptySafe(t *testing.T) {
+	p := &Platform{
+		platformName: "feishu",
+		imageBatch:   make(map[string]*imageBatchEntry),
+	}
+	// Should not panic, should not block.
+	p.flushImageBatches()
+}


### PR DESCRIPTION
Fixes #1395

## 问题
Feishu 移动端批量发送 N 张图片时，每张图片作为独立 `image` 事件到达,create_time 几乎相同。逐一立即 dispatch 会让 core/engine 的 create_time 水位线 (PR #1168) 把 create_time 最早的那一张判定为 stale 并丢弃,导致 agent 永远只能收到 N-1 张图片。

## 修复
在 Feishu Platform 增加 per-session image batch buffer,150ms 静默窗口内到达的图片合并为单条多图 `core.Message`。缓冲区仅对纯图片消息(parentID == "")生效;引用图保持原同步路径,PR #944 行为不受影响。`Stop()` 关闭前会同步 flush 暂存批次,避免关机时丢图。

## 变更
- `platform/feishu/feishu.go`
  - 新增 `imageBatch` map + `imageBatchEntry`,配合 `imageBatchWindow = 150 * time.Millisecond`
  - 新增 `bufferImage` / `flushImageBatchByRef` / `flushImageBatches` / `dispatchImageBatchEntry`
  - `case "image"` 仅在 `parentID == ""` 时走 batch 路径,否则保持原 dispatchCoreMessage
  - `Stop()` 末尾调用 `flushImageBatches()`
  - `imageBatch` 在 `bufferImage` 入口懒初始化,避免 `&Platform{}` 字面量测试 panic

- `platform/feishu/feishu_test.go`
  - `TestDispatchMessageCoalescesImageBatch` (2/3/4 张子用例,验证合并 + 顺序)
  - `TestDispatchMessageSingleImageRegression` (单图回归)
  - `TestDispatchMessageQuotedImageNotBatched` (引用图不合并)
  - `TestFlushImageBatchesStopsPendingTimers` / `TestFlushImageBatchesEmptySafe` (Stop 路径)

- `CHANGELOG.md` 新增 `## Unreleased` / `### Fixed` 条目

## 验证
- `go test ./platform/feishu/ -count=1`:PASS(包含 5 个新增测试 + 既有 35+ 用例)
- `go vet ./platform/feishu/...`:clean
- `gofmt -l`:clean

未覆盖风险:
- CGO/无 gcc,本地 `-race` 未能运行;但 batch 缓冲区全部由 `imageBatchMu` 串行访问,timer callback 通过 entry 指针一致性判别 stale,避免重复派发。

## 备注
- Codex + Feishu 场景复现 → 修后行为:发 N 张图,agent 收到 N 张图
- PR 标题不包含 #1395 数字以便 reviewer 自行关联 issue(标题已带 `Fixes #1395` body)