### PR TITLE
fix(cron): resync wall clock after system sleep

### DIFF
--- a/core/cron.go
+++ b/core/cron.go
@@ -420,10 +420,23 @@ type CronScheduler struct {
 	defaultSessionMode string                  // global default session mode; "" = reuse, "new_per_run" = fresh session each run
 }
 
+// cronWallClockResyncInterval bounds how long robfig/cron can wait on one
+// monotonic timer. On macOS the monotonic clock stops while the machine is
+// asleep, so a timer created for a weekday job before a long sleep can drift by
+// the full sleep duration. This internal entry wakes the scheduler regularly;
+// the scheduler then compares every job's Next value with the current wall
+// clock and runs an overdue job at most once.
+const cronWallClockResyncInterval = time.Minute
+
 func NewCronScheduler(store *CronStore) *CronScheduler {
+	c := cron.New()
+	// Keep this entry internal: it must not be persisted or exposed in the job
+	// ID map. Its empty callback only bounds the scheduler's timer duration.
+	c.Schedule(cron.Every(cronWallClockResyncInterval), cron.FuncJob(func() {}))
+
 	return &CronScheduler{
 		store:   store,
-		cron:    cron.New(),
+		cron:    c,
 		engines: make(map[string]*Engine),
 		entries: make(map[string]cron.EntryID),
 	}
@@ -470,6 +483,7 @@ func (cs *CronScheduler) Start() error {
 		}
 	}
 	cs.cron.Start()
+	slog.Info("cron: wall-clock resync enabled", "interval", cronWallClockResyncInterval)
 	slog.Info("cron: scheduler started", "jobs", len(jobs))
 	return nil
 }

--- a/core/cron_test.go
+++ b/core/cron_test.go
@@ -63,6 +63,35 @@ func TestCronStore_MuteToggle(t *testing.T) {
 	}
 }
 
+func TestCronScheduler_WallClockResyncBoundsWait(t *testing.T) {
+	store, err := NewCronStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scheduler := NewCronScheduler(store)
+	if err := scheduler.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(scheduler.Stop)
+
+	entries := scheduler.cron.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("internal cron entries = %d, want 1 wall-clock resync entry", len(entries))
+	}
+	if len(scheduler.entries) != 0 {
+		t.Fatalf("persisted entry map contains %d internal entries, want 0", len(scheduler.entries))
+	}
+
+	next := entries[0].Next
+	if next.IsZero() {
+		t.Fatal("wall-clock resync entry has zero next run")
+	}
+	if max := time.Now().Add(cronWallClockResyncInterval + time.Second); next.After(max) {
+		t.Fatalf("wall-clock resync next run = %v, want no later than %v", next, max)
+	}
+}
+
 func TestCronStore_MutePersistence(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewCronStore(dir)


### PR DESCRIPTION
## Summary

- add an internal one-minute cron entry that bounds the scheduler's timer wait
- force periodic wall-clock re-evaluation after system sleep or hibernation
- keep the resync entry out of persisted jobs and the public job ID map
- add a regression test that fails before the fix and verifies the bounded wait

## Root cause

`robfig/cron` waits for the next entry with a Go timer. On macOS, the monotonic
clock backing that timer does not advance while the machine sleeps. A timer
created before a long sleep therefore retains its pre-sleep duration after
wake, even though the wall clock has moved past one or more scheduled jobs.
Adding or editing a job wakes the scheduler and explains why overdue jobs run
immediately after manual interaction.

The internal one-minute entry limits any single timer wait to one active minute.
After wake, the scheduler rechecks current wall time and runs an overdue entry at
most once, using the existing `robfig/cron` behavior.

This does not wake a sleeping machine. It ensures missed jobs are reconsidered
within at most one active minute after resume.

## Validation

- `go test ./core -run '^TestCronScheduler_WallClockResyncBoundsWait$' -count=20`
- `go test ./core -run Cron -count=1`
- `go build ./...`
- `go vet ./...`
- macOS end-to-end run: scheduled for `21:22`, started at `21:22:00.008`, and
  completed at `21:25:21.530` with no job error

`go test ./...` also exposed existing asynchronous test flakes unrelated to
cron. `TestCUJ_A5_FileReachesAgent` reproduces on an unmodified `origin/main`
worktree with temporary-directory cleanup racing background session writes.

Fixes #1309
