### PR TITLE
fix(core): freeze streaming preview on interrupt, don't discard

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -4784,7 +4784,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		select {
 		case <-stopCh:
-			sp.discard()
+			// See EventError below for why freeze() not discard().
+			sp.freeze()
 			return
 		case event, ok = <-events:
 			if !ok {
@@ -4814,7 +4815,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			slog.Error("agent session idle timeout: no events for too long, killing session",
 				"session_key", sessionKey, "timeout", e.eventIdleTimeout, "elapsed", time.Since(turnStart))
 			cp.Finalize(ProgressCardStateFailed)
-			sp.discard()
+			// See EventError below for why freeze() not discard().
+			sp.freeze()
 			state.mu.Lock()
 			state.eventsNeedResync = true
 			p := state.platform
@@ -4827,7 +4829,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			slog.Warn("agent turn exceeded max_turn_time: sending stop signal, will force-kill if needed",
 				"session_key", sessionKey, "max_turn_time", e.maxTurnTime, "elapsed", elapsed)
 			cp.Finalize(ProgressCardStateFailed)
-			sp.discard()
+			// See EventError below for why freeze() not discard().
+			sp.freeze()
 			state.mu.Lock()
 			p := state.platform
 			state.mu.Unlock()
@@ -4878,7 +4881,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 		}
 
 		if state.isStopped() {
-			sp.discard()
+			// See EventError below for why freeze() not discard().
+			sp.freeze()
 			state.mu.Lock()
 			state.eventsNeedResync = true
 			state.mu.Unlock()
@@ -5958,7 +5962,14 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 		case EventError:
 			cp.Finalize(ProgressCardStateFailed)
-			sp.discard()
+			// Freeze (not discard) the streaming preview: discard() routes
+			// through PreviewCleaner.DeletePreviewMessage, which on Feishu/Lark
+			// surfaces as "XX 撤回了一条消息" and hides the partial answer the
+			// user just watched stream. freeze() commits the accumulated text
+			// in-place and marks the preview degraded. Same fix applied to the
+			// other "interrupt mid-stream" branches below (/stop, idle timeout,
+			// max_turn_time).
+			sp.freeze()
 			state.mu.Lock()
 			state.eventsNeedResync = true
 			state.mu.Unlock()


### PR DESCRIPTION
## Problem

When the streaming preview is interrupted mid-stream (`/stop`, idle timeout, `max_turn_time`, `EventError`, `isStopped`), `sp.discard()` calls `PreviewCleaner.DeletePreviewMessage`. On Feishu this surfaces as "XX 撤回了一条消息", hiding the partial answer the user just watched stream. On Discord/Telegram the card simply vanishes.

#882 replaced `sp.discard()` with `sp.finish()` for the `/stop` case. That fix was only correct for Feishu — `finish()` checks `PreviewFinishPreference.KeepPreviewOnFinish()` and updates the card in-place, but on platforms that don't implement that preference (Discord, Telegram, …) `finish()` still routes to `PreviewCleaner.DeletePreviewMessage` and the card disappears, same as `discard()`. The bug was masked because Feishu was the only streaming-preview platform covered by tests.

## Fix

Switch all five interrupt paths from `discard()` to `freeze()`. `freeze()` updates the card in-place via `MessageUpdater.UpdateMessage` and never calls `PreviewCleaner.DeletePreviewMessage`, so partial text survives uniformly across Feishu, Discord, Telegram, and any other streaming-preview platform. It also sets `degraded = true` so subsequent `appendText` knows to start a fresh card.

Supersedes #882.

## Sites changed

All in `core/engine.go`:

| Path                  | Line  | Trigger                                       |
| --------------------- | ----- | --------------------------------------------- |
| `<-stopCh`            | 4832  | user pressed `/stop`                          |
| idle timeout          | 4863  | no events for `eventIdleTimeout`              |
| `max_turn_time`       | 4877  | turn exceeded `maxTurnTime`                   |
| `state.isStopped()`   | 4929  | stopped via any other code path               |
| `EventError`          | 6070  | agent reported error                          |

## Sites intentionally not changed

These stay on `sp.discard()` — each for a reason that would be wrong to "freeze":

| Line  | Context                              | Why `discard`                                                |
| ----- | ------------------------------------ | ------------------------------------------------------------ |
| 4842  | `pendingSend` error                  | Send failed before stream started — no partial text to keep  |
| 5472  | `permTimer` + `<-stopCh`             | Stopping before permission reply — no text yet              |
| 5509  | permission pending + `<-stopCh`      | Same                                                         |
| 5741  | silent reply (`NO_REPLY`)            | Silent replies must vanish — that's the point                |
| 5827  | tool calls + `segmentStart > 0`      | Replacing already-streamed segments, not losing text         |
| 5837  | `suppressDuplicate`                  | Discarding the duplicate preview                             |
| 6133  | `isSilentReply` on abnormal exit     | Silent reply must disappear                                  |
| 6139  | `stripTrailingSilent`                | Same                                                         |
| 6153  | toolCount + segmentStart             | Segment replacement                                          |

These stay on `sp.finish(...)` — they're the "happy path" finalizers, not interrupt paths:

| Line  | Context                              | Why `finish`                                                 |
| ----- | ------------------------------------ | ------------------------------------------------------------ |
| 5709  | StreamingCard path silent cleanup    | Different code path (rich card, not preview)                 |
| 5845  | `EventResult` normal completion      | Need to send final accumulated text + status footer          |
| 6164  | `channelClosed`                      | Same — finalize stream with full text                        |

`sp.unfreeze()` at line 5521 (resume preview after permission granted) is also unchanged — that's the inverse of `freeze()`, not an alternative.

## Test plan

- [x] `/stop` mid-stream on Feishu: card stays, no "recall" message
- [x] `go test ./core/ -run TestCUJ` passes
- [x] `go build ./...` passes
