### PR TITLE
fix(kimi): support Kimi Code CLI >=0.27 stream-json dialect (empty replies + broken resume)

### DIFF
--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -89,7 +89,8 @@ func (ks *kimiSession) buildArgs(prompt string) []string {
 	}
 
 	if sid := ks.CurrentSessionID(); sid != "" {
-		args = append(args, "--resume", sid)
+		// Kimi Code CLI (>=0.27) renamed --resume to -S/--session.
+		args = append(args, "--session", sid)
 	}
 	if ks.model != "" {
 		args = append(args, "--model", ks.model)
@@ -329,12 +330,33 @@ func (ks *kimiSession) handleEvent(raw map[string]any) {
 		ks.handleAssistant(raw)
 	case "tool":
 		ks.handleTool(raw)
+	case "meta":
+		// Kimi Code CLI (>=0.27) emits the resume info as a JSON trailer
+		// instead of the legacy plaintext "To resume this session:" line.
+		if metaType, _ := raw["type"].(string); metaType == "session.resume_hint" {
+			if sid, _ := raw["session_id"].(string); sid != "" {
+				ks.sessionID.Store(sid)
+				slog.Debug("kimiSession: session id updated", "session_id", sid)
+			} else if cmd, _ := raw["command"].(string); cmd != "" {
+				if sid := extractResumeSessionID(cmd); sid != "" {
+					ks.sessionID.Store(sid)
+					slog.Debug("kimiSession: session id updated", "session_id", sid)
+				}
+			}
+		}
 	default:
 		slog.Debug("kimiSession: unhandled role", "role", role)
 	}
 }
 
 func (ks *kimiSession) handleAssistant(raw map[string]any) {
+	// Kimi Code CLI (>=0.27) emits content as a plain string; legacy kimi-cli
+	// used an array of typed blocks. Accept both.
+	if text, ok := raw["content"].(string); ok {
+		if text != "" {
+			ks.pendingMsgs = append(ks.pendingMsgs, text)
+		}
+	}
 	content, _ := raw["content"].([]any)
 	for _, item := range content {
 		block, ok := item.(map[string]any)
@@ -391,8 +413,12 @@ func (ks *kimiSession) handleAssistant(raw map[string]any) {
 
 func (ks *kimiSession) handleTool(raw map[string]any) {
 	toolCallID, _ := raw["tool_call_id"].(string)
-	content, _ := raw["content"].([]any)
 	var outputParts []string
+	// Kimi Code CLI (>=0.27) emits tool content as a plain string.
+	if text, ok := raw["content"].(string); ok && text != "" {
+		outputParts = append(outputParts, text)
+	}
+	content, _ := raw["content"].([]any)
 	for _, item := range content {
 		block, ok := item.(map[string]any)
 		if !ok {

--- a/agent/kimi/session_test.go
+++ b/agent/kimi/session_test.go
@@ -224,13 +224,13 @@ func TestBuildArgs_ResumeSession(t *testing.T) {
 	args := ks.buildArgs("continue")
 	resumeIdx := -1
 	for i, a := range args {
-		if a == "--resume" {
+		if a == "--session" {
 			resumeIdx = i
 			break
 		}
 	}
-	require.GreaterOrEqual(t, resumeIdx, 0, "args should include --resume; got %v", args)
-	require.Less(t, resumeIdx+1, len(args), "--resume should be followed by an id")
+	require.GreaterOrEqual(t, resumeIdx, 0, "args should include --session; got %v", args)
+	require.Less(t, resumeIdx+1, len(args), "--session should be followed by an id")
 	assert.Equal(t, "sess-xyz", args[resumeIdx+1])
 }
 


### PR DESCRIPTION
## Problem

Kimi Code CLI 0.27 (`brew install kimi-code`, Node build) changed its non-interactive stream-json output. Three drifts break the kimi agent — every turn renders as **"(empty response)"** and sessions never resume:

1. **Reply text dropped.** Assistant/tool events now emit `content` as a **plain string**; `handleAssistant`/`handleTool` only parse the legacy `content[]` typed-block array, so the final reply never reaches `pendingMsgs`.
2. **Resume id never captured.** The CLI no longer prints the plaintext `To resume this session:` line in stream-json mode — it emits a JSON trailer `{"role":"meta","type":"session.resume_hint","session_id":"...","command":"kimi -r ..."}`, which lands in `handleEvent`'s default case and is discarded. Every turn then spawns a fresh session (`agent_session="" is_resume=false`), so users lose all conversation continuity.
3. **Resume flag renamed.** 0.27 accepts `-S/--session`; the `--resume` flag that `buildArgs` sends is rejected (`error: unknown option '--resume'`).

## Fix

- `handleAssistant`/`handleTool`: accept both the legacy block-array and the new plain-string `content` shapes.
- `handleEvent`: handle `role:"meta"` / `type:"session.resume_hint"` and store the session id (from `session_id`, falling back to `extractResumeSessionID(command)`); the plaintext scan stays for older CLIs.
- `buildArgs`: emit `--session <id>` instead of `--resume <id>`.
- `TestBuildArgs_ResumeSession` updated accordingly; `go test ./agent/kimi/` passes.

## Verification

Running a live Telegram bridge against kimi-code 0.27.0: before the patch every turn logged `turn complete ... response_len=16` (the "(empty response)" placeholder) with `agent_session=""`; after the patch turns return the real reply text and consecutive turns share one kimi session id (`agent_session=session_e3da24c3-...` on both), i.e. resume works.

Related: the flag-probe approach from #1456 handles `--print`, but these three surfaces drifted separately.

Note: 0.27 also drops `--work-dir`/`--log-file`; not addressed here to keep the diff small — happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)