### PR TITLE
feat(telegram): configurable reactions + optional queue-busy notice

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -707,6 +707,9 @@ func main() {
 		if cfg.Queue.MaxDepth != nil && *cfg.Queue.MaxDepth > 0 {
 			engine.SetMaxQueuedMessages(*cfg.Queue.MaxDepth)
 		}
+		if cfg.Queue.Notice != nil {
+			engine.SetQueueNotice(*cfg.Queue.Notice)
+		}
 
 		// Wire auto-compress settings
 		if proj.AutoCompress.Enabled != nil && *proj.AutoCompress.Enabled {

--- a/config.example.toml
+++ b/config.example.toml
@@ -231,6 +231,17 @@ level = "info" # debug, info, warn, error
 # # env block, NOT here.
 # run_as_env = ["PGSSLROOTCERT", "PGSSLMODE"]
 # =============================================================================
+# Message Queue / 消息队列
+# =============================================================================
+# When a new message arrives while the agent is still processing a previous
+# turn, it is queued. By default a "message queued" notice is sent to the user.
+# 当上一轮还在处理时到达的新消息会被排队；默认会发一条"消息已收到，将排队处理"的提示。
+
+# [queue]
+# max_depth = 5   # Max queued messages per session (default: 5) / 每会话最大排队消息数（默认 5）
+# notice = true   # Send the "message queued" notice while busy (default: true); set false to stay silent and rely on reactions instead / 忙时是否发排队提示（默认 true）；false 则不发，改用表情反应
+
+# =============================================================================
 # Streaming Preview / 流式预览
 # =============================================================================
 # Real-time message preview: shows agent output as it streams, updating the
@@ -1131,7 +1142,11 @@ app_secret = "your-feishu-app-secret"
 # proxy_password = ""              # Optional proxy auth password / 代理密码
 # group_reply_all = false  # If true, respond to ALL group messages without @mention / 设为 true 群聊无需 @ 也响应
 # share_session_in_channel = false  # If true, all users in a group share one agent session / 群聊共享会话
-# enable_reactions = false  # If true, add ⚡ reaction to incoming messages / 设为 true 收到消息时添加 ⚡ 表情
+# enable_reactions = false  # If true, react to incoming messages / 设为 true 收到消息时添加表情
+# reaction_emoji = "⚡"     # Emoji for the in-progress reaction (default "⚡"); "none" disables / 处理中的表情（默认 ⚡）；"none" 禁用
+# done_emoji = "none"       # Emoji swapped in when the turn finishes, e.g. "✅"; empty/"none" disables / 完成时换成的表情（如 ✅）；空或 "none" 禁用
+#                           # Note: Telegram allows only one bot reaction per message, so done_emoji replaces reaction_emoji.
+#                           # 注意：Telegram 每条消息只允许机器人一个表情，所以 done 会替换掉收到时的表情。
 # progress_style = "compact"  # Progress rendering: legacy | compact (default). Telegram has no rich card UI,
 #                             # so "card" is normalized to "compact". Set "legacy" to disable streaming edits.
 #                             # 进度展示：legacy | compact（默认）。Telegram 不支持富卡片，"card" 会被规整为 "compact"。

--- a/config/config.go
+++ b/config/config.go
@@ -144,7 +144,8 @@ type CronConfig struct {
 
 // QueueConfig controls the per-session message queue.
 type QueueConfig struct {
-	MaxDepth *int `toml:"max_depth"` // max queued messages per session; default 5
+	MaxDepth *int  `toml:"max_depth"` // max queued messages per session; default 5
+	Notice   *bool `toml:"notice"`    // send the "message queued" notice while the session is busy; default true
 }
 
 // WebhookConfig controls the external HTTP webhook endpoint.

--- a/core/engine.go
+++ b/core/engine.go
@@ -393,6 +393,7 @@ type Engine struct {
 	agentSessionIdleTimeoutNanos atomic.Int64
 	agentSessionIdleSeq          atomic.Uint64
 	maxQueuedMessages            int
+	queueNoticeEnabled           bool
 	dirHistory                   *DirHistory
 	baseWorkDir                  string
 	projectState                 *ProjectStateStore
@@ -734,6 +735,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		references:            DefaultReferenceRenderCfg(),
 		eventIdleTimeout:      defaultEventIdleTimeout,
 		maxQueuedMessages:     defaultMaxQueuedMessages,
+		queueNoticeEnabled:    true,
 		showContextIndicator:  true,
 		showWorkdirIndicator:  true,
 		shell:                 defaultShell(),
@@ -1316,6 +1318,12 @@ func (e *Engine) SetMaxQueuedMessages(n int) {
 	if n > 0 {
 		e.maxQueuedMessages = n
 	}
+}
+
+// SetQueueNotice controls whether the "message queued" notice is sent when a
+// message arrives while the session is busy.
+func (e *Engine) SetQueueNotice(enabled bool) {
+	e.queueNoticeEnabled = enabled
 }
 
 func (e *Engine) SetRelayManager(rm *RelayManager) {
@@ -3142,7 +3150,9 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 		"user", msg.UserName,
 		"queue_depth", queueDepth,
 	)
-	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgMessageQueued))
+	if e.queueNoticeEnabled {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgMessageQueued))
+	}
 	return true
 }
 

--- a/platform/telegram/telegram.go
+++ b/platform/telegram/telegram.go
@@ -110,6 +110,8 @@ type Platform struct {
 	groupReplyAll         bool
 	shareSessionInChannel bool
 	enableReactions       bool
+	reactionEmoji         string // emoji for in-progress reaction (default "⚡"); "none" disables
+	doneEmoji             string // emoji swapped in when the turn completes; empty/"none" disables
 	progressStyle         string // "legacy" | "compact" — telegram has no rich card, so "card" is mapped to "compact"
 	httpClient            *http.Client
 
@@ -163,6 +165,17 @@ func New(opts map[string]any) (core.Platform, error) {
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	enableReactions, _ := opts["enable_reactions"].(bool)
+	reactionEmoji, _ := opts["reaction_emoji"].(string)
+	if reactionEmoji == "" {
+		reactionEmoji = "⚡" // preserve historical default (⚡)
+	}
+	if reactionEmoji == "none" {
+		reactionEmoji = ""
+	}
+	doneEmoji, _ := opts["done_emoji"].(string)
+	if doneEmoji == "none" {
+		doneEmoji = ""
+	}
 
 	// Default to "compact" so streaming edits work out of the box. Telegram has
 	// no rich card UI, so "card" is normalized to "compact". Users can opt out
@@ -188,6 +201,8 @@ func New(opts map[string]any) (core.Platform, error) {
 		groupReplyAll:         groupReplyAll,
 		shareSessionInChannel: shareSessionInChannel,
 		enableReactions:       enableReactions,
+		reactionEmoji:         reactionEmoji,
+		doneEmoji:             doneEmoji,
 		progressStyle:         progressStyle,
 		httpClient:            httpClient,
 	}, nil
@@ -448,8 +463,8 @@ func (p *Platform) handleMessage(ctx context.Context, msg *models.Message) {
 	}
 
 	rctx := replyContext{chatID: msg.Chat.ID, threadID: threadID, messageID: msg.ID}
-	if p.enableReactions {
-		go p.reactToMessage(ctx, msg.Chat.ID, msg.ID, "⚡")
+	if p.enableReactions && p.reactionEmoji != "" {
+		go p.reactToMessage(ctx, msg.Chat.ID, msg.ID, p.reactionEmoji)
 	}
 	botName := p.botUsername()
 
@@ -630,6 +645,21 @@ func (p *Platform) reactToMessage(ctx context.Context, chatID int64, messageID i
 	}); err != nil {
 		slog.Debug("telegram: set reaction failed", "error", err)
 	}
+}
+
+// AddDoneReaction implements TypingIndicatorDone. Telegram allows a bot only
+// one reaction per message, so this swaps the in-progress reaction on the
+// user's message for the configured done emoji, giving them a push when the
+// turn finishes.
+func (p *Platform) AddDoneReaction(rctx any) {
+	if !p.enableReactions || p.doneEmoji == "" {
+		return
+	}
+	rc, ok := rctx.(replyContext)
+	if !ok || rc.messageID == 0 {
+		return
+	}
+	go p.reactToMessage(context.Background(), rc.chatID, rc.messageID, p.doneEmoji)
 }
 
 func (p *Platform) buildSessionKey(chatID int64, threadID int, userID int64) string {


### PR DESCRIPTION
## Problem

On Telegram, cc-connect:
- hardcodes the ⚡ incoming reaction and ignores `reaction_emoji` / `done_emoji` (which the Feishu / DingTalk / WPS platforms already honor);
- never implements the "done" reaction (`TypingIndicatorDone`), so there's no completion signal;
- always sends the "message queued" busy notice, with no way to turn it off.

## Changes

- **telegram**: honor `reaction_emoji` (default `⚡`, back-compat; `"none"` disables) and `done_emoji` (`"none"`/empty disables) instead of the hardcoded `⚡`.
- **telegram**: implement `TypingIndicatorDone.AddDoneReaction` — swaps the in-progress reaction for `done_emoji` when the turn finishes (Telegram allows one bot reaction per message, so it replaces the in-progress one).
- **core/config**: add `[queue] notice` (default `true`); set `false` to suppress the "message queued" notice while the session is busy.
- **docs**: document the telegram reaction options and add a `[queue]` section in `config.example.toml`.

## Compatibility

Fully backward compatible — defaults preserve current behavior (⚡ incoming reaction, queue notice on).

## Testing

- `go build` / `go vet` / `go test ./platform/telegram/...` pass.
- queue-related `./core/...` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
