### PR TITLE
feat(core): notify IM user when agent process exits without producing a reply

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -43,6 +43,12 @@ type claudeSession struct {
 	done            chan struct{}
 	alive           atomic.Bool
 
+	// exitErr stores the trimmed fatal stderr captured when the process
+	// exited with an error (e.g. an immediate EPERM death right after
+	// spawn). Exposed via ExitError (core.ExitErrorReporter) so the engine
+	// can tell the user why a turn produced no reply.
+	exitErr atomic.Value // stores string
+
 	// activeModel stores the model id reported by the CLI's init event (e.g.
 	// "claude-opus-4-7[1m]"). It may be empty if the init event hasn't
 	// carried a model field yet; callers should fall back to the Agent's
@@ -520,6 +526,7 @@ func (cs *claudeSession) finishReadLoop(waitErrCh <-chan error, stderrBuf *bytes
 		}
 		if stderrMsg != "" {
 			slog.Error("claudeSession: process failed", "error", err, "stderr", stderrMsg)
+			cs.exitErr.Store(stderrMsg)
 			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)}
 			select {
 			case cs.events <- evt:
@@ -1166,6 +1173,16 @@ func (cs *claudeSession) GetContextUsage() *core.ContextUsage {
 
 func (cs *claudeSession) Alive() bool {
 	return cs.alive.Load()
+}
+
+// ExitError implements core.ExitErrorReporter. It returns the trimmed fatal
+// stderr of the dead process, or "" while the process is alive or when it
+// exited cleanly.
+func (cs *claudeSession) ExitError() string {
+	if v, ok := cs.exitErr.Load().(string); ok {
+		return v
+	}
+	return ""
 }
 
 func (cs *claudeSession) Close() error {

--- a/core/engine.go
+++ b/core/engine.go
@@ -5990,11 +5990,39 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 channelClosed:
 	// Channel closed - process exited unexpectedly
 	slog.Warn("agent process exited", "session_key", sessionKey)
+	// Capture the exit reason and stop flag BEFORE cleanup nils out
+	// state.agentSession — cleanup also marks the state stopped, so reading
+	// afterwards could not distinguish a user-initiated stop from a crash.
+	var exitDetail string
 	state.mu.Lock()
+	if reporter, ok := state.agentSession.(ExitErrorReporter); ok {
+		exitDetail = reporter.ExitError()
+	}
+	wasStopped := state.stopped
 	state.eventsNeedResync = true
 	state.mu.Unlock()
 	e.notifyDroppedQueuedMessages(state, fmt.Errorf("agent process exited"))
 	e.cleanupInteractiveState(sessionKey, state)
+
+	if len(textParts) == 0 {
+		// The process died without producing any reply for this turn. Unless
+		// the user stopped it on purpose, say so instead of going silent —
+		// e.g. a spawn-then-immediate-death on macOS TCC EPERM otherwise
+		// looks like the bot simply ignoring the message.
+		if !wasStopped {
+			state.mu.Lock()
+			p := state.platform
+			state.mu.Unlock()
+			cp.Finalize(ProgressCardStateFailed)
+			sp.discard()
+			userMsg := e.i18n.T(MsgAgentExitedAbnormally)
+			if exitDetail != "" {
+				userMsg = fmt.Sprintf(e.i18n.T(MsgAgentExitedAbnormallyDetail), truncateIf(exitDetail, 300))
+			}
+			e.send(p, replyCtx, userMsg)
+		}
+		return
+	}
 
 	if len(textParts) > 0 {
 		state.mu.Lock()

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -15867,3 +15867,116 @@ func TestProcessInteractiveEvents_StreamingCard_BareNoReply_Suppressed(t *testin
 		t.Fatalf("silent reply leaked NO_REPLY into the streaming card: %q", card.finalContent())
 	}
 }
+
+// --- channelClosed fallback: spawn-death notification tests ---
+
+// exitErrorSession wraps controllableAgentSession with a canned ExitError so
+// tests can simulate a process that died right after spawn (e.g. macOS TCC
+// EPERM) before emitting a single event. Close is overridden because the
+// tests close the events channel themselves to simulate the death.
+type exitErrorSession struct {
+	*controllableAgentSession
+	exitErr string
+}
+
+func (s *exitErrorSession) ExitError() string { return s.exitErr }
+func (s *exitErrorSession) Close() error {
+	s.alive = false
+	return nil
+}
+
+func TestProcessInteractiveEvents_SpawnDeathNotifiesUserWithExitError(t *testing.T) {
+	p := &stubPlatformEngine{n: "stub"}
+	inner := newControllableSession("dead-on-arrival")
+	sess := &exitErrorSession{controllableAgentSession: inner, exitErr: "error: An internal error occurred (EPERM)"}
+	e := NewEngine("test", &controllableAgent{nextSession: sess}, []Platform{p}, "", LangEnglish)
+
+	key := "test:chat:u-spawn-death"
+	session := e.sessions.GetOrCreateActive(key)
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	// Simulate the process dying immediately after spawn: the events channel
+	// closes without emitting a single event.
+	close(inner.events)
+	inner.alive = false
+
+	e.processInteractiveEvents(state, session, e.sessions, key, "m-spawn-death", time.Now(), nil, nil, "ctx")
+
+	sent := p.getSent()
+	if len(sent) == 0 {
+		t.Fatal("expected an abnormal-exit notification to be sent to the user, got none")
+	}
+	joined := strings.Join(sent, "\n")
+	if !strings.Contains(joined, "EPERM") {
+		t.Errorf("expected notification to include the exit error detail, got: %q", joined)
+	}
+	if !strings.Contains(joined, "exited unexpectedly") {
+		t.Errorf("expected the abnormal-exit message text, got: %q", joined)
+	}
+}
+
+func TestProcessInteractiveEvents_SpawnDeathWithoutDetailStillNotifies(t *testing.T) {
+	p := &stubPlatformEngine{n: "stub"}
+	inner := newControllableSession("dead-no-detail")
+	sess := &exitErrorSession{controllableAgentSession: inner} // no ExitError detail
+	e := NewEngine("test", &controllableAgent{nextSession: sess}, []Platform{p}, "", LangEnglish)
+
+	key := "test:chat:u-spawn-death-nodetail"
+	session := e.sessions.GetOrCreateActive(key)
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	close(inner.events)
+	inner.alive = false
+
+	e.processInteractiveEvents(state, session, e.sessions, key, "m-nodetail", time.Now(), nil, nil, "ctx")
+
+	sent := p.getSent()
+	if len(sent) == 0 {
+		t.Fatal("expected an abnormal-exit notification even without exit detail, got none")
+	}
+	if !strings.Contains(strings.Join(sent, "\n"), "exited unexpectedly") {
+		t.Errorf("expected the generic abnormal-exit message, got: %q", sent)
+	}
+}
+
+func TestProcessInteractiveEvents_UserStoppedExitStaysSilent(t *testing.T) {
+	p := &stubPlatformEngine{n: "stub"}
+	inner := newControllableSession("stopped-by-user")
+	sess := &exitErrorSession{controllableAgentSession: inner}
+	e := NewEngine("test", &controllableAgent{nextSession: sess}, []Platform{p}, "", LangEnglish)
+
+	key := "test:chat:u-user-stop"
+	session := e.sessions.GetOrCreateActive(key)
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	state.markStopped()
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	close(inner.events)
+	inner.alive = false
+
+	e.processInteractiveEvents(state, session, e.sessions, key, "m-user-stop", time.Now(), nil, nil, "ctx")
+
+	if sent := p.getSent(); len(sent) != 0 {
+		t.Fatalf("expected no notification after a user-initiated stop, got: %v", sent)
+	}
+}

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -378,31 +378,31 @@ const (
 	MsgCronIDLabel               MsgKey = "cron_id_label"
 	MsgCronFailedSuffix          MsgKey = "cron_failed_suffix"
 
-	MsgTimerNotAvailable  MsgKey = "timer_not_available"
-	MsgTimerUsage         MsgKey = "timer_usage"
-	MsgTimerAddUsage      MsgKey = "timer_add_usage"
-	MsgTimerAdded         MsgKey = "timer_added"
-	MsgTimerAddedExec     MsgKey = "timer_added_exec"
-	MsgTimerAddExecUsage  MsgKey = "timer_addexec_usage"
-	MsgTimerEmpty         MsgKey = "timer_empty"
-	MsgTimerListTitle     MsgKey = "timer_list_title"
-	MsgTimerListFooter    MsgKey = "timer_list_footer"
-	MsgTimerDelUsage      MsgKey = "timer_del_usage"
-	MsgTimerMuteUsage     MsgKey = "timer_mute_usage"
-	MsgTimerDeleted       MsgKey = "timer_deleted"
-	MsgTimerNotFound      MsgKey = "timer_not_found"
-	MsgTimerMuted         MsgKey = "timer_muted"
-	MsgTimerUnmuted       MsgKey = "timer_unmuted"
-	MsgTimerCardHint      MsgKey = "timer_card_hint"
-	MsgTimerBtnMute       MsgKey = "timer_btn_mute"
-	MsgTimerBtnUnmute     MsgKey = "timer_btn_unmute"
-	MsgTimerBtnDelete     MsgKey = "timer_btn_delete"
-	MsgTimerIDLabel       MsgKey = "timer_id_label"
-	MsgTimerScheduledLabel MsgKey = "timer_scheduled_label"
-	MsgTimerFailedSuffix  MsgKey = "timer_failed_suffix"
-	MsgCommandsTagAgent          MsgKey = "commands_tag_agent"
-	MsgCommandsTagShell          MsgKey = "commands_tag_shell"
-	MsgUpgradeTimeoutSuffix      MsgKey = "upgrade_timeout_suffix"
+	MsgTimerNotAvailable    MsgKey = "timer_not_available"
+	MsgTimerUsage           MsgKey = "timer_usage"
+	MsgTimerAddUsage        MsgKey = "timer_add_usage"
+	MsgTimerAdded           MsgKey = "timer_added"
+	MsgTimerAddedExec       MsgKey = "timer_added_exec"
+	MsgTimerAddExecUsage    MsgKey = "timer_addexec_usage"
+	MsgTimerEmpty           MsgKey = "timer_empty"
+	MsgTimerListTitle       MsgKey = "timer_list_title"
+	MsgTimerListFooter      MsgKey = "timer_list_footer"
+	MsgTimerDelUsage        MsgKey = "timer_del_usage"
+	MsgTimerMuteUsage       MsgKey = "timer_mute_usage"
+	MsgTimerDeleted         MsgKey = "timer_deleted"
+	MsgTimerNotFound        MsgKey = "timer_not_found"
+	MsgTimerMuted           MsgKey = "timer_muted"
+	MsgTimerUnmuted         MsgKey = "timer_unmuted"
+	MsgTimerCardHint        MsgKey = "timer_card_hint"
+	MsgTimerBtnMute         MsgKey = "timer_btn_mute"
+	MsgTimerBtnUnmute       MsgKey = "timer_btn_unmute"
+	MsgTimerBtnDelete       MsgKey = "timer_btn_delete"
+	MsgTimerIDLabel         MsgKey = "timer_id_label"
+	MsgTimerScheduledLabel  MsgKey = "timer_scheduled_label"
+	MsgTimerFailedSuffix    MsgKey = "timer_failed_suffix"
+	MsgCommandsTagAgent     MsgKey = "commands_tag_agent"
+	MsgCommandsTagShell     MsgKey = "commands_tag_shell"
+	MsgUpgradeTimeoutSuffix MsgKey = "upgrade_timeout_suffix"
 
 	MsgCronScheduleLabel MsgKey = "cron_schedule_label"
 	MsgCronNextRunLabel  MsgKey = "cron_next_run_label"
@@ -646,6 +646,9 @@ const (
 	MsgWsInitInvalidTarget      MsgKey = "ws_init_invalid_target"
 	MsgWsInitLocalPathsDisabled MsgKey = "ws_init_local_paths_disabled"
 	MsgBackgroundAutoDenied     MsgKey = "background_auto_denied"
+
+	MsgAgentExitedAbnormally       MsgKey = "agent_exited_abnormally"
+	MsgAgentExitedAbnormallyDetail MsgKey = "agent_exited_abnormally_detail"
 )
 
 var messages = map[MsgKey]map[Language]string{
@@ -799,6 +802,20 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "❌ 錯誤: %v",
 		LangJapanese:           "❌ エラー: %v",
 		LangSpanish:            "❌ Error: %v",
+	},
+	MsgAgentExitedAbnormally: {
+		LangEnglish:            "⚠️ The agent process exited unexpectedly before producing a reply. Check the cc-connect logs for details.",
+		LangChinese:            "⚠️ Agent 进程异常退出，本轮未产生回复。可检查 cc-connect 日志定位原因。",
+		LangTraditionalChinese: "⚠️ Agent 進程異常退出，本輪未產生回覆。可檢查 cc-connect 日誌定位原因。",
+		LangJapanese:           "⚠️ エージェントプロセスが応答を生成する前に予期せず終了しました。詳細は cc-connect のログを確認してください。",
+		LangSpanish:            "⚠️ El proceso del agente terminó inesperadamente antes de producir una respuesta. Revisa los registros de cc-connect para más detalles.",
+	},
+	MsgAgentExitedAbnormallyDetail: {
+		LangEnglish:            "⚠️ The agent process exited unexpectedly before producing a reply: %s",
+		LangChinese:            "⚠️ Agent 进程异常退出，本轮未产生回复：%s",
+		LangTraditionalChinese: "⚠️ Agent 進程異常退出，本輪未產生回覆：%s",
+		LangJapanese:           "⚠️ エージェントプロセスが応答を生成する前に予期せず終了しました：%s",
+		LangSpanish:            "⚠️ El proceso del agente terminó inesperadamente antes de producir una respuesta: %s",
 	},
 	MsgBackgroundAutoDenied: {
 		LangEnglish:            "⚠️ Background task requested permission for `%s` but was auto-denied (no active user turn). Send a message or use `/yolo` to approve future requests.",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -421,6 +421,16 @@ type AgentSession interface {
 	Close() error
 }
 
+// ExitErrorReporter is an optional interface an AgentSession may implement to
+// expose the fatal stderr captured when its underlying process died. The
+// engine uses it to surface actionable exit reasons (e.g. a macOS TCC EPERM
+// right after spawn) to the IM user instead of failing silently.
+type ExitErrorReporter interface {
+	// ExitError returns the trimmed stderr of the dead process, or "" if the
+	// process is alive or exited cleanly.
+	ExitError() string
+}
+
 // PermissionResult represents the user's decision on a permission request.
 type PermissionResult struct {
 	Behavior     string         `json:"behavior"`               // "allow" or "deny"


### PR DESCRIPTION
## Motivation

When the agent process dies mid-turn before emitting any text, the turn can end completely silently: the `EventError` from the agent session may be lost before the foreground loop consumes it, and the `channelClosed` path only relays partial text (of which there is none). From the user's perspective the bot reads the message and never answers — no error, no hint.

This bit me hard in production: a macOS TCC permission change caused every fresh `claude` spawn to die within ~20ms (`error: An internal error occurred (EPERM)`). All my bots went silent. The daemon logged `claudeSession: process failed` correctly, but nothing reached the IM side, so it took a log dive to even know where to look.

## Design

- New **optional** `core.ExitErrorReporter` interface (`ExitError() string`); agents can implement it to expose the fatal stderr captured at process death. Implemented for the claudecode session here — other agents opt in trivially later.
- `channelClosed` path in `processInteractiveEvents`: if the turn produced **no text** and the session was **not stopped on purpose** (`/stop`, `/detach`, cleanup), send an explicit abnormal-exit message, including the captured stderr (truncated to 300 chars) when available:
  > ⚠️ The agent process exited unexpectedly before producing a reply: error: An internal error occurred (EPERM)
- Turns with partial text keep the existing behavior (partial text is still delivered).
- i18n strings for all five languages.

## Tests

Three new tests: exit-with-detail notifies, exit-without-detail still notifies with the generic message, and user-initiated stop stays silent. `go build ./...`, `go vet`, and `go test -race ./core/ ./agent/claudecode/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)