### PR TITLE
feat(cursor): sync session names between cc-connect and Cursor CLI

### DIFF
--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -232,6 +232,8 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 
 func (a *Agent) Stop() error { return nil }
 
+var _ core.SessionRenamer = (*Agent)(nil)
+
 // ── SkillProvider implementation ──────────────────────────────
 
 func (a *Agent) SkillDirs() []string {

--- a/agent/cursor/session_name.go
+++ b/agent/cursor/session_name.go
@@ -9,7 +9,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+const sessionSidecarSchemaVersion = 1
 
 // meaningfulCursorSessionName reports whether name is a user-visible label from
 // Cursor CLI (/rename or auto-title), as opposed to the default placeholder.
@@ -116,5 +119,56 @@ func writeSessionDisplayName(dbPath, name string) error {
 	if out, err := exec.Command(sqliteBin, dbPath, query).CombinedOutput(); err != nil {
 		return fmt.Errorf("cursor: write meta: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+	return writeSessionSidecarTitle(filepath.Dir(dbPath), name, meta)
+}
+
+// writeSessionSidecarTitle updates meta.json, which agent ls reads for display titles.
+func writeSessionSidecarTitle(sessionDir, title string, storeMeta map[string]any) error {
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	nowMs := time.Now().UnixMilli()
+
+	sidecar := map[string]any{
+		"schemaVersion":   sessionSidecarSchemaVersion,
+		"createdAtMs":     sidecarCreatedAtMs(storeMeta),
+		"hasConversation": sidecarHasConversation(storeMeta),
+		"title":           title,
+		"updatedAtMs":     nowMs,
+	}
+
+	if data, err := os.ReadFile(metaPath); err == nil {
+		var existing map[string]any
+		if json.Unmarshal(data, &existing) == nil {
+			for _, key := range []string{
+				"schemaVersion", "createdAtMs", "hasConversation", "isSubagent", "cwd",
+			} {
+				if v, ok := existing[key]; ok {
+					sidecar[key] = v
+				}
+			}
+		}
+	}
+
+	sidecar["title"] = title
+	sidecar["updatedAtMs"] = nowMs
+
+	data, err := json.Marshal(sidecar)
+	if err != nil {
+		return fmt.Errorf("cursor: encode meta.json: %w", err)
+	}
+	if err := os.WriteFile(metaPath, data, 0o644); err != nil {
+		return fmt.Errorf("cursor: write meta.json: %w", err)
+	}
 	return nil
+}
+
+func sidecarCreatedAtMs(storeMeta map[string]any) int64 {
+	if v, ok := storeMeta["createdAt"].(float64); ok && v > 0 {
+		return int64(v)
+	}
+	return time.Now().UnixMilli()
+}
+
+func sidecarHasConversation(storeMeta map[string]any) bool {
+	blob, _ := storeMeta["latestRootBlobId"].(string)
+	return strings.TrimSpace(blob) != ""
 }

--- a/agent/cursor/session_name.go
+++ b/agent/cursor/session_name.go
@@ -1,0 +1,120 @@
+package cursor
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// meaningfulCursorSessionName reports whether name is a user-visible label from
+// Cursor CLI (/rename or auto-title), as opposed to the default placeholder.
+func meaningfulCursorSessionName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	switch strings.ToLower(name) {
+	case "new agent", "new chat":
+		return false
+	}
+	return true
+}
+
+func (a *Agent) GetSessionDisplayName(_ context.Context, sessionID string) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cursor: home dir: %w", err)
+	}
+	dbPath, err := sessionDBPath(homeDir, a.GetWorkDir(), sessionID)
+	if err != nil {
+		return "", err
+	}
+	meta := readSessionMeta(dbPath)
+	return strings.TrimSpace(meta.Name), nil
+}
+
+func (a *Agent) SetSessionDisplayName(_ context.Context, sessionID, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("cursor: empty session name")
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cursor: home dir: %w", err)
+	}
+	dbPath, err := sessionDBPath(homeDir, a.GetWorkDir(), sessionID)
+	if err != nil {
+		return err
+	}
+	return writeSessionDisplayName(dbPath, name)
+}
+
+func sessionDBPath(homeDir, workDir, sessionID string) (string, error) {
+	dir, err := findCursorSessionDir(homeDir, workDir, sessionID)
+	if err != nil {
+		return "", err
+	}
+	dbPath := filepath.Join(dir, "store.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		return "", fmt.Errorf("cursor: store.db for session %s: %w", sessionID, err)
+	}
+	return dbPath, nil
+}
+
+func writeSessionDisplayName(dbPath, name string) error {
+	sqliteBin, err := exec.LookPath("sqlite3")
+	if err != nil {
+		return fmt.Errorf("cursor: sqlite3 not found in PATH (required to sync session names)")
+	}
+
+	out, err := exec.Command(sqliteBin, dbPath,
+		"SELECT value FROM meta WHERE key='0' LIMIT 1;",
+	).Output()
+	if err != nil {
+		return fmt.Errorf("cursor: read meta: %w", err)
+	}
+
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return fmt.Errorf("cursor: meta row missing for session")
+	}
+
+	encodedHex := true
+	decoded, err := hex.DecodeString(raw)
+	if err != nil {
+		encodedHex = false
+		decoded = []byte(raw)
+	}
+
+	var meta map[string]any
+	if err := json.Unmarshal(decoded, &meta); err != nil {
+		return fmt.Errorf("cursor: decode meta json: %w", err)
+	}
+
+	meta["name"] = name
+
+	updated, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("cursor: encode meta json: %w", err)
+	}
+
+	var storeValue string
+	if encodedHex {
+		storeValue = hex.EncodeToString(updated)
+	} else {
+		storeValue = string(updated)
+	}
+
+	// Single-quote escape for sqlite3 CLI literal.
+	escaped := strings.ReplaceAll(storeValue, "'", "''")
+	query := fmt.Sprintf("UPDATE meta SET value='%s' WHERE key='0';", escaped)
+	if out, err := exec.Command(sqliteBin, dbPath, query).CombinedOutput(); err != nil {
+		return fmt.Errorf("cursor: write meta: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/agent/cursor/session_name_test.go
+++ b/agent/cursor/session_name_test.go
@@ -1,0 +1,89 @@
+package cursor
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestMeaningfulCursorSessionName(t *testing.T) {
+	tests := map[string]bool{
+		"":            false,
+		"New Agent":   false,
+		"new chat":    false,
+		"Hccepose":    true,
+		"CC Visibility": true,
+	}
+	for name, want := range tests {
+		if got := meaningfulCursorSessionName(name); got != want {
+			t.Errorf("meaningfulCursorSessionName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestWriteReadSessionDisplayName(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not available")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	workDir := filepath.Join(home, "project")
+	sessionID := "11111111-2222-3333-4444-555555555555"
+	hash := workspaceHash(workDir)
+	chatsDir := filepath.Join(home, ".cursor", "chats", hash, sessionID)
+	if err := os.MkdirAll(chatsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(chatsDir, "store.db")
+
+	meta := map[string]any{
+		"agentId":          sessionID,
+		"name":             "New Agent",
+		"mode":             "default",
+		"latestRootBlobId": "abc",
+	}
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hexVal := hex.EncodeToString(raw)
+
+	if out, err := exec.Command("sqlite3", dbPath,
+		"CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);",
+		fmt.Sprintf("INSERT INTO meta(key,value) VALUES('0','%s');", hexVal),
+	).CombinedOutput(); err != nil {
+		t.Fatalf("setup db: %v: %s", err, out)
+	}
+
+	if err := writeSessionDisplayName(dbPath, "Feishu Sync Name"); err != nil {
+		t.Fatalf("writeSessionDisplayName() error: %v", err)
+	}
+	got := readSessionMeta(dbPath)
+	if got.Name != "Feishu Sync Name" {
+		t.Fatalf("readSessionMeta().Name = %q, want %q", got.Name, "Feishu Sync Name")
+	}
+
+	agent := &Agent{workDir: workDir}
+	name, err := agent.GetSessionDisplayName(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("GetSessionDisplayName() error: %v", err)
+	}
+	if name != "Feishu Sync Name" {
+		t.Fatalf("GetSessionDisplayName() = %q, want %q", name, "Feishu Sync Name")
+	}
+
+	if err := agent.SetSessionDisplayName(context.Background(), sessionID, "Terminal Rename"); err != nil {
+		t.Fatalf("SetSessionDisplayName() error: %v", err)
+	}
+	got = readSessionMeta(dbPath)
+	if got.Name != "Terminal Rename" {
+		t.Fatalf("after SetSessionDisplayName, name = %q, want %q", got.Name, "Terminal Rename")
+	}
+}

--- a/agent/cursor/session_name_test.go
+++ b/agent/cursor/session_name_test.go
@@ -16,7 +16,7 @@ func TestMeaningfulCursorSessionName(t *testing.T) {
 		"":            false,
 		"New Agent":   false,
 		"new chat":    false,
-		"Hccepose":    true,
+		"Feature Work":  true,
 		"CC Visibility": true,
 	}
 	for name, want := range tests {
@@ -62,12 +62,38 @@ func TestWriteReadSessionDisplayName(t *testing.T) {
 		t.Fatalf("setup db: %v: %s", err, out)
 	}
 
+	oldSidecar := map[string]any{
+		"schemaVersion":   1,
+		"createdAtMs":     float64(1_700_000_000_000),
+		"hasConversation": true,
+		"title":           "Old Sidecar Title",
+		"updatedAtMs":     float64(1_700_000_000_000),
+	}
+	oldSidecarRaw, err := json.Marshal(oldSidecar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(chatsDir, "meta.json"), oldSidecarRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := writeSessionDisplayName(dbPath, "Feishu Sync Name"); err != nil {
 		t.Fatalf("writeSessionDisplayName() error: %v", err)
 	}
 	got := readSessionMeta(dbPath)
 	if got.Name != "Feishu Sync Name" {
 		t.Fatalf("readSessionMeta().Name = %q, want %q", got.Name, "Feishu Sync Name")
+	}
+	sidecarRaw, err := os.ReadFile(filepath.Join(chatsDir, "meta.json"))
+	if err != nil {
+		t.Fatalf("read meta.json: %v", err)
+	}
+	var sidecar map[string]any
+	if err := json.Unmarshal(sidecarRaw, &sidecar); err != nil {
+		t.Fatalf("decode meta.json: %v", err)
+	}
+	if sidecar["title"] != "Feishu Sync Name" {
+		t.Fatalf("meta.json title = %v, want %q", sidecar["title"], "Feishu Sync Name")
 	}
 
 	agent := &Agent{workDir: workDir}

--- a/core/engine.go
+++ b/core/engine.go
@@ -4097,6 +4097,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 				pendingName := session.GetName()
 				if pendingName != "" && pendingName != "session" && pendingName != "default" {
 					sessions.SetSessionName(newID, pendingName)
+					e.exportSessionNameToAgent(agent, newID, pendingName)
 				}
 			}
 			sessions.Save()
@@ -5307,6 +5308,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 						pendingName := session.GetName()
 						if pendingName != "" && pendingName != "session" && pendingName != "default" {
 							sessions.SetSessionName(event.SessionID, pendingName)
+							e.exportSessionNameToAgent(e.agent, event.SessionID, pendingName)
 						}
 					}
 					sessions.Save()
@@ -5441,6 +5443,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 							pendingName := session.GetName()
 							if pendingName != "" && pendingName != "session" && pendingName != "default" {
 								sessions.SetSessionName(currentID, pendingName)
+								e.exportSessionNameToAgent(e.agent, currentID, pendingName)
 							}
 						}
 					}
@@ -6837,6 +6840,7 @@ func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 			return
 		}
 		agentSessions = e.applySessionFilter(agentSessions, sessions)
+		e.syncSessionNamesFromAgent(agent, sessions, agentSessions)
 		if len(agentSessions) == 0 {
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgListEmpty))
 			return
@@ -6934,6 +6938,7 @@ func (e *Engine) cmdSwitch(p Platform, msg *Message, args []string) {
 		return
 	}
 	agentSessions = e.applySessionFilter(agentSessions, sessions)
+	e.syncSessionNamesFromAgent(agent, sessions, agentSessions)
 
 	matched := e.matchSession(agentSessions, sessions, query)
 	if matched == nil {
@@ -8368,6 +8373,7 @@ func (e *Engine) cmdName(p Platform, msg *Message, args []string) {
 			return
 		}
 		agentSessions = e.applySessionFilter(agentSessions, sessions)
+		e.syncSessionNamesFromAgent(agent, sessions, agentSessions)
 		if idx > len(agentSessions) {
 			e.reply(p, msg.ReplyCtx, fmt.Sprintf(e.i18n.T(MsgSwitchNoSession), idx))
 			return
@@ -8392,6 +8398,7 @@ func (e *Engine) cmdName(p Platform, msg *Message, args []string) {
 	}
 
 	sessions.SetSessionName(targetID, name)
+	e.exportSessionNameToAgent(agent, targetID, name)
 
 	shortID := targetID
 	if len(shortID) > 12 {
@@ -12332,6 +12339,7 @@ func (e *Engine) renderDeleteModeCard(sessionKey string) *Card {
 		return e.simpleCard(e.i18n.T(MsgDeleteModeTitle), "red", err.Error())
 	}
 	agentSessions = e.applySessionFilter(agentSessions, sessions)
+	e.syncSessionNamesFromAgent(agent, sessions, agentSessions)
 	dm := e.getDeleteModeState(sessionKey)
 	if dm == nil {
 		return e.simpleCard(e.i18n.T(MsgDeleteModeTitle), "red", e.i18n.T(MsgDeleteUsage))
@@ -12913,6 +12921,7 @@ func (e *Engine) renderListCard(sessionKey string, page int) (*Card, error) {
 		return nil, fmt.Errorf(e.i18n.T(MsgListError), err)
 	}
 	agentSessions = e.applySessionFilter(agentSessions, sessions)
+	e.syncSessionNamesFromAgent(agent, sessions, agentSessions)
 	if len(agentSessions) == 0 {
 		return e.simpleCard(e.i18n.Tf(MsgCardTitleSessions, agent.Name(), 0), "turquoise", e.i18n.T(MsgListEmpty)), nil
 	}
@@ -15258,6 +15267,7 @@ func (e *Engine) cmdDelete(p Platform, msg *Message, args []string) {
 		return
 	}
 	agentSessions = e.applySessionFilter(agentSessions, sessions)
+	e.syncSessionNamesFromAgent(agent, sessions, agentSessions)
 
 	prefix := strings.TrimSpace(args[0])
 	if isExplicitDeleteBatchArg(prefix) {
@@ -15681,6 +15691,7 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, sourceSessionKey,
 		pendingName := session.GetName()
 		if pendingName != "" && pendingName != "session" && pendingName != "default" {
 			sessions.SetSessionName(id, pendingName)
+			e.exportSessionNameToAgent(agent, id, pendingName)
 		}
 		sessions.Save()
 	}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -601,6 +601,14 @@ type SessionDeleter interface {
 	DeleteSession(ctx context.Context, sessionID string) error
 }
 
+// SessionRenamer is an optional interface for agents whose CLI sessions carry a
+// user-visible title (e.g. Cursor /rename). cc-connect mirrors names to/from its
+// session_names map for cross-platform consistency.
+type SessionRenamer interface {
+	GetSessionDisplayName(ctx context.Context, sessionID string) (string, error)
+	SetSessionDisplayName(ctx context.Context, sessionID, name string) error
+}
+
 type SessionTitleProvider interface {
 	GetSessionTitle(sessionID string) string
 }

--- a/core/session_name_sync.go
+++ b/core/session_name_sync.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+// syncSessionNamesFromAgent imports Cursor CLI session titles (/rename, IDE
+// rename) into cc-connect's session_names map. Terminal-originated names win
+// over stale cc-connect labels when they differ.
+func (e *Engine) syncSessionNamesFromAgent(agent Agent, sessions *SessionManager, listed []AgentSessionInfo) {
+	renamer, ok := agent.(SessionRenamer)
+	if !ok || len(listed) == 0 {
+		return
+	}
+	for _, info := range listed {
+		cursorName, err := renamer.GetSessionDisplayName(e.ctx, info.ID)
+		if err != nil {
+			slog.Debug("session name sync: read failed", "session_id", info.ID, "error", err)
+			continue
+		}
+		cursorName = strings.TrimSpace(cursorName)
+		if !meaningfulAgentSessionName(cursorName) {
+			continue
+		}
+		if sessions.GetSessionName(info.ID) == cursorName {
+			continue
+		}
+		sessions.SetSessionName(info.ID, cursorName)
+	}
+}
+
+func (e *Engine) exportSessionNameToAgent(agent Agent, sessionID, name string) {
+	renamer, ok := agent.(SessionRenamer)
+	if !ok {
+		return
+	}
+	name = strings.TrimSpace(name)
+	if sessionID == "" || !meaningfulAgentSessionName(name) {
+		return
+	}
+	if err := renamer.SetSessionDisplayName(context.Background(), sessionID, name); err != nil {
+		slog.Warn("session name sync: export to agent failed",
+			"session_id", sessionID, "name", name, "error", err)
+	}
+}
+
+func meaningfulAgentSessionName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	switch strings.ToLower(name) {
+	case "new agent", "new chat":
+		return false
+	}
+	return true
+}

--- a/core/session_name_sync_test.go
+++ b/core/session_name_sync_test.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"context"
+	"testing"
+)
+
+type stubRenamerAgent struct {
+	stubAgent
+	names map[string]string
+}
+
+func (a *stubRenamerAgent) GetSessionDisplayName(_ context.Context, sessionID string) (string, error) {
+	if a.names == nil {
+		return "", nil
+	}
+	return a.names[sessionID], nil
+}
+
+func (a *stubRenamerAgent) SetSessionDisplayName(_ context.Context, sessionID, name string) error {
+	if a.names == nil {
+		a.names = make(map[string]string)
+	}
+	a.names[sessionID] = name
+	return nil
+}
+
+func TestSyncSessionNamesFromAgent_ImportsTerminalRename(t *testing.T) {
+	agent := &stubRenamerAgent{
+		names: map[string]string{
+			"sess-1": "Terminal Title",
+		},
+	}
+	e := NewEngine("test", agent, nil, t.TempDir()+"/sessions.json", LangEnglish)
+	sm := e.sessions
+
+	e.syncSessionNamesFromAgent(agent, sm, []AgentSessionInfo{{ID: "sess-1"}})
+
+	if got := sm.GetSessionName("sess-1"); got != "Terminal Title" {
+		t.Fatalf("GetSessionName() = %q, want %q", got, "Terminal Title")
+	}
+}
+
+func TestSyncSessionNamesFromAgent_SkipsDefaultPlaceholder(t *testing.T) {
+	agent := &stubRenamerAgent{
+		names: map[string]string{
+			"sess-1": "New Agent",
+		},
+	}
+	e := NewEngine("test", agent, nil, t.TempDir()+"/sessions.json", LangEnglish)
+	sm := e.sessions
+	sm.SetSessionName("sess-1", "Feishu Name")
+
+	e.syncSessionNamesFromAgent(agent, sm, []AgentSessionInfo{{ID: "sess-1"}})
+
+	if got := sm.GetSessionName("sess-1"); got != "Feishu Name" {
+		t.Fatalf("GetSessionName() = %q, want preserved %q", got, "Feishu Name")
+	}
+}
+
+func TestCmdName_ExportsToAgentRenamer(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubRenamerAgent{}
+	e := NewEngine("test", agent, []Platform{p}, t.TempDir()+"/sessions.json", LangEnglish)
+
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	session := e.sessions.GetOrCreateActive(msg.SessionKey)
+	session.SetAgentSessionID("sess-export", "cursor")
+
+	e.cmdName(p, msg, []string{"My Feishu Name"})
+
+	if got := agent.names["sess-export"]; got != "My Feishu Name" {
+		t.Fatalf("agent name = %q, want %q", got, "My Feishu Name")
+	}
+	if got := e.sessions.GetSessionName("sess-export"); got != "My Feishu Name" {
+		t.Fatalf("session_names = %q, want %q", got, "My Feishu Name")
+	}
+}


### PR DESCRIPTION
Mirror /name and /rename titles bidirectionally via store.db meta.name and session_names so Feishu and terminal agent ls show the same labels.

  ## Summary
  - Bidirectional session name sync between cc-connect (Feishu `/name`)
  and Cursor CLI (`/rename` / IDE rename) via `store.db` `meta.name`
  - Import Cursor names on `/list` and `/switch`; export cc-connect names
