### PR TITLE
fix(codex): surface gpt-5.x in /model chooser (drop stale allowlist) (#1546) [cherry-pick to release/v1.5.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See `changelogs/v1.5.0-beta.1.md` for the full themed summary with credits.
 - **core**: always emit absolute paths from `SaveFilesToDisk` / `AppendFileRefs` — fixes relative `work_dir` attachments silently dropped by agent (#1462 fixing #1459, @chenhg5).
 - **core**: create queue placeholder before session lock — prevents concurrent message queue miss (#1389, @xxb).
 - **codex**: time out blocked app-server writes (#1448, @AaronZ345).
+- **codex**: `/model` chooser now surfaces `gpt-5.x` (and any future frontier chat model) when the model list is populated by fetching `GET /v1/models` from the provider. The previous hard-coded 11-entry allowlist (last updated 2026-03) silently filtered out every `gpt-5*` variant (including `gpt-5.6-sol/terra/luna`) returned by the API, so users on `codex-cli >= 0.143` could not pick GPT-5.6 in cc-connect. Replaced with pattern rules that accept `gpt-*` / `chatgpt-*` / `codex-*` / `o1-*` / `o3-*` / `o4-*` / `o5-*` families and reject non-chat modalities (embedding / whisper / tts / dall-e / audio-preview / realtime / transcribe / moderation / image / search-preview). Only affects the API-fetch fallback path; users with an explicit `model_catalog_json` or provider `models = [...]` config were unaffected (#1546, @qa-cursor).
 - **slack**: suppress `NO_REPLY` marker on streaming-card silent replies (#1397, @spinsirr).
 
 ## v1.4.1 (2026-06-28)

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -232,11 +232,53 @@ func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
 	}
 }
 
-var openaiChatModels = map[string]bool{
-	"o4-mini": true, "o3": true, "o3-mini": true, "o1": true, "o1-mini": true,
-	"gpt-4.1": true, "gpt-4.1-mini": true, "gpt-4.1-nano": true,
-	"gpt-4o": true, "gpt-4o-mini": true,
-	"codex-mini-latest": true,
+// nonChatSubstrings identifies non chat/completion modalities returned by
+// GET /v1/models that must not appear in the codex /model chooser.
+var nonChatSubstrings = []string{
+	"embedding", "whisper", "tts", "moderation", "dall-e",
+	"realtime", "transcribe", "search-preview", "image",
+	"audio-preview",
+}
+
+// isCodexChatModel reports whether an OpenAI-compatible model ID names a
+// chat/completion model that Codex CLI can drive. Used to filter the
+// /v1/models response into the /model command suggestion list.
+//
+// Rules (case-insensitive):
+//   - Reject any ID containing a non-chat modality substring (embedding,
+//     whisper, tts, dall-e, audio-preview, realtime, transcribe, moderation,
+//     image, search-preview).
+//   - Accept known chat family prefixes: gpt-*, chatgpt-*, codex-*, o1-*,
+//     o3-*, o4-*, o5-*.
+//   - Accept bare reasoning family IDs: o1 / o3 / o4 / o5.
+//
+// Uses pattern matching rather than a static allowlist so new frontier models
+// (gpt-5.x, gpt-6, o5-*, codex-*, etc.) are picked up automatically.
+func isCodexChatModel(id string) bool {
+	if id == "" {
+		return false
+	}
+	lower := strings.ToLower(id)
+	for _, s := range nonChatSubstrings {
+		if strings.Contains(lower, s) {
+			return false
+		}
+	}
+	switch {
+	case strings.HasPrefix(lower, "gpt-"),
+		strings.HasPrefix(lower, "chatgpt-"),
+		strings.HasPrefix(lower, "codex-"),
+		strings.HasPrefix(lower, "o1-"),
+		strings.HasPrefix(lower, "o3-"),
+		strings.HasPrefix(lower, "o4-"),
+		strings.HasPrefix(lower, "o5-"):
+		return true
+	}
+	switch lower {
+	case "o1", "o3", "o4", "o5":
+		return true
+	}
+	return false
 }
 
 func (a *Agent) fetchModelsFromAPI(ctx context.Context) []core.ModelOption {
@@ -290,7 +332,7 @@ func (a *Agent) fetchModelsFromAPI(ctx context.Context) []core.ModelOption {
 
 	var models []core.ModelOption
 	for _, m := range result.Data {
-		if openaiChatModels[m.ID] {
+		if isCodexChatModel(m.ID) {
 			models = append(models, core.ModelOption{Name: m.ID})
 		}
 	}

--- a/agent/codex/codex_model_test.go
+++ b/agent/codex/codex_model_test.go
@@ -81,3 +81,77 @@ func TestWorkspaceAgentOptions_PreservesStdIOAppServerURL(t *testing.T) {
 		t.Fatalf("WorkspaceAgentOptions()[app_server_url] = %#v, want stdio://", got)
 	}
 }
+
+func TestIsCodexChatModel(t *testing.T) {
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"", false},
+
+		// Legacy / current chat families (must keep working).
+		{"gpt-4o", true},
+		{"gpt-4o-mini", true},
+		{"gpt-4.1", true},
+		{"gpt-4.1-mini", true},
+		{"gpt-4.1-nano", true},
+		{"gpt-3.5-turbo", true},
+		{"chatgpt-4o-latest", true},
+		{"o1", true},
+		{"o1-mini", true},
+		{"o1-preview", true},
+		{"o3", true},
+		{"o3-mini", true},
+		{"o4", true},
+		{"o4-mini", true},
+		{"codex-mini-latest", true},
+
+		// GPT-5 series — the regression that motivated this change.
+		{"gpt-5", true},
+		{"gpt-5-mini", true},
+		{"gpt-5.3", true},
+		{"gpt-5.3-codex", true},
+		{"gpt-5.4", true},
+		{"gpt-5.5", true},
+		{"gpt-5.6", true},
+		{"gpt-5.6-sol", true},
+		{"gpt-5.6-terra", true},
+		{"gpt-5.6-luna", true},
+
+		// Case insensitivity (defensive; ids from /v1/models are usually lower).
+		{"GPT-5.6", true},
+		{"Codex-Mini-Latest", true},
+
+		// Non-chat modalities that /v1/models returns — must be rejected so
+		// they never show up in the /model chooser.
+		{"text-embedding-ada-002", false},
+		{"text-embedding-3-small", false},
+		{"text-embedding-3-large", false},
+		{"whisper-1", false},
+		{"tts-1", false},
+		{"tts-1-hd", false},
+		{"gpt-4o-realtime-preview", false},
+		{"gpt-4o-audio-preview", false},
+		{"gpt-4o-transcribe", false},
+		{"gpt-4o-search-preview", false},
+		{"dall-e-2", false},
+		{"dall-e-3", false},
+		{"gpt-image-1", false},
+		{"text-moderation-latest", false},
+		{"omni-moderation-latest", false},
+
+		// Unrelated model families that should not be surfaced.
+		{"babbage-002", false},
+		{"davinci-002", false},
+		{"claude-3-5-sonnet", false},
+		{"gemini-1.5-pro", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.id, func(t *testing.T) {
+			if got := isCodexChatModel(tc.id); got != tc.want {
+				t.Fatalf("isCodexChatModel(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #1546 to \`release/v1.5.0\`.

Original PR: #1546 (merged 2026-07-14 to \`main\` as commit \`52dfe8b7\`).

## Conflict resolution

\`CHANGELOG.md\` — merged mechanically:
- Kept HEAD's v1.5.0-beta.1 \`### Fixed\` section (already curated for the beta)
- Appended a compressed one-paragraph codex entry citing #1546 in the same \`Fixed\` list (positioned next to the existing \`codex\` line for readability)
- Dropped the verbose \`Unreleased\` copy of the entry (the verbose version lives on \`main\`; the compressed one belongs in the released v1.5.0 CHANGELOG)

Code files (\`agent/codex/codex.go\`, \`agent/codex/codex_model_test.go\`) applied cleanly with zero conflicts.

## Verification

\`\`\`
$ go build ./agent/codex/...      # green
$ go test ./agent/codex/ -run '^TestIsCodexChatModel$'  # 45/45 pass
$ go test ./agent/codex/ -count=1                       # green
\`\`\`

## Motivation

External user (Shawn / WeChat) reported: "5.6 的模型选不到，已经更新几次 cli 到 144 版本". The fix restores GPT-5.6 in the \`/model\` chooser for users who rely on the \`fetchModelsFromAPI\` fallback path (i.e. do not configure \`model_catalog_json\` or provider \`models = [...]\`).

Ships as part of the v1.5.0 stable release.

Made with [Cursor](https://cursor.com)