### PR TITLE
feat(acp): support model and mode switching

### DIFF
--- a/agent/acp/acp_integration_test.go
+++ b/agent/acp/acp_integration_test.go
@@ -1,0 +1,186 @@
+package acp
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// acpIntegrationAgent builds an Agent from CC_ACP_BIN / CC_ACP_ARGS, or
+// skips the test when CC_ACP_BIN is unset. CC_ACP_ARGS defaults to "acp"
+// and accepts a comma-separated list. These tests drive a real ACP agent
+// binary for manual end-to-end verification.
+func acpIntegrationAgent(t *testing.T) *Agent {
+	t.Helper()
+	bin := os.Getenv("CC_ACP_BIN")
+	if bin == "" {
+		t.Skip("set CC_ACP_BIN=/path/to/acp-agent (and optional CC_ACP_ARGS) to run ACP integration tests")
+	}
+	argsEnv := os.Getenv("CC_ACP_ARGS")
+	if argsEnv == "" {
+		argsEnv = "acp"
+	}
+	var args []any
+	for _, a := range strings.Split(argsEnv, ",") {
+		if a = strings.TrimSpace(a); a != "" {
+			args = append(args, a)
+		}
+	}
+	ag, err := New(map[string]any{"cmd": bin, "args": args, "work_dir": t.TempDir()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return ag.(*Agent)
+}
+
+// liveModelSwitcher mirrors core.LiveModelSwitcher (avoids an import cycle
+// concern on the test side).
+type liveModelSwitcher interface {
+	SetLiveModel(model string) bool
+}
+
+// liveModeSwitcher mirrors core.LiveModeSwitcher.
+type liveModeSwitcher interface {
+	SetLiveMode(mode string) bool
+}
+
+// TestIntegration_ACP_ModelSwitch verifies the full model-switch path
+// against a real ACP agent:
+//  1. AvailableModels fetches the model list via probeSessionConfig (from
+//     the `models` block or a configOptions model selector)
+//  2. GetModel reflects the server-reported current model after StartSession
+//  3. SetLiveModel switches live on the active session (session/set_model or
+//     session/set_config_option, depending on the agent's mechanism)
+//
+// Verified agents: kiro-cli, mimo, codebuddy (--acp), hermes (models block)
+// and opencode (configOptions).
+func TestIntegration_ACP_ModelSwitch(t *testing.T) {
+	a := acpIntegrationAgent(t)
+
+	// 1. AvailableModels probes when no session is active.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	models := a.AvailableModels(ctx)
+	if len(models) == 0 {
+		t.Skip("agent advertises no models — nothing to switch")
+	}
+	t.Logf("AvailableModels: %d models, first=%s", len(models), models[0].Name)
+
+	// 2. StartSession + GetModel.
+	sess, err := a.StartSession(ctx, "")
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	cur := a.GetModel()
+	t.Logf("current model after StartSession: %q", cur)
+	if cur == "" {
+		t.Fatal("GetModel() empty after StartSession — models block not parsed from session/new")
+	}
+
+	// 3. SetLiveModel to a different model.
+	lm, ok := sess.(liveModelSwitcher)
+	if !ok {
+		t.Fatal("session does not implement LiveModelSwitcher")
+	}
+	var target string
+	for _, m := range models {
+		if m.Name != cur {
+			target = m.Name
+			break
+		}
+	}
+	if target == "" {
+		t.Skip("only one model available, cannot test switch")
+	}
+	if !lm.SetLiveModel(target) {
+		t.Fatalf("SetLiveModel(%q) returned false", target)
+	}
+	t.Logf("SetLiveModel(%q) succeeded", target)
+
+	if got := a.GetModel(); got != target {
+		t.Fatalf("GetModel() after switch = %q, want %q", got, target)
+	}
+}
+
+// TestIntegration_ACP_ModeSwitch verifies the full mode-switch path (in
+// kiro's terms, agent switching) against a real ACP agent:
+//  1. PermissionModes fetches the mode list via probe (from the `modes`
+//     block or a configOptions mode selector) when no session is active
+//  2. GetMode reflects the server-reported current mode after StartSession
+//  3. SetLiveMode switches live on the active session (session/set_mode or
+//     session/set_config_option, depending on the agent's mechanism)
+//
+// Verified agents: kiro-cli (modes = kiro_default/...), mimo, codebuddy,
+// hermes (modes block) and opencode (configOptions).
+func TestIntegration_ACP_ModeSwitch(t *testing.T) {
+	a := acpIntegrationAgent(t)
+
+	// 1. PermissionModes probes when no session is active.
+	modes := a.PermissionModes()
+	if len(modes) == 0 {
+		t.Skip("agent advertises no modes — nothing to switch")
+	}
+	t.Logf("PermissionModes: %d modes, first=%s", len(modes), modes[0].Key)
+	for _, m := range modes {
+		t.Logf("  - %s: %s", m.Key, m.Desc)
+	}
+
+	// 2. StartSession + GetMode.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	sess, err := a.StartSession(ctx, "")
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	cur := a.GetMode()
+	t.Logf("current mode after StartSession: %q", cur)
+
+	// 3. SetLiveMode to a different mode.
+	lm, ok := sess.(liveModeSwitcher)
+	if !ok {
+		t.Fatal("session does not implement LiveModeSwitcher")
+	}
+	var target string
+	for _, m := range modes {
+		if m.Key != cur {
+			target = m.Key
+			break
+		}
+	}
+	if target == "" {
+		t.Skip("only one mode available, cannot test switch")
+	}
+	if !lm.SetLiveMode(target) {
+		t.Fatalf("SetLiveMode(%q) returned false", target)
+	}
+	t.Logf("SetLiveMode(%q) succeeded", target)
+}
+
+// TestIntegration_ACP_ProbeShortCtx reproduces and locks down a
+// regression: cmdModel/cmdMode only pass a 10s ctx to AvailableModels /
+// PermissionModes, while a slow-starting agent (e.g. kiro, which
+// initializes several MCP servers) can take longer to probe.
+// probeSessionConfig must use its own timeout instead of inheriting the
+// caller's short ctx, otherwise it surfaces
+// "probe initialize: context deadline exceeded".
+//
+// The test calls AvailableModels with a deliberately short (3s) ctx and
+// asserts models are still returned.
+func TestIntegration_ACP_ProbeShortCtx(t *testing.T) {
+	a := acpIntegrationAgent(t)
+
+	shortCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	models := a.AvailableModels(shortCtx)
+	if len(models) == 0 {
+		t.Skip("agent advertises no models — probe has nothing to fetch")
+	}
+	t.Logf("short-ctx probe OK: %d models", len(models))
+}

--- a/agent/acp/agent.go
+++ b/agent/acp/agent.go
@@ -2,6 +2,7 @@ package acp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -30,8 +31,9 @@ type Agent struct {
 	displayName  string // optional, for doctor (default "ACP")
 
 	// mode is the pending permission mode to apply to new sessions.
-	// When set, StartSession applies it via session/set_mode right after
-	// session/new. Empty means "use whatever the agent selects by default".
+	// When set, StartSession applies it via the session's SetLiveMode
+	// right after session/new. Empty means "use whatever the agent selects
+	// by default".
 	mode string
 
 	// listUnsupported caches a negative result after we probe the agent
@@ -45,9 +47,24 @@ type Agent struct {
 	// handshake so that future PermissionModes() calls can reflect the
 	// actual modes this specific ACP agent offers (rather than a
 	// hard-coded fallback that may not match).
-	modesMu       sync.RWMutex
-	modesCache    []core.PermissionModeInfo
-	modesCurrent  string
+	modesMu      sync.RWMutex
+	modesCache   []core.PermissionModeInfo
+	modesCurrent string
+
+	// modelsCache holds the latest `models` block observed via session/new
+	// or session/load. availableModels feeds the `/model` picker;
+	// currentModel reflects the active model. pendingModel holds a
+	// user-selected model to apply to future sessions (mirrors `mode`).
+	modelsMu        sync.RWMutex
+	availableModels []acpModelInfo
+	currentModel    string
+	pendingModel    string
+
+	// sessionConfigProbed marks whether probeSessionConfig has run once.
+	// A single probe fills both the modes and models caches, serving
+	// /mode and /model, so an agent advertising neither won't trigger a
+	// fresh process spawn on every command.
+	sessionConfigProbed atomic.Bool
 
 	mu sync.RWMutex
 }
@@ -58,6 +75,7 @@ type Agent struct {
 // would never see availableModes / capability advertisements.
 type sessionCallbacks interface {
 	reportModes(block acpModesBlock)
+	reportModels(block acpModelsBlock)
 	reportListSupported(supported bool)
 }
 
@@ -95,15 +113,15 @@ func New(opts map[string]any) (core.Agent, error) {
 	mode = strings.TrimSpace(mode)
 
 	return &Agent{
-		workDir:     workDir,
+		workDir:      workDir,
 		cmd:          cmdStr,
 		cliExtraArgs: cliExtraArgs,
-		args:        args,
-		staticEnv:   staticEnv,
-		extraEnv:    extra,
-		authMethod:  authMethod,
-		displayName: displayName,
-		mode:        mode,
+		args:         args,
+		staticEnv:    staticEnv,
+		extraEnv:     extra,
+		authMethod:   authMethod,
+		displayName:  displayName,
+		mode:         mode,
 	}, nil
 }
 
@@ -310,14 +328,24 @@ func (a *Agent) GetMode() string {
 }
 
 // PermissionModes returns the modes this ACP agent offers. The list is
-// populated from the latest `modes.availableModes` observed on
-// session/new or session/load; before the first successful handshake
-// it returns an empty slice, and the engine will hide the mode picker.
+// populated from the modes observed on session/new or session/load —
+// either the `modes` block or a configOptions mode selector. If nothing
+// has been observed yet (no session started), it triggers a one-time
+// probe so `/mode` can list options without requiring the user to start a
+// session first — this mirrors AvailableModels for `/model`.
 //
 // ACP doesn't send per-mode Desc/NameZh, so Description (if the server
 // sent one) maps to Desc for both locales. IM-side translators are
 // free to map well-known ids to localised strings later.
 func (a *Agent) PermissionModes() []core.PermissionModeInfo {
+	a.modesMu.RLock()
+	empty := len(a.modesCache) == 0
+	a.modesMu.RUnlock()
+
+	if empty {
+		a.ensureSessionConfigProbed()
+	}
+
 	a.modesMu.RLock()
 	defer a.modesMu.RUnlock()
 	out := make([]core.PermissionModeInfo, len(a.modesCache))
@@ -368,5 +396,183 @@ func (a *Agent) reportListSupported(supported bool) {
 		a.listUnsupported.Store(true)
 	} else {
 		a.listUnsupported.Store(false)
+	}
+}
+
+func (a *Agent) reportModels(block acpModelsBlock) {
+	a.modelsMu.Lock()
+	a.availableModels = append(a.availableModels[:0], block.AvailableModels...)
+	if block.CurrentModelID != "" {
+		a.currentModel = block.CurrentModelID
+	}
+	a.modelsMu.Unlock()
+}
+
+// -- ModelSwitcher implementation --
+//
+// Models come from either the `models` block or a configOptions entry with
+// category "model" (both are normalised into the same cache during the
+// handshake / probe).
+
+// SetModel records the user-selected model as the preference for future
+// sessions. For a running session the engine separately calls the
+// session's SetLiveModel to switch live.
+func (a *Agent) SetModel(model string) {
+	a.modelsMu.Lock()
+	a.pendingModel = model
+	// Optimistically update currentModel so GetModel / rendering reflect
+	// the user's intent immediately.
+	if model != "" {
+		a.currentModel = model
+	}
+	a.modelsMu.Unlock()
+	slog.Info("acp: model changed", "model", model)
+}
+
+// GetModel returns the current model. The most recent SetModel
+// (pendingModel, the user's intent) wins; otherwise it falls back to the
+// currentModel the server reported during the handshake. This mirrors
+// GetMode's precedence logic.
+func (a *Agent) GetModel() string {
+	a.modelsMu.RLock()
+	defer a.modelsMu.RUnlock()
+	if a.pendingModel != "" {
+		return a.pendingModel
+	}
+	return a.currentModel
+}
+
+// AvailableModels returns the models this ACP agent advertised, whether
+// via the `models` block or a configOptions model selector. When the
+// cache is empty (no session started yet), it triggers a one-time probe
+// to fetch them.
+//
+// Note: the ctx argument only satisfies the core.ModelSwitcher
+// interface; the probe uses its own timeout (see probeSessionConfig) and
+// is therefore not bounded by the caller's short ctx (cmdModel's 10s).
+func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
+	_ = ctx
+	a.modelsMu.RLock()
+	empty := len(a.availableModels) == 0
+	a.modelsMu.RUnlock()
+
+	if empty {
+		a.ensureSessionConfigProbed()
+	}
+
+	a.modelsMu.RLock()
+	defer a.modelsMu.RUnlock()
+	if len(a.availableModels) == 0 {
+		return nil
+	}
+	out := make([]core.ModelOption, 0, len(a.availableModels))
+	for _, m := range a.availableModels {
+		out = append(out, core.ModelOption{Name: m.ModelID, Desc: m.Description})
+	}
+	return out
+}
+
+// ensureSessionConfigProbed triggers a one-time probe (initialize +
+// session/new) when no session has advertised the session config yet.
+// A single probe fills both the modes and models caches, so /mode and
+// /model both benefit. Subsequent calls are cheap no-ops once probed.
+func (a *Agent) ensureSessionConfigProbed() {
+	if a.sessionConfigProbed.Load() {
+		return
+	}
+	// Nothing to spawn without a command (e.g. a zero-value Agent used in
+	// unit tests). Skip the probe rather than attempting a doomed exec.
+	a.mu.RLock()
+	cmd := a.cmd
+	a.mu.RUnlock()
+	if cmd == "" {
+		return
+	}
+	a.probeSessionConfig()
+}
+
+// probeSessionConfig spawns a short-lived ACP process, runs
+// initialize + session/new to obtain the mode and model selectors (from
+// the `modes`/`models` blocks or configOptions), then shuts it down.
+// Used to answer /model and /mode when no session is
+// active.
+//
+// The probe uses sessionConfigProbeTimeout rather than inheriting the
+// caller's possibly-short ctx (cmdModel/cmdMode only pass 10s). Some
+// agents (e.g. kiro CLI) initialize multiple MCP servers on startup and
+// can take longer than 10s, which would otherwise surface as
+// "probe initialize/session/new: context deadline exceeded". The child
+// process is reaped by teardown, so at worst the probe ends itself when
+// the timeout fires.
+func (a *Agent) probeSessionConfig() {
+	a.mu.RLock()
+	workDir := a.workDir
+	a.mu.RUnlock()
+	absWorkDir, _ := filepath.Abs(workDir)
+	if absWorkDir == "" {
+		absWorkDir = workDir
+	}
+
+	probeCtx, cancel := context.WithTimeout(context.Background(), sessionConfigProbeTimeout)
+	defer cancel()
+
+	tr, _, teardown, err := a.probeSpawn(probeCtx, absWorkDir)
+	if err != nil {
+		slog.Warn("acp: probeSessionConfig spawn failed", "error", err)
+		return
+	}
+	defer teardown()
+
+	if _, err := probeInitialize(probeCtx, tr); err != nil {
+		slog.Warn("acp: probeSessionConfig initialize failed", "error", err)
+		return
+	}
+
+	newRes, err := tr.call(probeCtx, "session/new", map[string]any{
+		"cwd":        absWorkDir,
+		"mcpServers": []any{},
+	})
+	if err != nil {
+		slog.Warn("acp: probeSessionConfig session/new failed", "error", err)
+		return
+	}
+	// session/new completed, so mark as probed to avoid respawning.
+	a.sessionConfigProbed.Store(true)
+	var sn struct {
+		SessionID     string            `json:"sessionId"`
+		Modes         *acpModesBlock    `json:"modes"`
+		Models        *acpModelsBlock   `json:"models"`
+		ConfigOptions []acpConfigOption `json:"configOptions"`
+	}
+	if json.Unmarshal(newRes, &sn) != nil {
+		return
+	}
+	// Mechanism A: top-level models/modes blocks.
+	if sn.Models != nil && len(sn.Models.AvailableModels) > 0 {
+		a.reportModels(*sn.Models)
+		slog.Info("acp: probeSessionConfig fetched models", "count", len(sn.Models.AvailableModels))
+	}
+	if sn.Modes != nil && len(sn.Modes.AvailableModes) > 0 {
+		a.reportModes(*sn.Modes)
+		slog.Info("acp: probeSessionConfig fetched modes", "count", len(sn.Modes.AvailableModes))
+	}
+	// Mechanism B: configOptions (model/mode selectors). The probe only
+	// needs to populate the agent-level caches so /model and /mode can
+	// list options; the configId used for live switching is recorded by
+	// the real session's absorbConfigOptions.
+	for i := range sn.ConfigOptions {
+		opt := sn.ConfigOptions[i]
+		switch opt.Category {
+		case "model":
+			if models := flattenModelOptions(opt); len(models) > 0 {
+				a.reportModels(acpModelsBlock{CurrentModelID: opt.CurrentValue, AvailableModels: models})
+				slog.Info("acp: probeSessionConfig fetched model configOption", "count", len(models))
+			}
+		case "mode":
+			if modes := flattenModeOptions(opt); len(modes) > 0 {
+				a.reportModes(acpModesBlock{CurrentModeID: opt.CurrentValue, AvailableModes: modes})
+				slog.Info("acp: probeSessionConfig fetched mode configOption", "count", len(modes))
+			}
+		}
 	}
 }

--- a/agent/acp/agent.go
+++ b/agent/acp/agent.go
@@ -426,7 +426,7 @@ func (a *Agent) SetModel(model string) {
 		a.currentModel = model
 	}
 	a.modelsMu.Unlock()
-	slog.Info("acp: model changed", "model", model)
+	slog.Debug("acp: model changed", "model", model)
 }
 
 // GetModel returns the current model. The most recent SetModel
@@ -547,32 +547,35 @@ func (a *Agent) probeSessionConfig() {
 	if json.Unmarshal(newRes, &sn) != nil {
 		return
 	}
-	// Mechanism A: top-level models/modes blocks.
-	if sn.Models != nil && len(sn.Models.AvailableModels) > 0 {
-		a.reportModels(*sn.Models)
-		slog.Info("acp: probeSessionConfig fetched models", "count", len(sn.Models.AvailableModels))
-	}
-	if sn.Modes != nil && len(sn.Modes.AvailableModes) > 0 {
-		a.reportModes(*sn.Modes)
-		slog.Info("acp: probeSessionConfig fetched modes", "count", len(sn.Modes.AvailableModes))
-	}
-	// Mechanism B: configOptions (model/mode selectors). The probe only
-	// needs to populate the agent-level caches so /model and /mode can
-	// list options; the configId used for live switching is recorded by
-	// the real session's absorbConfigOptions.
+	// configOptions (newer mechanism) takes precedence. Absorb it first and
+	// track which selector categories it provided; the legacy models/modes
+	// blocks then only fill categories configOptions did not supply. This
+	// mirrors the session's absorb precedence and is order-independent.
+	hasCfgModel, hasCfgMode := false, false
 	for i := range sn.ConfigOptions {
 		opt := sn.ConfigOptions[i]
 		switch opt.Category {
 		case "model":
 			if models := flattenModelOptions(opt); len(models) > 0 {
 				a.reportModels(acpModelsBlock{CurrentModelID: opt.CurrentValue, AvailableModels: models})
+				hasCfgModel = true
 				slog.Info("acp: probeSessionConfig fetched model configOption", "count", len(models))
 			}
 		case "mode":
 			if modes := flattenModeOptions(opt); len(modes) > 0 {
 				a.reportModes(acpModesBlock{CurrentModeID: opt.CurrentValue, AvailableModes: modes})
+				hasCfgMode = true
 				slog.Info("acp: probeSessionConfig fetched mode configOption", "count", len(modes))
 			}
 		}
+	}
+	// Legacy models/modes blocks fill only what configOptions did not provide.
+	if !hasCfgModel && sn.Models != nil && len(sn.Models.AvailableModels) > 0 {
+		a.reportModels(*sn.Models)
+		slog.Info("acp: probeSessionConfig fetched models", "count", len(sn.Models.AvailableModels))
+	}
+	if !hasCfgMode && sn.Modes != nil && len(sn.Modes.AvailableModes) > 0 {
+		a.reportModes(*sn.Modes)
+		slog.Info("acp: probeSessionConfig fetched modes", "count", len(sn.Modes.AvailableModes))
 	}
 }

--- a/agent/acp/agent.go
+++ b/agent/acp/agent.go
@@ -544,7 +544,8 @@ func (a *Agent) probeSessionConfig() {
 		Models        *acpModelsBlock   `json:"models"`
 		ConfigOptions []acpConfigOption `json:"configOptions"`
 	}
-	if json.Unmarshal(newRes, &sn) != nil {
+	if err := json.Unmarshal(newRes, &sn); err != nil {
+		slog.Warn("acp: probeSessionConfig parse session/new failed", "error", err)
 		return
 	}
 	// configOptions (newer mechanism) takes precedence. Absorb it first and

--- a/agent/acp/list_sessions.go
+++ b/agent/acp/list_sessions.go
@@ -27,11 +27,17 @@ var listSessionsProbeTimeout = 15 * time.Second
 // (see probeSessionConfig). It is deliberately independent from the
 // caller's ctx (cmdModel/cmdMode only pass 10s) because a cold start —
 // spawning the agent, initializing MCP servers, returning a possibly
-// large model list — can exceed 10s. The slowest tested agent (hermes,
-// 108 models) probes in ~11.4s steady-state; 15s sits right at the
-// load-jittered peak and times out intermittently, so 20s is used to
-// leave ~1.75x headroom while still bounding how long /model can block.
-var sessionConfigProbeTimeout = 20 * time.Second
+// large model list — can exceed 10s.
+//
+// This is an upper bound, not a fixed wait: fast agents return in well
+// under a second (mimo ~0.8s, codebuddy ~3s, kiro ~5s) and are unaffected.
+// It only matters for slow agents. The slowest tested (hermes, 108 models
+// fetched from a dynamic backend) has a highly variable probe: ~11-13s
+// typical but observed above 20s under load. 20s timed out intermittently
+// (probe returned an empty list -> /model showed "not supported"), so 30s
+// is used to reliably cover the worst case while leaving fast agents
+// unaffected.
+var sessionConfigProbeTimeout = 30 * time.Second
 
 // acpModeInfo mirrors the ACP `modes.availableModes[]` shape sent by
 // servers like `devin acp`, Cursor Agent, Copilot CLI, etc.

--- a/agent/acp/list_sessions.go
+++ b/agent/acp/list_sessions.go
@@ -22,6 +22,17 @@ import (
 // slow we'd rather return nothing than block `/ls` in IM.
 var listSessionsProbeTimeout = 15 * time.Second
 
+// sessionConfigProbeTimeout bounds a one-shot initialize + session/new
+// probe used to answer /model and /mode when no session is active
+// (see probeSessionConfig). It is deliberately independent from the
+// caller's ctx (cmdModel/cmdMode only pass 10s) because a cold start —
+// spawning the agent, initializing MCP servers, returning a possibly
+// large model list — can exceed 10s. The slowest tested agent (hermes,
+// 108 models) probes in ~11.4s steady-state; 15s sits right at the
+// load-jittered peak and times out intermittently, so 20s is used to
+// leave ~1.75x headroom while still bounding how long /model can block.
+var sessionConfigProbeTimeout = 20 * time.Second
+
 // acpModeInfo mirrors the ACP `modes.availableModes[]` shape sent by
 // servers like `devin acp`, Cursor Agent, Copilot CLI, etc.
 type acpModeInfo struct {
@@ -35,6 +46,59 @@ type acpModeInfo struct {
 type acpModesBlock struct {
 	CurrentModeID  string        `json:"currentModeId"`
 	AvailableModes []acpModeInfo `json:"availableModes"`
+}
+
+// acpModelInfo mirrors an entry in the ACP `models.availableModels[]`
+// array (early Zed-style model selector, used by Kiro CLI and others).
+// See: ACP model selector PR #182.
+type acpModelInfo struct {
+	ModelID     string `json:"modelId"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// acpModelsBlock mirrors the `models` object returned inside `session/new`
+// and `session/load` responses. It is the model-selector counterpart of
+// acpModesBlock (modes), and is switched via `session/set_model`.
+type acpModelsBlock struct {
+	CurrentModelID  string         `json:"currentModelId"`
+	AvailableModels []acpModelInfo `json:"availableModels"`
+}
+
+// acpConfigOption mirrors an entry in the newer ACP `configOptions[]`
+// mechanism (Session Config Options RFD), an alternative to the top-level
+// `models`/`modes` blocks. A single `configOptions` array carries multiple
+// selectors distinguished by Category ("model", "mode", "thought_level",
+// ...), and values are switched via `session/set_config_option`.
+// Agents such as OpenCode use this; kiro/mimo/codebuddy/hermes use the
+// `models`/`modes` blocks instead. cc-connect supports both.
+// See: https://agentclientprotocol.com/rfds/session-config-options
+type acpConfigOption struct {
+	ID           string                   `json:"id"`
+	Name         string                   `json:"name"`
+	Description  string                   `json:"description,omitempty"`
+	Category     string                   `json:"category,omitempty"`
+	Type         string                   `json:"type"`
+	CurrentValue string                   `json:"currentValue"`
+	Options      []acpConfigSelectOptions `json:"options"`
+}
+
+// acpConfigSelectOptions is an entry in a configOption's option list. It is
+// either a direct option (Value non-empty) or a group (Group non-empty with
+// nested Options).
+type acpConfigSelectOptions struct {
+	Value       string                  `json:"value,omitempty"`
+	Name        string                  `json:"name,omitempty"`
+	Description string                  `json:"description,omitempty"`
+	Group       string                  `json:"group,omitempty"`
+	Options     []acpConfigSelectOption `json:"options,omitempty"`
+}
+
+// acpConfigSelectOption is a single option inside a group.
+type acpConfigSelectOption struct {
+	Value       string `json:"value"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
 }
 
 // acpInitializeResult is the subset of `initialize` fields this package

--- a/agent/acp/models_test.go
+++ b/agent/acp/models_test.go
@@ -370,6 +370,53 @@ func TestSession_bothMechanisms_configOptionsWins(t *testing.T) {
 	assert(t, s2)
 }
 
+// Mixed mechanisms: an agent provides a model selector via configOptions
+// but a mode selector only via the legacy `modes` block. The two selectors
+// must resolve independently — model from configOptions (modelConfigID set),
+// mode from the block (modeConfigID empty). Order-independent.
+func TestSession_mixedMechanisms_modelCfgModeBlock(t *testing.T) {
+	assert := func(t *testing.T, s *acpSession) {
+		t.Helper()
+		s.modelsMu.RLock()
+		if s.modelConfigID != "model" || s.currentModel != "cfg-model" ||
+			len(s.availableModels) != 1 || s.availableModels[0].ModelID != "cfg-model" {
+			s.modelsMu.RUnlock()
+			t.Fatalf("model: configID=%q current=%q avail=%+v — want configOptions",
+				s.modelConfigID, s.currentModel, s.availableModels)
+		}
+		s.modelsMu.RUnlock()
+
+		s.modesMu.RLock()
+		defer s.modesMu.RUnlock()
+		if s.modeConfigID != "" || s.currentMode != "block-mode" ||
+			len(s.availableModes) != 1 || s.availableModes[0].ID != "block-mode" {
+			t.Fatalf("mode: configID=%q current=%q avail=%+v — want legacy block",
+				s.modeConfigID, s.currentMode, s.availableModes)
+		}
+	}
+	modeBlock := &acpModesBlock{
+		CurrentModeID:  "block-mode",
+		AvailableModes: []acpModeInfo{{ID: "block-mode", Name: "Block Mode"}},
+	}
+	// configOptions carries only a model selector (no mode category).
+	cfg := []acpConfigOption{{
+		ID: "model", Category: "model", CurrentValue: "cfg-model",
+		Options: []acpConfigSelectOptions{{Value: "cfg-model"}},
+	}}
+
+	// configOptions first, then the mode block (handshake order).
+	s1 := &acpSession{}
+	s1.absorbConfigOptions(cfg)
+	s1.absorbModes(modeBlock)
+	assert(t, s1)
+
+	// Reversed order must yield the same result.
+	s2 := &acpSession{}
+	s2.absorbModes(modeBlock)
+	s2.absorbConfigOptions(cfg)
+	assert(t, s2)
+}
+
 // --- concurrency safety (run with -race) ---------------------------
 
 func TestAgent_ConcurrentModelAccess(t *testing.T) {

--- a/agent/acp/models_test.go
+++ b/agent/acp/models_test.go
@@ -328,6 +328,48 @@ func TestFlattenModelOptions_flatAndGrouped(t *testing.T) {
 	}
 }
 
+// When an agent advertises BOTH the legacy models/modes blocks AND
+// configOptions selectors, the newer configOptions must win — regardless
+// of the absorb order — and the state must stay consistent (the switch
+// path via modelConfigID/modeConfigID must match the reported list).
+func TestSession_bothMechanisms_configOptionsWins(t *testing.T) {
+	assert := func(t *testing.T, s *acpSession) {
+		t.Helper()
+		s.modelsMu.RLock()
+		defer s.modelsMu.RUnlock()
+		if s.modelConfigID != "model" {
+			t.Fatalf("modelConfigID = %q, want model (configOptions wins)", s.modelConfigID)
+		}
+		if s.currentModel != "new-a" {
+			t.Fatalf("currentModel = %q, want new-a (consistent with configOptions)", s.currentModel)
+		}
+		if len(s.availableModels) != 2 || s.availableModels[0].ModelID != "new-a" {
+			t.Fatalf("availableModels = %+v, want the configOptions list", s.availableModels)
+		}
+	}
+	block := &acpModelsBlock{
+		CurrentModelID:  "old-a",
+		AvailableModels: []acpModelInfo{{ModelID: "old-a"}, {ModelID: "old-b"}},
+	}
+	cfg := []acpConfigOption{{
+		ID: "model", Category: "model", CurrentValue: "new-a",
+		Options: []acpConfigSelectOptions{{Value: "new-a"}, {Value: "new-b"}},
+	}}
+
+	// configOptions first, then the block (handshake order).
+	s1 := &acpSession{}
+	s1.absorbConfigOptions(cfg)
+	s1.absorbModels(block)
+	assert(t, s1)
+
+	// Reversed order must yield the same result — precedence is not
+	// order-dependent (the block is skipped once modelConfigID is set).
+	s2 := &acpSession{}
+	s2.absorbModels(block)
+	s2.absorbConfigOptions(cfg)
+	assert(t, s2)
+}
+
 // --- concurrency safety (run with -race) ---------------------------
 
 func TestAgent_ConcurrentModelAccess(t *testing.T) {

--- a/agent/acp/models_test.go
+++ b/agent/acp/models_test.go
@@ -1,0 +1,369 @@
+package acp
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// Compile-time interface conformance check.
+var _ core.ModelSwitcher = (*Agent)(nil)
+
+// NOTE: these unit tests use neutral fixture ids ("model-a", "mode-a", ...)
+// rather than real model/mode names on purpose. They exercise cache and
+// switching *logic* with deterministic inputs; the set of real models a
+// given ACP agent advertises changes over time and is verified separately
+// and dynamically in acp_integration_test.go (which reads the live list and
+// picks a target at runtime — never hard-coding a model name).
+
+// --- Agent: models cache & ModelSwitcher (models block) ------------
+
+func TestAgent_reportModels_populatesCache(t *testing.T) {
+	a := &Agent{}
+	a.reportModels(acpModelsBlock{
+		CurrentModelID: "model-b",
+		AvailableModels: []acpModelInfo{
+			{ModelID: "model-a", Name: "model-a", Description: "Auto select"},
+			{ModelID: "model-b", Name: "model-b", Description: "Balanced"},
+			{ModelID: "model-c", Name: "model-c", Description: "Most capable"},
+		},
+	})
+
+	if got := a.GetModel(); got != "model-b" {
+		t.Fatalf("GetModel() = %q, want model-b", got)
+	}
+	models := a.AvailableModels(context.Background())
+	if len(models) != 3 {
+		t.Fatalf("AvailableModels() len = %d, want 3", len(models))
+	}
+	if models[0].Name != "model-a" || models[0].Desc != "Auto select" {
+		t.Fatalf("models[0] = %+v, want model-a", models[0])
+	}
+	if models[1].Name != "model-b" {
+		t.Fatalf("models[1].Name = %q, want model-b", models[1].Name)
+	}
+}
+
+func TestAgent_GetModel_NoModels(t *testing.T) {
+	a := &Agent{}
+	a.sessionConfigProbed.Store(true) // avoid triggering a real probe/spawn
+	if got := a.GetModel(); got != "" {
+		t.Fatalf("GetModel() = %q, want empty", got)
+	}
+	if models := a.AvailableModels(context.Background()); models != nil {
+		t.Fatalf("AvailableModels() = %v, want nil", models)
+	}
+}
+
+// Regression: after `/model switch X`, the engine calls SetModel(X) then
+// reads back GetModel() to display and apply. The pending SetModel MUST
+// win over the server-reported currentModelId (mirrors GetMode).
+func TestAgent_SetModel_PendingWinsOverCurrent(t *testing.T) {
+	a := &Agent{}
+	a.reportModels(acpModelsBlock{
+		CurrentModelID: "model-a",
+		AvailableModels: []acpModelInfo{
+			{ModelID: "model-a", Name: "model-a"},
+			{ModelID: "model-b", Name: "model-b"},
+		},
+	})
+	a.SetModel("model-b")
+	if got := a.GetModel(); got != "model-b" {
+		t.Fatalf("GetModel() after SetModel = %q, want model-b", got)
+	}
+}
+
+func TestAgent_GetModel_FallbackToServerCurrent(t *testing.T) {
+	a := &Agent{}
+	// No SetModel: GetModel falls back to the server-reported currentModel.
+	a.reportModels(acpModelsBlock{
+		CurrentModelID:  "model-x",
+		AvailableModels: []acpModelInfo{{ModelID: "model-x", Name: "model-x"}},
+	})
+	if got := a.GetModel(); got != "model-x" {
+		t.Fatalf("GetModel() = %q, want model-x", got)
+	}
+}
+
+// --- Agent: PermissionModes probe behaviour ------------------------
+
+// The cache being populated means PermissionModes returns directly
+// without triggering a probe.
+func TestAgent_PermissionModes_returnsCachedModes(t *testing.T) {
+	a := &Agent{}
+	a.reportModes(acpModesBlock{
+		CurrentModeID: "mode-a",
+		AvailableModes: []acpModeInfo{
+			{ID: "mode-a", Name: "mode-a", Description: "First mode"},
+			{ID: "mode-b", Name: "mode-b", Description: "Second mode"},
+		},
+	})
+
+	modes := a.PermissionModes()
+	if len(modes) != 2 {
+		t.Fatalf("PermissionModes() len = %d, want 2", len(modes))
+	}
+	if modes[0].Key != "mode-a" || modes[1].Key != "mode-b" {
+		t.Fatalf("PermissionModes() = %+v", modes)
+	}
+}
+
+// Once probed, an empty cache must not trigger another probe (returns
+// empty rather than spawning).
+func TestAgent_PermissionModes_skipsProbeWhenProbed(t *testing.T) {
+	a := &Agent{}
+	a.sessionConfigProbed.Store(true) // probed but the agent has no modes
+
+	if modes := a.PermissionModes(); len(modes) != 0 {
+		t.Fatalf("PermissionModes() = %+v, want empty (probe skipped)", modes)
+	}
+}
+
+// modes and models share one probe flag: once probed, neither entry
+// point spawns again even with an empty cache.
+func TestAgent_SharedProbeFlag(t *testing.T) {
+	a := &Agent{}
+	a.sessionConfigProbed.Store(true)
+
+	if got := a.PermissionModes(); len(got) != 0 {
+		t.Fatalf("PermissionModes = %+v, want empty", got)
+	}
+	if got := a.AvailableModels(context.Background()); got != nil {
+		t.Fatalf("AvailableModels = %+v, want nil", got)
+	}
+}
+
+// A zero-value Agent (no cmd) must not attempt to spawn a probe process
+// when the caches are empty.
+func TestAgent_ensureProbe_noCmdNoSpawn(t *testing.T) {
+	a := &Agent{} // cmd == ""
+	if got := a.AvailableModels(context.Background()); got != nil {
+		t.Fatalf("AvailableModels = %+v, want nil", got)
+	}
+	if got := a.PermissionModes(); len(got) != 0 {
+		t.Fatalf("PermissionModes = %+v, want empty", got)
+	}
+	// Probe must not have been marked as run (no cmd to probe).
+	if a.sessionConfigProbed.Load() {
+		t.Fatal("sessionConfigProbed should stay false when cmd is empty")
+	}
+}
+
+// --- session: absorbModels / SetLiveModel / current_model_update ---
+
+func TestSession_absorbModels_reportsViaCallback(t *testing.T) {
+	cb := &fakeCallbacks{}
+	s := &acpSession{callbacks: cb}
+
+	s.absorbModels(&acpModelsBlock{
+		CurrentModelID:  "model-a",
+		AvailableModels: []acpModelInfo{{ModelID: "model-a", Name: "A"}, {ModelID: "model-b", Name: "B"}},
+	})
+
+	got, ok := cb.lastModels()
+	if !ok || got.CurrentModelID != "model-a" || len(got.AvailableModels) != 2 {
+		t.Fatalf("callback got %+v (ok=%v), want currentModelId=model-a with 2 models", got, ok)
+	}
+	s.modelsMu.RLock()
+	defer s.modelsMu.RUnlock()
+	if s.currentModel != "model-a" || len(s.availableModels) != 2 {
+		t.Fatalf("session cache: current=%q models=%d", s.currentModel, len(s.availableModels))
+	}
+}
+
+func TestSession_absorbModels_emptyNoOp(t *testing.T) {
+	cb := &fakeCallbacks{}
+	s := &acpSession{callbacks: cb}
+	s.absorbModels(nil)
+	s.absorbModels(&acpModelsBlock{})
+	if _, ok := cb.lastModels(); ok {
+		t.Fatal("callback should not fire for an empty models block")
+	}
+}
+
+func TestSession_matchAvailableModel(t *testing.T) {
+	s := &acpSession{
+		availableModels: []acpModelInfo{
+			{ModelID: "model-a", Name: "model-a"},
+			{ModelID: "model-b", Name: "model-b"},
+		},
+	}
+	if got := s.matchAvailableModel("model-b"); got != "model-b" {
+		t.Fatalf("match exact = %q", got)
+	}
+	if got := s.matchAvailableModel("MODEL-A"); got != "model-a" {
+		t.Fatalf("match case-insensitive = %q", got)
+	}
+	if got := s.matchAvailableModel("nonexistent"); got != "" {
+		t.Fatalf("match unknown = %q, want empty", got)
+	}
+}
+
+func TestSession_maybeAbsorbCurrentModelUpdate(t *testing.T) {
+	cb := &fakeCallbacks{}
+	s := &acpSession{
+		callbacks:       cb,
+		availableModels: []acpModelInfo{{ModelID: "model-a"}, {ModelID: "model-b"}},
+	}
+	params := []byte(`{"update":{"sessionUpdate":"current_model_update","currentModelId":"model-b"}}`)
+	s.maybeAbsorbCurrentModelUpdate(params)
+
+	got, ok := cb.lastModels()
+	if !ok || got.CurrentModelID != "model-b" {
+		t.Fatalf("reported currentModelId = %q (ok=%v), want model-b", got.CurrentModelID, ok)
+	}
+	s.modelsMu.RLock()
+	defer s.modelsMu.RUnlock()
+	if s.currentModel != "model-b" {
+		t.Fatalf("session currentModel = %q, want model-b", s.currentModel)
+	}
+}
+
+func TestSession_maybeAbsorbCurrentModelUpdate_ignoresOther(t *testing.T) {
+	cb := &fakeCallbacks{}
+	s := &acpSession{callbacks: cb}
+	// A mode update must not trigger the model callback.
+	params := []byte(`{"update":{"sessionUpdate":"current_mode_update","currentModeId":"mode-a"}}`)
+	s.maybeAbsorbCurrentModelUpdate(params)
+	if _, ok := cb.lastModels(); ok {
+		t.Fatal("model callback should not fire for a mode update")
+	}
+}
+
+// --- session: configOptions mechanism (OpenCode-style) ------------
+
+func TestSession_absorbConfigOptions_model(t *testing.T) {
+	cb := &fakeCallbacks{}
+	s := &acpSession{callbacks: cb}
+
+	s.absorbConfigOptions([]acpConfigOption{
+		{
+			ID:           "model",
+			Name:         "Model",
+			Category:     "model",
+			Type:         "select",
+			CurrentValue: "model-b",
+			Options: []acpConfigSelectOptions{
+				{Value: "model-a", Name: "Model A"},
+				{Value: "model-b", Name: "Model B"},
+			},
+		},
+	})
+
+	// Normalised into the models cache, with configId recorded for switching.
+	s.modelsMu.RLock()
+	defer s.modelsMu.RUnlock()
+	if s.currentModel != "model-b" {
+		t.Fatalf("currentModel = %q, want model-b", s.currentModel)
+	}
+	if len(s.availableModels) != 2 || s.availableModels[0].ModelID != "model-a" {
+		t.Fatalf("availableModels = %+v", s.availableModels)
+	}
+	if s.modelConfigID != "model" {
+		t.Fatalf("modelConfigID = %q, want model", s.modelConfigID)
+	}
+	if got, ok := cb.lastModels(); !ok || got.CurrentModelID != "model-b" {
+		t.Fatalf("reported models = %+v (ok=%v)", got, ok)
+	}
+}
+
+func TestSession_absorbConfigOptions_mode(t *testing.T) {
+	cb := &fakeCallbacks{}
+	s := &acpSession{callbacks: cb}
+
+	s.absorbConfigOptions([]acpConfigOption{
+		{
+			ID:           "mode",
+			Category:     "mode",
+			CurrentValue: "mode-a",
+			Options: []acpConfigSelectOptions{
+				{Value: "mode-a", Name: "Ask"},
+				{Value: "mode-b", Name: "Code"},
+			},
+		},
+	})
+
+	s.modesMu.RLock()
+	defer s.modesMu.RUnlock()
+	if s.currentMode != "mode-a" || s.modeConfigID != "mode" {
+		t.Fatalf("currentMode=%q modeConfigID=%q", s.currentMode, s.modeConfigID)
+	}
+	if len(s.availableModes) != 2 || s.availableModes[1].ID != "mode-b" {
+		t.Fatalf("availableModes = %+v", s.availableModes)
+	}
+}
+
+func TestSession_maybeAbsorbConfigOptionUpdate(t *testing.T) {
+	cb := &fakeCallbacks{}
+	s := &acpSession{callbacks: cb}
+	params := []byte(`{"update":{"sessionUpdate":"config_option_update","configOptions":[` +
+		`{"id":"model","category":"model","currentValue":"model-b","options":[{"value":"model-a"},{"value":"model-b"}]}]}}`)
+	s.maybeAbsorbConfigOptionUpdate(params)
+
+	got, ok := cb.lastModels()
+	if !ok || got.CurrentModelID != "model-b" {
+		t.Fatalf("reported currentModelId = %q (ok=%v), want model-b", got.CurrentModelID, ok)
+	}
+}
+
+func TestFlattenModelOptions_flatAndGrouped(t *testing.T) {
+	// Flat options.
+	flat := flattenModelOptions(acpConfigOption{
+		Options: []acpConfigSelectOptions{{Value: "a", Name: "A"}, {Value: "b", Name: "B"}},
+	})
+	if len(flat) != 2 || flat[0].ModelID != "a" || flat[1].Name != "B" {
+		t.Fatalf("flat = %+v", flat)
+	}
+	// Grouped options.
+	grouped := flattenModelOptions(acpConfigOption{
+		Options: []acpConfigSelectOptions{
+			{Group: "G1", Options: []acpConfigSelectOption{{Value: "x", Name: "X"}}},
+			{Group: "G2", Options: []acpConfigSelectOption{{Value: "y"}, {Value: "z"}}},
+		},
+	})
+	if len(grouped) != 3 || grouped[0].ModelID != "x" || grouped[2].ModelID != "z" {
+		t.Fatalf("grouped = %+v", grouped)
+	}
+}
+
+// --- concurrency safety (run with -race) ---------------------------
+
+func TestAgent_ConcurrentModelAccess(t *testing.T) {
+	a := &Agent{}
+	a.sessionConfigProbed.Store(true)
+	a.reportModels(acpModelsBlock{
+		CurrentModelID:  "model-a",
+		AvailableModels: []acpModelInfo{{ModelID: "model-a"}, {ModelID: "model-b"}},
+	})
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				a.reportModels(acpModelsBlock{
+					CurrentModelID:  "model-a",
+					AvailableModels: []acpModelInfo{{ModelID: "model-a"}, {ModelID: "model-b"}},
+				})
+			}
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = a.GetModel()
+			_ = a.AvailableModels(context.Background())
+			a.SetModel("model-b")
+		}
+		close(stop)
+	}()
+	wg.Wait()
+}

--- a/agent/acp/session.go
+++ b/agent/acp/session.go
@@ -44,13 +44,27 @@ type acpSession struct {
 	toolInputMu   sync.Mutex
 	toolInputByID map[string]string // toolCallId -> summarized tool input
 
-	// modesMu guards availableModes and currentMode. Both fields are
-	// populated on handshake (session/new or session/load response) and
-	// updated whenever SetLiveMode succeeds or the server announces a
-	// mode change via session/update.
+	// modesMu guards availableModes, currentMode and modeConfigID. Populated
+	// on handshake (session/new or session/load) and updated whenever
+	// SetLiveMode succeeds or the server announces a mode change.
+	// modeConfigID is non-empty when the mode selector came from the
+	// configOptions mechanism (switch via session/set_config_option);
+	// empty means the `modes` block is used (switch via session/set_mode).
 	modesMu        sync.RWMutex
 	availableModes []acpModeInfo
 	currentMode    string
+	modeConfigID   string
+
+	// modelsMu guards availableModels, currentModel and modelConfigID.
+	// Populated on handshake and updated when SetLiveModel succeeds or the
+	// server announces a model change. modelConfigID is non-empty when the
+	// model selector came from configOptions (switch via
+	// session/set_config_option); empty means the `models` block is used
+	// (switch via session/set_model).
+	modelsMu        sync.RWMutex
+	availableModels []acpModelInfo
+	currentModel    string
+	modelConfigID   string
 
 	callbacks sessionCallbacks // may be nil (tests, integration harness)
 }
@@ -71,7 +85,7 @@ type acpSessionConfig struct {
 	workDir         string
 	resumeSessionID string
 	authMethod      string
-	initialMode     string           // if non-empty, applied via session/set_mode after session/new
+	initialMode     string           // if non-empty, applied via SetLiveMode after session/new
 	callbacks       sessionCallbacks // may be nil
 }
 
@@ -216,12 +230,16 @@ func (s *acpSession) handshake(resumeSessionID string, authMethod string) error 
 			slog.Warn("acp: session/load failed, starting new session", "error", err)
 		} else {
 			var lr struct {
-				SessionID string         `json:"sessionId"`
-				Modes     *acpModesBlock `json:"modes"`
+				SessionID     string            `json:"sessionId"`
+				Modes         *acpModesBlock    `json:"modes"`
+				Models        *acpModelsBlock   `json:"models"`
+				ConfigOptions []acpConfigOption `json:"configOptions"`
 			}
 			if json.Unmarshal(loadRes, &lr) == nil && lr.SessionID != "" {
 				s.setACPSessionID(lr.SessionID)
 				s.absorbModes(lr.Modes)
+				s.absorbModels(lr.Models)
+				s.absorbConfigOptions(lr.ConfigOptions)
 				return nil
 			}
 		}
@@ -236,8 +254,10 @@ func (s *acpSession) handshake(resumeSessionID string, authMethod string) error 
 		return fmt.Errorf("acp: session/new: %w", err)
 	}
 	var sn struct {
-		SessionID string         `json:"sessionId"`
-		Modes     *acpModesBlock `json:"modes"`
+		SessionID     string            `json:"sessionId"`
+		Modes         *acpModesBlock    `json:"modes"`
+		Models        *acpModelsBlock   `json:"models"`
+		ConfigOptions []acpConfigOption `json:"configOptions"`
 	}
 	if err := json.Unmarshal(newRes, &sn); err != nil {
 		return fmt.Errorf("acp: parse session/new: %w", err)
@@ -247,6 +267,8 @@ func (s *acpSession) handshake(resumeSessionID string, authMethod string) error 
 	}
 	s.setACPSessionID(sn.SessionID)
 	s.absorbModes(sn.Modes)
+	s.absorbModels(sn.Models)
+	s.absorbConfigOptions(sn.ConfigOptions)
 	return nil
 }
 
@@ -269,6 +291,201 @@ func (s *acpSession) absorbModes(block *acpModesBlock) {
 	}
 }
 
+// absorbModels caches the ACP `models` block and reports it to the
+// parent agent. It is the model-selector counterpart of absorbModes,
+// called on handshake (session/new or session/load) and on
+// current_model_update notifications.
+func (s *acpSession) absorbModels(block *acpModelsBlock) {
+	if block == nil || len(block.AvailableModels) == 0 {
+		return
+	}
+	s.modelsMu.Lock()
+	s.availableModels = append(s.availableModels[:0], block.AvailableModels...)
+	if block.CurrentModelID != "" {
+		s.currentModel = block.CurrentModelID
+	}
+	s.modelsMu.Unlock()
+	if s.callbacks != nil {
+		s.callbacks.reportModels(*block)
+	}
+	slog.Debug("acp: absorbed models", "count", len(block.AvailableModels), "current", block.CurrentModelID)
+}
+
+// absorbConfigOptions handles the newer `configOptions` mechanism (an
+// alternative to the top-level `models`/`modes` blocks). It normalises the
+// model and mode selectors it finds into the same availableModels /
+// availableModes caches, and records the originating configId so live
+// switching routes through session/set_config_option.
+func (s *acpSession) absorbConfigOptions(options []acpConfigOption) {
+	for i := range options {
+		opt := options[i]
+		switch opt.Category {
+		case "model":
+			models := flattenModelOptions(opt)
+			if len(models) == 0 {
+				continue
+			}
+			s.modelsMu.Lock()
+			s.availableModels = models
+			if opt.CurrentValue != "" {
+				s.currentModel = opt.CurrentValue
+			}
+			s.modelConfigID = opt.ID
+			s.modelsMu.Unlock()
+			if s.callbacks != nil {
+				s.callbacks.reportModels(acpModelsBlock{CurrentModelID: opt.CurrentValue, AvailableModels: models})
+			}
+			slog.Debug("acp: absorbed model configOption", "configId", opt.ID, "count", len(models), "current", opt.CurrentValue)
+		case "mode":
+			modes := flattenModeOptions(opt)
+			if len(modes) == 0 {
+				continue
+			}
+			s.modesMu.Lock()
+			s.availableModes = modes
+			if opt.CurrentValue != "" {
+				s.currentMode = opt.CurrentValue
+			}
+			s.modeConfigID = opt.ID
+			s.modesMu.Unlock()
+			if s.callbacks != nil {
+				s.callbacks.reportModes(acpModesBlock{CurrentModeID: opt.CurrentValue, AvailableModes: modes})
+			}
+			slog.Debug("acp: absorbed mode configOption", "configId", opt.ID, "count", len(modes), "current", opt.CurrentValue)
+		}
+	}
+}
+
+// flattenModelOptions converts a configOption's option list (flat or
+// grouped) into acpModelInfo entries.
+func flattenModelOptions(opt acpConfigOption) []acpModelInfo {
+	var out []acpModelInfo
+	for _, o := range opt.Options {
+		if o.Group != "" {
+			for _, g := range o.Options {
+				out = append(out, acpModelInfo{ModelID: g.Value, Name: g.Name, Description: g.Description})
+			}
+		} else if o.Value != "" {
+			out = append(out, acpModelInfo{ModelID: o.Value, Name: o.Name, Description: o.Description})
+		}
+	}
+	return out
+}
+
+// flattenModeOptions converts a configOption's option list (flat or
+// grouped) into acpModeInfo entries.
+func flattenModeOptions(opt acpConfigOption) []acpModeInfo {
+	var out []acpModeInfo
+	for _, o := range opt.Options {
+		if o.Group != "" {
+			for _, g := range o.Options {
+				out = append(out, acpModeInfo{ID: g.Value, Name: g.Name, Description: g.Description})
+			}
+		} else if o.Value != "" {
+			out = append(out, acpModeInfo{ID: o.Value, Name: o.Name, Description: o.Description})
+		}
+	}
+	return out
+}
+
+// SetLiveModel implements core.LiveModelSwitcher. It applies a model
+// change to the running session and re-publishes the new state so
+// Agent.GetModel stays in sync. Returns true on success, false if the
+// model is unknown / the call errors / the session is closed.
+//
+// The switch routes through session/set_config_option when the model
+// selector came from the configOptions mechanism (modelConfigID set), or
+// session/set_model when it came from the `models` block.
+func (s *acpSession) SetLiveModel(model string) bool {
+	if !s.alive.Load() {
+		return false
+	}
+	sid := s.currentACPSessionID()
+	if sid == "" {
+		return false
+	}
+	modelID := s.matchAvailableModel(model)
+	if modelID == "" {
+		slog.Debug("acp: SetLiveModel rejected unknown model", "model", model, "session_id", sid)
+		return false
+	}
+
+	s.modelsMu.RLock()
+	configID := s.modelConfigID
+	s.modelsMu.RUnlock()
+
+	if configID != "" {
+		if !s.setConfigOption(sid, configID, modelID) {
+			return false
+		}
+	} else {
+		if _, err := s.tr.call(s.ctx, "session/set_model", map[string]any{
+			"sessionId": sid,
+			"modelId":   modelID,
+		}); err != nil {
+			slog.Warn("acp: session/set_model failed", "model", modelID, "session_id", sid, "error", err)
+			return false
+		}
+	}
+
+	// Both RPCs return without the full updated state, so optimistically
+	// update the local cache and re-publish to keep Agent.GetModel in sync.
+	s.modelsMu.Lock()
+	s.currentModel = modelID
+	available := append([]acpModelInfo(nil), s.availableModels...)
+	s.modelsMu.Unlock()
+	if s.callbacks != nil {
+		s.callbacks.reportModels(acpModelsBlock{
+			CurrentModelID:  modelID,
+			AvailableModels: available,
+		})
+	}
+	slog.Info("acp: live model applied", "model", modelID, "session_id", sid)
+	return true
+}
+
+// setConfigOption sends a session/set_config_option RPC. Returns true on
+// success. Any full configOptions payload in the response is absorbed to
+// keep caches fresh.
+func (s *acpSession) setConfigOption(sid, configID, value string) bool {
+	res, err := s.tr.call(s.ctx, "session/set_config_option", map[string]any{
+		"sessionId": sid,
+		"configId":  configID,
+		"value":     value,
+	})
+	if err != nil {
+		slog.Warn("acp: session/set_config_option failed", "configId", configID, "value", value, "session_id", sid, "error", err)
+		return false
+	}
+	var resp struct {
+		ConfigOptions []acpConfigOption `json:"configOptions"`
+	}
+	if json.Unmarshal(res, &resp) == nil && len(resp.ConfigOptions) > 0 {
+		s.absorbConfigOptions(resp.ConfigOptions)
+	}
+	return true
+}
+
+// matchAvailableModel resolves a user-typed model string to a known ACP
+// modelId from the cached availableModels list. Matching is case-
+// insensitive on both modelId and display name to accommodate IM input.
+// Returns "" if nothing matches or if models are unknown.
+func (s *acpSession) matchAvailableModel(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+	lower := strings.ToLower(input)
+	s.modelsMu.RLock()
+	defer s.modelsMu.RUnlock()
+	for _, m := range s.availableModels {
+		if strings.ToLower(m.ModelID) == lower || strings.ToLower(m.Name) == lower {
+			return m.ModelID
+		}
+	}
+	return ""
+}
+
 func (s *acpSession) setACPSessionID(id string) {
 	s.acpSessMu.Lock()
 	s.acpSessID = id
@@ -289,9 +506,12 @@ func (s *acpSession) CurrentMode() string {
 	return s.currentMode
 }
 
-// SetLiveMode applies a permission mode change to the running session
-// via `session/set_mode`. Returns true on success, false if the mode
-// is unknown / the call errors / the session is closed.
+// SetLiveMode applies a permission mode change to the running session.
+// The switch routes through session/set_config_option when the mode
+// selector came from the configOptions mechanism (modeConfigID set), or
+// session/set_mode when it came from the `modes` block. Returns true on
+// success, false if the mode is unknown / the call errors / the session
+// is closed.
 //
 // This is the implementation of core.LiveModeSwitcher for ACP
 // sessions; the engine invokes it when the user runs `/mode <x>`,
@@ -316,16 +536,27 @@ func (s *acpSession) SetLiveMode(mode string) bool {
 		)
 		return false
 	}
-	if _, err := s.tr.call(s.ctx, "session/set_mode", map[string]any{
-		"sessionId": sid,
-		"modeId":    modeID,
-	}); err != nil {
-		slog.Warn("acp: session/set_mode failed",
-			"mode", modeID,
-			"session_id", sid,
-			"error", err,
-		)
-		return false
+
+	s.modesMu.RLock()
+	configID := s.modeConfigID
+	s.modesMu.RUnlock()
+
+	if configID != "" {
+		if !s.setConfigOption(sid, configID, modeID) {
+			return false
+		}
+	} else {
+		if _, err := s.tr.call(s.ctx, "session/set_mode", map[string]any{
+			"sessionId": sid,
+			"modeId":    modeID,
+		}); err != nil {
+			slog.Warn("acp: session/set_mode failed",
+				"mode", modeID,
+				"session_id", sid,
+				"error", err,
+			)
+			return false
+		}
 	}
 	s.modesMu.Lock()
 	s.currentMode = modeID
@@ -372,6 +603,8 @@ func (s *acpSession) onNotification(method string, params json.RawMessage) {
 	}
 	s.cacheToolCallInput(params)
 	s.maybeAbsorbCurrentModeUpdate(params)
+	s.maybeAbsorbCurrentModelUpdate(params)
+	s.maybeAbsorbConfigOptionUpdate(params)
 	sid := s.currentACPSessionID()
 	// Debug log to capture raw session/update JSON for troubleshooting vendor compatibility
 	slog.Debug("acp: session/update", "session_id", sid, "params", string(params))
@@ -394,7 +627,7 @@ func (s *acpSession) maybeAbsorbCurrentModeUpdate(params json.RawMessage) {
 		return
 	}
 	var head struct {
-		Kind     string `json:"sessionUpdate"`
+		Kind          string `json:"sessionUpdate"`
 		CurrentModeID string `json:"currentModeId"`
 	}
 	if json.Unmarshal(wrap.Update, &head) != nil {
@@ -413,6 +646,64 @@ func (s *acpSession) maybeAbsorbCurrentModeUpdate(params json.RawMessage) {
 			AvailableModes: available,
 		})
 	}
+}
+
+// maybeAbsorbCurrentModelUpdate watches session/update notifications for
+// `current_model_update` (server-driven model switch, e.g. when the
+// agent changes model during execution or the user switches via another
+// client). Mirrors maybeAbsorbCurrentModeUpdate.
+func (s *acpSession) maybeAbsorbCurrentModelUpdate(params json.RawMessage) {
+	var wrap struct {
+		Update json.RawMessage `json:"update"`
+	}
+	if json.Unmarshal(params, &wrap) != nil || len(wrap.Update) == 0 {
+		return
+	}
+	var head struct {
+		Kind           string `json:"sessionUpdate"`
+		CurrentModelID string `json:"currentModelId"`
+	}
+	if json.Unmarshal(wrap.Update, &head) != nil {
+		return
+	}
+	if head.Kind != "current_model_update" || head.CurrentModelID == "" {
+		return
+	}
+	s.modelsMu.Lock()
+	s.currentModel = head.CurrentModelID
+	available := append([]acpModelInfo(nil), s.availableModels...)
+	s.modelsMu.Unlock()
+	if s.callbacks != nil {
+		s.callbacks.reportModels(acpModelsBlock{
+			CurrentModelID:  head.CurrentModelID,
+			AvailableModels: available,
+		})
+	}
+}
+
+// maybeAbsorbConfigOptionUpdate watches session/update notifications for
+// `config_option_update` (the configOptions-mechanism counterpart of
+// current_model_update / current_mode_update). It re-absorbs the full
+// configOptions payload so model/mode caches stay in sync when the agent
+// changes a selector during execution.
+func (s *acpSession) maybeAbsorbConfigOptionUpdate(params json.RawMessage) {
+	var wrap struct {
+		Update json.RawMessage `json:"update"`
+	}
+	if json.Unmarshal(params, &wrap) != nil || len(wrap.Update) == 0 {
+		return
+	}
+	var head struct {
+		Kind          string            `json:"sessionUpdate"`
+		ConfigOptions []acpConfigOption `json:"configOptions"`
+	}
+	if json.Unmarshal(wrap.Update, &head) != nil {
+		return
+	}
+	if head.Kind != "config_option_update" || len(head.ConfigOptions) == 0 {
+		return
+	}
+	s.absorbConfigOptions(head.ConfigOptions)
 }
 
 // cacheToolCallInput extracts and caches rawInput from tool_call and tool_call_update

--- a/agent/acp/session.go
+++ b/agent/acp/session.go
@@ -237,9 +237,9 @@ func (s *acpSession) handshake(resumeSessionID string, authMethod string) error 
 			}
 			if json.Unmarshal(loadRes, &lr) == nil && lr.SessionID != "" {
 				s.setACPSessionID(lr.SessionID)
+				s.absorbConfigOptions(lr.ConfigOptions)
 				s.absorbModes(lr.Modes)
 				s.absorbModels(lr.Models)
-				s.absorbConfigOptions(lr.ConfigOptions)
 				return nil
 			}
 		}
@@ -266,9 +266,12 @@ func (s *acpSession) handshake(resumeSessionID string, authMethod string) error 
 		return fmt.Errorf("acp: session/new: empty sessionId")
 	}
 	s.setACPSessionID(sn.SessionID)
+	// configOptions (newer mechanism) first so it claims the model/mode
+	// selectors; the legacy blocks then only fill selectors configOptions
+	// did not provide (absorbModes/absorbModels skip when the configId is set).
+	s.absorbConfigOptions(sn.ConfigOptions)
 	s.absorbModes(sn.Modes)
 	s.absorbModels(sn.Models)
-	s.absorbConfigOptions(sn.ConfigOptions)
 	return nil
 }
 
@@ -281,6 +284,13 @@ func (s *acpSession) absorbModes(block *acpModesBlock) {
 		return
 	}
 	s.modesMu.Lock()
+	// configOptions (the newer mechanism) takes precedence: if a mode
+	// selector was already absorbed from configOptions, don't let the
+	// legacy `modes` block overwrite it. Order-independent by design.
+	if s.modeConfigID != "" {
+		s.modesMu.Unlock()
+		return
+	}
 	s.availableModes = append(s.availableModes[:0], block.AvailableModes...)
 	if block.CurrentModeID != "" {
 		s.currentMode = block.CurrentModeID
@@ -300,6 +310,13 @@ func (s *acpSession) absorbModels(block *acpModelsBlock) {
 		return
 	}
 	s.modelsMu.Lock()
+	// configOptions (the newer mechanism) takes precedence: if a model
+	// selector was already absorbed from configOptions, don't let the
+	// legacy `models` block overwrite it. Order-independent by design.
+	if s.modelConfigID != "" {
+		s.modelsMu.Unlock()
+		return
+	}
 	s.availableModels = append(s.availableModels[:0], block.AvailableModels...)
 	if block.CurrentModelID != "" {
 		s.currentModel = block.CurrentModelID

--- a/agent/acp/session_mode_test.go
+++ b/agent/acp/session_mode_test.go
@@ -277,13 +277,27 @@ func TestProbeListSessions_parsesSessions(t *testing.T) {
 // fakeCallbacks captures reportModes / reportListSupported invocations
 // so tests can assert on them deterministically.
 type fakeCallbacks struct {
-	mu         sync.Mutex
-	modes      []acpModesBlock
-	listCalls  []bool
+	mu        sync.Mutex
+	modes     []acpModesBlock
+	models    []acpModelsBlock
+	listCalls []bool
 }
 
-func (f *fakeCallbacks) reportModes(b acpModesBlock)       { f.mu.Lock(); f.modes = append(f.modes, b); f.mu.Unlock() }
-func (f *fakeCallbacks) reportListSupported(supported bool) { f.mu.Lock(); f.listCalls = append(f.listCalls, supported); f.mu.Unlock() }
+func (f *fakeCallbacks) reportModes(b acpModesBlock) {
+	f.mu.Lock()
+	f.modes = append(f.modes, b)
+	f.mu.Unlock()
+}
+func (f *fakeCallbacks) reportModels(b acpModelsBlock) {
+	f.mu.Lock()
+	f.models = append(f.models, b)
+	f.mu.Unlock()
+}
+func (f *fakeCallbacks) reportListSupported(supported bool) {
+	f.mu.Lock()
+	f.listCalls = append(f.listCalls, supported)
+	f.mu.Unlock()
+}
 func (f *fakeCallbacks) lastModes() (acpModesBlock, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -291,6 +305,14 @@ func (f *fakeCallbacks) lastModes() (acpModesBlock, bool) {
 		return acpModesBlock{}, false
 	}
 	return f.modes[len(f.modes)-1], true
+}
+func (f *fakeCallbacks) lastModels() (acpModelsBlock, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.models) == 0 {
+		return acpModelsBlock{}, false
+	}
+	return f.models[len(f.models)-1], true
 }
 
 // newTestSession builds an acpSession with a pipe-backed transport

--- a/config.example.toml
+++ b/config.example.toml
@@ -1773,6 +1773,17 @@ app_secret = "your-feishu-app-secret"
 # For Devin specifically, prefer the dedicated `type = "devin"` section above.
 # 针对 Devin 建议直接使用上面的 type = "devin"；下面的 type = "acp" 主要给其他
 # 通用 ACP 工具使用。
+#
+# /model and /mode work automatically for ACP agents that expose model or
+# mode selectors. cc-connect reads the available list from the agent —
+# both the ACP `models`/`modes` blocks and the newer `configOptions`
+# mechanism are supported — and switches live via the matching ACP request,
+# with no extra config. Agents that expose neither simply have those
+# commands report "not supported".
+# 对于通过 ACP 暴露模型 / 模式选择器的 Agent，/model 与 /mode 开箱即用：
+# cc-connect 会自动从 Agent 读取可用列表（同时支持 ACP 的 models/modes 块与较新的
+# configOptions 机制），并通过对应的 ACP 请求实时切换，无需额外配置；两者都不暴露的
+# Agent 则会提示 "not supported"。
 
 # --- Example: Cursor Agent CLI (npm: @anthropic-ai/cursor-agent) ---
 # [[projects]]

--- a/core/engine.go
+++ b/core/engine.go
@@ -9349,7 +9349,29 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 		return
 	}
 	e.persistWorkspaceModelOverride(interactiveKey, msg.SessionKey, agent, target)
-	e.cleanupInteractiveState(interactiveKey)
+
+	// If the active session supports live model switching (e.g. ACP), apply
+	// it immediately. On success keep the current session running with no
+	// cleanup/restart; otherwise fall back to the CLI-agent model of
+	// cleaning up so the next message restarts with the new model.
+	liveSwitched := false
+	e.interactiveMu.Lock()
+	state := e.interactiveStates[interactiveKey]
+	e.interactiveMu.Unlock()
+	if state != nil {
+		state.mu.Lock()
+		sess := state.agentSession
+		state.mu.Unlock()
+		if sess != nil && sess.Alive() {
+			if lm, ok := sess.(LiveModelSwitcher); ok {
+				liveSwitched = lm.SetLiveModel(target)
+			}
+		}
+	}
+
+	if !liveSwitched {
+		e.cleanupInteractiveState(interactiveKey)
+	}
 
 	// Keep the existing agent session ID so the next StartSession uses
 	// --resume <id> --model <new>, which lets the CLI agent restore context

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -630,6 +630,12 @@ type LiveModeSwitcher interface {
 	SetLiveMode(mode string) bool
 }
 
+// LiveModelSwitcher is an optional interface for running agent sessions that
+// can apply a model change immediately without restarting the process.
+type LiveModelSwitcher interface {
+	SetLiveModel(model string) bool
+}
+
 // StartupWarner is an optional interface for agent sessions that need to surface
 // a one-time warning to the IM user at session start (e.g. when a requested
 // permission mode was silently downgraded due to OS constraints). The engine


### PR DESCRIPTION
## Summary

Adds `/model` and `/mode` support for ACP agents. cc-connect now reads a
model/mode selector list from the ACP agent and switches live on the active
session, covering both selector mechanisms in the ACP ecosystem — the early
`models`/`modes` blocks (`session/set_model` / `session/set_mode`) and the
newer `configOptions` RFD (`session/set_config_option`). Previously ACP
agents could not list or switch models/modes.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

Verified end-to-end against six real ACP agents:

| Agent | Mechanism | models | modes |
|-------|-----------|:------:|:-----:|
| kiro-cli | `models`/`modes` blocks | 15 | 5 |
| mimo | `models`/`modes` blocks | 16 | 3 |
| codebuddy | `models`/`modes` blocks | 15 | 7 |
| hermes | `models`/`modes` blocks | 108 | 3 |
| opencode | `configOptions` | 44 | 5 |
| copilot | `modes` block (mode-only) | — | 3 |

Graceful degradation is covered too: copilot exposes only a mode selector
(no models), so `/model` reports "not supported" while `/mode` works — and its
modeIds are full ACP spec URLs (e.g. `.../session-modes#plan`), which switch
correctly since the matcher makes no assumption about id format.

`go test -race ./agent/acp/` and `go test ./core/` pass. Integration tests are
gated on `CC_ACP_BIN` (skip cleanly in CI) and pick switch targets dynamically
from the live list — no model/mode names are hard-coded.

### Automated tests added in this PR

Unit tests (`agent/acp/models_test.go`, neutral fixtures):
- `TestAgent_reportModels_populatesCache` / `TestAgent_GetModel_NoModels` / `TestAgent_SetModel_PendingWinsOverCurrent` / `TestAgent_GetModel_FallbackToServerCurrent` — model cache & precedence
- `TestAgent_PermissionModes_returnsCachedModes` / `TestAgent_PermissionModes_skipsProbeWhenProbed` / `TestAgent_SharedProbeFlag` / `TestAgent_ensureProbe_noCmdNoSpawn` — probe gating
- `TestSession_absorbModels_*` / `TestSession_matchAvailableModel` / `TestSession_maybeAbsorbCurrentModelUpdate*` — models block path
- `TestSession_absorbConfigOptions_model` / `TestSession_absorbConfigOptions_mode` / `TestSession_maybeAbsorbConfigOptionUpdate` / `TestFlattenModelOptions_flatAndGrouped` — configOptions path
- `TestAgent_ConcurrentModelAccess` — `-race` concurrency guard

Integration tests (`agent/acp/acp_integration_test.go`, gated on `CC_ACP_BIN`):
- `TestIntegration_ACP_ModelSwitch` / `TestIntegration_ACP_ModeSwitch` — full list→switch path against a real agent
- `TestIntegration_ACP_ProbeShortCtx` — locks down that the probe uses its own timeout, not the caller's short 10s ctx

### For bug fixes only — regression test

N/A (new feature). Note: `TestIntegration_ACP_ProbeShortCtx` was added to lock
down a probe-timeout regression discovered during development (a slow cold
start exceeding the caller's 10s ctx).

### Critical User Journeys (CUJ) impact

- [x] C — agent execution control (`/mode`)
- [x] F — config switching (`/model`)

- [x] `go test ./core/ -run TestCUJ` passes locally.
- [x] Change is additive: non-ACP agents fall through the existing code path
      unchanged, so existing CUJ behavior is preserved.

## Manual / user-visible behavior change

For ACP agents that expose model/mode selectors, `/model` and `/mode` now list
the available options and switch live (no session restart), including before
the first session (a one-shot probe fetches the list). Agents exposing neither
report "not supported" as before. Non-ACP agents are unaffected.

## Checklist (reviewer will verify)

- [x] `go build ./core/... ./agent/... ./config/... ./platform/...` passes
      (note: `go build ./...` requires a prebuilt `web/dist`, unrelated to this change)
- [x] `go test ./...` passes for touched packages (`agent/acp`, `core`) incl. `-race`
- [x] `golangci-lint run --new-from-rev origin/main ./...` passes (0 issues)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/` (uses the new
      `core.LiveModelSwitcher` capability interface + type assertion)
- [x] No new user-facing strings (reuses existing `/model` `/mode` i18n keys)
- [x] No secrets / credentials in source

## Related

None.
