### PR TITLE
fix(claudecode): do not auto-approve AskUserQuestion in yolo/bypass mode

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -868,7 +868,7 @@ func (cs *claudeSession) handleControlRequest(raw map[string]any) {
 	toolName, _ := request["tool_name"].(string)
 	input, _ := request["input"].(map[string]any)
 
-	if cs.autoApprove.Load() {
+	if cs.autoApprove.Load() && toolName != "AskUserQuestion" {
 		slog.Debug("claudeSession: auto-approving", "request_id", requestID, "tool", toolName)
 		_ = cs.RespondPermission(requestID, core.PermissionResult{
 			Behavior:     "allow",

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -49,6 +49,94 @@ func TestHandleResultParsesUsage(t *testing.T) {
 	}
 }
 
+// writeCloser wraps a bytes.Buffer to satisfy io.WriteCloser without touching
+// any real pipe. Used in tests that exercise handleControlRequest paths which
+// may call RespondPermission (writing the allow/deny response to stdin).
+type writeCloser struct{ *bytes.Buffer }
+
+func (*writeCloser) Close() error { return nil }
+
+// TestHandleControlRequest_AskUserQuestionBypassesAutoApprove is a regression
+// test for the bug where yolo / bypassPermissions mode (autoApprove=true)
+// silently auto-approved AskUserQuestion. AskUserQuestion is a user-facing
+// question (rendered as a card with option buttons on Feishu/Telegram/etc.),
+// NOT a permission decision — it must always be forwarded to the platform
+// even when other tools are auto-approved.
+//
+// This test verifies:
+//  1. AskUserQuestion under autoApprove=true emits EventPermissionRequest
+//     (with Questions populated), instead of being auto-allowed.
+//  2. A regular tool (Bash) under autoApprove=true is still auto-approved
+//     (no event emitted) — the carve-out is AskUserQuestion-specific.
+func TestHandleControlRequest_AskUserQuestionBypassesAutoApprove(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events:  make(chan core.Event, 4),
+		ctx:     ctx,
+		ccHooks: newCCPermissionHookRunner(""),
+		stdin:   &writeCloser{new(bytes.Buffer)},
+	}
+	cs.autoApprove.Store(true)
+
+	// 1. AskUserQuestion must be forwarded despite autoApprove.
+	cs.handleControlRequest(map[string]any{
+		"request_id": "req-askq",
+		"request": map[string]any{
+			"subtype":   "can_use_tool",
+			"tool_name": "AskUserQuestion",
+			"input": map[string]any{
+				"questions": []any{
+					map[string]any{
+						"question": "pick one",
+						"header":   "test",
+						"options": []any{
+							map[string]any{"label": "A"},
+							map[string]any{"label": "B"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	select {
+	case evt := <-cs.events:
+		if evt.Type != core.EventPermissionRequest {
+			t.Fatalf("event type = %q, want %q", evt.Type, core.EventPermissionRequest)
+		}
+		if evt.ToolName != "AskUserQuestion" {
+			t.Errorf("ToolName = %q, want AskUserQuestion", evt.ToolName)
+		}
+		if len(evt.Questions) != 1 {
+			t.Errorf("Questions length = %d, want 1", len(evt.Questions))
+		}
+		if len(evt.Questions[0].Options) != 2 {
+			t.Errorf("Options length = %d, want 2", len(evt.Questions[0].Options))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AskUserQuestion was auto-approved instead of forwarded (no EventPermissionRequest emitted)")
+	}
+
+	// 2. A regular tool under autoApprove must still be auto-approved (no event).
+	cs.handleControlRequest(map[string]any{
+		"request_id": "req-bash",
+		"request": map[string]any{
+			"subtype":   "can_use_tool",
+			"tool_name": "Bash",
+			"input":     map[string]any{"command": "ls"},
+		},
+	})
+
+	select {
+	case evt := <-cs.events:
+		t.Fatalf("Bash should be auto-approved (no event expected), got %+v", evt)
+	case <-time.After(100 * time.Millisecond):
+		// expected: Bash auto-approved, no event forwarded
+	}
+}
+
 // TestHandleResultCompactionSubtypeIsNotTerminal is a regression test for
 // issue #481: Claude Code's mid-turn context compaction emits a
 // `type:"result"` event with `subtype:"compact"` (newer CLI) or


### PR DESCRIPTION
## Summary

In `yolo` / `bypassPermissions` mode (`autoApprove=true`), the claudecode agent auto-approved `AskUserQuestion` permission requests just like any other tool. As a result the question card (button options on Feishu/Lark, inline buttons on Telegram, etc.) was **never rendered** — the user could not see the question or click an answer. AskUserQuestion is a user-facing question, not a permission decision, so `yolo` must not swallow it.

This PR adds an `AskUserQuestion` carve-out to the auto-approve branch so it always flows through to the normal permission-request path and renders the question card.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only
- [ ] Internal refactor / chore

## Root cause

`agent/claudecode/session.go` `handleControlRequest`:

```go
if cs.autoApprove.Load() {
    _ = cs.RespondPermission(requestID, core.PermissionResult{
        Behavior:     "allow",
        UpdatedInput: input,
    })
    return   // ← AskUserQuestion also takes this path → silently allowed
}
```

`autoApprove` is set whenever `mode == "bypassPermissions"` (`session.go:1091`), which is what `mode = "yolo"` normalizes to. Newer Claude Code versions route `AskUserQuestion` through the permission-request stream (`can_use_tool` control request), so it hits this branch and never reaches `sendAskQuestionPrompt` (`core/engine.go:11453`) which renders the card.

Observed in production logs (3 consecutive calls, all auto-approved, none rendered):
```
claudeSession: auto-approving request_id=... tool=AskUserQuestion
```

## Fix

One extra condition on the auto-approve branch:

```go
if cs.autoApprove.Load() && toolName != "AskUserQuestion" {
    // ... auto-allow as before ...
    return
}
```

AskUserQuestion now falls through to the normal path: cc-hooks run first (a hook can still intercept), and otherwise an `EventPermissionRequest` (with `Questions` populated) is emitted for the platform to render.

## Testing

### Automated tests added in this PR

- `TestHandleControlRequest_AskUserQuestionBypassesAutoApprove` in `agent/claudecode/session_test.go` — asserts:
  - Under `autoApprove=true`, an `AskUserQuestion` control request emits `EventPermissionRequest` with `Questions` populated (not auto-allowed).
  - Under `autoApprove=true`, a regular tool (`Bash`) is still auto-approved (no event emitted) — the carve-out is AskUserQuestion-specific.

### For bug fixes only — regression test

- Regression test name: `TestHandleControlRequest_AskUserQuestionBypassesAutoApprove`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally (`git show origin/main:agent/claudecode/session.go > agent/claudecode/session.go`); the regression test failed as expected — `AskUserQuestion was auto-approved instead of forwarded (no EventPermissionRequest emitted)`. Restored the fix; test passes.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched
- [ ] A — basic conversation
- [ ] B — session lifecycle
- [x] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions
- [ ] E — scheduled tasks
- [ ] F — config switching
- [ ] G — error handling & robustness
- [x] I — UI rendering correctness (cards, streaming, display modes)

`go test ./core/ -run TestCUJ` not run — change is confined to `agent/claudecode/` control-request handling; no `core/` behavior touched. The fix restores the intended rendering path that `core/engine.go:sendAskQuestionPrompt` already provides.

## Manual / user-visible behavior change

**Before:** With `mode = "yolo"` (or `bypassPermissions`), invoking `AskUserQuestion` produced nothing visible on any platform — no card, no buttons, no question text. The tool returned immediately as if approved, and Claude Code received no user answer.

**After:** `AskUserQuestion` renders normally on all platforms regardless of mode:
- Feishu/Lark: card with one button per option (`ListItemBtnExtra`)
- Telegram: inline keyboard buttons
- Other platforms: numbered text list
- multiSelect: numbered text list on all platforms (unchanged)

Other tools are still auto-approved under `yolo`/`bypassPermissions` exactly as before.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./agent/claudecode/ -run TestHandleControlRequest_AskUserQuestionBypassesAutoApprove` passes
- [x] `go test ./agent/claudecode/` passes (full package, existing tests unaffected)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (no new user-facing text)
- [x] No secrets / credentials in source

## Related

- Rendering path: `core/engine.go:11453` `sendAskQuestionPrompt` (already correct — it just never received the event because autoApprove swallowed it).
- AskUserQuestion parsing: `agent/claudecode/claudecode.go:1375` `parseUserQuestions`.
- Auto-approve branch introduced in `ecd0e0070` (2026-02-28); never had an AskUserQuestion carve-out.