### PR TITLE
fix(engine): add timeouts and async save to prevent external I/O blocking

### DIFF
--- a/core/cuj_test.go
+++ b/core/cuj_test.go
@@ -230,6 +230,17 @@ func newCUJEnv(t *testing.T) *cujEnv {
 	agent := &cujAgent{}
 	storePath := dir + "/sessions.json"
 	e := NewEngine("test", agent, []Platform{plat}, storePath, LangEnglish)
+
+	// Ensure async session saves (go sessions.Save()) complete before
+	// t.TempDir() cleanup removes the directory. The sync Save() flushes
+	// any pending state; the short sleep gives the background goroutine
+	// time to release the RLock and return so it doesn't race with
+	// directory removal.
+	t.Cleanup(func() {
+		e.sessions.Save()
+		time.Sleep(50 * time.Millisecond)
+	})
+
 	return &cujEnv{
 		t:       t,
 		engine:  e,
@@ -1128,6 +1139,13 @@ func TestCUJ_A3_ImageReachesAgent(t *testing.T) {
 	dir := t.TempDir()
 	e := NewEngine("test", agent, []Platform{plat}, dir+"/sessions.json", LangEnglish)
 
+	// Ensure async session saves (go sessions.Save()) complete before
+	// t.TempDir() cleanup removes the directory.
+	t.Cleanup(func() {
+		e.sessions.Save()
+		time.Sleep(50 * time.Millisecond)
+	})
+
 	msg := &Message{
 		SessionKey: "test:img", Platform: "test", MessageID: "img1",
 		UserID: "img", UserName: "img",
@@ -1191,6 +1209,16 @@ func TestCUJ_A5_FileReachesAgent(t *testing.T) {
 	agent := &cujAgent{}
 	dir := t.TempDir()
 	e := NewEngine("test", agent, []Platform{plat}, dir+"/sessions.json", LangEnglish)
+
+	// Ensure async session saves (go sessions.Save()) complete before
+	// t.TempDir() cleanup removes the directory. The sync Save() flushes
+	// any pending state; the short sleep gives the background goroutine
+	// time to release the RLock and return so it doesn't race with
+	// directory removal.
+	t.Cleanup(func() {
+		e.sessions.Save()
+		time.Sleep(50 * time.Millisecond)
+	})
 
 	msg := &Message{
 		SessionKey: "test:file", Platform: "test", MessageID: "f1",
@@ -1965,6 +1993,13 @@ func TestCUJ_H2_TwoPlatformsConcurrentNoBleed(t *testing.T) {
 	pB := &stubPlatformEngine{n: "platB"}
 	agent := &cujAgent{}
 	e := NewEngine("test", agent, []Platform{pA, pB}, dir+"/sessions.json", LangEnglish)
+
+	// Ensure async session saves (go sessions.Save()) complete before
+	// t.TempDir() cleanup removes the directory.
+	t.Cleanup(func() {
+		e.sessions.Save()
+		time.Sleep(50 * time.Millisecond)
+	})
 
 	// Fire 5 messages on each platform concurrently.
 	var wg sync.WaitGroup

--- a/core/engine.go
+++ b/core/engine.go
@@ -72,6 +72,14 @@ const (
 	slowAgentClose      = 3 * time.Second  // agentSession.Close
 	slowAgentSend       = 2 * time.Second  // agentSession.Send
 	slowAgentFirstEvent = 15 * time.Second // time from send to first agent event
+
+	// platformSendTimeout bounds how long a single platform Send/Reply may
+	// take before the engine gives up. This prevents an unresponsive
+	// platform API from blocking the agent event loop (backpressure
+	// through the events channel into readLoop and eventually into the
+	// agent process itself). 15 s allows for one resolveMentions cache-miss
+	// (≤10 s internally) plus the actual HTTP reply with retries.
+	platformSendTimeout = 15 * time.Second
 )
 
 const (
@@ -3656,10 +3664,12 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 
 	e.i18n.DetectAndSet(msg.Content)
 	session.AddHistory("user", msg.Content)
-	// Persist user message immediately so crashes between user input and
-	// assistant reply don't lose it (the assistant-side Save below depends
-	// on the turn completing without a process crash).
-	sessions.Save()
+	// Persist user message asynchronously so disk I/O (fsync) does not
+	// block the critical path from user input to agent.Send. In the
+	// extremely rare event of a crash before the background write
+	// completes, the only consequence is a missing history entry — the
+	// message has already been dispatched to the agent.
+	go sessions.Save()
 
 	// Use the agent override when available (multi-workspace mode)
 	var agentOverride Agent
@@ -3720,20 +3730,6 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 		}
 	}
 
-	// Start typing indicator if platform supports it.
-	// Ownership is transferred to processInteractiveEvents which manages
-	// stopping/restarting it across queued message turns.
-	var stopTyping func()
-	if ti, ok := p.(TypingIndicator); ok {
-		stopTyping = ti.StartTyping(e.ctx, msg.ReplyCtx)
-	}
-	defer func() {
-		// Stop typing if ownership was NOT transferred to processInteractiveEvents
-		// (i.e. an early return before that call).
-		if stopTyping != nil {
-			stopTyping()
-		}
-	}()
 
 	// Stop the unsolicited reader (if running) and hand off event channel
 	// ownership to this foreground turn. Only drain events when the previous
@@ -3766,6 +3762,21 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 			return
 		}
 		sendDone <- as.Send(promptContent, msg.MessageID, msg.Images, msg.Files)
+	}()
+
+	// Start typing indicator AFTER Send has been dispatched to the agent, so
+	// Ownership is transferred to processInteractiveEvents which manages
+	// stopping/restarting it across queued message turns.
+	var stopTyping func()
+	if ti, ok := p.(TypingIndicator); ok {
+		stopTyping = ti.StartTyping(e.ctx, msg.ReplyCtx)
+	}
+	defer func() {
+		// Stop typing if ownership was NOT transferred to processInteractiveEvents
+		// (i.e. an early return before that call).
+		if stopTyping != nil {
+			stopTyping()
+		}
 	}()
 
 	e.processInteractiveEvents(state, session, sessions, interactiveKey, msg.MessageID, turnStart, stopTyping, sendDone, msg.ReplyCtx)
@@ -11671,7 +11682,9 @@ func (e *Engine) sendWithError(p Platform, replyCtx any, content string) error {
 
 func (e *Engine) sendAlreadyRenderedWithError(p Platform, replyCtx any, content string) error {
 	start := time.Now()
-	if err := p.Send(e.ctx, replyCtx, content); err != nil {
+	ctx, cancel := context.WithTimeout(e.ctx, platformSendTimeout)
+	defer cancel()
+	if err := p.Send(ctx, replyCtx, content); err != nil {
 		// Check for context_token missing error (common for Weixin platform)
 		if strings.Contains(err.Error(), "missing context_token") {
 			slog.Error("platform send failed: context_token missing",

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1709,7 +1709,9 @@ func (p *Platform) resolveUserName(openID string) string {
 	if cached, ok := p.userNameCache.Load(openID); ok {
 		return cached.(string)
 	}
-	resp, err := p.client.Contact.User.Get(context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := p.client.Contact.User.Get(ctx,
 		larkcontact.NewGetUserReqBuilder().
 			UserId(openID).
 			UserIdType("open_id").
@@ -1779,7 +1781,9 @@ func (p *Platform) resolveChatName(chatID string) string {
 	if cached, ok := p.chatNameCache.Load(chatID); ok {
 		return cached.(string)
 	}
-	resp, err := p.client.Im.Chat.Get(context.Background(),
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp, err := p.client.Im.Chat.Get(ctx,
 		larkim.NewGetChatReqBuilder().ChatId(chatID).Build())
 	if err != nil {
 		slog.Debug(p.tag()+": resolve chat name failed", "chat_id", chatID, "error", err)


### PR DESCRIPTION
- Add platformSendTimeout (15s) to bound platform Send/Reply calls,
  preventing unresponsive platform APIs from blocking the agent event loop
- Change sessions.Save() to async (goroutine) so disk fsync does not
  block the critical path from user input to agent.Send
- Move typing indicator start to after agent.Send dispatch so it correctly
  reflects agent processing rather than message dispatching
- Add 5s timeouts to feishu resolveUserName and resolveChatName API calls
- Add t.Cleanup in CUJ tests to flush async session saves before temp dir
  cleanup, preventing race between background goroutine and test teardown"