### PR TITLE
fix(claudecode): use CLI-reported context window for ctx %

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -53,6 +53,11 @@ type claudeSession struct {
 	usageMu   sync.Mutex
 	lastUsage *core.ContextUsage
 
+	// reportedCtxWindow holds the context window (tokens) the CLI reported
+	// for the active model in the last result event's modelUsage map. Zero
+	// until a result event carries it; claudeContextWindow is the fallback.
+	reportedCtxWindow atomic.Int64
+
 	// gracefulStopTimeout is how long Close() waits for a clean exit
 	// (stdin close → Stop hooks → process exit) before escalating to
 	// SIGTERM and then SIGKILL. Default: 120s to match claude-mem's
@@ -670,8 +675,7 @@ func (cs *claudeSession) handleAssistant(raw map[string]any) {
 		input, _, cc, cr := parseClaudeUsage(usageRaw)
 		used := input + cc + cr
 		if used > 0 {
-			model := cs.GetModel()
-			window := claudeContextWindow(model)
+			window := cs.contextWindow()
 			cs.usageMu.Lock()
 			prevOutput := 0
 			if cs.lastUsage != nil {
@@ -827,14 +831,23 @@ func (cs *claudeSession) handleResult(raw map[string]any) {
 	if usage, ok := raw["usage"].(map[string]any); ok {
 		inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens = parseClaudeUsage(usage)
 	}
-	if outputTokens > 0 {
-		cs.usageMu.Lock()
-		if cs.lastUsage != nil {
+	// The result event also carries a modelUsage map holding the authoritative
+	// context window per model. Prefer it over the model-id heuristic: models
+	// such as claude-opus-5 have a native 1M window with no "[1m]" suffix in
+	// their id, which the heuristic would under-report as 200k.
+	if window := parseModelUsageContextWindow(raw, cs.GetModel()); window > 0 {
+		cs.reportedCtxWindow.Store(int64(window))
+	}
+	window := cs.contextWindow()
+	cs.usageMu.Lock()
+	if cs.lastUsage != nil {
+		cs.lastUsage.ContextWindow = window
+		if outputTokens > 0 {
 			cs.lastUsage.OutputTokens = outputTokens
 			cs.lastUsage.TotalTokens = cs.lastUsage.UsedTokens + outputTokens
 		}
-		cs.usageMu.Unlock()
 	}
+	cs.usageMu.Unlock()
 
 	evt := core.Event{
 		Type:                     core.EventResult,
@@ -1256,6 +1269,49 @@ func shellJoinArgs(args []string) string {
 		b.WriteByte('\'')
 	}
 	return b.String()
+}
+
+// contextWindow returns the context window (tokens) to report for the active
+// model: the CLI-reported value captured from the last result event when one
+// has been seen, otherwise the model-id heuristic.
+func (cs *claudeSession) contextWindow() int {
+	if w := cs.reportedCtxWindow.Load(); w > 0 {
+		return int(w)
+	}
+	return claudeContextWindow(cs.GetModel())
+}
+
+// parseModelUsageContextWindow extracts contextWindow from a result event's
+// modelUsage map for the given model id. A turn may touch several models (a
+// subagent running on haiku, say), so the active model's entry wins; a lone
+// entry is used when no id matches. Returns 0 when nothing usable is present.
+func parseModelUsageContextWindow(raw map[string]any, model string) int {
+	byModel, ok := raw["modelUsage"].(map[string]any)
+	if !ok || len(byModel) == 0 {
+		return 0
+	}
+	windowOf := func(v any) int {
+		entry, ok := v.(map[string]any)
+		if !ok {
+			return 0
+		}
+		w, _ := entry["contextWindow"].(float64)
+		if w <= 0 {
+			return 0
+		}
+		return int(w)
+	}
+	if model != "" {
+		if w := windowOf(byModel[model]); w > 0 {
+			return w
+		}
+	}
+	if len(byModel) == 1 {
+		for _, v := range byModel {
+			return windowOf(v)
+		}
+	}
+	return 0
 }
 
 // claudeContextWindow returns the context window size (tokens) that best

--- a/agent/claudecode/session_test.go
+++ b/agent/claudecode/session_test.go
@@ -221,6 +221,126 @@ func TestHandleAssistantCapturesPerSubCallUsage(t *testing.T) {
 	}
 }
 
+// TestHandleResultUsesReportedContextWindow verifies that the CLI-reported
+// contextWindow in the result event's modelUsage map wins over the model-id
+// heuristic. claude-opus-5 has a native 1M window but no "[1m]" suffix in its
+// id, so the heuristic alone would report 200k and inflate ctx % 5x.
+func TestHandleResultUsesReportedContextWindow(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cs := &claudeSession{
+		events: make(chan core.Event, 8),
+		ctx:    ctx,
+	}
+	cs.sessionID.Store("test-session")
+	cs.alive.Store(true)
+	cs.activeModel.Store("claude-opus-5") // native 1M, no "[1m]" suffix
+
+	assistant := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{},
+			"usage": map[string]any{
+				"input_tokens":                float64(2),
+				"output_tokens":               float64(1),
+				"cache_creation_input_tokens": float64(19_800),
+				"cache_read_input_tokens":     float64(16_700),
+			},
+		},
+	}
+
+	cs.handleAssistant(assistant)
+	if usage := cs.GetContextUsage(); usage.ContextWindow != 200_000 {
+		t.Fatalf("pre-result ContextWindow = %d, want 200_000 (heuristic fallback)", usage.ContextWindow)
+	}
+
+	cs.handleResult(map[string]any{
+		"type":       "result",
+		"result":     "done",
+		"session_id": "test-session",
+		"usage": map[string]any{
+			"output_tokens": float64(65),
+		},
+		"modelUsage": map[string]any{
+			"claude-opus-5": map[string]any{
+				"contextWindow":  float64(1_000_000),
+				"canonicalModel": "claude-opus-5",
+			},
+		},
+	})
+
+	usage := cs.GetContextUsage()
+	if usage.ContextWindow != 1_000_000 {
+		t.Errorf("ContextWindow = %d, want 1_000_000 (reported by modelUsage)", usage.ContextWindow)
+	}
+	// The turn that reported the window must itself render the right ctx %:
+	// 36.5k of 1M is ~4%, not the 18% a 200k denominator produces.
+	pct := usage.UsedTokens * 100 / usage.ContextWindow
+	if pct != 3 {
+		t.Errorf("ctx %% = %d, want 3 (36.5k of 1M)", pct)
+	}
+
+	// Later assistant events reuse the reported window without waiting for
+	// another result event.
+	cs.handleAssistant(assistant)
+	if usage := cs.GetContextUsage(); usage.ContextWindow != 1_000_000 {
+		t.Errorf("post-result assistant ContextWindow = %d, want 1_000_000 (cached)", usage.ContextWindow)
+	}
+}
+
+func TestParseModelUsageContextWindow(t *testing.T) {
+	entry := func(window float64) map[string]any {
+		return map[string]any{"contextWindow": window}
+	}
+	tests := []struct {
+		name  string
+		raw   map[string]any
+		model string
+		want  int
+	}{
+		{"no modelUsage", map[string]any{"type": "result"}, "claude-opus-5", 0},
+		{"empty modelUsage", map[string]any{"modelUsage": map[string]any{}}, "claude-opus-5", 0},
+		{
+			"active model matches",
+			map[string]any{"modelUsage": map[string]any{
+				"claude-haiku-4-5": entry(200_000),
+				"claude-opus-5":    entry(1_000_000),
+			}},
+			"claude-opus-5",
+			1_000_000,
+		},
+		{
+			"sole entry used when model unknown",
+			map[string]any{"modelUsage": map[string]any{"claude-opus-5": entry(1_000_000)}},
+			"",
+			1_000_000,
+		},
+		{
+			"ambiguous multi-model, no match",
+			map[string]any{"modelUsage": map[string]any{
+				"claude-haiku-4-5": entry(200_000),
+				"claude-opus-5":    entry(1_000_000),
+			}},
+			"claude-sonnet-5",
+			0,
+		},
+		{
+			"zero window ignored",
+			map[string]any{"modelUsage": map[string]any{"claude-opus-5": entry(0)}},
+			"claude-opus-5",
+			0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseModelUsageContextWindow(tt.raw, tt.model); got != tt.want {
+				t.Errorf("parseModelUsageContextWindow() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHandleResultNoUsage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Problem

The reply footer's `ctx N%` derives its denominator purely from the model id: 1M only when the id carries a `[1m]` suffix, 200k otherwise (`claudeContextWindow`, session.go).

Claude 5 models have a **native** 1M window with no suffix in their id. `claude-opus-5` therefore gets measured against 200k:

```
claude-opus-5 · out 65 · in 2 cw 19.8k cr 16.7k · ctx 18%
```

`2 + 19.8k + 16.7k ≈ 36.5k`, which is ~4% of 1M — reported as 18%, a 5x inflation. On a long session this reads as "almost full" when the context is barely touched.

## Root cause

`claudeContextWindow`'s own doc comment describes itself as the fallback for "when the stream-json result event does not carry a modelUsage map" — but `handleResult` only ever parsed `raw["usage"]` and never read `raw["modelUsage"]`. The fallback was the only code path.

The CLI does send the authoritative value. Verified against the same `--output-format stream-json` channel cc-connect spawns:

```
result event keys: [..., 'modelUsage', 'usage', ...]
modelUsage: {"claude-opus-5": {..., "contextWindow": 1000000, "maxOutputTokens": 64000,
             "canonicalModel": "claude-opus-5", "provider": "firstParty"}}
```

and the `system/init` event's `model` field is `'claude-opus-5'` — byte-identical to the `modelUsage` key, so an exact-match lookup is sound.

## Fix

Parse `modelUsage[<active model>].contextWindow` in `handleResult`, cache it on the session, and prefer it over the model-id heuristic.

- The window is written back into `lastUsage` **before** `EventResult` is emitted, so the very first turn of a session already renders the correct percentage rather than waiting for a second turn.
- `claudeContextWindow` is untouched and remains the fallback: the assistant events preceding the first result event, and older CLIs that omit the map.
- A turn may touch several models (a subagent on haiku, say), so the active model's entry wins; a lone entry is used when no id matches; anything ambiguous falls back rather than guessing.

Chose this over extending the model-id whitelist (`fable`, `opus-5`, `sonnet-5`, …): the catalog already marks `opus-4.7/4.8/5`, `sonnet-5`, `fable-5` and `mythos-5` as `native_1m`, and the effective window also depends on account entitlement — a name list would need chasing on every model launch. Reading what the CLI reports is correct by construction.

Display-only impact: `GetContextUsage` has a single consumer (`replyFooterSessionContextUsage` → footer rendering). cc-connect has no auto-compaction logic of its own, so no behaviour beyond the footer changes.

## Tests

- `TestHandleResultUsesReportedContextWindow` — full assistant → result → assistant flow, asserting 200k before the result event, 1M after, and that later assistant events reuse the cached value.
- `TestParseModelUsageContextWindow` — table-driven over 6 shapes: absent map, empty map, multi-model with a match, sole entry with unknown model, multi-model with no match, zero window.

`go test -race ./agent/claudecode/` passes; existing `TestHandleAssistantCapturesPerSubCallUsage` (which covers the `[1m]` path) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)