### PR TITLE
fix(feishu): don't reply to unauthorized users for messages overheard via group_reply_all

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1352,7 +1352,14 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 
 	if !core.AllowList(p.allowFrom, userID) {
 		slog.Debug(p.tag()+": message from unauthorized user", "user", userID)
-		p.replyUnauthorizedAccess(ctx, replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey})
+		// Announce the rejection only when the sender deliberately addressed
+		// the bot (p2p chat or explicit @mention). Group messages merely
+		// overheard via group_reply_all are dropped silently — replying to
+		// every unauthorized group member would flood the chat, and the
+		// unauthorized-chat branch below is silent for the same reason.
+		if chatType != "group" || isBotMentioned(msg.Mentions, p.getBotOpenID()) {
+			p.replyUnauthorizedAccess(ctx, replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey})
+		}
 		return nil
 	}
 

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -397,6 +397,94 @@ func TestOnMessageRepliesToUnauthorizedMention(t *testing.T) {
 	}
 }
 
+func TestOnMessageDropsUnauthorizedOverheardGroupMessage(t *testing.T) {
+	const appID = "cli_unauthorized_silent"
+	const appSecret = "secret-unauthorized-silent"
+	const botOpenID = "ou_bot"
+	const userOpenID = "ou_blocked"
+
+	replyBodies := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/reply"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read reply body: %v", err)
+			}
+			replyBodies <- string(body)
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{"message_id": "om_reply_ok"},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:  "feishu",
+		domain:        srv.URL,
+		appID:         appID,
+		appSecret:     appSecret,
+		allowFrom:     "ou_allowed",
+		botOpenID:     botOpenID,
+		groupReplyAll: true,
+		dedup:         &core.MessageDedup{},
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(core.Platform, *core.Message) {
+			t.Fatal("handler should not run for unauthorized sender")
+		},
+	}
+
+	// A group message with no @bot mention: the platform only sees it because
+	// group_reply_all is enabled. Unauthorized senders must be dropped
+	// silently here — replying would announce the rejection for every single
+	// message in the chat.
+	chatType := "group"
+	msgType := "text"
+	senderType := "user"
+	content := `{"text":"hello"}`
+	createTime := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	err := p.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: stringPtr(userOpenID)},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   stringPtr("om_unauthorized_silent"),
+				ChatId:      stringPtr("oc_group"),
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     &content,
+				CreateTime:  &createTime,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onMessage() error = %v", err)
+	}
+
+	select {
+	case got := <-replyBodies:
+		t.Fatalf("unexpected reply to overheard unauthorized message: %q", got)
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
 func TestIsMessageRecalledDetectsWithdrawnMessageFromGetAPI(t *testing.T) {
 	const appID = "cli_recall_probe"
 	const appSecret = "secret-recall-probe"


### PR DESCRIPTION
## Problem

When `group_reply_all = true` (or `require_mention = false`), the bot receives **every** message in a group. If a sender is not in `allow_from`, the platform currently replies with the canned unauthorized-access message (`core.UnauthorizedAccessMessage`) — for **every message that user sends**. In an active group this floods the chat with "角色未授权，请联系管理员添加权限。" replies to people who never addressed the bot at all.

## Fix

In `platform/feishu`, only announce the rejection when the sender deliberately addressed the bot:

- p2p chat → still replies (unchanged)
- group message with an explicit @bot mention → still replies (unchanged, covered by the existing `TestOnMessageRepliesToUnauthorizedMention`)
- group message merely overheard via `group_reply_all` (no @bot mention) → dropped silently

This matches the existing behavior of the unauthorized-**chat** branch right below, which already drops silently, and the bot-menu handler, which also drops unauthorized events without replying.

Bots without `group_reply_all` are unaffected: group messages only reach the `allow_from` check after passing the mention gate.

## Tests

Added `TestOnMessageDropsUnauthorizedOverheardGroupMessage` as a companion to the existing `TestOnMessageRepliesToUnauthorizedMention`. `go test ./platform/feishu/` passes.

The same unconditional reply exists in the dingtalk and wecom-ws paths; happy to follow up there if you want the same semantics, but this PR keeps the change scoped to feishu where `group_reply_all` makes the flooding acute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)