### PR TITLE
feat(send): generate media via configurable providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 ### Added
 - **Feishu: outbound bot-to-bot @mention resolution** via new `mention_map` config option. Maps agent-friendly names (e.g. `BOT-A`) to Feishu open_ids so that when an agent writes `@BOT-A` in its reply, cc-connect converts it to a native Feishu `<at>` tag that triggers a real notification. Layered on top of `resolve_mentions` (group-member matching) with higher priority, so explicit config always wins (#1322).
+- **Generated media send-back**: `cc-connect send` can generate image, video, and
+  music through configured providers (`--generate-image`, `--generate-video`,
+  `--generate-music`) and send the result back through the existing
+  attachment/media delivery path. Image generation supports OpenAI-compatible
+  and MiniMax providers; command/OpenClaw adapters can bridge provider-specific
+  image, video, and music CLIs.
 
 ### Fixed
 - **codex**: `/model` chooser now surfaces `gpt-5.x` (and any future frontier chat model) when the model list is populated by fetching `GET /v1/models` from the provider. The previous hard-coded 11-entry allowlist (`o1/o3/o4/gpt-4o/gpt-4.1/codex-mini-latest`) had not been updated since 2026-03 and silently filtered out every `gpt-5*` variant (including `gpt-5.6-sol/terra/luna`) returned by the API, so users on `codex-cli >= 0.143` could not pick GPT-5.6 in cc-connect even after upgrading the CLI. The allowlist is replaced with pattern rules: accept the `gpt-*` / `chatgpt-*` / `codex-*` / `o1-*` / `o3-*` / `o4-*` / `o5-*` families plus the bare `o1/o3/o4/o5` IDs, and reject non-chat modalities (`embedding`, `whisper`, `tts`, `dall-e`, `audio-preview`, `realtime`, `transcribe`, `moderation`, `image`, `search-preview`). New frontier chat models are picked up automatically without a code change. Note: this only affects the API-fetch fallback path; users with an explicit `model_catalog_json` in `~/.codex/config.toml` or a `models = [...]` list in cc-connect's provider config were unaffected.

--- a/README.md
+++ b/README.md
@@ -532,10 +532,10 @@ This refreshes the cc-connect instructions in the project memory file so the age
 You can control this feature globally in `config.toml`:
 
 ```toml
-attachment_send = "on"  # default: "on"; set to "off" to block image/file send-back
+attachment_send = "on"  # default: "on"; set to "off" to block image/file/generated-media send-back
 ```
 
-This switch is independent from the agent's `/mode`. It only controls `cc-connect send --image/--file`. Voice send-back uses the TTS config instead.
+This switch is independent from the agent's `/mode`. It controls `cc-connect send --image/--file` and generated media delivery from `--generate-image/--generate-video/--generate-music`. Voice send-back uses the TTS config instead.
 
 Examples:
 
@@ -544,13 +544,17 @@ cc-connect send --image /absolute/path/to/chart.png
 cc-connect send --file /absolute/path/to/report.pdf
 cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
 cc-connect send --tts "Hello from cc-connect"
+cc-connect send --generate-image "A watercolor fox under moonlight"
+cc-connect send --generate-video "A cinematic sunrise over Hangzhou, 6 seconds"
+cc-connect send --generate-music "Ambient synthwave, night drive" --music-instrumental
 ```
 
 Notes:
 - Absolute paths are the safest option.
 - `--image` and `--file` can both be repeated.
 - `--tts` sends synthesized speech when the user asks for a voice reply.
-- `attachment_send = "off"` disables only attachment send-back; ordinary text replies still work.
+- `--generate-image`, `--generate-video`, and `--generate-music` use configured `[image]` / `[video]` / `[music]` providers. Built-in providers cover MiniMax and OpenAI-compatible image generation; command/OpenClaw adapters can bridge provider-specific image/video/music CLIs.
+- `attachment_send = "off"` disables attachment and generated-media send-back; ordinary text replies still work.
 - Attachments are capped at 50 MiB by default; configure with `max_attachment_size_mb` (or `CC_MAX_ATTACHMENT_SIZE_MB` env, same MiB unit).
 - This command is for generated attachments, not ordinary text replies.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -519,10 +519,10 @@ cc-connect doctor user-isolation
 你也可以在 `config.toml` 里全局控制这项能力：
 
 ```toml
-attachment_send = "on"  # 默认 "on"；设为 "off" 会禁用图片/文件回传
+attachment_send = "on"  # 默认 "on"；设为 "off" 会禁用图片/文件/生成媒体回传
 ```
 
-这个开关与 agent 的 `/mode` 独立，只控制 `cc-connect send --image/--file` 这条附件回传路径。语音回传走 TTS 配置。
+这个开关与 agent 的 `/mode` 独立，控制 `cc-connect send --image/--file` 以及 `--generate-image/--generate-video/--generate-music` 生成媒体回传。语音回传走 TTS 配置。
 
 回传方式：
 
@@ -531,13 +531,17 @@ cc-connect send --image /absolute/path/to/chart.png
 cc-connect send --file /absolute/path/to/report.pdf
 cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
 cc-connect send --tts "你好"
+cc-connect send --generate-image "月光下的水彩狐狸"
+cc-connect send --generate-video "杭州日出的电影感镜头，6 秒"
+cc-connect send --generate-music "夜间驾驶氛围 synthwave" --music-instrumental
 ```
 
 要点：
 - 使用绝对路径最稳妥。
 - `--image` 和 `--file` 都可以重复传多个。
 - `--tts` 用当前 TTS provider 合成并发送语音，适合用户自然要求“发语音”的场景。
-- `attachment_send = "off"` 只会关闭附件回传，普通文本回复仍然正常。
+- `--generate-image`、`--generate-video` 和 `--generate-music` 使用已配置的 `[image]` / `[video]` / `[music]` provider。内置 provider 覆盖 MiniMax 和 OpenAI-compatible 图片生成；command/OpenClaw adapter 可以接 provider-specific 的图片、视频、音乐 CLI。
+- `attachment_send = "off"` 会关闭附件和生成媒体回传，普通文本回复仍然正常。
 - 单个附件默认上限 50 MiB；可用 `max_attachment_size_mb` 配置（或环境变量 `CC_MAX_ATTACHMENT_SIZE_MB`，同样单位 MiB）。
 - 这个命令是给“生成后的附件回传”用的，不是给普通文本回复用的。
 

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -58,6 +58,83 @@ func resolveResetOnIdle(configured *int) (time.Duration, bool) {
 	return time.Duration(defaultResetOnIdleMins) * time.Minute, true
 }
 
+func resolveMiniMaxMediaAuth(dataDir, apiKey, baseURL, configFile, logPrefix string) (string, string) {
+	if strings.TrimSpace(apiKey) != "" {
+		return apiKey, baseURL
+	}
+	localCfg, err := config.LoadMiniMaxLocalConfig(dataDir, configFile)
+	if err != nil {
+		slog.Warn(logPrefix+": failed to load minimax local config", "error", err)
+		return "", baseURL
+	}
+	apiKey = localCfg.APIKey
+	if strings.TrimSpace(baseURL) == "" {
+		if localCfg.BaseURL != "" {
+			baseURL = localCfg.BaseURL
+		} else if localCfg.APIHost != "" {
+			baseURL = localCfg.APIHost
+		}
+	}
+	return apiKey, baseURL
+}
+
+func newCommandMediaGenerator(kind string, commandCfg config.MediaCommandConfig) *core.CommandMediaGenerator {
+	command := strings.TrimSpace(commandCfg.Command)
+	if command == "" {
+		return nil
+	}
+	gen := core.NewCommandMediaGenerator(kind, command, commandCfg.Args)
+	gen.WorkDir = commandCfg.WorkDir
+	gen.Env = append([]string(nil), commandCfg.Env...)
+	gen.Format = commandCfg.Format
+	if commandCfg.TimeoutSecs > 0 {
+		gen.Timeout = time.Duration(commandCfg.TimeoutSecs) * time.Second
+	}
+	return gen
+}
+
+func defaultOpenClawMediaCommand(kind string) config.MediaCommandConfig {
+	switch kind {
+	case "image":
+		return config.MediaCommandConfig{
+			Command: "openclaw",
+			Args:    []string{"capability", "image", "generate", "--prompt", "{{prompt}}", "--output", "{{output}}"},
+			Format:  "png",
+		}
+	case "video":
+		return config.MediaCommandConfig{
+			Command:     "openclaw",
+			Args:        []string{"capability", "video", "generate", "--prompt", "{{prompt}}", "--output", "{{output}}"},
+			Format:      "mp4",
+			TimeoutSecs: 900,
+		}
+	default:
+		return config.MediaCommandConfig{}
+	}
+}
+
+func mergeCommandMediaConfig(base, override config.MediaCommandConfig) config.MediaCommandConfig {
+	if strings.TrimSpace(override.Command) != "" {
+		base.Command = override.Command
+	}
+	if len(override.Args) > 0 {
+		base.Args = append([]string(nil), override.Args...)
+	}
+	if strings.TrimSpace(override.WorkDir) != "" {
+		base.WorkDir = override.WorkDir
+	}
+	if len(override.Env) > 0 {
+		base.Env = append([]string(nil), override.Env...)
+	}
+	if strings.TrimSpace(override.Format) != "" {
+		base.Format = override.Format
+	}
+	if override.TimeoutSecs > 0 {
+		base.TimeoutSecs = override.TimeoutSecs
+	}
+	return base
+}
+
 // logSizeSource describes where the resolved log size came from, so the
 // caller can log it and operators can audit the active setting without
 // grepping systemd/launchd definitions.
@@ -898,6 +975,151 @@ func main() {
 					return config.SaveTTSMode(mode)
 				})
 				slog.Info("tts: enabled", "provider", ttsCfg.Provider, "voice", ttsCfg.Voice, "mode", initMode)
+			}
+		}
+
+		// Wire text-to-image generation if enabled
+		if cfg.Image.Enabled {
+			imageCfg := &core.ImageGenerationCfg{
+				Enabled:      true,
+				MaxPromptLen: cfg.Image.MaxPromptLen,
+			}
+			switch strings.ToLower(strings.TrimSpace(cfg.Image.Provider)) {
+			case "openai", "openai-compatible", "openai_compatible":
+				apiKey := strings.TrimSpace(cfg.Image.OpenAI.APIKey)
+				if apiKey != "" {
+					gen := core.NewOpenAIImageGenerator(apiKey, cfg.Image.OpenAI.BaseURL, cfg.Image.OpenAI.Model, nil)
+					gen.Size = cfg.Image.OpenAI.Size
+					gen.Quality = cfg.Image.OpenAI.Quality
+					gen.ResponseFormat = cfg.Image.OpenAI.ResponseFormat
+					gen.OutputFormat = cfg.Image.OpenAI.OutputFormat
+					gen.Background = cfg.Image.OpenAI.Background
+					gen.Style = cfg.Image.OpenAI.Style
+					imageCfg.Provider = "openai"
+					imageCfg.Generator = gen
+				} else {
+					slog.Warn("image: openai provider enabled but api_key is empty")
+				}
+			case "command":
+				if gen := newCommandMediaGenerator("image", cfg.Image.Command); gen != nil {
+					imageCfg.Provider = "command"
+					imageCfg.Generator = gen
+				} else {
+					slog.Warn("image: command provider enabled but command is empty")
+				}
+			case "openclaw":
+				commandCfg := mergeCommandMediaConfig(defaultOpenClawMediaCommand("image"), cfg.Image.Command)
+				if gen := newCommandMediaGenerator("image", commandCfg); gen != nil {
+					imageCfg.Provider = "openclaw"
+					imageCfg.Generator = gen
+				} else {
+					slog.Warn("image: openclaw provider enabled but command is empty")
+				}
+			case "", "minimax":
+				apiKey, baseURL := resolveMiniMaxMediaAuth(cfg.DataDir, cfg.Image.MiniMax.APIKey, cfg.Image.MiniMax.BaseURL, cfg.Image.MiniMax.ConfigFile, "image")
+				if apiKey != "" {
+					gen := core.NewMiniMaxImageGenerator(apiKey, baseURL, cfg.Image.MiniMax.Model, nil)
+					gen.ResponseFormat = cfg.Image.MiniMax.ResponseFormat
+					gen.AspectRatio = cfg.Image.MiniMax.AspectRatio
+					gen.Width = cfg.Image.MiniMax.Width
+					gen.Height = cfg.Image.MiniMax.Height
+					gen.PromptOptimizer = cfg.Image.MiniMax.PromptOptimizer
+					imageCfg.Provider = "minimax"
+					imageCfg.Generator = gen
+				} else {
+					slog.Warn("image: minimax provider enabled but api_key is empty")
+				}
+			default:
+				slog.Warn("image: unsupported provider", "provider", cfg.Image.Provider)
+			}
+			if imageCfg.Generator != nil {
+				engine.SetImageGenerationConfig(imageCfg)
+				slog.Info("image: enabled", "provider", imageCfg.Provider)
+			}
+		}
+
+		// Wire text-to-video generation if enabled
+		if cfg.Video.Enabled {
+			videoCfg := &core.VideoGenerationCfg{
+				Enabled:      true,
+				MaxPromptLen: cfg.Video.MaxPromptLen,
+			}
+			switch strings.ToLower(strings.TrimSpace(cfg.Video.Provider)) {
+			case "", "minimax":
+				apiKey, baseURL := resolveMiniMaxMediaAuth(cfg.DataDir, cfg.Video.MiniMax.APIKey, cfg.Video.MiniMax.BaseURL, cfg.Video.MiniMax.ConfigFile, "video")
+				if apiKey != "" {
+					gen := core.NewMiniMaxVideoGenerator(apiKey, baseURL, cfg.Video.MiniMax.Model, nil)
+					gen.Duration = cfg.Video.MiniMax.Duration
+					gen.Resolution = cfg.Video.MiniMax.Resolution
+					if cfg.Video.MiniMax.PollIntervalSecs > 0 {
+						gen.PollInterval = time.Duration(cfg.Video.MiniMax.PollIntervalSecs) * time.Second
+					}
+					if cfg.Video.MiniMax.TimeoutSecs > 0 {
+						gen.Timeout = time.Duration(cfg.Video.MiniMax.TimeoutSecs) * time.Second
+					}
+					videoCfg.Provider = "minimax"
+					videoCfg.Generator = gen
+				} else {
+					slog.Warn("video: minimax provider enabled but api_key is empty")
+				}
+			case "command":
+				if gen := newCommandMediaGenerator("video", cfg.Video.Command); gen != nil {
+					videoCfg.Provider = "command"
+					videoCfg.Generator = gen
+				} else {
+					slog.Warn("video: command provider enabled but command is empty")
+				}
+			case "openclaw":
+				commandCfg := mergeCommandMediaConfig(defaultOpenClawMediaCommand("video"), cfg.Video.Command)
+				if gen := newCommandMediaGenerator("video", commandCfg); gen != nil {
+					videoCfg.Provider = "openclaw"
+					videoCfg.Generator = gen
+				} else {
+					slog.Warn("video: openclaw provider enabled but command is empty")
+				}
+			default:
+				slog.Warn("video: unsupported provider", "provider", cfg.Video.Provider)
+			}
+			if videoCfg.Generator != nil {
+				engine.SetVideoGenerationConfig(videoCfg)
+				slog.Info("video: enabled", "provider", videoCfg.Provider)
+			}
+		}
+
+		// Wire text-to-music generation if enabled
+		if cfg.Music.Enabled {
+			musicCfg := &core.MusicGenerationCfg{
+				Enabled:         true,
+				MaxPromptLen:    cfg.Music.MaxPromptLen,
+				LyricsOptimizer: cfg.Music.MiniMax.LyricsOptimizer,
+				Instrumental:    cfg.Music.MiniMax.Instrumental,
+			}
+			switch strings.ToLower(strings.TrimSpace(cfg.Music.Provider)) {
+			case "", "minimax":
+				apiKey, baseURL := resolveMiniMaxMediaAuth(cfg.DataDir, cfg.Music.MiniMax.APIKey, cfg.Music.MiniMax.BaseURL, cfg.Music.MiniMax.ConfigFile, "music")
+				if apiKey != "" {
+					gen := core.NewMiniMaxMusicGenerator(apiKey, baseURL, cfg.Music.MiniMax.Model, nil)
+					gen.SampleRate = cfg.Music.MiniMax.SampleRate
+					gen.Bitrate = cfg.Music.MiniMax.Bitrate
+					gen.Format = cfg.Music.MiniMax.Format
+					musicCfg.Provider = "minimax"
+					musicCfg.Generator = gen
+				} else {
+					slog.Warn("music: minimax provider enabled but api_key is empty")
+				}
+			case "command":
+				if gen := newCommandMediaGenerator("music", cfg.Music.Command); gen != nil {
+					musicCfg.Provider = "command"
+					musicCfg.Generator = gen
+				} else {
+					slog.Warn("music: command provider enabled but command is empty")
+				}
+			default:
+				slog.Warn("music: unsupported provider", "provider", cfg.Music.Provider)
+			}
+			if musicCfg.Generator != nil {
+				engine.SetMusicGenerationConfig(musicCfg)
+				slog.Info("music: enabled", "provider", musicCfg.Provider)
 			}
 		}
 

--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -110,6 +110,34 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 			}
 			i++
 			req.TTSText = args[i]
+		case "--generate-image":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--generate-image requires a prompt")
+			}
+			i++
+			req.ImagePrompt = args[i]
+		case "--generate-video":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--generate-video requires a prompt")
+			}
+			i++
+			req.VideoPrompt = args[i]
+		case "--generate-music":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--generate-music requires a prompt")
+			}
+			i++
+			req.MusicPrompt = args[i]
+		case "--music-lyrics":
+			if i+1 >= len(args) {
+				return req, "", fmt.Errorf("--music-lyrics requires a value")
+			}
+			i++
+			req.MusicLyrics = args[i]
+		case "--music-instrumental":
+			req.MusicInstrumental = true
+		case "--music-lyrics-optimizer":
+			req.MusicLyricsOptimizer = true
 		case "--image":
 			if i+1 >= len(args) {
 				return req, "", fmt.Errorf("--image requires a path")
@@ -208,8 +236,9 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 	req.Audios = audioFiles
 	req.Videos = videoFiles
 
-	if req.Message == "" && req.TTSText == "" && len(req.Images) == 0 && len(req.Files) == 0 && len(req.Audios) == 0 && len(req.Videos) == 0 {
-		return req, "", fmt.Errorf("message, tts text, or attachment is required")
+	if req.Message == "" && req.TTSText == "" && req.ImagePrompt == "" && req.VideoPrompt == "" && req.MusicPrompt == "" &&
+		len(req.Images) == 0 && len(req.Files) == 0 && len(req.Audios) == 0 && len(req.Videos) == 0 {
+		return req, "", fmt.Errorf("message, tts text, generated media prompt, or attachment is required")
 	}
 
 	return req, dataDir, nil
@@ -366,9 +395,12 @@ func printSendUsage() {
        cc-connect send [options] --audio <path>
        cc-connect send [options] --video <path>
        cc-connect send [options] --tts <text>
+       cc-connect send [options] --generate-image <prompt>
+       cc-connect send [options] --generate-video <prompt>
+       cc-connect send [options] --generate-music <prompt>
        echo "msg" | cc-connect send [options] --stdin
 
-Send a message, attachment, or synthesized voice message to an active cc-connect session.
+Send a message, attachment, synthesized voice message, or generated media to an active cc-connect session.
 
 Options:
   -m, --message <text>     Message to send (preferred over positional args)
@@ -380,6 +412,13 @@ Options:
       --audio <path>       Send an audio attachment (repeatable)
       --video <path>       Send a video attachment (repeatable)
       --stdin              Read message from stdin (best for long/special-char messages)
+      --generate-image <p> Generate an image via configured [image] provider and send it
+      --generate-video <p> Generate a video via configured [video] provider and send it
+      --generate-music <p> Generate music via configured [music] provider and send it
+      --music-lyrics <txt> Lyrics for --generate-music
+      --music-instrumental Generate instrumental music
+      --music-lyrics-optimizer
+                           Let provider generate lyrics from the music prompt
       --at-users <ids>     @ user IDs, comma-separated (DingTalk)
       --at-all             @ everyone (DingTalk)
   -p, --project <name>     Target project (optional if only one project)
@@ -395,6 +434,9 @@ Examples:
   cc-connect send --video /tmp/demo.mp4
   cc-connect send --audio /tmp/voice.opus
   cc-connect send --tts "Hello from cc-connect"
+  cc-connect send --generate-image "A watercolor fox under moonlight"
+  cc-connect send --generate-video "A cinematic sunrise over Hangzhou, 6 seconds"
+  cc-connect send --generate-music "Ambient synthwave, night drive" --music-instrumental
   cc-connect send --stdin <<'EOF'
     Long message with "special" chars, $variables, and newlines
   EOF`)

--- a/cmd/cc-connect/send_test.go
+++ b/cmd/cc-connect/send_test.go
@@ -204,6 +204,32 @@ func TestParseSendArgs_TTSOnly(t *testing.T) {
 	}
 }
 
+func TestParseSendArgs_GeneratedMediaPrompts(t *testing.T) {
+	req, _, err := parseSendArgs([]string{
+		"--generate-image", "watercolor fox",
+		"--generate-video", "cinematic sunset",
+		"--generate-music", "ambient synthwave",
+		"--music-lyrics", "[Verse]\nhello",
+		"--music-instrumental",
+		"--music-lyrics-optimizer",
+	})
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if req.ImagePrompt != "watercolor fox" {
+		t.Fatalf("image prompt = %q", req.ImagePrompt)
+	}
+	if req.VideoPrompt != "cinematic sunset" {
+		t.Fatalf("video prompt = %q", req.VideoPrompt)
+	}
+	if req.MusicPrompt != "ambient synthwave" || req.MusicLyrics != "[Verse]\nhello" {
+		t.Fatalf("music prompt/lyrics = %q/%q", req.MusicPrompt, req.MusicLyrics)
+	}
+	if !req.MusicInstrumental || !req.MusicLyricsOptimizer {
+		t.Fatalf("music flags = instrumental:%v optimizer:%v", req.MusicInstrumental, req.MusicLyricsOptimizer)
+	}
+}
+
 func TestParseSendArgs_AudioRejectsNonAudio(t *testing.T) {
 	dir := t.TempDir()
 	docPath := filepath.Join(dir, "report.txt")
@@ -313,10 +339,11 @@ func TestResolveMaxAttachmentSize(t *testing.T) {
 
 func TestBuildSendPayload_JSONRoundTrip(t *testing.T) {
 	req := core.SendRequest{
-		Project:    "demo",
-		SessionKey: "telegram:1:2",
-		Message:    "done",
-		TTSText:    "voice done",
+		Project:     "demo",
+		SessionKey:  "telegram:1:2",
+		Message:     "done",
+		TTSText:     "voice done",
+		ImagePrompt: "watercolor fox",
 		Images: []core.ImageAttachment{{
 			MimeType: "image/png",
 			Data:     []byte("img"),
@@ -343,6 +370,9 @@ func TestBuildSendPayload_JSONRoundTrip(t *testing.T) {
 	}
 	if decoded.TTSText != "voice done" {
 		t.Fatalf("decoded tts_text = %q", decoded.TTSText)
+	}
+	if decoded.ImagePrompt != "watercolor fox" {
+		t.Fatalf("decoded image_prompt = %q", decoded.ImagePrompt)
 	}
 	if len(decoded.Files) != 1 || string(decoded.Files[0].Data) != "doc" {
 		t.Fatalf("decoded files = %#v", decoded.Files)

--- a/config.example.toml
+++ b/config.example.toml
@@ -39,10 +39,12 @@
 # 会话数据存储目录（默认 ~/.cc-connect），以 JSON 文件保存对话历史和会话状态。
 # data_dir = "/path/to/custom/dir"
 
-# Attachment send-back switch for `cc-connect send --image/--file`.
+# Attachment send-back switch for `cc-connect send --image/--file`
+# and generated media sent by `--generate-image/--generate-video/--generate-music`.
 # Independent from the agent's /mode. Set to "off" to block IM image/file send-back.
 # `cc-connect send --message` without attachments is unaffected.
-# 附件回传开关，用于控制 `cc-connect send --image/--file`。
+# 附件回传开关，用于控制 `cc-connect send --image/--file`
+# 以及 `--generate-image/--generate-video/--generate-music` 生成后的媒体附件回传。
 # 它与 agent 的 /mode 独立；设为 "off" 会禁用通过 IM 回传图片/文件。
 # 不带附件的 `cc-connect send --message` 不受影响。
 # attachment_send = "on"
@@ -537,6 +539,101 @@ level = "info" # debug, info, warn, error
 # base_url = ""              # optional: default "https://api.xiaomimimo.com/v1" / 留空使用默认地址
 #                            # Token Plan 国内地址：https://token-plan-cn.xiaomimimo.com/v1
 # model    = "mimo-v2.5-tts" # "mimo-v2.5-tts" | "mimo-v2.5-tts-voicedesign" | "mimo-v2.5-tts-voiceclone"
+
+# =============================================================================
+# Generated Image, Video, and Music Send-Back / 图片、视频与音乐生成回传
+# =============================================================================
+# Enable these sections to let agents call `cc-connect send --generate-image`,
+# `--generate-video`, or `--generate-music` directly through configured providers
+# or command adapters such as OpenClaw/vendor CLIs.
+# The generated media is sent back as an attachment, so `attachment_send = "off"`
+# blocks delivery before provider generation starts.
+# 启用后，Agent 可以直接调用 `cc-connect send --generate-image`、
+# `--generate-video` 或 `--generate-music`，通过内置 provider 或 OpenClaw/厂商 CLI
+# 这类 command adapter 生成。生成结果作为附件回传，因此 `attachment_send = "off"`
+# 会在调用 provider 前直接拒绝。
+
+# [image]
+# enabled = false
+# provider = "openai"       # "openai" (OpenAI-compatible), "minimax", "command", or "openclaw"
+# max_prompt_len = 0          # max rune count before rejecting generation; 0 = no limit
+#
+# [image.openai]
+# api_key = "your-openai-api-key"
+# base_url = ""                    # optional: default "https://api.openai.com/v1"; may point to an OpenAI-compatible /v1 endpoint
+# model = "gpt-image-1"
+# size = ""                        # e.g. "1024x1024"; empty = provider/model default
+# quality = ""                     # e.g. "auto", "high", "medium", "low", "standard", "hd"
+# response_format = ""             # "b64_json" or "url" for DALL-E-compatible providers; empty for GPT image models
+# output_format = ""               # "png", "jpeg", or "webp" for GPT image models
+# background = ""                  # "transparent", "opaque", or "auto" for supported GPT image models
+# style = ""                       # "vivid" or "natural" for DALL-E 3
+#
+# [image.minimax]
+# api_key = "your-minimax-api-key" # optional: if empty, cc-connect reads ~/.cc-connect/config/minimax.json
+# base_url = ""                    # optional: default "https://api.minimaxi.com"
+# model = "image-01"
+# config_file = ""                 # optional MiniMax JSON config path; default data_dir/config/minimax.json
+# response_format = "base64"       # "base64" (default) or "url"
+# aspect_ratio = ""                # e.g. "1:1" or "16:9"; empty = provider default
+# width = 0                        # optional custom width; set together with height
+# height = 0                       # optional custom height; set together with width
+# prompt_optimizer = false
+#
+# [image.command]
+# command = "openclaw"             # executed directly without a shell; leave empty unless provider = "command" or overriding provider = "openclaw"
+# args = ["capability", "image", "generate", "--prompt", "{{prompt}}", "--output", "{{output}}"]
+# work_dir = ""
+# env = []                         # optional KEY=value entries appended to the process env
+# format = "png"                   # used for {{output}} extension and attachment MIME
+# timeout_secs = 600
+#
+# [video]
+# enabled = false
+# provider = "minimax"             # "minimax", "command", or "openclaw"
+# max_prompt_len = 0          # max rune count before rejecting generation; 0 = no limit
+#
+# [video.minimax]
+# api_key = "your-minimax-api-key" # optional: if empty, cc-connect reads ~/.cc-connect/config/minimax.json
+# base_url = ""                    # optional: default "https://api.minimaxi.com"
+# model = "MiniMax-Hailuo-2.3"
+# config_file = ""                 # optional MiniMax JSON config path; default data_dir/config/minimax.json
+# duration = 6                     # seconds; 0 = provider default
+# resolution = "1080P"             # empty = provider default
+# poll_interval_secs = 10
+# timeout_secs = 600
+#
+# [video.command]
+# command = "openclaw"
+# args = ["capability", "video", "generate", "--model", "byteplus/seedance-1-0-lite-t2v-250428", "--prompt", "{{prompt}}", "--output", "{{output}}"]
+# work_dir = ""
+# env = []
+# format = "mp4"
+# timeout_secs = 900
+#
+# [music]
+# enabled = false
+# provider = "minimax"             # "minimax" or "command"; use command for Suno/vendor wrappers
+# max_prompt_len = 0          # max rune count before rejecting generation; 0 = no limit
+#
+# [music.minimax]
+# api_key = "your-minimax-api-key" # optional: if empty, cc-connect reads ~/.cc-connect/config/minimax.json
+# base_url = ""                    # optional: default "https://api.minimaxi.com"
+# model = "music-2.6"
+# config_file = ""                 # optional MiniMax JSON config path; default data_dir/config/minimax.json
+# sample_rate = 44100
+# bitrate = 256000
+# format = "mp3"
+# lyrics_optimizer = true          # useful for prompt-only lyric songs
+# instrumental = false
+#
+# [music.command]
+# command = "suno-generate"        # example wrapper; cc-connect only expects media bytes/file output
+# args = ["--prompt", "{{prompt}}", "--lyrics", "{{lyrics}}", "--instrumental", "{{instrumental}}", "--output", "{{output}}"]
+# work_dir = ""
+# env = []
+# format = "mp3"
+# timeout_secs = 900
 
 # =============================================================================
 # Daemon Mode / 守护进程模式

--- a/config/config.go
+++ b/config/config.go
@@ -99,6 +99,9 @@ type Config struct {
 	Language           string                  `toml:"language"` // "en" or "zh", default is "en"
 	Speech             SpeechConfig            `toml:"speech"`
 	TTS                TTSConfig               `toml:"tts"`
+	Image              ImageConfig             `toml:"image"`
+	Video              VideoConfig             `toml:"video"`
+	Music              MusicConfig             `toml:"music"`
 	Display            DisplayConfig           `toml:"display"`
 	StreamPreview      StreamPreviewConfig     `toml:"stream_preview"`      // real-time streaming preview
 	InstantReply       InstantReplyConfig      `toml:"instant_reply"`       // immediate confirmation reply
@@ -317,6 +320,85 @@ type TTSConfig struct {
 		BaseURL string `toml:"base_url"`
 		Model   string `toml:"model"`
 	} `toml:"mimo"`
+}
+
+// MediaCommandConfig configures a local command that returns generated media.
+// The command is executed directly without a shell. Args may contain
+// {{prompt}}, {{output}}, {{format}}, and for music {{lyrics}}/{{instrumental}}.
+type MediaCommandConfig struct {
+	Command     string   `toml:"command"`
+	Args        []string `toml:"args"`
+	WorkDir     string   `toml:"work_dir"`
+	Env         []string `toml:"env"`
+	Format      string   `toml:"format"`
+	TimeoutSecs int      `toml:"timeout_secs"`
+}
+
+// ImageConfig configures direct text-to-image generation for cc-connect send.
+type ImageConfig struct {
+	Enabled      bool   `toml:"enabled"`
+	Provider     string `toml:"provider"`       // "openai" | "minimax" | "command" | "openclaw"
+	MaxPromptLen int    `toml:"max_prompt_len"` // max rune count before rejecting generation; 0 = no limit
+	OpenAI       struct {
+		APIKey         string `toml:"api_key"`
+		BaseURL        string `toml:"base_url"`        // default https://api.openai.com/v1; may point to an OpenAI-compatible /v1 endpoint
+		Model          string `toml:"model"`           // default "gpt-image-1"
+		Size           string `toml:"size"`            // e.g. "1024x1024"; provider/model default when empty
+		Quality        string `toml:"quality"`         // e.g. "auto", "high", "medium", "low", "standard", "hd"
+		ResponseFormat string `toml:"response_format"` // "b64_json" or "url" for DALL-E-compatible providers; empty for GPT image models
+		OutputFormat   string `toml:"output_format"`   // "png", "jpeg", or "webp" for GPT image models
+		Background     string `toml:"background"`      // "transparent", "opaque", or "auto" for supported GPT image models
+		Style          string `toml:"style"`           // "vivid" or "natural" for DALL-E 3
+	} `toml:"openai"`
+	MiniMax struct {
+		APIKey          string `toml:"api_key"`
+		BaseURL         string `toml:"base_url"`
+		Model           string `toml:"model"`
+		ConfigFile      string `toml:"config_file"`      // optional JSON auth file; default data_dir/config/minimax.json when api_key is empty
+		ResponseFormat  string `toml:"response_format"`  // "base64" (default) or "url"
+		AspectRatio     string `toml:"aspect_ratio"`     // e.g. "1:1", "16:9"; provider default when empty
+		Width           int    `toml:"width"`            // optional custom width; set together with height
+		Height          int    `toml:"height"`           // optional custom height; set together with width
+		PromptOptimizer bool   `toml:"prompt_optimizer"` // provider prompt optimizer
+	} `toml:"minimax"`
+	Command MediaCommandConfig `toml:"command"`
+}
+
+// VideoConfig configures direct text-to-video generation for cc-connect send.
+type VideoConfig struct {
+	Enabled      bool   `toml:"enabled"`
+	Provider     string `toml:"provider"`       // "minimax" | "command" | "openclaw"
+	MaxPromptLen int    `toml:"max_prompt_len"` // max rune count before rejecting generation; 0 = no limit
+	MiniMax      struct {
+		APIKey           string `toml:"api_key"`
+		BaseURL          string `toml:"base_url"`
+		Model            string `toml:"model"`
+		ConfigFile       string `toml:"config_file"`        // optional JSON auth file; default data_dir/config/minimax.json when api_key is empty
+		Duration         int    `toml:"duration"`           // seconds; provider default when 0
+		Resolution       string `toml:"resolution"`         // e.g. "1080P"; provider default when empty
+		PollIntervalSecs int    `toml:"poll_interval_secs"` // default 10
+		TimeoutSecs      int    `toml:"timeout_secs"`       // default 600
+	} `toml:"minimax"`
+	Command MediaCommandConfig `toml:"command"`
+}
+
+// MusicConfig configures direct text-to-music generation for cc-connect send.
+type MusicConfig struct {
+	Enabled      bool   `toml:"enabled"`
+	Provider     string `toml:"provider"`       // "minimax" | "command"
+	MaxPromptLen int    `toml:"max_prompt_len"` // max rune count before rejecting generation; 0 = no limit
+	MiniMax      struct {
+		APIKey          string `toml:"api_key"`
+		BaseURL         string `toml:"base_url"`
+		Model           string `toml:"model"`
+		ConfigFile      string `toml:"config_file"` // optional JSON auth file; default data_dir/config/minimax.json when api_key is empty
+		SampleRate      int    `toml:"sample_rate"` // default 44100
+		Bitrate         int    `toml:"bitrate"`     // default 256000
+		Format          string `toml:"format"`      // default "mp3"
+		LyricsOptimizer bool   `toml:"lyrics_optimizer"`
+		Instrumental    bool   `toml:"instrumental"`
+	} `toml:"minimax"`
+	Command MediaCommandConfig `toml:"command"`
 }
 
 // TTSAgentConfig overrides global [tts] synthesis parameters for one project.

--- a/core/api.go
+++ b/core/api.go
@@ -48,18 +48,24 @@ type APIServer struct {
 // the dispatch layer in engine.go. See cc-connect internal task
 // t-20260615-cqjbk1.
 type SendRequest struct {
-	Project    string            `json:"project"`
-	SessionKey string            `json:"session_key"`
-	Message    string            `json:"message"`
-	WorkDir    string            `json:"work_dir,omitempty"`
-	CWD        string            `json:"cwd,omitempty"`
-	TTSText    string            `json:"tts_text,omitempty"`
-	Images     []ImageAttachment `json:"images,omitempty"`
-	Files      []FileAttachment  `json:"files,omitempty"`
-	Audios     []FileAttachment  `json:"audios,omitempty"`
-	Videos     []FileAttachment  `json:"videos,omitempty"`
-	AtUsers    []string          `json:"at_users,omitempty"`
-	AtAll      bool              `json:"at_all,omitempty"`
+	Project              string            `json:"project"`
+	SessionKey           string            `json:"session_key"`
+	Message              string            `json:"message"`
+	WorkDir              string            `json:"work_dir,omitempty"`
+	CWD                  string            `json:"cwd,omitempty"`
+	TTSText              string            `json:"tts_text,omitempty"`
+	ImagePrompt          string            `json:"image_prompt,omitempty"`
+	VideoPrompt          string            `json:"video_prompt,omitempty"`
+	MusicPrompt          string            `json:"music_prompt,omitempty"`
+	MusicLyrics          string            `json:"music_lyrics,omitempty"`
+	MusicInstrumental    bool              `json:"music_instrumental,omitempty"`
+	MusicLyricsOptimizer bool              `json:"music_lyrics_optimizer,omitempty"`
+	Images               []ImageAttachment `json:"images,omitempty"`
+	Files                []FileAttachment  `json:"files,omitempty"`
+	Audios               []FileAttachment  `json:"audios,omitempty"`
+	Videos               []FileAttachment  `json:"videos,omitempty"`
+	AtUsers              []string          `json:"at_users,omitempty"`
+	AtAll                bool              `json:"at_all,omitempty"`
 }
 
 // NewAPIServer creates an API server on a Unix socket.
@@ -217,8 +223,11 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	if req.Message == "" && strings.TrimSpace(req.TTSText) == "" && len(req.Images) == 0 && len(req.Files) == 0 && len(req.Audios) == 0 && len(req.Videos) == 0 {
-		http.Error(w, "message, tts_text, or attachment is required", http.StatusBadRequest)
+	if req.Message == "" && strings.TrimSpace(req.TTSText) == "" &&
+		strings.TrimSpace(req.ImagePrompt) == "" &&
+		strings.TrimSpace(req.VideoPrompt) == "" && strings.TrimSpace(req.MusicPrompt) == "" &&
+		len(req.Images) == 0 && len(req.Files) == 0 && len(req.Audios) == 0 && len(req.Videos) == 0 {
+		http.Error(w, "message, tts_text, image_prompt, video_prompt, music_prompt, or attachment is required", http.StatusBadRequest)
 		return
 	}
 
@@ -275,6 +284,27 @@ func (s *APIServer) handleSend(w http.ResponseWriter, r *http.Request) {
 
 	if strings.TrimSpace(req.TTSText) != "" {
 		if err := engine.SendTTSToSession(req.SessionKey, req.TTSText); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if strings.TrimSpace(req.ImagePrompt) != "" {
+		if err := engine.SendGeneratedImageToSession(req.SessionKey, req.ImagePrompt); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if strings.TrimSpace(req.VideoPrompt) != "" {
+		if err := engine.SendGeneratedVideoToSession(req.SessionKey, req.VideoPrompt); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if strings.TrimSpace(req.MusicPrompt) != "" {
+		if err := engine.SendGeneratedMusicToSession(req.SessionKey, req.MusicPrompt, req.MusicLyrics, req.MusicInstrumental, req.MusicLyricsOptimizer); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -91,6 +91,106 @@ func TestHandleSend_AllowsTTSTextOnly(t *testing.T) {
 	}
 }
 
+type recordingVideoGenerator struct {
+	prompt string
+	calls  int
+}
+
+func (g *recordingVideoGenerator) GenerateVideo(_ context.Context, prompt string) ([]byte, string, error) {
+	g.prompt = prompt
+	g.calls++
+	return []byte("video-bytes"), "mp4", nil
+}
+
+type recordingImageGenerator struct {
+	prompt string
+	calls  int
+}
+
+func (g *recordingImageGenerator) GenerateImage(_ context.Context, prompt string) ([]byte, string, error) {
+	g.prompt = prompt
+	g.calls++
+	return []byte("image-bytes"), "png", nil
+}
+
+type recordingMusicGenerator struct {
+	prompt string
+	opts   MusicGenerationOpts
+	calls  int
+}
+
+func (g *recordingMusicGenerator) GenerateMusic(_ context.Context, prompt string, opts MusicGenerationOpts) ([]byte, string, error) {
+	g.prompt = prompt
+	g.opts = opts
+	g.calls++
+	return []byte("music-bytes"), "mp3", nil
+}
+
+func TestHandleSend_AllowsGeneratedImageVideoAndMusic(t *testing.T) {
+	image := &recordingImageGenerator{}
+	video := &recordingVideoGenerator{}
+	music := &recordingMusicGenerator{}
+	platform := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	engine := NewEngine("test", &stubAgent{}, []Platform{platform}, "", LangEnglish)
+	engine.SetImageGenerationConfig(&ImageGenerationCfg{Enabled: true, Provider: "minimax", Generator: image})
+	engine.SetVideoGenerationConfig(&VideoGenerationCfg{Enabled: true, Provider: "minimax", Generator: video})
+	engine.SetMusicGenerationConfig(&MusicGenerationCfg{Enabled: true, Provider: "minimax", Generator: music})
+	engine.interactiveStates["session-1"] = &interactiveState{
+		platform: platform,
+		replyCtx: "reply-ctx",
+	}
+
+	api := &APIServer{engines: map[string]*Engine{"test": engine}}
+	body, err := json.Marshal(SendRequest{
+		Project:              "test",
+		SessionKey:           "session-1",
+		ImagePrompt:          "watercolor fox",
+		VideoPrompt:          "cinematic sunset",
+		MusicPrompt:          "ambient synthwave",
+		MusicLyrics:          "[Verse]\nhello",
+		MusicInstrumental:    true,
+		MusicLyricsOptimizer: true,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleSend(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if image.calls != 1 || image.prompt != "watercolor fox" {
+		t.Fatalf("image calls/prompt = %d/%q", image.calls, image.prompt)
+	}
+	if video.calls != 1 || video.prompt != "cinematic sunset" {
+		t.Fatalf("video calls/prompt = %d/%q", video.calls, video.prompt)
+	}
+	if music.calls != 1 || music.prompt != "ambient synthwave" {
+		t.Fatalf("music calls/prompt = %d/%q", music.calls, music.prompt)
+	}
+	if music.opts.Lyrics != "[Verse]\nhello" || !music.opts.Instrumental || !music.opts.LyricsOptimizer {
+		t.Fatalf("music opts = %#v", music.opts)
+	}
+	if len(platform.images) != 1 {
+		t.Fatalf("sent images = %d, want 1", len(platform.images))
+	}
+	if platform.images[0].MimeType != "image/png" || string(platform.images[0].Data) != "image-bytes" {
+		t.Fatalf("image attachment = %#v", platform.images[0])
+	}
+	if len(platform.files) != 2 {
+		t.Fatalf("sent files = %d, want 2", len(platform.files))
+	}
+	if platform.files[0].MimeType != "video/mp4" || string(platform.files[0].Data) != "video-bytes" {
+		t.Fatalf("video file = %#v", platform.files[0])
+	}
+	if platform.files[1].MimeType != "audio/mpeg" || string(platform.files[1].Data) != "music-bytes" {
+		t.Fatalf("music file = %#v", platform.files[1])
+	}
+}
+
 // TestHandleSend_UnknownProjectReturns404 ensures the API does NOT silently
 // fall back to the only registered engine when the caller named a different
 // project. Previously a typo'd project name routed messages to whatever
@@ -394,14 +494,7 @@ func TestHandleCronExec_TriggersJob(t *testing.T) {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 	}
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(platform.getSent()) >= 2 {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("timed out waiting for local api trigger, sent=%v", platform.getSent())
+	waitForCronExecCompletion(t, store, job.ID, platform, 2)
 }
 
 func TestHandleCronExec_RunAliasRouteTriggersJob(t *testing.T) {
@@ -449,14 +542,38 @@ func TestHandleCronExec_RunAliasRouteTriggersJob(t *testing.T) {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 	}
 
+	waitForCronExecCompletion(t, store, job.ID, platform, 2)
+}
+
+func waitForCronExecCompletion(t *testing.T, store *CronStore, jobID string, platform *stubCronReplyTargetPlatform, wantSent int) {
+	t.Helper()
+
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if len(platform.getSent()) >= 2 {
+		sent := platform.getSent()
+		lastRun, lastErr := cronJobRunState(store, jobID)
+		if len(sent) >= wantSent && !lastRun.IsZero() {
+			if lastErr != "" {
+				t.Fatalf("cron job %s completed with error: %s", jobID, lastErr)
+			}
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for local api alias trigger, sent=%v", platform.getSent())
+
+	lastRun, lastErr := cronJobRunState(store, jobID)
+	t.Fatalf("timed out waiting for cron exec %s, sent=%v last_run=%v last_error=%q", jobID, platform.getSent(), lastRun, lastErr)
+}
+
+func cronJobRunState(store *CronStore, jobID string) (time.Time, string) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	for _, job := range store.jobs {
+		if job.ID == jobID {
+			return job.LastRun, job.LastError
+		}
+	}
+	return time.Time{}, ""
 }
 
 func TestHandleCronExec_ProjectMissingIsBadRequest(t *testing.T) {

--- a/core/engine.go
+++ b/core/engine.go
@@ -338,6 +338,9 @@ type Engine struct {
 	i18n                  *I18n
 	speech                SpeechCfg
 	tts                   *TTSCfg
+	image                 *ImageGenerationCfg
+	video                 *VideoGenerationCfg
+	music                 *MusicGenerationCfg
 	display               DisplayCfg
 	injectSender          bool
 	attachmentSendEnabled bool
@@ -854,6 +857,21 @@ func (e *Engine) SetSpeechConfig(cfg SpeechCfg) {
 // SetTTSConfig configures the text-to-speech subsystem.
 func (e *Engine) SetTTSConfig(cfg *TTSCfg) {
 	e.tts = cfg
+}
+
+// SetImageGenerationConfig configures direct image generation for the send API.
+func (e *Engine) SetImageGenerationConfig(cfg *ImageGenerationCfg) {
+	e.image = cfg
+}
+
+// SetVideoGenerationConfig configures direct video generation for the send API.
+func (e *Engine) SetVideoGenerationConfig(cfg *VideoGenerationCfg) {
+	e.video = cfg
+}
+
+// SetMusicGenerationConfig configures direct music generation for the send API.
+func (e *Engine) SetMusicGenerationConfig(cfg *MusicGenerationCfg) {
+	e.music = cfg
 }
 
 // SetTTSSaveFunc registers a callback that persists TTS mode changes.
@@ -11199,6 +11217,129 @@ func (e *Engine) SendTTSToSession(sessionKey, text string) error {
 	return e.synthesizeAndSendTTS(p, replyCtx, text)
 }
 
+// SendGeneratedImageToSession generates an image with the configured provider
+// and sends it as a native image attachment to an active session.
+func (e *Engine) SendGeneratedImageToSession(sessionKey, prompt string) error {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return fmt.Errorf("image prompt is required")
+	}
+	if e.image == nil || !e.image.Enabled {
+		return fmt.Errorf("image generation is not configured")
+	}
+	if e.image.Generator == nil {
+		return fmt.Errorf("image generation provider is not configured")
+	}
+	if e.image.MaxPromptLen > 0 && utf8.RuneCountInString(prompt) > e.image.MaxPromptLen {
+		return fmt.Errorf("image prompt exceeds max_prompt_len (%d > %d)", utf8.RuneCountInString(prompt), e.image.MaxPromptLen)
+	}
+	if !e.attachmentSendEnabled {
+		return ErrAttachmentSendDisabled
+	}
+	if _, _, _, err := e.resolveOutboundSessionTarget(sessionKey, true); err != nil {
+		return err
+	}
+	slog.Info("image: starting generation", "provider", e.image.Provider, "prompt_len", len(prompt))
+	data, format, err := e.image.Generator.GenerateImage(e.ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("generate image: %w", err)
+	}
+	image := ImageAttachment{
+		MimeType: generatedMediaMime("image", format),
+		Data:     data,
+		FileName: generatedMediaFileName("image", format),
+	}
+	if err := e.SendToSessionWithAttachments(sessionKey, "", []ImageAttachment{image}, nil, nil, false); err != nil {
+		return fmt.Errorf("send image: %w", err)
+	}
+	slog.Info("image: generated file sent", "provider", e.image.Provider, "format", format, "size", len(data))
+	return nil
+}
+
+// SendGeneratedVideoToSession generates a video with the configured provider
+// and sends it as a file attachment to an active session.
+func (e *Engine) SendGeneratedVideoToSession(sessionKey, prompt string) error {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return fmt.Errorf("video prompt is required")
+	}
+	if e.video == nil || !e.video.Enabled {
+		return fmt.Errorf("video generation is not configured")
+	}
+	if e.video.Generator == nil {
+		return fmt.Errorf("video generation provider is not configured")
+	}
+	if e.video.MaxPromptLen > 0 && utf8.RuneCountInString(prompt) > e.video.MaxPromptLen {
+		return fmt.Errorf("video prompt exceeds max_prompt_len (%d > %d)", utf8.RuneCountInString(prompt), e.video.MaxPromptLen)
+	}
+	if !e.attachmentSendEnabled {
+		return ErrAttachmentSendDisabled
+	}
+	if _, _, _, err := e.resolveOutboundSessionTarget(sessionKey, true); err != nil {
+		return err
+	}
+	slog.Info("video: starting generation", "provider", e.video.Provider, "prompt_len", len(prompt))
+	data, format, err := e.video.Generator.GenerateVideo(e.ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("generate video: %w", err)
+	}
+	file := FileAttachment{
+		MimeType: generatedMediaMime("video", format),
+		Data:     data,
+		FileName: generatedMediaFileName("video", format),
+	}
+	if err := e.SendVideosToSession(sessionKey, []FileAttachment{file}); err != nil {
+		return fmt.Errorf("send video: %w", err)
+	}
+	slog.Info("video: generated file sent", "provider", e.video.Provider, "format", format, "size", len(data))
+	return nil
+}
+
+// SendGeneratedMusicToSession generates music with the configured provider
+// and sends it as an audio attachment to an active session.
+func (e *Engine) SendGeneratedMusicToSession(sessionKey, prompt, lyrics string, instrumental bool, lyricsOptimizer bool) error {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return fmt.Errorf("music prompt is required")
+	}
+	if e.music == nil || !e.music.Enabled {
+		return fmt.Errorf("music generation is not configured")
+	}
+	if e.music.Generator == nil {
+		return fmt.Errorf("music generation provider is not configured")
+	}
+	if e.music.MaxPromptLen > 0 && utf8.RuneCountInString(prompt) > e.music.MaxPromptLen {
+		return fmt.Errorf("music prompt exceeds max_prompt_len (%d > %d)", utf8.RuneCountInString(prompt), e.music.MaxPromptLen)
+	}
+	if !e.attachmentSendEnabled {
+		return ErrAttachmentSendDisabled
+	}
+	if _, _, _, err := e.resolveOutboundSessionTarget(sessionKey, true); err != nil {
+		return err
+	}
+
+	opts := MusicGenerationOpts{
+		Lyrics:          lyrics,
+		Instrumental:    instrumental || e.music.Instrumental,
+		LyricsOptimizer: lyricsOptimizer || e.music.LyricsOptimizer,
+	}
+	slog.Info("music: starting generation", "provider", e.music.Provider, "prompt_len", len(prompt), "instrumental", opts.Instrumental, "lyrics_optimizer", opts.LyricsOptimizer)
+	data, format, err := e.music.Generator.GenerateMusic(e.ctx, prompt, opts)
+	if err != nil {
+		return fmt.Errorf("generate music: %w", err)
+	}
+	file := FileAttachment{
+		MimeType: generatedMediaMime("music", format),
+		Data:     data,
+		FileName: generatedMediaFileName("music", format),
+	}
+	if err := e.SendAudiosToSession(sessionKey, []FileAttachment{file}); err != nil {
+		return fmt.Errorf("send music: %w", err)
+	}
+	slog.Info("music: generated file sent", "provider", e.music.Provider, "format", format, "size", len(data))
+	return nil
+}
+
 // SendAudiosToSession routes outbound audio attachments to the
 // platform's AudioSender (native voice bubble + transcoding) when
 // supported, falling back to FileSender otherwise. Used by
@@ -11311,7 +11452,6 @@ func audioFormatHint(a FileAttachment) string {
 func videoFormatHint(v FileAttachment) string {
 	return audioFormatHint(v)
 }
-
 func (e *Engine) resolveOutboundSessionTarget(sessionKey string, hasAttachments bool) (*interactiveState, Platform, any, error) {
 	e.interactiveMu.Lock()
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -798,6 +798,35 @@ func TestEngineSendToSessionWithAttachments_DisabledByConfig(t *testing.T) {
 	}
 }
 
+func TestEngineSendGeneratedMedia_DisabledByConfigSkipsProviders(t *testing.T) {
+	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetAttachmentSendEnabled(false)
+	image := &recordingImageGenerator{}
+	video := &recordingVideoGenerator{}
+	music := &recordingMusicGenerator{}
+	e.SetImageGenerationConfig(&ImageGenerationCfg{Enabled: true, Provider: "minimax", Generator: image})
+	e.SetVideoGenerationConfig(&VideoGenerationCfg{Enabled: true, Provider: "minimax", Generator: video})
+	e.SetMusicGenerationConfig(&MusicGenerationCfg{Enabled: true, Provider: "minimax", Generator: music})
+	e.interactiveStates["session-1"] = &interactiveState{
+		platform: p,
+		replyCtx: "ctx-1",
+	}
+
+	if err := e.SendGeneratedImageToSession("session-1", "watercolor fox"); !errors.Is(err, ErrAttachmentSendDisabled) {
+		t.Fatalf("image err = %v, want ErrAttachmentSendDisabled", err)
+	}
+	if err := e.SendGeneratedVideoToSession("session-1", "cinematic sunset"); !errors.Is(err, ErrAttachmentSendDisabled) {
+		t.Fatalf("video err = %v, want ErrAttachmentSendDisabled", err)
+	}
+	if err := e.SendGeneratedMusicToSession("session-1", "ambient synthwave", "", false, false); !errors.Is(err, ErrAttachmentSendDisabled) {
+		t.Fatalf("music err = %v, want ErrAttachmentSendDisabled", err)
+	}
+	if image.calls != 0 || video.calls != 0 || music.calls != 0 {
+		t.Fatalf("provider calls = image:%d video:%d music:%d, want all 0", image.calls, video.calls, music.calls)
+	}
+}
+
 func TestEngineSendToSessionWithAttachments_MultiWorkspaceRawSessionKey(t *testing.T) {
 	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
@@ -2347,6 +2376,12 @@ func TestAgentSystemPrompt_MentionsAttachmentSend(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "cc-connect send --tts") {
 		t.Fatalf("prompt missing tts send instructions: %q", prompt)
+	}
+	if !strings.Contains(prompt, "cc-connect send --generate-video") {
+		t.Fatalf("prompt missing generated video instructions: %q", prompt)
+	}
+	if !strings.Contains(prompt, "cc-connect send --generate-music") {
+		t.Fatalf("prompt missing generated music instructions: %q", prompt)
 	}
 	if !strings.Contains(prompt, "NO_REPLY") {
 		t.Fatalf("prompt missing silent reply guidance for voice tool: %q", prompt)
@@ -7992,6 +8027,9 @@ func TestSetupMemoryFile_RefreshesLegacyInstructions(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "cc-connect send --image") {
 		t.Fatalf("expected refreshed attachment instructions, got %q", string(content))
+	}
+	if !strings.Contains(string(content), "cc-connect send --generate-video") {
+		t.Fatalf("expected refreshed generated media instructions, got %q", string(content))
 	}
 }
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -87,7 +87,7 @@ Your normal text responses are automatically delivered to the user — just repl
 
 ## Available tools
 
-### Send generated images, files, or voice messages back to the user
+### Send generated images, files, media, or voice messages back to the user
 When you generate a local image or file that should be sent to the user, use:
 
   cc-connect send --image /absolute/path/to/image.png
@@ -104,7 +104,15 @@ When sending an audio (mp3/wav/m4a/ogg/opus) or video (mp4/mov/webm) clip that s
 
 These render as native media on platforms that support it (e.g. Feishu voice bubbles, Telegram voice messages). cc-connect transparently transcodes audio to the platform's preferred codec (e.g. opus for Feishu). On platforms without dedicated audio/video support cc-connect automatically falls back to the file-attachment path so delivery is preserved. Do NOT downgrade the user's request to --file when they explicitly asked for audio or video.
 
-When the user explicitly asks you to synthesize speech from text, use:
+When the user asks you to generate an image, video, or music and cc-connect has a matching provider configured, generate and send it directly with:
+
+  cc-connect send --generate-image "image prompt"
+  cc-connect send --generate-video "video prompt"
+  cc-connect send --generate-music "music prompt" --music-instrumental
+
+Use --music-lyrics for explicit lyrics, or --music-lyrics-optimizer to let the provider create lyrics from the prompt.
+
+When the user explicitly asks you to send a voice/audio reply, synthesize and send it with:
 
   cc-connect send --tts "text to speak"
 

--- a/core/media_generation.go
+++ b/core/media_generation.go
@@ -1,0 +1,967 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ImageGenerator generates an image attachment from a text prompt.
+type ImageGenerator interface {
+	GenerateImage(ctx context.Context, prompt string) (data []byte, format string, err error)
+}
+
+// VideoGenerator generates a video attachment from a text prompt.
+type VideoGenerator interface {
+	GenerateVideo(ctx context.Context, prompt string) (data []byte, format string, err error)
+}
+
+// MusicGenerator generates an audio/music attachment from a prompt and options.
+type MusicGenerator interface {
+	GenerateMusic(ctx context.Context, prompt string, opts MusicGenerationOpts) (data []byte, format string, err error)
+}
+
+// ImageGenerationCfg holds image generation configuration for the engine.
+type ImageGenerationCfg struct {
+	Enabled      bool
+	Provider     string
+	Generator    ImageGenerator
+	MaxPromptLen int
+}
+
+// VideoGenerationCfg holds video generation configuration for the engine.
+type VideoGenerationCfg struct {
+	Enabled      bool
+	Provider     string
+	Generator    VideoGenerator
+	MaxPromptLen int
+}
+
+// MusicGenerationCfg holds music generation configuration for the engine.
+type MusicGenerationCfg struct {
+	Enabled         bool
+	Provider        string
+	Generator       MusicGenerator
+	MaxPromptLen    int
+	LyricsOptimizer bool
+	Instrumental    bool
+}
+
+// MusicGenerationOpts carries per-request music generation controls.
+type MusicGenerationOpts struct {
+	Lyrics          string
+	LyricsOptimizer bool
+	Instrumental    bool
+}
+
+// CommandMediaGenerator runs a configured local command to produce media bytes.
+// It is intentionally provider-neutral: the command can be OpenClaw, a vendor
+// CLI, or a small wrapper around any async media API. Commands are executed
+// directly without a shell, and may either write to {{output}} or emit bytes on
+// stdout.
+type CommandMediaGenerator struct {
+	Kind    string
+	Command string
+	Args    []string
+	WorkDir string
+	Env     []string
+	Format  string
+	Timeout time.Duration
+}
+
+// MiniMaxImageGenerator implements MiniMax text-to-image generation.
+type MiniMaxImageGenerator struct {
+	APIKey          string
+	BaseURL         string
+	Model           string
+	ResponseFormat  string
+	AspectRatio     string
+	Width           int
+	Height          int
+	PromptOptimizer bool
+	Client          *http.Client
+	DownloadClient  *http.Client
+}
+
+// OpenAIImageGenerator implements the OpenAI-compatible Images API.
+type OpenAIImageGenerator struct {
+	APIKey         string
+	BaseURL        string
+	Model          string
+	Size           string
+	Quality        string
+	ResponseFormat string
+	OutputFormat   string
+	Background     string
+	Style          string
+	Client         *http.Client
+	DownloadClient *http.Client
+}
+
+func NewCommandMediaGenerator(kind, command string, args []string) *CommandMediaGenerator {
+	return &CommandMediaGenerator{
+		Kind:    kind,
+		Command: command,
+		Args:    append([]string(nil), args...),
+		Format:  defaultGeneratedMediaFormat(kind),
+		Timeout: 10 * time.Minute,
+	}
+}
+
+func (g *CommandMediaGenerator) GenerateImage(ctx context.Context, prompt string) ([]byte, string, error) {
+	return g.generate(ctx, prompt, nil)
+}
+
+func (g *CommandMediaGenerator) GenerateVideo(ctx context.Context, prompt string) ([]byte, string, error) {
+	return g.generate(ctx, prompt, nil)
+}
+
+func (g *CommandMediaGenerator) GenerateMusic(ctx context.Context, prompt string, opts MusicGenerationOpts) ([]byte, string, error) {
+	values := map[string]string{
+		"lyrics":       opts.Lyrics,
+		"instrumental": fmt.Sprintf("%t", opts.Instrumental),
+	}
+	return g.generate(ctx, prompt, values)
+}
+
+func (g *CommandMediaGenerator) generate(ctx context.Context, prompt string, values map[string]string) ([]byte, string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil, "", fmt.Errorf("%s prompt is required", g.kindForError())
+	}
+	command := strings.TrimSpace(g.Command)
+	if command == "" {
+		return nil, "", fmt.Errorf("%s command is required", g.kindForError())
+	}
+	format := normalizeMediaFormat(g.Format, g.Kind)
+	tmpDir, err := os.MkdirTemp("", "cc-connect-media-*")
+	if err != nil {
+		return nil, "", fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	outputPath := filepath.Join(tmpDir, "output."+format)
+	replacements := map[string]string{
+		"prompt": prompt,
+		"output": outputPath,
+		"format": format,
+	}
+	for k, v := range values {
+		replacements[k] = v
+	}
+	args, usesOutput := replaceCommandMediaArgs(g.Args, replacements)
+	runCtx := ctx
+	cancel := func() {}
+	if g.Timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, g.Timeout)
+	}
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, command, args...)
+	if strings.TrimSpace(g.WorkDir) != "" {
+		cmd.Dir = g.WorkDir
+	}
+	if len(g.Env) > 0 {
+		cmd.Env = append(os.Environ(), g.Env...)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if runCtx.Err() != nil {
+			return nil, "", fmt.Errorf("%s command timed out: %w", g.kindForError(), runCtx.Err())
+		}
+		return nil, "", fmt.Errorf("%s command failed: %w: %s", g.kindForError(), err, strings.TrimSpace(stderr.String()))
+	}
+	var data []byte
+	if usesOutput {
+		data, err = os.ReadFile(outputPath)
+		if err != nil {
+			return nil, "", fmt.Errorf("read command output file: %w", err)
+		}
+	} else {
+		data = stdout.Bytes()
+	}
+	if len(data) == 0 {
+		return nil, "", fmt.Errorf("%s command returned empty media", g.kindForError())
+	}
+	return data, format, nil
+}
+
+func (g *CommandMediaGenerator) kindForError() string {
+	if strings.TrimSpace(g.Kind) == "" {
+		return "media"
+	}
+	return strings.TrimSpace(g.Kind)
+}
+
+func replaceCommandMediaArgs(args []string, values map[string]string) ([]string, bool) {
+	out := make([]string, 0, len(args))
+	usesOutput := false
+	for _, arg := range args {
+		replaced := arg
+		for k, v := range values {
+			token := "{{" + k + "}}"
+			if strings.Contains(replaced, token) && k == "output" {
+				usesOutput = true
+			}
+			replaced = strings.ReplaceAll(replaced, token, v)
+		}
+		out = append(out, replaced)
+	}
+	return out, usesOutput
+}
+
+func NewMiniMaxImageGenerator(apiKey, baseURL, model string, client *http.Client) *MiniMaxImageGenerator {
+	if baseURL == "" {
+		baseURL = "https://api.minimaxi.com"
+	}
+	if model == "" {
+		model = "image-01"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Minute}
+	}
+	return &MiniMaxImageGenerator{
+		APIKey:         apiKey,
+		BaseURL:        strings.TrimRight(baseURL, "/"),
+		Model:          model,
+		ResponseFormat: "base64",
+		Client:         client,
+		DownloadClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func NewOpenAIImageGenerator(apiKey, baseURL, model string, client *http.Client) *OpenAIImageGenerator {
+	if baseURL == "" {
+		baseURL = "https://api.openai.com/v1"
+	}
+	if model == "" {
+		model = "gpt-image-1"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Minute}
+	}
+	return &OpenAIImageGenerator{
+		APIKey:         apiKey,
+		BaseURL:        strings.TrimRight(baseURL, "/"),
+		Model:          model,
+		Client:         client,
+		DownloadClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func (o *OpenAIImageGenerator) GenerateImage(ctx context.Context, prompt string) ([]byte, string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil, "", fmt.Errorf("image prompt is required")
+	}
+	body := map[string]any{
+		"model":  o.Model,
+		"prompt": prompt,
+		"n":      1,
+	}
+	if strings.TrimSpace(o.Size) != "" {
+		body["size"] = strings.TrimSpace(o.Size)
+	}
+	if strings.TrimSpace(o.Quality) != "" {
+		body["quality"] = strings.TrimSpace(o.Quality)
+	}
+	if strings.TrimSpace(o.ResponseFormat) != "" {
+		body["response_format"] = strings.TrimSpace(o.ResponseFormat)
+	}
+	if strings.TrimSpace(o.OutputFormat) != "" {
+		body["output_format"] = strings.TrimSpace(o.OutputFormat)
+	}
+	if strings.TrimSpace(o.Background) != "" {
+		body["background"] = strings.TrimSpace(o.Background)
+	}
+	if strings.TrimSpace(o.Style) != "" {
+		body["style"] = strings.TrimSpace(o.Style)
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, "", fmt.Errorf("openai image: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(o.BaseURL, "/")+"/images/generations", bytes.NewReader(payload))
+	if err != nil {
+		return nil, "", fmt.Errorf("openai image: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+o.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := o.Client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("openai image: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("openai image: read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("openai image API %d: %s", resp.StatusCode, trimForError(data))
+	}
+	var result struct {
+		Data []struct {
+			B64JSON string `json:"b64_json"`
+			URL     string `json:"url"`
+		} `json:"data"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, "", fmt.Errorf("openai image: parse response: %w", err)
+	}
+	if result.Error != nil && strings.TrimSpace(result.Error.Message) != "" {
+		return nil, "", fmt.Errorf("openai image API error: %s", result.Error.Message)
+	}
+	if len(result.Data) == 0 {
+		return nil, "", fmt.Errorf("openai image: empty image data")
+	}
+	outputFormat := normalizeImageFormat(o.OutputFormat)
+	if strings.TrimSpace(result.Data[0].B64JSON) != "" {
+		img, format, err := decodeImageBase64(result.Data[0].B64JSON)
+		if err != nil {
+			return nil, "", fmt.Errorf("openai image: decode image base64: %w", err)
+		}
+		if outputFormat != "" {
+			format = outputFormat
+		}
+		return img, format, nil
+	}
+	if strings.TrimSpace(result.Data[0].URL) != "" {
+		client := o.DownloadClient
+		if client == nil {
+			client = o.Client
+		}
+		img, format, err := downloadGeneratedImage(ctx, client, result.Data[0].URL)
+		if err != nil {
+			return nil, "", fmt.Errorf("openai image: download image: %w", err)
+		}
+		return img, format, nil
+	}
+	return nil, "", fmt.Errorf("openai image: empty image data")
+}
+
+func (m *MiniMaxImageGenerator) GenerateImage(ctx context.Context, prompt string) ([]byte, string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil, "", fmt.Errorf("image prompt is required")
+	}
+	responseFormat := strings.TrimSpace(m.ResponseFormat)
+	if responseFormat == "" {
+		responseFormat = "base64"
+	}
+	body := map[string]any{
+		"model":           m.Model,
+		"prompt":          prompt,
+		"response_format": responseFormat,
+		"n":               1,
+	}
+	if strings.TrimSpace(m.AspectRatio) != "" {
+		body["aspect_ratio"] = strings.TrimSpace(m.AspectRatio)
+	} else if m.Width > 0 && m.Height > 0 {
+		body["width"] = m.Width
+		body["height"] = m.Height
+	}
+	if m.PromptOptimizer {
+		body["prompt_optimizer"] = true
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax image: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(m.BaseURL, "/")+"/v1/image_generation", bytes.NewReader(payload))
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax image: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := m.Client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax image: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax image: read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("minimax image API %d: %s", resp.StatusCode, trimForError(data))
+	}
+	var result struct {
+		Data struct {
+			ImageURLs   []string `json:"image_urls"`
+			Images      []string `json:"images"`
+			Image       string   `json:"image"`
+			ImageBase64 string   `json:"image_base64"`
+			URL         string   `json:"url"`
+		} `json:"data"`
+		BaseResp struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, "", fmt.Errorf("minimax image: parse response: %w", err)
+	}
+	if result.BaseResp.StatusCode != 0 {
+		return nil, "", fmt.Errorf("minimax image API error %d: %s", result.BaseResp.StatusCode, result.BaseResp.StatusMsg)
+	}
+	if len(result.Data.Images) > 0 && strings.TrimSpace(result.Data.Images[0]) != "" {
+		img, format, err := decodeImageBase64(result.Data.Images[0])
+		if err != nil {
+			return nil, "", fmt.Errorf("minimax image: decode image base64: %w", err)
+		}
+		return img, format, nil
+	}
+	for _, raw := range []string{result.Data.Image, result.Data.ImageBase64} {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		img, format, err := decodeImageBase64(raw)
+		if err != nil {
+			return nil, "", fmt.Errorf("minimax image: decode image base64: %w", err)
+		}
+		return img, format, nil
+	}
+	if len(result.Data.ImageURLs) > 0 && strings.TrimSpace(result.Data.ImageURLs[0]) != "" {
+		img, format, err := m.downloadImage(ctx, result.Data.ImageURLs[0])
+		if err != nil {
+			return nil, "", fmt.Errorf("minimax image: download image: %w", err)
+		}
+		return img, format, nil
+	}
+	if strings.TrimSpace(result.Data.URL) != "" {
+		img, format, err := m.downloadImage(ctx, result.Data.URL)
+		if err != nil {
+			return nil, "", fmt.Errorf("minimax image: download image: %w", err)
+		}
+		return img, format, nil
+	}
+	return nil, "", fmt.Errorf("minimax image: empty image data")
+}
+
+func (m *MiniMaxImageGenerator) downloadImage(ctx context.Context, downloadURL string) ([]byte, string, error) {
+	client := m.DownloadClient
+	if client == nil {
+		client = m.Client
+	}
+	return downloadGeneratedImage(ctx, client, downloadURL)
+}
+
+func downloadGeneratedImage(ctx context.Context, client *http.Client, downloadURL string) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("create download request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("download: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("read download: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("download API %d: %s", resp.StatusCode, trimForError(data))
+	}
+	if len(data) == 0 {
+		return nil, "", fmt.Errorf("download returned empty image")
+	}
+	format := imageFormatFromMIME(resp.Header.Get("Content-Type"))
+	if format == "" {
+		if u, err := url.Parse(downloadURL); err == nil {
+			format = strings.TrimPrefix(strings.ToLower(path.Ext(u.Path)), ".")
+		}
+	}
+	if format == "" {
+		format = "png"
+	}
+	return data, format, nil
+}
+
+func decodeImageBase64(raw string) ([]byte, string, error) {
+	format := "png"
+	value := strings.TrimSpace(raw)
+	if i := strings.Index(value, ","); strings.HasPrefix(value, "data:") && i >= 0 {
+		format = imageFormatFromMIME(value[len("data:"):i])
+		value = value[i+1:]
+	}
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(data) == 0 {
+		return nil, "", fmt.Errorf("decoded empty image")
+	}
+	if format == "" {
+		format = "png"
+	}
+	return data, format, nil
+}
+
+func imageFormatFromMIME(mimeType string) string {
+	mt := strings.ToLower(strings.TrimSpace(mimeType))
+	if i := strings.Index(mt, ";"); i >= 0 {
+		mt = strings.TrimSpace(mt[:i])
+	}
+	switch mt {
+	case "image/jpeg", "image/jpg":
+		return "jpg"
+	case "image/png":
+		return "png"
+	case "image/webp":
+		return "webp"
+	case "image/gif":
+		return "gif"
+	default:
+		return ""
+	}
+}
+
+func normalizeImageFormat(format string) string {
+	f := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(format)), ".")
+	switch f {
+	case "jpeg":
+		return "jpg"
+	case "jpg", "png", "webp", "gif":
+		return f
+	default:
+		return ""
+	}
+}
+
+// MiniMaxVideoGenerator implements MiniMax asynchronous video generation.
+type MiniMaxVideoGenerator struct {
+	APIKey         string
+	BaseURL        string
+	Model          string
+	Duration       int
+	Resolution     string
+	PollInterval   time.Duration
+	Timeout        time.Duration
+	Client         *http.Client
+	DownloadClient *http.Client
+}
+
+func NewMiniMaxVideoGenerator(apiKey, baseURL, model string, client *http.Client) *MiniMaxVideoGenerator {
+	if baseURL == "" {
+		baseURL = "https://api.minimaxi.com"
+	}
+	if model == "" {
+		model = "MiniMax-Hailuo-2.3"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	return &MiniMaxVideoGenerator{
+		APIKey:         apiKey,
+		BaseURL:        strings.TrimRight(baseURL, "/"),
+		Model:          model,
+		PollInterval:   10 * time.Second,
+		Timeout:        10 * time.Minute,
+		Client:         client,
+		DownloadClient: &http.Client{Timeout: 5 * time.Minute},
+	}
+}
+
+func (m *MiniMaxVideoGenerator) GenerateVideo(ctx context.Context, prompt string) ([]byte, string, error) {
+	if strings.TrimSpace(prompt) == "" {
+		return nil, "", fmt.Errorf("video prompt is required")
+	}
+	timeout := m.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	taskID, err := m.createVideoTask(ctx, prompt)
+	if err != nil {
+		return nil, "", err
+	}
+	fileID, err := m.pollVideoTask(ctx, taskID)
+	if err != nil {
+		return nil, "", err
+	}
+	downloadURL, err := m.retrieveFileURL(ctx, fileID)
+	if err != nil {
+		return nil, "", err
+	}
+	data, err := m.downloadFile(ctx, downloadURL)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, "mp4", nil
+}
+
+func (m *MiniMaxVideoGenerator) createVideoTask(ctx context.Context, prompt string) (string, error) {
+	body := map[string]any{
+		"prompt": prompt,
+		"model":  m.Model,
+	}
+	if m.Duration > 0 {
+		body["duration"] = m.Duration
+	}
+	if strings.TrimSpace(m.Resolution) != "" {
+		body["resolution"] = strings.TrimSpace(m.Resolution)
+	}
+	var resp struct {
+		TaskID   string `json:"task_id"`
+		BaseResp struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	if err := m.doJSON(ctx, http.MethodPost, "/v1/video_generation", nil, body, &resp); err != nil {
+		return "", fmt.Errorf("minimax video: create task: %w", err)
+	}
+	if resp.BaseResp.StatusCode != 0 {
+		return "", fmt.Errorf("minimax video API error %d: %s", resp.BaseResp.StatusCode, resp.BaseResp.StatusMsg)
+	}
+	if strings.TrimSpace(resp.TaskID) == "" {
+		return "", fmt.Errorf("minimax video: empty task_id")
+	}
+	return resp.TaskID, nil
+}
+
+func (m *MiniMaxVideoGenerator) pollVideoTask(ctx context.Context, taskID string) (string, error) {
+	interval := m.PollInterval
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("minimax video: polling task %s: %w", taskID, ctx.Err())
+		case <-timer.C:
+		}
+		var resp struct {
+			Status       string `json:"status"`
+			FileID       string `json:"file_id"`
+			ErrorMessage string `json:"error_message"`
+			BaseResp     struct {
+				StatusCode int    `json:"status_code"`
+				StatusMsg  string `json:"status_msg"`
+			} `json:"base_resp"`
+		}
+		q := url.Values{"task_id": []string{taskID}}
+		if err := m.doJSON(ctx, http.MethodGet, "/v1/query/video_generation", q, nil, &resp); err != nil {
+			return "", fmt.Errorf("minimax video: query task: %w", err)
+		}
+		if resp.BaseResp.StatusCode != 0 {
+			return "", fmt.Errorf("minimax video query API error %d: %s", resp.BaseResp.StatusCode, resp.BaseResp.StatusMsg)
+		}
+		status := strings.ToLower(strings.TrimSpace(resp.Status))
+		switch status {
+		case "success", "completed", "succeeded":
+			if strings.TrimSpace(resp.FileID) == "" {
+				return "", fmt.Errorf("minimax video: task succeeded without file_id")
+			}
+			return resp.FileID, nil
+		case "fail", "failed", "error":
+			if resp.ErrorMessage == "" {
+				resp.ErrorMessage = resp.BaseResp.StatusMsg
+			}
+			return "", fmt.Errorf("minimax video task failed: %s", resp.ErrorMessage)
+		}
+		timer.Reset(interval)
+	}
+}
+
+func (m *MiniMaxVideoGenerator) retrieveFileURL(ctx context.Context, fileID string) (string, error) {
+	var resp struct {
+		File struct {
+			DownloadURL string `json:"download_url"`
+		} `json:"file"`
+		BaseResp struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	q := url.Values{"file_id": []string{fileID}}
+	if err := m.doJSON(ctx, http.MethodGet, "/v1/files/retrieve", q, nil, &resp); err != nil {
+		return "", fmt.Errorf("minimax video: retrieve file: %w", err)
+	}
+	if resp.BaseResp.StatusCode != 0 {
+		return "", fmt.Errorf("minimax video retrieve API error %d: %s", resp.BaseResp.StatusCode, resp.BaseResp.StatusMsg)
+	}
+	if strings.TrimSpace(resp.File.DownloadURL) == "" {
+		return "", fmt.Errorf("minimax video: empty download_url")
+	}
+	return resp.File.DownloadURL, nil
+}
+
+func (m *MiniMaxVideoGenerator) downloadFile(ctx context.Context, downloadURL string) ([]byte, error) {
+	client := m.DownloadClient
+	if client == nil {
+		client = m.Client
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create download request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read download: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download API %d: %s", resp.StatusCode, trimForError(data))
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("download returned empty file")
+	}
+	return data, nil
+}
+
+func (m *MiniMaxVideoGenerator) doJSON(ctx context.Context, method, path string, q url.Values, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+	u := strings.TrimRight(m.BaseURL, "/") + path
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, reader)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.APIKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := m.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("API %d: %s", resp.StatusCode, trimForError(data))
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	return nil
+}
+
+// MiniMaxMusicGenerator implements MiniMax music generation.
+type MiniMaxMusicGenerator struct {
+	APIKey     string
+	BaseURL    string
+	Model      string
+	SampleRate int
+	Bitrate    int
+	Format     string
+	Client     *http.Client
+}
+
+func NewMiniMaxMusicGenerator(apiKey, baseURL, model string, client *http.Client) *MiniMaxMusicGenerator {
+	if baseURL == "" {
+		baseURL = "https://api.minimaxi.com"
+	}
+	if model == "" {
+		model = "music-2.6"
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Minute}
+	}
+	return &MiniMaxMusicGenerator{
+		APIKey:     apiKey,
+		BaseURL:    strings.TrimRight(baseURL, "/"),
+		Model:      model,
+		SampleRate: 44100,
+		Bitrate:    256000,
+		Format:     "mp3",
+		Client:     client,
+	}
+}
+
+func (m *MiniMaxMusicGenerator) GenerateMusic(ctx context.Context, prompt string, opts MusicGenerationOpts) ([]byte, string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil, "", fmt.Errorf("music prompt is required")
+	}
+	format := strings.TrimSpace(m.Format)
+	if format == "" {
+		format = "mp3"
+	}
+	sampleRate := m.SampleRate
+	if sampleRate <= 0 {
+		sampleRate = 44100
+	}
+	bitrate := m.Bitrate
+	if bitrate <= 0 {
+		bitrate = 256000
+	}
+	body := map[string]any{
+		"model":         m.Model,
+		"prompt":        prompt,
+		"output_format": "hex",
+		"audio_setting": map[string]any{
+			"sample_rate": sampleRate,
+			"bitrate":     bitrate,
+			"format":      format,
+		},
+	}
+	if opts.Instrumental {
+		body["is_instrumental"] = true
+	} else {
+		if strings.TrimSpace(opts.Lyrics) != "" {
+			body["lyrics"] = opts.Lyrics
+		}
+		if opts.LyricsOptimizer || strings.TrimSpace(opts.Lyrics) == "" {
+			body["lyrics_optimizer"] = true
+		}
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(m.BaseURL, "/")+"/v1/music_generation", bytes.NewReader(payload))
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := m.Client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("minimax music API %d: %s", resp.StatusCode, trimForError(data))
+	}
+	var result struct {
+		Data struct {
+			Audio    string `json:"audio"`
+			AudioURL string `json:"audio_url"`
+			Status   int    `json:"status"`
+		} `json:"data"`
+		BaseResp struct {
+			StatusCode int    `json:"status_code"`
+			StatusMsg  string `json:"status_msg"`
+		} `json:"base_resp"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, "", fmt.Errorf("minimax music: parse response: %w", err)
+	}
+	if result.BaseResp.StatusCode != 0 {
+		return nil, "", fmt.Errorf("minimax music API error %d: %s", result.BaseResp.StatusCode, result.BaseResp.StatusMsg)
+	}
+	if strings.TrimSpace(result.Data.Audio) == "" {
+		return nil, "", fmt.Errorf("minimax music: empty audio data")
+	}
+	audio, err := hex.DecodeString(result.Data.Audio)
+	if err != nil {
+		return nil, "", fmt.Errorf("minimax music: decode audio hex: %w", err)
+	}
+	if len(audio) == 0 {
+		return nil, "", fmt.Errorf("minimax music: decoded empty audio")
+	}
+	return audio, format, nil
+}
+
+func generatedMediaFileName(kind, format string) string {
+	ext := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(format)), ".")
+	if ext == "" {
+		ext = "bin"
+	}
+	return fmt.Sprintf("generated-%s-%d.%s", kind, time.Now().UnixMilli(), ext)
+}
+
+func defaultGeneratedMediaFormat(kind string) string {
+	switch kind {
+	case "image":
+		return "png"
+	case "video":
+		return "mp4"
+	case "music":
+		return "mp3"
+	default:
+		return "bin"
+	}
+}
+
+func normalizeMediaFormat(format, kind string) string {
+	f := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(format)), ".")
+	if f == "" || !isSafeMediaFormat(f) {
+		return defaultGeneratedMediaFormat(kind)
+	}
+	return f
+}
+
+func isSafeMediaFormat(format string) bool {
+	for _, r := range format {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func generatedMediaMime(kind, format string) string {
+	ext := "." + strings.TrimPrefix(strings.ToLower(strings.TrimSpace(format)), ".")
+	if mt := mime.TypeByExtension(ext); mt != "" {
+		return mt
+	}
+	switch kind {
+	case "image":
+		if ext == ".jpg" || ext == ".jpeg" {
+			return "image/jpeg"
+		}
+		return "image/" + strings.TrimPrefix(ext, ".")
+	case "video":
+		return "video/" + strings.TrimPrefix(ext, ".")
+	case "music":
+		if ext == ".mp3" {
+			return "audio/mpeg"
+		}
+		return "audio/" + strings.TrimPrefix(ext, ".")
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func trimForError(data []byte) string {
+	s := strings.TrimSpace(string(data))
+	if len(s) > 2048 {
+		s = s[:2048] + "..."
+	}
+	return s
+}

--- a/core/media_generation_test.go
+++ b/core/media_generation_test.go
@@ -1,0 +1,426 @@
+package core
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMiniMaxImageGenerator_GenerateBase64Image(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody map[string]any
+	rawImage := []byte{0x89, 'P', 'N', 'G'}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"images": []string{"data:image/png;base64," + base64.StdEncoding.EncodeToString(rawImage)},
+			},
+			"base_resp": map[string]any{
+				"status_code": 0,
+				"status_msg":  "success",
+			},
+		})
+	}))
+	defer ts.Close()
+
+	gen := NewMiniMaxImageGenerator("sk-test", ts.URL, "image-01", ts.Client())
+	gen.AspectRatio = "16:9"
+	image, format, err := gen.GenerateImage(context.Background(), "watercolor fox")
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if string(image) != string(rawImage) || format != "png" {
+		t.Fatalf("image/format = %q/%q, want png bytes/png", image, format)
+	}
+	if gotPath != "/v1/image_generation" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer sk-test" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotBody["model"] != "image-01" || gotBody["prompt"] != "watercolor fox" {
+		t.Fatalf("body = %#v", gotBody)
+	}
+	if gotBody["response_format"] != "base64" || gotBody["n"] != float64(1) || gotBody["aspect_ratio"] != "16:9" {
+		t.Fatalf("image options not sent: %#v", gotBody)
+	}
+}
+
+func TestMiniMaxImageGenerator_GenerateURLImage(t *testing.T) {
+	var requested []string
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.Method+" "+r.URL.String())
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/image_generation":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			if body["response_format"] != "url" || body["width"] != float64(1024) || body["height"] != float64(768) {
+				t.Fatalf("body = %#v", body)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"image_urls": []string{ts.URL + "/generated.webp"},
+				},
+				"base_resp": map[string]any{"status_code": 0},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/generated.webp":
+			w.Header().Set("Content-Type", "image/webp")
+			_, _ = w.Write([]byte("webp-bytes"))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ts.Close()
+
+	gen := NewMiniMaxImageGenerator("sk-test", ts.URL, "", ts.Client())
+	gen.ResponseFormat = "url"
+	gen.Width = 1024
+	gen.Height = 768
+	gen.DownloadClient = ts.Client()
+
+	image, format, err := gen.GenerateImage(context.Background(), "poster")
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if string(image) != "webp-bytes" || format != "webp" {
+		t.Fatalf("image/format = %q/%q", image, format)
+	}
+	got := strings.Join(requested, "\n")
+	for _, want := range []string{"POST /v1/image_generation", "GET /generated.webp"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("requests =\n%s\nmissing %s", got, want)
+		}
+	}
+}
+
+func TestOpenAIImageGenerator_GenerateBase64Image(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody map[string]any
+	rawImage := []byte{0x89, 'P', 'N', 'G'}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"b64_json": base64.StdEncoding.EncodeToString(rawImage)},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	gen := NewOpenAIImageGenerator("sk-openai", ts.URL+"/v1", "gpt-image-1", ts.Client())
+	gen.Size = "1024x1024"
+	gen.Quality = "high"
+	gen.OutputFormat = "webp"
+
+	image, format, err := gen.GenerateImage(context.Background(), "watercolor fox")
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if string(image) != string(rawImage) || format != "webp" {
+		t.Fatalf("image/format = %q/%q, want png bytes/webp", image, format)
+	}
+	if gotPath != "/v1/images/generations" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer sk-openai" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotBody["model"] != "gpt-image-1" || gotBody["prompt"] != "watercolor fox" || gotBody["n"] != float64(1) {
+		t.Fatalf("body = %#v", gotBody)
+	}
+	if gotBody["size"] != "1024x1024" || gotBody["quality"] != "high" || gotBody["output_format"] != "webp" {
+		t.Fatalf("openai options not sent: %#v", gotBody)
+	}
+	if _, ok := gotBody["response_format"]; ok {
+		t.Fatalf("response_format should be omitted by default for GPT image models: %#v", gotBody)
+	}
+}
+
+func TestOpenAIImageGenerator_GenerateURLImage(t *testing.T) {
+	var requested []string
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.Method+" "+r.URL.String())
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/images/generations":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			if body["response_format"] != "url" || body["style"] != "natural" {
+				t.Fatalf("body = %#v", body)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
+					{"url": ts.URL + "/openai-image.png"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/openai-image.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("png-bytes"))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ts.Close()
+
+	gen := NewOpenAIImageGenerator("sk-openai", ts.URL+"/v1", "dall-e-3", ts.Client())
+	gen.ResponseFormat = "url"
+	gen.Style = "natural"
+	gen.DownloadClient = ts.Client()
+
+	image, format, err := gen.GenerateImage(context.Background(), "poster")
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if string(image) != "png-bytes" || format != "png" {
+		t.Fatalf("image/format = %q/%q", image, format)
+	}
+	got := strings.Join(requested, "\n")
+	for _, want := range []string{"POST /v1/images/generations", "GET /openai-image.png"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("requests =\n%s\nmissing %s", got, want)
+		}
+	}
+}
+
+func TestCommandMediaGeneratorHelper(t *testing.T) {
+	if os.Getenv("CC_CONNECT_COMMAND_MEDIA_HELPER") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) < 2 {
+		_, _ = os.Stderr.WriteString("missing helper args")
+		os.Exit(2)
+	}
+	args = args[1:]
+	switch args[0] {
+	case "file":
+		if len(args) < 3 {
+			_, _ = os.Stderr.WriteString("missing file helper args")
+			os.Exit(2)
+		}
+		if err := os.WriteFile(args[1], []byte(args[2]), 0o600); err != nil {
+			_, _ = os.Stderr.WriteString(err.Error())
+			os.Exit(2)
+		}
+	case "stdout":
+		if len(args) < 2 {
+			_, _ = os.Stderr.WriteString("missing stdout helper args")
+			os.Exit(2)
+		}
+		_, _ = os.Stdout.WriteString(strings.Join(args[1:], "|"))
+	default:
+		_, _ = os.Stderr.WriteString("unknown helper mode")
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func TestCommandMediaGenerator_GenerateImageFromOutputFile(t *testing.T) {
+	gen := NewCommandMediaGenerator("image", os.Args[0], []string{
+		"-test.run=TestCommandMediaGeneratorHelper",
+		"--",
+		"file",
+		"{{output}}",
+		"{{prompt}}",
+	})
+	gen.Env = []string{"CC_CONNECT_COMMAND_MEDIA_HELPER=1"}
+	gen.Format = "webp"
+
+	image, format, err := gen.GenerateImage(context.Background(), "command image")
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if string(image) != "command image" || format != "webp" {
+		t.Fatalf("image/format = %q/%q", image, format)
+	}
+}
+
+func TestCommandMediaGenerator_GenerateMusicFromStdout(t *testing.T) {
+	gen := NewCommandMediaGenerator("music", os.Args[0], []string{
+		"-test.run=TestCommandMediaGeneratorHelper",
+		"--",
+		"stdout",
+		"{{prompt}}",
+		"{{lyrics}}",
+		"{{instrumental}}",
+	})
+	gen.Env = []string{"CC_CONNECT_COMMAND_MEDIA_HELPER=1"}
+	gen.Format = "wav"
+
+	audio, format, err := gen.GenerateMusic(context.Background(), "suno song", MusicGenerationOpts{
+		Lyrics:       "[Verse] hello",
+		Instrumental: true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateMusic() error = %v", err)
+	}
+	if string(audio) != "suno song|[Verse] hello|true" || format != "wav" {
+		t.Fatalf("audio/format = %q/%q", audio, format)
+	}
+}
+
+func TestNormalizeMediaFormatRejectsPathSeparators(t *testing.T) {
+	if got := normalizeMediaFormat("../mp4", "video"); got != "mp4" {
+		t.Fatalf("normalizeMediaFormat() = %q, want mp4", got)
+	}
+	if got := normalizeMediaFormat("webp", "image"); got != "webp" {
+		t.Fatalf("normalizeMediaFormat() = %q, want webp", got)
+	}
+}
+
+func TestMiniMaxMusicGenerator_GenerateHexAudio(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"audio":  "6d7033",
+				"status": 2,
+			},
+			"base_resp": map[string]any{
+				"status_code": 0,
+				"status_msg":  "success",
+			},
+		})
+	}))
+	defer ts.Close()
+
+	gen := NewMiniMaxMusicGenerator("sk-test", ts.URL, "music-2.6-free", ts.Client())
+	audio, format, err := gen.GenerateMusic(context.Background(), "ambient piano", MusicGenerationOpts{
+		LyricsOptimizer: true,
+		Instrumental:    true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateMusic() error = %v", err)
+	}
+	if string(audio) != "mp3" || format != "mp3" {
+		t.Fatalf("audio/format = %q/%q, want mp3/mp3", audio, format)
+	}
+	if gotPath != "/v1/music_generation" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer sk-test" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotBody["model"] != "music-2.6-free" || gotBody["prompt"] != "ambient piano" {
+		t.Fatalf("body = %#v", gotBody)
+	}
+	if gotBody["is_instrumental"] != true {
+		t.Fatalf("music flags not sent: %#v", gotBody)
+	}
+	if gotBody["lyrics_optimizer"] != nil {
+		t.Fatalf("lyrics_optimizer should not be sent for instrumental music: %#v", gotBody)
+	}
+}
+
+func TestMiniMaxMusicGenerator_PromptOnlyEnablesLyricsOptimizer(t *testing.T) {
+	var gotBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"audio":  "6d7033",
+				"status": 2,
+			},
+			"base_resp": map[string]any{
+				"status_code": 0,
+				"status_msg":  "success",
+			},
+		})
+	}))
+	defer ts.Close()
+
+	gen := NewMiniMaxMusicGenerator("sk-test", ts.URL, "", ts.Client())
+	if _, _, err := gen.GenerateMusic(context.Background(), "upbeat pop chorus", MusicGenerationOpts{}); err != nil {
+		t.Fatalf("GenerateMusic() error = %v", err)
+	}
+	if gotBody["lyrics_optimizer"] != true {
+		t.Fatalf("lyrics_optimizer not auto-enabled for prompt-only song: %#v", gotBody)
+	}
+	if gotBody["is_instrumental"] != nil {
+		t.Fatalf("is_instrumental should not be sent by default: %#v", gotBody)
+	}
+}
+
+func TestMiniMaxVideoGenerator_GeneratePollsAndDownloads(t *testing.T) {
+	var requested []string
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.Method+" "+r.URL.String())
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/video_generation":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode create: %v", err)
+			}
+			if body["prompt"] != "cinematic sunset" || body["model"] != "MiniMax-Hailuo-2.3" {
+				t.Fatalf("create body = %#v", body)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"task_id": "task-1", "base_resp": map[string]any{"status_code": 0}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/query/video_generation":
+			if r.URL.Query().Get("task_id") != "task-1" {
+				t.Fatalf("task_id = %q", r.URL.Query().Get("task_id"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "Success", "file_id": "file-1", "base_resp": map[string]any{"status_code": 0}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/files/retrieve":
+			if r.URL.Query().Get("file_id") != "file-1" {
+				t.Fatalf("file_id = %q", r.URL.Query().Get("file_id"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"file": map[string]any{"download_url": ts.URL + "/download.mp4"}, "base_resp": map[string]any{"status_code": 0}})
+		case r.Method == http.MethodGet && r.URL.Path == "/download.mp4":
+			_, _ = w.Write([]byte("video-bytes"))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ts.Close()
+
+	gen := NewMiniMaxVideoGenerator("sk-test", ts.URL, "", ts.Client())
+	gen.PollInterval = time.Millisecond
+	gen.Timeout = time.Second
+	gen.DownloadClient = ts.Client()
+
+	video, format, err := gen.GenerateVideo(context.Background(), "cinematic sunset")
+	if err != nil {
+		t.Fatalf("GenerateVideo() error = %v", err)
+	}
+	if string(video) != "video-bytes" || format != "mp4" {
+		t.Fatalf("video/format = %q/%q", video, format)
+	}
+	got := strings.Join(requested, "\n")
+	for _, want := range []string{"POST /v1/video_generation", "GET /v1/query/video_generation?task_id=task-1", "GET /v1/files/retrieve?file_id=file-1", "GET /download.mp4"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("requests =\n%s\nmissing %s", got, want)
+		}
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -736,9 +736,9 @@ Switch: `/tts always` or `/tts voice_only`
 
 ---
 
-## Image, File, and Voice Send-Back
+## Image, File, Voice, and Generated Media Send-Back
 
-When an agent generates a local image, PDF, report, bundle, or other file and needs to deliver it directly to the current chat, use attachment mode in `cc-connect send`. When the user explicitly asks for a voice message, the agent can also send synthesized speech through the same CLI.
+When an agent generates a local image, PDF, report, bundle, or other file and needs to deliver it directly to the current chat, use attachment mode in `cc-connect send`. When the user explicitly asks for a voice message, the agent can also send synthesized speech through the same CLI. If `[image]`, `[video]`, or `[music]` is configured, the agent can generate image/video/music directly through the provider and send the result back as an attachment.
 
 **Currently supported platforms:**
 - Feishu
@@ -762,6 +762,7 @@ These two commands write the same cc-connect instructions. Either one is enough.
 - normal text replies should be returned normally
 - generated attachments should be sent back with `cc-connect send --image/--file`
 - requested voice messages should be sent with `cc-connect send --tts`
+- generated image/video/music should be sent with `cc-connect send --generate-image`, `--generate-video`, or `--generate-music`
 
 If you have run setup before, run it again after upgrading so the instructions are refreshed to the latest version.
 
@@ -773,7 +774,89 @@ Add this to `config.toml` if you want to disable agent-driven attachment send-ba
 attachment_send = "off"
 ```
 
-The default is `on`. This switch is independent from the agent's `/mode` and only affects `cc-connect send --image/--file`. Synthesized voice send-back uses the `[tts]` provider config and is controlled by TTS availability instead.
+The default is `on`. This switch is independent from the agent's `/mode` and affects `cc-connect send --image/--file` plus generated media delivery from `--generate-image/--generate-video/--generate-music`. Synthesized voice send-back uses the `[tts]` provider config and is controlled by TTS availability instead.
+
+### Generated image/video/music providers
+
+Generated media uses provider settings in `config.toml`. Image generation supports OpenAI-compatible image endpoints, MiniMax, and command adapters. Video generation supports MiniMax plus command/OpenClaw adapters, so provider-specific models such as Seedance can be exposed through OpenClaw or another CLI. Music generation supports MiniMax plus command wrappers, which can target Suno or other music APIs.
+
+The command adapter executes the configured command directly without a shell. Arguments may use `{{prompt}}`, `{{output}}`, and `{{format}}`; music commands may also use `{{lyrics}}` and `{{instrumental}}`. If `{{output}}` appears in the args, cc-connect reads that file after the command exits. Otherwise it treats stdout as the generated media bytes.
+
+Anthropic API keys are not used here as a native media-generation provider. Anthropic's public API supports image input/vision understanding, but it is not an image/video/music generation endpoint.
+
+If a MiniMax `api_key` is empty, cc-connect reads the same MiniMax JSON config path used by TTS (`data_dir/config/minimax.json` by default).
+
+```toml
+[image]
+enabled = true
+provider = "openai"          # "openai" (OpenAI-compatible), "minimax", "command", or "openclaw"
+
+[image.openai]
+api_key = "${OPENAI_API_KEY}"
+base_url = ""                # default: https://api.openai.com/v1; may point to an OpenAI-compatible /v1 endpoint
+model = "gpt-image-1"
+size = ""                    # e.g. "1024x1024"; empty = provider/model default
+quality = ""                 # e.g. "auto", "high", "medium", "low", "standard", "hd"
+response_format = ""         # "b64_json" or "url" for DALL-E-compatible providers; empty for GPT image models
+output_format = ""           # "png", "jpeg", or "webp" for GPT image models
+background = ""              # "transparent", "opaque", or "auto" for supported GPT image models
+style = ""                   # "vivid" or "natural" for DALL-E 3
+
+[image.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # default: https://api.minimaxi.com
+model = "image-01"
+response_format = "base64" # "base64" (default) or "url"
+aspect_ratio = ""          # e.g. "1:1" or "16:9"; empty = provider default
+width = 0                  # optional custom width; set together with height
+height = 0                 # optional custom height; set together with width
+prompt_optimizer = false
+
+[image.command]
+command = "openclaw"
+args = ["capability", "image", "generate", "--prompt", "{{prompt}}", "--output", "{{output}}"]
+format = "png"
+timeout_secs = 600
+
+[video]
+enabled = true
+provider = "openclaw"        # "minimax", "command", or "openclaw"
+
+[video.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # default: https://api.minimaxi.com
+model = "MiniMax-Hailuo-2.3"
+duration = 6
+resolution = "1080P"
+poll_interval_secs = 10
+timeout_secs = 600
+
+[video.command]
+command = "openclaw"
+args = ["capability", "video", "generate", "--model", "byteplus/seedance-1-0-lite-t2v-250428", "--prompt", "{{prompt}}", "--output", "{{output}}"]
+format = "mp4"
+timeout_secs = 900
+
+[music]
+enabled = true
+provider = "command"         # "minimax" or "command"
+
+[music.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # default: https://api.minimaxi.com
+model = "music-2.6"
+sample_rate = 44100
+bitrate = 256000
+format = "mp3"
+lyrics_optimizer = true
+instrumental = false
+
+[music.command]
+command = "suno-generate"
+args = ["--prompt", "{{prompt}}", "--lyrics", "{{lyrics}}", "--instrumental", "{{instrumental}}", "--output", "{{output}}"]
+format = "mp3"
+timeout_secs = 900
+```
 
 ### CLI examples
 
@@ -782,16 +865,25 @@ cc-connect send --image /absolute/path/to/chart.png
 cc-connect send --file /absolute/path/to/report.pdf
 cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
 cc-connect send --tts "Hello from cc-connect"
+cc-connect send --generate-image "A watercolor fox under moonlight"
+cc-connect send --generate-video "A cinematic sunrise over Hangzhou, 6 seconds"
+cc-connect send --generate-music "Ambient synthwave, night drive" --music-instrumental
+cc-connect send --generate-music "Upbeat pop chorus about shipping code" --music-lyrics-optimizer
 ```
 
 Notes:
 - `--image` is for image attachments.
 - `--file` is for any file attachment.
 - `--tts` synthesizes text and sends the generated audio through the active TTS provider.
+- `--generate-image` uses the configured provider and sends the generated result as an image attachment.
+- `--generate-video` and `--generate-music` use configured providers and send the generated media through video/audio attachment paths.
+- `provider = "openclaw"` is a convenience command adapter for OpenClaw image/video generation. Add `[image.command]` or `[video.command]` args to pin provider-specific models.
+- `provider = "command"` works with any local wrapper that writes to `{{output}}` or emits media bytes on stdout.
+- `--music-lyrics` provides explicit lyrics; `--music-lyrics-optimizer` lets the provider generate lyrics from the music prompt.
 - `--message` is optional and sends a text note before the attachments.
 - `--image` and `--file` can both be repeated.
 - Absolute paths are recommended so the command does not depend on the agent's current working directory.
-- With `attachment_send = "off"`, image/file send-back is blocked but ordinary text replies still work.
+- With `attachment_send = "off"`, image/file/generated-media send-back is blocked but ordinary text replies still work.
 - Each attachment is capped at **50 MiB** by default. Configure it with `max_attachment_size_mb` (MiB) in config.toml, or override that value with the `CC_MAX_ATTACHMENT_SIZE_MB` env var (same MiB unit; takes precedence when set), e.g. `CC_MAX_ATTACHMENT_SIZE_MB=100 cc-connect send --file big.bin`.
 
 ### Typical use cases
@@ -800,6 +892,7 @@ Notes:
 2. The agent generates a PDF, Markdown export, log bundle, or patch file that should be delivered as an attachment.
 3. The agent wants to send a short status message together with one or more generated files.
 4. The user asks the agent to "send this as voice" without typing a slash command.
+5. The user asks the agent to generate an image, short video, or piece of music and the matching provider is configured.
 
 ### Important notes
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -649,9 +649,9 @@ speed = 0.96
 
 ---
 
-## 图片、文件与语音回传
+## 图片、文件、语音和生成媒体回传
 
-当 Agent 在本地生成了图片、PDF、日志包、报表等文件，需要把结果直接发回当前聊天时，可以使用 `cc-connect send` 的附件模式。用户明确要求“发语音”时，Agent 也可以用同一个 CLI 走 TTS 合成并发送语音。
+当 Agent 在本地生成了图片、PDF、日志包、报表等文件，需要把结果直接发回当前聊天时，可以使用 `cc-connect send` 的附件模式。用户明确要求“发语音”时，Agent 也可以用同一个 CLI 走 TTS 合成并发送语音。如果配置了 `[image]`、`[video]` 或 `[music]`，Agent 还可以直接通过 provider 生成图片/视频/音乐，并把结果作为附件回传。
 
 **当前支持平台：**
 - 飞书
@@ -675,6 +675,7 @@ speed = 0.96
 - 普通文本回复直接正常输出
 - 生成附件后用 `cc-connect send --image/--file` 回传
 - 用户要求语音时用 `cc-connect send --tts` 回传
+- 生成图片/视频/音乐时用 `cc-connect send --generate-image`、`--generate-video` 或 `--generate-music` 回传
 
 如果你以前已经执行过 setup，也建议升级后重新执行一次，以刷新到最新指令。
 
@@ -686,7 +687,89 @@ speed = 0.96
 attachment_send = "off"
 ```
 
-默认值是 `on`。这个开关与 agent 的 `/mode` 独立，只影响 `cc-connect send --image/--file` 这条图片/文件回传路径。TTS 语音回传走 `[tts]` provider 配置，由 TTS 是否可用决定。
+默认值是 `on`。这个开关与 agent 的 `/mode` 独立，影响 `cc-connect send --image/--file` 以及 `--generate-image/--generate-video/--generate-music` 生成媒体回传。TTS 语音回传走 `[tts]` provider 配置，由 TTS 是否可用决定。
+
+### 生成图片/视频/音乐 provider
+
+生成媒体使用 `config.toml` 里的 provider 配置。图片生成支持 OpenAI-compatible 图片接口、MiniMax 和 command adapter。视频生成支持 MiniMax，也支持 command/OpenClaw adapter，所以 Seedance 这类 provider-specific 模型可以通过 OpenClaw 或其他 CLI 暴露出来。音乐生成支持 MiniMax，也支持 command wrapper，可以接 Suno 或其他音乐生成 API。
+
+command adapter 会直接执行配置里的命令，不经过 shell。参数里可以使用 `{{prompt}}`、`{{output}}`、`{{format}}`；音乐命令还可以使用 `{{lyrics}}` 和 `{{instrumental}}`。如果 args 里出现 `{{output}}`，cc-connect 会在命令结束后读取这个文件；否则把 stdout 当成生成媒体字节。
+
+Anthropic API key 不会被当成这里的原生媒体生成 provider。Anthropic 公开 API 支持图片输入和视觉理解，但不是图片/视频/音乐生成接口。
+
+如果 MiniMax `api_key` 留空，cc-connect 会读取与 TTS 相同的 MiniMax JSON 配置路径（默认 `data_dir/config/minimax.json`）。
+
+```toml
+[image]
+enabled = true
+provider = "openai"          # "openai"（OpenAI-compatible）、"minimax"、"command" 或 "openclaw"
+
+[image.openai]
+api_key = "${OPENAI_API_KEY}"
+base_url = ""                # 默认：https://api.openai.com/v1；也可以指向 OpenAI-compatible /v1 endpoint
+model = "gpt-image-1"
+size = ""                    # 例如 "1024x1024"；留空使用 provider/model 默认值
+quality = ""                 # 例如 "auto", "high", "medium", "low", "standard", "hd"
+response_format = ""         # DALL-E-compatible provider 可用 "b64_json" 或 "url"；GPT image model 留空
+output_format = ""           # GPT image model 可用 "png", "jpeg", "webp"
+background = ""              # 支持的 GPT image model 可用 "transparent", "opaque", "auto"
+style = ""                   # DALL-E 3 可用 "vivid" 或 "natural"
+
+[image.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # 默认：https://api.minimaxi.com
+model = "image-01"
+response_format = "base64" # "base64"（默认）或 "url"
+aspect_ratio = ""          # 例如 "1:1" 或 "16:9"；留空使用 provider 默认值
+width = 0                  # 可选自定义宽度；需要与 height 一起设置
+height = 0                 # 可选自定义高度；需要与 width 一起设置
+prompt_optimizer = false
+
+[image.command]
+command = "openclaw"
+args = ["capability", "image", "generate", "--prompt", "{{prompt}}", "--output", "{{output}}"]
+format = "png"
+timeout_secs = 600
+
+[video]
+enabled = true
+provider = "openclaw"        # "minimax"、"command" 或 "openclaw"
+
+[video.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # 默认：https://api.minimaxi.com
+model = "MiniMax-Hailuo-2.3"
+duration = 6
+resolution = "1080P"
+poll_interval_secs = 10
+timeout_secs = 600
+
+[video.command]
+command = "openclaw"
+args = ["capability", "video", "generate", "--model", "byteplus/seedance-1-0-lite-t2v-250428", "--prompt", "{{prompt}}", "--output", "{{output}}"]
+format = "mp4"
+timeout_secs = 900
+
+[music]
+enabled = true
+provider = "command"         # "minimax" 或 "command"
+
+[music.minimax]
+api_key = "${MINIMAX_API_KEY}"
+base_url = ""              # 默认：https://api.minimaxi.com
+model = "music-2.6"
+sample_rate = 44100
+bitrate = 256000
+format = "mp3"
+lyrics_optimizer = true
+instrumental = false
+
+[music.command]
+command = "suno-generate"
+args = ["--prompt", "{{prompt}}", "--lyrics", "{{lyrics}}", "--instrumental", "{{instrumental}}", "--output", "{{output}}"]
+format = "mp3"
+timeout_secs = 900
+```
 
 ### CLI 用法
 
@@ -695,16 +778,25 @@ cc-connect send --image /absolute/path/to/chart.png
 cc-connect send --file /absolute/path/to/report.pdf
 cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
 cc-connect send --tts "你好"
+cc-connect send --generate-image "月光下的水彩狐狸"
+cc-connect send --generate-video "杭州日出的电影感镜头，6 秒"
+cc-connect send --generate-music "夜间驾驶氛围 synthwave" --music-instrumental
+cc-connect send --generate-music "关于发布代码的轻快流行副歌" --music-lyrics-optimizer
 ```
 
 说明：
 - `--image` 用于图片附件。
 - `--file` 用于任意文件附件。
 - `--tts` 会合成文本并通过当前 TTS provider 发送语音。
+- `--generate-image` 使用已配置 provider 生成图片，并以图片附件回传。
+- `--generate-video` 和 `--generate-music` 使用已配置 provider 生成媒体，并走视频/音频附件路径回传。
+- `provider = "openclaw"` 是 OpenClaw 图片/视频生成的便捷 command adapter；需要固定具体 provider/model 时，在 `[image.command]` 或 `[video.command]` 里写 args。
+- `provider = "command"` 可以接任何本地 wrapper，只要它写入 `{{output}}` 或把媒体字节输出到 stdout。
+- `--music-lyrics` 提供明确歌词；`--music-lyrics-optimizer` 让 provider 根据音乐 prompt 生成歌词。
 - `--message` 可选，用于先发一段说明文字，再发附件。
 - `--image` 和 `--file` 都可以重复多次。
 - 建议使用绝对路径，避免 Agent 当前工作目录变化导致找不到文件。
-- 如果设置了 `attachment_send = "off"`，图片/文件回传会被拒绝，但普通文本回复仍然正常。
+- 如果设置了 `attachment_send = "off"`，图片/文件/生成媒体回传会被拒绝，但普通文本回复仍然正常。
 - 每个附件默认上限 **50 MiB**。可在 config.toml 用 `max_attachment_size_mb`（单位 MiB）调整，或用环境变量 `CC_MAX_ATTACHMENT_SIZE_MB` 覆盖该值（同样单位 MiB，设置后优先级更高），例如 `CC_MAX_ATTACHMENT_SIZE_MB=100 cc-connect send --file big.bin`。
 
 ### 典型场景
@@ -713,10 +805,11 @@ cc-connect send --tts "你好"
 2. Agent 生成了 PDF、Markdown 导出、日志包或补丁文件，需要作为附件交付。
 3. Agent 想告诉用户“结果已生成”，同时附上一个或多个文件。
 4. 用户自然说“发句 xx 的语音”，不想手输 slash 命令。
+5. 用户要求生成图片、短视频或音乐，且对应 provider 已配置。
 
 ### 注意事项
 
-- 这个命令是给“附件和语音回传”用的，不要拿它代替普通文本回复。
+- 这个命令是给“附件、生成媒体和语音回传”用的，不要拿它代替普通文本回复。
 - 只能发送本机上 Agent 可访问到的文件。
 - 必须存在活跃会话；如果当前项目没有活动聊天上下文，命令会失败。
 - 目标平台在投递时还会校验自己的文件大小/类型上限；实际生效的是它与 `max_attachment_size_mb` 中**更小**的那个（通过了 cc-connect 的文件仍可能在投递时被平台拒绝）。


### PR DESCRIPTION
## Summary
- add configurable `[image]`, `[video]`, and `[music]` provider blocks for direct generated media send-back
- implement MiniMax text-to-image, text-to-video, and text-to-music generators, including base64/url image handling, async video polling/download, and hex audio decoding
- add OpenAI-compatible image generation through `/images/generations`, with base64 and URL result handling
- add a provider-neutral `command` media generator that can read bytes from stdout or a configured `{{output}}` file
- add `openclaw` convenience wiring for image/video generation, with `[image.command]` / `[video.command]` args available for provider-specific models such as Seedance
- keep music extensible through `[music.command]`, so Suno or other music APIs can be bridged by local wrappers without hard-coding each vendor SDK into cc-connect
- add `cc-connect send --generate-image`, `--generate-video`, `--generate-music`, `--music-lyrics`, `--music-instrumental`, and `--music-lyrics-optimizer`
- refresh agent prompt, docs, config example, and changelog so agents can discover and use the generated-media path

## Notes
- This intentionally complements #1359 instead of replacing it. #1359 routes existing `--audio` / `--video` files to native media senders; this PR creates media from prompts, then sends generated images through `ImageSender`, generated video through `SendVideosToSession`, and generated music through `SendAudiosToSession`.
- Generated media respects `attachment_send = "off"` before provider generation starts.
- OpenAI-compatible support is scoped to image generation endpoints. Anthropic API keys are not treated as native media-generation providers because Anthropic's public API is for text/vision understanding, not image/video/music generation.
- The command adapter executes commands directly without a shell. It supports `{{prompt}}`, `{{output}}`, `{{format}}`, and for music `{{lyrics}}` / `{{instrumental}}` placeholders.
- If MiniMax `api_key` is empty, the generator reuses the local MiniMax JSON config path used by TTS.
- MiniMax image generation defaults to `response_format = "base64"` so the provider result is immediately sent as an image attachment; `url` responses are also supported.
- Prompt-only lyric music requests can opt into lyrics optimization; instrumental requests stay instrumental.
- Supersedes the closed prototype #1287, rebased onto current `main` and updated for dedicated image/audio/video sender interfaces.

## Tests
- `git diff --check HEAD~1..HEAD`
- `go test ./core ./config`
- `go test -tags no_web ./cmd/cc-connect`
- `GOOS=linux go test -tags no_web -c -o /private/tmp/cc-connect-provider-pr-cmd.test ./cmd/cc-connect`