### PR TITLE
fix(pi): keep turn open while Pi auto-retries transient errors (willRetry)

### DIFF
--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -989,6 +989,95 @@ func TestHandleEvent_AgentEndEmitsResult(t *testing.T) {
 	}
 }
 
+// ── handleEvent: agent_end willRetry (transient error auto-retry) ──
+//
+// Pi auto-retries transient provider failures (e.g. HTTP 429) inside the
+// same turn: it emits agent_end with willRetry=true, then re-runs the agent
+// loop. Closing the turn on the first agent_end (or on the intermediate
+// message_end error) makes the engine report a failure that Pi is about to
+// recover from, and the retry outcome is dropped as stale events.
+
+func TestHandleEvent_AgentEndWillRetryKeepsTurnOpen(t *testing.T) {
+	s := newTestSession(true) // rpc=true
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_end",
+		"message": map[string]any{
+			"role":         "assistant",
+			"errorMessage": "429 rate_limit_error",
+		},
+	})
+	s.handleEvent(map[string]any{"type": "agent_end", "willRetry": true, "messages": []any{}})
+
+	evts := drainEvents(s)
+	if len(evts) != 0 {
+		t.Fatalf("willRetry agent_end must not close the turn, got %d events: %#v", len(evts), evts)
+	}
+	if s.pendingErr == "" {
+		t.Error("pendingErr must be retained while Pi is retrying")
+	}
+}
+
+func TestHandleEvent_AgentEndFlushesPendingError(t *testing.T) {
+	s := newTestSession(true) // rpc=true
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_end",
+		"message": map[string]any{
+			"role":         "assistant",
+			"errorMessage": "429 rate_limit_error",
+		},
+	})
+	s.handleEvent(map[string]any{"type": "agent_end", "willRetry": false, "messages": []any{}})
+
+	evts := drainEvents(s)
+	if len(evts) != 2 {
+		t.Fatalf("expected EventError + EventResult, got %d events: %#v", len(evts), evts)
+	}
+	if evts[0].Type != core.EventError {
+		t.Errorf("first event = %s, want EventError", evts[0].Type)
+	}
+	if evts[0].Error == nil || !strings.Contains(evts[0].Error.Error(), "429") {
+		t.Errorf("error = %v, want deferred 429", evts[0].Error)
+	}
+	if evts[1].Type != core.EventResult {
+		t.Errorf("second event = %s, want EventResult", evts[1].Type)
+	}
+	if s.pendingErr != "" {
+		t.Errorf("pendingErr must be cleared after flush, got %q", s.pendingErr)
+	}
+}
+
+func TestHandleEvent_AgentEndRetrySuccessDropsPendingError(t *testing.T) {
+	s := newTestSession(true) // rpc=true
+	defer s.cancel()
+
+	// Transient 429 -> Pi retries (willRetry) -> retry succeeds.
+	s.handleEvent(map[string]any{
+		"type": "message_end",
+		"message": map[string]any{
+			"role":         "assistant",
+			"errorMessage": "429 rate_limit_error",
+		},
+	})
+	s.handleEvent(map[string]any{"type": "agent_end", "willRetry": true, "messages": []any{}})
+	s.handleEvent(map[string]any{
+		"type":    "message_end",
+		"message": map[string]any{"role": "assistant"},
+	})
+	s.handleEvent(map[string]any{"type": "agent_end", "willRetry": false, "messages": []any{}})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("expected only EventResult after successful retry, got %d events: %#v", len(evts), evts)
+	}
+	if evts[0].Type != core.EventResult {
+		t.Errorf("expected EventResult, got %s", evts[0].Type)
+	}
+}
+
 func TestHandleEvent_UnhandledType(t *testing.T) {
 	s := newTestSession()
 	defer s.cancel()
@@ -1477,15 +1566,15 @@ func TestHandleMessageEnd_AssistantError(t *testing.T) {
 		},
 	})
 
+	// Errors are deferred (buffered in pendingErr) so transient provider
+	// failures that Pi auto-retries are not surfaced mid-turn. The agent_end
+	// handler flushes the buffer once the turn truly ends.
 	evts := drainEvents(s)
-	if len(evts) != 1 {
-		t.Fatalf("got %d events, want 1", len(evts))
+	if len(evts) != 0 {
+		t.Fatalf("expected no immediate events for assistant error, got %d", len(evts))
 	}
-	if evts[0].Type != core.EventError {
-		t.Errorf("type = %s", evts[0].Type)
-	}
-	if evts[0].Error == nil || !strings.Contains(evts[0].Error.Error(), "400") {
-		t.Errorf("error = %v", evts[0].Error)
+	if s.pendingErr != "400 model not supported" {
+		t.Errorf("pendingErr = %q, want %q", s.pendingErr, "400 model not supported")
 	}
 }
 

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -75,6 +75,15 @@ type piSession struct {
 	usageMu     sync.Mutex
 	lastUsage   *core.ContextUsage
 
+	// pendingErr buffers the most recent assistant errorMessage. Pi
+	// auto-retries transient provider failures (e.g. HTTP 429 rate limits)
+	// inside the same turn and announces this via agent_end.willRetry.
+	// Surfacing such errors immediately would make the engine fail the
+	// turn while Pi is still recovering it, and the retry outcome would
+	// be dropped as stale events. Only written from handleEvent, which
+	// runs on a single goroutine per mode.
+	pendingErr string
+
 	// RPC-only fields (nil/zero when rpc=false)
 	rpcCmd     *exec.Cmd
 	rpcStdin   io.WriteCloser
@@ -412,7 +421,17 @@ func (s *piSession) sendJSON(prompt string) error {
 		}
 	}
 
-	// Signal turn completion
+	// Signal turn completion. Flush a deferred terminal error first in
+	// case the process exited without a final non-retry agent_end (the
+	// agent_end handler normally flushes pendingErr already).
+	if s.pendingErr != "" {
+		errEvt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", s.pendingErr)}
+		s.pendingErr = ""
+		select {
+		case s.events <- errEvt:
+		case <-s.ctx.Done():
+		}
+	}
 	sid := s.CurrentSessionID()
 	evt := core.Event{Type: core.EventResult, SessionID: sid, Done: true}
 	select {
@@ -505,6 +524,25 @@ func (s *piSession) handleEvent(raw map[string]any) {
 
 	case "agent_end":
 		s.handleAgentEnd(raw)
+		if willRetry, _ := raw["willRetry"].(bool); willRetry {
+			// Pi is auto-retrying a transient failure (e.g. 429) inside
+			// this turn: it emits agent_end with willRetry=true, then
+			// re-runs the agent loop and emits a fresh agent_start /
+			// agent_end cycle. Keep the turn open and wait for the
+			// retry outcome instead of closing the turn on a failure
+			// Pi is about to recover from.
+			break
+		}
+		if s.pendingErr != "" {
+			// Turn is really over and the last assistant message failed:
+			// surface the deferred error before closing the turn.
+			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", s.pendingErr)}
+			s.pendingErr = ""
+			select {
+			case s.events <- evt:
+			case <-s.ctx.Done():
+			}
+		}
 		if s.rpc {
 			// RPC mode: agent_end marks turn completion; json mode relies
 			// on process exit to emit EventResult.
@@ -880,11 +918,15 @@ func (s *piSession) handleMessageEnd(raw map[string]any) {
 
 	case "assistant":
 		if errMsg, ok := msg["errorMessage"].(string); ok && errMsg != "" {
-			evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", errMsg)}
-			select {
-			case s.events <- evt:
-			case <-s.ctx.Done():
-			}
+			// Defer surfacing: Pi may auto-retry this turn (announced
+			// via agent_end.willRetry). The buffered error is flushed
+			// by the agent_end handler once the turn truly ends, or by
+			// sendJSON on process exit.
+			s.pendingErr = errMsg
+		} else {
+			// A healthy assistant message supersedes any earlier error
+			// that Pi has already retried successfully.
+			s.pendingErr = ""
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Pi (earendil-works/pi-coding-agent) has a built-in agent-level auto-retry for transient provider failures (HTTP 429 rate limits, 5xx, overloaded, network errors). When a run ends with a retryable error, Pi emits `agent_end` **with `willRetry: true`**, then re-runs the agent loop and emits a fresh `agent_start` / `agent_end` cycle. (See `dist/core/agent-session.js`: `_emit({ ...event, willRetry: this._willRetryAfterAgentEnd(event) })`.)

cc-connect's pi adapter doesn't read `willRetry`, and surfaces every assistant `errorMessage` immediately as `EventError` (`handleMessageEnd`). The engine treats `EventError` as turn-fatal (`core/engine.go`: finalize failed card, push error to platform, `return`). As a result, on every transient 429:

1. The user immediately sees a hard error on the platform (e.g. Feishu);
2. The turn is closed from cc-connect's perspective (json mode: `EventError` ends the loop; rpc mode: first `agent_end` also emits `EventResult Done`);
3. Pi keeps retrying in the background and usually **recovers within seconds**, but the recovered run's events are drained as stale (`drained stale events from previous turn`) and the user never sees the result.

Real-world impact: with rate-limited providers (e.g. Kimi `rate_limit_error: The engine is currently overloaded`), users see "429 error → silence" on virtually every busy turn, even though Pi's retry succeeds almost every time. May be related to #1499 / #1498.

## Fix

In `agent/pi/session.go` (shared by json and rpc modes):

- **Buffer, don't emit**: the latest assistant `errorMessage` goes into `s.pendingErr` instead of an immediate `EventError`. A subsequent healthy assistant `message_end` clears the buffer.
- **`willRetry` keeps the turn open**: on `agent_end` with `willRetry: true`, emit nothing — the retried run produces a fresh event cycle.
- **Terminal `agent_end` flushes**: with `willRetry` absent/false, a buffered error is emitted as `EventError` before the turn closes — the failure UX for truly-final errors is unchanged (and older Pi builds without `willRetry` behave exactly as before, just deferred by one event).
- **`sendJSON` exit fallback**: flushes `pendingErr` on process exit in case no terminal `agent_end` was observed.

Verified against pi-coding-agent 0.81: both `--mode json` and `--mode rpc` stream the same session events, so `agent_end.willRetry` is available in both modes.

## Tests

- Updated `TestHandleMessageEnd_AssistantError` for deferred buffering.
- New: `TestHandleEvent_AgentEndWillRetryKeepsTurnOpen`, `TestHandleEvent_AgentEndFlushesPendingError`, `TestHandleEvent_AgentEndRetrySuccessDropsPendingError`.
- `go build ./...`, `go vet ./agent/pi/`, `go test ./agent/pi/` and `go test ./core/` all pass (go 1.25.0).

## Notes

- No config or behavior change for other agents; the change is scoped to the pi adapter.
- A nice follow-up (out of scope): render a transient "retrying…" hint on the platform when `willRetry` is seen, e.g. via the progress card.