### PR TITLE
fix(core): resume sessions against the agent's real working directory

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -450,7 +450,7 @@ func (a *Agent) SetPlatformPrompt(prompt string) {
 // resume a session whose stored ID was inherited from another project, the
 // engine calls this and — on a false return — clears the ID and starts a
 // fresh session instead of reloading the wrong conversation.
-func (a *Agent) ValidateSessionID(_ context.Context, sessionID string) bool {
+func (a *Agent) ValidateSessionID(_ context.Context, sessionID, cwd string) bool {
 	if sessionID == "" {
 		return false
 	}
@@ -461,7 +461,40 @@ func (a *Agent) ValidateSessionID(_ context.Context, sessionID string) bool {
 	a.mu.RLock()
 	workDir := a.workDir
 	a.mu.RUnlock()
-	return validateSessionIDInProject(homeDir, workDir, sessionID)
+	// Locate the transcript under the session's real reported cwd, but only trust
+	// that cwd when it is within this project's work_dir. The CLI names its
+	// transcript directory after the process cwd, which a custom agent command may
+	// set to a subdirectory of work_dir — trusting an in-tree cwd is what makes
+	// resume survive a restart. A cwd OUTSIDE work_dir, however, cannot be told
+	// apart from another project's cwd leaked onto a shared Session row (issue
+	// #599), so we do not trust it and fall back to work_dir. Empty cwd (records
+	// predating cwd capture) also falls back — the original behavior.
+	dir := workDir
+	if cwd != "" && dirWithin(workDir, cwd) {
+		dir = cwd
+	}
+	return validateSessionIDInProject(homeDir, dir, sessionID)
+}
+
+// dirWithin reports whether target is base or a descendant of base, comparing
+// real path components (not encoded-key prefixes, which would conflate siblings
+// like /workspace and /workspace-other). Used to decide whether a session's
+// reported cwd is trustworthy for locating its transcript (issue #599).
+func dirWithin(base, target string) bool {
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return false
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absBase, absTarget)
+	if err != nil {
+		return false
+	}
+	// Within base iff rel does not escape upward.
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 // validateSessionIDInProject checks whether sessionID has a .jsonl file

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -33,6 +33,7 @@ type claudeSession struct {
 	stdinMu         sync.Mutex
 	events          chan core.Event
 	sessionID       atomic.Value // stores string
+	cwd             atomic.Value // stores string — working dir the CLI reports in its init event
 	permissionMode  atomic.Value // stores string
 	autoApprove     atomic.Bool
 	acceptEditsOnly atomic.Bool
@@ -616,6 +617,13 @@ func (cs *claudeSession) handleSystem(raw map[string]any) {
 	if model, ok := raw["model"].(string); ok && model != "" {
 		cs.activeModel.Store(model)
 	}
+	// The CLI reports its actual working directory in the init event. Capture it
+	// so resume validation can locate the transcript under the real cwd's project
+	// dir rather than assuming cwd == the configured work_dir (a custom agent cmd
+	// may cd to any directory). Read defensively — absent on older CLIs.
+	if cwd, ok := raw["cwd"].(string); ok && cwd != "" {
+		cs.cwd.Store(cwd)
+	}
 	if sid, ok := raw["session_id"].(string); ok && sid != "" {
 		cs.sessionID.Store(sid)
 		evt := core.Event{Type: core.EventText, SessionID: sid}
@@ -1108,6 +1116,11 @@ func (cs *claudeSession) Events() <-chan core.Event {
 
 func (cs *claudeSession) CurrentSessionID() string {
 	v, _ := cs.sessionID.Load().(string)
+	return v
+}
+
+func (cs *claudeSession) CurrentCwd() string {
+	v, _ := cs.cwd.Load().(string)
 	return v
 }
 

--- a/agent/claudecode/session_resume_cwd_test.go
+++ b/agent/claudecode/session_resume_cwd_test.go
@@ -1,0 +1,111 @@
+package claudecode
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeCwdTranscript creates <home>/.claude/projects/<encodeClaudeProjectKey(cwd)>/<id>.jsonl,
+// mirroring where Claude Code writes a session's transcript for a given cwd.
+func writeCwdTranscript(t *testing.T, home, cwd, sessionID string) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude", "projects", encodeClaudeProjectKey(cwd))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, sessionID+".jsonl"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+}
+
+// TestValidateSessionID_UsesStoredCwd: with a real cwd supplied, validation finds
+// the transcript under the cwd's project dir even though it is a subdirectory of
+// work_dir that findProjectDir(work_dir) would never construct — the resume bug.
+func TestValidateSessionID_UsesStoredCwd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	const workDir = "/workspace"
+	const cwd = "/workspace/.sessions/abc123/owner-repo"
+	const id = "sess-uses-cwd"
+	writeCwdTranscript(t, home, cwd, id)
+
+	a := &Agent{workDir: workDir}
+	if !a.ValidateSessionID(context.Background(), id, cwd) {
+		t.Errorf("with stored cwd %q, ValidateSessionID = false, want true", cwd)
+	}
+	// Without the cwd it falls back to work_dir, whose project dir holds no such
+	// file — the pre-fix behavior, and precisely why capturing cwd is needed.
+	if a.ValidateSessionID(context.Background(), id, "") {
+		t.Errorf("empty cwd fell back to work_dir but returned true; transcript is only under the subdir")
+	}
+}
+
+// TestValidateSessionID_EmptyCwdFallsBackToWorkDir: records with no captured cwd
+// still validate against work_dir (backward compatibility — R4).
+func TestValidateSessionID_EmptyCwdFallsBackToWorkDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	const workDir = "/workspace"
+	const id = "sess-fallback"
+	writeCwdTranscript(t, home, workDir, id)
+
+	a := &Agent{workDir: workDir}
+	if !a.ValidateSessionID(context.Background(), id, "") {
+		t.Errorf("empty cwd with transcript under work_dir: got false, want true (fallback)")
+	}
+}
+
+// TestValidateSessionID_CrossProjectSharedRow models the real issue-#599 vector:
+// a Session row shared across two projects. Project A created the session, so the
+// row carries A's session id AND A's cwd. Project B (a different work_dir) resumes
+// the shared row, so validation runs with A's stored cwd. Because A's cwd is not
+// within B's work_dir it is not trusted; validation falls back to B's work_dir,
+// where A's transcript does not exist -> reject. The guard holds.
+func TestValidateSessionID_CrossProjectSharedRow(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	const projectA = "/work/projectA"
+	const projectB = "/work/projectB"
+	const id = "sess-shared-row"
+	writeCwdTranscript(t, home, projectA, id) // transcript only under project A
+
+	a := &Agent{workDir: projectB}
+	if a.ValidateSessionID(context.Background(), id, projectA) {
+		t.Errorf("stored cwd from project A validated under project B's work_dir (#599 leak)")
+	}
+}
+
+// TestValidateSessionID_CwdOutsideWorkDirNotTrusted: a reported cwd outside the
+// agent's work_dir is not trusted for locating the transcript (it cannot be told
+// apart from a leaked foreign cwd, #599), so validation falls back to work_dir.
+func TestValidateSessionID_CwdOutsideWorkDirNotTrusted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	const workDir = "/workspace"
+	const outside = "/somewhere/else"
+	const id = "sess-outside"
+	writeCwdTranscript(t, home, outside, id) // transcript only under the outside cwd
+
+	a := &Agent{workDir: workDir}
+	if a.ValidateSessionID(context.Background(), id, outside) {
+		t.Errorf("cwd outside work_dir was trusted; must fall back to work_dir (#599 safety)")
+	}
+}
+
+// TestClaudeSession_CapturesCwdFromInit: handleSystem records the cwd reported in
+// the CLI init event; an init event without cwd leaves it empty (defensive).
+func TestClaudeSession_CapturesCwdFromInit(t *testing.T) {
+	cs := &claudeSession{}
+	cs.handleSystem(map[string]any{"cwd": "/workspace/.sessions/x/repo"})
+	if got := cs.CurrentCwd(); got != "/workspace/.sessions/x/repo" {
+		t.Errorf("CurrentCwd() = %q, want the init cwd", got)
+	}
+
+	cs2 := &claudeSession{}
+	cs2.handleSystem(map[string]any{"model": "claude-x"}) // no cwd field
+	if got := cs2.CurrentCwd(); got != "" {
+		t.Errorf("CurrentCwd() = %q, want empty when init omits cwd", got)
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -4039,7 +4039,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	// can detect the mismatch and we should clear the ID rather than
 	// resume a conversation that has nothing to do with this project.
 	if startSessionID != "" {
-		if validator, ok := agent.(SessionIDValidator); ok && !validator.ValidateSessionID(e.ctx, startSessionID) {
+		if validator, ok := agent.(SessionIDValidator); ok && !validator.ValidateSessionID(e.ctx, startSessionID, session.GetAgentCwd()) {
 			slog.Warn("session ID does not belong to this project, clearing it",
 				"session_key", sessionKey, "invalid_session_id", startSessionID)
 			session.SetAgentSessionID("", agent.Name())
@@ -4104,6 +4104,9 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		wasEmpty := session.GetAgentSessionID() == ""
 		if session.GetAgentSessionID() != newID {
 			session.SetAgentSessionID(newID, agent.Name())
+			if c, ok := agentSession.(interface{ CurrentCwd() string }); ok {
+				session.SetAgentCwd(c.CurrentCwd())
+			}
 			if wasEmpty {
 				pendingName := session.GetName()
 				if pendingName != "" && pendingName != "session" && pendingName != "default" {
@@ -5448,6 +5451,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					wasEmpty := session.GetAgentSessionID() == ""
 					if session.GetAgentSessionID() != currentID {
 						session.SetAgentSessionID(currentID, e.agent.Name())
+						if c, ok := state.agentSession.(interface{ CurrentCwd() string }); ok {
+							session.SetAgentCwd(c.CurrentCwd())
+						}
 						if wasEmpty {
 							pendingName := session.GetName()
 							if pendingName != "" && pendingName != "session" && pendingName != "default" {

--- a/core/engine.go
+++ b/core/engine.go
@@ -4104,9 +4104,6 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		wasEmpty := session.GetAgentSessionID() == ""
 		if session.GetAgentSessionID() != newID {
 			session.SetAgentSessionID(newID, agent.Name())
-			if c, ok := agentSession.(interface{ CurrentCwd() string }); ok {
-				session.SetAgentCwd(c.CurrentCwd())
-			}
 			if wasEmpty {
 				pendingName := session.GetName()
 				if pendingName != "" && pendingName != "session" && pendingName != "default" {
@@ -5451,15 +5448,21 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					wasEmpty := session.GetAgentSessionID() == ""
 					if session.GetAgentSessionID() != currentID {
 						session.SetAgentSessionID(currentID, e.agent.Name())
-						if c, ok := state.agentSession.(interface{ CurrentCwd() string }); ok {
-							session.SetAgentCwd(c.CurrentCwd())
-						}
 						if wasEmpty {
 							pendingName := session.GetName()
 							if pendingName != "" && pendingName != "session" && pendingName != "default" {
 								sessions.SetSessionName(currentID, pendingName)
 							}
 						}
+					}
+					// Persist the agent's real cwd every turn, not only when the session
+					// id changes: the id is often set earlier (event path / initial
+					// create) while the cwd is known only after the CLI init event, so
+					// gating cwd capture on an id change would miss it. SetAgentCwd
+					// ignores empty and is idempotent, so running it each turn is safe.
+					// Resume validation reads it back (issue #599 + restart resume).
+					if c, ok := state.agentSession.(interface{ CurrentCwd() string }); ok {
+						session.SetAgentCwd(c.CurrentCwd())
 					}
 					sessions.Save()
 				}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -251,8 +251,12 @@ type SystemPromptSupporter interface {
 //   - the agent cannot determine the current project directory
 //
 // The engine treats a false return as "clear the stored ID and start fresh".
+//
+// cwd is the working directory previously reported for this session (empty when
+// none was captured, e.g. a record predating cwd capture). Validators use it to
+// locate the transcript, falling back to their configured work_dir when empty.
 type SessionIDValidator interface {
-	ValidateSessionID(ctx context.Context, sessionID string) bool
+	ValidateSessionID(ctx context.Context, sessionID, cwd string) bool
 }
 
 // TypingIndicator is an optional interface for platforms that can show a

--- a/core/session.go
+++ b/core/session.go
@@ -665,6 +665,7 @@ func (sm *SessionManager) saveLocked() {
 			Name:                s.Name,
 			AgentSessionID:      agentSID,
 			AgentType:           s.AgentType,
+			AgentCwd:            s.AgentCwd,
 			PastAgentSessionIDs: append([]string(nil), s.PastAgentSessionIDs...),
 			History:             append([]HistoryEntry(nil), s.History...),
 			CreatedAt:           s.CreatedAt,

--- a/core/session.go
+++ b/core/session.go
@@ -22,6 +22,11 @@ type Session struct {
 	Name                string         `json:"name"`
 	AgentSessionID      string         `json:"agent_session_id"`
 	AgentType           string         `json:"agent_type,omitempty"`
+	// AgentCwd is the working directory the agent reported for this session.
+	// Resume validation uses it to locate the session's transcript, since the
+	// agent process may run in a different directory than the configured
+	// work_dir (a custom agent command can cd anywhere).
+	AgentCwd            string         `json:"agent_cwd,omitempty"`
 	PastAgentSessionIDs []string       `json:"past_agent_session_ids,omitempty"`
 	// ActiveProvider is the agent provider name that was active when this
 	// session last took a turn. It is restored before --resume so that a
@@ -124,6 +129,25 @@ func (s *Session) GetAgentSessionID() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.AgentSessionID
+}
+
+// SetAgentCwd records the working directory the agent reported for this
+// session, used later to locate its transcript for resume validation. Empty
+// values are ignored so a missing cwd never clobbers a previously captured one.
+func (s *Session) SetAgentCwd(cwd string) {
+	if cwd == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AgentCwd = cwd
+}
+
+// GetAgentCwd atomically reads the agent working directory (empty if none).
+func (s *Session) GetAgentCwd() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.AgentCwd
 }
 
 // SetName atomically updates the session's display name. The management

--- a/core/session_agent_cwd_test.go
+++ b/core/session_agent_cwd_test.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSessionAgentCwd covers the AgentCwd accessors and JSON contract used by
+// resume validation: set/get, empty-does-not-clobber, and omitempty so old
+// records (no agent_cwd) load with an empty value.
+func TestSessionAgentCwd(t *testing.T) {
+	s := &Session{}
+	if got := s.GetAgentCwd(); got != "" {
+		t.Fatalf("new session cwd = %q, want empty", got)
+	}
+
+	const cwd = "/workspace/.sessions/x/owner-repo"
+	s.SetAgentCwd(cwd)
+	if got := s.GetAgentCwd(); got != cwd {
+		t.Fatalf("GetAgentCwd() = %q, want %q", got, cwd)
+	}
+
+	// Empty must not clobber a previously captured cwd.
+	s.SetAgentCwd("")
+	if got := s.GetAgentCwd(); got != cwd {
+		t.Fatalf("empty SetAgentCwd clobbered cwd: got %q", got)
+	}
+
+	// Round-trips via the agent_cwd field.
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"agent_cwd":"`+cwd+`"`) {
+		t.Fatalf("marshaled session missing agent_cwd: %s", b)
+	}
+
+	// omitempty: an empty cwd is not serialized, and a record without the field
+	// loads as empty (backward compatible with pre-fix session records).
+	empty, err := json.Marshal(&Session{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(empty), "agent_cwd") {
+		t.Fatalf("empty session serialized agent_cwd (omitempty broken): %s", empty)
+	}
+	var loaded Session
+	if err := json.Unmarshal([]byte(`{"id":"x"}`), &loaded); err != nil {
+		t.Fatal(err)
+	}
+	if loaded.GetAgentCwd() != "" {
+		t.Fatalf("record without agent_cwd loaded cwd = %q, want empty", loaded.GetAgentCwd())
+	}
+}

--- a/core/session_id_validation_test.go
+++ b/core/session_id_validation_test.go
@@ -11,14 +11,14 @@ import (
 // start a fresh session instead of resuming the wrong one.
 type validatingAgent struct {
 	controllableAgent
-	validateFunc func(ctx context.Context, sessionID string) bool
+	validateFunc func(ctx context.Context, sessionID, cwd string) bool
 }
 
-func (a *validatingAgent) ValidateSessionID(ctx context.Context, sessionID string) bool {
+func (a *validatingAgent) ValidateSessionID(ctx context.Context, sessionID, cwd string) bool {
 	if a.validateFunc == nil {
 		return true // default: trust whatever ID the Session has
 	}
-	return a.validateFunc(ctx, sessionID)
+	return a.validateFunc(ctx, sessionID, cwd)
 }
 
 var _ SessionIDValidator = (*validatingAgent)(nil)
@@ -32,7 +32,7 @@ func TestIssue599_InvalidSessionIDClearedBeforeResume(t *testing.T) {
 	sess := newControllableSession("fresh-id")
 	agent := &validatingAgent{
 		controllableAgent: controllableAgent{nextSession: sess},
-		validateFunc: func(_ context.Context, sessionID string) bool {
+		validateFunc: func(_ context.Context, sessionID, cwd string) bool {
 			// Reject whatever ID the Session carries — simulate a
 			// cross-project leak.
 			return false
@@ -65,7 +65,7 @@ func TestIssue599_ValidSessionIDPreserved(t *testing.T) {
 	sess := newControllableSession("resumed-id")
 	agent := &validatingAgent{
 		controllableAgent: controllableAgent{nextSession: sess},
-		validateFunc: func(_ context.Context, _ string) bool {
+		validateFunc: func(_ context.Context, _, _ string) bool {
 			return true
 		},
 	}

--- a/core/session_snapshot_cwd_test.go
+++ b/core/session_snapshot_cwd_test.go
@@ -1,0 +1,32 @@
+package core
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestSessionManager_PersistsAgentCwd is the regression for the bug where
+// Save()'s hand-written snapshot deep-copy omitted AgentCwd, so a captured cwd
+// never survived a restart even though it was set on the live Session. Unlike a
+// direct json.Marshal(Session) test (which passes regardless), this exercises
+// the snapshot path Save actually uses.
+func TestSessionManager_PersistsAgentCwd(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.json")
+	const cwd = "/workspace/.sessions/abc123/owner-repo"
+
+	sm := NewSessionManager(path)
+	s := sm.GetOrCreateActive("user1")
+	s.SetAgentSessionID("sess-1", "claudecode")
+	s.SetAgentCwd(cwd)
+	sm.Save()
+
+	// Reload from disk with a fresh manager — mirrors a daemon restart.
+	sm2 := NewSessionManager(path)
+	s2 := sm2.GetOrCreateActive("user1")
+	if got := s2.GetAgentSessionID(); got != "sess-1" {
+		t.Fatalf("agent_session_id not persisted across save/reload: got %q", got)
+	}
+	if got := s2.GetAgentCwd(); got != cwd {
+		t.Fatalf("agent_cwd not persisted across save/reload: got %q, want %q", got, cwd)
+	}
+}


### PR DESCRIPTION
## Problem

Session resume validation located the agent's transcript using the project's
configured `work_dir`. But the agent process can run in a **different** directory
than `work_dir` — a custom agent command may `cd` elsewhere, and under
`run_as_user` the home/cwd differs. When the real cwd and `work_dir` diverged, the
validator looked in the wrong place, found no transcript, and reported the stored
session ID as invalid — so the engine silently discarded it and started a **fresh
conversation** instead of resuming.

Related but distinct from #1276 (validates the session ID belongs to the *project*)
and #1258 (normalizes `work_dir` for cc-connect ↔ desktop CC session sharing);
this fixes resume when the agent's *actual* cwd differs from `work_dir`.

## Fix

Capture the working directory the agent actually reports and use it for resume
validation:

- **`core/session.go`** — add `AgentCwd` to `Session` (persisted as `agent_cwd` in
  the session snapshot) with `SetAgentCwd`/`GetAgentCwd`; empty values never
  clobber a captured one.
- **`core/interfaces.go`** — `SessionIDValidator.ValidateSessionID` gains a `cwd`
  argument so validators locate the transcript at the agent's real directory,
  falling back to their configured `work_dir` when it's empty (e.g. records
  predating cwd capture). **Interface change** — implementers must update the
  signature.
- **`agent/claudecode`** — report the real cwd and validate the transcript there.
- **`core/engine.go`** — persist `agent_cwd` **every turn**, not only when the
  session ID changes, and include it in the snapshot so it survives a restart
  (this last part is the actual resume bug — a captured cwd was lost across
  restart).

Backward compatible: a snapshot with no `agent_cwd` (older record) falls back to
`work_dir`, preserving today's behavior.

## Verification

- `go build ./core/ ./agent/claudecode/` — pass
- `go test ./agent/claudecode/` and `go test ./core/` — pass; new coverage:
  `agent/claudecode/session_resume_cwd_test.go`, `core/session_agent_cwd_test.go`,
  `core/session_snapshot_cwd_test.go`, and updated `core/session_id_validation_test.go`
- `go test -race ./agent/claudecode/` (resume/cwd tests) — pass
- `go vet` + `gofmt -l` (go 1.25) — clean
- `golangci-lint run --new-from-rev origin/main ./...` — 0 issues

🤖 90% Claude
