### PR TITLE
fix(usage): render single 7-day window only once

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -8617,9 +8617,15 @@ func selectUsageWindows(report *UsageReport) (*UsageWindow, *UsageWindow) {
 			}
 		}
 		if primary == nil && len(bucket.Windows) > 0 {
-			primary = &bucket.Windows[0]
+			// Fall back to the first window when no 5-hour quota is reported
+			// (e.g. Codex accounts whose first bucket only exposes a 7-day
+			// window). Skip it if the slot is already occupied by the 7-day
+			// window so the same block is not rendered twice.
+			if secondary != &bucket.Windows[0] {
+				primary = &bucket.Windows[0]
+			}
 		}
-		if secondary == nil && len(bucket.Windows) > 1 {
+		if secondary == nil && len(bucket.Windows) > 1 && &bucket.Windows[1] != primary {
 			secondary = &bucket.Windows[1]
 		}
 		if primary != nil || secondary != nil {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6092,6 +6092,32 @@ func TestCmdUsage_LocalizedChinese(t *testing.T) {
 	}
 }
 
+func TestFormatUsageReport_SingleSevenDayWindowDoesNotDuplicate(t *testing.T) {
+	report := &UsageReport{
+		Email: "dev@example.com",
+		Plan:  "team",
+		Buckets: []UsageBucket{{
+			Name:         "Rate limit",
+			Allowed:      true,
+			LimitReached: false,
+			Windows: []UsageWindow{
+				{Name: "Primary", UsedPercent: 40, WindowSeconds: 604800, ResetAfterSeconds: 100000},
+			},
+		}},
+	}
+
+	got := formatUsageReport(report, LangEnglish)
+	if c := strings.Count(got, "7d limit"); c != 1 {
+		t.Fatalf("7d limit rendered %d times, want 1: %q", c, got)
+	}
+	if c := strings.Count(got, "Remaining: 60%"); c != 1 {
+		t.Fatalf("Remaining: 60%% rendered %d times, want 1: %q", c, got)
+	}
+	if strings.Contains(got, "5h limit") {
+		t.Fatalf("usage text = %q, should not invent a 5-hour window", got)
+	}
+}
+
 func TestCmdCommands_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)


### PR DESCRIPTION
Fixes #1575

## Summary
- `selectUsageWindows` previously assigned the same 7-day window to both primary and secondary when a Codex account reports no 5-hour window, causing `formatUsageBlocks` to render it twice in `/usage`.
- Skip the primary fallback when the first window is already bound to the secondary slot, and reuse the same guard for the secondary fallback.

## Test plan
- `GOFLAGS=-tags=no_web go test ./core -count=1` (full suite).
- `GOFLAGS=-tags=no_web go test ./core -count=1 -run "TestFormatUsageReport|TestCmdUsage"` (5 tests pass; new `TestFormatUsageReport_SingleSevenDayWindowDoesNotDuplicate` covers the regression).
- `golangci-lint run --new-from-rev origin/main --timeout=5m ./core/...` (0 issues).
- Manual: run `/usage` against a Codex account whose first rate-limit bucket reports only a 7-day window and confirm a single block is rendered.

Related: #1509