### PR TITLE
fix(cursor): save inbound images to disk and pass path refs

### DIFF
--- a/agent/cursor/session.go
+++ b/agent/cursor/session.go
@@ -76,12 +76,31 @@ func newCursorSession(ctx context.Context, cmd string, extraArgs []string, workD
 }
 
 func (cs *cursorSession) Send(prompt string, messageID string, images []core.ImageAttachment, files []core.FileAttachment) error {
+	// Cursor Agent CLI has no --image flag; headless vision works by putting
+	// image paths in the prompt so the agent can Read them (same as files).
+	// See https://cursor.com/docs/cli/headless#working-with-images
+	var localPaths []string
 	if len(images) > 0 {
-		slog.Warn("cursorSession: images not yet supported in CLI mode, ignoring")
+		imgFiles := make([]core.FileAttachment, 0, len(images))
+		for i, img := range images {
+			name := img.FileName
+			if name == "" {
+				name = fmt.Sprintf("img_%d_%d%s", time.Now().UnixMilli(), i, cursorImageExt(img.MimeType))
+			}
+			imgFiles = append(imgFiles, core.FileAttachment{
+				MimeType: img.MimeType,
+				Data:     img.Data,
+				FileName: name,
+			})
+		}
+		localPaths = append(localPaths, core.SaveFilesToDisk(cs.workDir, messageID, imgFiles)...)
+		slog.Info("cursorSession: saved inbound images for CLI path refs", "count", len(imgFiles), "saved", len(localPaths))
 	}
 	if len(files) > 0 {
-		filePaths := core.SaveFilesToDisk(cs.workDir, messageID, files)
-		prompt = core.AppendFileRefs(prompt, filePaths)
+		localPaths = append(localPaths, core.SaveFilesToDisk(cs.workDir, messageID, files)...)
+	}
+	if len(localPaths) > 0 {
+		prompt = core.AppendFileRefs(prompt, localPaths)
 	}
 	if !cs.alive.Load() {
 		return fmt.Errorf("session is closed")
@@ -608,6 +627,21 @@ func (cs *cursorSession) Close() error {
 		slog.Warn("cursorSession: close timed out, abandoning wg.Wait")
 	}
 	return nil
+}
+
+func cursorImageExt(mimeType string) string {
+	switch strings.ToLower(mimeType) {
+	case "image/png":
+		return ".png"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	default:
+		return ".png"
+	}
 }
 
 func truncateStr(s string, maxRunes int) string {


### PR DESCRIPTION
## Summary
- Stop ignoring inbound images in the Cursor agent adapter (`cursorSession: images not yet supported in CLI mode, ignoring`).
- Save images via `core.SaveFilesToDisk` (same path as file attachments) and append absolute path refs with `core.AppendFileRefs`, matching [Cursor CLI headless image guidance](https://cursor.com/docs/cli/headless#working-with-images).
- Related to #1112 (`image_mode=path` direction); this is a Cursor-specific path-mode fix without introducing a new config knob yet.

## Test plan
- [x] `go test ./agent/cursor/ -count=1`
- [x] Feishu → `type = "cursor"` project: send an image + text (“你能看到这张图吗？”); confirm log `cursorSession: saved inbound images for CLI path refs` and agent describes the image
- [ ] Regression: text-only and file-only messages still work on Cursor projects


Made with [Cursor](https://cursor.com)