### PR TITLE
fix(antigravity): preserve session ID for resume

### DIFF
--- a/agent/antigravity/session.go
+++ b/agent/antigravity/session.go
@@ -231,7 +231,11 @@ func (as *antigravitySession) readLoop(ctx context.Context, cmd *exec.Cmd, stdou
 			_ = os.Remove(f)
 		}
 
-		// Detect conversation ID if this was the first turn of a fresh session
+		err := cmd.Wait()
+
+		// Detect conversation ID if this was the first turn of a fresh session.
+		// agy may flush the chat file only while the process is exiting, so wait
+		// for process reaping before scanning the chat directory.
 		if as.CurrentSessionID() == "" {
 			var sid string
 			for attempt := 0; attempt < 15; attempt++ {
@@ -244,7 +248,7 @@ func (as *antigravitySession) readLoop(ctx context.Context, cmd *exec.Cmd, stdou
 			if sid != "" {
 				as.chatID.Store(sid)
 				slog.Debug("antigravitySession: detected session ID", "session_id", sid)
-				// Emit an EventText carrying the session ID back to core
+				// Emit an EventText carrying the session ID back to core.
 				select {
 				case as.events <- core.Event{Type: core.EventText, SessionID: sid}:
 				case <-as.ctx.Done():
@@ -252,7 +256,6 @@ func (as *antigravitySession) readLoop(ctx context.Context, cmd *exec.Cmd, stdou
 			}
 		}
 
-		err := cmd.Wait()
 		sid := as.CurrentSessionID()
 		if err != nil {
 			stderrMsg := strings.TrimSpace(stderrBuf.String())
@@ -265,7 +268,7 @@ func (as *antigravitySession) readLoop(ctx context.Context, cmd *exec.Cmd, stdou
 			}
 		}
 
-		// Finalize turn
+		// Finalize turn.
 		select {
 		case as.events <- core.Event{Type: core.EventResult, SessionID: sid, Done: true}:
 		case <-as.ctx.Done():

--- a/agent/antigravity/session_test.go
+++ b/agent/antigravity/session_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -82,6 +83,74 @@ func TestBuildAntigravityArgs_PromptAtEnd(t *testing.T) {
 	}
 	if contains(args, "-m") || contains(args, "--model") {
 		t.Fatalf("did not expect model flags in args, got: %v", args)
+	}
+}
+
+func TestAntigravitySession_ResumePassesConversationID(t *testing.T) {
+	if os.Getenv("GO_WANT_ANTIGRAVITY_HELPER") == "1" {
+		argsPath := os.Getenv("CC_ANTIGRAVITY_ARGS_FILE")
+		if argsPath == "" {
+			os.Exit(2)
+		}
+		if err := os.WriteFile(argsPath, []byte(strings.Join(os.Args, "\x00")), 0o600); err != nil {
+			os.Exit(2)
+		}
+		_, _ = io.WriteString(os.Stdout, "ok\n")
+		os.Exit(0)
+	}
+
+	argsPath := t.TempDir() + string(os.PathSeparator) + "args"
+	workDir := t.TempDir()
+	s, err := newAntigravitySession(
+		context.Background(),
+		os.Args[0],
+		[]string{"-test.run=TestAntigravitySession_ResumePassesConversationID", "--"},
+		workDir,
+		"",
+		"default",
+		"conversation-1",
+		[]string{
+			"GO_WANT_ANTIGRAVITY_HELPER=1",
+			"CC_ANTIGRAVITY_ARGS_FILE=" + argsPath,
+		},
+		0,
+	)
+	if err != nil {
+		t.Fatalf("newAntigravitySession: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if err := s.Send("second turn", "", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	select {
+	case event := <-s.Events():
+		if event.Type != core.EventText {
+			t.Fatalf("first event type = %q, want %q", event.Type, core.EventText)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for helper output")
+	}
+	select {
+	case event := <-s.Events():
+		if event.Type != core.EventResult || !event.Done {
+			t.Fatalf("completion event = %+v, want done EventResult", event)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for EventResult")
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	args := strings.Split(string(data), "\x00")
+	if !contains(args, "--conversation") || !contains(args, "conversation-1") {
+		t.Fatalf("resume args = %v, want --conversation conversation-1", args)
+	}
+	if !contains(args, "-p") || !contains(args, "second turn") {
+		t.Fatalf("prompt args = %v, want -p second turn", args)
 	}
 }
 


### PR DESCRIPTION
Fixes #1571

## 变更说明
- 等待 agy 进程退出并完成会话文件落盘后再发现首轮 conversation ID，避免 `agent_session_id` 为空。
- 保持已保存的 ID 通过 `--conversation <id>` 传给后续 turn。
- 增加真实 session adapter 调用的 resume 参数回归测试。

## 测试
- `go test ./agent/antigravity -count=1`
- `go test ./agent/... -count=1`
- `/root/go/bin/golangci-lint run --new-from-rev origin/main ./agent/antigravity/...`
- `GOFLAGS=-tags=no_web go build ./...`（运行中）

未覆盖真实 agy/Feishu 凭据下的手工联调。