### PR TITLE
fix(claudecode): prefer ai-title/custom-title in session list summaries

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -632,27 +632,48 @@ func scanSessionMeta(path string) (string, int) {
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 256*1024), 256*1024)
 
-	var summary string
+	var firstUserMessage string
+	var aiTitle string
+	var customTitle string
 	var count int
 
 	for scanner.Scan() {
 		var entry struct {
-			Type    string `json:"type"`
-			Message struct {
+			Type        string `json:"type"`
+			AITitle     string `json:"aiTitle"`
+			CustomTitle string `json:"customTitle"`
+			Message     struct {
 				Content json.RawMessage `json:"content"`
 			} `json:"message"`
 		}
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
 			continue
 		}
-		if entry.Type == "user" || entry.Type == "assistant" {
+		switch entry.Type {
+		case "ai-title":
+			if entry.AITitle != "" {
+				aiTitle = entry.AITitle
+			}
+		case "custom-title":
+			if entry.CustomTitle != "" {
+				customTitle = entry.CustomTitle
+			}
+		case "user", "assistant":
 			count++
-			if entry.Type == "user" {
+			if entry.Type == "user" && firstUserMessage == "" {
 				if s := extractStringContent(entry.Message.Content); s != "" {
-					summary = s
+					firstUserMessage = s
 				}
 			}
 		}
+	}
+
+	summary := customTitle
+	if summary == "" {
+		summary = aiTitle
+	}
+	if summary == "" {
+		summary = firstUserMessage
 	}
 	summary = stripXMLTags(summary)
 	summary = strings.TrimSpace(summary)

--- a/agent/claudecode/claudecode_test.go
+++ b/agent/claudecode/claudecode_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -708,9 +709,52 @@ func TestScanSessionMeta_ArrayContent(t *testing.T) {
 		t.Errorf("scanSessionMeta count = %d, want 4 (2 user + 2 assistant, array content should not be skipped)", count)
 	}
 
-	// Summary should come from the last user message with string content (line 2)
+	// Summary should come from the first user message with string content (line 2)
 	if summary != "Hello world" {
 		t.Errorf("scanSessionMeta summary = %q, want %q", summary, "Hello world")
+	}
+}
+
+func TestScanSessionMeta_AITitleAndCustomTitle(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.jsonl")
+
+	lines := []string{
+		`{"type": "user", "message": {"content": "[cc-connect sender_id=abc] first prompt"}}`,
+		`{"type": "assistant", "message": {"content": "reply"}}`,
+		`{"type": "ai-title", "sessionId": "sess-1", "aiTitle": "查看cc-connect开机自启功能"}`,
+	}
+	data := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatalf("write test jsonl: %v", err)
+	}
+
+	summary, count := scanSessionMeta(path)
+	if count != 2 {
+		t.Errorf("scanSessionMeta count = %d, want 2", count)
+	}
+	if summary != "查看cc-connect开机自启功能" {
+		t.Errorf("scanSessionMeta summary = %q, want ai-title", summary)
+	}
+}
+
+func TestScanSessionMeta_CustomTitleOverridesAITitle(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.jsonl")
+
+	lines := []string{
+		`{"type": "user", "message": {"content": "ignored fallback"}}`,
+		`{"type": "ai-title", "sessionId": "sess-1", "aiTitle": "AI generated title"}`,
+		`{"type": "custom-title", "sessionId": "sess-1", "customTitle": "User renamed title"}`,
+	}
+	data := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatalf("write test jsonl: %v", err)
+	}
+
+	summary, _ := scanSessionMeta(path)
+	if summary != "User renamed title" {
+		t.Errorf("scanSessionMeta summary = %q, want custom-title", summary)
 	}
 }
 


### PR DESCRIPTION
## Summary

Update Claude Code session list summaries to read `custom-title` and `ai-title` entries from JSONL transcripts before falling back to the first user message.

## Motivation

When cc-connect tears down a Claude Code agent process, the Stop hook often does not run, so `ai-title` is never promoted to `custom-title`. `/list` then shows the first user message — typically a `[cc-connect sender_id=...]` metadata string — instead of the AI-generated title.

Fixes #1548

## Changes

- `scanSessionMeta` now resolves titles with priority: `custom-title` > `ai-title` > first user message
- Added regression tests for ai-title fallback and custom-title precedence

## Tests

```
go test ./agent/claudecode/... -count=1 -run TestScanSessionMeta
go test ./agent/claudecode/... -count=1
```

All tests pass.

## Notes

This is a read-side fix for `/list` display. Writing `custom-title` on graceful shutdown would also help Claude Desktop and CLI `--resume`, but is out of scope for this minimal change.
