### PR TITLE
feat(feishu): on-demand download of quoted files when user mentions bot (#1560)

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1443,7 +1443,15 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			return
 		}
 		text := stripMentions(textBody.Text, mentions, p.getBotOpenID())
-		if text == "" && quoted.text == "" && len(quoted.images) == 0 {
+		// On-demand quoted-file retrieval (issue #1560): the filter
+		// decides whether ANY of the quoted file candidates are eligible
+		// (gates: @bot mention AND same IM user as the trigger). Only
+		// then do we actually fetch the bytes — never eagerly. Quote
+		// without mention, or an ordinary un-quoted message, results in
+		// zero file-resource API calls.
+		approvedFileMetas := p.filterQuotedFilesForUser(quoted.files, mentions, userID)
+		quotedFiles := p.downloadQuotedFiles(ctx, approvedFileMetas)
+		if text == "" && quoted.text == "" && len(quoted.images) == 0 && len(quotedFiles) == 0 {
 			slog.Debug(p.tag()+": dropping empty text after mention stripping",
 				"message_id", messageID,
 				"raw_text_len", len(textBody.Text),
@@ -1455,7 +1463,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quoted.text, Images: quoted.images, ReplyCtx: rctx,
+			Content: text, ExtraContent: quoted.text, Images: quoted.images, Files: quotedFiles, ReplyCtx: rctx,
 			UserMessageTimeMs: createTimeMs,
 		})
 
@@ -1904,14 +1912,33 @@ func (p *Platform) resolveMentionsInContent(ctx context.Context, chatID, content
 type chainMessage struct {
 	senderName string
 	senderType string // "user" or "app"
-	text       string
-	images     []core.ImageAttachment
-	parentID   string
+	senderID   string // Feishu open_id (or app_id for bots) — used by the caller
+	// to enforce same-user privacy when forwarding quoted files.
+	text     string
+	images   []core.ImageAttachment
+	files    []quotedFileMeta
+	parentID string
+}
+
+// quotedFileMeta records one downloaded-file candidate from a quoted parent
+// message. We deliberately keep this as metadata only (no Data bytes) so
+// the file-resource API call can be deferred until the dispatcher is sure
+// the trigger actually requires it — issue #1560 acceptance rule:
+// "quote without mention → no fetch" and "ordinary message → no fetch".
+// The Feishu sender id travels with each meta so the dispatcher can drop
+// entries whose sender differs from the user who triggered the @bot
+// mention (the privacy rule).
+type quotedFileMeta struct {
+	fileKey   string
+	fileName  string
+	messageID string
+	senderID  string
 }
 
 type quotedMessage struct {
 	text   string
 	images []core.ImageAttachment
+	files  []quotedFileMeta
 }
 
 // maxReplyChainDepth is the maximum number of parent messages to traverse
@@ -1922,6 +1949,8 @@ const maxReplyChainDepth = 5
 // is replying to, and returns formatted context plus downloaded attachments.
 // For multi-level reply chains, it traces parent_id links up to maxReplyChainDepth
 // levels and returns the full conversation chain.
+// Files in the chain are downloaded on-demand; the per-file sender_id is
+// kept so the dispatcher can enforce same-user privacy (issue #1560).
 // Returns empty content on any failure (graceful degradation — the user's own
 // message is still delivered without the quote).
 func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) quotedMessage {
@@ -1929,7 +1958,11 @@ func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) quot
 	if len(chain) == 0 {
 		return quotedMessage{}
 	}
-	return quotedMessage{text: formatReplyChain(chain), images: collectReplyChainImages(chain)}
+	return quotedMessage{
+		text:   formatReplyChain(chain),
+		images: collectReplyChainImages(chain),
+		files:  collectReplyChainFiles(chain),
+	}
 }
 
 // resolveBotSenderName returns a display name for a bot sender in a quoted
@@ -1987,6 +2020,7 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 	// Extract plain text based on message type.
 	var text string
 	var images []core.ImageAttachment
+	var files []quotedFileMeta
 	switch item.MsgType {
 	case "text":
 		var textBody struct {
@@ -2015,10 +2049,53 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 				images = append(images, core.ImageAttachment{MimeType: mimeType, Data: imgData})
 			}
 		}
+	case "file":
+		// Quoted file attachment (issue #1560). We do NOT download the file
+		// body here — that would defeat the "fetch only when bot is
+		// mentioned + same user" gate. Instead we capture only the
+		// metadata (file_key, file_name, message_id, sender_id); the
+		// dispatcher downloads the bytes later if and only if the trigger
+		// conditions hold.
+		text = "[file]"
+		var fileBody struct {
+			FileKey  string `json:"file_key"`
+			FileName string `json:"file_name"`
+		}
+		if err := json.Unmarshal([]byte(content), &fileBody); err == nil && fileBody.FileKey != "" {
+			files = append(files, quotedFileMeta{
+				fileKey:   fileBody.FileKey,
+				fileName:  fileBody.FileName,
+				messageID: messageID,
+				senderID:  item.Sender.ID,
+			})
+		}
+	case "media":
+		// Quoted video/audio — same lazy-download treatment as "file": we
+		// keep only the metadata so the dispatcher can decide whether to
+		// pull the bytes based on the @bot + same-user gates.
+		text = "[media]"
+		var mediaBody struct {
+			FileKey  string `json:"file_key"`
+			FileName string `json:"file_name"`
+		}
+		if err := json.Unmarshal([]byte(content), &mediaBody); err == nil && mediaBody.FileKey != "" {
+			files = append(files, quotedFileMeta{
+				fileKey:   mediaBody.FileKey,
+				fileName:  mediaBody.FileName,
+				messageID: messageID,
+				senderID:  item.Sender.ID,
+			})
+		}
 	case "interactive":
 		text = extractInteractiveCardText(content)
 	default:
 		text = fmt.Sprintf("[%s]", item.MsgType)
+	}
+	// Empty quoted payloads (no text, no images, no files) are dropped here:
+	// keeping a chainMessage with an empty text would otherwise produce an
+	// empty reply prefix and an empty files slice in the dispatch layer.
+	if text == "" && len(images) == 0 && len(files) == 0 {
+		return nil
 	}
 	if text == "" {
 		return nil
@@ -2043,8 +2120,10 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 	return &chainMessage{
 		senderName: senderName,
 		senderType: item.Sender.SenderType,
+		senderID:   item.Sender.ID,
 		text:       text,
 		images:     images,
+		files:      files,
 		parentID:   item.ParentID,
 	}
 }
@@ -2055,6 +2134,19 @@ func collectReplyChainImages(chain []chainMessage) []core.ImageAttachment {
 		images = append(images, msg.images...)
 	}
 	return images
+}
+
+// collectReplyChainFiles flattens file metadata from every chainMessage.
+// Only the metadata is returned — actual download of file bytes is the
+// dispatcher's job (gated on @bot mention + same-user privacy). Including
+// the sender_id per entry is essential: without it the dispatcher cannot
+// tell whose file is whose when the chain spans multiple IM users.
+func collectReplyChainFiles(chain []chainMessage) []quotedFileMeta {
+	var metas []quotedFileMeta
+	for _, msg := range chain {
+		metas = append(metas, msg.files...)
+	}
+	return metas
 }
 
 // fetchReplyChain iteratively traverses parent_id links to build a reply chain.
@@ -3289,6 +3381,90 @@ func isBotMentioned(mentions []*larkim.MentionEvent, botOpenID string) bool {
 		}
 	}
 	return false
+}
+
+// filterQuotedFilesForUser applies the two gating rules for issue #1560
+// without downloading anything yet:
+//  1. The triggering message must explicitly @-mention the bot. We never
+//     pull quoted files for messages that quote a file but do not address
+//     the bot — avoids silent background work on every chatter message
+//     and bounds Feishu's high-frequency read path on the file-resource
+//     API.
+//  2. Each quoted file's Feishu sender must match the user who triggered
+//     the current message. This is the privacy guard: even though the
+//     reporter said "user A uploaded and user A re-quotes", the
+//     implementation must refuse to forward a file uploaded by a different
+//     group member. Sender ids come from Feishu's open_id (user) or
+//     app_id (bot) — both are stable, comparable strings.
+//
+// Returns metadata for the surviving entries. The caller is then expected
+// to call downloadQuotedFiles once to actually fetch the bytes, so that
+// downloads happen strictly *after* both gates have been satisfied.
+func (p *Platform) filterQuotedFilesForUser(metas []quotedFileMeta, mentions []*larkim.MentionEvent, userID string) []quotedFileMeta {
+	if len(metas) == 0 || userID == "" {
+		return nil
+	}
+	if !isBotMentioned(mentions, p.getBotOpenID()) {
+		return nil
+	}
+	var kept []quotedFileMeta
+	for _, m := range metas {
+		if m.senderID == "" || m.senderID != userID {
+			// Either the upstream sender is unknown (defensive — should not
+			// happen for messages we successfully fetched) or it differs
+			// from the current user. Either way we drop the file: same-user
+			// is the explicit privacy default per the reporter's choice (a).
+			slog.Debug(p.tag()+": dropping quoted file: same-user mismatch",
+				"file_name", m.fileName,
+				"file_sender", m.senderID,
+				"current_user", userID,
+			)
+			continue
+		}
+		kept = append(kept, m)
+	}
+	return kept
+}
+
+// downloadQuotedFiles performs the actual on-demand downloads for each
+// surviving quotedFileMeta entry. Each call hits Feishu's
+// /open-apis/im/v1/messages/:message_id/resources/:file_key endpoint.
+// We make one call per entry so a single failure cannot break the rest.
+// Per the issue #1560 acceptance rules this function MUST be reached only
+// after filterQuotedFilesForUser has approved each entry — otherwise the
+// on-demand fetch guarantee is violated.
+func (p *Platform) downloadQuotedFiles(ctx context.Context, metas []quotedFileMeta) []core.FileAttachment {
+	if len(metas) == 0 {
+		return nil
+	}
+	var out []core.FileAttachment
+	for _, m := range metas {
+		if m.fileKey == "" || m.messageID == "" {
+			continue
+		}
+		data, err := p.downloadResource(m.messageID, m.fileKey, "file")
+		if err != nil {
+			slog.Warn(p.tag()+": download quoted file failed; skipping this entry",
+				"error", err,
+				"message_id", m.messageID,
+				"file_key", m.fileKey,
+				"file_name", m.fileName,
+			)
+			continue
+		}
+		out = append(out, core.FileAttachment{
+			MimeType: detectMimeType(data),
+			Data:     data,
+			FileName: m.fileName,
+		})
+	}
+	if len(out) > 0 {
+		slog.Info(p.tag()+": downloaded quoted file(s) for same-user quote",
+			"count", len(out),
+			"requested", len(metas),
+		)
+	}
+	return out
 }
 
 // isAttachmentMsgType reports whether a Feishu message type carries only an

--- a/platform/feishu/quote_file_test.go
+++ b/platform/feishu/quote_file_test.go
@@ -234,7 +234,6 @@ func TestDispatchMessageQuotedFileAcceptance(t *testing.T) {
 		parentID         string
 		mentions         []*larkim.MentionEvent
 		expectFiles      int
-		expectFileName   string
 		expectFileNameIs string // matcher: "report.txt" or "" (none)
 	}
 

--- a/platform/feishu/quote_file_test.go
+++ b/platform/feishu/quote_file_test.go
@@ -1,0 +1,421 @@
+package feishu
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+// TestFilterQuotedFilesForUser covers the two gating rules for issue #1560
+// in isolation: only @-bot-triggers forward files, and only the same IM user
+// is allowed to forward them.
+func TestFilterQuotedFilesForUser(t *testing.T) {
+	const botOpenID = "ou_bot"
+	const currentUser = "ou_alice"
+	const otherUser = "ou_bob"
+
+	buildMetas := func() []quotedFileMeta {
+		return []quotedFileMeta{
+			{fileKey: "k1", fileName: "doc.txt", messageID: "om1", senderID: currentUser},
+			{fileKey: "k2", fileName: "doc2.txt", messageID: "om2", senderID: otherUser},
+		}
+	}
+	botMention := []*larkim.MentionEvent{
+		{Key: strPtr("@bot"), Id: &larkim.UserId{OpenId: strPtr(botOpenID)}, Name: strPtr("Bot")},
+	}
+
+	tests := []struct {
+		name     string
+		mentions []*larkim.MentionEvent
+		userID   string
+		metas    []quotedFileMeta
+		wantLen  int
+		wantFile string // if wantLen==1, expected fileName
+	}{
+		{
+			name:     "bot mentioned and same-user file is kept",
+			mentions: botMention,
+			userID:   currentUser,
+			metas:    buildMetas(),
+			wantLen:  1,
+			wantFile: "doc.txt",
+		},
+		{
+			name:     "bot mentioned but no metas returns empty",
+			mentions: botMention,
+			userID:   currentUser,
+			metas:    nil,
+			wantLen:  0,
+		},
+		{
+			name:     "quote without bot mention returns empty (privacy gate)",
+			mentions: nil, // no @bot
+			userID:   currentUser,
+			metas:    buildMetas(),
+			wantLen:  0,
+		},
+		{
+			name:     "empty user id returns empty (defensive)",
+			mentions: botMention,
+			userID:   "",
+			metas:    buildMetas(),
+			wantLen:  0,
+		},
+		{
+			name:     "bot mentioned but files belong to other user returns empty",
+			mentions: botMention,
+			userID:   currentUser,
+			metas: []quotedFileMeta{
+				{fileKey: "sk", fileName: "secret.txt", messageID: "om_s", senderID: otherUser},
+			},
+			wantLen: 0,
+		},
+		{
+			name:     "bot mentioned but multiple files include foreign users drops the foreign ones",
+			mentions: botMention,
+			userID:   currentUser,
+			metas: []quotedFileMeta{
+				{fileKey: "k_mine", fileName: "mine.txt", messageID: "om_m", senderID: currentUser},
+				{fileKey: "k_theirs", fileName: "theirs.txt", messageID: "om_t", senderID: otherUser},
+			},
+			wantLen:  1,
+			wantFile: "mine.txt",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Platform{platformName: "feishu", botOpenID: botOpenID}
+			got := p.filterQuotedFilesForUser(tc.metas, tc.mentions, tc.userID)
+			if len(got) != tc.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), tc.wantLen)
+			}
+			if tc.wantLen == 1 && got[0].fileName != tc.wantFile {
+				t.Fatalf("fileName = %q, want %q", got[0].fileName, tc.wantFile)
+			}
+		})
+	}
+}
+
+// TestDispatchMessageQuotedFileAcceptance verifies the three scenarios from
+// the issue #1560 acceptance criteria:
+//  1. quote + @bot mention -> on-demand file fetch + attachment forward
+//  2. quote without @bot   -> no fetch (file resource endpoint not called)
+//  3. ordinary message     -> no fetch
+//
+// The mock httptest server records all incoming paths so we can assert that
+// the resource endpoint is hit exactly once across the three cases.
+func TestDispatchMessageQuotedFileAcceptance(t *testing.T) {
+	const appID = "cli_quote_file"
+	const appSecret = "secret-quote-file"
+	const botOpenID = "ou_bot"
+	const currentUser = "ou_alice"
+	const parentMessageID = "om_parent_file"
+	const fileKey = "file_v1"
+	const fileName = "report.txt"
+
+	// Fake file payload. Bytes happen to start with "%PDF" so detectMimeType
+	// classifies it as application/pdf — works for both build and runtime.
+	fileData := []byte("%PDF-1.4\nfake pdf body\n")
+
+	type hit struct {
+		path string
+		q    string
+	}
+	hits := make(chan hit, 32)
+
+	// servedOnce tracks whether the file resource endpoint was ever hit.
+	// The test asserts this flag matches the scenario expectations.
+	var fileResourceCalls int
+	// Endpoint at which we expect to see the file resource call.
+	const fileResourcePath = "/open-apis/im/v1/messages/" + parentMessageID + "/resources/" + fileKey
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits <- hit{path: r.URL.Path, q: r.URL.Query().Get("type")}
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID:
+			w.Header().Set("Content-Type", "application/json")
+			// Return a quoted file message whose sender matches the current
+			// user. The acceptance flow is "user A uploads, user A re-quotes
+			// with @bot" — same-user privacy rule must allow it through.
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"items": []map[string]any{
+						{
+							"msg_type":  "file",
+							"parent_id": "",
+							"sender": map[string]any{
+								"id":          currentUser,
+								"sender_type": "user",
+							},
+							"body": map[string]any{
+								"content": `{"file_key":"` + fileKey + `","file_name":"` + fileName + `"}`,
+							},
+						},
+					},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/contact/v3/users/"+currentUser):
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"user": map[string]any{
+						"name": "Alice",
+					},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/im/v1/chats/"):
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		case r.URL.Path == fileResourcePath:
+			fileResourceCalls++
+			if r.URL.Query().Get("type") != "file" {
+				t.Errorf("file resource call type = %q, want file", r.URL.Query().Get("type"))
+			}
+			w.Header().Set("Content-Type", "application/pdf")
+			if _, err := w.Write(fileData); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+		default:
+			// Unexpected path: count but don't fail the test here — the
+			// per-scenario assertions below cover expected behaviour.
+			t.Logf("unexpected mock path: %s", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		}
+	}))
+	defer srv.Close()
+	// Drain hits asynchronously so the handler never blocks.
+	go func() {
+		for range hits {
+		}
+	}()
+
+	newClient := func(handler func(_ core.Platform, msg *core.Message)) *Platform {
+		return &Platform{
+			platformName: "feishu",
+			domain:       srv.URL,
+			appID:        appID,
+			appSecret:    appSecret,
+			botOpenID:    botOpenID,
+			handler:      handler,
+			client: lark.NewClient(appID, appSecret,
+				lark.WithOpenBaseUrl(srv.URL),
+				lark.WithHttpClient(srv.Client()),
+			),
+		}
+	}
+
+	botMentionEvents := []*larkim.MentionEvent{
+		{Key: strPtr("@bot"), Id: &larkim.UserId{OpenId: strPtr(botOpenID)}, Name: strPtr("Bot")},
+	}
+
+	type scenario struct {
+		name             string
+		parentID         string
+		mentions         []*larkim.MentionEvent
+		expectFiles      int
+		expectFileName   string
+		expectFileNameIs string // matcher: "report.txt" or "" (none)
+	}
+
+	scenarios := []scenario{
+		{
+			name:             "mention+quote fetches and forwards file",
+			parentID:         parentMessageID,
+			mentions:         botMentionEvents,
+			expectFiles:      1,
+			expectFileNameIs: fileName,
+		},
+		{
+			name:             "quote without mention does not fetch",
+			parentID:         parentMessageID,
+			mentions:         nil, // no @bot
+			expectFiles:      0,
+			expectFileNameIs: "",
+		},
+		{
+			name:             "ordinary message does not fetch",
+			parentID:         "", // no quote at all
+			mentions:         botMentionEvents,
+			expectFiles:      0,
+			expectFileNameIs: "",
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			// Reset the per-scenario counter: the acceptance rules need to
+			// be matched across the scenarios as a set.
+			before := fileResourceCalls
+
+			got := make(chan *core.Message, 1)
+			p := newClient(func(_ core.Platform, msg *core.Message) {
+				got <- msg
+			})
+
+			p.dispatchMessage(
+				context.Background(),
+				"text",
+				`{"text":"@bot 请帮我分析文件"}`,
+				sc.mentions,
+				"om_child_"+sc.name,
+				"feishu:oc_chat:ou_alice",
+				currentUser,
+				"oc_chat",
+				replyContext{messageID: "om_child_" + sc.name, sessionKey: "feishu:oc_chat:ou_alice"},
+				sc.parentID,
+				0,
+			)
+
+			select {
+			case msg := <-got:
+				if len(msg.Files) != sc.expectFiles {
+					t.Fatalf("len(Files) = %d, want %d (Files=%+v)", len(msg.Files), sc.expectFiles, msg.Files)
+				}
+				if sc.expectFiles == 1 && msg.Files[0].FileName != sc.expectFileNameIs {
+					t.Fatalf("Files[0].FileName = %q, want %q", msg.Files[0].FileName, sc.expectFileNameIs)
+				}
+				if sc.expectFiles == 1 && string(msg.Files[0].Data) != string(fileData) {
+					t.Fatalf("Files[0].Data bytes differ from mocked file body")
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("timed out waiting for dispatched message")
+			}
+
+			after := fileResourceCalls
+			scenariosCalled := after - before
+			// Per-scenario assertion: the file resource endpoint must only
+			// be hit when the scenario expects it. This is the strongest
+			// proof of "on-demand only" — the server-side counter is the
+			// ground truth.
+			wantCalls := 0
+			if sc.expectFiles > 0 {
+				wantCalls = 1
+			}
+			if scenariosCalled != wantCalls {
+				t.Fatalf("scenario %q: file resource calls = %d, want %d", sc.name, scenariosCalled, wantCalls)
+			}
+		})
+	}
+}
+
+// TestDispatchMessageQuotedFileForeignUserDropped verifies the same-user
+// privacy guard: when a quoted file was uploaded by a different IM user,
+// the file MUST be forwarded only as a [file] marker — the binary payload
+// is not attached to the dispatched core.Message.
+func TestDispatchMessageQuotedFileForeignUserDropped(t *testing.T) {
+	const appID = "cli_quote_file_foreign"
+	const appSecret = "secret-quote-file-foreign"
+	const botOpenID = "ou_bot"
+	const currentUser = "ou_alice"
+	const foreignUser = "ou_bob"
+	const parentMessageID = "om_parent_foreign"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID:
+			w.Header().Set("Content-Type", "application/json")
+			// Quoted file is uploaded by `foreignUser`, NOT by currentUser.
+			writeJSON(t, w, map[string]any{
+				"code": 0, "msg": "success",
+				"data": map[string]any{
+					"items": []map[string]any{
+						{
+							"msg_type":  "file",
+							"parent_id": "",
+							"sender": map[string]any{
+								"id":          foreignUser,
+								"sender_type": "user",
+							},
+							"body": map[string]any{
+								"content": `{"file_key":"file_foreign","file_name":"secret.txt"}`,
+							},
+						},
+					},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/im/v1/messages/"+parentMessageID+"/resources/"):
+			// Even if the resource API succeeds, the same-user guard must
+			// keep the file out of the dispatched payload. We return the
+			// bytes anyway; the assertion is purely about the *outcome*.
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("should not be forwarded"))
+		case strings.HasPrefix(r.URL.Path, "/open-apis/contact/v3/users/"):
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/im/v1/chats/"):
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	got := make(chan *core.Message, 1)
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		botOpenID:    botOpenID,
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) { got <- msg },
+	}
+
+	p.dispatchMessage(
+		context.Background(),
+		"text",
+		`{"text":"@bot 看看这个文件"}`,
+		[]*larkim.MentionEvent{
+			{Key: strPtr("@bot"), Id: &larkim.UserId{OpenId: strPtr(botOpenID)}, Name: strPtr("Bot")},
+		},
+		"om_child_foreign",
+		"feishu:oc_chat:ou_alice",
+		currentUser,
+		"oc_chat",
+		replyContext{messageID: "om_child_foreign", sessionKey: "feishu:oc_chat:ou_alice"},
+		parentMessageID,
+		0,
+	)
+
+	select {
+	case msg := <-got:
+		if len(msg.Files) != 0 {
+			t.Fatalf("foreign-user quoted file was forwarded (len(Files)=%d) — same-user guard broken", len(msg.Files))
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for dispatched foreign-user message")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1560 — when a Feishu group member uploads a file and then replies/quotes it while @-mentioning the bot, the bot could not see the file because cc-connect does not persist message bodies.

This PR introduces on-demand quoted-file retrieval that runs **only** when the reply explicitly @-mentions the bot AND the original file's Feishu sender matches the user who triggered the mention.

## Acceptance criteria mapping

| PM criterion | Where it is enforced |
| --- | --- |
| Detect reply/quote metadata (parent_id / file_key) | `fetchSingleMessage` now extracts metadata from `file` and `media` chain items into a new `quotedFileMeta` struct |
| Only fetch when triggering message quotes a file AND mentions the bot | `filterQuotedFilesForUser` gates on `isBotMentioned`. If the gate fails, zero calls hit `/open-apis/im/v1/messages/:id/resources/:file_key` |
| Same IM user / same session only (no cross-user) | `filterQuotedFilesForUser` also drops any meta whose `senderID` differs from the triggering `userID` |
| Transient in-session state — dropped on offline | The new `quotedFileMeta` lives only inside the per-invocation chain slice; nothing is written into `~/.cc-connect/sessions/*.json` |
| Route through existing attachment processing | Once filtered + downloaded, files are attached as `core.FileAttachment` on `core.Message.Files`, the same path `SaveFilesToDisk` consumes (issue #1552 alignment) |
| Tests for mention+quote fetch / quote-only no fetch / ordinary no fetch | `platform/feishu/quote_file_test.go` (new) — see `TestDispatchMessageQuotedFileAcceptance` |
| Validate required Feishu scopes and rate-limit behavior | Reads require `im:message` (or `im:message:readonly`) + `im:resource`. Feishu returns explicit scope errors which are logged and the file is skipped — bounded by `withTransientRetry`. Rate-limit pressure is bounded *structurally* because no fetch happens unless the gate passes |

## Non-goals

- No full message-history persistence (the reporter's chosen option `c`).
- No cross-user file retrieval (privacy default safe even though the reporter only asked for same-user).
- No unrelated attachment-collision fixes — that lives in PR #1557 (issue #1552).

## Files touched

- `platform/feishu/feishu.go` — extend `chainMessage`, add `quotedFileMeta`, extend `fetchSingleMessage` (`file`+ `media` cases), add `filterQuotedFilesForUser`, `downloadQuotedFiles`; wire both into `dispatchMessage` `text` branch.
- `platform/feishu/quote_file_test.go` (new) — covers the full acceptance matrix plus same-user privacy rejection.

## Tests

```shell
go build ./platform/feishu/...        # ok
go test ./platform/feishu/            # ok (37s, all existing + new pass)
go test ./core/...                    # ok (49s, untouched code)
```

## Risks

- Same-user check compares Feishu open_id (user) or app_id (bot). Both are stable across the lifetime of the chat — false positives (a user changing open_id in the same chat) are rare; if it ever happens we get an empty Files slice and the agent sees "[file]" in `ExtraContent` only. That is a graceful degradation already covered by the existing chain-text fallback.
- For multi-level reply chains the same gate is applied per chain entry, so an internal-layer cross-user file is dropped but a same-layer same-user file still goes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)