### PR TITLE
relay: route inter-bot visibility echoes back into caller's feishu thread

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -25,6 +25,22 @@ type ReplyContextReconstructor interface {
 	ReconstructReplyCtx(sessionKey string) (any, error)
 }
 
+// RelayGroupVisibilityTarget is an optional interface for platforms that
+// want to customise the session key used when echoing relay request /
+// response messages into the group chat for visibility.  Platforms that
+// understand the concept of a thread, topic, or sub-conversation can
+// return a thread-scoped session key so the visibility echoes land in
+// the same conversation that triggered the relay; platforms without
+// such a concept simply don't implement this interface and core falls
+// back to the legacy "<platform>:<chatID>:relay" target.
+//
+// Returning (key, true) → core uses key verbatim as the group session
+// key for visibility echoes.
+// Returning ("", false) → core falls back to the legacy default.
+type RelayGroupVisibilityTarget interface {
+	RelayGroupVisibilityKey(callerSessionKey string) (groupSessionKey string, ok bool)
+}
+
 // MessageRecallDetector is an optional interface for platforms that can check
 // whether the message targeted by a reply context was recalled/deleted.
 type MessageRecallDetector interface {

--- a/core/relay.go
+++ b/core/relay.go
@@ -240,8 +240,11 @@ func (rm *RelayManager) Send(ctx context.Context, req RelayRequest) (*RelayRespo
 		toName = binding.Bots[req.To]
 	}
 
-	// Post the forwarded message to the group chat for visibility.
-	groupSessionKey := platform + ":" + chatID + ":relay"
+	// Post the forwarded message to the group chat for visibility.  The
+	// default target is "<platform>:<chatID>:relay"; platforms that
+	// understand thread / topic semantics can override this by
+	// implementing core.RelayGroupVisibilityTarget on their Platform impl.
+	groupSessionKey := rm.resolveGroupVisibilityKey(platform, chatID, req.SessionKey, sourceEngine)
 	if sourceEngine != nil && visibility != RelayVisibilityNone {
 		label := relayVisibilityRequestLabel(visibility, fromName, toName, req.Message)
 		rm.sendToGroup(ctx, sourceEngine, platform, groupSessionKey, label)
@@ -346,6 +349,36 @@ func parseSessionKeyParts(sessionKey string) (platform, chatID string, err error
 		return parts[0], parts[2], nil
 	}
 	return parts[0], parts[1], nil
+}
+
+// resolveGroupVisibilityKey computes the session key used for relay
+// visibility echoes.  It defaults to "<platform>:<chatID>:relay" and
+// gives the caller's platform a chance to override via the optional
+// core.RelayGroupVisibilityTarget interface.
+//
+// Looking the platform up via sourceEngine.platforms (not targetEngine)
+// matches the existing sendToGroup() resolution path — the visibility
+// echo is dispatched as the source bot, so the source engine's
+// platform impl is authoritative for the key format.
+func (rm *RelayManager) resolveGroupVisibilityKey(platform, chatID, callerSessionKey string, sourceEngine *Engine) string {
+	defaultKey := platform + ":" + chatID + ":relay"
+	if sourceEngine == nil {
+		return defaultKey
+	}
+	for _, p := range sourceEngine.platforms {
+		if p.Name() != platform {
+			continue
+		}
+		d, ok := p.(RelayGroupVisibilityTarget)
+		if !ok {
+			return defaultKey
+		}
+		if k, ok := d.RelayGroupVisibilityKey(callerSessionKey); ok && k != "" {
+			return k
+		}
+		return defaultKey
+	}
+	return defaultKey
 }
 
 // ── Persistence ─────────────────────────────────────────────

--- a/core/relay_test.go
+++ b/core/relay_test.go
@@ -63,6 +63,201 @@ func (p *relayVisibilityPlatform) ReconstructReplyCtx(sessionKey string) (any, e
 	return sessionKey, nil
 }
 
+func (p *relayVisibilityPlatform) getReconstructed() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.reconstructed))
+	copy(out, p.reconstructed)
+	return out
+}
+
+// runRelayVisibilityScenarioWith is like runRelayVisibilityScenario but
+// accepts a custom session key and returns the reconstructed session keys
+// captured by the source and target platforms, so contract tests can pin
+// exactly which group session key core computed.
+func runRelayVisibilityScenarioWith(t *testing.T, visibility string, sessionKey string) (
+	resp string, sourceSent []string, targetSent []string, sourceKeys []string, targetKeys []string,
+) {
+	t.Helper()
+
+	sourcePlatform := &relayVisibilityPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	targetPlatform := &relayVisibilityPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	sourceEngine := NewEngine("source", &stubAgent{}, []Platform{sourcePlatform}, "", LangEnglish)
+	targetSession := newControllableSession("target-session")
+	targetEngine := NewEngine("target", &controllableAgent{nextSession: targetSession}, []Platform{targetPlatform}, "", LangEnglish)
+
+	rm := NewRelayManager("")
+	rm.Bind("feishu", "chat-1", map[string]string{
+		"source": "source-bot",
+		"target": "target-bot",
+	})
+	rm.RegisterEngine("source", sourceEngine)
+	rm.RegisterEngine("target", targetEngine)
+	if visibility != "" {
+		rm.SetVisibility(visibility)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := rm.Send(context.Background(), RelayRequest{
+			From:       "source",
+			To:         "target",
+			SessionKey: sessionKey,
+			Message:    "go",
+		})
+		done <- err
+	}()
+	targetSession.events <- Event{Type: EventResult, Content: "ok"}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Send() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send() did not return")
+	}
+
+	return "ok", sourcePlatform.getSent(), targetPlatform.getSent(), sourcePlatform.getReconstructed(), targetPlatform.getReconstructed()
+}
+
+// stubVisibilityTargetPlatform is a stubPlatformEngine that opts into
+// core.RelayGroupVisibilityTarget, so core/relay tests can pin the exact
+// contract: when the platform returns ok=true, core MUST use its key
+// verbatim; when ok=false (or the interface isn't implemented), core MUST
+// fall back to "<platform>:<chatID>:relay".
+type stubVisibilityTargetPlatform struct {
+	relayVisibilityPlatform
+	overrideKey string
+	overrideOK  bool
+	seenCaller  []string
+}
+
+func (p *stubVisibilityTargetPlatform) RelayGroupVisibilityKey(callerSessionKey string) (string, bool) {
+	p.mu.Lock()
+	p.seenCaller = append(p.seenCaller, callerSessionKey)
+	p.mu.Unlock()
+	return p.overrideKey, p.overrideOK
+}
+
+// TestRelayGroupVisibility_DelegatesToPlatformInterface — when the
+// platform implements RelayGroupVisibilityTarget AND returns ok=true,
+// core MUST use the platform-supplied key for BOTH the request echo
+// and the response echo.
+func TestRelayGroupVisibility_DelegatesToPlatformInterface(t *testing.T) {
+	src := &stubVisibilityTargetPlatform{
+		relayVisibilityPlatform: relayVisibilityPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}},
+		overrideKey:             "feishu:chat-1:root:om_abc",
+		overrideOK:              true,
+	}
+	tgt := &stubVisibilityTargetPlatform{
+		relayVisibilityPlatform: relayVisibilityPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}},
+		overrideKey:             "feishu:chat-1:root:om_abc",
+		overrideOK:              true,
+	}
+	sourceEngine := NewEngine("source", &stubAgent{}, []Platform{src}, "", LangEnglish)
+	targetSession := newControllableSession("target-session")
+	targetEngine := NewEngine("target", &controllableAgent{nextSession: targetSession}, []Platform{tgt}, "", LangEnglish)
+
+	rm := NewRelayManager("")
+	rm.Bind("feishu", "chat-1", map[string]string{"source": "source-bot", "target": "target-bot"})
+	rm.RegisterEngine("source", sourceEngine)
+	rm.RegisterEngine("target", targetEngine)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := rm.Send(context.Background(), RelayRequest{
+			From:       "source",
+			To:         "target",
+			SessionKey: "feishu:chat-1:root:om_abc",
+			Message:    "go",
+		})
+		done <- err
+	}()
+	targetSession.events <- Event{Type: EventResult, Content: "ok"}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Send() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send() did not return")
+	}
+
+	const want = "feishu:chat-1:root:om_abc"
+	if got := src.getReconstructed(); len(got) != 1 || got[0] != want {
+		t.Fatalf("source reconstructed = %#v, want [%q]", got, want)
+	}
+	if got := tgt.getReconstructed(); len(got) != 1 || got[0] != want {
+		t.Fatalf("target reconstructed = %#v, want [%q]", got, want)
+	}
+}
+
+// TestRelayGroupVisibility_FallsBackWhenPlatformReturnsNotOK — even
+// when the platform implements the interface, ok=false MUST cause core
+// to use the legacy "<platform>:<chatID>:relay" key.
+func TestRelayGroupVisibility_FallsBackWhenPlatformReturnsNotOK(t *testing.T) {
+	src := &stubVisibilityTargetPlatform{
+		relayVisibilityPlatform: relayVisibilityPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}},
+		overrideOK:              false, // returns ("", false)
+	}
+	tgt := &stubVisibilityTargetPlatform{
+		relayVisibilityPlatform: relayVisibilityPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}},
+		overrideOK:              false,
+	}
+	sourceEngine := NewEngine("source", &stubAgent{}, []Platform{src}, "", LangEnglish)
+	targetSession := newControllableSession("target-session")
+	targetEngine := NewEngine("target", &controllableAgent{nextSession: targetSession}, []Platform{tgt}, "", LangEnglish)
+	rm := NewRelayManager("")
+	rm.Bind("feishu", "chat-1", map[string]string{"source": "source-bot", "target": "target-bot"})
+	rm.RegisterEngine("source", sourceEngine)
+	rm.RegisterEngine("target", targetEngine)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := rm.Send(context.Background(), RelayRequest{
+			From:       "source",
+			To:         "target",
+			SessionKey: "feishu:chat-1:root:om_xyz", // even thread-shaped
+			Message:    "go",
+		})
+		done <- err
+	}()
+	targetSession.events <- Event{Type: EventResult, Content: "ok"}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Send() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send() did not return")
+	}
+
+	const want = "feishu:chat-1:relay"
+	if got := src.getReconstructed(); len(got) != 1 || got[0] != want {
+		t.Fatalf("source reconstructed = %#v, want [%q] (must fall back)", got, want)
+	}
+	if got := tgt.getReconstructed(); len(got) != 1 || got[0] != want {
+		t.Fatalf("target reconstructed = %#v, want [%q] (must fall back)", got, want)
+	}
+}
+
+// TestRelayGroupVisibility_FallsBackWhenPlatformDoesNotImplement — a
+// platform that does NOT implement RelayGroupVisibilityTarget (the
+// vanilla relayVisibilityPlatform) MUST get the legacy ":relay" key.
+// This pins the default for the 13 non-feishu platforms in production.
+func TestRelayGroupVisibility_FallsBackWhenPlatformDoesNotImplement(t *testing.T) {
+	_, _, _, sourceKeys, targetKeys :=
+		runRelayVisibilityScenarioWith(t, "", "feishu:chat-1:root:om_does_not_matter")
+
+	const want = "feishu:chat-1:relay"
+	if len(sourceKeys) != 1 || sourceKeys[0] != want {
+		t.Fatalf("source reconstructed = %#v, want [%q]", sourceKeys, want)
+	}
+	if len(targetKeys) != 1 || targetKeys[0] != want {
+		t.Fatalf("target reconstructed = %#v, want [%q]", targetKeys, want)
+	}
+}
+
 func runRelayVisibilityScenario(t *testing.T, visibility string) (resp string, sourceSent []string, targetSent []string) {
 	t.Helper()
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -175,6 +175,9 @@ type Platform struct {
 	richCardImageUploadFunc func(context.Context, string) (string, error)
 }
 
+// compile-time interface assertions
+var _ core.RelayGroupVisibilityTarget = (*Platform)(nil)
+
 type interactivePlatform struct {
 	*Platform
 }
@@ -3312,6 +3315,27 @@ func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 		}
 	}
 	return rc, nil
+}
+
+// RelayGroupVisibilityKey implements core.RelayGroupVisibilityTarget for
+// feishu.  When the caller session key targets a feishu thread (its
+// third colon-separated segment carries a non-empty "root:" or
+// "thread:" prefix produced by makeSessionKey), the visibility echo
+// gets routed back into that thread; otherwise the platform returns
+// ("", false) so core falls back to the channel-level ":relay" default.
+func (p *Platform) RelayGroupVisibilityKey(callerSessionKey string) (string, bool) {
+	parts := strings.SplitN(callerSessionKey, ":", 3)
+	if len(parts) < 3 || parts[0] != "feishu" {
+		return "", false
+	}
+	chatID := parts[1]
+	third := parts[2]
+	for _, pfx := range []string{"root:", "thread:"} {
+		if after, ok := strings.CutPrefix(third, pfx); ok && after != "" {
+			return "feishu:" + chatID + ":" + third, true
+		}
+	}
+	return "", false
 }
 
 func parseThreadRootID(sessionTail string) (string, bool) {

--- a/platform/feishu/relay_group_visibility_test.go
+++ b/platform/feishu/relay_group_visibility_test.go
@@ -1,0 +1,58 @@
+package feishu
+
+import (
+	"testing"
+)
+
+// TestPlatform_RelayGroupVisibilityKey pins the contract feishu's
+// Platform satisfies for core.RelayGroupVisibilityTarget: only feishu
+// session keys whose third segment carries a non-empty "root:..." or
+// "thread:..." prefix turn into a thread-scoped visibility key; every
+// other shape (bare-user keys, short keys, empty tails, or anything
+// from a foreign platform) returns ("", false) so core falls back to
+// its legacy "<platform>:<chatID>:relay" default.
+func TestPlatform_RelayGroupVisibilityKey(t *testing.T) {
+	p := &Platform{}
+
+	cases := []struct {
+		name       string
+		sessionKey string
+		wantKey    string
+		wantOK     bool
+	}{
+		// ── feishu thread shapes (hits) ──────────────────────────
+		{"feishu root", "feishu:oc_chat:root:om_msg", "feishu:oc_chat:root:om_msg", true},
+		{"feishu thread", "feishu:oc_chat:thread:omt_thr", "feishu:oc_chat:thread:omt_thr", true},
+
+		// ── feishu non-thread shapes (misses) ────────────────────
+		{"feishu bare user", "feishu:oc_chat:ou_user", "", false},
+		{"feishu empty root tail", "feishu:oc_chat:root:", "", false},
+		{"feishu empty thread tail", "feishu:oc_chat:thread:", "", false},
+		{"feishu only two parts", "feishu:oc_chat", "", false},
+
+		// ── foreign platforms (must miss even if shape coincides) ─
+		{"slack t prefix", "slack:C123:t:1717000000.000100", "", false},
+		{"slack bare user", "slack:C123:U456", "", false},
+		{"telegram numeric", "telegram:-100123:456:789", "", false},
+		{"dingtalk bare user", "dingtalk:g:cid123:staff42", "", false},
+		{"wecom bare user", "wecom:wcid:wuser", "", false},
+		{"matrix at user", "matrix:!room:server.tld:@alice:server.tld", "", false},
+
+		// ── adversarial: foreign platform with feishu-looking 3rd
+		//   segment must still miss ───────────────────────────────
+		{"slack with root prefix", "slack:C123:root:fake", "", false},
+
+		// ── degenerate inputs ────────────────────────────────────
+		{"empty string", "", "", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotKey, gotOK := p.RelayGroupVisibilityKey(c.sessionKey)
+			if gotKey != c.wantKey || gotOK != c.wantOK {
+				t.Fatalf("RelayGroupVisibilityKey(%q) = (%q, %v), want (%q, %v)",
+					c.sessionKey, gotKey, gotOK, c.wantKey, c.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When two cc-connect bots are bound in the same feishu group and one of them invokes `cc-connect relay send` to talk to the other **from inside a thread**, the relay's request and response visibility echoes get posted into the **group's top-level channel** instead of back into the originating thread.

End-user effect: multi-bot conversations are basically untrackable. The thread that asked the question sees nothing back, while the channel gets sprinkled with disembodied `[A → B] please ask ...` / `[B] here is the answer ...` echoes that no one can trace to context.

Expected behaviour: if a bot was @-ed inside a thread, every visibility echo from the resulting relay exchange should land **inside that same thread**.

## How it's fixed

`core.RelayManager.Send()` previously computed the visibility-echo session key with a hard-coded `<platform>:<chatID>:relay` shape, with no awareness of threads.

This PR introduces an optional, duck-typed `core.RelayGroupVisibilityTarget` interface (same pattern as the existing `ReplyContextReconstructor` / `CronReplyTargetResolver` interfaces). When a Platform implements it, `core` asks the Platform what session key to use for the echo; otherwise core falls back to the legacy `<platform>:<chatID>:relay` target verbatim.

Only `*platform/feishu.Platform` implements it in this PR: it inspects the caller's session key, and when it carries a feishu thread shape (`feishu:<chat>:root:om_xxx` or `feishu:<chat>:thread:omt_xxx`) returns that thread key so the echoes go back into the thread. The other 13 platforms (`dingtalk`, `slack`, `wecom`, `discord`, `qq`, `qqbot`, `telegram`, `line`, `matrix`, `max`, `weibo`, `wps-xiezuo`, `weixin`) do not implement the interface and see **no behavioural change** — they continue to use the legacy `<platform>:<chatID>:relay` target byte-for-byte.

Putting the session-key recognition on the platform side (where the matching session-key construction in `makeSessionKey` lives) also keeps `core` free of platform-name string literals, preserving cc-connect's existing single-direction `core ← platform` dependency.

## How to test

```bash
go test ./core/... ./platform/feishu/... -count=1
go vet ./core/... ./platform/feishu/...
```

### Automated coverage

Two layers, designed to be equivalent to in-process end-to-end coverage without needing to stand up a real feishu transport:

1. **`core/relay_test.go` — 3 contract tests** pin the delegation behaviour in `RelayManager.Send()`:
   - `TestRelayGroupVisibility_DelegatesToPlatformInterface` — when the platform implements the interface and returns `(key, true)`, both the request echo and the response echo are dispatched against that key.
   - `TestRelayGroupVisibility_FallsBackWhenPlatformReturnsNotOK` — when the platform implements the interface but returns `("", false)`, the echoes fall back to `<platform>:<chatID>:relay`.
   - `TestRelayGroupVisibility_FallsBackWhenPlatformDoesNotImplement` — when the platform does not implement the interface at all, the echoes fall back to `<platform>:<chatID>:relay`.

2. **`platform/feishu/relay_group_visibility_test.go` — 14-case table-driven test** pins feishu's session-key recognition rules. Includes feishu-shape hits (`root:`, `thread:`), feishu-shape misses (bare user, empty tail, short key), and adversarial cases for foreign-platform shapes (e.g. `slack:C123:t:<ts>` must NOT be routed through feishu's helper; a `slack:C123:root:fake` key with a feishu-looking prefix must still be rejected because the platform-name guard runs first).

### Manual reproduction (the original bug)

In a group with two cc-connect bots A and B that have run `/bind <project>` against each other:

1. Open a feishu thread in that group (reply to any message to create a topic / thread).
2. Inside the thread, send `@A cc-connect relay send --to B "hello B"`.
3. Before this PR: the `[A → B] hello B` echo and B's reply echo land in the **group channel**, outside the thread.
4. After this PR: both echoes land **inside the thread**, alongside the original `@A` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
