### PR TITLE
fix(feishu): preserve p2p card action routing

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -147,6 +147,7 @@ type Platform struct {
 	userNameCache    sync.Map          // open_id -> display name
 	chatNameCache    sync.Map          // chat_id -> chat name
 	chatMemberCache  sync.Map          // chatID -> *chatMemberEntry
+	chatTypeCache    sync.Map          // accepted chatID -> p2p or group
 	recalledMu       sync.Mutex
 	recalledMsgIDs   map[string]time.Time // message_id -> recall time, short TTL race guard
 	// Webhook mode fields (for Lark international version)
@@ -662,11 +663,16 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		return nil, nil
 	}
 
-	// Check allow_chat filter: skip card actions from chats this platform doesn't own.
-	if event.Event.Context != nil && event.Event.Context.OpenChatID != "" {
-		if !core.AllowList(p.allowChat, event.Event.Context.OpenChatID) {
-			return nil, nil
-		}
+	userID := ""
+	if event.Event.Operator != nil {
+		userID = event.Event.Operator.OpenID
+	}
+	chatID := ""
+	if event.Event.Context != nil {
+		chatID = event.Event.Context.OpenChatID
+	}
+	if !p.cardActionAllowed(chatID, userID) {
+		return nil, nil
 	}
 
 	actionVal, _ := event.Event.Action.Value["action"].(string)
@@ -690,14 +696,8 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		}
 	}
 
-	userID := ""
-	if event.Event.Operator != nil {
-		userID = event.Event.Operator.OpenID
-	}
-	chatID := ""
 	messageID := ""
 	if event.Event.Context != nil {
-		chatID = event.Event.Context.OpenChatID
 		messageID = event.Event.Context.OpenMessageID
 	}
 	if chatID == "" {
@@ -890,6 +890,37 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 	}
 
 	return nil, nil
+}
+
+func (p *Platform) rememberAcceptedChatType(chatID, chatType string) {
+	if chatID == "" {
+		return
+	}
+	switch chatType {
+	case "p2p", "group":
+		p.chatTypeCache.Store(chatID, chatType)
+	}
+}
+
+func (p *Platform) cardActionAllowed(chatID, userID string) bool {
+	if !core.AllowList(p.allowFrom, userID) {
+		return false
+	}
+	if chatID == "" {
+		return !p.groupOnly
+	}
+	if cachedType, ok := p.chatTypeCache.Load(chatID); ok {
+		switch cachedType {
+		case "p2p":
+			return !p.groupOnly
+		case "group":
+			return core.AllowList(p.allowChat, chatID)
+		}
+	}
+	if p.groupOnly {
+		return false
+	}
+	return core.AllowList(p.allowChat, chatID)
 }
 
 func (p *Platform) addReaction(messageID string) string {
@@ -1364,6 +1395,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 		slog.Debug(p.tag()+": p2p message skipped (group_only=true)", "chat_type", chatType)
 		return nil
 	}
+	p.rememberAcceptedChatType(chatID, chatType)
 
 	if msg.Content == nil && msgType != "merge_forward" {
 		slog.Debug(p.tag()+": message content is nil", "message_id", messageID, "type", msgType)

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -2188,6 +2188,268 @@ func TestOnMessage_GracePeriodMessageIsProcessed(t *testing.T) {
 	}
 }
 
+func TestCardAction_PrivateChatBypassesGroupAllowChatAfterAcceptedMessage(t *testing.T) {
+	platformAny, err := New(map[string]any{
+		"app_id":             "cli_xxx",
+		"app_secret":         "secret",
+		"enable_feishu_card": true,
+		"allow_from":         "ou_allowed",
+		"allow_chat":         "oc_allowed_group",
+		"group_reply_all":    true,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip := platformAny.(*interactivePlatform)
+
+	msgCh := make(chan *core.Message, 2)
+	ip.handler = func(_ core.Platform, msg *core.Message) { msgCh <- msg }
+
+	messageID := "om_private_seed"
+	chatID := "oc_private"
+	openID := "ou_allowed"
+	msgType := "text"
+	chatType := "p2p"
+	senderType := "user"
+	content := `{"text":"seed"}`
+	createTime := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	ip.userNameCache.Store(openID, "Allowed User")
+	ip.chatNameCache.Store(chatID, "Private Chat")
+
+	if err := ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   &messageID,
+				ChatId:      &chatID,
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     &content,
+				CreateTime:  &createTime,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("onMessage() error = %v", err)
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "seed" {
+			t.Fatalf("seed content = %q, want seed", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected accepted private message to be dispatched")
+	}
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: openID},
+			Action: &callback.CallBackAction{Value: map[string]any{
+				"action":      "cmd:/verify-private",
+				"after_click": map[string]any{"title": "Done"},
+			}},
+			Context: &callback.Context{OpenChatID: chatID, OpenMessageID: "om_private_card"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp == nil || resp.Card == nil {
+		t.Fatalf("expected private card replacement response, got %#v", resp)
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "/verify-private" {
+			t.Fatalf("card action content = %q, want /verify-private", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected private card command to be dispatched")
+	}
+}
+
+func TestCardAction_AccessChecksRemainFailClosed(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowFrom string
+		allowChat string
+		groupOnly bool
+		operator  string
+		chatID    string
+		wantPass  bool
+	}{
+		{
+			name:      "allowed group chat remains routable",
+			allowFrom: "ou_allowed",
+			allowChat: "oc_allowed_group",
+			operator:  "ou_allowed",
+			chatID:    "oc_allowed_group",
+			wantPass:  true,
+		},
+		{
+			name:      "unknown chat outside group allowlist is blocked",
+			allowFrom: "ou_allowed",
+			allowChat: "oc_allowed_group",
+			operator:  "ou_allowed",
+			chatID:    "oc_unknown",
+		},
+		{
+			name:      "unauthorized operator is blocked",
+			allowFrom: "ou_allowed",
+			allowChat: "*",
+			operator:  "ou_denied",
+			chatID:    "oc_allowed_group",
+		},
+		{
+			name:      "group only blocks unclassified callback",
+			allowFrom: "ou_allowed",
+			allowChat: "*",
+			groupOnly: true,
+			operator:  "ou_allowed",
+			chatID:    "oc_unclassified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			platformAny, err := New(map[string]any{
+				"app_id":             "cli_xxx",
+				"app_secret":         "secret",
+				"enable_feishu_card": true,
+				"allow_from":         tt.allowFrom,
+				"allow_chat":         tt.allowChat,
+				"group_only":         tt.groupOnly,
+			})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			ip := platformAny.(*interactivePlatform)
+			ip.userNameCache.Store(tt.operator, "Test Operator")
+			ip.chatNameCache.Store(tt.chatID, "Test Chat")
+
+			msgCh := make(chan *core.Message, 1)
+			ip.handler = func(_ core.Platform, msg *core.Message) { msgCh <- msg }
+
+			resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+				Event: &callback.CardActionTriggerRequest{
+					Operator: &callback.Operator{OpenID: tt.operator},
+					Action: &callback.CallBackAction{Value: map[string]any{
+						"action":      "cmd:/access-check",
+						"after_click": map[string]any{"title": "Done"},
+					}},
+					Context: &callback.Context{OpenChatID: tt.chatID, OpenMessageID: "om_access_card"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("onCardAction() error = %v", err)
+			}
+
+			if tt.wantPass {
+				if resp == nil || resp.Card == nil {
+					t.Fatalf("expected allowed card response, got %#v", resp)
+				}
+				select {
+				case <-msgCh:
+				case <-time.After(2 * time.Second):
+					t.Fatal("expected allowed card command to be dispatched")
+				}
+				return
+			}
+
+			if resp != nil {
+				t.Errorf("blocked card response = %#v, want nil", resp)
+			}
+			select {
+			case msg := <-msgCh:
+				t.Errorf("blocked card command was dispatched: %q", msg.Content)
+			case <-time.After(100 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestCardAction_GroupOnlyAllowsAcceptedGroup(t *testing.T) {
+	platformAny, err := New(map[string]any{
+		"app_id":             "cli_xxx",
+		"app_secret":         "secret",
+		"enable_feishu_card": true,
+		"allow_from":         "ou_allowed",
+		"allow_chat":         "oc_allowed_group",
+		"group_only":         true,
+		"group_reply_all":    true,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip := platformAny.(*interactivePlatform)
+	ip.userNameCache.Store("ou_allowed", "Allowed User")
+	ip.chatNameCache.Store("oc_allowed_group", "Allowed Group")
+
+	msgCh := make(chan *core.Message, 2)
+	ip.handler = func(_ core.Platform, msg *core.Message) { msgCh <- msg }
+
+	messageID := "om_group_seed"
+	chatID := "oc_allowed_group"
+	openID := "ou_allowed"
+	msgType := "text"
+	chatType := "group"
+	senderType := "user"
+	content := `{"text":"seed"}`
+	createTime := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	if err := ip.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: &openID},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   &messageID,
+				ChatId:      &chatID,
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     &content,
+				CreateTime:  &createTime,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("onMessage() error = %v", err)
+	}
+
+	select {
+	case <-msgCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected accepted group message to be dispatched")
+	}
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: openID},
+			Action: &callback.CallBackAction{Value: map[string]any{
+				"action":      "cmd:/group-action",
+				"after_click": map[string]any{"title": "Done"},
+			}},
+			Context: &callback.Context{OpenChatID: chatID, OpenMessageID: "om_group_card"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp == nil || resp.Card == nil {
+		t.Fatalf("expected accepted group card response, got %#v", resp)
+	}
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "/group-action" {
+			t.Fatalf("card action content = %q, want /group-action", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected accepted group card command to be dispatched")
+	}
+}
+
 func TestCmdAction_WithoutAfterClick_DispatchesAndReturnsNil(t *testing.T) {
 	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
 	if err != nil {


### PR DESCRIPTION
## Summary

- remember each accepted Feishu chat type per platform instance
- let known P2P card callbacks bypass the group-only `allow_chat` filter
- keep group callbacks allowlisted, apply `allow_from` to card operators, and reject unknown callback types under `group_only`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

### Automated tests added in this PR

- `TestCardAction_PrivateChatBypassesGroupAllowChatAfterAcceptedMessage` in `platform/feishu/platform_test.go` — an accepted P2P message seeds the chat type and the subsequent card callback is dispatched even when the group allowlist excludes that chat ID
- `TestCardAction_AccessChecksRemainFailClosed` — allowed groups remain routable while unknown chats, unauthorized operators, and unknown `group_only` callbacks are rejected
- `TestCardAction_GroupOnlyAllowsAcceptedGroup` — an accepted group message seeds the type and preserves group callback routing

### For bug fixes only — regression test

- Regression test name: `TestCardAction_PrivateChatBypassesGroupAllowChatAfterAcceptedMessage`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle
- [ ] C — agent execution control
- [x] D — security & permissions
- [ ] E — scheduled tasks
- [ ] F — config switching
- [x] G — error handling & robustness
- [x] H — multi-platform / multi-project isolation
- [x] I — UI rendering correctness

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

With a restricted group allowlist, a private-chat card click is no longer silently dropped after that platform instance has accepted a normal P2P message. Known groups still require `allow_chat`, and unauthorized operators remain blocked.

The cache is process-local. After a restart, an older P2P card stays fail closed until an accepted ordinary P2P message repopulates the cache. Under `group_only`, unclassified callbacks are rejected until an accepted group message establishes the chat type.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes for the Linux target used by CI
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (no new user-facing strings)
- [x] No secrets / credentials in source

Focused verification completed:

- `go test ./platform/feishu -count=1`
- `go vet ./platform/feishu`
- `go test ./platform/feishu -run 'TestCardAction' -count=20`
- `GOOS=linux GOARCH=amd64 go vet ./...`
- `GOOS=linux GOARCH=amd64 go build ./...`
- web assets built with the CI pnpm major before repository-wide compilation

Repository-wide `go test ./...` was also attempted on Windows. The unchanged upstream baseline fails there on existing Unix-specific assumptions such as `sh`/`true`, POSIX path expectations, and POSIX file modes; the modified Feishu package passes in full. This draft PR leaves the Ubuntu CI run as the authoritative full-suite result.

## Related

The group-chat allowlist introduced in #613 checks `allow_chat` only for ordinary group messages. Card callbacks do not include `chat_type`, so the old callback path checked every non-empty `OpenChatID` against the group allowlist and silently dropped private-chat actions before command dispatch or an `after_click` replacement response.
