### PR TITLE
feat(core): render /provider as inline buttons on button-capable platforms (#1460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 - **Feishu: outbound bot-to-bot @mention resolution** via new `mention_map` config option. Maps agent-friendly names (e.g. `BOT-A`) to Feishu open_ids so that when an agent writes `@BOT-A` in its reply, cc-connect converts it to a native Feishu `<at>` tag that triggers a real notification. Layered on top of `resolve_mentions` (group-member matching) with higher priority, so explicit config always wins (#1322).
+- **/provider: inline buttons on button-capable platforms** (#1460). `/provider` now mirrors `/model`: on platforms without card support but with inline-button support, it emits one button per provider (3 per row) whose Data dispatches to the existing `/provider switch <name>` handler, plus a Clear button on its own row when a provider is active. The active provider's button label is prefixed with `▶` to match the text-body marker. The card-mode branch (`supportsCards`) is unchanged so Feishu/QQBot/DingTalk-style rich cards stay consistent across platforms; plain-text platforms fall back via `replyWithButtons` → `reply` exactly like `/model`. New tests cover the inline-button path, the active marker, the no-active Clear-button suppression, and the 3-per-row layout. The legacy plain-text test still passes unchanged.
 
 ### Fixed
 - **Feishu recall fallback probes**: throttle repeated active-message recall checks so long-running turns do not continuously call platform message APIs.

--- a/core/engine.go
+++ b/core/engine.go
@@ -10181,6 +10181,8 @@ func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
 			sb.WriteString("\n\n")
 		}
 		sb.WriteString(e.i18n.T(MsgProviderListTitle))
+		var buttons [][]ButtonOption
+		var row []ButtonOption
 		for _, prov := range providers {
 			marker := "  "
 			if current != nil && prov.Name == current.Name {
@@ -10194,9 +10196,29 @@ func (e *Engine) cmdProvider(p Platform, msg *Message, args []string) {
 				detail += " [" + prov.Model + "]"
 			}
 			sb.WriteString(fmt.Sprintf("%s%s\n", marker, detail))
+
+			label := prov.Name
+			if current != nil && prov.Name == current.Name {
+				label = "▶ " + label
+			}
+			row = append(row, ButtonOption{Text: label, Data: fmt.Sprintf("cmd:/provider switch %s", prov.Name)})
+			if len(row) >= 3 {
+				buttons = append(buttons, row)
+				row = nil
+			}
+		}
+		if len(row) > 0 {
+			buttons = append(buttons, row)
+		}
+		if current != nil {
+			// Mirror /model's layout: every switchable state gets a Clear
+			// button on its own row, so the user can drop back to the
+			// default provider without typing the full command. The Clear
+			// handler is the existing "clear"/"reset"/"none" subcommand.
+			buttons = append(buttons, []ButtonOption{{Text: "Clear", Data: "cmd:/provider clear"}})
 		}
 		sb.WriteString("\n" + e.i18n.T(MsgProviderSwitchHint))
-		e.reply(p, msg.ReplyCtx, sb.String())
+		e.replyWithButtons(p, msg.ReplyCtx, sb.String(), buttons)
 		return
 	}
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1100,10 +1100,10 @@ func TestProcessInteractiveEvents_NonTerminalResultContinuesTurn(t *testing.T) {
 	session := e.sessions.GetOrCreateActive(sessionKey)
 	agentSession := newControllableSession("s1")
 	state := &interactiveState{
-		agentSession:                  agentSession,
-		platform:                      p,
-		replyCtx:                      "ctx-1",
-		currentTurnUserMessageTimeMs:  100,
+		agentSession:                   agentSession,
+		platform:                       p,
+		replyCtx:                       "ctx-1",
+		currentTurnUserMessageTimeMs:   100,
 		lastCompletedUserMessageTimeMs: 0,
 	}
 	e.interactiveStates[sessionKey] = state
@@ -4355,6 +4355,167 @@ func TestCmdProvider_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	}
 	if !strings.Contains(p.sent[0], "switch") {
 		t.Fatalf("provider text = %q, want switch hint", p.sent[0])
+	}
+}
+
+// TestCmdProvider_UsesInlineButtonsOnButtonOnlyPlatform mirrors the
+// /model behavior on platforms that do not support cards but do support
+// inline buttons. cmdProvider must emit one button per provider whose
+// Data starts with "cmd:/provider switch " so the platform callback
+// path can dispatch to the same switch handler as the text command.
+func TestCmdProvider_UsesInlineButtonsOnButtonOnlyPlatform(t *testing.T) {
+	p := &stubInlineButtonPlatform{stubPlatformEngine: stubPlatformEngine{n: "inline-only"}}
+	agent := &stubProviderAgent{
+		providers: []ProviderConfig{
+			{Name: "openai", BaseURL: "https://api.openai.com", Model: "gpt-4.1"},
+			{Name: "azure", BaseURL: "https://azure.example", Model: "gpt-4.1-mini"},
+		},
+		active: "openai",
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	e.cmdProvider(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, nil)
+
+	if len(p.buttonRows) == 0 {
+		t.Fatal("expected /provider to send inline buttons on button-only platform")
+	}
+	// Flatten all button rows so we can assert on the full set without
+	// caring about the exact 3-per-row layout.
+	var all []ButtonOption
+	for _, row := range p.buttonRows {
+		all = append(all, row...)
+	}
+	wantData := []string{
+		"cmd:/provider switch openai",
+		"cmd:/provider switch azure",
+		"cmd:/provider clear",
+	}
+	for _, want := range wantData {
+		found := false
+		for _, b := range all {
+			if b.Data == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("button with Data=%q not found in %d buttons across %d rows", want, len(all), len(p.buttonRows))
+		}
+	}
+}
+
+// TestCmdProvider_ButtonsMarkActiveProvider verifies the active provider
+// button carries the ▶ marker in its label, mirroring the text-body
+// marker convention used by /model and the legacy text path.
+func TestCmdProvider_ButtonsMarkActiveProvider(t *testing.T) {
+	p := &stubInlineButtonPlatform{stubPlatformEngine: stubPlatformEngine{n: "inline-only"}}
+	agent := &stubProviderAgent{
+		providers: []ProviderConfig{
+			{Name: "openai"},
+			{Name: "azure"},
+		},
+		active: "azure",
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	e.cmdProvider(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, nil)
+
+	var all []ButtonOption
+	for _, row := range p.buttonRows {
+		all = append(all, row...)
+	}
+	var active, inactive *ButtonOption
+	for i := range all {
+		switch all[i].Data {
+		case "cmd:/provider switch azure":
+			active = &all[i]
+		case "cmd:/provider switch openai":
+			inactive = &all[i]
+		}
+	}
+	if active == nil {
+		t.Fatalf("active azure button missing; got %+v", all)
+	}
+	if inactive == nil {
+		t.Fatalf("inactive openai button missing; got %+v", all)
+	}
+	if !strings.HasPrefix(active.Text, "▶") {
+		t.Errorf("active button label = %q, want ▶ prefix", active.Text)
+	}
+	if strings.HasPrefix(inactive.Text, "▶") {
+		t.Errorf("inactive button label = %q, must NOT carry ▶ prefix", inactive.Text)
+	}
+}
+
+// TestCmdProvider_NoClearButtonWhenNoActiveProvider guards the empty-
+// active edge: when no provider is currently active, there is nothing
+// to clear, so the Clear button must not appear. This avoids the user
+// landing on a button that does nothing useful on first boot.
+func TestCmdProvider_NoClearButtonWhenNoActiveProvider(t *testing.T) {
+	p := &stubInlineButtonPlatform{stubPlatformEngine: stubPlatformEngine{n: "inline-only"}}
+	agent := &stubProviderAgent{
+		providers: []ProviderConfig{
+			{Name: "openai"},
+			{Name: "azure"},
+		},
+		// active == "" — no provider currently selected
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	e.cmdProvider(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, nil)
+
+	var all []ButtonOption
+	for _, row := range p.buttonRows {
+		all = append(all, row...)
+	}
+	for _, b := range all {
+		if b.Data == "cmd:/provider clear" {
+			t.Errorf("Clear button must NOT be shown when no provider is active; got button %+v", b)
+		}
+	}
+	// Sanity: the provider switch buttons must still be there.
+	if len(all) < 2 {
+		t.Errorf("expected ≥2 provider buttons, got %d: %+v", len(all), all)
+	}
+}
+
+// TestCmdProvider_ButtonsCapRowAtThree verifies the 3-per-row layout
+// matches /model: with 5 providers we should see 2 rows of 3 + a final
+// row carrying the remainder plus the Clear button (since one provider
+// is active).
+func TestCmdProvider_ButtonsCapRowAtThree(t *testing.T) {
+	p := &stubInlineButtonPlatform{stubPlatformEngine: stubPlatformEngine{n: "inline-only"}}
+	agent := &stubProviderAgent{
+		providers: []ProviderConfig{
+			{Name: "p1"}, {Name: "p2"}, {Name: "p3"}, {Name: "p4"}, {Name: "p5"},
+		},
+		active: "p3",
+	}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	e.cmdProvider(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, nil)
+
+	// Expected layout: [p1, p2, ▶ p3] [p4, p5] [Clear]
+	// The Clear button lives on its own row so it is visually distinct
+	// from the destructive-free switch list — see the cmdProvider code
+	// where Clear is appended after the provider-button loop completes.
+	wantRows := [][]string{
+		{"p1", "p2", "▶ p3"},
+		{"p4", "p5"},
+		{"Clear"},
+	}
+	if len(p.buttonRows) != len(wantRows) {
+		t.Fatalf("got %d button rows, want %d: %+v", len(p.buttonRows), len(wantRows), p.buttonRows)
+	}
+	for i, want := range wantRows {
+		if len(p.buttonRows[i]) != len(want) {
+			t.Fatalf("row %d has %d buttons, want %d: %+v", i, len(p.buttonRows[i]), len(want), p.buttonRows[i])
+		}
+		for j, wantText := range want {
+			if p.buttonRows[i][j].Text != wantText {
+				t.Errorf("row %d button %d Text = %q, want %q", i, j, p.buttonRows[i][j].Text, wantText)
+			}
+		}
 	}
 }
 
@@ -15016,8 +15177,8 @@ func TestIsAllowResponse_WithMultipleMentions(t *testing.T) {
 func TestIsAllowResponse_NotInsideOtherWord(t *testing.T) {
 	cases := []string{
 		"禁止允许这种",
-		"不允许这样",   // "不允许" has its own deny entry, but as part of "不允许这样" the user clearly is denying / negating, never allowing.
-		"我不太允许这件事", // long sentence, no token equals "允许"
+		"不允许这样",                            // "不允许" has its own deny entry, but as part of "不允许这样" the user clearly is denying / negating, never allowing.
+		"我不太允许这件事",                         // long sentence, no token equals "允许"
 		"please don't allowall the things", // FieldsFunc keeps "allowall" intact, but it is the approveAll single-token form, not allow.
 		"hello world",
 		"",
@@ -15045,7 +15206,7 @@ func TestIsDenyResponse_WithMention(t *testing.T) {
 	}
 
 	negatives := []string{
-		"拒绝症患者",       // embedded — must not match
+		"拒绝症患者",        // embedded — must not match
 		"我们都不应该 hello", // unrelated
 	}
 	for _, s := range negatives {


### PR DESCRIPTION
Fixes #1460

## 问题
`/model` 在 button-capable 平台渲染 inline buttons，`/provider` 只渲染纯
文本。移动端用户体验差，UX 不一致。

## 修复
`cmdProvider` 的 `!supportsCards` 分支改成跟 `cmdModel` 同款 inline
buttons 渲染模式：

- 每个 provider 一个 button，Data 走 `cmd:/provider switch <name>`，
  复用既有的 `switchProvider` 路径
- 3 个一行排版，剩余单独一行
- 当前激活的 provider button label 前缀加 `▶`，跟文本体的 marker
  对齐
- 当 current != nil 时，附加一个独立的 Clear button (Data:
  `cmd:/provider clear`)，让用户不用手输也能切回默认 provider
- 文本体保持 `Active provider / list / switch hint` 原样，跟
  `/model` 完全一致
- card 模式分支 (`supportsCards`) 一行没动，跨平台 card 体验
  不退化
- 普通文本平台 (`replyWithButtons` 内部 fallback 到 `e.reply`)
  行为不变，原有 `TestCmdProvider_UsesLegacyTextOnPlatformWithoutCardSupport`
  仍然 pass

不动 i18n key（复用 `MsgProviderListTitle` / `MsgProviderSwitchHint`），
不动 `ProviderSwitcher` interface，不动其他命令的 button 化。

## 变更
- `core/engine.go`: `cmdProvider` `!supportsCards` 分支构造 buttons +
  `e.reply` → `e.replyWithButtons`
- `core/engine_test.go`: 新增 4 个测试覆盖 inline button 路径
- `CHANGELOG.md`: Unreleased / Added 加一条

## 测试
- `go test ./core/` 全量通过（48.9s）
- `gofmt -l core/engine.go core/engine_test.go` 干净
- `go vet ./core/` 干净
- 新增测试:
  - `TestCmdProvider_UsesInlineButtonsOnButtonOnlyPlatform` — 验证 button Data 是 `cmd:/provider switch <name>` 格式 + Clear 出现
  - `TestCmdProvider_ButtonsMarkActiveProvider` — active 的 button label 有 `▶` 前缀，inactive 没有
  - `TestCmdProvider_NoClearButtonWhenNoActiveProvider` — 无 active 时不渲染 Clear
  - `TestCmdProvider_ButtonsCapRowAtThree` — 5 provider 排成 `[p1, p2, ▶ p3] [p4, p5] [Clear]`
- 既有 `TestCmdProvider_UsesLegacyTextOnPlatformWithoutCardSupport` 不变仍 pass

## 风险
- 低：完全镜像 `/model` 已有 pattern
- 边界：provider 名称含空格/特殊字符 — 用 `prov.Name` 拼接，跟
  `cmdModel` 用 `m.Name` 一致不 escape。如果实际触发 Telegram
  64-byte callback 限制，再换 index 跟 `cmdModel` 完全对齐
- 边界：>9 provider 排版 — 3 个一行，多余一行，跟 `/model` 一致
- 缓解：单元测试覆盖 active 标记 + Clear 边界 + row 排版

## 关联
- Issue: #1460
- Base: `main`（按 dev-base-on-main 规范）
- 分支: `agent/cc-connect/dev-claudecode/t-20260628-plybsj-1460-provider-buttons`
- Worktree: `/root/code/spaceship/worktrees/cc-connect/agent/cc-connect/dev-claudecode/t-20260628-plybsj-1460-provider-buttons`

🤖 Generated with [Claude Code](https://claude.com/claude-code)