### PR TITLE
fix(core): resume stream preview after permission prompt resolves

### DIFF
--- a/core/cuj_test.go
+++ b/core/cuj_test.go
@@ -2172,10 +2172,6 @@ func (env *cujEnv) streamingPlat() *cujStreamingPlatform {
 // Tests use this to drive multi-event turns such as
 // "text → permission request → (test resolves) → text → result"
 // which a single nextEventOverride cannot express.
-type nextSessionEventsHook struct {
-	events  []Event
-	delayMs int
-}
 
 func (a *cujAgent) setNextSessionEvents(events []Event, delayMs int) {
 	a.mu.Lock()

--- a/core/cuj_test.go
+++ b/core/cuj_test.go
@@ -58,6 +58,14 @@ type cujAgent struct {
 	// allows recovery-path CUJs to assert that the user can retry.
 	failStartCount int
 	failStartErr   error
+
+	// nextSessionEvents, when non-nil, is consumed by the next StartSession
+	// call: the new session's event sequence is initialized to this slice.
+	// Used by tests that need to drive a multi-event turn (text chunks +
+	// permission request + result) from a single Send call. See
+	// setNextSessionEvents on cujAgent.
+	nextSessionEvents    []Event
+	nextSessionDelayMs   int
 }
 
 func (a *cujAgent) Name() string { return "cuj" }
@@ -76,6 +84,10 @@ func (a *cujAgent) StartSession(_ context.Context, _ string) (AgentSession, erro
 	a.nextID++
 	s := newCUJAgentSession()
 	a.sessions = append(a.sessions, s)
+	s.pendingEvents = a.nextSessionEvents
+	s.pendingDelayMs = a.nextSessionDelayMs
+	a.nextSessionEvents = nil
+	a.nextSessionDelayMs = 0
 	return s, nil
 }
 
@@ -102,6 +114,15 @@ type cujAgentSession struct {
 	// then return to normal replies. Use this to simulate tool failures,
 	// per-turn agent errors, etc.
 	nextEventOverride *Event
+
+	// pendingEvents, when non-nil, is the sequence of events emitted by
+	// Send's goroutine on the NEXT Send. Consumed atomically with the
+	// goroutine read, so callers (typically cujAgent.StartSession) can
+	// pre-set this once and have the engine process the whole sequence
+	// (e.g. text → permission request → text → result) from a single
+	// Send. pendingDelayMs is the gap between consecutive events.
+	pendingEvents  []Event
+	pendingDelayMs int
 
 	// observed
 	sentPrompts []string
@@ -131,9 +152,28 @@ func (s *cujAgentSession) Send(prompt string, _ []ImageAttachment, _ []FileAttac
 	reply := s.reply
 	delay := s.delayMs
 	override := s.nextEventOverride
+	pending := s.pendingEvents
+	pendingDelay := s.pendingDelayMs
 	s.nextEventOverride = nil
+	s.pendingEvents = nil
+	s.pendingDelayMs = 0
 	s.mu.Unlock()
 	go func() {
+		if pending != nil {
+			for _, ev := range pending {
+				if pendingDelay > 0 {
+					time.Sleep(time.Duration(pendingDelay) * time.Millisecond)
+				}
+				select {
+				case s.events <- ev:
+				case <-time.After(5 * time.Second):
+					// Engine gone or stalled; stop emitting to avoid
+					// hanging the test goroutine.
+					return
+				}
+			}
+			return
+		}
 		if delay > 0 {
 			time.Sleep(time.Duration(delay) * time.Millisecond)
 		}
@@ -2006,6 +2046,287 @@ func TestCUJ_H2_TwoPlatformsConcurrentNoBleed(t *testing.T) {
 	}
 	if len(pB.getSent()) == 0 {
 		t.Fatal("platB received no replies")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Streaming-aware platform + agent extension for CUJ tests that need to
+// exercise the streamPreview (sp) code path.
+//
+// Default cujEnv uses stubPlatformEngine, which only implements plain Send
+// and Reply. That platform does NOT support MessageUpdater, so the engine
+// skips sp entirely (sp.canPreview() returns false). For CUJs that need to
+// observe streaming behavior — e.g. the "streaming resumes after a
+// permission prompt" fix — we use cujStreamingPlatform, which implements
+// MessageUpdater + PreviewStarter and tracks preview activity separately
+// from regular Sends.
+// ---------------------------------------------------------------------------
+
+type cujStreamingUpdate struct {
+	Handle  any
+	Content string
+}
+
+type cujStreamingPlatform struct {
+	stubPlatformEngine
+	mu             sync.Mutex
+	previewOpens   []string
+	previewUpdates []cujStreamingUpdate
+	nextHandle     int
+}
+
+func (p *cujStreamingPlatform) SendPreviewStart(_ context.Context, _ any, content string) (any, error) {
+	p.mu.Lock()
+	p.nextHandle++
+	handle := fmt.Sprintf("preview-%d", p.nextHandle)
+	p.previewOpens = append(p.previewOpens, content)
+	p.mu.Unlock()
+	return handle, nil
+}
+
+func (p *cujStreamingPlatform) UpdateMessage(_ context.Context, handle any, content string) error {
+	p.mu.Lock()
+	p.previewUpdates = append(p.previewUpdates, cujStreamingUpdate{Handle: handle, Content: content})
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *cujStreamingPlatform) getPreviewOpens() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.previewOpens))
+	copy(out, p.previewOpens)
+	return out
+}
+
+func (p *cujStreamingPlatform) getPreviewUpdates() []cujStreamingUpdate {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]cujStreamingUpdate, len(p.previewUpdates))
+	copy(out, p.previewUpdates)
+	return out
+}
+
+func newCUJStreamingEnv(t *testing.T) *cujEnv {
+	t.Helper()
+	dir := t.TempDir()
+	plat := &cujStreamingPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
+	agent := &cujAgent{}
+	storePath := dir + "/sessions.json"
+	e := NewEngine("test", agent, []Platform{plat}, storePath, LangEnglish)
+	// env.plat is typed *stubPlatformEngine so that userSends (which
+	// calls plat(env.plat) to bridge into a Platform interface) works.
+	// We point it at the same embedded instance the engine holds, so
+	// every observer (env.plat, env.streamingPlat()) sees one platform.
+	return &cujEnv{
+		t:       t,
+		engine:  e,
+		plat:    &plat.stubPlatformEngine,
+		agent:   agent,
+		tempDir: dir,
+	}
+}
+
+// sendStreaming drives the engine through ReceiveMessage using the full
+// cujStreamingPlatform (not just its embedded stubPlatformEngine). This is
+// essential for CUJs that need the engine to see MessageUpdater and
+// PreviewStarter capabilities — passing only the embedded stubPlatformEngine
+// would hide those methods from the engine's type assertions and the
+// streamPreview path would never activate.
+func (env *cujEnv) sendStreaming(userID, content string) string {
+	env.t.Helper()
+	sessionKey := "test:" + userID
+	msg := &Message{
+		SessionKey: sessionKey,
+		Platform:   "test",
+		MessageID:  "msg-" + content[:min(8, len(content))],
+		UserID:     userID,
+		UserName:   userID,
+		Content:    content,
+		ReplyCtx:   "ctx-" + userID,
+	}
+	env.engine.ReceiveMessage(env.streamingPlat(), msg)
+	return sessionKey
+}
+
+// streamingEnvPlat returns the underlying cujStreamingPlatform for a CUJ
+// test that used newCUJStreamingEnv. Engine holds a []Platform slice, so we
+// reach it back through the engine to expose the typed pointer for typed
+// assertions (getPreviewOpens, getPreviewUpdates).
+func (env *cujEnv) streamingPlat() *cujStreamingPlatform {
+	env.t.Helper()
+	for _, p := range env.engine.platforms {
+		if sp, ok := p.(*cujStreamingPlatform); ok {
+			return sp
+		}
+	}
+	env.t.Fatal("no cujStreamingPlatform registered with engine")
+	return nil
+}
+
+// nextSessionEvents lets a test preload the event sequence that the next
+// StartSession's session.Send goroutine will emit. Once consumed, it is
+// reset to nil so subsequent calls fall back to the default
+// "emit a single EventResult" behavior.
+//
+// Tests use this to drive multi-event turns such as
+// "text → permission request → (test resolves) → text → result"
+// which a single nextEventOverride cannot express.
+type nextSessionEventsHook struct {
+	events  []Event
+	delayMs int
+}
+
+func (a *cujAgent) setNextSessionEvents(events []Event, delayMs int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.nextSessionEvents = append([]Event(nil), events...)
+	a.nextSessionDelayMs = delayMs
+}
+
+// ===========================================================================
+// CUJ-STREAM-1 · After a permission prompt (AskUserQuestion or regular
+// permission request) the agent emits more text in the same turn. The user
+// MUST see that text streamed into a NEW card via the platform's
+// MessageUpdater, not buffered until end of turn and sent as a single bulk
+// message. The bug shipped because the engine's EventPermissionRequest
+// handler called sp.freeze() + sp.detachPreview() which permanently
+// degraded the stream preview; sp.unfreeze() (added in
+// fix/stream-preview-after-permission) restores the preview so a fresh
+// card can open.
+//
+// SPOTLIGHT: 🟢 This is the regression CUJ for the user-reported
+// "no streaming after the agent asks me a question" bug. It exercises the
+// full engine + streamPreview path: text → permission request → freeze+detach
+// → user resolves → sp.unfreeze → new card opens → more text streams →
+// result finalizes the new card. The pre-fix code would have produced
+// exactly one preview open and one giant bulk Send of the post-resolution
+// text at end of turn.
+//
+// ≥3 user actions: (1) send prompt, (2) receive question card + tap an
+// option, (3) observe the agent's continuation stream.
+// ===========================================================================
+
+func TestCUJ_STREAM1_StreamingResumesAfterPermissionPrompt(t *testing.T) {
+	env := newCUJStreamingEnv(t)
+	key := "test:jack"
+
+	// Pre-load the agent's event sequence for the upcoming turn:
+	//   1. text chunk the agent produced before needing to ask
+	//   2. permission request (AskUserQuestion) — engine freezes sp here
+	//   3. (engine is now blocked on pending.Resolved — test resolves)
+	//   4. text chunk the agent produced AFTER the user answered
+	//   5. final EventResult — engine finalizes the new card
+	preText := "pre-permission intro one two three four five six"
+	postText := "post-resolution reply one two three four five six"
+	finalText := "final summary text"
+	env.agent.setNextSessionEvents([]Event{
+		{Type: EventText, Content: preText},
+		{
+			Type:      EventPermissionRequest,
+			ToolName:  "AskUserQuestion",
+			RequestID: "req-cuj-stream-1",
+			Questions: []UserQuestion{
+				{
+					Question: "Continue?",
+					Options: []UserQuestionOption{
+						{Label: "Yes", Description: "keep going"},
+						{Label: "No", Description: "stop"},
+					},
+				},
+			},
+		},
+		{Type: EventText, Content: postText},
+		{Type: EventResult, Content: finalText, Done: true},
+	}, 0)
+
+	plat := env.streamingPlat()
+
+	// === User action 1: send a prompt. ===
+	env.sendStreaming("jack", "please do a thing")
+
+	// The engine reads the pre-permission text and the permission request
+	// before blocking on Resolved. We must observe:
+	//   - one preview open containing the pre-permission text
+	//   - the question card (regular Send, not preview)
+	env.waitFor("pre-permission preview open", 2*time.Second, func() bool {
+		opens := plat.getPreviewOpens()
+		return len(opens) >= 1 && strings.Contains(opens[0], "pre-permission")
+	})
+	env.waitFor("question card sent", 2*time.Second, func() bool {
+		for _, m := range plat.getSent() {
+			if strings.Contains(m, "Continue?") {
+				return true
+			}
+		}
+		return false
+	})
+
+	// Sanity: at this point, the engine is blocked on <-pending.Resolved.
+	// No post-resolution content should be visible yet on either channel.
+	if opens := plat.getPreviewOpens(); len(opens) != 1 {
+		t.Fatalf("pre-resolution preview opens = %d, want exactly 1 (the pre-permission card); got %#v", len(opens), opens)
+	}
+	for _, m := range plat.getSent() {
+		if strings.Contains(m, postText) {
+			t.Fatalf("post-resolution text leaked into getSent() before the user resolved the prompt: %v", plat.getSent())
+		}
+	}
+
+	// === User action 2: answer the question with "Yes" (option 1). ===
+	env.engine.handlePendingPermission(plat, &Message{
+		SessionKey: key,
+		UserID:     "jack",
+		Content:    "1",
+		ReplyCtx:   "ctx-jack",
+	}, "1", key)
+
+	// === User action 3: observe the post-resolution continuation stream. ===
+	// The FIX: a SECOND preview open must appear, containing only the
+	// post-resolution text. The pre-permission preview handle was detached
+	// during freeze(), so this is necessarily a fresh card.
+	env.waitFor("post-resolution preview open", 2*time.Second, func() bool {
+		opens := plat.getPreviewOpens()
+		return len(opens) >= 2 && strings.Contains(opens[1], "post-resolution")
+	})
+
+	// The post-resolution card must NOT contain the pre-permission text —
+	// that would mean we wrote new content on top of the frozen card
+	// instead of opening a new one.
+	opens := plat.getPreviewOpens()
+	if strings.Contains(opens[1], "pre-permission") {
+		t.Fatalf("post-resolution card contains pre-permission text: %q (regression: new card not a clean slate)", opens[1])
+	}
+
+	// Wait for the engine to finalize the turn. sp.finish() must succeed
+	// (preview was active) so the post-resolution text is delivered via
+	// UpdateMessage, NOT via a separate plain Send of fullResponse.
+	env.waitFor("turn finalizes", 2*time.Second, func() bool {
+		// Either the final update landed, or — if the bug regressed —
+		// the bulk send of the post-resolution text landed in getSent().
+		if env.sentContains(finalText) {
+			return true
+		}
+		for _, u := range plat.getPreviewUpdates() {
+			if strings.Contains(u.Content, finalText) {
+				return true
+			}
+		}
+		return false
+	})
+
+	// CRITICAL ASSERTION (the regression check):
+	// The post-resolution text must NOT have been bulk-sent via plain Send.
+	// On the fixed path, sp.finish() returns true (preview was active and
+	// UpdateMessage succeeded), so the engine skips the
+	// sendChunksWithStatusFooter fallback. On the buggy path, sp was
+	// permanently degraded, sp.finish() returned false, and the engine
+	// bulk-sent fullResponse via plain Send — which is the user-visible
+	// "I see everything at the end of the turn" symptom.
+	for _, m := range plat.getSent() {
+		if strings.Contains(m, postText) {
+			t.Fatalf("post-resolution text was bulk-sent via plain Send (regression: streaming broken after permission prompt). getSent=%#v", plat.getSent())
+		}
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -5192,6 +5192,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			<-pending.Resolved
 			slog.Info("permission resolved", "request_id", event.RequestID)
 
+			// The stream preview was frozen+detached when this permission
+			// request was emitted, so any subsequent EventText in this turn
+			// would otherwise be buffered until EventResult and sent as a
+			// single bulk message (regression fixed by
+			// fix/stream-preview-after-permission). unfreeze() restores the
+			// preview so the post-resolution output opens a fresh streaming
+			// card and continues to update incrementally.
+			sp.unfreeze()
+
 			// Restart idle timer after permission is resolved
 			if idleTimer != nil {
 				idleTimer.Reset(e.eventIdleTimeout)

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -320,6 +320,50 @@ func (sp *streamPreview) freeze() {
 	sp.degraded = true
 }
 
+// unfreeze reverses a prior freeze()+detachPreview() so the preview resumes
+// streaming. After unfreeze, the next appendText() will create a NEW preview
+// message (the prior handle was detached), giving the post-interruption
+// output its own card instead of being buffered until end of turn.
+//
+// Required pairing: callers must invoke unfreeze() only after a matching
+// freeze()+detachPreview() (or an equivalent sequence that left previewMsgID
+// nil and degraded true). It is intended to be called once the user-visible
+// interruption (permission prompt, AskUserQuestion) has been resolved and
+// the agent is producing new output in the same turn.
+//
+// Why a new card: the old preview message is committed by freeze() as a
+// permanent in-place update of the pre-interruption text. Keeping a handle
+// to it would overwrite that committed message with the post-interruption
+// content. Detach+re-attach on the next appendText is what the surrounding
+// code (engine EventPermissionRequest handler) does today, and unfreeze()
+// simply restores the streamPreview's degraded state so that flow can run
+// again on the same turn.
+func (sp *streamPreview) unfreeze() {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+
+	sp.cancelTimerLocked()
+
+	// Allow appendText() to bypass the interval/MinDeltaChars throttle on
+	// the first chunk after the interruption: lastSentAt is the only gate
+	// the throttle checks, and zeroing it makes that gate fall through.
+	sp.lastSentAt = time.Time{}
+
+	// Start a fresh accumulation window so the new card is a clean slate.
+	// Without this, the dedupe in flushLocked (text == sp.lastSentText)
+	// would suppress the first send of the new card, and the new card
+	// would appear empty until enough chars accumulated to force a flush.
+	sp.fullText = ""
+	sp.lastSentText = ""
+	sp.lastSentViaUpdate = false
+	sp.pendingStatus = ""
+
+	// previewMsgID stays nil (set by the matching detachPreview()). The
+	// next flushLocked() will see nil and call SendPreviewStart, opening
+	// a fresh card.
+	sp.degraded = false
+}
+
 // discard removes the preview message when possible and disables further
 // preview updates. Call this when the caller intends to send a separate
 // non-preview message (for example after tool use or on terminal errors).

--- a/core/streaming_test.go
+++ b/core/streaming_test.go
@@ -460,3 +460,152 @@ func TestStreamPreview_AppliesTransform(t *testing.T) {
 		t.Fatalf("final message = %q, want transformed final preview", got)
 	}
 }
+
+// TestStreamPreview_UnfreezeResumesStreaming is the unit-level regression
+// test for the bug where sp.freeze()+detachPreview() (emitted by the
+// EventPermissionRequest handler in core/engine.go) permanently degraded
+// the stream preview. After a permission prompt or AskUserQuestion was
+// resolved, all subsequent text in the same turn was buffered until
+// EventResult and sent as a single bulk message, instead of opening a new
+// streaming card.
+//
+// The fix is sp.unfreeze() in core/streaming.go, called by the engine
+// after <-pending.Resolved returns. This test exercises the unfreeze
+// contract in isolation: after freeze+detach, the preview is inactive;
+// after unfreeze, canPreview() returns true and the next appendText opens
+// a NEW preview card containing only the post-unfreeze text.
+func TestStreamPreview_UnfreezeResumesStreaming(t *testing.T) {
+	mp := &mockUpdaterPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    50,
+		MinDeltaChars: 5,
+		MaxChars:      500,
+	}
+
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+
+	// 1. Stream the pre-interruption segment so a preview handle is live.
+	sp.appendText("pre-interruption text")
+	time.Sleep(100 * time.Millisecond)
+	preMsgs := mp.getMessages()
+	if len(preMsgs) == 0 || !strings.HasPrefix(preMsgs[len(preMsgs)-1], "start:") {
+		t.Fatalf("expected an initial preview start, got %#v", preMsgs)
+	}
+
+	// 2. Simulate the engine's EventPermissionRequest path: freeze the
+	// preview (committing the pre-interruption text in place) and detach
+	// the handle so the next flush opens a new card.
+	sp.freeze()
+	sp.detachPreview()
+
+	// 3. While frozen, canPreview() must report false. Otherwise the
+	// engine's text-throttling branch would attempt updates on a degraded
+	// preview and silently drop them.
+	if sp.canPreview() {
+		t.Fatal("canPreview() = true while frozen, want false (regression: degraded not set)")
+	}
+
+	// 4. Simulate the user resolving the permission/question and the
+	// engine calling sp.unfreeze() to restore the preview.
+	sp.unfreeze()
+
+	if !sp.canPreview() {
+		t.Fatal("canPreview() = false after unfreeze, want true (unfreeze did not clear degraded)")
+	}
+
+	// 5. Stream the post-interruption text. We must observe a NEW preview
+	// start (proving the post-resolution text gets its own card, not
+	// overwriting the frozen pre-interruption card) and the text must be
+	// the post-unfreeze content only.
+	sp.appendText("post-resolution chunk one two three")
+	time.Sleep(100 * time.Millisecond)
+
+	postMsgs := mp.getMessages()
+	if len(postMsgs) <= len(preMsgs) {
+		t.Fatalf("expected new messages after unfreeze, preMsgs=%d postMsgs=%d (%#v)",
+			len(preMsgs), len(postMsgs), postMsgs)
+	}
+
+	// Find the post-unfreeze start: the first message that contains
+	// "post-resolution" and was issued after the pre-interruption messages.
+	var postStart string
+	for _, m := range postMsgs[len(preMsgs):] {
+		if strings.Contains(m, "post-resolution") {
+			postStart = m
+			break
+		}
+	}
+	if postStart == "" {
+		t.Fatalf("no post-unfreeze message contains 'post-resolution'; messages = %#v", postMsgs)
+	}
+	if !strings.HasPrefix(postStart, "start:") {
+		t.Fatalf("post-unfreeze first message = %q, want a new 'start:' (regression: post text was buffered, not streamed into a fresh card)", postStart)
+	}
+	if strings.Contains(postStart, "pre-interruption") {
+		t.Fatalf("post-unfreeze card contains pre-interruption text: %q (regression: new card is not a clean slate)", postStart)
+	}
+}
+
+// TestStreamPreview_UnfreezeBypassesThrottleOnFirstChunk locks down the
+// behavior that the first chunk emitted after unfreeze is NOT throttled by
+// the MinDeltaChars / IntervalMs gates. Without resetting lastSentAt, a
+// user who answers an AskUserQuestion would see a 1.5s blank interval
+// before the agent's next text appeared — defeating the point of resuming
+// streaming. The reset is the entire reason lastSentAt is zeroed in
+// unfreeze().
+func TestStreamPreview_UnfreezeBypassesThrottleOnFirstChunk(t *testing.T) {
+	mp := &mockUpdaterPlatform{}
+	cfg := StreamPreviewCfg{
+		Enabled:       true,
+		IntervalMs:    5000, // huge interval so any non-zero lastSentAt would suppress the first chunk
+		MinDeltaChars: 100,  // huge delta so any non-zero lastSentAt would suppress the first chunk
+		MaxChars:      500,
+	}
+
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+	sp.appendText("pre text")
+	time.Sleep(100 * time.Millisecond)
+
+	sp.freeze()
+	sp.detachPreview()
+	sp.unfreeze()
+
+	// Tiny chunk that would NEVER pass the throttle on a non-zero
+	// lastSentAt. The fact that it gets through proves lastSentAt was
+	// reset to zero by unfreeze().
+	sp.appendText("hi")
+	time.Sleep(50 * time.Millisecond)
+
+	msgs := mp.getMessages()
+	// Find the most recent message and assert it contains "hi".
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m, "hi") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("first post-unfreeze chunk 'hi' was throttled and never sent; messages = %#v", msgs)
+	}
+}
+
+// TestStreamPreview_UnfreezeIdempotent verifies that calling unfreeze() on
+// an already-active (non-degraded) preview does not crash. The engine may
+// in principle never call unfreeze() in that state, but the test guards
+// against future callers that might.
+func TestStreamPreview_UnfreezeIdempotent(t *testing.T) {
+	mp := &mockUpdaterPlatform{}
+	cfg := DefaultStreamPreviewCfg()
+
+	sp := newStreamPreview(cfg, mp, "ctx", context.Background(), nil)
+	sp.unfreeze() // no-op on a never-frozen preview; must not panic
+
+	if sp.degraded {
+		t.Fatal("unfreeze on a non-degraded preview marked it degraded")
+	}
+	if !sp.canPreview() {
+		t.Fatal("canPreview() = false after no-op unfreeze, want true")
+	}
+}


### PR DESCRIPTION
## Why

After the agent emits a permission request or AskUserQuestion and the
user resolves it, subsequent text in the same turn loses streaming
updates on Feishu / Telegram / Discord / WeCom / QQ / QQ Bot / LINE /
Weibo (all platforms without `StreamingCardPlatform`) — it arrives as
a single bulk message at end of turn instead of streaming
character-by-character into a new card. Affects every agent that emits
`EventPermissionRequest` (Claude Code, Codex, ...).

## Summary

- `core/streaming.go`: add `streamPreview.unfreeze()` — reverses the
  permanent degradation caused by `sp.freeze() + sp.detachPreview()`
  so a fresh streaming card can open on the same turn.
- `core/engine.go`: call `sp.unfreeze()` after `<-pending.Resolved` in
  the `EventPermissionRequest` handler. One line of behavioral change.
- `core/streaming_test.go`: 3 unit tests covering the unfreeze contract
  (resume, throttle bypass on first chunk, idempotency).
- `core/cuj_test.go`: new `TestCUJ_STREAM1_StreamingResumesAfterPermissionPrompt`
  end-to-end CUJ — verifies the user sees a new streaming card with
  the post-resolution text instead of a bulk Send at end of turn.
  Verified to FAIL on pre-fix code (post-text leaked into `getSent()`
  via `sendChunksWithStatusFooter`).
- New test infrastructure: `cujStreamingPlatform` (Platform stub with
  MessageUpdater + PreviewStarter) and `cujAgent.setNextSessionEvents`
  for driving multi-event turns. Isolated from existing CUJs.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 -p 1 ./core/ -run 'TestStreamPreview|TestCUJ_STREAM'`
  — 18 passed (3 new `unfreeze` unit tests + 14 existing stream
  preview tests + 1 new CUJ).
- [x] `go test -race ./agent/pi/ ./config/ ./platform/feishu/` — full
  packages affected by the user-visible scenario.
- [x] `go test -count=1 -p 1 ./core/` — full core package, only the
  pre-existing `TestCUJ_A3`/`TestCUJ_A5` macOS TempDir cleanup flakes
  appear (unrelated to this PR; verified to also flake on `main`).
- [x] Manual: verified on Feishu + pi agent (`rpc = true`, quiet mode,
  thinking hidden). After answering an AskUserQuestion, the
  continuation text now streams into a new card as expected.