### PR TITLE
fix(claudecode): detect missing work_dir at startup with a clear error

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -129,6 +129,9 @@ func New(opts map[string]any) (core.Agent, error) {
 	if workDir == "" {
 		workDir = "."
 	}
+	if _, err := os.Stat(workDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("claudecode: work_dir %q does not exist", workDir)
+	}
 	cmd, cliExtraArgs := core.ParseCmdOpts(opts, "claude")
 	cmdArgsFlag, _ := opts["cmd_args_flag"].(string)
 	if cmdArgsFlag == "" {

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -12,7 +13,7 @@ import (
 
 func TestNew_ParsesRunAsUserAndRunAsEnv(t *testing.T) {
 	opts := map[string]any{
-		"work_dir":    "/tmp/claudecode-test",
+		"work_dir":    t.TempDir(),
 		"run_as_user": "partseeker-coder",
 		"run_as_env":  []any{"PGSSLROOTCERT", "PGSSLMODE"},
 	}
@@ -37,7 +38,7 @@ func TestNew_RunAsUserSkipsClaudeLookPath(t *testing.T) {
 	// skipped because the target user's PATH is what matters. Verify that
 	// New() doesn't fail even when claude isn't on this test process's PATH.
 	opts := map[string]any{
-		"work_dir":    "/tmp/claudecode-test",
+		"work_dir":    t.TempDir(),
 		"run_as_user": "target-that-definitely-exists",
 	}
 	// Note: this test relies on New() NOT calling exec.LookPath("claude")
@@ -634,7 +635,7 @@ func TestWorkspaceAgentOptions_RoundTripsThroughNew(t *testing.T) {
 		routerAPIKey:     "secret",
 	}
 	opts := parent.WorkspaceAgentOptions()
-	opts["work_dir"] = "/tmp/claudecode-test"
+	opts["work_dir"] = t.TempDir()
 	opts["run_as_user"] = "skip-lookpath"
 
 	a, err := New(opts)
@@ -873,4 +874,17 @@ func TestValidateSessionIDInProject_CrossProjectLeak(t *testing.T) {
 // regression can ship.
 func TestAgent_ImplementsSessionIDValidator(t *testing.T) {
 	var _ core.SessionIDValidator = (*Agent)(nil)
+}
+
+func TestNew_WorkDirDoesNotExist(t *testing.T) {
+	opts := map[string]any{
+		"work_dir": "/tmp/cc-connect-nonexistent-dir-that-should-not-exist",
+	}
+	_, err := New(opts)
+	if err == nil {
+		t.Fatal("expected error for non-existent work_dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("expected 'does not exist' in error, got: %v", err)
+	}
 }

--- a/agent/claudecode/project_env_test.go
+++ b/agent/claudecode/project_env_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestNew_ParsesProjectEnvFromOpts(t *testing.T) {
 	opts := map[string]any{
-		"work_dir":    "/tmp/test",
+		"work_dir":    t.TempDir(),
 		"run_as_user": "skip-lookpath",
 		"env": map[string]string{
 			"ANTHROPIC_BASE_URL":            "https://api.kimi.com/coding",
@@ -46,7 +46,7 @@ func TestNew_ParsesProjectEnvFromOpts(t *testing.T) {
 
 func TestNew_ParsesProjectEnvFromMapStringAny(t *testing.T) {
 	opts := map[string]any{
-		"work_dir":    "/tmp/test",
+		"work_dir":    t.TempDir(),
 		"run_as_user": "test-user",
 		"env": map[string]any{
 			"ANTHROPIC_BASE_URL":   "https://api.mimo.com/v1",
@@ -75,7 +75,7 @@ func TestNew_ParsesProjectEnvFromMapStringAny(t *testing.T) {
 
 func TestNew_NoEnvOpts(t *testing.T) {
 	opts := map[string]any{
-		"work_dir":    "/tmp/test",
+		"work_dir":    t.TempDir(),
 		"run_as_user": "test-user",
 	}
 
@@ -95,7 +95,7 @@ func TestNew_NoEnvOpts(t *testing.T) {
 
 func TestNew_ProjectEnvOverridesProviderEnv(t *testing.T) {
 	opts := map[string]any{
-		"work_dir":    "/tmp/test",
+		"work_dir":    t.TempDir(),
 		"run_as_user": "test-user",
 		"env": map[string]string{
 			"ANTHROPIC_BASE_URL":   "https://api.deepseek.com/v1",


### PR DESCRIPTION
## Summary

When `work_dir` in `config.toml` points to a non-existent directory, cc-connect currently surfaces a confusing OS-level error that blames the Claude binary:

```
error="claudeSession: start: fork/exec /opt/homebrew/bin/claude: no such file or directory"
```

This PR adds a preflight `os.Stat` check in `agent/claudecode/New()` so the user gets an actionable error at startup instead:

```
claudecode: work_dir "/path/does/not/exist" does not exist
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

### Automated tests added in this PR

- `TestNew_WorkDirDoesNotExist` in `agent/claudecode/claudecode_test.go` — asserts that `New()` returns an error containing `"does not exist"` when the configured `work_dir` path does not exist on disk.
- Updated 7 existing `TestNew_*` tests in `claudecode_test.go` and `project_env_test.go` that used hard-coded paths (`/tmp/claudecode-test`, `/tmp/test`) not guaranteed to exist; replaced with `t.TempDir()` so they remain valid after this check is added.

### For bug fixes only — regression test

- Regression test name: `TestNew_WorkDirDoesNotExist`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally; the regression test failed as expected (`expected error for non-existent work_dir, got nil`).

### Critical User Journeys (CUJ) impact

- [x] G — error handling & robustness (LLM failure, ws reconnect, agent crash)

`go test ./core/ -run TestCUJ` passes locally.

## Manual / user-visible behavior change

Starting cc-connect with a non-existent `work_dir` now immediately prints a clear error naming the bad path, instead of a misleading `fork/exec … no such file or directory` message that points at the Claude binary.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes (with `-race` if touching concurrency)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (if any new user-facing text)
- [x] No secrets / credentials in source

## Related

- Related PR: #1072 — that PR validated `work_dir` at the web-API layer (`core/setup.go`). This PR is complementary: it validates at agent instantiation time, covering paths configured via `config.toml` and any other non-web flow.