### PR TITLE
fix(codex): handle large app-server resume responses

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -325,7 +325,6 @@ func (s *appServerSession) ensureThread(resumeID string) error {
 	if resumeID != "" && resumeID != core.ContinueSession {
 		params := s.threadRequestParams()
 		params["threadId"] = resumeID
-		params["persistExtendedHistory"] = true
 
 		var resp threadResumeResponse
 		if err := s.request("thread/resume", params, &resp); err != nil {
@@ -970,24 +969,18 @@ func (s *appServerSession) Close() error {
 
 func (s *appServerSession) readLoop(r io.Reader) {
 	defer s.wg.Done()
-	scanner := bufio.NewScanner(r)
-	scanBuf := make([]byte, 0, 64*1024)
-	const maxLineSize = 10 * 1024 * 1024 // 10MB
-	scanner.Buffer(scanBuf, maxLineSize)
 
-	for scanner.Scan() {
+	err := readJSONLines(r, func(data []byte) error {
 		select {
 		case <-s.ctx.Done():
-			return
+			return s.ctx.Err()
 		default:
 		}
-
-		data := scanner.Bytes()
 
 		var probe map[string]json.RawMessage
 		if err := json.Unmarshal(data, &probe); err != nil {
 			slog.Debug("codex app-server: invalid JSON", "error", err)
-			continue
+			return nil
 		}
 
 		_, hasID := probe["id"]
@@ -999,7 +992,7 @@ func (s *appServerSession) readLoop(r io.Reader) {
 			var resp rpcResponseEnvelope
 			if err := json.Unmarshal(data, &resp); err != nil {
 				slog.Debug("codex app-server: bad response envelope", "error", err)
-				continue
+				return nil
 			}
 			s.handleResponse(resp)
 
@@ -1012,31 +1005,24 @@ func (s *appServerSession) readLoop(r io.Reader) {
 			var notif rpcNotificationEnvelope
 			if err := json.Unmarshal(data, &notif); err != nil {
 				slog.Debug("codex app-server: bad notification envelope", "error", err)
-				continue
+				return nil
 			}
 			s.handleNotification(notif.Method, notif.Params)
 		}
-	}
+		return nil
+	})
 
-	err := scanner.Err()
 	if err != nil {
 		if s.ctx.Err() == nil && !errors.Is(err, io.EOF) {
 			slog.Warn("codex app-server read failed", "error", err)
-			if errors.Is(err, bufio.ErrTooLong) {
-				s.emitError(fmt.Errorf("codex app-server line exceeds max size (%d bytes): %w", maxLineSize, err))
-			} else {
-				s.emitError(fmt.Errorf("codex app-server connection closed: %w", err))
-			}
+			s.emitError(fmt.Errorf("codex app-server connection closed: %w", err))
 		}
-		s.alive.Store(false)
-		s.rejectPending(err)
-		s.rejectPendingApprovals(err)
-		return
+	} else {
+		err = io.EOF
 	}
-
 	s.alive.Store(false)
-	s.rejectPending(io.EOF)
-	s.rejectPendingApprovals(io.EOF)
+	s.rejectPending(err)
+	s.rejectPendingApprovals(err)
 }
 
 func (s *appServerSession) stderrLoop(r io.Reader) {

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -177,6 +177,96 @@ func TestAppServerSession_RequestTimeoutIncludesBlockedStdinWrite(t *testing.T) 
 	}
 }
 
+func TestAppServerSession_ReadLoopHandlesLargeResponseLine(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan rpcResponseEnvelope, 1)
+	s := &appServerSession{
+		ctx:     ctx,
+		events:  make(chan core.Event, 1),
+		pending: map[int64]chan rpcResponseEnvelope{1: ch},
+	}
+
+	var input bytes.Buffer
+	input.WriteString(`{"jsonrpc":"2.0","id":1,"result":{"cwd":"/tmp/project","model":"gpt-test","reasoningEffort":"high","thread":{"id":"thread-large"},"initialTurnsPage":{"data":"`)
+	input.WriteString(strings.Repeat("x", 11*1024*1024))
+	input.WriteString(`"}}}` + "\n")
+
+	s.wg.Add(1)
+	go s.readLoop(&input)
+
+	select {
+	case resp := <-ch:
+		if resp.Error != nil {
+			t.Fatalf("response error = %v", resp.Error)
+		}
+		var decoded threadResumeResponse
+		if err := json.Unmarshal(resp.Result, &decoded); err != nil {
+			t.Fatalf("unmarshal result: %v", err)
+		}
+		if decoded.Thread.ID != "thread-large" {
+			t.Fatalf("thread id = %q, want thread-large", decoded.Thread.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for large response")
+	}
+
+	s.wg.Wait()
+}
+
+func TestAppServerSession_ResumeDoesNotRequestExtendedHistory(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stdin := &lockedWriteCloser{}
+	s := &appServerSession{
+		ctx:     ctx,
+		stdin:   stdin,
+		pending: make(map[int64]chan rpcResponseEnvelope),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.ensureThread("thread-existing")
+	}()
+
+	line := waitForWrittenJSONLine(t, stdin)
+	var request struct {
+		ID     int64          `json:"id"`
+		Method string         `json:"method"`
+		Params map[string]any `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(line), &request); err != nil {
+		t.Fatalf("decode request %q: %v", line, err)
+	}
+	if request.Method != "thread/resume" {
+		t.Fatalf("method = %q, want thread/resume", request.Method)
+	}
+	if got := request.Params["threadId"]; got != "thread-existing" {
+		t.Fatalf("threadId = %#v, want thread-existing", got)
+	}
+	if got := request.Params["persistExtendedHistory"]; got != false {
+		t.Fatalf("persistExtendedHistory = %#v, want false", got)
+	}
+
+	s.handleResponse(rpcResponseEnvelope{
+		ID: request.ID,
+		Result: json.RawMessage(
+			`{"cwd":"/tmp/project","model":"gpt-test","thread":{"id":"thread-existing"}}`,
+		),
+	})
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ensureThread() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for thread resume")
+	}
+}
+
 func TestMapAppServerRateLimits_PrefersMultiBucketView(t *testing.T) {
 	report := mapAppServerRateLimits(appServerRateLimitsResponse{
 		RateLimits: appServerRateLimitSnapshot{


### PR DESCRIPTION
## Summary

- avoid requesting extended history when resuming Codex app-server threads
- read Codex app-server stdout with the existing line reader instead of `bufio.Scanner`
- add regression coverage for both resume request parameters and JSON-RPC response lines larger than 10 MiB

## Why

Large Codex app-server `thread/resume` responses can include `initialTurnsPage` payloads that exceed the current 10 MiB scanner token limit. When this happens, cc-connect fails the resume with `bufio.Scanner: token too long` and falls back to a fresh session even though the target Codex thread is valid.

This is a concrete variant of #189.

The primary fix is to keep `persistExtendedHistory` disabled because cc-connect does not consume the returned history. Reusing `readJSONLines` is a defensive fix for other large newline-framed app-server messages; it also keeps the app-server transport consistent with the existing Codex JSONL transport.

## Validation

- `go test ./agent/codex ./core`
- `go test -tags no_web ./...`
- `make build-noweb`
- manual smoke test against a large Codex session file: cc-connect successfully resumed the target thread instead of falling back to a fresh session

The rebased single-commit branch was additionally checked with `go test ./agent/codex`. A plain `go test ./...` in the clean checkout reached all packages but still has unrelated environment failures: the embedded web package has no `web/dist`, and `platform/cloud-web`'s gateway webhook test returned HTTP 502.
