### PR TITLE
fix(claudecode): report 1M context window for Mythos-class models (Fable/Mythos)

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -1261,14 +1261,19 @@ func shellJoinArgs(args []string) string {
 // claudeContextWindow returns the context window size (tokens) that best
 // matches the given Claude model id. Used as a fallback when the stream-json
 // result event does not carry a modelUsage map. The "[1m]" suffix
-// (case-insensitive) signals the 1M-context variants; everything else
-// defaults to the standard 200k window.
+// (case-insensitive) signals the 1M-context variants of 200k-window models
+// (e.g. "sonnet[1m]"). Mythos-class models (Fable/Mythos, Claude 5 family)
+// ship with a native 1M window and no suffix in their model ids; everything
+// else defaults to the standard 200k window.
 func claudeContextWindow(model string) int {
 	lower := strings.ToLower(strings.TrimSpace(model))
 	if lower == "" {
 		return 200_000
 	}
 	if strings.Contains(lower, "[1m]") {
+		return 1_000_000
+	}
+	if strings.Contains(lower, "fable") || strings.Contains(lower, "mythos") {
 		return 1_000_000
 	}
 	return 200_000

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -775,3 +775,27 @@ func TestHelperProcess(t *testing.T) {
 		os.Exit(2)
 	}
 }
+
+func TestClaudeContextWindow(t *testing.T) {
+	cases := []struct {
+		model string
+		want  int
+	}{
+		{"", 200_000},
+		{"claude-sonnet-5", 200_000},
+		{"claude-opus-4-8", 200_000},
+		{"sonnet[1m]", 1_000_000},
+		{"claude-sonnet-5[1M]", 1_000_000},
+		// Mythos-class models (Fable/Mythos) ship with a native 1M window
+		// and no "[1m]" suffix in their model ids.
+		{"claude-fable-5", 1_000_000},
+		{"claude-mythos-5", 1_000_000},
+		{"Claude-Fable-5", 1_000_000},
+		{"fable", 1_000_000},
+	}
+	for _, tc := range cases {
+		if got := claudeContextWindow(tc.model); got != tc.want {
+			t.Errorf("claudeContextWindow(%q) = %d, want %d", tc.model, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The reply footer's `ctx N%` is computed against `claudeContextWindow(model)`, which only recognizes the `[1m]` model-name suffix and falls back to 200k for every other model id.

Claude 5 Mythos-class models (`claude-fable-5`, `claude-mythos-5`) ship with a **native 1M context window** and carry no `[1m]` suffix in their model ids. As a result:

- denominator = 200k while the real window is 1M
- once the conversation crosses 200k prompt tokens, `ctx %` pins at **100%** (capped) even though actual usage is ~20-30%

Real-world footer showing the bug (prompt was ~295k tokens, actual usage ~29% of 1M):

```
claude-fable-5 · out 273 · in 2 cw 359 cr 294.5k · ctx 100%
```

## Fix

Match `fable` / `mythos` (case-insensitive) in the model id and return 1,000,000. The existing `[1m]` suffix rule for 200k-window models (e.g. `sonnet[1m]`) is unchanged, and unknown models still default to 200k.

## Testing

- Added `TestClaudeContextWindow` table test covering: empty string, standard 200k models, `[1m]` suffix variants, and Fable/Mythos ids (mixed case).
- `go test ./agent/claudecode/` passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)