### PR TITLE
fix(core): preserve queued messages after recall

### DIFF
--- a/core/cuj_test.go
+++ b/core/cuj_test.go
@@ -1230,6 +1230,97 @@ func TestCUJ_A6_A7_CoveredByPlatformLayer(t *testing.T) {
 }
 
 // ===========================================================================
+// CUJ-A8 · Recalling one queued message must not discard messages sent after it
+// ===========================================================================
+
+func TestCUJ_A8_RecallPreservesLaterQueuedMessage(t *testing.T) {
+	env := newCUJEnv(t)
+	key := "test:recall-user"
+
+	// Keep the first turn busy long enough to queue two later messages. The
+	// first queued message will be recalled after it becomes the active turn;
+	// the second queued message must survive that cancellation boundary.
+	env.agent.setNextSessionEvents([]Event{{Type: EventResult, Content: "first reply", Done: true}}, 250)
+	env.engine.ReceiveMessage(plat(env.plat), &Message{
+		SessionKey: key,
+		Platform:   "test",
+		MessageID:  "msg-first",
+		UserID:     "recall-user",
+		UserName:   "recall-user",
+		Content:    "first long-running request",
+		ReplyCtx:   "ctx-first",
+	})
+
+	env.waitFor("first agent session starts", 2*time.Second, func() bool {
+		env.agent.mu.Lock()
+		defer env.agent.mu.Unlock()
+		return len(env.agent.sessions) == 1
+	})
+	env.agent.mu.Lock()
+	firstSession := env.agent.sessions[0]
+	env.agent.mu.Unlock()
+	firstSession.mu.Lock()
+	firstSession.delayMs = 5_000
+	firstSession.mu.Unlock()
+
+	// B and C both arrive while A is busy, so they are accepted in FIFO order.
+	env.engine.ReceiveMessage(plat(env.plat), &Message{
+		SessionKey: key,
+		Platform:   "test",
+		MessageID:  "msg-recalled",
+		UserID:     "recall-user",
+		UserName:   "recall-user",
+		Content:    "this queued request will be recalled",
+		ReplyCtx:   "ctx-recalled",
+	})
+	env.engine.ReceiveMessage(plat(env.plat), &Message{
+		SessionKey: key,
+		Platform:   "test",
+		MessageID:  "msg-after-recall",
+		UserID:     "recall-user",
+		UserName:   "recall-user",
+		Content:    "answer this message after the recall",
+		ReplyCtx:   "ctx-after-recall",
+	})
+
+	// Wait until B is actually active, then deliver the platform recall event.
+	// This pins the same path as the Feishu fallback probe in the live incident.
+	env.waitFor("recalled queued message becomes active", 2*time.Second, func() bool {
+		env.engine.interactiveMu.Lock()
+		state := env.engine.interactiveStates[key]
+		env.engine.interactiveMu.Unlock()
+		if state == nil {
+			return false
+		}
+		state.mu.Lock()
+		defer state.mu.Unlock()
+		return state.currentMessageID == "msg-recalled"
+	})
+	env.engine.ReceiveMessage(plat(env.plat), &Message{
+		Platform:  "test",
+		MessageID: "msg-recalled",
+		Recalled:  true,
+	})
+
+	// The user-visible contract: C is still delivered to a replacement agent
+	// session and receives a final reply. Before the fix, the silent recall path
+	// cleared the whole pending queue, so this condition timed out.
+	env.waitFor("message after recall receives a reply", 3*time.Second, func() bool {
+		return env.sentContains("ok")
+	})
+	env.agent.mu.Lock()
+	started := append([]*cujAgentSession(nil), env.agent.sessions...)
+	env.agent.mu.Unlock()
+	if len(started) < 2 {
+		t.Fatalf("agent sessions started = %d, want replacement session after recall", len(started))
+	}
+	prompts := started[len(started)-1].getSentPrompts()
+	if len(prompts) != 1 || !strings.Contains(prompts[0], "answer this message after the recall") {
+		t.Fatalf("replacement session prompts = %v, want only the later queued message", prompts)
+	}
+}
+
+// ===========================================================================
 // SPRINT 2 · B organization (session lifecycle remaining)
 // ===========================================================================
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -3827,6 +3827,15 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	}
 	stopTyping = nil // ownership transferred; prevent defer from double-stopping
 
+	// Recalling the active message stops its agent process, but messages queued
+	// after the recalled one are independent user turns and must survive. Move
+	// them into a replacement interactive state and continue with the oldest
+	// queued message while retaining ownership of the session lock.
+	if e.resumePendingAfterStoppedTurn(state, session, sessions, interactiveKey, agent, workspaceDir, ccSessionKey) {
+		unlocked = true // the nested processor now owns and releases the lock
+		return
+	}
+
 	// Start unsolicited reader and arm the idle close timer BEFORE draining
 	// queued messages. drainPendingMessages releases the session lock, and
 	// without this ordering the next user message can race in, call
@@ -3851,6 +3860,71 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	if e.drainPendingMessages(state, session, sessions, interactiveKey) {
 		unlocked = true
 	}
+}
+
+// resumePendingAfterStoppedTurn starts a replacement agent session for user
+// messages that were queued after an intentionally stopped turn (currently a
+// recalled active message). It returns true after transferring session-lock
+// ownership to the replacement processor.
+func (e *Engine) resumePendingAfterStoppedTurn(state *interactiveState, session *Session, sessions *SessionManager, interactiveKey string, agent Agent, workspaceDir, ccSessionKey string) bool {
+	state.mu.Lock()
+	if !state.stopped || len(state.pendingMessages) == 0 {
+		state.mu.Unlock()
+		return false
+	}
+	pending := append([]queuedMessage(nil), state.pendingMessages...)
+	state.pendingMessages = nil
+	state.mu.Unlock()
+
+	// New messages can arrive after the recalled state is detached but before
+	// this goroutine regains control. They live in a placeholder state; append
+	// them after the older preserved queue so FIFO order remains intact.
+	e.interactiveMu.Lock()
+	placeholder := e.interactiveStates[interactiveKey]
+	if placeholder == nil || placeholder == state {
+		placeholder = &interactiveState{eventsNeedResync: true}
+		e.interactiveStates[interactiveKey] = placeholder
+	}
+	placeholder.mu.Lock()
+	pending = append(pending, placeholder.pendingMessages...)
+	placeholder.pendingMessages = append([]queuedMessage(nil), pending[1:]...)
+	placeholder.mu.Unlock()
+	e.interactiveMu.Unlock()
+
+	next := pending[0]
+	messageSessionKey := next.msgSessionKey
+	if messageSessionKey == "" {
+		messageSessionKey = ccSessionKey
+	}
+	if messageSessionKey == "" {
+		messageSessionKey = interactiveKey
+	}
+	messagePlatform := next.msgPlatform
+	if messagePlatform == "" && next.platform != nil {
+		messagePlatform = next.platform.Name()
+	}
+
+	nextMessage := &Message{
+		SessionKey:        messageSessionKey,
+		Platform:          messagePlatform,
+		MessageID:         next.messageID,
+		UserID:            next.userID,
+		UserName:          next.userName,
+		Content:           next.content,
+		Images:            next.images,
+		Files:             next.files,
+		FromVoice:         next.fromVoice,
+		ReplyCtx:          next.replyCtx,
+		ChannelKey:        next.channelKey,
+		UserMessageTimeMs: next.userMessageTimeMs,
+	}
+	slog.Info("resuming queued messages after stopped turn",
+		"session", interactiveKey,
+		"next_msg_id", next.messageID,
+		"remaining_queue", len(pending)-1,
+	)
+	e.processInteractiveMessageWith(next.platform, nextMessage, session, agent, sessions, interactiveKey, workspaceDir, ccSessionKey)
+	return true
 }
 
 // getOrCreateWorkspaceAgent returns (or creates) a per-workspace agent and session manager.
@@ -6074,6 +6148,13 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 channelClosed:
 	// Channel closed - process exited unexpectedly
+	// An intentional stop (notably message recall) closes the agent channel too.
+	// Its queued successors are recovered by processInteractiveMessageWith, so
+	// do not misclassify that close as a crash and drain their queue here.
+	if state.isStopped() {
+		sp.discard()
+		return
+	}
 	slog.Warn("agent process exited", "session_key", sessionKey)
 	state.mu.Lock()
 	state.eventsNeedResync = true
@@ -10121,10 +10202,6 @@ func (e *Engine) stopInteractiveSessionWithOptions(sessionKey string, notifyQueu
 		}
 		if notifyQueued {
 			e.notifyDroppedQueuedMessages(state, fmt.Errorf("session cancelled"))
-		} else {
-			state.mu.Lock()
-			state.pendingMessages = nil
-			state.mu.Unlock()
 		}
 
 		// Mark eventsNeedResync so the next turn drains stale events from
@@ -10162,10 +10239,6 @@ normalCleanup:
 	}
 	if notifyQueued {
 		e.notifyDroppedQueuedMessages(state, fmt.Errorf("session reset"))
-	} else {
-		state.mu.Lock()
-		state.pendingMessages = nil
-		state.mu.Unlock()
 	}
 	e.closeAgentSessionAsync(sessionKey, agentSession)
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -10499,6 +10499,74 @@ func TestHandleMessageRecallStopsCurrentMessageSilently(t *testing.T) {
 	}
 }
 
+func TestHandleMessageRecallPreservesLaterQueueWhenAgentChannelCloses(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	oldSession := newQueuingSession("old-session")
+	replacementSession := newResultAgentSession("reply after recall")
+
+	var startMu sync.Mutex
+	startCount := 0
+	agent := &controllableAgent{startSessionFn: func(_ context.Context, _ string) (AgentSession, error) {
+		startMu.Lock()
+		defer startMu.Unlock()
+		startCount++
+		if startCount == 1 {
+			return oldSession, nil
+		}
+		return replacementSession, nil
+	}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	key := "test:recall-queue"
+
+	e.ReceiveMessage(p, &Message{
+		SessionKey: key, Platform: "test", MessageID: "msg-first",
+		UserID: "user", UserName: "user", Content: "first", ReplyCtx: "ctx-first",
+	})
+	waitForSendCount := func(want int) {
+		t.Helper()
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			oldSession.sendMu.Lock()
+			got := len(oldSession.sendCalls)
+			oldSession.sendMu.Unlock()
+			if got >= want {
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		t.Fatalf("old session send count did not reach %d", want)
+	}
+	waitForSendCount(1)
+
+	e.ReceiveMessage(p, &Message{
+		SessionKey: key, Platform: "test", MessageID: "msg-recalled",
+		UserID: "user", UserName: "user", Content: "recalled", ReplyCtx: "ctx-recalled",
+	})
+	e.ReceiveMessage(p, &Message{
+		SessionKey: key, Platform: "test", MessageID: "msg-later",
+		UserID: "user", UserName: "user", Content: "later message", ReplyCtx: "ctx-later",
+	})
+
+	oldSession.events <- Event{Type: EventResult, Content: "first reply", Done: true}
+	waitForSendCount(2)
+
+	e.ReceiveMessage(p, &Message{Platform: "test", MessageID: "msg-recalled", Recalled: true})
+	sent := waitForPlatformSend(p, 4, 3*time.Second)
+	foundReply := false
+	for _, message := range sent {
+		if message == "reply after recall" {
+			foundReply = true
+			break
+		}
+	}
+	if !foundReply {
+		t.Fatalf("sent = %v, want reply for later queued message after recall", sent)
+	}
+	if len(replacementSession.sentPrompts) != 1 || !strings.Contains(replacementSession.sentPrompts[0], "later message") {
+		t.Fatalf("replacement prompts = %v, want later queued message", replacementSession.sentPrompts)
+	}
+}
+
 func TestHandleMessageRecallRemovesQueuedMessageSilently(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)


### PR DESCRIPTION
## Summary

- preserve messages queued after an active message is recalled
- resume the oldest surviving message in a replacement agent session while retaining FIFO order
- avoid treating an intentionally closed agent event channel as a crash that drops the queue

## Root cause

The silent recall path cleared the entire `pendingMessages` queue when stopping the recalled turn. Messages sent after the recalled message were therefore accepted and acknowledged, then discarded without a response.

## Tests

- `go test -race ./core -run 'TestCUJ_A8_RecallPreservesLaterQueuedMessage|TestHandleMessageRecallPreservesLaterQueueWhenAgentChannelCloses' -count=1`
- `go test ./core -count=1`
- `go test -tags no_web ./... -count=1`
