### PR TITLE
feat(yuanbao): add Tencent Yuanbao Bot API platform

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -249,6 +249,9 @@ func main() {
 		case "weixin":
 			runWeixin(os.Args[2:])
 			return
+		case "yuanbao":
+			runYuanbao(os.Args[2:])
+			return
 		case "doctor":
 			runDoctor(os.Args[2:])
 			return
@@ -1632,6 +1635,7 @@ Examples:
   cc-connect cron list                List all scheduled tasks
   cc-connect feishu setup             Setup Feishu/Lark bot credentials
   cc-connect weixin setup             Setup Weixin (ilink) with QR or --token
+  cc-connect yuanbao setup            Setup Yuanbao bot with --token app_key:app_secret
   cc-connect update                   Update to the latest version
   cc-connect config format            Format the config file
   cc-connect config example > c.toml  Save example config to a file

--- a/cmd/cc-connect/plugin_platform_yuanbao.go
+++ b/cmd/cc-connect/plugin_platform_yuanbao.go
@@ -1,0 +1,5 @@
+//go:build !no_yuanbao
+
+package main
+
+import _ "github.com/chenhg5/cc-connect/platform/yuanbao"

--- a/cmd/cc-connect/yuanbao.go
+++ b/cmd/cc-connect/yuanbao.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/config"
+	"github.com/chenhg5/cc-connect/platform/yuanbao"
+)
+
+func runYuanbao(args []string) {
+	if len(args) == 0 {
+		printYuanbaoUsage()
+		return
+	}
+
+	switch args[0] {
+	case "setup":
+		runYuanbaoSetup(args[1:], yuanbaoSetupModeAuto)
+	case "bind", "link":
+		runYuanbaoSetup(args[1:], yuanbaoSetupModeBind)
+	case "help", "--help", "-h":
+		printYuanbaoUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown yuanbao subcommand: %s\n\n", args[0])
+		printYuanbaoUsage()
+		os.Exit(1)
+	}
+}
+
+const (
+	yuanbaoSetupModeAuto = "auto"
+	yuanbaoSetupModeBind = "bind"
+)
+
+func runYuanbaoSetup(args []string, requestedMode string) {
+	fs := flag.NewFlagSet("yuanbao "+requestedMode, flag.ExitOnError)
+	configFile := fs.String("config", "", "path to config file")
+	project := fs.String("project", "", "project name (optional if only one project)")
+	platformIndex := fs.Int("platform-index", 0, "1-based index among yuanbao platforms in the project (0 = first)")
+	token := fs.String("token", "", "Yuanbao bot token (format: app_key:app_secret)")
+	apiDomain := fs.String("api-domain", "", "yuanbao API base URL (default https://bot.yuanbao.tencent.com)")
+	wsURL := fs.String("ws-url", "", "yuanbao WebSocket URL (default wss://bot-wss.yuanbao.tencent.com/wss/connection)")
+	routeEnv := fs.String("route-env", "", "optional X-Route-Env header (e.g. prod, dev)")
+	allowFrom := fs.String("allow-from", "", "restrict access to this user id (comma separated); empty = open")
+	skipVerify := fs.Bool("skip-verify", false, "skip probing the sign-token API before saving")
+	_ = fs.Parse(args)
+
+	initConfigPath(*configFile)
+	if _, err := os.Stat(config.ConfigPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: config file not found at %s (%v)\n", config.ConfigPath, err)
+		os.Exit(1)
+	}
+
+	botToken, err := resolveYuanbaoBotToken(requestedMode, *token)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	targetProject, err := resolveTargetProject(*project)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	apiDomainValue := strings.TrimSpace(*apiDomain)
+	wsURLValue := strings.TrimSpace(*wsURL)
+	routeEnvValue := strings.TrimSpace(*routeEnv)
+	allowFromValue := strings.TrimSpace(*allowFrom)
+
+	if !*skipVerify {
+		appKey, appSecret := splitYuanbaoTokenForVerify(botToken)
+		fmt.Println("Verifying credentials against yuanbao sign-token API…")
+		botID, err := yuanbao.VerifyCredentials(appKey, appSecret, apiDomainValue, routeEnvValue)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: credential verification failed: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Tip: re-check --token (must be app_key:app_secret), or use --skip-verify to write anyway.")
+			os.Exit(1)
+		}
+		fmt.Printf("✅ Verified. bot_id = %s\n", botID)
+	}
+
+	workDir, _ := os.Getwd()
+	provision, err := config.EnsureProjectWithYuanbaoPlatform(config.EnsureProjectWithYuanbaoOptions{
+		ProjectName: targetProject,
+		WorkDir:     workDir,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: prepare project failed: %v\n", err)
+		os.Exit(1)
+	}
+	if provision.Created {
+		fmt.Printf("Created project %q automatically.\n", targetProject)
+	} else if provision.AddedPlatform {
+		fmt.Printf("Project %q had no Yuanbao platform; added one automatically.\n", targetProject)
+	}
+
+	saveResult, err := config.SaveYuanbaoPlatformCredentials(config.YuanbaoCredentialUpdateOptions{
+		ProjectName:   targetProject,
+		PlatformIndex: *platformIndex,
+		BotToken:      botToken,
+		APIDomain:     apiDomainValue,
+		WSURL:         wsURLValue,
+		RouteEnv:      routeEnvValue,
+		AllowFrom:     allowFromValue,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: update config failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("✅ Yuanbao bot configured for project %q\n", saveResult.ProjectName)
+	fmt.Printf("   Platform: yuanbao (projects[%d].platforms[%d])\n", saveResult.ProjectIndex, saveResult.PlatformAbsIndex)
+	if saveResult.AllowFrom != "" {
+		fmt.Printf("   allow_from: %s\n", saveResult.AllowFrom)
+	}
+	fmt.Println()
+	fmt.Println("Next: run cc-connect (or restart the daemon) and the platform will")
+	fmt.Println("auto-fetch sign-tokens via bot_token and connect over WebSocket.")
+}
+
+func resolveYuanbaoBotToken(mode, raw string) (string, error) {
+	token := strings.TrimSpace(raw)
+	idx := strings.Index(token, ":")
+	if token == "" || idx <= 0 || idx >= len(token)-1 {
+		if mode == yuanbaoSetupModeBind {
+			return "", fmt.Errorf("bind mode requires --token (format: app_key:app_secret)")
+		}
+		return "", fmt.Errorf("--token is required (format: app_key:app_secret)")
+	}
+	return token, nil
+}
+
+// splitYuanbaoTokenForVerify is the same split as platform/yuanbao's
+// splitBotToken, inlined here so the CLI doesn't need to import internal
+// helpers of the platform package.
+func splitYuanbaoTokenForVerify(raw string) (appKey, appSecret string) {
+	raw = strings.TrimSpace(raw)
+	idx := strings.Index(raw, ":")
+	if idx <= 0 || idx >= len(raw)-1 {
+		return "", ""
+	}
+	return strings.TrimSpace(raw[:idx]), strings.TrimSpace(raw[idx+1:])
+}
+
+func printYuanbaoUsage() {
+	fmt.Println(`Usage: cc-connect yuanbao <command> [options]
+
+Commands:
+  setup   Save --token (app_key:app_secret) for a Yuanbao bot (verifies with sign-token API)
+  bind    Same as setup, but fails if --token is missing
+
+Options:
+  --config <path>           Path to config file
+  --project <name>          Target project (created if missing, like weixin setup)
+  --platform-index <n>      1-based yuanbao platform index in project (default: first)
+  --token <app_key:secret>  Yuanbao bot token (split on first ":")
+  --api-domain <url>        Sign-token API base (default https://bot.yuanbao.tencent.com)
+  --ws-url <url>            WebSocket URL (default wss://bot-wss.yuanbao.tencent.com/wss/connection)
+  --route-env <env>         X-Route-Env header (e.g. prod, dev)
+  --allow-from <id,id>      Restrict access to these user ids (comma separated)
+  --skip-verify             Write credentials without probing sign-token API
+
+Examples:
+  cc-connect yuanbao setup --project my-bot --token DO7xNwDY...:CWLjJDW4...
+  cc-connect yuanbao bind --project my-bot --token app_key:app_secret
+  cc-connect yuanbao setup --project my-bot --token app_key:app_secret --allow-from open_id_1,open_id_2`)
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -1386,6 +1386,22 @@ app_secret = "your-feishu-app-secret"
 # proxy_username = ""
 # proxy_password = ""
 
+# -----------------------------------------------------------------------------
+# Tencent Yuanbao (yuanbao.tencent.com bot platform)
+# 腾讯元宝机器人：WebSocket 长连接平台，通过 bot_token 自动换取 sign-token
+# Setup helper: `cc-connect yuanbao setup --project <name> --token app_key:app_secret`
+# -----------------------------------------------------------------------------
+#
+# [[projects.platforms]]
+# type = "yuanbao"
+#
+# [projects.platforms.options]
+# bot_token  = "your-app-key:your-app-secret"
+# api_domain = "https://bot.yuanbao.tencent.com"                          # optional / 可选
+# ws_url     = "wss://bot-wss.yuanbao.tencent.com/wss/connection"         # optional / 可选
+# route_env  = "prod"                                                    # optional X-Route-Env / 可选路由头
+# allow_from = "*"                                                       # or "open_id_1,open_id_2"
+
 # =============================================================================
 # Project 2: Using Cursor Agent / 项目 2：使用 Cursor Agent (uncomment to enable / 取消注释以启用)
 # =============================================================================

--- a/config/config.go
+++ b/config/config.go
@@ -2519,6 +2519,303 @@ func SaveWeixinPlatformCredentials(opts WeixinCredentialUpdateOptions) (*WeixinC
 	}, nil
 }
 
+func firstYuanbaoPlatformIndex(platforms []PlatformConfig) int {
+	for i := range platforms {
+		t := strings.ToLower(strings.TrimSpace(platforms[i].Type))
+		if t == "yuanbao" {
+			return i
+		}
+	}
+	return -1
+}
+
+// EnsureProjectWithYuanbaoOptions controls project auto-provisioning for Yuanbao setup.
+type EnsureProjectWithYuanbaoOptions struct {
+	ProjectName      string
+	CloneFromProject string
+	WorkDir          string
+	AgentType        string
+}
+
+// EnsureProjectWithYuanbaoResult describes whether project provisioning created a new project or platform block.
+type EnsureProjectWithYuanbaoResult struct {
+	Created          bool
+	AddedPlatform    bool
+	ProjectIndex     int
+	PlatformAbsIndex int
+}
+
+// EnsureProjectWithYuanbaoPlatform ensures the target project exists and has a yuanbao platform entry.
+func EnsureProjectWithYuanbaoPlatform(opts EnsureProjectWithYuanbaoOptions) (*EnsureProjectWithYuanbaoResult, error) {
+	configMu.Lock()
+	defer configMu.Unlock()
+
+	if ConfigPath == "" {
+		return nil, fmt.Errorf("config path not set")
+	}
+	projectName := strings.TrimSpace(opts.ProjectName)
+	if projectName == "" {
+		return nil, fmt.Errorf("project name is required")
+	}
+
+	data, err := os.ReadFile(ConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	raw := string(data)
+	cfg := &Config{}
+	if err := toml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	for i := range cfg.Projects {
+		if cfg.Projects[i].Name != projectName {
+			continue
+		}
+		platformIdx := firstYuanbaoPlatformIndex(cfg.Projects[i].Platforms)
+		added := false
+		if platformIdx < 0 {
+			lines, hadTrailing := splitConfigLines(raw)
+			spans := buildRawProjectSpans(lines)
+			if i >= len(spans) {
+				return nil, fmt.Errorf("project %q located in parsed config but not raw file", projectName)
+			}
+			insertAt := spans[i].end + 1
+			block := make([]string, 0, 7)
+			if insertAt > 0 && strings.TrimSpace(lines[insertAt-1]) != "" {
+				block = append(block, "")
+			}
+			block = append(block, "[[projects.platforms]]")
+			block = append(block, `type = "yuanbao"`)
+			block = append(block, "")
+			block = append(block, "[projects.platforms.options]")
+			if insertAt < len(lines) && strings.TrimSpace(lines[insertAt]) != "" {
+				block = append(block, "")
+			}
+			lines = insertLines(lines, insertAt, block)
+			if err := writeRawConfig(joinConfigLines(lines, hadTrailing)); err != nil {
+				return nil, err
+			}
+			platformIdx = len(cfg.Projects[i].Platforms)
+			added = true
+		}
+		return &EnsureProjectWithYuanbaoResult{
+			Created:          false,
+			AddedPlatform:    added,
+			ProjectIndex:     i,
+			PlatformAbsIndex: platformIdx,
+		}, nil
+	}
+
+	proj := ProjectConfig{
+		Name:      projectName,
+		Agent:     pickAgentTemplateForNewProject(cfg, EnsureProjectWithFeishuOptions{CloneFromProject: opts.CloneFromProject, WorkDir: opts.WorkDir, AgentType: opts.AgentType}),
+		Platforms: []PlatformConfig{{Type: "yuanbao", Options: map[string]any{}}},
+	}
+	if proj.Agent.Type == "" {
+		proj.Agent.Type = "codex"
+	}
+	if proj.Agent.Options == nil {
+		proj.Agent.Options = map[string]any{}
+	}
+	workDir := strings.TrimSpace(opts.WorkDir)
+	if workDir != "" {
+		proj.Agent.Options["work_dir"] = workDir
+	}
+
+	lines, hadTrailing := splitConfigLines(raw)
+	if len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) != "" {
+		lines = append(lines, "")
+	}
+	lines = append(lines, "[[projects]]")
+	lines = append(lines, fmt.Sprintf("name = %s", quoteTomlString(proj.Name)))
+	lines = append(lines, "")
+	lines = append(lines, "[projects.agent]")
+	lines = append(lines, fmt.Sprintf("type = %s", quoteTomlString(proj.Agent.Type)))
+	lines = append(lines, "")
+	lines = append(lines, "[projects.agent.options]")
+	if wd, ok := proj.Agent.Options["work_dir"].(string); ok && strings.TrimSpace(wd) != "" {
+		lines = append(lines, fmt.Sprintf("work_dir = %s", quoteTomlString(wd)))
+	}
+	if mode, ok := proj.Agent.Options["mode"].(string); ok && strings.TrimSpace(mode) != "" {
+		lines = append(lines, fmt.Sprintf("mode = %s", quoteTomlString(mode)))
+	}
+	lines = append(lines, "")
+	lines = append(lines, "[[projects.platforms]]")
+	lines = append(lines, `type = "yuanbao"`)
+	lines = append(lines, "")
+	lines = append(lines, "[projects.platforms.options]")
+	if err := writeRawConfig(joinConfigLines(lines, hadTrailing)); err != nil {
+		return nil, err
+	}
+
+	return &EnsureProjectWithYuanbaoResult{
+		Created:          true,
+		AddedPlatform:    false,
+		ProjectIndex:     len(cfg.Projects),
+		PlatformAbsIndex: 0,
+	}, nil
+}
+
+// YuanbaoCredentialUpdateOptions updates credentials for a project's Yuanbao platform.
+type YuanbaoCredentialUpdateOptions struct {
+	ProjectName   string
+	PlatformIndex int    // 1-based index among yuanbao platforms; 0 = first
+	BotToken      string // "app_key:app_secret"; required
+	APIDomain     string // optional; empty = do not change
+	WSURL         string // optional; empty = do not change
+	RouteEnv      string // optional; empty = do not change
+	AllowFrom     string // optional; empty = do not change
+}
+
+// YuanbaoCredentialUpdateResult describes where credentials were written.
+type YuanbaoCredentialUpdateResult struct {
+	ProjectName      string
+	ProjectIndex     int
+	PlatformAbsIndex int
+	AllowFrom        string
+}
+
+// SaveYuanbaoPlatformCredentials updates bot_token (and optional fields)
+// for a project's Yuanbao platform.
+func SaveYuanbaoPlatformCredentials(opts YuanbaoCredentialUpdateOptions) (*YuanbaoCredentialUpdateResult, error) {
+	configMu.Lock()
+	defer configMu.Unlock()
+
+	if ConfigPath == "" {
+		return nil, fmt.Errorf("config path not set")
+	}
+	if strings.TrimSpace(opts.ProjectName) == "" {
+		return nil, fmt.Errorf("project name is required")
+	}
+	botToken := strings.TrimSpace(opts.BotToken)
+	idx := strings.Index(botToken, ":")
+	if botToken == "" || idx <= 0 || idx >= len(botToken)-1 {
+		return nil, fmt.Errorf("bot_token is required (format: app_key:app_secret)")
+	}
+	if opts.PlatformIndex < 0 {
+		return nil, fmt.Errorf("platform index must be >= 0")
+	}
+
+	data, err := os.ReadFile(ConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	raw := string(data)
+	cfg := &Config{}
+	if err := toml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	projectIdx := -1
+	for i := range cfg.Projects {
+		if cfg.Projects[i].Name == opts.ProjectName {
+			projectIdx = i
+			break
+		}
+	}
+	if projectIdx < 0 {
+		return nil, fmt.Errorf("project %q not found", opts.ProjectName)
+	}
+
+	proj := &cfg.Projects[projectIdx]
+	candidates := make([]int, 0, len(proj.Platforms))
+	for i := range proj.Platforms {
+		t := strings.ToLower(strings.TrimSpace(proj.Platforms[i].Type))
+		if t == "yuanbao" {
+			candidates = append(candidates, i)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("project %q has no yuanbao platform", opts.ProjectName)
+	}
+
+	targetPos := 0
+	if opts.PlatformIndex > 0 {
+		targetPos = opts.PlatformIndex - 1
+	}
+	if targetPos < 0 || targetPos >= len(candidates) {
+		return nil, fmt.Errorf(
+			"platform index %d out of range: project %q has %d yuanbao platform(s)",
+			opts.PlatformIndex, opts.ProjectName, len(candidates),
+		)
+	}
+
+	absIdx := candidates[targetPos]
+	platform := &proj.Platforms[absIdx]
+	if platform.Options == nil {
+		platform.Options = map[string]any{}
+	}
+
+	platform.Options["bot_token"] = botToken
+
+	allowFrom := strings.TrimSpace(stringOption(platform.Options["allow_from"]))
+	if v := strings.TrimSpace(opts.AllowFrom); v != "" {
+		allowFrom = v
+		platform.Options["allow_from"] = v
+	}
+
+	lines, hadTrailing := splitConfigLines(raw)
+	spans := buildRawProjectSpans(lines)
+	if projectIdx >= len(spans) {
+		return nil, fmt.Errorf("project %q located in parsed config but not raw file", opts.ProjectName)
+	}
+	if absIdx >= len(spans[projectIdx].platforms) {
+		return nil, fmt.Errorf("yuanbao platform located in parsed config but not raw file")
+	}
+
+	reloadSpan := func() rawPlatformSpan {
+		spans = buildRawProjectSpans(lines)
+		return spans[projectIdx].platforms[absIdx]
+	}
+	span := reloadSpan()
+
+	if span.optionsStart < 0 {
+		insertAt := span.end + 1
+		block := make([]string, 0, 4)
+		if insertAt > 0 && strings.TrimSpace(lines[insertAt-1]) != "" {
+			block = append(block, "")
+		}
+		block = append(block, "[projects.platforms.options]")
+		if insertAt < len(lines) && strings.TrimSpace(lines[insertAt]) != "" {
+			block = append(block, "")
+		}
+		lines = insertLines(lines, insertAt, block)
+		span = reloadSpan()
+	}
+
+	lines = upsertTomlStringKey(lines, span.optionsStart+1, span.optionsEnd, "bot_token", botToken)
+	span = reloadSpan()
+
+	if v := strings.TrimSpace(opts.APIDomain); v != "" {
+		lines = upsertTomlStringKey(lines, span.optionsStart+1, span.optionsEnd, "api_domain", v)
+		span = reloadSpan()
+	}
+	if v := strings.TrimSpace(opts.WSURL); v != "" {
+		lines = upsertTomlStringKey(lines, span.optionsStart+1, span.optionsEnd, "ws_url", v)
+		span = reloadSpan()
+	}
+	if v := strings.TrimSpace(opts.RouteEnv); v != "" {
+		lines = upsertTomlStringKey(lines, span.optionsStart+1, span.optionsEnd, "route_env", v)
+		span = reloadSpan()
+	}
+	if v := strings.TrimSpace(opts.AllowFrom); v != "" {
+		lines = upsertTomlStringKey(lines, span.optionsStart+1, span.optionsEnd, "allow_from", v)
+		span = reloadSpan()
+	}
+
+	if err := writeRawConfig(joinConfigLines(lines, hadTrailing)); err != nil {
+		return nil, err
+	}
+
+	return &YuanbaoCredentialUpdateResult{
+		ProjectName:      opts.ProjectName,
+		ProjectIndex:     projectIdx,
+		PlatformAbsIndex: absIdx,
+		AllowFrom:        allowFrom,
+	}, nil
+}
+
 func pickAgentTemplateForNewProject(cfg *Config, opts EnsureProjectWithFeishuOptions) AgentConfig {
 	cloneName := strings.TrimSpace(opts.CloneFromProject)
 	if cloneName != "" {

--- a/platform/yuanbao/platform.go
+++ b/platform/yuanbao/platform.go
@@ -1,0 +1,660 @@
+package yuanbao
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	heartbeatInterval     = 30 * time.Second
+	heartbeatTimeout      = 10 * time.Second
+	heartbeatThreshold    = 2
+	authTimeout           = 10 * time.Second
+	replyHeartbeatIntv    = 2 * time.Second
+	replyHeartbeatTimeout = 30 * time.Second
+	dedupCleanupInterval  = 5 * time.Minute
+)
+
+var authFailedCodes = map[int]bool{
+	4001: true, 4002: true, 4003: true,
+}
+
+type replyContext struct {
+	chatType string
+	chatID   string
+	targetID string
+}
+
+type Platform struct {
+	appKey    string
+	appSecret string
+	allowFrom string
+	apiDomain string
+	wsURL     string
+	routeEnv  string
+
+	mu      sync.Mutex
+	ws      *websocket.Conn
+	handler core.MessageHandler
+	tokens  *tokenManager
+	botID   string
+	source  string
+
+	heartbeatTimer     *time.Timer
+	dedupCleanupTimer  *time.Timer
+	dedupSet           map[string]time.Time
+	replyHBTimers      map[string]*time.Timer
+	replyHBStop        map[string]chan struct{}
+	reconnectAttempts  int
+	shouldReconnect    bool
+	done               chan struct{}
+	pendingAcks        map[string]chan<- []byte
+	pendingMu          sync.Mutex
+	consecutiveHbFails int
+}
+
+func New(opts map[string]any) (core.Platform, error) {
+	botToken, _ := opts["bot_token"].(string)
+	appKey, appSecret := splitBotToken(botToken)
+	allowFrom, _ := opts["allow_from"].(string)
+	if appKey == "" || appSecret == "" {
+		return nil, fmt.Errorf("yuanbao: bot_token is required (format: app_key:app_secret)")
+	}
+	apiDomain, _ := opts["api_domain"].(string)
+	wsURL, _ := opts["ws_url"].(string)
+	routeEnv, _ := opts["route_env"].(string)
+	if apiDomain == "" {
+		apiDomain = defaultAPIDomain
+	}
+	if wsURL == "" {
+		wsURL = defaultWSURL
+	}
+	core.CheckAllowFrom("yuanbao", allowFrom)
+	return &Platform{
+		appKey: appKey, appSecret: appSecret, allowFrom: allowFrom,
+		apiDomain: apiDomain, wsURL: wsURL, routeEnv: routeEnv,
+		tokens:        newTokenManager(),
+		dedupSet:      make(map[string]time.Time),
+		replyHBTimers: make(map[string]*time.Timer),
+		replyHBStop:   make(map[string]chan struct{}),
+		pendingAcks:   make(map[string]chan<- []byte),
+		done:          make(chan struct{}),
+	}, nil
+}
+
+func (p *Platform) Name() string { return "yuanbao" }
+
+// splitBotToken splits a "app_key:app_secret" string. An empty input yields
+// empty outputs so callers can detect the missing-config case with a simple
+// `appKey == "" || appSecret == ""` check.
+func splitBotToken(raw string) (appKey, appSecret string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", ""
+	}
+	idx := strings.Index(raw, ":")
+	if idx <= 0 || idx >= len(raw)-1 {
+		return "", ""
+	}
+	return strings.TrimSpace(raw[:idx]), strings.TrimSpace(raw[idx+1:])
+}
+
+func (p *Platform) Start(handler core.MessageHandler) error {
+	p.handler = handler
+	p.shouldReconnect = true
+	go p.run()
+	return nil
+}
+
+func (p *Platform) run() {
+	for {
+		p.mu.Lock()
+		p.reconnectAttempts = 0
+		p.mu.Unlock()
+		if !p.connect() {
+			p.mu.Lock()
+			shouldReconnect := p.shouldReconnect
+			p.mu.Unlock()
+			if !shouldReconnect {
+				return
+			}
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		<-p.done
+		p.mu.Lock()
+		shouldReconnect := p.shouldReconnect
+		attempts := p.reconnectAttempts
+		p.mu.Unlock()
+		if !shouldReconnect {
+			return
+		}
+		delay := time.Duration(min(1000*(1<<uint(attempts)), 60000)) * time.Millisecond
+		p.mu.Lock()
+		p.reconnectAttempts++
+		p.mu.Unlock()
+		slog.Info("yuanbao: reconnecting", "attempt", attempts+1, "delay", delay)
+		time.Sleep(delay)
+	}
+}
+
+func (p *Platform) connect() bool {
+	tokenData, err := p.tokens.getToken(p.appKey, p.appSecret, p.apiDomain, p.routeEnv)
+	if err != nil {
+		slog.Error("yuanbao: get sign token failed", "error", err)
+		return false
+	}
+	if tokenData.botID != "" {
+		p.mu.Lock()
+		p.botID = tokenData.botID
+		p.source = tokenData.source
+		p.mu.Unlock()
+	}
+	u, err := url.Parse(p.wsURL)
+	if err != nil {
+		slog.Error("yuanbao: invalid ws url", "url", p.wsURL, "error", err)
+		return false
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		slog.Error("yuanbao: websocket dial failed", "error", err)
+		return false
+	}
+	p.mu.Lock()
+	p.ws = conn
+	p.done = make(chan struct{})
+	p.mu.Unlock()
+	if !p.authenticate(tokenData.token) {
+		p.mu.Lock()
+		_ = p.ws.Close()
+		p.ws = nil
+		p.mu.Unlock()
+		return false
+	}
+	slog.Info("yuanbao: connected and authenticated", "bot_id", p.botID)
+	p.startHeartbeat()
+	p.startDedupCleanup()
+	go p.readLoop()
+	return true
+}
+
+func (p *Platform) authenticate(token string) bool {
+	msgID := fmt.Sprintf("auth_%d", time.Now().UnixNano())
+	authBytes := encodeAuthBind(p.botID, p.source, token, msgID, "", "darwin", "", p.routeEnv)
+	p.mu.Lock()
+	ws := p.ws
+	p.mu.Unlock()
+	if ws == nil {
+		return false
+	}
+	if err := ws.WriteMessage(websocket.BinaryMessage, authBytes); err != nil {
+		slog.Error("yuanbao: write auth bind failed", "error", err)
+		return false
+	}
+	if err := ws.SetReadDeadline(time.Now().Add(authTimeout)); err != nil {
+		slog.Error("yuanbao: set read deadline failed", "error", err)
+		return false
+	}
+	defer func() { _ = ws.SetReadDeadline(time.Time{}) }()
+	for {
+		_, raw, err := ws.ReadMessage()
+		if err != nil {
+			slog.Error("yuanbao: read auth response failed", "error", err)
+			return false
+		}
+		msg, err := decodeConnMsg(raw)
+		if err != nil {
+			continue
+		}
+		if msg.head.cmdType == cmdTypeResponse && msg.head.cmd == cmdAuthBind {
+			rsp := decodeAuthBindRsp(msg.data)
+			if rsp.code == 0 {
+				return true
+			}
+			slog.Error("yuanbao: auth failed", "code", rsp.code, "message", rsp.message)
+			if authFailedCodes[rsp.code] {
+				p.tokens.forceRefresh()
+			}
+			return false
+		}
+	}
+}
+
+func (p *Platform) readLoop() {
+	ws := p.getWS()
+	if ws == nil {
+		return
+	}
+	defer func() {
+		p.stopHeartbeat()
+		p.stopDedupCleanup()
+		p.stopAllReplyHeartbeats()
+		if p.ws != nil {
+			_ = p.ws.Close()
+		}
+		close(p.done)
+	}()
+	for {
+		if err := ws.SetReadDeadline(time.Now().Add(90 * time.Second)); err != nil {
+			return
+		}
+		_, raw, err := ws.ReadMessage()
+		if err != nil {
+			return
+		}
+		p.handleFrame(raw)
+	}
+}
+
+func (p *Platform) handleFrame(raw []byte) {
+	msg, err := decodeConnMsg(raw)
+	if err != nil {
+		return
+	}
+	head := msg.head
+	switch {
+	case head.cmdType == cmdTypeResponse && head.cmd == cmdPing:
+		p.resolvePendingAck(head.msgID, nil)
+	case head.cmdType == cmdTypeResponse && (head.cmd == "send_c2c_message" || head.cmd == "send_group_message" ||
+		head.cmd == "send_private_heartbeat" || head.cmd == "send_group_heartbeat"):
+		return
+	case head.cmdType == cmdTypeResponse:
+		if head.cmd != cmdAuthBind {
+			p.resolvePendingAck(head.msgID, msg.data)
+		}
+	case head.cmdType == cmdTypePush:
+		if head.needAck {
+			if ws := p.getWS(); ws != nil {
+				_ = ws.WriteMessage(websocket.BinaryMessage, encodePushAck(head))
+			}
+		}
+		if head.cmd == "inbound_message" || head.cmd == "InboundMessagePush" {
+			p.handleInboundPush(msg.data)
+		} else if len(msg.data) > 0 {
+			p.handleInboundPush(msg.data)
+		}
+	case head.cmd == cmdKickout:
+		slog.Warn("yuanbao: kicked out by server")
+		p.mu.Lock()
+		p.shouldReconnect = false
+		p.mu.Unlock()
+		p.disconnect()
+	}
+}
+
+func (p *Platform) handleInboundPush(data []byte) {
+	push := p.decodePush(data)
+	if push == nil {
+		slog.Warn("yuanbao: failed to decode inbound push")
+		return
+	}
+	if push.msgID != "" {
+		p.mu.Lock()
+		if _, ok := p.dedupSet[push.msgID]; ok {
+			p.mu.Unlock()
+			return
+		}
+		p.dedupSet[push.msgID] = time.Now()
+		p.mu.Unlock()
+	}
+	botID := p.getBotID()
+	if push.fromAccount == botID || !core.AllowList(p.allowFrom, push.fromAccount) {
+		return
+	}
+	text := inboundText(push)
+	if text == "" {
+		return
+	}
+	isGroup := push.groupCode != ""
+	var chatID, targetID string
+	if isGroup {
+		chatID = "group:" + push.groupCode
+		targetID = push.groupCode
+	} else {
+		chatID = "dm:" + push.fromAccount
+		targetID = push.fromAccount
+	}
+	userName := push.senderNickname
+	if userName == "" {
+		userName = push.fromAccount
+	}
+	p.handler(p, &core.Message{
+		SessionKey: fmt.Sprintf("yuanbao:%s", chatID),
+		Platform:   "yuanbao",
+		MessageID:  push.msgID,
+		UserID:     push.fromAccount,
+		UserName:   userName,
+		ChatName:   push.groupName,
+		Content:    text,
+		ReplyCtx: replyContext{
+			chatType: map[bool]string{true: "group", false: "dm"}[isGroup],
+			chatID:   chatID,
+			targetID: targetID,
+		},
+	})
+}
+
+func (p *Platform) decodePush(data []byte) *inboundPush {
+	var jp jsonInboundPush
+	if json.Unmarshal(data, &jp) == nil && jp.FromAccount != "" {
+		return &inboundPush{
+			callbackCommand: jp.CallbackCommand,
+			fromAccount:     jp.FromAccount,
+			toAccount:       jp.ToAccount,
+			senderNickname:  jp.SenderNickname,
+			groupCode:       jp.GroupCode,
+			groupName:       jp.GroupName,
+			msgID:           jp.MsgID,
+			msgKey:          jp.MsgKey,
+			msgTime:         jp.MsgTime,
+			msgBody:         parseJSONMsgBody(jp.MsgBody),
+		}
+	}
+	return decodeInboundPush(data)
+}
+
+func parseJSONMsgBody(raw json.RawMessage) []msgBodyElement {
+	if len(raw) == 0 {
+		return nil
+	}
+	var items []map[string]interface{}
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil
+	}
+	var result []msgBodyElement
+	for _, item := range items {
+		elem := msgBodyElement{}
+		if mt, _ := item["msg_type"].(string); mt != "" {
+			elem.msgType = mt
+		} else if mt, _ := item["MsgType"].(string); mt != "" {
+			elem.msgType = mt
+		}
+		if content, ok := item["msg_content"].(map[string]interface{}); ok {
+			elem.msgContent = content
+		} else if mc, ok := item["MsgContent"]; ok {
+			switch v := mc.(type) {
+			case map[string]interface{}:
+				elem.msgContent = v
+			case string:
+				_ = json.Unmarshal([]byte(v), &elem.msgContent)
+			}
+		}
+		result = append(result, elem)
+	}
+	return result
+}
+
+func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return fmt.Errorf("yuanbao: invalid reply context type %T", rctx)
+	}
+	if content == "" {
+		return nil
+	}
+	content = core.StripMarkdown(content)
+	p.startReplyHeartbeat(rc.chatID)
+	defer p.stopReplyHeartbeat(rc.chatID, true)
+	msgBody := [][]byte{encodeTextBody(content)}
+	var frame []byte
+	if rc.chatType == "group" {
+		frame = encodeSendGroupMessage(rc.targetID, msgBody, p.getBotID(), "", "", "")
+	} else {
+		frame = encodeSendC2CMessage(rc.targetID, msgBody, p.getBotID(), "", 0, "", "")
+	}
+	ws := p.getWS()
+	if ws == nil {
+		return fmt.Errorf("yuanbao: not connected")
+	}
+	err := ws.WriteMessage(websocket.BinaryMessage, frame)
+	if err != nil {
+		slog.Error("yuanbao: reply send failed", "error", err)
+	}
+	return err
+}
+
+func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
+	return p.Reply(ctx, rctx, content)
+}
+
+func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) < 2 || parts[0] != "yuanbao" {
+		return nil, fmt.Errorf("yuanbao: invalid session key %q", sessionKey)
+	}
+	chatID := parts[1]
+	isGroup := strings.HasPrefix(chatID, "group:")
+	targetID := strings.TrimPrefix(chatID, "dm:")
+	targetID = strings.TrimPrefix(targetID, "group:")
+	return replyContext{
+		chatType: map[bool]string{true: "group", false: "dm"}[isGroup],
+		chatID:   chatID,
+		targetID: targetID,
+	}, nil
+}
+
+func (p *Platform) Stop() error {
+	p.mu.Lock()
+	p.shouldReconnect = false
+	ws := p.ws
+	p.mu.Unlock()
+	if ws != nil {
+		_ = ws.Close()
+	}
+	return nil
+}
+
+func (p *Platform) startHeartbeat() {
+	p.stopHeartbeat()
+	p.mu.Lock()
+	p.heartbeatTimer = time.AfterFunc(heartbeatInterval, p.doHeartbeat)
+	p.mu.Unlock()
+}
+
+func (p *Platform) stopHeartbeat() {
+	p.mu.Lock()
+	if p.heartbeatTimer != nil {
+		p.heartbeatTimer.Stop()
+		p.heartbeatTimer = nil
+	}
+	p.mu.Unlock()
+}
+
+func (p *Platform) doHeartbeat() {
+	ws := p.getWS()
+	if ws == nil {
+		return
+	}
+	msgID := fmt.Sprintf("ping_%d", time.Now().UnixNano())
+	pingBytes := encodePing(msgID)
+	ack := make(chan []byte, 1)
+	p.pendingMu.Lock()
+	p.pendingAcks[msgID] = ack
+	p.pendingMu.Unlock()
+	if err := ws.WriteMessage(websocket.BinaryMessage, pingBytes); err != nil {
+		p.scheduleReconnect()
+		return
+	}
+	select {
+	case <-ack:
+		p.mu.Lock()
+		p.consecutiveHbFails = 0
+		p.mu.Unlock()
+	case <-time.After(heartbeatTimeout):
+		p.mu.Lock()
+		p.consecutiveHbFails++
+		if p.consecutiveHbFails >= heartbeatThreshold {
+			p.mu.Unlock()
+			slog.Warn("yuanbao: heartbeat timeout, reconnecting")
+			p.scheduleReconnect()
+			return
+		}
+		p.mu.Unlock()
+	}
+	p.mu.Lock()
+	p.heartbeatTimer = time.AfterFunc(heartbeatInterval, p.doHeartbeat)
+	p.mu.Unlock()
+}
+
+func (p *Platform) startReplyHeartbeat(chatID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, ok := p.replyHBTimers[chatID]; ok {
+		return
+	}
+	stop := make(chan struct{})
+	p.replyHBStop[chatID] = stop
+	// Send initial heartbeat directly without re-acquiring the lock.
+	if p.ws != nil {
+		var frame []byte
+		if strings.HasPrefix(chatID, "group:") {
+			frame = encodeSendGroupHeartbeat(p.botID, strings.TrimPrefix(chatID, "group:"), 1)
+		} else {
+			frame = encodeSendPrivateHeartbeat(p.botID, strings.TrimPrefix(chatID, "dm:"), 1)
+		}
+		_ = p.ws.WriteMessage(websocket.BinaryMessage, frame)
+	}
+	timer := time.AfterFunc(replyHeartbeatIntv, func() {
+		select {
+		case <-stop:
+			return
+		default:
+			p.doReplyHeartbeat(chatID)
+		}
+	})
+	p.replyHBTimers[chatID] = timer
+	go func() {
+		time.Sleep(replyHeartbeatTimeout)
+		p.stopReplyHeartbeat(chatID, true)
+	}()
+}
+
+func (p *Platform) doReplyHeartbeat(chatID string) {
+	ws := p.getWS()
+	if ws == nil {
+		return
+	}
+	botID := p.getBotID()
+	var frame []byte
+	if strings.HasPrefix(chatID, "group:") {
+		frame = encodeSendGroupHeartbeat(botID, strings.TrimPrefix(chatID, "group:"), 1)
+	} else {
+		frame = encodeSendPrivateHeartbeat(botID, strings.TrimPrefix(chatID, "dm:"), 1)
+	}
+	_ = ws.WriteMessage(websocket.BinaryMessage, frame)
+}
+
+func (p *Platform) stopReplyHeartbeat(chatID string, sendFinish bool) {
+	p.mu.Lock()
+	if t, ok := p.replyHBTimers[chatID]; ok {
+		t.Stop()
+		delete(p.replyHBTimers, chatID)
+	}
+	if stop, ok := p.replyHBStop[chatID]; ok {
+		close(stop)
+		delete(p.replyHBStop, chatID)
+	}
+	botID, ws := p.botID, p.ws
+	p.mu.Unlock()
+	if sendFinish && ws != nil {
+		var frame []byte
+		if strings.HasPrefix(chatID, "group:") {
+			frame = encodeSendGroupHeartbeat(botID, strings.TrimPrefix(chatID, "group:"), 2)
+		} else {
+			frame = encodeSendPrivateHeartbeat(botID, strings.TrimPrefix(chatID, "dm:"), 2)
+		}
+		_ = ws.WriteMessage(websocket.BinaryMessage, frame)
+	}
+}
+
+func (p *Platform) stopAllReplyHeartbeats() {
+	p.mu.Lock()
+	for chatID, t := range p.replyHBTimers {
+		t.Stop()
+		if stop, ok := p.replyHBStop[chatID]; ok {
+			close(stop)
+		}
+	}
+	p.replyHBTimers = make(map[string]*time.Timer)
+	p.replyHBStop = make(map[string]chan struct{})
+	p.mu.Unlock()
+}
+
+func (p *Platform) startDedupCleanup() {
+	p.mu.Lock()
+	p.dedupCleanupTimer = time.AfterFunc(dedupCleanupInterval, func() {
+		p.mu.Lock()
+		p.dedupSet = make(map[string]time.Time)
+		p.mu.Unlock()
+		p.startDedupCleanup()
+	})
+	p.mu.Unlock()
+}
+
+func (p *Platform) stopDedupCleanup() {
+	p.mu.Lock()
+	if p.dedupCleanupTimer != nil {
+		p.dedupCleanupTimer.Stop()
+		p.dedupCleanupTimer = nil
+	}
+	p.mu.Unlock()
+}
+
+func (p *Platform) scheduleReconnect() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.ws != nil {
+		_ = p.ws.Close()
+	}
+	close(p.done)
+	p.done = make(chan struct{})
+}
+
+func (p *Platform) disconnect() {
+	p.mu.Lock()
+	ws := p.ws
+	p.mu.Unlock()
+	if ws != nil {
+		_ = ws.Close()
+	}
+}
+
+func (p *Platform) getWS() *websocket.Conn {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.ws
+}
+
+func (p *Platform) getBotID() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.botID
+}
+
+func (p *Platform) resolvePendingAck(msgID string, data []byte) {
+	p.pendingMu.Lock()
+	ch, ok := p.pendingAcks[msgID]
+	if ok {
+		delete(p.pendingAcks, msgID)
+	}
+	p.pendingMu.Unlock()
+	if ok && ch != nil {
+		select {
+		case ch <- data:
+		default:
+		}
+	}
+}
+
+func init() {
+	core.RegisterPlatform("yuanbao", New)
+}

--- a/platform/yuanbao/proto.go
+++ b/platform/yuanbao/proto.go
@@ -1,0 +1,627 @@
+package yuanbao
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	cmdTypeRequest  = 0
+	cmdTypeResponse = 1
+	cmdTypePush     = 2
+	cmdTypePushAck  = 3
+
+	cmdAuthBind   = "auth-bind"
+	cmdPing       = "ping"
+	cmdKickout    = "kickout"
+	cmdUpdateMeta = "update-meta"
+
+	moduleConnAccess = "conn_access"
+	bizPkg           = "yuanbao_openclaw_proxy"
+	instanceID       = 17
+)
+
+const (
+	wtVarint = 0
+	wt64Bit  = 1
+	wtLen    = 2
+	wt32Bit  = 5
+)
+
+type buffer struct{ data []byte }
+
+func newBuffer(capacity int) *buffer {
+	return &buffer{data: make([]byte, 0, capacity)}
+}
+func (b *buffer) bytes() []byte { return b.data }
+
+func (b *buffer) writeVarint(v uint64) {
+	for {
+		bits := v & 0x7F
+		v >>= 7
+		if v != 0 {
+			b.data = append(b.data, byte(bits)|0x80)
+		} else {
+			b.data = append(b.data, byte(bits))
+			return
+		}
+	}
+}
+
+func (b *buffer) writeFieldNum(fieldNum int, wireType int) {
+	b.writeVarint(uint64(fieldNum<<3 | wireType))
+}
+
+func (b *buffer) writeString(s string) {
+	b.writeVarint(uint64(len(s)))
+	b.data = append(b.data, []byte(s)...)
+}
+
+func (b *buffer) writeBytes(data []byte) {
+	b.writeVarint(uint64(len(data)))
+	b.data = append(b.data, data...)
+}
+
+func (b *buffer) writeVarintField(num int, val uint64) {
+	b.writeFieldNum(num, wtVarint)
+	b.writeVarint(val)
+}
+
+func (b *buffer) writeStringField(num int, val string) {
+	if val == "" {
+		return
+	}
+	b.writeFieldNum(num, wtLen)
+	b.writeString(val)
+}
+
+func (b *buffer) writeBytesField(num int, val []byte) {
+	if len(val) == 0 {
+		return
+	}
+	b.writeFieldNum(num, wtLen)
+	b.writeBytes(val)
+}
+
+func (b *buffer) writeHead(cmdType int, cmd string, seqNo int, msgID string, module string, needAck bool, status int) []byte {
+	hb := newBuffer(64)
+	if cmdType != 0 {
+		hb.writeVarintField(1, uint64(cmdType))
+	}
+	if cmd != "" {
+		hb.writeStringField(2, cmd)
+	}
+	if seqNo != 0 {
+		hb.writeVarintField(3, uint64(seqNo))
+	}
+	if msgID != "" {
+		hb.writeStringField(4, msgID)
+	}
+	if module != "" {
+		hb.writeStringField(5, module)
+	}
+	if needAck {
+		hb.writeVarintField(6, 1)
+	}
+	if status != 0 {
+		hb.writeVarintField(10, uint64(status))
+	}
+	return hb.bytes()
+}
+
+func encodeConnMsgFull(cmdType int, cmd string, seqNo int, msgID string, module string, data []byte, needAck bool) []byte {
+	b := newBuffer(128 + len(data))
+	headBytes := (&buffer{}).writeHead(cmdType, cmd, seqNo, msgID, module, needAck, 0)
+	b.writeBytesField(1, headBytes)
+	if len(data) > 0 {
+		b.writeBytesField(2, data)
+	}
+	return b.bytes()
+}
+
+type field struct {
+	fieldNum int
+	wireType int
+	value    interface{}
+}
+
+func parseFields(data []byte) ([]field, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("yuanbao: empty data")
+	}
+	var fields []field
+	pos := 0
+	for pos < len(data) {
+		tag, n := decodeVarint(data[pos:])
+		if n == 0 {
+			return nil, fmt.Errorf("yuanbao: parse varint tag failed at %d", pos)
+		}
+		pos += n
+		fieldNum := int(tag >> 3)
+		wt := int(tag & 0x07)
+		switch wt {
+		case wtVarint:
+			val, n := decodeVarint(data[pos:])
+			if n == 0 {
+				return nil, fmt.Errorf("yuanbao: parse varint at %d", pos)
+			}
+			fields = append(fields, field{fieldNum, wt, val})
+			pos += n
+		case wtLen:
+			ln, n := decodeVarint(data[pos:])
+			if n == 0 {
+				return nil, fmt.Errorf("yuanbao: parse length at %d", pos)
+			}
+			pos += n
+			if pos+int(ln) > len(data) {
+				return nil, fmt.Errorf("yuanbao: length %d exceeds data at %d", ln, pos)
+			}
+			val := make([]byte, ln)
+			copy(val, data[pos:pos+int(ln)])
+			fields = append(fields, field{fieldNum, wt, val})
+			pos += int(ln)
+		case wt64Bit:
+			if pos+8 > len(data) {
+				return nil, fmt.Errorf("yuanbao: 64-bit truncated at %d", pos)
+			}
+			fields = append(fields, field{fieldNum, wt, binary.LittleEndian.Uint64(data[pos : pos+8])})
+			pos += 8
+		case wt32Bit:
+			if pos+4 > len(data) {
+				return nil, fmt.Errorf("yuanbao: 32-bit truncated at %d", pos)
+			}
+			fields = append(fields, field{fieldNum, wt, uint64(binary.LittleEndian.Uint32(data[pos : pos+4]))})
+			pos += 4
+		default:
+			return nil, fmt.Errorf("yuanbao: unknown wire type %d at %d", wt, pos)
+		}
+	}
+	return fields, nil
+}
+
+func decodeVarint(data []byte) (uint64, int) {
+	var result uint64
+	var shift uint
+	for i, b := range data {
+		result |= uint64(b&0x7F) << shift
+		shift += 7
+		if b&0x80 == 0 {
+			return result, i + 1
+		}
+		if shift >= 64 {
+			return 0, 0
+		}
+	}
+	return 0, 0
+}
+
+func getString(fields []field, num int) string {
+	for _, f := range fields {
+		if f.fieldNum == num && f.wireType == wtLen {
+			if b, ok := f.value.([]byte); ok {
+				return string(b)
+			}
+		}
+	}
+	return ""
+}
+
+func getVarint(fields []field, num int) uint64 {
+	for _, f := range fields {
+		if f.fieldNum == num && f.wireType == wtVarint {
+			if v, ok := f.value.(uint64); ok {
+				return v
+			}
+		}
+	}
+	return 0
+}
+
+func getBytes(fields []field, num int) []byte {
+	for _, f := range fields {
+		if f.fieldNum == num && f.wireType == wtLen {
+			if b, ok := f.value.([]byte); ok {
+				return b
+			}
+		}
+	}
+	return nil
+}
+
+func getRepeatedBytes(fields []field, num int) [][]byte {
+	var result [][]byte
+	for _, f := range fields {
+		if f.fieldNum == num && f.wireType == wtLen {
+			if b, ok := f.value.([]byte); ok {
+				result = append(result, b)
+			}
+		}
+	}
+	return result
+}
+
+type connHead struct {
+	cmdType int
+	cmd     string
+	seqNo   int
+	msgID   string
+	module  string
+	needAck bool
+	status  int
+}
+
+type connMsg struct {
+	head  connHead
+	seqNo int
+	data  []byte
+}
+
+func decodeConnMsg(raw []byte) (*connMsg, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("yuanbao: empty conn msg")
+	}
+	fields, err := parseFields(raw)
+	if err != nil {
+		return nil, err
+	}
+	headBytes := getBytes(fields, 1)
+	payload := getBytes(fields, 2)
+	var head connHead
+	if len(headBytes) > 0 {
+		hf, err := parseFields(headBytes)
+		if err != nil {
+			return nil, fmt.Errorf("yuanbao: parse head: %w", err)
+		}
+		head = connHead{
+			cmdType: int(getVarint(hf, 1)),
+			cmd:     getString(hf, 2),
+			seqNo:   int(getVarint(hf, 3)),
+			msgID:   getString(hf, 4),
+			module:  getString(hf, 5),
+			needAck: getVarint(hf, 6) != 0,
+			status:  int(getVarint(hf, 10)),
+		}
+	}
+	return &connMsg{head: head, seqNo: head.seqNo, data: payload}, nil
+}
+
+type authBindRsp struct {
+	code      int
+	message   string
+	connectID string
+}
+
+func encodeAuthBind(uid, source, token, msgID, appVersion, operationSystem, botVersion, routeEnv string) []byte {
+	ab := newBuffer(128)
+	ab.writeStringField(1, uid)
+	ab.writeStringField(2, source)
+	ab.writeStringField(3, token)
+	authBuf := ab.bytes()
+	db := newBuffer(64)
+	db.writeStringField(1, appVersion)
+	db.writeStringField(2, operationSystem)
+	db.writeStringField(10, fmt.Sprintf("%d", instanceID))
+	db.writeStringField(24, botVersion)
+	devBuf := db.bytes()
+	rb := newBuffer(128 + len(authBuf) + len(devBuf))
+	rb.writeStringField(1, "ybBot")
+	rb.writeBytesField(2, authBuf)
+	rb.writeBytesField(3, devBuf)
+	rb.writeStringField(5, routeEnv)
+	return encodeConnMsgFull(cmdTypeRequest, cmdAuthBind, nextSeqNo(), msgID, moduleConnAccess, rb.bytes(), false)
+}
+
+func decodeAuthBindRsp(data []byte) authBindRsp {
+	fields, _ := parseFields(data)
+	return authBindRsp{
+		code:      int(getVarint(fields, 1)),
+		message:   getString(fields, 2),
+		connectID: getString(fields, 3),
+	}
+}
+
+func encodePing(msgID string) []byte {
+	return encodeConnMsgFull(cmdTypeRequest, cmdPing, nextSeqNo(), msgID, moduleConnAccess, nil, false)
+}
+
+func encodePushAck(h connHead) []byte {
+	return encodeConnMsgFull(cmdTypePushAck, h.cmd, nextSeqNo(), h.msgID, h.module, nil, false)
+}
+
+type inboundPush struct {
+	callbackCommand string
+	fromAccount     string
+	toAccount       string
+	senderNickname  string
+	groupID         string
+	groupCode       string
+	groupName       string
+	msgSeq          int
+	msgRandom       int
+	msgTime         int
+	msgKey          string
+	msgID           string
+	msgBody         []msgBodyElement
+	cloudCustomData string
+	botOwnerID      string
+	clawMsgType     int
+	traceID         string
+}
+
+type msgBodyElement struct {
+	msgType    string
+	msgContent map[string]interface{}
+}
+
+func decodeInboundPush(data []byte) *inboundPush {
+	fields, err := parseFields(data)
+	if err != nil {
+		return nil
+	}
+	traceID := ""
+	if logExtBytes := getBytes(fields, 20); len(logExtBytes) > 0 {
+		if lf, err := parseFields(logExtBytes); err == nil {
+			traceID = getString(lf, 1)
+		}
+	}
+	var msgBody []msgBodyElement
+	for _, elBytes := range getRepeatedBytes(fields, 13) {
+		if el, err := decodeMsgBodyElement(elBytes); err == nil {
+			msgBody = append(msgBody, el)
+		}
+	}
+	return &inboundPush{
+		callbackCommand: getString(fields, 1),
+		fromAccount:     getString(fields, 2),
+		toAccount:       getString(fields, 3),
+		senderNickname:  getString(fields, 4),
+		groupID:         getString(fields, 5),
+		groupCode:       getString(fields, 6),
+		groupName:       getString(fields, 7),
+		msgSeq:          int(getVarint(fields, 8)),
+		msgRandom:       int(getVarint(fields, 9)),
+		msgTime:         int(getVarint(fields, 10)),
+		msgKey:          getString(fields, 11),
+		msgID:           getString(fields, 12),
+		msgBody:         msgBody,
+		cloudCustomData: getString(fields, 14),
+		botOwnerID:      getString(fields, 16),
+		clawMsgType:     int(getVarint(fields, 18)),
+		traceID:         traceID,
+	}
+}
+
+func decodeMsgBodyElement(data []byte) (msgBodyElement, error) {
+	fields, err := parseFields(data)
+	if err != nil {
+		return msgBodyElement{}, err
+	}
+	elem := msgBodyElement{msgType: getString(fields, 1)}
+	if contentBytes := getBytes(fields, 2); len(contentBytes) > 0 {
+		if cf, err := parseFields(contentBytes); err == nil {
+			elem.msgContent = decodeMsgContent(cf)
+		}
+	}
+	return elem, nil
+}
+
+func decodeMsgContent(fields []field) map[string]interface{} {
+	m := make(map[string]interface{})
+	for _, f := range fields {
+		switch f.fieldNum {
+		case 1:
+			if s, ok := f.value.([]byte); ok {
+				m["text"] = string(s)
+			}
+		case 2:
+			if s, ok := f.value.([]byte); ok {
+				m["uuid"] = string(s)
+			}
+		case 3:
+			if v, ok := f.value.(uint64); ok {
+				m["imageFormat"] = int(v)
+			}
+		case 4:
+			if s, ok := f.value.([]byte); ok {
+				m["data"] = string(s)
+			}
+		case 5:
+			if s, ok := f.value.([]byte); ok {
+				m["desc"] = string(s)
+			}
+		case 10:
+			if s, ok := f.value.([]byte); ok {
+				m["url"] = string(s)
+			}
+		case 12:
+			if s, ok := f.value.([]byte); ok {
+				m["fileName"] = string(s)
+			}
+		case 15:
+			if s, ok := f.value.([]byte); ok {
+				m["originalUrl"] = string(s)
+			}
+		}
+	}
+	return m
+}
+
+func encodeTextBody(text string) []byte {
+	cb := newBuffer(64)
+	cb.writeStringField(1, text)
+	contentBuf := cb.bytes()
+	eb := newBuffer(64 + len(contentBuf))
+	eb.writeStringField(1, "TIMTextElem")
+	eb.writeBytesField(2, contentBuf)
+	return eb.bytes()
+}
+
+func encodeSendC2CMessage(toAccount string, msgBody [][]byte, fromAccount string, msgID string, msgRandom int, groupCode string, traceID string) []byte {
+	bb := newBuffer(256)
+	reqID := msgID
+	if msgID != "" {
+		bb.writeStringField(1, msgID)
+	}
+	bb.writeStringField(2, toAccount)
+	bb.writeStringField(3, fromAccount)
+	if msgRandom != 0 {
+		bb.writeVarintField(4, uint64(msgRandom))
+	}
+	for _, body := range msgBody {
+		bb.writeBytesField(5, body)
+	}
+	bb.writeStringField(6, groupCode)
+	if traceID != "" {
+		logBytes := func() []byte { var lb buffer; lb.writeStringField(1, traceID); return lb.bytes() }()
+		bb.writeBytesField(8, logBytes)
+	}
+	if reqID == "" {
+		reqID = fmt.Sprintf("c2c_%d", nextSeqNo())
+	}
+	return encodeConnMsgFull(cmdTypeRequest, "send_c2c_message", nextSeqNo(), reqID, bizPkg, bb.bytes(), false)
+}
+
+func encodeSendGroupMessage(groupCode string, msgBody [][]byte, fromAccount string, msgID string, refMsgID string, traceID string) []byte {
+	bb := newBuffer(256)
+	reqID := msgID
+	if msgID != "" {
+		bb.writeStringField(1, msgID)
+	}
+	bb.writeStringField(2, groupCode)
+	bb.writeStringField(3, fromAccount)
+	for _, body := range msgBody {
+		bb.writeBytesField(6, body)
+	}
+	bb.writeStringField(7, refMsgID)
+	if traceID != "" {
+		logBytes := func() []byte { var lb buffer; lb.writeStringField(1, traceID); return lb.bytes() }()
+		bb.writeBytesField(9, logBytes)
+	}
+	if reqID == "" {
+		reqID = fmt.Sprintf("grp_%d", nextSeqNo())
+	}
+	return encodeConnMsgFull(cmdTypeRequest, "send_group_message", nextSeqNo(), reqID, bizPkg, bb.bytes(), false)
+}
+
+func encodeSendPrivateHeartbeat(fromAccount, toAccount string, heartbeat int) []byte {
+	bb := newBuffer(64)
+	bb.writeStringField(1, fromAccount)
+	bb.writeStringField(2, toAccount)
+	bb.writeVarintField(3, uint64(heartbeat))
+	return encodeConnMsgFull(cmdTypeRequest, "send_private_heartbeat", nextSeqNo(),
+		fmt.Sprintf("hb_priv_%d", nextSeqNo()), bizPkg, bb.bytes(), false)
+}
+
+func encodeSendGroupHeartbeat(fromAccount, groupCode string, heartbeat int) []byte {
+	bb := newBuffer(64)
+	bb.writeStringField(1, fromAccount)
+	bb.writeStringField(2, "")
+	bb.writeStringField(3, groupCode)
+	bb.writeVarintField(4, uint64(time.Now().UnixMilli()))
+	bb.writeVarintField(5, uint64(heartbeat))
+	return encodeConnMsgFull(cmdTypeRequest, "send_group_heartbeat", nextSeqNo(),
+		fmt.Sprintf("hb_grp_%d", nextSeqNo()), bizPkg, bb.bytes(), false)
+}
+
+func inboundText(push *inboundPush) string {
+	var parts []string
+	for _, body := range push.msgBody {
+		switch body.msgType {
+		case "TIMTextElem":
+			if text, ok := body.msgContent["text"]; ok {
+				if s, ok := text.(string); ok {
+					parts = append(parts, s)
+				}
+			}
+		case "TIMImageElem":
+			url := extractImageElemURL(body.msgContent)
+			if url != "" {
+				parts = append(parts, "[图片] "+url)
+			} else {
+				parts = append(parts, "[图片]")
+			}
+		case "TIMFileElem":
+			fileName, _ := body.msgContent["file_name"].(string)
+			if fileName == "" {
+				fileName, _ = body.msgContent["fileName"].(string)
+			}
+			if fileName != "" {
+				parts = append(parts, "[文件: "+fileName+"]")
+			} else {
+				parts = append(parts, "[文件]")
+			}
+		case "TIMFaceElem":
+			parts = append(parts, "[表情]")
+		case "TIMSoundElem":
+			parts = append(parts, "[语音]")
+		case "TIMCustomElem":
+			if data, ok := body.msgContent["data"]; ok {
+				if s, ok := data.(string); ok && s != "" {
+					var parsed map[string]interface{}
+					if err := json.Unmarshal([]byte(s), &parsed); err == nil {
+						if text, _ := parsed["text"].(string); text != "" {
+							parts = append(parts, text)
+						} else {
+							parts = append(parts, s)
+						}
+					} else {
+						parts = append(parts, s)
+					}
+				}
+			}
+		default:
+			if desc, ok := body.msgContent["desc"]; ok {
+				if s, ok := desc.(string); ok {
+					parts = append(parts, s)
+				}
+			}
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// extractImageElemURL tries to extract an image URL from a TIMImageElem msgContent.
+// Priority: image_info_array → url → originalUrl.
+func extractImageElemURL(c map[string]interface{}) string {
+	if infoArray, ok := c["image_info_array"].([]interface{}); ok {
+		for _, item := range infoArray {
+			if info, ok := item.(map[string]interface{}); ok {
+				// type=1: original, 2: large, 3: thumbnail
+				if u, _ := info["url"].(string); u != "" {
+					return u
+				}
+			}
+		}
+	}
+	if url, _ := c["url"].(string); url != "" {
+		return url
+	}
+	if url, _ := c["originalUrl"].(string); url != "" {
+		return url
+	}
+	return ""
+}
+
+type jsonInboundPush struct {
+	CallbackCommand string          `json:"callback_command"`
+	FromAccount     string          `json:"from_account"`
+	ToAccount       string          `json:"to_account"`
+	SenderNickname  string          `json:"sender_nickname"`
+	GroupCode       string          `json:"group_code"`
+	GroupName       string          `json:"group_name"`
+	MsgID           string          `json:"msg_id"`
+	MsgKey          string          `json:"msg_key"`
+	MsgBody         json.RawMessage `json:"msg_body"`
+	MsgTime         int             `json:"msg_time"`
+}
+
+var seqCounter uint32
+
+func nextSeqNo() int {
+	n := seqCounter
+	seqCounter++
+	return int(n)
+}

--- a/platform/yuanbao/proto_test.go
+++ b/platform/yuanbao/proto_test.go
@@ -1,0 +1,340 @@
+package yuanbao
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestVarintRoundTrip(t *testing.T) {
+	cases := []uint64{0, 1, 127, 128, 255, 256, 65535, 1 << 20, 1 << 31, 1 << 63}
+	for _, v := range cases {
+		b := &buffer{}
+		b.writeVarint(v)
+		got, n := decodeVarint(b.bytes())
+		if n == 0 {
+			t.Errorf("decodeVarint(%d) returned 0", v)
+			continue
+		}
+		if got != v {
+			t.Errorf("round-trip: input=%d, got=%d", v, got)
+		}
+	}
+}
+
+func TestVarintOverflow(t *testing.T) {
+	v := uint64(1<<63 | 0x7FFFFFFFFFFFFFFF)
+	b := &buffer{}
+	b.writeVarint(v)
+	got, n := decodeVarint(b.bytes())
+	if n == 0 {
+		t.Fatal("decodeVarint overflow returned 0")
+	}
+	if got != v {
+		t.Errorf("overflow: got %d, want %d", got, v)
+	}
+}
+
+func TestEncodeDecodeConnMsg(t *testing.T) {
+	data := []byte("hello world")
+	encoded := encodeConnMsgFull(1, "test_cmd", 42, "msg-001", "test_module", data, true)
+	msg, err := decodeConnMsg(encoded)
+	if err != nil {
+		t.Fatalf("decodeConnMsg: %v", err)
+	}
+	if msg.head.cmdType != 1 {
+		t.Errorf("cmdType: want 1, got %d", msg.head.cmdType)
+	}
+	if msg.head.cmd != "test_cmd" {
+		t.Errorf("cmd: got %q", msg.head.cmd)
+	}
+	if msg.head.seqNo != 42 {
+		t.Errorf("seqNo: want 42, got %d", msg.head.seqNo)
+	}
+	if msg.head.msgID != "msg-001" {
+		t.Errorf("msgID: got %q", msg.head.msgID)
+	}
+	if string(msg.data) != "hello world" {
+		t.Errorf("data: got %q", string(msg.data))
+	}
+}
+
+func TestConnMsgWithoutData(t *testing.T) {
+	encoded := encodeConnMsgFull(1, "test", 1, "id", "m", nil, false)
+	msg, err := decodeConnMsg(encoded)
+	if err != nil {
+		t.Fatalf("decode empty: %v", err)
+	}
+	if msg.head.cmdType != 1 {
+		t.Errorf("cmdType: want 0, got %d", msg.head.cmdType)
+	}
+}
+
+func TestAuthBindEncode(t *testing.T) {
+	encoded := encodeAuthBind("bot-123", "bot", "token-abc", "auth-001", "", "", "", "")
+	msg, err := decodeConnMsg(encoded)
+	if err != nil {
+		t.Fatalf("decode auth bind: %v", err)
+	}
+	if msg.head.cmd != "auth-bind" {
+		t.Errorf("cmd: want 'auth-bind', got %q", msg.head.cmd)
+	}
+	if msg.head.module != "conn_access" {
+		t.Errorf("module: want 'conn_access', got %q", msg.head.module)
+	}
+}
+
+func TestDecodeAuthBindRsp(t *testing.T) {
+	b := &buffer{}
+	b.writeVarintField(1, 0)
+	b.writeStringField(2, "ok")
+	b.writeStringField(3, "conn-001")
+	rsp := decodeAuthBindRsp(b.bytes())
+	if rsp.code != 0 {
+		t.Errorf("code: want 0, got %d", rsp.code)
+	}
+	if rsp.connectID != "conn-001" {
+		t.Errorf("connectID: got %q", rsp.connectID)
+	}
+}
+
+func TestAuthBindRspError(t *testing.T) {
+	b := &buffer{}
+	b.writeVarintField(1, 4001)
+	rsp := decodeAuthBindRsp(b.bytes())
+	if rsp.code != 4001 {
+		t.Errorf("code: want 4001, got %d", rsp.code)
+	}
+}
+
+func TestPingEncode(t *testing.T) {
+	encoded := encodePing("ping-001")
+	msg, err := decodeConnMsg(encoded)
+	if err != nil {
+		t.Fatalf("decode ping: %v", err)
+	}
+	if msg.head.cmd != "ping" {
+		t.Errorf("cmd: got %q", msg.head.cmd)
+	}
+}
+
+func TestPushAck(t *testing.T) {
+	h := connHead{cmdType: cmdTypePush, cmd: "inbound_message", seqNo: 100, msgID: "push-001", module: bizPkg}
+	encoded := encodePushAck(h)
+	msg, err := decodeConnMsg(encoded)
+	if err != nil {
+		t.Fatalf("decode push ack: %v", err)
+	}
+	if msg.head.cmdType != cmdTypePushAck {
+		t.Errorf("cmdType: want %d, got %d", cmdTypePushAck, msg.head.cmdType)
+	}
+}
+
+func TestEncodeDecodeTextBody(t *testing.T) {
+	body := encodeTextBody("hello世界")
+	fields, err := parseFields(body)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	msgType := getString(fields, 1)
+	if msgType != "TIMTextElem" {
+		t.Errorf("msgType: got %q", msgType)
+	}
+	content := getBytes(fields, 2)
+	cf, _ := parseFields(content)
+	text := getString(cf, 1)
+	if text != "hello世界" {
+		t.Errorf("text: got %q", text)
+	}
+}
+
+func TestEncodeC2CMessage(t *testing.T) {
+	body := [][]byte{encodeTextBody("你好")}
+	encoded := encodeSendC2CMessage("user-001", body, "bot-123", "", 0, "", "")
+	msg, err := decodeConnMsg(encoded)
+	if err != nil {
+		t.Fatalf("decode c2c: %v", err)
+	}
+	if msg.head.cmd != "send_c2c_message" {
+		t.Errorf("cmd: got %q", msg.head.cmd)
+	}
+}
+
+func TestEncodeGroupMessage(t *testing.T) {
+	body := [][]byte{encodeTextBody("群消息")}
+	encoded := encodeSendGroupMessage("group-001", body, "bot-123", "", "", "")
+	msg, err := decodeConnMsg(encoded)
+	if err != nil {
+		t.Fatalf("decode group: %v", err)
+	}
+	if msg.head.cmd != "send_group_message" {
+		t.Errorf("cmd: got %q", msg.head.cmd)
+	}
+}
+
+func TestDecodeInboundPush(t *testing.T) {
+	cb := &buffer{}
+	cb.writeStringField(1, "hello")
+	eb := &buffer{}
+	eb.writeStringField(1, "TIMTextElem")
+	eb.writeBytesField(2, cb.bytes())
+	pb := &buffer{}
+	pb.writeStringField(1, "C2CCallback")
+	pb.writeStringField(2, "from-user")
+	pb.writeStringField(3, "bot")
+	pb.writeStringField(4, "User1")
+	pb.writeStringField(12, "msg-001")
+	pb.writeBytesField(13, eb.bytes())
+
+	push := decodeInboundPush(pb.bytes())
+	if push == nil {
+		t.Fatal("nil push")
+	}
+	if push.fromAccount != "from-user" {
+		t.Errorf("fromAccount: got %q", push.fromAccount)
+	}
+	if len(push.msgBody) != 1 || push.msgBody[0].msgType != "TIMTextElem" {
+		t.Errorf("msgBody: got %d elements", len(push.msgBody))
+	}
+}
+
+func TestDecodeInboundPushGroup(t *testing.T) {
+	cb := &buffer{}
+	cb.writeStringField(1, "群消息")
+	eb := &buffer{}
+	eb.writeStringField(1, "TIMTextElem")
+	eb.writeBytesField(2, cb.bytes())
+	pb := &buffer{}
+	pb.writeStringField(2, "from-user")
+	pb.writeStringField(4, "User1")
+	pb.writeStringField(6, "grp-001")
+	pb.writeStringField(7, "测试群")
+	pb.writeStringField(12, "msg-002")
+	pb.writeBytesField(13, eb.bytes())
+
+	push := decodeInboundPush(pb.bytes())
+	if push == nil || push.groupCode != "grp-001" {
+		t.Errorf("groupCode: got %q", push.groupCode)
+	}
+}
+
+func TestInboundText(t *testing.T) {
+	push := &inboundPush{msgBody: []msgBodyElement{
+		{msgType: "TIMTextElem", msgContent: map[string]interface{}{"text": "你好"}},
+		{msgType: "TIMImageElem", msgContent: map[string]interface{}{"originalUrl": "http://img"}},
+	}}
+	text := inboundText(push)
+	if text == "" {
+		t.Fatal("empty text")
+	}
+}
+
+func TestInboundTextEmpty(t *testing.T) {
+	if text := inboundText(&inboundPush{}); text != "" {
+		t.Errorf("expected empty, got %q", text)
+	}
+}
+
+func TestHeartbeatEncoding(t *testing.T) {
+	f := encodeSendPrivateHeartbeat("bot-123", "user-001", 1)
+	m, _ := decodeConnMsg(f)
+	if m.head.cmd != "send_private_heartbeat" {
+		t.Errorf("cmd: got %q", m.head.cmd)
+	}
+}
+
+func TestGroupHeartbeatEncoding(t *testing.T) {
+	f := encodeSendGroupHeartbeat("bot-123", "group-001", 1)
+	m, _ := decodeConnMsg(f)
+	if m.head.cmd != "send_group_heartbeat" {
+		t.Errorf("cmd: got %q", m.head.cmd)
+	}
+}
+
+func TestSeqNoIncrement(t *testing.T) {
+	old := seqCounter
+	a, b, c := nextSeqNo(), nextSeqNo(), nextSeqNo()
+	if b != a+1 || c != b+1 {
+		t.Errorf("not monotonic: %d %d %d", a, b, c)
+	}
+	seqCounter = old
+}
+
+func TestSignature(t *testing.T) {
+	nonce := "abc123"
+	ts := "2026-01-01T00:00:00+08:00"
+	sig := computeSignature(nonce, ts, "key", "secret")
+	decoded, _ := hex.DecodeString(sig)
+	if len(decoded) != 32 {
+		t.Errorf("sig len: want 32, got %d", len(decoded))
+	}
+}
+
+func TestSignatureDeterministic(t *testing.T) {
+	a := computeSignature("n1", "t1", "k1", "s1")
+	b := computeSignature("n1", "t1", "k1", "s1")
+	if a != b {
+		t.Error("not deterministic")
+	}
+}
+
+func TestSignatureDifferent(t *testing.T) {
+	a := computeSignature("n1", "t1", "k1", "s1")
+	b := computeSignature("n2", "t1", "k1", "s1")
+	if a == b {
+		t.Error("should differ")
+	}
+}
+
+func TestParseRepeatedFields(t *testing.T) {
+	b := &buffer{}
+	b.writeStringField(1, "a")
+	b.writeStringField(2, "x")
+	b.writeStringField(1, "b")
+	fields, _ := parseFields(b.bytes())
+	if len(fields) != 3 {
+		t.Fatalf("want 3 fields, got %d", len(fields))
+	}
+	vals := getRepeatedBytes(fields, 1)
+	if len(vals) != 2 {
+		t.Errorf("want 2 repeated, got %d", len(vals))
+	}
+}
+
+func TestJSONInboundPush(t *testing.T) {
+	p := &Platform{}
+	push := p.decodePush([]byte(`{"callback_command":"C2CCallback","from_account":"user-001","msg_body":[{"msg_type":"TIMTextElem","msg_content":{"text":"你好"}}]}`))
+	if push == nil || push.fromAccount != "user-001" || len(push.msgBody) != 1 {
+		t.Fatal("json push parse failed")
+	}
+}
+
+func TestJSONPascalCase(t *testing.T) {
+	p := &Platform{}
+	push := p.decodePush([]byte(`{"From_Account":"user","MsgBody":[{"MsgType":"TIMTextElem","MsgContent":{"text":"hi"}}]}`))
+	if push == nil || push.fromAccount != "user" {
+		t.Fatal("pascal case parse failed")
+	}
+}
+
+func TestMultipleMsgBodies(t *testing.T) {
+	body := [][]byte{encodeTextBody("a"), encodeTextBody("b")}
+	encoded := encodeSendC2CMessage("user-001", body, "bot-123", "multi-001", 0, "", "")
+	msg, _ := decodeConnMsg(encoded)
+	if msg.head.msgID != "multi-001" {
+		t.Errorf("msgID: got %q", msg.head.msgID)
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	_, err := parseFields([]byte{0xFF, 0xFF, 0xFF})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestDecodeNil(t *testing.T) {
+	msg, err := decodeConnMsg(nil)
+	if err == nil || msg != nil {
+		t.Error("expected error for nil")
+	}
+}

--- a/platform/yuanbao/sign.go
+++ b/platform/yuanbao/sign.go
@@ -1,0 +1,208 @@
+package yuanbao
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultAPIDomain = "https://bot.yuanbao.tencent.com"
+	defaultWSURL     = "wss://bot-wss.yuanbao.tencent.com/wss/connection"
+	tokenPath        = "/api/v5/robotLogic/sign-token"
+	maxRetries       = 3
+	retryDelay       = time.Second
+	cacheRefreshSecs = 60
+	httpTimeout      = 10 * time.Second
+)
+
+type tokenData struct {
+	token    string
+	botID    string
+	duration int
+	product  string
+	source   string
+}
+
+type cachedToken struct {
+	tokenData
+	expireAt time.Time
+}
+
+type tokenManager struct {
+	mu       sync.Mutex
+	cache    *cachedToken
+	inflight chan struct{}
+}
+
+func newTokenManager() *tokenManager {
+	return &tokenManager{
+		inflight: make(chan struct{}, 1),
+	}
+}
+
+func (tm *tokenManager) getToken(appKey, appSecret, apiDomain, routeEnv string) (*tokenData, error) {
+	tm.mu.Lock()
+	if tm.cache != nil && time.Now().Before(tm.cache.expireAt) {
+		data := &tm.cache.tokenData
+		tm.mu.Unlock()
+		return data, nil
+	}
+	tm.mu.Unlock()
+
+	select {
+	case tm.inflight <- struct{}{}:
+	default:
+		tm.inflight <- struct{}{}
+	}
+	defer func() { <-tm.inflight }()
+
+	tm.mu.Lock()
+	if tm.cache != nil && time.Now().Before(tm.cache.expireAt) {
+		data := &tm.cache.tokenData
+		tm.mu.Unlock()
+		return data, nil
+	}
+	tm.mu.Unlock()
+
+	data, err := fetchToken(appKey, appSecret, apiDomain, routeEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	dur := time.Duration(data.duration) * time.Second
+	if dur < 300*time.Second {
+		dur = 3600 * time.Second
+	}
+	tm.mu.Lock()
+	tm.cache = &cachedToken{
+		tokenData: *data,
+		expireAt:  time.Now().Add(dur - cacheRefreshSecs*time.Second),
+	}
+	tm.mu.Unlock()
+	return data, nil
+}
+
+func (tm *tokenManager) forceRefresh() {
+	tm.mu.Lock()
+	tm.cache = nil
+	tm.mu.Unlock()
+}
+
+func computeSignature(nonce, timestamp, appKey, appSecret string) string {
+	mac := hmac.New(sha256.New, []byte(appSecret))
+	mac.Write([]byte(nonce + timestamp + appKey + appSecret))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func buildTimestamp() string {
+	now := time.Now().UTC().Add(8 * time.Hour)
+	s := now.Format("2006-01-02T15:04:05+08:00")
+	return s
+}
+
+func fetchToken(appKey, appSecret, apiDomain, routeEnv string) (*tokenData, error) {
+	if apiDomain == "" {
+		apiDomain = defaultAPIDomain
+	}
+	urlStr := strings.TrimRight(apiDomain, "/") + tokenPath
+	client := &http.Client{Timeout: httpTimeout}
+	var lastErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(retryDelay)
+		}
+		nonceBytes := make([]byte, 16)
+		if _, err := rand.Read(nonceBytes); err != nil {
+			lastErr = fmt.Errorf("yuanbao: generate nonce: %w", err)
+			continue
+		}
+		nonce := hex.EncodeToString(nonceBytes)
+		timestamp := buildTimestamp()
+		signature := computeSignature(nonce, timestamp, appKey, appSecret)
+
+		payload := map[string]string{
+			"app_key": appKey, "nonce": nonce,
+			"signature": signature, "timestamp": timestamp,
+		}
+		body, _ := json.Marshal(payload)
+
+		req, err := http.NewRequest("POST", urlStr, strings.NewReader(string(body)))
+		if err != nil {
+			lastErr = fmt.Errorf("yuanbao: create request: %w", err)
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-AppVersion", "cc-connect-yuanbao/1.0.0")
+		req.Header.Set("X-Instance-Id", fmt.Sprintf("%d", instanceID))
+		req.Header.Set("X-Bot-Version", "cc-connect-yuanbao/1.0.0")
+		if routeEnv != "" {
+			req.Header.Set("X-Route-Env", routeEnv)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("yuanbao: request failed: %w", err)
+			continue
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("yuanbao: sign token API returned %d: %s", resp.StatusCode, string(respBody))
+			continue
+		}
+
+		var result struct {
+			Code int `json:"code"`
+			Data *struct {
+				Token    string `json:"token"`
+				BotID    string `json:"bot_id"`
+				Duration int    `json:"duration"`
+				Product  string `json:"product"`
+				Source   string `json:"source"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			lastErr = fmt.Errorf("yuanbao: parse response: %w", err)
+			continue
+		}
+		if result.Code == 10099 && attempt < maxRetries {
+			continue
+		}
+		if result.Code != 0 {
+			return nil, fmt.Errorf("yuanbao: sign token error code=%d", result.Code)
+		}
+		if result.Data == nil {
+			return nil, fmt.Errorf("yuanbao: sign token response missing data")
+		}
+		return &tokenData{
+			token: result.Data.Token, botID: result.Data.BotID,
+			duration: result.Data.Duration, product: result.Data.Product,
+			source: result.Data.Source,
+		}, nil
+	}
+	return nil, lastErr
+}
+
+// VerifyCredentials probes the sign-token API with app_key/app_secret and
+// returns the bot_id on success. Used by `cc-connect yuanbao setup` so users
+// see a clear error before the platform starts retrying on a background loop.
+func VerifyCredentials(appKey, appSecret, apiDomain, routeEnv string) (botID string, err error) {
+	if strings.TrimSpace(appKey) == "" || strings.TrimSpace(appSecret) == "" {
+		return "", fmt.Errorf("yuanbao: bot_token is required (format: app_key:app_secret)")
+	}
+	data, err := fetchToken(appKey, appSecret, apiDomain, routeEnv)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(data.botID), nil
+}

--- a/web/src/lib/platformMeta.ts
+++ b/web/src/lib/platformMeta.ts
@@ -85,6 +85,13 @@ export const platformMeta: Record<string, PlatformMeta> = {
       { key: 'share_session_in_channel', labelKey: 'fields.sharedGroupSession', type: 'boolean', group: 'advanced' },
     ],
   },
+  yuanbao: {
+    label: 'Yuanbao (腾讯元宝)',
+    fields: [
+      { key: 'bot_token', labelKey: 'fields.botToken', required: true, type: 'password', placeholder: 'app_key:app_secret' },
+      { key: 'allow_from', labelKey: 'fields.allowFrom', placeholder: '* (all)', group: 'advanced' },
+    ],
+  },
   line: {
     label: 'LINE',
     fields: [

--- a/web/src/pages/Projects/ProjectDetail.tsx
+++ b/web/src/pages/Projects/ProjectDetail.tsx
@@ -25,6 +25,7 @@ const PLATFORM_OPTIONS: { key: string; label: string; color: string; abbr: strin
   { key: 'wecom', label: 'WeChat Work', abbr: 'WC', color: 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400' },
   { key: 'qq', label: 'QQ (OneBot)', abbr: 'QQ', color: 'bg-cyan-50 dark:bg-cyan-900/30 text-cyan-600 dark:text-cyan-400' },
   { key: 'qqbot', label: 'QQ Bot (Official)', abbr: 'QB', color: 'bg-cyan-50 dark:bg-cyan-900/30 text-cyan-600 dark:text-cyan-400' },
+  { key: 'yuanbao', label: 'Yuanbao', abbr: 'YB', color: 'bg-rose-50 dark:bg-rose-900/30 text-rose-600 dark:text-rose-400' },
   { key: 'line', label: 'LINE', abbr: 'LN', color: 'bg-lime-50 dark:bg-lime-900/30 text-lime-600 dark:text-lime-400' },
   { key: 'weibo', label: 'Weibo (微博)', abbr: 'WB', color: 'bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400' },
 ];

--- a/web/src/pages/Projects/ProjectList.tsx
+++ b/web/src/pages/Projects/ProjectList.tsx
@@ -32,6 +32,7 @@ const PLATFORM_OPTIONS: { key: string; label: string; color: string; qr?: boolea
   { key: 'wecom', label: 'WeChat Work', color: 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400' },
   { key: 'qq', label: 'QQ (OneBot)', color: 'bg-cyan-50 dark:bg-cyan-900/30 text-cyan-600 dark:text-cyan-400' },
   { key: 'qqbot', label: 'QQ Bot (Official)', color: 'bg-cyan-50 dark:bg-cyan-900/30 text-cyan-600 dark:text-cyan-400' },
+  { key: 'yuanbao', label: 'Yuanbao', color: 'bg-rose-50 dark:bg-rose-900/30 text-rose-600 dark:text-rose-400' },
   { key: 'line', label: 'LINE', color: 'bg-lime-50 dark:bg-lime-900/30 text-lime-600 dark:text-lime-400' },
   { key: 'weibo', label: 'Weibo (微博)', color: 'bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400' },
 ];


### PR DESCRIPTION
## Summary

Add support for Tencent Yuanbao (腾讯元宝) bot platform — a WebSocket-based messaging platform by Tencent. Users can connect their coding agents to Yuanbao through cc-connect.

### New files

- `platform/yuanbao/platform.go` — Yuanbao platform adapter (WebSocket connect, auth, heartbeat, message receive/send, reply heartbeat)
- `platform/yuanbao/proto.go` — Protobuf wire protocol encoding/decoding for Yuanbao gateway
- `platform/yuanbao/sign.go` — Sign-token API client (app_key + app_secret → temporary token)
- `platform/yuanbao/proto_test.go` — Protocol round-trip tests
- `cmd/cc-connect/plugin_platform_yuanbao.go` — Selective compilation build tag
- `cmd/cc-connect/yuanbao.go` — CLI setup command (`cc-connect yuanbao setup --token app_key:app_secret`)

### Changes to existing files

- `config/config.go` — Add `EnsureProjectWithYuanbaoPlatform` / `SaveYuanbaoPlatformCredentials` helper functions
- `config.example.toml` — Document yuanbao platform config example
- `cmd/cc-connect/main.go` — Register `yuanbao` subcommand and update help text
- `web/src/lib/platformMeta.ts` — Add yuanbao to web admin UI platform selector
- `web/src/pages/Projects/ProjectList.tsx` — Add yuanbao platform card
- `web/src/pages/Projects/ProjectDetail.tsx` — Add yuanbao badge

### Key design decisions

- **bot_token** — single config field `app_key:app_secret` (split at `:`), not two separate fields
- **WebSocket** — persistent WSS connection to `bot-wss.yuanbao.tencent.com`, with auto-refreshed sign-tokens
- **init() registration** — registers via `core.RegisterPlatform("yuanbao", New)`, aligned with all other platform packages
- **Reply heartbeat** — sends periodic WS_HEARTBEAT_RUNNING while Reply is in progress (prevents server-side timeout)
- **Dedup** — in-memory message ID dedup with 5-min cleanup cycle

### Bugs fixed during development

1. **Deadlock in startReplyHeartbeat** — `p.mu` lock was held while calling `doReplyHeartbeat` → `getWS()` which re-acquires `p.mu`. Fixed by accessing `p.ws`/`p.botID` directly under the held lock.

2. **Thinking text sent prematurely** — engine's EventThinking handler was flushing accumulated text segments for non-preview platforms before EventResult. Removed early `sendWorkspace` calls so all text is delivered at turn completion.

3. **Inbound image message display** — Only `originalUrl` was read for TIMImageElem; now tries `image_info_array` → `url` → `originalUrl`, matching the TypeScript reference implementation.

4. **Missing msgContent fields (TIMFileElem, TIMCustomElem)** — Added file message and custom message parsing for better compatibility.

5. **Missing `strings` import** — Added import needed by `strings.Join` in `inboundText`.