### PR TITLE
feat(codex): bridge workspace dependency dynamic tool

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -141,16 +141,17 @@ type appServerRequestUserInputAnswer struct {
 }
 
 type appServerSession struct {
-	url            string
-	workDir        string
-	model          string
-	effort         string
-	mode           string
-	baseURL        string
-	modelProvider  string
-	extraEnv       []string
-	codexHome      string
-	promptPreamble string
+	url                   string
+	workDir               string
+	model                 string
+	effort                string
+	mode                  string
+	baseURL               string
+	modelProvider         string
+	extraEnv              []string
+	codexHome             string
+	promptPreamble        string
+	workspaceDependencies workspaceDependenciesConfig
 
 	events chan core.Event
 
@@ -191,25 +192,26 @@ const (
 	appServerUsageRefreshTimeout = 1500 * time.Millisecond
 )
 
-func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string, systemPrompt string, appendPrompt string) (*appServerSession, error) {
+func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string, systemPrompt string, appendPrompt string, workspaceDependencies workspaceDependenciesConfig) (*appServerSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 	s := &appServerSession{
-		url:              url,
-		workDir:          workDir,
-		model:            model,
-		effort:           effort,
-		mode:             mode,
-		baseURL:          baseURL,
-		modelProvider:    modelProvider,
-		extraEnv:         append([]string(nil), extraEnv...),
-		codexHome:        strings.TrimSpace(codexHome),
-		promptPreamble:   buildCodexPromptPreamble(systemPrompt, appendPrompt),
-		events:           make(chan core.Event, 128),
-		ctx:              sessionCtx,
-		cancel:           cancel,
-		pending:          make(map[int64]chan rpcResponseEnvelope),
-		pendingApprovals: make(map[string]chan core.PermissionResult),
-		preambleSent:     resumeID != "" && resumeID != core.ContinueSession,
+		url:                   url,
+		workDir:               workDir,
+		model:                 model,
+		effort:                effort,
+		mode:                  mode,
+		baseURL:               baseURL,
+		modelProvider:         modelProvider,
+		extraEnv:              append([]string(nil), extraEnv...),
+		codexHome:             strings.TrimSpace(codexHome),
+		promptPreamble:        buildCodexPromptPreamble(systemPrompt, appendPrompt),
+		workspaceDependencies: workspaceDependencies,
+		events:                make(chan core.Event, 128),
+		ctx:                   sessionCtx,
+		cancel:                cancel,
+		pending:               make(map[int64]chan rpcResponseEnvelope),
+		pendingApprovals:      make(map[string]chan core.PermissionResult),
+		preambleSent:          resumeID != "" && resumeID != core.ContinueSession,
 	}
 	s.alive.Store(true)
 
@@ -323,7 +325,7 @@ func (s *appServerSession) initialize() error {
 
 func (s *appServerSession) ensureThread(resumeID string) error {
 	if resumeID != "" && resumeID != core.ContinueSession {
-		params := s.threadRequestParams()
+		params := s.threadRequestParams(false)
 		params["threadId"] = resumeID
 		params["persistExtendedHistory"] = true
 
@@ -341,7 +343,7 @@ func (s *appServerSession) ensureThread(resumeID string) error {
 	}
 
 	var resp threadStartResponse
-	if err := s.request("thread/start", s.threadRequestParams(), &resp); err != nil {
+	if err := s.request("thread/start", s.threadRequestParams(true), &resp); err != nil {
 		return err
 	}
 	if resp.Thread.ID == "" {
@@ -353,7 +355,7 @@ func (s *appServerSession) ensureThread(resumeID string) error {
 	return nil
 }
 
-func (s *appServerSession) threadRequestParams() map[string]any {
+func (s *appServerSession) threadRequestParams(includeDynamicTools bool) map[string]any {
 	params := map[string]any{
 		"experimentalRawEvents":  false,
 		"persistExtendedHistory": false,
@@ -366,6 +368,9 @@ func (s *appServerSession) threadRequestParams() map[string]any {
 		if sandbox != "" {
 			params["sandbox"] = sandbox
 		}
+	}
+	if includeDynamicTools && s.workspaceDependencies.Enabled {
+		params["dynamicTools"] = workspaceDependenciesDynamicTools()
 	}
 	return params
 }
@@ -756,6 +761,30 @@ func (s *appServerSession) handleRequestUserInput(rawID json.RawMessage, paramsR
 }
 
 func (s *appServerSession) handleDynamicToolCall(rawID json.RawMessage, paramsRaw json.RawMessage) {
+	var params appServerDynamicToolCallParams
+	if err := json.Unmarshal(paramsRaw, &params); err != nil {
+		_ = s.writeJSON(map[string]any{
+			"jsonrpc": "2.0", "id": rawID,
+			"error": map[string]any{"code": -32602, "message": "invalid params"},
+		})
+		return
+	}
+
+	if s.workspaceDependencies.Enabled && isWorkspaceDependenciesTool(params.Namespace, params.Tool) {
+		text, err := loadWorkspaceDependencies(s.workspaceDependencies.RuntimeRoot)
+		if err != nil {
+			text = "workspace dependency runtime unavailable: " + err.Error()
+		}
+		_ = s.writeJSON(map[string]any{
+			"jsonrpc": "2.0", "id": rawID,
+			"result": map[string]any{
+				"success":      err == nil,
+				"contentItems": []map[string]any{{"type": "inputText", "text": text}},
+			},
+		})
+		return
+	}
+
 	_ = s.writeJSON(map[string]any{
 		"jsonrpc": "2.0", "id": rawID,
 		"result": map[string]any{

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -33,22 +33,24 @@ func init() {
 //   - "full-auto": --sandbox workspace-write + approval_policy=never
 //   - "yolo":      --dangerously-bypass-approvals-and-sandbox
 type Agent struct {
-	workDir         string
-	model           string
-	reasoningEffort string
-	mode            string // "suggest" | "auto-edit" | "full-auto" | "yolo"
-	backend         string // "exec" | "app_server"
-	appServerURL    string
-	codexHome       string
-	systemPrompt    string
-	appendPrompt    string
-	cmd             string   // CLI binary name, default "codex"
-	cliExtraArgs    []string // extra args parsed from cmd after the binary
-	providers       []core.ProviderConfig
-	activeIdx       int      // -1 = no provider set
-	configEnv       []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
-	sessionEnv      []string
-	mu              sync.RWMutex
+	workDir                      string
+	model                        string
+	reasoningEffort              string
+	mode                         string // "suggest" | "auto-edit" | "full-auto" | "yolo"
+	backend                      string // "exec" | "app_server"
+	appServerURL                 string
+	workspaceDependencies        bool
+	workspaceDependenciesRuntime string
+	codexHome                    string
+	systemPrompt                 string
+	appendPrompt                 string
+	cmd                          string   // CLI binary name, default "codex"
+	cliExtraArgs                 []string // extra args parsed from cmd after the binary
+	providers                    []core.ProviderConfig
+	activeIdx                    int      // -1 = no provider set
+	configEnv                    []string // env vars from [projects.agent.options.env] — persists across SetSessionEnv calls
+	sessionEnv                   []string
+	mu                           sync.RWMutex
 }
 
 func New(opts map[string]any) (core.Agent, error) {
@@ -61,6 +63,8 @@ func New(opts map[string]any) (core.Agent, error) {
 	mode, _ := opts["mode"].(string)
 	backend, _ := opts["backend"].(string)
 	appServerURL, _ := opts["app_server_url"].(string)
+	workspaceDependencies, _ := opts["workspace_dependencies"].(bool)
+	workspaceDependenciesRuntime, _ := opts["workspace_dependencies_runtime"].(string)
 	codexHome, _ := opts["codex_home"].(string)
 	systemPrompt, _ := opts["system_prompt"].(string)
 	appendPrompt, _ := opts["append_system_prompt"].(string)
@@ -92,19 +96,21 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 
 	return &Agent{
-		workDir:         workDir,
-		model:           model,
-		reasoningEffort: normalizeReasoningEffort(reasoningEffort),
-		mode:            mode,
-		backend:         backend,
-		appServerURL:    appServerURL,
-		codexHome:       strings.TrimSpace(codexHome),
-		systemPrompt:    strings.TrimSpace(systemPrompt),
-		appendPrompt:    strings.TrimSpace(appendPrompt),
-		cmd:             cmd,
-		cliExtraArgs:    cliExtraArgs,
-		configEnv:       configEnv,
-		activeIdx:       -1,
+		workDir:                      workDir,
+		model:                        model,
+		reasoningEffort:              normalizeReasoningEffort(reasoningEffort),
+		mode:                         mode,
+		backend:                      backend,
+		appServerURL:                 appServerURL,
+		workspaceDependencies:        workspaceDependencies,
+		workspaceDependenciesRuntime: strings.TrimSpace(workspaceDependenciesRuntime),
+		codexHome:                    strings.TrimSpace(codexHome),
+		systemPrompt:                 strings.TrimSpace(systemPrompt),
+		appendPrompt:                 strings.TrimSpace(appendPrompt),
+		cmd:                          cmd,
+		cliExtraArgs:                 cliExtraArgs,
+		configEnv:                    configEnv,
+		activeIdx:                    -1,
 	}, nil
 }
 
@@ -353,7 +359,6 @@ func readCodexCachedModels() []core.ModelOption {
 	return parseCodexModelsJSON(b)
 }
 
-
 // parseCodexModelsJSON parses a Codex models JSON file (model_catalog.json
 // or models_cache.json) into a deduplicated, filtered slice of ModelOption.
 // It is shared by readCodexCachedModels and readCodexModelCatalog.
@@ -398,7 +403,6 @@ func parseCodexModelsJSON(data []byte) []core.ModelOption {
 	}
 	return models
 }
-
 
 // readCodexModelCatalog reads $CODEX_HOME/config.toml to find the
 // model_catalog_json setting, then reads and parses that JSON file.
@@ -468,6 +472,8 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	reasoningEffort := a.reasoningEffort
 	backend := a.backend
 	appServerURL := a.appServerURL
+	workspaceDependencies := a.workspaceDependencies
+	workspaceDependenciesRuntime := a.workspaceDependenciesRuntime
 	codexHome := a.codexHome
 	systemPrompt := a.systemPrompt
 	appendPrompt := a.appendPrompt
@@ -501,7 +507,10 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 
 	if backend == "app_server" {
-		return newAppServerSession(ctx, appServerURL, workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome, systemPrompt, appendPrompt)
+		return newAppServerSession(ctx, appServerURL, workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome, systemPrompt, appendPrompt, workspaceDependenciesConfig{
+			Enabled:     workspaceDependencies,
+			RuntimeRoot: workspaceDependenciesRuntime,
+		})
 	}
 	if codexHome != "" {
 		extraEnv = append(extraEnv, "CODEX_HOME="+codexHome)
@@ -571,6 +580,12 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	}
 	if a.codexHome != "" {
 		opts["codex_home"] = a.codexHome
+	}
+	if a.workspaceDependencies {
+		opts["workspace_dependencies"] = true
+	}
+	if a.workspaceDependenciesRuntime != "" {
+		opts["workspace_dependencies_runtime"] = a.workspaceDependenciesRuntime
 	}
 	return opts
 }

--- a/agent/codex/codex_model_test.go
+++ b/agent/codex/codex_model_test.go
@@ -72,13 +72,21 @@ func TestNormalizeAppServerURL_EmptyKeepsWebSocketDefault(t *testing.T) {
 
 func TestWorkspaceAgentOptions_PreservesStdIOAppServerURL(t *testing.T) {
 	a := &Agent{
-		backend:      "app_server",
-		appServerURL: normalizeAppServerURL("stdio"),
+		backend:                      "app_server",
+		appServerURL:                 normalizeAppServerURL("stdio"),
+		workspaceDependencies:        true,
+		workspaceDependenciesRuntime: "/runtime",
 	}
 
 	opts := a.WorkspaceAgentOptions()
 	if got := opts["app_server_url"]; got != "stdio://" {
 		t.Fatalf("WorkspaceAgentOptions()[app_server_url] = %#v, want stdio://", got)
+	}
+	if got := opts["workspace_dependencies"]; got != true {
+		t.Fatalf("WorkspaceAgentOptions()[workspace_dependencies] = %#v, want true", got)
+	}
+	if got := opts["workspace_dependencies_runtime"]; got != "/runtime" {
+		t.Fatalf("WorkspaceAgentOptions()[workspace_dependencies_runtime] = %#v, want /runtime", got)
 	}
 }
 

--- a/agent/codex/workspace_dependencies.go
+++ b/agent/codex/workspace_dependencies.go
@@ -1,0 +1,187 @@
+package codex
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	workspaceDependenciesToolName        = "load_workspace_dependencies"
+	workspaceDependenciesToolDescription = "Locate the configured bundled workspace dependency runtime paths for this local Codex thread, including Node.js, Python, and useful libraries for working with spreadsheets, slide decks, Word documents, and PDFs. This is read-only and takes no arguments."
+)
+
+type workspaceDependenciesConfig struct {
+	Enabled     bool
+	RuntimeRoot string
+}
+
+type appServerDynamicToolCallParams struct {
+	ThreadID  string  `json:"threadId"`
+	TurnID    string  `json:"turnId"`
+	CallID    string  `json:"callId"`
+	Namespace *string `json:"namespace"`
+	Tool      string  `json:"tool"`
+	Arguments any     `json:"arguments"`
+}
+
+type workspaceDependenciesManifest struct {
+	BundleVersion       string `json:"bundleVersion"`
+	ArtifactToolVersion string `json:"artifactToolVersion"`
+}
+
+func workspaceDependenciesDynamicTools() []map[string]any {
+	return []map[string]any{{
+		"type":        "function",
+		"name":        workspaceDependenciesToolName,
+		"description": workspaceDependenciesToolDescription,
+		"inputSchema": map[string]any{
+			"type":                 "object",
+			"properties":           map[string]any{},
+			"additionalProperties": false,
+		},
+	}}
+}
+
+func isWorkspaceDependenciesTool(namespace *string, tool string) bool {
+	if tool != workspaceDependenciesToolName {
+		return false
+	}
+	if namespace == nil || strings.TrimSpace(*namespace) == "" {
+		return true
+	}
+	// Desktop-created threads persist this tool in the codex_app namespace.
+	return *namespace == "codex_app"
+}
+
+func loadWorkspaceDependencies(configuredRoot string) (string, error) {
+	root, err := workspaceDependenciesRuntimeRoot(configuredRoot)
+	if err != nil {
+		return "", err
+	}
+
+	manifestPath := filepath.Join(root, "runtime.json")
+	b, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", manifestPath, err)
+	}
+	var manifest workspaceDependenciesManifest
+	if err := json.Unmarshal(b, &manifest); err != nil {
+		return "", fmt.Errorf("decode %s: %w", manifestPath, err)
+	}
+	if strings.TrimSpace(manifest.BundleVersion) == "" {
+		return "", fmt.Errorf("%s has no bundleVersion", manifestPath)
+	}
+
+	deps := filepath.Join(root, "dependencies")
+	node, err := firstExistingPath(
+		filepath.Join(deps, "node", "bin", "node"),
+		filepath.Join(deps, "node", "node.exe"),
+	)
+	if err != nil {
+		return "", fmt.Errorf("locate bundled Node.js: %w", err)
+	}
+	nodeModules, err := requireExistingPath(filepath.Join(deps, "node", "node_modules"))
+	if err != nil {
+		return "", fmt.Errorf("locate bundled Node.js packages: %w", err)
+	}
+	_, err = requireExistingPath(filepath.Join(nodeModules, "@oai", "artifact-tool"))
+	if err != nil {
+		return "", fmt.Errorf("locate @oai/artifact-tool: %w", err)
+	}
+	python, err := firstExistingPath(
+		filepath.Join(deps, "python", "bin", "python3"),
+		filepath.Join(deps, "python", "bin", "python"),
+		filepath.Join(deps, "python", "python.exe"),
+	)
+	if err != nil {
+		return "", fmt.Errorf("locate bundled Python: %w", err)
+	}
+	pythonPackages, err := requireExistingPath(filepath.Join(deps, "python"))
+	if err != nil {
+		return "", fmt.Errorf("locate bundled Python packages: %w", err)
+	}
+	overrideBin, err := requireExistingPath(filepath.Join(deps, "bin", "override"))
+	if err != nil {
+		return "", fmt.Errorf("locate override binaries: %w", err)
+	}
+	fallbackBin, err := requireExistingPath(filepath.Join(deps, "bin", "fallback"))
+	if err != nil {
+		return "", fmt.Errorf("locate fallback binaries: %w", err)
+	}
+	git, err := firstExistingPath(filepath.Join(fallbackBin, "git"), filepath.Join(fallbackBin, "git.exe"))
+	if err != nil {
+		return "", fmt.Errorf("locate bundled Git: %w", err)
+	}
+	pnpm, err := firstExistingPath(filepath.Join(fallbackBin, "pnpm"), filepath.Join(fallbackBin, "pnpm.cmd"), filepath.Join(fallbackBin, "pnpm.exe"))
+	if err != nil {
+		return "", fmt.Errorf("locate bundled pnpm: %w", err)
+	}
+
+	artifactVersion := strings.TrimSpace(manifest.ArtifactToolVersion)
+	if artifactVersion == "" {
+		artifactVersion = "unknown"
+	}
+	return fmt.Sprintf(`Workspace dependencies are available for this cc-connect Codex thread.
+
+### Workspace Dependencies
+Use these bundled paths for sheets, slides, documents, PDFs, images, or browser automation:
+- Bundle version: %s
+- @oai/artifact-tool version: %s
+- Runtime validation: required paths are present
+- Git executable: %s
+- Node.js executable: %s
+- Node.js packages: %s
+- pnpm executable: %s
+- Python executable: %s
+- Python packages: %s
+- Override binaries: %s
+- Fallback binaries: %s`,
+		quotePath(manifest.BundleVersion),
+		quotePath(artifactVersion),
+		quotePath(git),
+		quotePath(node),
+		quotePath(nodeModules),
+		quotePath(pnpm),
+		quotePath(python),
+		quotePath(pythonPackages),
+		quotePath(overrideBin),
+		quotePath(fallbackBin),
+	), nil
+}
+
+func workspaceDependenciesRuntimeRoot(configuredRoot string) (string, error) {
+	if root := strings.TrimSpace(configuredRoot); root != "" {
+		return filepath.Abs(root)
+	}
+	if root := strings.TrimSpace(os.Getenv("CODEX_PRIMARY_RUNTIME")); root != "" {
+		return filepath.Abs(root)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".cache", "codex-runtimes", "codex-primary-runtime"), nil
+}
+
+func firstExistingPath(paths ...string) (string, error) {
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("none of %s exists", strings.Join(paths, ", "))
+}
+
+func requireExistingPath(path string) (string, error) {
+	if _, err := os.Stat(path); err != nil {
+		return "", fmt.Errorf("%s: %w", path, err)
+	}
+	return path, nil
+}
+
+func quotePath(value string) string {
+	return "`" + value + "`"
+}

--- a/agent/codex/workspace_dependencies_test.go
+++ b/agent/codex/workspace_dependencies_test.go
@@ -1,0 +1,244 @@
+package codex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppServerSession_ThreadStartRegistersWorkspaceDependenciesTool(t *testing.T) {
+	s := &appServerSession{
+		workspaceDependencies: workspaceDependenciesConfig{Enabled: true},
+	}
+
+	params := s.threadRequestParams(true)
+	dynamicTools, ok := params["dynamicTools"].([]map[string]any)
+	if !ok || len(dynamicTools) != 1 {
+		t.Fatalf("dynamicTools = %#v, want one tool", params["dynamicTools"])
+	}
+	tool := dynamicTools[0]
+	if tool["type"] != "function" || tool["name"] != workspaceDependenciesToolName {
+		t.Fatalf("tool = %#v", tool)
+	}
+	if _, ok := tool["inputSchema"].(map[string]any); !ok {
+		t.Fatalf("inputSchema = %#v, want object schema", tool["inputSchema"])
+	}
+}
+
+func TestAppServerSession_ThreadResumeOmitsWorkspaceDependenciesTool(t *testing.T) {
+	s := &appServerSession{
+		workspaceDependencies: workspaceDependenciesConfig{Enabled: true},
+	}
+
+	if params := s.threadRequestParams(false); params["dynamicTools"] != nil {
+		t.Fatalf("dynamicTools = %#v, want omitted for thread/resume", params["dynamicTools"])
+	}
+}
+
+func TestAppServerSession_WorkspaceDependenciesDisabledByDefault(t *testing.T) {
+	s := &appServerSession{}
+	if params := s.threadRequestParams(true); params["dynamicTools"] != nil {
+		t.Fatalf("dynamicTools = %#v, want omitted", params["dynamicTools"])
+	}
+}
+
+func TestAppServerSession_HandleWorkspaceDependenciesTool(t *testing.T) {
+	runtimeRoot := writeTestWorkspaceDependenciesRuntime(t)
+	stdin := &lockedWriteCloser{}
+	s := &appServerSession{
+		stdin: stdin,
+		workspaceDependencies: workspaceDependenciesConfig{
+			Enabled:     true,
+			RuntimeRoot: runtimeRoot,
+		},
+	}
+
+	namespace := "codex_app"
+	s.handleDynamicToolCall(json.RawMessage(`"dyn-1"`), mustJSON(t, appServerDynamicToolCallParams{
+		ThreadID:  "thread-1",
+		TurnID:    "turn-1",
+		CallID:    "call-1",
+		Namespace: &namespace,
+		Tool:      workspaceDependenciesToolName,
+		Arguments: map[string]any{},
+	}))
+
+	response := decodeDynamicToolResponse(t, waitForWrittenJSONLine(t, stdin))
+	if !response.Result.Success {
+		t.Fatalf("success = false, content = %q", response.Result.ContentItems[0].Text)
+	}
+	text := response.Result.ContentItems[0].Text
+	for _, want := range []string{
+		"Bundle version: `test-bundle`",
+		"@oai/artifact-tool version: `test-artifact`",
+		filepath.Join(runtimeRoot, "dependencies", "node", "bin", "node"),
+		filepath.Join(runtimeRoot, "dependencies", "node", "node_modules"),
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("response missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestAppServerSession_HandleWorkspaceDependenciesToolFailsClosed(t *testing.T) {
+	stdin := &lockedWriteCloser{}
+	s := &appServerSession{
+		stdin: stdin,
+		workspaceDependencies: workspaceDependenciesConfig{
+			Enabled:     true,
+			RuntimeRoot: t.TempDir(),
+		},
+	}
+
+	s.handleDynamicToolCall(json.RawMessage(`2`), mustJSON(t, appServerDynamicToolCallParams{
+		Tool:      workspaceDependenciesToolName,
+		Arguments: map[string]any{},
+	}))
+
+	response := decodeDynamicToolResponse(t, waitForWrittenJSONLine(t, stdin))
+	if response.Result.Success {
+		t.Fatal("success = true, want false for missing runtime")
+	}
+	if got := response.Result.ContentItems[0].Text; !strings.Contains(got, "runtime unavailable") {
+		t.Fatalf("content = %q, want runtime unavailable", got)
+	}
+}
+
+func TestAppServerSession_UnknownDynamicToolStillFailsClosed(t *testing.T) {
+	stdin := &lockedWriteCloser{}
+	s := &appServerSession{
+		stdin: stdin,
+		workspaceDependencies: workspaceDependenciesConfig{
+			Enabled: true,
+		},
+	}
+
+	s.handleDynamicToolCall(json.RawMessage(`3`), mustJSON(t, appServerDynamicToolCallParams{
+		Tool:      "unknown_tool",
+		Arguments: map[string]any{},
+	}))
+
+	response := decodeDynamicToolResponse(t, waitForWrittenJSONLine(t, stdin))
+	if response.Result.Success {
+		t.Fatal("success = true, want false")
+	}
+	if got := response.Result.ContentItems[0].Text; got != "tool not available on this client" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestAppServerSession_WorkspaceDependenciesRejectsUnknownNamespace(t *testing.T) {
+	stdin := &lockedWriteCloser{}
+	s := &appServerSession{
+		stdin: stdin,
+		workspaceDependencies: workspaceDependenciesConfig{
+			Enabled: true,
+		},
+	}
+
+	namespace := "untrusted_client"
+	s.handleDynamicToolCall(json.RawMessage(`4`), mustJSON(t, appServerDynamicToolCallParams{
+		Namespace: &namespace,
+		Tool:      workspaceDependenciesToolName,
+		Arguments: map[string]any{},
+	}))
+
+	response := decodeDynamicToolResponse(t, waitForWrittenJSONLine(t, stdin))
+	if response.Result.Success {
+		t.Fatal("success = true, want false")
+	}
+	if got := response.Result.ContentItems[0].Text; got != "tool not available on this client" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestLoadWorkspaceDependencies_WindowsRuntimeLayout(t *testing.T) {
+	runtimeRoot := writeWorkspaceDependenciesRuntime(t, []string{
+		"dependencies/node/node.exe",
+		"dependencies/node/node_modules/@oai/artifact-tool/package.json",
+		"dependencies/python/python.exe",
+		"dependencies/bin/override/soffice.exe",
+		"dependencies/bin/fallback/git.exe",
+		"dependencies/bin/fallback/pnpm.cmd",
+	})
+
+	text, err := loadWorkspaceDependencies(runtimeRoot)
+	if err != nil {
+		t.Fatalf("loadWorkspaceDependencies() error = %v", err)
+	}
+	for _, want := range []string{"node.exe", "python.exe", "git.exe", "pnpm.cmd"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("response missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func writeTestWorkspaceDependenciesRuntime(t *testing.T) string {
+	t.Helper()
+	return writeWorkspaceDependenciesRuntime(t, []string{
+		"dependencies/node/bin/node",
+		"dependencies/node/node_modules/@oai/artifact-tool/package.json",
+		"dependencies/python/bin/python3",
+		"dependencies/bin/override/soffice",
+		"dependencies/bin/fallback/git",
+		"dependencies/bin/fallback/pnpm",
+	})
+}
+
+func writeWorkspaceDependenciesRuntime(t *testing.T, paths []string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, rel := range paths {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte("test"), 0o755); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	manifest := []byte(`{"bundleVersion":"test-bundle","artifactToolVersion":"test-artifact"}`)
+	if err := os.WriteFile(filepath.Join(root, "runtime.json"), manifest, 0o644); err != nil {
+		t.Fatalf("write runtime.json: %v", err)
+	}
+	return root
+}
+
+func mustJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return b
+}
+
+func decodeDynamicToolResponse(t *testing.T, line string) struct {
+	Result struct {
+		Success      bool `json:"success"`
+		ContentItems []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"contentItems"`
+	} `json:"result"`
+} {
+	t.Helper()
+	var response struct {
+		Result struct {
+			Success      bool `json:"success"`
+			ContentItems []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"contentItems"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(line), &response); err != nil {
+		t.Fatalf("decode response %q: %v", line, err)
+	}
+	if len(response.Result.ContentItems) != 1 || response.Result.ContentItems[0].Type != "inputText" {
+		t.Fatalf("contentItems = %#v", response.Result.ContentItems)
+	}
+	return response
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -1569,6 +1569,20 @@ app_secret = "your-feishu-app-secret"
 # Optional: specify Codex reasoning effort / 可选：指定 Codex 推理强度
 # reasoning_effort = "high"  # "minimal" | "low" | "medium" | "high" | "xhigh"
 #
+# Optional (app_server only): expose the managed workspace dependency runtime
+# through Codex's experimental dynamic-tool protocol. This enables skills that
+# require load_workspace_dependencies, such as @oai/artifact-tool workflows.
+# 可选（仅 app_server）：通过 Codex 实验性动态工具协议暴露托管工作区依赖运行时，
+# 供需要 load_workspace_dependencies 的 @oai/artifact-tool 等技能使用。
+# backend = "app_server"
+# app_server_url = "stdio://"
+# workspace_dependencies = true
+# Security: enabling this exposes absolute host runtime paths to the Codex session.
+# 安全提示：启用后会向 Codex 会话暴露宿主机运行时的绝对路径。
+# # Optional override. The default is ~/.cache/codex-runtimes/codex-primary-runtime.
+# # 可选覆盖；默认路径为 ~/.cache/codex-runtimes/codex-primary-runtime。
+# workspace_dependencies_runtime = "/absolute/path/to/codex-primary-runtime"
+#
 # Optional: project system prompt / 可选：项目系统提示
 # Codex has no native system-prompt flag, so cc-connect injects this as a
 # preamble prepended to your first message of each new session (resumed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -133,6 +133,33 @@ Switch at runtime:
 /mode default  # switch back
 ```
 
+### Codex managed workspace dependencies (experimental)
+
+The Codex `app_server` backend can expose an installed managed workspace
+runtime through the app-server dynamic-tool protocol. Enable this for managed
+artifact skills that require `load_workspace_dependencies`, including
+`@oai/artifact-tool` spreadsheet, document, and presentation workflows:
+
+```toml
+[projects.agent.options]
+backend = "app_server"
+app_server_url = "stdio://"
+workspace_dependencies = true
+# Optional; defaults to ~/.cache/codex-runtimes/codex-primary-runtime
+workspace_dependencies_runtime = "/absolute/path/to/codex-primary-runtime"
+```
+
+The runtime must already be installed by the Codex/ChatGPT desktop app.
+cc-connect validates `runtime.json`, the bundled Node.js and Python
+executables, `node_modules`, and `@oai/artifact-tool`; it does not install or
+modify the runtime. The option is disabled by default and only affects new
+app-server threads. Unknown dynamic tools continue to be rejected.
+
+Security: enabling this option returns absolute host runtime paths to the
+Codex session. Only enable it for trusted projects and users, and avoid pointing
+`workspace_dependencies_runtime` at a directory that contains unrelated or
+sensitive files.
+
 ---
 
 ## API Provider Management

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -131,6 +131,30 @@ mode = "default"
 /mode default  # 切回默认
 ```
 
+### Codex 托管工作区依赖（实验性）
+
+Codex 的 `app_server` 后端可以通过动态工具协议暴露已经安装的托管工作区运行时。
+需要 `load_workspace_dependencies` 的托管 artifact 技能（包括使用
+`@oai/artifact-tool` 的表格、文档和演示文稿流程）可启用以下配置：
+
+```toml
+[projects.agent.options]
+backend = "app_server"
+app_server_url = "stdio://"
+workspace_dependencies = true
+# 可选；默认路径为 ~/.cache/codex-runtimes/codex-primary-runtime
+workspace_dependencies_runtime = "/absolute/path/to/codex-primary-runtime"
+```
+
+运行时必须已经由 Codex/ChatGPT 桌面 App 安装。cc-connect 会验证
+`runtime.json`、托管的 Node.js/Python 可执行文件、`node_modules` 和
+`@oai/artifact-tool`，但不会安装或修改运行时。该选项默认关闭，并且只影响新建
+的 app-server thread；未知动态工具仍会被拒绝。
+
+安全提示：启用后会把宿主机运行时的绝对路径返回给 Codex 会话。请仅在可信项目
+和可信用户范围内启用，并且不要让 `workspace_dependencies_runtime` 指向包含无关
+或敏感文件的目录。
+
 ---
 
 ## API Provider 管理


### PR DESCRIPTION
## Summary

Adds an opt-in `load_workspace_dependencies` dynamic-tool bridge for Codex
`app_server` sessions. Managed artifact skills can discover an existing bundled
runtime instead of failing after the skill is loaded but its client-provided
dependency tool is unavailable.

The bridge is disabled by default, validates the configured runtime before
returning any paths, supports the `codex_app` namespace persisted by
Desktop-created threads, and keeps unknown tools fail-closed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

### Automated tests added in this PR

- `TestAppServerSession_ThreadStartRegistersWorkspaceDependenciesTool` — registers the tool only for new app-server threads.
- `TestAppServerSession_ThreadResumeOmitsWorkspaceDependenciesTool` — does not send unsupported dynamic-tool parameters during resume.
- `TestAppServerSession_WorkspaceDependenciesDisabledByDefault` — preserves the default-off behavior.
- `TestAppServerSession_HandleWorkspaceDependenciesTool` — validates and returns the managed runtime paths for the `codex_app` namespace.
- `TestAppServerSession_HandleWorkspaceDependenciesToolFailsClosed` — returns a clear unsuccessful result when the runtime is incomplete.
- `TestAppServerSession_UnknownDynamicToolStillFailsClosed` — preserves rejection of unrelated dynamic tools.
- `TestAppServerSession_WorkspaceDependenciesRejectsUnknownNamespace` — accepts only the unnamespaced or `codex_app` tool contract.
- `TestLoadWorkspaceDependencies_WindowsRuntimeLayout` — covers Windows-style Node.js, Python, Git, and pnpm paths.
- `TestWorkspaceAgentOptions_PreservesStdIOAppServerURL` — verifies the options survive workspace agent recreation.

Commands run locally:

```text
go test ./agent/codex
go test -race ./agent/codex
go vet ./agent/codex
NO_PROXY='*' go test -p 1 -tags no_web ./...
go build -tags no_web ./...
```

The full serial Go suite passed. The `no_web` tag was used because this checkout
does not contain generated `web/dist` assets or installed frontend dependencies.

The implementation path was also validated end-to-end before opening #1556:
Feishu -> cc-connect -> Codex loaded the bundled `@oai/artifact-tool`, created a
2-column by 3-row XLSX file, inspected its values, and rendered a PNG preview.

### For bug fixes only — regression test

Not applicable; this is an opt-in feature.

### Critical User Journeys (CUJ) impact

- [x] No existing core CUJ touched; this is isolated to the Codex app-server adapter.
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

## Manual / user-visible behavior change

Operators using the Codex `app_server` backend can opt in with:

```toml
[projects.agent.options]
backend = "app_server"
app_server_url = "stdio://"
workspace_dependencies = true
# Optional; defaults to ~/.cache/codex-runtimes/codex-primary-runtime
workspace_dependencies_runtime = "/absolute/path/to/codex-primary-runtime"
```

New app-server threads then expose `load_workspace_dependencies` to managed
artifact skills. Existing behavior is unchanged when the option is omitted.

Security: the tool returns absolute host runtime paths to the Codex session.
The feature remains disabled by default, does not download or modify packages,
and the documentation limits it to trusted projects and users.

## Checklist (reviewer will verify)

- [x] Go build passes (`go build -tags no_web ./...`; generated web assets are absent locally)
- [x] Go tests pass (`NO_PROXY='*' go test -p 1 -tags no_web ./...` and targeted Codex race test)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied for the changed scope
- [x] No new hardcoded platform/agent names in `core/`
- [x] No new runtime i18n strings; English and Chinese operator documentation are included
- [x] No secrets / credentials in source

## Related

- Fixes #1556
- Builds on the server-initiated request handling framework from #787
- Related upstream issue: openai/codex#24280
