### PR TITLE
fix(kimi): conditionally pass --print so newer Kimi Code CLI works (#1456)

### DIFF
--- a/agent/kimi/kimi.go
+++ b/agent/kimi/kimi.go
@@ -22,10 +22,17 @@ func init() {
 	core.RegisterAgent("kimi", New)
 }
 
-// Agent drives Kimi Code CLI using --print --output-format stream-json.
+// Agent drives Kimi Code CLI in non-interactive mode via `--prompt` (and,
+// when supported by the installed binary, `--print --output-format stream-json`).
+//
+// The legacy kimi-cli requires the `--print` flag for `--output-format` to
+// take effect, while the newer Kimi Code CLI removed `--print` entirely and
+// uses `--prompt` alone to enter non-interactive mode (see #1456). We probe
+// `kimi --help` once at construction to detect which surface is installed and
+// adapt the args we pass at Send() time.
 //
 // Modes:
-//   - "default": standard mode (note: --print implicitly enables --yolo)
+//   - "default": standard mode (non-interactive `--prompt` auto-approves tools)
 //   - "yolo":    auto-approve all tool calls
 //   - "plan":    read-only plan mode
 //   - "quiet":   alias for --quiet (print + text + final-message-only)
@@ -40,6 +47,7 @@ type Agent struct {
 	providers    []core.ProviderConfig
 	activeIdx    int // -1 = no provider set
 	sessionEnv   []string
+	flagSupport  kimiFlagSupport // detected once at New() via `kimi --help`
 	mu           sync.RWMutex
 }
 
@@ -75,6 +83,11 @@ func New(opts map[string]any) (core.Agent, error) {
 		return nil, fmt.Errorf("kimi: %q CLI not found in PATH, install with: pip install kimi-cli", cmd)
 	}
 
+	// Probe once so Send() can build args that match the installed CLI
+	// surface (see #1456). The probe has its own timeout; failures fall
+	// back to assuming the modern CLI (no --print).
+	flagSupport := probeKimiFlags(context.Background(), cmd, 5*time.Second)
+
 	return &Agent{
 		workDir:      workDir,
 		model:        model,
@@ -84,6 +97,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		configEnv:    core.ParseConfigEnv(opts),
 		timeout:      timeout,
 		activeIdx:    -1,
+		flagSupport:  flagSupport,
 	}, nil
 }
 
@@ -165,6 +179,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	extraEnv := append([]string(nil), a.configEnv...)
 	extraEnv = append(extraEnv, a.providerEnvLocked()...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
+	flagSupport := a.flagSupport
 	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
 		if m := a.providers[a.activeIdx].Model; m != "" {
 			model = m
@@ -172,7 +187,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
-	return newKimiSession(ctx, cmd, extraArgs, workDir, model, mode, sessionID, extraEnv, timeout)
+	return newKimiSession(ctx, cmd, extraArgs, workDir, model, mode, sessionID, extraEnv, timeout, flagSupport)
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/kimi/probe.go
+++ b/agent/kimi/probe.go
@@ -1,0 +1,95 @@
+package kimi
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// kimiFlagSupport records which optional CLI flags the locally installed Kimi
+// binary understands. It is populated once at Agent construction by probing
+// `kimi --help` so that buildArgs can adapt to CLI versions that have added
+// or removed flags.
+//
+// Why this exists:
+//
+//	The newer Kimi Code CLI removed the standalone `--print` flag — passing it
+//	now produces: `error: unknown option '--print' (Did you mean --prompt?)`.
+//	The older kimi-cli still requires `--print` for `--output-format` to take
+//	effect. We probe the help text once and adapt accordingly. See #1456.
+type kimiFlagSupport struct {
+	Print bool
+}
+
+// probeKimiFlags runs `<cmd> --help` with a short timeout and returns the
+// detected flag-support set. If the probe fails (binary missing, timeout,
+// non-zero exit, unrecognisable output) the returned struct has all fields
+// false — i.e. we conservatively assume the newer CLI surface, which matches
+// the direction Kimi Code CLI is moving and avoids the hard-failure mode of
+// passing `--print` to a CLI that no longer accepts it.
+func probeKimiFlags(parent context.Context, cmd string, timeout time.Duration) kimiFlagSupport {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	c := exec.CommandContext(ctx, cmd, "--help")
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	if err := c.Run(); err != nil {
+		slog.Debug("kimi: flag probe failed, assuming modern CLI surface",
+			"cmd", cmd, "error", err)
+		return kimiFlagSupport{}
+	}
+
+	flags := parseKimiHelpFlags(out.String())
+	support := kimiFlagSupport{
+		Print: flags["--print"],
+	}
+	slog.Debug("kimi: flag probe complete", "cmd", cmd, "support", support)
+	return support
+}
+
+// parseKimiHelpFlags scans the output of `kimi --help` and returns the set of
+// long flag names (`--xxx`) it advertises. It handles the two common option-
+// table layouts Kimi has shipped:
+//
+//	Typer/click box style:   "│ --print            Run in print mode (...) │"
+//	Standard click style:    "  -p, --prompt TEXT  User prompt (...)"
+//	Slash aliases:           "  --thinking/--no-thinking   Enable thinking."
+//
+// To stay robust against future layout tweaks the parser only treats a line
+// as a flag-definition line when one of its first two whitespace-separated
+// tokens starts with `--`; description prose later in the line is ignored.
+func parseKimiHelpFlags(helpText string) map[string]bool {
+	flags := make(map[string]bool)
+	for _, rawLine := range strings.Split(helpText, "\n") {
+		line := strings.TrimLeft(rawLine, " \t│|*")
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		// Look at up to the first two tokens so `-p, --prompt …` works
+		// alongside `--print …`. Anything past that is help-text prose.
+		for i := 0; i < len(fields) && i < 2; i++ {
+			tok := strings.TrimRight(fields[i], ",")
+			if !strings.HasPrefix(tok, "--") {
+				continue
+			}
+			for _, name := range strings.Split(tok, "/") {
+				name = strings.TrimSpace(name)
+				name = strings.TrimRight(name, ",")
+				if !strings.HasPrefix(name, "--") || len(name) <= 2 {
+					continue
+				}
+				flags[name] = true
+			}
+		}
+	}
+	return flags
+}

--- a/agent/kimi/probe_test.go
+++ b/agent/kimi/probe_test.go
@@ -1,0 +1,96 @@
+package kimi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// legacyKimiHelp is a representative slice of the older kimi-cli `--help`
+// output (still on the kimi-cli `main` branch as of 2026). It advertises
+// both `--print` and `--prompt`.
+const legacyKimiHelp = `
+ Usage: kimi [OPTIONS] COMMAND [ARGS]...
+
+ Kimi, your next CLI agent.
+
+ ╭─ Options ──────────────────────────────────────────────────────────────╮
+ │ --version          -V          Show version and exit.                  │
+ │ --work-dir         -w DIRECTORY Working directory for the agent.       │
+ │ --session          -S [ID]     Resume a session.                       │
+ │ --continue         -C          Continue the previous session.          │
+ │ --model            -m TEXT     LLM model to use.                       │
+ │ --thinking/--no-thinking       Enable thinking mode.                   │
+ │ --yolo             -y          Automatically approve all actions.      │
+ │ --plan                         Start in plan mode.                     │
+ │ --prompt           -p TEXT     User prompt to the agent.               │
+ │ --print                        Run in print mode (non-interactive).    │
+ │ --output-format    FORMAT      Output format to use.                   │
+ │ --quiet                        Alias for --print --output-format text. │
+ ╰────────────────────────────────────────────────────────────────────────╯
+`
+
+// modernKimiHelp emulates the newer Kimi Code CLI, where --print has been
+// removed entirely. This is the surface that triggers #1456 today.
+const modernKimiHelp = `
+ Usage: kimi [OPTIONS] COMMAND [ARGS]...
+
+ Kimi, your next CLI agent.
+
+ Options:
+   -V, --version              Show version and exit.
+   -w, --work-dir DIRECTORY   Working directory for the agent.
+   -S, --session [ID]         Resume a session.
+   -c, --continue             Continue the most recent session.
+   -m, --model TEXT           LLM model to use.
+   -p, --prompt TEXT          Run a single prompt non-interactively.
+   --output-format FORMAT     Non-interactive output format.
+   -y, --yolo                 Auto-approve regular tool calls.
+   --plan                     Start a new session in Plan mode.
+`
+
+func TestParseKimiHelpFlags_LegacyAdvertisesPrint(t *testing.T) {
+	flags := parseKimiHelpFlags(legacyKimiHelp)
+	assert.True(t, flags["--print"], "legacy help text advertises --print")
+	assert.True(t, flags["--prompt"], "legacy help text advertises --prompt")
+	assert.True(t, flags["--output-format"])
+	assert.True(t, flags["--plan"])
+	assert.True(t, flags["--thinking"], "alias-split should pick up --thinking")
+	assert.True(t, flags["--no-thinking"], "alias-split should pick up --no-thinking")
+}
+
+func TestParseKimiHelpFlags_ModernHidesPrint(t *testing.T) {
+	flags := parseKimiHelpFlags(modernKimiHelp)
+	// Regression for #1456: the new Kimi Code CLI must not be detected
+	// as supporting --print.
+	assert.False(t, flags["--print"], "modern help text must not advertise --print")
+	assert.True(t, flags["--prompt"], "modern CLI still advertises --prompt")
+	assert.True(t, flags["--output-format"])
+}
+
+func TestParseKimiHelpFlags_IgnoresPositionalAndShortOnly(t *testing.T) {
+	help := `
+  Arguments:
+    COMMAND   Optional sub-command
+
+  Options:
+    -h        Show short-only help (must be ignored)
+    --        Bare double-dash (must be ignored)
+    --debug   Toggle debug mode
+`
+	flags := parseKimiHelpFlags(help)
+	assert.True(t, flags["--debug"])
+	assert.False(t, flags["--"], "bare -- must not be treated as a flag")
+	assert.False(t, flags["-h"], "short-only flags are not in the long-flag set")
+}
+
+func TestProbeKimiFlags_FallbackOnMissingBinary(t *testing.T) {
+	// A binary that almost certainly does not exist. probeKimiFlags must
+	// not panic and must return the zero-value (modern-CLI default).
+	got := probeKimiFlags(context.Background(),
+		"kimi-binary-that-does-not-exist-1456-test",
+		200*time.Millisecond)
+	assert.Equal(t, kimiFlagSupport{}, got)
+}

--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -21,40 +21,44 @@ import (
 )
 
 // kimSession manages multi-turn conversations with the Kimi CLI.
-// Each Send() launches a new `kimi --print --output-format stream-json` process
-// with --resume for conversation continuity.
+// Each Send() launches a new `kimi --prompt` process (with `--print
+// --output-format stream-json` when the installed binary still supports
+// --print) and uses --resume for conversation continuity. The exact flag
+// surface is decided by the Agent's one-shot probe; see kimiFlagSupport.
 type kimiSession struct {
-	cmd       string
-	extraArgs []string // extra args from cmd, prepended before kimi args
-	workDir   string
-	model     string
-	mode      string
-	timeout   time.Duration
-	extraEnv  []string
-	events    chan core.Event
-	sessionID atomic.Value // stores string — Kimi session ID
-	ctx       context.Context
-	cancel    context.CancelFunc
-	wg        sync.WaitGroup
-	alive     atomic.Bool
+	cmd         string
+	extraArgs   []string // extra args from cmd, prepended before kimi args
+	workDir     string
+	model       string
+	mode        string
+	timeout     time.Duration
+	extraEnv    []string
+	flagSupport kimiFlagSupport
+	events      chan core.Event
+	sessionID   atomic.Value // stores string — Kimi session ID
+	ctx         context.Context
+	cancel      context.CancelFunc
+	wg          sync.WaitGroup
+	alive       atomic.Bool
 
 	pendingMsgs []string // buffered assistant text messages
 }
 
-func newKimiSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration) (*kimiSession, error) {
+func newKimiSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, resumeID string, extraEnv []string, timeout time.Duration, flagSupport kimiFlagSupport) (*kimiSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	ks := &kimiSession{
-		cmd:       cmd,
-		extraArgs: extraArgs,
-		workDir:   workDir,
-		model:     model,
-		mode:      mode,
-		timeout:   timeout,
-	extraEnv:  extraEnv,
-		events:    make(chan core.Event, 64),
-		ctx:       sessionCtx,
-		cancel:    cancel,
+		cmd:         cmd,
+		extraArgs:   extraArgs,
+		workDir:     workDir,
+		model:       model,
+		mode:        mode,
+		timeout:     timeout,
+		extraEnv:    extraEnv,
+		flagSupport: flagSupport,
+		events:      make(chan core.Event, 64),
+		ctx:         sessionCtx,
+		cancel:      cancel,
 	}
 	ks.alive.Store(true)
 
@@ -63,6 +67,39 @@ func newKimiSession(ctx context.Context, cmd string, extraArgs []string, workDir
 	}
 
 	return ks, nil
+}
+
+// buildArgs constructs the Kimi CLI argument slice for a single non-interactive
+// turn. Extracted from Send() so the version-aware flag selection can be unit
+// tested without launching the CLI. The `--print` flag is only emitted when
+// the locally installed binary advertises it in `kimi --help`; the newer Kimi
+// Code CLI dropped that flag and rejects it outright (see issue #1456).
+func (ks *kimiSession) buildArgs(prompt string) []string {
+	args := append([]string{}, ks.extraArgs...)
+	if ks.flagSupport.Print {
+		args = append(args, "--print")
+	}
+	args = append(args, "--output-format", "stream-json")
+
+	switch ks.mode {
+	case "plan":
+		args = append(args, "--plan")
+	case "quiet":
+		args = append(args, "--quiet")
+	}
+
+	if sid := ks.CurrentSessionID(); sid != "" {
+		args = append(args, "--resume", sid)
+	}
+	if ks.model != "" {
+		args = append(args, "--model", ks.model)
+	}
+	if ks.workDir != "" {
+		args = append(args, "--work-dir", ks.workDir)
+	}
+
+	args = append(args, "--prompt", prompt)
+	return args
 }
 
 func (ks *kimiSession) Send(prompt string, images []core.ImageAttachment, files []core.FileAttachment) error {
@@ -124,30 +161,7 @@ func (ks *kimiSession) Send(prompt string, images []core.ImageAttachment, files 
 		fullPrompt += "\n\n[Attached files saved at: " + strings.Join(fileRefs, ", ") + "]"
 	}
 
-	args := append(append([]string{}, ks.extraArgs...),
-		"--print",
-		"--output-format", "stream-json",
-	)
-
-	switch ks.mode {
-	case "plan":
-		args = append(args, "--plan")
-	case "quiet":
-		args = append(args, "--quiet")
-	}
-
-	sid := ks.CurrentSessionID()
-	if sid != "" {
-		args = append(args, "--resume", sid)
-	}
-	if ks.model != "" {
-		args = append(args, "--model", ks.model)
-	}
-	if ks.workDir != "" {
-		args = append(args, "--work-dir", ks.workDir)
-	}
-
-	args = append(args, "--prompt", fullPrompt)
+	args := ks.buildArgs(fullPrompt)
 
 	var cancel context.CancelFunc
 	var ctx context.Context
@@ -164,7 +178,10 @@ func (ks *kimiSession) Send(prompt string, images []core.ImageAttachment, files 
 		}
 	}()
 
-	slog.Debug("kimiSession: launching", "resume", sid != "", "args", core.RedactArgs(args))
+	slog.Debug("kimiSession: launching",
+		"resume", ks.CurrentSessionID() != "",
+		"supports_print", ks.flagSupport.Print,
+		"args", core.RedactArgs(args))
 	cmd := exec.CommandContext(ctx, ks.cmd, args...)
 	cmd.WaitDelay = 1 * time.Second
 	cmd.Dir = ks.workDir
@@ -435,7 +452,11 @@ func (ks *kimiSession) flushPendingAsText() {
 	}
 }
 
-// RespondPermission is a no-op — Kimi CLI permissions are handled via --print (implicit --yolo).
+// RespondPermission is a no-op — Kimi CLI auto-approves tool calls in
+// non-interactive mode. The legacy kimi-cli triggers this via --print's
+// implicit --yolo; the newer Kimi Code CLI does it implicitly when invoked
+// with --prompt (its "auto" permission default). Either way, cc-connect
+// never sees an interactive permission request from Kimi.
 func (ks *kimiSession) RespondPermission(_ string, _ core.PermissionResult) error {
 	return nil
 }

--- a/agent/kimi/session_test.go
+++ b/agent/kimi/session_test.go
@@ -170,7 +170,7 @@ func TestBuildArgs_NoPrintSupportOmitsPrintFlag(t *testing.T) {
 	ctx := context.Background()
 	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{Print: false})
 	require.NoError(t, err)
-	defer ks.Close()
+	defer func() { _ = ks.Close() }()
 
 	args := ks.buildArgs("hello")
 
@@ -191,7 +191,7 @@ func TestBuildArgs_PrintSupportIncludesPrintFlag(t *testing.T) {
 	ctx := context.Background()
 	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{Print: true})
 	require.NoError(t, err)
-	defer ks.Close()
+	defer func() { _ = ks.Close() }()
 
 	args := ks.buildArgs("hello")
 	assert.Contains(t, args, "--print")
@@ -205,7 +205,7 @@ func TestBuildArgs_PlanMode(t *testing.T) {
 	ctx := context.Background()
 	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "kimi-k2", "plan", "", nil, 0, kimiFlagSupport{Print: false})
 	require.NoError(t, err)
-	defer ks.Close()
+	defer func() { _ = ks.Close() }()
 
 	args := ks.buildArgs("plan this")
 	assert.Contains(t, args, "--plan")
@@ -219,7 +219,7 @@ func TestBuildArgs_ResumeSession(t *testing.T) {
 	ctx := context.Background()
 	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "sess-xyz", nil, 0, kimiFlagSupport{Print: false})
 	require.NoError(t, err)
-	defer ks.Close()
+	defer func() { _ = ks.Close() }()
 
 	args := ks.buildArgs("continue")
 	resumeIdx := -1

--- a/agent/kimi/session_test.go
+++ b/agent/kimi/session_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewKimiSession(t *testing.T) {
 	ctx := context.Background()
-	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "kimi-k2", "default", "resume-123", nil, 0)
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "kimi-k2", "default", "resume-123", nil, 0, kimiFlagSupport{})
 	require.NoError(t, err)
 	require.NotNil(t, ks)
 	assert.True(t, ks.Alive())
@@ -41,7 +41,7 @@ func TestExtractResumeSessionID(t *testing.T) {
 
 func TestHandleAssistantWithText(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
 	defer ks.Close()
 
 	ks.handleEvent(map[string]any{
@@ -58,7 +58,7 @@ func TestHandleAssistantWithText(t *testing.T) {
 
 func TestHandleAssistantWithThink(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
 	defer ks.Close()
 
 	ks.handleEvent(map[string]any{
@@ -78,7 +78,7 @@ func TestHandleAssistantWithThink(t *testing.T) {
 
 func TestHandleAssistantWithToolCalls(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
 	defer ks.Close()
 
 	ks.handleEvent(map[string]any{
@@ -109,7 +109,7 @@ func TestHandleAssistantWithToolCalls(t *testing.T) {
 
 func TestHandleTool(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
 	defer ks.Close()
 
 	ks.handleEvent(map[string]any{
@@ -129,7 +129,7 @@ func TestHandleTool(t *testing.T) {
 
 func TestFlushPendingAsText(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
 	defer ks.Close()
 
 	ks.pendingMsgs = []string{"Hello", " ", "world"}
@@ -144,7 +144,7 @@ func TestFlushPendingAsText(t *testing.T) {
 
 func TestFlushPendingAsThinking(t *testing.T) {
 	ctx := context.Background()
-	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0)
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
 	defer ks.Close()
 
 	ks.pendingMsgs = []string{"Thinking..."}
@@ -160,6 +160,78 @@ func TestTruncate(t *testing.T) {
 	assert.Equal(t, "hello", truncate("hello", 10))
 	assert.Equal(t, "hello world", truncate("hello world", 11))
 	assert.Equal(t, "hello worl...", truncate("hello world", 10))
+}
+
+// TestBuildArgs_NoPrintSupportOmitsPrintFlag is the regression test for #1456.
+// When the locally installed Kimi CLI does not advertise --print in its help
+// output, cc-connect must omit that flag — otherwise the newer Kimi Code CLI
+// exits with `error: unknown option '--print' (Did you mean --prompt?)`.
+func TestBuildArgs_NoPrintSupportOmitsPrintFlag(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{Print: false})
+	require.NoError(t, err)
+	defer ks.Close()
+
+	args := ks.buildArgs("hello")
+
+	for _, a := range args {
+		if a == "--print" {
+			t.Fatalf("buildArgs unexpectedly emitted --print when flagSupport.Print=false; args=%v", args)
+		}
+	}
+	// --prompt must still be present so Kimi enters non-interactive mode.
+	assert.Contains(t, args, "--prompt")
+	assert.Contains(t, args, "hello")
+}
+
+// TestBuildArgs_PrintSupportIncludesPrintFlag covers the legacy kimi-cli
+// branch — the binary advertises --print, so we must keep emitting it for
+// --output-format stream-json to take effect.
+func TestBuildArgs_PrintSupportIncludesPrintFlag(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{Print: true})
+	require.NoError(t, err)
+	defer ks.Close()
+
+	args := ks.buildArgs("hello")
+	assert.Contains(t, args, "--print")
+	assert.Contains(t, args, "--output-format")
+	assert.Contains(t, args, "stream-json")
+}
+
+// TestBuildArgs_PlanMode confirms plan mode still passes --plan independent
+// of --print support.
+func TestBuildArgs_PlanMode(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "kimi-k2", "plan", "", nil, 0, kimiFlagSupport{Print: false})
+	require.NoError(t, err)
+	defer ks.Close()
+
+	args := ks.buildArgs("plan this")
+	assert.Contains(t, args, "--plan")
+	assert.Contains(t, args, "--model")
+	assert.Contains(t, args, "kimi-k2")
+}
+
+// TestBuildArgs_ResumeSession ensures session continuity flags are emitted
+// regardless of the --print probe result.
+func TestBuildArgs_ResumeSession(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "sess-xyz", nil, 0, kimiFlagSupport{Print: false})
+	require.NoError(t, err)
+	defer ks.Close()
+
+	args := ks.buildArgs("continue")
+	resumeIdx := -1
+	for i, a := range args {
+		if a == "--resume" {
+			resumeIdx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, resumeIdx, 0, "args should include --resume; got %v", args)
+	require.Less(t, resumeIdx+1, len(args), "--resume should be followed by an id")
+	assert.Equal(t, "sess-xyz", args[resumeIdx+1])
 }
 
 func drainEvents(ch <-chan core.Event, max int) []core.Event {


### PR DESCRIPTION
Closes #1456.

## Problem

cc-connect unconditionally passes `--print --output-format stream-json --prompt …` to the Kimi CLI. The newer Kimi Code CLI removed the standalone `--print` flag and exits immediately with:

```
error: unknown option '--print' (Did you mean --prompt?)
```

Every Kimi chat is broken for users on the new CLI.

## Root Cause

The two Kimi CLIs in the wild have opposing requirements for non-interactive runs:

| CLI                  | `--print`? | `--output-format` requires |
|----------------------|------------|-----------------------------|
| legacy `kimi-cli`    | yes        | `--print`                   |
| new Kimi Code CLI    | removed    | `--prompt`                  |

A fixed arg list cannot satisfy both, and unlike `--quiet` (#806 / PR #1253) `--print` cannot be emulated client-side — it is the CLI's own non-interactive mode toggle.

## Fix

Probe `kimi --help` once at `Agent` construction and cache the detected flag set. `buildArgs()` (newly extracted from `Send()` so it is unit-testable) only emits `--print` when the installed binary still advertises it. Probe failure / timeout falls back to *no* `--print`, which matches the direction Kimi CLI is moving and avoids the hard-failure mode of the current code.

- `agent/kimi/probe.go` — `parseKimiHelpFlags()` pure parser + bounded `probeKimiFlags()` (5s timeout, swallows errors).
- `agent/kimi/kimi.go` — `Agent` caches `kimiFlagSupport`, threads it into `newKimiSession`; doc comments updated.
- `agent/kimi/session.go` — `kimiSession.flagSupport` + `buildArgs()` helper; conditional `--print`; permission-mode comment updated to cover both legacy (`--print` implicit `--yolo`) and modern (`--prompt` auto-permission) behaviors.

## Tests

Regression + coverage:

- `TestBuildArgs_NoPrintSupportOmitsPrintFlag` — **regression test for #1456**; fails on pre-fix code, passes on this branch.
- `TestBuildArgs_PrintSupportIncludesPrintFlag` — legacy CLI branch.
- `TestBuildArgs_PlanMode` / `TestBuildArgs_ResumeSession` — other arg paths.
- `TestParseKimiHelpFlags_LegacyAdvertisesPrint` / `TestParseKimiHelpFlags_ModernHidesPrint` — parser handles both typer box-drawing and standard click \`-p, --prompt\` layouts.
- `TestParseKimiHelpFlags_IgnoresPositionalAndShortOnly` — robustness.
- `TestProbeKimiFlags_FallbackOnMissingBinary` — probe failure path returns zero value (modern-CLI default).

Verified locally:

\`\`\`
go test ./agent/kimi/...
go test -race ./agent/kimi/...
go test ./core/ -run TestCUJ
go vet ./...
go build ./...
\`\`\`

Pre-existing \`agent/acp\` integration test (\`TestCursorCLI_ACPHandshake\`) still fails on \`origin/main\` — needs \`cursor agent login\`, unrelated to this change.

## Non-goals

- Does **not** touch the cursor agent; Claude Code CLI still supports \`--print\`, cursor's hard-coded flag is fine.
- Does **not** change \`--quiet\` handling; PR #1253 owns that fix for #806.
- Does **not** introduce new config schema.

## Workaround (for users hitting this before merge)

Switch agent type to \`claudecode\` / \`codex\` / \`opencode\` while we ship, or pin to an older \`kimi-cli\` version that still has \`--print\`.

— Filed by \`cc-connect/dev-cursor\` per PM (\`cc-connect/pm\`) scoping in #1456.

Made with [Cursor](https://cursor.com)