### PR TITLE
fix(slack): ignore edited @mentions instead of re-running the agent

### DIFF
--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -179,6 +179,16 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					return
 				}
 
+				// Editing a mention re-fires a fresh app_mention with Edited set;
+				// ignore it rather than reprocessing the edit as a new prompt.
+				// This also drops edit-to-add-mention (a message edited to newly
+				// @-mention the bot) — an accepted limitation, matching how
+				// Telegram and Discord ignore all inbound edits.
+				if ev.Edited != nil {
+					slog.Debug("slack: ignoring edited app_mention", "user", ev.User, "channel", ev.Channel)
+					return
+				}
+
 				if ts := ev.TimeStamp; ts != "" {
 					if dotIdx := strings.IndexByte(ts, '.'); dotIdx > 0 {
 						if sec, err := strconv.ParseInt(ts[:dotIdx], 10, 64); err == nil {

--- a/platform/slack/slack_test.go
+++ b/platform/slack/slack_test.go
@@ -2,12 +2,73 @@ package slack
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/chenhg5/cc-connect/core"
 	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
 )
+
+// appMentionEvent wraps an AppMentionEvent in the socketmode/EventsAPI envelope
+// that handleEvent unwraps. Request is nil so handleEvent skips the socket Ack.
+func appMentionEvent(ev *slackevents.AppMentionEvent) socketmode.Event {
+	return socketmode.Event{
+		Type: socketmode.EventTypeEventsAPI,
+		Data: slackevents.EventsAPIEvent{
+			Type: slackevents.CallbackEvent,
+			InnerEvent: slackevents.EventsAPIInnerEvent{
+				Type: "app_mention",
+				Data: ev,
+			},
+		},
+	}
+}
+
+func TestHandleEvent_EditedAppMentionIgnored(t *testing.T) {
+	var calls int
+	p := &Platform{
+		channelNameCache: map[string]string{"C1": "general"},
+		handler:          func(core.Platform, *core.Message) { calls++ },
+	}
+	p.userNameCache.Store("U1", "Alice") // seed caches so a missed guard fails cleanly, not via nil client
+	// A current ts keeps the old-message guard from dropping the event first,
+	// so a regressed Edited guard would let this reach the handler (calls == 1).
+	now := time.Now().Unix()
+	p.handleEvent(appMentionEvent(&slackevents.AppMentionEvent{
+		User:      "U1",
+		Text:      "<@B> redo it",
+		Channel:   "C1",
+		TimeStamp: fmt.Sprintf("%d.000100", now),
+		Edited:    &slackevents.Edited{User: "U1", TimeStamp: fmt.Sprintf("%d.000000", now+1)},
+	}))
+	if calls != 0 {
+		t.Fatalf("edited app_mention dispatched %d messages, want 0", calls)
+	}
+}
+
+func TestHandleEvent_NormalAppMentionDispatches(t *testing.T) {
+	var calls int
+	p := &Platform{
+		channelNameCache: map[string]string{"C1": "general"},
+		handler:          func(core.Platform, *core.Message) { calls++ },
+	}
+	p.userNameCache.Store("U1", "Alice") // avoid nil client in resolveUserName
+	// A realistic (current) ts, like a real mention: passes the old-message
+	// guard and, with no Edited marker, must reach the handler.
+	p.handleEvent(appMentionEvent(&slackevents.AppMentionEvent{
+		User:      "U1",
+		Text:      "<@B> run tests",
+		Channel:   "C1",
+		TimeStamp: fmt.Sprintf("%d.000200", time.Now().Unix()),
+	}))
+	if calls != 1 {
+		t.Fatalf("normal app_mention dispatched %d messages, want 1", calls)
+	}
+}
 
 func TestStripAppMentionText(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Problem

Editing a message that @-mentions the bot makes Slack re-fire a fresh
`app_mention` event, this time with `Edited` set. The Socket Mode handler in
`platform/slack/slack.go` had no edit guard, so it reprocessed the edited mention
as a brand-new inbound message and started a **duplicate agent turn** — a user who
only meant to correct a typo triggers the agent to run again.

Telegram and Discord already ignore inbound edits; Slack was the outlier.

(Distinct from the Socket Mode retransmission dedup in #364 — that handles Slack
redelivering the *same* event; here Slack sends a *new* event for a user edit.)

## Fix

In the `AppMentionEvent` branch of `handleEvent`, drop the event when
`ev.Edited != nil`, before it reaches the message handler:

```go
if ev.Edited != nil {
    slog.Debug("slack: ignoring edited app_mention", "user", ev.User, "channel", ev.Channel)
    return
}
```

Accepted limitation, matching Telegram/Discord: this also ignores an
*edit-to-add-mention* (a message edited to newly @-mention the bot). Inbound edits
are ignored uniformly rather than special-cased.

## Verification

- `TestHandleEvent_EditedAppMentionIgnored` — an edited `app_mention` with a
  current timestamp (so the pre-existing old-message guard doesn't mask the
  result) dispatches 0 messages. Fails on pre-fix code.
- `TestHandleEvent_NormalAppMentionDispatches` — a normal current-timestamp
  mention still dispatches exactly 1 message (guards against over-dropping).
- `go build ./platform/slack/ ./core/` ✓
- `go vet ./platform/slack/` ✓
- `go test ./platform/slack/` ✓ · `go test -race ./platform/slack/` ✓
- `gofmt -l` clean ✓

🤖 90% Claude