### PR TITLE
Chatarch/feishu thread upstream 20260623

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -670,9 +670,12 @@ func main() {
 			engine.SetMaxTurnTime(time.Duration(*cfg.MaxTurnTimeMins) * time.Minute)
 		}
 
-		// Wire queue depth
+		// Wire queue behavior
 		if cfg.Queue.MaxDepth != nil && *cfg.Queue.MaxDepth > 0 {
 			engine.SetMaxQueuedMessages(*cfg.Queue.MaxDepth)
+		}
+		if cfg.Queue.BusyInputMode != "" {
+			engine.SetBusyInputMode(core.BusyInputMode(cfg.Queue.BusyInputMode))
 		}
 
 		// Wire auto-compress settings

--- a/config.example.toml
+++ b/config.example.toml
@@ -997,10 +997,11 @@ app_secret = "your-feishu-app-secret"
 #                           # Agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 # group_reply_all = false   # If true, respond to ALL group messages without requiring @mention
 #                           # 设为 true 时，群聊中无需 @机器人 也会响应所有消息（默认 false）
-# share_session_in_channel = false  # If true, all users in a group share one agent session
-#                                   # 设为 true 时，群聊内所有用户共享同一个 Agent 会话
-# thread_isolation = false  # If true, group messages use Feishu reply threads as session boundaries (one thread/root = one agent session)
-#                           # 设为 true 时，群聊按飞书话题/根消息隔离会话（一个 thread/root 对应一个 Agent 会话）
+# share_session_in_channel = false  # If true, all users in a group share one main-chat agent session
+#                                   # 设为 true 时，群聊主对话内所有用户共享同一个 Agent 会话
+# thread_isolation = false  # If true, created Feishu threads can admit attachment-only follow-ups without re-mentioning the bot.
+#                           # Native Feishu thread sessions are created explicitly with /thread or /t; incidental root/thread metadata does not trigger thread mode.
+#                           # 设为 true 时，已创建的飞书话题可接收不重复 @bot 的附件跟进；原生话题会话由 /thread 或 /t 显式创建。
 # reply_to_trigger = true   # Default: bot uses “reply to message” API (quotes the user’s message). Set false to post plain chat messages instead.
 #                           # 默认 true：用「回复消息」API（引用用户消息）。设为 false 则在会话里发普通消息、不引用触发消息。
 # progress_style = "legacy" # Progress rendering style: legacy | compact | card

--- a/config.example.toml
+++ b/config.example.toml
@@ -142,6 +142,14 @@ level = "info" # debug, info, warn, error
 # 推荐值：30–60。默认 0（禁用）。
 # max_turn_time_mins = 0  # default: disabled / 默认禁用
 
+# Busy ordinary-message handling while an agent turn is already running.
+# 忙时普通消息处理方式：当上一轮 agent 任务仍在运行时，新普通消息如何处理。
+# [queue]
+# max_depth = 5                  # max queued messages per session / 每个会话最大排队消息数
+# busy_input_mode = "queue"       # "queue" (default) or "interrupt"
+#                                # queue: process after current task finishes / 当前任务结束后再处理
+#                                # interrupt: stop current task and process the new message / 打断当前任务并处理新消息
+
 # Auto-reset the active session after the user has been inactive for a while.
 # Unlike idle_timeout_mins, this does not detect stuck agent execution. It
 # rotates to a fresh cc-connect session when the user comes back after being idle.

--- a/config/config.go
+++ b/config/config.go
@@ -136,9 +136,10 @@ type CronConfig struct {
 	SessionMode string `toml:"session_mode"` // default session mode: "" or "reuse" (default) or "new_per_run"
 }
 
-// QueueConfig controls the per-session message queue.
+// QueueConfig controls the per-session message queue and busy-message behavior.
 type QueueConfig struct {
-	MaxDepth *int `toml:"max_depth"` // max queued messages per session; default 5
+	MaxDepth      *int   `toml:"max_depth"`       // max queued messages per session; default 5
+	BusyInputMode string `toml:"busy_input_mode"` // "queue" (default) or "interrupt"
 }
 
 // WebhookConfig controls the external HTTP webhook endpoint.
@@ -976,6 +977,11 @@ func (c *Config) validate() error {
 func (c *Config) validateInternal(permissive bool) error {
 	if err := validateDisplayConfig("display", &c.Display); err != nil {
 		return err
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Queue.BusyInputMode)) {
+	case "", "queue", "interrupt":
+	default:
+		return fmt.Errorf("config: queue.busy_input_mode must be \"queue\" or \"interrupt\"")
 	}
 	switch strings.ToLower(strings.TrimSpace(c.AttachmentSend)) {
 	case "", "on", "off":
@@ -3478,6 +3484,11 @@ func GetGlobalSettings() map[string]any {
 		queueMax = *cfg.Queue.MaxDepth
 	}
 	result["queue_max_depth"] = queueMax
+	queueMode := strings.ToLower(strings.TrimSpace(cfg.Queue.BusyInputMode))
+	if queueMode == "" {
+		queueMode = "queue"
+	}
+	result["queue_busy_input_mode"] = queueMode
 	return result
 }
 
@@ -3496,6 +3507,7 @@ type GlobalSettingsUpdate struct {
 	RateLimitMax       *int    `json:"rate_limit_max_messages"`
 	RateLimitWindow    *int    `json:"rate_limit_window_secs"`
 	QueueMaxDepth      *int    `json:"queue_max_depth"`
+	QueueBusyInputMode *string `json:"queue_busy_input_mode"`
 }
 
 // SaveGlobalSettings persists global settings to config.toml.
@@ -3551,6 +3563,9 @@ func SaveGlobalSettings(u GlobalSettingsUpdate) error {
 	}
 	if u.QueueMaxDepth != nil {
 		cfg.Queue.MaxDepth = u.QueueMaxDepth
+	}
+	if u.QueueBusyInputMode != nil {
+		cfg.Queue.BusyInputMode = strings.ToLower(strings.TrimSpace(*u.QueueBusyInputMode))
 	}
 	return saveConfig(cfg)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -104,6 +104,28 @@ func TestConfigValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "accepts queue busy input mode",
+			cfg: Config{
+				Queue:    QueueConfig{BusyInputMode: "queue"},
+				Projects: []ProjectConfig{validProject("demo")},
+			},
+		},
+		{
+			name: "accepts interrupt busy input mode",
+			cfg: Config{
+				Queue:    QueueConfig{BusyInputMode: "interrupt"},
+				Projects: []ProjectConfig{validProject("demo")},
+			},
+		},
+		{
+			name: "rejects invalid busy input mode",
+			cfg: Config{
+				Queue:    QueueConfig{BusyInputMode: "steer"},
+				Projects: []ProjectConfig{validProject("demo")},
+			},
+			wantErr: `queue.busy_input_mode must be "queue" or "interrupt"`,
+		},
+		{
 			name: "accepts valid references config",
 			cfg: Config{
 				Projects: []ProjectConfig{

--- a/core/engine.go
+++ b/core/engine.go
@@ -5850,6 +5850,7 @@ var builtinCommands = []struct {
 	{[]string{"web"}, "web"},
 	{[]string{"diff"}, "diff"},
 	{[]string{"ps", "btw"}, "ps"},
+	{[]string{"thread", "t"}, "thread"},
 }
 
 func (e *Engine) cmdPs(p Platform, msg *Message, args []string) {
@@ -5881,6 +5882,41 @@ func (e *Engine) cmdPs(p Platform, msg *Message, args []string) {
 		return
 	}
 	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsSent))
+}
+
+func (e *Engine) cmdThread(p Platform, msg *Message, args []string) {
+	prompt := strings.TrimSpace(strings.Join(args, " "))
+	if prompt == "" {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgThreadUsage))
+		return
+	}
+	creator, ok := p.(ThreadCreator)
+	if !ok {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgThreadNotSupported))
+		return
+	}
+	target, err := creator.CreateThread(e.ctx, msg.ReplyCtx)
+	if err != nil {
+		slog.Error("thread: create failed", "platform", p.Name(), "error", err)
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgThreadCreateFailed, err))
+		return
+	}
+	if target.SessionKey == "" || target.ReplyCtx == nil {
+		slog.Error("thread: platform returned invalid target", "platform", p.Name(), "session_key", target.SessionKey)
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgThreadInvalidTarget))
+		return
+	}
+
+	threadMsg := *msg
+	threadMsg.SessionKey = target.SessionKey
+	threadMsg.ReplyCtx = target.ReplyCtx
+	threadMsg.Content = prompt
+	threadMsg.Images = nil
+	threadMsg.Files = nil
+	threadMsg.Audio = nil
+	threadMsg.ExtraContent = ""
+	threadMsg.Recalled = false
+	e.handleMessage(p, &threadMsg)
 }
 
 // matchPrefix finds a unique command matching the given prefix.
@@ -6099,6 +6135,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdWeb(p, msg, args)
 	case "ps":
 		e.cmdPs(p, msg, args)
+	case "thread":
+		e.cmdThread(p, msg, args)
 	default:
 		if custom, ok := e.commands.Resolve(cmd); ok {
 			if disabledCmds[strings.ToLower(custom.Name)] {

--- a/core/engine.go
+++ b/core/engine.go
@@ -30,6 +30,22 @@ const maxPlatformMessageLen = 4000
 const telegramBotCommandLimit = 100
 const defaultMaxQueuedMessages = 5 // default cap for queued messages per session
 
+type BusyInputMode string
+
+const (
+	BusyInputModeQueue     BusyInputMode = "queue"
+	BusyInputModeInterrupt BusyInputMode = "interrupt"
+)
+
+func normalizeBusyInputMode(mode BusyInputMode) BusyInputMode {
+	switch BusyInputMode(strings.ToLower(strings.TrimSpace(string(mode)))) {
+	case BusyInputModeInterrupt:
+		return BusyInputModeInterrupt
+	default:
+		return BusyInputModeQueue
+	}
+}
+
 // previewText truncates s to maxRunes runes for safe inclusion in debug logs.
 // Truncation uses runes (not bytes) so multi-byte characters render cleanly.
 // Newlines are replaced with literal "\n" to keep each log entry on one line.
@@ -245,6 +261,7 @@ type Engine struct {
 	eventIdleTimeout  time.Duration
 	maxTurnTime       time.Duration // absolute wall-clock cap per turn (0 = disabled)
 	maxQueuedMessages int
+	busyInputMode     BusyInputMode
 	dirHistory        *DirHistory
 	baseWorkDir       string
 	projectState      *ProjectStateStore
@@ -270,8 +287,8 @@ type Engine struct {
 	filterExternalSessions bool
 
 	// Shell configuration for /shell, cron exec, hooks, webhook exec
-	shell       string // shell binary path (e.g. "sh", "/bin/zsh")
-	shellFlag   string // shell flag (e.g. "-c", "-Command", "/C")
+	shell        string // shell binary path (e.g. "sh", "/bin/zsh")
+	shellFlag    string // shell flag (e.g. "-c", "-Command", "/C")
 	shellProfile string // prepended to every command (e.g. "source ~/.zshrc;")
 
 	// Multi-workspace mode
@@ -562,6 +579,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		references:            DefaultReferenceRenderCfg(),
 		eventIdleTimeout:      defaultEventIdleTimeout,
 		maxQueuedMessages:     defaultMaxQueuedMessages,
+		busyInputMode:         BusyInputModeQueue,
 		showContextIndicator:  true,
 		showWorkdirIndicator:  true,
 		shell:                 defaultShell(),
@@ -1120,6 +1138,12 @@ func (e *Engine) SetMaxQueuedMessages(n int) {
 	if n > 0 {
 		e.maxQueuedMessages = n
 	}
+}
+
+// SetBusyInputMode controls how ordinary messages are handled while a turn is busy.
+// The default is queue, preserving existing behavior.
+func (e *Engine) SetBusyInputMode(mode BusyInputMode) {
+	e.busyInputMode = normalizeBusyInputMode(mode)
 }
 
 func (e *Engine) SetRelayManager(rm *RelayManager) {
@@ -2488,6 +2512,17 @@ func (e *Engine) waitForSessionLock(session *Session, timeout time.Duration) boo
 	}
 }
 
+func (e *Engine) interruptBusySession(interactiveKey string, session *Session) bool {
+	if interactiveKey == "" || session == nil {
+		return false
+	}
+	stopped := e.stopInteractiveSessionWithOptions(interactiveKey, false)
+	if stopped {
+		slog.Info("busy input interrupted running session", "interactive_key", interactiveKey)
+	}
+	return stopped
+}
+
 func (e *Engine) startMessageRecallMonitor(sessionKey string) context.CancelFunc {
 	ctx, cancel := context.WithCancel(e.ctx)
 	go func() {
@@ -2727,6 +2762,17 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 			}
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
 			return
+		}
+		if e.busyInputMode == BusyInputModeInterrupt {
+			if e.interruptBusySession(interactiveKey, session) {
+				e.reply(p, msg.ReplyCtx, e.i18n.T(MsgBusyInterrupted))
+				if e.waitForSessionLock(session, recalledStopLockWait) {
+					goto sessionLocked
+				}
+				slog.Warn("busy interrupt requested but session lock did not release before timeout",
+					"session", msg.SessionKey, "interactive_key", interactiveKey)
+				return
+			}
 		}
 		// Session is busy — try to queue the message for the running turn
 		// so the agent processes it immediately after the current turn ends.

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -7024,6 +7024,7 @@ func TestHandlePendingPermission_CronFallback(t *testing.T) {
 // controllableAgentSession is an AgentSession stub whose session ID, liveness,
 // and events channel can be controlled by the test.
 type controllableAgentSession struct {
+	mu              sync.Mutex
 	sessionID       string
 	alive           bool
 	events          chan Event
@@ -7061,9 +7062,15 @@ func (s *controllableAgentSession) GetUsage(_ context.Context) (*UsageReport, er
 	return s.report, s.usageErr
 }
 func (s *controllableAgentSession) GetContextUsage() *ContextUsage { return s.contextUsage }
-func (s *controllableAgentSession) Alive() bool                    { return s.alive }
+func (s *controllableAgentSession) Alive() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.alive
+}
 func (s *controllableAgentSession) Close() error {
+	s.mu.Lock()
 	s.alive = false
+	s.mu.Unlock()
 	close(s.events)
 	select {
 	case <-s.closed:
@@ -8257,7 +8264,9 @@ func newBlockingCloseSession(id string) *blockingCloseAgentSession {
 }
 
 func (s *blockingCloseAgentSession) Close() error {
+	s.mu.Lock()
 	s.alive = false
+	s.mu.Unlock()
 	select {
 	case s.closeStarted <- struct{}{}:
 	default:

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -72,6 +72,43 @@ func (p *stubPlatformEngine) Send(_ context.Context, _ any, content string) erro
 }
 func (p *stubPlatformEngine) Stop() error { return nil }
 
+type typingRecorderPlatform struct {
+	stubPlatformEngine
+	starts []any
+	stops  []any
+}
+
+func (p *typingRecorderPlatform) StartTyping(_ context.Context, replyCtx any) func() {
+	p.mu.Lock()
+	p.starts = append(p.starts, replyCtx)
+	p.mu.Unlock()
+	return func() {
+		p.mu.Lock()
+		p.stops = append(p.stops, replyCtx)
+		p.mu.Unlock()
+	}
+}
+
+func (p *typingRecorderPlatform) typingSnapshot() (starts []any, stops []any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	starts = append([]any(nil), p.starts...)
+	stops = append([]any(nil), p.stops...)
+	return starts, stops
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, cond func() bool, message string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(message)
+}
+
 func (p *stubPlatformEngine) getSent() []string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -1100,10 +1137,10 @@ func TestProcessInteractiveEvents_NonTerminalResultContinuesTurn(t *testing.T) {
 	session := e.sessions.GetOrCreateActive(sessionKey)
 	agentSession := newControllableSession("s1")
 	state := &interactiveState{
-		agentSession:                  agentSession,
-		platform:                      p,
-		replyCtx:                      "ctx-1",
-		currentTurnUserMessageTimeMs:  100,
+		agentSession:                   agentSession,
+		platform:                       p,
+		replyCtx:                       "ctx-1",
+		currentTurnUserMessageTimeMs:   100,
 		lastCompletedUserMessageTimeMs: 0,
 	}
 	e.interactiveStates[sessionKey] = state
@@ -9144,6 +9181,181 @@ func TestQueueMessage_NilAgentSession_DuringStartup(t *testing.T) {
 	state.mu.Unlock()
 }
 
+func TestBusyInputModeInterruptStopsCurrentSessionWithoutQueueing(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	running := newControllableSession("running")
+	next := newControllableSession("next")
+	startCalls := 0
+	agent := &controllableAgent{
+		startSessionFn: func(_ context.Context, _ string) (AgentSession, error) {
+			startCalls++
+			if startCalls == 1 {
+				return running, nil
+			}
+			return next, nil
+		},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetBusyInputMode(BusyInputModeInterrupt)
+
+	key := "test:interrupt-user"
+	firstSession := e.sessions.GetOrCreateActive(key)
+	if !firstSession.TryLock() {
+		t.Fatal("expected to lock first session")
+	}
+
+	doneFirst := make(chan struct{})
+	go func() {
+		defer close(doneFirst)
+		e.processInteractiveMessageWith(p, &Message{
+			SessionKey: key,
+			MessageID:  "m1",
+			UserID:     "u1",
+			UserName:   "User",
+			Platform:   "test",
+			Content:    "long running task",
+			ReplyCtx:   "ctx-1",
+		}, firstSession, agent, e.sessions, key, "", key)
+	}()
+
+	select {
+	case <-time.After(2 * time.Second):
+		// Expected: first turn is still waiting for agent events.
+	case <-doneFirst:
+		t.Fatal("first turn ended before interrupt")
+	}
+
+	e.handleMessage(p, &Message{
+		SessionKey: key,
+		MessageID:  "m2",
+		UserID:     "u1",
+		UserName:   "User",
+		Platform:   "test",
+		Content:    "new instruction",
+		ReplyCtx:   "ctx-2",
+	})
+
+	select {
+	case <-running.closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("interrupt mode did not close the running agent session")
+	}
+
+	select {
+	case <-doneFirst:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first turn did not exit after interrupt")
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		e.interactiveMu.Lock()
+		state := e.interactiveStates[key]
+		e.interactiveMu.Unlock()
+		if state != nil {
+			state.mu.Lock()
+			queued := len(state.pendingMessages)
+			current := state.agentSession
+			state.mu.Unlock()
+			if queued != 0 {
+				t.Fatalf("interrupt mode queued %d messages, want 0", queued)
+			}
+			if current == next {
+				break
+			}
+		}
+		select {
+		case <-deadline:
+			t.Fatal("interrupt mode did not start processing the new message")
+		default:
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+
+	sent := p.getSent()
+	gotInterruptAck := false
+	for _, line := range sent {
+		if line == e.i18n.T(MsgBusyInterrupted) {
+			gotInterruptAck = true
+		}
+		if strings.Contains(line, e.i18n.T(MsgMessageQueued)) {
+			t.Fatalf("interrupt mode should not send queued reply, got %v", sent)
+		}
+	}
+	if !gotInterruptAck {
+		t.Fatalf("interrupt mode should send interrupt ack %q, got %v", e.i18n.T(MsgBusyInterrupted), sent)
+	}
+}
+
+func TestBusyInputModeInterruptSwitchesProcessingIndicatorToNewMessage(t *testing.T) {
+	p := &typingRecorderPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
+	running := newControllableSession("running")
+	next := newControllableSession("next")
+	startCalls := 0
+	agent := &controllableAgent{
+		startSessionFn: func(_ context.Context, _ string) (AgentSession, error) {
+			startCalls++
+			if startCalls == 1 {
+				return running, nil
+			}
+			return next, nil
+		},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetBusyInputMode(BusyInputModeInterrupt)
+
+	key := "test:interrupt-indicator"
+	firstSession := e.sessions.GetOrCreateActive(key)
+	if !firstSession.TryLock() {
+		t.Fatal("expected to lock first session")
+	}
+
+	doneFirst := make(chan struct{})
+	go func() {
+		defer close(doneFirst)
+		e.processInteractiveMessageWith(p, &Message{
+			SessionKey: key,
+			MessageID:  "m1",
+			UserID:     "u1",
+			UserName:   "User",
+			Platform:   "test",
+			Content:    "long running task",
+			ReplyCtx:   "ctx-1",
+		}, firstSession, agent, e.sessions, key, "", key)
+	}()
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		starts, _ := p.typingSnapshot()
+		return len(starts) == 1 && starts[0] == "ctx-1"
+	}, "first message processing indicator did not start")
+
+	e.handleMessage(p, &Message{
+		SessionKey: key,
+		MessageID:  "m2",
+		UserID:     "u1",
+		UserName:   "User",
+		Platform:   "test",
+		Content:    "new instruction",
+		ReplyCtx:   "ctx-2",
+	})
+
+	select {
+	case <-running.closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("interrupt mode did not close the running agent session")
+	}
+	select {
+	case <-doneFirst:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first turn did not exit after interrupt")
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		starts, stops := p.typingSnapshot()
+		return len(starts) >= 2 && starts[0] == "ctx-1" && starts[1] == "ctx-2" && len(stops) >= 1 && stops[0] == "ctx-1"
+	}, "interrupt did not move processing indicator from old message to new message")
+}
+
 // TestProcessInteractiveMessageWith_NilAgentSession_NoPanic is a regression
 // test for issue #1181. When a long-running agent turn is force-killed
 // (e.g. by max_turn_time_mins) the cleanup path may leave an interactive
@@ -14877,8 +15089,8 @@ func TestIsAllowResponse_WithMultipleMentions(t *testing.T) {
 func TestIsAllowResponse_NotInsideOtherWord(t *testing.T) {
 	cases := []string{
 		"禁止允许这种",
-		"不允许这样",   // "不允许" has its own deny entry, but as part of "不允许这样" the user clearly is denying / negating, never allowing.
-		"我不太允许这件事", // long sentence, no token equals "允许"
+		"不允许这样",                            // "不允许" has its own deny entry, but as part of "不允许这样" the user clearly is denying / negating, never allowing.
+		"我不太允许这件事",                         // long sentence, no token equals "允许"
 		"please don't allowall the things", // FieldsFunc keeps "allowall" intact, but it is the approveAll single-token form, not allow.
 		"hello world",
 		"",
@@ -14906,7 +15118,7 @@ func TestIsDenyResponse_WithMention(t *testing.T) {
 	}
 
 	negatives := []string{
-		"拒绝症患者",       // embedded — must not match
+		"拒绝症患者",        // embedded — must not match
 		"我们都不应该 hello", // unrelated
 	}
 	for _, s := range negatives {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -72,6 +72,20 @@ func (p *stubPlatformEngine) Send(_ context.Context, _ any, content string) erro
 }
 func (p *stubPlatformEngine) Stop() error { return nil }
 
+type threadCreatingPlatform struct {
+	stubPlatformEngine
+	createCalls  int
+	lastReplyCtx any
+	result       ThreadTarget
+	err          error
+}
+
+func (p *threadCreatingPlatform) CreateThread(ctx context.Context, replyCtx any) (ThreadTarget, error) {
+	p.createCalls++
+	p.lastReplyCtx = replyCtx
+	return p.result, p.err
+}
+
 type typingRecorderPlatform struct {
 	stubPlatformEngine
 	starts []any
@@ -232,6 +246,33 @@ func (s *resultAgentSession) Events() <-chan Event                              
 func (s *resultAgentSession) CurrentSessionID() string                             { return "result-session" }
 func (s *resultAgentSession) Alive() bool                                          { return true }
 func (s *resultAgentSession) Close() error                                         { return nil }
+
+type promptRecordingAgentSession struct {
+	sessionID string
+	prompts   chan string
+	events    chan Event
+}
+
+func newPromptRecordingAgentSession(sessionID string) *promptRecordingAgentSession {
+	return &promptRecordingAgentSession{
+		sessionID: sessionID,
+		prompts:   make(chan string, 1),
+		events:    make(chan Event, 1),
+	}
+}
+
+func (s *promptRecordingAgentSession) Send(prompt string, _ []ImageAttachment, _ []FileAttachment) error {
+	s.prompts <- prompt
+	s.events <- Event{Type: EventResult, Content: "thread done", Done: true}
+	return nil
+}
+func (s *promptRecordingAgentSession) RespondPermission(_ string, _ PermissionResult) error {
+	return nil
+}
+func (s *promptRecordingAgentSession) Events() <-chan Event     { return s.events }
+func (s *promptRecordingAgentSession) CurrentSessionID() string { return s.sessionID }
+func (s *promptRecordingAgentSession) Alive() bool              { return true }
+func (s *promptRecordingAgentSession) Close() error             { return nil }
 
 type stubLifecyclePlatform struct {
 	stubPlatformEngine
@@ -2524,6 +2565,110 @@ func TestEngine_DisabledCommandsWildcard(t *testing.T) {
 	}
 	if !strings.Contains(p.sent[0], "disabled") && !strings.Contains(p.sent[0], "禁用") {
 		t.Errorf("expected disabled message, got: %s", p.sent[0])
+	}
+}
+
+func TestCmdThreadCreatesIsolatedSessionWithoutTouchingParent(t *testing.T) {
+	threadSession := newPromptRecordingAgentSession("thread-agent-session")
+	agent := &controllableAgent{
+		startSessionFn: func(_ context.Context, sessionID string) (AgentSession, error) {
+			if sessionID != "" {
+				t.Fatalf("thread turn started with resume session id %q, want empty new session", sessionID)
+			}
+			return threadSession, nil
+		},
+	}
+	p := &threadCreatingPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "test"},
+		result: ThreadTarget{
+			SessionKey: "test:chat:root:thread-1",
+			ReplyCtx:   "thread-ctx",
+		},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	e.handleMessage(p, &Message{
+		SessionKey: "test:chat:user-1",
+		Platform:   "test",
+		MessageID:  "m-parent",
+		UserID:     "user-1",
+		UserName:   "User",
+		Content:    "/thread build isolated feature",
+		ReplyCtx:   "parent-ctx",
+	})
+
+	if p.createCalls != 1 {
+		t.Fatalf("CreateThread calls = %d, want 1", p.createCalls)
+	}
+	if p.lastReplyCtx != "parent-ctx" {
+		t.Fatalf("CreateThread replyCtx = %v, want parent-ctx", p.lastReplyCtx)
+	}
+
+	select {
+	case prompt := <-threadSession.prompts:
+		if prompt != "build isolated feature" {
+			t.Fatalf("thread prompt = %q, want build isolated feature", prompt)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("thread prompt was not sent to agent")
+	}
+
+	if parentID := e.sessions.ActiveSessionID("test:chat:user-1"); parentID != "" {
+		t.Fatalf("parent session was created/touched: active id %q", parentID)
+	}
+	if threadID := e.sessions.ActiveSessionID("test:chat:root:thread-1"); threadID == "" {
+		t.Fatal("thread session was not created")
+	}
+}
+
+func TestCmdThreadDoesNotInterruptBusyParentSession(t *testing.T) {
+	threadSession := newPromptRecordingAgentSession("thread-agent-session")
+	parentSession := newControllableSession("parent-agent-session")
+	agent := &controllableAgent{
+		startSessionFn: func(_ context.Context, _ string) (AgentSession, error) {
+			return threadSession, nil
+		},
+	}
+	p := &threadCreatingPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "test"},
+		result:             ThreadTarget{SessionKey: "test:chat:root:thread-2", ReplyCtx: "thread-ctx-2"},
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	parentKey := "test:chat:user-1"
+	parent := e.sessions.GetOrCreateActive(parentKey)
+	if !parent.TryLock() {
+		t.Fatal("expected to lock parent session")
+	}
+	defer parent.UnlockWithoutUpdate()
+	e.interactiveMu.Lock()
+	e.interactiveStates[parentKey] = &interactiveState{agentSession: parentSession, platform: p, replyCtx: "parent-ctx"}
+	e.interactiveMu.Unlock()
+
+	e.handleMessage(p, &Message{
+		SessionKey: parentKey,
+		Platform:   "test",
+		MessageID:  "m-parent",
+		UserID:     "user-1",
+		UserName:   "User",
+		Content:    "/thread do independent work",
+		ReplyCtx:   "parent-ctx",
+	})
+
+	select {
+	case prompt := <-threadSession.prompts:
+		if prompt != "do independent work" {
+			t.Fatalf("thread prompt = %q, want do independent work", prompt)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("thread prompt was not sent to agent")
+	}
+
+	if !parentSession.Alive() {
+		t.Fatal("parent agent session was interrupted by /thread")
+	}
+	if p.createCalls != 1 {
+		t.Fatalf("CreateThread calls = %d, want 1", p.createCalls)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -174,6 +174,7 @@ const (
 	MsgPreviousProcessing        MsgKey = "previous_processing"
 	MsgQueueFull                 MsgKey = "queue_full"
 	MsgMessageQueued             MsgKey = "message_queued"
+	MsgBusyInterrupted           MsgKey = "busy_interrupted"
 	MsgNoToolsAllowed            MsgKey = "no_tools_allowed"
 	MsgCurrentTools              MsgKey = "current_tools"
 	MsgCurrentSession            MsgKey = "current_session"
@@ -743,6 +744,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "📬 訊息已收到，將在目前任務完成後處理。",
 		LangJapanese:           "📬 メッセージを受信しました。現在のタスク完了後に処理します。",
 		LangSpanish:            "📬 Mensaje recibido — se procesará después de que termine la tarea actual.",
+	},
+	MsgBusyInterrupted: {
+		LangEnglish:            "⚡ Interrupting current task. I'll respond to your message shortly.",
+		LangChinese:            "⚡ 正在中断当前任务，马上处理你的新消息。",
+		LangTraditionalChinese: "⚡ 正在中斷目前任務，馬上處理你的新訊息。",
+		LangJapanese:           "⚡ 現在のタスクを中断しています。まもなく新しいメッセージに応答します。",
+		LangSpanish:            "⚡ Interrumpiendo la tarea actual. Responderé a tu mensaje en breve.",
 	},
 	MsgQueueFull: {
 		LangEnglish:            "📬 Message queue is full (%d pending). Please wait for current tasks to complete.",

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -379,31 +379,31 @@ const (
 	MsgCronIDLabel               MsgKey = "cron_id_label"
 	MsgCronFailedSuffix          MsgKey = "cron_failed_suffix"
 
-	MsgTimerNotAvailable  MsgKey = "timer_not_available"
-	MsgTimerUsage         MsgKey = "timer_usage"
-	MsgTimerAddUsage      MsgKey = "timer_add_usage"
-	MsgTimerAdded         MsgKey = "timer_added"
-	MsgTimerAddedExec     MsgKey = "timer_added_exec"
-	MsgTimerAddExecUsage  MsgKey = "timer_addexec_usage"
-	MsgTimerEmpty         MsgKey = "timer_empty"
-	MsgTimerListTitle     MsgKey = "timer_list_title"
-	MsgTimerListFooter    MsgKey = "timer_list_footer"
-	MsgTimerDelUsage      MsgKey = "timer_del_usage"
-	MsgTimerMuteUsage     MsgKey = "timer_mute_usage"
-	MsgTimerDeleted       MsgKey = "timer_deleted"
-	MsgTimerNotFound      MsgKey = "timer_not_found"
-	MsgTimerMuted         MsgKey = "timer_muted"
-	MsgTimerUnmuted       MsgKey = "timer_unmuted"
-	MsgTimerCardHint      MsgKey = "timer_card_hint"
-	MsgTimerBtnMute       MsgKey = "timer_btn_mute"
-	MsgTimerBtnUnmute     MsgKey = "timer_btn_unmute"
-	MsgTimerBtnDelete     MsgKey = "timer_btn_delete"
-	MsgTimerIDLabel       MsgKey = "timer_id_label"
-	MsgTimerScheduledLabel MsgKey = "timer_scheduled_label"
-	MsgTimerFailedSuffix  MsgKey = "timer_failed_suffix"
-	MsgCommandsTagAgent          MsgKey = "commands_tag_agent"
-	MsgCommandsTagShell          MsgKey = "commands_tag_shell"
-	MsgUpgradeTimeoutSuffix      MsgKey = "upgrade_timeout_suffix"
+	MsgTimerNotAvailable    MsgKey = "timer_not_available"
+	MsgTimerUsage           MsgKey = "timer_usage"
+	MsgTimerAddUsage        MsgKey = "timer_add_usage"
+	MsgTimerAdded           MsgKey = "timer_added"
+	MsgTimerAddedExec       MsgKey = "timer_added_exec"
+	MsgTimerAddExecUsage    MsgKey = "timer_addexec_usage"
+	MsgTimerEmpty           MsgKey = "timer_empty"
+	MsgTimerListTitle       MsgKey = "timer_list_title"
+	MsgTimerListFooter      MsgKey = "timer_list_footer"
+	MsgTimerDelUsage        MsgKey = "timer_del_usage"
+	MsgTimerMuteUsage       MsgKey = "timer_mute_usage"
+	MsgTimerDeleted         MsgKey = "timer_deleted"
+	MsgTimerNotFound        MsgKey = "timer_not_found"
+	MsgTimerMuted           MsgKey = "timer_muted"
+	MsgTimerUnmuted         MsgKey = "timer_unmuted"
+	MsgTimerCardHint        MsgKey = "timer_card_hint"
+	MsgTimerBtnMute         MsgKey = "timer_btn_mute"
+	MsgTimerBtnUnmute       MsgKey = "timer_btn_unmute"
+	MsgTimerBtnDelete       MsgKey = "timer_btn_delete"
+	MsgTimerIDLabel         MsgKey = "timer_id_label"
+	MsgTimerScheduledLabel  MsgKey = "timer_scheduled_label"
+	MsgTimerFailedSuffix    MsgKey = "timer_failed_suffix"
+	MsgCommandsTagAgent     MsgKey = "commands_tag_agent"
+	MsgCommandsTagShell     MsgKey = "commands_tag_shell"
+	MsgUpgradeTimeoutSuffix MsgKey = "upgrade_timeout_suffix"
 
 	MsgCronScheduleLabel MsgKey = "cron_schedule_label"
 	MsgCronNextRunLabel  MsgKey = "cron_next_run_label"
@@ -510,14 +510,18 @@ const (
 
 	MsgCommandTimeout MsgKey = "command_timeout"
 
-	MsgBannedWordBlocked MsgKey = "banned_word_blocked"
-	MsgCommandDisabled   MsgKey = "command_disabled"
-	MsgAdminRequired     MsgKey = "admin_required"
-	MsgRateLimited       MsgKey = "rate_limited"
-	MsgPsSent            MsgKey = "ps_sent"
-	MsgPsSendFailed      MsgKey = "ps_send_failed"
-	MsgPsEmpty           MsgKey = "ps_empty"
-	MsgPsNoSession       MsgKey = "ps_no_session"
+	MsgBannedWordBlocked   MsgKey = "banned_word_blocked"
+	MsgCommandDisabled     MsgKey = "command_disabled"
+	MsgAdminRequired       MsgKey = "admin_required"
+	MsgRateLimited         MsgKey = "rate_limited"
+	MsgPsSent              MsgKey = "ps_sent"
+	MsgPsSendFailed        MsgKey = "ps_send_failed"
+	MsgPsEmpty             MsgKey = "ps_empty"
+	MsgPsNoSession         MsgKey = "ps_no_session"
+	MsgThreadUsage         MsgKey = "thread_usage"
+	MsgThreadNotSupported  MsgKey = "thread_not_supported"
+	MsgThreadCreateFailed  MsgKey = "thread_create_failed"
+	MsgThreadInvalidTarget MsgKey = "thread_invalid_target"
 
 	MsgWhoamiTitle     MsgKey = "whoami_title"
 	MsgWhoamiCardTitle MsgKey = "whoami_card_title"
@@ -584,6 +588,7 @@ const (
 	MsgBuiltinCmdDir       MsgKey = "dir"
 	MsgBuiltinCmdDiff      MsgKey = "diff"
 	MsgBuiltinCmdPs        MsgKey = "ps"
+	MsgBuiltinCmdThread    MsgKey = "thread"
 
 	MsgDiffEmpty       MsgKey = "diff_empty"
 	MsgDiffNoDiff2HTML MsgKey = "diff_no_diff2html"
@@ -1216,6 +1221,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <number>|1,2,3|3-7|1,3-5,8 — Delete session(s)\n" +
 			"/name [number] <text> — Name a session\n" +
 			"/current — Show active session\n" +
+			"/thread <message> — Create an isolated platform thread\n" +
 			"/history [n] — Show last n messages",
 		LangChinese: "**会话管理**\n" +
 			"/new [名称] — 创建新会话\n" +
@@ -1225,6 +1231,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <序号>|1,2,3|3-7|1,3-5,8 — 删除会话\n" +
 			"/name [序号] <名称> — 命名会话\n" +
 			"/current — 查看当前会话\n" +
+			"/thread <消息> — 创建独立的话题会话\n" +
 			"/history [n] — 查看最近 n 条消息",
 		LangTraditionalChinese: "**會話管理**\n" +
 			"/new [名稱] — 建立新會話\n" +
@@ -1234,6 +1241,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <序號>|1,2,3|3-7|1,3-5,8 — 刪除會話\n" +
 			"/name [序號] <名稱> — 命名會話\n" +
 			"/current — 查看當前會話\n" +
+			"/thread <訊息> — 建立獨立的話題會話\n" +
 			"/history [n] — 查看最近 n 條訊息",
 		LangJapanese: "**セッション管理**\n" +
 			"/new [名前] — 新しいセッションを開始\n" +
@@ -1243,6 +1251,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <番号>|1,2,3|3-7|1,3-5,8 — セッション削除\n" +
 			"/name [番号] <名前> — セッションに名前を付ける\n" +
 			"/current — 現在のセッションを表示\n" +
+			"/thread <メッセージ> — 分離されたプラットフォームスレッドを作成\n" +
 			"/history [n] — 直近 n 件のメッセージを表示",
 		LangSpanish: "**Gestión de sesiones**\n" +
 			"/new [nombre] — Iniciar nueva sesión\n" +
@@ -1252,6 +1261,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/delete <número>|1,2,3|3-7|1,3-5,8 — Eliminar sesión(es)\n" +
 			"/name [número] <texto> — Nombrar sesión\n" +
 			"/current — Mostrar sesión activa\n" +
+			"/thread <mensaje> — Crear un hilo aislado\n" +
 			"/history [n] — Mostrar últimos n mensajes",
 	},
 	MsgHelpAgentSection: {
@@ -3381,6 +3391,34 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "現在実行中のタスクはありません。",
 		LangSpanish:            "No hay ninguna tarea en ejecución.",
 	},
+	MsgThreadUsage: {
+		LangEnglish:            "Usage: `/thread <message>`",
+		LangChinese:            "用法：`/thread <消息>`",
+		LangTraditionalChinese: "用法：`/thread <訊息>`",
+		LangJapanese:           "使い方：`/thread <メッセージ>`",
+		LangSpanish:            "Uso: `/thread <mensaje>`",
+	},
+	MsgThreadNotSupported: {
+		LangEnglish:            "This platform does not support creating threads.",
+		LangChinese:            "当前平台不支持创建话题。",
+		LangTraditionalChinese: "目前平台不支援建立話題。",
+		LangJapanese:           "このプラットフォームはスレッド作成に対応していません。",
+		LangSpanish:            "Esta plataforma no admite crear hilos.",
+	},
+	MsgThreadCreateFailed: {
+		LangEnglish:            "Failed to create thread: %v",
+		LangChinese:            "创建话题失败：%v",
+		LangTraditionalChinese: "建立話題失敗：%v",
+		LangJapanese:           "スレッドの作成に失敗しました：%v",
+		LangSpanish:            "Error al crear el hilo: %v",
+	},
+	MsgThreadInvalidTarget: {
+		LangEnglish:            "Thread was created but no isolated session target was returned.",
+		LangChinese:            "话题已创建，但没有返回独立会话目标。",
+		LangTraditionalChinese: "話題已建立，但沒有返回獨立會話目標。",
+		LangJapanese:           "スレッドは作成されましたが、分離されたセッション対象が返されませんでした。",
+		LangSpanish:            "El hilo se creó, pero no devolvió un destino de sesión aislado.",
+	},
 	MsgWhoamiTitle: {
 		LangEnglish:            "🪪 **Your Identity**",
 		LangChinese:            "🪪 **你的身份信息**",
@@ -3791,6 +3829,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "向正在執行的任務追加補充資訊",
 		LangJapanese:           "実行中のタスクに補足情報を送信",
 		LangSpanish:            "Enviar un P.S. a la tarea en curso",
+	},
+	MsgBuiltinCmdThread: {
+		LangEnglish:            "Create an isolated platform thread, arg: <message>",
+		LangChinese:            "创建独立的话题会话，参数: <消息>",
+		LangTraditionalChinese: "建立獨立的話題會話，參數: <訊息>",
+		LangJapanese:           "分離されたプラットフォームスレッドを作成、引数: <メッセージ>",
+		LangSpanish:            "Crear un hilo aislado, arg: <mensaje>",
 	},
 	MsgDiffEmpty: {
 		LangEnglish:            "No diff — clean working tree (or no changes vs `%s`).",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -25,6 +25,21 @@ type ReplyContextReconstructor interface {
 	ReconstructReplyCtx(sessionKey string) (any, error)
 }
 
+// ThreadTarget identifies the newly-created platform thread/topic lane that
+// should receive the prompt from a /thread command.
+type ThreadTarget struct {
+	SessionKey string
+	ReplyCtx   any
+}
+
+// ThreadCreator is an optional platform capability for creating a native
+// thread/topic from an incoming message reply context. The engine remains
+// platform-agnostic: platforms decide how to create the thread and how to
+// construct its isolated session key/reply context.
+type ThreadCreator interface {
+	CreateThread(ctx context.Context, replyCtx any) (ThreadTarget, error)
+}
+
 // MessageRecallDetector is an optional interface for platforms that can check
 // whether the message targeted by a reply context was recalled/deleted.
 type MessageRecallDetector interface {

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -109,13 +109,16 @@ app_id = "cli_axxxxxxxxxxxx"
 app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # domain = "https://open.feishu.cn" # 可选：覆盖运行时 API/WebSocket 域名
 # enable_feishu_card = true  # 可选：关闭后统一回退纯文本回复
-# thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
+# share_session_in_channel = false # 可选：true 时群聊主对话所有人共享一个会话
+# thread_isolation = true    # 可选：已创建的 /thread 话题可接收不重复 @bot 的附件跟进
 # progress_style = "legacy"  # 可选：legacy | compact | card
 # done_emoji = "none"          # 可选：agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 ```
 
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
-> 如果开启 `thread_isolation = true`，群聊里每个根消息 / reply thread 会对应一个独立 agent session；私聊行为保持原样。
+> 普通群聊主对话默认按 `chat_id + user_id` 隔离；设置 `share_session_in_channel = true` 后，群聊主对话所有用户共享一个 agent session。
+> 原生飞书话题不会因为事件里带有 `root_id` / `thread_id` 就自动触发；只有显式 `/thread <prompt>` 或 `/t <prompt>` 会创建并登记一个独立 thread session。
+> 如果开启 `thread_isolation = true`，已创建/登记的 thread 可接收不重复 @bot 的附件跟进；私聊行为保持原样。
 > `progress_style = "compact"` 会把思考/工具进度合并到一条可更新消息里，减少刷屏；`legacy` 保持原有逐条发送；`card` 会使用结构化卡片（标题 + 进度块）持续更新同一条消息，观感比纯文本更清晰。
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
 > `done_emoji` 设置后，agent 每次完成回复时会在用户消息上添加指定表情（如 `"Done"` → ✅）。先移除 "OnIt" 表情（如果有），再添加 done 表情。在 quiet 模式下特别有用，因为飞书卡片原地更新不触发推送，done 表情可以通知用户 agent 已完成。设为 `"none"` 或不配置则禁用。

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -3108,15 +3108,6 @@ func (p *Platform) makeSessionKey(msg *larkim.EventMessage, chatID, userID strin
 		if p.isCreatedThreadSession(sessionKey) {
 			return sessionKey
 		}
-		if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
-			return sessionKey
-		}
-	}
-	if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
-		rootID := stringValue(msg.MessageId)
-		if rootID != "" {
-			return p.threadSessionKey(chatID, rootID)
-		}
 	}
 	if p.shareSessionInChannel {
 		return fmt.Sprintf("%s:%s", p.tag(), chatID)
@@ -3140,7 +3131,7 @@ func (p *Platform) shouldReplyInThread(rc replyContext) bool {
 	if rc.messageID == "" {
 		return false
 	}
-	return isThreadSessionKey(rc.sessionKey)
+	return p.isCreatedThreadSession(rc.sessionKey)
 }
 
 // shouldUseThreadOrReplyAPI is true when we should call Im.Message.Reply (optionally with ReplyInThread).

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -167,6 +167,12 @@ type Platform struct {
 	// without requiring another @bot mention. Value is the last-seen time so
 	// stale entries can be expired by a future TTL sweep if needed.
 	activeThreadSessions sync.Map // sessionKey -> time.Time
+	// createdThreadSessions tracks native threads created explicitly by /thread.
+	// These are opt-in isolated sessions even when global thread_isolation is
+	// disabled, so follow-up messages in the same platform thread continue the
+	// /thread-created session without turning every existing thread into an
+	// isolated session.
+	createdThreadSessions sync.Map // sessionKey -> time.Time
 
 	richCardImageMu         sync.Mutex
 	richCardImageResolved   map[string]string
@@ -3067,16 +3073,49 @@ func stripMentions(text string, mentions []*larkim.MentionEvent, botOpenID strin
 	return strings.TrimSpace(text)
 }
 
+func (p *Platform) threadSessionKey(chatID, threadID string) string {
+	return fmt.Sprintf("%s:%s:root:%s", p.tag(), chatID, threadID)
+}
+
+func messageThreadRootID(msg *larkim.EventMessage) string {
+	if msg == nil {
+		return ""
+	}
+	rootID := stringValue(msg.ThreadId)
+	if rootID == "" {
+		rootID = stringValue(msg.RootId)
+	}
+	return rootID
+}
+
+func (p *Platform) markCreatedThreadSession(sessionKey string) {
+	if !isThreadSessionKey(sessionKey) {
+		return
+	}
+	p.createdThreadSessions.Store(sessionKey, time.Now())
+}
+
+func (p *Platform) isCreatedThreadSession(sessionKey string) bool {
+	_, ok := p.createdThreadSessions.Load(sessionKey)
+	return ok
+}
+
 // TODO: Session-key derivation and reply-thread behavior are split across multiple code paths here.
 // Should revisit thread/root handling without changing thread_isolation=false behavior.
 func (p *Platform) makeSessionKey(msg *larkim.EventMessage, chatID, userID string) string {
-	if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
-		rootID := stringValue(msg.RootId)
-		if rootID == "" {
-			rootID = stringValue(msg.MessageId)
+	if rootID := messageThreadRootID(msg); rootID != "" {
+		sessionKey := p.threadSessionKey(chatID, rootID)
+		if p.isCreatedThreadSession(sessionKey) {
+			return sessionKey
 		}
+		if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
+			return sessionKey
+		}
+	}
+	if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
+		rootID := stringValue(msg.MessageId)
 		if rootID != "" {
-			return fmt.Sprintf("%s:%s:root:%s", p.tag(), chatID, rootID)
+			return p.threadSessionKey(chatID, rootID)
 		}
 	}
 	if p.shareSessionInChannel {
@@ -3101,7 +3140,7 @@ func (p *Platform) shouldReplyInThread(rc replyContext) bool {
 	if rc.messageID == "" {
 		return false
 	}
-	return p.threadIsolation && isThreadSessionKey(rc.sessionKey)
+	return isThreadSessionKey(rc.sessionKey)
 }
 
 // shouldUseThreadOrReplyAPI is true when we should call Im.Message.Reply (optionally with ReplyInThread).
@@ -3127,6 +3166,74 @@ func (p *Platform) buildReplyMessageReqBody(rc replyContext, msgType, content st
 		body.ReplyInThread(true)
 	}
 	return body.Build()
+}
+
+func (p *Platform) CreateThread(ctx context.Context, rctx any) (core.ThreadTarget, error) {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return core.ThreadTarget{}, fmt.Errorf("%s: invalid reply context type %T", p.tag(), rctx)
+	}
+	if rc.messageID == "" {
+		return core.ThreadTarget{}, fmt.Errorf("%s: messageID is empty, cannot create thread", p.tag())
+	}
+	if rc.chatID == "" {
+		return core.ThreadTarget{}, fmt.Errorf("%s: chatID is empty, cannot create thread", p.tag())
+	}
+
+	req := larkim.NewReplyMessageReqBuilder().
+		MessageId(rc.messageID).
+		Body(larkim.NewReplyMessageReqBodyBuilder().
+			MsgType(larkim.MsgTypeText).
+			Content(`{"text":"⏳"}`).
+			ReplyInThread(true).
+			Build()).
+		Build()
+
+	var resp *larkim.ReplyMessageResp
+	err := p.withTransientRetry(ctx, "create thread", func() error {
+		return p.withFreshTenantAccessTokenRetry(ctx, "create thread", func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			var err error
+			resp, err = client.Im.Message.Reply(ctx, req, options...)
+			if err != nil {
+				return fmt.Errorf("%s: create thread reply api call: %w", p.tag(), err)
+			}
+			if !resp.Success() {
+				return fmt.Errorf("%s: create thread failed code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return core.ThreadTarget{}, err
+	}
+	if resp == nil || resp.Data == nil {
+		return core.ThreadTarget{}, fmt.Errorf("%s: create thread returned empty response", p.tag())
+	}
+
+	threadID := stringValue(resp.Data.ThreadId)
+	if threadID == "" {
+		threadID = stringValue(resp.Data.RootId)
+	}
+	if threadID == "" {
+		threadID = stringValue(resp.Data.MessageId)
+	}
+	if threadID == "" {
+		return core.ThreadTarget{}, fmt.Errorf("%s: create thread returned no thread id", p.tag())
+	}
+	messageID := stringValue(resp.Data.MessageId)
+	if messageID == "" {
+		messageID = rc.messageID
+	}
+	sessionKey := p.threadSessionKey(rc.chatID, threadID)
+	p.markCreatedThreadSession(sessionKey)
+	return core.ThreadTarget{
+		SessionKey: sessionKey,
+		ReplyCtx: replyContext{
+			messageID:  messageID,
+			chatID:     rc.chatID,
+			sessionKey: sessionKey,
+		},
+	}, nil
 }
 
 func (p *Platform) replyMessage(ctx context.Context, rc replyContext, msgType, content string) error {

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -1226,6 +1226,23 @@ func extractBasePlatform(p core.Platform) *Platform {
 	return nil
 }
 
+func TestNewPlatform_DefaultReactionEmojiKeepsCCConnectStatus(t *testing.T) {
+	p, err := newPlatform("feishu", lark.FeishuBaseUrl, map[string]any{
+		"app_id":     "cli_test",
+		"app_secret": "secret",
+	})
+	if err != nil {
+		t.Fatalf("newPlatform error: %v", err)
+	}
+	fp := extractBasePlatform(p)
+	if fp == nil {
+		t.Fatal("expected *Platform or *interactivePlatform")
+	}
+	if fp.reactionEmoji != "OnIt" {
+		t.Fatalf("default reactionEmoji = %q, want OnIt", fp.reactionEmoji)
+	}
+}
+
 func TestNewPlatform_RequireMentionFalseAliasesGroupReplyAll(t *testing.T) {
 	// Regression test for #1141: users set require_mention = false but feishu
 	// reads group_reply_all. The two options must be equivalent so that

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -98,15 +98,15 @@ func TestCreateThreadRepliesInThreadAndReturnsIsolatedTarget(t *testing.T) {
 	var sawReplyInThread bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+		switch r.URL.Path {
+		case "/open-apis/auth/v3/tenant_access_token/internal":
 			writeJSON(t, w, map[string]any{
 				"code":                0,
 				"msg":                 "success",
 				"expire":              7200,
 				"tenant_access_token": "tenant-token",
 			})
-		case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID+"/reply":
+		case "/open-apis/im/v1/messages/" + parentMessageID + "/reply":
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatalf("read body: %v", err)

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -1232,13 +1232,17 @@ func TestOnMessageThreadIsolationAdmitsAttachmentWithoutMention(t *testing.T) {
 		},
 	}
 
-	// Step 1: opening message @mentions the bot — establishes the thread.
-	if err := p.onMessage(context.Background(), buildEvent(rootMsgID, "text", `{"text":"@_user_1 看看这个"}`, botMention, "")); err != nil {
+	threadKey := "feishu:" + chatID + ":root:" + rootMsgID
+	p.markCreatedThreadSession(threadKey)
+
+	// Step 1: opening message @mentions the bot inside a thread that was
+	// already created by /thread — this establishes the active thread for
+	// attachment-only follow-ups.
+	if err := p.onMessage(context.Background(), buildEvent("om_thread_open", "text", `{"text":"@_user_1 看看这个"}`, botMention, rootMsgID)); err != nil {
 		t.Fatalf("onMessage(root) error = %v", err)
 	}
-	threadKey := "feishu:" + chatID + ":root:" + rootMsgID
 	if !p.isActiveThreadSession(threadKey) {
-		t.Fatalf("thread %q should be marked active after @bot text", threadKey)
+		t.Fatalf("thread %q should be marked active after @bot text in created thread", threadKey)
 	}
 	select {
 	case <-received:

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -88,6 +88,78 @@ func TestDispatchMessageDropsRecalledMessageBeforeHandler(t *testing.T) {
 	}
 }
 
+func TestCreateThreadRepliesInThreadAndReturnsIsolatedTarget(t *testing.T) {
+	const appID = "cli_thread_create"
+	const appSecret = "dummy"
+	const parentMessageID = "om_parent"
+	const chatID = "oc_chat"
+	const threadID = "omt_created"
+
+	var sawReplyInThread bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID+"/reply":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if !strings.Contains(string(body), `"reply_in_thread":true`) {
+				t.Fatalf("reply body = %s, want reply_in_thread=true", string(body))
+			}
+			sawReplyInThread = true
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"message_id": "om_seed",
+					"thread_id":  threadID,
+				},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:    "feishu",
+		domain:          srv.URL,
+		appID:           appID,
+		appSecret:       appSecret,
+		threadIsolation: true,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+	}
+
+	target, err := p.CreateThread(context.Background(), replyContext{
+		messageID:  parentMessageID,
+		chatID:     chatID,
+		sessionKey: "feishu:oc_chat:ou_user",
+	})
+	if err != nil {
+		t.Fatalf("CreateThread() error = %v", err)
+	}
+	if !sawReplyInThread {
+		t.Fatal("reply API was not called with reply_in_thread=true")
+	}
+	if target.SessionKey != "feishu:oc_chat:root:omt_created" {
+		t.Fatalf("SessionKey = %q, want feishu:oc_chat:root:omt_created", target.SessionKey)
+	}
+	if rc, ok := target.ReplyCtx.(replyContext); !ok || rc.messageID != "om_seed" || rc.chatID != chatID || rc.sessionKey != target.SessionKey {
+		t.Fatalf("ReplyCtx = %#v, want seed replyContext for target", target.ReplyCtx)
+	}
+}
+
 func TestDispatchMessageIncludesQuotedImage(t *testing.T) {
 	const appID = "cli_quote_image"
 	const appSecret = "secret-quote-image"

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -703,7 +703,7 @@ func TestLark_SessionKeyPrefix(t *testing.T) {
 	}
 }
 
-func TestLark_ThreadIsolationUsesRootSessionKey(t *testing.T) {
+func TestLark_GroupMentionWithRootIDUsesMainChatSessionUntilThreadCreated(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
 	})
@@ -759,8 +759,18 @@ func TestLark_ThreadIsolationUsesRootSessionKey(t *testing.T) {
 	if receivedMsg == nil {
 		t.Fatal("handler not called")
 	}
-	if receivedMsg.SessionKey != "lark:oc_test:root:om_root" {
-		t.Fatalf("SessionKey = %q, want lark:oc_test:root:om_root", receivedMsg.SessionKey)
+	if receivedMsg.SessionKey != "lark:oc_test:ou_test" {
+		t.Fatalf("SessionKey = %q, want lark:oc_test:ou_test", receivedMsg.SessionKey)
+	}
+	rc, ok := receivedMsg.ReplyCtx.(replyContext)
+	if !ok {
+		t.Fatalf("ReplyCtx type = %T, want replyContext", receivedMsg.ReplyCtx)
+	}
+	if rc.sessionKey != "lark:oc_test:ou_test" {
+		t.Fatalf("replyContext.sessionKey = %q, want lark:oc_test:ou_test", rc.sessionKey)
+	}
+	if ip.shouldReplyInThread(rc) {
+		t.Fatal("ordinary group mention with root_id should not reply in thread before /thread creates one")
 	}
 }
 
@@ -823,7 +833,7 @@ func TestLark_CreatedThreadRoutesP2PFollowupsWhenThreadIsolationDisabled(t *test
 	}
 }
 
-func TestLark_ThreadIsolationUsesThreadIDWhenRootIDMissing(t *testing.T) {
+func TestLark_GroupMentionWithThreadIDUsesMainChatSessionUntilThreadCreated(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
 	})
@@ -885,13 +895,22 @@ func TestLark_ThreadIsolationUsesThreadIDWhenRootIDMissing(t *testing.T) {
 		}
 	}
 
-	want := "lark:oc_test:root:omt_thread"
+	want := "lark:oc_test:ou_test"
 	if got[0].SessionKey != want || got[1].SessionKey != want {
 		t.Fatalf("SessionKeys = [%q, %q], want both %q", got[0].SessionKey, got[1].SessionKey, want)
 	}
+	for i, msg := range got {
+		rc, ok := msg.ReplyCtx.(replyContext)
+		if !ok {
+			t.Fatalf("message %d ReplyCtx type = %T, want replyContext", i, msg.ReplyCtx)
+		}
+		if ip.shouldReplyInThread(rc) {
+			t.Fatalf("message %d should not reply in thread before /thread creates one", i)
+		}
+	}
 }
 
-func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t *testing.T) {
+func TestLark_GroupReplyAllWithThreadIsolationUsesMainChatSessionWithoutMention(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
 		"group_reply_all": true, "thread_isolation": true,
@@ -936,15 +955,18 @@ func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t
 
 	select {
 	case receivedMsg := <-msgCh:
-		if receivedMsg.SessionKey != "lark:oc_test:root:om_root" {
-			t.Fatalf("SessionKey = %q, want lark:oc_test:root:om_root", receivedMsg.SessionKey)
+		if receivedMsg.SessionKey != "lark:oc_test:ou_test" {
+			t.Fatalf("SessionKey = %q, want lark:oc_test:ou_test", receivedMsg.SessionKey)
 		}
 		rc, ok := receivedMsg.ReplyCtx.(replyContext)
 		if !ok {
 			t.Fatalf("ReplyCtx type = %T, want replyContext", receivedMsg.ReplyCtx)
 		}
-		if rc.sessionKey != "lark:oc_test:root:om_root" {
-			t.Fatalf("replyContext.sessionKey = %q, want lark:oc_test:root:om_root", rc.sessionKey)
+		if rc.sessionKey != "lark:oc_test:ou_test" {
+			t.Fatalf("replyContext.sessionKey = %q, want lark:oc_test:ou_test", rc.sessionKey)
+		}
+		if ip.shouldReplyInThread(rc) {
+			t.Fatal("group_reply_all root message should not reply in thread before /thread creates one")
 		}
 		if rc.messageID != "om_root" {
 			t.Fatalf("replyContext.messageID = %q, want om_root", rc.messageID)
@@ -955,6 +977,9 @@ func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t
 }
 
 func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
+	createdThreadPlatform := &Platform{}
+	createdThreadPlatform.markCreatedThreadSession("feishu:oc_chat:root:omt_created")
+
 	tests := []struct {
 		name          string
 		platform      *Platform
@@ -962,10 +987,10 @@ func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 		wantThreading bool
 	}{
 		{
-			name:          "thread isolation enabled",
+			name:          "unregistered thread-shaped session key does not reply in thread",
 			platform:      &Platform{threadIsolation: true},
 			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:om_root"},
-			wantThreading: true,
+			wantThreading: false,
 		},
 		{
 			name:          "thread isolation does not affect p2p session",
@@ -974,8 +999,8 @@ func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 			wantThreading: false,
 		},
 		{
-			name:          "thread session key replies in thread even when global isolation disabled",
-			platform:      &Platform{},
+			name:          "created thread session key replies in thread even when global isolation disabled",
+			platform:      createdThreadPlatform,
 			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:omt_created"},
 			wantThreading: true,
 		},

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -764,6 +764,133 @@ func TestLark_ThreadIsolationUsesRootSessionKey(t *testing.T) {
 	}
 }
 
+func TestLark_CreatedThreadRoutesP2PFollowupsWhenThreadIsolationDisabled(t *testing.T) {
+	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": false,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform(lark) error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+	ip.botOpenID = "ou_bot"
+
+	chatID := "oc_test"
+	threadID := "omt_created"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "p2p"
+	senderType := "user"
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	threadKey := "lark:oc_test:root:omt_created"
+
+	ip.markCreatedThreadSession(threadKey)
+
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		msgCh <- msg
+	}
+
+	if err := ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   stringPtr("om_child"),
+				ThreadId:    &threadID,
+				ChatId:      &chatID,
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     stringPtr(`{"text":"@bot follow up"}`),
+				CreateTime:  &createText,
+				Mentions: []*larkim.MentionEvent{
+					{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("onMessage(follow-up) error = %v", err)
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.SessionKey != threadKey {
+			t.Fatalf("SessionKey = %q, want %q", msg.SessionKey, threadKey)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for follow-up message")
+	}
+}
+
+func TestLark_ThreadIsolationUsesThreadIDWhenRootIDMissing(t *testing.T) {
+	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
+		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true, "thread_isolation": true,
+	})
+	if err != nil {
+		t.Fatalf("newPlatform(lark) error = %v", err)
+	}
+	ip := p.(*interactivePlatform)
+	ip.botOpenID = "ou_bot"
+
+	chatID := "oc_test"
+	threadID := "omt_thread"
+	openID := "ou_test"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	createText := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+	msgCh := make(chan *core.Message, 2)
+	ip.handler = func(_ core.Platform, msg *core.Message) {
+		msgCh <- msg
+	}
+
+	dispatchThreadMessage := func(messageID, content string) {
+		t.Helper()
+		if err := ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+			Event: &larkim.P2MessageReceiveV1Data{
+				Sender: &larkim.EventSender{
+					SenderId:   &larkim.UserId{OpenId: &openID},
+					SenderType: &senderType,
+				},
+				Message: &larkim.EventMessage{
+					MessageId:   &messageID,
+					ThreadId:    &threadID,
+					ChatId:      &chatID,
+					ChatType:    &chatType,
+					MessageType: &msgType,
+					Content:     &content,
+					CreateTime:  &createText,
+					Mentions: []*larkim.MentionEvent{
+						{Key: stringPtr("@bot"), Id: &larkim.UserId{OpenId: stringPtr("ou_bot")}},
+					},
+				},
+			},
+		}); err != nil {
+			t.Fatalf("onMessage(%s) error = %v", messageID, err)
+		}
+	}
+
+	dispatchThreadMessage("om_child_1", `{"text":"@bot first"}`)
+	dispatchThreadMessage("om_child_2", `{"text":"@bot second"}`)
+
+	var got []*core.Message
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-msgCh:
+			got = append(got, msg)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for message %d", i+1)
+		}
+	}
+
+	want := "lark:oc_test:root:omt_thread"
+	if got[0].SessionKey != want || got[1].SessionKey != want {
+		t.Fatalf("SessionKeys = [%q, %q], want both %q", got[0].SessionKey, got[1].SessionKey, want)
+	}
+}
+
 func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
@@ -845,6 +972,12 @@ func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 			platform:      &Platform{threadIsolation: true},
 			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:ou_user"},
 			wantThreading: false,
+		},
+		{
+			name:          "thread session key replies in thread even when global isolation disabled",
+			platform:      &Platform{},
+			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:omt_created"},
+			wantThreading: true,
 		},
 		{
 			name:          "plain reply remains non-threaded",


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill in the sections below.
The reviewer will use the checklist at the bottom to gate merge.
-->

## Summary

<!-- 1-3 sentences explaining WHAT this PR does and WHY. -->

## Type of change

<!-- Mark all that apply: -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

<!-- Explain how you verified the change. Be specific. -->

### Automated tests added in this PR

<!-- List the test functions you added or modified. -->

- `TestX_Y_Z` in `path/to/file_test.go` — what it asserts

### For bug fixes only — regression test

<!-- A bug fix PR MUST include a regression test that:
     (1) fails on the pre-fix code, and
     (2) passes on the fixed code.
     Name it so the bug is searchable later. -->

- Regression test name: `Test...`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

<!-- See AGENTS.md → "Critical User Journeys (CUJ)" and the inventory in
     projects/cc-connect/agents/qa-cursor/release-gate/CUJ-INVENTORY.md.
     Mark which CUJ groups this PR touches: -->

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

<!-- Describe what a user will see or do differently after this PR.
     If none, write "None". -->

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [ ] No new hardcoded platform/agent names in `core/`
- [ ] i18n strings have all-language translations (if any new user-facing text)
- [ ] No secrets / credentials in source

## Related

<!-- Link to issue, RFC, design doc, prior PR, etc. -->

- Issue: https://github.com/chenhg5/cc-connect/issues/1079
- Related PR:
