### PR TITLE
fix: prevent NO_REPLY markers from leaking to users

### DIFF
--- a/core/cuj_test.go
+++ b/core/cuj_test.go
@@ -1951,6 +1951,51 @@ func TestCUJ_I4_StreamingToggleLinkedToIntegration(t *testing.T) {
 	t.Log("CUJ-I4: covered by release-gate TestCC_STREAM_01_off + TestCC_STREAM_02_on + core/streaming_test.go (14 unit tests)")
 }
 
+// CUJ-I5 · 后台 agent 事件中的 NO_REPLY 是协议控制标记，用户不应看到它。
+//
+// 用户动作：先发起一次普通对话，等待后台 agent 回合，再继续两次对话。
+// 这覆盖 runUnsolicitedReader 的实际平台投递路径，而不只测试内部事件处理。
+func TestCUJ_I5_UnsolicitedNoReplyIsNotSentToUser(t *testing.T) {
+	env := newCUJEnv(t)
+	key := env.userSends("i5", "first visible turn")
+	env.waitFor("first visible reply", 2*time.Second, func() bool {
+		return len(env.plat.getSent()) == 1
+	})
+
+	env.agent.mu.Lock()
+	if len(env.agent.sessions) != 1 {
+		env.agent.mu.Unlock()
+		t.Fatalf("agent sessions = %d, want 1", len(env.agent.sessions))
+	}
+	agentSession := env.agent.sessions[0]
+	env.agent.mu.Unlock()
+
+	session := env.activeSession(key)
+	historyLen := session.HistoryLen()
+	agentSession.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
+	env.waitFor("unsolicited silent turn to finish", 2*time.Second, func() bool {
+		return session.HistoryLen() == historyLen+1
+	})
+	if sent := env.plat.getSent(); len(sent) != 1 {
+		t.Fatalf("silent unsolicited turn sent %d messages, want 0 additional: %v", len(sent)-1, sent)
+	}
+
+	// 用户动作 2：后台静默回合后仍可正常继续对话。
+	env.userSends("i5", "second visible turn")
+	env.waitFor("second visible reply", 2*time.Second, func() bool {
+		return len(env.plat.getSent()) == 2
+	})
+
+	// 用户动作 3：再次对话，确认协议标记未污染后续用户可见消息。
+	env.userSends("i5", "third visible turn")
+	env.waitFor("third visible reply", 2*time.Second, func() bool {
+		return len(env.plat.getSent()) == 3
+	})
+	if env.sentContains("NO_REPLY") {
+		t.Fatalf("user-visible messages leaked NO_REPLY: %v", env.plat.getSent())
+	}
+}
+
 // ===========================================================================
 // CUJ-H2 · Two platforms attached to the same engine handle concurrent
 // messages without bleeding state into each other.

--- a/core/engine.go
+++ b/core/engine.go
@@ -4581,10 +4581,24 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 					fullResponse = strings.Join(textParts, "")
 				}
 
-				if fullResponse != "" {
-					for _, chunk := range splitMessage(fullResponse, maxPlatformMessageLen) {
+				outbound := fullResponse
+				if len(textParts) > 0 {
+					if textResponse := joinTextSegments(textParts); textResponse != "" {
+						outbound = textResponse
+					}
+				}
+				if isSilentReply(outbound) {
+					outbound = ""
+				} else if stripped, ok := stripTrailingSilent(outbound); ok {
+					outbound = stripped
+				}
+
+				if outbound != "" {
+					for _, chunk := range splitMessage(outbound, maxPlatformMessageLen) {
 						e.send(p, replyCtx, chunk)
 					}
+				} else if fullResponse != "" {
+					slog.Info("unsolicited silent reply suppressed", "session", sessionKey)
 				}
 
 				// Safety note: concurrent writes to session.History by the
@@ -4979,7 +4993,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 						sp.freeze()
 						sp.detachPreview()
 					} else {
-						segment := strings.Join(textParts[segmentStart:], "")
+						segment := joinTextSegments(textParts[segmentStart:])
 						if segment != "" {
 							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
 								sendWorkspace(p, replyCtx, chunk)
@@ -5002,7 +5016,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				previewActive := sp.canPreview()
 				if len(textParts) > segmentStart {
 					if !previewActive {
-						segment := strings.Join(textParts[segmentStart:], "")
+						segment := joinTextSegments(textParts[segmentStart:])
 						if segment != "" {
 							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
 								sendWorkspace(p, replyCtx, chunk)
@@ -5066,7 +5080,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 						sp.freeze()
 						sp.detachPreview()
 					} else {
-						segment := strings.Join(textParts[segmentStart:], "")
+						segment := joinTextSegments(textParts[segmentStart:])
 						if segment != "" {
 							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
 								sendWorkspace(p, replyCtx, chunk)
@@ -5110,7 +5124,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				previewActive := sp.canPreview()
 				if len(textParts) > segmentStart {
 					if !previewActive {
-						segment := strings.Join(textParts[segmentStart:], "")
+						segment := joinTextSegments(textParts[segmentStart:])
 						if segment != "" {
 							for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
 								sendWorkspace(p, replyCtx, chunk)
@@ -5358,7 +5372,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			previewActive := sp.canPreview()
 			if len(textParts) > segmentStart {
 				if !previewActive {
-					segment := strings.Join(textParts[segmentStart:], "")
+					segment := joinTextSegments(textParts[segmentStart:])
 					if segment != "" {
 						for _, chunk := range splitMessage(segment, maxPlatformMessageLen) {
 							sendWorkspace(p, replyCtx, chunk)
@@ -5475,9 +5489,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			// contains ALL text across tool boundaries. Prefer the full accumulated
 			// text over event.Content which only contains the last assistant segment.
 			if len(textParts) > 0 && segmentStart == 0 && !e.display.ToolMessages {
-				fullResponse = strings.Join(textParts, "")
+				fullResponse = joinTextSegments(textParts)
+				if fullResponse == "" {
+					fullResponse = strings.Join(textParts, "")
+				}
 			} else if fullResponse == "" && len(textParts) > 0 {
-				fullResponse = strings.Join(textParts, "")
+				fullResponse = joinTextSegments(textParts)
+				if fullResponse == "" {
+					fullResponse = strings.Join(textParts, "")
+				}
 			}
 			if fullResponse == "" {
 				fullResponse = e.i18n.T(MsgEmptyResponse)
@@ -5654,8 +5674,8 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				// orphaned shell. Finalizing-in-place avoids the "撤回了一条消息"
 				// gray bar that DeletePreviewMessage would leave in Lark.
 				if hasRichCard && cardMessageID != nil {
-					silentBody := partialText
-					if stripped, ok := stripTrailingSilent(partialText); ok {
+					silentBody := joinTextSegments(textParts)
+					if stripped, ok := stripTrailingSilent(silentBody); ok {
 						silentBody = strings.TrimRight(stripped, " \t\r\n")
 					}
 					if silentBody != "" || len(toolSteps) > 0 {
@@ -5727,7 +5747,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				// side-channel messages and segmentStart stays 0, so keep normal finalize flow.
 				sp.discard()
 				if segmentStart < len(textParts) {
-					unsent := strings.Join(textParts[segmentStart:], "")
+					unsent := joinTextSegments(textParts[segmentStart:])
 					if unsent != "" {
 						if !sendChunksWithStatusFooter(e.ctx, p, replyCtx, unsent, statusFooter, sendWorkspaceWithError) {
 							return
@@ -6015,7 +6035,10 @@ channelClosed:
 		p := state.platform
 		state.mu.Unlock()
 
-		fullResponse := strings.Join(textParts, "")
+		fullResponse := joinTextSegments(textParts)
+		if fullResponse == "" {
+			fullResponse = strings.Join(textParts, "")
+		}
 		session.AddHistory("assistant", fullResponse)
 		// Persist immediately — this path runs on abnormal channel close,
 		// so deferring the save until the next foreground turn risks losing
@@ -6046,7 +6069,7 @@ channelClosed:
 		if toolCount > 0 && segmentStart > 0 {
 			sp.discard()
 			if segmentStart < len(textParts) {
-				unsent := strings.Join(textParts[segmentStart:], "")
+				unsent := joinTextSegments(textParts[segmentStart:])
 				if unsent != "" {
 					for _, chunk := range splitMessage(unsent, maxPlatformMessageLen) {
 						if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
@@ -16815,6 +16838,17 @@ func couldBeSilentPrefix(text string) bool {
 		return true
 	}
 	return strings.HasPrefix("NO_REPLY", strings.ToUpper(t))
+}
+
+// joinTextSegments 拼接待投递的文本块，并移除末尾独立的 NO_REPLY 标记。
+// 该标记可能单独作为一个 EventText 到达；直接拼接会让前一块文本与
+// NO_REPLY 紧邻，导致仅依赖文本边界的 stripTrailingSilent 无法识别。
+func joinTextSegments(parts []string) string {
+	end := len(parts)
+	for end > 0 && isSilentReply(parts[end-1]) {
+		end--
+	}
+	return strings.Join(parts[:end], "")
 }
 
 func isEllipsisOnly(text string) bool {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2277,6 +2277,65 @@ func TestProcessInteractiveEvents_RichCard_TextThenNoReply_PreservesBody(t *test
 	}
 }
 
+// TestProcessInteractiveEvents_RichCard_TextThenBareNoReplyPart_PreservesBody
+// 覆盖 agent 将 NO_REPLY 作为无前置换行的独立 EventText 块输出的情况。
+// 最终卡片应保留可见正文，同时移除协议标记。
+func TestProcessInteractiveEvents_RichCard_TextThenBareNoReplyPart_PreservesBody(t *testing.T) {
+	starts, _, updates, deletes := runRichCardSilentScenario(t, "bare-noreply-part", []string{"已发给业务回填。", "NO_REPLY"}, "NO_REPLY")
+	if len(starts) == 0 {
+		t.Fatal("expected SendPreviewStart for the visible text chunk, got 0")
+	}
+	if deletes != 0 {
+		t.Fatalf("expected no DeletePreviewMessage, got %d", deletes)
+	}
+	if len(updates) == 0 {
+		t.Fatal("expected final rich-card update")
+	}
+	last := updates[len(updates)-1]
+	if !strings.Contains(last, "已发给业务回填。") {
+		t.Fatalf("final card should preserve pre-NO_REPLY text, got %q", last)
+	}
+	if strings.Contains(last, "NO_REPLY") {
+		t.Fatalf("final card should not contain NO_REPLY marker, got %q", last)
+	}
+}
+
+// TestProcessInteractiveEvents_DoesNotFlushNoReplyBeforeTool 验证工具调用前
+// 的裸 NO_REPLY EventText 不会在渲染工具消息时作为文本分段投递。
+func TestProcessInteractiveEvents_DoesNotFlushNoReplyBeforeTool(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	defer func() { _ = e.Stop() }()
+	e.SetDisplayConfig(DisplayCfg{
+		Mode:             "full",
+		ThinkingMessages: true,
+		ToolMessages:     true,
+		ThinkingMaxLen:   300,
+		ToolMaxLen:       500,
+	})
+
+	sessionKey := "test:noreply-before-tool"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("noreply-before-tool")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventText, Content: "NO_REPLY"}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "true"}
+	agentSession.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-noreply-before-tool", time.Now(), nil, nil, state.replyCtx)
+
+	for _, message := range p.getSent() {
+		if strings.Contains(message, "NO_REPLY") {
+			t.Fatalf("tool-boundary flush leaked NO_REPLY marker: %q", message)
+		}
+	}
+}
+
 // TestProcessInteractiveEvents_RichCard_ToolThenNoReply verifies that when a
 // turn issues tool calls (creating the rich card with visible tool steps) and
 // then resolves to NO_REPLY, the card is finalized to Done — not deleted.
@@ -13900,6 +13959,46 @@ func TestUnsolicitedReader_RelaysEventResult(t *testing.T) {
 	state.mu.Unlock()
 	if resync {
 		t.Error("expected eventsNeedResync=false after clean unsolicited EventResult")
+	}
+}
+
+// TestUnsolicitedReader_SuppressesNoReply 验证后台 agent turn 与前台 turn
+// 一样遵守 NO_REPLY 静默协议。
+func TestUnsolicitedReader_SuppressesNoReply(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newControllableSession("unsol-noreply")
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	defer func() { _ = e.Stop() }()
+
+	sessions := e.sessions
+	session := sessions.GetOrCreateActive("test:ch1:noreply")
+	state := &interactiveState{
+		agentSession:     sess,
+		platform:         p,
+		replyCtx:         "ctx",
+		eventsNeedResync: false,
+	}
+	iKey := "test:ch1:noreply"
+	e.interactiveMu.Lock()
+	e.interactiveStates[iKey] = state
+	e.interactiveMu.Unlock()
+
+	e.startUnsolicitedReader(state, session, sessions, iKey, "")
+	defer e.stopUnsolicitedReader(state)
+
+	sess.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
+
+	deadline := time.After(time.Second)
+	for session.HistoryLen() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("unsolicited reader did not process NO_REPLY result")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	if sent := p.getSent(); len(sent) != 0 {
+		t.Fatalf("NO_REPLY must be suppressed for unsolicited turns, got %v", sent)
 	}
 }
 


### PR DESCRIPTION
## Summary

Prevent the internal `NO_REPLY` protocol marker from being delivered to users when an agent emits it as a standalone text event. This covers both interactive turn finalization and unsolicited/background agent events, while preserving any visible text that preceded the marker.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

- `go build ./...`
- `go test -race ./core -run "^(TestUnsolicitedReader_SuppressesNoReply|TestProcessInteractiveEvents_RichCard_TextThenBareNoReplyPart_PreservesBody|TestProcessInteractiveEvents_DoesNotFlushNoReplyBeforeTool)$" -count=1 -v`
- `go test ./core -run TestCUJ -count=1`

`go test ./... -count=1` was also run, but does not pass locally due to unrelated environment-sensitive failures in `agent/codex`, `agent/iflow`, macOS `daemon` launchd status detection, and a pre-existing temporary-directory cleanup race in `TestCUJ_A5_FileReachesAgent`. The full CUJ suite passed on retry.

### Automated tests added in this PR

- `TestUnsolicitedReader_SuppressesNoReply` in `core/engine_test.go` — background agent results containing only `NO_REPLY` send no platform message.
- `TestProcessInteractiveEvents_RichCard_TextThenBareNoReplyPart_PreservesBody` in `core/engine_test.go` — a standalone trailing marker is removed without losing preceding rich-card text.
- `TestProcessInteractiveEvents_DoesNotFlushNoReplyBeforeTool` in `core/engine_test.go` — a tool-boundary flush never sends the marker.
- `TestCUJ_I5_UnsolicitedNoReplyIsNotSentToUser` in `core/cuj_test.go` — an end-to-end user journey verifies silent background output and subsequent conversation.

### For bug fixes only — regression test

- Regression test names: `TestUnsolicitedReader_SuppressesNoReply`, `TestCUJ_I5_UnsolicitedNoReplyIsNotSentToUser`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [x] G — error handling & robustness (background event handling)
- [x] I — UI rendering correctness (protocol marker suppression)

- [x] `go test ./core/ -run TestCUJ` passes locally.
- [x] Corresponding CUJ test added: `TestCUJ_I5_UnsolicitedNoReplyIsNotSentToUser`.

## Manual / user-visible behavior change

A bare `NO_REPLY` control marker is no longer sent into a chat or rendered in a card. Any visible text emitted before a trailing standalone marker remains visible.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency; see Testing)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied (full test limitation above)
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (no user-facing strings added)
- [x] No secrets / credentials in source

## Related

- Issue: None
- Follow-up to #1397: it fixed the StreamingCard finalization path; this PR covers standalone EventText segments and unsolicited/background events.
