### PR TITLE
fix(kimi): adapt to newer Kimi Code CLI (0.28.1) flag and stream changes

### DIFF
--- a/agent/kimi/probe.go
+++ b/agent/kimi/probe.go
@@ -16,12 +16,16 @@ import (
 //
 // Why this exists:
 //
-//	The newer Kimi Code CLI removed the standalone `--print` flag — passing it
-//	now produces: `error: unknown option '--print' (Did you mean --prompt?)`.
-//	The older kimi-cli still requires `--print` for `--output-format` to take
-//	effect. We probe the help text once and adapt accordingly. See #1456.
+//	The newer Kimi Code CLI removed the standalone `--print`, `--work-dir`,
+//	`--resume` and `--quiet` flags — passing `--work-dir` to 0.28.1 produces
+//	`error: unknown option '--work-dir'`. The older kimi-cli still requires
+//	`--print` for `--output-format` to take effect and supports `--resume`.
+//	We probe the help text once and adapt accordingly. See #1456.
 type kimiFlagSupport struct {
-	Print bool
+	Print   bool
+	WorkDir bool
+	Resume  bool
+	Quiet   bool
 }
 
 // probeKimiFlags runs `<cmd> --help` with a short timeout and returns the
@@ -49,7 +53,10 @@ func probeKimiFlags(parent context.Context, cmd string, timeout time.Duration) k
 
 	flags := parseKimiHelpFlags(out.String())
 	support := kimiFlagSupport{
-		Print: flags["--print"],
+		Print:   flags["--print"],
+		WorkDir: flags["--work-dir"],
+		Resume:  flags["--resume"],
+		Quiet:   flags["--quiet"],
 	}
 	slog.Debug("kimi: flag probe complete", "cmd", cmd, "support", support)
 	return support

--- a/agent/kimi/probe_test.go
+++ b/agent/kimi/probe_test.go
@@ -10,7 +10,7 @@ import (
 
 // legacyKimiHelp is a representative slice of the older kimi-cli `--help`
 // output (still on the kimi-cli `main` branch as of 2026). It advertises
-// both `--print` and `--prompt`.
+// `--print`, `--work-dir`, `--resume` and `--quiet` alongside `--prompt`.
 const legacyKimiHelp = `
  Usage: kimi [OPTIONS] COMMAND [ARGS]...
 
@@ -20,6 +20,7 @@ const legacyKimiHelp = `
  │ --version          -V          Show version and exit.                  │
  │ --work-dir         -w DIRECTORY Working directory for the agent.       │
  │ --session          -S [ID]     Resume a session.                       │
+ │ --resume           -r ID       Resume a session by ID.                 │
  │ --continue         -C          Continue the previous session.          │
  │ --model            -m TEXT     LLM model to use.                       │
  │ --thinking/--no-thinking       Enable thinking mode.                   │
@@ -32,29 +33,34 @@ const legacyKimiHelp = `
  ╰────────────────────────────────────────────────────────────────────────╯
 `
 
-// modernKimiHelp emulates the newer Kimi Code CLI, where --print has been
-// removed entirely. This is the surface that triggers #1456 today.
+// modernKimiHelp is the real `kimi --help` output of Kimi Code CLI 0.28.1.
+// It has no --print, no --work-dir, no --resume and no --quiet; session
+// resume is done via the hidden `-r` alias (the CLI's own resume_hint
+// meta line says `kimi -r <id>`).
 const modernKimiHelp = `
- Usage: kimi [OPTIONS] COMMAND [ARGS]...
-
- Kimi, your next CLI agent.
-
- Options:
-   -V, --version              Show version and exit.
-   -w, --work-dir DIRECTORY   Working directory for the agent.
-   -S, --session [ID]         Resume a session.
-   -c, --continue             Continue the most recent session.
-   -m, --model TEXT           LLM model to use.
-   -p, --prompt TEXT          Run a single prompt non-interactively.
-   --output-format FORMAT     Non-interactive output format.
-   -y, --yolo                 Auto-approve regular tool calls.
-   --plan                     Start a new session in Plan mode.
+Usage: kimi [options] [command]
+Options:
+  -V, --version
+  -S, --session [id]            Resume a session. With ID: resume that session. Without ID: interactively pick.
+  -c, --continue                Continue the previous session for the working directory.
+  -y, --yolo                    Auto-approve regular tool calls
+  --auto                        Start in auto permission mode
+  -m, --model <model>           LLM model alias
+  -p, --prompt <prompt>         Run one prompt non-interactively and print the response.
+  --output-format <format>      (choices: "text", "stream-json")
+  --skills-dir <dir>
+  --add-dir <dir>
+  --plan                        Start in plan mode.
+  -h, --help
 `
 
 func TestParseKimiHelpFlags_LegacyAdvertisesPrint(t *testing.T) {
 	flags := parseKimiHelpFlags(legacyKimiHelp)
 	assert.True(t, flags["--print"], "legacy help text advertises --print")
 	assert.True(t, flags["--prompt"], "legacy help text advertises --prompt")
+	assert.True(t, flags["--work-dir"], "legacy help text advertises --work-dir")
+	assert.True(t, flags["--resume"], "legacy help text advertises --resume")
+	assert.True(t, flags["--quiet"], "legacy help text advertises --quiet")
 	assert.True(t, flags["--output-format"])
 	assert.True(t, flags["--plan"])
 	assert.True(t, flags["--thinking"], "alias-split should pick up --thinking")
@@ -66,8 +72,16 @@ func TestParseKimiHelpFlags_ModernHidesPrint(t *testing.T) {
 	// Regression for #1456: the new Kimi Code CLI must not be detected
 	// as supporting --print.
 	assert.False(t, flags["--print"], "modern help text must not advertise --print")
+	// 0.28.1 also dropped these flags; passing them is a hard error.
+	assert.False(t, flags["--work-dir"], "0.28.1 does not advertise --work-dir")
+	assert.False(t, flags["--resume"], "0.28.1 does not advertise --resume")
+	assert.False(t, flags["--quiet"], "0.28.1 does not advertise --quiet")
 	assert.True(t, flags["--prompt"], "modern CLI still advertises --prompt")
 	assert.True(t, flags["--output-format"])
+	assert.True(t, flags["--plan"])
+	assert.True(t, flags["--help"])
+	assert.True(t, flags["--add-dir"])
+	assert.True(t, flags["--skills-dir"])
 }
 
 func TestParseKimiHelpFlags_IgnoresPositionalAndShortOnly(t *testing.T) {

--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -74,6 +74,10 @@ func newKimiSession(ctx context.Context, cmd string, extraArgs []string, workDir
 // tested without launching the CLI. The `--print` flag is only emitted when
 // the locally installed binary advertises it in `kimi --help`; the newer Kimi
 // Code CLI dropped that flag and rejects it outright (see issue #1456).
+// The same probing gates `--work-dir` (dropped by 0.28.1 — cmd.Dir covers the
+// working directory instead), `--quiet` (degraded to a debug log) and
+// `--resume` (falling back to the hidden `-r` alias the modern CLI still
+// honours).
 func (ks *kimiSession) buildArgs(prompt string) []string {
 	args := append([]string{}, ks.extraArgs...)
 	if ks.flagSupport.Print {
@@ -85,17 +89,28 @@ func (ks *kimiSession) buildArgs(prompt string) []string {
 	case "plan":
 		args = append(args, "--plan")
 	case "quiet":
-		args = append(args, "--quiet")
+		if ks.flagSupport.Quiet {
+			args = append(args, "--quiet")
+		} else {
+			slog.Debug("kimiSession: --quiet not supported by installed CLI, degrading to default mode")
+		}
 	}
 
 	if sid := ks.CurrentSessionID(); sid != "" {
-		args = append(args, "--resume", sid)
+		if ks.flagSupport.Resume {
+			args = append(args, "--resume", sid)
+		} else {
+			args = append(args, "-r", sid)
+		}
 	}
 	if ks.model != "" {
 		args = append(args, "--model", ks.model)
 	}
 	if ks.workDir != "" {
-		args = append(args, "--work-dir", ks.workDir)
+		if ks.flagSupport.WorkDir {
+			args = append(args, "--work-dir", ks.workDir)
+		}
+		// Otherwise rely on cmd.Dir, which Send() sets to ks.workDir.
 	}
 
 	args = append(args, "--prompt", prompt)
@@ -321,6 +336,9 @@ func extractResumeSessionID(line string) string {
 // Kimi CLI stream-json message roles:
 //   - "assistant": content (think + text), tool_calls
 //   - "tool":      content (tool execution result), tool_call_id
+//   - "meta":      session hints; the newer Kimi Code CLI (0.28.1) emits
+//     {"role":"meta","type":"session.resume_hint","session_id":"..."}
+//     instead of the legacy plain-text "To resume this session:" line.
 func (ks *kimiSession) handleEvent(raw map[string]any) {
 	role, _ := raw["role"].(string)
 
@@ -329,32 +347,48 @@ func (ks *kimiSession) handleEvent(raw map[string]any) {
 		ks.handleAssistant(raw)
 	case "tool":
 		ks.handleTool(raw)
+	case "meta":
+		if t, _ := raw["type"].(string); t == "session.resume_hint" {
+			if id, _ := raw["session_id"].(string); id != "" {
+				ks.sessionID.Store(id)
+				slog.Debug("kimiSession: session id from meta resume_hint", "session_id", id)
+			}
+		}
 	default:
 		slog.Debug("kimiSession: unhandled role", "role", role)
 	}
 }
 
 func (ks *kimiSession) handleAssistant(raw map[string]any) {
-	content, _ := raw["content"].([]any)
-	for _, item := range content {
-		block, ok := item.(map[string]any)
-		if !ok {
-			continue
+	// The newer Kimi Code CLI (0.28.1) emits content as a plain string
+	// ({"role":"assistant","content":"ok"}), while the legacy kimi-cli emits
+	// a block array. Accept both so string content is not silently dropped.
+	if text, ok := raw["content"].(string); ok {
+		if text != "" {
+			ks.pendingMsgs = append(ks.pendingMsgs, text)
 		}
-		blockType, _ := block["type"].(string)
-		switch blockType {
-		case "think", "thinking":
-			if think, ok := block["think"].(string); ok && think != "" {
-				evt := core.Event{Type: core.EventThinking, Content: think}
-				select {
-				case ks.events <- evt:
-				case <-ks.ctx.Done():
-					return
-				}
+	} else {
+		content, _ := raw["content"].([]any)
+		for _, item := range content {
+			block, ok := item.(map[string]any)
+			if !ok {
+				continue
 			}
-		case "text":
-			if text, ok := block["text"].(string); ok && text != "" {
-				ks.pendingMsgs = append(ks.pendingMsgs, text)
+			blockType, _ := block["type"].(string)
+			switch blockType {
+			case "think", "thinking":
+				if think, ok := block["think"].(string); ok && think != "" {
+					evt := core.Event{Type: core.EventThinking, Content: think}
+					select {
+					case ks.events <- evt:
+					case <-ks.ctx.Done():
+						return
+					}
+				}
+			case "text":
+				if text, ok := block["text"].(string); ok && text != "" {
+					ks.pendingMsgs = append(ks.pendingMsgs, text)
+				}
 			}
 		}
 	}
@@ -391,21 +425,27 @@ func (ks *kimiSession) handleAssistant(raw map[string]any) {
 
 func (ks *kimiSession) handleTool(raw map[string]any) {
 	toolCallID, _ := raw["tool_call_id"].(string)
-	content, _ := raw["content"].([]any)
-	var outputParts []string
-	for _, item := range content {
-		block, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		blockType, _ := block["type"].(string)
-		if blockType == "text" {
-			if text, ok := block["text"].(string); ok {
-				outputParts = append(outputParts, text)
+	var output string
+	if text, ok := raw["content"].(string); ok {
+		// Newer Kimi Code CLI: tool content is a plain string.
+		output = text
+	} else {
+		content, _ := raw["content"].([]any)
+		var outputParts []string
+		for _, item := range content {
+			block, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			blockType, _ := block["type"].(string)
+			if blockType == "text" {
+				if text, ok := block["text"].(string); ok {
+					outputParts = append(outputParts, text)
+				}
 			}
 		}
+		output = strings.Join(outputParts, "")
 	}
-	output := strings.Join(outputParts, "")
 
 	if output != "" {
 		slog.Debug("kimiSession: tool result", "tool_call_id", toolCallID)

--- a/agent/kimi/session_test.go
+++ b/agent/kimi/session_test.go
@@ -214,10 +214,10 @@ func TestBuildArgs_PlanMode(t *testing.T) {
 }
 
 // TestBuildArgs_ResumeSession ensures session continuity flags are emitted
-// regardless of the --print probe result.
+// via --resume for the legacy CLI surface that advertises it.
 func TestBuildArgs_ResumeSession(t *testing.T) {
 	ctx := context.Background()
-	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "sess-xyz", nil, 0, kimiFlagSupport{Print: false})
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "sess-xyz", nil, 0, kimiFlagSupport{Print: false, Resume: true})
 	require.NoError(t, err)
 	defer func() { _ = ks.Close() }()
 
@@ -232,6 +232,159 @@ func TestBuildArgs_ResumeSession(t *testing.T) {
 	require.GreaterOrEqual(t, resumeIdx, 0, "args should include --resume; got %v", args)
 	require.Less(t, resumeIdx+1, len(args), "--resume should be followed by an id")
 	assert.Equal(t, "sess-xyz", args[resumeIdx+1])
+}
+
+// TestBuildArgs_ModernCLISurface is the regression test for the Kimi Code
+// CLI 0.28.1 incompatibility: with a probe result of all-false (the 0.28.1
+// help surface), buildArgs must not emit --work-dir / --resume / --quiet /
+// --print (0.28.1 rejects them with `error: unknown option`), and must
+// resume sessions via the hidden `-r` alias instead.
+func TestBuildArgs_ModernCLISurface(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp/work", "kimi-k2", "quiet", "session_3062f47b", nil, 0, kimiFlagSupport{})
+	require.NoError(t, err)
+	defer func() { _ = ks.Close() }()
+
+	args := ks.buildArgs("hello")
+	for _, banned := range []string{"--work-dir", "--resume", "--quiet", "--print"} {
+		assert.NotContains(t, args, banned, "0.28.1 rejects %s; args=%v", banned, args)
+	}
+	// Resume must fall back to the hidden -r alias.
+	rIdx := -1
+	for i, a := range args {
+		if a == "-r" {
+			rIdx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, rIdx, 0, "args should include -r for resume; got %v", args)
+	require.Less(t, rIdx+1, len(args), "-r should be followed by the session id")
+	assert.Equal(t, "session_3062f47b", args[rIdx+1])
+	// Working directory is handled via cmd.Dir instead of --work-dir.
+	assert.Equal(t, "/tmp/work", ks.workDir)
+	// Non-interactive turn still uses --prompt + --output-format.
+	assert.Contains(t, args, "--prompt")
+	assert.Contains(t, args, "--output-format")
+	assert.Contains(t, args, "stream-json")
+}
+
+// TestBuildArgs_LegacyCLISurface pins the legacy kimi-cli behaviour: when
+// the probe reports full support, every legacy flag must still be emitted
+// exactly as before the version-aware change.
+func TestBuildArgs_LegacyCLISurface(t *testing.T) {
+	ctx := context.Background()
+	legacy := kimiFlagSupport{Print: true, WorkDir: true, Resume: true, Quiet: true}
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp/work", "kimi-k2", "quiet", "sess-abc", nil, 0, legacy)
+	require.NoError(t, err)
+	defer func() { _ = ks.Close() }()
+
+	args := ks.buildArgs("hello")
+	assert.Contains(t, args, "--print")
+	assert.Contains(t, args, "--quiet")
+	assert.Contains(t, args, "--resume")
+	assert.Contains(t, args, "sess-abc")
+	assert.Contains(t, args, "--work-dir")
+	assert.Contains(t, args, "/tmp/work")
+	assert.Contains(t, args, "--prompt")
+	assert.NotContains(t, args, "-r")
+}
+
+// TestHandleEvent_MetaResumeHint is the regression test for session-ID
+// capture on Kimi Code CLI 0.28.1, which reports the session via a JSON
+// meta line instead of the legacy plain-text "To resume this session:".
+func TestHandleEvent_MetaResumeHint(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
+	require.NoError(t, err)
+	defer func() { _ = ks.Close() }()
+
+	ks.handleEvent(map[string]any{
+		"role":       "meta",
+		"type":       "session.resume_hint",
+		"session_id": "session_3062f47b-aaaa",
+		"command":    "kimi -r session_3062f47b-aaaa",
+		"content":    "To resume this session: kimi -r session_3062f47b-aaaa",
+	})
+
+	assert.Equal(t, "session_3062f47b-aaaa", ks.CurrentSessionID())
+
+	// Meta lines with other types must not clobber the session ID.
+	ks.handleEvent(map[string]any{"role": "meta", "type": "other", "session_id": "bogus"})
+	assert.Equal(t, "session_3062f47b-aaaa", ks.CurrentSessionID())
+}
+
+// TestHandleAssistant_StringContent is the regression test for 0.28.1's
+// NDJSON shape where assistant content is a plain string, not a block
+// array. Previously the []any assertion failed and the whole assistant
+// message was silently dropped.
+func TestHandleAssistant_StringContent(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
+	require.NoError(t, err)
+	defer func() { _ = ks.Close() }()
+
+	ks.handleEvent(map[string]any{
+		"role":    "assistant",
+		"content": "ok",
+	})
+
+	require.Len(t, ks.pendingMsgs, 1, "string content must be buffered as text")
+	assert.Equal(t, "ok", ks.pendingMsgs[0])
+
+	ks.flushPendingAsText()
+	events := drainEvents(ks.events, 1)
+	require.Len(t, events, 1)
+	assert.Equal(t, core.EventText, events[0].Type)
+	assert.Equal(t, "ok", events[0].Content)
+}
+
+// TestHandleAssistant_StringContentWithToolCalls ensures tool_calls are
+// still honoured when assistant content is a plain string (0.28.1 shape):
+// the string text must be flushed as thinking before the tool event.
+func TestHandleAssistant_StringContentWithToolCalls(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
+	require.NoError(t, err)
+	defer func() { _ = ks.Close() }()
+
+	ks.handleEvent(map[string]any{
+		"role":    "assistant",
+		"content": "Let me check",
+		"tool_calls": []any{
+			map[string]any{
+				"id":       "tool_1",
+				"function": map[string]any{"name": "Shell", "arguments": `{"command":"ls"}`},
+			},
+		},
+	})
+
+	events := drainEvents(ks.events, 3)
+	require.Len(t, events, 2)
+	assert.Equal(t, core.EventThinking, events[0].Type)
+	assert.Equal(t, "Let me check", events[0].Content)
+	assert.Equal(t, core.EventToolUse, events[1].Type)
+	assert.Equal(t, "Shell", events[1].ToolName)
+}
+
+// TestHandleTool_StringContent ensures tool results survive 0.28.1's
+// plain-string content shape too.
+func TestHandleTool_StringContent(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
+	require.NoError(t, err)
+	defer func() { _ = ks.Close() }()
+
+	ks.handleEvent(map[string]any{
+		"role":         "tool",
+		"tool_call_id": "tool_1",
+		"content":      "file.txt\n",
+	})
+
+	events := drainEvents(ks.events, 1)
+	require.Len(t, events, 1)
+	assert.Equal(t, core.EventToolResult, events[0].Type)
+	assert.Equal(t, "tool_1", events[0].ToolName)
+	assert.Contains(t, events[0].ToolResult, "file.txt")
 }
 
 func drainEvents(ch <-chan core.Event, max int) []core.Event {


### PR DESCRIPTION
The newer Kimi Code CLI removed the standalone --work-dir, --quiet, --resume and --print flags, and changed the stream-json format:

- Probe kimi --help for --work-dir/--quiet/--resume in addition to --print, and only emit flags the installed binary advertises. Passing --work-dir to 0.28.1 errors with 'unknown option'.
- Fall back to cmd.Dir (already set to the session workDir) when --work-dir is unsupported; degrade --quiet to a debug log; use the hidden -r alias when --resume is gone.
- Accept assistant/tool content as a plain string, not just block arrays, so text is no longer silently dropped.
- Handle the meta session.resume_hint event the new CLI emits instead of the legacy plain-text resume line.

<!--
Thanks for contributing! Please fill in the sections below.
The reviewer will use the checklist at the bottom to gate merge.
-->

## Summary

<!-- 1-3 sentences explaining WHAT this PR does and WHY. -->

## Type of change

<!-- Mark all that apply: -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

<!-- Explain how you verified the change. Be specific. -->

### Automated tests added in this PR

<!-- List the test functions you added or modified. -->

- `TestX_Y_Z` in `path/to/file_test.go` — what it asserts

### For bug fixes only — regression test

<!-- A bug fix PR MUST include a regression test that:
     (1) fails on the pre-fix code, and
     (2) passes on the fixed code.
     Name it so the bug is searchable later. -->

- Regression test name: `Test...`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

<!-- See AGENTS.md → "Critical User Journeys (CUJ)" and the inventory in
     projects/cc-connect/agents/qa-cursor/release-gate/CUJ-INVENTORY.md.
     Mark which CUJ groups this PR touches: -->

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [x] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [x] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

<!-- Describe what a user will see or do differently after this PR.
     If none, write "None". -->

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [ ] No new hardcoded platform/agent names in `core/`
- [ ] i18n strings have all-language translations (if any new user-facing text)
- [ ] No secrets / credentials in source

## Related

<!-- Link to issue, RFC, design doc, prior PR, etc. -->

- Issue:
- Related PR:
