### PR TITLE
fix(core): open API control socket to run_as_user agents

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1272,7 +1272,7 @@ func main() {
 	}
 
 	// Start internal API server for CLI send
-	apiSrv, err := core.NewAPIServer(cfg.DataDir)
+	apiSrv, err := core.NewAPIServer(cfg.DataDir, cfg.RunAsUsers())
 	if err != nil {
 		slog.Warn("api server unavailable", "error", err)
 	} else {

--- a/cmd/cc-connect/runas_startup.go
+++ b/cmd/cc-connect/runas_startup.go
@@ -39,13 +39,7 @@ func runRunAsUserStartupChecks(ctx context.Context, cfg *config.Config) error {
 		otherUsers []string
 	}
 	var pendingProjects []pending
-	var allUsers []string
-	for _, proj := range cfg.Projects {
-		if proj.RunAsUser == "" {
-			continue
-		}
-		allUsers = append(allUsers, proj.RunAsUser)
-	}
+	allUsers := cfg.RunAsUsers()
 	for _, proj := range cfg.Projects {
 		if proj.RunAsUser == "" {
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -1423,6 +1423,23 @@ func (cfg *Config) ResolveProviderRefs() {
 	}
 }
 
+// RunAsUsers returns the distinct, non-empty run_as_user values across all
+// projects, in first-seen config order. Consumers that need the set of OS
+// users the agents run as (startup preflight, API-socket access) share this
+// rather than re-deriving it.
+func (cfg *Config) RunAsUsers() []string {
+	var users []string
+	seen := make(map[string]bool)
+	for _, proj := range cfg.Projects {
+		if proj.RunAsUser == "" || seen[proj.RunAsUser] {
+			continue
+		}
+		seen[proj.RunAsUser] = true
+		users = append(users, proj.RunAsUser)
+	}
+	return users
+}
+
 // ResolveForAgent applies per-agent-type overrides (Endpoints, AgentModels,
 // AgentModelLists) to a copy of the provider and returns it.
 func (p ProviderConfig) ResolveForAgent(agentType string) ProviderConfig {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3474,3 +3474,46 @@ func TestRemoveGlobalProvider_CleansUpProviderRefs(t *testing.T) {
 		t.Errorf("proj2 provider_refs: want [], got %v", refs2)
 	}
 }
+
+func TestConfigRunAsUsers(t *testing.T) {
+	tests := []struct {
+		name  string
+		users []string // run_as_user per project ("" = unset)
+		want  []string
+	}{
+		{
+			name:  "distinct users in config order, empty skipped",
+			users: []string{"alice", "", "bob"},
+			want:  []string{"alice", "bob"},
+		},
+		{
+			name:  "duplicates collapse to one",
+			users: []string{"claude", "claude"},
+			want:  []string{"claude"},
+		},
+		{
+			name:  "none set returns empty",
+			users: []string{"", ""},
+			want:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Config
+			for i, u := range tt.users {
+				p := validProject("proj" + string(rune('0'+i)))
+				p.RunAsUser = u
+				cfg.Projects = append(cfg.Projects, p)
+			}
+			got := cfg.RunAsUsers()
+			if len(got) != len(tt.want) {
+				t.Fatalf("RunAsUsers() = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("RunAsUsers()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/core/api.go
+++ b/core/api.go
@@ -62,8 +62,10 @@ type SendRequest struct {
 	AtAll      bool              `json:"at_all,omitempty"`
 }
 
-// NewAPIServer creates an API server on a Unix socket.
-func NewAPIServer(dataDir string) (*APIServer, error) {
+// NewAPIServer creates an API server on a Unix socket. runAsUsers is the set of
+// configured run_as_user targets (see Config.RunAsUsers); when non-empty the
+// socket is opened to those agent user(s) so they can connect without EACCES.
+func NewAPIServer(dataDir string, runAsUsers []string) (*APIServer, error) {
 	sockDir := filepath.Join(dataDir, "run")
 	if err := os.MkdirAll(sockDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create run dir: %w", err)
@@ -80,6 +82,11 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 	if err := os.Chmod(sockPath, 0o600); err != nil {
 		_ = listener.Close()
 		return nil, fmt.Errorf("chmod socket: %w", err)
+	}
+	// Open the socket to the run_as_user agent(s). Non-fatal: on failure the
+	// socket still works for root, the agent just can't connect (issue #1527).
+	if err := grantSocketAccess(sockPath, runAsUsers); err != nil {
+		slog.Warn("api socket: could not grant run_as_user access", "error", err)
 	}
 
 	s := &APIServer{

--- a/core/api_socket_unix.go
+++ b/core/api_socket_unix.go
@@ -13,10 +13,18 @@
 // it to exactly the configured agent user(s):
 //
 //   - one target  -> chown owner to that user, keep 0600 (only that user + root)
-//   - N targets    -> if they share a narrow (non-broad) primary group, chgrp to
-//                      it + 0660; otherwise refuse and leave the socket
-//                      restricted (never silently widen access)
+//   - N targets    -> if they share a group we can confirm is narrow (see
+//                      isNarrowSharedGroup), chgrp to it + 0660; otherwise
+//                      refuse and leave the socket 0600 (never silently widen)
 //   - no targets   -> leave untouched (default deployment is unchanged)
+//
+// Caveat on the N-target path: 0660 grants access to every member of the shared
+// group, and we cannot enumerate group membership portably. "Narrow" therefore
+// means "not a known system/shared group" (gid range + name denylist), not
+// "contains only the agent users" — an operator who adds another account to
+// that group grants it control-socket access. The single-target path (the
+// common case, and the one issue #1527 hits) has no such caveat: 0600 owned by
+// the agent restricts to that user plus root.
 package core
 
 import (
@@ -46,12 +54,37 @@ type socketAccess struct {
 	mode os.FileMode
 }
 
-// broadGroups are well-known shared groups that would over-expose a control
-// socket if used for 0660 group access. If configured run_as_users share one
-// of these as their primary group, we refuse rather than widen access.
+// minSharedGID is the lowest group id we treat as a plausibly-narrow,
+// application-created group. Groups below it are system/shared groups
+// (root=0, wheel, staff=20, users=100, ...) that must never gate a 0660
+// control socket. 1000 is the conventional Linux GID_MIN; on macOS an
+// operator wanting the multi-user path must likewise use a >=1000 group.
+const minSharedGID = 1000
+
+// broadGroups are well-known shared groups refused by name as a second line
+// of defence behind the gid-range check in isNarrowSharedGroup. Names are a
+// belt-and-suspenders signal, not the primary guard — see that function.
 var broadGroups = map[string]bool{
 	"root": true, "wheel": true, "sudo": true, "admin": true, "adm": true,
 	"staff": true, "users": true, "daemon": true, "bin": true, "sys": true,
+	"nogroup": true, "nobody": true, "docker": true, "www-data": true,
+}
+
+// isNarrowSharedGroup reports whether a group shared by multiple run_as_users
+// is safe to expose the socket to at 0660. It fails closed: we can only
+// positively confirm narrowness from the gid range and a name denylist, not
+// from membership (Go's os/user cannot enumerate group members portably), so
+// anything we cannot confirm is treated as broad and refused. This does NOT
+// prove the group contains only the agent users — an operator who adds a third
+// account to a narrow group grants it socket access (documented at file head).
+func isNarrowSharedGroup(gid int, group string) bool {
+	if group == "" {
+		return false // unresolved group name — cannot verify, refuse
+	}
+	if gid < minSharedGID || gid >= 65534 {
+		return false // system/shared groups and the nobody/nogroup sentinels
+	}
+	return !broadGroups[strings.ToLower(group)]
 }
 
 func lookupUnixUser(username string) (userIdent, error) {
@@ -106,8 +139,8 @@ func planSocketAccess(runAsUsers []string, lookup userLookupFunc) (socketAccess,
 				return none, fmt.Errorf("run_as_users do not share a primary group (%q vs gid %d); set a shared group and socket perms explicitly", name, gid)
 			}
 		}
-		if broadGroups[strings.ToLower(group)] || gid == 0 {
-			return none, fmt.Errorf("run_as_users share broad primary group %q (gid %d); refusing to expose control socket to it", group, gid)
+		if !isNarrowSharedGroup(gid, group) {
+			return none, fmt.Errorf("run_as_users share group %q (gid %d) that is not a confirmed narrow group; refusing to expose control socket to it — set socket perms explicitly", group, gid)
 		}
 		return socketAccess{uid: -1, gid: gid, mode: 0o660}, nil
 	}

--- a/core/api_socket_unix.go
+++ b/core/api_socket_unix.go
@@ -1,0 +1,135 @@
+//go:build !windows
+
+// api_socket_unix.go — grant the API control socket to the run_as_user
+// agent(s).
+//
+// The daemon creates the socket 0600 owned by the process user (root when a
+// project uses run_as_user, since spawning via `sudo -iu` requires a root
+// supervisor). The agent then runs as a different, unprivileged user and gets
+// EACCES on connect(), so `send`/`cron`/`timer`/`relay` all fail (issue #1527).
+//
+// Unlike the non-secret system-prompt file (#1429, fixed by chmod 0644), this
+// socket accepts control requests, so it must NOT be world-accessible. We open
+// it to exactly the configured agent user(s):
+//
+//   - one target  -> chown owner to that user, keep 0600 (only that user + root)
+//   - N targets    -> if they share a narrow (non-broad) primary group, chgrp to
+//                      it + 0660; otherwise refuse and leave the socket
+//                      restricted (never silently widen access)
+//   - no targets   -> leave untouched (default deployment is unchanged)
+package core
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+)
+
+// userIdent is the resolved Unix identity of a run_as_user target.
+type userIdent struct {
+	uid   int
+	gid   int    // primary group id
+	group string // primary group name
+}
+
+// userLookupFunc resolves a username to its Unix identity. Abstracted so the
+// permission-planning logic is testable without real OS users.
+type userLookupFunc func(username string) (userIdent, error)
+
+// socketAccess is the ownership/mode change to apply to the socket. A uid or
+// gid of -1 means "leave unchanged"; a mode of 0 means "leave mode unchanged".
+type socketAccess struct {
+	uid  int
+	gid  int
+	mode os.FileMode
+}
+
+// broadGroups are well-known shared groups that would over-expose a control
+// socket if used for 0660 group access. If configured run_as_users share one
+// of these as their primary group, we refuse rather than widen access.
+var broadGroups = map[string]bool{
+	"root": true, "wheel": true, "sudo": true, "admin": true, "adm": true,
+	"staff": true, "users": true, "daemon": true, "bin": true, "sys": true,
+}
+
+func lookupUnixUser(username string) (userIdent, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return userIdent{}, err
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return userIdent{}, fmt.Errorf("parse uid %q: %w", u.Uid, err)
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return userIdent{}, fmt.Errorf("parse gid %q: %w", u.Gid, err)
+	}
+	group := ""
+	if g, err := user.LookupGroupId(u.Gid); err == nil {
+		group = g.Name
+	}
+	return userIdent{uid: uid, gid: gid, group: group}, nil
+}
+
+// planSocketAccess decides how to open the socket to the given run_as_user
+// targets. It never returns a plan that widens access beyond the target
+// user(s); ambiguous multi-user cases return an error so the caller leaves the
+// socket restricted.
+func planSocketAccess(runAsUsers []string, lookup userLookupFunc) (socketAccess, error) {
+	none := socketAccess{uid: -1, gid: -1, mode: 0}
+	switch len(runAsUsers) {
+	case 0:
+		return none, nil
+	case 1:
+		id, err := lookup(runAsUsers[0])
+		if err != nil {
+			return none, fmt.Errorf("resolve run_as_user %q: %w", runAsUsers[0], err)
+		}
+		// Owner becomes the agent; 0600 already restricts to owner + root.
+		return socketAccess{uid: id.uid, gid: -1, mode: 0}, nil
+	default:
+		gid := -1
+		group := ""
+		for _, name := range runAsUsers {
+			id, err := lookup(name)
+			if err != nil {
+				return none, fmt.Errorf("resolve run_as_user %q: %w", name, err)
+			}
+			if gid == -1 {
+				gid, group = id.gid, id.group
+				continue
+			}
+			if id.gid != gid {
+				return none, fmt.Errorf("run_as_users do not share a primary group (%q vs gid %d); set a shared group and socket perms explicitly", name, gid)
+			}
+		}
+		if broadGroups[strings.ToLower(group)] || gid == 0 {
+			return none, fmt.Errorf("run_as_users share broad primary group %q (gid %d); refusing to expose control socket to it", group, gid)
+		}
+		return socketAccess{uid: -1, gid: gid, mode: 0o660}, nil
+	}
+}
+
+// grantSocketAccess opens the socket at sockPath to the configured run_as_user
+// agent(s) per planSocketAccess. Callers treat a returned error as non-fatal
+// (the socket still works for root); it just means the agent can't connect.
+func grantSocketAccess(sockPath string, runAsUsers []string) error {
+	acc, err := planSocketAccess(runAsUsers, lookupUnixUser)
+	if err != nil {
+		return err
+	}
+	if acc.uid != -1 || acc.gid != -1 {
+		if err := os.Chown(sockPath, acc.uid, acc.gid); err != nil {
+			return fmt.Errorf("chown socket: %w", err)
+		}
+	}
+	if acc.mode != 0 {
+		if err := os.Chmod(sockPath, acc.mode); err != nil {
+			return fmt.Errorf("chmod socket: %w", err)
+		}
+	}
+	return nil
+}

--- a/core/api_socket_unix_test.go
+++ b/core/api_socket_unix_test.go
@@ -1,0 +1,169 @@
+//go:build !windows
+
+package core
+
+import (
+	"net"
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+func TestPlanSocketAccess(t *testing.T) {
+	// Fake lookup: users a/b share narrow group "cc-agents" (gid 3000);
+	// user c is in the broad "staff" group (gid 20); user d is in its own
+	// private group (gid 4000); "ghost" does not exist.
+	idents := map[string]userIdent{
+		"a": {uid: 1001, gid: 3000, group: "cc-agents"},
+		"b": {uid: 1002, gid: 3000, group: "cc-agents"},
+		"c": {uid: 1003, gid: 20, group: "staff"},
+		"d": {uid: 1004, gid: 4000, group: "d"},
+	}
+	lookup := func(name string) (userIdent, error) {
+		id, ok := idents[name]
+		if !ok {
+			return userIdent{}, os.ErrNotExist
+		}
+		return id, nil
+	}
+
+	tests := []struct {
+		name    string
+		users   []string
+		want    socketAccess
+		wantErr bool
+	}{
+		{
+			name:  "no users leaves socket untouched",
+			users: nil,
+			want:  socketAccess{uid: -1, gid: -1, mode: 0},
+		},
+		{
+			name:  "single user chowns owner, keeps mode",
+			users: []string{"a"},
+			want:  socketAccess{uid: 1001, gid: -1, mode: 0},
+		},
+		{
+			name:  "shared narrow group chgrps and relaxes to 0660",
+			users: []string{"a", "b"},
+			want:  socketAccess{uid: -1, gid: 3000, mode: 0o660},
+		},
+		{
+			name:    "shared broad group refuses (no silent widening)",
+			users:   []string{"c", "c"},
+			wantErr: true,
+		},
+		{
+			name:    "distinct groups refuse",
+			users:   []string{"a", "d"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown user propagates error",
+			users:   []string{"ghost"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := planSocketAccess(tt.users, lookup)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("planSocketAccess(%v) = %+v, want error", tt.users, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("planSocketAccess(%v) unexpected error: %v", tt.users, err)
+			}
+			if got != tt.want {
+				t.Errorf("planSocketAccess(%v) = %+v, want %+v", tt.users, got, tt.want)
+			}
+		})
+	}
+}
+
+// newUnixSocket creates a listening unix socket at 0600, mirroring
+// NewAPIServer's setup, and returns its path. It chdirs into the temp dir and
+// binds a short relative name to stay under the platform's sun_path length
+// limit (~104 bytes on macOS), which the long t.TempDir() path would exceed.
+func newUnixSocket(t *testing.T) string {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	sock := "api.sock"
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	if err := os.Chmod(sock, 0o600); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	return sock
+}
+
+func statMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	return fi.Mode().Perm()
+}
+
+func statUID(t *testing.T, path string) int {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("stat sys not *syscall.Stat_t")
+	}
+	return int(st.Uid)
+}
+
+func TestGrantSocketAccess_NoUsersLeaves0600(t *testing.T) {
+	sock := newUnixSocket(t)
+	if err := grantSocketAccess(sock, nil); err != nil {
+		t.Fatalf("grantSocketAccess: %v", err)
+	}
+	if mode := statMode(t, sock); mode != 0o600 {
+		t.Errorf("mode = %o, want 0600", mode)
+	}
+}
+
+func TestGrantSocketAccess_SingleUserChownsOwner(t *testing.T) {
+	// chown to self is permitted without privileges; chown to a different
+	// uid needs root, so we use the current user as the single target.
+	cur, err := user.Current()
+	if err != nil {
+		t.Skipf("cannot resolve current user: %v", err)
+	}
+	wantUID, _ := strconv.Atoi(cur.Uid)
+
+	sock := newUnixSocket(t)
+	if err := grantSocketAccess(sock, []string{cur.Username}); err != nil {
+		t.Fatalf("grantSocketAccess: %v", err)
+	}
+	if uid := statUID(t, sock); uid != wantUID {
+		t.Errorf("owner uid = %d, want %d", uid, wantUID)
+	}
+	if mode := statMode(t, sock); mode != 0o600 {
+		t.Errorf("mode = %o, want 0600 (single-user keeps owner-only)", mode)
+	}
+}
+
+func TestGrantSocketAccess_UnknownUserErrors(t *testing.T) {
+	sock := newUnixSocket(t)
+	err := grantSocketAccess(sock, []string{"definitely-no-such-user-xyz"})
+	if err == nil {
+		t.Fatal("grantSocketAccess with unknown user: want error, got nil")
+	}
+	if mode := statMode(t, sock); mode != 0o600 {
+		t.Errorf("mode = %o, want 0600 (unchanged on failure)", mode)
+	}
+}

--- a/core/api_socket_unix_test.go
+++ b/core/api_socket_unix_test.go
@@ -20,6 +20,15 @@ func TestPlanSocketAccess(t *testing.T) {
 		"b": {uid: 1002, gid: 3000, group: "cc-agents"},
 		"c": {uid: 1003, gid: 20, group: "staff"},
 		"d": {uid: 1004, gid: 4000, group: "d"},
+		// shared narrow gid but its name did not resolve (absent from /etc/group)
+		"e": {uid: 1005, gid: 3000, group: ""},
+		"f": {uid: 1006, gid: 3000, group: ""},
+		// shared but low system gid with a non-denylisted name
+		"g": {uid: 1007, gid: 500, group: "ops"},
+		"h": {uid: 1008, gid: 500, group: "ops"},
+		// shared nobody/nogroup sentinel gid
+		"i": {uid: 1009, gid: 65534, group: "nogroup"},
+		"j": {uid: 1010, gid: 65534, group: "nogroup"},
 	}
 	lookup := func(name string) (userIdent, error) {
 		id, ok := idents[name]
@@ -46,6 +55,10 @@ func TestPlanSocketAccess(t *testing.T) {
 			want:  socketAccess{uid: 1001, gid: -1, mode: 0},
 		},
 		{
+			// grantSocketAccess/NewAPIServer cannot exercise this end-to-end
+			// (needs two real users sharing a narrow group + privilege to
+			// chgrp), so this fake-lookup case is the only coverage of the
+			// 0660 branch — intentional, not a gap.
 			name:  "shared narrow group chgrps and relaxes to 0660",
 			users: []string{"a", "b"},
 			want:  socketAccess{uid: -1, gid: 3000, mode: 0o660},
@@ -58,6 +71,21 @@ func TestPlanSocketAccess(t *testing.T) {
 		{
 			name:    "distinct groups refuse",
 			users:   []string{"a", "d"},
+			wantErr: true,
+		},
+		{
+			name:    "shared but unresolved group name refuses (cannot verify narrow)",
+			users:   []string{"e", "f"},
+			wantErr: true,
+		},
+		{
+			name:    "shared low system gid refuses even with unlisted name",
+			users:   []string{"g", "h"},
+			wantErr: true,
+		},
+		{
+			name:    "shared nobody/nogroup sentinel gid refuses",
+			users:   []string{"i", "j"},
 			wantErr: true,
 		},
 		{
@@ -136,9 +164,13 @@ func TestGrantSocketAccess_NoUsersLeaves0600(t *testing.T) {
 	}
 }
 
-func TestGrantSocketAccess_SingleUserChownsOwner(t *testing.T) {
-	// chown to self is permitted without privileges; chown to a different
-	// uid needs root, so we use the current user as the single target.
+func TestGrantSocketAccess_SingleUserKeeps0600(t *testing.T) {
+	// The single-target path chowns the owner and keeps 0600. We can only
+	// chown to self without root, and the socket is already owned by the
+	// current euid, so the uid assertion below cannot fail here — the "compute
+	// the right uid" contract is proven by TestPlanSocketAccess. What this test
+	// meaningfully guards is that the single-user path does NOT relax the mode
+	// (stays owner-only 0600) and succeeds without error.
 	cur, err := user.Current()
 	if err != nil {
 		t.Skipf("cannot resolve current user: %v", err)
@@ -165,5 +197,56 @@ func TestGrantSocketAccess_UnknownUserErrors(t *testing.T) {
 	}
 	if mode := statMode(t, sock); mode != 0o600 {
 		t.Errorf("mode = %o, want 0600 (unchanged on failure)", mode)
+	}
+}
+
+// newTestAPIServer builds an APIServer in a short relative data dir (to stay
+// under the sun_path length limit) and registers cleanup.
+func newTestAPIServer(t *testing.T, runAsUsers []string) *APIServer {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	srv, err := NewAPIServer(".", runAsUsers)
+	if err != nil {
+		t.Fatalf("NewAPIServer: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	return srv
+}
+
+func TestNewAPIServer_NoRunAsUsersKeeps0600(t *testing.T) {
+	srv := newTestAPIServer(t, nil)
+	if mode := statMode(t, srv.SocketPath()); mode != 0o600 {
+		t.Errorf("mode = %o, want 0600", mode)
+	}
+}
+
+func TestNewAPIServer_SingleRunAsUserKeeps0600(t *testing.T) {
+	// As with TestGrantSocketAccess_SingleUserKeeps0600, the uid assertion
+	// cannot fail unprivileged (socket already owned by current euid); this
+	// guards that wiring run_as_users through NewAPIServer does not relax the
+	// mode away from owner-only 0600.
+	cur, err := user.Current()
+	if err != nil {
+		t.Skipf("cannot resolve current user: %v", err)
+	}
+	wantUID, _ := strconv.Atoi(cur.Uid)
+	srv := newTestAPIServer(t, []string{cur.Username})
+	if uid := statUID(t, srv.SocketPath()); uid != wantUID {
+		t.Errorf("owner uid = %d, want %d", uid, wantUID)
+	}
+	if mode := statMode(t, srv.SocketPath()); mode != 0o600 {
+		t.Errorf("mode = %o, want 0600", mode)
+	}
+}
+
+func TestNewAPIServer_GrantFailureIsNonFatal(t *testing.T) {
+	// An unresolvable run_as_user must not fail construction (R5): the socket
+	// still works for root, the agent just can't connect.
+	srv := newTestAPIServer(t, []string{"definitely-no-such-user-xyz"})
+	if srv == nil {
+		t.Fatal("NewAPIServer returned nil server on grant failure")
+	}
+	if mode := statMode(t, srv.SocketPath()); mode != 0o600 {
+		t.Errorf("mode = %o, want 0600 (unchanged on failed grant)", mode)
 	}
 }

--- a/core/api_socket_windows.go
+++ b/core/api_socket_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package core
+
+// grantSocketAccess is a no-op on Windows: run_as_user is rejected at config
+// parse time, and Windows has no equivalent Unix ownership model for the socket.
+func grantSocketAccess(sockPath string, runAsUsers []string) error {
+	return nil
+}


### PR DESCRIPTION
## Problem

With `run_as_user` set, cc-connect runs as root and spawns the agent as a
different unprivileged user. The daemon's API control socket
(`<data_dir>/run/api.sock`) is created `0600` owned by root (`core/api.go`), and
the `send` / `timer/*` / `cron/*` subcommands the agent is told to run all dial it.
Because the socket is `0600` root-owned and the agent runs as another user, every
dial fails with `EACCES` (`connect: permission denied`) — so an agent under
`run_as_user` cannot send back images, set timers, or create cron jobs.

Same class as #1429 (a `0600` root-owned file unreadable by the `run_as_user`
agent, fixed there for the system-prompt file but not the socket), and the
permission-side counterpart to #966.

Closes #1527.

## Fix

Open the socket to the configured `run_as_user` target(s) immediately after it is
created, without widening access to anyone else:

- **`core/api.go`** — `NewAPIServer` now takes the `run_as_user` set and calls
  `grantSocketAccess` after the `0600` chmod. Non-fatal: on failure the socket
  still works for root and only a warning is logged.
- **`core/api_socket_unix.go`** (`grantSocketAccess`):
  - **one target** → `chown` the socket to that user, keep `0600` (only that user
    + root).
  - **N targets that share a confirmably narrow group** (`isNarrowSharedGroup`) →
    `chgrp` to it + `0660`.
  - **N targets with no narrow shared group** → **fail closed**: leave `0600`,
    never silently widen.
  - **no targets** → untouched (default deployment unchanged).
- **`core/api_socket_windows.go`** — no-op (`run_as_user` is POSIX-only).
- **`config/config.go`** — `Config.RunAsUsers()` collects the distinct
  `run_as_user` values, reused by the startup checks (first commit).

The socket ownership model is the only behavior change; nothing changes when
`run_as_user` is unset.

## Verification

- `go build ./core/ ./config/` ✓ · `go vet ./core/ ./config/` ✓ ·
  `GOOS=windows go build ./core/` ✓
- `gofmt -l` clean (go 1.25, per `go.mod`) ✓
- `go test ./core/ ./config/` ✓ — new `core/api_socket_unix_test.go` covers the
  single-user chown, the shared-group `chgrp`+`0660`, the fail-closed path, and the
  no-target no-op; `config` covers `RunAsUsers()`.
- `go test -race` on the socket / run-as-user tests ✓
- Note: `TestCUJ_A3_ImageReachesAgent` is flaky here via a temp-dir cleanup race —
  it also fails on the untouched base, so it is unrelated to this change.

🤖 90% Claude
