### PR TITLE
fix(codex): time out blocked app-server writes

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -1595,13 +1595,24 @@ func (s *appServerSession) requestWithTimeout(method string, params any, out any
 		"params":  params,
 	}
 
-	if err := s.writeJSON(payload); err != nil {
+	deadline := time.Now().Add(timeout)
+	if err := s.writeJSONWithTimeout(method, payload, timeout); err != nil {
 		s.pendingMu.Lock()
 		delete(s.pending, id)
 		s.pendingMu.Unlock()
 		return err
 	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		s.pendingMu.Lock()
+		delete(s.pending, id)
+		s.pendingMu.Unlock()
+		return fmt.Errorf("%s timed out", method)
+	}
 
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	ctxDone := s.contextDone()
 	select {
 	case resp := <-ch:
 		if resp.Error != nil {
@@ -1613,14 +1624,71 @@ func (s *appServerSession) requestWithTimeout(method string, params any, out any
 			}
 		}
 		return nil
-	case <-s.ctx.Done():
-		return s.ctx.Err()
-	case <-time.After(timeout):
+	case <-ctxDone:
+		return s.contextErr()
+	case <-timer.C:
 		s.pendingMu.Lock()
 		delete(s.pending, id)
 		s.pendingMu.Unlock()
 		return fmt.Errorf("%s timed out", method)
 	}
+}
+
+func (s *appServerSession) writeJSONWithTimeout(method string, v any, timeout time.Duration) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- s.writeJSON(v)
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	ctxDone := s.contextDone()
+	select {
+	case err := <-done:
+		return err
+	case <-ctxDone:
+		return s.contextErr()
+	case <-timer.C:
+		err := fmt.Errorf("%s write timed out", method)
+		slog.Warn("codex app-server write timed out, closing session", "method", method, "timeout", timeout)
+		s.abortTransport()
+		return err
+	}
+}
+
+func (s *appServerSession) contextDone() <-chan struct{} {
+	if s.ctx == nil {
+		return nil
+	}
+	return s.ctx.Done()
+}
+
+func (s *appServerSession) contextErr() error {
+	if s.ctx == nil {
+		return context.Canceled
+	}
+	if err := s.ctx.Err(); err != nil {
+		return err
+	}
+	return context.Canceled
+}
+
+func (s *appServerSession) abortTransport() {
+	s.alive.Store(false)
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	s.procMu.Lock()
+	if s.stdin != nil {
+		_ = s.stdin.Close()
+		s.stdin = nil
+	}
+	if s.cmd != nil && s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+	}
+	s.procMu.Unlock()
 }
 
 func (s *appServerSession) notify(method string, params any) error {

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -131,6 +131,52 @@ func TestAppServerSession_HandleThreadTokenUsageUpdatedCachesContextUsage(t *tes
 	}
 }
 
+func TestAppServerSession_RequestTimeoutIncludesBlockedStdinWrite(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stdin := newBlockingWriteCloser()
+	defer func() { _ = stdin.Close() }()
+
+	s := &appServerSession{
+		ctx:     ctx,
+		cancel:  cancel,
+		events:  make(chan core.Event),
+		stdin:   stdin,
+		pending: make(map[int64]chan rpcResponseEnvelope),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		var out map[string]any
+		done <- s.requestWithTimeout("turn/start", map[string]any{
+			"input": strings.Repeat("x", 1024),
+		}, &out, 25*time.Millisecond)
+	}()
+
+	select {
+	case <-stdin.started:
+	case <-time.After(time.Second):
+		t.Fatal("request did not attempt to write to stdin")
+	}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("requestWithTimeout returned nil, want write timeout")
+		}
+		if !strings.Contains(err.Error(), "turn/start") || !strings.Contains(err.Error(), "write timed out") {
+			t.Fatalf("error = %q, want turn/start write timeout", err.Error())
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("requestWithTimeout did not return while stdin write was blocked")
+	}
+
+	if !stdin.Closed() {
+		t.Fatal("blocked stdin was not closed after timeout")
+	}
+}
+
 func TestMapAppServerRateLimits_PrefersMultiBucketView(t *testing.T) {
 	report := mapAppServerRateLimits(appServerRateLimitsResponse{
 		RateLimits: appServerRateLimitSnapshot{
@@ -324,6 +370,50 @@ func (w *lockedWriteCloser) String() string {
 }
 
 var _ io.WriteCloser = (*lockedWriteCloser)(nil)
+
+type blockingWriteCloser struct {
+	started   chan struct{}
+	closed    chan struct{}
+	closeOnce sync.Once
+
+	mu       sync.Mutex
+	isClosed bool
+}
+
+func newBlockingWriteCloser() *blockingWriteCloser {
+	return &blockingWriteCloser{
+		started: make(chan struct{}),
+		closed:  make(chan struct{}),
+	}
+}
+
+func (w *blockingWriteCloser) Write([]byte) (int, error) {
+	select {
+	case <-w.started:
+	default:
+		close(w.started)
+	}
+	<-w.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (w *blockingWriteCloser) Close() error {
+	w.closeOnce.Do(func() {
+		w.mu.Lock()
+		w.isClosed = true
+		w.mu.Unlock()
+		close(w.closed)
+	})
+	return nil
+}
+
+func (w *blockingWriteCloser) Closed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.isClosed
+}
+
+var _ io.WriteCloser = (*blockingWriteCloser)(nil)
 
 func serverRequestProbe(t *testing.T, idJSON, method string, params any) map[string]json.RawMessage {
 	t.Helper()


### PR DESCRIPTION
## Summary
- include Codex app-server stdin writes in requestWithTimeout instead of only timing out after a write succeeds
- abort the app-server transport when a write blocks past the request timeout so engine can surface the send error instead of waiting for the outer idle timeout
- add a regression test for a blocked stdin write during turn/start

## Tests
- go test ./agent/codex -count=1
- go test ./agent/codex ./core
- go test -tags no_web ./cmd/cc-connect ./agent/codex ./core (cmd/cc-connect and agent/codex passed; core hit the existing macOS TempDir cleanup race in CUJ image/file tests)
- go test -tags no_web ./core -run TestCUJ_A5_FileReachesAgent -count=1
