### PR TITLE
feat(providers): add Zhipu GLM (z.ai + bigmodel CN) presets

### DIFF
--- a/provider-presets.json
+++ b/provider-presets.json
@@ -59,6 +59,62 @@
       }
     },
     {
+      "name": "zhipu-glm",
+      "display_name": "Zhipu GLM (z.ai)",
+      "invite_url": "https://z.ai/subscribe",
+      "description": "Zhipu GLM Coding Plan — flat-rate monthly subscription for GLM-4.7 / GLM-5.2 (1M context) via z.ai's Anthropic- and OpenAI-compatible endpoints. Works in Claude Code, Codex and OpenCode.",
+      "description_zh": "智谱 GLM Coding Plan（z.ai 国际站）— 包月订阅，提供 GLM-4.7 / GLM-5.2（1M 上下文），兼容 Anthropic 与 OpenAI 接口，可用于 Claude Code、Codex、OpenCode。订阅 key 按套餐配额计费，非按量。",
+      "features": ["GLM-5.2", "1M Context", "订阅制 (非按量)", "高性价比"],
+      "tier": 1,
+      "website": "https://z.ai",
+      "agents": {
+        "claudecode": {
+          "base_url": "https://api.z.ai/api/anthropic",
+          "model": "glm-4.7",
+          "models": ["glm-4.7", "glm-5.2", "glm-5.2[1m]", "glm-4.6", "glm-4.5-air"]
+        },
+        "codex": {
+          "base_url": "https://api.z.ai/api/coding/paas/v4",
+          "model": "glm-4.7",
+          "models": ["glm-4.7", "glm-5.2", "glm-5.2[1m]"],
+          "codex_config": { "wire_api": "chat" }
+        },
+        "opencode": {
+          "base_url": "https://api.z.ai/api/coding/paas/v4",
+          "model": "glm-4.7",
+          "models": ["glm-4.7", "glm-5.2", "glm-5.2[1m]"]
+        }
+      }
+    },
+    {
+      "name": "zhipu-glm-cn",
+      "display_name": "智谱 GLM (中国站)",
+      "invite_url": "https://bigmodel.cn/claude-code",
+      "description": "Zhipu GLM Coding Plan, China endpoint (open.bigmodel.cn) — lower latency for users in mainland China. GLM-4.7 / GLM-5.2 via Anthropic- and OpenAI-compatible APIs.",
+      "description_zh": "智谱 GLM Coding Plan 国内站（open.bigmodel.cn）— 大陆用户延迟更低。GLM-4.7 / GLM-5.2，兼容 Anthropic 与 OpenAI 接口，可用于 Claude Code、Codex、OpenCode。",
+      "features": ["GLM-5.2", "1M Context", "订阅制 (非按量)", "低延迟 (CN)"],
+      "tier": 1,
+      "website": "https://bigmodel.cn",
+      "agents": {
+        "claudecode": {
+          "base_url": "https://open.bigmodel.cn/api/anthropic",
+          "model": "glm-4.7",
+          "models": ["glm-4.7", "glm-5.2", "glm-5.2[1m]", "glm-4.6", "glm-4.5-air"]
+        },
+        "codex": {
+          "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+          "model": "glm-4.7",
+          "models": ["glm-4.7", "glm-5.2", "glm-5.2[1m]"],
+          "codex_config": { "wire_api": "chat" }
+        },
+        "opencode": {
+          "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+          "model": "glm-4.7",
+          "models": ["glm-4.7", "glm-5.2", "glm-5.2[1m]"]
+        }
+      }
+    },
+    {
       "name": "aigocode",
       "display_name": "AIGoCode",
       "invite_url": "https://aigocode.com/invite/CYY3C85C",


### PR DESCRIPTION
## Summary

Adds two `provider-presets.json` entries for **Zhipu GLM**, so users can one-click select it the same way as the existing MiniMax / SiliconFlow / AIHubMix presets:

- **`zhipu-glm`** — international endpoint (`z.ai`)
- **`zhipu-glm-cn`** — mainland China endpoint (`open.bigmodel.cn`), lower latency for CN users

This mirrors the existing `minimax` / `minimax-cn` split.

## Why

GLM Coding Plan is a popular **flat-rate subscription** (not pay-per-token) that is explicitly designed to be consumed *through* Claude Code / Codex / OpenCode via an Anthropic- and OpenAI-compatible endpoint. cc-connect already supports this via the provider mechanism, but Zhipu GLM was missing from the bundled preset list — users had to hand-configure base URLs and model ids. These presets fill that gap.

## Details

Per agent type:
- **claudecode** → Anthropic-compatible endpoint `…/api/anthropic`
- **codex** → OpenAI-compatible coding endpoint `…/api/coding/paas/v4`, `codex_config.wire_api = "chat"`
- **opencode** → same OpenAI-compatible coding endpoint

Model choices:
- default **`glm-4.7`** (z.ai's own canonical Claude Code mapping; works across all plan tiers)
- `models` also exposes `glm-5.2`, `glm-5.2[1m]` (1M context), `glm-4.6`, `glm-4.5-air`

Endpoints/models verified against Z.AI & bigmodel docs (June 2026):
- https://docs.z.ai/devpack/tool/claude — `ANTHROPIC_BASE_URL = https://api.z.ai/api/anthropic`
- bigmodel CN — `ANTHROPIC_BASE_URL = https://open.bigmodel.cn/api/anthropic`

## Testing

- `provider-presets.json` validates as JSON; preset count 20 → 22.
- **Data-only** change (this file is fetched at runtime); no Go code paths are affected, so `go test ./...` behavior is unchanged.

## Notes for maintainer

- `invite_url` points to the plain subscribe pages — feel free to swap in a referral/affiliate link if you have one for GLM.
- Happy to adjust the default model (e.g. to `glm-5.2`) or trim the model list if you prefer.