### PR TITLE
feat(agent): add first-class Grok Build (xAI) adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ go build -tags 'no_discord no_dingtalk no_qq no_qqbot no_line' ./cmd/cc-connect
 ```
 
 Available tags: `no_acp`, `no_claudecode`, `no_codex`, `no_copilot`, `no_cursor`, `no_gemini`,
-`no_iflow`, `no_opencode`, `no_qoder`, `no_feishu`, `no_telegram`,
+`no_grok`, `no_iflow`, `no_opencode`, `no_qoder`, `no_feishu`, `no_telegram`,
 `no_discord`, `no_slack`, `no_dingtalk`, `no_wecom`, `no_weixin`, `no_qq`, `no_qqbot`,
 `no_line`, `no_weibo`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- **Grok Build agent** (`type = "grok"`): first-class adapter for xAI's Grok Build CLI. Headless mode via `-p` / `--prompt-file` with `--output-format streaming-json`, session resume (`--resume`), permission modes (`default` / `accept_edits` / `yolo` / `plan` / `dont_ask`), model probing via `grok models`, and coalesced thought/text token streams so IM platforms are not spammed with per-token thinking bubbles. See `config.example.toml` and install Grok Build from https://x.ai/cli.
 - **`agent_session_idle_timeout_mins`**: new per-project config option that closes an idle live agent process after a clean turn while preserving the cc-connect session and saved agent session ID. The next message starts a new agent process and resumes the same conversation. Set to `0` or leave unset to disable (#1338).
 - **Reasonix agent**: new agent adapter for Reasonix multi-model coding agent, bridging via HTTP serve API (POST /submit, SSE /events, POST /approve). Supports default/yolo/plan permission modes, SSE auto-reconnect with backoff, and thinking accumulator. (#1281)
 - **cloud_web platform**: 新增 self-hosted IM Gateway 作为 first-class platform 接入 (CWIP v1 协议,支持 websocket / long_poll / gateway 3 种 transport,完整 inbound/outbound + capability negotiation + graceful degradation)。 详见 docs/cloud-web.md + #1282。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ go build -tags 'no_discord no_dingtalk no_qq no_qqbot no_line' ./cmd/cc-connect
 ```
 
 Available tags: `no_acp`, `no_claudecode`, `no_codex`, `no_cursor`, `no_gemini`,
-`no_iflow`, `no_opencode`, `no_qoder`, `no_feishu`, `no_telegram`,
+`no_grok`, `no_iflow`, `no_opencode`, `no_qoder`, `no_feishu`, `no_telegram`,
 `no_discord`, `no_slack`, `no_dingtalk`, `no_wecom`, `no_weixin`, `no_qq`, `no_qqbot`,
 `no_line`, `no_weibo`, `no_matrix`, `no_webex`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -86,6 +86,10 @@ npm install -g @iflow-ai/iflow-cli
 
 # Qoder CLI
 curl -fsSL https://qoder.com/install | bash
+
+# Grok Build (xAI)
+curl -fsSL https://x.ai/cli/install.sh | bash
+grok login   # or export XAI_API_KEY=...
 ```
 
 For **Cursor Agent** and **OpenCode**, follow their official install docs:
@@ -101,6 +105,7 @@ gemini --version
 iflow --version
 opencode --version
 qodercli --version
+grok version
 ```
 
 ## Step 3: Create config.toml
@@ -143,7 +148,7 @@ level = "info"  # debug, info, warn, error
 name = "my-project"
 
 [projects.agent]
-type = "claudecode"  # or "codex", "cursor", "gemini", "qoder", "opencode", "iflow"
+type = "claudecode"  # or "codex", "cursor", "gemini", "grok", "qoder", "opencode", "iflow", ...
 
 [projects.agent.options]
 work_dir = "/absolute/path/to/your/project"

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,8 @@ PLATFORMS := \
 #   make build EXCLUDE=discord,dingtalk,qq,qqbot,line
 # ---------------------------------------------------------------------------
 
-ALL_AGENTS    := acp antigravity claudecode codex copilot cursor devin gemini iflow kimi opencode pi qoder tmux
-ALL_PLATFORMS := feishu telegram discord slack dingtalk wecom weixin qq qqbot line weibo max matrix webex wps-agentspace
-ALL_AGENTS    := acp antigravity claudecode codex copilot cursor devin gemini iflow kimi opencode pi qoder reasonix tmux
-ALL_PLATFORMS := feishu telegram discord slack dingtalk wecom weixin qq qqbot line weibo max matrix webex cloud_web
+ALL_AGENTS    := acp antigravity claudecode codex copilot cursor devin gemini grok iflow kimi opencode pi qoder reasonix tmux
+ALL_PLATFORMS := feishu telegram discord slack dingtalk wecom weixin qq qqbot line weibo max matrix webex cloud_web wps-agentspace
 ALL_EXTRAS    := web
 
 COMMA := ,

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ High-level view of what each **built-in platform** can do in cc-connect.
 ## ✨ Why cc-connect?
 
 ### 🤖 Universal Agent Support
-**10+ AI Agents** — Claude Code, Codex, Cursor Agent, Kimi CLI, Qoder CLI, Gemini CLI, OpenCode, iFlow CLI, Pi, Devin, Copilot — plus any agent that supports the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents). Use whichever fits your workflow, or all of them at once.
+**10+ AI Agents** — Claude Code, Codex, Cursor Agent, Kimi CLI, Grok Build, Qoder CLI, Gemini CLI, OpenCode, iFlow CLI, Pi, Devin, Copilot — plus any agent that supports the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents). Use whichever fits your workflow, or all of them at once.
 
 ### 📱 Platform Flexibility
 **13 Chat Platforms** — Feishu, WPS Xiezuo, DingTalk, Slack, Telegram, Discord, WeChat Work, Weibo, LINE, QQ, QQ Bot (Official), Matrix, plus **Weixin (personal ilink)** for **personal WeChat**. Most platforms need **zero public IP**.
@@ -371,6 +371,7 @@ cc-connect update --pre     # Include pre-releases
 | Agent | OpenCode (Crush) | ✅ Supported |
 | Agent | iFlow CLI | ✅ Supported |
 | Agent | Kimi CLI (Moonshot) | ✅ Supported |
+| Agent | Grok Build (xAI) | ✅ Supported |
 | Agent | Pi (Cursor Background Agent) | ✅ Supported |
 | Agent | Copilot (GitHub) | ✅ Supported |
 | Agent | ACP (Agent Client Protocol) | ✅ Any [ACP-compatible agent](https://agentclientprotocol.com/get-started/agents) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -236,7 +236,7 @@ cc-connect 已支持 Kimi CLI。立即体验高性价比的 [Kimi Code 订阅](h
 ## ✨ 为什么选择 cc-connect？
 
 ### 🤖 通用 Agent 支持
-**10+ 大 AI Agent** — Claude Code、Codex、Cursor Agent、Kimi CLI、Qoder CLI、Gemini CLI、OpenCode、iFlow CLI、Pi、Devin、Copilot，还可通过 [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents) 接入更多 Agent。按需选用，或同时使用全部。
+**10+ 大 AI Agent** — Claude Code、Codex、Cursor Agent、Kimi CLI、Grok Build、Qoder CLI、Gemini CLI、OpenCode、iFlow CLI、Pi、Devin、Copilot，还可通过 [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/agents) 接入更多 Agent。按需选用，或同时使用全部。
 
 ### 📱 平台灵活性
 **13 大聊天平台** — 飞书、WPS 协作、钉钉、Slack、Telegram、Discord、企业微信、微博、LINE、QQ、QQ 官方机器人、Matrix，以及 **微信个人号（ilink）**。大部分平台**无需公网 IP**。
@@ -369,6 +369,7 @@ cc-connect update --pre     # 含预发布版本
 | Agent | OpenCode (Crush) | ✅ 已支持 |
 | Agent | iFlow CLI | ✅ 已支持 |
 | Agent | Kimi CLI (Moonshot) | ✅ 已支持 |
+| Agent | Grok Build (xAI) | ✅ 已支持 |
 | Agent | Pi (Cursor Background Agent) | ✅ 已支持 |
 | Agent | Copilot (GitHub) | ✅ 已支持 |
 | Agent | ACP (Agent Client Protocol) | ✅ 支持任何 [ACP 兼容 Agent](https://agentclientprotocol.com/get-started/agents) |

--- a/agent/grok/grok.go
+++ b/agent/grok/grok.go
@@ -1,0 +1,608 @@
+package grok
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func init() {
+	core.RegisterAgent("grok", New)
+}
+
+// Agent drives the official Grok Build CLI (https://x.ai/cli) in headless mode:
+//
+//	grok -p <prompt> --output-format streaming-json [--resume <id>] ...
+//
+// Modes map onto Grok's --permission-mode (+ --always-approve for non-plan):
+//   - "default":           permission-mode default + always-approve
+//   - "accept_edits":      permission-mode acceptEdits + always-approve
+//   - "yolo":              permission-mode bypassPermissions + always-approve
+//   - "plan":              permission-mode plan (read-only; no always-approve)
+//   - "dont_ask":          permission-mode dontAsk + always-approve
+type Agent struct {
+	workDir         string
+	model           string
+	mode            string
+	cmd             string
+	cliExtraArgs    []string
+	configEnv       []string
+	timeout         time.Duration
+	reasoningEffort string
+	maxTurns        int
+	providers       []core.ProviderConfig
+	activeIdx       int
+	sessionEnv      []string
+	mu              sync.RWMutex
+}
+
+func New(opts map[string]any) (core.Agent, error) {
+	workDir, _ := opts["work_dir"].(string)
+	if workDir == "" {
+		workDir = "."
+	}
+	model, _ := opts["model"].(string)
+	mode, _ := opts["mode"].(string)
+	mode = normalizeMode(mode)
+	cmd, extraArgs := core.ParseCmdOpts(opts, "grok")
+
+	reasoning, _ := opts["reasoning_effort"].(string)
+	if reasoning == "" {
+		reasoning, _ = opts["effort"].(string)
+	}
+	reasoning = strings.TrimSpace(reasoning)
+
+	maxTurns := intFromOpts(opts, "max_turns", 0)
+	timeoutMins := intFromOpts(opts, "timeout_mins", 0)
+	var timeout time.Duration
+	if timeoutMins > 0 {
+		timeout = time.Duration(timeoutMins) * time.Minute
+	}
+
+	if _, err := exec.LookPath(cmd); err != nil {
+		return nil, fmt.Errorf("grok: %q CLI not found in PATH, install with: curl -fsSL https://x.ai/cli/install.sh | bash", cmd)
+	}
+
+	return &Agent{
+		workDir:         workDir,
+		model:           model,
+		mode:            mode,
+		cmd:             cmd,
+		cliExtraArgs:    extraArgs,
+		configEnv:       core.ParseConfigEnv(opts),
+		timeout:         timeout,
+		reasoningEffort: reasoning,
+		maxTurns:        maxTurns,
+		activeIdx:       -1,
+	}, nil
+}
+
+func intFromOpts(opts map[string]any, key string, def int) int {
+	switch v := opts[key].(type) {
+	case int64:
+		return int(v)
+	case int:
+		return v
+	case float64:
+		return int(v)
+	default:
+		if v != nil {
+			slog.Debug("grok: option has unexpected type", "key", key, "type", fmt.Sprintf("%T", v))
+		}
+		return def
+	}
+}
+
+func normalizeMode(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "yolo", "force", "bypass", "auto", "bypasspermissions":
+		return "yolo"
+	case "plan":
+		return "plan"
+	case "accept_edits", "acceptedits", "auto_edit", "autoedit", "edit":
+		return "accept_edits"
+	case "dont_ask", "dontask", "no_ask":
+		return "dont_ask"
+	default:
+		return "default"
+	}
+}
+
+// permissionModeFlag maps our mode key to Grok's --permission-mode value.
+func permissionModeFlag(mode string) string {
+	switch mode {
+	case "yolo":
+		return "bypassPermissions"
+	case "plan":
+		return "plan"
+	case "accept_edits":
+		return "acceptEdits"
+	case "dont_ask":
+		return "dontAsk"
+	default:
+		return "default"
+	}
+}
+
+func (a *Agent) Name() string           { return "grok" }
+func (a *Agent) CLIBinaryName() string  { return a.cmd }
+func (a *Agent) CLIDisplayName() string { return "Grok Build" }
+
+func (a *Agent) SetWorkDir(dir string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.workDir = dir
+	slog.Info("grok: work_dir changed", "work_dir", dir)
+}
+
+func (a *Agent) GetWorkDir() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.workDir
+}
+
+func (a *Agent) SetModel(model string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.model = model
+	slog.Info("grok: model changed", "model", model)
+}
+
+func (a *Agent) GetModel() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return core.GetProviderModel(a.providers, a.activeIdx, a.model)
+}
+
+func (a *Agent) configuredModels() []core.ModelOption {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return core.GetProviderModels(a.providers, a.activeIdx)
+}
+
+func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
+	if models := a.configuredModels(); len(models) > 0 {
+		return models
+	}
+	if models := a.probeModels(ctx); len(models) > 0 {
+		return models
+	}
+	return []core.ModelOption{
+		{Name: "grok-4.5", Desc: "Grok 4.5 (default)"},
+	}
+}
+
+// probeModels runs `grok models` and parses the plain-text listing.
+func (a *Agent) probeModels(ctx context.Context) []core.ModelOption {
+	a.mu.RLock()
+	cmdName := a.cmd
+	a.mu.RUnlock()
+
+	cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, cmdName, "models")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		slog.Debug("grok: models probe failed", "error", err)
+		return nil
+	}
+	var models []core.ModelOption
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		// Lines look like: "  * grok-4.5 (default)" or "  * grok-4.5"
+		line = strings.TrimPrefix(line, "*")
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(strings.ToLower(line), "you are") ||
+			strings.HasPrefix(strings.ToLower(line), "default model") ||
+			strings.HasPrefix(strings.ToLower(line), "available models") {
+			continue
+		}
+		// Drop trailing annotation like "(default)"
+		name := line
+		if i := strings.Index(name, " "); i > 0 {
+			name = name[:i]
+		}
+		name = strings.TrimSpace(name)
+		if name == "" || !strings.HasPrefix(name, "grok") {
+			continue
+		}
+		desc := line
+		if desc == name {
+			desc = name
+		}
+		models = append(models, core.ModelOption{Name: name, Desc: desc})
+	}
+	return models
+}
+
+func (a *Agent) SetSessionEnv(env []string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sessionEnv = env
+}
+
+func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentSession, error) {
+	a.mu.Lock()
+	model := a.model
+	mode := a.mode
+	cmd := a.cmd
+	extraArgs := append([]string{}, a.cliExtraArgs...)
+	workDir := a.workDir
+	timeout := a.timeout
+	reasoning := a.reasoningEffort
+	maxTurns := a.maxTurns
+	extraEnv := append([]string(nil), a.configEnv...)
+	extraEnv = append(extraEnv, a.providerEnvLocked()...)
+	extraEnv = append(extraEnv, a.sessionEnv...)
+	if a.activeIdx >= 0 && a.activeIdx < len(a.providers) {
+		if m := a.providers[a.activeIdx].Model; m != "" {
+			model = m
+		}
+	}
+	a.mu.Unlock()
+
+	return newGrokSession(ctx, sessionConfig{
+		cmd:             cmd,
+		extraArgs:       extraArgs,
+		workDir:         workDir,
+		model:           model,
+		mode:            mode,
+		resumeID:        sessionID,
+		extraEnv:        extraEnv,
+		timeout:         timeout,
+		reasoningEffort: reasoning,
+		maxTurns:        maxTurns,
+	})
+}
+
+func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
+	return listGrokSessions(a.workDir)
+}
+
+func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
+	path := findGrokSessionDir(sessionID)
+	if path == "" {
+		return fmt.Errorf("session not found: %s", sessionID)
+	}
+	return os.RemoveAll(path)
+}
+
+func (a *Agent) Stop() error { return nil }
+
+// ── ModeSwitcher ────────────────────────────────────────────────
+
+func (a *Agent) SetMode(mode string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.mode = normalizeMode(mode)
+	slog.Info("grok: mode changed", "mode", a.mode)
+}
+
+func (a *Agent) GetMode() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.mode
+}
+
+func (a *Agent) PermissionModes() []core.PermissionModeInfo {
+	return []core.PermissionModeInfo{
+		{Key: "default", Name: "Default", NameZh: "默认",
+			Desc: "Standard permissions (always-approve in headless)", DescZh: "标准权限（无头模式自动批准）"},
+		{Key: "accept_edits", Name: "Accept Edits", NameZh: "自动编辑",
+			Desc: "Auto-approve edit tools", DescZh: "自动批准编辑类工具"},
+		{Key: "yolo", Name: "YOLO", NameZh: "全自动",
+			Desc: "Bypass all permission prompts", DescZh: "跳过所有权限确认"},
+		{Key: "plan", Name: "Plan", NameZh: "规划模式",
+			Desc: "Read-only plan mode, no execution", DescZh: "只读规划模式，不做修改"},
+		{Key: "dont_ask", Name: "Don't Ask", NameZh: "不问确认",
+			Desc: "Don't ask for permission", DescZh: "不再询问权限"},
+	}
+}
+
+// ── SkillProvider ───────────────────────────────────────────────
+
+func (a *Agent) SkillDirs() []string {
+	absDir, err := filepath.Abs(a.workDir)
+	if err != nil {
+		absDir = a.workDir
+	}
+	dirs := []string{filepath.Join(absDir, ".grok", "skills")}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".grok", "skills"))
+	}
+	return dirs
+}
+
+// ── MemoryFileProvider ──────────────────────────────────────────
+
+func (a *Agent) ProjectMemoryFile() string {
+	absDir, err := filepath.Abs(a.workDir)
+	if err != nil {
+		absDir = a.workDir
+	}
+	// Grok Build uses AGENTS.md project conventions.
+	return filepath.Join(absDir, "AGENTS.md")
+}
+
+func (a *Agent) GlobalMemoryFile() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	// Prefer AGENTS.md under ~/.grok if present; otherwise empty.
+	p := filepath.Join(homeDir, ".grok", "AGENTS.md")
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	return ""
+}
+
+// ── ProviderSwitcher ────────────────────────────────────────────
+
+func (a *Agent) SetProviders(providers []core.ProviderConfig) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.providers = providers
+}
+
+func (a *Agent) SetActiveProvider(name string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if name == "" {
+		a.activeIdx = -1
+		slog.Info("grok: provider cleared")
+		return true
+	}
+	for i, p := range a.providers {
+		if p.Name == name {
+			a.activeIdx = i
+			slog.Info("grok: provider switched", "provider", name)
+			return true
+		}
+	}
+	return false
+}
+
+func (a *Agent) GetActiveProvider() *core.ProviderConfig {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.activeIdx < 0 || a.activeIdx >= len(a.providers) {
+		return nil
+	}
+	p := a.providers[a.activeIdx]
+	return &p
+}
+
+func (a *Agent) ListProviders() []core.ProviderConfig {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	result := make([]core.ProviderConfig, len(a.providers))
+	copy(result, a.providers)
+	return result
+}
+
+func (a *Agent) providerEnvLocked() []string {
+	if a.activeIdx < 0 || a.activeIdx >= len(a.providers) {
+		return nil
+	}
+	p := a.providers[a.activeIdx]
+	var env []string
+	if p.APIKey != "" {
+		env = append(env, "XAI_API_KEY="+p.APIKey)
+	}
+	if p.BaseURL != "" {
+		env = append(env, "XAI_API_BASE_URL="+p.BaseURL)
+	}
+	for k, v := range p.Env {
+		env = append(env, k+"="+v)
+	}
+	return env
+}
+
+// ── Session listing ─────────────────────────────────────────────
+
+func grokSessionsBaseDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(homeDir, ".grok", "sessions")
+}
+
+// grokSessionSlug encodes an absolute work dir the way Grok Build stores it:
+// every path separator becomes %2F (url.PathEscape of the whole path).
+func grokSessionSlug(absWorkDir string) string {
+	return url.PathEscape(absWorkDir)
+}
+
+func resolveWorkDir(workDir string) string {
+	abs, err := filepath.Abs(workDir)
+	if err != nil {
+		return workDir
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return abs
+}
+
+func listGrokSessions(workDir string) ([]core.AgentSessionInfo, error) {
+	absWorkDir := resolveWorkDir(workDir)
+	base := grokSessionsBaseDir()
+	if base == "" {
+		return nil, nil
+	}
+
+	// Prefer the project-scoped directory; fall back to scanning all projects.
+	candidates := []string{filepath.Join(base, grokSessionSlug(absWorkDir))}
+	// macOS often stores /tmp under /private/tmp — also try unresolved Abs.
+	if alt, err := filepath.Abs(workDir); err == nil && alt != absWorkDir {
+		candidates = append(candidates, filepath.Join(base, grokSessionSlug(alt)))
+	}
+
+	seen := make(map[string]bool)
+	var sessions []core.AgentSessionInfo
+
+	scanDir := func(dir string) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			info := parseGrokSessionDir(filepath.Join(dir, e.Name()), absWorkDir)
+			if info == nil || seen[info.ID] {
+				continue
+			}
+			seen[info.ID] = true
+			sessions = append(sessions, *info)
+		}
+	}
+
+	for _, c := range candidates {
+		scanDir(c)
+	}
+
+	// If nothing matched the slug, scan all project dirs and filter by cwd in summary.
+	if len(sessions) == 0 {
+		entries, err := os.ReadDir(base)
+		if err == nil {
+			for _, e := range entries {
+				if !e.IsDir() {
+					continue
+				}
+				scanDir(filepath.Join(base, e.Name()))
+			}
+		}
+	}
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].ModifiedAt.After(sessions[j].ModifiedAt)
+	})
+	return sessions, nil
+}
+
+func parseGrokSessionDir(sessionDir, filterWorkDir string) *core.AgentSessionInfo {
+	summaryPath := filepath.Join(sessionDir, "summary.json")
+	data, err := os.ReadFile(summaryPath)
+	if err != nil {
+		return nil
+	}
+	var summary struct {
+		Info struct {
+			ID  string `json:"id"`
+			Cwd string `json:"cwd"`
+		} `json:"info"`
+		SessionSummary  string `json:"session_summary"`
+		GeneratedTitle  string `json:"generated_title"`
+		NumMessages     int    `json:"num_messages"`
+		NumChatMessages int    `json:"num_chat_messages"`
+		UpdatedAt       string `json:"updated_at"`
+		LastActiveAt    string `json:"last_active_at"`
+	}
+	if json.Unmarshal(data, &summary) != nil {
+		return nil
+	}
+
+	sessionID := summary.Info.ID
+	if sessionID == "" {
+		sessionID = filepath.Base(sessionDir)
+	}
+
+	if filterWorkDir != "" && summary.Info.Cwd != "" {
+		cwdResolved := resolveWorkDir(summary.Info.Cwd)
+		cwdAbs, _ := filepath.Abs(summary.Info.Cwd)
+		if cwdResolved != filterWorkDir && cwdAbs != filterWorkDir && summary.Info.Cwd != filterWorkDir {
+			return nil
+		}
+	}
+
+	summaryText := strings.TrimSpace(summary.SessionSummary)
+	if summaryText == "" {
+		summaryText = strings.TrimSpace(summary.GeneratedTitle)
+	}
+	if utf8.RuneCountInString(summaryText) > 60 {
+		summaryText = string([]rune(summaryText)[:60]) + "..."
+	}
+
+	msgCount := summary.NumChatMessages
+	if msgCount == 0 {
+		msgCount = summary.NumMessages
+	}
+
+	mod := time.Time{}
+	for _, ts := range []string{summary.LastActiveAt, summary.UpdatedAt} {
+		if ts == "" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+			mod = t
+			break
+		}
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			mod = t
+			break
+		}
+	}
+	if mod.IsZero() {
+		if fi, err := os.Stat(sessionDir); err == nil {
+			mod = fi.ModTime()
+		}
+	}
+
+	return &core.AgentSessionInfo{
+		ID:           sessionID,
+		Summary:      summaryText,
+		MessageCount: msgCount,
+		ModifiedAt:   mod,
+	}
+}
+
+func findGrokSessionDir(sessionID string) string {
+	base := grokSessionsBaseDir()
+	if base == "" || sessionID == "" {
+		return ""
+	}
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(base, e.Name(), sessionID)
+		if fi, err := os.Stat(candidate); err == nil && fi.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// Compile-time interface checks.
+var (
+	_ core.Agent              = (*Agent)(nil)
+	_ core.AgentDoctorInfo    = (*Agent)(nil)
+	_ core.ModeSwitcher       = (*Agent)(nil)
+	_ core.WorkDirSwitcher    = (*Agent)(nil)
+	_ core.ModelSwitcher      = (*Agent)(nil)
+	_ core.SessionEnvInjector = (*Agent)(nil)
+	_ core.ProviderSwitcher   = (*Agent)(nil)
+	_ core.MemoryFileProvider = (*Agent)(nil)
+	_ core.SkillProvider      = (*Agent)(nil)
+	_ core.SessionDeleter     = (*Agent)(nil)
+)

--- a/agent/grok/grok_test.go
+++ b/agent/grok/grok_test.go
@@ -1,0 +1,138 @@
+package grok
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeMode(t *testing.T) {
+	cases := map[string]string{
+		"":                  "default",
+		"default":           "default",
+		"yolo":              "yolo",
+		"YOLO":              "yolo",
+		"bypassPermissions": "yolo",
+		"plan":              "plan",
+		"acceptEdits":       "accept_edits",
+		"auto_edit":         "accept_edits",
+		"dontAsk":           "dont_ask",
+		"dont_ask":          "dont_ask",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, normalizeMode(in), "input %q", in)
+	}
+}
+
+func TestPermissionModeFlag(t *testing.T) {
+	assert.Equal(t, "default", permissionModeFlag("default"))
+	assert.Equal(t, "bypassPermissions", permissionModeFlag("yolo"))
+	assert.Equal(t, "plan", permissionModeFlag("plan"))
+	assert.Equal(t, "acceptEdits", permissionModeFlag("accept_edits"))
+	assert.Equal(t, "dontAsk", permissionModeFlag("dont_ask"))
+}
+
+func TestGrokSessionSlug(t *testing.T) {
+	assert.Equal(t, "%2FUsers%2Fliyang", grokSessionSlug("/Users/liyang"))
+	assert.Equal(t, "%2Ftmp", grokSessionSlug("/tmp"))
+}
+
+func TestParseGrokSessionDir(t *testing.T) {
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, "019f-test")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	summary := map[string]any{
+		"info": map[string]any{
+			"id":  "019f-test",
+			"cwd": "/Users/liyang/project",
+		},
+		"session_summary":   "Fix the flaky test",
+		"num_chat_messages": 12,
+		"updated_at":        "2026-07-17T01:00:00Z",
+		"last_active_at":    "2026-07-17T02:00:00Z",
+	}
+	data, err := json.Marshal(summary)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "summary.json"), data, 0o644))
+
+	info := parseGrokSessionDir(sessionDir, "/Users/liyang/project")
+	require.NotNil(t, info)
+	assert.Equal(t, "019f-test", info.ID)
+	assert.Equal(t, "Fix the flaky test", info.Summary)
+	assert.Equal(t, 12, info.MessageCount)
+	assert.False(t, info.ModifiedAt.IsZero())
+	assert.Equal(t, 2026, info.ModifiedAt.UTC().Year())
+
+	assert.Nil(t, parseGrokSessionDir(sessionDir, "/other/path"))
+}
+
+func TestFindGrokSessionDirEmpty(t *testing.T) {
+	assert.Equal(t, "", findGrokSessionDir(""))
+}
+
+func TestAgentBasics(t *testing.T) {
+	a := &Agent{
+		workDir:   "/tmp/proj",
+		model:     "grok-4.5",
+		mode:      "default",
+		cmd:       "grok",
+		activeIdx: -1,
+	}
+	assert.Equal(t, "grok", a.Name())
+	assert.Equal(t, "grok", a.CLIBinaryName())
+	assert.Equal(t, "Grok Build", a.CLIDisplayName())
+	assert.Equal(t, "/tmp/proj", a.GetWorkDir())
+	assert.Equal(t, "grok-4.5", a.GetModel())
+	assert.Equal(t, "default", a.GetMode())
+
+	a.SetWorkDir("/tmp/other")
+	assert.Equal(t, "/tmp/other", a.GetWorkDir())
+	a.SetModel("grok-4.5-fast")
+	assert.Equal(t, "grok-4.5-fast", a.GetModel())
+	a.SetMode("yolo")
+	assert.Equal(t, "yolo", a.GetMode())
+	assert.NotEmpty(t, a.PermissionModes())
+
+	models := a.AvailableModels(context.Background())
+	require.NotEmpty(t, models)
+	assert.Equal(t, "grok-4.5", models[0].Name)
+
+	assert.Contains(t, a.ProjectMemoryFile(), "AGENTS.md")
+	assert.Contains(t, a.SkillDirs()[0], ".grok")
+}
+
+func TestProviderAPIKeyEnv(t *testing.T) {
+	a := &Agent{activeIdx: -1, cmd: "grok", workDir: "."}
+	a.SetProviders([]core.ProviderConfig{
+		{
+			Name:    "xai",
+			APIKey:  "xai-secret",
+			BaseURL: "https://api.x.ai/v1",
+			Env:     map[string]string{"EXTRA": "1"},
+		},
+	})
+	assert.True(t, a.SetActiveProvider("xai"))
+	env := a.providerEnvLocked()
+	assert.Contains(t, env, "XAI_API_KEY=xai-secret")
+	assert.Contains(t, env, "XAI_API_BASE_URL=https://api.x.ai/v1")
+	assert.Contains(t, env, "EXTRA=1")
+
+	assert.True(t, a.SetActiveProvider(""))
+	assert.Nil(t, a.providerEnvLocked())
+}
+
+func TestNewRequiresBinary(t *testing.T) {
+	_, err := New(map[string]any{
+		"work_dir": t.TempDir(),
+		"cmd":      "this-binary-should-not-exist-cc-connect-grok",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/agent/grok/session.go
+++ b/agent/grok/session.go
@@ -1,0 +1,677 @@
+package grok
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// sessionConfig holds StartSession snapshot values.
+type sessionConfig struct {
+	cmd             string
+	extraArgs       []string
+	workDir         string
+	model           string
+	mode            string
+	resumeID        string
+	extraEnv        []string
+	timeout         time.Duration
+	reasoningEffort string
+	maxTurns        int
+}
+
+// grokSession runs multi-turn chats via headless `grok -p` processes.
+// Each Send() launches one process; conversation continuity uses --resume.
+//
+// Grok's streaming-json emits thought/text as *token deltas* (often one word
+// or even one character per line). We coalesce those into whole EventThinking /
+// EventText payloads so the engine does not spam the IM platform with one
+// bubble per token (the WeChat "☁️ The / user / sent / …" failure mode).
+type grokSession struct {
+	cmd             string
+	extraArgs       []string
+	workDir         string
+	model           string
+	mode            string
+	timeout         time.Duration
+	extraEnv        []string
+	reasoningEffort string
+	maxTurns        int
+
+	events    chan core.Event
+	sessionID atomic.Value // string
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	alive     atomic.Bool
+
+	// sendMu serializes Send() so two turns never race on the same session.
+	sendMu sync.Mutex
+
+	// Stream coalescing (owned by the single readLoop goroutine per turn).
+	pendingThought strings.Builder
+	pendingText    strings.Builder
+}
+
+func newGrokSession(ctx context.Context, cfg sessionConfig) (*grokSession, error) {
+	sessionCtx, cancel := context.WithCancel(ctx)
+	gs := &grokSession{
+		cmd:             cfg.cmd,
+		extraArgs:       append([]string{}, cfg.extraArgs...),
+		workDir:         cfg.workDir,
+		model:           cfg.model,
+		mode:            cfg.mode,
+		timeout:         cfg.timeout,
+		extraEnv:        append([]string{}, cfg.extraEnv...),
+		reasoningEffort: cfg.reasoningEffort,
+		maxTurns:        cfg.maxTurns,
+		events:          make(chan core.Event, 64),
+		ctx:             sessionCtx,
+		cancel:          cancel,
+	}
+	gs.alive.Store(true)
+	if cfg.resumeID != "" && cfg.resumeID != core.ContinueSession {
+		gs.sessionID.Store(cfg.resumeID)
+	}
+	return gs, nil
+}
+
+// buildArgs constructs the CLI argv for one headless turn.
+// promptFile, when non-empty, is passed via --prompt-file (preferred for
+// multi-line prompts). Otherwise -p receives promptInline.
+func (gs *grokSession) buildArgs(promptInline, promptFile string) []string {
+	args := append([]string{}, gs.extraArgs...)
+	args = append(args, "--output-format", "streaming-json")
+
+	// Working directory — prefer explicit --cwd so resume land in the right project.
+	if gs.workDir != "" {
+		args = append(args, "--cwd", gs.workDir)
+	}
+
+	// Permission / approval. Headless has no TUI to click "allow", so non-plan
+	// modes always pass --always-approve to avoid hanging the IM turn.
+	perm := permissionModeFlag(gs.mode)
+	args = append(args, "--permission-mode", perm)
+	if gs.mode != "plan" {
+		args = append(args, "--always-approve")
+	}
+
+	if sid := gs.CurrentSessionID(); sid != "" {
+		args = append(args, "--resume", sid)
+	}
+	if gs.model != "" {
+		args = append(args, "-m", gs.model)
+	}
+	if gs.reasoningEffort != "" {
+		args = append(args, "--reasoning-effort", gs.reasoningEffort)
+	}
+	if gs.maxTurns > 0 {
+		args = append(args, "--max-turns", fmt.Sprintf("%d", gs.maxTurns))
+	}
+
+	if promptFile != "" {
+		args = append(args, "--prompt-file", promptFile)
+	} else {
+		args = append(args, "-p", promptInline)
+	}
+	return args
+}
+
+func (gs *grokSession) Send(prompt string, images []core.ImageAttachment, files []core.FileAttachment) error {
+	if !gs.alive.Load() {
+		return fmt.Errorf("session is closed")
+	}
+
+	gs.sendMu.Lock()
+	// Unlock is deferred in the goroutine after the process finishes so
+	// concurrent Send() calls queue rather than overlapping processes.
+	// We unlock early only on pre-start failure.
+
+	// Persist attachments so Grok tools can open them by path.
+	attachDir := filepath.Join(gs.workDir, ".cc-connect", "attachments")
+	if (len(images) > 0 || len(files) > 0) && os.MkdirAll(attachDir, 0o755) != nil {
+		attachDir = os.TempDir()
+	}
+
+	var imageRefs []string
+	for i, img := range images {
+		ext := ".png"
+		switch img.MimeType {
+		case "image/jpeg":
+			ext = ".jpg"
+		case "image/gif":
+			ext = ".gif"
+		case "image/webp":
+			ext = ".webp"
+		}
+		fname := fmt.Sprintf("img_%d_%d%s", time.Now().UnixMilli(), i, ext)
+		fpath := filepath.Join(attachDir, fname)
+		if err := os.WriteFile(fpath, img.Data, 0o644); err != nil {
+			slog.Warn("grokSession: failed to save image", "error", err)
+			continue
+		}
+		imageRefs = append(imageRefs, fpath)
+	}
+
+	var fileRefs []string
+	for i, f := range files {
+		fname := filepath.Base(f.FileName)
+		if fname == "" || fname == "." || fname == ".." {
+			fname = fmt.Sprintf("file_%d_%d", time.Now().UnixMilli(), i)
+		}
+		fpath := filepath.Join(attachDir, fname)
+		if err := os.WriteFile(fpath, f.Data, 0o644); err != nil {
+			slog.Warn("grokSession: failed to save file", "error", err)
+			continue
+		}
+		fileRefs = append(fileRefs, fpath)
+	}
+
+	fullPrompt := prompt
+	if len(imageRefs) > 0 {
+		if fullPrompt == "" {
+			fullPrompt = "Please analyze the attached image(s)."
+		}
+		fullPrompt += "\n\n[Attached images saved at: " + strings.Join(imageRefs, ", ") + "]"
+	}
+	if len(fileRefs) > 0 {
+		if fullPrompt == "" {
+			fullPrompt = "Please analyze the attached file(s)."
+		}
+		fullPrompt += "\n\n[Attached files saved at: " + strings.Join(fileRefs, ", ") + "]"
+	}
+
+	// Prefer --prompt-file so multi-line / long prompts survive argv limits.
+	var promptFile string
+	var promptInline string
+	tmp, err := os.CreateTemp("", "cc-connect-grok-prompt-*.txt")
+	if err != nil {
+		promptInline = fullPrompt
+	} else {
+		if _, werr := tmp.WriteString(fullPrompt); werr != nil {
+			tmp.Close()
+			os.Remove(tmp.Name())
+			promptInline = fullPrompt
+		} else {
+			tmp.Close()
+			// World-readable is intentional: when run_as_user differs from the
+			// supervisor user the agent still needs to read the prompt file.
+			_ = os.Chmod(tmp.Name(), 0o644)
+			promptFile = tmp.Name()
+		}
+	}
+
+	args := gs.buildArgs(promptInline, promptFile)
+
+	var cancel context.CancelFunc
+	var ctx context.Context
+	if gs.timeout > 0 {
+		ctx, cancel = context.WithTimeout(gs.ctx, gs.timeout)
+	} else {
+		ctx, cancel = context.WithCancel(gs.ctx)
+	}
+
+	started := false
+	defer func() {
+		if !started {
+			cancel()
+			if promptFile != "" {
+				os.Remove(promptFile)
+			}
+			gs.sendMu.Unlock()
+		}
+	}()
+
+	slog.Debug("grokSession: launching",
+		"resume", gs.CurrentSessionID() != "",
+		"args", core.RedactArgs(args))
+
+	cmd := exec.CommandContext(ctx, gs.cmd, args...)
+	cmd.WaitDelay = 1 * time.Second
+	cmd.Dir = gs.workDir
+	env := os.Environ()
+	if len(gs.extraEnv) > 0 {
+		env = core.MergeEnv(env, gs.extraEnv)
+	}
+	cmd.Env = env
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("grokSession: stdout pipe: %w", err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("grokSession: start: %w", err)
+	}
+
+	started = true
+	gs.wg.Add(1)
+	go func() {
+		defer gs.wg.Done()
+		defer cancel()
+		defer gs.sendMu.Unlock()
+		defer func() {
+			if promptFile != "" {
+				os.Remove(promptFile)
+			}
+			for _, f := range append(imageRefs, fileRefs...) {
+				os.Remove(f)
+			}
+		}()
+		gs.readLoop(ctx, cmd, stdout, &stderrBuf)
+	}()
+
+	return nil
+}
+
+func (gs *grokSession) readLoop(ctx context.Context, cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
+	go func() {
+		<-ctx.Done()
+		stdout.Close()
+	}()
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	var scanErr error
+	var lastUsage map[string]any
+	var sawEnd bool
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		slog.Debug("grokSession: raw", "line", truncate(line, 500))
+
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			slog.Debug("grokSession: non-JSON line", "line", line)
+			continue
+		}
+		if usage, ok := raw["usage"].(map[string]any); ok {
+			lastUsage = usage
+		}
+		if gs.handleEvent(raw) {
+			sawEnd = true
+		}
+	}
+	scanErr = scanner.Err()
+	waitErr := cmd.Wait()
+
+	if scanErr != nil {
+		slog.Error("grokSession: scanner error", "error", scanErr)
+		gs.emit(core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", scanErr)})
+	}
+
+	if waitErr != nil && !sawEnd {
+		stderrMsg := strings.TrimSpace(stderrBuf.String())
+		if stderrMsg != "" {
+			slog.Error("grokSession: process failed", "error", waitErr, "stderr", stderrMsg)
+			gs.emit(core.Event{Type: core.EventError, Error: fmt.Errorf("%s", stderrMsg)})
+			return
+		}
+		// Process failed with empty stderr and no end event — still surface error.
+		if ctx.Err() != nil {
+			gs.emit(core.Event{Type: core.EventError, Error: fmt.Errorf("grok turn canceled: %w", ctx.Err())})
+			return
+		}
+		gs.emit(core.Event{Type: core.EventError, Error: fmt.Errorf("grok process: %w", waitErr)})
+		return
+	}
+
+	// Guarantee a terminal EventResult so the engine closes the turn even if
+	// the CLI omitted the final {"type":"end"} line (e.g. truncated stream).
+	if !sawEnd {
+		gs.flushThought()
+		gs.flushText()
+		evt := core.Event{
+			Type:      core.EventResult,
+			SessionID: gs.CurrentSessionID(),
+			Done:      true,
+		}
+		applyUsage(&evt, lastUsage)
+		gs.emit(evt)
+	}
+}
+
+// handleEvent maps one streaming-json object to core events.
+// Returns true when this was a terminal "end" event.
+func (gs *grokSession) handleEvent(raw map[string]any) bool {
+	typ, _ := raw["type"].(string)
+	typ = strings.ToLower(strings.TrimSpace(typ))
+
+	switch typ {
+	case "thought", "thinking", "reasoning":
+		// Token deltas — buffer only; flush when the stream leaves thinking.
+		if text := eventDataString(raw); text != "" {
+			gs.pendingThought.WriteString(text)
+		}
+		return false
+
+	case "text", "message", "assistant", "agent_message", "agent_message_chunk":
+		// Leaving the thought stream: emit one consolidated thinking event.
+		gs.flushThought()
+		if text := eventDataString(raw); text != "" {
+			gs.pendingText.WriteString(text)
+		}
+		return false
+
+	case "tool", "tool_use", "tool_call", "function_call":
+		gs.flushThought()
+		gs.flushText()
+		name, input, id := extractTool(raw)
+		if name != "" {
+			gs.emit(core.Event{
+				Type:      core.EventToolUse,
+				ToolName:  name,
+				ToolInput: truncate(input, 500),
+				RequestID: id,
+			})
+		}
+		return false
+
+	case "tool_result", "tool_response", "function_result":
+		gs.flushThought()
+		gs.flushText()
+		name, result, _ := extractToolResult(raw)
+		if result != "" || name != "" {
+			gs.emit(core.Event{
+				Type:       core.EventToolResult,
+				ToolName:   name,
+				ToolResult: truncate(result, 500),
+			})
+		}
+		return false
+
+	case "error":
+		gs.flushThought()
+		gs.flushText()
+		msg := eventDataString(raw)
+		if msg == "" {
+			if m, ok := raw["message"].(string); ok {
+				msg = m
+			}
+		}
+		if msg == "" {
+			msg = "grok error"
+		}
+		gs.emit(core.Event{Type: core.EventError, Error: fmt.Errorf("%s", msg)})
+		return false
+
+	case "end", "result", "done", "complete":
+		gs.flushThought()
+		gs.flushText()
+		if sid, ok := raw["sessionId"].(string); ok && sid != "" {
+			gs.sessionID.Store(sid)
+		} else if sid, ok := raw["session_id"].(string); ok && sid != "" {
+			gs.sessionID.Store(sid)
+		}
+		evt := core.Event{
+			Type:      core.EventResult,
+			SessionID: gs.CurrentSessionID(),
+			Done:      true,
+		}
+		if usage, ok := raw["usage"].(map[string]any); ok {
+			applyUsage(&evt, usage)
+		}
+		// Some end events include a final text blob.
+		if text := eventDataString(raw); text != "" {
+			// Prefer streaming text already emitted; only use as Content for footer/fallback.
+			evt.Content = text
+		}
+		gs.emit(evt)
+		return true
+
+	default:
+		// Best-effort: nested content with type field, or data-only text chunks.
+		if text := eventDataString(raw); text != "" && (raw["type"] == nil || typ == "") {
+			gs.pendingText.WriteString(text)
+		} else {
+			slog.Debug("grokSession: unhandled event type", "type", typ)
+		}
+		return false
+	}
+}
+
+func (gs *grokSession) flushThought() {
+	if gs.pendingThought.Len() == 0 {
+		return
+	}
+	text := gs.pendingThought.String()
+	gs.pendingThought.Reset()
+	if strings.TrimSpace(text) == "" {
+		return
+	}
+	gs.emit(core.Event{Type: core.EventThinking, Content: text})
+}
+
+func (gs *grokSession) flushText() {
+	if gs.pendingText.Len() == 0 {
+		return
+	}
+	text := gs.pendingText.String()
+	gs.pendingText.Reset()
+	if text == "" {
+		return
+	}
+	gs.emit(core.Event{Type: core.EventText, Content: text, SessionID: gs.CurrentSessionID()})
+}
+
+func eventDataString(raw map[string]any) string {
+	// Primary shape: {"type":"text","data":"..."}
+	switch v := raw["data"].(type) {
+	case string:
+		return v
+	case map[string]any:
+		if t, ok := v["text"].(string); ok {
+			return t
+		}
+		if t, ok := v["content"].(string); ok {
+			return t
+		}
+	}
+	if t, ok := raw["text"].(string); ok {
+		return t
+	}
+	if t, ok := raw["content"].(string); ok {
+		return t
+	}
+	if t, ok := raw["delta"].(string); ok {
+		return t
+	}
+	return ""
+}
+
+func extractTool(raw map[string]any) (name, input, id string) {
+	if n, ok := raw["name"].(string); ok {
+		name = n
+	}
+	if n, ok := raw["tool"].(string); ok && name == "" {
+		name = n
+	}
+	if n, ok := raw["toolName"].(string); ok && name == "" {
+		name = n
+	}
+	if idv, ok := raw["id"].(string); ok {
+		id = idv
+	}
+	if idv, ok := raw["toolCallId"].(string); ok && id == "" {
+		id = idv
+	}
+	if idv, ok := raw["tool_call_id"].(string); ok && id == "" {
+		id = idv
+	}
+
+	// Nested tool_call / function shapes.
+	if name == "" {
+		if tc, ok := raw["tool_call"].(map[string]any); ok {
+			name, input, id = extractTool(tc)
+			return
+		}
+		if fn, ok := raw["function"].(map[string]any); ok {
+			if n, ok := fn["name"].(string); ok {
+				name = n
+			}
+			switch a := fn["arguments"].(type) {
+			case string:
+				input = a
+			case map[string]any:
+				b, _ := json.Marshal(a)
+				input = string(b)
+			}
+		}
+	}
+
+	if input == "" {
+		switch a := raw["input"].(type) {
+		case string:
+			input = a
+		case map[string]any:
+			b, _ := json.Marshal(a)
+			input = string(b)
+		}
+	}
+	if input == "" {
+		switch a := raw["arguments"].(type) {
+		case string:
+			input = a
+		case map[string]any:
+			b, _ := json.Marshal(a)
+			input = string(b)
+		}
+	}
+	if input == "" {
+		if d := eventDataString(raw); d != "" && d != name {
+			input = d
+		}
+	}
+	return name, input, id
+}
+
+func extractToolResult(raw map[string]any) (name, result, id string) {
+	if n, ok := raw["name"].(string); ok {
+		name = n
+	}
+	if n, ok := raw["toolName"].(string); ok && name == "" {
+		name = n
+	}
+	if idv, ok := raw["tool_call_id"].(string); ok {
+		id = idv
+	}
+	if idv, ok := raw["toolCallId"].(string); ok && id == "" {
+		id = idv
+	}
+	if id != "" && name == "" {
+		name = id
+	}
+	result = eventDataString(raw)
+	if result == "" {
+		if o, ok := raw["output"].(string); ok {
+			result = o
+		}
+	}
+	if result == "" {
+		if o, ok := raw["result"].(string); ok {
+			result = o
+		}
+	}
+	return name, result, id
+}
+
+func applyUsage(evt *core.Event, usage map[string]any) {
+	if usage == nil {
+		return
+	}
+	evt.InputTokens = intFromAny(usage["input_tokens"])
+	if evt.InputTokens == 0 {
+		evt.InputTokens = intFromAny(usage["inputTokens"])
+	}
+	evt.OutputTokens = intFromAny(usage["output_tokens"])
+	if evt.OutputTokens == 0 {
+		evt.OutputTokens = intFromAny(usage["outputTokens"])
+	}
+	evt.CacheReadInputTokens = intFromAny(usage["cache_read_input_tokens"])
+	if evt.CacheReadInputTokens == 0 {
+		evt.CacheReadInputTokens = intFromAny(usage["cacheReadInputTokens"])
+	}
+}
+
+func intFromAny(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	default:
+		return 0
+	}
+}
+
+func (gs *grokSession) emit(evt core.Event) {
+	select {
+	case gs.events <- evt:
+	case <-gs.ctx.Done():
+	}
+}
+
+// RespondPermission is a no-op: headless mode uses --always-approve (except plan).
+func (gs *grokSession) RespondPermission(_ string, _ core.PermissionResult) error {
+	return nil
+}
+
+func (gs *grokSession) Events() <-chan core.Event { return gs.events }
+
+func (gs *grokSession) CurrentSessionID() string {
+	v, _ := gs.sessionID.Load().(string)
+	return v
+}
+
+func (gs *grokSession) Alive() bool { return gs.alive.Load() }
+
+func (gs *grokSession) Close() error {
+	gs.alive.Store(false)
+	gs.cancel()
+	done := make(chan struct{})
+	go func() {
+		gs.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		close(gs.events)
+	case <-time.After(8 * time.Second):
+		slog.Warn("grokSession: close timed out, abandoning wg.Wait")
+	}
+	return nil
+}
+
+func truncate(s string, maxRunes int) string {
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	return string([]rune(s)[:maxRunes]) + "..."
+}
+
+var _ core.AgentSession = (*grokSession)(nil)

--- a/agent/grok/session_test.go
+++ b/agent/grok/session_test.go
@@ -1,0 +1,211 @@
+package grok
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGrokSession(t *testing.T) {
+	ctx := context.Background()
+	gs, err := newGrokSession(ctx, sessionConfig{
+		cmd:      "grok",
+		workDir:  "/tmp",
+		model:    "grok-4.5",
+		mode:     "default",
+		resumeID: "resume-abc",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, gs)
+	assert.True(t, gs.Alive())
+	assert.Equal(t, "resume-abc", gs.CurrentSessionID())
+
+	err = gs.Close()
+	assert.NoError(t, err)
+	assert.False(t, gs.Alive())
+}
+
+func TestBuildArgs_PromptFileAndResume(t *testing.T) {
+	gs, err := newGrokSession(context.Background(), sessionConfig{
+		cmd:      "grok",
+		workDir:  "/proj",
+		model:    "grok-4.5",
+		mode:     "yolo",
+		resumeID: "sid-1",
+	})
+	require.NoError(t, err)
+	defer gs.Close()
+
+	args := gs.buildArgs("", "/tmp/prompt.txt")
+	assert.Contains(t, args, "--output-format")
+	assert.Contains(t, args, "streaming-json")
+	assert.Contains(t, args, "--cwd")
+	assert.Contains(t, args, "/proj")
+	assert.Contains(t, args, "--resume")
+	assert.Contains(t, args, "sid-1")
+	assert.Contains(t, args, "-m")
+	assert.Contains(t, args, "grok-4.5")
+	assert.Contains(t, args, "--permission-mode")
+	assert.Contains(t, args, "bypassPermissions")
+	assert.Contains(t, args, "--always-approve")
+	assert.Contains(t, args, "--prompt-file")
+	assert.Contains(t, args, "/tmp/prompt.txt")
+	assert.NotContains(t, args, "-p")
+}
+
+func TestBuildArgs_PlanModeNoAlwaysApprove(t *testing.T) {
+	gs, err := newGrokSession(context.Background(), sessionConfig{
+		cmd:     "grok",
+		workDir: "/proj",
+		mode:    "plan",
+	})
+	require.NoError(t, err)
+	defer gs.Close()
+
+	args := gs.buildArgs("hello", "")
+	assert.Contains(t, args, "plan")
+	assert.NotContains(t, args, "--always-approve")
+	assert.Contains(t, args, "-p")
+	assert.Contains(t, args, "hello")
+}
+
+func TestBuildArgs_InlinePrompt(t *testing.T) {
+	gs, err := newGrokSession(context.Background(), sessionConfig{
+		cmd:  "grok",
+		mode: "default",
+	})
+	require.NoError(t, err)
+	defer gs.Close()
+
+	args := gs.buildArgs("ping", "")
+	// Find -p value
+	for i, a := range args {
+		if a == "-p" && i+1 < len(args) {
+			assert.Equal(t, "ping", args[i+1])
+			return
+		}
+	}
+	t.Fatal("expected -p flag")
+}
+
+func TestHandleEvent_ThoughtTextEnd(t *testing.T) {
+	gs, err := newGrokSession(context.Background(), sessionConfig{cmd: "grok"})
+	require.NoError(t, err)
+	defer gs.Close()
+
+	// Grok streams thought/text as token deltas — must coalesce.
+	gs.handleEvent(map[string]any{"type": "thought", "data": "hmm"})
+	gs.handleEvent(map[string]any{"type": "thought", "data": " "})
+	gs.handleEvent(map[string]any{"type": "thought", "data": "ok"})
+	gs.handleEvent(map[string]any{"type": "text", "data": "po"})
+	gs.handleEvent(map[string]any{"type": "text", "data": "ng"})
+	terminal := gs.handleEvent(map[string]any{
+		"type":      "end",
+		"sessionId": "019f-test-session",
+		"usage": map[string]any{
+			"input_tokens":            float64(100),
+			"output_tokens":           float64(5),
+			"cache_read_input_tokens": float64(50),
+		},
+	})
+	assert.True(t, terminal)
+	assert.Equal(t, "019f-test-session", gs.CurrentSessionID())
+
+	events := drainEvents(gs.events, 3)
+	require.Len(t, events, 3)
+
+	assert.Equal(t, core.EventThinking, events[0].Type)
+	assert.Equal(t, "hmm ok", events[0].Content)
+
+	assert.Equal(t, core.EventText, events[1].Type)
+	assert.Equal(t, "pong", events[1].Content)
+
+	assert.Equal(t, core.EventResult, events[2].Type)
+	assert.True(t, events[2].Done)
+	assert.Equal(t, "019f-test-session", events[2].SessionID)
+	assert.Equal(t, 100, events[2].InputTokens)
+	assert.Equal(t, 5, events[2].OutputTokens)
+	assert.Equal(t, 50, events[2].CacheReadInputTokens)
+}
+
+func TestHandleEvent_ThoughtTokensNotEmittedPerToken(t *testing.T) {
+	gs, err := newGrokSession(context.Background(), sessionConfig{cmd: "grok"})
+	require.NoError(t, err)
+	defer gs.Close()
+
+	// Mimic the WeChat spam case: one EventThinking per word would be wrong.
+	for _, w := range []string{"The", " user", " sent", " just", " \"", "1", "\"."} {
+		gs.handleEvent(map[string]any{"type": "thought", "data": w})
+	}
+	// No non-thought event yet → nothing flushed.
+	select {
+	case e := <-gs.events:
+		t.Fatalf("unexpected early event: %+v", e)
+	case <-time.After(50 * time.Millisecond):
+	}
+	gs.flushThought()
+	events := drainEvents(gs.events, 1)
+	require.Len(t, events, 1)
+	assert.Equal(t, core.EventThinking, events[0].Type)
+	assert.Equal(t, `The user sent just "1".`, events[0].Content)
+}
+
+func TestHandleEvent_ToolUseAndResult(t *testing.T) {
+	gs, err := newGrokSession(context.Background(), sessionConfig{cmd: "grok"})
+	require.NoError(t, err)
+	defer gs.Close()
+
+	gs.handleEvent(map[string]any{
+		"type": "tool_use",
+		"name": "Shell",
+		"id":   "t1",
+		"input": map[string]any{
+			"command": "echo hi",
+		},
+	})
+	gs.handleEvent(map[string]any{
+		"type":         "tool_result",
+		"tool_call_id": "t1",
+		"data":         "hi\n",
+	})
+
+	events := drainEvents(gs.events, 2)
+	require.Len(t, events, 2)
+	assert.Equal(t, core.EventToolUse, events[0].Type)
+	assert.Equal(t, "Shell", events[0].ToolName)
+	assert.Contains(t, events[0].ToolInput, "echo hi")
+	assert.Equal(t, "t1", events[0].RequestID)
+
+	assert.Equal(t, core.EventToolResult, events[1].Type)
+	assert.Equal(t, "hi\n", events[1].ToolResult)
+}
+
+func TestHandleEvent_Error(t *testing.T) {
+	gs, err := newGrokSession(context.Background(), sessionConfig{cmd: "grok"})
+	require.NoError(t, err)
+	defer gs.Close()
+
+	gs.handleEvent(map[string]any{"type": "error", "message": "boom"})
+	events := drainEvents(gs.events, 1)
+	require.Len(t, events, 1)
+	assert.Equal(t, core.EventError, events[0].Type)
+	require.Error(t, events[0].Error)
+	assert.Contains(t, events[0].Error.Error(), "boom")
+}
+
+func drainEvents(ch <-chan core.Event, n int) []core.Event {
+	var out []core.Event
+	for i := 0; i < n; i++ {
+		select {
+		case e := <-ch:
+			out = append(out, e)
+		case <-time.After(2 * time.Second):
+			return out
+		}
+	}
+	return out
+}

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1526,7 +1526,7 @@ level = "info"
 name = "my-project"
 
 [projects.agent]
-type = "claudecode"   # "claudecode", "codex", "cursor", "gemini", "qoder", "opencode", or "iflow"
+type = "claudecode"   # "claudecode", "codex", "cursor", "gemini", "grok", "qoder", "opencode", "iflow", ...
 
 [projects.agent.options]
 work_dir = "/path/to/your/project"
@@ -1566,7 +1566,7 @@ func printUsage() {
  \___\__|      \___\___/|_| |_|_| |_|\___|\___|\__|  %s%s
 
   Bridge your messaging platforms to local AI coding agents.
-  Supports: Claude Code, Codex, Cursor, Gemini CLI, Qoder CLI, OpenCode
+  Supports: Claude Code, Codex, Cursor, Gemini CLI, Grok Build, Qoder CLI, OpenCode
   Platforms: Feishu, Telegram, Slack, DingTalk, Discord, LINE, WeChat Work, Weixin, QQ, QQ Bot
 
   GitHub:  https://github.com/chenhg5/cc-connect

--- a/cmd/cc-connect/plugin_agent_grok.go
+++ b/cmd/cc-connect/plugin_agent_grok.go
@@ -1,0 +1,5 @@
+//go:build !no_grok
+
+package main
+
+import _ "github.com/chenhg5/cc-connect/agent/grok"

--- a/config.example.toml
+++ b/config.example.toml
@@ -2074,6 +2074,58 @@ app_secret = "your-feishu-app-secret"
 # token = "your-telegram-bot-token"
 
 # =============================================================================
+# Project: Grok Build (xAI) / 项目：Grok Build (xAI)
+# =============================================================================
+# Prerequisites / 前置条件:
+#   1. Install Grok Build CLI: curl -fsSL https://x.ai/cli/install.sh | bash
+#      安装 Grok Build CLI（见 https://x.ai/cli ）
+#   2. Authenticate: `grok login`  OR  set XAI_API_KEY
+#      登录：`grok login` 或设置环境变量 XAI_API_KEY
+#
+# How it works / 工作原理:
+#   cc-connect drives headless Grok via:
+#     grok -p/--prompt-file ... --output-format streaming-json [--resume <id>]
+#   Streaming events (thought/text/end) are mapped to core.Event and delivered
+#   to your messaging platform. Sessions live under ~/.grok/sessions/.
+#   cc-connect 通过无头模式驱动 Grok，将 streaming-json 事件映射为 IM 消息；
+#   会话保存在 ~/.grok/sessions/。
+
+# [[projects]]
+# name = "my-grok-project"
+#
+# [projects.agent]
+# type = "grok"
+#
+# [projects.agent.options]
+# work_dir = "/path/to/project"
+# mode = "yolo"            # "default" | "accept_edits" | "yolo" | "plan" | "dont_ask"
+# cmd = "grok"             # CLI binary name (default: "grok")
+# model = "grok-4.5"       # optional; run `grok models` to list
+# # reasoning_effort = "high"  # optional: low | medium | high | ...
+# # max_turns = 50             # optional agent turn cap
+# timeout_mins = 30        # per-turn timeout; 0 = no limit
+# # env = { XAI_API_KEY = "xai-..." }
+#
+# Mode options / 模式说明:
+# - "default":      permission-mode default + --always-approve (headless-safe)
+# - "accept_edits": auto-approve edit tools
+# - "yolo":         bypass all permission prompts
+# - "plan":         read-only plan mode (no always-approve)
+# - "dont_ask":     dontAsk permission mode
+#
+# # Optional provider block (injects XAI_API_KEY) / 可选 Provider
+# # [[projects.agent.providers]]
+# # name = "xai"
+# # api_key = "xai-..."
+# # # base_url = "https://api.x.ai/v1"
+#
+# [[projects.platforms]]
+# type = "telegram"
+#
+# [projects.platforms.options]
+# token = "your-telegram-bot-token"
+
+# =============================================================================
 # Project: Using GitHub Copilot / 项目：使用 GitHub Copilot (uncomment to enable / 取消注释以启用)
 # =============================================================================
 # Prerequisites / 前置条件:


### PR DESCRIPTION
## Summary

- Add a first-class `type = "grok"` agent adapter for [xAI Grok Build CLI](https://x.ai/cli).
- Drive headless mode with `-p` / `--prompt-file` and `--output-format streaming-json`, plus `--resume` for multi-turn continuity.
- Map permission modes (`default` / `accept_edits` / `yolo` / `plan` / `dont_ask`) to Grok's `--permission-mode` (and `--always-approve` for non-plan modes so IM turns do not hang).
- Coalesce streaming thought/text **token deltas** into single `EventThinking` / `EventText` events so messaging platforms are not flooded with per-token bubbles.
- Wire build tag / plugin import, Makefile `ALL_AGENTS`, `config.example.toml`, README / INSTALL / CHANGELOG.

## Configuration (example)

```toml
[projects.agent]
type = "grok"

[projects.agent.options]
work_dir = "/path/to/project"
mode = "yolo"
model = "grok-4.5"
cmd = "grok"
```

Prerequisites: install Grok Build (`curl -fsSL https://x.ai/cli/install.sh | bash`) and `grok login` (or `XAI_API_KEY`).

## Test plan

- [x] `go test ./agent/grok/`
- [ ] `go test ./...` (full suite)
- [x] Local smoke: headless `grok -p ... --output-format streaming-json`
- [x] Local integration smoke: WeChat (weixin) → Grok turn complete and reply delivered
- [ ] CI green

## Notes

- Does not change core platform hardcoding rules; agent is registered via plugin + `init()`.
- No auto-merge requested; please review when ready.