### PR TITLE
fix(claudecode): preserve [projects.agent.options.env] under run_as_user (#1589)

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -367,36 +367,10 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	// MCP grandchildren (e.g. the Telegram bridge bun process) spinning at
 	// 100% CPU after their parent's stdio pipe closes.
 	prepareCmdForKill(cmd)
-	// Filter out CLAUDECODE env var to prevent "nested session" detection,
-	// since cc-connect is a bridge, not a nested Claude Code session.
-	env := filterEnv(os.Environ(), "CLAUDECODE")
-	if len(extraEnv) > 0 {
-		env = core.MergeEnv(env, extraEnv)
-	}
-	// Signal to PermissionRequest hooks that they are running inside
-	// cc-connect. Hooks can check this env var to skip LLM calls on
-	// the Claude Code side (the hook result is ignored anyway when
-	// --permission-prompt-tool stdio is active). cc-connect runs the
-	// hook itself without this env var, so the real work happens only
-	// once.
-	env = core.MergeEnv(env, []string{"CC_CONNECT_PERMISSION_HOOK_SKIP=1"})
-	// Carry the intended working directory across the sudo -i boundary so the
-	// re-chdir wrapper in BuildSpawnCommand can restore it (sudo -i would
-	// otherwise leave the agent in the target user's HOME). Only meaningful
-	// under isolation; FilterEnvForSpawn keeps it because mergedAllowlist
-	// includes RunAsChdirEnv whenever WorkDir is set.
-	if spawnOpts.IsolationMode() && workDir != "" {
-		env = core.MergeEnv(env, []string{core.RunAsChdirEnv + "=" + workDir})
-	}
-	// When run_as_user is set, strip the supervisor's environment down to
-	// the allowlist before passing it to sudo. sudo --preserve-env also
-	// enforces this, but filtering here makes the cc-connect spawn argv
-	// the single source of truth.
-	env = core.FilterEnvForSpawn(env, spawnOpts)
-	cmd.Env = env
+	cmd.Env = buildClaudeChildEnv(os.Environ(), extraEnv, spawnOpts, workDir)
 
 	var providerEnvSnapshot []string
-	for _, e := range env {
+	for _, e := range cmd.Env {
 		for _, prefix := range []string{"ANTHROPIC_", "CLAUDE_", "AWS_", "NO_PROXY", "DISABLE_"} {
 			if strings.HasPrefix(e, prefix) {
 				providerEnvSnapshot = append(providerEnvSnapshot, e)
@@ -1284,4 +1258,60 @@ func filterEnv(env []string, key string) []string {
 		}
 	}
 	return out
+}
+
+// buildClaudeChildEnv assembles the env slice passed to the Claude Code child
+// process. It is the single source of truth for what the spawned claude CLI
+// inherits, and is extracted so it can be unit-tested without spawning.
+//
+// Layers, in order:
+//
+//  1. Drop CLAUDECODE so the child does not mistake itself for a nested
+//     Claude Code session (#1143 follow-up).
+//  2. Merge extraEnv (the Agent's runtime env: configEnv from
+//     [projects.agent.options.env], provider keys, session-injected vars).
+//     These are the user's documented config and must always reach the child
+//     — including under run_as_user isolation, where FilterEnvForSpawn would
+//     otherwise strip OTEL_* unless explicitly listed in run_as_env (#1589).
+//  3. Add CC_CONNECT_PERMISSION_HOOK_SKIP so PermissionRequest hooks can
+//     detect they're running inside cc-connect and skip their own LLM call.
+//  4. Add CC_RUNAS_CHDIR when running under sudo -i isolation with a
+//     workspace path, so the re-chdir wrapper can restore the intended cwd.
+//  5. Apply FilterEnvForSpawn last so the allowlist only restricts what is
+//     inherited from the supervisor's env, not what the user explicitly
+//     configured via [projects.agent.options.env]. extraEnv is then merged
+//     back on top so explicit OTEL_*, CLAUDE_CODE_*, or any other prefix the
+//     user set in config always survives.
+func buildClaudeChildEnv(osEnv, extraEnv []string, spawnOpts core.SpawnOptions, workDir string) []string {
+	env := filterEnv(osEnv, "CLAUDECODE")
+	// Signal to PermissionRequest hooks that they are running inside
+	// cc-connect. Hooks can check this env var to skip LLM calls on
+	// the Claude Code side (the hook result is ignored anyway when
+	// --permission-prompt-tool stdio is active). cc-connect runs the
+	// hook itself without this env var, so the real work happens only
+	// once.
+	env = core.MergeEnv(env, []string{"CC_CONNECT_PERMISSION_HOOK_SKIP=1"})
+	// Carry the intended working directory across the sudo -i boundary so the
+	// re-chdir wrapper in BuildSpawnCommand can restore it (sudo -i would
+	// otherwise leave the agent in the target user's HOME). Only meaningful
+	// under isolation; FilterEnvForSpawn keeps it because mergedAllowlist
+	// includes RunAsChdirEnv whenever WorkDir is set.
+	if spawnOpts.IsolationMode() && workDir != "" {
+		env = core.MergeEnv(env, []string{core.RunAsChdirEnv + "=" + workDir})
+	}
+	// When run_as_user is set, strip the supervisor's environment down to
+	// the allowlist before passing it to sudo. sudo --preserve-env also
+	// enforces this, but filtering here makes the cc-connect spawn argv
+	// the single source of truth.
+	env = core.FilterEnvForSpawn(env, spawnOpts)
+	// extraEnv (which carries configEnv from [projects.agent.options.env])
+	// is the user's explicit configuration. FilterEnvForSpawn only governs
+	// what the supervisor's env contributes; the user's documented config
+	// must always reach the child, even when the allowlist does not list
+	// those keys. Re-merge after the filter so OTEL_* and other user-set
+	// vars survive run_as_user isolation (#1589).
+	if len(extraEnv) > 0 {
+		env = core.MergeEnv(env, extraEnv)
+	}
+	return env
 }

--- a/agent/claudecode/session_env_test.go
+++ b/agent/claudecode/session_env_test.go
@@ -1,0 +1,157 @@
+package claudecode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// TestBuildClaudeChildEnv_PreservesConfigEnvNoIsolation exercises the
+// agent-mode cron default path: no run_as_user, no allowlist filtering, so
+// [projects.agent.options.env] entries must reach cmd.Env verbatim. Includes
+// the OTEL_* entries from issue #1589.
+func TestBuildClaudeChildEnv_PreservesConfigEnvNoIsolation(t *testing.T) {
+	osEnv := []string{
+		"PATH=/usr/bin:/bin",
+		"HOME=/root",
+		"CLAUDECODE=1", // must be stripped
+	}
+	extraEnv := []string{
+		"CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1",
+		"OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318",
+		"OTEL_TRACES_EXPORTER=otlp",
+		"OTEL_SERVICE_NAME=oh-my-kb",
+		"OTEL_LOGS_EXPORTER=otlp",
+		"OTEL_METRICS_EXPORTER=otlp",
+		"OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf",
+		"OTEL_LOG_USER_PROMPTS=1",
+		"OTEL_LOG_TOOL_DETAILS=1",
+	}
+
+	got := buildClaudeChildEnv(osEnv, extraEnv, core.SpawnOptions{}, "/tmp")
+
+	if hasEnvKey(got, "CLAUDECODE") {
+		t.Errorf("CLAUDECODE must be stripped from inherited env, got %v", got)
+	}
+	if gotKey := getEnvValue(got, "PATH"); gotKey != "/usr/bin:/bin" {
+		t.Errorf("PATH = %q, want /usr/bin:/bin", gotKey)
+	}
+	if gotKey := getEnvValue(got, "HOME"); gotKey != "/root" {
+		t.Errorf("HOME = %q, want /root", gotKey)
+	}
+	if gotKey := getEnvValue(got, "CC_CONNECT_PERMISSION_HOOK_SKIP"); gotKey != "1" {
+		t.Errorf("CC_CONNECT_PERMISSION_HOOK_SKIP = %q, want 1", gotKey)
+	}
+	for _, entry := range extraEnv {
+		key := strings.SplitN(entry, "=", 2)[0]
+		if gotKey := getEnvValue(got, key); gotKey == "" {
+			t.Errorf("configEnv key %s missing from child env: %v", key, got)
+		}
+	}
+}
+
+// TestBuildClaudeChildEnv_PreservesConfigEnvUnderIsolation is the regression
+// net for issue #1589. With run_as_user active and a minimal allowlist that
+// does not list OTEL_*, configEnv values (which include OTEL_*) must still
+// reach the child — they're the user's documented configuration and the
+// allowlist only governs inherited env.
+func TestBuildClaudeChildEnv_PreservesConfigEnvUnderIsolation(t *testing.T) {
+	osEnv := []string{
+		"PATH=/usr/bin:/bin",
+		"HOME=/root",
+		"OTEL_SERVICE_NAME=inherited-from-supervisor",
+	}
+	extraEnv := []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318",
+		"OTEL_TRACES_EXPORTER=otlp",
+		"OTEL_SERVICE_NAME=oh-my-kb",
+		"OTEL_LOGS_EXPORTER=otlp",
+		"OTEL_METRICS_EXPORTER=otlp",
+		"OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf",
+		"OTEL_LOG_USER_PROMPTS=1",
+		"OTEL_LOG_TOOL_DETAILS=1",
+		"CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1",
+	}
+	spawnOpts := core.SpawnOptions{
+		RunAsUser: "someuser",
+		// Empty EnvAllowlist: DefaultEnvAllowlist only has LANG/LC_*/TERM.
+		// Without the #1589 fix, every OTEL_* configEnv key gets stripped
+		// because the allowlist is the single source of truth post-filter.
+		WorkDir: "/workspace/proj",
+	}
+
+	got := buildClaudeChildEnv(osEnv, extraEnv, spawnOpts, "/workspace/proj")
+
+	if hasEnvKey(got, "CLAUDECODE") {
+		t.Errorf("CLAUDECODE must be stripped, got %v", got)
+	}
+	// CC_RUNAS_CHDIR is in the merged allowlist when WorkDir is set; it must
+	// survive.
+	if gotKey := getEnvValue(got, core.RunAsChdirEnv); gotKey != "/workspace/proj" {
+		t.Errorf("%s = %q, want /workspace/proj", core.RunAsChdirEnv, gotKey)
+	}
+	// Every configEnv key, including OTEL_* (case-insensitive), must reach
+	// the child. This is the case-insensitive full-section assertion the PM
+	// acceptance criteria requires.
+	for _, entry := range extraEnv {
+		key := strings.SplitN(entry, "=", 2)[0]
+		wantValue := strings.SplitN(entry, "=", 2)[1]
+		gotValue := getEnvValue(got, key)
+		if gotValue == "" {
+			t.Errorf("configEnv key %s missing under run_as_user isolation: %v", key, got)
+			continue
+		}
+		// Case-insensitive comparison for OTEL_* to guard against future
+		// case-normalisation regressions in the env pipeline.
+		if !strings.EqualFold(gotValue, wantValue) {
+			t.Errorf("configEnv key %s = %q, want %q (case-insensitive)", key, gotValue, wantValue)
+		}
+	}
+}
+
+// TestBuildClaudeChildEnv_DropsInheritedOTELUnderIsolation documents the
+// existing behavior: env inherited from the supervisor process is subject
+// to the run_as_user allowlist and gets stripped if not listed. This is the
+// security boundary; only explicit [projects.agent.options.env] entries
+// survive.
+func TestBuildClaudeChildEnv_DropsInheritedOTELUnderIsolation(t *testing.T) {
+	osEnv := []string{
+		"OTEL_SERVICE_NAME=inherited-from-supervisor",
+		"PATH=/usr/bin:/bin",
+	}
+	spawnOpts := core.SpawnOptions{RunAsUser: "someuser"}
+
+	got := buildClaudeChildEnv(osEnv, nil, spawnOpts, "")
+
+	if gotKey := getEnvValue(got, "OTEL_SERVICE_NAME"); gotKey != "" {
+		t.Errorf("inherited OTEL_SERVICE_NAME must be stripped by IsolationMode filter, got %q", gotKey)
+	}
+	if gotKey := getEnvValue(got, "PATH"); gotKey != "" {
+		t.Errorf("inherited PATH must be stripped by IsolationMode filter, got %q", gotKey)
+	}
+}
+
+func hasEnvKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func getEnvValue(env []string, key string) string {
+	prefix := strings.ToUpper(key) + "="
+	for _, e := range env {
+		upper := strings.ToUpper(e)
+		if strings.HasPrefix(upper, prefix) {
+			idx := strings.IndexByte(e, '=')
+			if idx >= 0 {
+				return e[idx+1:]
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Fixes #1589

## Problem

On cc-connect v1.5.0-beta.2, an agent-mode cron `--prompt` triggered
Claude Code child process was missing every `OTEL_*` env var declared in
`[projects.agent.options.env]`. Only `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`
reached the child, because that's the only one Claude Code SDK v2.1.217's
telemetry gate does not strip. `--exec` cron was unaffected because it does
not spawn the Claude Code agent.

Reporter config (yaojit on macOS darwin arm64):

```toml
[projects.agent.options.env]
CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = "1"
OTEL_EXPORTER_OTLP_ENDPOINT          = "http://localhost:4318"
OTEL_TRACES_EXPORTER                 = "otlp"
OTEL_SERVICE_NAME                    = "oh-my-kb"
OTEL_LOGS_EXPORTER                   = "otlp"
OTEL_METRICS_EXPORTER                = "otlp"
OTEL_EXPORTER_OTLP_PROTOCOL          = "http/protobuf"
OTEL_LOG_USER_PROMPTS                = "1"
OTEL_LOG_TOOL_DETAILS                = "1"
```

## Root cause

When `run_as_user` is set, `core.FilterEnvForSpawn` strips the supervisor's
env down to `mergedAllowlist` (`DefaultEnvAllowlist` + `run_as_env` +
`CC_RUNAS_CHDIR`). Previously this filter ran **after** merging `extraEnv`
(the agent's runtime env, which carries configEnv). So every key not on the
allowlist was silently dropped from the Claude Code child — including OTEL_*
unless the user also added `OTEL_*` to `run_as_env`.

`DefaultEnvAllowlist` is intentionally minimal: `LANG`, `LC_ALL`,
`LC_CTYPE`, `LC_MESSAGES`, `TERM`. There is no OTEL_* in there, and we
shouldn't add one — the allowlist's job is to constrain what the
**supervisor's** env contributes, not what the user explicitly configured
in their project.

## Fix

Refactor `agent/claudecode/session.go`: extract env construction into the
testable helper `buildClaudeChildEnv`, and reorder so `extraEnv` is merged
**after** `FilterEnvForSpawn`. The allowlist now correctly governs only
the inherited supervisor env; `[projects.agent.options.env]` always reaches
the child, regardless of allowlist contents.

This is the agent-side analog of how `extraEnv` already works for
`--exec` cron: explicit user config is the most trusted source and must
not be filtered away.

## Behavior changes

- `run_as_user` users now see OTEL_*, CLAUDE_CODE_*, and any other keys in
  `[projects.agent.options.env]` reach the Claude Code child. Previously
  these were silently stripped unless also added to `run_as_env`.
- Inherited OTEL_* from the supervisor's environment is still correctly
  stripped (security boundary preserved — supervisor env ≠ user config).
- Non-`run_as_user` users see no change (the filter was a no-op for them).
- `--exec` cron path is unchanged.

## Test plan

New file `agent/claudecode/session_env_test.go` with three regression tests:

1. `TestBuildClaudeChildEnv_PreservesConfigEnvNoIsolation` — default
   cron path; all 8 OTEL_* + `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` reach
   the child verbatim.

2. `TestBuildClaudeChildEnv_PreservesConfigEnvUnderIsolation` — **the
   #1589 regression net.** `SpawnOptions{RunAsUser: "someuser"}` with the
   default minimal allowlist. Every configEnv key (case-insensitive
   full-section assertion per PM acceptance criteria) must reach the child.

3. `TestBuildClaudeChildEnv_DropsInheritedOTELUnderIsolation` — documents
   the security boundary: `OTEL_SERVICE_NAME=inherited-from-supervisor` in
   `os.Environ()` is correctly stripped by `FilterEnvForSpawn`.

## Verification

- `GOFLAGS=-tags=no_web go test ./agent/claudecode -count=1` → ok 10.3s
  (3 new tests + all existing tests pass)
- `GOFLAGS=-tags=no_web go test ./agent/... -count=1` → all packages ok
- `GOFLAGS=-tags=no_web go test ./core/... -count=1` → ok 50.0s
- `GOFLAGS=-tags=no_web go build ./...` → clean
- `golangci-lint run --new-from-rev origin/main ./agent/claudecode/...`
  → 0 issues (v2.11.4)