### PR TITLE
fix(kimi): support newer Kimi Code CLI stream format and flags

### DIFF
--- a/agent/kimi/probe.go
+++ b/agent/kimi/probe.go
@@ -20,8 +20,12 @@ import (
 //	now produces: `error: unknown option '--print' (Did you mean --prompt?)`.
 //	The older kimi-cli still requires `--print` for `--output-format` to take
 //	effect. We probe the help text once and adapt accordingly. See #1456.
+//
+//	The newer Kimi Code CLI also dropped `--work-dir` (its working directory
+//	is the process cwd), so support for that flag is probed as well.
 type kimiFlagSupport struct {
-	Print bool
+	Print   bool
+	WorkDir bool
 }
 
 // probeKimiFlags runs `<cmd> --help` with a short timeout and returns the
@@ -49,7 +53,8 @@ func probeKimiFlags(parent context.Context, cmd string, timeout time.Duration) k
 
 	flags := parseKimiHelpFlags(out.String())
 	support := kimiFlagSupport{
-		Print: flags["--print"],
+		Print:   flags["--print"],
+		WorkDir: flags["--work-dir"],
 	}
 	slog.Debug("kimi: flag probe complete", "cmd", cmd, "support", support)
 	return support

--- a/agent/kimi/session.go
+++ b/agent/kimi/session.go
@@ -94,7 +94,10 @@ func (ks *kimiSession) buildArgs(prompt string) []string {
 	if ks.model != "" {
 		args = append(args, "--model", ks.model)
 	}
-	if ks.workDir != "" {
+	// The newer Kimi Code CLI dropped `--work-dir` (passing it fails with
+	// "unknown option"); the working directory is already carried by
+	// cmd.Dir, so only emit the flag for binaries that still advertise it.
+	if ks.workDir != "" && ks.flagSupport.WorkDir {
 		args = append(args, "--work-dir", ks.workDir)
 	}
 
@@ -321,6 +324,7 @@ func extractResumeSessionID(line string) string {
 // Kimi CLI stream-json message roles:
 //   - "assistant": content (think + text), tool_calls
 //   - "tool":      content (tool execution result), tool_call_id
+//   - "meta":      session metadata (newer Kimi Code CLI resume hint)
 func (ks *kimiSession) handleEvent(raw map[string]any) {
 	role, _ := raw["role"].(string)
 
@@ -329,13 +333,46 @@ func (ks *kimiSession) handleEvent(raw map[string]any) {
 		ks.handleAssistant(raw)
 	case "tool":
 		ks.handleTool(raw)
+	case "meta":
+		ks.handleMeta(raw)
 	default:
 		slog.Debug("kimiSession: unhandled role", "role", role)
 	}
 }
 
+// contentBlocks normalises the `content` field of a stream-json message.
+// The legacy kimi-cli emits an array of typed blocks, while the newer Kimi
+// Code CLI emits a plain string — treat a string as a single text block.
+func contentBlocks(raw map[string]any) []any {
+	switch c := raw["content"].(type) {
+	case []any:
+		return c
+	case string:
+		if c == "" {
+			return nil
+		}
+		return []any{map[string]any{"type": "text", "text": c}}
+	default:
+		return nil
+	}
+}
+
+// handleMeta captures the session id reported by the newer Kimi Code CLI,
+// which emits the resume hint as a stdout meta event
+// ({"role":"meta","type":"session.resume_hint","session_id":"..."}) instead
+// of the legacy stderr notice scanned in readLoop.
+func (ks *kimiSession) handleMeta(raw map[string]any) {
+	if t, _ := raw["type"].(string); t != "session.resume_hint" {
+		return
+	}
+	if id, _ := raw["session_id"].(string); id != "" {
+		ks.sessionID.Store(id)
+		slog.Debug("kimiSession: session id from meta event", "session_id", id)
+	}
+}
+
 func (ks *kimiSession) handleAssistant(raw map[string]any) {
-	content, _ := raw["content"].([]any)
+	content := contentBlocks(raw)
 	for _, item := range content {
 		block, ok := item.(map[string]any)
 		if !ok {
@@ -391,7 +428,7 @@ func (ks *kimiSession) handleAssistant(raw map[string]any) {
 
 func (ks *kimiSession) handleTool(raw map[string]any) {
 	toolCallID, _ := raw["tool_call_id"].(string)
-	content, _ := raw["content"].([]any)
+	content := contentBlocks(raw)
 	var outputParts []string
 	for _, item := range content {
 		block, ok := item.(map[string]any)

--- a/agent/kimi/session_test.go
+++ b/agent/kimi/session_test.go
@@ -247,3 +247,98 @@ func drainEvents(ch <-chan core.Event, max int) []core.Event {
 	}
 	return events
 }
+
+// TestBuildArgs_NoWorkDirSupportOmitsFlag covers the newer Kimi Code CLI,
+// which rejects --work-dir; cmd.Dir still carries the working directory.
+func TestBuildArgs_NoWorkDirSupportOmitsFlag(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{WorkDir: false})
+	require.NoError(t, err)
+	defer func() { _ = ks.Close() }()
+
+	args := ks.buildArgs("hello")
+	for _, a := range args {
+		if a == "--work-dir" {
+			t.Fatalf("buildArgs unexpectedly emitted --work-dir when flagSupport.WorkDir=false; args=%v", args)
+		}
+	}
+	assert.Contains(t, args, "--prompt")
+}
+
+// TestBuildArgs_WorkDirSupportIncludesFlag covers the legacy kimi-cli
+// branch — the binary advertises --work-dir, so we keep emitting it.
+func TestBuildArgs_WorkDirSupportIncludesFlag(t *testing.T) {
+	ctx := context.Background()
+	ks, err := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{WorkDir: true})
+	require.NoError(t, err)
+	defer func() { _ = ks.Close() }()
+
+	args := ks.buildArgs("hello")
+	idx := -1
+	for i, a := range args {
+		if a == "--work-dir" {
+			idx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, idx, 0, "args should include --work-dir; got %v", args)
+	require.Less(t, idx+1, len(args), "--work-dir should be followed by a directory")
+	assert.Equal(t, "/tmp", args[idx+1])
+}
+
+// TestHandleAssistantWithStringContent covers the newer Kimi Code CLI stream
+// format, where assistant content is a plain string instead of typed blocks.
+func TestHandleAssistantWithStringContent(t *testing.T) {
+	ctx := context.Background()
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
+	defer ks.Close()
+
+	ks.handleEvent(map[string]any{
+		"role":    "assistant",
+		"content": "Hello from Kimi Code!",
+	})
+
+	assert.Len(t, ks.pendingMsgs, 1)
+	assert.Equal(t, "Hello from Kimi Code!", ks.pendingMsgs[0])
+}
+
+// TestHandleToolWithStringContent covers tool results whose content is a
+// plain string (newer Kimi Code CLI format).
+func TestHandleToolWithStringContent(t *testing.T) {
+	ctx := context.Background()
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
+	defer ks.Close()
+
+	ks.handleEvent(map[string]any{
+		"role":         "tool",
+		"tool_call_id": "Bash_0",
+		"content":      "total 36\n",
+	})
+
+	events := drainEvents(ks.events, 1)
+	require.Len(t, events, 1)
+	assert.Equal(t, core.EventToolResult, events[0].Type)
+	assert.Equal(t, "Bash_0", events[0].ToolName)
+	assert.Contains(t, events[0].ToolResult, "total 36")
+}
+
+// TestHandleMetaResumeHint covers the newer Kimi Code CLI, which reports the
+// session id as a stdout meta event rather than on stderr.
+func TestHandleMetaResumeHint(t *testing.T) {
+	ctx := context.Background()
+	ks, _ := newKimiSession(ctx, "kimi", nil, "/tmp", "", "default", "", nil, 0, kimiFlagSupport{})
+	defer ks.Close()
+
+	ks.handleEvent(map[string]any{
+		"role":       "meta",
+		"type":       "session.resume_hint",
+		"session_id": "session_abc-123",
+		"command":    "kimi -r session_abc-123",
+	})
+
+	assert.Equal(t, "session_abc-123", ks.CurrentSessionID())
+
+	// Unrelated meta events must not clobber the session id.
+	ks.handleEvent(map[string]any{"role": "meta", "type": "other"})
+	assert.Equal(t, "session_abc-123", ks.CurrentSessionID())
+}


### PR DESCRIPTION
## Problem

The `kimi` agent was written against the legacy kimi-cli. The newer **Kimi Code CLI** (kimi-code, verified with v0.29.1) breaks the integration in three ways:

1. **`--work-dir` rejected — every turn fails.** `buildArgs` always appends `--work-dir <dir>`, but the new CLI removed that flag: `error: unknown option '--work-dir'`.
2. **Assistant text lost — empty replies.** The new CLI emits `content` as a plain string (`{"role":"assistant","content":"..."}`) instead of an array of typed blocks. `handleAssistant`/`handleTool` silently drop it, so chat platforms only receive tool-call previews followed by an empty response.
3. **Session id never captured — no multi-turn continuity.** The new CLI reports the resume hint as a stdout meta event (`{"role":"meta","type":"session.resume_hint","session_id":"..."}`) instead of the legacy stderr line `To resume this session: kimi -r <id>`. The id is never stored, so every incoming message starts a brand-new Kimi session.

## Changes

- **`agent/kimi/probe.go`** — probe `--work-dir` support alongside `--print` (new `kimiFlagSupport.WorkDir` field), same "probe once at agent construction" mechanism introduced for #1456.
- **`agent/kimi/session.go` `buildArgs`** — only emit `--work-dir` when the binary advertises it. The working directory is already carried by `cmd.Dir`, which both CLI generations honor, so no functionality is lost for the new CLI.
- **`agent/kimi/session.go`** — new `contentBlocks` normalizer accepting both the legacy block-array and the new plain-string `content`; used by `handleAssistant` and `handleTool`.
- **`agent/kimi/session.go`** — new `handleMeta` capturing `session_id` from `session.resume_hint` meta events. The stderr scan in `readLoop` is kept for legacy binaries.

Fully backward-compatible: legacy kimi-cli behavior is unchanged on every path (flag still emitted when advertised, block-array content parsed as before, stderr resume hint still honored).

## Tests

New unit tests, following the existing `kimiFlagSupport` test conventions:

- `TestBuildArgs_NoWorkDirSupportOmitsFlag` / `TestBuildArgs_WorkDirSupportIncludesFlag`
- `TestHandleAssistantWithStringContent` / `TestHandleToolWithStringContent`
- `TestHandleMetaResumeHint`

`go test ./agent/kimi/` — 31/31 pass. Full `go test ./...` — all packages pass.

## Production validation

These fixes were developed and verified live against **Kimi Code CLI 0.29.1** on the **WeCom (websocket)** platform: multi-turn conversations now resume the same Kimi session (`--resume`), replies render in full, and sessions can be taken over in the Kimi TUI (`kimi --session <id>`) — confirming the session ids land in the CLI's own session store.
