### PR TITLE
feat(feishu): add group thread isolation lists

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -601,6 +601,21 @@ func main() {
 			engine.SetHooks(core.NewHookManager(proj.Name, coreHooks, shell, shellFlag, shellProfile))
 		}
 
+		if len(cfg.PreflightChecks) > 0 {
+			corePreflight := make([]core.PreflightCheckConfig, len(cfg.PreflightChecks))
+			for i, check := range cfg.PreflightChecks {
+				corePreflight[i] = core.PreflightCheckConfig{
+					Event:          check.Event,
+					Type:           check.Type,
+					URL:            check.URL,
+					Timeout:        check.Timeout,
+					OnError:        check.OnError,
+					IncludeContent: check.IncludeContent,
+				}
+			}
+			engine.SetPreflight(core.NewPreflightManager(proj.Name, corePreflight))
+		}
+
 		// Wire local reference normalization / rendering
 		engine.SetReferenceConfig(core.ReferenceRenderCfg{
 			NormalizeAgents: proj.References.NormalizeAgents,

--- a/config.example.toml
+++ b/config.example.toml
@@ -1023,6 +1023,10 @@ app_secret = "your-feishu-app-secret"
 #                                   # 设为 true 时，群聊内所有用户共享同一个 Agent 会话
 # thread_isolation = false  # If true, group messages use Feishu reply threads as session boundaries (one thread/root = one agent session)
 #                           # 设为 true 时，群聊按飞书话题/根消息隔离会话（一个 thread/root 对应一个 Agent 会话）
+# thread_isolation_black_group = ""  # When thread_isolation=true, comma-separated group chat_ids that should keep normal replies
+#                                    # thread_isolation=true 时，逗号分隔的群聊 chat_id 黑名单；命中后仍使用普通回复
+# thread_isolation_white_group = ""  # When thread_isolation=false, comma-separated group chat_ids that should use threaded replies
+#                                    # thread_isolation=false 时，逗号分隔的群聊 chat_id 白名单；命中后使用话题回复
 # reply_to_trigger = true   # Default: bot uses “reply to message” API (quotes the user’s message). Set false to post plain chat messages instead.
 #                           # 默认 true：用「回复消息」API（引用用户消息）。设为 false 则在会话里发普通消息、不引用触发消息。
 # progress_style = "legacy" # Progress rendering style: legacy | compact | card

--- a/config.example.toml
+++ b/config.example.toml
@@ -443,6 +443,28 @@ level = "info" # debug, info, warn, error
 # type = "http"
 # url = "https://my-server.com/cc-connect/on-error"
 #
+# =============================================================================
+# Preflight Checks (Decision Gates / 前置检查)
+# =============================================================================
+# Preflight checks run before normal message hooks and before the agent receives
+# an inbound message. They are intended for deployment-specific gates such as
+# entitlement checks, required user authorization, quota, or service readiness.
+# 前置检查会在普通消息 hook 和 Agent 收到消息之前执行，适合做可用范围、
+# 用户授权、额度或服务状态等部署侧校验。
+#
+# Response JSON / 返回 JSON:
+#   {"decision":"continue"}                         # allow normal processing / 放行
+#   {"decision":"block","message":"Please authorize"} # reply and stop / 回复并阻断
+#   {"decision":"ignore"}                           # silently stop / 静默丢弃
+#
+# [[preflight_checks]]
+# event = "message.preflight"                 # default message.preflight
+# type = "http"
+# url = "http://127.0.0.1:17860/api/cc-connect/preflight"
+# timeout = 3
+# on_error = "block"                          # block, continue, or ignore; default block
+# include_content = false                     # default false; avoid sending user text unless required
+#
 # [[hooks]]
 # event = "*"
 # type = "http"

--- a/config.example.toml
+++ b/config.example.toml
@@ -415,6 +415,16 @@ level = "info" # debug, info, warn, error
 #   error              — an error occurs / 发生错误
 #   *                  — match all events / 匹配所有事件
 #
+# Hook payloads include stable session metadata in extra.cc_session_id and
+# extra.agent_session_id when available. message.received and session.started
+# also include trigger message metadata such as extra.message_id, channel_id,
+# channel_key and chat_name. message.sent includes extra.trigger_message_id
+# so consumers can correlate an agent reply with the user message that caused it.
+# Hook payload 会在可用时通过 extra.cc_session_id 和 extra.agent_session_id
+# 提供稳定会话信息。message.received 与 session.started 还会带上触发消息的
+# extra.message_id、channel_id、channel_key、chat_name 等信息。message.sent
+# 会带上 extra.trigger_message_id，便于消费方把 Agent 回复关联到触发它的用户消息。
+#
 # Handler types / 处理器类型:
 #   command — run a shell command; event context in CC_HOOK_* env vars
 #           — 执行 Shell 命令；事件上下文通过 CC_HOOK_* 环境变量传递

--- a/config/config.go
+++ b/config/config.go
@@ -111,6 +111,7 @@ type Config struct {
 	Bridge             BridgeConfig            `toml:"bridge"`
 	Management         ManagementConfig        `toml:"management"`
 	Hooks              []HookConfig            `toml:"hooks"`
+	PreflightChecks    []PreflightCheckConfig  `toml:"preflight_checks"`
 	IdleTimeoutMins    *int                    `toml:"idle_timeout_mins,omitempty"`  // max minutes between consecutive agent events; 0 = no timeout; default 120
 	MaxTurnTimeMins    *int                    `toml:"max_turn_time_mins,omitempty"` // absolute wall-clock cap per turn in minutes; 0 = disabled (default)
 	// WorkspaceIdleTimeoutMins controls the workspace idle reaper timeout
@@ -173,6 +174,16 @@ type HookConfig struct {
 	URL     string `toml:"url,omitempty"`     // HTTP endpoint (type=http)
 	Timeout int    `toml:"timeout,omitempty"` // seconds; 0 = default
 	Async   *bool  `toml:"async,omitempty"`   // nil = true (async by default)
+}
+
+// PreflightCheckConfig is a decision-capable inbound message gate.
+type PreflightCheckConfig struct {
+	Event          string `toml:"event,omitempty"`           // default: message.preflight
+	Type           string `toml:"type"`                      // "http"
+	URL            string `toml:"url,omitempty"`             // HTTP endpoint (type=http)
+	Timeout        int    `toml:"timeout,omitempty"`         // seconds; 0 = default
+	OnError        string `toml:"on_error,omitempty"`        // block, continue, or ignore; default block
+	IncludeContent bool   `toml:"include_content,omitempty"` // default false
 }
 
 // ManagementConfig controls the HTTP Management API for external tools.
@@ -1020,6 +1031,11 @@ func (c *Config) validateInternal(permissive bool) error {
 	default:
 		return fmt.Errorf("config: relay.visibility must be \"full\", \"summary\", or \"none\"")
 	}
+	for i, check := range c.PreflightChecks {
+		if err := validatePreflightCheckConfig(fmt.Sprintf("preflight_checks[%d]", i), check); err != nil {
+			return err
+		}
+	}
 	if len(c.Projects) == 0 {
 		return fmt.Errorf("config: at least one [[projects]] entry is required")
 	}
@@ -1070,6 +1086,30 @@ func (c *Config) validateInternal(permissive bool) error {
 		}
 	}
 	return nil
+}
+
+func validatePreflightCheckConfig(prefix string, check PreflightCheckConfig) error {
+	if strings.TrimSpace(check.Event) != "" && !strings.EqualFold(strings.TrimSpace(check.Event), "message.preflight") && strings.TrimSpace(check.Event) != "*" {
+		return fmt.Errorf("config: %s.event must be \"message.preflight\" or \"*\"", prefix)
+	}
+	if strings.TrimSpace(check.Type) != "http" {
+		return fmt.Errorf("config: %s.type must be \"http\"", prefix)
+	}
+	if strings.TrimSpace(check.URL) == "" {
+		return fmt.Errorf("config: %s.url is required", prefix)
+	}
+	if !strings.HasPrefix(check.URL, "http://") && !strings.HasPrefix(check.URL, "https://") {
+		return fmt.Errorf("config: %s.url must start with http:// or https://", prefix)
+	}
+	if check.Timeout < 0 {
+		return fmt.Errorf("config: %s.timeout must be >= 0", prefix)
+	}
+	switch strings.ToLower(strings.TrimSpace(check.OnError)) {
+	case "", "block", "continue", "ignore":
+		return nil
+	default:
+		return fmt.Errorf("config: %s.on_error must be \"block\", \"continue\", or \"ignore\"", prefix)
+	}
 }
 
 func validateDisplayConfig(prefix string, display *DisplayConfig) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -702,6 +702,77 @@ func TestLoad_MissingEnvPlaceholderBecomesEmptyString(t *testing.T) {
 	}
 }
 
+func TestLoad_PreflightChecks(t *testing.T) {
+	configPath := writeConfigFixture(t, `
+[[preflight_checks]]
+event = "message.preflight"
+type = "http"
+url = "http://127.0.0.1:17860/api/cc-connect/preflight"
+timeout = 3
+on_error = "block"
+include_content = true
+
+[[projects]]
+name = "demo"
+
+[projects.agent]
+type = "codex"
+
+[projects.agent.options]
+work_dir = "/tmp/demo"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+token = "token"
+`)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if len(cfg.PreflightChecks) != 1 {
+		t.Fatalf("PreflightChecks len = %d, want 1", len(cfg.PreflightChecks))
+	}
+	check := cfg.PreflightChecks[0]
+	if check.Event != "message.preflight" || check.Type != "http" || check.URL == "" {
+		t.Fatalf("unexpected preflight check: %+v", check)
+	}
+	if check.Timeout != 3 || check.OnError != "block" || !check.IncludeContent {
+		t.Fatalf("unexpected preflight options: %+v", check)
+	}
+}
+
+func TestLoad_PreflightChecksRejectInvalidOnError(t *testing.T) {
+	configPath := writeConfigFixture(t, `
+[[preflight_checks]]
+type = "http"
+url = "http://127.0.0.1:17860/api/cc-connect/preflight"
+on_error = "retry"
+
+[[projects]]
+name = "demo"
+
+[projects.agent]
+type = "codex"
+
+[projects.agent.options]
+work_dir = "/tmp/demo"
+
+[[projects.platforms]]
+type = "telegram"
+
+[projects.platforms.options]
+token = "token"
+`)
+
+	_, err := Load(configPath)
+	if err == nil || !strings.Contains(err.Error(), `preflight_checks[0].on_error`) {
+		t.Fatalf("Load() error = %v, want invalid preflight on_error", err)
+	}
+}
+
 func TestListProjects(t *testing.T) {
 	writeTestConfig(t, baseConfigTOML)
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -430,6 +430,7 @@ type Engine struct {
 	configReloadFunc func() (*ConfigReloadResult, error)
 
 	hooks              *HookManager
+	preflight          *PreflightManager
 	cronScheduler      *CronScheduler
 	timerScheduler     *TimerScheduler
 	heartbeatScheduler *HeartbeatScheduler
@@ -908,6 +909,11 @@ func (e *Engine) reapIdleWorkspaces() {
 // SetHooks configures the lifecycle event hook manager.
 func (e *Engine) SetHooks(hm *HookManager) {
 	e.hooks = hm
+}
+
+// SetPreflight configures decision-capable preflight checks.
+func (e *Engine) SetPreflight(pm *PreflightManager) {
+	e.preflight = pm
 }
 
 // SetShell configures the shell binary, flag, and shell profile used for exec.
@@ -2806,6 +2812,38 @@ func (e *Engine) startMessageRecallMonitor(sessionKey string) context.CancelFunc
 	return cancel
 }
 
+func (e *Engine) evaluateMessagePreflight(msg *Message) PreflightDecision {
+	if e.preflight == nil {
+		return PreflightDecision{Decision: PreflightContinue}
+	}
+	extra := map[string]any{
+		"has_images":           len(msg.Images) > 0,
+		"has_files":            len(msg.Files) > 0,
+		"has_audio":            msg.Audio != nil,
+		"has_location":         msg.Location != nil,
+		"from_voice":           msg.FromVoice,
+		"user_message_time_ms": msg.UserMessageTimeMs,
+	}
+	if msg.ExtraContent != "" {
+		extra["has_extra_content"] = true
+	}
+	if msg.ChannelKey != "" {
+		extra["channel_key"] = msg.ChannelKey
+	}
+	return e.preflight.Evaluate(PreflightEvent{
+		Event:      PreflightEventMessage,
+		SessionKey: msg.SessionKey,
+		Platform:   msg.Platform,
+		MessageID:  msg.MessageID,
+		ChannelID:  effectiveChannelID(msg),
+		UserID:     msg.UserID,
+		UserName:   msg.UserName,
+		ChatName:   msg.ChatName,
+		Content:    msg.Content,
+		Extra:      extra,
+	})
+}
+
 func (e *Engine) handleMessage(p Platform, msg *Message) {
 	if msg.Recalled {
 		e.handleMessageRecall(p, msg)
@@ -2826,6 +2864,26 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 			"session", msg.SessionKey, "user", msg.UserName,
 			"content", previewText(msg.Content, 500),
 		)
+	}
+
+	if decision := e.evaluateMessagePreflight(msg); decision.Decision != PreflightContinue {
+		slog.Info("message stopped by preflight",
+			"platform", msg.Platform,
+			"msg_id", msg.MessageID,
+			"session", msg.SessionKey,
+			"user", msg.UserName,
+			"decision", decision.Decision,
+			"code", decision.Code,
+			"reason", decision.Reason,
+		)
+		if decision.Decision == PreflightBlock {
+			reply := strings.TrimSpace(decision.Message)
+			if reply == "" {
+				reply = e.i18n.T(MsgPreflightBlocked)
+			}
+			e.reply(p, msg.ReplyCtx, reply)
+		}
+		return
 	}
 
 	_, hookSessions := e.sessionContextForKey(msg.SessionKey)

--- a/core/engine.go
+++ b/core/engine.go
@@ -58,6 +58,76 @@ func previewText(s string, maxRunes int) string {
 	return out
 }
 
+func hookExtraForSession(session *Session) map[string]any {
+	if session == nil {
+		return nil
+	}
+	extra := map[string]any{
+		"cc_session_id": session.ID,
+	}
+	if name := session.GetName(); name != "" {
+		extra["cc_session_name"] = name
+	}
+	if agentSessionID := session.GetAgentSessionID(); agentSessionID != "" {
+		extra["agent_session_id"] = agentSessionID
+	}
+	return extra
+}
+
+func hookExtraForSessionMessage(session *Session, msg *Message) map[string]any {
+	extra := hookExtraForSession(session)
+	if extra == nil {
+		extra = make(map[string]any)
+	}
+	if msg == nil {
+		return extra
+	}
+	if msg.MessageID != "" {
+		extra["message_id"] = msg.MessageID
+	}
+	if msg.ChannelID != "" {
+		extra["channel_id"] = msg.ChannelID
+	} else if channelID := effectiveChannelID(msg); channelID != "" {
+		extra["channel_id"] = channelID
+	}
+	if msg.ChannelKey != "" {
+		extra["channel_key"] = msg.ChannelKey
+	}
+	if msg.ChatName != "" {
+		extra["chat_name"] = msg.ChatName
+	}
+	if msg.UserMessageTimeMs != 0 {
+		extra["user_message_time_ms"] = msg.UserMessageTimeMs
+	}
+	if len(msg.Images) > 0 {
+		extra["has_images"] = true
+	}
+	if len(msg.Files) > 0 {
+		extra["has_files"] = true
+	}
+	if msg.Audio != nil {
+		extra["has_audio"] = true
+	}
+	if msg.Location != nil {
+		extra["has_location"] = true
+	}
+	if msg.FromVoice {
+		extra["from_voice"] = true
+	}
+	return extra
+}
+
+func hookExtraForSentMessage(session *Session, triggerMessageID string) map[string]any {
+	extra := hookExtraForSession(session)
+	if extra == nil {
+		extra = make(map[string]any)
+	}
+	if triggerMessageID != "" {
+		extra["trigger_message_id"] = triggerMessageID
+	}
+	return extra
+}
+
 const (
 	defaultThinkingMaxLen = 300
 	defaultToolMaxLen     = 500
@@ -2758,6 +2828,8 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		)
 	}
 
+	_, hookSessions := e.sessionContextForKey(msg.SessionKey)
+	hookSession := hookSessions.GetOrCreateActive(msg.SessionKey)
 	e.hooks.Emit(HookEvent{
 		Event:      HookEventMessageReceived,
 		SessionKey: msg.SessionKey,
@@ -2765,6 +2837,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		UserID:     msg.UserID,
 		UserName:   msg.UserName,
 		Content:    msg.Content,
+		Extra:      hookExtraForSessionMessage(hookSession, msg),
 	})
 
 	// Voice message: transcribe to text first
@@ -3652,7 +3725,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	if agent != e.agent {
 		agentOverride = agent
 	}
-	state := e.getOrCreateInteractiveStateWith(interactiveKey, p, msg.ReplyCtx, session, sessions, agentOverride, ccSessionKey)
+	state := e.getOrCreateInteractiveStateWithTrigger(interactiveKey, p, msg.ReplyCtx, session, sessions, agentOverride, ccSessionKey, msg)
 
 	// Set workspaceDir on the state for idle reaper identification
 	if workspaceDir != "" {
@@ -3922,6 +3995,10 @@ func adoptPendingFromPlaceholder(existing, newState *interactiveState) {
 // When agentOverride is non-nil it is used instead of e.agent to start the session.
 // ccSessionKey, when non-empty, is used for CC_SESSION_KEY env injection; otherwise sessionKey is used.
 func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, replyCtx any, session *Session, sessions *SessionManager, agentOverride Agent, ccSessionKey string) *interactiveState {
+	return e.getOrCreateInteractiveStateWithTrigger(sessionKey, p, replyCtx, session, sessions, agentOverride, ccSessionKey, nil)
+}
+
+func (e *Engine) getOrCreateInteractiveStateWithTrigger(sessionKey string, p Platform, replyCtx any, session *Session, sessions *SessionManager, agentOverride Agent, ccSessionKey string, triggerMsg *Message) *interactiveState {
 	e.interactiveMu.Lock()
 	defer e.interactiveMu.Unlock()
 
@@ -4116,17 +4193,40 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 
 	slog.Info("session spawned", "session_key", sessionKey, "agent_session", session.GetAgentSessionID(), "is_resume", isResume, "elapsed", startElapsed)
 
+	startedExtra := hookExtraForSessionMessage(session, triggerMsg)
+	startedExtra["is_resume"] = isResume
 	e.hooks.Emit(HookEvent{
 		Event:      HookEventSessionStarted,
 		SessionKey: sessionKey,
 		Platform:   p.Name(),
-		Extra: map[string]any{
-			"agent_session_id": session.GetAgentSessionID(),
-			"is_resume":        isResume,
-		},
+		UserID:     triggerMessageUserID(triggerMsg),
+		UserName:   triggerMessageUserName(triggerMsg),
+		Content:    triggerMessageContent(triggerMsg),
+		Extra:      startedExtra,
 	})
 
 	return state
+}
+
+func triggerMessageUserID(msg *Message) string {
+	if msg == nil {
+		return ""
+	}
+	return msg.UserID
+}
+
+func triggerMessageUserName(msg *Message) string {
+	if msg == nil {
+		return ""
+	}
+	return msg.UserName
+}
+
+func triggerMessageContent(msg *Message) string {
+	if msg == nil {
+		return ""
+	}
+	return msg.Content
 }
 
 // cleanupInteractiveState removes the interactive state for the given session key
@@ -5524,6 +5624,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					SessionKey: sessionKey,
 					Platform:   p.Name(),
 					Content:    baseResponse,
+					Extra:      hookExtraForSentMessage(session, msgID),
 				})
 			}
 
@@ -6027,6 +6128,7 @@ channelClosed:
 			SessionKey: sessionKey,
 			Platform:   p.Name(),
 			Content:    fullResponse,
+			Extra:      hookExtraForSentMessage(session, msgID),
 		})
 
 		if toolCount > 0 && segmentStart > 0 {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -3358,6 +3358,53 @@ func TestHandleMessage_MultiWorkspacePreservesCCSessionKey(t *testing.T) {
 	}
 }
 
+func TestHandleMessage_PreflightBlockSkipsHookAndAgent(t *testing.T) {
+	hookCalls := atomic.Int32{}
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hookCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hookSrv.Close()
+
+	preflightSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"decision":"block","code":"missing_scope","message":"请先完成飞书授权"}`))
+	}))
+	defer preflightSrv.Close()
+
+	p := &stubPlatformEngine{n: "feishu"}
+	agentSession := newResultAgentSession("agent reply")
+	agent := &resultAgent{session: agentSession}
+	e := NewEngine("test", agent, []Platform{p}, "", LangChinese)
+	e.SetHooks(NewHookManager("test", []HookConfig{
+		{Event: string(HookEventMessageReceived), Type: "http", URL: hookSrv.URL, Async: boolPtr(false)},
+	}, "sh", "-c", ""))
+	e.SetPreflight(NewPreflightManager("test", []PreflightCheckConfig{
+		{Type: "http", URL: preflightSrv.URL, Timeout: 1},
+	}))
+
+	e.handleMessage(p, &Message{
+		SessionKey: "feishu:oc_group",
+		Platform:   "feishu",
+		MessageID:  "om_1",
+		UserID:     "ou_user",
+		UserName:   "张三",
+		ChatName:   "售后群",
+		Content:    "hello",
+		ReplyCtx:   "ctx",
+	})
+
+	sent := p.getSent()
+	if len(sent) != 1 || sent[0] != "请先完成飞书授权" {
+		t.Fatalf("sent = %v, want exactly the preflight block message", sent)
+	}
+	if hookCalls.Load() != 0 {
+		t.Fatalf("message.received hook calls = %d, want 0", hookCalls.Load())
+	}
+	if len(agentSession.sentPrompts) != 0 {
+		t.Fatalf("agent prompts = %v, want none", agentSession.sentPrompts)
+	}
+}
 
 func TestHandleMessage_ReceivedHookIncludesMessageContext(t *testing.T) {
 	eventCh := make(chan HookEvent, 1)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2,8 +2,11 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -3352,6 +3355,243 @@ func TestHandleMessage_MultiWorkspacePreservesCCSessionKey(t *testing.T) {
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}
+	}
+}
+
+
+func TestHandleMessage_ReceivedHookIncludesMessageContext(t *testing.T) {
+	eventCh := make(chan HookEvent, 1)
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev HookEvent
+		if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+			t.Errorf("decode hook event: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		eventCh <- ev
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hookSrv.Close()
+
+	p := &stubPlatformEngine{n: "feishu"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangChinese)
+	e.SetHooks(NewHookManager("test", []HookConfig{
+		{Event: string(HookEventMessageReceived), Type: "http", URL: hookSrv.URL, Async: boolPtr(false)},
+	}, "sh", "-c", ""))
+
+	e.handleMessage(p, &Message{
+		SessionKey: "feishu:oc_group:ou_user",
+		Platform:   "feishu",
+		MessageID:  "om_received",
+		ChannelID:  "oc_group",
+		ChannelKey: "feishu:oc_group",
+		UserID:     "ou_user",
+		UserName:   "张三",
+		ChatName:   "售后群",
+		Content:    "/help",
+		ReplyCtx:   "ctx",
+	})
+
+	select {
+	case ev := <-eventCh:
+		if ev.Event != HookEventMessageReceived {
+			t.Fatalf("event = %s, want %s", ev.Event, HookEventMessageReceived)
+		}
+		if ev.SessionKey != "feishu:oc_group:ou_user" || ev.Platform != "feishu" {
+			t.Fatalf("session/platform = %q/%q", ev.SessionKey, ev.Platform)
+		}
+		if got := ev.Extra["message_id"]; got != "om_received" {
+			t.Fatalf("message_id = %#v, want om_received", got)
+		}
+		if got := ev.Extra["channel_id"]; got != "oc_group" {
+			t.Fatalf("channel_id = %#v, want oc_group", got)
+		}
+		if got := ev.Extra["channel_key"]; got != "feishu:oc_group" {
+			t.Fatalf("channel_key = %#v, want feishu:oc_group", got)
+		}
+		if got := ev.Extra["chat_name"]; got != "售后群" {
+			t.Fatalf("chat_name = %#v, want 售后群", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for message.received hook")
+	}
+}
+
+func TestHandleMessage_HookIncludesActiveCCSessionIDAcrossNew(t *testing.T) {
+	var eventsMu sync.Mutex
+	var events []HookEvent
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev HookEvent
+		if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+			t.Errorf("decode hook event: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		eventsMu.Lock()
+		events = append(events, ev)
+		eventsMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hookSrv.Close()
+
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangChinese)
+	e.SetHooks(NewHookManager("test", []HookConfig{
+		{Event: string(HookEventMessageReceived), Type: "http", URL: hookSrv.URL, Async: boolPtr(false)},
+	}, "sh", "-c", ""))
+
+	e.handleMessage(p, &Message{
+		SessionKey: "test:chat:user",
+		Platform:   "test",
+		MessageID:  "m_new",
+		UserID:     "user",
+		UserName:   "张三",
+		Content:    "/new first",
+		ReplyCtx:   "ctx-new",
+	})
+	e.handleMessage(p, &Message{
+		SessionKey: "test:chat:user",
+		Platform:   "test",
+		MessageID:  "m_help",
+		UserID:     "user",
+		UserName:   "张三",
+		Content:    "/help",
+		ReplyCtx:   "ctx-help",
+	})
+
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
+	if len(events) != 2 {
+		t.Fatalf("hook events = %d, want 2: %#v", len(events), events)
+	}
+	if got := events[0].Extra["cc_session_id"]; got != "s1" {
+		t.Fatalf("first cc_session_id = %#v, want s1", got)
+	}
+	if got := events[1].Extra["cc_session_id"]; got != "s2" {
+		t.Fatalf("second cc_session_id = %#v, want s2 after /new", got)
+	}
+}
+
+func TestProcessInteractiveEvents_MessageSentHookIncludesCCSessionID(t *testing.T) {
+	var eventsMu sync.Mutex
+	var events []HookEvent
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev HookEvent
+		if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+			t.Errorf("decode hook event: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		eventsMu.Lock()
+		events = append(events, ev)
+		eventsMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hookSrv.Close()
+
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangChinese)
+	e.SetHooks(NewHookManager("test", []HookConfig{
+		{Event: string(HookEventMessageSent), Type: "http", URL: hookSrv.URL, Async: boolPtr(false)},
+	}, "sh", "-c", ""))
+
+	sessionKey := "test:chat:user"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	session.SetAgentSessionID("agent-session-1", "stub")
+	agentSession := newControllableSession("agent-session-1")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1",
+	}
+	e.interactiveStates[sessionKey] = state
+	agentSession.events <- Event{Type: EventResult, Content: "assistant reply", Done: true}
+
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, "ctx-1")
+
+	eventsMu.Lock()
+	defer eventsMu.Unlock()
+	if len(events) != 1 {
+		t.Fatalf("hook events = %d, want 1: %#v", len(events), events)
+	}
+	if got := events[0].Extra["cc_session_id"]; got != "s1" {
+		t.Fatalf("cc_session_id = %#v, want s1", got)
+	}
+	if got := events[0].Extra["agent_session_id"]; got != "agent-session-1" {
+		t.Fatalf("agent_session_id = %#v, want agent-session-1", got)
+	}
+	if got := events[0].Extra["trigger_message_id"]; got != "m1" {
+		t.Fatalf("trigger_message_id = %#v, want m1", got)
+	}
+}
+
+func TestSessionStartedHookIncludesTriggerMessageContext(t *testing.T) {
+	eventCh := make(chan HookEvent, 1)
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev HookEvent
+		if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+			t.Errorf("decode hook event: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		eventCh <- ev
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hookSrv.Close()
+
+	p := &stubPlatformEngine{n: "feishu"}
+	agent := &resultAgent{session: newResultAgentSession("assistant reply")}
+	e := NewEngine("test", agent, []Platform{p}, "", LangChinese)
+	e.SetHooks(NewHookManager("test", []HookConfig{
+		{Event: string(HookEventSessionStarted), Type: "http", URL: hookSrv.URL, Async: boolPtr(false)},
+	}, "sh", "-c", ""))
+
+	e.handleMessage(p, &Message{
+		SessionKey: "feishu:oc_group:ou_user",
+		Platform:   "feishu",
+		MessageID:  "om_trigger",
+		ChannelID:  "oc_group",
+		UserID:     "ou_user",
+		UserName:   "张三",
+		ChatName:   "售后群",
+		Content:    "帮我看这个售后单",
+		ReplyCtx:   "ctx",
+	})
+
+	select {
+	case ev := <-eventCh:
+		if ev.Event != HookEventSessionStarted {
+			t.Fatalf("event = %s, want %s", ev.Event, HookEventSessionStarted)
+		}
+		if ev.SessionKey != "feishu:oc_group:ou_user" {
+			t.Fatalf("session_key = %q", ev.SessionKey)
+		}
+		if ev.Platform != "feishu" {
+			t.Fatalf("platform = %q", ev.Platform)
+		}
+		if ev.UserID != "ou_user" || ev.UserName != "张三" || ev.Content != "帮我看这个售后单" {
+			t.Fatalf("trigger message context missing: user_id=%q user_name=%q content=%q", ev.UserID, ev.UserName, ev.Content)
+		}
+		if got := ev.Extra["cc_session_id"]; got != "s1" {
+			t.Fatalf("cc_session_id = %#v, want s1", got)
+		}
+		if got := ev.Extra["agent_session_id"]; got != "result-session" {
+			t.Fatalf("agent_session_id = %#v, want result-session", got)
+		}
+		if got := ev.Extra["is_resume"]; got != false {
+			t.Fatalf("is_resume = %#v, want false", got)
+		}
+		if got := ev.Extra["message_id"]; got != "om_trigger" {
+			t.Fatalf("message_id = %#v, want om_trigger", got)
+		}
+		if got := ev.Extra["channel_id"]; got != "oc_group" {
+			t.Fatalf("channel_id = %#v, want oc_group", got)
+		}
+		if got := ev.Extra["chat_name"]; got != "售后群" {
+			t.Fatalf("chat_name = %#v, want 售后群", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for session.started hook")
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -160,6 +160,7 @@ type MsgKey string
 
 const (
 	MsgStarting                  MsgKey = "starting"
+	MsgPreflightBlocked          MsgKey = "preflight_blocked"
 	MsgThinking                  MsgKey = "thinking"
 	MsgTool                      MsgKey = "tool"
 	MsgToolResult                MsgKey = "tool_result"
@@ -378,31 +379,31 @@ const (
 	MsgCronIDLabel               MsgKey = "cron_id_label"
 	MsgCronFailedSuffix          MsgKey = "cron_failed_suffix"
 
-	MsgTimerNotAvailable  MsgKey = "timer_not_available"
-	MsgTimerUsage         MsgKey = "timer_usage"
-	MsgTimerAddUsage      MsgKey = "timer_add_usage"
-	MsgTimerAdded         MsgKey = "timer_added"
-	MsgTimerAddedExec     MsgKey = "timer_added_exec"
-	MsgTimerAddExecUsage  MsgKey = "timer_addexec_usage"
-	MsgTimerEmpty         MsgKey = "timer_empty"
-	MsgTimerListTitle     MsgKey = "timer_list_title"
-	MsgTimerListFooter    MsgKey = "timer_list_footer"
-	MsgTimerDelUsage      MsgKey = "timer_del_usage"
-	MsgTimerMuteUsage     MsgKey = "timer_mute_usage"
-	MsgTimerDeleted       MsgKey = "timer_deleted"
-	MsgTimerNotFound      MsgKey = "timer_not_found"
-	MsgTimerMuted         MsgKey = "timer_muted"
-	MsgTimerUnmuted       MsgKey = "timer_unmuted"
-	MsgTimerCardHint      MsgKey = "timer_card_hint"
-	MsgTimerBtnMute       MsgKey = "timer_btn_mute"
-	MsgTimerBtnUnmute     MsgKey = "timer_btn_unmute"
-	MsgTimerBtnDelete     MsgKey = "timer_btn_delete"
-	MsgTimerIDLabel       MsgKey = "timer_id_label"
-	MsgTimerScheduledLabel MsgKey = "timer_scheduled_label"
-	MsgTimerFailedSuffix  MsgKey = "timer_failed_suffix"
-	MsgCommandsTagAgent          MsgKey = "commands_tag_agent"
-	MsgCommandsTagShell          MsgKey = "commands_tag_shell"
-	MsgUpgradeTimeoutSuffix      MsgKey = "upgrade_timeout_suffix"
+	MsgTimerNotAvailable    MsgKey = "timer_not_available"
+	MsgTimerUsage           MsgKey = "timer_usage"
+	MsgTimerAddUsage        MsgKey = "timer_add_usage"
+	MsgTimerAdded           MsgKey = "timer_added"
+	MsgTimerAddedExec       MsgKey = "timer_added_exec"
+	MsgTimerAddExecUsage    MsgKey = "timer_addexec_usage"
+	MsgTimerEmpty           MsgKey = "timer_empty"
+	MsgTimerListTitle       MsgKey = "timer_list_title"
+	MsgTimerListFooter      MsgKey = "timer_list_footer"
+	MsgTimerDelUsage        MsgKey = "timer_del_usage"
+	MsgTimerMuteUsage       MsgKey = "timer_mute_usage"
+	MsgTimerDeleted         MsgKey = "timer_deleted"
+	MsgTimerNotFound        MsgKey = "timer_not_found"
+	MsgTimerMuted           MsgKey = "timer_muted"
+	MsgTimerUnmuted         MsgKey = "timer_unmuted"
+	MsgTimerCardHint        MsgKey = "timer_card_hint"
+	MsgTimerBtnMute         MsgKey = "timer_btn_mute"
+	MsgTimerBtnUnmute       MsgKey = "timer_btn_unmute"
+	MsgTimerBtnDelete       MsgKey = "timer_btn_delete"
+	MsgTimerIDLabel         MsgKey = "timer_id_label"
+	MsgTimerScheduledLabel  MsgKey = "timer_scheduled_label"
+	MsgTimerFailedSuffix    MsgKey = "timer_failed_suffix"
+	MsgCommandsTagAgent     MsgKey = "commands_tag_agent"
+	MsgCommandsTagShell     MsgKey = "commands_tag_shell"
+	MsgUpgradeTimeoutSuffix MsgKey = "upgrade_timeout_suffix"
 
 	MsgCronScheduleLabel MsgKey = "cron_schedule_label"
 	MsgCronNextRunLabel  MsgKey = "cron_next_run_label"
@@ -655,6 +656,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "⏳ 處理中...",
 		LangJapanese:           "⏳ 処理中...",
 		LangSpanish:            "⏳ Procesando...",
+	},
+	MsgPreflightBlocked: {
+		LangEnglish:            "Request blocked by preflight check. Please contact the administrator.",
+		LangChinese:            "请求未通过使用前检查，请联系管理员。",
+		LangTraditionalChinese: "請求未通過使用前檢查，請聯絡管理員。",
+		LangJapanese:           "事前チェックでリクエストがブロックされました。管理者に連絡してください。",
+		LangSpanish:            "Solicitud bloqueada por la comprobacion previa. Contacta al administrador.",
 	},
 	MsgThinking: {
 		LangEnglish: "💭 %s",

--- a/core/preflight.go
+++ b/core/preflight.go
@@ -1,0 +1,259 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// PreflightEventType enumerates decision-capable gate events.
+type PreflightEventType string
+
+const (
+	PreflightEventMessage PreflightEventType = "message.preflight"
+)
+
+// PreflightDecisionValue is the action returned by a preflight check.
+type PreflightDecisionValue string
+
+const (
+	PreflightContinue PreflightDecisionValue = "continue"
+	PreflightBlock    PreflightDecisionValue = "block"
+	PreflightIgnore   PreflightDecisionValue = "ignore"
+)
+
+const maxPreflightResponseBytes = 64 * 1024
+
+// PreflightCheckConfig is a decision-capable HTTP gate.
+type PreflightCheckConfig struct {
+	Event          string `toml:"event" json:"event,omitempty"` // default: message.preflight
+	Type           string `toml:"type" json:"type"`             // "http"
+	URL            string `toml:"url" json:"url,omitempty"`
+	Timeout        int    `toml:"timeout" json:"timeout,omitempty"`   // seconds; 0 = 5s
+	OnError        string `toml:"on_error" json:"on_error,omitempty"` // block, continue, ignore; default block
+	IncludeContent bool   `toml:"include_content" json:"include_content,omitempty"`
+}
+
+func (c PreflightCheckConfig) eventName() string {
+	if strings.TrimSpace(c.Event) == "" {
+		return string(PreflightEventMessage)
+	}
+	return c.Event
+}
+
+func (c PreflightCheckConfig) timeoutDuration() time.Duration {
+	if c.Timeout > 0 {
+		return time.Duration(c.Timeout) * time.Second
+	}
+	return 5 * time.Second
+}
+
+func (c PreflightCheckConfig) onErrorDecision(err error) PreflightDecision {
+	decision := PreflightBlock
+	switch PreflightDecisionValue(strings.ToLower(strings.TrimSpace(c.OnError))) {
+	case PreflightContinue:
+		decision = PreflightContinue
+	case PreflightIgnore:
+		decision = PreflightIgnore
+	case PreflightBlock, "":
+		decision = PreflightBlock
+	}
+	return PreflightDecision{
+		Decision: decision,
+		Code:     "preflight_error",
+		Reason:   err.Error(),
+	}
+}
+
+// PreflightEvent is the payload sent to preflight checks.
+type PreflightEvent struct {
+	Event      PreflightEventType `json:"event"`
+	Timestamp  time.Time          `json:"timestamp"`
+	Project    string             `json:"project"`
+	SessionKey string             `json:"session_key,omitempty"`
+	Platform   string             `json:"platform,omitempty"`
+	MessageID  string             `json:"message_id,omitempty"`
+	ChannelID  string             `json:"channel_id,omitempty"`
+	UserID     string             `json:"user_id,omitempty"`
+	UserName   string             `json:"user_name,omitempty"`
+	ChatName   string             `json:"chat_name,omitempty"`
+	Content    string             `json:"content,omitempty"`
+	Extra      map[string]any     `json:"extra,omitempty"`
+}
+
+// PreflightDecision is the normalized decision returned by preflight checks.
+type PreflightDecision struct {
+	Decision   PreflightDecisionValue `json:"decision"`
+	Code       string                 `json:"code,omitempty"`
+	Message    string                 `json:"message,omitempty"`
+	Reason     string                 `json:"reason,omitempty"`
+	RetryAfter int                    `json:"retry_after,omitempty"`
+}
+
+type preflightHTTPResponse struct {
+	Decision   string `json:"decision"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	Reason     string `json:"reason"`
+	RetryAfter int    `json:"retry_after"`
+}
+
+// PreflightManager evaluates configured preflight checks.
+type PreflightManager struct {
+	checks  []PreflightCheckConfig
+	project string
+	mu      sync.RWMutex
+	client  *http.Client
+}
+
+// NewPreflightManager creates a manager for decision-capable preflight checks.
+func NewPreflightManager(project string, checks []PreflightCheckConfig) *PreflightManager {
+	valid := make([]PreflightCheckConfig, 0, len(checks))
+	for _, check := range checks {
+		if err := validatePreflightCheckConfig(check); err != nil {
+			slog.Warn("preflight: skipping invalid config", "project", project, "error", err)
+			continue
+		}
+		valid = append(valid, check)
+	}
+	return &PreflightManager{
+		checks:  valid,
+		project: project,
+		client:  &http.Client{},
+	}
+}
+
+func validatePreflightCheckConfig(c PreflightCheckConfig) error {
+	if c.eventName() == "" {
+		return fmt.Errorf("event is required")
+	}
+	if HookHandlerType(c.Type) != HookHandlerHTTP {
+		return fmt.Errorf("unknown preflight type %q (must be http)", c.Type)
+	}
+	if c.URL == "" {
+		return fmt.Errorf("url is required for type=http")
+	}
+	if !strings.HasPrefix(c.URL, "http://") && !strings.HasPrefix(c.URL, "https://") {
+		return fmt.Errorf("url must start with http:// or https://")
+	}
+	switch PreflightDecisionValue(strings.ToLower(strings.TrimSpace(c.OnError))) {
+	case "", PreflightBlock, PreflightContinue, PreflightIgnore:
+		return nil
+	default:
+		return fmt.Errorf("on_error must be block, continue, or ignore")
+	}
+}
+
+// Evaluate runs matching preflight checks. All checks must continue; the first
+// block or ignore decision stops evaluation.
+func (pm *PreflightManager) Evaluate(event PreflightEvent) PreflightDecision {
+	if pm == nil {
+		return PreflightDecision{Decision: PreflightContinue}
+	}
+	if event.Event == "" {
+		event.Event = PreflightEventMessage
+	}
+	event.Project = pm.project
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+
+	pm.mu.RLock()
+	checks := pm.checks
+	pm.mu.RUnlock()
+
+	for i := range checks {
+		check := &checks[i]
+		if !matchEvent(check.eventName(), string(event.Event)) {
+			continue
+		}
+		payload := event
+		if !check.IncludeContent {
+			payload.Content = ""
+		}
+		decision, err := pm.executeHTTP(check, payload)
+		if err != nil {
+			decision = check.onErrorDecision(err)
+		}
+		if decision.Decision == "" {
+			decision.Decision = PreflightContinue
+		}
+		switch decision.Decision {
+		case PreflightContinue:
+			continue
+		case PreflightBlock, PreflightIgnore:
+			return decision
+		default:
+			err := fmt.Errorf("invalid decision %q", decision.Decision)
+			return check.onErrorDecision(err)
+		}
+	}
+	return PreflightDecision{Decision: PreflightContinue}
+}
+
+func (pm *PreflightManager) executeHTTP(check *PreflightCheckConfig, event PreflightEvent) (PreflightDecision, error) {
+	body, err := json.Marshal(event)
+	if err != nil {
+		return PreflightDecision{}, fmt.Errorf("marshal event: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), check.timeoutDuration())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, check.URL, bytes.NewReader(body))
+	if err != nil {
+		return PreflightDecision{}, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "CC-Connect-Preflight/1.0")
+	req.Header.Set("X-Preflight-Event", string(event.Event))
+
+	resp, err := pm.client.Do(req)
+	if err != nil {
+		return PreflightDecision{}, fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return PreflightDecision{}, fmt.Errorf("http status %d", resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxPreflightResponseBytes))
+	if err != nil {
+		return PreflightDecision{}, fmt.Errorf("read response: %w", err)
+	}
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return PreflightDecision{Decision: PreflightContinue}, nil
+	}
+
+	var parsed preflightHTTPResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return PreflightDecision{}, fmt.Errorf("parse response: %w", err)
+	}
+	return PreflightDecision{
+		Decision:   PreflightDecisionValue(strings.ToLower(strings.TrimSpace(parsed.Decision))),
+		Code:       parsed.Code,
+		Message:    parsed.Message,
+		Reason:     parsed.Reason,
+		RetryAfter: parsed.RetryAfter,
+	}, nil
+}
+
+// Checks returns the current preflight check configurations.
+func (pm *PreflightManager) Checks() []PreflightCheckConfig {
+	if pm == nil {
+		return nil
+	}
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	out := make([]PreflightCheckConfig, len(pm.checks))
+	copy(out, pm.checks)
+	return out
+}

--- a/core/preflight_test.go
+++ b/core/preflight_test.go
@@ -1,0 +1,108 @@
+package core
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPreflightManager_HTTPBlockDecisionOmitsContentByDefault(t *testing.T) {
+	var got PreflightEvent
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"decision":"block","code":"missing_scope","message":"请先完成授权"}`))
+	}))
+	defer srv.Close()
+
+	pm := NewPreflightManager("proj", []PreflightCheckConfig{
+		{
+			Event:   string(PreflightEventMessage),
+			Type:    "http",
+			URL:     srv.URL,
+			Timeout: 1,
+		},
+	})
+
+	decision := pm.Evaluate(PreflightEvent{
+		Event:      PreflightEventMessage,
+		SessionKey: "feishu:oc_group",
+		Platform:   "feishu",
+		MessageID:  "om_1",
+		ChannelID:  "oc_group",
+		UserID:     "ou_user",
+		UserName:   "张三",
+		ChatName:   "售后群",
+		Content:    "sensitive prompt",
+	})
+
+	if decision.Decision != PreflightBlock {
+		t.Fatalf("decision = %q, want %q", decision.Decision, PreflightBlock)
+	}
+	if decision.Code != "missing_scope" || decision.Message != "请先完成授权" {
+		t.Fatalf("unexpected decision payload: %+v", decision)
+	}
+	if got.Project != "proj" {
+		t.Fatalf("project = %q, want proj", got.Project)
+	}
+	if got.Event != PreflightEventMessage || got.MessageID != "om_1" || got.ChannelID != "oc_group" {
+		t.Fatalf("unexpected request event: %+v", got)
+	}
+	if got.Content != "" {
+		t.Fatalf("content should be omitted by default, got %q", got.Content)
+	}
+}
+
+func TestPreflightManager_HTTPIncludeContentAndErrorPolicy(t *testing.T) {
+	t.Run("include content", func(t *testing.T) {
+		var got PreflightEvent
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"decision":"continue"}`))
+		}))
+		defer srv.Close()
+
+		pm := NewPreflightManager("proj", []PreflightCheckConfig{
+			{Type: "http", URL: srv.URL, IncludeContent: true},
+		})
+
+		decision := pm.Evaluate(PreflightEvent{Event: PreflightEventMessage, Content: "hello"})
+		if decision.Decision != PreflightContinue {
+			t.Fatalf("decision = %q, want %q", decision.Decision, PreflightContinue)
+		}
+		if got.Content != "hello" {
+			t.Fatalf("content = %q, want hello", got.Content)
+		}
+	})
+
+	t.Run("defaults to block on error", func(t *testing.T) {
+		pm := NewPreflightManager("proj", []PreflightCheckConfig{
+			{Type: "http", URL: "http://127.0.0.1:1", Timeout: 1},
+		})
+
+		decision := pm.Evaluate(PreflightEvent{Event: PreflightEventMessage})
+		if decision.Decision != PreflightBlock {
+			t.Fatalf("decision = %q, want %q", decision.Decision, PreflightBlock)
+		}
+		if !strings.Contains(decision.Code, "preflight") {
+			t.Fatalf("expected preflight error code, got %+v", decision)
+		}
+	})
+
+	t.Run("can continue on error", func(t *testing.T) {
+		pm := NewPreflightManager("proj", []PreflightCheckConfig{
+			{Type: "http", URL: "http://127.0.0.1:1", Timeout: 1, OnError: string(PreflightContinue)},
+		})
+
+		decision := pm.Evaluate(PreflightEvent{Event: PreflightEventMessage})
+		if decision.Decision != PreflightContinue {
+			t.Fatalf("decision = %q, want %q", decision.Decision, PreflightContinue)
+		}
+	})
+}

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -107,9 +107,10 @@ func init() {
 }
 
 type replyContext struct {
-	messageID  string
-	chatID     string
-	sessionKey string
+	messageID       string
+	chatID          string
+	sessionKey      string
+	nativeThreadMsg bool
 }
 
 type Platform struct {
@@ -130,6 +131,8 @@ type Platform struct {
 	respondToAtEveryoneAndHere bool
 	shareSessionInChannel      bool
 	threadIsolation            bool
+	threadIsolationBlackGroup  string
+	threadIsolationWhiteGroup  string
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
 	noReplyToTrigger bool
 	resolveMentions  bool
@@ -168,6 +171,7 @@ type Platform struct {
 	// without requiring another @bot mention. Value is the last-seen time so
 	// stale entries can be expired by a future TTL sweep if needed.
 	activeThreadSessions sync.Map // sessionKey -> time.Time
+	nativeThreadSessions sync.Map // sessionKey -> time.Time
 
 	richCardImageMu         sync.Mutex
 	richCardImageResolved   map[string]string
@@ -310,6 +314,8 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
+	threadIsolationBlackGroup, _ := opts["thread_isolation_black_group"].(string)
+	threadIsolationWhiteGroup, _ := opts["thread_isolation_white_group"].(string)
 	resolveMentionsOpt, _ := opts["resolve_mentions"].(bool)
 	noReplyToTrigger := false
 	if v, ok := opts["reply_to_trigger"].(bool); ok && !v {
@@ -401,6 +407,8 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
 		shareSessionInChannel:      shareSessionInChannel,
 		threadIsolation:            threadIsolation,
+		threadIsolationBlackGroup:  threadIsolationBlackGroup,
+		threadIsolationWhiteGroup:  threadIsolationWhiteGroup,
 		resolveMentions:            resolveMentionsOpt,
 		noReplyToTrigger:           noReplyToTrigger,
 		client:                     lark.NewClient(appID, appSecret, clientOpts...),
@@ -1340,7 +1348,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 			// through without re-mentioning the bot. Plain text and rich-text
 			// posts still require an explicit @bot to avoid pulling in
 			// unrelated chatter.
-			case p.threadIsolation && isAttachmentMsgType(msgType) && p.isActiveThreadSession(sessionKey):
+			case isAttachmentMsgType(msgType) && p.isActiveThreadSession(sessionKey):
 				slog.Debug(p.tag()+": passing attachment through active thread without mention",
 					"chat_id", chatID, "session_key", sessionKey, "msg_type", msgType, "message_id", messageID)
 			default:
@@ -1378,7 +1386,8 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	mentions := msg.Mentions
 	parentID := stringValue(msg.ParentId)
 
-	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey, nativeThreadMsg: isNativeThreadMessage(msg)}
+	p.markNativeThreadSession(sessionKey, rctx.nativeThreadMsg)
 	slog.Debug(p.tag()+": routed inbound message",
 		"message_id", messageID,
 		"session_key", sessionKey,
@@ -1387,7 +1396,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 
 	// Mark this thread as bot-engaged so subsequent attachment-only messages
 	// in the same thread can pass through without re-mentioning the bot.
-	p.markThreadSessionActive(sessionKey)
+	p.markThreadSessionActiveForContext(sessionKey, rctx.nativeThreadMsg)
 
 	// Dispatch message handling asynchronously so the SDK event loop is not
 	// blocked by IO-heavy operations (image/audio download, handler HTTP calls).
@@ -1429,7 +1438,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	// inside a thread — the thread already provides conversational context, and
 	// long quoted prefixes can drown out the user's actual text (issue #764).
 	var quoted quotedMessage
-	if parentID != "" && !(p.threadIsolation && isThreadSessionKey(sessionKey)) {
+	if parentID != "" && !p.shouldUseThreadContext(sessionKey) {
 		quoted = p.fetchQuotedMessage(ctx, parentID)
 	}
 
@@ -3305,9 +3314,16 @@ func isAttachmentMsgType(msgType string) bool {
 
 // markThreadSessionActive records that a thread sessionKey has been engaged
 // by an @bot message, enabling attachment-only follow-ups inside the thread.
-// No-op when thread isolation is disabled or sessionKey is not a thread key.
+// No-op when this chat should not use thread isolation or sessionKey is not a thread key.
 func (p *Platform) markThreadSessionActive(sessionKey string) {
-	if !p.threadIsolation || !isThreadSessionKey(sessionKey) {
+	p.markThreadSessionActiveForContext(sessionKey, false)
+}
+
+func (p *Platform) markThreadSessionActiveForContext(sessionKey string, nativeThreadMsg bool) {
+	if !nativeThreadMsg && !p.shouldTreatSessionAsThread(sessionKey) {
+		return
+	}
+	if !isThreadSessionKey(sessionKey) {
 		return
 	}
 	p.activeThreadSessions.Store(sessionKey, time.Now())
@@ -3316,10 +3332,25 @@ func (p *Platform) markThreadSessionActive(sessionKey string) {
 // isActiveThreadSession reports whether the given sessionKey corresponds to a
 // thread that has previously been engaged by an @bot message.
 func (p *Platform) isActiveThreadSession(sessionKey string) bool {
-	if !p.threadIsolation || !isThreadSessionKey(sessionKey) {
+	if !p.shouldTreatSessionAsThread(sessionKey) && !p.isNativeThreadSession(sessionKey) {
 		return false
 	}
 	_, ok := p.activeThreadSessions.Load(sessionKey)
+	return ok
+}
+
+func (p *Platform) markNativeThreadSession(sessionKey string, nativeThreadMsg bool) {
+	if !nativeThreadMsg || !isThreadSessionKey(sessionKey) {
+		return
+	}
+	p.nativeThreadSessions.Store(sessionKey, time.Now())
+}
+
+func (p *Platform) isNativeThreadSession(sessionKey string) bool {
+	if !isThreadSessionKey(sessionKey) {
+		return false
+	}
+	_, ok := p.nativeThreadSessions.Load(sessionKey)
 	return ok
 }
 
@@ -3348,7 +3379,7 @@ func stripMentions(text string, mentions []*larkim.MentionEvent, botOpenID strin
 // TODO: Session-key derivation and reply-thread behavior are split across multiple code paths here.
 // Should revisit thread/root handling without changing thread_isolation=false behavior.
 func (p *Platform) makeSessionKey(msg *larkim.EventMessage, chatID, userID string) string {
-	if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
+	if msg != nil && stringValue(msg.ChatType) == "group" && p.shouldUseThreadIsolationForMessage(msg, chatID) {
 		rootID := stringValue(msg.RootId)
 		if rootID == "" {
 			rootID = stringValue(msg.MessageId)
@@ -3361,6 +3392,49 @@ func (p *Platform) makeSessionKey(msg *larkim.EventMessage, chatID, userID strin
 		return fmt.Sprintf("%s:%s", p.tag(), chatID)
 	}
 	return fmt.Sprintf("%s:%s:%s", p.tag(), chatID, userID)
+}
+
+func (p *Platform) shouldUseThreadIsolationForMessage(msg *larkim.EventMessage, chatID string) bool {
+	if msg == nil || stringValue(msg.ChatType) != "group" {
+		return false
+	}
+	if isNativeThreadMessage(msg) {
+		return true
+	}
+	return p.shouldUseThreadIsolationForChat(chatID)
+}
+
+func isNativeThreadMessage(msg *larkim.EventMessage) bool {
+	if msg == nil {
+		return false
+	}
+	return stringValue(msg.ThreadId) != "" || stringValue(msg.RootId) != ""
+}
+
+func (p *Platform) shouldUseThreadIsolationForChat(chatID string) bool {
+	if p.threadIsolation {
+		return !configuredListContains(p.threadIsolationBlackGroup, chatID)
+	}
+	return configuredListContains(p.threadIsolationWhiteGroup, chatID)
+}
+
+func configuredListContains(list, value string) bool {
+	return strings.TrimSpace(list) != "" && core.AllowList(list, value)
+}
+
+func (p *Platform) shouldTreatSessionAsThread(sessionKey string) bool {
+	if !isThreadSessionKey(sessionKey) {
+		return false
+	}
+	chatID, ok := chatIDFromSessionKey(sessionKey)
+	if !ok {
+		return false
+	}
+	return p.shouldUseThreadIsolationForChat(chatID)
+}
+
+func (p *Platform) shouldUseThreadContext(sessionKey string) bool {
+	return p.isNativeThreadSession(sessionKey) || p.shouldTreatSessionAsThread(sessionKey)
 }
 
 func (p *Platform) sessionKeyFromCardAction(chatID, userID string, value map[string]any) string {
@@ -3379,7 +3453,7 @@ func (p *Platform) shouldReplyInThread(rc replyContext) bool {
 	if rc.messageID == "" {
 		return false
 	}
-	return p.threadIsolation && isThreadSessionKey(rc.sessionKey)
+	return rc.nativeThreadMsg || p.shouldUseThreadContext(rc.sessionKey)
 }
 
 // shouldUseThreadOrReplyAPI is true when we should call Im.Message.Reply (optionally with ReplyInThread).
@@ -3657,6 +3731,14 @@ func isThreadSessionKey(sessionKey string) bool {
 	}
 	_, ok := parseThreadRootID(parts[2])
 	return ok
+}
+
+func chatIDFromSessionKey(sessionKey string) (string, bool) {
+	parts := strings.SplitN(sessionKey, ":", 3)
+	if len(parts) < 2 || parts[1] == "" {
+		return "", false
+	}
+	return parts[1], true
 }
 
 // feishuPreviewHandle stores the message ID for an editable preview message.

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -1060,6 +1060,22 @@ func TestMarkAndIsActiveThreadSession(t *testing.T) {
 			t.Fatal("thread should be active after mark")
 		}
 	})
+
+	t.Run("thread isolation enabled but blacklisted group is no-op", func(t *testing.T) {
+		p := &Platform{threadIsolation: true, threadIsolationBlackGroup: "oc_chat"}
+		p.markThreadSessionActive(threadKey)
+		if p.isActiveThreadSession(threadKey) {
+			t.Fatal("blacklisted group should not record active thread session")
+		}
+	})
+
+	t.Run("thread isolation disabled but whitelisted group records thread", func(t *testing.T) {
+		p := &Platform{threadIsolationWhiteGroup: "oc_chat"}
+		p.markThreadSessionActive(threadKey)
+		if !p.isActiveThreadSession(threadKey) {
+			t.Fatal("whitelisted group should record active thread session")
+		}
+	})
 }
 
 // TestOnMessageThreadIsolationAdmitsAttachmentWithoutMention covers the fix

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -648,6 +648,26 @@ func TestNewFeishu_InvalidCustomDomain(t *testing.T) {
 	}
 }
 
+func TestNewFeishu_ThreadIsolationGroupLists(t *testing.T) {
+	pAny, err := New(map[string]any{
+		"app_id":                       "cli_xxx",
+		"app_secret":                   "secret",
+		"thread_isolation_black_group": "oc_plain_a, oc_plain_b",
+		"thread_isolation_white_group": "oc_thread_a, oc_thread_b",
+		"enable_feishu_card":           false,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	p := pAny.(*Platform)
+	if p.threadIsolationBlackGroup != "oc_plain_a, oc_plain_b" {
+		t.Fatalf("threadIsolationBlackGroup = %q", p.threadIsolationBlackGroup)
+	}
+	if p.threadIsolationWhiteGroup != "oc_thread_a, oc_thread_b" {
+		t.Fatalf("threadIsolationWhiteGroup = %q", p.threadIsolationWhiteGroup)
+	}
+}
+
 func TestLark_SessionKeyPrefix(t *testing.T) {
 	p, err := newPlatform("lark", lark.LarkBaseUrl, map[string]any{
 		"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true,
@@ -827,6 +847,122 @@ func TestLark_GroupReplyAllWithThreadIsolationUsesRootSessionKeyWithoutMention(t
 	}
 }
 
+func TestFeishu_MakeSessionKeyThreadIsolationGroupLists(t *testing.T) {
+	chatID := "oc_chat"
+	userID := "ou_user"
+	messageID := "om_msg"
+	rootID := "om_root"
+	threadID := "omt_thread"
+
+	tests := []struct {
+		name string
+		p    *Platform
+		msg  *larkim.EventMessage
+		want string
+	}{
+		{
+			name: "global on regular group uses thread key",
+			p:    &Platform{platformName: "feishu", threadIsolation: true},
+			msg: &larkim.EventMessage{
+				MessageId: &messageID,
+				ChatType:  stringPtr("group"),
+			},
+			want: "feishu:oc_chat:root:om_msg",
+		},
+		{
+			name: "global on blacklist regular group uses direct key",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           true,
+				threadIsolationBlackGroup: "oc_chat",
+				threadIsolationWhiteGroup: "oc_other",
+				shareSessionInChannel:     false,
+			},
+			msg: &larkim.EventMessage{
+				MessageId: &messageID,
+				ChatType:  stringPtr("group"),
+			},
+			want: "feishu:oc_chat:ou_user",
+		},
+		{
+			name: "global off whitelist regular group uses thread key",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           false,
+				threadIsolationWhiteGroup: "oc_chat",
+			},
+			msg: &larkim.EventMessage{
+				MessageId: &messageID,
+				ChatType:  stringPtr("group"),
+			},
+			want: "feishu:oc_chat:root:om_msg",
+		},
+		{
+			name: "global off non-whitelist regular group uses direct key",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           false,
+				threadIsolationWhiteGroup: "oc_other",
+			},
+			msg: &larkim.EventMessage{
+				MessageId: &messageID,
+				ChatType:  stringPtr("group"),
+			},
+			want: "feishu:oc_chat:ou_user",
+		},
+		{
+			name: "native topic uses thread key even when global off and not whitelisted",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           false,
+				threadIsolationWhiteGroup: "oc_other",
+			},
+			msg: &larkim.EventMessage{
+				MessageId: &messageID,
+				RootId:    &rootID,
+				ThreadId:  &threadID,
+				ChatType:  stringPtr("group"),
+			},
+			want: "feishu:oc_chat:root:om_root",
+		},
+		{
+			name: "private chat unaffected by whitelist",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           false,
+				threadIsolationWhiteGroup: "oc_chat",
+			},
+			msg: &larkim.EventMessage{
+				MessageId: &messageID,
+				ChatType:  stringPtr("p2p"),
+			},
+			want: "feishu:oc_chat:ou_user",
+		},
+		{
+			name: "blacklisted regular group still honors shared channel session",
+			p: &Platform{
+				platformName:              "feishu",
+				threadIsolation:           true,
+				threadIsolationBlackGroup: "oc_chat",
+				shareSessionInChannel:     true,
+			},
+			msg: &larkim.EventMessage{
+				MessageId: &messageID,
+				ChatType:  stringPtr("group"),
+			},
+			want: "feishu:oc_chat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.p.makeSessionKey(tt.msg, chatID, userID); got != tt.want {
+				t.Fatalf("makeSessionKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -838,6 +974,40 @@ func TestBuildReplyMessageReqBody_SetsReplyInThreadFlag(t *testing.T) {
 			name:          "thread isolation enabled",
 			platform:      &Platform{threadIsolation: true},
 			replyCtx:      replyContext{messageID: "om_reply", sessionKey: "feishu:oc_chat:root:om_root"},
+			wantThreading: true,
+		},
+		{
+			name: "thread isolation enabled but blacklisted chat remains non-threaded",
+			platform: &Platform{
+				threadIsolation:           true,
+				threadIsolationBlackGroup: "oc_chat",
+			},
+			replyCtx:      replyContext{messageID: "om_reply", chatID: "oc_chat", sessionKey: "feishu:oc_chat:root:om_root"},
+			wantThreading: false,
+		},
+		{
+			name: "thread isolation disabled but whitelisted chat replies in thread",
+			platform: &Platform{
+				threadIsolation:           false,
+				threadIsolationWhiteGroup: "oc_chat",
+			},
+			replyCtx:      replyContext{messageID: "om_reply", chatID: "oc_chat", sessionKey: "feishu:oc_chat:root:om_root"},
+			wantThreading: true,
+		},
+		{
+			name:          "native topic replies in thread even when global isolation is off",
+			platform:      &Platform{threadIsolation: false},
+			replyCtx:      replyContext{messageID: "om_reply", chatID: "oc_chat", sessionKey: "feishu:oc_chat:root:om_root", nativeThreadMsg: true},
+			wantThreading: true,
+		},
+		{
+			name: "previously seen native topic replies in thread after context reconstruction",
+			platform: func() *Platform {
+				p := &Platform{threadIsolation: false}
+				p.markNativeThreadSession("feishu:oc_chat:root:om_root", true)
+				return p
+			}(),
+			replyCtx:      replyContext{messageID: "om_root", chatID: "oc_chat", sessionKey: "feishu:oc_chat:root:om_root"},
 			wantThreading: true,
 		},
 		{


### PR DESCRIPTION
## Summary

Add per-group controls for Feishu `thread_isolation` so deployments can opt specific regular groups in or out without changing private-chat behavior. Native Feishu topic messages are always kept in topic-thread reply mode, even when global `thread_isolation` is disabled.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

### Automated tests added in this PR

- `TestNewFeishu_ThreadIsolationGroupLists` in `platform/feishu/platform_test.go` — verifies the new Feishu platform options are parsed into the platform.
- `TestFeishu_MakeSessionKeyThreadIsolationGroupLists` in `platform/feishu/platform_test.go` — verifies global-on blacklist, global-off whitelist, native topic, private chat, and shared-channel session-key behavior.
- `TestBuildReplyMessageReqBody_SetsReplyInThreadFlag` in `platform/feishu/platform_test.go` — extended to verify blacklist/whitelist/native-topic reply-thread decisions.
- `TestMarkAndIsActiveThreadSession` in `platform/feishu/feishu_test.go` — extended to verify active thread tracking honors blacklist/whitelist behavior.

Commands run locally:

```bash
GOTOOLCHAIN=auto /opt/homebrew/bin/go test ./platform/feishu -run 'TestNewFeishu_ThreadIsolationGroupLists|TestFeishu_MakeSessionKeyThreadIsolationGroupLists|TestBuildReplyMessageReqBody_SetsReplyInThreadFlag|TestMarkAndIsActiveThreadSession' -v
GOTOOLCHAIN=auto /opt/homebrew/bin/go test ./platform/feishu
```

Both commands passed.

`GOTOOLCHAIN=auto /opt/homebrew/bin/go test ./...` was also run. It failed on unrelated local/environment-sensitive tests outside this change:

- `core`: `TestCUJ_A3_ImageReachesAgent` and `TestCUJ_A5_FileReachesAgent` failed during `TempDir RemoveAll cleanup: directory not empty`.
- `daemon`: `TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable` failed with `Status().Running = false, want true`.

All Feishu platform tests passed in that full-suite run.

### For bug fixes only — regression test

- Regression test name: N/A — this is a new feature.
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

- [x] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

Feishu platform users can now configure:

- `thread_isolation_black_group`: when `thread_isolation = true`, listed group chat IDs keep normal non-topic replies.
- `thread_isolation_white_group`: when `thread_isolation = false`, listed group chat IDs use topic-thread replies.

Native Feishu topic messages continue to reply in the topic thread regardless of the global `thread_isolation` setting. Private chat behavior is unchanged.

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied where applicable to this scoped Feishu platform change
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (if any new user-facing text)
- [x] No secrets / credentials in source

## Related

- Issue:
- Related PR:
