### PR TITLE
Integrate WPS Agentspace platform with auto-login and token encryption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PLATFORMS := \
 # ---------------------------------------------------------------------------
 
 ALL_AGENTS    := acp antigravity claudecode codex copilot cursor devin gemini iflow kimi opencode pi qoder tmux
-ALL_PLATFORMS := feishu telegram discord slack dingtalk wecom weixin qq qqbot line weibo max matrix webex
+ALL_PLATFORMS := feishu telegram discord slack dingtalk wecom weixin qq qqbot line weibo max matrix webex wps-agentspace
 ALL_EXTRAS    := web
 
 COMMA := ,

--- a/cmd/cc-connect/plugin_platform_wps_agentspace.go
+++ b/cmd/cc-connect/plugin_platform_wps_agentspace.go
@@ -1,0 +1,7 @@
+//go:build !no_wps_agentspace
+
+package main
+
+import (
+	_ "github.com/chenhg5/cc-connect/platform/wps-agentspace"
+)

--- a/config.example.toml
+++ b/config.example.toml
@@ -2028,3 +2028,33 @@ app_secret = "your-feishu-app-secret"
 # [[projects.agent.providers]]
 # name = "google"
 # api_key = "your-gemini-api-key"    # GEMINI_API_KEY
+
+# =============================================================================
+# Project 10: WPS Agentspace / 项目 10：WPS 数字员工 (uncomment to enable / 取消注释以启用)
+# =============================================================================
+# WPS数字员工平台接入，无需创建WPS应用，通过数字员工WebSocket连接
+# WPS Agentspace platform integration, connects via Digital Employee WebSocket
+#
+# 获取方式 / How to get credentials:
+#   app_id: WPS协作 -> 数字员工 -> 设置 -> App ID
+#   wps_sid: 浏览器登录 https://agentspace.wps.cn -> F12 -> Application -> Cookies -> wps_sid
+#
+# [[projects]]
+# name = "wps-agentspace"
+#
+# [projects.agent]
+# type = "claudecode"
+#
+# [projects.agent.options]
+# work_dir = "/path/to/project"
+# mode = "bypassPermissions"
+#
+# [[projects.platforms]]
+# type = "wps-agentspace"
+#
+# [projects.platforms.options]
+# app_id = "your-wps-app-id"           # WPS数字员工 App ID
+# wps_sid = "your-wps-sid"             # WPS登录凭证 (Cookie中的wps_sid)
+# device_name = "cc-connect"           # 设备名称（可选）
+# device_uuid = ""                     # 设备UUID（可选，留空自动生成）
+

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/slack-go/slack v0.16.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/crypto v0.50.0
 	maunium.net/go/mautrix v0.27.0
 	modernc.org/sqlite v1.49.1
 	rsc.io/qr v0.2.0
@@ -61,7 +62,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.8.2 // indirect
 	go.mau.fi/util v0.9.8 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
 	github.com/go-telegram/bot v1.20.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
 	github.com/line/line-bot-sdk-go/v8 v8.19.0
@@ -38,7 +39,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -101,8 +103,14 @@ func init() {
 func New(opts map[string]any) (core.Platform, error) {
 	appID, _ := opts["app_id"].(string)
 	wpsSid, _ := opts["wps_sid"].(string)
+
+	// If wps_sid is empty, try auto-login
 	if wpsSid == "" {
-		return nil, fmt.Errorf("wps-agentspace: wps_sid is required")
+		sid, err := autoLogin(appID)
+		if err != nil {
+			return nil, fmt.Errorf("wps-agentspace: auto-login failed: %w", err)
+		}
+		wpsSid = sid
 	}
 
 	deviceUuid, _ := opts["device_uuid"].(string)
@@ -541,12 +549,128 @@ func (p *Platform) writeLoop(conn *websocket.Conn) {
 // --- Crypto utilities ---
 
 const (
-	aesAlg       = "aes-256-gcm"
-	keyLength    = 32
-	ivLength     = 12
-	saltLength   = 16
+	aesAlg           = "aes-256-gcm"
+	keyLength        = 32
+	ivLength         = 12
+	saltLength       = 16
 	defaultKeySource = "openclaw_agentspace"
+
+	// OAuth endpoints
+	loginURLAPI  = "https://agentspace.wps.cn/v7/devhub/users/login_url"
+	userTokenAPI = "https://agentspace.wps.cn/v7/devhub/users/user_token"
+	userInfoAPI  = "https://agentspace.wps.cn/v7/devhub/users/current"
 )
+
+// autoLogin performs OAuth login to get wps_sid.
+func autoLogin(appID string) (string, error) {
+	state := generateUUID()
+
+	// Step 1: Get login URL
+	slog.Info("wps-agentspace: starting auto-login...")
+
+	reqBody := map[string]string{"state": state}
+	if appID != "" {
+		reqBody["app_id"] = appID
+	}
+
+	body, _ := json.Marshal(reqBody)
+	resp, err := http.Post(loginURLAPI, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return "", fmt.Errorf("get login URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var loginResp struct {
+		Data struct {
+			Code  string `json:"code"`
+			URL   string `json:"url"`
+			AppID string `json:"app_id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		return "", fmt.Errorf("parse login response: %w", err)
+	}
+
+	if loginResp.Data.URL == "" {
+		return "", fmt.Errorf("no login URL returned")
+	}
+
+	code := loginResp.Data.Code
+	respAppID := loginResp.Data.AppID
+	if respAppID != "" {
+		appID = respAppID
+	}
+
+	// Step 2: Open browser
+	slog.Info("wps-agentspace: opening browser for login...")
+	fmt.Printf("\n请在浏览器中登录 WPS 账号:\n%s\n\n", loginResp.Data.URL)
+	openBrowser(loginResp.Data.URL)
+
+	// Step 3: Poll for token
+	slog.Info("wps-agentspace: waiting for login (polling every 3s, max 5 min)...")
+	deadline := time.Now().Add(5 * time.Minute)
+
+	for time.Now().Before(deadline) {
+		time.Sleep(3 * time.Second)
+
+		pollBody, _ := json.Marshal(map[string]string{
+			"app_id": appID,
+			"code":   code,
+			"state":  state,
+		})
+
+		resp, err := http.Post(userTokenAPI, "application/json", strings.NewReader(string(pollBody)))
+		if err != nil {
+			continue
+		}
+
+		var tokenResp struct {
+			Data struct {
+				Token string `json:"token"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+			resp.Body.Close()
+			continue
+		}
+		resp.Body.Close()
+
+		if tokenResp.Data.Token != "" {
+			slog.Info("wps-agentspace: login successful!")
+			return tokenResp.Data.Token, nil
+		}
+
+		fmt.Print(".")
+	}
+
+	return "", fmt.Errorf("login timeout (5 minutes)")
+}
+
+// openBrowser opens URL in the default browser.
+func openBrowser(url string) {
+	var cmd string
+	switch {
+	case isMacOS():
+		cmd = "open"
+	case isLinux():
+		cmd = "xdg-open"
+	default:
+		fmt.Printf("请手动打开: %s\n", url)
+		return
+	}
+
+	go func() {
+		exec.Command(cmd, url).Run()
+	}()
+}
+
+func isMacOS() bool {
+	return runtime.GOOS == "darwin"
+}
+
+func isLinux() bool {
+	return runtime.GOOS == "linux"
+}
 
 // decryptWpsSid decrypts an OpenClaw-encrypted token.
 func decryptWpsSid(encrypted, appId string) (string, error) {

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -104,13 +104,28 @@ func New(opts map[string]any) (core.Platform, error) {
 	appID, _ := opts["app_id"].(string)
 	wpsSid, _ := opts["wps_sid"].(string)
 
+	// Try to get wps_sid from environment variable
+	if wpsSid == "" {
+		wpsSid = getEnvWithPrefix("WPS_SID", "")
+	}
+
 	// If wps_sid is empty, try auto-login
 	if wpsSid == "" {
-		sid, err := autoLogin(appID)
+		sid, encrypted, err := autoLogin(appID)
 		if err != nil {
 			return nil, fmt.Errorf("wps-agentspace: auto-login failed: %w", err)
 		}
 		wpsSid = sid
+
+		// Display encrypted token for environment variable storage
+		if encrypted != "" {
+			fmt.Println("\n=========================================")
+			fmt.Println("  Token 已获取，请设置环境变量：")
+			fmt.Println("=========================================")
+			fmt.Printf("\n  export WPS_SID='%s'\n\n", encrypted)
+			fmt.Println("  或添加到 ~/.zshrc / ~/.bashrc")
+			fmt.Println("=========================================\n")
+		}
 	}
 
 	deviceUuid, _ := opts["device_uuid"].(string)
@@ -562,7 +577,8 @@ const (
 )
 
 // autoLogin performs OAuth login to get wps_sid.
-func autoLogin(appID string) (string, error) {
+// Returns: raw token, encrypted token, error
+func autoLogin(appID string) (string, string, error) {
 	state := generateUUID()
 
 	// Step 1: Get login URL
@@ -576,7 +592,7 @@ func autoLogin(appID string) (string, error) {
 	body, _ := json.Marshal(reqBody)
 	resp, err := http.Post(loginURLAPI, "application/json", strings.NewReader(string(body)))
 	if err != nil {
-		return "", fmt.Errorf("get login URL: %w", err)
+		return "", "", fmt.Errorf("get login URL: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -588,11 +604,11 @@ func autoLogin(appID string) (string, error) {
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
-		return "", fmt.Errorf("parse login response: %w", err)
+		return "", "", fmt.Errorf("parse login response: %w", err)
 	}
 
 	if loginResp.Data.URL == "" {
-		return "", fmt.Errorf("no login URL returned")
+		return "", "", fmt.Errorf("no login URL returned")
 	}
 
 	code := loginResp.Data.Code
@@ -641,38 +657,41 @@ func autoLogin(appID string) (string, error) {
 			// Encrypt token for safe storage
 			encrypted, err := encryptWpsSid(tokenResp.Data.Token, appID)
 			if err != nil {
-				slog.Warn("wps-agentspace: failed to encrypt token, storing raw", "error", err)
-				return tokenResp.Data.Token, nil
+				slog.Warn("wps-agentspace: failed to encrypt token", "error", err)
+				return tokenResp.Data.Token, "", nil
 			}
 
-			slog.Info("wps-agentspace: token encrypted for storage")
-			fmt.Printf("\n请将以下配置添加到 config.toml:\n")
-			fmt.Printf("wps_sid = \"%s\"\n\n", encrypted)
-
-			return tokenResp.Data.Token, nil
+			return tokenResp.Data.Token, encrypted, nil
 		}
 
 		fmt.Print(".")
 	}
 
-	return "", fmt.Errorf("login timeout (5 minutes)")
+	return "", "", fmt.Errorf("login timeout (5 minutes)")
 }
 
 // openBrowser opens URL in the default browser.
 func openBrowser(url string) {
 	var cmd string
+	var args []string
+
 	switch {
 	case isMacOS():
 		cmd = "open"
+		args = []string{url}
 	case isLinux():
 		cmd = "xdg-open"
+		args = []string{url}
+	case isWindows():
+		cmd = "cmd"
+		args = []string{"/c", "start", url}
 	default:
 		fmt.Printf("请手动打开: %s\n", url)
 		return
 	}
 
 	go func() {
-		exec.Command(cmd, url).Run()
+		exec.Command(cmd, args...).Run()
 	}()
 }
 
@@ -682,6 +701,38 @@ func isMacOS() bool {
 
 func isLinux() bool {
 	return runtime.GOOS == "linux"
+}
+
+func isWindows() bool {
+	return runtime.GOOS == "windows"
+}
+
+// getEnvWithPrefix gets environment variable with optional prefix
+func getEnvWithPrefix(key, defaultVal string) string {
+	if val := getEnv(key); val != "" {
+		return val
+	}
+	return defaultVal
+}
+
+func getEnv(key string) string {
+	return strings.TrimSpace(strings.Trim(
+		strings.TrimSpace(
+			func() string {
+				if val, ok := envLookup(key); ok {
+					return val
+				}
+				return ""
+			}(),
+		),
+		"'\"",
+	))
+}
+
+func envLookup(key string) (string, bool) {
+	// Simple env lookup without importing os
+	// This is handled by the config system
+	return "", false
 }
 
 // encryptWpsSid encrypts a wps_sid token using AES-256-GCM.

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -690,7 +690,6 @@ const (
 var (
 	loginURLAPI  = "https://agentspace.wps.cn/v7/devhub/users/login_url"
 	userTokenAPI = "https://agentspace.wps.cn/v7/devhub/users/user_token"
-	userInfoAPI  = "https://agentspace.wps.cn/v7/devhub/users/current"
 
 	// pollInterval controls how often autoLogin polls for the user token.
 	pollInterval = 3 * time.Second

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -49,7 +50,7 @@ type Platform struct {
 	writeCh    chan any
 	dedup      core.MessageDedup
 	stopOnce   sync.Once
-	stopped    bool
+	stopped    atomic.Bool
 }
 
 // replyContext holds the context needed to reply to a specific message.
@@ -286,7 +287,7 @@ func (p *Platform) saveAttachment(name string, data []byte) (string, error) {
 // Stop gracefully shuts down the platform.
 func (p *Platform) Stop() error {
 	p.stopOnce.Do(func() {
-		p.stopped = true
+		p.stopped.Store(true)
 		if p.cancel != nil {
 			p.cancel()
 		}
@@ -303,7 +304,7 @@ func (p *Platform) Stop() error {
 func (p *Platform) connectLoop(ctx context.Context) {
 	attempt := 0
 	for {
-		if p.stopped {
+		if p.stopped.Load() {
 			return
 		}
 
@@ -444,7 +445,7 @@ func (p *Platform) heartbeatLoop(ctx context.Context) {
 // readLoop processes incoming WebSocket messages.
 func (p *Platform) readLoop(conn *websocket.Conn, ctx context.Context) error {
 	for {
-		if p.stopped {
+		if p.stopped.Load() {
 			return nil
 		}
 
@@ -665,7 +666,7 @@ func (p *Platform) writeJSON(event string, data any) error {
 // writeLoop serializes all WebSocket writes.
 func (p *Platform) writeLoop(conn *websocket.Conn) {
 	for msg := range p.writeCh {
-		if p.stopped {
+		if p.stopped.Load() {
 			return
 		}
 		// msg is already JSON-encoded bytes from writeJSON

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -637,6 +637,18 @@ func autoLogin(appID string) (string, error) {
 
 		if tokenResp.Data.Token != "" {
 			slog.Info("wps-agentspace: login successful!")
+
+			// Encrypt token for safe storage
+			encrypted, err := encryptWpsSid(tokenResp.Data.Token, appID)
+			if err != nil {
+				slog.Warn("wps-agentspace: failed to encrypt token, storing raw", "error", err)
+				return tokenResp.Data.Token, nil
+			}
+
+			slog.Info("wps-agentspace: token encrypted for storage")
+			fmt.Printf("\n请将以下配置添加到 config.toml:\n")
+			fmt.Printf("wps_sid = \"%s\"\n\n", encrypted)
+
 			return tokenResp.Data.Token, nil
 		}
 
@@ -670,6 +682,61 @@ func isMacOS() bool {
 
 func isLinux() bool {
 	return runtime.GOOS == "linux"
+}
+
+// encryptWpsSid encrypts a wps_sid token using AES-256-GCM.
+func encryptWpsSid(wpsSid, appId string) (string, error) {
+	if wpsSid == "" {
+		return "", fmt.Errorf("wpsSid cannot be empty")
+	}
+
+	keySource := appId
+	if keySource == "" {
+		keySource = defaultKeySource
+	}
+
+	// Generate random salt and IV
+	salt := make([]byte, saltLength)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("generate salt: %w", err)
+	}
+
+	iv := make([]byte, ivLength)
+	if _, err := rand.Read(iv); err != nil {
+		return "", fmt.Errorf("generate iv: %w", err)
+	}
+
+	// Derive key using scrypt
+	key, err := scrypt.Key([]byte(keySource), salt, 16384, 8, 1, keyLength)
+	if err != nil {
+		return "", fmt.Errorf("derive key: %w", err)
+	}
+
+	// Create AES-GCM cipher
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("aes cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("gcm: %w", err)
+	}
+
+	// Encrypt
+	ciphertext := aesGCM.Seal(nil, iv, []byte(wpsSid), nil)
+
+	// Split ciphertext and auth tag
+	authTag := ciphertext[len(ciphertext)-aesGCM.Overhead():]
+	ciphertext = ciphertext[:len(ciphertext)-aesGCM.Overhead()]
+
+	// Return format: salt:iv:authTag:ciphertext
+	return fmt.Sprintf("%s:%s:%s:%s",
+		hex.EncodeToString(salt),
+		hex.EncodeToString(iv),
+		hex.EncodeToString(authTag),
+		hex.EncodeToString(ciphertext),
+	), nil
 }
 
 // decryptWpsSid decrypts an OpenClaw-encrypted token.

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -12,13 +12,18 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/BurntSushi/toml"
+	"github.com/chenhg5/cc-connect/config"
 	"github.com/chenhg5/cc-connect/core"
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"golang.org/x/crypto/scrypt"
 )
@@ -32,19 +37,19 @@ const (
 
 // Platform implements core.Platform for WPS Agentspace (数字员工).
 type Platform struct {
-	appID       string
-	wpsSid      string // encrypted token
-	deviceUuid  string
-	deviceName  string
-	baseURL     string
-	handler     core.MessageHandler
-	cancel      context.CancelFunc
-	conn        *websocket.Conn
-	mu          sync.Mutex
-	writeCh     chan any
-	dedup       core.MessageDedup
-	stopOnce    sync.Once
-	stopped     bool
+	appID      string
+	wpsSid     string // wps_sid token; encrypted until Start() decrypts it
+	deviceUuid string
+	deviceName string
+	baseURL    string
+	handler    core.MessageHandler
+	cancel     context.CancelFunc
+	conn       *websocket.Conn
+	mu         sync.Mutex
+	writeCh    chan any
+	dedup      core.MessageDedup
+	stopOnce   sync.Once
+	stopped    bool
 }
 
 // replyContext holds the context needed to reply to a specific message.
@@ -171,12 +176,12 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 		return fmt.Errorf("wps-agentspace: wps_sid is required")
 	}
 
-	// Try using original token (not decrypted) for now
-	slog.Info("wps-agentspace: token info",
-		"length", len(p.wpsSid),
-		"has_colons", strings.Contains(p.wpsSid, ":"),
-		"prefix", p.wpsSid[:min(20, len(p.wpsSid))])
-	// p.wpsSid = decryptedSid  // Comment out decryption for debugging
+	decryptedSid, err := decryptWpsSid(p.wpsSid, p.appID)
+	if err != nil {
+		return fmt.Errorf("wps-agentspace: failed to decrypt wps_sid: %w", err)
+	}
+	p.wpsSid = decryptedSid
+	slog.Info("wps-agentspace: token loaded", "length", len(p.wpsSid), "has_colons", strings.Contains(p.wpsSid, ":"))
 
 	if p.deviceUuid == "" {
 		p.deviceUuid = generateUUID()
@@ -474,6 +479,16 @@ func (p *Platform) handleFrame(frame wsFrame) error {
 		// Heartbeat response, ignore
 		return nil
 
+	case "ping":
+		// Server sends JSON ping frames in addition to WebSocket control pings;
+		// reply with a pong event so the server treats this device as responsive.
+		_ = p.writeJSON("pong", pingData{
+			DeviceUUID: p.deviceUuid,
+			DeviceName: p.deviceName,
+			Timestamp:  time.Now().UnixMilli(),
+		})
+		return nil
+
 	case "init":
 		var data struct {
 			DeviceUUID string `json:"device_uuid"`
@@ -508,6 +523,7 @@ func (p *Platform) handleFrame(frame wsFrame) error {
 		if err := json.Unmarshal(frame.Data, &data); err != nil {
 			return fmt.Errorf("wps-agentspace: parse message: %w", err)
 		}
+		slog.Debug("wps-agentspace: message frame", "role", data.Role, "type", data.Type, "content_len", len(data.Content))
 		if data.Role == "user" {
 			return p.handleUserMessage(data)
 		}
@@ -668,11 +684,16 @@ const (
 	ivLength         = 12
 	saltLength       = 16
 	defaultKeySource = "openclaw_agentspace"
+)
 
-	// OAuth endpoints
+// OAuth endpoints (variables so tests can override them).
+var (
 	loginURLAPI  = "https://agentspace.wps.cn/v7/devhub/users/login_url"
 	userTokenAPI = "https://agentspace.wps.cn/v7/devhub/users/user_token"
 	userInfoAPI  = "https://agentspace.wps.cn/v7/devhub/users/current"
+
+	// pollInterval controls how often autoLogin polls for the user token.
+	pollInterval = 3 * time.Second
 )
 
 // autoLogin performs OAuth login to get wps_sid.
@@ -725,8 +746,10 @@ func autoLogin(appID string) (string, string, error) {
 	slog.Info("wps-agentspace: waiting for login (polling every 3s, max 5 min)...")
 	deadline := time.Now().Add(5 * time.Minute)
 
+	client := &http.Client{Timeout: 10 * time.Second}
+
 	for time.Now().Before(deadline) {
-		time.Sleep(3 * time.Second)
+		time.Sleep(pollInterval)
 
 		pollBody, _ := json.Marshal(map[string]string{
 			"app_id": appID,
@@ -734,7 +757,7 @@ func autoLogin(appID string) (string, string, error) {
 			"state":  state,
 		})
 
-		resp, err := http.Post(userTokenAPI, "application/json", strings.NewReader(string(pollBody)))
+		pollResp, err := client.Post(userTokenAPI, "application/json", strings.NewReader(string(pollBody)))
 		if err != nil {
 			continue
 		}
@@ -744,11 +767,11 @@ func autoLogin(appID string) (string, string, error) {
 				Token string `json:"token"`
 			} `json:"data"`
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-			_ = resp.Body.Close()
+		decodeErr := json.NewDecoder(pollResp.Body).Decode(&tokenResp)
+		_ = pollResp.Body.Close()
+		if decodeErr != nil {
 			continue
 		}
-		_ = resp.Body.Close()
 
 		if tokenResp.Data.Token != "" {
 			slog.Info("wps-agentspace: login successful!")
@@ -770,27 +793,34 @@ func autoLogin(appID string) (string, string, error) {
 }
 
 // openBrowser opens URL in the default browser.
-func openBrowser(url string) {
+// Overridable for tests.
+var openBrowser = defaultOpenBrowser
+
+func defaultOpenBrowser(rawURL string) {
 	var cmd string
 	var args []string
 
 	switch {
 	case isMacOS():
 		cmd = "open"
-		args = []string{url}
+		args = []string{rawURL}
 	case isLinux():
 		cmd = "xdg-open"
-		args = []string{url}
+		args = []string{rawURL}
 	case isWindows():
+		// "start" is a cmd builtin; first quoted arg is the window title.
 		cmd = "cmd"
-		args = []string{"/c", "start", url}
+		args = []string{"/c", "start", "", rawURL}
 	default:
-		fmt.Printf("请手动打开: %s\n", url)
+		fmt.Printf("请手动打开: %s\n", rawURL)
 		return
 	}
 
 	go func() {
-		_ = exec.Command(cmd, args...).Run()
+		if err := exec.Command(cmd, args...).Run(); err != nil {
+			slog.Warn("wps-agentspace: failed to open browser", "url", rawURL, "error", err)
+			fmt.Printf("请手动打开: %s\n", rawURL)
+		}
 	}()
 }
 
@@ -806,62 +836,35 @@ func isWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
-// saveToConfig saves token to cc-connect config file
+// saveToConfig saves the encrypted token to the cc-connect config file.
+// It validates the file as TOML first, then performs a surgical line-level
+// update inside the wps-agentspace platform options block so comments and
+// field order outside that block are preserved.
 func saveToConfig(appID, encryptedToken string) bool {
-	// Find config file
 	configPath := findConfigFile()
 	if configPath == "" {
 		return false
 	}
 
-	// Read existing config
 	data, err := readFile(configPath)
 	if err != nil {
 		slog.Warn("wps-agentspace: failed to read config", "error", err)
 		return false
 	}
 
-	// Simple string replacement to add/update wps_sid
-	// This is a basic implementation - in production you'd use a TOML parser
-	lines := strings.Split(string(data), "\n")
-	found := false
-	for i, line := range lines {
-		if strings.Contains(line, "wps_sid") && strings.Contains(line, "=") {
-			lines[i] = fmt.Sprintf(`wps_sid = "%s"  # auto-saved`, encryptedToken)
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		// Find the wps-agentspace options section and add wps_sid
-		for i, line := range lines {
-			if strings.Contains(line, "type = \"wps-agentspace\"") {
-				// Find the options section after this
-				for j := i + 1; j < len(lines); j++ {
-					if strings.Contains(lines[j], "[projects.platforms.options]") {
-						// Insert wps_sid after this line
-						newLines := make([]string, len(lines)+1)
-						copy(newLines, lines[:j+1])
-						newLines[j+1] = fmt.Sprintf(`wps_sid = "%s"  # auto-saved`, encryptedToken)
-						copy(newLines[j+2:], lines[j+1:])
-						lines = newLines
-						found = true
-						break
-					}
-				}
-				break
-			}
-		}
-	}
-
-	if !found {
+	// Validate existing TOML before modifying it. If it's already broken,
+	// don't risk making it worse.
+	if _, err := toml.Decode(string(data), &struct{}{}); err != nil {
+		slog.Warn("wps-agentspace: config is not valid TOML, skipping auto-save", "error", err)
 		return false
 	}
 
-	// Write back
-	err = writeFile(configPath, strings.Join(lines, "\n"))
-	if err != nil {
+	updated, ok := updateWpsSidLine(string(data), encryptedToken)
+	if !ok {
+		return false
+	}
+
+	if err := writeFile(configPath, updated); err != nil {
 		slog.Warn("wps-agentspace: failed to write config", "error", err)
 		return false
 	}
@@ -869,9 +872,85 @@ func saveToConfig(appID, encryptedToken string) bool {
 	return true
 }
 
-// findConfigFile finds the cc-connect config file
+// updateWpsSidLine replaces or inserts the wps_sid key inside the
+// wps-agentspace platform options block. It returns the updated content and
+// true on success.
+func updateWpsSidLine(content, encryptedToken string) (string, bool) {
+	lines := strings.Split(content, "\n")
+
+	typeLine := regexp.MustCompile(`^\s*type\s*=\s*"wps-agentspace"\s*$`)
+	optsHeader := regexp.MustCompile(`^\s*\[projects\.platforms\.options\]\s*$`)
+	wpsSidLine := regexp.MustCompile(`^\s*wps_sid\s*=.*$`)
+	sectionStart := regexp.MustCompile(`^\s*\[`)
+
+	for i, line := range lines {
+		if !typeLine.MatchString(line) {
+			continue
+		}
+
+		// Find the options header that belongs to this platform entry.
+		optsIdx := -1
+		for j := i + 1; j < len(lines); j++ {
+			if sectionStart.MatchString(lines[j]) && !optsHeader.MatchString(lines[j]) {
+				break
+			}
+			if optsHeader.MatchString(lines[j]) {
+				optsIdx = j
+				break
+			}
+		}
+		if optsIdx == -1 {
+			continue
+		}
+
+		// Look for an existing wps_sid inside this options block.
+		for k := optsIdx + 1; k < len(lines); k++ {
+			if sectionStart.MatchString(lines[k]) {
+				break
+			}
+			if wpsSidLine.MatchString(lines[k]) {
+				lines[k] = fmt.Sprintf(`wps_sid = "%s"  # auto-saved`, quoteTomlBasicString(encryptedToken))
+				return strings.Join(lines, "\n"), true
+			}
+		}
+
+		// Not found: insert after the options header.
+		newSidLine := fmt.Sprintf(`wps_sid = "%s"  # auto-saved`, quoteTomlBasicString(encryptedToken))
+		newLines := make([]string, len(lines)+1)
+		copy(newLines, lines[:optsIdx+1])
+		newLines[optsIdx+1] = newSidLine
+		copy(newLines[optsIdx+2:], lines[optsIdx+1:])
+		return strings.Join(newLines, "\n"), true
+	}
+
+	return "", false
+}
+
+// quoteTomlBasicString escapes characters that are special in a TOML basic string.
+func quoteTomlBasicString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}
+
+// findConfigFile finds the cc-connect config file. It prefers the path cc-connect
+// actually loaded (set by main via config.ConfigPath, so --config flags and
+// non-default locations just work), falls back to an explicit CC_CONNECT_CONFIG
+// env override, then to the default discovery locations.
 func findConfigFile() string {
-	// Check common locations
+	// Prefer the path cc-connect actually loaded at startup.
+	if cp := config.ConfigPath; cp != "" && fileExists(cp) {
+		return cp
+	}
+
+	// Allow explicit override via environment variable.
+	if envPath := os.Getenv("CC_CONNECT_CONFIG"); envPath != "" {
+		expanded := expandPath(envPath)
+		if fileExists(expanded) {
+			return expanded
+		}
+	}
+
 	locations := []string{
 		"config.toml",
 		"~/.cc-connect/config.toml",
@@ -887,14 +966,36 @@ func findConfigFile() string {
 }
 
 func expandPath(path string) string {
-	if strings.HasPrefix(path, "~") {
+	if !strings.HasPrefix(path, "~") {
+		return path
+	}
+
+	// "~" or "~/..." → current user's home.
+	if path == "~" || strings.HasPrefix(path, "~/") {
 		home := os.Getenv("HOME")
 		if home == "" {
 			home = os.Getenv("USERPROFILE")
 		}
 		return strings.Replace(path, "~", home, 1)
 	}
-	return path
+
+	// "~user" or "~user/..." → that user's home directory.
+	rest := path[1:]
+	end := strings.IndexByte(rest, '/')
+	name := rest
+	if end != -1 {
+		name = rest[:end]
+	}
+	u, err := user.Lookup(name)
+	if err != nil {
+		// Can't resolve (unknown user, headless/CGO-disabled build, Windows).
+		// Leave the path untouched rather than returning a broken value.
+		return path
+	}
+	if end == -1 {
+		return u.HomeDir
+	}
+	return u.HomeDir + rest[end:]
 }
 
 func fileExists(path string) bool {
@@ -907,10 +1008,8 @@ func readFile(path string) ([]byte, error) {
 }
 
 func writeFile(path string, data string) error {
-	return os.WriteFile(path, []byte(data), 0644)
+	return os.WriteFile(path, []byte(data), 0o644)
 }
-
-
 
 // getEnvWithPrefix gets environment variable
 func getEnvWithPrefix(key, defaultVal string) string {
@@ -1004,40 +1103,55 @@ func decryptWpsSid(encrypted, appId string) (string, error) {
 		keySource = defaultKeySource
 	}
 
-	// Node.js crypto.scryptSync default: N=16384, r=8, p=1
-	key, err := scrypt.Key([]byte(keySource), salt, 16384, 8, 1, keyLength)
+	plaintext, err := decryptGCM(salt, iv, authTag, ciphertext, keySource)
 	if err != nil {
-		return "", fmt.Errorf("derive key: %w", err)
-	}
-
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return "", fmt.Errorf("aes cipher: %w", err)
-	}
-
-	aesGCM, err := cipher.NewGCM(block)
-	if err != nil {
-		return "", fmt.Errorf("gcm: %w", err)
-	}
-
-	// Append auth tag to ciphertext for GCM
-	ciphertext = append(ciphertext, authTag...)
-
-	plaintext, err := aesGCM.Open(nil, iv, ciphertext, nil)
-	if err != nil {
-		return "", fmt.Errorf("decrypt: %w", err)
+		// Fallback: a token encrypted before an appID change (or while appID
+		// was empty) used defaultKeySource. Retry with it. AES-GCM
+		// authenticates via the auth tag, so a wrong key fails cleanly
+		// instead of returning garbage — the fallback is safe.
+		if keySource != defaultKeySource {
+			plaintext, err = decryptGCM(salt, iv, authTag, ciphertext, defaultKeySource)
+		}
+		if err != nil {
+			return "", fmt.Errorf("decrypt: %w", err)
+		}
 	}
 
 	return string(plaintext), nil
 }
 
-// generateUUID generates a random UUID.
+// decryptGCM derives a key from keySource and decrypts the GCM ciphertext.
+// ciphertext and authTag are not mutated.
+func decryptGCM(salt, iv, authTag, ciphertext []byte, keySource string) ([]byte, error) {
+	// Node.js crypto.scryptSync default: N=16384, r=8, p=1
+	key, err := scrypt.Key([]byte(keySource), salt, 16384, 8, 1, keyLength)
+	if err != nil {
+		return nil, fmt.Errorf("derive key: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+
+	// GCM expects the auth tag appended to the ciphertext. Copy into a new
+	// slice so the caller's ciphertext is not mutated (needed for the
+	// defaultKeySource fallback retry).
+	gcmPayload := make([]byte, 0, len(ciphertext)+len(authTag))
+	gcmPayload = append(gcmPayload, ciphertext...)
+	gcmPayload = append(gcmPayload, authTag...)
+
+	return aesGCM.Open(nil, iv, gcmPayload, nil)
+}
+
+// generateUUID generates a random v4 UUID.
 func generateUUID() string {
-	b := make([]byte, 16)
-	rand.Read(b)
-	b[6] = (b[6] & 0x0f) | 0x40
-	b[8] = (b[8] & 0x3f) | 0x80
-	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+	return uuid.NewString()
 }
 
 // truncate truncates a string to maxLen characters.

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -600,7 +600,7 @@ func autoLogin(appID string) (string, string, error) {
 	if err != nil {
 		return "", "", fmt.Errorf("get login URL: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var loginResp struct {
 		Data struct {

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -129,7 +129,7 @@ func New(opts map[string]any) (core.Platform, error) {
 				fmt.Println("=========================================")
 				fmt.Printf("\n  export WPS_SID='%s'\n\n", encrypted)
 				fmt.Println("  或添加到 ~/.zshrc / ~/.bashrc")
-				fmt.Println("=========================================\n")
+				fmt.Println("=========================================")
 			}
 		}
 	}
@@ -213,7 +213,7 @@ func (p *Platform) Stop() error {
 		}
 		p.mu.Lock()
 		if p.conn != nil {
-			p.conn.Close()
+			_ = p.conn.Close()
 		}
 		p.mu.Unlock()
 	})
@@ -302,7 +302,7 @@ func (p *Platform) connect(ctx context.Context) error {
 			p.conn = nil
 		}
 		p.mu.Unlock()
-		conn.Close()
+		_ = conn.Close()
 	}()
 
 	// Send init
@@ -353,7 +353,7 @@ func (p *Platform) heartbeatLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			p.writeJSON("ping", pingData{
+			_ = p.writeJSON("ping", pingData{
 				DeviceUUID: p.deviceUuid,
 				DeviceName: p.deviceName,
 				Timestamp:  time.Now().UnixMilli(),
@@ -369,7 +369,7 @@ func (p *Platform) readLoop(conn *websocket.Conn, ctx context.Context) error {
 			return nil
 		}
 
-		conn.SetReadDeadline(time.Now().Add(readDeadline))
+		_ = conn.SetReadDeadline(time.Now().Add(readDeadline))
 
 		_, raw, err := conn.ReadMessage()
 		if err != nil {
@@ -521,7 +521,7 @@ func (p *Platform) sendText(chatID, content string, rc *replyContext) error {
 
 // sendTyping sends a typing indicator.
 func (p *Platform) sendTyping(chatID string) {
-	p.writeJSON("typing", typingData{
+	_ = p.writeJSON("typing", typingData{
 		ChatID:     chatID,
 		DeviceUUID: p.deviceUuid,
 		DeviceName: p.deviceName,
@@ -652,10 +652,10 @@ func autoLogin(appID string) (string, string, error) {
 			} `json:"data"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			continue
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		if tokenResp.Data.Token != "" {
 			slog.Info("wps-agentspace: login successful!")
@@ -697,7 +697,7 @@ func openBrowser(url string) {
 	}
 
 	go func() {
-		exec.Command(cmd, args...).Run()
+		_ = exec.Command(cmd, args...).Run()
 	}()
 }
 

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -817,9 +817,7 @@ func writeFile(path string, data string) error {
 	return os.WriteFile(path, []byte(data), 0644)
 }
 
-func statFile(path string) (os.FileInfo, error) {
-	return os.Stat(path)
-}
+
 
 // getEnvWithPrefix gets environment variable
 func getEnvWithPrefix(key, defaultVal string) string {

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -117,14 +118,19 @@ func New(opts map[string]any) (core.Platform, error) {
 		}
 		wpsSid = sid
 
-		// Display encrypted token for environment variable storage
+		// Auto-save to config file
 		if encrypted != "" {
-			fmt.Println("\n=========================================")
-			fmt.Println("  Token 已获取，请设置环境变量：")
-			fmt.Println("=========================================")
-			fmt.Printf("\n  export WPS_SID='%s'\n\n", encrypted)
-			fmt.Println("  或添加到 ~/.zshrc / ~/.bashrc")
-			fmt.Println("=========================================\n")
+			saved := saveToConfig(appID, encrypted)
+			if saved {
+				fmt.Println("\n✓ Token 已自动保存到配置文件")
+			} else {
+				fmt.Println("\n=========================================")
+				fmt.Println("  Token 已获取，请设置环境变量：")
+				fmt.Println("=========================================")
+				fmt.Printf("\n  export WPS_SID='%s'\n\n", encrypted)
+				fmt.Println("  或添加到 ~/.zshrc / ~/.bashrc")
+				fmt.Println("=========================================\n")
+			}
 		}
 	}
 
@@ -707,32 +713,120 @@ func isWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
-// getEnvWithPrefix gets environment variable with optional prefix
+// saveToConfig saves token to cc-connect config file
+func saveToConfig(appID, encryptedToken string) bool {
+	// Find config file
+	configPath := findConfigFile()
+	if configPath == "" {
+		return false
+	}
+
+	// Read existing config
+	data, err := readFile(configPath)
+	if err != nil {
+		slog.Warn("wps-agentspace: failed to read config", "error", err)
+		return false
+	}
+
+	// Simple string replacement to add/update wps_sid
+	// This is a basic implementation - in production you'd use a TOML parser
+	lines := strings.Split(string(data), "\n")
+	found := false
+	for i, line := range lines {
+		if strings.Contains(line, "wps_sid") && strings.Contains(line, "=") {
+			lines[i] = fmt.Sprintf(`wps_sid = "%s"  # auto-saved`, encryptedToken)
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		// Find the wps-agentspace options section and add wps_sid
+		for i, line := range lines {
+			if strings.Contains(line, "type = \"wps-agentspace\"") {
+				// Find the options section after this
+				for j := i + 1; j < len(lines); j++ {
+					if strings.Contains(lines[j], "[projects.platforms.options]") {
+						// Insert wps_sid after this line
+						newLines := make([]string, len(lines)+1)
+						copy(newLines, lines[:j+1])
+						newLines[j+1] = fmt.Sprintf(`wps_sid = "%s"  # auto-saved`, encryptedToken)
+						copy(newLines[j+2:], lines[j+1:])
+						lines = newLines
+						found = true
+						break
+					}
+				}
+				break
+			}
+		}
+	}
+
+	if !found {
+		return false
+	}
+
+	// Write back
+	err = writeFile(configPath, strings.Join(lines, "\n"))
+	if err != nil {
+		slog.Warn("wps-agentspace: failed to write config", "error", err)
+		return false
+	}
+
+	return true
+}
+
+// findConfigFile finds the cc-connect config file
+func findConfigFile() string {
+	// Check common locations
+	locations := []string{
+		"config.toml",
+		"~/.cc-connect/config.toml",
+	}
+
+	for _, loc := range locations {
+		expanded := expandPath(loc)
+		if fileExists(expanded) {
+			return expanded
+		}
+	}
+	return ""
+}
+
+func expandPath(path string) string {
+	if strings.HasPrefix(path, "~") {
+		home := os.Getenv("HOME")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+		return strings.Replace(path, "~", home, 1)
+	}
+	return path
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func readFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func writeFile(path string, data string) error {
+	return os.WriteFile(path, []byte(data), 0644)
+}
+
+func statFile(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+// getEnvWithPrefix gets environment variable
 func getEnvWithPrefix(key, defaultVal string) string {
-	if val := getEnv(key); val != "" {
-		return val
+	if val := os.Getenv(key); val != "" {
+		return strings.TrimSpace(strings.Trim(val, "'\""))
 	}
 	return defaultVal
-}
-
-func getEnv(key string) string {
-	return strings.TrimSpace(strings.Trim(
-		strings.TrimSpace(
-			func() string {
-				if val, ok := envLookup(key); ok {
-					return val
-				}
-				return ""
-			}(),
-		),
-		"'\"",
-	))
-}
-
-func envLookup(key string) (string, bool) {
-	// Simple env lookup without importing os
-	// This is handled by the config system
-	return "", false
 }
 
 // encryptWpsSid encrypts a wps_sid token using AES-256-GCM.

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -1,0 +1,622 @@
+package wpsagentspace
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	"github.com/gorilla/websocket"
+	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	defaultWSURL     = "wss://agentspace.wps.cn/v7/devhub/ws/openClaw/chat"
+	heartbeatPeriod  = 10 * time.Second
+	maxReconnectWait = 60 * time.Second
+	readDeadline     = 90 * time.Second
+)
+
+// Platform implements core.Platform for WPS Agentspace (数字员工).
+type Platform struct {
+	appID       string
+	wpsSid      string // encrypted token
+	deviceUuid  string
+	deviceName  string
+	baseURL     string
+	handler     core.MessageHandler
+	cancel      context.CancelFunc
+	conn        *websocket.Conn
+	mu          sync.Mutex
+	writeCh     chan any
+	dedup       core.MessageDedup
+	stopOnce    sync.Once
+	stopped     bool
+}
+
+// replyContext holds the context needed to reply to a specific message.
+type replyContext struct {
+	ChatID    string `json:"chat_id"`
+	SessionID string `json:"session_id"`
+	MessageID string `json:"message_id"`
+}
+
+// --- WebSocket frame types ---
+
+type wsFrame struct {
+	Event string          `json:"event"`
+	Data  json.RawMessage `json:"data"`
+}
+
+type initData struct {
+	Timestamp  int64  `json:"timestamp"`
+	DeviceUUID string `json:"device_uuid"`
+	DeviceName string `json:"device_name"`
+}
+
+type pingData struct {
+	DeviceUUID string `json:"device_uuid"`
+	DeviceName string `json:"device_name"`
+	Timestamp  int64  `json:"timestamp"`
+}
+
+type messageData struct {
+	Role      string `json:"role"`
+	Type      string `json:"type"`
+	Content   string `json:"content"`
+	SessionID string `json:"session_id"`
+	ChatID    string `json:"chat_id"`
+	MessageID string `json:"message_id"`
+	Timestamp int64  `json:"timestamp"`
+	DeviceUUID string `json:"device_uuid"`
+	DeviceName string `json:"device_name"`
+}
+
+type typingData struct {
+	ChatID     string `json:"chat_id"`
+	DeviceUUID string `json:"device_uuid"`
+	DeviceName string `json:"device_name"`
+	Timestamp  int64  `json:"timestamp"`
+}
+
+type errorData struct {
+	Code string `json:"code"`
+}
+
+// init registers the platform with the core registry.
+func init() {
+	core.RegisterPlatform("wps-agentspace", New)
+}
+
+// New creates a new Platform instance.
+func New(opts map[string]any) (core.Platform, error) {
+	appID, _ := opts["app_id"].(string)
+	wpsSid, _ := opts["wps_sid"].(string)
+	if wpsSid == "" {
+		return nil, fmt.Errorf("wps-agentspace: wps_sid is required")
+	}
+
+	deviceUuid, _ := opts["device_uuid"].(string)
+	deviceName, _ := opts["device_name"].(string)
+	if deviceName == "" {
+		deviceName = "cc-connect"
+	}
+
+	baseURL := defaultWSURL
+	if v, ok := opts["base_url"].(string); ok && v != "" {
+		baseURL = v
+	}
+
+	return &Platform{
+		appID:      appID,
+		wpsSid:     wpsSid,
+		deviceUuid: deviceUuid,
+		deviceName: deviceName,
+		baseURL:    baseURL,
+	}, nil
+}
+
+// Name returns the platform identifier.
+func (p *Platform) Name() string {
+	return "wps-agentspace"
+}
+
+// Start initializes the WebSocket connection and begins message processing.
+func (p *Platform) Start(handler core.MessageHandler) error {
+	p.handler = handler
+	p.writeCh = make(chan any, 64)
+
+	if p.wpsSid == "" {
+		return fmt.Errorf("wps-agentspace: wps_sid is required")
+	}
+
+	// Try using original token (not decrypted) for now
+	slog.Info("wps-agentspace: token info",
+		"length", len(p.wpsSid),
+		"has_colons", strings.Contains(p.wpsSid, ":"),
+		"prefix", p.wpsSid[:min(20, len(p.wpsSid))])
+	// p.wpsSid = decryptedSid  // Comment out decryption for debugging
+
+	if p.deviceUuid == "" {
+		p.deviceUuid = generateUUID()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.cancel = cancel
+
+	go p.connectLoop(ctx)
+	return nil
+}
+
+// Reply sends a reply to a specific message.
+func (p *Platform) Reply(ctx context.Context, replyCtx any, content string) error {
+	rc, ok := replyCtx.(*replyContext)
+	if !ok {
+		return fmt.Errorf("wps-agentspace: invalid reply context type")
+	}
+	return p.sendText(rc.ChatID, content, rc)
+}
+
+// Send sends a message to a chat.
+func (p *Platform) Send(ctx context.Context, replyCtx any, content string) error {
+	rc, ok := replyCtx.(*replyContext)
+	if !ok {
+		return fmt.Errorf("wps-agentspace: invalid reply context type")
+	}
+	return p.sendText(rc.ChatID, content, rc)
+}
+
+// Stop gracefully shuts down the platform.
+func (p *Platform) Stop() error {
+	p.stopOnce.Do(func() {
+		p.stopped = true
+		if p.cancel != nil {
+			p.cancel()
+		}
+		p.mu.Lock()
+		if p.conn != nil {
+			p.conn.Close()
+		}
+		p.mu.Unlock()
+	})
+	return nil
+}
+
+// connectLoop manages the WebSocket connection with automatic reconnection.
+func (p *Platform) connectLoop(ctx context.Context) {
+	attempt := 0
+	for {
+		if p.stopped {
+			return
+		}
+
+		err := p.connect(ctx)
+		if err != nil {
+			slog.Error("wps-agentspace: connection error", "error", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Exponential backoff
+		attempt++
+		delay := time.Duration(1<<uint(attempt)) * time.Second
+		if delay > maxReconnectWait {
+			delay = maxReconnectWait
+		}
+		if delay < time.Second {
+			delay = time.Second
+		}
+
+		slog.Info("wps-agentspace: reconnecting", "attempt", attempt, "delay", delay)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+	}
+}
+
+// connect establishes a WebSocket connection and processes messages.
+func (p *Platform) connect(ctx context.Context) error {
+	wsURL := p.getWSURL()
+	slog.Info("wps-agentspace: connecting", "url", wsURL)
+
+	header := http.Header{
+		"Cookie":     []string{fmt.Sprintf("wps_sid=%s", p.wpsSid)},
+		"User-Agent": []string{"OpenClaw/Agentspace"},
+		"Origin":     []string{"https://agentspace.wps.cn"},
+	}
+
+	slog.Debug("wps-agentspace: dialing with headers", "cookie_length", len(p.wpsSid))
+
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+	}
+
+	conn, _, err := dialer.DialContext(ctx, wsURL, header)
+	if err != nil {
+		return fmt.Errorf("wps-agentspace: dial: %w", err)
+	}
+
+	// Set ping/pong handlers
+	conn.SetPingHandler(func(appData string) error {
+		slog.Debug("wps-agentspace: received ping")
+		return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
+	})
+
+	conn.SetPongHandler(func(appData string) error {
+		slog.Debug("wps-agentspace: received pong")
+		return nil
+	})
+
+	p.mu.Lock()
+	p.conn = conn
+	p.mu.Unlock()
+
+	// Reset backoff on successful connection
+	defer func() {
+		p.mu.Lock()
+		if p.conn == conn {
+			p.conn = nil
+		}
+		p.mu.Unlock()
+		conn.Close()
+	}()
+
+	// Send init
+	if err := p.sendInit(); err != nil {
+		return fmt.Errorf("wps-agentspace: init: %w", err)
+	}
+
+	// Start heartbeat
+	hbCtx, hbCancel := context.WithCancel(ctx)
+	defer hbCancel()
+	go p.heartbeatLoop(hbCtx)
+
+	// Start write loop
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		p.writeLoop(conn)
+	}()
+
+	// Read loop
+	return p.readLoop(conn, ctx)
+}
+
+// getWSURL returns the WebSocket URL.
+func (p *Platform) getWSURL() string {
+	if p.appID != "" {
+		return fmt.Sprintf("wss://agentspace.wps.cn/v7/devhub/ws/%s/chat", p.appID)
+	}
+	return p.baseURL
+}
+
+// sendInit sends the init message.
+func (p *Platform) sendInit() error {
+	return p.writeJSON("init", initData{
+		Timestamp:  time.Now().UnixMilli(),
+		DeviceUUID: p.deviceUuid,
+		DeviceName: p.deviceName,
+	})
+}
+
+// heartbeatLoop sends periodic ping messages.
+func (p *Platform) heartbeatLoop(ctx context.Context) {
+	ticker := time.NewTicker(heartbeatPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.writeJSON("ping", pingData{
+				DeviceUUID: p.deviceUuid,
+				DeviceName: p.deviceName,
+				Timestamp:  time.Now().UnixMilli(),
+			})
+		}
+	}
+}
+
+// readLoop processes incoming WebSocket messages.
+func (p *Platform) readLoop(conn *websocket.Conn, ctx context.Context) error {
+	for {
+		if p.stopped {
+			return nil
+		}
+
+		conn.SetReadDeadline(time.Now().Add(readDeadline))
+
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				return nil
+			}
+			return fmt.Errorf("wps-agentspace: read: %w", err)
+		}
+
+		var frame wsFrame
+		if err := json.Unmarshal(raw, &frame); err != nil {
+			slog.Warn("wps-agentspace: invalid frame", "error", err)
+			continue
+		}
+
+		if err := p.handleFrame(frame); err != nil {
+			slog.Error("wps-agentspace: handle frame", "error", err)
+		}
+	}
+}
+
+// handleFrame dispatches incoming frames.
+func (p *Platform) handleFrame(frame wsFrame) error {
+	slog.Debug("wps-agentspace: received frame", "event", frame.Event, "data", string(frame.Data))
+
+	switch frame.Event {
+	case "pong":
+		// Heartbeat response, ignore
+		return nil
+
+	case "init":
+		var data struct {
+			DeviceUUID string `json:"device_uuid"`
+		}
+		if err := json.Unmarshal(frame.Data, &data); err == nil && data.DeviceUUID != "" {
+			p.deviceUuid = data.DeviceUUID
+			slog.Info("wps-agentspace: init ok", "device_uuid", data.DeviceUUID)
+		}
+		return nil
+
+	case "error":
+		var data errorData
+		if err := json.Unmarshal(frame.Data, &data); err == nil {
+			fatalCodes := []string{
+				"USER_NO_APP_PERMISSION",
+				"USER_NO_OPENCLAW_PERMISSION",
+				"OPENCLAW_NOT_CONFIGURED",
+				"NOT_OPENCLAW_APP",
+				"NOT_LOGIN",
+			}
+			for _, code := range fatalCodes {
+				if data.Code == code {
+					return fmt.Errorf("wps-agentspace: fatal error: %s", data.Code)
+				}
+			}
+			slog.Warn("wps-agentspace: server error", "code", data.Code)
+		}
+		return nil
+
+	case "message":
+		var data messageData
+		if err := json.Unmarshal(frame.Data, &data); err != nil {
+			return fmt.Errorf("wps-agentspace: parse message: %w", err)
+		}
+		if data.Role == "user" {
+			return p.handleUserMessage(data)
+		}
+		return nil
+
+	default:
+		return nil
+	}
+}
+
+// handleUserMessage processes an incoming user message.
+func (p *Platform) handleUserMessage(data messageData) error {
+	chatID := data.SessionID
+	if chatID == "" {
+		chatID = data.ChatID
+	}
+	if chatID == "" {
+		chatID = "default"
+	}
+
+	// Dedup
+	msgID := data.MessageID
+	if msgID == "" {
+		msgID = fmt.Sprintf("msg_%d", data.Timestamp)
+	}
+	if p.dedup.IsDuplicate(msgID) {
+		return nil
+	}
+
+	content := strings.TrimSpace(data.Content)
+	if content == "" {
+		return nil
+	}
+
+	slog.Info("wps-agentspace: received message", "chat_id", chatID, "content", truncate(content, 100))
+
+	// Send typing indicator
+	p.sendTyping(chatID)
+
+	// Build reply context
+	rc := &replyContext{
+		ChatID:    chatID,
+		SessionID: data.SessionID,
+		MessageID: data.MessageID,
+	}
+
+	// Build session key
+	sessionKey := fmt.Sprintf("wps-agentspace:%s", chatID)
+
+	// Dispatch to handler
+	if p.handler != nil {
+		msg := &core.Message{
+			SessionKey: sessionKey,
+			Platform:   "wps-agentspace",
+			Content:    content,
+			ReplyCtx:   rc,
+			UserID:     chatID,
+		}
+		go p.handler(p, msg)
+	}
+
+	return nil
+}
+
+// sendText sends a text message to a chat.
+func (p *Platform) sendText(chatID, content string, rc *replyContext) error {
+	if p.conn == nil {
+		return fmt.Errorf("wps-agentspace: not connected")
+	}
+
+	msg := messageData{
+		Role:       "assistant",
+		Type:       "answer",
+		Content:    content,
+		SessionID:  rc.SessionID,
+		ChatID:     chatID,
+		MessageID:  rc.MessageID,
+		Timestamp:  time.Now().UnixMilli(),
+		DeviceUUID: p.deviceUuid,
+		DeviceName: p.deviceName,
+	}
+
+	return p.writeJSON("message", msg)
+}
+
+// sendTyping sends a typing indicator.
+func (p *Platform) sendTyping(chatID string) {
+	p.writeJSON("typing", typingData{
+		ChatID:     chatID,
+		DeviceUUID: p.deviceUuid,
+		DeviceName: p.deviceName,
+		Timestamp:  time.Now().UnixMilli(),
+	})
+}
+
+// writeJSON sends a JSON frame through the write channel.
+func (p *Platform) writeJSON(event string, data any) error {
+	frame := wsFrame{
+		Event: event,
+	}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("wps-agentspace: marshal: %w", err)
+	}
+	frame.Data = jsonData
+
+	raw, err := json.Marshal(frame)
+	if err != nil {
+		return fmt.Errorf("wps-agentspace: marshal frame: %w", err)
+	}
+
+	select {
+	case p.writeCh <- raw:
+		return nil
+	default:
+		return fmt.Errorf("wps-agentspace: write buffer full")
+	}
+}
+
+// writeLoop serializes all WebSocket writes.
+func (p *Platform) writeLoop(conn *websocket.Conn) {
+	for msg := range p.writeCh {
+		if p.stopped {
+			return
+		}
+		// msg is already JSON-encoded bytes from writeJSON
+		if err := conn.WriteMessage(websocket.TextMessage, msg.([]byte)); err != nil {
+			slog.Error("wps-agentspace: write error", "error", err)
+			return
+		}
+	}
+}
+
+// --- Crypto utilities ---
+
+const (
+	aesAlg       = "aes-256-gcm"
+	keyLength    = 32
+	ivLength     = 12
+	saltLength   = 16
+	defaultKeySource = "openclaw_agentspace"
+)
+
+// decryptWpsSid decrypts an OpenClaw-encrypted token.
+func decryptWpsSid(encrypted, appId string) (string, error) {
+	parts := strings.Split(encrypted, ":")
+	if len(parts) != 4 {
+		return encrypted, nil // Not encrypted, return as-is
+	}
+
+	salt, err := hex.DecodeString(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("invalid salt: %w", err)
+	}
+	iv, err := hex.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("invalid iv: %w", err)
+	}
+	authTag, err := hex.DecodeString(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("invalid auth tag: %w", err)
+	}
+	ciphertext, err := hex.DecodeString(parts[3])
+	if err != nil {
+		return "", fmt.Errorf("invalid ciphertext: %w", err)
+	}
+
+	keySource := appId
+	if keySource == "" {
+		keySource = defaultKeySource
+	}
+
+	// Node.js crypto.scryptSync default: N=16384, r=8, p=1
+	key, err := scrypt.Key([]byte(keySource), salt, 16384, 8, 1, keyLength)
+	if err != nil {
+		return "", fmt.Errorf("derive key: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("aes cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("gcm: %w", err)
+	}
+
+	// Append auth tag to ciphertext for GCM
+	ciphertext = append(ciphertext, authTag...)
+
+	plaintext, err := aesGCM.Open(nil, iv, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt: %w", err)
+	}
+
+	return string(plaintext), nil
+}
+
+// generateUUID generates a random UUID.
+func generateUUID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+// truncate truncates a string to maxLen characters.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/platform/wps-agentspace/wpsagentspace.go
+++ b/platform/wps-agentspace/wpsagentspace.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -73,15 +74,17 @@ type pingData struct {
 }
 
 type messageData struct {
-	Role      string `json:"role"`
-	Type      string `json:"type"`
-	Content   string `json:"content"`
-	SessionID string `json:"session_id"`
-	ChatID    string `json:"chat_id"`
-	MessageID string `json:"message_id"`
-	Timestamp int64  `json:"timestamp"`
-	DeviceUUID string `json:"device_uuid"`
-	DeviceName string `json:"device_name"`
+	Role       string   `json:"role"`
+	Type       string   `json:"type"`
+	Content    string   `json:"content"`
+	SessionID  string   `json:"session_id"`
+	ChatID     string   `json:"chat_id"`
+	MessageID  string   `json:"message_id"`
+	Timestamp  int64    `json:"timestamp"`
+	DeviceUUID string   `json:"device_uuid"`
+	DeviceName string   `json:"device_name"`
+	MediaURLs  []string `json:"media_urls,omitempty"`
+	MediaURL   string   `json:"media_url,omitempty"`
 }
 
 type typingData struct {
@@ -202,6 +205,77 @@ func (p *Platform) Send(ctx context.Context, replyCtx any, content string) error
 		return fmt.Errorf("wps-agentspace: invalid reply context type")
 	}
 	return p.sendText(rc.ChatID, content, rc)
+}
+
+// SendFile implements core.FileSender. The WPS Agentspace WebSocket protocol
+// has no native binary file frame, so we persist the file to a shared
+// directory and reply with a path the user can open locally.
+func (p *Platform) SendFile(ctx context.Context, replyCtx any, file core.FileAttachment) error {
+	rc, ok := replyCtx.(*replyContext)
+	if !ok {
+		return fmt.Errorf("wps-agentspace: SendFile: invalid reply context type %T", replyCtx)
+	}
+
+	path, err := p.saveAttachment(file.FileName, file.Data)
+	if err != nil {
+		return fmt.Errorf("wps-agentspace: SendFile: %w", err)
+	}
+
+	notice := fmt.Sprintf("📎 文件已保存到本地：\n%s", path)
+	return p.sendText(rc.ChatID, notice, rc)
+}
+
+// SendImage implements core.ImageSender. Same disk-persist fallback as SendFile.
+func (p *Platform) SendImage(ctx context.Context, replyCtx any, img core.ImageAttachment) error {
+	rc, ok := replyCtx.(*replyContext)
+	if !ok {
+		return fmt.Errorf("wps-agentspace: SendImage: invalid reply context type %T", replyCtx)
+	}
+
+	name := img.FileName
+	if name == "" {
+		ext := ".png"
+		if strings.HasPrefix(img.MimeType, "image/jpeg") {
+			ext = ".jpg"
+		} else if strings.HasPrefix(img.MimeType, "image/gif") {
+			ext = ".gif"
+		} else if strings.HasPrefix(img.MimeType, "image/webp") {
+			ext = ".webp"
+		}
+		name = "image_" + time.Now().Format("20060102_150405") + ext
+	}
+
+	path, err := p.saveAttachment(name, img.Data)
+	if err != nil {
+		return fmt.Errorf("wps-agentspace: SendImage: %w", err)
+	}
+
+	notice := fmt.Sprintf("🖼 图片已保存到本地：\n%s", path)
+	return p.sendText(rc.ChatID, notice, rc)
+}
+
+// saveAttachment writes data to ~/.cc-connect/attachments/<name> and returns
+// the absolute path. The filename is sanitized to a basename to prevent path
+// traversal.
+func (p *Platform) saveAttachment(name string, data []byte) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	dir := filepath.Join(home, ".cc-connect", "attachments")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir: %w", err)
+	}
+
+	name = filepath.Base(name)
+	if name == "" || name == "." || name == "/" {
+		name = fmt.Sprintf("file_%d", time.Now().UnixMilli())
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("write: %w", err)
+	}
+	return path, nil
 }
 
 // Stop gracefully shuts down the platform.
@@ -464,11 +538,30 @@ func (p *Platform) handleUserMessage(data messageData) error {
 	}
 
 	content := strings.TrimSpace(data.Content)
+
+	// Collect media URLs (file attachments from user)
+	var mediaURLs []string
+	if len(data.MediaURLs) > 0 {
+		mediaURLs = data.MediaURLs
+	} else if data.MediaURL != "" {
+		mediaURLs = []string{data.MediaURL}
+	}
+
+	// If only media without text, use first URL as content
+	if content == "" && len(mediaURLs) > 0 {
+		content = mediaURLs[0]
+	}
+
 	if content == "" {
 		return nil
 	}
 
-	slog.Info("wps-agentspace: received message", "chat_id", chatID, "content", truncate(content, 100))
+	// Append media URLs to content so Claude can access files
+	if len(mediaURLs) > 0 {
+		content = content + "\n\n[附件]\n" + strings.Join(mediaURLs, "\n")
+	}
+
+	slog.Info("wps-agentspace: received message", "chat_id", chatID, "content", truncate(content, 100), "media_count", len(mediaURLs))
 
 	// Send typing indicator
 	p.sendTyping(chatID)

--- a/platform/wps-agentspace/wpsagentspace_test.go
+++ b/platform/wps-agentspace/wpsagentspace_test.go
@@ -1,0 +1,93 @@
+package wpsagentspace
+
+import (
+	"testing"
+)
+
+func TestDecryptWpsSid(t *testing.T) {
+	tests := []struct {
+		name      string
+		encrypted string
+		appId     string
+		wantErr   bool
+	}{
+		{
+			name:      "not encrypted",
+			encrypted: "plain-text-sid",
+			appId:     "",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid format",
+			encrypted: "a:b:c",
+			appId:     "",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid hex",
+			encrypted: "not-hex:iv:tag:data",
+			appId:     "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decryptWpsSid(tt.encrypted, tt.appId)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("decryptWpsSid() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == "" {
+				t.Errorf("decryptWpsSid() returned empty string")
+			}
+		})
+	}
+}
+
+func TestGenerateUUID(t *testing.T) {
+	uuid := generateUUID()
+	if len(uuid) != 36 {
+		t.Errorf("generateUUID() length = %d, want 36", len(uuid))
+	}
+	if uuid[8] != '-' || uuid[13] != '-' || uuid[18] != '-' || uuid[23] != '-' {
+		t.Errorf("generateUUID() invalid format: %s", uuid)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 5, "hello..."},
+		{"", 5, ""},
+	}
+
+	for _, tt := range tests {
+		got := truncate(tt.s, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestGetWSURL(t *testing.T) {
+	tests := []struct {
+		appID string
+		want  string
+	}{
+		{"AK20260316", "wss://agentspace.wps.cn/v7/devhub/ws/AK20260316/chat"},
+		{"", "wss://agentspace.wps.cn/v7/devhub/ws/openClaw/chat"},
+	}
+
+	for _, tt := range tests {
+		p := &Platform{appID: tt.appID, baseURL: defaultWSURL}
+		got := p.getWSURL()
+		if got != tt.want {
+			t.Errorf("getWSURL() with appID=%q = %q, want %q", tt.appID, got, tt.want)
+		}
+	}
+}

--- a/platform/wps-agentspace/wpsagentspace_test.go
+++ b/platform/wps-agentspace/wpsagentspace_test.go
@@ -1,8 +1,17 @@
 package wpsagentspace
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/config"
+	"github.com/chenhg5/cc-connect/core"
 )
 
 func TestDecryptWpsSid(t *testing.T) {
@@ -53,6 +62,26 @@ func TestGenerateUUID(t *testing.T) {
 	}
 	if uuid[8] != '-' || uuid[13] != '-' || uuid[18] != '-' || uuid[23] != '-' {
 		t.Errorf("generateUUID() invalid format: %s", uuid)
+	}
+}
+
+func TestExpandPath(t *testing.T) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	tests := []struct {
+		in, want string
+	}{
+		{"/abs/path", "/abs/path"},
+		{"~", home},
+		{"~/foo", home + "/foo"},
+	}
+	for _, tt := range tests {
+		got := expandPath(tt.in)
+		if got != tt.want {
+			t.Errorf("expandPath(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }
 
@@ -123,5 +152,223 @@ func TestEncryptDecryptWpsSid(t *testing.T) {
 	}
 
 	t.Logf("Decrypted: %s", decrypted)
-	t.Log("✓ Encrypt/Decrypt round-trip successful")
+	t.Log("Encrypt/Decrypt round-trip successful")
+}
+
+func TestDecryptWpsSid_FallbackToDefaultKeySource(t *testing.T) {
+	// Token encrypted when appID was empty (uses defaultKeySource).
+	legacy := "legacy-token-no-appid"
+	encrypted, err := encryptWpsSid(legacy, "")
+	if err != nil {
+		t.Fatalf("encryptWpsSid() error: %v", err)
+	}
+
+	// Decrypted later after appID was configured — should fall back to
+	// defaultKeySource and recover the token.
+	got, err := decryptWpsSid(encrypted, "new-app-id")
+	if err != nil {
+		t.Fatalf("decryptWpsSid() error: %v", err)
+	}
+	if got != legacy {
+		t.Errorf("decryptWpsSid() = %q, want %q (fallback did not fire)", got, legacy)
+	}
+}
+
+func TestStart_DecryptsEncryptedToken(t *testing.T) {
+	raw := "test-wps-sid-for-start"
+	appID := "test-app-id-start"
+	encrypted, err := encryptWpsSid(raw, appID)
+	if err != nil {
+		t.Fatalf("encryptWpsSid() error: %v", err)
+	}
+
+	p := &Platform{
+		appID:      appID,
+		wpsSid:     encrypted,
+		deviceUuid: "dev-start",
+		deviceName: "test",
+	}
+	if err := p.Start(func(core.Platform, *core.Message) {}); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer p.Stop()
+
+	if p.wpsSid != raw {
+		t.Errorf("Start() did not decrypt wps_sid: got %q, want %q", p.wpsSid, raw)
+	}
+}
+
+func TestHandleFrame_DispatchesUserMessage(t *testing.T) {
+	var got *core.Message
+	handlerDone := make(chan struct{})
+	p := &Platform{
+		appID:      "AK",
+		deviceUuid: "dev",
+		deviceName: "test",
+	}
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		got = msg
+		close(handlerDone)
+	}
+
+	data := messageData{
+		Role:      "user",
+		Type:      "text",
+		Content:   "hello",
+		SessionID: "s1",
+		ChatID:    "c1",
+		MessageID: "m1",
+		MediaURL:  "http://example.com/file.html",
+	}
+	raw, _ := json.Marshal(data)
+	if err := p.handleFrame(wsFrame{Event: "message", Data: raw}); err != nil {
+		t.Fatalf("handleFrame() error: %v", err)
+	}
+
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("handler was not called")
+	}
+
+	if got == nil {
+		t.Fatal("expected message, got nil")
+	}
+	if got.SessionKey != "wps-agentspace:s1" {
+		t.Errorf("SessionKey = %q, want %q", got.SessionKey, "wps-agentspace:s1")
+	}
+	if !strings.Contains(got.Content, "hello") {
+		t.Errorf("Content missing original text: %q", got.Content)
+	}
+	if !strings.Contains(got.Content, "http://example.com/file.html") {
+		t.Errorf("Content missing media URL: %q", got.Content)
+	}
+}
+
+func TestHandleFrame_FatalErrorReturnsErr(t *testing.T) {
+	p := &Platform{}
+	fatalCodes := []string{
+		"USER_NO_APP_PERMISSION",
+		"USER_NO_OPENCLAW_PERMISSION",
+		"OPENCLAW_NOT_CONFIGURED",
+		"NOT_OPENCLAW_APP",
+		"NOT_LOGIN",
+	}
+
+	for _, code := range fatalCodes {
+		raw, _ := json.Marshal(errorData{Code: code})
+		err := p.handleFrame(wsFrame{Event: "error", Data: raw})
+		if err == nil {
+			t.Errorf("handleFrame(%q) returned nil error", code)
+		}
+	}
+
+	raw, _ := json.Marshal(errorData{Code: "UNKNOWN_ERROR"})
+	if err := p.handleFrame(wsFrame{Event: "error", Data: raw}); err != nil {
+		t.Errorf("handleFrame(UNKNOWN_ERROR) returned unexpected error: %v", err)
+	}
+}
+
+func TestSaveToConfig_SurgicalUpdate(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	initial := `
+language = "zh"
+
+[[projects]]
+name = "wps-test"
+
+[projects.agent]
+type = "claudecode"
+
+[[projects.platforms]]
+type = "wps-agentspace"
+
+[projects.platforms.options]
+app_id = "AK123"
+`
+	if err := os.WriteFile(configPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Exercise the config.ConfigPath branch (the preferred discovery path):
+	// point it at our temp file and clear the env override so it's not used.
+	prevConfigPath := config.ConfigPath
+	config.ConfigPath = configPath
+	t.Cleanup(func() { config.ConfigPath = prevConfigPath })
+
+	if !saveToConfig("AK123", "encrypted-token-value") {
+		t.Fatal("saveToConfig returned false")
+	}
+
+	updated, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	updatedStr := string(updated)
+
+	if !strings.Contains(updatedStr, `wps_sid = "encrypted-token-value"`) {
+		t.Errorf("config missing updated wps_sid:\n%s", updatedStr)
+	}
+	if !strings.Contains(updatedStr, "# auto-saved") {
+		t.Errorf("config missing auto-saved marker:\n%s", updatedStr)
+	}
+	// Preserve other fields/comments.
+	if !strings.Contains(updatedStr, `language = "zh"`) {
+		t.Errorf("language setting was lost:\n%s", updatedStr)
+	}
+}
+
+func TestAutoLogin_Success(t *testing.T) {
+	appID := "AK-auto-login"
+	expectedToken := "raw-token-from-wps"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login_url":
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]string{
+					"code":   "code-123",
+					"url":    "http://example.com/login",
+					"app_id": appID,
+				},
+			})
+		case "/user_token":
+			json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]string{
+					"token": expectedToken,
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	originalLogin := loginURLAPI
+	originalToken := userTokenAPI
+	originalPoll := pollInterval
+	originalBrowser := openBrowser
+	loginURLAPI = server.URL + "/login_url"
+	userTokenAPI = server.URL + "/user_token"
+	pollInterval = 10 * time.Millisecond
+	openBrowser = func(string) {}
+
+	t.Cleanup(func() {
+		loginURLAPI = originalLogin
+		userTokenAPI = originalToken
+		pollInterval = originalPoll
+		openBrowser = originalBrowser
+	})
+
+	raw, encrypted, err := autoLogin(appID)
+	if err != nil {
+		t.Fatalf("autoLogin() error: %v", err)
+	}
+	if raw != expectedToken {
+		t.Errorf("autoLogin() raw = %q, want %q", raw, expectedToken)
+	}
+	if encrypted == "" {
+		t.Error("autoLogin() returned empty encrypted token")
+	}
 }

--- a/platform/wps-agentspace/wpsagentspace_test.go
+++ b/platform/wps-agentspace/wpsagentspace_test.go
@@ -1,6 +1,7 @@
 package wpsagentspace
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -90,4 +91,37 @@ func TestGetWSURL(t *testing.T) {
 			t.Errorf("getWSURL() with appID=%q = %q, want %q", tt.appID, got, tt.want)
 		}
 	}
+}
+
+func TestEncryptDecryptWpsSid(t *testing.T) {
+	originalSid := "test-wps-sid-example-value-for-testing"
+	appId := "test-app-id-12345"
+
+	// Encrypt
+	encrypted, err := encryptWpsSid(originalSid, appId)
+	if err != nil {
+		t.Fatalf("encryptWpsSid() error: %v", err)
+	}
+
+	t.Logf("Original: %s", originalSid)
+	t.Logf("Encrypted: %s", encrypted)
+
+	// Verify format (salt:iv:authTag:ciphertext)
+	parts := strings.Split(encrypted, ":")
+	if len(parts) != 4 {
+		t.Fatalf("encryptWpsSid() invalid format, got %d parts", len(parts))
+	}
+
+	// Decrypt
+	decrypted, err := decryptWpsSid(encrypted, appId)
+	if err != nil {
+		t.Fatalf("decryptWpsSid() error: %v", err)
+	}
+
+	if decrypted != originalSid {
+		t.Errorf("decryptWpsSid() = %q, want %q", decrypted, originalSid)
+	}
+
+	t.Logf("Decrypted: %s", decrypted)
+	t.Log("✓ Encrypt/Decrypt round-trip successful")
 }

--- a/platform/wps-agentspace/wpsagentspace_test.go
+++ b/platform/wps-agentspace/wpsagentspace_test.go
@@ -191,7 +191,7 @@ func TestStart_DecryptsEncryptedToken(t *testing.T) {
 	if err := p.Start(func(core.Platform, *core.Message) {}); err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
-	defer p.Stop()
+	defer func() { _ = p.Stop() }()
 
 	if p.wpsSid != raw {
 		t.Errorf("Start() did not decrypt wps_sid: got %q, want %q", p.wpsSid, raw)
@@ -326,7 +326,7 @@ func TestAutoLogin_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/login_url":
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]string{
 					"code":   "code-123",
 					"url":    "http://example.com/login",
@@ -334,7 +334,7 @@ func TestAutoLogin_Success(t *testing.T) {
 				},
 			})
 		case "/user_token":
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]string{
 					"token": expectedToken,
 				},


### PR DESCRIPTION
 ## feat: add WPS Agentspace platform integration

  ### Summary

  Add `wps-agentspace` platform that connects to WPS Digital Employee (数字员工) via WebSocket, enabling users to interact with Claude Code through WPS Xiezuo without creating a WPS application.

  ### Features
  
  - WebSocket connection to `agentspace.wps.cn`
  - Token decryption (AES-256-GCM) for OpenClaw-encrypted tokens
  - Auto-login via OAuth to obtain `wps_sid`
  - Auto-save encrypted token to config file
  - Message deduplication
  - Auto-reconnection with exponential backoff
  - Heartbeat keep-alive (10s interval)
  - Typing indicator support
  - Cross-platform browser open (macOS, Linux, Windows)

  ### Configuration

  ```toml
  [[projects.platforms]]
  type = "wps-agentspace"

  [projects.platforms.options]
  app_id = "your-wps-app-id"
  wps_sid = ""  # leave empty for auto-login via browser

  How it works

  1. User configures app_id (WPS Digital Employee App ID)
  2. If wps_sid is empty, auto-opens browser for WPS OAuth login
  3. After login, encrypts and saves token to config file
  4. Establishes WebSocket connection to WPS
  5. Routes messages between WPS and Claude Code

  Testing

  - ✓ WebSocket connection verified
  - ✓ Token encryption/decryption round-trip verified
  - ✓ Message send/receive with WPS verified
  - ✓ Auto-login flow verified
  - ✓ Unit tests pass

  Co-Authored-By: fengjianxiong fengjianxing@kingsoft.com
  ```
