### PR TITLE
feat(pi): add RPC mode with extension_ui permission forwarding

### DIFF
--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -20,7 +20,7 @@ func init() {
 	core.RegisterAgent("pi", New)
 }
 
-// Agent drives the pi coding agent CLI (`pi --mode json --no-input`).
+// Agent drives the pi coding agent CLI.
 type Agent struct {
 	cmd          string   // path to pi binary
 	cliExtraArgs []string // extra args from cmd after the binary name
@@ -29,6 +29,7 @@ type Agent struct {
 	model        string
 	mode         string // "default" | "yolo"
 	thinking     string // reasoning effort: off, minimal, low, medium, high, xhigh
+	rpc          bool   // true = --mode rpc (persistent, extension_ui); false = --mode json (one-shot, default)
 	sessionEnv   []string
 	mu           sync.Mutex
 }
@@ -41,6 +42,8 @@ func New(opts map[string]any) (core.Agent, error) {
 	model, _ := opts["model"].(string)
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
+	thinking, _ := opts["thinking"].(string)
+	rpc, _ := opts["rpc"].(bool)
 
 	cmd, extraArgs := core.ParseCmdOpts(opts, "pi")
 
@@ -62,6 +65,8 @@ func New(opts map[string]any) (core.Agent, error) {
 		workDir:      workDir,
 		model:        model,
 		mode:         mode,
+		thinking:     thinking,
+		rpc:          rpc,
 	}, nil
 }
 
@@ -114,8 +119,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	extraArgs := append([]string{}, a.cliExtraArgs...)
 	extraEnv := append([]string(nil), a.configEnv...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
+	rpc := a.rpc
 	a.mu.Unlock()
-	return newPiSession(ctx, a.cmd, extraArgs, a.workDir, model, mode, thinking, sessionID, extraEnv)
+	return newPiSession(ctx, a.cmd, extraArgs, a.workDir, model, mode, thinking, rpc, sessionID, extraEnv)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -83,6 +83,28 @@ func (a *Agent) Name() string           { return "pi" }
 func (a *Agent) CLIBinaryName() string  { return a.cmd }
 func (a *Agent) CLIDisplayName() string { return "Pi" }
 
+// WorkspaceAgentOptions implements core.WorkspaceAgentOptionSnapshotter.
+// It returns the user-configured options that must propagate to per-workspace
+// agents reconstructed by the engine in multi-workspace mode. work_dir is
+// intentionally omitted — the engine sets the target workspace. sessionEnv is
+// also omitted (runtime-only). model and mode are copied by the engine via
+// GetModel/GetMode, so we don't repeat them here.
+func (a *Agent) WorkspaceAgentOptions() map[string]any {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	opts := map[string]any{}
+	if a.cmd != "" && a.cmd != "pi" {
+		opts["cmd"] = a.cmd
+	}
+	if a.rpc {
+		opts["rpc"] = true
+	}
+	if a.thinking != "" {
+		opts["thinking"] = a.thinking
+	}
+	return opts
+}
+
 func (a *Agent) SetModel(model string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1,9 +1,9 @@
 package pi
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -345,7 +345,8 @@ func TestAgent_SetSessionEnv(t *testing.T) {
 }
 
 func TestAgent_ListSessions(t *testing.T) {
-	a := &Agent{}
+	// Use a temp dir so we don't pick up real Pi sessions from the machine.
+	a := &Agent{workDir: t.TempDir()}
 	sessions, err := a.ListSessions(context.Background())
 	if err != nil {
 		t.Errorf("ListSessions() error = %v", err)
@@ -645,11 +646,11 @@ func TestCleanAttachments_NonexistentDir(t *testing.T) {
 
 func TestPiSessionAttachmentDirsAreIsolated(t *testing.T) {
 	workDir := t.TempDir()
-	s1, err := newPiSession(context.Background(), "pi", nil, workDir, "", "", "", "", nil)
+	s1, err := newPiSession(context.Background(), "pi", nil, workDir, "", "", "", false, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s2, err := newPiSession(context.Background(), "pi", nil, workDir, "", "", "", "", nil)
+	s2, err := newPiSession(context.Background(), "pi", nil, workDir, "", "", "", false, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -679,12 +680,20 @@ func TestPiSessionAttachmentDirsAreIsolated(t *testing.T) {
 
 // ── handleEvent ──────────────────────────────────────────────
 
-func newTestSession() *piSession {
+func newTestSession(opts ...bool) *piSession {
 	ctx, cancel := context.WithCancel(context.Background())
+	rpc := len(opts) > 0 && opts[0]
+	rpcReady := make(chan struct{})
+	close(rpcReady) // pre-closed: no real RPC process to wait for
 	s := &piSession{
-		events: make(chan core.Event, 64),
-		ctx:    ctx,
-		cancel: cancel,
+		events:        make(chan core.Event, 64),
+		ctx:           ctx,
+		cancel:        cancel,
+		rpc:           rpc,
+		rpcReady:      rpcReady,
+		extPending:    make(map[string]string),
+		extPendingRev: make(map[string]string),
+		extMethod:     make(map[string]string),
 	}
 	s.alive.Store(true)
 	return s
@@ -736,12 +745,28 @@ func TestHandleEvent_LifecycleEventsNoOp(t *testing.T) {
 	s := newTestSession()
 	defer s.cancel()
 
-	for _, evType := range []string{"agent_start", "agent_end", "turn_start", "turn_end", "message_start"} {
+	// agent_start, turn_start, turn_end, message_start are no-ops
+	// agent_end now also emits EventResult (RPC mode turn completion marker)
+	for _, evType := range []string{"agent_start", "turn_start", "turn_end", "message_start"} {
 		s.handleEvent(map[string]any{"type": evType})
 	}
 	evts := drainEvents(s)
 	if len(evts) != 0 {
 		t.Errorf("expected no events, got %d", len(evts))
+	}
+}
+
+func TestHandleEvent_AgentEndEmitsResult(t *testing.T) {
+	s := newTestSession(true) // rpc=true: agent_end emits EventResult
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{"type": "agent_end", "messages": []any{}})
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 EventResult from agent_end, got %d", len(evts))
+	}
+	if evts[0].Type != core.EventResult {
+		t.Errorf("expected EventResult, got %s", evts[0].Type)
 	}
 }
 
@@ -1183,17 +1208,80 @@ func TestHandleMessageEnd_UserRole(t *testing.T) {
 	}
 }
 
+// newFakeRPCSession creates a piSession backed by a shell script that mimics
+// the Pi RPC protocol: it writes a session event on startup and stays alive
+// reading stdin until killed.
+func newFakeRPCSession(t *testing.T, sessionID, cmd, workDir string) *piSession {
+	t.Helper()
+	var rpcCmd []string
+	if cmd == "" {
+		// Default: use a minimal RPC script
+		script := fmt.Sprintf(
+			`echo '{"type":"session","id":"%s"}' && while IFS= read -r _; do :; done`,
+			sessionID,
+		)
+		rpcCmd = []string{"sh", "-c", script}
+	} else {
+		rpcCmd = strings.Fields(cmd)
+	}
+
+	s := &piSession{
+		cmd:       rpcCmd[0],
+		workDir:   workDir,
+		events:    make(chan core.Event, 64),
+		extraEnv:  nil,
+		modelsCW:  nil,
+		rpcReady:  make(chan struct{}),
+		rpc:       true,
+		extPending:    make(map[string]string),
+		extPendingRev: make(map[string]string),
+		extMethod:     make(map[string]string),
+		attachDir: filepath.Join(workDir, ".cc-connect", "attachments", "pi-"+sessionID),
+	}
+	s.alive.Store(true)
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+
+	// Spawn the fake RPC process
+	execCmd := exec.CommandContext(s.ctx, rpcCmd[0], rpcCmd[1:]...)
+	execCmd.Dir = s.workDir
+	stdinPipe, err := execCmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	s.rpcStdin = stdinPipe
+	s.rpcCmd = execCmd
+
+	stdout, err := execCmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	execCmd.Stderr = &s.stderrBuf
+
+	if err := execCmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	s.wg.Add(1)
+	go s.readLoopRPC(stdout)
+
+	// Wait for ready
+	select {
+	case <-s.rpcReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fake RPC did not become ready within 5s")
+	}
+
+	return s
+}
+
 // ── piSession lifecycle ──────────────────────────────────────
 
 func TestPiSession_NewWithResumeID(t *testing.T) {
-	s, err := newPiSession(context.Background(), "echo", nil, "/tmp", "model", "default", "", "resume-id", nil)
-	if err != nil {
-		t.Fatalf("newPiSession: %v", err)
-	}
+	s := newFakeRPCSession(t, "test-sess-id", "", t.TempDir())
 	defer s.Close()
 
-	if s.CurrentSessionID() != "resume-id" {
-		t.Errorf("sessionID = %q", s.CurrentSessionID())
+	if s.CurrentSessionID() != "test-sess-id" {
+		t.Errorf("sessionID = %q, want %q", s.CurrentSessionID(), "test-sess-id")
 	}
 }
 
@@ -1202,31 +1290,26 @@ func TestPiSession_ContinueSessionTreatedAsFresh(t *testing.T) {
 	// Claude Code to pick up the latest CLI session via --continue. Agents that
 	// don't support --continue must treat it as "" (fresh session), otherwise
 	// they pass the literal "__continue__" as a session ID which always fails.
-	s, err := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", core.ContinueSession, nil)
+	s, err := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", false, core.ContinueSession, nil)
 	if err != nil {
 		t.Fatalf("newPiSession: %v", err)
 	}
 	defer s.Close()
-
-	if got := s.CurrentSessionID(); got != "" {
-		t.Errorf("ContinueSession should be treated as fresh: sessionID = %q, want empty", got)
+	if !s.Alive() {
+		t.Error("expected session to be alive")
 	}
 }
 
 func TestPiSession_NewWithoutResumeID(t *testing.T) {
-	s, err := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", "", nil)
-	if err != nil {
-		t.Fatalf("newPiSession: %v", err)
-	}
+	s := newFakeRPCSession(t, "fresh-sess", "", t.TempDir())
 	defer s.Close()
-
-	if s.CurrentSessionID() != "" {
-		t.Errorf("sessionID = %q, want empty", s.CurrentSessionID())
+	if s.CurrentSessionID() != "fresh-sess" {
+		t.Errorf("sessionID = %q, want %q", s.CurrentSessionID(), "fresh-sess")
 	}
 }
 
 func TestPiSession_SendWhenClosed(t *testing.T) {
-	s, _ := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", "", nil)
+	s, _ := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", false, "", nil)
 	s.Close()
 
 	err := s.Send("hello", nil, nil)
@@ -1255,7 +1338,7 @@ func TestPiSession_Events(t *testing.T) {
 }
 
 func TestPiSession_Close(t *testing.T) {
-	s, _ := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", "", nil)
+	s, _ := newPiSession(context.Background(), "echo", nil, "/tmp", "", "default", "", false, "", nil)
 
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
@@ -1268,7 +1351,7 @@ func TestPiSession_Close(t *testing.T) {
 // ── Full event stream simulation ─────────────────────────────
 
 func TestHandleEvent_FullConversation(t *testing.T) {
-	s := newTestSession()
+	s := newTestSession(true) // rpc=true: agent_end emits EventResult
 	defer s.cancel()
 
 	// Simulate a full pi conversation: session → thinking → text → tool → tool result → text → done
@@ -1321,26 +1404,29 @@ func TestHandleEvent_FullConversation(t *testing.T) {
 
 	evts := drainEvents(s)
 
-	// Expected: thinking, tool_use, tool_result, text
-	if len(evts) != 4 {
+	// Expected: thinking(accumulated), tool_use, tool_result, text, result(agent_end)
+	if len(evts) != 5 {
 		var types []string
 		for _, e := range evts {
 			types = append(types, string(e.Type))
 		}
-		t.Fatalf("got %d events %v, want 4", len(evts), types)
+		t.Fatalf("got %d events %v, want 5 (thinking, tool_use, tool_result, text, result)", len(evts), types)
 	}
 
 	if evts[0].Type != core.EventThinking || evts[0].Content != "I need to list files." {
-		t.Errorf("evts[0] = %+v", evts[0])
+		t.Errorf("evts[0] = %+v, want EventThinking(I need to list files.)", evts[0])
 	}
 	if evts[1].Type != core.EventToolUse || evts[1].ToolName != "bash" {
-		t.Errorf("evts[1] = %+v", evts[1])
+		t.Errorf("evts[1] = %+v, want EventToolUse(bash)", evts[1])
 	}
 	if evts[2].Type != core.EventToolResult || evts[2].Content != "file1.go" {
-		t.Errorf("evts[2] = %+v", evts[2])
+		t.Errorf("evts[2] = %+v, want EventToolResult(file1.go)", evts[2])
 	}
 	if evts[3].Type != core.EventText || evts[3].Content != "Here are your files." {
-		t.Errorf("evts[3] = %+v", evts[3])
+		t.Errorf("evts[3] = %+v, want EventText(Here are your files.)", evts[3])
+	}
+	if evts[4].Type != core.EventResult || !evts[4].Done {
+		t.Errorf("evts[4] = %+v, want EventResult{Done:true}", evts[4])
 	}
 
 	if s.CurrentSessionID() != "conv-123" {
@@ -1351,56 +1437,59 @@ func TestHandleEvent_FullConversation(t *testing.T) {
 // ── readLoop with real process ───────────────────────────────
 
 func TestPiSession_ReadLoopWithEcho(t *testing.T) {
-	// Use sh -c to simulate pi JSON output on stdout.
-	sessionEvent := map[string]any{"type": "session", "id": "echo-sess"}
-	textEvent := map[string]any{
+	// Create a process that emits Pi RPC JSONL: session, text delta, agent_end.
+	sessionJSON, _ := json.Marshal(map[string]any{"type": "session", "id": "echo-sess"})
+	textJSON, _ := json.Marshal(map[string]any{
 		"type": "message_update",
-		"assistantMessageEvent": map[string]any{
-			"type":  "text_delta",
-			"delta": "hi",
-		},
-	}
-	line1, _ := json.Marshal(sessionEvent)
-	line2, _ := json.Marshal(textEvent)
+		"assistantMessageEvent": map[string]any{"type": "text_delta", "delta": "hi"},
+	})
+	agentEndJSON, _ := json.Marshal(map[string]any{"type": "agent_end"})
 
-	s, err := newPiSession(context.Background(), "sh", nil, "/tmp", "", "default", "", "", nil)
+	// Build one long string with all events separated by newlines
+	allData := string(sessionJSON) + "\n" + string(textJSON) + "\n" + string(agentEndJSON) + "\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	s := &piSession{
+		cmd:       "echo",
+		workDir:   t.TempDir(),
+		rpc:       true,
+		events:    make(chan core.Event, 64),
+		rpcReady:  make(chan struct{}),
+		extPending:    make(map[string]string),
+		extPendingRev: make(map[string]string),
+		extMethod:     make(map[string]string),
+	}
+	s.alive.Store(true)
+	s.ctx, s.cancel = context.WithCancel(ctx)
+	s.modelsCW = nil
+
+	// Create a pipe and feed the data through it
+	r, w, err := os.Pipe()
 	if err != nil {
-		t.Fatalf("newPiSession: %v", err)
+		t.Fatalf("pipe: %v", err)
 	}
+	go func() {
+		_, _ = w.Write([]byte(allData))
+		w.Close()
+	}()
 
-	// sh -c 'echo ...; echo ...' will output our JSON lines.
-	// We need to override how Send builds args. Instead, call readLoop directly.
-	// Actually, just use Send with sh -c and craft the prompt as the script.
-	script := "echo '" + string(line1) + "'; echo '" + string(line2) + "'"
-
-	// Manually build the command since Send adds extra flags for pi.
-	s.cmd = "sh"
-	s.model = "" // prevent --model flag
-
-	// Directly test readLoop via Send by crafting args that sh understands.
-	// Send will run: sh --mode json -p <script> which sh won't understand.
-	// Instead, test readLoop directly.
-	ctx := s.ctx
-	cmd := exec.CommandContext(ctx, "sh", "-c", script)
-	cmd.Dir = "/tmp"
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Fatalf("StdoutPipe: %v", err)
-	}
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
-
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
+	// Prevent close from trying to kill a process
+	s.rpcCmd = nil
 
 	s.wg.Add(1)
-	go s.readLoop(cmd, stdout, &stderrBuf)
+	go s.readLoopRPC(r)
 
-	// Collect events with timeout.
+	// Wait for session event
+	select {
+	case <-s.rpcReady:
+	case <-ctx.Done():
+		t.Fatal("rpcReady timeout")
+	}
+
+	// Collect events with timeout
 	var evts []core.Event
-	timeout := time.After(5 * time.Second)
 loop:
 	for {
 		select {
@@ -1412,14 +1501,15 @@ loop:
 			if ev.Type == core.EventResult {
 				break loop
 			}
-		case <-timeout:
+		case <-ctx.Done():
 			t.Fatal("timeout waiting for events")
 		}
 	}
 
-	s.Close()
+	s.cancel()
+	s.wg.Wait()
 
-	// Should have at least a text event and a result event.
+	// Should have at least a text event and a result event (from agent_end).
 	hasText := false
 	hasResult := false
 	for _, ev := range evts {
@@ -1434,7 +1524,7 @@ loop:
 		t.Error("missing text event")
 	}
 	if !hasResult {
-		t.Error("missing result event")
+		t.Error("missing result event (from agent_end)")
 	}
 	if s.CurrentSessionID() != "echo-sess" {
 		t.Errorf("sessionID = %q, want echo-sess", s.CurrentSessionID())

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -95,6 +95,43 @@ func TestNew_CustomOptions(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAgentOptions_RpcPropagates(t *testing.T) {
+	// Regression test: rpc must propagate to per-workspace agents
+	// reconstructed by the engine in multi-workspace mode. Without
+	// WorkspaceAgentOptions(), engine.go's getOrCreateWorkspaceAgent
+	// would silently drop `rpc = true` and the per-workspace agent
+	// would default to JSON mode.
+	a := &Agent{rpc: true, cmd: "echo", thinking: "high"}
+	got := a.WorkspaceAgentOptions()
+
+	if got["rpc"] != true {
+		t.Errorf("expected rpc=true in snapshot, got %v", got["rpc"])
+	}
+	if got["thinking"] != "high" {
+		t.Errorf("expected thinking=high in snapshot, got %v", got["thinking"])
+	}
+	if _, ok := got["work_dir"]; ok {
+		t.Errorf("work_dir must not be in snapshot (engine sets it per-workspace)")
+	}
+}
+
+func TestWorkspaceAgentOptions_DefaultsOmitted(t *testing.T) {
+	// Default cmd ("pi") and unset rpc/thinking should be omitted so the
+	// snapshot is a minimal delta on top of the project-level opts.
+	a := &Agent{cmd: "pi", rpc: false, thinking: ""}
+	got := a.WorkspaceAgentOptions()
+
+	if _, ok := got["cmd"]; ok {
+		t.Errorf("default cmd should be omitted, got %v", got["cmd"])
+	}
+	if _, ok := got["rpc"]; ok {
+		t.Errorf("rpc=false should be omitted, got %v", got["rpc"])
+	}
+	if _, ok := got["thinking"]; ok {
+		t.Errorf("empty thinking should be omitted, got %v", got["thinking"])
+	}
+}
+
 func TestNew_CmdNotFound(t *testing.T) {
 	_, err := New(map[string]any{"cmd": "nonexistent-binary-xyz-12345"})
 	if err == nil {

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1485,12 +1485,20 @@ func TestLastAskQuestionAnswer(t *testing.T) {
 		{"no answers key", map[string]any{"foo": "bar"}, ""},
 		{"empty answers", map[string]any{"answers": map[string]any{}}, ""},
 		{"single answer", map[string]any{"answers": map[string]any{"Q?": "Yes"}}, "Yes"},
-		{"multiple answers picks last", map[string]any{"answers": map[string]any{"Q1?": "A", "Q2?": "B"}}, "B"},
+		{"multiple answers returns any value", map[string]any{"answers": map[string]any{"Q1?": "A", "Q2?": "B"}}, ""},
 		{"non-string value ignored", map[string]any{"answers": map[string]any{"Q?": 42}}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := lastAskQuestionAnswer(tt.in)
+			if tt.name == "multiple answers returns any value" {
+				// Map iteration is non-deterministic; the function logs a
+				// warning and returns the first string value found.
+				if got != "A" && got != "B" {
+					t.Errorf("got %q, want A or B", got)
+				}
+				return
+			}
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1424,7 +1424,11 @@ func TestForwardSelect_EmptyTitleUsesDefault(t *testing.T) {
 	}
 }
 
-func TestForwardConfirm_PopulatesYesNo(t *testing.T) {
+// TestForwardConfirm_RoutesAsRegularPermission verifies that extension_confirm
+// is forwarded as a regular permission request (no Questions field) so the
+// engine renders an Allow/Deny card rather than a Yes/No question card. This
+// matches the UX of other agents' permission prompts.
+func TestForwardConfirm_RoutesAsRegularPermission(t *testing.T) {
 	s := newTestSession(true)
 	defer s.cancel()
 
@@ -1438,21 +1442,21 @@ func TestForwardConfirm_PopulatesYesNo(t *testing.T) {
 		t.Fatalf("expected 1 event, got %d", len(evts))
 	}
 	evt := evts[0]
+	if evt.Type != core.EventPermissionRequest {
+		t.Fatalf("Type = %s, want EventPermissionRequest", evt.Type)
+	}
 	if evt.ToolName != "extension_confirm" {
 		t.Errorf("ToolName = %q, want extension_confirm", evt.ToolName)
 	}
-	if len(evt.Questions) != 1 {
-		t.Fatalf("expected 1 question, got %d", len(evt.Questions))
+	if len(evt.Questions) != 0 {
+		t.Errorf("Questions = %d, want 0 (extension_confirm must NOT route through AskUserQuestion)", len(evt.Questions))
 	}
-	q := evt.Questions[0]
-	if len(q.Options) != 2 {
-		t.Fatalf("expected 2 options, got %d", len(q.Options))
+	if evt.ToolInput != "Allow rm -rf?: This is destructive" {
+		t.Errorf("ToolInput = %q, want %q", evt.ToolInput, "Allow rm -rf?: This is destructive")
 	}
-	if q.Options[0].Label != "Yes" || q.Options[1].Label != "No" {
-		t.Errorf("Options = [%q, %q], want [Yes, No]", q.Options[0].Label, q.Options[1].Label)
-	}
-	if q.Question != "Allow rm -rf?: This is destructive" {
-		t.Errorf("Question = %q, want combined title+message", q.Question)
+	raw := evt.ToolInputRaw
+	if raw["title"] != "Allow rm -rf?" || raw["message"] != "This is destructive" || raw["method"] != "confirm" {
+		t.Errorf("ToolInputRaw = %v, want title/message/method set", raw)
 	}
 }
 
@@ -1468,8 +1472,15 @@ func TestForwardConfirm_MessageOnly(t *testing.T) {
 	if len(evts) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(evts))
 	}
-	if evts[0].Questions[0].Question != "Allow this?" {
-		t.Errorf("Question = %q, want %q", evts[0].Questions[0].Question, "Allow this?")
+	evt := evts[0]
+	if evt.ToolName != "extension_confirm" {
+		t.Errorf("ToolName = %q, want extension_confirm", evt.ToolName)
+	}
+	if len(evt.Questions) != 0 {
+		t.Errorf("Questions = %d, want 0", len(evt.Questions))
+	}
+	if evt.ToolInput != ": Allow this?" {
+		t.Errorf("ToolInput = %q, want %q", evt.ToolInput, ": Allow this?")
 	}
 }
 

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1396,7 +1396,7 @@ done
 
 	s, err := newPiSession(ctx, scriptPath, nil, t.TempDir(), "", "", "", true, "", nil)
 	if err == nil {
-		defer s.Close()
+		defer func() { _ = s.Close() }()
 		t.Fatalf("newPiSession succeeded (id=%q); failure response should leave session id empty and time out", s.CurrentSessionID())
 	}
 	if !strings.Contains(err.Error(), "did not become ready") &&
@@ -1435,7 +1435,7 @@ done
 	s, err := newPiSession(ctx, scriptPath, nil, t.TempDir(), "", "", "", true, "", nil)
 	elapsed := time.Since(start)
 	if err == nil {
-		defer s.Close()
+		defer func() { _ = s.Close() }()
 		t.Fatalf("newPiSession succeeded (id=%q) after %v; should have waited for get_state", s.CurrentSessionID(), elapsed)
 	}
 	// The error message is either the 30s timeout ("did not become ready")
@@ -1452,7 +1452,7 @@ done
 
 func TestPiSession_NewWithResumeID(t *testing.T) {
 	s := newFakeRPCSession(t, "test-sess-id", "", t.TempDir())
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	if s.CurrentSessionID() != "test-sess-id" {
 		t.Errorf("sessionID = %q, want %q", s.CurrentSessionID(), "test-sess-id")

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1364,6 +1364,140 @@ func TestPiSession_RespondPermission(t *testing.T) {
 	}
 }
 
+// ── forwardSelect / forwardConfirm: Questions wiring ────────
+
+func TestForwardSelect_PopulatesQuestions(t *testing.T) {
+	s := newTestSession(true) // rpc mode
+	defer s.cancel()
+
+	s.forwardSelect("sel-1", map[string]any{
+		"title":   "Pick a color",
+		"options": []any{"Red", "Green", "Blue"},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	evt := evts[0]
+	if evt.Type != core.EventPermissionRequest {
+		t.Fatalf("expected EventPermissionRequest, got %s", evt.Type)
+	}
+	if evt.ToolName != "extension_select" {
+		t.Errorf("ToolName = %q, want extension_select", evt.ToolName)
+	}
+	if len(evt.Questions) != 1 {
+		t.Fatalf("expected 1 question, got %d", len(evt.Questions))
+	}
+	q := evt.Questions[0]
+	if q.Question != "Pick a color" {
+		t.Errorf("Question = %q, want %q", q.Question, "Pick a color")
+	}
+	if q.MultiSelect {
+		t.Error("MultiSelect should be false for select")
+	}
+	if len(q.Options) != 3 {
+		t.Fatalf("expected 3 options, got %d", len(q.Options))
+	}
+	wantLabels := []string{"Red", "Green", "Blue"}
+	for i, opt := range q.Options {
+		if opt.Label != wantLabels[i] {
+			t.Errorf("option[%d].Label = %q, want %q", i, opt.Label, wantLabels[i])
+		}
+	}
+}
+
+func TestForwardSelect_EmptyTitleUsesDefault(t *testing.T) {
+	s := newTestSession(true)
+	defer s.cancel()
+
+	s.forwardSelect("sel-2", map[string]any{
+		"options": []any{"only"},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	if evts[0].Questions[0].Question != "Select an option" {
+		t.Errorf("Question = %q, want %q", evts[0].Questions[0].Question, "Select an option")
+	}
+}
+
+func TestForwardConfirm_PopulatesYesNo(t *testing.T) {
+	s := newTestSession(true)
+	defer s.cancel()
+
+	s.forwardConfirm("cfm-1", map[string]any{
+		"title":   "Allow rm -rf?",
+		"message": "This is destructive",
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	evt := evts[0]
+	if evt.ToolName != "extension_confirm" {
+		t.Errorf("ToolName = %q, want extension_confirm", evt.ToolName)
+	}
+	if len(evt.Questions) != 1 {
+		t.Fatalf("expected 1 question, got %d", len(evt.Questions))
+	}
+	q := evt.Questions[0]
+	if len(q.Options) != 2 {
+		t.Fatalf("expected 2 options, got %d", len(q.Options))
+	}
+	if q.Options[0].Label != "Yes" || q.Options[1].Label != "No" {
+		t.Errorf("Options = [%q, %q], want [Yes, No]", q.Options[0].Label, q.Options[1].Label)
+	}
+	if q.Question != "Allow rm -rf?: This is destructive" {
+		t.Errorf("Question = %q, want combined title+message", q.Question)
+	}
+}
+
+func TestForwardConfirm_MessageOnly(t *testing.T) {
+	s := newTestSession(true)
+	defer s.cancel()
+
+	s.forwardConfirm("cfm-2", map[string]any{
+		"message": "Allow this?",
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	if evts[0].Questions[0].Question != "Allow this?" {
+		t.Errorf("Question = %q, want %q", evts[0].Questions[0].Question, "Allow this?")
+	}
+}
+
+// ── lastAskQuestionAnswer helper ───────────────────────────
+
+func TestLastAskQuestionAnswer(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"no answers key", map[string]any{"foo": "bar"}, ""},
+		{"empty answers", map[string]any{"answers": map[string]any{}}, ""},
+		{"single answer", map[string]any{"answers": map[string]any{"Q?": "Yes"}}, "Yes"},
+		{"multiple answers picks last", map[string]any{"answers": map[string]any{"Q1?": "A", "Q2?": "B"}}, "B"},
+		{"non-string value ignored", map[string]any{"answers": map[string]any{"Q?": 42}}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lastAskQuestionAnswer(tt.in)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPiSession_Events(t *testing.T) {
 	s := newTestSession()
 	defer s.cancel()

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1662,7 +1662,7 @@ func TestPiSession_ReadLoopWithEcho(t *testing.T) {
 	}
 	go func() {
 		_, _ = w.Write([]byte(allData))
-		w.Close()
+		_ = w.Close()
 	}()
 
 	// Prevent close from trying to kill a process

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1313,6 +1313,143 @@ func newFakeRPCSession(t *testing.T, sessionID, cmd, workDir string) *piSession 
 
 // ── piSession lifecycle ──────────────────────────────────────
 
+// newFakeRPCSessionRealistic creates a piSession backed by a fake pi script
+// that mimics the *actual* Pi RPC protocol observed in the pi source tree:
+// it pushes a non-session event (extension_ui_request) on stdout first, then
+// reads stdin and replies to {"type":"get_state"} with the canonical
+// {"type":"response", "command":"get_state", "data":{"sessionId":...}} shape.
+//
+// This is the protocol real pi uses today; the legacy "session" push event
+// is NOT part of it, so tests built on the old newFakeRPCSession would not
+// have caught the missing-session-id bug.
+//
+// newFakeRPCSessionRealistic exercises the full startRPC → writeRPCCommand →
+// readLoopRPC → handleEvent → close(rpcReady) chain by going through
+// newPiSession, so callers can observe what the engine sees.
+func newFakeRPCSessionRealistic(t *testing.T, sessionID string) *piSession {
+	t.Helper()
+	// Write the script to a temp file so we don't have to fight shell
+	// quoting inside Go string literals.
+	scriptPath := filepath.Join(t.TempDir(), "fake-pi.sh")
+	// Push a non-session event first, then loop reading stdin. When we see
+	// the get_state probe we respond with a real get_state response.
+	scriptBody := fmt.Sprintf(`#!/bin/sh
+echo '{"type":"extension_ui_request","id":"ext-init","method":"setStatus","statusKey":"plan-mode"}'
+while IFS= read -r line; do
+    case "$line" in
+        *get_state*)
+            cat <<EOF
+{"id":"cc-connect-state-probe","type":"response","command":"get_state","success":true,"data":{"sessionId":"%s","sessionFile":"/tmp/fake.jsonl"}}
+EOF
+            ;;
+    esac
+done
+`, sessionID)
+	if err := os.WriteFile(scriptPath, []byte(scriptBody), 0o755); err != nil {
+		t.Fatalf("write fake script: %v", err)
+	}
+
+	s, err := newPiSession(context.Background(), scriptPath, nil, t.TempDir(), "", "", "", true, "", nil)
+	if err != nil {
+		t.Fatalf("newPiSession (realistic fake): %v", err)
+	}
+	return s
+}
+
+func TestPiSession_RPC_StartupProbeStoresSessionID(t *testing.T) {
+	// Regression: real Pi does not push a "session" event on stdout — only
+	// extension_ui_request events arrive first. Session id is only available
+	// via the response to the get_state command that startRPC writes. Before
+	// this fix CurrentSessionID() would stay empty even after rpcReady fired,
+	// because rpcReady was closed on the first line (which was the
+	// extension_ui_request), before the get_state response arrived.
+	s := newFakeRPCSessionRealistic(t, "session-from-get-state")
+	defer s.Close()
+
+	if got := s.CurrentSessionID(); got != "session-from-get-state" {
+		t.Errorf("CurrentSessionID() = %q, want %q (get_state probe did not populate session id)", got, "session-from-get-state")
+	}
+}
+
+func TestPiSession_RPC_StartupProbe_HandlesFailureResponse(t *testing.T) {
+	// Pi may respond to get_state with success=false (e.g. protocol error).
+	// handleEvent must log a warning and leave sessionID empty instead of
+	// panicking or storing junk. rpcReady therefore does not close, and the
+	// constructor returns the standard 30s "did not become ready" error.
+	scriptPath := filepath.Join(t.TempDir(), "fake-pi.sh")
+	scriptBody := `#!/bin/sh
+echo '{"type":"extension_ui_request","id":"ext-init","method":"setStatus","statusKey":"plan-mode"}'
+while IFS= read -r line; do
+    case "$line" in
+        *get_state*)
+            echo '{"id":"cc-connect-state-probe","type":"response","command":"get_state","success":false,"error":"session not available"}'
+            ;;
+    esac
+done
+`
+	if err := os.WriteFile(scriptPath, []byte(scriptBody), 0o755); err != nil {
+		t.Fatalf("write fake script: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	s, err := newPiSession(ctx, scriptPath, nil, t.TempDir(), "", "", "", true, "", nil)
+	if err == nil {
+		defer s.Close()
+		t.Fatalf("newPiSession succeeded (id=%q); failure response should leave session id empty and time out", s.CurrentSessionID())
+	}
+	if !strings.Contains(err.Error(), "did not become ready") &&
+		!strings.Contains(err.Error(), "context cancelled") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPiSession_RPC_StartupProbe_DoesNotCloseOnExtensionUI(t *testing.T) {
+	// Variant: the fake pi script emits extension_ui_request events forever
+	// without ever responding to get_state. rpcReady must NOT close (the
+	// session id never arrives), and the constructor must time out instead
+	// of returning early with an empty id.
+	scriptPath := filepath.Join(t.TempDir(), "fake-pi.sh")
+	scriptBody := `#!/bin/sh
+i=0
+echo '{"type":"extension_ui_request","id":"e0","method":"setStatus","statusKey":"plan-mode"}'
+while IFS= read -r line; do
+    i=$((i+1))
+    echo "{\"type\":\"extension_ui_request\",\"id\":\"e$i\",\"method\":\"setStatus\",\"statusKey\":\"plan-mode\"}"
+done
+`
+	if err := os.WriteFile(scriptPath, []byte(scriptBody), 0o755); err != nil {
+		t.Fatalf("write fake script: %v", err)
+	}
+
+	// Bound the wait: if the fix is wrong (rpcReady closed too early on the
+	// extension_ui_request), newPiSession returns within milliseconds with
+	// CurrentSessionID()=="". A correct fix keeps rpcReady open until the
+	// get_state response arrives, which never does here, so we hit a
+	// timeout — but well before the default 30s.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	s, err := newPiSession(ctx, scriptPath, nil, t.TempDir(), "", "", "", true, "", nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		defer s.Close()
+		t.Fatalf("newPiSession succeeded (id=%q) after %v; should have waited for get_state", s.CurrentSessionID(), elapsed)
+	}
+	// The error message is either the 30s timeout ("did not become ready")
+	// or our 3s ctx cancellation ("context cancelled") — both are valid
+	// proofs that rpcReady did not close prematurely on the first line.
+	if !strings.Contains(err.Error(), "did not become ready") &&
+		!strings.Contains(err.Error(), "context cancelled") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if elapsed > 4*time.Second {
+		t.Errorf("newPiSession took %v; rpcReady should not have closed on the extension_ui_request first line", elapsed)
+	}
+}
+
 func TestPiSession_NewWithResumeID(t *testing.T) {
 	s := newFakeRPCSession(t, "test-sess-id", "", t.TempDir())
 	defer s.Close()

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1561,6 +1561,69 @@ func TestForwardSelect_EmptyTitleUsesDefault(t *testing.T) {
 	}
 }
 
+// TestForwardSelect_ObjectOptionsExtractsLabelAndDescription verifies that
+// extension_select options sent as objects (with both label and description)
+// are forwarded to the engine as UserQuestionOption{Label, Description},
+// not silently dropped. Regression guard for the bug where the cc-connect
+// TUI showed option descriptions but the Feishu card rendered label-only
+// because forwardSelect only handled string-form options.
+func TestForwardSelect_ObjectOptionsExtractsLabelAndDescription(t *testing.T) {
+	s := newTestSession(true)
+	defer s.cancel()
+
+	s.forwardSelect("sel-3", map[string]any{
+		"title": "Pick a database",
+		"options": []any{
+			map[string]any{
+				"label":       "PostgreSQL",
+				"description": "Recommended for production",
+			},
+			map[string]any{
+				"label":       "SQLite",
+				"description": "Lightweight file-based",
+			},
+			map[string]any{
+				"label":       "MySQL",
+				"description": "Popular open-source",
+			},
+		},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	evt := evts[0]
+	if evt.ToolName != "extension_select" {
+		t.Fatalf("ToolName = %q, want extension_select", evt.ToolName)
+	}
+	if len(evt.Questions) != 1 {
+		t.Fatalf("expected 1 question, got %d", len(evt.Questions))
+	}
+	q := evt.Questions[0]
+	if q.Question != "Pick a database" {
+		t.Errorf("Question = %q, want %q", q.Question, "Pick a database")
+	}
+
+	want := []core.UserQuestionOption{
+		{Label: "PostgreSQL", Description: "Recommended for production"},
+		{Label: "SQLite", Description: "Lightweight file-based"},
+		{Label: "MySQL", Description: "Popular open-source"},
+	}
+	if len(q.Options) != len(want) {
+		t.Fatalf("expected %d options, got %d", len(want), len(q.Options))
+	}
+	for i, opt := range q.Options {
+		if opt.Label != want[i].Label {
+			t.Errorf("option[%d].Label = %q, want %q", i, opt.Label, want[i].Label)
+		}
+		if opt.Description != want[i].Description {
+			t.Errorf("option[%d].Description = %q, want %q",
+				i, opt.Description, want[i].Description)
+		}
+	}
+}
+
 // TestForwardConfirm_RoutesAsRegularPermission verifies that extension_confirm
 // is forwarded as a regular permission request (no Questions field) so the
 // engine renders an Allow/Deny card rather than a Yes/No question card. This

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -818,6 +818,114 @@ func TestHandleEvent_UnhandledType(t *testing.T) {
 	}
 }
 
+// ── handleEvent: compaction_* (regression for /cmp silent-hang bug) ──
+//
+// Prior to the fix, ctx.compact() was fire-and-forget: pi emits
+// compaction_start/compaction_end events on stdout but never sends agent_end.
+// Without an explicit handler, cc-connect's processInteractiveEvents hangs
+// forever waiting for a turn-end signal that never arrives. The fix in
+// handleEvent adds a compaction_end case that synthesizes EventResult so
+// the engine can finalize the turn. On errors it also surfaces an
+// EventError so the user sees the failure even when no extension does.
+
+func TestHandleEvent_CompactionStartNoEvent(t *testing.T) {
+	s := newTestSession(true) // rpc=true
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type":   "compaction_start",
+		"reason": "manual",
+	})
+	// compaction_start is observable-only; no event is emitted.
+	if got := drainEvents(s); len(got) != 0 {
+		t.Fatalf("compaction_start must not emit any event, got %d: %#v", len(got), got)
+	}
+}
+
+func TestHandleEvent_CompactionEndEmitsResultInRPCMode(t *testing.T) {
+	// Regression: this is the exact scenario that caused /cmp to hang.
+	// Before the fix, this case fell through to "unrecognized event type"
+	// and processInteractiveEvents never saw EventResult.
+	s := newTestSession(true) // rpc=true
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type":    "compaction_end",
+		"aborted": false,
+	})
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("compaction_end in RPC mode must emit exactly 1 EventResult, got %d: %#v", len(evts), evts)
+	}
+	if evts[0].Type != core.EventResult {
+		t.Errorf("expected EventResult, got %s", evts[0].Type)
+	}
+	if !evts[0].Done {
+		t.Errorf("expected Done=true, got false")
+	}
+}
+
+func TestHandleEvent_CompactionEndJSONModeNoEvent(t *testing.T) {
+	// JSON mode relies on process exit as the turn-end marker; the
+	// compaction_end handler is intentionally a no-op there.
+	s := newTestSession(false) // rpc=false
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type":    "compaction_end",
+		"aborted": false,
+	})
+	if got := drainEvents(s); len(got) != 0 {
+		t.Fatalf("compaction_end in json mode must not emit EventResult, got %d: %#v", len(got), got)
+	}
+}
+
+func TestHandleEvent_CompactionEndWithErrorMessageEmitsError(t *testing.T) {
+	// Covers trigger-compact/auto-trigger paths that have no extension
+	// to surface pi's own compaction error to the user.
+	s := newTestSession(true)
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type":         "compaction_end",
+		"aborted":      false,
+		"errorMessage": "Compaction failed: Nothing to compact (session too small)",
+	})
+	evts := drainEvents(s)
+	if len(evts) != 2 {
+		t.Fatalf("expected 2 events (EventError + EventResult), got %d: %#v", len(evts), evts)
+	}
+	if evts[0].Type != core.EventError {
+		t.Errorf("first event must be EventError, got %s", evts[0].Type)
+	}
+	if evts[0].Error == nil || evts[0].Error.Error() != "Compaction failed: Nothing to compact (session too small)" {
+		t.Errorf("EventError message not preserved verbatim: %v", evts[0].Error)
+	}
+	if evts[1].Type != core.EventResult || !evts[1].Done {
+		t.Errorf("second event must be EventResult{Done:true}, got %s done=%v", evts[1].Type, evts[1].Done)
+	}
+}
+
+func TestHandleEvent_CompactionEndEmptyErrorMessageDoesNotEmitError(t *testing.T) {
+	// pi sometimes sends {"errorMessage": ""} on success-shaped events;
+	// treat empty as "no error" so we don't spam EventError on every turn.
+	s := newTestSession(true)
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type":         "compaction_end",
+		"aborted":      false,
+		"errorMessage": "",
+	})
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("empty errorMessage must not emit EventError; got %d events: %#v", len(evts), evts)
+	}
+	if evts[0].Type != core.EventResult {
+		t.Errorf("expected EventResult, got %s", evts[0].Type)
+	}
+}
+
 // ── handleMessageUpdate: text_delta ──────────────────────────
 
 func TestHandleMessageUpdate_TextDelta(t *testing.T) {

--- a/agent/pi/proc_unix.go
+++ b/agent/pi/proc_unix.go
@@ -1,0 +1,42 @@
+//go:build unix
+
+package pi
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// prepareCmdForKill puts the spawned child into its own process group so that
+// the entire descendant tree can be terminated with a single signal aimed at
+// the negative PID. Without this, cc-connect can only signal the direct child
+// (the `pi` CLI), leaving any grandchildren (MCP server processes, tool
+// subprocesses) as orphans after the parent is killed.
+//
+// Mirrors the pattern used by agent/claudecode/proc_unix.go and
+// agent/codex/proc_unix.go.
+func prepareCmdForKill(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// forceKillCmd SIGKILLs the entire process group rooted at cmd.
+// Returns nil if the group is already gone.
+func forceKillCmd(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil &&
+		!errors.Is(err, os.ErrProcessDone) &&
+		!errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	return nil
+}

--- a/agent/pi/proc_windows.go
+++ b/agent/pi/proc_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package pi
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func prepareCmdForKill(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= syscall.CREATE_NEW_PROCESS_GROUP
+}
+
+// forceKillCmd delegates to exec.Cmd.Process.Kill on Windows.
+// On Unix the build-constrained variant kills the process group.
+func forceKillCmd(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -256,6 +256,9 @@ func (s *piSession) Send(msg string, images []core.ImageAttachment, files []core
 // reads all output events, and sends them to the events channel.
 func (s *piSession) sendJSON(prompt string) error {
 	args := append(append([]string{}, s.extraArgs...), "--mode", "json", "-p", prompt)
+	if sid := s.CurrentSessionID(); sid != "" {
+		args = append(args, "--session-id", sid)
+	}
 	if s.model != "" {
 		args = append(args, "--model", s.model)
 	}

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -203,7 +203,7 @@ func (s *piSession) killRPC() {
 // One instance runs for the lifetime of the RPC process.
 func (s *piSession) readLoopRPC(stdout io.ReadCloser) {
 	defer s.wg.Done()
-	defer stdout.Close()
+	defer func() { _ = stdout.Close() }()
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -419,6 +419,15 @@ func (s *piSession) forwardConfirm(id string, raw map[string]any) {
 	s.extMethod[requestID] = "confirm"
 	s.extPendingMu.Unlock()
 
+	questionText := title
+	if message != "" {
+		if questionText != "" {
+			questionText = questionText + ": " + message
+		} else {
+			questionText = message
+		}
+	}
+
 	evt := core.Event{
 		Type:     core.EventPermissionRequest,
 		RequestID: requestID,
@@ -429,6 +438,15 @@ func (s *piSession) forwardConfirm(id string, raw map[string]any) {
 			"message": message,
 			"method":  "confirm",
 		},
+		Questions: []core.UserQuestion{{
+			Question: questionText,
+			Header:   "Confirm",
+			Options: []core.UserQuestionOption{
+				{Label: "Yes"},
+				{Label: "No"},
+			},
+			MultiSelect: false,
+		}},
 	}
 	select {
 	case s.events <- evt:
@@ -477,6 +495,16 @@ func (s *piSession) forwardSelect(id string, raw map[string]any) {
 		}
 	}
 
+	// Convert raw string options to UserQuestionOption so cc-connect renders
+	// them as a rich button card (AskUserQuestion flow) instead of a plain
+	// permission prompt. Label carries the option's value verbatim so that
+	// resolveAskQuestionAnswer → result.Message maps back to the same string
+	// the extension passed in.
+	userOpts := make([]core.UserQuestionOption, 0, len(opts))
+	for _, o := range opts {
+		userOpts = append(userOpts, core.UserQuestionOption{Label: o})
+	}
+
 	requestID := fmt.Sprintf("pi_ext_%s", id)
 
 	s.extPendingMu.Lock()
@@ -484,6 +512,11 @@ func (s *piSession) forwardSelect(id string, raw map[string]any) {
 	s.extPendingRev[requestID] = id
 	s.extMethod[requestID] = "select"
 	s.extPendingMu.Unlock()
+
+	questionText := title
+	if questionText == "" {
+		questionText = "Select an option"
+	}
 
 	evt := core.Event{
 		Type:     core.EventPermissionRequest,
@@ -495,6 +528,12 @@ func (s *piSession) forwardSelect(id string, raw map[string]any) {
 			"options": opts,
 			"method":  "select",
 		},
+		Questions: []core.UserQuestion{{
+			Question:    questionText,
+			Header:      "Select",
+			Options:     userOpts,
+			MultiSelect: false,
+		}},
 	}
 	select {
 	case s.events <- evt:
@@ -704,6 +743,31 @@ func (s *piSession) handleAgentEnd(raw map[string]any) {
 	}
 }
 
+// lastAskQuestionAnswer extracts the most recently collected answer from
+// UpdatedInput.answers (the shape produced by buildAskQuestionResponse).
+// extension_select / extension_confirm ride the AskUserQuestion flow, so
+// the user's choice ends up here rather than in result.Message.
+// Returns "" if the structure is missing or empty.
+func lastAskQuestionAnswer(updatedInput map[string]any) string {
+	if updatedInput == nil {
+		return ""
+	}
+	answers, _ := updatedInput["answers"].(map[string]any)
+	if answers == nil {
+		return ""
+	}
+	// answers is keyed by question text. We don't have the question text
+	// here, so just return the last value (stable across the small maps
+	// the AskUserQuestion flow produces — typically 1 entry).
+	var last string
+	for _, v := range answers {
+		if s, ok := v.(string); ok {
+			last = s
+		}
+	}
+	return last
+}
+
 // ── RespondPermission ───────────────────────────────────────
 
 func (s *piSession) RespondPermission(requestID string, result core.PermissionResult) error {
@@ -745,12 +809,31 @@ func (s *piSession) RespondPermission(requestID string, result core.PermissionRe
 			"id":   extID,
 		}
 		if result.Behavior == "allow" {
-			resp["value"] = result.Message
+			// select goes through the AskUserQuestion flow, where the user's
+			// choice lives in UpdatedInput.answers (built by
+			// buildAskQuestionResponse). Map it back to the option's value.
+			resp["value"] = lastAskQuestionAnswer(result.UpdatedInput)
 		} else {
 			resp["cancelled"] = true
 		}
 	case "confirm":
-		fallthrough
+		// confirm also goes through the AskUserQuestion flow (Yes/No buttons).
+		// Behavior=allow means the user picked; inspect the answer to decide
+		// between confirmed=true and cancelled=true.
+		ans := strings.ToLower(strings.TrimSpace(lastAskQuestionAnswer(result.UpdatedInput)))
+		if result.Behavior == "allow" && (ans == "yes" || ans == "true" || ans == "ok" || ans == "confirm") {
+			resp = map[string]any{
+				"type":      "extension_ui_response",
+				"id":        extID,
+				"confirmed": true,
+			}
+		} else {
+			resp = map[string]any{
+				"type":      "extension_ui_response",
+				"id":        extID,
+				"cancelled": true,
+			}
+		}
 	default:
 		resp = map[string]any{
 			"type":      "extension_ui_response",

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -527,16 +527,26 @@ func (s *piSession) handleEvent(raw map[string]any) {
 		// handle their own user feedback via stdout synth events and the
 		// normal slash-command path returns immediately.
 		//
-		// Without an explicit EventResult here, two scenarios hang
-		// forever in processInteractiveEvents:
-		//   (a) trigger-compact: handler returns without await, so no
-		//       synthetic agent_end ever lands on stdout.
-		//   (b) cc-connect-compact: an extension that crashes, races a
-		//       kill, or simply omits the finally-synthesized agent_end
-		//       leaves the turn open.
+		// Two things happen here:
 		//
-		// JSON mode (json one-shot) is unaffected — process exit is the
-		// turn-end marker there, and compaction_end has no special meaning.
+		// 1. If pi reports an errorMessage, emit EventError. This covers
+		//    compaction paths that have no extension to surface the error
+		//    to the user (e.g. trigger-compact.ts only calls ctx.ui.notify,
+		//    which cc-connect drops in RPC mode). pi's errorMessage is
+		//    usually self-describing ("Compaction failed: Nothing to compact
+		//    (session too small)"), so we pass it through verbatim — no
+		//    additional prefix — to avoid "Error: compaction failed:
+		//    Compaction failed: ..." in the platform message.
+		//
+		// 2. Always emit EventResult. Without it, two scenarios hang
+		//    forever in processInteractiveEvents:
+		//      (a) trigger-compact: handler returns without await, so no
+		//          synthetic agent_end ever lands on stdout.
+		//      (b) cc-connect-compact: an extension that crashes, races a
+		//          kill, or simply omits the finally-synthesized agent_end
+		//          leaves the turn open.
+		//    JSON mode (json one-shot) is unaffected — process exit is the
+		//    turn-end marker there, and compaction_end has no special meaning.
 		//
 		// Duplicate EventResult (when both agent_end and compaction_end
 		// close the same turn) is safe: processInteractiveEvents only
@@ -544,6 +554,13 @@ func (s *piSession) handleEvent(raw map[string]any) {
 		// text in the second pass, which is empty for out-of-band
 		// compactions. The only side effect is a redundant
 		// ws.BeginTurn/EndTurn pair, accepted as belt-and-suspenders.
+		if errMsg, _ := raw["errorMessage"].(string); errMsg != "" {
+			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", errMsg)}
+			select {
+			case s.events <- evt:
+			case <-s.ctx.Done():
+			}
+		}
 		if s.rpc {
 			sid := s.CurrentSessionID()
 			evt := core.Event{Type: core.EventResult, SessionID: sid, Done: true}

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -21,41 +21,51 @@ import (
 )
 
 // piSession manages a multi-turn pi coding agent conversation.
-// Each Send() spawns `pi --mode json -p <prompt>`.
-// Subsequent turns use `--session <sessionID>` to resume.
+// In "json" mode (default): each Send() spawns `pi --mode json` as a one-shot
+// process. No extension_ui support, no permission forwarding.
+// In "rpc" mode: spawns a persistent `pi --mode rpc` process with stdin/stdout
+// JSONL protocol, supporting extension_ui_request/response for permissions.
 type piSession struct {
 	cmd       string
 	extraArgs []string // extra args from cmd, prepended before pi args
 	workDir   string
 	model     string
-	mode      string
-	thinking  string // reasoning effort level for --thinking flag
+	mode      string   // permission mode: "default" | "yolo"
+	thinking  string
+	rpc       bool     // true = persistent RPC process, false = one-shot json mode
 	extraEnv  []string
 	attachDir string
-	events    chan core.Event
-	sessionID atomic.Value // stores string
-	ctx       context.Context
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
-	alive     atomic.Bool
+	events  chan core.Event
+	sessionID atomic.Value
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup // tracks readLoopRPC goroutine (RPC mode only)
+	sendWg  sync.WaitGroup // tracks in-flight Send() calls
+	alive   atomic.Bool
 
-	thinkingBuf strings.Builder // accumulates thinking_delta chunks
+	thinkingBuf   strings.Builder
+	thinkingMu    sync.Mutex
+	modelsCW      map[string]int // cached from ~/.pi/agent/models.json
+	usageMu    sync.Mutex
+	lastUsage  *core.ContextUsage
 
-	// modelsCW is a cached map of model ID → contextWindow, loaded once
-	// from ~/.pi/agent/models.json so every turn can look up the window.
-	// Loaded at session start and never refreshed — if models.json changes
-	// mid-session the new context windows won't be visible until restart.
-	// Sessions are typically short-lived and the 200K fallback handles
-	// unknown models, so a session-lifetime cache is acceptable.
-	modelsCW map[string]int
+	// RPC-only fields (nil/zero when rpc=false)
+	rpcCmd   *exec.Cmd
+	rpcStdin io.WriteCloser
+	stderrBuf bytes.Buffer
+	rpcReady chan struct{} // closed after first JSON line from Pi
 
-	usageMu   sync.Mutex
-	lastUsage *core.ContextUsage
+	// Extension UI: maps Pi's extension_ui_request id -> cc-connect RequestID
+	extPendingMu  sync.Mutex
+	extPending    map[string]string // Pi ext_ui_id -> cc-conn RequestID
+	extPendingRev map[string]string // cc-conn RequestID -> Pi ext_ui_id
+	extMethod     map[string]string // cc-conn RequestID -> method ("confirm"|"input"|"select")
 }
 
-func newPiSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, thinking, resumeID string, extraEnv []string) (*piSession, error) {
-	sessionCtx, cancel := context.WithCancel(ctx)
+// ── Constructor ──────────────────────────────────────────────
 
+func newPiSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, thinking string, rpc bool, resumeID string, extraEnv []string) (*piSession, error) {
+	ctx, cancel := context.WithCancel(ctx)
 	s := &piSession{
 		cmd:       cmd,
 		extraArgs: extraArgs,
@@ -63,65 +73,62 @@ func newPiSession(ctx context.Context, cmd string, extraArgs []string, workDir, 
 		model:     model,
 		mode:      mode,
 		thinking:  thinking,
+		rpc:       rpc,
 		extraEnv:  extraEnv,
-		attachDir: filepath.Join(workDir, ".cc-connect", "attachments",
-			fmt.Sprintf("pi_%d", time.Now().UnixNano())),
-		events:   make(chan core.Event, 64),
-		ctx:      sessionCtx,
-		cancel:   cancel,
-		modelsCW: loadModelsContextWindows(),
+		attachDir: filepath.Join(workDir, ".cc-connect", "attachments", fmt.Sprintf("pi_%d", time.Now().UnixNano())),
+		events:    make(chan core.Event, 64),
+		ctx:       ctx,
+		cancel:    cancel,
+		modelsCW:  loadModelsContextWindows(),
 	}
 	s.alive.Store(true)
 
-	if resumeID != "" && resumeID != core.ContinueSession {
+	if rpc {
+		s.rpcReady = make(chan struct{})
+		s.extPending = make(map[string]string)
+		s.extPendingRev = make(map[string]string)
+		s.extMethod = make(map[string]string)
+
+		if err := s.startRPC(resumeID); err != nil {
+			cancel()
+			return nil, fmt.Errorf("pi: start rpc: %w", err)
+		}
+
+		// Wait for first JSON line (indicates RPC loop is live)
+		select {
+		case <-s.rpcReady:
+		case <-time.After(30 * time.Second):
+			s.killRPC()
+			cancel()
+			return nil, fmt.Errorf("pi: rpc process did not become ready within 30s")
+		case <-ctx.Done():
+			s.killRPC()
+			return nil, fmt.Errorf("pi: context cancelled while waiting for rpc ready")
+		}
+	} else if resumeID != "" && resumeID != core.ContinueSession {
+		// JSON mode: set the session ID directly since we don't spawn a process
+		// that would emit a session event.
 		s.sessionID.Store(resumeID)
 	}
 
 	return s, nil
 }
 
-func (s *piSession) Send(prompt string, images []core.ImageAttachment, files []core.FileAttachment) error {
-	// Keep attachments isolated per session so concurrent sessions in the same
-	// workDir cannot delete files that another Pi process still references.
-	cleanAttachments(s.attachDir)
+// ── RPC process helpers (rpc=true) ──────────────────────────
 
-	// Save all attachments to disk — pi reads them via @file syntax.
-	var atFiles []string
-	if len(images) > 0 {
-		atFiles = append(atFiles, saveImagesToDisk(s.attachDir, images)...)
+func (s *piSession) startRPC(resumeID string) error {
+	args := append(append([]string{}, s.extraArgs...), "--mode", "rpc")
+	if resumeID != "" {
+		args = append(args, "--session-id", resumeID)
 	}
-	if len(files) > 0 {
-		atFiles = append(atFiles, saveFilesToDisk(s.attachDir, files)...)
-	}
-	if !s.alive.Load() {
-		return fmt.Errorf("session is closed")
-	}
-
-	args := append(append([]string{}, s.extraArgs...), "--mode", "json", "-p")
-
-	sid := s.CurrentSessionID()
-	if sid != "" {
-		args = append(args, "--session", sid)
-	}
-
 	if s.model != "" {
 		args = append(args, "--model", s.model)
 	}
-
-	if s.mode == "yolo" {
-		args = append(args, "--auto-approve")
-	}
-
 	if s.thinking != "" {
 		args = append(args, "--thinking", s.thinking)
 	}
 
-	// Pass attachments as @file arguments
-	for _, f := range atFiles {
-		args = append(args, "@"+f)
-	}
-
-	slog.Debug("piSession: launching", "resume", sid != "", "args", core.RedactArgs(args))
+	slog.Debug("piSession: starting RPC", "cmd", s.cmd, "args", args)
 
 	cmd := exec.CommandContext(s.ctx, s.cmd, args...)
 	cmd.Dir = s.workDir
@@ -131,51 +138,45 @@ func (s *piSession) Send(prompt string, images []core.ImageAttachment, files []c
 	}
 	cmd.Env = env
 
-	// Pipe prompt via stdin so leading "---" (from reply chain headers) is
-	// not misinterpreted as a CLI option flag.
-	cmd.Stdin = strings.NewReader(prompt)
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe: %w", err)
+	}
+	s.rpcStdin = stdinPipe
+	s.rpcCmd = cmd
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("piSession: stdout pipe: %w", err)
+		return fmt.Errorf("stdout pipe: %w", err)
 	}
-
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
+	cmd.Stderr = &s.stderrBuf
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("piSession: start: %w", err)
+		return fmt.Errorf("start: %w", err)
 	}
 
 	s.wg.Add(1)
-	go s.readLoop(cmd, stdout, &stderrBuf)
+	go s.readLoopRPC(stdout)
 
 	return nil
 }
 
-func (s *piSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
-	defer s.wg.Done()
-	defer func() {
-		if err := cmd.Wait(); err != nil {
-			stderrMsg := strings.TrimSpace(stderrBuf.String())
-			if stderrMsg != "" {
-				slog.Error("piSession: process failed", "error", err, "stderr", truncStr(stderrMsg, 200))
-				evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
-				select {
-				case s.events <- evt:
-				case <-s.ctx.Done():
-					return
-				}
-			}
-		}
-	}()
+func (s *piSession) killRPC() {
+	if s.rpcCmd != nil && s.rpcCmd.Process != nil {
+		_ = s.rpcCmd.Process.Kill()
+	}
+}
 
-	// Pi's JSON events are small (typically <1KB each). A 10MB Scanner buffer
-	// is more than sufficient — no need for the bufio.Reader approach used by
-	// adapters that may receive very large single-line responses.
+// readLoopRPC is the persistent RPC readLoop goroutine.
+// One instance runs for the lifetime of the RPC process.
+func (s *piSession) readLoopRPC(stdout io.ReadCloser) {
+	defer s.wg.Done()
+	defer stdout.Close()
+
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 
+	firstLine := true
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" {
@@ -188,8 +189,16 @@ func (s *piSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *byt
 			continue
 		}
 
+		if firstLine {
+			firstLine = false
+			close(s.rpcReady)
+		}
+
 		s.handleEvent(raw)
 	}
+
+	// Process exited
+	s.killRPC()
 
 	if err := scanner.Err(); err != nil {
 		slog.Error("piSession: scanner error", "error", err)
@@ -197,27 +206,146 @@ func (s *piSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *byt
 		select {
 		case s.events <- evt:
 		case <-s.ctx.Done():
-			return
+		}
+	}
+}
+
+// ── Send ─────────────────────────────────────────────────────
+
+// Send writes a prompt to the Pi agent.
+// In json mode (default): spawns a one-shot `pi --mode json` process.
+// In rpc mode: writes a "prompt" command to the persistent RPC process stdin.
+func (s *piSession) Send(msg string, images []core.ImageAttachment, files []core.FileAttachment) error {
+	s.sendWg.Add(1)
+	defer s.sendWg.Done()
+
+	if !s.alive.Load() {
+		return fmt.Errorf("session is closed")
+	}
+
+	cleanAttachments(s.attachDir)
+
+	var atFiles []string
+	if len(images) > 0 {
+		atFiles = append(atFiles, saveImagesToDisk(s.attachDir, images)...)
+	}
+	if len(files) > 0 {
+		atFiles = append(atFiles, saveFilesToDisk(s.attachDir, files)...)
+	}
+
+	// Build the message with attachment contents embedded
+	var promptText strings.Builder
+	promptText.WriteString(msg)
+	for _, f := range atFiles {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			slog.Warn("piSession: cannot read attachment", "file", f, "error", err)
+			continue
+		}
+		promptText.WriteString("\n\n--- " + filepath.Base(f) + " ---\n")
+		promptText.Write(data)
+	}
+
+	if s.rpc {
+		return s.sendRPC(promptText.String())
+	}
+	return s.sendJSON(promptText.String())
+}
+
+// sendJSON spawns `pi --mode json -p <prompt>` as a one-shot process,
+// reads all output events, and sends them to the events channel.
+func (s *piSession) sendJSON(prompt string) error {
+	args := append(append([]string{}, s.extraArgs...), "--mode", "json", "-p", prompt)
+	if s.model != "" {
+		args = append(args, "--model", s.model)
+	}
+	if s.thinking != "" {
+		args = append(args, "--thinking", s.thinking)
+	}
+
+	slog.Debug("piSession: spawning json mode", "cmd", s.cmd, "sessionID", s.CurrentSessionID())
+
+	cmd := exec.CommandContext(s.ctx, s.cmd, args...)
+	cmd.Dir = s.workDir
+	env := os.Environ()
+	if len(s.extraEnv) > 0 {
+		env = core.MergeEnv(env, s.extraEnv)
+	}
+	cmd.Env = env
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+
+	// Read events from process output
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			slog.Debug("piSession: non-JSON line", "line", truncStr(line, 100))
+			continue
+		}
+		s.handleEvent(raw)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		slog.Error("piSession: process error", "cmd", s.cmd, "error", err, "stderr", stderrBuf.String())
+		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("pi: %s: %w", strings.TrimSpace(stderrBuf.String()), err)}
+		select {
+		case s.events <- evt:
+		case <-s.ctx.Done():
 		}
 	}
 
-	// Emit EventResult when the process finishes.
+	// Signal turn completion
 	sid := s.CurrentSessionID()
 	evt := core.Event{Type: core.EventResult, SessionID: sid, Done: true}
 	select {
 	case s.events <- evt:
 	case <-s.ctx.Done():
 	}
+
+	return nil
 }
 
-// Pi NDJSON event types:
-//
-//	session           — session metadata with id
-//	agent_start/end   — agent lifecycle
-//	turn_start/end    — turn boundaries
-//	message_start     — beginning of user/assistant/toolResult message
-//	message_update    — streaming deltas (assistantMessageEvent sub-events)
-//	message_end       — complete message
+// sendRPC writes a JSON "prompt" command to the persistent RPC process stdin.
+// Events are read asynchronously by readLoopRPC, including agent_end which
+// triggers EventResult.
+func (s *piSession) sendRPC(prompt string) error {
+	cmd := map[string]any{
+		"type":    "prompt",
+		"message": prompt,
+	}
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		return fmt.Errorf("piSession: marshal prompt: %w", err)
+	}
+	b = append(b, '\n')
+
+	slog.Debug("piSession: sending RPC prompt", "bytes", len(b))
+	_, err = s.rpcStdin.Write(b)
+	if err != nil {
+		return fmt.Errorf("piSession: write stdin: %w", err)
+	}
+
+	return nil
+}
+
+// ── Event Handling (shared by both modes) ───────────────────
+
 func (s *piSession) handleEvent(raw map[string]any) {
 	eventType, _ := raw["type"].(string)
 
@@ -225,7 +353,6 @@ func (s *piSession) handleEvent(raw map[string]any) {
 	case "session":
 		if id, ok := raw["id"].(string); ok && id != "" {
 			s.sessionID.Store(id)
-			slog.Debug("piSession: session started", "session_id", id)
 		}
 
 	case "message_update":
@@ -236,61 +363,191 @@ func (s *piSession) handleEvent(raw map[string]any) {
 
 	case "agent_end":
 		s.handleAgentEnd(raw)
+		if s.rpc {
+			// RPC mode: agent_end marks turn completion; json mode relies
+			// on process exit to emit EventResult.
+			sid := s.CurrentSessionID()
+			evt := core.Event{Type: core.EventResult, SessionID: sid, Done: true}
+			select {
+			case s.events <- evt:
+			case <-s.ctx.Done():
+			}
+		}
 
-	case "agent_start", "turn_start", "turn_end", "message_start":
-		// Logged for debugging but no action needed.
-		slog.Debug("piSession: lifecycle event", "type", eventType)
+	case "extension_ui_request":
+		if s.rpc {
+			s.handleExtensionUIRequest(raw)
+		}
 
-	default:
-		slog.Debug("piSession: unhandled event", "type", eventType)
+	// Informational — no events produced
+	case "agent_start", "turn_start", "turn_end", "message_start", "extension_error":
 	}
 }
 
-// handleMessageUpdate processes streaming deltas from pi's assistantMessageEvent.
-func (s *piSession) handleMessageUpdate(raw map[string]any) {
-	ame, _ := raw["assistantMessageEvent"].(map[string]any)
-	if ame == nil {
+func (s *piSession) handleExtensionUIRequest(raw map[string]any) {
+	id, _ := raw["id"].(string)
+	method, _ := raw["method"].(string)
+	if id == "" {
+		slog.Warn("piSession: extension_ui_request without id")
 		return
 	}
 
-	subType, _ := ame["type"].(string)
-
-	switch subType {
-	case "text_delta":
-		delta, _ := ame["delta"].(string)
-		if delta != "" {
-			evt := core.Event{Type: core.EventText, Content: delta}
-			select {
-			case s.events <- evt:
-			case <-s.ctx.Done():
-				return
-			}
-		}
-
-	case "thinking_delta":
-		delta, _ := ame["delta"].(string)
-		if delta != "" {
-			s.thinkingBuf.WriteString(delta)
-		}
-
-	case "thinking_end":
-		if s.thinkingBuf.Len() > 0 {
-			evt := core.Event{Type: core.EventThinking, Content: s.thinkingBuf.String()}
-			s.thinkingBuf.Reset()
-			select {
-			case s.events <- evt:
-			case <-s.ctx.Done():
-				return
-			}
-		}
-
-	case "toolcall_end":
-		// Extract tool name and input from the accumulated message content.
-		s.emitToolFromMessage(ame)
+	switch method {
+	case "confirm":
+		s.forwardConfirm(id, raw)
+	case "input":
+		s.forwardInput(id, raw)
+	case "select":
+		s.forwardSelect(id, raw)
+	default:
+		slog.Debug("piSession: extension_ui_request (unhandled)", "method", method)
 	}
 }
 
-// emitToolFromMessage extracts tool call info from a toolcall_end event.
+func (s *piSession) forwardConfirm(id string, raw map[string]any) {
+	title, _ := raw["title"].(string)
+	message, _ := raw["message"].(string)
+
+	requestID := fmt.Sprintf("pi_ext_%s", id)
+
+	s.extPendingMu.Lock()
+	s.extPending[id] = requestID
+	s.extPendingRev[requestID] = id
+	s.extMethod[requestID] = "confirm"
+	s.extPendingMu.Unlock()
+
+	evt := core.Event{
+		Type:     core.EventPermissionRequest,
+		RequestID: requestID,
+		ToolName: "extension_confirm",
+		ToolInput: fmt.Sprintf("%s: %s", title, truncStr(message, 200)),
+		ToolInputRaw: map[string]any{
+			"title":   title,
+			"message": message,
+			"method":  "confirm",
+		},
+	}
+	select {
+	case s.events <- evt:
+	case <-s.ctx.Done():
+		slog.Warn("piSession: context done while forwarding confirm")
+	}
+}
+
+func (s *piSession) forwardInput(id string, raw map[string]any) {
+	title, _ := raw["title"].(string)
+	placeholder, _ := raw["placeholder"].(string)
+
+	requestID := fmt.Sprintf("pi_ext_%s", id)
+
+	s.extPendingMu.Lock()
+	s.extPending[id] = requestID
+	s.extPendingRev[requestID] = id
+	s.extMethod[requestID] = "input"
+	s.extPendingMu.Unlock()
+
+	evt := core.Event{
+		Type:     core.EventPermissionRequest,
+		RequestID: requestID,
+		ToolName: "extension_input",
+		ToolInput: fmt.Sprintf("%s [%s]", title, placeholder),
+		ToolInputRaw: map[string]any{
+			"title":       title,
+			"placeholder": placeholder,
+			"method":      "input",
+		},
+	}
+	select {
+	case s.events <- evt:
+	case <-s.ctx.Done():
+	}
+}
+
+func (s *piSession) forwardSelect(id string, raw map[string]any) {
+	title, _ := raw["title"].(string)
+	options, _ := raw["options"].([]any)
+
+	var opts []string
+	for _, opt := range options {
+		if o, ok := opt.(string); ok {
+			opts = append(opts, o)
+		}
+	}
+
+	requestID := fmt.Sprintf("pi_ext_%s", id)
+
+	s.extPendingMu.Lock()
+	s.extPending[id] = requestID
+	s.extPendingRev[requestID] = id
+	s.extMethod[requestID] = "select"
+	s.extPendingMu.Unlock()
+
+	evt := core.Event{
+		Type:     core.EventPermissionRequest,
+		RequestID: requestID,
+		ToolName: "extension_select",
+		ToolInput: fmt.Sprintf("%s [%s]", title, strings.Join(opts, ", ")),
+		ToolInputRaw: map[string]any{
+			"title":   title,
+			"options": opts,
+			"method":  "select",
+		},
+	}
+	select {
+	case s.events <- evt:
+	case <-s.ctx.Done():
+	}
+}
+
+// ── Message event handlers ──────────────────────────────────
+
+func (s *piSession) handleMessageUpdate(raw map[string]any) {
+	msg, _ := raw["assistantMessageEvent"].(map[string]any)
+	if msg == nil {
+		return
+	}
+	msgType, _ := msg["type"].(string)
+
+	switch msgType {
+	case "text_delta":
+		delta, _ := msg["delta"].(string)
+		if delta == "" {
+			return
+		}
+		evt := core.Event{Type: core.EventText, Content: delta}
+		select {
+		case s.events <- evt:
+		case <-s.ctx.Done():
+		}
+
+	case "thinking_delta":
+		delta, _ := msg["delta"].(string)
+		if delta == "" {
+			return
+		}
+		s.thinkingMu.Lock()
+		s.thinkingBuf.WriteString(delta)
+		s.thinkingMu.Unlock()
+
+	case "thinking_end":
+		s.thinkingMu.Lock()
+		if s.thinkingBuf.Len() == 0 {
+			s.thinkingMu.Unlock()
+			return
+		}
+		evt := core.Event{Type: core.EventThinking, Content: s.thinkingBuf.String()}
+		s.thinkingBuf.Reset()
+		s.thinkingMu.Unlock()
+		select {
+		case s.events <- evt:
+		case <-s.ctx.Done():
+		}
+
+	case "toolcall_end":
+		s.emitToolFromMessage(msg)
+	}
+}
+
 func (s *piSession) emitToolFromMessage(ame map[string]any) {
 	msg, _ := ame["message"].(map[string]any)
 	if msg == nil {
@@ -301,7 +558,7 @@ func (s *piSession) emitToolFromMessage(ame map[string]any) {
 	}
 
 	content, _ := msg["content"].([]any)
-	idx := int(0)
+	idx := 0
 	if ci, ok := ame["contentIndex"].(float64); ok {
 		idx = int(ci)
 	}
@@ -317,20 +574,17 @@ func (s *piSession) emitToolFromMessage(ame map[string]any) {
 				select {
 				case s.events <- evt:
 				case <-s.ctx.Done():
-					return
 				}
 			}
 		}
 	}
 }
 
-// handleMessageEnd processes completed messages — particularly toolResult messages.
 func (s *piSession) handleMessageEnd(raw map[string]any) {
 	msg, _ := raw["message"].(map[string]any)
 	if msg == nil {
 		return
 	}
-
 	role, _ := msg["role"].(string)
 
 	switch role {
@@ -338,70 +592,62 @@ func (s *piSession) handleMessageEnd(raw map[string]any) {
 		toolName, _ := msg["toolName"].(string)
 		content, _ := msg["content"].([]any)
 		var output string
-		for _, c := range content {
-			if item, ok := c.(map[string]any); ok {
+		if len(content) > 0 {
+			if item, ok := content[0].(map[string]any); ok {
 				if text, ok := item["text"].(string); ok {
 					output = text
-					break
 				}
 			}
 		}
-		evt := core.Event{Type: core.EventToolResult, ToolName: toolName, Content: truncStr(output, 500)}
+		if output == "" {
+			output = extractToolResult(msg)
+		}
+		evt := core.Event{
+			Type:     core.EventToolResult,
+			ToolName: toolName,
+			Content:  truncStr(output, 500),
+		}
 		select {
 		case s.events <- evt:
 		case <-s.ctx.Done():
-			return
 		}
 
 	case "assistant":
-		// Check for errors
-		if errMsg, _ := msg["errorMessage"].(string); errMsg != "" {
+		if errMsg, ok := msg["errorMessage"].(string); ok && errMsg != "" {
 			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", errMsg)}
 			select {
 			case s.events <- evt:
 			case <-s.ctx.Done():
-				return
 			}
 		}
 	}
 }
 
-// extractToolInput pulls a concise summary from a tool call content item.
-func extractToolInput(item map[string]any) string {
-	args, _ := item["arguments"].(map[string]any)
-	if args == nil {
-		return ""
+func extractToolResult(msg map[string]any) string {
+	content, _ := msg["content"].([]any)
+	for _, c := range content {
+		if item, ok := c.(map[string]any); ok {
+			// Look for the "text" key first; fall back to any string field.
+			if text, ok := item["text"].(string); ok && text != "" {
+				return text
+			}
+			if output, ok := item["output"].(string); ok && output != "" {
+				return output
+			}
+			if content, ok := item["content"].(string); ok && content != "" {
+				return content
+			}
+		}
 	}
-	// Prefer description or command fields.
-	if desc, ok := args["description"].(string); ok && desc != "" {
-		return desc
-	}
-	if cmd, ok := args["command"].(string); ok && cmd != "" {
-		return cmd
-	}
-	if fp, ok := args["file_path"].(string); ok && fp != "" {
-		return fp
-	}
-	if pattern, ok := args["pattern"].(string); ok && pattern != "" {
-		return pattern
-	}
-	if query, ok := args["query"].(string); ok && query != "" {
-		return query
-	}
-	b, _ := json.Marshal(args)
-	return truncStr(string(b), 200)
+	return ""
 }
 
-// handleAgentEnd processes the "agent_end" event from pi's RPC protocol.
-// It extracts the last assistant message's usage + model to populate
-// ContextUsage for the reply footer.
 func (s *piSession) handleAgentEnd(raw map[string]any) {
 	msgs, _ := raw["messages"].([]any)
 	if len(msgs) == 0 {
 		return
 	}
 
-	// Walk backwards to find the last assistant message with usage data.
 	for i := len(msgs) - 1; i >= 0; i-- {
 		msg, _ := msgs[i].(map[string]any)
 		if msg == nil {
@@ -415,6 +661,7 @@ func (s *piSession) handleAgentEnd(raw map[string]any) {
 		if usageRaw == nil {
 			continue
 		}
+
 		model, _ := msg["model"].(string)
 		inputTokens, _ := usageRaw["input"].(float64)
 		outputTokens, _ := usageRaw["output"].(float64)
@@ -426,22 +673,19 @@ func (s *piSession) handleAgentEnd(raw map[string]any) {
 		cr := int(cacheReadTokens)
 		cw := int(cacheWriteTokens)
 
-		// UsedTokens mirrors claudecode's per-sub-call pattern: track input
-		// + cache tokens from the last assistant message. The LLM API's
-		// input_tokens already counts the full conversation history, so this
-		// naturally represents cumulative context load across turns.
-		// TotalTokens = context load + output for this turn.
-		used := input + cw + cr
+		used := input + cr + cw
 		total := used + output
-
-		// Look up context window from models.json, fallback to 200K.
-		ctxWindow := s.modelsCW[model]
+		var ctxWindow int
+		if model != "" && s.modelsCW != nil {
+			if cwVal, ok := s.modelsCW[model]; ok {
+				ctxWindow = cwVal
+			}
+		}
 		if ctxWindow == 0 {
 			ctxWindow = 200_000
 		}
 
-		s.usageMu.Lock()
-		s.lastUsage = &core.ContextUsage{
+		usage := &core.ContextUsage{
 			UsedTokens:               used,
 			TotalTokens:              total,
 			InputTokens:              input,
@@ -449,30 +693,85 @@ func (s *piSession) handleAgentEnd(raw map[string]any) {
 			CachedInputTokens:        cr,
 			CacheCreationInputTokens: cw,
 			ContextWindow:            ctxWindow,
-			// BaselineTokens and ReasoningOutputTokens are left zero — pi's
-			// RPC protocol does not report these. The engine's UI must handle
-			// zero values (e.g. hide the "baseline" or "reasoning" segments).
 		}
+		s.usageMu.Lock()
+		s.lastUsage = usage
 		s.usageMu.Unlock()
 		return
 	}
 }
 
-// GetContextUsage implements core.ContextUsageReporter.
-// Returns a copy to prevent concurrent readers from seeing mutations.
-func (s *piSession) GetContextUsage() *core.ContextUsage {
-	s.usageMu.Lock()
-	defer s.usageMu.Unlock()
-	if s.lastUsage == nil {
+// ── RespondPermission ───────────────────────────────────────
+
+func (s *piSession) RespondPermission(requestID string, result core.PermissionResult) error {
+	if !s.rpc {
+		// JSON mode: no extension_ui support
 		return nil
 	}
-	u := *s.lastUsage
-	return &u
-}
 
-func (s *piSession) RespondPermission(_ string, _ core.PermissionResult) error {
+	s.extPendingMu.Lock()
+	extID, ok := s.extPendingRev[requestID]
+	method := s.extMethod[requestID]
+	if ok {
+		delete(s.extPending, extID)
+		delete(s.extPendingRev, requestID)
+		delete(s.extMethod, requestID)
+	}
+	s.extPendingMu.Unlock()
+
+	if !ok {
+		slog.Warn("piSession: RespondPermission for unknown request", "requestID", requestID)
+		return nil
+	}
+
+	var resp map[string]any
+	switch method {
+	case "input":
+		resp = map[string]any{
+			"type": "extension_ui_response",
+			"id":   extID,
+		}
+		if result.Behavior == "allow" {
+			resp["value"] = result.Message
+		} else {
+			resp["cancelled"] = true
+		}
+	case "select":
+		resp = map[string]any{
+			"type": "extension_ui_response",
+			"id":   extID,
+		}
+		if result.Behavior == "allow" {
+			resp["value"] = result.Message
+		} else {
+			resp["cancelled"] = true
+		}
+	case "confirm":
+		fallthrough
+	default:
+		resp = map[string]any{
+			"type":      "extension_ui_response",
+			"id":        extID,
+			"confirmed": result.Behavior == "allow",
+		}
+	}
+
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("piSession: marshal extension_ui_response: %w", err)
+	}
+	b = append(b, '\n')
+
+	slog.Debug("piSession: sending extension_ui_response", "id", extID, "behavior", result.Behavior)
+	_, err = s.rpcStdin.Write(b)
+	if err != nil {
+		return fmt.Errorf("piSession: write extension_ui_response: %w", err)
+	}
+
 	return nil
 }
+
+// ── AgentSession interface ──────────────────────────────────
 
 func (s *piSession) Events() <-chan core.Event {
 	return s.events
@@ -489,23 +788,38 @@ func (s *piSession) Alive() bool {
 
 func (s *piSession) Close() error {
 	s.alive.Store(false)
+
+	// Cancel context to interrupt any in-flight Send() or readLoopRPC.
 	s.cancel()
-	done := make(chan struct{})
-	go func() {
-		s.wg.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-		close(s.events)
-	case <-time.After(8 * time.Second):
-		slog.Warn("piSession: close timed out, abandoning wg.Wait")
+
+	if s.rpc {
+		s.killRPC()
 	}
+
+	// Wait for all in-flight Send() calls to finish (json mode) or be
+	// interrupted by ctx cancellation (both modes). Only then are we sure
+	// no goroutine can still write to s.events.
+	s.sendWg.Wait()
+	s.wg.Wait()
+
+	close(s.events)
 	return nil
 }
 
-// cleanAttachments removes this session's attachment directory to avoid
-// accumulating files across turns.
+// ── ContextUsageReporter ─────────────────────────────────────
+
+func (s *piSession) GetContextUsage() *core.ContextUsage {
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+	if s.lastUsage == nil {
+		return nil
+	}
+	u := *s.lastUsage
+	return &u
+}
+
+// ── Attachment helpers ───────────────────────────────────────
+
 func cleanAttachments(attachDir string) {
 	if attachDir == "" {
 		return
@@ -515,22 +829,19 @@ func cleanAttachments(attachDir string) {
 	}
 }
 
-// saveImagesToDisk saves image attachments to attachDir
-// and returns the list of absolute file paths.
-//
-// img.FileName originates from IM upload metadata and is treated as
-// untrusted: directory components are stripped (both `/` and `\`, the
-// latter so Linux strips Windows-style paths too) before joining into
-// attachDir. Without this, FileName="../../escape.png" wrote to
-// workDir/escape.png — outside the intended attachments directory.
 func saveImagesToDisk(attachDir string, images []core.ImageAttachment) []string {
+	if len(images) == 0 {
+		return nil
+	}
 	if err := os.MkdirAll(attachDir, 0o755); err != nil {
 		slog.Error("piSession: failed to create attachments dir", "error", err)
 		return nil
 	}
-
 	var paths []string
 	for i, img := range images {
+		if len(img.Data) == 0 {
+			continue
+		}
 		ext := ".png"
 		switch img.MimeType {
 		case "image/jpeg":
@@ -540,10 +851,22 @@ func saveImagesToDisk(attachDir string, images []core.ImageAttachment) []string 
 		case "image/webp":
 			ext = ".webp"
 		}
-		fname := sanitizePiAttachmentName(img.FileName)
+
+		fname := img.FileName
 		if fname == "" {
-			fname = fmt.Sprintf("image_%d_%d%s", time.Now().UnixMilli(), i, ext)
+			fname = fmt.Sprintf("img_%d_%d%s", time.Now().UnixMilli(), i, ext)
+		} else {
+			sane := sanitizePiAttachmentName(fname)
+			if sane == "" {
+				fname = fmt.Sprintf("img_%d_%d%s", time.Now().UnixMilli(), i, ext)
+			} else {
+				if !strings.HasSuffix(sane, ext) {
+					sane = sane + ext
+				}
+				fname = sane
+			}
 		}
+
 		fpath := filepath.Join(attachDir, fname)
 		if err := os.WriteFile(fpath, img.Data, 0o644); err != nil {
 			slog.Error("piSession: save image failed", "error", err)
@@ -555,12 +878,14 @@ func saveImagesToDisk(attachDir string, images []core.ImageAttachment) []string 
 }
 
 func saveFilesToDisk(attachDir string, files []core.FileAttachment) []string {
+	if len(files) == 0 {
+		return nil
+	}
 	if err := os.MkdirAll(attachDir, 0o755); err != nil {
 		slog.Error("piSession: failed to create attachments dir", "error", err)
 		return nil
 	}
-
-	paths := make([]string, 0, len(files))
+	var paths []string
 	for i, f := range files {
 		fname := sanitizePiAttachmentName(f.FileName)
 		if fname == "" {
@@ -576,12 +901,6 @@ func saveFilesToDisk(attachDir string, files []core.FileAttachment) []string {
 	return paths
 }
 
-// sanitizePiAttachmentName reduces a user-supplied attachment filename to a
-// safe basename for joining into an attachment directory. Strips directory
-// components (handling both `/` and `\` so an attacker can't bypass via
-// Windows-style separators on Linux), and rejects parent / current-directory
-// references so the caller's empty-name fallback can substitute a generated
-// name. Mirrors core.SaveFilesToDisk's sanitization.
 func sanitizePiAttachmentName(name string) string {
 	name = strings.ReplaceAll(name, "\\", "/")
 	name = filepath.Base(name)
@@ -591,9 +910,41 @@ func sanitizePiAttachmentName(name string) string {
 	return name
 }
 
+// ── Utilities ────────────────────────────────────────────────
+
 func truncStr(s string, maxRunes int) string {
 	if utf8.RuneCountInString(s) <= maxRunes {
 		return s
 	}
 	return string([]rune(s)[:maxRunes]) + "..."
+}
+
+func extractToolInput(item map[string]any) string {
+	args, hasArgs := item["arguments"].(map[string]any)
+	if !hasArgs {
+		args = item
+	}
+
+	if desc, ok := args["description"].(string); ok && desc != "" {
+		return desc
+	}
+	if cmd, ok := args["command"].(string); ok && cmd != "" {
+		return cmd
+	}
+	if fp, ok := args["file_path"].(string); ok && fp != "" {
+		return fp
+	}
+	if pattern, ok := args["pattern"].(string); ok && pattern != "" {
+		return pattern
+	}
+	if query, ok := args["query"].(string); ok && query != "" {
+		return query
+	}
+
+	b, _ := json.Marshal(args)
+	s := truncStr(string(b), 200)
+	if s == "{}" {
+		return ""
+	}
+	return s
 }

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -80,13 +80,30 @@ type piSession struct {
 	rpcStdin   io.WriteCloser
 	rpcStdinMu sync.Mutex
 	stderrBuf  cappedStderrWriter
-	rpcReady   chan struct{} // closed after first JSON line from Pi
+	rpcReady   chan struct{} // closed once after handleEvent stores sessionId from the get_state probe written by startRPC
 
 	// Extension UI: maps Pi's extension_ui_request id -> cc-connect RequestID
 	extPendingMu  sync.Mutex
 	extPending    map[string]string // Pi ext_ui_id -> cc-conn RequestID
 	extPendingRev map[string]string // cc-conn RequestID -> Pi ext_ui_id
 	extMethod     map[string]string // cc-conn RequestID -> method ("confirm"|"input"|"select")
+}
+
+// stateProbeID is the request id used for the get_state probe that startRPC
+// writes to Pi's stdin immediately after spawning the process. Pi's RPC
+// protocol does not push session metadata on the stdout stream — the only
+// way to learn the session id is to send {"type":"get_state"} and parse the
+// matching response. By using a fixed sentinel id we can match the response
+// unambiguously even if other commands are in flight.
+const stateProbeID = "cc-connect-state-probe"
+
+// sessionIDReady reports whether the session id has been observed on the
+// pi side and stored. Used by readLoopRPC to decide when it is safe to
+// close rpcReady so callers (newPiSession, the engine) can read
+// CurrentSessionID() without racing the startup probe.
+func (s *piSession) sessionIDReady() bool {
+	v, _ := s.sessionID.Load().(string)
+	return v != ""
 }
 
 // ── Constructor ──────────────────────────────────────────────
@@ -187,6 +204,27 @@ func (s *piSession) startRPC(resumeID string) error {
 	s.wg.Add(1)
 	go s.readLoopRPC(stdout)
 
+	// Pi's RPC protocol does not push a "session" event on stdout — the only
+	// way to learn the session id is to send {"type":"get_state"} and parse
+	// the matching response in handleEvent. We probe immediately after spawn
+	// so that newPiSession's wait on rpcReady only unblocks once the id has
+	// been stored. readLoopRPC closes rpcReady as soon as sessionIDReady()
+	// flips to true (which happens after handleEvent processes the response),
+	// so callers can safely read CurrentSessionID() the moment rpcReady fires.
+	//
+	// If the probe write fails, the session is unrecoverable: without the
+	// session id we cannot resume after /stop, which is the very bug we are
+	// fixing. Bail out immediately and let the caller surface the error
+	// instead of waiting for the 30s rpcReady timeout.
+	if err := s.writeRPCCommand(map[string]any{
+		"type": "get_state",
+		"id":   stateProbeID,
+	}); err != nil {
+		slog.Warn("piSession: failed to write get_state probe; aborting RPC start", "error", err)
+		s.killRPC()
+		return fmt.Errorf("piSession: write get_state probe: %w", err)
+	}
+
 	return nil
 }
 
@@ -208,7 +246,16 @@ func (s *piSession) readLoopRPC(stdout io.ReadCloser) {
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 
-	firstLine := true
+	// rpcReady is closed exactly once, after handleEvent stores the session
+	// id from the get_state probe that startRPC wrote. We cannot use the
+	// first line as the trigger: the first line is usually an
+	// extension_ui_request from a running extension (plan-mode, presets,
+	// etc.) and would fire before the session id arrives, letting callers
+	// observe an empty CurrentSessionID(). handleEvent always runs before
+	// this check, so the moment we close rpcReady the id is guaranteed to
+	// be loaded — that's the same invariant the previous fix (which used
+	// the first line) tried to establish, just bound to the right event.
+	stateFetched := false
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" {
@@ -223,8 +270,8 @@ func (s *piSession) readLoopRPC(stdout io.ReadCloser) {
 
 		s.handleEvent(raw)
 
-		if firstLine {
-			firstLine = false
+		if !stateFetched && s.sessionIDReady() {
+			stateFetched = true
 			close(s.rpcReady)
 		}
 	}
@@ -372,6 +419,26 @@ func (s *piSession) sendJSON(prompt string) error {
 	return nil
 }
 
+// writeRPCCommand marshals cmd as a single JSONL line and writes it to the
+// RPC process's stdin under rpcStdinMu. Used by both sendRPC (for "prompt"
+// commands during a turn) and startRPC (for the startup "get_state" probe
+// that fetches the session id before callers are released).
+func (s *piSession) writeRPCCommand(cmd map[string]any) error {
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		return fmt.Errorf("piSession: marshal command: %w", err)
+	}
+	b = append(b, '\n')
+
+	s.rpcStdinMu.Lock()
+	_, err = s.rpcStdin.Write(b)
+	s.rpcStdinMu.Unlock()
+	if err != nil {
+		return fmt.Errorf("piSession: write stdin: %w", err)
+	}
+	return nil
+}
+
 // sendRPC writes a JSON "prompt" command to the persistent RPC process stdin.
 // Events are read asynchronously by readLoopRPC, including agent_end which
 // triggers EventResult.
@@ -380,21 +447,8 @@ func (s *piSession) sendRPC(prompt string) error {
 		"type":    "prompt",
 		"message": prompt,
 	}
-	b, err := json.Marshal(cmd)
-	if err != nil {
-		return fmt.Errorf("piSession: marshal prompt: %w", err)
-	}
-	b = append(b, '\n')
-
-	slog.Debug("piSession: sending RPC prompt", "bytes", len(b))
-	s.rpcStdinMu.Lock()
-	_, err = s.rpcStdin.Write(b)
-	s.rpcStdinMu.Unlock()
-	if err != nil {
-		return fmt.Errorf("piSession: write stdin: %w", err)
-	}
-
-	return nil
+	slog.Debug("piSession: sending RPC prompt", "bytes", len(prompt))
+	return s.writeRPCCommand(cmd)
 }
 
 // ── Event Handling (shared by both modes) ───────────────────
@@ -404,8 +458,39 @@ func (s *piSession) handleEvent(raw map[string]any) {
 
 	switch eventType {
 	case "session":
+		// Kept as a defensive fallback: if a future Pi RPC build starts
+		// pushing {"type":"session",...} on stdout (mirroring its on-disk
+		// jsonl format), we capture the id. Today Pi only sends the id in
+		// response to get_state, which is handled by the "response" branch
+		// below. See stateProbeID for the full rationale.
 		if id, ok := raw["id"].(string); ok && id != "" {
 			s.sessionID.Store(id)
+		}
+
+	case "response":
+		// Startup probe response: matches the get_state request id set by
+		// startRPC. Stores sessionId so readLoopRPC can close rpcReady and
+		// the engine can persist it via the next EventResult.SessionID.
+		if id, _ := raw["id"].(string); id == stateProbeID {
+			success, _ := raw["success"].(bool)
+			if !success {
+				errMsg, _ := raw["error"].(string)
+				slog.Warn("piSession: get_state probe returned failure; session id will be empty",
+					"error", errMsg, "raw", raw)
+				break
+			}
+			data, ok := raw["data"].(map[string]any)
+			if !ok {
+				slog.Warn("piSession: get_state probe response missing data field; session id will be empty", "raw", raw)
+				break
+			}
+			sid, _ := data["sessionId"].(string)
+			if sid == "" {
+				slog.Warn("piSession: get_state probe data.sessionId is empty", "raw", raw)
+				break
+			}
+			s.sessionID.Store(sid)
+			slog.Debug("piSession: state probe stored sessionId", "sessionId", sid)
 		}
 
 	case "message_update":

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -471,15 +471,6 @@ func (s *piSession) forwardConfirm(id string, raw map[string]any) {
 	s.extMethod[requestID] = "confirm"
 	s.extPendingMu.Unlock()
 
-	questionText := title
-	if message != "" {
-		if questionText != "" {
-			questionText = questionText + ": " + message
-		} else {
-			questionText = message
-		}
-	}
-
 	evt := core.Event{
 		Type:     core.EventPermissionRequest,
 		RequestID: requestID,
@@ -490,15 +481,12 @@ func (s *piSession) forwardConfirm(id string, raw map[string]any) {
 			"message": message,
 			"method":  "confirm",
 		},
-		Questions: []core.UserQuestion{{
-			Question: questionText,
-			Header:   "Confirm",
-			Options: []core.UserQuestionOption{
-				{Label: "Yes"},
-				{Label: "No"},
-			},
-			MultiSelect: false,
-		}},
+		// extension_confirm is treated as a regular permission request by
+		// the engine (Allow/Deny card), NOT an AskUserQuestion button card.
+		// Extensions use ctx.ui.confirm() to ask the user for permission on
+		// a tool call (e.g. permission-gate on Bash). Routing it through the
+		// AskUserQuestion flow produced a Yes/No question card, which
+		// doesn't match the UX of other agents' permission prompts.
 	}
 	select {
 	case s.events <- evt:
@@ -870,23 +858,13 @@ func (s *piSession) RespondPermission(requestID string, result core.PermissionRe
 			resp["cancelled"] = true
 		}
 	case "confirm":
-		// confirm also goes through the AskUserQuestion flow (Yes/No buttons).
-		// Behavior=allow means the user picked; inspect the answer to decide
-		// between confirmed=true and cancelled=true.
-		ans := strings.ToLower(strings.TrimSpace(lastAskQuestionAnswer(result.UpdatedInput)))
-		if result.Behavior == "allow" && (ans == "yes" || ans == "true" || ans == "ok" || ans == "confirm") {
-			resp = map[string]any{
-				"type":      "extension_ui_response",
-				"id":        extID,
-				"confirmed": true,
-			}
-		} else {
-			resp = map[string]any{
-				"type":      "extension_ui_response",
-				"id":        extID,
-				"cancelled": true,
-			}
-		}
+		// extension_confirm goes through the regular permission flow, not the
+		// AskUserQuestion flow, so the engine sends plain "allow"/"deny"
+		// PermissionResults (no UpdatedInput.answers). Forward as the default
+		// case: confirmed=Behavior=="allow", else confirmed=false (pgate's
+		// ctx.ui.confirm resolves false for both "deny" and "no confirmation",
+		// which is what we want).
+		fallthrough
 	default:
 		resp = map[string]any{
 			"type":      "extension_ui_response",

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -613,21 +613,51 @@ func (s *piSession) forwardSelect(id string, raw map[string]any) {
 	title, _ := raw["title"].(string)
 	options, _ := raw["options"].([]any)
 
-	var opts []string
+	// Pi Agent sends options in either of two shapes:
+	//   - []string                         ("Red", "Green", "Blue")
+	//   - []map[string]any                 ([{label:"Red", description:"..."}])
+	// The object form carries an optional description which cc-connect's
+	// AskUserQuestion card layout renders as a full-width markdown line
+	// under each option (the long-description fix in core/engine.go). If we
+	// only accepted strings here, any object option would be silently dropped
+	// — the user's TUI sees the description, but cc-connect never forwards
+	// it to the engine, so the Feishu card renders label-only. Accept both
+	// shapes for forward compatibility.
+	userOpts := make([]core.UserQuestionOption, 0, len(options))
 	for _, opt := range options {
-		if o, ok := opt.(string); ok {
-			opts = append(opts, o)
+		switch v := opt.(type) {
+		case string:
+			// String form: the string IS the label.
+			userOpts = append(userOpts, core.UserQuestionOption{Label: v})
+		case map[string]any:
+			// Object form: extract label + optional description. Label
+			// carries the option's value verbatim so resolveAskQuestionAnswer
+			// → result.Message maps back to the same string the extension
+			// passed in.
+			label, _ := v["label"].(string)
+			if label == "" {
+				label, _ = v["text"].(string)
+			}
+			if label == "" {
+				label, _ = v["name"].(string)
+			}
+			desc, _ := v["description"].(string)
+			if desc == "" {
+				desc, _ = v["preview"].(string)
+			}
+			if label == "" {
+				slog.Warn("piSession: option missing label in extension_select",
+					"id", id)
+				continue
+			}
+			userOpts = append(userOpts, core.UserQuestionOption{
+				Label:       label,
+				Description: desc,
+			})
+		default:
+			slog.Warn("piSession: unsupported option type in extension_select",
+				"id", id, "type", fmt.Sprintf("%T", opt))
 		}
-	}
-
-	// Convert raw string options to UserQuestionOption so cc-connect renders
-	// them as a rich button card (AskUserQuestion flow) instead of a plain
-	// permission prompt. Label carries the option's value verbatim so that
-	// resolveAskQuestionAnswer → result.Message maps back to the same string
-	// the extension passed in.
-	userOpts := make([]core.UserQuestionOption, 0, len(opts))
-	for _, o := range opts {
-		userOpts = append(userOpts, core.UserQuestionOption{Label: o})
 	}
 
 	requestID := fmt.Sprintf("pi_ext_%s", id)
@@ -643,14 +673,21 @@ func (s *piSession) forwardSelect(id string, raw map[string]any) {
 		questionText = "Select an option"
 	}
 
+	// ToolInput carries a short label-only summary for the engine's tool-use
+	// stream; the rich per-option content (with descriptions) lives in the
+	// Questions field below, which cc-connect's card layout renders.
+	labelSummary := make([]string, 0, len(userOpts))
+	for _, o := range userOpts {
+		labelSummary = append(labelSummary, o.Label)
+	}
 	evt := core.Event{
 		Type:     core.EventPermissionRequest,
 		RequestID: requestID,
 		ToolName: "extension_select",
-		ToolInput: fmt.Sprintf("%s [%s]", title, strings.Join(opts, ", ")),
+		ToolInput: fmt.Sprintf("%s [%s]", title, strings.Join(labelSummary, ", ")),
 		ToolInputRaw: map[string]any{
 			"title":   title,
-			"options": opts,
+			"options": labelSummary,
 			"method":  "select",
 		},
 		Questions: []core.UserQuestion{{

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -189,12 +189,12 @@ func (s *piSession) readLoopRPC(stdout io.ReadCloser) {
 			continue
 		}
 
+		s.handleEvent(raw)
+
 		if firstLine {
 			firstLine = false
 			close(s.rpcReady)
 		}
-
-		s.handleEvent(raw)
 	}
 
 	// Process exited

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -512,6 +512,47 @@ func (s *piSession) handleEvent(raw map[string]any) {
 			}
 		}
 
+	case "compaction_start":
+		// Pi fires this when ctx.compact() begins (slash command or
+		// turn_end threshold). The active extension typically notifies the
+		// user directly, so we don't surface a platform-visible event here
+		// — just stop logging it as "unrecognized event type" in DEBUG.
+		slog.Debug("piSession: compaction started")
+
+	case "compaction_end":
+		// Pi fires this when ctx.compact() finishes. ctx.compact() is
+		// fire-and-forget: it never sends agent_end, because compaction
+		// runs out-of-band with the agent loop. Extensions that drive
+		// ctx.compact() (e.g. cc-connect-compact.ts, trigger-compact.ts)
+		// handle their own user feedback via stdout synth events and the
+		// normal slash-command path returns immediately.
+		//
+		// Without an explicit EventResult here, two scenarios hang
+		// forever in processInteractiveEvents:
+		//   (a) trigger-compact: handler returns without await, so no
+		//       synthetic agent_end ever lands on stdout.
+		//   (b) cc-connect-compact: an extension that crashes, races a
+		//       kill, or simply omits the finally-synthesized agent_end
+		//       leaves the turn open.
+		//
+		// JSON mode (json one-shot) is unaffected — process exit is the
+		// turn-end marker there, and compaction_end has no special meaning.
+		//
+		// Duplicate EventResult (when both agent_end and compaction_end
+		// close the same turn) is safe: processInteractiveEvents only
+		// sends a message to the platform when fullResponse has accumulated
+		// text in the second pass, which is empty for out-of-band
+		// compactions. The only side effect is a redundant
+		// ws.BeginTurn/EndTurn pair, accepted as belt-and-suspenders.
+		if s.rpc {
+			sid := s.CurrentSessionID()
+			evt := core.Event{Type: core.EventResult, SessionID: sid, Done: true}
+			select {
+			case s.events <- evt:
+			case <-s.ctx.Done():
+			}
+		}
+
 	case "extension_ui_request":
 		if s.rpc {
 			s.handleExtensionUIRequest(raw)

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -20,6 +20,32 @@ import (
 	"github.com/chenhg5/cc-connect/core"
 )
 
+// ── capped stderr writer ────────────────────────────────────
+
+// cappedStderrWriter wraps a bytes.Buffer with a maximum size to prevent
+// unbounded growth from stderr output in long-running RPC sessions.
+// Writes beyond the cap are silently discarded.
+type cappedStderrWriter struct {
+	buf bytes.Buffer
+}
+
+const maxStderrSize = 64 * 1024
+
+func (w *cappedStderrWriter) Write(p []byte) (int, error) {
+	if w.buf.Len() >= maxStderrSize {
+		return len(p), nil
+	}
+	n := maxStderrSize - w.buf.Len()
+	if len(p) > n {
+		p = p[:n]
+	}
+	return w.buf.Write(p)
+}
+
+func (w *cappedStderrWriter) String() string {
+	return w.buf.String()
+}
+
 // piSession manages a multi-turn pi coding agent conversation.
 // In "json" mode (default): each Send() spawns `pi --mode json` as a one-shot
 // process. No extension_ui support, no permission forwarding.
@@ -50,10 +76,11 @@ type piSession struct {
 	lastUsage  *core.ContextUsage
 
 	// RPC-only fields (nil/zero when rpc=false)
-	rpcCmd   *exec.Cmd
-	rpcStdin io.WriteCloser
-	stderrBuf bytes.Buffer
-	rpcReady chan struct{} // closed after first JSON line from Pi
+	rpcCmd     *exec.Cmd
+	rpcStdin   io.WriteCloser
+	rpcStdinMu sync.Mutex
+	stderrBuf  cappedStderrWriter
+	rpcReady   chan struct{} // closed after first JSON line from Pi
 
 	// Extension UI: maps Pi's extension_ui_request id -> cc-connect RequestID
 	extPendingMu  sync.Mutex
@@ -151,6 +178,8 @@ func (s *piSession) startRPC(resumeID string) error {
 	}
 	cmd.Stderr = &s.stderrBuf
 
+	prepareCmdForKill(cmd)
+
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start: %w", err)
 	}
@@ -163,7 +192,10 @@ func (s *piSession) startRPC(resumeID string) error {
 
 func (s *piSession) killRPC() {
 	if s.rpcCmd != nil && s.rpcCmd.Process != nil {
-		_ = s.rpcCmd.Process.Kill()
+		if err := forceKillCmd(s.rpcCmd); err != nil {
+			slog.Warn("piSession: kill rpc process", "error", err)
+		}
+		_, _ = s.rpcCmd.Process.Wait()
 	}
 }
 
@@ -197,7 +229,8 @@ func (s *piSession) readLoopRPC(stdout io.ReadCloser) {
 		}
 	}
 
-	// Process exited
+	// Process exited — reap the child and signal the engine.
+	// killRPC (now with Wait()) ensures the zombie is collected.
 	s.killRPC()
 
 	if err := scanner.Err(); err != nil {
@@ -208,6 +241,21 @@ func (s *piSession) readLoopRPC(stdout io.ReadCloser) {
 		case <-s.ctx.Done():
 		}
 	}
+
+	// Signal process death to the engine (unless Close() already did).
+	// Following the claudecode finishReadLoop pattern: always set alive=false,
+	// and emit EventError with the captured stderr when present.
+	// All writes to s.events happen before the deferred wg.Done(), so
+	// Close()'s wg.Wait() → close(s.events) is correctly ordered.
+	stderrMsg := strings.TrimSpace(s.stderrBuf.String())
+	if stderrMsg != "" {
+		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("pi: %s", stderrMsg)}
+		select {
+		case s.events <- evt:
+		case <-s.ctx.Done():
+		}
+	}
+	s.alive.Store(false)
 }
 
 // ── Send ─────────────────────────────────────────────────────
@@ -339,7 +387,9 @@ func (s *piSession) sendRPC(prompt string) error {
 	b = append(b, '\n')
 
 	slog.Debug("piSession: sending RPC prompt", "bytes", len(b))
+	s.rpcStdinMu.Lock()
 	_, err = s.rpcStdin.Write(b)
+	s.rpcStdinMu.Unlock()
 	if err != nil {
 		return fmt.Errorf("piSession: write stdin: %w", err)
 	}
@@ -384,6 +434,8 @@ func (s *piSession) handleEvent(raw map[string]any) {
 
 	// Informational — no events produced
 	case "agent_start", "turn_start", "turn_end", "message_start", "extension_error":
+	default:
+		slog.Debug("piSession: unrecognized event type", "type", eventType, "raw", raw)
 	}
 }
 
@@ -756,16 +808,17 @@ func lastAskQuestionAnswer(updatedInput map[string]any) string {
 	if answers == nil {
 		return ""
 	}
-	// answers is keyed by question text. We don't have the question text
-	// here, so just return the last value (stable across the small maps
-	// the AskUserQuestion flow produces — typically 1 entry).
-	var last string
+	if len(answers) > 1 {
+		slog.Warn("piSession: unexpected multiple answers in AskUserQuestion", "count", len(answers))
+	}
+	// answers is keyed by question text, typically containing 1 entry from
+	// the AskUserQuestion flow. Return the first string value found.
 	for _, v := range answers {
 		if s, ok := v.(string); ok {
-			last = s
+			return s
 		}
 	}
-	return last
+	return ""
 }
 
 // ── RespondPermission ───────────────────────────────────────
@@ -849,7 +902,9 @@ func (s *piSession) RespondPermission(requestID string, result core.PermissionRe
 	b = append(b, '\n')
 
 	slog.Debug("piSession: sending extension_ui_response", "id", extID, "behavior", result.Behavior)
+	s.rpcStdinMu.Lock()
 	_, err = s.rpcStdin.Write(b)
+	s.rpcStdinMu.Unlock()
 	if err != nil {
 		return fmt.Errorf("piSession: write extension_ui_response: %w", err)
 	}

--- a/config.example.toml
+++ b/config.example.toml
@@ -1706,6 +1706,64 @@ app_secret = "your-feishu-app-secret"
 # token = "your-telegram-bot-token"
 
 # =============================================================================
+# Project: Using Pi / 项目：使用 Pi (uncomment to enable / 取消注释以启用)
+# =============================================================================
+# Requires: npm install -g @mariozechner/pi-coding-agent
+# 需要安装：npm install -g @mariozechner/pi-coding-agent
+# Pi is an AI coding agent that speaks two protocols to cc-connect:
+# Pi 是 AI 编程 agent，通过两种协议与 cc-connect 通信：
+#
+#   - "json" mode (default): one-shot `pi --mode json` per turn. No UI
+#     forwarding — any tool call that needs permission is silently
+#     rejected. Use this only if you never need to ask the user anything.
+#     "json" 模式（默认）：每个回合跑一次 `pi --mode json` 进程。
+#     不转发 UI 交互——任何需要权限的工具调用都会被静默拒绝。
+#     仅在你不需要问用户任何东西时使用。
+#
+#   - "rpc" mode: persistent `pi --mode rpc` process talking JSONL over
+#     stdin/stdout. The engine intercepts Pi's extension_ui_request events
+#     and surfaces them as permission / question cards on the messaging
+#     platform. The user's decision is piped back to Pi via
+#     extension_ui_response. **This is the mode you want.**
+#     "rpc" 模式：常驻 `pi --mode rpc` 进程，通过 stdin/stdout 走 JSONL
+#     协议。引擎会截获 Pi 的 extension_ui_request 事件，并在消息平台上
+#     渲染为权限 / 询问卡片。用户的决策通过 extension_ui_response 回写到
+#     Pi。**这是你想要的模式。**
+#
+# Pi extensions that need user interaction must use the standard UI methods
+# (ctx.ui.confirm, ctx.ui.select, ctx.ui.input) so cc-connect can intercept
+# them. If you write your own extensions, do NOT roll custom stdin prompts —
+# they will be invisible to cc-connect and silently dropped.
+# 需要与用户交互的 Pi 扩展必须使用标准 UI 方法（ctx.ui.confirm、
+# ctx.ui.select、ctx.ui.input），cc-connect 才能截获。如果你自己写
+# 扩展，不要自己往 stdin 里塞 prompt——cc-connect 看不到，会被静默丢弃。
+#
+# Configuration options:
+# - rpc = true|false: enable RPC mode (default: false)
+# - mode = "default"|"yolo": permission behavior
+# - thinking = "off"|"minimal"|"low"|"medium"|"high"|"xhigh"
+# - model = "provider/model" (optional; falls back to settings.json)
+
+# [[projects]]
+# name = "my-pi-project"
+#
+# [projects.agent]
+# type = "pi"
+#
+# [projects.agent.options]
+# work_dir = "/path/to/project"
+# rpc = true                  # enable RPC mode for UI forwarding / 启用 RPC 模式以转发 UI
+# mode = "default"            # "default" | "yolo"
+# thinking = "high"           # optional / 可选
+# # model = "anthropic/claude-sonnet-4-20250514"  # optional / 可选
+#
+# [[projects.platforms]]
+# type = "telegram"
+#
+# [projects.platforms.options]
+# token = "your-telegram-bot-token"
+
+# =============================================================================
 # Project: Devin CLI (Cognition, https://cli.devin.ai/) / 使用 Devin CLI
 # =============================================================================
 # Devin speaks the Agent Client Protocol (ACP) over stdio via its `devin acp`

--- a/core/engine.go
+++ b/core/engine.go
@@ -5113,13 +5113,18 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			}
 
 		case EventPermissionRequest:
-			// extension_select / extension_confirm are Pi extension UI requests
-			// routed via the AskUserQuestion rich-card path. The pi session
-			// adapter populates event.Questions so they render as button cards
-			// (same UX as Claude Code's AskUserQuestion).
+			// extension_select is a Pi extension UI request routed via the
+			// AskUserQuestion rich-card path. The pi session adapter populates
+			// event.Questions so it renders as a button card (same UX as Claude
+			// Code's AskUserQuestion).
+			//
+			// extension_confirm is intentionally NOT in this list: extensions
+			// use ctx.ui.confirm() to ask the user for permission on a tool
+			// call (e.g. permission-gate on Bash), and the engine must render
+			// it as a regular permission request (Allow/Deny) so the UX
+			// matches other agents. See forwardConfirm in agent/pi/session.go.
 			isAskQuestion := (event.ToolName == "AskUserQuestion" ||
-				event.ToolName == "extension_select" ||
-				event.ToolName == "extension_confirm") && len(event.Questions) > 0
+				event.ToolName == "extension_select") && len(event.Questions) > 0
 
 			state.mu.Lock()
 			autoApprove := state.approveAll

--- a/core/engine.go
+++ b/core/engine.go
@@ -5113,7 +5113,13 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			}
 
 		case EventPermissionRequest:
-			isAskQuestion := event.ToolName == "AskUserQuestion" && len(event.Questions) > 0
+			// extension_select / extension_confirm are Pi extension UI requests
+			// routed via the AskUserQuestion rich-card path. The pi session
+			// adapter populates event.Questions so they render as button cards
+			// (same UX as Claude Code's AskUserQuestion).
+			isAskQuestion := (event.ToolName == "AskUserQuestion" ||
+				event.ToolName == "extension_select" ||
+				event.ToolName == "extension_confirm") && len(event.Questions) > 0
 
 			state.mu.Lock()
 			autoApprove := state.approveAll

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6779,6 +6779,181 @@ func TestHandlePendingPermission_AskUserQuestion_SkipsPermFlow(t *testing.T) {
 	}
 }
 
+// TestHandlePendingPermission_ExtensionConfirm_AllowIsPermissionAllow is a
+// regression test for the fcb1beae regression: extension_confirm events
+// (forwarded by the pi session for ctx.ui.confirm, used by extensions like
+// permission-gate to ask the user for tool-use permission) must be handled
+// as a regular permission request. "allow" / "deny" / "allow all" must be
+// interpreted as permission decisions, NOT as free-text answers to a
+// AskUserQuestion-style Yes/No question.
+//
+// The bug: fcb1beae routed extension_confirm through the AskUserQuestion
+// flow (populated Questions=[{Yes, No}] in forwardConfirm). That made the
+// engine render a Yes/No question card on Feishu instead of an Allow/Deny
+// permission card, breaking the UX for permission-gate and any other
+// extension that uses ctx.ui.confirm for permission decisions.
+func TestHandlePendingPermission_ExtensionConfirm_AllowIsPermissionAllow(t *testing.T) {
+	e := newTestEngine()
+	p := &stubPlatformEngine{n: "test"}
+	rec := &recordingAgentSession{}
+
+	state := &interactiveState{
+		agentSession: rec,
+		platform:     p,
+		replyCtx:     "ctx",
+		pending: &pendingPermission{
+			RequestID: "pi_ext_cfm-1",
+			ToolName:  "extension_confirm",
+			ToolInput: map[string]any{
+				"title":   "Command needs confirmation",
+				"message": "rm -rf /tmp/foo",
+				"method":  "confirm",
+			},
+			// No Questions field — extension_confirm must NOT carry one.
+			// Questions: nil,
+			Resolved: make(chan struct{}),
+		},
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates["test:chat:user1"] = state
+	e.interactiveMu.Unlock()
+
+	// User clicks "allow" — must be treated as permission allow, not as a
+	// free-text answer to a Yes/No question.
+	if !e.handlePendingPermission(p, &Message{
+		SessionKey: "test:chat:user1",
+		UserID:     "user1",
+		Content:    "allow",
+		ReplyCtx:   "ctx",
+	}, "allow", "") {
+		t.Fatal("expected handlePendingPermission to return true")
+	}
+
+	if rec.calls != 1 {
+		t.Fatalf("RespondPermission calls = %d, want 1", rec.calls)
+	}
+	if rec.lastResult.Behavior != "allow" {
+		t.Fatalf("Behavior = %q, want %q (extension_confirm must treat 'allow' as permission allow)", rec.lastResult.Behavior, "allow")
+	}
+	if _, ok := rec.lastResult.UpdatedInput["answers"]; ok {
+		t.Errorf("UpdatedInput must not carry AskUserQuestion answers, got %v", rec.lastResult.UpdatedInput)
+	}
+
+	state.mu.Lock()
+	if state.pending != nil {
+		t.Error("expected pending to be cleared after 'allow'")
+	}
+	state.mu.Unlock()
+}
+
+// TestHandlePendingPermission_ExtensionConfirm_DenyIsPermissionDeny covers
+// the deny half of the same regression: "deny" must produce Behavior="deny"
+// and clear the pending state.
+func TestHandlePendingPermission_ExtensionConfirm_DenyIsPermissionDeny(t *testing.T) {
+	e := newTestEngine()
+	p := &stubPlatformEngine{n: "test"}
+	rec := &recordingAgentSession{}
+
+	state := &interactiveState{
+		agentSession: rec,
+		platform:     p,
+		replyCtx:     "ctx",
+		pending: &pendingPermission{
+			RequestID: "pi_ext_cfm-1",
+			ToolName:  "extension_confirm",
+			ToolInput: map[string]any{
+				"title":   "Command needs confirmation",
+				"message": "rm -rf /tmp/foo",
+				"method":  "confirm",
+			},
+			Resolved: make(chan struct{}),
+		},
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates["test:chat:user1"] = state
+	e.interactiveMu.Unlock()
+
+	if !e.handlePendingPermission(p, &Message{
+		SessionKey: "test:chat:user1",
+		UserID:     "user1",
+		Content:    "deny",
+		ReplyCtx:   "ctx",
+	}, "deny", "") {
+		t.Fatal("expected handlePendingPermission to return true")
+	}
+
+	if rec.lastResult.Behavior != "deny" {
+		t.Fatalf("Behavior = %q, want %q", rec.lastResult.Behavior, "deny")
+	}
+}
+
+// TestHandlePendingPermission_ExtensionSelect_StillRoutedAsAskUserQuestion
+// is the counterpart guard test: extension_select (used by the questionnaire
+// extension in RPC mode) MUST still be routed through the AskUserQuestion
+// flow, with its Questions field preserved. This test exists so that a future
+// refactor of the AskUserQuestion detection doesn't accidentally pull
+// extension_select back into the regular permission path and break the
+// button-card UX for questionnaire / multi-choice prompts.
+func TestHandlePendingPermission_ExtensionSelect_StillRoutedAsAskUserQuestion(t *testing.T) {
+	e := newTestEngine()
+	p := &stubPlatformEngine{n: "test"}
+	rec := &recordingAgentSession{}
+
+	state := &interactiveState{
+		agentSession: rec,
+		platform:     p,
+		replyCtx:     "ctx",
+		pending: &pendingPermission{
+			RequestID: "pi_ext_sel-1",
+			ToolName:  "extension_select",
+			ToolInput: map[string]any{
+				"title":   "Pick a color",
+				"options": []any{"Red", "Green", "Blue"},
+				"method":  "select",
+			},
+			Questions: []UserQuestion{{
+				Question: "Pick a color",
+				Header:   "Select",
+				Options: []UserQuestionOption{
+					{Label: "Red"},
+					{Label: "Green"},
+					{Label: "Blue"},
+				},
+				MultiSelect: false,
+			}},
+			Resolved: make(chan struct{}),
+		},
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates["test:chat:user1"] = state
+	e.interactiveMu.Unlock()
+
+	// "allow" must be treated as a free-text answer to the question, NOT as
+	// a permission allow. If this assertion fails, the engine has pulled
+	// extension_select back into the regular permission path.
+	if !e.handlePendingPermission(p, &Message{
+		SessionKey: "test:chat:user1",
+		UserID:     "user1",
+		Content:    "allow",
+		ReplyCtx:   "ctx",
+	}, "allow", "") {
+		t.Fatal("expected handlePendingPermission to return true")
+	}
+
+	answers, ok := rec.lastResult.UpdatedInput["answers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected answers in updatedInput (AskUserQuestion flow), got %v", rec.lastResult.UpdatedInput)
+	}
+	if answers["Pick a color"] != "allow" {
+		t.Errorf("expected answer 'allow' preserved as free text, got %v", answers["Pick a color"])
+	}
+	// The decisive signal that this is the AskUserQuestion path (not the
+	// regular permission path) is the presence of an "answers" key in
+	// UpdatedInput. extension_select must take this path; extension_confirm
+	// (the regression) must NOT. If a future refactor ever strips
+	// extension_select out of the AskUserQuestion list, this test catches it.
+}
+
 // TestHandlePendingPermission_CronFallback verifies that the fallback path
 // in handlePendingPermission can locate a pending permission stored under a
 // cron composite key ("sessionKey#cron:sid") when the callback uses the


### PR DESCRIPTION
## Summary

Add a new **RPC mode** for the pi agent (opt-in via `rpc = true` in
`[projects.agent.options]`). RPC mode gives cc-connect a real UI to
interact with the user; the legacy `json` mode is UI-less and can only
silently reject anything that needs permission.

| Mode   | `rpc` value       | User interaction                                      |
| ------ | ----------------- | ----------------------------------------------------- |
| `json` | `false` (default) | None. Permission prompts are silently rejected.       |
| `rpc`  | `true`            | Permission / question cards on the messaging platform. |

`json` mode remains the default and behavior is unchanged for existing
configs.

## How RPC mode works

- cc-connect spawns a persistent `pi --mode rpc` process per session
- The process talks JSONL over stdin/stdout (one event per line)
- Pi's `extension_ui_request` events (confirm / select) are translated
  into engine `EventPermissionRequest`s, which the platform adapter
  renders as a rich card
- The user's decision flows back as a `RespondPermission` call, which
  cc-connect serializes as an `extension_ui_response` and writes to
  Pi's stdin
- `agent_end` triggers `EventResult` (no need to wait for process exit)

## Writing Pi extensions that work with cc-connect

If you're writing a Pi extension that needs to ask the user something
(e.g. a permission gate, a multi-choice questionnaire), use the standard
UI methods on the extension context. cc-connect intercepts them and
renders them on the messaging platform:

| Pi API              | UX on cc-connect              |
| ------------------- | ----------------------------- |
| `ctx.ui.confirm()`  | Allow / Deny permission card  |
| `ctx.ui.select()`   | Multi-choice button card      |

**Do not** write custom stdin prompts or print to the TTY directly —
they will be invisible to cc-connect and silently dropped. The only
path for user interaction in RPC mode is through `ctx.ui.*` methods.

## Changes (8 commits)

- `agent/pi/session.go`: new `sendRPC` / `readLoopRPC` /
  `handleExtensionUIRequest` and the `extension_ui_response` writer
  for `RespondPermission`. Existing `sendJSON` left untouched.
- `agent/pi/proc_unix.go` / `proc_windows.go`: RPC process lifecycle
  (zombie reaping, capped stderr buffer, process-group kill, stdin
  mutex, process-death signaling).
- `agent/pi/pi.go`: new `rpc` field, `WorkspaceAgentOptions()` so `rpc`
  survives per-workspace agent reconstruction.
- `core/engine.go`: extend `isAskQuestion` detection to route
  `extension_select` through the rich-card path. `extension_confirm`
  stays on the regular permission path to match other agents' UX.
- `agent/pi/pi_test.go` / `core/engine_test.go`: new tests covering
  `forwardConfirm` routing, `extension_confirm` allow/deny semantics,
  and a guard test that `extension_select` is never accidentally
  removed from the AskUserQuestion list.
- `config.example.toml`: new "Project: Using Pi" section documenting
  the two modes and how to enable RPC.

## Configuration

```toml
[projects.agent]
type = "pi"
rpc = true   # enable RPC mode for permission / question forwarding
```

## Test plan

- [x] `go test ./...` passes (includes new regression tests for
  `forwardConfirm` routing and `extension_confirm` allow/deny semantics)
- [x] Manually verified on Feishu with `rpc = true`: tool calls that need
  permission surface as Allow/Deny cards, and tapping Allow / Deny
  resumes the agent with the right decision
