### PR TITLE
fix(qoder): deliver prompt via stdin to avoid reply-chain parse error

### DIFF
--- a/agent/qoder/qoder.go
+++ b/agent/qoder/qoder.go
@@ -17,7 +17,8 @@ func init() {
 	core.RegisterAgent("qoder", New)
 }
 
-// Agent drives Qoder CLI using `qodercli -p <prompt> -f stream-json`.
+// Agent drives Qoder CLI using `qodercli -p -f stream-json --input-format stream-json`,
+// delivering each prompt via stdin as a stream-json user frame.
 type Agent struct {
 	workDir      string
 	cmd          string   // CLI binary name (default: "qodercli")

--- a/agent/qoder/qoder_test.go
+++ b/agent/qoder/qoder_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -467,5 +469,115 @@ func drainQoderEvents(qs *qoderSession) []core.Event {
 		default:
 			return events
 		}
+	}
+}
+
+// TestSend_ReplyChainPromptNotPassedAsPositionalArg is a regression test for the
+// bug where a reply-style message broke qodercli argument parsing.
+//
+// When a user replies to a message, cc-connect prefixes the prompt with
+// "--- Reply chain (N messages) ---". The qoder adapter used to pass the prompt
+// as a positional argument: `qodercli -p <prompt> ...`. qodercli's CLI parser
+// (commander.js) treats a positional that starts with "-" as an unknown option,
+// so the turn failed immediately with `error: unknown option '--'`.
+//
+// The fix delivers the prompt via stdin (stream-json input) instead, so it never
+// appears in argv. The fake qodercli below mimics the parser: it errors out if it
+// sees a "---"-prefixed argument (pre-fix behavior) and otherwise reads the
+// prompt from stdin and returns a successful result (post-fix behavior). The test
+// therefore fails on the pre-fix code and passes on the fixed code.
+func TestSend_ReplyChainPromptNotPassedAsPositionalArg(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+
+	shellScript := `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    ---*) printf "error: unknown option '%s'\n" "$arg" >&2; exit 1 ;;
+  esac
+done
+IFS= read -r _frame || true
+printf '{"type":"system","subtype":"init","session_id":"fake-qoder-sid"}\n'
+printf '{"type":"result","subtype":"success","result":"regression-ok","session_id":"fake-qoder-sid"}\n'
+`
+	powershellScript := `foreach ($a in $args) {
+  if ($a -like '---*') {
+    [Console]::Error.WriteLine("error: unknown option '$a'")
+    exit 1
+  }
+}
+$null = [Console]::In.ReadLine()
+Write-Output '{"type":"system","subtype":"init","session_id":"fake-qoder-sid"}'
+Write-Output '{"type":"result","subtype":"success","result":"regression-ok","session_id":"fake-qoder-sid"}'
+exit 0
+`
+	writeFakeQoderScript(t, binDir, shellScript, powershellScript)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	agent, err := New(map[string]any{"work_dir": workDir})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	sess, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	defer sess.Close()
+
+	// Single-line, "---"-prefixed prompt mirroring the reply-chain format while
+	// staying free of shell/batch metacharacters for the fake binary.
+	prompt := "--- Reply chain 2 messages --- regenerate report link"
+	if err := sess.Send(prompt, "", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	timeout := time.After(15 * time.Second)
+	for {
+		select {
+		case ev, ok := <-sess.Events():
+			if !ok {
+				t.Fatal("events channel closed before a result was received")
+			}
+			switch ev.Type {
+			case core.EventError:
+				t.Fatalf("regression: prompt was rejected by the CLI parser (likely passed as a positional argument): %v", ev.Error)
+			case core.EventResult:
+				if ev.Content != "regression-ok" {
+					t.Errorf("result content = %q, want %q", ev.Content, "regression-ok")
+				}
+				return
+			}
+		case <-timeout:
+			t.Fatal("timeout waiting for result event")
+		}
+	}
+}
+
+// writeFakeQoderScript writes an executable named "qodercli" into dir so that
+// exec.LookPath("qodercli") resolves it via the test's PATH override. On Unix it
+// is a shell script; on Windows it is a .cmd shim that forwards arguments to a
+// PowerShell script.
+func writeFakeQoderScript(t *testing.T, dir, shellScript, powershellScript string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		psPath := filepath.Join(dir, "qodercli.ps1")
+		if err := os.WriteFile(psPath, []byte(powershellScript), 0o644); err != nil {
+			t.Fatalf("write fake qodercli powershell script: %v", err)
+		}
+		cmdPath := filepath.Join(dir, "qodercli.cmd")
+		cmdScript := "@echo off\r\n" +
+			"powershell -NoProfile -ExecutionPolicy Bypass -File \"%~dp0qodercli.ps1\" %*\r\n" +
+			"exit /b %ERRORLEVEL%\r\n"
+		if err := os.WriteFile(cmdPath, []byte(cmdScript), 0o755); err != nil {
+			t.Fatalf("write fake qodercli cmd shim: %v", err)
+		}
+		return
+	}
+	scriptPath := filepath.Join(dir, "qodercli")
+	if err := os.WriteFile(scriptPath, []byte(shellScript), 0o755); err != nil {
+		t.Fatalf("write fake qodercli: %v", err)
 	}
 }

--- a/agent/qoder/qoder_test.go
+++ b/agent/qoder/qoder_test.go
@@ -525,7 +525,7 @@ exit 0
 	if err != nil {
 		t.Fatalf("StartSession: %v", err)
 	}
-	defer sess.Close()
+	defer func() { _ = sess.Close() }()
 
 	// Single-line, "---"-prefixed prompt mirroring the reply-chain format while
 	// staying free of shell/batch metacharacters for the fake binary.

--- a/agent/qoder/session.go
+++ b/agent/qoder/session.go
@@ -20,7 +20,8 @@ import (
 )
 
 // qoderSession manages a multi-turn Qoder conversation.
-// Each Send() spawns `qodercli -p <prompt> -f stream-json -q`.
+// Each Send() spawns `qodercli -p -f stream-json --input-format stream-json -q`
+// and writes the prompt to stdin as a single stream-json user frame.
 // Subsequent turns use `-r <sessionID>` to resume the conversation.
 type qoderSession struct {
 	cmd            string
@@ -92,7 +93,12 @@ func (qs *qoderSession) Send(prompt string, messageID string, images []core.Imag
 		return fmt.Errorf("session is closed")
 	}
 
-	args := append(append([]string{}, qs.extraArgs...), "-p", prompt, "-f", "stream-json", "-q", "-w", qs.workDir)
+	// The prompt is delivered via stdin (stream-json input) rather than as a
+	// positional argument. qodercli's CLI parser treats a positional query
+	// starting with "-" as an unknown option, and cc-connect prepends
+	// "--- Reply chain ..." when a message is a reply, which previously broke
+	// parsing with `error: unknown option '--'`.
+	args := append(append([]string{}, qs.extraArgs...), "-p", "-f", "stream-json", "--input-format", "stream-json", "-q", "-w", qs.workDir)
 
 	sid := qs.CurrentSessionID()
 	if sid != "" {
@@ -119,6 +125,11 @@ func (qs *qoderSession) Send(prompt string, messageID string, images []core.Imag
 		cmd.Env = core.MergeEnv(os.Environ(), qs.extraEnv)
 	}
 
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("qoderSession: stdin pipe: %w", err)
+	}
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("qoderSession: stdout pipe: %w", err)
@@ -129,6 +140,24 @@ func (qs *qoderSession) Send(prompt string, messageID string, images []core.Imag
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("qoderSession: start: %w", err)
+	}
+
+	// Deliver the prompt as a single stream-json user frame, then close stdin
+	// (EOF) so qodercli processes this turn and exits.
+	frame, err := json.Marshal(map[string]any{
+		"type":    "user",
+		"message": map[string]any{"role": "user", "content": prompt},
+	})
+	if err != nil {
+		_ = stdin.Close()
+		return fmt.Errorf("qoderSession: marshal prompt: %w", err)
+	}
+	if _, err := stdin.Write(append(frame, '\n')); err != nil {
+		_ = stdin.Close()
+		return fmt.Errorf("qoderSession: write stdin: %w", err)
+	}
+	if err := stdin.Close(); err != nil {
+		return fmt.Errorf("qoderSession: close stdin: %w", err)
 	}
 
 	qs.wg.Add(1)


### PR DESCRIPTION
## Summary

Fixes a bug where reply-style messages (which cc-connect prefixes with `--- Reply chain (N messages) ---`) broke qodercli argument parsing. The qoder adapter passed the prompt as a positional argument; qodercli's commander.js parser treated the `---`-prefixed positional as an unknown option and exited with `error: unknown option '--'` before doing any work. This PR delivers the prompt via stdin (stream-json input) instead, so it never appears in argv and is no longer subject to option parsing.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

Verified against a real qodercli 1.1.4:

- Reproduced the original failure: a `--- Reply chain ...` prompt passed as a positional arg yields `error: unknown option '---...'`.
- Confirmed the stdin path works end-to-end: the same prompt delivered via `--input-format stream-json` produces a successful `result` event.
- Ran the existing integration test `TestQoderSession` (`QODER_INTEGRATION=1`) against the patched `Send()` — passes.

### Automated tests added in this PR

- `TestSend_ReplyChainPromptNotPassedAsPositionalArg` in `agent/qoder/qoder_test.go` — uses a fake `qodercli` (cross-platform: a shell script on Unix, a `.cmd` shim + `.ps1` on Windows) that mimics qodercli's parser: it exits with `error: unknown option` if any argv element starts with `---`, otherwise reads the prompt from stdin and returns a successful stream-json result.

### For bug fixes only — regression test

- Regression test name: `TestSend_ReplyChainPromptNotPassedAsPositionalArg`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally; the regression test failed as expected (`error: unknown option '--- Reply chain 2 messages --- ...'`).

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [x] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [x] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally. (Not run: no system-wide Go toolchain in the test environment; the qoder package builds, vets clean, and `go test ./agent/qoder/` passes.)
- [x] If the change alters an existing user-visible flow, the corresponding CUJ test was updated (or a new CUJ added) to cover the new behavior. (A dedicated regression test was added in the qoder package.)

## Manual / user-visible behavior change

Replying to / quoting a bot message now works for the qoder agent instead of failing with `error: unknown option '--'`. No behavior change for top-level messages.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes (qoder package verified; building the full binary additionally requires the `web/dist` frontend assets)
- [x] `go test ./...` passes for `./agent/qoder/` (including the new regression test)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (if any new user-facing text) — N/A, no new user-facing strings
- [x] No secrets / credentials in source

## Related

- Issue: #1602
- Related PR: N/A
