### PR TITLE
fix(antigravity): discover sessions from Antigravity CLI brain and cache

### DIFF
--- a/agent/antigravity/antigravity.go
+++ b/agent/antigravity/antigravity.go
@@ -232,37 +232,59 @@ func (a *Agent) DeleteSession(_ context.Context, sessionID string) error {
 	if err != nil {
 		return fmt.Errorf("antigravity: cannot determine home dir: %w", err)
 	}
-	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", antigravityProjectSlug(a.workDir), "chats")
-	entries, err := os.ReadDir(chatsDir)
-	if err != nil {
-		return fmt.Errorf("session file not found: %s", sessionID)
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
-			continue
-		}
-		fpath := filepath.Join(chatsDir, entry.Name())
-		file, err := os.Open(fpath)
-		if err != nil {
-			continue
-		}
 
-		scanner := bufio.NewScanner(file)
-		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-		if scanner.Scan() {
-			var sf struct {
-				SessionID string `json:"sessionId"`
-			}
-			if json.Unmarshal([]byte(scanner.Text()), &sf) == nil && sf.SessionID == sessionID {
-				_ = file.Close()
-				return os.Remove(fpath)
+	deleted := false
+
+	// Check ~/.gemini/antigravity-cli/brain/<sessionID>
+	brainPath := filepath.Join(homeDir, ".gemini", "antigravity-cli", "brain", sessionID)
+	if _, err := os.Stat(brainPath); err == nil {
+		if err := os.RemoveAll(brainPath); err == nil {
+			deleted = true
+		}
+	}
+
+	// Check ~/.gemini/antigravity-cli/conversations/<sessionID>.*
+	convsDir := filepath.Join(homeDir, ".gemini", "antigravity-cli", "conversations")
+	if entries, err := os.ReadDir(convsDir); err == nil {
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), sessionID) {
+				_ = os.Remove(filepath.Join(convsDir, entry.Name()))
+				deleted = true
 			}
 		}
-		if err := scanner.Err(); err != nil {
+	}
+
+	// Check legacy ~/.gemini/tmp/<slug>/chats/
+	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", antigravityProjectSlug(a.workDir), "chats")
+	if entries, err := os.ReadDir(chatsDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+				continue
+			}
+			fpath := filepath.Join(chatsDir, entry.Name())
+			file, err := os.Open(fpath)
+			if err != nil {
+				continue
+			}
+			scanner := bufio.NewScanner(file)
+			scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+			if scanner.Scan() {
+				var sf struct {
+					SessionID string `json:"sessionId"`
+				}
+				if json.Unmarshal([]byte(scanner.Text()), &sf) == nil && sf.SessionID == sessionID {
+					_ = file.Close()
+					_ = os.Remove(fpath)
+					deleted = true
+					break
+				}
+			}
 			_ = file.Close()
-			continue
 		}
-		_ = file.Close()
+	}
+
+	if deleted {
+		return nil
 	}
 	return fmt.Errorf("session file not found: %s", sessionID)
 }
@@ -463,102 +485,167 @@ func listAntigravitySessions(workDir string) ([]core.AgentSessionInfo, error) {
 		return nil, fmt.Errorf("antigravity: cannot determine home dir: %w", err)
 	}
 
-	slug := antigravityProjectSlug(workDir)
-	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", slug, "chats")
+	sessionMap := make(map[string]core.AgentSessionInfo)
 
-	entries, err := os.ReadDir(chatsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
+	// 1. Read ~/.gemini/antigravity-cli/cache/conversation_metadata.json
+	metaPath := filepath.Join(homeDir, ".gemini", "antigravity-cli", "cache", "conversation_metadata.json")
+	if data, err := os.ReadFile(metaPath); err == nil {
+		var meta struct {
+			Conversations map[string]struct {
+				Summary struct {
+					ID        string    `json:"ID"`
+					Title     string    `json:"Title"`
+					Preview   string    `json:"Preview"`
+					NumSteps  int       `json:"NumSteps"`
+					UpdatedAt time.Time `json:"UpdatedAt"`
+				} `json:"summary"`
+				IsInternal       bool      `json:"is_internal"`
+				LastModifiedTime time.Time `json:"last_modified_time"`
+			} `json:"conversations"`
 		}
-		return nil, fmt.Errorf("antigravity: read chats dir: %w", err)
+		if json.Unmarshal(data, &meta) == nil {
+			for id, conv := range meta.Conversations {
+				if conv.IsInternal || id == "" {
+					continue
+				}
+				summary := conv.Summary.Preview
+				if summary == "" {
+					summary = conv.Summary.Title
+				}
+				if summary == "" {
+					summary = id
+				}
+				if utf8.RuneCountInString(summary) > 60 {
+					summary = string([]rune(summary)[:60]) + "..."
+				}
+				modTime := conv.LastModifiedTime
+				if modTime.IsZero() {
+					modTime = conv.Summary.UpdatedAt
+				}
+				sessionMap[id] = core.AgentSessionInfo{
+					ID:           id,
+					Summary:      summary,
+					MessageCount: conv.Summary.NumSteps,
+					ModifiedAt:   modTime,
+				}
+			}
+		}
 	}
 
-	var sessions []core.AgentSessionInfo
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
-			continue
+	// 2. Scan ~/.gemini/antigravity-cli/brain/ for session directories
+	brainDir := filepath.Join(homeDir, ".gemini", "antigravity-cli", "brain")
+	if entries, err := os.ReadDir(brainDir); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			id := entry.Name()
+			if _, exists := sessionMap[id]; exists {
+				continue
+			}
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			sessionMap[id] = core.AgentSessionInfo{
+				ID:           id,
+				Summary:      id,
+				MessageCount: 1,
+				ModifiedAt:   info.ModTime(),
+			}
 		}
+	}
 
-		fpath := filepath.Join(chatsDir, entry.Name())
-		file, err := os.Open(fpath)
-		if err != nil {
-			continue
-		}
-
-		var sf sessionFile
-		var summary string
-		msgCount := 0
-		hasUserMsg := false
-
-		scanner := bufio.NewScanner(file)
-		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-		lineNum := 0
-		for scanner.Scan() {
-			line := scanner.Text()
-			if line == "" {
+	// 3. Scan legacy ~/.gemini/tmp/<slug>/chats/
+	slug := antigravityProjectSlug(workDir)
+	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", slug, "chats")
+	if entries, err := os.ReadDir(chatsDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
 				continue
 			}
 
-			if lineNum == 0 {
-				if err := json.Unmarshal([]byte(line), &sf); err != nil || sf.SessionID == "" {
-					break
+			fpath := filepath.Join(chatsDir, entry.Name())
+			file, err := os.Open(fpath)
+			if err != nil {
+				continue
+			}
+
+			var sf sessionFile
+			var summary string
+			msgCount := 0
+			hasUserMsg := false
+
+			scanner := bufio.NewScanner(file)
+			scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+			lineNum := 0
+			for scanner.Scan() {
+				line := scanner.Text()
+				if line == "" {
+					continue
 				}
-				lineNum++
-				continue
-			}
 
-			var sl sessionLine
-			if json.Unmarshal([]byte(line), &sl) == nil {
-				if sl.Set != nil && !sl.Set.LastUpdated.IsZero() {
-					sf.LastUpdated = sl.Set.LastUpdated
-				} else if sl.Type != "" {
-					msgCount++
-					if sl.Type == "user" {
-						hasUserMsg = true
-						if summary == "" && len(sl.Content) > 0 {
-							text := strings.TrimSpace(sl.Content[0].Text)
-							for _, chunk := range strings.Split(text, "\n") {
-								chunk = strings.TrimSpace(chunk)
-								if chunk != "" {
-									summary = chunk
-									break
+				if lineNum == 0 {
+					if err := json.Unmarshal([]byte(line), &sf); err != nil || sf.SessionID == "" {
+						break
+					}
+					lineNum++
+					continue
+				}
+
+				var sl sessionLine
+				if json.Unmarshal([]byte(line), &sl) == nil {
+					if sl.Set != nil && !sl.Set.LastUpdated.IsZero() {
+						sf.LastUpdated = sl.Set.LastUpdated
+					} else if sl.Type != "" {
+						msgCount++
+						if sl.Type == "user" {
+							hasUserMsg = true
+							if summary == "" && len(sl.Content) > 0 {
+								text := strings.TrimSpace(sl.Content[0].Text)
+								for _, chunk := range strings.Split(text, "\n") {
+									chunk = strings.TrimSpace(chunk)
+									if chunk != "" {
+										summary = chunk
+										break
+									}
 								}
 							}
 						}
 					}
 				}
+				lineNum++
 			}
-			lineNum++
-		}
-		if err := scanner.Err(); err != nil {
 			_ = file.Close()
-			continue
-		}
-		_ = file.Close()
 
-		if sf.SessionID == "" || sf.Kind == "subagent" || !hasUserMsg {
-			continue
-		}
+			if sf.SessionID == "" || sf.Kind == "subagent" || !hasUserMsg {
+				continue
+			}
 
-		if summary == "" {
-			summary = sf.SessionID
-		}
-		if utf8.RuneCountInString(summary) > 60 {
-			summary = string([]rune(summary)[:60]) + "..."
-		}
+			if summary == "" {
+				summary = sf.SessionID
+			}
+			if utf8.RuneCountInString(summary) > 60 {
+				summary = string([]rune(summary)[:60]) + "..."
+			}
 
-		modTime := sf.LastUpdated
-		if modTime.IsZero() {
-			modTime = sf.StartTime
-		}
+			modTime := sf.LastUpdated
+			if modTime.IsZero() {
+				modTime = sf.StartTime
+			}
 
-		sessions = append(sessions, core.AgentSessionInfo{
-			ID:           sf.SessionID,
-			Summary:      summary,
-			MessageCount: msgCount,
-			ModifiedAt:   modTime,
-		})
+			sessionMap[sf.SessionID] = core.AgentSessionInfo{
+				ID:           sf.SessionID,
+				Summary:      summary,
+				MessageCount: msgCount,
+				ModifiedAt:   modTime,
+			}
+		}
+	}
+
+	var sessions []core.AgentSessionInfo
+	for _, info := range sessionMap {
+		sessions = append(sessions, info)
 	}
 
 	sort.Slice(sessions, func(i, j int) bool {

--- a/agent/antigravity/session.go
+++ b/agent/antigravity/session.go
@@ -77,6 +77,34 @@ func (as *antigravitySession) Send(prompt string, messageID string, images []cor
 	preEntries := make(map[string]bool)
 	homeDir, err := os.UserHomeDir()
 	if err == nil {
+		absWorkDir, _ := filepath.Abs(as.workDir)
+		absWorkDir = filepath.Clean(absWorkDir)
+
+		// 1. Capture from ~/.gemini/antigravity-cli/cache/last_conversations.json
+		lastConvPath := filepath.Join(homeDir, ".gemini", "antigravity-cli", "cache", "last_conversations.json")
+		if data, err := os.ReadFile(lastConvPath); err == nil {
+			var lastMap map[string]string
+			if json.Unmarshal(data, &lastMap) == nil {
+				if cid := lastMap[absWorkDir]; cid != "" {
+					preEntries[cid] = true
+				}
+				if cid := lastMap[as.workDir]; cid != "" {
+					preEntries[cid] = true
+				}
+			}
+		}
+
+		// 2. Capture from ~/.gemini/antigravity-cli/brain/
+		brainDir := filepath.Join(homeDir, ".gemini", "antigravity-cli", "brain")
+		if entries, err := os.ReadDir(brainDir); err == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					preEntries[entry.Name()] = true
+				}
+			}
+		}
+
+		// 3. Capture from legacy path
 		slug := antigravityProjectSlug(as.workDir)
 		chatsDir := filepath.Join(homeDir, ".gemini", "tmp", slug, "chats")
 		if entries, err := os.ReadDir(chatsDir); err == nil {
@@ -333,6 +361,74 @@ func (as *antigravitySession) detectNewSessionID(preEntries map[string]bool, sen
 	if err != nil {
 		return ""
 	}
+
+	absWorkDir, err := filepath.Abs(as.workDir)
+	if err != nil {
+		absWorkDir = as.workDir
+	}
+	absWorkDir = filepath.Clean(absWorkDir)
+
+	// 1. Check ~/.gemini/antigravity-cli/cache/last_conversations.json
+	lastConvPath := filepath.Join(homeDir, ".gemini", "antigravity-cli", "cache", "last_conversations.json")
+	if data, err := os.ReadFile(lastConvPath); err == nil {
+		var lastMap map[string]string
+		if json.Unmarshal(data, &lastMap) == nil {
+			if cid, ok := lastMap[absWorkDir]; ok && cid != "" && !preEntries[cid] {
+				return cid
+			}
+			if cid, ok := lastMap[as.workDir]; ok && cid != "" && !preEntries[cid] {
+				return cid
+			}
+		}
+	}
+
+	// 2. Check ~/.gemini/antigravity-cli/brain/
+	brainDir := filepath.Join(homeDir, ".gemini", "antigravity-cli", "brain")
+	if entries, err := os.ReadDir(brainDir); err == nil {
+		type candidate struct {
+			sessionID string
+			modTime   time.Time
+			diff      time.Duration
+		}
+		var candidates []candidate
+		for _, entry := range entries {
+			if !entry.IsDir() || preEntries[entry.Name()] {
+				continue
+			}
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			mod := info.ModTime()
+			if !sendStartedAt.IsZero() && mod.Before(sendStartedAt.Add(-2*time.Second)) {
+				continue
+			}
+			diff := time.Duration(0)
+			if !sendStartedAt.IsZero() {
+				if mod.After(sendStartedAt) {
+					diff = mod.Sub(sendStartedAt)
+				} else {
+					diff = sendStartedAt.Sub(mod)
+				}
+			}
+			candidates = append(candidates, candidate{
+				sessionID: entry.Name(),
+				modTime:   mod,
+				diff:      diff,
+			})
+		}
+		if len(candidates) > 0 {
+			sort.Slice(candidates, func(i, j int) bool {
+				if candidates[i].diff == candidates[j].diff {
+					return candidates[i].modTime.After(candidates[j].modTime)
+				}
+				return candidates[i].diff < candidates[j].diff
+			})
+			return candidates[0].sessionID
+		}
+	}
+
+	// 3. Legacy path
 	slug := antigravityProjectSlug(as.workDir)
 	chatsDir := filepath.Join(homeDir, ".gemini", "tmp", slug, "chats")
 

--- a/agent/antigravity/session_test.go
+++ b/agent/antigravity/session_test.go
@@ -2,8 +2,10 @@ package antigravity
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -224,6 +226,40 @@ func TestExtractPermissionPrompt_SplitChunksDetectedInWindow(t *testing.T) {
 	got, ok := extractPermissionPrompt(part1 + part2)
 	if !ok || got == "" {
 		t.Fatalf("expected split prompt to be detected, got ok=%v prompt=%q", ok, got)
+	}
+}
+
+func TestDetectNewSessionID_AntigravityCLI(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	workDir := t.TempDir()
+	s, err := newAntigravitySession(context.Background(), "echo", nil, workDir, "", "default", "", nil, 0)
+	if err != nil {
+		t.Fatalf("newAntigravitySession: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	cacheDir := filepath.Join(fakeHome, ".gemini", "antigravity-cli", "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir cacheDir: %v", err)
+	}
+
+	preEntries := map[string]bool{"old-session-1": true}
+	sendStartedAt := time.Now()
+
+	// Write last_conversations.json mapping workDir to new-session-123
+	lastMap := map[string]string{
+		filepath.Clean(workDir): "new-session-123",
+	}
+	data, _ := json.Marshal(lastMap)
+	if err := os.WriteFile(filepath.Join(cacheDir, "last_conversations.json"), data, 0o600); err != nil {
+		t.Fatalf("write last_conversations.json: %v", err)
+	}
+
+	got := s.detectNewSessionID(preEntries, sendStartedAt)
+	if got != "new-session-123" {
+		t.Fatalf("detectNewSessionID = %q, want %q", got, "new-session-123")
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill in the sections below.
The reviewer will use the checklist at the bottom to gate merge.
-->

## Summary

Fixes an issue where the `antigravity` agent spawned a new CLI session for every incoming message instead of resuming existing conversations. The adapter now discovers session IDs from Antigravity CLI (`agy`) storage paths (`~/.gemini/antigravity-cli/cache/last_conversations.json` and `~/.gemini/antigravity-cli/brain/`), enabling subsequent turns to correctly pass `--conversation <session_id>`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

### Automated tests added in this PR

- `TestDetectNewSessionID_AntigravityCLI` in `agent/antigravity/session_test.go` — asserts that `detectNewSessionID` correctly discovers assigned session IDs from `~/.gemini/antigravity-cli/cache/last_conversations.json` and `brain/` directories.

### For bug fixes only — regression test

- Regression test name: `TestDetectNewSessionID_AntigravityCLI`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [x] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [x] `go test ./core/ -run TestCUJ` passes locally.
- [x] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

Subsequent chat messages sent to an `antigravity` project session will now seamlessly resume the existing conversation instead of launching isolated, single-turn sessions.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes (with `-race` if touching concurrency)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (if any new user-facing text)
- [x] No secrets / credentials in source

## Related

- Issue:
- Related PR: