### PR TITLE
feat(cron/timer): per-job model override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ credentials/
 
 .codex
 cc-connect-new
+core/test_ws_*.json

--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -490,6 +490,20 @@ func validateSessionIDInProject(homeDir, workDir, sessionID string) bool {
 
 // StartSession creates a persistent interactive Claude Code session.
 func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentSession, error) {
+	return a.startSession(ctx, sessionID, "")
+}
+
+// StartSessionWithModel implements core.ModelOverrideStarter: identical to
+// StartSession, but the spawned CLI runs with modelOverride instead of the
+// configured model. The agent's stored model is not mutated, so concurrent
+// sessions of the same project keep their configured model. The override also
+// wins over the active provider's model — an explicit per-job model is the
+// most specific intent.
+func (a *Agent) StartSessionWithModel(ctx context.Context, sessionID string, modelOverride string) (core.AgentSession, error) {
+	return a.startSession(ctx, sessionID, modelOverride)
+}
+
+func (a *Agent) startSession(ctx context.Context, sessionID string, modelOverride string) (core.AgentSession, error) {
 	a.mu.Lock()
 	tools := make([]string, len(a.allowedTools))
 	copy(tools, a.allowedTools)
@@ -511,6 +525,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 		if m := a.providers[activeIdx].Model; m != "" {
 			model = m
 		}
+	}
+	if modelOverride != "" {
+		model = modelOverride
 	}
 	slog.Debug("claudecode: StartSession provider state",
 		"activeIdx", activeIdx,

--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -57,7 +57,7 @@ func closeCronResponseBody(body io.Closer) {
 }
 
 func runCronAdd(args []string) {
-	var project, sessionKey, cronExpr, prompt, execCmd, desc, dataDir, sessionMode string
+	var project, sessionKey, cronExpr, prompt, execCmd, desc, dataDir, sessionMode, model string
 	var timeoutMins *int
 	var silent bool
 
@@ -103,6 +103,11 @@ func runCronAdd(args []string) {
 			if i+1 < len(args) {
 				i++
 				sessionMode = args[i]
+			}
+		case "--model":
+			if i+1 < len(args) {
+				i++
+				model = args[i]
 			}
 		case "--timeout-mins":
 			if i+1 < len(args) {
@@ -171,6 +176,9 @@ func runCronAdd(args []string) {
 	}
 	if sessionMode != "" {
 		body["session_mode"] = sessionMode
+	}
+	if model != "" {
+		body["model"] = model
 	}
 	if timeoutMins != nil {
 		body["timeout_mins"] = *timeoutMins
@@ -627,6 +635,7 @@ Options:
       --exec <command>       Shell command (runs directly, mutually exclusive with --prompt)
       --desc <text>          Short description
       --session-mode <mode>  reuse (default) or new-per-run — fresh agent session each run
+      --model <model>        model override for this job's turns (e.g. haiku, sonnet); default: agent's configured model
       --timeout-mins <n>     Max minutes to wait per run (0 = no limit; default 30 if omitted)
       --silent               Suppress cron start notification
       --data-dir <path>      Data directory (default: ~/.cc-connect)

--- a/cmd/cc-connect/timer.go
+++ b/cmd/cc-connect/timer.go
@@ -38,7 +38,7 @@ func runTimer(args []string) {
 }
 
 func runTimerAdd(args []string) {
-	var project, sessionKey, delay, atTime, prompt, execCmd, desc, dataDir, sessionMode string
+	var project, sessionKey, delay, atTime, prompt, execCmd, desc, dataDir, sessionMode, model string
 	var timeoutMins *int
 	var mute bool
 
@@ -89,6 +89,11 @@ func runTimerAdd(args []string) {
 			if i+1 < len(args) {
 				i++
 				sessionMode = args[i]
+			}
+		case "--model":
+			if i+1 < len(args) {
+				i++
+				model = args[i]
 			}
 		case "--timeout-mins":
 			if i+1 < len(args) {
@@ -160,6 +165,9 @@ func runTimerAdd(args []string) {
 	}
 	if sessionMode != "" {
 		body["session_mode"] = sessionMode
+	}
+	if model != "" {
+		body["model"] = model
 	}
 	if timeoutMins != nil {
 		body["timeout_mins"] = *timeoutMins
@@ -413,6 +421,7 @@ Options:
       --exec <command>       Shell command (runs directly, mutually exclusive with --prompt)
       --desc <text>          Short description
       --session-mode <mode>  reuse (default) or new-per-run
+      --model <model>        model override for this job's turn (e.g. haiku, sonnet); default: agent's configured model
       --timeout-mins <n>     Max minutes to wait per run (0 = no limit; default 30)
       --mute                 Suppress all messages (start + result)
       --data-dir <path>      Data directory (default: ~/.cc-connect)

--- a/core/api.go
+++ b/core/api.go
@@ -325,6 +325,7 @@ type CronAddRequest struct {
 	Silent      *bool  `json:"silent,omitempty"`
 	SessionMode string `json:"session_mode,omitempty"`
 	Mode        string `json:"mode,omitempty"`
+	Model       string `json:"model,omitempty"`
 	TimeoutMins *int   `json:"timeout_mins,omitempty"`
 }
 
@@ -404,6 +405,7 @@ func (s *APIServer) handleCronAdd(w http.ResponseWriter, r *http.Request) {
 		Silent:      req.Silent,
 		SessionMode: NormalizeCronSessionMode(req.SessionMode),
 		Mode:        req.Mode,
+		Model:       req.Model,
 		TimeoutMins: req.TimeoutMins,
 	}
 	job.CreatedAt = time.Now()
@@ -581,6 +583,7 @@ type TimerAddRequest struct {
 	Mute        bool   `json:"mute,omitempty"`
 	SessionMode string `json:"session_mode,omitempty"`
 	Mode        string `json:"mode,omitempty"`
+	Model       string `json:"model,omitempty"`
 	TimeoutMins *int   `json:"timeout_mins,omitempty"`
 }
 
@@ -663,6 +666,7 @@ func (s *APIServer) handleTimerAdd(w http.ResponseWriter, r *http.Request) {
 		Mute:        req.Mute,
 		SessionMode: req.SessionMode,
 		Mode:        req.Mode,
+		Model:       req.Model,
 		TimeoutMins: req.TimeoutMins,
 		CreatedAt:   time.Now(),
 	}

--- a/core/cron.go
+++ b/core/cron.go
@@ -34,6 +34,7 @@ type CronJob struct {
 	Mute        bool      `json:"mute,omitempty"`         // suppress ALL messages (start + result); job runs silently
 	SessionMode string    `json:"session_mode,omitempty"` // "" or "reuse" = share active session; "new_per_run" = fresh session each run
 	Mode        string    `json:"mode,omitempty"`         // permission mode override for this job; "" = use project default
+	Model       string    `json:"model,omitempty"`        // model override for this job's turns; "" = agent's configured model
 	TimeoutMins *int      `json:"timeout_mins,omitempty"` // nil = default 30m wait; 0 = no limit; >0 = minutes
 	CreatedAt   time.Time `json:"created_at"`
 	LastRun     time.Time `json:"last_run,omitempty"`
@@ -363,6 +364,11 @@ func updateJobField(job *CronJob, field string, value any) error {
 	case "mode":
 		if v, ok := value.(string); ok {
 			job.Mode = v
+			return nil
+		}
+	case "model":
+		if v, ok := value.(string); ok {
+			job.Model = v
 			return nil
 		}
 	case "timeout_mins":

--- a/core/cron_model_test.go
+++ b/core/cron_model_test.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestUpdateJobField_Model guards the `cron edit <id> model <value>` path:
+// updateJobField must accept a string value for "model" and reject non-strings,
+// mirroring the other string fields.
+func TestUpdateJobField_Model(t *testing.T) {
+	job := &CronJob{ID: "j1"}
+
+	if err := updateJobField(job, "model", "haiku"); err != nil {
+		t.Fatalf("updateJobField(model, haiku): %v", err)
+	}
+	if job.Model != "haiku" {
+		t.Errorf("job.Model = %q, want haiku", job.Model)
+	}
+
+	if err := updateJobField(job, "model", ""); err != nil {
+		t.Fatalf("updateJobField(model, empty): %v", err)
+	}
+	if job.Model != "" {
+		t.Errorf("job.Model = %q, want empty (override cleared)", job.Model)
+	}
+
+	if err := updateJobField(job, "model", 42); err == nil {
+		t.Error("updateJobField(model, 42) succeeded, want type error")
+	}
+}
+
+// TestCronJobModel_JSONRoundTrip ensures the model field persists through the
+// store's JSON encoding and is omitted when empty (no store-format churn for
+// existing jobs).
+func TestCronJobModel_JSONRoundTrip(t *testing.T) {
+	job := &CronJob{ID: "j1", Model: "sonnet"}
+	b, err := json.Marshal(job)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back CronJob
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.Model != "sonnet" {
+		t.Errorf("round-trip Model = %q, want sonnet", back.Model)
+	}
+
+	empty, err := json.Marshal(&CronJob{ID: "j2"})
+	if err != nil {
+		t.Fatalf("marshal empty: %v", err)
+	}
+	if string(empty) != "" && jsonHasKey(empty, "model") {
+		t.Errorf("empty Model serialized into JSON: %s", empty)
+	}
+}
+
+func jsonHasKey(b []byte, key string) bool {
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -1499,13 +1499,14 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 	}
 
 	msg := &Message{
-		SessionKey:   sessionKey,
-		Platform:     platformName,
-		UserID:       "cron",
-		UserName:     "cron",
-		Content:      content,
-		ReplyCtx:     replyCtx,
-		ModeOverride: job.Mode,
+		SessionKey:    sessionKey,
+		Platform:      platformName,
+		UserID:        "cron",
+		UserName:      "cron",
+		Content:       content,
+		ReplyCtx:      replyCtx,
+		ModeOverride:  job.Mode,
+		ModelOverride: job.Model,
 	}
 
 	// Resolve workspace-specific agent and sessions for multi-workspace mode.
@@ -1702,13 +1703,14 @@ func (e *Engine) ExecuteTimerJob(job *TimerJob) error {
 	}
 
 	msg := &Message{
-		SessionKey:   sessionKey,
-		Platform:     platformName,
-		UserID:       "timer",
-		UserName:     "timer",
-		Content:      content,
-		ReplyCtx:     replyCtx,
-		ModeOverride: job.Mode,
+		SessionKey:    sessionKey,
+		Platform:      platformName,
+		UserID:        "timer",
+		UserName:      "timer",
+		Content:       content,
+		ReplyCtx:      replyCtx,
+		ModeOverride:  job.Mode,
+		ModelOverride: job.Model,
 	}
 
 	agent := e.agent
@@ -3652,7 +3654,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	if agent != e.agent {
 		agentOverride = agent
 	}
-	state := e.getOrCreateInteractiveStateWith(interactiveKey, p, msg.ReplyCtx, session, sessions, agentOverride, ccSessionKey)
+	state := e.getOrCreateInteractiveStateWith(interactiveKey, p, msg.ReplyCtx, session, sessions, agentOverride, ccSessionKey, msg.ModelOverride)
 
 	// Set workspaceDir on the state for idle reaper identification
 	if workspaceDir != "" {
@@ -3921,7 +3923,7 @@ func adoptPendingFromPlaceholder(existing, newState *interactiveState) {
 
 // When agentOverride is non-nil it is used instead of e.agent to start the session.
 // ccSessionKey, when non-empty, is used for CC_SESSION_KEY env injection; otherwise sessionKey is used.
-func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, replyCtx any, session *Session, sessions *SessionManager, agentOverride Agent, ccSessionKey string) *interactiveState {
+func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, replyCtx any, session *Session, sessions *SessionManager, agentOverride Agent, ccSessionKey string, modelOverride string) *interactiveState {
 	e.interactiveMu.Lock()
 	defer e.interactiveMu.Unlock()
 
@@ -4037,8 +4039,23 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		}
 	}
 	isResume := startSessionID != ""
+	// Per-message model override (cron/timer jobs with a model field): spawn
+	// this session with the override without touching the agent's configured
+	// model. Agents that don't implement ModelOverrideStarter fall back to
+	// their configured model.
+	startSession := agent.StartSession
+	if modelOverride != "" {
+		if mos, ok := agent.(ModelOverrideStarter); ok {
+			startSession = func(ctx context.Context, sid string) (AgentSession, error) {
+				return mos.StartSessionWithModel(ctx, sid, modelOverride)
+			}
+			slog.Info("spawning session with model override", "session_key", sessionKey, "model", modelOverride)
+		} else {
+			slog.Warn("model override requested but agent does not support it", "session_key", sessionKey, "agent", agent.Name(), "model", modelOverride)
+		}
+	}
 	startAt := time.Now()
-	agentSession, err := agent.StartSession(e.ctx, startSessionID)
+	agentSession, err := startSession(e.ctx, startSessionID)
 	startElapsed := time.Since(startAt)
 	if err != nil {
 		// If resume/continue failed, try a fresh session as fallback.
@@ -4051,7 +4068,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 			session.SetAgentSessionID("", agent.Name())
 			sessions.Save()
 			startAt = time.Now()
-			agentSession, err = agent.StartSession(e.ctx, "")
+			agentSession, err = startSession(e.ctx, "")
 			startElapsed = time.Since(startAt)
 			if err == nil {
 				slog.Info("fresh session started after resume failure",

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -7473,7 +7473,7 @@ func TestSessionMismatch_RecyclesStaleAgent(t *testing.T) {
 	// The active Session now wants a DIFFERENT agent session ID.
 	session := &Session{AgentSessionID: "new-agent-id"}
 
-	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 
 	if state.agentSession == oldSess {
 		t.Fatal("expected stale agent session to be replaced")
@@ -7510,7 +7510,7 @@ func TestSessionClearedAfterNew_RecyclesAliveAgent(t *testing.T) {
 
 	session := &Session{AgentSessionID: ""}
 
-	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 	if state.agentSession == oldSess {
 		t.Fatal("expected stale agent to be recycled when AgentSessionID was cleared")
 	}
@@ -7545,7 +7545,7 @@ func TestSessionMismatch_ReusesWhenIDsMatch(t *testing.T) {
 
 	session := &Session{AgentSessionID: "matching-id"}
 
-	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 	if state != existingState {
 		t.Fatal("expected existing state to be reused when session IDs match")
 	}
@@ -7563,7 +7563,7 @@ func TestSessionIDWriteback_ImmediateAfterStartSession(t *testing.T) {
 	key := "test:user1"
 	session := &Session{AgentSessionID: ""} // empty — no prior binding
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 
 	got := session.GetAgentSessionID()
 
@@ -7584,7 +7584,7 @@ func TestSessionIDWriteback_MapsSessionName(t *testing.T) {
 	key := "test:user1"
 	session := e.sessions.NewSession(key, "我的自定义会话")
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 
 	got := e.sessions.GetSessionName("agent-uuid-456")
 	if got != "我的自定义会话" {
@@ -7606,7 +7606,7 @@ func TestSessionIDWriteback_TracksLiveForkedID(t *testing.T) {
 	key := "test:user1"
 	session := &Session{AgentSessionID: "existing-uuid"}
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 
 	got := session.GetAgentSessionID()
 
@@ -7632,7 +7632,7 @@ func TestInteractiveWriteBack_TracksForkedSessionID(t *testing.T) {
 	// Session already holds the original (now stale) ID from a prior turn.
 	session := &Session{AgentSessionID: "orig-id", AgentType: "controllable"}
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 
 	if got := session.GetAgentSessionID(); got != "forked-id" {
 		t.Fatalf("AgentSessionID = %q, want %q — must track the live forked ID", got, "forked-id")
@@ -7654,7 +7654,7 @@ func TestInteractiveWriteBack_NamingBindsOnlyOnFirstAssignment(t *testing.T) {
 	session := &Session{Name: "my-feature", AgentType: "controllable"}
 
 	// First assignment: name should bind to first-id.
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 	if got := e.sessions.GetSessionName("first-id"); got != "my-feature" {
 		t.Fatalf("first-id name = %q, want %q on first assignment", got, "my-feature")
 	}
@@ -7667,7 +7667,7 @@ func TestInteractiveWriteBack_NamingBindsOnlyOnFirstAssignment(t *testing.T) {
 	delete(e.interactiveStates, key) // force a fresh start path
 	e.interactiveMu.Unlock()
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 	if got := session.GetAgentSessionID(); got != "forked-id" {
 		t.Fatalf("AgentSessionID = %q, want %q after fork", got, "forked-id")
 	}
@@ -7734,7 +7734,7 @@ func TestResumeFallback_ClearsStaleSessionID(t *testing.T) {
 	// Session has a stale AgentSessionID from a previously killed agent.
 	session := &Session{AgentSessionID: "stale-id", AgentType: "controllable"}
 
-	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "", "")
 
 	// The new agent session should be the fresh one.
 	if state.agentSession != freshSess {
@@ -7775,7 +7775,7 @@ func TestStaleGoroutineCleanup_RaceSimulation(t *testing.T) {
 
 	// Step 3: New turn creates Session B and calls getOrCreateInteractiveStateWith.
 	sessionB := &Session{AgentSessionID: ""}
-	newState := e.getOrCreateInteractiveStateWith(key, p, "ctx", sessionB, e.sessions, nil, "")
+	newState := e.getOrCreateInteractiveStateWith(key, p, "ctx", sessionB, e.sessions, nil, "", "")
 
 	// Verify S2 is in the map.
 	e.interactiveMu.Lock()
@@ -8253,7 +8253,7 @@ func TestResumeFailureFallbackToFreshSession(t *testing.T) {
 	session.SetAgentSessionID("old-session-id", "stub")
 
 	p := &stubPlatformEngine{n: "test"}
-	state := e.getOrCreateInteractiveStateWith("test:user1", p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith("test:user1", p, "ctx", session, e.sessions, nil, "", "")
 
 	if state.agentSession == nil {
 		t.Fatal("expected agentSession to be non-nil after fallback")
@@ -8291,7 +8291,7 @@ func TestFreshSessionWithoutSavedSessionIDStartsFresh(t *testing.T) {
 	session := e.sessions.GetOrCreateActive("test:user2")
 
 	p := &stubPlatformEngine{n: "test"}
-	state := e.getOrCreateInteractiveStateWith("test:user2", p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith("test:user2", p, "ctx", session, e.sessions, nil, "", "")
 
 	if state.agentSession == nil {
 		t.Fatal("expected agentSession to be non-nil")
@@ -8328,7 +8328,7 @@ func TestWorkspaceReconnectWithSavedSessionIDUsesExactResume(t *testing.T) {
 	session.SetAgentSessionID("saved-session-id", "stub")
 
 	p := &stubPlatformEngine{n: "test"}
-	state := e.getOrCreateInteractiveStateWith("test:user3", p, "ctx", session, e.sessions, nil, "")
+	state := e.getOrCreateInteractiveStateWith("test:user3", p, "ctx", session, e.sessions, nil, "", "")
 
 	if state.agentSession == nil {
 		t.Fatal("expected agentSession to be non-nil")

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -480,6 +480,15 @@ type ModelSwitcher interface {
 	AvailableModels(ctx context.Context) []ModelOption
 }
 
+// ModelOverrideStarter is an optional interface for agents that can start a
+// session with a one-off model override. Unlike ModelSwitcher.SetModel, the
+// override applies only to the session being started and never mutates the
+// agent's configured model, so concurrent sessions of the same project are
+// unaffected (used by cron/timer jobs with a per-job model).
+type ModelOverrideStarter interface {
+	StartSessionWithModel(ctx context.Context, sessionID string, model string) (AgentSession, error)
+}
+
 // ReasoningEffortSwitcher is an optional interface for agents that support
 // runtime switching of reasoning effort.
 type ReasoningEffortSwitcher interface {

--- a/core/message.go
+++ b/core/message.go
@@ -227,6 +227,11 @@ type Message struct {
 	ReplyCtx     any                 // platform-specific context needed for replying
 	FromVoice    bool                // true if message originated from voice transcription
 	ModeOverride string              // if set, temporarily override agent permission mode for this message
+	// ModelOverride, when set, spawns THIS message's agent session with the
+	// given model instead of the agent's configured one (cron/timer jobs with
+	// a model field). Spawn-time only — it never mutates the agent's stored
+	// model, so concurrent sessions of the same project are unaffected.
+	ModelOverride string
 	// IsPermissionResponse is set by inline-button / card-action paths in
 	// platforms when a synthesized message is forwarded as a permission
 	// decision (e.g. Telegram handleCallbackQuery for perm:allow/deny,

--- a/core/session_id_validation_test.go
+++ b/core/session_id_validation_test.go
@@ -50,7 +50,7 @@ func TestIssue599_InvalidSessionIDClearedBeforeResume(t *testing.T) {
 	// Simulate a stored cross-project session ID.
 	s := &Session{AgentSessionID: "leaked-id-from-other-project"}
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", s, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, "ctx", s, e.sessions, nil, "", "")
 
 	if startedWith != "" {
 		t.Errorf("StartSession called with %q, want \"\" (fresh start; leaked id must NOT be passed through)", startedWith)
@@ -80,7 +80,7 @@ func TestIssue599_ValidSessionIDPreserved(t *testing.T) {
 
 	s := &Session{AgentSessionID: "valid-id-abc"}
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", s, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, "ctx", s, e.sessions, nil, "", "")
 
 	if startedWith != "valid-id-abc" {
 		t.Errorf("StartSession called with %q, want %q (resume path)", startedWith, "valid-id-abc")
@@ -106,7 +106,7 @@ func TestIssue599_AgentWithoutValidatorNotBlocked(t *testing.T) {
 
 	s := &Session{AgentSessionID: "any-id"}
 
-	e.getOrCreateInteractiveStateWith(key, p, "ctx", s, e.sessions, nil, "")
+	e.getOrCreateInteractiveStateWith(key, p, "ctx", s, e.sessions, nil, "", "")
 
 	if startedWith != "any-id" {
 		t.Errorf("StartSession called with %q, want %q (no validator = pass through)", startedWith, "any-id")

--- a/core/timer.go
+++ b/core/timer.go
@@ -27,6 +27,7 @@ type TimerJob struct {
 	Mute        bool      `json:"mute,omitempty"`         // suppress ALL messages (start + result)
 	SessionMode string    `json:"session_mode,omitempty"` // "" or "reuse" = share active session; "new_per_run" = fresh session each run
 	Mode        string    `json:"mode,omitempty"`         // permission mode override; "" = use project default
+	Model       string    `json:"model,omitempty"`        // model override for this job's turn; "" = agent's configured model
 	TimeoutMins *int      `json:"timeout_mins,omitempty"` // nil = default 30m; 0 = no limit; >0 = minutes
 	CreatedAt   time.Time `json:"created_at"`
 	Fired       bool      `json:"fired"`


### PR DESCRIPTION
## What

Adds an optional per-job **model override** to cron and timer jobs. A job can run its turns on a different model than the agent's configured default, without mutating that default — so concurrent sessions of the same project are unaffected.

```bash
cc-connect cron  add  --cron "*/15 * * * *" --prompt "..." --model haiku
cc-connect cron  edit <id> model sonnet
cc-connect timer add  --delay 30m --prompt "..." --model haiku
```

## Why

A recurring cron sweep (polling, triage, mechanical bookkeeping) often doesn't need the same high-end model the interactive session uses. Today the model is fixed per-project (`projects.agent.options.model`), so the only way to make a cheap background job use a cheaper model is to downgrade the whole project — which also downgrades the user's interactive turns. This lets a frequent, mechanical job run on a smaller/cheaper model while interactive summons keep the configured one.

## How

- `model` field added to `CronJob` / `TimerJob` (JSON `omitempty`, so existing job stores are untouched) and to the `/cron/add`, `/cron/edit`, `/timer/add` API payloads + CLI flags.
- New optional interface `core.ModelOverrideStarter` with `StartSessionWithModel(ctx, sessionID, model)`. The engine calls it at spawn time **only** when the job carries a model; agents that don't implement it fall back to their normal `StartSession` (a warning is logged), so this is fully backward compatible.
- `claudecode` implements it by refactoring `StartSession` into a shared `startSession(ctx, sessionID, modelOverride)` — the override replaces the `--model` value for that one spawn and never touches `a.model`.
- The override is spawn-time only: `Message.ModelOverride` carries it from the cron/timer executor into `getOrCreateInteractiveStateWith`, applied as a one-off `startSession` closure.

## Tests

- `core/cron_model_test.go`: `updateJobField("model", …)` accept/reject + JSON round-trip (omitempty when empty).
- Existing engine/session tests updated for the new spawn signature; `go build ./...` and the core/cmd/agent test suites pass.
