### PR TITLE
feat(bridge): add usage observer telemetry

### DIFF
--- a/core/bridge.go
+++ b/core/bridge.go
@@ -34,6 +34,12 @@ type BridgeServer struct {
 	mu       sync.RWMutex
 	adapters map[string]*bridgeAdapter // platform name → adapter
 
+	// observers receive usage-only events for ALL platforms (no message
+	// content), letting external dashboards/telemetry track per-turn token
+	// consumption across every adapter and runtime without joining reply
+	// routing. They never appear in adapters and are not reply targets.
+	observers map[*bridgeAdapter]struct{}
+
 	enginesMu sync.RWMutex
 	engines   map[string]*bridgeEngineRef // project name → engine ref
 }
@@ -103,6 +109,11 @@ type bridgeRegister struct {
 	Capabilities []string       `json:"capabilities"`
 	Project      string         `json:"project,omitempty"`
 	Metadata     map[string]any `json:"metadata,omitempty"`
+	// ObserveUsage registers this connection as a usage-only observer instead
+	// of a platform adapter. The observer receives per-turn token usage for
+	// every platform/runtime and never participates in reply routing. When
+	// true, Platform is informational (used only for logging).
+	ObserveUsage bool `json:"observe_usage,omitempty"`
 }
 
 type bridgeMessage struct {
@@ -190,6 +201,7 @@ func newBridgeServer(port int, token, path string, corsOrigins []string, insecur
 		corsOrigins: corsOrigins,
 		insecure:    insecure,
 		adapters:    make(map[string]*bridgeAdapter),
+		observers:   make(map[*bridgeAdapter]struct{}),
 		engines:     make(map[string]*bridgeEngineRef),
 	}
 }
@@ -343,6 +355,26 @@ func (bp *BridgePlatform) Reply(ctx context.Context, replyCtx any, content strin
 
 func (bp *BridgePlatform) Send(ctx context.Context, replyCtx any, content string) error {
 	return bp.Reply(ctx, replyCtx, content)
+}
+
+// EmitUsage implements UsageEmitter. It builds a usage-only event (no content)
+// and fans it out to all registered usage observers. Best-effort by contract:
+// callers must never depend on delivery.
+func (bp *BridgePlatform) EmitUsage(usage TurnUsage) {
+	msg := map[string]any{
+		"type":                        "usage",
+		"session_key":                 usage.SessionKey,
+		"platform":                    usage.Platform,
+		"input_tokens":                usage.InputTokens,
+		"output_tokens":               usage.OutputTokens,
+		"cache_read_input_tokens":     usage.CacheReadInputTokens,
+		"cache_creation_input_tokens": usage.CacheCreationInputTokens,
+		"ts":                          time.Now().Unix(),
+	}
+	if usage.AgentType != "" {
+		msg["agent_type"] = usage.AgentType
+	}
+	bp.server.broadcastUsage(msg)
 }
 
 func (bp *BridgePlatform) ReconstructReplyCtx(sessionKey string) (any, error) {
@@ -779,6 +811,44 @@ func (bs *BridgeServer) handleConnection(conn *websocket.Conn) {
 		return
 	}
 
+	if reg.Platform == "" && reg.ObserveUsage {
+		// Pure usage observer (no platform): a monitoring-only client that
+		// receives per-turn token usage for ALL platforms but never joins
+		// reply routing. Adapters that also want usage telemetry register
+		// normally with a platform AND observe_usage:true (additive, below).
+		// Usage events carry no message content.
+		obs := &bridgeAdapter{
+			conn:   conn,
+			server: bs,
+		}
+		bs.mu.Lock()
+		bs.observers[obs] = struct{}{}
+		bs.mu.Unlock()
+
+		if err := writeJSON(conn, &obs.writeMu, map[string]any{"type": "register_ack", "ok": true, "observer": true}); err != nil {
+			slog.Debug("bridge: write observer ack failed", "error", err)
+			return
+		}
+		slog.Info("bridge: usage observer registered")
+
+		defer func() {
+			bs.mu.Lock()
+			delete(bs.observers, obs)
+			bs.mu.Unlock()
+			slog.Info("bridge: usage observer disconnected")
+		}()
+
+		// Observers only listen; read & discard so disconnects are detected.
+		for {
+			if err := conn.SetReadDeadline(time.Now().Add(90 * time.Second)); err != nil {
+				return
+			}
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}
+
 	if reg.Platform == "" {
 		if err := writeJSON(conn, nil, map[string]any{"type": "register_ack", "ok": false, "error": "platform name is required"}); err != nil {
 			slog.Debug("bridge: write register ack failed", "error", err)
@@ -807,9 +877,18 @@ func (bs *BridgeServer) handleConnection(conn *websocket.Conn) {
 		slog.Info("bridge: replaced existing adapter", "platform", reg.Platform)
 	}
 	bs.adapters[reg.Platform] = adapter
+	// Additive usage subscription: an adapter may also observe per-turn
+	// token usage for all platforms on the same connection.
+	if reg.ObserveUsage {
+		bs.observers[adapter] = struct{}{}
+	}
 	bs.mu.Unlock()
 
-	if err := writeJSON(conn, &adapter.writeMu, map[string]any{"type": "register_ack", "ok": true}); err != nil {
+	ack := map[string]any{"type": "register_ack", "ok": true}
+	if reg.ObserveUsage {
+		ack["observer"] = true
+	}
+	if err := writeJSON(conn, &adapter.writeMu, ack); err != nil {
 		slog.Debug("bridge: write register ack failed", "error", err)
 		return
 	}
@@ -821,13 +900,14 @@ func (bs *BridgeServer) handleConnection(conn *websocket.Conn) {
 		}
 	}
 
-	slog.Info("bridge: adapter registered", "platform", reg.Platform, "capabilities", reg.Capabilities)
+	slog.Info("bridge: adapter registered", "platform", reg.Platform, "capabilities", reg.Capabilities, "observe_usage", reg.ObserveUsage)
 
 	defer func() {
 		bs.mu.Lock()
 		if bs.adapters[reg.Platform] == adapter {
 			delete(bs.adapters, reg.Platform)
 		}
+		delete(bs.observers, adapter) // no-op if not subscribed
 		bs.mu.Unlock()
 		slog.Info("bridge: adapter disconnected", "platform", reg.Platform)
 	}()
@@ -1308,6 +1388,25 @@ func (bs *BridgeServer) sendToAdapter(platform string, msg map[string]any) error
 		return fmt.Errorf("bridge: adapter %q not connected", platform)
 	}
 	return writeJSON(a.conn, &a.writeMu, msg)
+}
+
+// broadcastUsage fans a usage-only event out to every registered usage observer.
+// The event carries no message content. Observers are snapshotted under the
+// read lock and written outside it (mirroring sendToAdapter) so a slow or dead
+// observer connection cannot block registration or other observers.
+func (bs *BridgeServer) broadcastUsage(msg map[string]any) {
+	bs.mu.RLock()
+	observers := make([]*bridgeAdapter, 0, len(bs.observers))
+	for obs := range bs.observers {
+		observers = append(observers, obs)
+	}
+	bs.mu.RUnlock()
+
+	for _, obs := range observers {
+		if err := writeJSON(obs.conn, &obs.writeMu, msg); err != nil {
+			slog.Debug("bridge: usage observer write failed", "error", err)
+		}
+	}
 }
 
 func bridgeMetadataStringListContains(metadata map[string]any, key, want string) bool {

--- a/core/bridge.go
+++ b/core/bridge.go
@@ -173,6 +173,12 @@ func NewBridgeServerInsecure(port int, token, path string, corsOrigins []string)
 	return newBridgeServer(port, token, path, corsOrigins, true)
 }
 
+// globalBridgeServer is the process-wide bridge instance, set by newBridgeServer.
+// Exactly one bridge server is created at startup and shared across all engines,
+// so the engine can read this to broadcast per-turn usage to observers for EVERY
+// turn — not just the ones routed through a bridge-backed platform.
+var globalBridgeServer *BridgeServer
+
 func newBridgeServer(port int, token, path string, corsOrigins []string, insecure bool) *BridgeServer {
 	if port <= 0 {
 		port = 9810
@@ -194,7 +200,7 @@ func newBridgeServer(port int, token, path string, corsOrigins []string, insecur
 		slog.Warn("bridge: running in INSECURE mode without authentication - only use for local development!")
 	}
 
-	return &BridgeServer{
+	bs := &BridgeServer{
 		port:        port,
 		token:       token,
 		path:        path,
@@ -204,6 +210,8 @@ func newBridgeServer(port int, token, path string, corsOrigins []string, insecur
 		observers:   make(map[*bridgeAdapter]struct{}),
 		engines:     make(map[string]*bridgeEngineRef),
 	}
+	globalBridgeServer = bs
+	return bs
 }
 
 // NewPlatform creates a BridgePlatform for a specific project engine.
@@ -355,26 +363,6 @@ func (bp *BridgePlatform) Reply(ctx context.Context, replyCtx any, content strin
 
 func (bp *BridgePlatform) Send(ctx context.Context, replyCtx any, content string) error {
 	return bp.Reply(ctx, replyCtx, content)
-}
-
-// EmitUsage implements UsageEmitter. It builds a usage-only event (no content)
-// and fans it out to all registered usage observers. Best-effort by contract:
-// callers must never depend on delivery.
-func (bp *BridgePlatform) EmitUsage(usage TurnUsage) {
-	msg := map[string]any{
-		"type":                        "usage",
-		"session_key":                 usage.SessionKey,
-		"platform":                    usage.Platform,
-		"input_tokens":                usage.InputTokens,
-		"output_tokens":               usage.OutputTokens,
-		"cache_read_input_tokens":     usage.CacheReadInputTokens,
-		"cache_creation_input_tokens": usage.CacheCreationInputTokens,
-		"ts":                          time.Now().Unix(),
-	}
-	if usage.AgentType != "" {
-		msg["agent_type"] = usage.AgentType
-	}
-	bp.server.broadcastUsage(msg)
 }
 
 func (bp *BridgePlatform) ReconstructReplyCtx(sessionKey string) (any, error) {
@@ -1390,11 +1378,30 @@ func (bs *BridgeServer) sendToAdapter(platform string, msg map[string]any) error
 	return writeJSON(a.conn, &a.writeMu, msg)
 }
 
-// broadcastUsage fans a usage-only event out to every registered usage observer.
-// The event carries no message content. Observers are snapshotted under the
-// read lock and written outside it (mirroring sendToAdapter) so a slow or dead
+// BroadcastUsage fans a best-effort usage-only event (token counts, NO message
+// content) to every registered usage observer. It is called by the engine at
+// turn-complete for EVERY turn regardless of which IM platform ran it, via the
+// package-level globalBridgeServer. Observers are snapshotted under the read
+// lock and written outside it (mirroring sendToAdapter) so a slow or dead
 // observer connection cannot block registration or other observers.
-func (bs *BridgeServer) broadcastUsage(msg map[string]any) {
+func (bs *BridgeServer) BroadcastUsage(usage TurnUsage) {
+	msg := map[string]any{
+		"type":                        "usage",
+		"session_key":                 usage.SessionKey,
+		"platform":                    usage.Platform,
+		"input_tokens":                usage.InputTokens,
+		"output_tokens":               usage.OutputTokens,
+		"cache_read_input_tokens":     usage.CacheReadInputTokens,
+		"cache_creation_input_tokens": usage.CacheCreationInputTokens,
+		"ts":                          time.Now().Unix(),
+	}
+	if usage.AgentType != "" {
+		msg["agent_type"] = usage.AgentType
+	}
+	if usage.TurnID != "" {
+		msg["turn_id"] = usage.TurnID
+	}
+
 	bs.mu.RLock()
 	observers := make([]*bridgeAdapter, 0, len(bs.observers))
 	for obs := range bs.observers {

--- a/core/bridge.go
+++ b/core/bridge.go
@@ -1401,6 +1401,15 @@ func (bs *BridgeServer) BroadcastUsage(usage TurnUsage) {
 	if usage.TurnID != "" {
 		msg["turn_id"] = usage.TurnID
 	}
+	if usage.UserID != "" {
+		msg["user_id"] = usage.UserID
+	}
+	if usage.UserName != "" {
+		msg["user_name"] = usage.UserName
+	}
+	if usage.ChatName != "" {
+		msg["chat_name"] = usage.ChatName
+	}
 
 	bs.mu.RLock()
 	observers := make([]*bridgeAdapter, 0, len(bs.observers))

--- a/core/bridge_usage_observer_test.go
+++ b/core/bridge_usage_observer_test.go
@@ -1,0 +1,152 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// registerPureObserver registers a connection as a usage-only observer with no
+// platform (a monitoring-only client that is never a reply target) and returns
+// the decoded register_ack.
+func registerPureObserver(t *testing.T, conn *websocket.Conn) map[string]any {
+	t.Helper()
+	mustWriteJSON(t, conn, map[string]any{
+		"type":          "register",
+		"observe_usage": true,
+	})
+	var ack map[string]any
+	mustReadJSON(t, conn, &ack)
+	return ack
+}
+
+// registerObserverAdapter registers a normal platform adapter that ALSO
+// subscribes to usage events (additive) — the single-connection case where a
+// client keeps full send/receive AND usage telemetry.
+func registerObserverAdapter(t *testing.T, conn *websocket.Conn, platform string) map[string]any {
+	t.Helper()
+	mustWriteJSON(t, conn, map[string]any{
+		"type":          "register",
+		"platform":      platform,
+		"capabilities":  []string{"text"},
+		"observe_usage": true,
+	})
+	var ack map[string]any
+	mustReadJSON(t, conn, &ack)
+	return ack
+}
+
+// TestBridge_UsageObserver covers all three connection roles at the bridge
+// layer (the engine side is a best-effort type-assertion that delegates to
+// BridgePlatform.EmitUsage, exercised directly here):
+//   - a pure observer (no platform) is acked as observer and never becomes an
+//     adapter;
+//   - an adapter may additionally subscribe with observe_usage:true and keep
+//     full send/receive while also receiving usage (additive);
+//   - EmitUsage fans a usage-only event to every subscriber;
+//   - the event carries token counts but NO message content;
+//   - a plain platform adapter (no observe_usage) never receives it.
+func TestBridge_UsageObserver(t *testing.T) {
+	bs, wsURL := startTestBridge(t, "")
+	bp := bs.NewPlatform("test-proj")
+
+	// Two pure observers (no platform).
+	obs1 := dialWS(t, wsURL, nil)
+	if ack := registerPureObserver(t, obs1); ack["ok"] != true || ack["observer"] != true {
+		t.Fatalf("pure observer1 ack = %v, want ok+observer", ack)
+	}
+	obs2 := dialWS(t, wsURL, nil)
+	if ack := registerPureObserver(t, obs2); ack["ok"] != true || ack["observer"] != true {
+		t.Fatalf("pure observer2 ack = %v, want ok+observer", ack)
+	}
+
+	// A platform adapter that ALSO subscribes to usage (single-connection case).
+	hybrid := dialWS(t, wsURL, nil)
+	if ack := registerObserverAdapter(t, hybrid, "hermit"); ack["ok"] != true || ack["observer"] != true {
+		t.Fatalf("hybrid adapter ack = %v, want ok+observer", ack)
+	}
+
+	// A plain platform adapter — must be invisible to usage broadcasts.
+	adapter := dialWS(t, wsURL, nil)
+	register(t, adapter, "feishu", []string{"text"})
+
+	// The hybrid is a real adapter; pure observers must NOT leak into adapters.
+	adapters := bs.ConnectedAdapters()
+	if len(adapters) != 2 {
+		t.Fatalf("ConnectedAdapters = %v, want exactly [feishu hermit] (pure observers must not register as adapters)", adapters)
+	}
+	hasFeishu, hasHermit := false, false
+	for _, a := range adapters {
+		if a == "feishu" {
+			hasFeishu = true
+		}
+		if a == "hermit" {
+			hasHermit = true
+		}
+	}
+	if !hasFeishu || !hasHermit {
+		t.Fatalf("ConnectedAdapters = %v, want both feishu and hermit", adapters)
+	}
+
+	// Same EmitUsage call the engine makes at turn-complete.
+	bp.EmitUsage(TurnUsage{
+		SessionKey:               "feishu:chat-1:user-1",
+		Platform:                 "feishu",
+		AgentType:                "claudecode",
+		InputTokens:              932,
+		OutputTokens:             587,
+		CacheReadInputTokens:     126016,
+		CacheCreationInputTokens: 3,
+	})
+
+	jsonInt := func(m map[string]any, k string) int {
+		t.Helper()
+		v, ok := m[k].(float64)
+		if !ok {
+			t.Fatalf("missing/non-numeric %q in usage event: %v", k, m)
+		}
+		return int(v)
+	}
+
+	// All three subscribers (2 pure observers + the hybrid adapter) receive it.
+	for i, conn := range []*websocket.Conn{obs1, obs2, hybrid} {
+		msg := readMsg(t, conn)
+		if msg["type"] != "usage" {
+			t.Fatalf("subscriber%d: type = %v, want usage", i+1, msg["type"])
+		}
+		if msg["session_key"] != "feishu:chat-1:user-1" {
+			t.Fatalf("subscriber%d: session_key = %v", i+1, msg["session_key"])
+		}
+		if msg["platform"] != "feishu" {
+			t.Fatalf("subscriber%d: platform = %v", i+1, msg["platform"])
+		}
+		if msg["agent_type"] != "claudecode" {
+			t.Fatalf("subscriber%d: agent_type = %v", i+1, msg["agent_type"])
+		}
+		if got := jsonInt(msg, "input_tokens"); got != 932 {
+			t.Fatalf("subscriber%d: input_tokens = %d, want 932", i+1, got)
+		}
+		if got := jsonInt(msg, "output_tokens"); got != 587 {
+			t.Fatalf("subscriber%d: output_tokens = %d, want 587", i+1, got)
+		}
+		if got := jsonInt(msg, "cache_read_input_tokens"); got != 126016 {
+			t.Fatalf("subscriber%d: cache_read_input_tokens = %d, want 126016", i+1, got)
+		}
+		if got := jsonInt(msg, "cache_creation_input_tokens"); got != 3 {
+			t.Fatalf("subscriber%d: cache_creation_input_tokens = %d, want 3", i+1, got)
+		}
+		if _, ok := msg["content"]; ok {
+			t.Fatalf("subscriber%d: usage event must not carry message content", i+1)
+		}
+	}
+
+	// The plain adapter must NOT receive the usage event.
+	if err := adapter.SetReadDeadline(time.Now().Add(300 * time.Millisecond)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	var leak map[string]any
+	if err := adapter.ReadJSON(&leak); err == nil {
+		t.Fatalf("plain platform adapter leaked usage event: %v", leak)
+	}
+}

--- a/core/bridge_usage_observer_test.go
+++ b/core/bridge_usage_observer_test.go
@@ -94,6 +94,9 @@ func TestBridge_UsageObserver(t *testing.T) {
 		Platform:                 "feishu",
 		AgentType:                "claudecode",
 		TurnID:                   "om_turn_1",
+		UserID:                   "user-1",
+		UserName:                 "Alice",
+		ChatName:                 "Test Group",
 		InputTokens:              932,
 		OutputTokens:             587,
 		CacheReadInputTokens:     126016,
@@ -126,6 +129,15 @@ func TestBridge_UsageObserver(t *testing.T) {
 		}
 		if msg["turn_id"] != "om_turn_1" {
 			t.Fatalf("subscriber%d: turn_id = %v, want om_turn_1", i+1, msg["turn_id"])
+		}
+		if msg["user_id"] != "user-1" {
+			t.Fatalf("subscriber%d: user_id = %v, want user-1", i+1, msg["user_id"])
+		}
+		if msg["user_name"] != "Alice" {
+			t.Fatalf("subscriber%d: user_name = %v, want Alice", i+1, msg["user_name"])
+		}
+		if msg["chat_name"] != "Test Group" {
+			t.Fatalf("subscriber%d: chat_name = %v, want Test Group", i+1, msg["chat_name"])
 		}
 		if got := jsonInt(msg, "input_tokens"); got != 932 {
 			t.Fatalf("subscriber%d: input_tokens = %d, want 932", i+1, got)

--- a/core/bridge_usage_observer_test.go
+++ b/core/bridge_usage_observer_test.go
@@ -38,18 +38,17 @@ func registerObserverAdapter(t *testing.T, conn *websocket.Conn, platform string
 }
 
 // TestBridge_UsageObserver covers all three connection roles at the bridge
-// layer (the engine side is a best-effort type-assertion that delegates to
-// BridgePlatform.EmitUsage, exercised directly here):
+// layer (the engine side is a best-effort broadcast via BroadcastUsage,
+// exercised directly here):
 //   - a pure observer (no platform) is acked as observer and never becomes an
 //     adapter;
 //   - an adapter may additionally subscribe with observe_usage:true and keep
 //     full send/receive while also receiving usage (additive);
-//   - EmitUsage fans a usage-only event to every subscriber;
+//   - BroadcastUsage fans a usage-only event to every subscriber;
 //   - the event carries token counts but NO message content;
 //   - a plain platform adapter (no observe_usage) never receives it.
 func TestBridge_UsageObserver(t *testing.T) {
 	bs, wsURL := startTestBridge(t, "")
-	bp := bs.NewPlatform("test-proj")
 
 	// Two pure observers (no platform).
 	obs1 := dialWS(t, wsURL, nil)
@@ -89,11 +88,12 @@ func TestBridge_UsageObserver(t *testing.T) {
 		t.Fatalf("ConnectedAdapters = %v, want both feishu and hermit", adapters)
 	}
 
-	// Same EmitUsage call the engine makes at turn-complete.
-	bp.EmitUsage(TurnUsage{
+	// Same BroadcastUsage call the engine makes at turn-complete.
+	bs.BroadcastUsage(TurnUsage{
 		SessionKey:               "feishu:chat-1:user-1",
 		Platform:                 "feishu",
 		AgentType:                "claudecode",
+		TurnID:                   "om_turn_1",
 		InputTokens:              932,
 		OutputTokens:             587,
 		CacheReadInputTokens:     126016,
@@ -123,6 +123,9 @@ func TestBridge_UsageObserver(t *testing.T) {
 		}
 		if msg["agent_type"] != "claudecode" {
 			t.Fatalf("subscriber%d: agent_type = %v", i+1, msg["agent_type"])
+		}
+		if msg["turn_id"] != "om_turn_1" {
+			t.Fatalf("subscriber%d: turn_id = %v, want om_turn_1", i+1, msg["turn_id"])
 		}
 		if got := jsonInt(msg, "input_tokens"); got != 932 {
 			t.Fatalf("subscriber%d: input_tokens = %d, want 932", i+1, got)

--- a/core/engine.go
+++ b/core/engine.go
@@ -329,6 +329,7 @@ type queuedMessage struct {
 	fromVoice         bool
 	userID            string
 	userName          string // sender's display name for sender injection
+	chatName          string // human-readable chat/group name for usage reporting
 	msgPlatform       string // platform name for sender injection
 	msgSessionKey     string // session key for extracting chat ID
 	channelKey        string // platform-provided channel identifier (preferred over sessionKey extraction)
@@ -341,6 +342,9 @@ type interactiveState struct {
 	platform               Platform
 	replyCtx               any
 	currentMessageID       string
+	currentTurnUserID      string
+	currentTurnUserName    string
+	currentTurnChatName    string
 	workspaceDir           string
 	agent                  Agent
 	mu                     sync.Mutex
@@ -2877,6 +2881,7 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 		fromVoice:         msg.FromVoice,
 		userID:            msg.UserID,
 		userName:          msg.UserName,
+		chatName:          msg.ChatName,
 		msgPlatform:       msg.Platform,
 		msgSessionKey:     msg.SessionKey,
 		channelKey:        msg.ChannelKey,
@@ -3421,6 +3426,9 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	state.platform = p
 	state.replyCtx = msg.ReplyCtx
 	state.currentMessageID = msg.MessageID
+	state.currentTurnUserID = msg.UserID
+	state.currentTurnUserName = msg.UserName
+	state.currentTurnChatName = msg.ChatName
 	state.currentTurnUserMessageTimeMs = msg.UserMessageTimeMs
 	state.mu.Unlock()
 	stopRecallMonitor := e.startMessageRecallMonitor(interactiveKey)
@@ -5179,16 +5187,27 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			// singleton, so broadcast for EVERY turn regardless of which IM
 			// platform ran it. Failures here must never affect the turn.
 			if globalBridgeServer != nil {
-				globalBridgeServer.BroadcastUsage(TurnUsage{
-					SessionKey:               sessionKey,
-					Platform:                 state.platform.Name(),
-					AgentType:                e.AgentTypeName(),
-					TurnID:                   msgID,
-					InputTokens:              event.InputTokens,
-					OutputTokens:             event.OutputTokens,
-					CacheReadInputTokens:     event.CacheReadInputTokens,
-					CacheCreationInputTokens: event.CacheCreationInputTokens,
-				})
+				state.mu.Lock()
+				usagePlatform := state.platform
+				usageUserID := state.currentTurnUserID
+				usageUserName := state.currentTurnUserName
+				usageChatName := state.currentTurnChatName
+				state.mu.Unlock()
+				if usagePlatform != nil {
+					globalBridgeServer.BroadcastUsage(TurnUsage{
+						SessionKey:               sessionKey,
+						Platform:                 usagePlatform.Name(),
+						AgentType:                e.AgentTypeName(),
+						TurnID:                   msgID,
+						UserID:                   usageUserID,
+						UserName:                 usageUserName,
+						ChatName:                 usageChatName,
+						InputTokens:              event.InputTokens,
+						OutputTokens:             event.OutputTokens,
+						CacheReadInputTokens:     event.CacheReadInputTokens,
+						CacheCreationInputTokens: event.CacheCreationInputTokens,
+					})
+				}
 			}
 			// DEBUG: full assistant response for in-depth debugging.
 			if slog.Default().Enabled(e.ctx, slog.LevelDebug) {
@@ -5408,6 +5427,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				state.platform = queued.platform
 				state.replyCtx = queued.replyCtx
 				state.currentMessageID = queued.messageID
+				state.currentTurnUserID = queued.userID
+				state.currentTurnUserName = queued.userName
+				state.currentTurnChatName = queued.chatName
 				state.fromVoice = queued.fromVoice
 				state.currentTurnUserMessageTimeMs = queued.userMessageTimeMs
 				state.mu.Unlock()
@@ -5741,6 +5763,9 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 		state.platform = queued.platform
 		state.replyCtx = queued.replyCtx
 		state.currentMessageID = queued.messageID
+		state.currentTurnUserID = queued.userID
+		state.currentTurnUserName = queued.userName
+		state.currentTurnChatName = queued.chatName
 		state.fromVoice = queued.fromVoice
 		state.currentTurnUserMessageTimeMs = queued.userMessageTimeMs
 		state.mu.Unlock()

--- a/core/engine.go
+++ b/core/engine.go
@@ -270,8 +270,8 @@ type Engine struct {
 	filterExternalSessions bool
 
 	// Shell configuration for /shell, cron exec, hooks, webhook exec
-	shell       string // shell binary path (e.g. "sh", "/bin/zsh")
-	shellFlag   string // shell flag (e.g. "-c", "-Command", "/C")
+	shell        string // shell binary path (e.g. "sh", "/bin/zsh")
+	shellFlag    string // shell flag (e.g. "-c", "-Command", "/C")
 	shellProfile string // prepended to every command (e.g. "source ~/.zshrc;")
 
 	// Multi-workspace mode
@@ -5174,6 +5174,20 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				"output_tokens", event.OutputTokens,
 				"silent", isSilent,
 			)
+			// Best-effort: report this turn's token usage to external observers
+			// (dashboards/telemetry). Only bridge-backed platforms implement
+			// UsageEmitter; failures here must never affect the turn.
+			if emitter, ok := state.platform.(UsageEmitter); ok {
+				emitter.EmitUsage(TurnUsage{
+					SessionKey:               sessionKey,
+					Platform:                 state.platform.Name(),
+					AgentType:                e.AgentTypeName(),
+					InputTokens:              event.InputTokens,
+					OutputTokens:             event.OutputTokens,
+					CacheReadInputTokens:     event.CacheReadInputTokens,
+					CacheCreationInputTokens: event.CacheCreationInputTokens,
+				})
+			}
 			// DEBUG: full assistant response for in-depth debugging.
 			if slog.Default().Enabled(e.ctx, slog.LevelDebug) {
 				slog.Debug("turn response",

--- a/core/engine.go
+++ b/core/engine.go
@@ -5175,13 +5175,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				"silent", isSilent,
 			)
 			// Best-effort: report this turn's token usage to external observers
-			// (dashboards/telemetry). Only bridge-backed platforms implement
-			// UsageEmitter; failures here must never affect the turn.
-			if emitter, ok := state.platform.(UsageEmitter); ok {
-				emitter.EmitUsage(TurnUsage{
+			// (dashboards/telemetry). The bridge server is the process-wide
+			// singleton, so broadcast for EVERY turn regardless of which IM
+			// platform ran it. Failures here must never affect the turn.
+			if globalBridgeServer != nil {
+				globalBridgeServer.BroadcastUsage(TurnUsage{
 					SessionKey:               sessionKey,
 					Platform:                 state.platform.Name(),
 					AgentType:                e.AgentTypeName(),
+					TurnID:                   msgID,
 					InputTokens:              event.InputTokens,
 					OutputTokens:             event.OutputTokens,
 					CacheReadInputTokens:     event.CacheReadInputTokens,

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -32,19 +32,11 @@ type TurnUsage struct {
 	SessionKey               string `json:"session_key"`
 	Platform                 string `json:"platform"`
 	AgentType                string `json:"agent_type,omitempty"`
+	TurnID                   string `json:"turn_id,omitempty"`
 	InputTokens              int    `json:"input_tokens"`
 	OutputTokens             int    `json:"output_tokens"`
 	CacheReadInputTokens     int    `json:"cache_read_input_tokens"`
 	CacheCreationInputTokens int    `json:"cache_creation_input_tokens"`
-}
-
-// UsageEmitter is an optional interface for platforms that forward per-turn
-// token usage to external observers such as dashboards or telemetry collectors.
-// Only platforms wired to an observer bus (e.g. the WebSocket bridge) implement
-// it; others simply ignore usage reporting. The engine calls it best-effort
-// after each turn completes and must never depend on delivery.
-type UsageEmitter interface {
-	EmitUsage(usage TurnUsage)
 }
 
 // MessageRecallDetector is an optional interface for platforms that can check

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -33,6 +33,9 @@ type TurnUsage struct {
 	Platform                 string `json:"platform"`
 	AgentType                string `json:"agent_type,omitempty"`
 	TurnID                   string `json:"turn_id,omitempty"`
+	UserID                   string `json:"user_id,omitempty"`
+	UserName                 string `json:"user_name,omitempty"`
+	ChatName                 string `json:"chat_name,omitempty"`
 	InputTokens              int    `json:"input_tokens"`
 	OutputTokens             int    `json:"output_tokens"`
 	CacheReadInputTokens     int    `json:"cache_read_input_tokens"`

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -25,6 +25,28 @@ type ReplyContextReconstructor interface {
 	ReconstructReplyCtx(sessionKey string) (any, error)
 }
 
+// TurnUsage captures a single turn's token consumption, reported to usage
+// observers. It intentionally carries NO message content, so it is safe to
+// forward to external monitoring/telemetry surfaces.
+type TurnUsage struct {
+	SessionKey               string `json:"session_key"`
+	Platform                 string `json:"platform"`
+	AgentType                string `json:"agent_type,omitempty"`
+	InputTokens              int    `json:"input_tokens"`
+	OutputTokens             int    `json:"output_tokens"`
+	CacheReadInputTokens     int    `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int    `json:"cache_creation_input_tokens"`
+}
+
+// UsageEmitter is an optional interface for platforms that forward per-turn
+// token usage to external observers such as dashboards or telemetry collectors.
+// Only platforms wired to an observer bus (e.g. the WebSocket bridge) implement
+// it; others simply ignore usage reporting. The engine calls it best-effort
+// after each turn completes and must never depend on delivery.
+type UsageEmitter interface {
+	EmitUsage(usage TurnUsage)
+}
+
 // MessageRecallDetector is an optional interface for platforms that can check
 // whether the message targeted by a reply context was recalled/deleted.
 type MessageRecallDetector interface {


### PR DESCRIPTION
## Summary
- add a bridge usage observer so cross-platform bridge sessions can emit token usage telemetry
- include inbound message id and user identity metadata in usage events
- add regression coverage for usage observer payloads and message/user metadata propagation

## Tests
- `PATH=/tmp/cc-connect-go-1.25.0-arm64/go/bin:$PATH go test -count=1 ./core ./platform/feishu`
- `PATH=/tmp/cc-connect-go-1.25.0-arm64/go/bin:$PATH go test -count=1 ./core -run 'TestBridge|TestUsage|UsageObserver'`

## Notes
- `go test ./...` was attempted with Go 1.25.0, but failed on unrelated/environmental failures in this local checkout: missing `web/dist` embedded assets, an `agent/codex` runtime-config test failure, and a `daemon` launchd status test failure.
