### PR TITLE
fix(slack): add working-indicator reactions to the triggering message, not the thread root

### DIFF
--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -27,6 +27,19 @@ func init() {
 type replyContext struct {
 	channel   string
 	timestamp string // thread_ts for threading replies
+	msgTS     string // ts of the message that triggered this turn (reaction target)
+}
+
+// reactionTS returns the timestamp reactions should target: the triggering
+// message itself when known, otherwise the thread root. This matters in
+// threads, where the root can be an unrelated message posted days earlier by
+// someone else — the working indicator belongs on the message that summoned
+// the bot.
+func (rc replyContext) reactionTS() string {
+	if rc.msgTS != "" {
+		return rc.msgTS
+	}
+	return rc.timestamp
 }
 
 type Platform struct {
@@ -218,7 +231,7 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					Files:     docFiles,
 					Audio:     audio,
 					MessageID: ev.TimeStamp,
-					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: threadTS},
+					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: threadTS, msgTS: ev.TimeStamp},
 				}
 				p.handler(p, msg)
 
@@ -279,7 +292,7 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					ChatName: p.resolveChannelNameForMsg(ev.Channel),
 					Content:  ev.Text, Images: images, Files: docFiles, Audio: audio,
 					MessageID: ts,
-					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: threadTS},
+					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: threadTS, msgTS: ts},
 				}
 				p.handler(p, msg)
 			}
@@ -681,11 +694,11 @@ func (p *Platform) FormattingInstructions() string {
 // All reactions are removed when the returned stop function is called.
 func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
 	rc, ok := rctx.(replyContext)
-	if !ok || rc.channel == "" || rc.timestamp == "" {
+	if !ok || rc.channel == "" || rc.reactionTS() == "" {
 		return func() {}
 	}
 
-	ref := slack.ItemRef{Channel: rc.channel, Timestamp: rc.timestamp}
+	ref := slack.ItemRef{Channel: rc.channel, Timestamp: rc.reactionTS()}
 	var mu sync.Mutex
 	var added []string
 

--- a/platform/slack/slack_test.go
+++ b/platform/slack/slack_test.go
@@ -41,6 +41,43 @@ func TestStripAppMentionText(t *testing.T) {
 	}
 }
 
+func TestReplyContextReactionTS(t *testing.T) {
+	tests := []struct {
+		name string
+		rc   replyContext
+		want string
+	}{
+		{
+			name: "mention inside a thread targets the mention, not the root",
+			rc:   replyContext{channel: "C1", timestamp: "1700000000.000100", msgTS: "1700000500.000200"},
+			want: "1700000500.000200",
+		},
+		{
+			name: "top-level mention where root and message coincide",
+			rc:   replyContext{channel: "C1", timestamp: "1700000000.000100", msgTS: "1700000000.000100"},
+			want: "1700000000.000100",
+		},
+		{
+			name: "reconstructed context (cron, send-to-session) falls back to the thread root",
+			rc:   replyContext{channel: "C1", timestamp: "1700000000.000100"},
+			want: "1700000000.000100",
+		},
+		{
+			name: "slash-command context has no reaction target",
+			rc:   replyContext{channel: "C1"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rc.reactionTS(); got != tt.want {
+				t.Fatalf("reactionTS() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDownloadSlackFile_HTMLDetection(t *testing.T) {
 	// Test that we detect HTML responses (Slack login page) and return an error
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

On Slack, the working-indicator reactions (👀 → 🕐 → …) that `StartTyping` adds while the agent works are attached to `replyContext.timestamp`, which holds the **thread root ts** (kept for reply threading). When the bot is mentioned **inside an existing thread**, the indicator therefore lands on the thread's root — often an unrelated message posted days earlier by someone else — instead of the message that actually summoned the bot. This PR carries the triggering message's own ts alongside the threading ts and prefers it as the reaction target.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

- `go build ./...`, `go vet ./...`, `go test -race ./platform/slack/` — all green.
- `go test ./...` — green except `platform/cloud-web:TestGatewayWebhook`, which fails identically on a clean `origin/main` checkout in my environment (pre-existing, unrelated). `agent/codex` and `agent/opencode` pass in isolation on this branch; their one-off failures in a fully parallel run were resource-contention flakes, also untouched by this change.
- Manually observed in a production Slack workspace on v1.4.1 / v1.5.0-beta.1: mentions inside long-running threads consistently put 👀 on the (unrelated) root message; with this change the target is the summoning message. Contexts with no message ts keep the previous behavior.

### Automated tests added in this PR

- `TestReplyContextReactionTS` in `platform/slack/slack_test.go` — asserts the reaction target selection: mention-in-thread targets the mention itself (the regression case), top-level mention where root == message, fallback to thread root for reconstructed contexts (cron / send-to-session), and no target for slash-command contexts.

### For bug fixes only — regression test

`TestReplyContextReactionTS/"mention inside a thread targets the mention, not the root"` encodes the previously-broken case: before this change the reaction path only ever saw the thread root ts.

## Behavior notes

- `app_mention` and `message` events now populate `msgTS` (the event's own ts); `StartTyping` prefers it via `reactionTS()`.
- Contexts that have no triggering message — slash commands and `ReconstructReplyCtx` (cron / timers / send-to-session) — leave `msgTS` empty and fall back to the previous target, so their behavior is unchanged.
- Reply threading is untouched: `timestamp` keeps its existing meaning and usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
