### PR TITLE
feat: support per-session work_dir via inbound message

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -2833,6 +2833,14 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 		}
 	}
 
+	// Inbound work_dir: platform adapters (e.g. cloud-web) can set
+	// msg.WorkDir to bind this session to a per-message working directory,
+	// enabling the same project to serve concurrent sessions in different
+	// directories (e.g. CI reviewing multiple PR branches in parallel).
+	if msg.WorkDir != "" {
+		e.bindSendWorkDir(msg.SessionKey, msg.WorkDir)
+	}
+
 	// Multi-workspace resolution
 	var wsAgent Agent
 	var wsSessions *SessionManager

--- a/core/message.go
+++ b/core/message.go
@@ -242,6 +242,12 @@ type Message struct {
 	// drop late redeliveries that reuse a new message_id but an older create_time
 	// than a message already processed. Zero means unset (no ordering hint).
 	UserMessageTimeMs int64
+	// WorkDir, when set by the platform adapter, binds this session to a
+	// per-session working directory. The engine calls bindSendWorkDir so the
+	// agent spawned for this session_key uses an isolated workspace instead
+	// of the project-level work_dir. Platforms populate this from their
+	// inbound message payload (e.g. cloud-web "work_dir" JSON field).
+	WorkDir string
 }
 
 // EventType distinguishes different kinds of agent output.

--- a/platform/cloud-web/cloudweb.go
+++ b/platform/cloud-web/cloudweb.go
@@ -323,6 +323,7 @@ func (p *Platform) handleMessage(raw []byte) {
 		Files:      decodeFiles(m.Files),
 		Audio:      decodeAudio(m.Audio),
 		ReplyCtx:   rc,
+		WorkDir:    m.WorkDir,
 	}
 
 	p.mu.RLock()

--- a/platform/cloud-web/protocol.go
+++ b/platform/cloud-web/protocol.go
@@ -128,6 +128,7 @@ type wireInboundMessage struct {
 	Images     []wireImage `json:"images,omitempty"`
 	Files      []wireFile  `json:"files,omitempty"`
 	Audio      *wireAudio  `json:"audio,omitempty"`
+	WorkDir    string      `json:"work_dir,omitempty"`
 }
 
 type wireCardAction struct {


### PR DESCRIPTION
## Problem

`--cwd` on `cc-connect send` binds `work_dir` only for **outbound** (agent→user) messages. Inbound messages from platforms (e.g. cloud-web webhook) always use the project-level `work_dir`, making it impossible for concurrent sessions within the same project to operate in different directories.

This forces CI/CD pipelines that review multiple PRs in parallel to either:
- Define duplicate projects with different `work_dir` paths (verbose, doesn't scale)
- Rely on prompt-level absolute paths (fragile, agent may ignore)

Related: #800 (per-worktree sessions within a single project)

## Solution

Add an optional `work_dir` field to the inbound message payload. When set, the engine calls the existing `bindSendWorkDir(sessionKey, workDir)` before workspace resolution, so `getOrCreateWorkspaceAgent` spawns an agent in the specified directory.

This makes `--cwd` behavior **symmetric**: both outbound (`cc-connect send --cwd`) and inbound (platform message `work_dir`) can bind a session to a per-message working directory.

### Cloud Web example

```json
{
  "type": "message",
  "msg_id": "review-001",
  "session_key": "cloud_web:pr-123:ci-bot",
  "user_id": "ci-bot",
  "content": "review this PR",
  "work_dir": "/path/to/pr-123-worktree"
}
```

### Use case: CI code review

A single `code-review` project handles multiple PR reviews concurrently. Each webhook message specifies a different `work_dir` (git worktree), and the agent for each session runs in the correct PR branch checkout.

## Changes

| File | Change |
|------|--------|
| `core/message.go` | Add `WorkDir` field to `Message` struct |
| `core/engine.go` | Call `bindSendWorkDir` when `msg.WorkDir` is set (before existing workspace resolution) |
| `platform/cloud-web/protocol.go` | Add `work_dir` to `wireInboundMessage` |
| `platform/cloud-web/cloudweb.go` | Propagate `work_dir` to `core.Message` |

4 files, 16 lines added. No breaking changes — the field is optional and zero-value preserves existing behavior.