### PR TITLE
支持 message.received 钩子消费消息以跳过默认 Agent

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -586,12 +586,13 @@ func main() {
 			coreHooks := make([]core.HookConfig, len(cfg.Hooks))
 			for i, h := range cfg.Hooks {
 				coreHooks[i] = core.HookConfig{
-					Event:   h.Event,
-					Type:    h.Type,
-					Command: h.Command,
-					URL:     h.URL,
-					Timeout: h.Timeout,
-					Async:   h.Async,
+					Event:           h.Event,
+					Type:            h.Type,
+					Command:         h.Command,
+					URL:             h.URL,
+					Timeout:         h.Timeout,
+					Async:           h.Async,
+					ConsumeResponse: h.ConsumeResponse,
 				}
 			}
 			engine.SetHooks(core.NewHookManager(proj.Name, coreHooks, shell, shellFlag, shellProfile))

--- a/config.example.toml
+++ b/config.example.toml
@@ -410,6 +410,18 @@ level = "info" # debug, info, warn, error
 # async = true                    # default true; set false to block until done
 # timeout = 10                    # seconds; default 10s for command, 5s for http
 #
+# A message.received HTTP hook can consume a message when it returns
+# {"handled": true}. This skips the default Agent for that message.
+# message.received HTTP 钩子可以返回 {"handled": true} 来消费消息，
+# 消费后该消息不会再进入默认 Agent。
+#
+# [[hooks]]
+# event = "message.received"
+# type = "http"
+# url = "http://127.0.0.1:8090/inbound"
+# consume_response = true          # default false; only applies to HTTP hooks
+# timeout = 5
+#
 # [[hooks]]
 # event = "error"
 # type = "http"

--- a/config/config.go
+++ b/config/config.go
@@ -167,12 +167,13 @@ type BridgeConfig struct {
 
 // HookConfig is a single event hook rule.
 type HookConfig struct {
-	Event   string `toml:"event"`             // event name or "*"
-	Type    string `toml:"type"`              // "command" or "http"
-	Command string `toml:"command,omitempty"` // shell command (type=command)
-	URL     string `toml:"url,omitempty"`     // HTTP endpoint (type=http)
-	Timeout int    `toml:"timeout,omitempty"` // seconds; 0 = default
-	Async   *bool  `toml:"async,omitempty"`   // nil = true (async by default)
+	Event           string `toml:"event"`                      // event name or "*"
+	Type            string `toml:"type"`                       // "command" or "http"
+	Command         string `toml:"command,omitempty"`          // shell command (type=command)
+	URL             string `toml:"url,omitempty"`              // HTTP endpoint (type=http)
+	Timeout         int    `toml:"timeout,omitempty"`          // seconds; 0 = default
+	Async           *bool  `toml:"async,omitempty"`            // nil = true (async by default)
+	ConsumeResponse bool   `toml:"consume_response,omitempty"` // HTTP hook may handle and consume the event response
 }
 
 // ManagementConfig controls the HTTP Management API for external tools.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -662,6 +662,28 @@ func TestLoad_MissingEnvPlaceholderBecomesEmptyString(t *testing.T) {
 	}
 }
 
+func TestLoad_HookConsumeResponse(t *testing.T) {
+	configPath := writeConfigFixture(t, baseConfigTOML+`
+
+[[hooks]]
+event = "message.received"
+type = "http"
+url = "http://127.0.0.1:8090/hook"
+consume_response = true
+`)
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if len(cfg.Hooks) != 1 {
+		t.Fatalf("hooks len = %d, want 1", len(cfg.Hooks))
+	}
+	if !cfg.Hooks[0].ConsumeResponse {
+		t.Fatal("consume_response was not loaded")
+	}
+}
+
 func TestListProjects(t *testing.T) {
 	writeTestConfig(t, baseConfigTOML)
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -2688,14 +2688,21 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		)
 	}
 
-	e.hooks.Emit(HookEvent{
+	if decision := e.hooks.EmitConsumable(HookEvent{
 		Event:      HookEventMessageReceived,
 		SessionKey: msg.SessionKey,
 		Platform:   msg.Platform,
 		UserID:     msg.UserID,
 		UserName:   msg.UserName,
 		Content:    msg.Content,
-	})
+	}); decision.Handled {
+		slog.Info("message handled by hook",
+			"platform", msg.Platform, "msg_id", msg.MessageID,
+			"session", msg.SessionKey, "user", msg.UserName,
+			"reason", decision.Reason,
+		)
+		return
+	}
 
 	// Voice message: transcribe to text first
 	if msg.Audio != nil {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1100,10 +1102,10 @@ func TestProcessInteractiveEvents_NonTerminalResultContinuesTurn(t *testing.T) {
 	session := e.sessions.GetOrCreateActive(sessionKey)
 	agentSession := newControllableSession("s1")
 	state := &interactiveState{
-		agentSession:                  agentSession,
-		platform:                      p,
-		replyCtx:                      "ctx-1",
-		currentTurnUserMessageTimeMs:  100,
+		agentSession:                   agentSession,
+		platform:                       p,
+		replyCtx:                       "ctx-1",
+		currentTurnUserMessageTimeMs:   100,
 		lastCompletedUserMessageTimeMs: 0,
 	}
 	e.interactiveStates[sessionKey] = state
@@ -14972,8 +14974,8 @@ func TestIsAllowResponse_WithMultipleMentions(t *testing.T) {
 func TestIsAllowResponse_NotInsideOtherWord(t *testing.T) {
 	cases := []string{
 		"禁止允许这种",
-		"不允许这样",   // "不允许" has its own deny entry, but as part of "不允许这样" the user clearly is denying / negating, never allowing.
-		"我不太允许这件事", // long sentence, no token equals "允许"
+		"不允许这样",                            // "不允许" has its own deny entry, but as part of "不允许这样" the user clearly is denying / negating, never allowing.
+		"我不太允许这件事",                         // long sentence, no token equals "允许"
 		"please don't allowall the things", // FieldsFunc keeps "allowall" intact, but it is the approveAll single-token form, not allow.
 		"hello world",
 		"",
@@ -15001,7 +15003,7 @@ func TestIsDenyResponse_WithMention(t *testing.T) {
 	}
 
 	negatives := []string{
-		"拒绝症患者",       // embedded — must not match
+		"拒绝症患者",        // embedded — must not match
 		"我们都不应该 hello", // unrelated
 	}
 	for _, s := range negatives {
@@ -15331,5 +15333,84 @@ func TestAgentSystemPrompt_DocumentsAudioVideoFlags(t *testing.T) {
 	// doesn't silently downgrade --audio/--video to --file.
 	if !strings.Contains(prompt, "Do NOT downgrade") {
 		t.Error("AgentSystemPrompt missing the 'Do NOT downgrade' anti-regression line")
+	}
+}
+
+func TestHandleMessage_MessageReceivedConsumableHookHandledSkipsDefaultProcessing(t *testing.T) {
+	var hookCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hookCalls.Add(1)
+		_, _ = w.Write([]byte(`{"handled":true,"reason":"workbench"}`))
+	}))
+	defer srv.Close()
+
+	startCh := make(chan struct{}, 1)
+	agent := &controllableAgent{
+		startSessionFn: func(context.Context, string) (AgentSession, error) {
+			startCh <- struct{}{}
+			return newResultAgentSession("agent reply"), nil
+		},
+	}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetBannedWords([]string{"blocked"})
+	e.SetHooks(NewHookManager("test", []HookConfig{
+		{Event: "message.received", Type: "http", URL: srv.URL, ConsumeResponse: true},
+	}, "sh", "-c", ""))
+
+	e.handleMessage(p, &Message{
+		SessionKey: "test:u1",
+		Platform:   "test",
+		UserID:     "u1",
+		UserName:   "user",
+		Content:    "blocked",
+		ReplyCtx:   "ctx",
+	})
+
+	if hookCalls.Load() != 1 {
+		t.Fatalf("hook calls = %d, want 1", hookCalls.Load())
+	}
+	if got := p.getSent(); len(got) != 0 {
+		t.Fatalf("sent replies = %#v, want none after handled hook", got)
+	}
+	select {
+	case <-startCh:
+		t.Fatal("agent started even though message.received hook handled the message")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestHandleMessage_MessageReceivedConsumableHookUnhandledContinuesDefaultProcessing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"handled":false}`))
+	}))
+	defer srv.Close()
+
+	startCh := make(chan struct{}, 1)
+	agent := &controllableAgent{
+		startSessionFn: func(context.Context, string) (AgentSession, error) {
+			startCh <- struct{}{}
+			return newResultAgentSession("agent reply"), nil
+		},
+	}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetHooks(NewHookManager("test", []HookConfig{
+		{Event: "message.received", Type: "http", URL: srv.URL, ConsumeResponse: true},
+	}, "sh", "-c", ""))
+
+	e.handleMessage(p, &Message{
+		SessionKey: "test:u1",
+		Platform:   "test",
+		UserID:     "u1",
+		UserName:   "user",
+		Content:    "hello",
+		ReplyCtx:   "ctx",
+	})
+
+	select {
+	case <-startCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not start after unhandled hook response")
 	}
 }

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -325,7 +325,7 @@ func (hm *HookManager) executeHTTPDecision(h *HookConfig, event HookEvent, consu
 			"url", h.URL, "reason", parsed.Reason,
 		)
 	}
-	return HookDecision{Handled: parsed.Handled, Reason: parsed.Reason}
+	return HookDecision(parsed)
 }
 
 // eventToEnv converts a HookEvent to environment variables for shell hooks.

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -17,14 +18,14 @@ import (
 type HookEventType string
 
 const (
-	HookEventMessageReceived    HookEventType = "message.received"
-	HookEventMessageSent        HookEventType = "message.sent"
-	HookEventSessionStarted     HookEventType = "session.started"
-	HookEventSessionEnded       HookEventType = "session.ended"
-	HookEventCronTriggered      HookEventType = "cron.triggered"
-	HookEventTimerTriggered     HookEventType = "timer.triggered"
+	HookEventMessageReceived     HookEventType = "message.received"
+	HookEventMessageSent         HookEventType = "message.sent"
+	HookEventSessionStarted      HookEventType = "session.started"
+	HookEventSessionEnded        HookEventType = "session.ended"
+	HookEventCronTriggered       HookEventType = "cron.triggered"
+	HookEventTimerTriggered      HookEventType = "timer.triggered"
 	HookEventPermissionRequested HookEventType = "permission.requested"
-	HookEventError              HookEventType = "error"
+	HookEventError               HookEventType = "error"
 )
 
 // HookHandlerType is the execution strategy for a hook.
@@ -37,12 +38,13 @@ const (
 
 // HookConfig is the user-facing configuration for a single hook rule.
 type HookConfig struct {
-	Event   string `toml:"event" json:"event"`
-	Type    string `toml:"type" json:"type"`       // "command" or "http"
-	Command string `toml:"command" json:"command,omitempty"`
-	URL     string `toml:"url" json:"url,omitempty"`
-	Timeout int    `toml:"timeout" json:"timeout,omitempty"` // seconds; 0 = default (10s cmd, 5s http)
-	Async   *bool  `toml:"async" json:"async,omitempty"`     // nil = true (async by default)
+	Event           string `toml:"event" json:"event"`
+	Type            string `toml:"type" json:"type"` // "command" or "http"
+	Command         string `toml:"command" json:"command,omitempty"`
+	URL             string `toml:"url" json:"url,omitempty"`
+	Timeout         int    `toml:"timeout" json:"timeout,omitempty"` // seconds; 0 = default (10s cmd, 5s http)
+	Async           *bool  `toml:"async" json:"async,omitempty"`     // nil = true (async by default)
+	ConsumeResponse bool   `toml:"consume_response" json:"consume_response,omitempty"`
 }
 
 func (h *HookConfig) isAsync() bool {
@@ -59,6 +61,10 @@ func (h *HookConfig) timeoutDuration() time.Duration {
 	return 10 * time.Second
 }
 
+func (h *HookConfig) consumesResponse() bool {
+	return h.ConsumeResponse && HookHandlerType(h.Type) == HookHandlerHTTP
+}
+
 // HookEvent is the payload delivered to hook handlers.
 type HookEvent struct {
 	Event      HookEventType  `json:"event"`
@@ -73,15 +79,28 @@ type HookEvent struct {
 	Extra      map[string]any `json:"extra,omitempty"`
 }
 
+// HookDecision is returned by consumable hooks that can take over message handling.
+type HookDecision struct {
+	Handled bool
+	Reason  string
+}
+
+type hookHTTPResponse struct {
+	Handled bool   `json:"handled"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+const maxHookResponseBytes = 64 * 1024
+
 // HookManager dispatches lifecycle events to configured hook handlers.
 type HookManager struct {
-	hooks       []HookConfig
-	project     string
-	shell       string // shell binary (e.g. "sh", "/bin/zsh")
-	shellFlag   string // shell flag (e.g. "-c", "-Command")
+	hooks        []HookConfig
+	project      string
+	shell        string // shell binary (e.g. "sh", "/bin/zsh")
+	shellFlag    string // shell flag (e.g. "-c", "-Command")
 	shellProfile string // prepended to every command
-	mu          sync.RWMutex
-	client      *http.Client
+	mu           sync.RWMutex
+	client       *http.Client
 }
 
 // NewHookManager creates a manager for the given project name.
@@ -95,12 +114,12 @@ func NewHookManager(project string, hooks []HookConfig, shell, shellFlag, shellP
 		valid = append(valid, h)
 	}
 	return &HookManager{
-		hooks:       valid,
-		project:     project,
-		shell:       shell,
-		shellFlag:   shellFlag,
+		hooks:        valid,
+		project:      project,
+		shell:        shell,
+		shellFlag:    shellFlag,
 		shellProfile: shellProfile,
-		client:      &http.Client{},
+		client:       &http.Client{},
 	}
 }
 
@@ -153,6 +172,42 @@ func (hm *HookManager) Emit(event HookEvent) {
 	}
 }
 
+// EmitConsumable dispatches matching hooks and returns whether a hook handled the event.
+func (hm *HookManager) EmitConsumable(event HookEvent) HookDecision {
+	if hm == nil {
+		return HookDecision{}
+	}
+	event.Project = hm.project
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+
+	hm.mu.RLock()
+	hooks := hm.hooks
+	hm.mu.RUnlock()
+
+	var decision HookDecision
+	for i := range hooks {
+		h := &hooks[i]
+		if !matchEvent(h.Event, string(event.Event)) {
+			continue
+		}
+		if h.consumesResponse() {
+			next := hm.executeHTTPDecision(h, event, true)
+			if next.Handled && !decision.Handled {
+				decision = next
+			}
+			continue
+		}
+		if h.isAsync() {
+			go hm.execute(h, event)
+		} else {
+			hm.execute(h, event)
+		}
+	}
+	return decision
+}
+
 // matchEvent checks if a hook's event pattern matches the fired event.
 // Supports exact match and wildcard "*".
 func matchEvent(pattern, event string) bool {
@@ -197,10 +252,14 @@ func (hm *HookManager) executeCommand(h *HookConfig, event HookEvent) {
 }
 
 func (hm *HookManager) executeHTTP(h *HookConfig, event HookEvent) {
+	_ = hm.executeHTTPDecision(h, event, false)
+}
+
+func (hm *HookManager) executeHTTPDecision(h *HookConfig, event HookEvent, consumeResponse bool) HookDecision {
 	body, err := json.Marshal(event)
 	if err != nil {
 		slog.Warn("hooks: marshal event failed", "error", err)
-		return
+		return HookDecision{}
 	}
 
 	timeout := h.timeoutDuration()
@@ -210,7 +269,7 @@ func (hm *HookManager) executeHTTP(h *HookConfig, event HookEvent) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.URL, bytes.NewReader(body))
 	if err != nil {
 		slog.Warn("hooks: create request failed", "url", h.URL, "error", err)
-		return
+		return HookDecision{}
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "CC-Connect-Hooks/1.0")
@@ -222,21 +281,51 @@ func (hm *HookManager) executeHTTP(h *HookConfig, event HookEvent) {
 			"project", hm.project, "event", event.Event,
 			"url", h.URL, "error", err,
 		)
-		return
+		return HookDecision{}
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode >= 400 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		slog.Warn("hooks: http response error",
 			"project", hm.project, "event", event.Event,
 			"url", h.URL, "status", resp.StatusCode,
 		)
-		return
+		return HookDecision{}
 	}
 	slog.Debug("hooks: http delivered",
 		"project", hm.project, "event", event.Event,
 		"url", h.URL, "status", resp.StatusCode,
 	)
+	if !consumeResponse {
+		return HookDecision{}
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxHookResponseBytes))
+	if err != nil {
+		slog.Warn("hooks: read http response failed",
+			"project", hm.project, "event", event.Event,
+			"url", h.URL, "error", err,
+		)
+		return HookDecision{}
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return HookDecision{}
+	}
+	var parsed hookHTTPResponse
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		slog.Warn("hooks: parse http response failed",
+			"project", hm.project, "event", event.Event,
+			"url", h.URL, "error", err,
+		)
+		return HookDecision{}
+	}
+	if parsed.Handled {
+		slog.Info("hooks: event handled by http response",
+			"project", hm.project, "event", event.Event,
+			"url", h.URL, "reason", parsed.Reason,
+		)
+	}
+	return HookDecision{Handled: parsed.Handled, Reason: parsed.Reason}
 }
 
 // eventToEnv converts a HookEvent to environment variables for shell hooks.

--- a/core/hooks_test.go
+++ b/core/hooks_test.go
@@ -20,11 +20,11 @@ func boolPtr(v bool) *bool { return &v }
 func TestNewHookManager_ValidatesConfig(t *testing.T) {
 	hooks := []HookConfig{
 		{Event: "message.received", Type: "command", Command: "echo ok"},
-		{Event: "", Type: "command", Command: "echo bad"},         // missing event
-		{Event: "error", Type: "http", URL: ""},                   // missing url
-		{Event: "error", Type: "http", URL: "ftp://bad"},          // bad url scheme
-		{Event: "error", Type: "unknown", Command: "echo"},        // bad type
-		{Event: "error", Type: "command", Command: ""},            // missing command
+		{Event: "", Type: "command", Command: "echo bad"},  // missing event
+		{Event: "error", Type: "http", URL: ""},            // missing url
+		{Event: "error", Type: "http", URL: "ftp://bad"},   // bad url scheme
+		{Event: "error", Type: "unknown", Command: "echo"}, // bad type
+		{Event: "error", Type: "command", Command: ""},     // missing command
 		{Event: "message.sent", Type: "http", URL: "http://ok.com"},
 	}
 	hm := NewHookManager("test", hooks, "sh", "-c", "")
@@ -530,5 +530,182 @@ func TestEmit_TimestampAutoFilled(t *testing.T) {
 
 	if receivedTime.Before(before) {
 		t.Errorf("expected auto-filled timestamp >= %v, got %v", before, receivedTime)
+	}
+}
+
+func TestEmitConsumable_HTTPHookHandledResponse(t *testing.T) {
+	var received atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		received.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"handled":true,"reason":"workbench"}`))
+	}))
+	defer srv.Close()
+
+	hm := NewHookManager("proj", []HookConfig{
+		{Event: "message.received", Type: "http", URL: srv.URL, Async: boolPtr(true), ConsumeResponse: true},
+	}, "sh", "-c", "")
+
+	decision := hm.EmitConsumable(HookEvent{Event: HookEventMessageReceived, Content: "hello"})
+
+	if !decision.Handled {
+		t.Fatalf("expected handled decision")
+	}
+	if decision.Reason != "workbench" {
+		t.Fatalf("reason = %q, want workbench", decision.Reason)
+	}
+	if received.Load() != 1 {
+		t.Fatalf("expected one request, got %d", received.Load())
+	}
+}
+
+func TestEmit_HTTPHookWithConsumeResponseDoesNotReadResponse(t *testing.T) {
+	headersSent := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(headersSent)
+		time.Sleep(time.Second)
+		_, _ = w.Write([]byte(`{"handled":true}`))
+	}))
+	defer srv.Close()
+
+	hm := NewHookManager("proj", []HookConfig{
+		{Event: "message.received", Type: "http", URL: srv.URL, Async: boolPtr(false), ConsumeResponse: true},
+	}, "sh", "-c", "")
+
+	start := time.Now()
+	hm.Emit(HookEvent{Event: HookEventMessageReceived})
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("Emit blocked for %v; default Emit must not read hook responses", elapsed)
+	}
+	select {
+	case <-headersSent:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("server did not receive hook request")
+	}
+}
+
+func TestEmitConsumable_HTTPHookUnhandledResponses(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "handled false",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"handled":false}`))
+			},
+		},
+		{
+			name: "empty body",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "invalid json",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`not-json`))
+			},
+		},
+		{
+			name: "http error",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+		},
+		{
+			name: "http non-2xx",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotModified)
+				_, _ = w.Write([]byte(`{"handled":true}`))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			hm := NewHookManager("proj", []HookConfig{
+				{Event: "message.received", Type: "http", URL: srv.URL, Async: boolPtr(false), ConsumeResponse: true},
+			}, "sh", "-c", "")
+
+			if decision := hm.EmitConsumable(HookEvent{Event: HookEventMessageReceived}); decision.Handled {
+				t.Fatalf("expected unhandled decision, got %#v", decision)
+			}
+		})
+	}
+}
+
+func TestEmitConsumable_HTTPHookFailureFallsBackToUnhandled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		time.Sleep(1500 * time.Millisecond)
+	}))
+	url := srv.URL
+	srv.Close()
+
+	hm := NewHookManager("proj", []HookConfig{
+		{Event: "message.received", Type: "http", URL: url, Async: boolPtr(false), Timeout: 1, ConsumeResponse: true},
+	}, "sh", "-c", "")
+
+	if decision := hm.EmitConsumable(HookEvent{Event: HookEventMessageReceived}); decision.Handled {
+		t.Fatalf("expected unhandled decision on hook failure, got %#v", decision)
+	}
+}
+
+func TestEmitConsumable_HTTPHookTimeoutFallsBackToUnhandled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		time.Sleep(1500 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	hm := NewHookManager("proj", []HookConfig{
+		{Event: "message.received", Type: "http", URL: srv.URL, Async: boolPtr(false), Timeout: 1, ConsumeResponse: true},
+	}, "sh", "-c", "")
+
+	if decision := hm.EmitConsumable(HookEvent{Event: HookEventMessageReceived}); decision.Handled {
+		t.Fatalf("expected unhandled decision on hook timeout, got %#v", decision)
+	}
+}
+
+func TestEmitConsumable_MultipleHooksFiresAllAndHandlesIfAnyHandled(t *testing.T) {
+	var first, second, third atomic.Int32
+	firstSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		first.Add(1)
+		_, _ = w.Write([]byte(`{"handled":false}`))
+	}))
+	defer firstSrv.Close()
+	secondSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		second.Add(1)
+		_, _ = w.Write([]byte(`{"handled":true,"reason":"second"}`))
+	}))
+	defer secondSrv.Close()
+	thirdSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		third.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer thirdSrv.Close()
+
+	hm := NewHookManager("proj", []HookConfig{
+		{Event: "message.received", Type: "http", URL: firstSrv.URL, Async: boolPtr(false), ConsumeResponse: true},
+		{Event: "message.received", Type: "http", URL: secondSrv.URL, Async: boolPtr(false), ConsumeResponse: true},
+		{Event: "message.received", Type: "http", URL: thirdSrv.URL, Async: boolPtr(false)},
+	}, "sh", "-c", "")
+
+	decision := hm.EmitConsumable(HookEvent{Event: HookEventMessageReceived})
+
+	if !decision.Handled || decision.Reason != "second" {
+		t.Fatalf("decision = %#v, want handled by second hook", decision)
+	}
+	if first.Load() != 1 || second.Load() != 1 || third.Load() != 1 {
+		t.Fatalf("hook counts = first:%d second:%d third:%d, want all 1", first.Load(), second.Load(), third.Load())
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill in the sections below.
The reviewer will use the checklist at the bottom to gate merge.
-->

## Summary

<!-- 1-3 sentences explaining WHAT this PR does and WHY. -->

## Type of change

<!-- Mark all that apply: -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

<!-- Explain how you verified the change. Be specific. -->

### Automated tests added in this PR

<!-- List the test functions you added or modified. -->

- `TestX_Y_Z` in `path/to/file_test.go` — what it asserts

### For bug fixes only — regression test

<!-- A bug fix PR MUST include a regression test that:
     (1) fails on the pre-fix code, and
     (2) passes on the fixed code.
     Name it so the bug is searchable later. -->

- Regression test name: `Test...`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

<!-- See AGENTS.md → "Critical User Journeys (CUJ)" and the inventory in
     projects/cc-connect/agents/qa-cursor/release-gate/CUJ-INVENTORY.md.
     Mark which CUJ groups this PR touches: -->

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [x] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [x] `go test ./core/ -run TestCUJ` passes locally.
- [x] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

<!-- Describe what a user will see or do differently after this PR.
     If none, write "None". -->

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [ ] No new hardcoded platform/agent names in `core/`
- [ ] i18n strings have all-language translations (if any new user-facing text)
- [x] No secrets / credentials in source

## Related

<!-- Link to issue, RFC, design doc, prior PR, etc. -->

- Issue:
- Related PR:
