### PR TITLE
test(core): fix TempDir cleanup race in CUJ A3/A5

### DIFF
--- a/core/cuj_test.go
+++ b/core/cuj_test.go
@@ -64,8 +64,8 @@ type cujAgent struct {
 	// Used by tests that need to drive a multi-event turn (text chunks +
 	// permission request + result) from a single Send call. See
 	// setNextSessionEvents on cujAgent.
-	nextSessionEvents    []Event
-	nextSessionDelayMs   int
+	nextSessionEvents  []Event
+	nextSessionDelayMs int
 }
 
 func (a *cujAgent) Name() string { return "cuj" }
@@ -1130,8 +1130,8 @@ func TestCUJ_A3_ImageReachesAgent(t *testing.T) {
 	msg := &Message{
 		SessionKey: "test:img", Platform: "test", MessageID: "img1",
 		UserID: "img", UserName: "img",
-		Content: "what is in this image",
-		Images:  []ImageAttachment{{MimeType: "image/png", Data: []byte("\x89PNG fake"), FileName: "chart.png"}},
+		Content:  "what is in this image",
+		Images:   []ImageAttachment{{MimeType: "image/png", Data: []byte("\x89PNG fake"), FileName: "chart.png"}},
 		ReplyCtx: "ctx",
 	}
 	e.ReceiveMessage(plat, msg)
@@ -1147,6 +1147,30 @@ func TestCUJ_A3_ImageReachesAgent(t *testing.T) {
 		select {
 		case <-deadline:
 			t.Fatal("agent never received the message with image")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Wait for the turn to fully complete (reply delivered) before returning:
+	// the turn tail persists sessions.json inside t.TempDir, and returning
+	// early races that write against the TempDir cleanup.
+	waitForTurnReply(t, plat)
+}
+
+// waitForTurnReply blocks until the platform has received at least one
+// message, i.e. the current turn has fully completed and its session
+// persistence is done.
+func waitForTurnReply(t *testing.T, plat *stubPlatformEngine) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if len(plat.getSent()) > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("turn never completed (no reply reached the platform)")
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}
@@ -1194,8 +1218,8 @@ func TestCUJ_A5_FileReachesAgent(t *testing.T) {
 	msg := &Message{
 		SessionKey: "test:file", Platform: "test", MessageID: "f1",
 		UserID: "file", UserName: "file",
-		Content: "read this file",
-		Files:   []FileAttachment{{MimeType: "text/plain", Data: []byte("hello world"), FileName: "note.txt"}},
+		Content:  "read this file",
+		Files:    []FileAttachment{{MimeType: "text/plain", Data: []byte("hello world"), FileName: "note.txt"}},
 		ReplyCtx: "ctx",
 	}
 	e.ReceiveMessage(plat, msg)
@@ -1206,7 +1230,7 @@ func TestCUJ_A5_FileReachesAgent(t *testing.T) {
 		n := len(agent.sessions)
 		agent.mu.Unlock()
 		if n > 0 {
-			return
+			break
 		}
 		select {
 		case <-deadline:
@@ -1215,6 +1239,10 @@ func TestCUJ_A5_FileReachesAgent(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
+
+	// See TestCUJ_A3_ImageReachesAgent: don't race TempDir cleanup against
+	// the turn tail's session persistence.
+	waitForTurnReply(t, plat)
 }
 
 // CUJ-A6 / A7 are intentionally covered at the platform layer
@@ -2325,4 +2353,3 @@ func TestCUJ_STREAM1_StreamingResumesAfterPermissionPrompt(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
## Problem

`TestCUJ_A3_ImageReachesAgent` and `TestCUJ_A5_FileReachesAgent` return as soon as the agent observes the message, while the turn tail is still persisting `sessions.json` inside `t.TempDir()`. The test then races TempDir cleanup against that write and fails intermittently with:

```
testing.go: TempDir RemoveAll cleanup: unlinkat .../001: directory not empty
```

Reproducible on a clean checkout of current `main` with `go test -parallel=4 -race ./core/` (A5 fails most runs here; A3 joins in under load). The leaked goroutine can also log a spurious `session: failed to write ... invalid argument` after the TempDir is gone.

## Fix

Wait until the reply reaches the platform (i.e. the turn is fully drained, session persistence done) before the test returns — the same pattern `TestCUJ_A4` already uses. Shared as a small `waitForTurnReply` helper used by both tests.

Verified: `-count=5` in isolation and full `go test -parallel=4 -race ./core/` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)