### PR TITLE
fix(core): isolate scheduled prompt sessions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ the full themed summary; per-beta details remain in the beta sections below.
   because a later queued message has a higher `create_time` (#1286)
 - **core**: make `/history` entry truncation configurable via
   `[display].history_max_len`, defaulting to 1000; `0` disables truncation (#1291)
+- **cron/timer**: prompt jobs default to a fresh agent session per run, avoiding busy
+  chat sessions; use `session_mode = "reuse"` to keep shared-session behavior
 - **tts/minimax**: drop `status=2` trailer chunk to stop audio playing twice (#1364)
 - **tests**: add provider-resume regression tests for codex / opencode / kimi (#1366)
 

--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -626,7 +626,7 @@ Options:
       --prompt <text>        Task prompt (runs through agent)
       --exec <command>       Shell command (runs directly, mutually exclusive with --prompt)
       --desc <text>          Short description
-      --session-mode <mode>  reuse (default) or new-per-run — fresh agent session each run
+      --session-mode <mode>  new-per-run (default) or reuse — fresh agent session each run unless reusing
       --timeout-mins <n>     Max minutes to wait per run (0 = no limit; default 30 if omitted)
       --silent               Suppress cron start notification
       --data-dir <path>      Data directory (default: ~/.cc-connect)

--- a/cmd/cc-connect/timer.go
+++ b/cmd/cc-connect/timer.go
@@ -412,7 +412,7 @@ Options:
       --prompt <text>        Task prompt (runs through agent)
       --exec <command>       Shell command (runs directly, mutually exclusive with --prompt)
       --desc <text>          Short description
-      --session-mode <mode>  reuse (default) or new-per-run
+      --session-mode <mode>  new-per-run (default) or reuse
       --timeout-mins <n>     Max minutes to wait per run (0 = no limit; default 30)
       --mute                 Suppress all messages (start + result)
       --data-dir <path>      Data directory (default: ~/.cc-connect)

--- a/config.example.toml
+++ b/config.example.toml
@@ -331,8 +331,8 @@ level = "info" # debug, info, warn, error
 # [cron]
 # silent = false             # Suppress "⏰ task name" notification when cron starts (default: false)
 #                            # 静默模式：不发送定时任务开始执行的通知消息（默认 false）
-# session_mode = "reuse"     # Default session mode for all cron jobs: "reuse" (default) or "new_per_run"
-#                            # 定时任务默认会话模式："reuse"（复用活跃会话）或 "new_per_run"（每次新建会话）
+# session_mode = "new_per_run" # Default session mode for cron/timer jobs: "new_per_run" (default) or "reuse"
+#                              # 定时/延时任务默认会话模式："new_per_run"（默认，每次新建会话）或 "reuse"（复用活跃会话）
 
 # =============================================================================
 # Webhook / 外部 Webhook 端点

--- a/config/config.go
+++ b/config/config.go
@@ -139,7 +139,7 @@ type Config struct {
 // CronConfig controls cron job behavior.
 type CronConfig struct {
 	Silent      *bool  `toml:"silent"`       // suppress cron start notification; default false
-	SessionMode string `toml:"session_mode"` // default session mode: "" or "reuse" (default) or "new_per_run"
+	SessionMode string `toml:"session_mode"` // default session mode: "new_per_run" (default) or "reuse"
 }
 
 // QueueConfig controls the per-session message queue.

--- a/core/cron.go
+++ b/core/cron.go
@@ -71,6 +71,8 @@ func (j *CronJob) UsesNewSessionPerRun() bool {
 	return NormalizeCronSessionMode(j.SessionMode) == "new_per_run"
 }
 
+// defaultScheduledSessionMode is the built-in default for scheduled cron and
+// timer jobs. It can be overridden globally by scheduler config or per job.
 const defaultScheduledSessionMode = "new_per_run"
 
 // NormalizeCronSessionMode maps CLI/API aliases to canonical values ("", "reuse", "new_per_run").

--- a/core/cron.go
+++ b/core/cron.go
@@ -32,7 +32,7 @@ type CronJob struct {
 	Enabled     bool      `json:"enabled"`
 	Silent      *bool     `json:"silent,omitempty"`       // suppress start notification; nil = use global default
 	Mute        bool      `json:"mute,omitempty"`         // suppress ALL messages (start + result); job runs silently
-	SessionMode string    `json:"session_mode,omitempty"` // "" or "reuse" = share active session; "new_per_run" = fresh session each run
+	SessionMode string    `json:"session_mode,omitempty"` // "" = scheduler default; "reuse" = share active session; "new_per_run" = fresh session each run
 	Mode        string    `json:"mode,omitempty"`         // permission mode override for this job; "" = use project default
 	TimeoutMins *int      `json:"timeout_mins,omitempty"` // nil = default 30m wait; 0 = no limit; >0 = minutes
 	CreatedAt   time.Time `json:"created_at"`
@@ -71,14 +71,18 @@ func (j *CronJob) UsesNewSessionPerRun() bool {
 	return NormalizeCronSessionMode(j.SessionMode) == "new_per_run"
 }
 
-// NormalizeCronSessionMode maps CLI/API aliases to canonical values ("", "new_per_run").
+const defaultScheduledSessionMode = "new_per_run"
+
+// NormalizeCronSessionMode maps CLI/API aliases to canonical values ("", "reuse", "new_per_run").
 // Returns the original string if unrecognized (caller should validate).
 func NormalizeCronSessionMode(s string) string {
 	s = strings.TrimSpace(s)
 	low := strings.ToLower(s)
 	switch low {
-	case "", "reuse":
+	case "":
 		return ""
+	case "reuse":
+		return "reuse"
 	case "new_per_run", "new-per-run":
 		return "new_per_run"
 	default:
@@ -97,7 +101,7 @@ func validateCronJob(j *CronJob) error {
 		return fmt.Errorf("session_key is required")
 	}
 	mode := NormalizeCronSessionMode(j.SessionMode)
-	if mode != "" && mode != "new_per_run" {
+	if mode != "" && mode != "reuse" && mode != "new_per_run" {
 		return fmt.Errorf("invalid session_mode %q (want reuse, new_per_run, or new-per-run)", j.SessionMode)
 	}
 	if j.Mode != "" {
@@ -417,15 +421,16 @@ type CronScheduler struct {
 	mu                 sync.RWMutex
 	entries            map[string]cron.EntryID // job ID → cron entry
 	defaultSilent      bool                    // global default for suppressing cron start notifications
-	defaultSessionMode string                  // global default session mode; "" = reuse, "new_per_run" = fresh session each run
+	defaultSessionMode string                  // global default session mode; "reuse" = share active session, "new_per_run" = fresh session each run
 }
 
 func NewCronScheduler(store *CronStore) *CronScheduler {
 	return &CronScheduler{
-		store:   store,
-		cron:    cron.New(),
-		engines: make(map[string]*Engine),
-		entries: make(map[string]cron.EntryID),
+		store:              store,
+		cron:               cron.New(),
+		engines:            make(map[string]*Engine),
+		entries:            make(map[string]cron.EntryID),
+		defaultSessionMode: defaultScheduledSessionMode,
 	}
 }
 
@@ -563,7 +568,7 @@ func (cs *CronScheduler) UpdateJob(id string, field string, value any) error {
 	if field == "session_mode" {
 		if v, ok := value.(string); ok && v != "" {
 			mode := NormalizeCronSessionMode(v)
-			if mode != "" && mode != "new_per_run" {
+			if mode != "" && mode != "reuse" && mode != "new_per_run" {
 				return fmt.Errorf("invalid session_mode %q (want reuse, new_per_run, or new-per-run)", v)
 			}
 		}
@@ -731,7 +736,6 @@ type mutePlatform struct {
 
 func (m *mutePlatform) Reply(_ context.Context, _ any, _ string) error { return nil }
 func (m *mutePlatform) Send(_ context.Context, _ any, _ string) error  { return nil }
-
 
 func GenerateCronID() string {
 	b := make([]byte, 4)

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -114,7 +114,6 @@ func TestMutePlatform_DiscardMessages(t *testing.T) {
 	}
 }
 
-
 func TestCronJob_MuteField(t *testing.T) {
 	job := &CronJob{ID: "m1", Mute: false}
 	if job.Mute {
@@ -670,21 +669,33 @@ func TestCronScheduler_AddJob_EmptySessionKey(t *testing.T) {
 }
 
 func TestCronScheduler_AddJob_NormalizesSessionMode(t *testing.T) {
-	dir := t.TempDir()
-	store, err := NewCronStore(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cs := NewCronScheduler(store)
-	job := &CronJob{
-		ID: "n1", Project: "p", SessionKey: "test:1:1",
-		CronExpr: "0 6 * * *", Prompt: "hi", SessionMode: "new-per-run",
-	}
-	if err := cs.AddJob(job); err != nil {
-		t.Fatal(err)
-	}
-	if job.SessionMode != "new_per_run" {
-		t.Errorf("SessionMode = %q, want new_per_run", job.SessionMode)
+	for _, tt := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "new per run alias", in: "new-per-run", want: "new_per_run"},
+		{name: "reuse explicit", in: "REUSE", want: "reuse"},
+		{name: "empty inherits scheduler default", in: "", want: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := NewCronStore(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cs := NewCronScheduler(store)
+			job := &CronJob{
+				ID: "n1", Project: "p", SessionKey: "test:1:1",
+				CronExpr: "0 6 * * *", Prompt: "hi", SessionMode: tt.in,
+			}
+			if err := cs.AddJob(job); err != nil {
+				t.Fatal(err)
+			}
+			if job.SessionMode != tt.want {
+				t.Errorf("SessionMode = %q, want %q", job.SessionMode, tt.want)
+			}
+		})
 	}
 }
 
@@ -696,30 +707,30 @@ func TestCronScheduler_UsesNewSession_GlobalDefault(t *testing.T) {
 	}
 	cs := NewCronScheduler(store)
 
-	// Test 1: global default is "new_per_run", job has no session_mode set
-	cs.SetDefaultSessionMode("new_per_run")
+	// Built-in default is "new_per_run", so legacy jobs with no per-job
+	// session_mode no longer block behind the active chat session.
 	job := &CronJob{SessionMode: ""}
 	if !cs.UsesNewSession(job) {
-		t.Error("global new_per_run + job empty: expected UsesNewSession=true")
+		t.Error("built-in new_per_run + job empty: expected UsesNewSession=true")
 	}
 
-	// Test 2: per-job "reuse" overrides global "new_per_run"
+	// Per-job "reuse" overrides the built-in "new_per_run" default.
 	job.SessionMode = "reuse"
 	if cs.UsesNewSession(job) {
-		t.Error("global new_per_run + job reuse: expected UsesNewSession=false")
+		t.Error("built-in new_per_run + job reuse: expected UsesNewSession=false")
 	}
 
-	// Test 3: per-job "new_per_run" overrides global default (reuse)
-	cs.SetDefaultSessionMode("")
-	job.SessionMode = "new_per_run"
-	if !cs.UsesNewSession(job) {
-		t.Error("global reuse + job new_per_run: expected UsesNewSession=true")
-	}
-
-	// Test 4: both global and job are default (reuse)
+	// A global "reuse" setting restores old reuse-by-default behavior.
+	cs.SetDefaultSessionMode("reuse")
 	job.SessionMode = ""
 	if cs.UsesNewSession(job) {
 		t.Error("global reuse + job empty: expected UsesNewSession=false")
+	}
+
+	// Per-job "new_per_run" overrides global reuse.
+	job.SessionMode = "new_per_run"
+	if !cs.UsesNewSession(job) {
+		t.Error("global reuse + job new_per_run: expected UsesNewSession=true")
 	}
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -649,6 +649,20 @@ func waitDeleteModePhase(t *testing.T, e *Engine, sessionKey, targetPhase string
 	t.Fatalf("timed out waiting for delete mode phase %q", targetPhase)
 }
 
+func waitRefreshedCards(t *testing.T, p *stubCardPlatform, min int) []*Card {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		refreshed := p.getRefreshedCards()
+		if len(refreshed) >= min {
+			return refreshed
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d refreshed cards", min)
+	return nil
+}
+
 type stubProviderAgent struct {
 	stubAgent
 	providers []ProviderConfig
@@ -4141,10 +4155,7 @@ func TestDeleteMode_ConfirmAndSubmitDeletesSelectedSessions(t *testing.T) {
 	if got, want := strings.Join(agent.deleted, ","), "session-1,session-3"; got != want {
 		t.Fatalf("deleted = %q, want %q", got, want)
 	}
-	refreshed := p.getRefreshedCards()
-	if len(refreshed) == 0 {
-		t.Fatal("expected refreshed result card via RefreshCard")
-	}
+	refreshed := waitRefreshedCards(t, p, 1)
 	pushedCard := refreshed[len(refreshed)-1]
 	if !strings.Contains(pushedCard.RenderText(), "Session deleted: One") {
 		t.Fatalf("result text = %q, want delete result", pushedCard.RenderText())
@@ -4176,10 +4187,7 @@ func TestDeleteMode_SubmitReportsMissingSelectedSessions(t *testing.T) {
 	}
 	// Wait for async deletion to complete.
 	waitDeleteModePhase(t, e, msg.SessionKey, "result")
-	refreshed := p.getRefreshedCards()
-	if len(refreshed) == 0 {
-		t.Fatal("expected refreshed result card via RefreshCard")
-	}
+	refreshed := waitRefreshedCards(t, p, 1)
 	pushedCard := refreshed[len(refreshed)-1]
 	resultText := pushedCard.RenderText()
 	if !strings.Contains(resultText, "Session deleted: One") {
@@ -4281,10 +4289,8 @@ func TestDeleteMode_SubmitBlocksActiveSession(t *testing.T) {
 	if len(agent.deleted) != 0 {
 		t.Fatalf("deleted = %v, want none", agent.deleted)
 	}
-	if len(p.getRefreshedCards()) == 0 {
-		t.Fatal("expected refreshed result card via RefreshCard")
-	}
-	pushedCard := p.getRefreshedCards()[len(p.getRefreshedCards())-1]
+	refreshed := waitRefreshedCards(t, p, 1)
+	pushedCard := refreshed[len(refreshed)-1]
 	if !strings.Contains(pushedCard.RenderText(), "Cannot delete the currently active session") {
 		t.Fatalf("result text = %q, want active-session warning", pushedCard.RenderText())
 	}
@@ -4357,10 +4363,7 @@ func TestDeleteMode_FormSubmitShowsConfirmThenDeletes(t *testing.T) {
 	if got, want := strings.Join(agent.deleted, ","), "session-1,session-3"; got != want {
 		t.Fatalf("deleted = %q, want %q", got, want)
 	}
-	refreshed := p.getRefreshedCards()
-	if len(refreshed) == 0 {
-		t.Fatal("expected pushed result card via RefreshCard")
-	}
+	refreshed := waitRefreshedCards(t, p, 1)
 	pushedCard := refreshed[len(refreshed)-1]
 	if !strings.Contains(pushedCard.RenderText(), "Session deleted: One") {
 		t.Fatalf("result text = %q, want delete result", pushedCard.RenderText())

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -13332,6 +13332,7 @@ func TestExecuteCronJob_ResolvesCronReplyTarget(t *testing.T) {
 		SessionKey:  "discord:channel-1:user-1",
 		Prompt:      "summarize activity",
 		Description: "Daily summary",
+		SessionMode: "reuse",
 	}
 	if err := store.Add(job); err != nil {
 		t.Fatalf("store.Add() error = %v", err)

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -136,7 +136,7 @@ When the user asks you to do something on a schedule (e.g. "每天早上6点帮�
 Environment variables CC_PROJECT and CC_SESSION_KEY are already set, so you do NOT need to specify --project or --session-key.
 
 Optional flags:
-  --session-mode <mode>     reuse (default) or new-per-run (fresh session each trigger)
+  --session-mode <mode>     new-per-run (default; fresh session each trigger) or reuse
   --timeout-mins <n>        max wait per run in minutes (default 30, 0 = unlimited)
   --exec <command>          run a shell command directly instead of --prompt
 
@@ -189,7 +189,7 @@ Environment variables CC_PROJECT and CC_SESSION_KEY are already set.
 Optional flags:
   --exec <command>          run a shell command directly instead of --prompt
   --desc <text>             short description
-  --session-mode <mode>     reuse (default) or new-per-run (fresh session each run)
+  --session-mode <mode>     new-per-run (default; fresh session each run) or reuse
   --timeout-mins <n>        max wait per run in minutes (default 30, 0 = unlimited)
   --mute                    suppress all messages (start notification + result)
 

--- a/core/timer.go
+++ b/core/timer.go
@@ -25,7 +25,7 @@ type TimerJob struct {
 	Description string    `json:"description"`
 	Silent      *bool     `json:"silent,omitempty"`       // suppress start notification; nil = use global default
 	Mute        bool      `json:"mute,omitempty"`         // suppress ALL messages (start + result)
-	SessionMode string    `json:"session_mode,omitempty"` // "" or "reuse" = share active session; "new_per_run" = fresh session each run
+	SessionMode string    `json:"session_mode,omitempty"` // "" = scheduler default; "reuse" = share active session; "new_per_run" = fresh session each run
 	Mode        string    `json:"mode,omitempty"`         // permission mode override; "" = use project default
 	TimeoutMins *int      `json:"timeout_mins,omitempty"` // nil = default 30m; 0 = no limit; >0 = minutes
 	CreatedAt   time.Time `json:"created_at"`
@@ -71,7 +71,7 @@ func validateTimerJob(j *TimerJob) error {
 		return fmt.Errorf("prompt and exec are mutually exclusive")
 	}
 	mode := NormalizeCronSessionMode(j.SessionMode)
-	if mode != "" && mode != "new_per_run" {
+	if mode != "" && mode != "reuse" && mode != "new_per_run" {
 		return fmt.Errorf("invalid session_mode %q (want reuse, new_per_run, or new-per-run)", j.SessionMode)
 	}
 	if j.Mode != "" {
@@ -238,10 +238,10 @@ func (s *TimerStore) ListPending() []*TimerJob {
 
 // TimerScheduler runs one-shot timer jobs using time.AfterFunc.
 type TimerScheduler struct {
-	store    *TimerStore
-	engines  map[string]*Engine
-	mu       sync.RWMutex
-	timers   map[string]*time.Timer // job ID → active timer
+	store              *TimerStore
+	engines            map[string]*Engine
+	mu                 sync.RWMutex
+	timers             map[string]*time.Timer // job ID → active timer
 	defaultSilent      bool
 	defaultSessionMode string
 }
@@ -252,9 +252,10 @@ const missedJobGracePeriod = 5 * time.Minute
 
 func NewTimerScheduler(store *TimerStore) *TimerScheduler {
 	return &TimerScheduler{
-		store:   store,
-		engines: make(map[string]*Engine),
-		timers:  make(map[string]*time.Timer),
+		store:              store,
+		engines:            make(map[string]*Engine),
+		timers:             make(map[string]*time.Timer),
+		defaultSessionMode: defaultScheduledSessionMode,
 	}
 }
 

--- a/core/timer_test.go
+++ b/core/timer_test.go
@@ -17,11 +17,11 @@ func TestParseDelayOrTime_Relative(t *testing.T) {
 		{"1h30m", false},
 		{"2h30m15s", false},
 		{"500ms", false},
-		{"0s", true},       // zero = not positive
-		{"-1h", true},      // negative
-		{"", true},         // empty
-		{"garbage", true},  // invalid
-		{"2", true},        // bare number
+		{"0s", true},      // zero = not positive
+		{"-1h", true},     // negative
+		{"", true},        // empty
+		{"garbage", true}, // invalid
+		{"2", true},       // bare number
 	}
 
 	for _, tt := range tests {
@@ -460,6 +460,11 @@ func TestValidateTimerJob(t *testing.T) {
 			job:     &TimerJob{SessionKey: "feishu:chat1:user1", ScheduledAt: now.Add(time.Hour), Prompt: "test", SessionMode: "new-per-run"},
 			wantErr: false,
 		},
+		{
+			name:    "valid reuse session_mode",
+			job:     &TimerJob{SessionKey: "feishu:chat1:user1", ScheduledAt: now.Add(time.Hour), Prompt: "test", SessionMode: "reuse"},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -472,6 +477,35 @@ func TestValidateTimerJob(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestTimerScheduler_UsesNewSession_Defaults(t *testing.T) {
+	store, err := NewTimerStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := NewTimerScheduler(store)
+
+	job := &TimerJob{SessionMode: ""}
+	if !ts.UsesNewSession(job) {
+		t.Error("built-in new_per_run + job empty: expected UsesNewSession=true")
+	}
+
+	job.SessionMode = "reuse"
+	if ts.UsesNewSession(job) {
+		t.Error("built-in new_per_run + job reuse: expected UsesNewSession=false")
+	}
+
+	ts.SetDefaultSessionMode("reuse")
+	job.SessionMode = ""
+	if ts.UsesNewSession(job) {
+		t.Error("global reuse + job empty: expected UsesNewSession=false")
+	}
+
+	job.SessionMode = "new_per_run"
+	if !ts.UsesNewSession(job) {
+		t.Error("global reuse + job new_per_run: expected UsesNewSession=true")
 	}
 }
 

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -918,7 +918,7 @@ Adds a cron job. Either `prompt` or `exec` must be provided, not both.
 | `work_dir`   | string  | no       | Working directory for exec                    |
 | `description`| string  | no       | Human-readable label                           |
 | `silent`     | boolean | no       | Suppress start notification                   |
-| `session_mode` | string | no       | `reuse` (default) or `new_per_run` — new agent session each run |
+| `session_mode` | string | no       | `new_per_run` (default) or `reuse` — new agent session each run unless explicitly reusing the active session |
 | `timeout_mins` | int    | no       | Scheduler wait per run: omit = 30 min, `0` = no time limit |
 
 **Response:**

--- a/docs/management-api.zh-CN.md
+++ b/docs/management-api.zh-CN.md
@@ -890,7 +890,7 @@ GET /api/v1/status?token=mgmt-secret
 | `work_dir`    | string  | 否   | exec 的工作目录                             |
 | `description` | string  | 否   | 人类可读的标签                              |
 | `silent`      | boolean | 否   | 是否隐藏启动通知                            |
-| `session_mode` | string | 否   | `reuse`（默认）或 `new_per_run`：每次运行新建 agent 会话 |
+| `session_mode` | string | 否   | `new_per_run`（默认）或 `reuse`：默认每次运行新建 agent 会话；显式 reuse 时复用活跃会话 |
 | `timeout_mins` | int    | 否   | 单次调度最长等待：省略=30 分钟，`0`=不限制 |
 
 **响应：**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -839,7 +839,7 @@ cc-connect cron exec <job-id>
 cc-connect cron del <job-id>
 ```
 
-Optional: `--session-mode new-per-run` starts a fresh agent session on each run (default is `reuse`, same as before). `--timeout-mins N` sets how long the scheduler waits per run (`0` = no limit; omit = 30 minutes).
+By default, prompt cron jobs start a fresh agent session on each run so they do not block behind an active chat turn. Use `--session-mode reuse` to share the active session. `--timeout-mins N` sets how long the scheduler waits per run (`0` = no limit; omit = 30 minutes).
 
 ### Natural Language (Claude Code)
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -752,7 +752,7 @@ cc-connect cron exec <job-id>
 cc-connect cron del <job-id>
 ```
 
-可选：`--session-mode new-per-run` 每次触发使用新的 agent 会话（默认 `reuse` 与旧行为一致）。`--timeout-mins N` 设置单次调度最长等待分钟数（`0` 表示不限制；省略为 30 分钟）。
+默认情况下，prompt cron 每次触发都会使用新的 agent 会话，避免被正在进行的聊天 turn 阻塞。需要复用活跃会话时可设置 `--session-mode reuse`。`--timeout-mins N` 设置单次调度最长等待分钟数（`0` 表示不限制；省略为 30 分钟）。
 
 ### 自然语言（Claude Code）
 


### PR DESCRIPTION
## Summary
- Default cron and timer prompt jobs to a fresh agent session per run.
- Keep the old shared-session behavior available only when `session_mode = "reuse"` or `--session-mode reuse` is set explicitly.
- Update CLI help, config comments, docs, changelog, and tests for the new default.

## Root cause
Scheduled prompt jobs inherited the active chat session by default. When a cron fired while the user session was already busy, it could fail with a busy-session error or wait behind unrelated interactive work. The scheduled task should be isolated by default instead of competing with normal chat turns.

## Test Plan
- `go test -count=1 ./core ./config`
- `GOOS=linux GOARCH=amd64 go test -c -tags no_web ./cmd/cc-connect`
- `git diff --check`

Supersedes #1349. This is the same rebased patch on a fresh PR branch.
