### PR TITLE
feat(codex): make AskUserQuestion timeout configurable (#1484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 - **Feishu: outbound bot-to-bot @mention resolution** via new `mention_map` config option. Maps agent-friendly names (e.g. `BOT-A`) to Feishu open_ids so that when an agent writes `@BOT-A` in its reply, cc-connect converts it to a native Feishu `<at>` tag that triggers a real notification. Layered on top of `resolve_mentions` (group-member matching) with higher priority, so explicit config always wins (#1322).
+- **codex: configurable AskUserQuestion timeout** via new `[projects.agent.options] request_user_input_timeout_mins` integer (default 5). When the Codex app-server forwards an `item/tool/requestUserInput` approval to a remote IM user, cc-connect waits up to this many minutes for the reply before resolving to deny (fail-closed). Set `0` to wait indefinitely — the approval stays pending until the user replies, the session cancels, or the agent shuts down. Negative or unparseable values log a startup warning and fall back to 5. Affects only the codex app-server backend (#1484).
 
 ### Fixed
 - **Feishu recall fallback probes**: throttle repeated active-message recall checks so long-running turns do not continuously call platform message APIs.

--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -152,6 +153,12 @@ type appServerSession struct {
 	codexHome      string
 	promptPreamble string
 
+	// requestUserInputTimeout bounds how long the AskUserQuestion approval
+	// waits for a remote user reply. Zero means indefinite (no timer is
+	// created); positive values are used directly. See config option
+	// `request_user_input_timeout_mins` (#1484).
+	requestUserInputTimeout time.Duration
+
 	events chan core.Event
 
 	ctx    context.Context
@@ -189,27 +196,83 @@ type appServerSession struct {
 const (
 	appServerRequestTimeout      = 120 * time.Second
 	appServerUsageRefreshTimeout = 1500 * time.Millisecond
+
+	// defaultAppServerRequestUserInputTimeout is the fallback used when the
+	// user has not configured `request_user_input_timeout_mins`. Matches the
+	// legacy hard-coded 5-minute wait so existing deployments see no change.
+	defaultAppServerRequestUserInputTimeout = 5 * time.Minute
 )
 
-func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string, systemPrompt string, appendPrompt string) (*appServerSession, error) {
+// parseRequestUserInputTimeoutMins converts the raw `request_user_input_timeout_mins`
+// config value into a time.Duration for the app-server AskUserQuestion approval wait.
+//
+// Semantics (see issue #1484):
+//   - missing / nil / empty string → defaultAppServerRequestUserInputTimeout (5 min)
+//   - 0 → 0 (caller must NOT create a timer; indefinite wait until user reply or ctx cancel)
+//   - positive integer → that many minutes
+//   - negative or unparseable value → warn and fall back to defaultAppServerRequestUserInputTimeout
+func parseRequestUserInputTimeoutMins(raw any) time.Duration {
+	defaultMins := int(defaultAppServerRequestUserInputTimeout / time.Minute)
+	if raw == nil {
+		return defaultAppServerRequestUserInputTimeout
+	}
+	var mins int
+	parsed := true
+	switch v := raw.(type) {
+	case int:
+		mins = v
+	case int64:
+		mins = int(v)
+	case float64:
+		mins = int(v)
+	case string:
+		s := strings.TrimSpace(v)
+		if s == "" {
+			return defaultAppServerRequestUserInputTimeout
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			slog.Warn("codex: invalid request_user_input_timeout_mins, fallback to default",
+				"value", v, "default_mins", defaultMins)
+			return defaultAppServerRequestUserInputTimeout
+		}
+		mins = n
+	default:
+		parsed = false
+	}
+	if !parsed {
+		slog.Warn("codex: invalid request_user_input_timeout_mins type, fallback to default",
+			"type", fmt.Sprintf("%T", raw), "default_mins", defaultMins)
+		return defaultAppServerRequestUserInputTimeout
+	}
+	if mins < 0 {
+		slog.Warn("codex: negative request_user_input_timeout_mins, fallback to default",
+			"value", mins, "default_mins", defaultMins)
+		return defaultAppServerRequestUserInputTimeout
+	}
+	return time.Duration(mins) * time.Minute
+}
+
+func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string, systemPrompt string, appendPrompt string, requestUserInputTimeout time.Duration) (*appServerSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 	s := &appServerSession{
-		url:              url,
-		workDir:          workDir,
-		model:            model,
-		effort:           effort,
-		mode:             mode,
-		baseURL:          baseURL,
-		modelProvider:    modelProvider,
-		extraEnv:         append([]string(nil), extraEnv...),
-		codexHome:        strings.TrimSpace(codexHome),
-		promptPreamble:   buildCodexPromptPreamble(systemPrompt, appendPrompt),
-		events:           make(chan core.Event, 128),
-		ctx:              sessionCtx,
-		cancel:           cancel,
-		pending:          make(map[int64]chan rpcResponseEnvelope),
-		pendingApprovals: make(map[string]chan core.PermissionResult),
-		preambleSent:     resumeID != "" && resumeID != core.ContinueSession,
+		url:                     url,
+		workDir:                 workDir,
+		model:                   model,
+		effort:                  effort,
+		mode:                    mode,
+		baseURL:                 baseURL,
+		modelProvider:           modelProvider,
+		extraEnv:                append([]string(nil), extraEnv...),
+		codexHome:               strings.TrimSpace(codexHome),
+		promptPreamble:          buildCodexPromptPreamble(systemPrompt, appendPrompt),
+		requestUserInputTimeout: requestUserInputTimeout,
+		events:                  make(chan core.Event, 128),
+		ctx:                     sessionCtx,
+		cancel:                  cancel,
+		pending:                 make(map[int64]chan rpcResponseEnvelope),
+		pendingApprovals:        make(map[string]chan core.PermissionResult),
+		preambleSent:            resumeID != "" && resumeID != core.ContinueSession,
 	}
 	s.alive.Store(true)
 
@@ -733,14 +796,18 @@ func (s *appServerSession) handleRequestUserInput(rawID json.RawMessage, paramsR
 	})
 
 	go func() {
-		timer := time.NewTimer(5 * time.Minute)
-		defer timer.Stop()
+		var timerC <-chan time.Time
+		if s.requestUserInputTimeout > 0 {
+			timer := time.NewTimer(s.requestUserInputTimeout)
+			defer timer.Stop()
+			timerC = timer.C
+		}
 		var result core.PermissionResult
 		select {
 		case result = <-ch:
 		case <-s.ctx.Done():
 			result = core.PermissionResult{Behavior: "deny"}
-		case <-timer.C:
+		case <-timerC:
 			result = core.PermissionResult{Behavior: "deny"}
 		}
 		s.approvalsMu.Lock()

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -361,3 +361,201 @@ func waitForWrittenJSONLine(t *testing.T, w *lockedWriteCloser) string {
 		}
 	}
 }
+
+// waitForNoWrittenJSONLine polls for up to `wait` and fails if any non-empty
+// JSON line is written. Used to verify indefinite-wait (timeout=0) paths
+// do not produce an early deny response.
+func waitForNoWrittenJSONLine(t *testing.T, w *lockedWriteCloser, wait time.Duration) {
+	t.Helper()
+	deadline := time.After(wait)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			if got := strings.TrimSpace(w.String()); got != "" {
+				t.Fatalf("expected no JSON written during %s, got %q", wait, got)
+			}
+			return
+		case <-ticker.C:
+			if got := strings.TrimSpace(w.String()); got != "" {
+				t.Fatalf("expected no JSON written during %s, got %q", wait, got)
+			}
+		}
+	}
+}
+
+// TestParseRequestUserInputTimeoutMins covers the request_user_input_timeout_mins
+// config helper (issue #1484): defaults, explicit values, the 0=indefinite sentinel,
+// and the warning+fallback path for negative / unparseable / wrong-type values.
+func TestParseRequestUserInputTimeoutMins(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+		want time.Duration
+	}{
+		{name: "nil uses default", raw: nil, want: defaultAppServerRequestUserInputTimeout},
+		{name: "empty string uses default", raw: "", want: defaultAppServerRequestUserInputTimeout},
+		{name: "explicit int 5", raw: int(5), want: 5 * time.Minute},
+		{name: "explicit int64 10", raw: int64(10), want: 10 * time.Minute},
+		{name: "explicit float64 7", raw: float64(7), want: 7 * time.Minute},
+		{name: "string 15", raw: "15", want: 15 * time.Minute},
+		{name: "string 0 means indefinite", raw: "0", want: 0},
+		{name: "int 0 means indefinite", raw: int(0), want: 0},
+		{name: "negative int falls back to default", raw: int(-3), want: defaultAppServerRequestUserInputTimeout},
+		{name: "negative string falls back to default", raw: "-2", want: defaultAppServerRequestUserInputTimeout},
+		{name: "unparseable string falls back to default", raw: "abc", want: defaultAppServerRequestUserInputTimeout},
+		{name: "unsupported type falls back to default", raw: []string{"x"}, want: defaultAppServerRequestUserInputTimeout},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRequestUserInputTimeoutMins(tt.raw)
+			if got != tt.want {
+				t.Fatalf("parseRequestUserInputTimeoutMins(%#v) = %s, want %s", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleRequestUserInput_TimeoutReturnsDeny verifies that when the user
+// never replies within the configured timeout, the approval goroutine resolves
+// to deny (fail-closed) and writes an empty-answer response back to Codex
+// (issue #1484).
+func TestHandleRequestUserInput_TimeoutReturnsDeny(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stdin := &lockedWriteCloser{}
+	s := &appServerSession{
+		events:                  make(chan core.Event, 4),
+		ctx:                     ctx,
+		pendingApprovals:        make(map[string]chan core.PermissionResult),
+		stdin:                   stdin,
+		requestUserInputTimeout: 50 * time.Millisecond,
+	}
+
+	s.handleServerRequest(serverRequestProbe(t, `"rui-timeout"`, "item/tool/requestUserInput", map[string]any{
+		"threadId": "thread-1",
+		"turnId":   "turn-1",
+		"itemId":   "call-timeout",
+		"questions": []any{
+			map[string]any{
+				"id":       "database",
+				"header":   "Database",
+				"question": "Which database should we use?",
+				"options": []any{
+					map[string]any{"label": "Postgres", "description": ""},
+				},
+			},
+		},
+	}))
+
+	// Drain the AskUserQuestion event so the goroutine proceeds.
+	select {
+	case <-s.events:
+	case <-time.After(time.Second):
+		t.Fatal("expected AskUserQuestion event")
+	}
+
+	line := waitForWrittenJSONLine(t, stdin)
+	var envelope struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      string `json:"id"`
+		Result  struct {
+			Answers map[string]struct {
+				Answers []string `json:"answers"`
+			} `json:"answers"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+		t.Fatalf("decode response %q: %v", line, err)
+	}
+	if envelope.JSONRPC != "2.0" || envelope.ID != "rui-timeout" {
+		t.Fatalf("envelope = %#v", envelope)
+	}
+	if len(envelope.Result.Answers) != 0 {
+		t.Fatalf("expected empty answers on timeout (fail-closed), got %#v", envelope.Result.Answers)
+	}
+}
+
+// TestHandleRequestUserInput_ZeroTimeoutWaitsIndefinitely verifies that
+// requestUserInputTimeout=0 disables the timer entirely — the approval
+// goroutine must block until the user replies or the session cancels
+// (issue #1484). We assert nothing is written within a generous wait window
+// when no reply is sent, then verify the user reply still produces the
+// expected response.
+func TestHandleRequestUserInput_ZeroTimeoutWaitsIndefinitely(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stdin := &lockedWriteCloser{}
+	s := &appServerSession{
+		events:                  make(chan core.Event, 4),
+		ctx:                     ctx,
+		pendingApprovals:        make(map[string]chan core.PermissionResult),
+		stdin:                   stdin,
+		requestUserInputTimeout: 0, // 0 = indefinite wait, no timer
+	}
+
+	s.handleServerRequest(serverRequestProbe(t, `"rui-indef"`, "item/tool/requestUserInput", map[string]any{
+		"threadId": "thread-1",
+		"turnId":   "turn-1",
+		"itemId":   "call-indef",
+		"questions": []any{
+			map[string]any{
+				"id":       "database",
+				"header":   "Database",
+				"question": "Which database should we use?",
+				"options": []any{
+					map[string]any{"label": "Postgres", "description": ""},
+				},
+			},
+		},
+	}))
+
+	var event core.Event
+	select {
+	case event = <-s.events:
+	case <-time.After(time.Second):
+		t.Fatal("expected AskUserQuestion event")
+	}
+
+	// With timeout=0 the goroutine must NOT write any response yet.
+	// Wait 200ms (much longer than the legacy 5-min would imply nothing
+	// happens here anyway) and confirm the stdin is still empty.
+	waitForNoWrittenJSONLine(t, stdin, 200*time.Millisecond)
+
+	// Now send the user reply and verify the goroutine wakes up and writes
+	// the expected answer.
+	if err := s.RespondPermission(event.RequestID, core.PermissionResult{
+		Behavior: "allow",
+		UpdatedInput: map[string]any{
+			"answers": map[string]any{
+				"Which database should we use?": "Postgres",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("RespondPermission() error = %v", err)
+	}
+
+	line := waitForWrittenJSONLine(t, stdin)
+	var envelope struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      string `json:"id"`
+		Result  struct {
+			Answers map[string]struct {
+				Answers []string `json:"answers"`
+			} `json:"answers"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+		t.Fatalf("decode response %q: %v", line, err)
+	}
+	if envelope.ID != "rui-indef" {
+		t.Fatalf("envelope id = %q, want rui-indef", envelope.ID)
+	}
+	got := envelope.Result.Answers["database"].Answers
+	if len(got) != 1 || got[0] != "Postgres" {
+		t.Fatalf("answers[database] = %#v, want [Postgres]", got)
+	}
+}

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/BurntSushi/toml"
 
@@ -48,7 +49,10 @@ type Agent struct {
 	activeIdx       int      // -1 = no provider set
 	configEnv       []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
 	sessionEnv      []string
-	mu              sync.RWMutex
+	// requestUserInputTimeout bounds how long app-server AskUserQuestion waits
+	// for a remote user reply (issue #1484). 0 = indefinite wait, positive = use it.
+	requestUserInputTimeout time.Duration
+	mu                      sync.RWMutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -92,19 +96,20 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 
 	return &Agent{
-		workDir:         workDir,
-		model:           model,
-		reasoningEffort: normalizeReasoningEffort(reasoningEffort),
-		mode:            mode,
-		backend:         backend,
-		appServerURL:    appServerURL,
-		codexHome:       strings.TrimSpace(codexHome),
-		systemPrompt:    strings.TrimSpace(systemPrompt),
-		appendPrompt:    strings.TrimSpace(appendPrompt),
-		cmd:             cmd,
-		cliExtraArgs:    cliExtraArgs,
-		configEnv:       configEnv,
-		activeIdx:       -1,
+		workDir:                 workDir,
+		model:                   model,
+		reasoningEffort:         normalizeReasoningEffort(reasoningEffort),
+		mode:                    mode,
+		backend:                 backend,
+		appServerURL:            appServerURL,
+		codexHome:               strings.TrimSpace(codexHome),
+		systemPrompt:            strings.TrimSpace(systemPrompt),
+		appendPrompt:            strings.TrimSpace(appendPrompt),
+		cmd:                     cmd,
+		cliExtraArgs:            cliExtraArgs,
+		configEnv:               configEnv,
+		requestUserInputTimeout: parseRequestUserInputTimeoutMins(opts["request_user_input_timeout_mins"]),
+		activeIdx:               -1,
 	}, nil
 }
 
@@ -311,7 +316,6 @@ func readCodexCachedModels() []core.ModelOption {
 	return parseCodexModelsJSON(b)
 }
 
-
 // parseCodexModelsJSON parses a Codex models JSON file (model_catalog.json
 // or models_cache.json) into a deduplicated, filtered slice of ModelOption.
 // It is shared by readCodexCachedModels and readCodexModelCatalog.
@@ -356,7 +360,6 @@ func parseCodexModelsJSON(data []byte) []core.ModelOption {
 	}
 	return models
 }
-
 
 // readCodexModelCatalog reads $CODEX_HOME/config.toml to find the
 // model_catalog_json setting, then reads and parses that JSON file.
@@ -432,6 +435,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	cliBin := a.cmd
 	cliExtraArgs := a.cliExtraArgs
 	workDir := a.workDir
+	requestUserInputTimeout := a.requestUserInputTimeout
 	// Order matters for MergeEnv override semantics (later wins):
 	//   1. configEnv — static env from [projects.agent.options.env]
 	//   2. providerEnv — per-provider keys (OPENAI_API_KEY etc.)
@@ -459,7 +463,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 
 	if backend == "app_server" {
-		return newAppServerSession(ctx, appServerURL, workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome, systemPrompt, appendPrompt)
+		return newAppServerSession(ctx, appServerURL, workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome, systemPrompt, appendPrompt, requestUserInputTimeout)
 	}
 	if codexHome != "" {
 		extraEnv = append(extraEnv, "CODEX_HOME="+codexHome)

--- a/config.example.toml
+++ b/config.example.toml
@@ -1519,7 +1519,21 @@ app_secret = "your-feishu-app-secret"
 # 追加在 system_prompt 之后，包含在同一段注入的前导内容中。可单独使用，也可与
 # system_prompt 同时使用。
 # append_system_prompt = "Always respond in Chinese and prefer concise answers."
-#
+
+# Optional: timeout (in minutes) for AskUserQuestion approvals forwarded to
+# remote IM users. When the user does not reply in time, the request resolves
+# to deny (fail-closed) and Codex proceeds without that decision. Default 5
+# (matches legacy hard-coded behavior). Set 0 to wait indefinitely — the
+# approval stays pending until the user replies, the session cancels, or the
+# agent shuts down. Negative or unparseable values log a startup warning and
+# fall back to 5. Has no effect on the exec backend (which has no IPC channel).
+# 可选：转发到 IM 远程用户的 AskUserQuestion 审批超时时间（分钟）。用户在超时内未
+# 回复时，请求按 deny 失败关闭处理，Codex 将在缺少该决策的情况下继续。默认 5
+# （与旧版硬编码行为一致）。设为 0 表示无限等待 — 审批将一直挂起，直到用户回复、
+# 会话被取消、或 agent 关闭。负数或不可解析的值会在启动时打 warning 并回退到 5。
+# 对 exec 后端无效（exec 后端没有 IPC 通道）。
+# request_user_input_timeout_mins = 5
+
 # # Active provider / 当前激活的 provider
 # # provider = "openai"
 #


### PR DESCRIPTION
## Summary
The Codex app-server's `handleRequestUserInput` previously hard-coded a
5-minute wait for the remote user reply. This was too short for IM users on
mobile (delayed push notification, intentionally deferred decision) —
especially for high-stakes questions like planning/scope/implementation
direction. The wait is now driven by a new config option:

```
[projects.agent.options]
request_user_input_timeout_mins = 5   # default (backward compatible)
```

Semantics:
- `0` → **indefinite wait** (no timer is created; the approval stays pending
  until the user replies, the session cancels, or the agent shuts down).
- positive integer → wait up to that many minutes, then resolve to
  **deny (fail-closed)**.
- negative / unparseable / wrong type → startup warning + fallback to the
  5-minute default.

Fixes #1484

## Changes
- **`agent/codex/appserver_session.go`** — added `requestUserInputTimeout`
  field on `appServerSession`, threaded it through `newAppServerSession`,
  and gated the `time.NewTimer` creation on `timeout > 0` inside
  `handleRequestUserInput`. When `timeout == 0`, the timer is not created
  and the `<-timerC` case in the select blocks forever (nil channel),
  so the goroutine only exits when the user replies or the session
  context cancels. Added a small `parseRequestUserInputTimeoutMins`
  helper that owns the validation + warning logic.
- **`agent/codex/codex.go`** — added a `requestUserInputTimeout
  time.Duration` field on `Agent`, populated by the helper in `New()`,
  and forwarded to `newAppServerSession` in `StartSession` (only on the
  `app_server` backend path; `exec` backend has no IPC).
- **`config.example.toml`** — documented the new option under the codex
  `[projects.agent.options]` section, including the `0 = indefinite` note.
- **`CHANGELOG.md`** — Unreleased/Added entry referencing #1484.
- **`agent/codex/appserver_session_test.go`** — three new tests:
  1. `TestParseRequestUserInputTimeoutMins` — table-driven across
     `int`/`int64`/`float64`/`string`/`0`/negative/unparseable/wrong-type
     and the empty/nil cases.
  2. `TestHandleRequestUserInput_TimeoutReturnsDeny` — sets
     `requestUserInputTimeout=50ms`, sends the request, does **not**
     reply, and verifies the response written to Codex has **empty
     answers** (fail-closed).
  3. `TestHandleRequestUserInput_ZeroTimeoutWaitsIndefinitely` — sets
     `requestUserInputTimeout=0`, asserts no JSON is written for 200ms
     (longer than the legacy 5-min would imply nothing happens anyway),
     then sends the user reply and verifies the expected answer is
     written.

## Scope decisions
- The two other 5-minute hard-coded timers in
  `handleApprovalRequest` and `handlePermissionsApproval` are
  **deliberately left untouched** to keep this PR scoped to #1484.
  They can be migrated to the same config option (or its own
  sibling) in a follow-up if users report similar pain points.
- No changes to the codex `exec` backend (no approval IPC).
- No new external dependencies.

## Cancel-boundary notes (per task spec)
The 0-indefinite path was checked for goroutine leaks / stuck timers:

- When `timeout > 0`, the timer is created via `time.NewTimer(...)` and
  stopped with `defer timer.Stop()`, so the timer resource is released
  regardless of which branch wins the select.
- When `timeout == 0`, no timer is created at all — there is nothing to
  leak. The goroutine blocks on `<-s.ctx.Done()` (in addition to the
  user reply channel), which is cancelled by `Close()`. So even if the
  agent process dies abruptly, the engine calls `Close()`, `Close()`
  calls `s.cancel()`, and the goroutine exits. There is no scenario
  where the goroutine outlives its session.
- `Close()` does wait up to 2 s for `s.wg` (which includes this
  goroutine via `wg.Add(3)` in `connect()`… actually no — the approval
  goroutine is **not** tracked by `s.wg`; this matches the pre-existing
  pattern for all three approval handlers. But `Close()` still cancels
  the context, so the goroutine exits within nanoseconds of session
  shutdown; it just doesn't block `Close()`'s 2 s cap. This is
  identical to the pre-existing behavior and is out of scope here.)

## Test plan
- [x] `go test ./agent/codex/... -count=1` — full suite passes in ~1.1s
- [x] `go vet ./agent/codex/... ./agent/kimi/... ./core/...` — clean
- [x] `gofmt -w` on all modified files — clean
- [x] 3 new tests added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)