### PR TITLE
fix(opencode): stream persistent HTTP sessions

### DIFF
--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -23,7 +23,7 @@ func init() {
 	core.RegisterAgent("opencode", New)
 }
 
-// Agent drives the OpenCode CLI in headless mode using `opencode run --format json`.
+// Agent drives OpenCode via the CLI or a persistent HTTP/SSE server connection.
 //
 // Modes:
 //   - "default": standard mode
@@ -34,8 +34,11 @@ type Agent struct {
 	mode                 string
 	cmd                  string   // CLI binary name, default "opencode"
 	cliExtraArgs         []string // extra args from cmd after the binary name
+	connectionURL        string
+	username             string
+	password             string
 	configEnv            []string // env vars from [projects.agent.options.env]
-	agentName            string // passed as --agent to opencode (for plugin-defined agents)
+	agentName            string   // passed as --agent to opencode (for plugin-defined agents)
 	providers            []core.ProviderConfig
 	activeIdx            int
 	sessionEnv           []string
@@ -70,6 +73,16 @@ func New(opts map[string]any) (core.Agent, error) {
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
 	cmd, extraArgs := core.ParseCmdOpts(opts, "opencode")
+	connectionURL, _ := opts["connection_url"].(string)
+	if connectionURL != "" {
+		var err error
+		connectionURL, err = normalizeConnectionURL(connectionURL)
+		if err != nil {
+			return nil, err
+		}
+	}
+	username, _ := opts["username"].(string)
+	password, _ := opts["password"].(string)
 	agentName, _ := opts["agent"].(string) // --agent flag for plugin-defined agents (#1210)
 	ccDataDir, _ := opts["cc_data_dir"].(string)
 	ccProject, _ := opts["cc_project"].(string)
@@ -80,7 +93,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 
 	if _, err := exec.LookPath(cmd); err != nil {
-		return nil, fmt.Errorf("opencode: %q CLI not found in PATH, install from: https://github.com/opencode-ai/opencode", cmd)
+		return nil, fmt.Errorf("opencode: %q CLI not found in PATH, install from: https://github.com/anomalyco/opencode", cmd)
 	}
 
 	return &Agent{
@@ -89,6 +102,9 @@ func New(opts map[string]any) (core.Agent, error) {
 		mode:                 mode,
 		cmd:                  cmd,
 		cliExtraArgs:         extraArgs,
+		connectionURL:        connectionURL,
+		username:             username,
+		password:             password,
 		configEnv:            core.ParseConfigEnv(opts),
 		agentName:            agentName,
 		activeIdx:            -1,
@@ -466,6 +482,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	mode := a.mode
 	cmd := a.cmd
 	extraArgs := append([]string{}, a.cliExtraArgs...)
+	connectionURL := a.connectionURL
+	username := a.username
+	password := a.password
 	workDir := a.workDir
 	agentName := a.agentName
 	extraEnv := append([]string(nil), a.configEnv...)
@@ -478,6 +497,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
+	if connectionURL != "" {
+		return newOpencodeHTTPSession(ctx, connectionURL, username, password, workDir, model, mode, agentName, sessionID, extraEnv)
+	}
 	return newOpencodeSession(ctx, cmd, extraArgs, workDir, model, mode, agentName, sessionID, extraEnv)
 }
 

--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -47,6 +47,8 @@ type opencodeSession struct {
 	httpPartMu        sync.Mutex
 	httpPartText      map[string]string
 	httpAssistantMsg  map[string]struct{}
+	agentErrMu        sync.Mutex
+	agentErr          error
 }
 
 func newOpencodeSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
@@ -427,12 +429,35 @@ func (s *opencodeSession) handleReasoning(raw map[string]any) {
 func (s *opencodeSession) handleError(raw map[string]any) {
 	errMsg := extractErrorMessage(raw)
 	slog.Error("opencodeSession: agent error", "error", errMsg)
-	evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", errMsg)}
+	err := fmt.Errorf("%s", errMsg)
+	s.rememberAgentError(err)
+	evt := core.Event{Type: core.EventError, Error: err}
 	select {
 	case s.events <- evt:
 	case <-s.ctx.Done():
 		return
 	}
+}
+
+func (s *opencodeSession) rememberAgentError(err error) {
+	if err == nil {
+		return
+	}
+	s.agentErrMu.Lock()
+	s.agentErr = err
+	s.agentErrMu.Unlock()
+}
+
+func (s *opencodeSession) clearAgentError() {
+	s.agentErrMu.Lock()
+	s.agentErr = nil
+	s.agentErrMu.Unlock()
+}
+
+func (s *opencodeSession) currentAgentError() error {
+	s.agentErrMu.Lock()
+	defer s.agentErrMu.Unlock()
+	return s.agentErr
 }
 
 // extractErrorMessage tries to pull a human-readable message from various

--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,9 +21,7 @@ import (
 	"github.com/chenhg5/cc-connect/core"
 )
 
-// opencodeSession manages multi-turn conversations with the OpenCode CLI.
-// Each Send() launches a new `opencode run --format json` process
-// with --session for conversation continuity.
+// opencodeSession manages multi-turn conversations with OpenCode.
 type opencodeSession struct {
 	cmd               string
 	extraArgs         []string // extra args from cmd, prepended before opencode args
@@ -39,6 +38,15 @@ type opencodeSession struct {
 	alive             atomic.Bool
 	expectingContinue atomic.Bool // true when compaction_continue received, waiting for next step
 	resultSent        atomic.Bool // true when EventResult has been sent for this turn
+	httpClient        *http.Client
+	connectionURL     string
+	username          string
+	password          string
+	pendingMu         sync.Mutex
+	pendingQuestions  map[string][]core.UserQuestion
+	httpPartMu        sync.Mutex
+	httpPartText      map[string]string
+	httpAssistantMsg  map[string]struct{}
 }
 
 func newOpencodeSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
@@ -80,6 +88,9 @@ func (s *opencodeSession) Send(prompt string, images []core.ImageAttachment, fil
 
 	s.resultSent.Store(false)
 	s.expectingContinue.Store(false)
+	if s.httpClient != nil {
+		return s.sendHTTP(prompt, imagePaths)
+	}
 
 	chatID := s.CurrentSessionID()
 	isResume := chatID != ""
@@ -487,7 +498,7 @@ func (s *opencodeSession) handleStepFinish(raw map[string]any) {
 	}
 	slog.Debug("opencodeSession: step finished", "reason", reason, "session_id", s.CurrentSessionID())
 
-	if reason == "stop" {
+	if reason == "stop" && s.httpClient == nil {
 		s.sendEventResult()
 	}
 }
@@ -506,8 +517,11 @@ func (s *opencodeSession) sendEventResult() {
 	}
 }
 
-// RespondPermission is a no-op — OpenCode handles permissions internally.
-func (s *opencodeSession) RespondPermission(_ string, _ core.PermissionResult) error {
+// RespondPermission is handled over HTTP in persistent-server mode.
+func (s *opencodeSession) RespondPermission(requestID string, result core.PermissionResult) error {
+	if s.httpClient != nil {
+		return s.respondHTTPPermission(requestID, result)
+	}
 	return nil
 }
 

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -216,6 +216,8 @@ func (s *opencodeSession) handleHTTPEvent(data []byte) {
 			s.resultSent.Store(false)
 		case "idle":
 			s.sendEventResult()
+		case "retry":
+			s.handleHTTPRetryStatus(status)
 		}
 	case "session.idle":
 		s.sendEventResult()
@@ -226,6 +228,37 @@ func (s *opencodeSession) handleHTTPEvent(data []byte) {
 	case "question.asked", "question.v2.asked":
 		s.handleHTTPQuestion(props)
 	}
+}
+
+func (s *opencodeSession) handleHTTPRetryStatus(status map[string]any) {
+	message := strings.TrimSpace(stringValue(status["message"]))
+	if message == "" || !isHTTPRetryFatal(message) {
+		return
+	}
+	err := fmt.Errorf("%s", message)
+	s.rememberAgentError(err)
+	s.emitHTTPEvent(core.Event{Type: core.EventError, Error: err})
+}
+
+func isHTTPRetryFatal(message string) bool {
+	lower := strings.ToLower(message)
+	for _, marker := range []string{
+		"usage limit",
+		"rate limit",
+		"quota",
+		"insufficient balance",
+		"payment required",
+		"429",
+		"使用上限",
+		"限额",
+		"余额不足",
+		"额度",
+	} {
+		if strings.Contains(lower, strings.ToLower(marker)) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *opencodeSession) handleHTTPPart(props map[string]any) {

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -1,0 +1,515 @@
+package opencode
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func normalizeConnectionURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", fmt.Errorf("opencode: invalid connection_url %q", raw)
+	}
+	return strings.TrimRight(raw, "/"), nil
+}
+
+func newOpencodeHTTPSession(ctx context.Context, connectionURL, username, password, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
+	s, err := newOpencodeSession(ctx, "", nil, workDir, model, mode, agentName, resumeID, extraEnv)
+	if err != nil {
+		return nil, err
+	}
+	s.httpClient = &http.Client{}
+	s.connectionURL = connectionURL
+	s.username = username
+	s.password = password
+	s.pendingQuestions = make(map[string][]core.UserQuestion)
+	s.httpPartText = make(map[string]string)
+	s.httpAssistantMsg = make(map[string]struct{})
+	if s.username == "" {
+		s.username = opencodeEnv(extraEnv, "OPENCODE_SERVER_USERNAME")
+		if s.username == "" {
+			s.username = "opencode"
+		}
+	}
+	if s.password == "" {
+		s.password = opencodeEnv(extraEnv, "OPENCODE_SERVER_PASSWORD")
+	}
+
+	if s.CurrentSessionID() == "" {
+		var created struct {
+			ID string `json:"id"`
+		}
+		if err := s.doHTTPJSON(http.MethodPost, "/session", map[string]any{}, &created); err != nil {
+			s.cancel()
+			return nil, fmt.Errorf("opencode: create HTTP session: %w", err)
+		}
+		if created.ID == "" {
+			s.cancel()
+			return nil, fmt.Errorf("opencode: create HTTP session: empty session ID")
+		}
+		s.chatID.Store(created.ID)
+	}
+
+	if err := s.startHTTPEventStream(); err != nil {
+		s.cancel()
+		return nil, err
+	}
+	return s, nil
+}
+
+func opencodeEnv(env []string, key string) string {
+	for i := len(env) - 1; i >= 0; i-- {
+		name, value, ok := strings.Cut(env[i], "=")
+		if ok && name == key {
+			return value
+		}
+	}
+	return os.Getenv(key)
+}
+
+func (s *opencodeSession) sendHTTP(prompt string, imagePaths []string) error {
+	parts := make([]map[string]any, 0, len(imagePaths)+1)
+	for _, path := range imagePaths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("opencode: read staged image: %w", err)
+		}
+		mimeType := mime.TypeByExtension(filepath.Ext(path))
+		if mimeType == "" {
+			mimeType = "image/png"
+		}
+		parts = append(parts, map[string]any{
+			"type":     "file",
+			"url":      "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(data),
+			"filename": filepath.Base(path),
+			"mime":     mimeType,
+		})
+	}
+	parts = append(parts, map[string]any{"type": "text", "text": prompt})
+
+	body := map[string]any{"parts": parts}
+	if s.agentName != "" {
+		body["agent"] = s.agentName
+	}
+	if providerID, modelID, ok := strings.Cut(s.model, "/"); ok && providerID != "" && modelID != "" {
+		body["model"] = map[string]any{"providerID": providerID, "modelID": modelID}
+	}
+	return s.doHTTPJSON(http.MethodPost, "/session/"+url.PathEscape(s.CurrentSessionID())+"/message", body, nil)
+}
+
+func (s *opencodeSession) startHTTPEventStream() error {
+	resp, err := s.doHTTPRequest(http.MethodGet, "/event", nil)
+	if err != nil {
+		return fmt.Errorf("opencode: connect event stream: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		return s.httpStatusError(resp)
+	}
+	s.wg.Add(1)
+	go s.readHTTPEvents(resp.Body)
+	return nil
+}
+
+func (s *opencodeSession) readHTTPEvents(body io.ReadCloser) {
+	defer s.wg.Done()
+	defer body.Close()
+
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	var data strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if data.Len() > 0 {
+				s.handleHTTPEvent([]byte(data.String()))
+				data.Reset()
+			}
+			continue
+		}
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		if data.Len() > 0 {
+			data.WriteByte('\n')
+		}
+		data.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+	}
+	if s.ctx.Err() != nil {
+		return
+	}
+	s.alive.Store(false)
+	err := scanner.Err()
+	if err == nil {
+		err = io.EOF
+	}
+	s.emitHTTPEvent(core.Event{Type: core.EventError, Error: fmt.Errorf("opencode: event stream closed: %w", err)})
+}
+
+func (s *opencodeSession) handleHTTPEvent(data []byte) {
+	var event struct {
+		Type       string         `json:"type"`
+		Properties map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(data, &event); err != nil {
+		slog.Debug("opencode: invalid SSE event", "error", err)
+		return
+	}
+	props := event.Properties
+	sessionID, _ := props["sessionID"].(string)
+	if sessionID != "" && sessionID != s.CurrentSessionID() {
+		return
+	}
+
+	switch event.Type {
+	case "message.part.updated":
+		s.handleHTTPPart(props)
+	case "session.status":
+		status, _ := props["status"].(map[string]any)
+		switch statusType, _ := status["type"].(string); statusType {
+		case "busy":
+			s.resultSent.Store(false)
+		case "idle":
+			s.sendEventResult()
+		}
+	case "session.idle":
+		s.sendEventResult()
+	case "session.error":
+		s.handleError(map[string]any{"error": props["error"]})
+	case "permission.asked":
+		s.handleHTTPPermission(props)
+	case "question.asked", "question.v2.asked":
+		s.handleHTTPQuestion(props)
+	}
+}
+
+func (s *opencodeSession) handleHTTPPart(props map[string]any) {
+	part, _ := props["part"].(map[string]any)
+	if part == nil {
+		return
+	}
+	if sessionID, _ := part["sessionID"].(string); sessionID != s.CurrentSessionID() {
+		return
+	}
+	raw := map[string]any{"part": part}
+	switch partType, _ := part["type"].(string); partType {
+	case "text":
+		s.handleHTTPText(part)
+	case "reasoning":
+		s.handleHTTPReasoning(part)
+	case "tool":
+		state, _ := part["state"].(map[string]any)
+		status, _ := state["status"].(string)
+		if status == "completed" || status == "error" {
+			s.handleToolUse(raw)
+		}
+	case "step-start":
+		s.markHTTPAssistantMessage(part)
+		s.handleStepStart(raw)
+	case "step-finish":
+		s.handleStepFinish(raw)
+	}
+}
+
+func (s *opencodeSession) markHTTPAssistantMessage(part map[string]any) {
+	messageID := stringValue(part["messageID"])
+	if messageID == "" {
+		return
+	}
+	s.httpPartMu.Lock()
+	s.httpAssistantMsg[messageID] = struct{}{}
+	s.httpPartMu.Unlock()
+}
+
+func (s *opencodeSession) isHTTPAssistantPart(part map[string]any) bool {
+	messageID := stringValue(part["messageID"])
+	if messageID == "" {
+		return false
+	}
+	s.httpPartMu.Lock()
+	_, ok := s.httpAssistantMsg[messageID]
+	s.httpPartMu.Unlock()
+	return ok
+}
+
+func (s *opencodeSession) handleHTTPText(part map[string]any) {
+	if !s.isHTTPAssistantPart(part) {
+		return
+	}
+	text := s.httpPartDelta(part)
+	if text == "" {
+		return
+	}
+
+	metadata, _ := part["metadata"].(map[string]any)
+	synthetic, _ := part["synthetic"].(bool)
+	if synthetic && metadata != nil {
+		if cc, ok := metadata["compaction_continue"].(bool); ok && cc {
+			slog.Info("opencodeSession: compaction_continue detected, marking expectingContinue", "session_id", s.CurrentSessionID())
+			s.expectingContinue.Store(true)
+			return
+		}
+	}
+
+	s.emitHTTPEvent(core.Event{Type: core.EventText, Content: text, Metadata: metadata, Synthetic: synthetic})
+}
+
+func (s *opencodeSession) handleHTTPReasoning(part map[string]any) {
+	if !s.isHTTPAssistantPart(part) {
+		return
+	}
+	text := s.httpPartDelta(part)
+	if text == "" {
+		return
+	}
+	s.emitHTTPEvent(core.Event{Type: core.EventThinking, Content: text})
+}
+
+func (s *opencodeSession) httpPartDelta(part map[string]any) string {
+	text := stringValue(part["text"])
+	if text == "" {
+		return ""
+	}
+	key := httpPartKey(part)
+	if key == "" {
+		if opencodePartEnded(part) {
+			return text
+		}
+		return ""
+	}
+
+	s.httpPartMu.Lock()
+	defer s.httpPartMu.Unlock()
+	previous := s.httpPartText[key]
+	s.httpPartText[key] = text
+	if previous == "" {
+		return text
+	}
+	if strings.HasPrefix(text, previous) {
+		return text[len(previous):]
+	}
+	return text
+}
+
+func httpPartKey(part map[string]any) string {
+	if id := stringValue(part["id"]); id != "" {
+		return id
+	}
+	partType := stringValue(part["type"])
+	messageID := stringValue(part["messageID"])
+	if partType != "" && messageID != "" {
+		return messageID + ":" + partType
+	}
+	return ""
+}
+
+func opencodePartEnded(part map[string]any) bool {
+	timing, _ := part["time"].(map[string]any)
+	end, ok := timing["end"]
+	return ok && end != nil
+}
+
+func (s *opencodeSession) handleHTTPPermission(props map[string]any) {
+	requestID, _ := props["id"].(string)
+	permission, _ := props["permission"].(string)
+	patterns := opencodeStrings(props["patterns"])
+	if s.mode == "yolo" {
+		if err := s.RespondPermission(requestID, core.PermissionResult{Behavior: "allow"}); err != nil {
+			s.emitHTTPEvent(core.Event{Type: core.EventError, Error: err})
+		}
+		return
+	}
+	input := map[string]any{"patterns": patterns}
+	if metadata, ok := props["metadata"].(map[string]any); ok {
+		input["metadata"] = metadata
+	}
+	s.emitHTTPEvent(core.Event{
+		Type:         core.EventPermissionRequest,
+		RequestID:    requestID,
+		ToolName:     permission,
+		ToolInput:    strings.Join(patterns, ", "),
+		ToolInputRaw: input,
+	})
+}
+
+func (s *opencodeSession) handleHTTPQuestion(props map[string]any) {
+	requestID, _ := props["id"].(string)
+	if requestID == "" {
+		return
+	}
+	rawQuestions, _ := props["questions"].([]any)
+	questions := make([]core.UserQuestion, 0, len(rawQuestions))
+	for _, raw := range rawQuestions {
+		question, _ := raw.(map[string]any)
+		if question == nil {
+			continue
+		}
+		options := make([]core.UserQuestionOption, 0)
+		rawOptions, _ := question["options"].([]any)
+		for _, rawOption := range rawOptions {
+			option, _ := rawOption.(map[string]any)
+			if option == nil {
+				continue
+			}
+			options = append(options, core.UserQuestionOption{
+				Label:       stringValue(option["label"]),
+				Description: stringValue(option["description"]),
+			})
+		}
+		questions = append(questions, core.UserQuestion{
+			Question:    stringValue(question["question"]),
+			Header:      stringValue(question["header"]),
+			Options:     options,
+			MultiSelect: boolValue(question["multiple"]),
+		})
+	}
+	if len(questions) == 0 {
+		return
+	}
+	s.pendingMu.Lock()
+	s.pendingQuestions[requestID] = questions
+	s.pendingMu.Unlock()
+	s.emitHTTPEvent(core.Event{
+		Type:         core.EventPermissionRequest,
+		RequestID:    requestID,
+		ToolName:     "AskUserQuestion",
+		ToolInputRaw: map[string]any{"questions": rawQuestions},
+		Questions:    questions,
+	})
+}
+
+func (s *opencodeSession) respondHTTPPermission(requestID string, result core.PermissionResult) error {
+	s.pendingMu.Lock()
+	questions, isQuestion := s.pendingQuestions[requestID]
+	s.pendingMu.Unlock()
+	if isQuestion {
+		path := "/question/" + url.PathEscape(requestID)
+		if !strings.EqualFold(result.Behavior, "allow") {
+			return s.doHTTPJSON(http.MethodPost, path+"/reject", nil, nil)
+		}
+		answersByQuestion, _ := result.UpdatedInput["answers"].(map[string]any)
+		answers := make([][]string, 0, len(questions))
+		for _, question := range questions {
+			answer := strings.TrimSpace(stringValue(answersByQuestion[question.Question]))
+			if question.MultiSelect {
+				answers = append(answers, strings.FieldsFunc(answer, func(r rune) bool { return r == ',' || r == '，' }))
+			} else {
+				answers = append(answers, []string{answer})
+			}
+		}
+		if err := s.doHTTPJSON(http.MethodPost, path+"/reply", map[string]any{"answers": answers}, nil); err != nil {
+			return err
+		}
+		s.pendingMu.Lock()
+		delete(s.pendingQuestions, requestID)
+		s.pendingMu.Unlock()
+		return nil
+	}
+
+	reply := "reject"
+	if strings.EqualFold(result.Behavior, "allow") {
+		reply = "once"
+	}
+	return s.doHTTPJSON(http.MethodPost, "/permission/"+url.PathEscape(requestID)+"/reply", map[string]any{
+		"reply":   reply,
+		"message": result.Message,
+	}, nil)
+}
+
+func (s *opencodeSession) doHTTPJSON(method, path string, body, output any) error {
+	resp, err := s.doHTTPRequest(method, path, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return s.httpStatusError(resp)
+	}
+	if output == nil {
+		_, err = io.Copy(io.Discard, resp.Body)
+		return err
+	}
+	if err := json.NewDecoder(resp.Body).Decode(output); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+func (s *opencodeSession) doHTTPRequest(method, path string, body any) (*http.Response, error) {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(data)
+	}
+	u, err := url.Parse(s.connectionURL + path)
+	if err != nil {
+		return nil, err
+	}
+	if s.workDir != "" {
+		query := u.Query()
+		query.Set("directory", s.workDir)
+		u.RawQuery = query.Encode()
+	}
+	req, err := http.NewRequestWithContext(s.ctx, method, u.String(), reader)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if s.password != "" {
+		req.SetBasicAuth(s.username, s.password)
+	}
+	return s.httpClient.Do(req)
+}
+
+func (s *opencodeSession) httpStatusError(resp *http.Response) error {
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	return fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(data)))
+}
+
+func (s *opencodeSession) emitHTTPEvent(event core.Event) {
+	select {
+	case s.events <- event:
+	case <-s.ctx.Done():
+	}
+}
+
+func opencodeStrings(value any) []string {
+	items, _ := value.([]any)
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if text, ok := item.(string); ok {
+			result = append(result, text)
+		}
+	}
+	return result
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
+func boolValue(value any) bool {
+	result, _ := value.(bool)
+	return result
+}

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -83,6 +84,7 @@ func opencodeEnv(env []string, key string) string {
 }
 
 func (s *opencodeSession) sendHTTP(prompt string, imagePaths []string) error {
+	s.clearAgentError()
 	parts := make([]map[string]any, 0, len(imagePaths)+1)
 	for _, path := range imagePaths {
 		data, err := os.ReadFile(path)
@@ -109,7 +111,35 @@ func (s *opencodeSession) sendHTTP(prompt string, imagePaths []string) error {
 	if providerID, modelID, ok := strings.Cut(s.model, "/"); ok && providerID != "" && modelID != "" {
 		body["model"] = map[string]any{"providerID": providerID, "modelID": modelID}
 	}
-	return s.doHTTPJSON(http.MethodPost, "/session/"+url.PathEscape(s.CurrentSessionID())+"/message", body, nil)
+	if err := s.doHTTPJSON(http.MethodPost, "/session/"+url.PathEscape(s.CurrentSessionID())+"/message", body, nil); err != nil {
+		if agentErr := s.waitHTTPAgentError(750 * time.Millisecond); agentErr != nil {
+			return agentErr
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *opencodeSession) waitHTTPAgentError(timeout time.Duration) error {
+	if err := s.currentAgentError(); err != nil {
+		return err
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return nil
+		case <-timer.C:
+			return s.currentAgentError()
+		case <-ticker.C:
+			if err := s.currentAgentError(); err != nil {
+				return err
+			}
+		}
+	}
 }
 
 func (s *opencodeSession) startHTTPEventStream() error {

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -148,7 +148,7 @@ func (s *opencodeSession) startHTTPEventStream() error {
 		return fmt.Errorf("opencode: connect event stream: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		return s.httpStatusError(resp)
 	}
 	s.wg.Add(1)
@@ -158,7 +158,7 @@ func (s *opencodeSession) startHTTPEventStream() error {
 
 func (s *opencodeSession) readHTTPEvents(body io.ReadCloser) {
 	defer s.wg.Done()
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
@@ -466,7 +466,7 @@ func (s *opencodeSession) doHTTPJSON(method, path string, body, output any) erro
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return s.httpStatusError(resp)
 	}

--- a/agent/opencode/session_http_live_test.go
+++ b/agent/opencode/session_http_live_test.go
@@ -1,0 +1,94 @@
+package opencode
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestOpencodeHTTPModeLiveServer(t *testing.T) {
+	connectionURL := os.Getenv("OPENCODE_LIVE_URL")
+	if connectionURL == "" {
+		t.Skip("set OPENCODE_LIVE_URL to run against a local opencode serve")
+	}
+
+	agent, err := New(map[string]any{
+		"work_dir":       t.TempDir(),
+		"connection_url": connectionURL,
+		"username":       os.Getenv("OPENCODE_LIVE_USERNAME"),
+		"password":       os.Getenv("OPENCODE_LIVE_PASSWORD"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	if session.CurrentSessionID() == "" {
+		t.Fatal("expected live HTTP session ID")
+	}
+	if os.Getenv("OPENCODE_LIVE_SEND") == "" {
+		return
+	}
+
+	sendDone := make(chan error, 1)
+	startedAt := time.Now()
+	go func() {
+		sendDone <- session.Send("Reply exactly with CC_CONNECT_LIVE_OK.", nil, nil)
+	}()
+
+	var text strings.Builder
+	firstTextAt := time.Time{}
+	sendDoneAt := time.Time{}
+	var sendErr error
+	deadline := time.After(2 * time.Minute)
+	for {
+		select {
+		case err := <-sendDone:
+			sendDoneAt = time.Now()
+			sendErr = err
+		case event := <-session.Events():
+			switch event.Type {
+			case core.EventText:
+				if firstTextAt.IsZero() {
+					firstTextAt = time.Now()
+				}
+				text.WriteString(event.Content)
+			case core.EventResult:
+				if sendDoneAt.IsZero() {
+					select {
+					case sendErr = <-sendDone:
+						sendDoneAt = time.Now()
+					case <-time.After(10 * time.Second):
+						t.Fatal("timed out waiting for prompt response after EventResult")
+					}
+				}
+				if sendErr != nil {
+					t.Fatal(sendErr)
+				}
+				if firstTextAt.IsZero() {
+					t.Fatal("expected at least one streamed text event")
+				}
+				if !strings.Contains(text.String(), "CC_CONNECT_LIVE_OK") {
+					t.Fatalf("live response text = %q, want CC_CONNECT_LIVE_OK", text.String())
+				}
+				if strings.Contains(text.String(), "Reply exactly") {
+					t.Fatalf("live response echoed user prompt: %q", text.String())
+				}
+				t.Logf("first_text_after=%s prompt_response_after=%s total=%s", firstTextAt.Sub(startedAt), sendDoneAt.Sub(startedAt), time.Since(startedAt))
+				return
+			case core.EventError:
+				t.Fatal(event.Error)
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for live response; text so far: %q", text.String())
+		}
+	}
+}

--- a/agent/opencode/session_http_live_test.go
+++ b/agent/opencode/session_http_live_test.go
@@ -29,7 +29,7 @@ func TestOpencodeHTTPModeLiveServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	if session.CurrentSessionID() == "" {
 		t.Fatal("expected live HTTP session ID")

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -402,7 +402,7 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	select {
 	case <-sseConnected:
@@ -550,7 +550,7 @@ func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	select {
 	case <-sseConnected:

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -505,6 +505,68 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 	}
 }
 
+func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails(t *testing.T) {
+	events := make(chan string, 4)
+	sseConnected := make(chan struct{})
+	var connectedOnce sync.Once
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /session", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"ses_http"}`))
+	})
+	mux.HandleFunc("GET /event", func(w http.ResponseWriter, r *http.Request) {
+		flusher := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		connectedOnce.Do(func() { close(sseConnected) })
+		for {
+			select {
+			case event := <-events:
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
+	mux.HandleFunc("POST /session/ses_http/message", func(w http.ResponseWriter, _ *http.Request) {
+		events <- `{"type":"session.error","properties":{"sessionID":"ses_http","error":{"name":"PaymentRequiredError","data":{"message":"Insufficient balance. Please recharge your account."}}}}`
+		http.Error(w, `{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"err_quota"}}`, http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	agent, err := New(map[string]any{
+		"cmd":            "/bin/false",
+		"work_dir":       t.TempDir(),
+		"connection_url": server.URL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	select {
+	case <-sseConnected:
+	case <-time.After(time.Second):
+		t.Fatal("SSE was not connected before Send")
+	}
+
+	err = session.Send("hello", nil, nil)
+	if err == nil {
+		t.Fatal("Send returned nil, want quota error")
+	}
+	if got := err.Error(); !strings.Contains(got, "PaymentRequiredError") || !strings.Contains(got, "Insufficient balance") {
+		t.Fatalf("Send error = %q, want SSE quota error", got)
+	}
+}
+
 func waitOpencodeEvent(t *testing.T, events <-chan core.Event) core.Event {
 	t.Helper()
 	select {

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -567,6 +567,27 @@ func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails(t *testing
 	}
 }
 
+func TestOpencodeHTTPMode_RetryStatusWithUsageLimitEmitsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{
+		events:        make(chan core.Event, 4),
+		ctx:           ctx,
+		connectionURL: "http://localhost:4096",
+	}
+	s.chatID.Store("ses_http")
+
+	s.handleHTTPEvent([]byte(`{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"retry","attempt":1,"message":"已达到 5 小时的使用上限。您的限额将在 2026-07-14 20:40:01 重置。"}}}`))
+
+	event := waitOpencodeEvent(t, s.Events())
+	if event.Type != core.EventError {
+		t.Fatalf("event type = %q, want EventError", event.Type)
+	}
+	if event.Error == nil || !strings.Contains(event.Error.Error(), "使用上限") {
+		t.Fatalf("event error = %v, want usage limit message", event.Error)
+	}
+}
+
 func waitOpencodeEvent(t *testing.T, events <-chan core.Event) core.Event {
 	t.Helper()
 	select {

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -3,12 +3,17 @@ package opencode
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -331,6 +336,192 @@ func TestHandleToolUseErrorNoMessageNoText(t *testing.T) {
 		if evt.Type == core.EventText {
 			t.Errorf("unexpected EventText for error with no message: %q", evt.Content)
 		}
+	}
+}
+
+func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *testing.T) {
+	events := make(chan string, 16)
+	sseConnected := make(chan struct{})
+	promptStarted := make(chan struct{})
+	releasePrompt := make(chan struct{})
+	permissionReply := make(chan map[string]any, 1)
+	questionReply := make(chan map[string]any, 1)
+	var connectedOnce sync.Once
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /session", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"ses_http"}`))
+	})
+	mux.HandleFunc("GET /event", func(w http.ResponseWriter, r *http.Request) {
+		flusher := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		connectedOnce.Do(func() { close(sseConnected) })
+		for {
+			select {
+			case event := <-events:
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
+	mux.HandleFunc("POST /session/ses_http/message", func(w http.ResponseWriter, _ *http.Request) {
+		close(promptStarted)
+		<-releasePrompt
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"info":{},"parts":[]}`))
+	})
+	mux.HandleFunc("POST /permission/per_1/reply", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		permissionReply <- body
+		_, _ = w.Write([]byte(`true`))
+	})
+	mux.HandleFunc("POST /question/que_1/reply", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		questionReply <- body
+		_, _ = w.Write([]byte(`true`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	agent, err := New(map[string]any{
+		"cmd":            "/bin/false",
+		"work_dir":       t.TempDir(),
+		"connection_url": server.URL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	select {
+	case <-sseConnected:
+	case <-time.After(time.Second):
+		t.Fatal("SSE was not connected before Send")
+	}
+
+	sendDone := make(chan error, 1)
+	go func() { sendDone <- session.Send("hello", nil, nil) }()
+	select {
+	case <-promptStarted:
+	case <-time.After(time.Second):
+		t.Fatal("prompt request did not start")
+	}
+
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_user","messageID":"msg_user","type":"text","sessionID":"ses_http","text":"hello"}}}`
+	assertNoOpencodeEvent(t, session.Events())
+
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"busy"}}}`
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_step","messageID":"msg_assistant","type":"step-start","sessionID":"ses_http"}}}`
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_1","messageID":"msg_assistant","type":"text","sessionID":"ses_http","text":"fi"}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventText || event.Content != "fi" {
+		t.Fatalf("first event = %#v, want streamed text", event)
+	}
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_1","messageID":"msg_assistant","type":"text","sessionID":"ses_http","text":"first","time":{"end":1}}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventText || event.Content != "rst" {
+		t.Fatalf("text delta = %#v, want streamed delta", event)
+	}
+	select {
+	case err := <-sendDone:
+		t.Fatalf("Send returned before prompt response: %v", err)
+	default:
+	}
+
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"idle"}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventResult {
+		t.Fatalf("idle event = %#v, want EventResult", event)
+	}
+	close(releasePrompt)
+	if err := <-sendDone; err != nil {
+		t.Fatal(err)
+	}
+
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"busy"}}}`
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_bg_step","messageID":"msg_background","type":"step-start","sessionID":"ses_http"}}}`
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_bg_text","messageID":"msg_background","type":"text","sessionID":"ses_http","text":"background done","time":{"end":1}}}}`
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"idle"}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventText || event.Content != "background done" {
+		t.Fatalf("background event = %#v, want unsolicited text", event)
+	}
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventResult {
+		t.Fatalf("background idle = %#v, want EventResult", event)
+	}
+
+	events <- `{"type":"permission.asked","properties":{"id":"per_1","sessionID":"ses_http","permission":"bash","patterns":["git status"],"metadata":{},"always":[]}}`
+	permission := waitOpencodeEvent(t, session.Events())
+	if permission.Type != core.EventPermissionRequest || permission.RequestID != "per_1" || permission.ToolName != "bash" {
+		t.Fatalf("permission event = %#v", permission)
+	}
+	if err := session.RespondPermission("per_1", core.PermissionResult{Behavior: "allow"}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case body := <-permissionReply:
+		if body["reply"] != "once" {
+			t.Fatalf("permission reply = %#v, want once", body)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("permission reply was not posted")
+	}
+
+	events <- `{"type":"question.asked","properties":{"id":"que_1","sessionID":"ses_http","questions":[{"question":"Pick a path","header":"Decision","options":[{"label":"A","description":"Alpha"},{"label":"B","description":"Beta"}],"multiple":false}]}}`
+	question := waitOpencodeEvent(t, session.Events())
+	if question.Type != core.EventPermissionRequest || question.RequestID != "que_1" || question.ToolName != "AskUserQuestion" {
+		t.Fatalf("question event = %#v", question)
+	}
+	if len(question.Questions) != 1 || question.Questions[0].Question != "Pick a path" || len(question.Questions[0].Options) != 2 {
+		t.Fatalf("parsed questions = %#v", question.Questions)
+	}
+	if err := session.RespondPermission("que_1", core.PermissionResult{
+		Behavior: "allow",
+		UpdatedInput: map[string]any{
+			"answers": map[string]any{"Pick a path": "A"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case body := <-questionReply:
+		answers, ok := body["answers"].([]any)
+		if !ok || len(answers) != 1 {
+			t.Fatalf("question reply = %#v, want one answer row", body)
+		}
+		firstAnswer, ok := answers[0].([]any)
+		if !ok || len(firstAnswer) != 1 || firstAnswer[0] != "A" {
+			t.Fatalf("question answers = %#v, want [[A]]", body["answers"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("question reply was not posted")
+	}
+}
+
+func waitOpencodeEvent(t *testing.T, events <-chan core.Event) core.Event {
+	t.Helper()
+	select {
+	case event := <-events:
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OpenCode event")
+		return core.Event{}
+	}
+}
+
+func assertNoOpencodeEvent(t *testing.T, events <-chan core.Event) {
+	t.Helper()
+	select {
+	case event := <-events:
+		t.Fatalf("unexpected OpenCode event: %#v", event)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1745,10 +1745,10 @@ app_secret = "your-feishu-app-secret"
 # =============================================================================
 # Project 6: Using OpenCode / 项目 6：使用 OpenCode (uncomment to enable / 取消注释以启用)
 # =============================================================================
-# Requires: OpenCode CLI — https://github.com/opencode-ai/opencode
+# Requires: OpenCode CLI — https://github.com/anomalyco/opencode
 # 需要安装：OpenCode CLI
-# Uses `opencode run --format json` under the hood.
-# 底层使用 `opencode run --format json` 命令。
+# By default, uses `opencode run --format json` under the hood.
+# 默认底层使用 `opencode run --format json` 命令。
 
 # [[projects]]
 # name = "my-opencode-project"
@@ -1759,6 +1759,14 @@ app_secret = "your-feishu-app-secret"
 # [projects.agent.options]
 # work_dir = "/path/to/project"
 # mode = "default"  # "default" | "yolo"
+#
+# Optional: connect to `opencode serve` instead of starting short-lived CLI runs.
+# This keeps `/event` SSE connected before each prompt, so streaming steps,
+# background callbacks, and permission/question prompts continue to reach cc-connect.
+# 可选：连接到 `opencode serve`，保持 `/event` SSE 长连接，以支持后台回调和决策提示。
+# connection_url = "http://127.0.0.1:4096"
+# username = "opencode"
+# password = "your-opencode-server-password"
 #
 # Mode options / 模式说明:
 # - "default": Standard mode / 标准模式

--- a/config.example.toml
+++ b/config.example.toml
@@ -1027,6 +1027,8 @@ app_secret = "your-feishu-app-secret"
 #                           # 默认 true：用「回复消息」API（引用用户消息）。设为 false 则在会话里发普通消息、不引用触发消息。
 # progress_style = "legacy" # Progress rendering style: legacy | compact | card
 #                           # 进度消息展示风格：legacy（逐条消息）| compact（单消息持续更新）| card（结构化卡片）
+# ws_watchdog_timeout_mins = 15  # Restart cc-connect if Feishu WebSocket receives no events for this many minutes (0 = disabled).
+#                                # 飞书 WebSocket 连续这么多分钟没有任何下行事件时重启 cc-connect 以自恢复（0 = 禁用）。
 # resolve_mentions = false  # Auto-resolve @name in outgoing messages to Feishu at tags by matching group member names
 #                           # 自动将发出消息中的 @显示名 替换为飞书 at 标签（通过匹配群成员名称）
 # mention_map = { BOT-A = "ou_bot_a_open_id", BOT-B = "ou_bot_b_open_id" }

--- a/core/engine.go
+++ b/core/engine.go
@@ -4808,6 +4808,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			state.eventsNeedResync = true
 			p := state.platform
 			state.mu.Unlock()
+			agentName := e.agent.Name()
+			if state.agent != nil {
+				agentName = state.agent.Name()
+			}
+			session.SetAgentSessionID("", agentName)
+			sessions.Save()
 			e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), "agent session timed out (no response)"))
 			e.cleanupInteractiveState(sessionKey, state)
 			return

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -10820,6 +10820,7 @@ func TestEventIdleTimeout_CleansUpSession(t *testing.T) {
 	e.interactiveMu.Unlock()
 
 	session := e.sessions.GetOrCreateActive(key)
+	session.SetAgentSessionID("idle-test", agent.Name())
 	session.TryLock()
 
 	done := make(chan struct{})
@@ -10843,6 +10844,9 @@ func TestEventIdleTimeout_CleansUpSession(t *testing.T) {
 	}
 	if !foundTimeout {
 		t.Fatalf("expected timeout error message, got %v", sent)
+	}
+	if got := session.GetAgentSessionID(); got != "" {
+		t.Fatalf("agent session ID = %q, want cleared after idle timeout", got)
 	}
 }
 

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -113,6 +113,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # progress_style = "legacy"  # 可选：legacy | compact | card
 # done_emoji = "none"          # 可选：agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 # image_batch_window_ms = 500  # 可选：连续多图合批窗口（默认 500ms，详见下文）
+# ws_watchdog_timeout_mins = 15  # 可选：WebSocket 连续无下行事件超过 N 分钟后重启 cc-connect 自恢复；0 表示禁用
 ```
 
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
@@ -121,6 +122,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
 > `done_emoji` 设置后，agent 每次完成回复时会在用户消息上添加指定表情（如 `"Done"` → ✅）。先移除 "OnIt" 表情（如果有），再添加 done 表情。在 quiet 模式下特别有用，因为飞书卡片原地更新不触发推送，done 表情可以通知用户 agent 已完成。设为 `"none"` 或不配置则禁用。
 > `image_batch_window_ms` 控制连续多张图片合并成一条 agent 消息的等待窗口（默认 500ms）。飞书手机端一次连发多张图时，每张图是独立事件；cc-connect 会在窗口内将它们合并成一条多图消息再分发给 agent。如果你的网络/设备发送间隔超过 500ms 且仍被拆成多轮回复（每张图独立处理），可调高到 800–1200ms；如果以单图为主、希望响应更快，可适当调低。设为 `0` 时回退到默认 500ms。
+> `ws_watchdog_timeout_mins` 是长连接自恢复保护。飞书官方 SDK 默认约每 2 分钟 ping / 重连一次，但家用路由器断网可能留下 TCP 半开连接，导致 SDK 读循环不退出、无法进入重连。配置该值后，cc-connect 会在 WebSocket 连续无下行事件超过阈值时主动退出，由 systemd / daemon 拉起新进程并建立新连接。设为 `0` 可禁用。
 
 ---
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -14,11 +14,13 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -131,24 +133,28 @@ type Platform struct {
 	shareSessionInChannel      bool
 	threadIsolation            bool
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
-	noReplyToTrigger bool
-	resolveMentions  bool
-	client           *lark.Client
-	replayClient     *lark.Client
-	replayClientMu   sync.Mutex
-	wsClient         *larkws.Client
-	handler          core.MessageHandler
-	cardNavHandler   core.CardNavigationHandler
-	cancel           context.CancelFunc
-	dedup            *core.MessageDedup
-	botOpenID        string
-	peerBots         map[string]string // app_id -> friendly alias, for quoted-reply attribution
-	mentionMap       map[string]string // agent name -> open_id (for outbound @ resolution)
-	userNameCache    sync.Map          // open_id -> display name
-	chatNameCache    sync.Map          // chat_id -> chat name
-	chatMemberCache  sync.Map          // chatID -> *chatMemberEntry
-	recalledMu       sync.Mutex
-	recalledMsgIDs   map[string]time.Time // message_id -> recall time, short TTL race guard
+	noReplyToTrigger   bool
+	resolveMentions    bool
+	client             *lark.Client
+	replayClient       *lark.Client
+	replayClientMu     sync.Mutex
+	wsClient           *larkws.Client
+	handler            core.MessageHandler
+	cardNavHandler     core.CardNavigationHandler
+	cancel             context.CancelFunc
+	wsLastActivity     atomic.Int64
+	wsWatchdogTimeout  time.Duration
+	wsWatchdogInterval time.Duration
+	restartWS          func()
+	dedup              *core.MessageDedup
+	botOpenID          string
+	peerBots           map[string]string // app_id -> friendly alias, for quoted-reply attribution
+	mentionMap         map[string]string // agent name -> open_id (for outbound @ resolution)
+	userNameCache      sync.Map          // open_id -> display name
+	chatNameCache      sync.Map          // chat_id -> chat name
+	chatMemberCache    sync.Map          // chatID -> *chatMemberEntry
+	recalledMu         sync.Mutex
+	recalledMsgIDs     map[string]time.Time // message_id -> recall time, short TTL race guard
 	// Webhook mode fields (for Lark international version)
 	server       *http.Server
 	port         string
@@ -194,6 +200,11 @@ type Platform struct {
 // image sends. Operators that need a longer or shorter window can override
 // it via the platform option `image_batch_window_ms`.
 const defaultImageBatchWindow = 500 * time.Millisecond
+
+const (
+	defaultWSWatchdogTimeout  = time.Duration(0)
+	defaultWSWatchdogInterval = 1 * time.Minute
+)
 
 // batchWindow returns the effective image-batch coalesce window for this
 // Platform. Tests and zero-initialised Platforms fall back to the default so
@@ -369,6 +380,18 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		imageBatchWindow = time.Duration(ms) * time.Millisecond
 	}
 
+	wsWatchdogTimeout := defaultWSWatchdogTimeout
+	if raw, ok := opts["ws_watchdog_timeout_mins"]; ok {
+		mins, err := coerceMilliseconds(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: invalid ws_watchdog_timeout_mins %v: %w", name, raw, err)
+		}
+		if mins < 0 {
+			return nil, fmt.Errorf("%s: ws_watchdog_timeout_mins must be >= 0, got %d", name, mins)
+		}
+		wsWatchdogTimeout = time.Duration(mins) * time.Minute
+	}
+
 	// Webhook mode configuration (for Lark international version)
 	port, _ := opts["port"].(string)
 	if port == "" {
@@ -413,6 +436,8 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		mentionMap:                 mentionMap,
 		imageBatch:                 make(map[string]*imageBatchEntry),
 		imageBatchWindow:           imageBatchWindow,
+		wsWatchdogTimeout:          wsWatchdogTimeout,
+		wsWatchdogInterval:         defaultWSWatchdogInterval,
 	}
 	if !useInteractiveCard {
 		base.self = base
@@ -502,6 +527,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 
 	p.eventHandler = dispatcher.NewEventDispatcher("", p.encryptKey).
 		OnP2MessageReceiveV1(func(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
+			p.markWSActivity()
 			// Fan out to all platforms sharing this WebSocket connection.
 			// Each platform's onMessage applies its own allow_chat filter.
 			for _, sibling := range p.sharedGroup.allPlatforms() {
@@ -512,6 +538,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			return nil
 		}).
 		OnP2MessageRecalledV1(func(ctx context.Context, event *larkim.P2MessageRecalledV1) error {
+			p.markWSActivity()
 			for _, sibling := range p.sharedGroup.allPlatforms() {
 				if err := sibling.onMessageRecalled(ctx, event); err != nil {
 					slog.Error("shared ws: onMessageRecalled error", "err", err)
@@ -520,23 +547,29 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			return nil
 		}).
 		OnP2MessageReadV1(func(ctx context.Context, event *larkim.P2MessageReadV1) error {
+			p.markWSActivity()
 			return nil // ignore read receipts
 		}).
 		OnP2ChatAccessEventBotP2pChatEnteredV1(func(ctx context.Context, event *larkim.P2ChatAccessEventBotP2pChatEnteredV1) error {
+			p.markWSActivity()
 			slog.Debug(p.platformName+": user opened bot chat", "app_id", p.appID)
 			return nil
 		}).
 		OnP1P2PChatCreatedV1(func(ctx context.Context, event *larkim.P1P2PChatCreatedV1) error {
+			p.markWSActivity()
 			slog.Debug(p.platformName+": p2p chat created", "app_id", p.appID)
 			return nil
 		}).
 		OnP2MessageReactionCreatedV1(func(ctx context.Context, event *larkim.P2MessageReactionCreatedV1) error {
+			p.markWSActivity()
 			return nil // ignore reaction events (triggered by our own addReaction)
 		}).
 		OnP2MessageReactionDeletedV1(func(ctx context.Context, event *larkim.P2MessageReactionDeletedV1) error {
+			p.markWSActivity()
 			return nil // ignore reaction removal events (triggered by our own removeReaction)
 		}).
 		OnP2CardActionTrigger(func(ctx context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
+			p.markWSActivity()
 			// Fan out card actions: try each platform, return first non-nil response.
 			// Each platform's onCardAction checks allow_chat before processing.
 			for _, sibling := range p.sharedGroup.allPlatforms() {
@@ -551,6 +584,7 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 			return nil, nil
 		}).
 		OnP2BotMenuV6(func(ctx context.Context, event *larkapplication.P2BotMenuV6) error {
+			p.markWSActivity()
 			for _, sibling := range p.sharedGroup.allPlatforms() {
 				if err := sibling.onBotMenu(event); err != nil {
 					slog.Error("shared ws: onBotMenu error", "err", err)
@@ -574,6 +608,46 @@ func (p *Platform) shouldUseWebhookMode() bool {
 	return strings.TrimSpace(p.encryptKey) != ""
 }
 
+func (p *Platform) markWSActivity() {
+	p.wsLastActivity.Store(time.Now().UnixNano())
+}
+
+func (p *Platform) watchWebSocket(ctx context.Context) {
+	if p.wsWatchdogTimeout <= 0 {
+		return
+	}
+	interval := p.wsWatchdogInterval
+	if interval <= 0 {
+		interval = defaultWSWatchdogInterval
+	}
+	restart := p.restartWS
+	if restart == nil {
+		restart = func() {
+			slog.Error(p.tag()+": websocket watchdog stale, restarting process",
+				"timeout", p.wsWatchdogTimeout)
+			os.Exit(2)
+		}
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			last := time.Unix(0, p.wsLastActivity.Load())
+			if last.IsZero() {
+				p.markWSActivity()
+				continue
+			}
+			if time.Since(last) >= p.wsWatchdogTimeout {
+				restart()
+				return
+			}
+		}
+	}
+}
+
 // startWebSocketMode starts the WebSocket long connection mode.
 func (p *Platform) startWebSocketMode() error {
 	wsOpts := []larkws.ClientOption{
@@ -590,12 +664,14 @@ func (p *Platform) startWebSocketMode() error {
 	p.mu.Lock()
 	p.cancel = cancel
 	p.mu.Unlock()
+	p.markWSActivity()
 
 	go func() {
 		if err := p.wsClient.Start(ctx); err != nil {
 			slog.Error(p.tag()+": websocket error", "error", err)
 		}
 	}()
+	go p.watchWebSocket(ctx)
 
 	return nil
 }

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -118,6 +118,44 @@ func TestNew_ProgressStyleRejectsInvalidValue(t *testing.T) {
 	}
 }
 
+func TestNew_ParsesWebSocketWatchdogTimeout(t *testing.T) {
+	pAny, err := New(map[string]any{
+		"app_id":                   "cli_xxx",
+		"app_secret":               "secret",
+		"ws_watchdog_timeout_mins": 3,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	p := pAny.(*interactivePlatform).Platform
+	if got := p.wsWatchdogTimeout; got != 3*time.Minute {
+		t.Fatalf("wsWatchdogTimeout = %v, want 3m", got)
+	}
+}
+
+func TestFeishuWebSocketWatchdogRestartsWhenStale(t *testing.T) {
+	p := &Platform{
+		platformName:       "feishu",
+		wsWatchdogTimeout:  20 * time.Millisecond,
+		wsWatchdogInterval: 5 * time.Millisecond,
+	}
+	p.markWSActivity()
+	restarted := make(chan struct{}, 1)
+	p.restartWS = func() {
+		restarted <- struct{}{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.watchWebSocket(ctx)
+
+	select {
+	case <-restarted:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not restart stale websocket")
+	}
+}
+
 func TestDetectFeishuFileMessageType(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Add an optional OpenCode `connection_url` mode that talks to `opencode serve` over HTTP and keeps `/event` SSE connected before prompts are sent.
- Stream assistant text/reasoning/tool/status events from SSE while the synchronous `/session/{id}/message` request is still running, preserving progress updates and background callbacks.
- Forward OpenCode permission/question requests back through cc-connect, and ignore user prompt text parts so replies do not echo the user's own message.

## Why
`opencode run --attach` is short-lived in cc-connect. When the client process exits at the end of a turn, OpenCode server-side background callbacks can be lost. The OpenCode CLI already subscribes to `/event` SSE internally; this patch mirrors that behavior in cc-connect when `connection_url` is configured.

Related: #1534, especially https://github.com/chenhg5/cc-connect/issues/1534#issuecomment-4953811313

## Test Plan
- `GOCACHE=/tmp/cc-connect-go-cache go test ./agent/opencode -count=1`
- `GOPATH=/tmp/cc-connect-go GOMODCACHE=/tmp/cc-connect-go/pkg/mod GOCACHE=/tmp/cc-connect-go-cache go build ./...`
- Live local validation against `opencode serve`: `OPENCODE_LIVE_URL=... OPENCODE_LIVE_USERNAME=... OPENCODE_LIVE_PASSWORD=... OPENCODE_LIVE_SEND=1 go test ./agent/opencode -run TestOpencodeHTTPModeLiveServer -count=1 -v`
- Manual Feishu validation with the rebuilt local service: streaming works, background callbacks survive, and user prompts are no longer echoed in bot replies.