### PR TITLE
chore(gitignore): add .worktrees/ — local-only multi-agent scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,15 @@ Desktop.ini
 .planning/
 
 # ============================================================================
+# Local git worktrees
+# ============================================================================
+# Convention: ad-hoc worktrees created with
+#   git worktree add .worktrees/<task-name> origin/<branch>
+# are local-only scratch directories used by multiple agents (qa, dev, release)
+# for parallel branch work. They must never be committed.
+.worktrees/
+
+# ============================================================================
 # Security
 # ============================================================================
 # Never commit secrets or credentials


### PR DESCRIPTION
## What

Add `.worktrees/` to `.gitignore`.

## Why

Multiple AI agents (qa-*, dev-*, release-*) routinely create ad-hoc git worktrees under `.worktrees/<task-name>` for parallel branch work — PR review, hotfix prep, release cherry-pick, etc. These are **local-only scratch directories** by team convention and must never be committed.

Without this rule, an accidental `git add .` or `git add -A` from the repo root stages tens of worktrees (897 MB locally on the current shared machine, 39 worktrees).

## Risk

None. `.worktrees/` is never tracked; this just makes it formally ignored, hiding it from `git status` and preventing the accidental-stage footgun.

## Test plan

- [x] `git status` after applying no longer lists `.worktrees/` as untracked
- [x] Existing worktrees still function (`git worktree list` unaffected)
- [x] Build / tests are unrelated to this change

## Related

- Concurrent branch safety design doc (qa-cursor internal): `2026-06-25-concurrent-branch-safety.md`
- Incident closure: `2026-06-25-release-branch-contamination-closure.md`

Made with [Cursor](https://cursor.com)