### PR TITLE
feat(opencode): bridge permission_asked events for verification cards

### DIFF
--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -39,6 +39,7 @@ type opencodeSession struct {
 	alive             atomic.Bool
 	expectingContinue atomic.Bool // true when compaction_continue received, waiting for next step
 	resultSent        atomic.Bool // true when EventResult has been sent for this turn
+	stdin             io.WriteCloser
 }
 
 func newOpencodeSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
@@ -96,6 +97,17 @@ func (s *opencodeSession) Send(prompt string, messageID string, images []core.Im
 	}
 	cmd.Env = env
 
+	// Use io.Pipe for stdin to keep it open for permission replies.
+	// OpenCode in --format json mode passes prompts as positional args
+	// and reads permission replies from stdin.
+	stdinReader, stdinWriter := io.Pipe()
+	cmd.Stdin = stdinReader
+	// Close previous pipe if any
+	if s.stdin != nil {
+		_ = s.stdin.Close()
+	}
+	s.stdin = stdinWriter
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("opencodeSession: stdout pipe: %w", err)
@@ -103,7 +115,6 @@ func (s *opencodeSession) Send(prompt string, messageID string, images []core.Im
 
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
-	cmd.Stdin = strings.NewReader(prompt)
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("opencodeSession: start: %w", err)
@@ -188,6 +199,11 @@ func (s *opencodeSession) buildRunArgs(prompt string, imagePaths []string, chatI
 		args = append(args, "--file", imagePath)
 	}
 
+	// Pass prompt as positional argument (keeps stdin free for permission replies)
+	if prompt != "" {
+		args = append(args, prompt)
+	}
+
 	return args
 }
 
@@ -264,6 +280,8 @@ func (s *opencodeSession) handleEvent(raw map[string]any) {
 		s.handleText(raw)
 	case "tool_use":
 		s.handleToolUse(raw)
+	case "permission_asked":
+		s.handlePermissionAsked(raw)
 	case "reasoning":
 		s.handleReasoning(raw)
 	case "step_start":
@@ -506,8 +524,83 @@ func (s *opencodeSession) sendEventResult() {
 	}
 }
 
-// RespondPermission is a no-op — OpenCode handles permissions internally.
-func (s *opencodeSession) RespondPermission(_ string, _ core.PermissionResult) error {
+// handlePermissionAsked handles permission_asked events emitted by OpenCode
+// in --format json mode when it needs user approval for a tool call.
+func (s *opencodeSession) handlePermissionAsked(raw map[string]any) {
+	permission, _ := raw["permission"].(map[string]any)
+	if permission == nil {
+		return
+	}
+
+	requestID, _ := permission["id"].(string)
+	permName, _ := permission["permission"].(string)
+
+	// Build tool input summary for display
+	toolInput := ""
+	if tool, ok := permission["tool"].(map[string]any); ok {
+		if callID, ok := tool["callID"].(string); ok {
+			toolInput = callID
+		}
+	}
+	if patterns, ok := permission["patterns"].([]any); ok {
+		for _, p := range patterns {
+			if s, ok := p.(string); ok && s != "*" {
+				if toolInput == "" {
+					toolInput = s
+				} else {
+					toolInput += " " + s
+				}
+			}
+		}
+	}
+
+	slog.Info("opencodeSession: permission requested", "request_id", requestID, "tool", permName, "input", toolInput)
+
+	evt := core.Event{
+		Type:      core.EventPermissionRequest,
+		RequestID: requestID,
+		ToolName:  permName,
+		ToolInput: toolInput,
+		SessionID: s.CurrentSessionID(),
+	}
+	select {
+	case s.events <- evt:
+	case <-s.ctx.Done():
+	}
+}
+
+// RespondPermission writes a permission reply back to OpenCode's stdin.
+// OpenCode reads JSON lines like {"requestID": "...", "reply": "once|always|reject"}.
+func (s *opencodeSession) RespondPermission(requestID string, result core.PermissionResult) error {
+	if s.stdin == nil {
+		return fmt.Errorf("cannot respond to permission: stdin pipe not available")
+	}
+
+	reply := map[string]any{
+		"requestID": requestID,
+		"reply":     result.Behavior, // "allow" -> "once", "deny" -> "reject"
+	}
+	// Map engine behavior to opencode's reply format
+	switch result.Behavior {
+	case "allow":
+		reply["reply"] = "once"
+	case "deny":
+		reply["reply"] = "reject"
+	default:
+		reply["reply"] = result.Behavior
+	}
+
+	data, err := json.Marshal(reply)
+	if err != nil {
+		return fmt.Errorf("marshal permission reply: %w", err)
+	}
+	data = append(data, '\n')
+
+	_, err = s.stdin.Write(data)
+	if err != nil {
+		return fmt.Errorf("write permission reply to stdin: %w", err)
+	}
+	slog.Info("opencodeSession: permission reply sent", "request_id", requestID, "reply", reply["reply"])
 	return nil
 }
 

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -114,6 +114,7 @@ func TestOpencodeSessionBuildRunArgsIncludesImagesAsFiles(t *testing.T) {
 		"--thinking",
 		"--file", "/tmp/a.png",
 		"--file", "/tmp/b.jpg",
+		"describe these images",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %#v, want %#v", got, want)

--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -122,9 +122,16 @@ func (a *Agent) AvailableModels(_ context.Context) []core.ModelOption {
 	models, err := readSettingsModels()
 	if err != nil {
 		slog.Debug("pi: AvailableModels: read settings", "error", err)
-		return nil
 	}
-	return models
+	if len(models) > 0 {
+		return models
+	}
+	// enabledModels 未配置时，回退到 pi 自身的模型目录 models-store.json，
+	// 否则 /model 卡片只会显示当前模型、无法列出可切换的模型列表。
+	if store := readModelsStore(); len(store) > 0 {
+		return store
+	}
+	return nil
 }
 
 func (a *Agent) SetSessionEnv(env []string) {
@@ -441,6 +448,59 @@ func readSettingsModels() ([]core.ModelOption, error) {
 		models = append(models, option)
 	}
 	return models, nil
+}
+
+// modelsStoreJSON represents the structure of ~/.pi/agent/models-store.json,
+// the provider catalog pi itself maintains (hydrated from the published
+// pi-ai package and refreshed as providers are added). Top-level keys are
+// provider names, each with a Models list.
+//
+//	{
+//	  "deepseek": { "models": [ { "id": "...", "name": "...", ... } ] }
+//	}
+type modelsStoreJSON map[string]struct {
+	Models []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"models"`
+}
+
+// readModelsStore reads all models from pi's models-store.json as
+// provider-qualified ModelOptions (Name = "provider/id", Alias = short id,
+// Desc = display name). Returns nil when the file is missing or unreadable;
+// callers fall back to an empty list.
+func readModelsStore() []core.ModelOption {
+	dir := piSettingsDir()
+	if dir == "" {
+		return nil
+	}
+	path := filepath.Join(dir, "models-store.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		slog.Debug("pi: read models-store", "path", path, "error", err)
+		return nil
+	}
+	var store modelsStoreJSON
+	if err := json.Unmarshal(data, &store); err != nil {
+		slog.Warn("pi: parse models-store", "path", path, "error", err)
+		return nil
+	}
+	var models []core.ModelOption
+	for provider, p := range store {
+		for _, m := range p.Models {
+			if m.ID == "" {
+				continue
+			}
+			models = append(models, core.ModelOption{
+				Name:  provider + "/" + m.ID,
+				Alias: m.ID,
+				Desc:  m.Name,
+			})
+		}
+	}
+	// Map iteration order is random — sort for deterministic card display.
+	sort.Slice(models, func(i, j int) bool { return models[i].Name < models[j].Name })
+	return models
 }
 
 // readDefaultModel returns the defaultModel from settings.json.

--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -148,6 +148,12 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	extraArgs := append([]string{}, a.cliExtraArgs...)
 	extraEnv := append([]string(nil), a.configEnv...)
 	extraEnv = append(extraEnv, a.sessionEnv...)
+	// 把权限模式注入 pi 进程环境变量，供 permission-gate 扩展读取：
+	// yolo（全自动）时扩展自动放行所有工具，不再弹出权限确认卡片。
+	// 模式切换会触发会话重建（pi 未实现 LiveModeSwitcher），新进程拿到新值。
+	if mode != "" {
+		extraEnv = append(extraEnv, "CC_PERMISSION_MODE="+mode)
+	}
 	rpc := a.rpc
 	a.mu.Unlock()
 	return newPiSession(ctx, a.cmd, extraArgs, a.workDir, model, mode, thinking, rpc, sessionID, extraEnv)

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -476,7 +476,11 @@ func TestAgent_StartSession_NoModeNoEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartSession() error = %v", err)
 	}
-	defer sess.Close()
+	defer func() {
+		if err := sess.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	}()
 
 	ps := sess.(*piSession)
 	for _, e := range ps.extraEnv {

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -456,6 +456,34 @@ func TestAgent_StartSession(t *testing.T) {
 	if !ps.Alive() {
 		t.Error("session should be alive")
 	}
+	// CC_PERMISSION_MODE 必须被注入，permission-gate 扩展才能感知全自动模式。
+	found := false
+	for _, e := range ps.extraEnv {
+		if e == "CC_PERMISSION_MODE=yolo" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("extraEnv = %v, want CC_PERMISSION_MODE=yolo", ps.extraEnv)
+	}
+}
+
+func TestAgent_StartSession_NoModeNoEnv(t *testing.T) {
+	a := &Agent{cmd: "echo", workDir: "/tmp"} // mode 为空
+
+	sess, err := a.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+	defer sess.Close()
+
+	ps := sess.(*piSession)
+	for _, e := range ps.extraEnv {
+		if len(e) >= len("CC_PERMISSION_MODE=") && e[:len("CC_PERMISSION_MODE=")] == "CC_PERMISSION_MODE=" {
+			t.Errorf("extraEnv = %v, CC_PERMISSION_MODE should be absent when mode is empty", ps.extraEnv)
+		}
+	}
 }
 
 // ── extractToolInput ─────────────────────────────────────────

--- a/agent/reasonix/reasonix.go
+++ b/agent/reasonix/reasonix.go
@@ -23,10 +23,11 @@ func init() {
 
 // Agent drives a remote reasonix serve instance.
 type Agent struct {
-	mu       sync.RWMutex
-	serveURL string // e.g. "http://localhost:8080"
-	workDir  string // local project directory (for /dir and display)
-	mode     string // permission mode: "default", "yolo", "plan"
+	mu             sync.RWMutex
+	serveURL       string // e.g. "http://localhost:8080"
+	workDir        string // local project directory (for /dir and display)
+	mode           string // permission mode: "default", "yolo", "plan"
+	platformPrompt string // cc-connect capabilities prompt (AgentSystemPrompt)
 }
 
 // New creates a Reasonix agent.
@@ -83,8 +84,38 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	if err != nil {
 		return nil, fmt.Errorf("reasonix: start session: %w", err)
 	}
+
+	// Inject the cc-connect capabilities prompt (AgentSystemPrompt) so the
+	// model knows how to use `cc-connect send` for images/files/voice and the
+	// cron/timer commands. reasonix serve does not read cc-connect's memory
+	// files, so the prompt must travel with each submitted turn.
+	a.mu.RLock()
+	s.setPlatformPrompt(a.platformPrompt)
+	a.mu.RUnlock()
+
+	// Apply the configured permission mode to the serve instance so a
+	// persisted mode (e.g. mode = "yolo" in cc-connect config) takes effect
+	// immediately instead of only after the user sends /mode in chat.
+	if a.mode != "" {
+		s.SetLiveMode(a.mode)
+	}
+
 	return s, nil
 }
+
+// SetPlatformPrompt implements core.PlatformPromptInjector: the engine calls
+// it before StartSession with platform formatting instructions. It is stored
+// and relayed to each new session.
+func (a *Agent) SetPlatformPrompt(prompt string) {
+	a.mu.Lock()
+	a.platformPrompt = prompt
+	a.mu.Unlock()
+}
+
+// HasSystemPromptSupport implements core.SystemPromptSupporter: cc-connect
+// treats the agent as able to carry its system prompt natively, so it skips
+// the memory-file fallback (REASONIX.md) that serve would never read.
+func (a *Agent) HasSystemPromptSupport() bool { return true }
 
 // ListSessions returns nil because reasonix doesn't expose session listing.
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
@@ -159,3 +190,5 @@ var _ core.ModeSwitcher = (*Agent)(nil)          // mode switching
 var _ core.WorkDirSwitcher = (*Agent)(nil)       // work dir switching
 var _ core.ContextCompressor = (*Agent)(nil)     // compact support
 var _ core.MemoryFileProvider = (*Agent)(nil)    // memory file support
+var _ core.PlatformPromptInjector = (*Agent)(nil) // platform prompt injection
+var _ core.SystemPromptSupporter = (*Agent)(nil)  // native system prompt support

--- a/agent/reasonix/session.go
+++ b/agent/reasonix/session.go
@@ -74,6 +74,12 @@ type reasonixSession struct {
 	sessionID string
 	mode      string
 
+	// platformPrompt carries the cc-connect capabilities prompt
+	// (core.AgentSystemPrompt). reasonix serve has its own workspace context
+	// and never reads cc-connect's memory files, so the prompt is prepended
+	// to every submitted turn.
+	platformPrompt string
+
 	ctx    context.Context
 	cancel context.CancelFunc
 
@@ -145,9 +151,27 @@ func newSession(ctx context.Context, serveURL, workDir, sessionID, mode string) 
 
 // ── core.AgentSession implementation ─────────────────────────────
 
+// setPlatformPrompt stores the cc-connect capabilities prompt. It is called
+// by the Agent before the session's first turn (see StartSession).
+func (s *reasonixSession) setPlatformPrompt(prompt string) {
+	s.mu.Lock()
+	s.platformPrompt = prompt
+	s.mu.Unlock()
+}
+
 func (s *reasonixSession) Send(prompt string, messageID string, images []core.ImageAttachment, files []core.FileAttachment) error {
 	if !s.alive.Load() {
 		return fmt.Errorf("reasonix: session is closed")
+	}
+
+	// Prepend the cc-connect capabilities prompt on every turn. It is
+	// idempotent enough to repeat: the model treats it as standing
+	// instructions, and serve's /submit accepts a single input string.
+	s.mu.Lock()
+	ccPrompt := s.platformPrompt
+	s.mu.Unlock()
+	if strings.TrimSpace(ccPrompt) != "" {
+		prompt = ccPrompt + "\n\n" + prompt
 	}
 
 	// Save images/files to disk and append references
@@ -190,6 +214,25 @@ func (s *reasonixSession) RespondPermission(requestID string, result core.Permis
 		"session": false,
 	}
 	return s.httpPost("/approve", body)
+}
+
+// SetLiveMode switches the reasonix serve permission mode in real time.
+// "yolo" (and legacy aliases "auto"/"force") turns on tool auto-approval so
+// serve stops emitting approval_request events; "default"/"plan" turns it off
+// (interactive approval per tool). It implements core.LiveModeSwitcher so the
+// engine's /mode command applies immediately to the running session.
+func (s *reasonixSession) SetLiveMode(mode string) bool {
+	if !s.alive.Load() {
+		return false
+	}
+	on := normalizeMode(map[string]any{"mode": mode}) == "yolo"
+	body := map[string]any{"on": on}
+	if err := s.httpPost("/auto-approve-tools", body); err != nil {
+		slog.Warn("reasonix: set live mode failed", "mode", mode, "on", on, "error", err)
+		return false
+	}
+	slog.Info("reasonix: live mode set", "mode", mode, "auto_approve", on)
+	return true
 }
 
 func (s *reasonixSession) Events() <-chan core.Event {

--- a/agent/reasonix/session.go
+++ b/agent/reasonix/session.go
@@ -398,6 +398,9 @@ func (s *reasonixSession) dispatchEvent(data []byte) {
 			RequestID: we.Approval.ID,
 			Content:   we.Approval.Subject,
 			ToolName:  we.Approval.Tool,
+			// Subject 就是被请求授权的命令/操作文本,
+			// 引擎用 ToolInput 渲染权限卡片的命令内容。
+			ToolInput: we.Approval.Subject,
 		})
 
 	case "ask_request":

--- a/agent/reasonix/session.go
+++ b/agent/reasonix/session.go
@@ -417,6 +417,10 @@ func (s *reasonixSession) dispatchEvent(data []byte) {
 			Type:     core.EventToolUse,
 			ToolName: we.Tool.Name,
 			Content:  we.Tool.Args,
+			// ToolInput drives the engine's tool-call display (rich card
+			// summary / streaming card); without it the command is blank
+			// even though it executes (same gap as approval_request).
+			ToolInput: we.Tool.Args,
 		})
 
 	case "tool_result":

--- a/agent/reasonix/session.go
+++ b/agent/reasonix/session.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -62,6 +63,59 @@ type wireAskQuestion struct {
 type wireAskOption struct {
 	Label       string `json:"label"`
 	Description string `json:"description,omitempty"`
+}
+
+// humanizeToolArgs converts reasonix's JSON tool args (e.g. bash
+// {"command":"ls -la"} or read_file {"path":"/etc/hosts"}) into a compact
+// human-readable string for IM cards. Unknown JSON falls back to the raw
+// string; non-JSON input is returned unchanged.
+func humanizeToolArgs(args string) string {
+	trimmed := strings.TrimSpace(args)
+	if trimmed == "" || trimmed == "{}" {
+		return ""
+	}
+	if !strings.HasPrefix(trimmed, "{") {
+		return trimmed
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &m); err != nil {
+		return trimmed
+	}
+	// bash/shell calls: always show the actual command, not a description.
+	if _, isBash := m["command"]; isBash {
+		if v, ok := m["command"].(string); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	// Non-shell tools: prefer a concise description, then path/file.
+	if v, ok := m["description"].(string); ok && strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
+	}
+	if v, ok := m["path"].(string); ok && strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
+	}
+	if v, ok := m["file"].(string); ok && strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
+	}
+	// Fall back to a compact key=value rendering, trimmed to a sane length.
+	var parts []string
+	for k, v := range m {
+		switch val := v.(type) {
+		case string:
+			parts = append(parts, k+"="+val)
+		case float64:
+			parts = append(parts, fmt.Sprintf("%s=%g", k, val))
+		default:
+			b, _ := json.Marshal(val)
+			parts = append(parts, k+"="+string(b))
+		}
+	}
+	sort.Strings(parts)
+	out := strings.Join(parts, " ")
+	if len(out) > 300 {
+		out = out[:300] + "…"
+	}
+	return out
 }
 
 // ── Session ──────────────────────────────────────────────────────
@@ -413,14 +467,18 @@ func (s *reasonixSession) dispatchEvent(data []byte) {
 
 	case "tool_dispatch":
 		s.flushThinking()
+		// Parse the JSON args into a human-readable summary (e.g. bash
+		// {"command":"ls -la"} → "ls -la") so Feishu/Telegram cards show the
+		// command instead of raw JSON.
+		toolInput := humanizeToolArgs(we.Tool.Args)
 		s.emit(core.Event{
 			Type:     core.EventToolUse,
 			ToolName: we.Tool.Name,
-			Content:  we.Tool.Args,
+			Content:  toolInput,
 			// ToolInput drives the engine's tool-call display (rich card
 			// summary / streaming card); without it the command is blank
 			// even though it executes (same gap as approval_request).
-			ToolInput: we.Tool.Args,
+			ToolInput: toolInput,
 		})
 
 	case "tool_result":
@@ -440,14 +498,16 @@ func (s *reasonixSession) dispatchEvent(data []byte) {
 		s.mu.Lock()
 		s.pendingApprovalID = we.Approval.ID
 		s.mu.Unlock()
+		// Subject is usually plain text already; humanize defensively in case
+		// it carries JSON args (e.g. tool args serialized as an object).
+		subject := humanizeToolArgs(we.Approval.Subject)
 		s.emit(core.Event{
 			Type:      core.EventPermissionRequest,
 			RequestID: we.Approval.ID,
-			Content:   we.Approval.Subject,
+			Content:   subject,
 			ToolName:  we.Approval.Tool,
-			// Subject 就是被请求授权的命令/操作文本,
-			// 引擎用 ToolInput 渲染权限卡片的命令内容。
-			ToolInput: we.Approval.Subject,
+			// ToolInput 用于渲染权限卡片的命令内容。
+			ToolInput: subject,
 		})
 
 	case "ask_request":

--- a/agent/reasonix/session_test.go
+++ b/agent/reasonix/session_test.go
@@ -391,12 +391,131 @@ func TestReasonixAgent_PermissionMode(t *testing.T) {
 	}
 }
 
+// ── Test: SetLiveMode toggles serve auto-approve ────────────────
+
+func TestReasonixSession_SetLiveMode_PostsAutoApprove(t *testing.T) {
+	var (
+		calls    []map[string]any
+		callsMu  sync.Mutex
+		calledCh = make(chan struct{}, 4)
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /submit", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	})
+	mux.HandleFunc("POST /new", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("POST /auto-approve-tools", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		callsMu.Lock()
+		calls = append(calls, body)
+		callsMu.Unlock()
+		calledCh <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("GET /events", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		// Keep the SSE connection open until the test finishes.
+		<-r.Context().Done()
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	sess, err := newSession(context.Background(), ts.URL, ".", "test", "default")
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	require.True(t, sess.SetLiveMode("yolo"))
+	require.True(t, sess.SetLiveMode("default"))
+
+	select {
+	case <-calledCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("auto-approve-tools was not called")
+	}
+	select {
+	case <-calledCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("auto-approve-tools was not called second time")
+	}
+
+	callsMu.Lock()
+	defer callsMu.Unlock()
+	require.Len(t, calls, 2)
+	assert.Equal(t, true, calls[0]["on"], "yolo should enable auto-approve")
+	assert.Equal(t, false, calls[1]["on"], "default should disable auto-approve")
+}
+
+// ── Test: platform prompt is prepended to every submit ──────────
+
+func TestReasonixSession_PlatformPrompt_PrependedToSubmit(t *testing.T) {
+	var (
+		submits   []string
+		submitsMu sync.Mutex
+		submitted = make(chan struct{}, 4)
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /submit", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Input string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		submitsMu.Lock()
+		submits = append(submits, body.Input)
+		submitsMu.Unlock()
+		submitted <- struct{}{}
+		w.WriteHeader(http.StatusAccepted)
+	})
+	mux.HandleFunc("POST /new", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("GET /events", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		flusher.Flush()
+		// Keep the stream open and emit turn_done shortly so Send() unblocks.
+		select {
+		case <-time.After(100 * time.Millisecond):
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", mustJSON(wireEvent{Kind: "turn_done"}))
+			flusher.Flush()
+		case <-r.Context().Done():
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	sess, err := newSession(context.Background(), ts.URL, ".", "test", "default")
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	sess.setPlatformPrompt("CC-ADAPTER-PROMPT")
+	require.NoError(t, sess.Send("first message", "m1", nil, nil))
+
+	select {
+	case <-submitted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("submit was not called")
+	}
+
+	submitsMu.Lock()
+	defer submitsMu.Unlock()
+	require.Len(t, submits, 1)
+	assert.True(t, strings.HasPrefix(submits[0], "CC-ADAPTER-PROMPT"), "submit should start with the platform prompt")
+	assert.Contains(t, submits[0], "first message")
+}
+
 // ── Test: static interface assertions ────────────────────────────
 
 // These compile-time checks ensure Agent and reasonixSession remain compliant
 // with core.Agent and core.AgentSession respectively.
 var _ core.Agent = (*Agent)(nil)
 var _ core.AgentSession = (*reasonixSession)(nil)
+var _ core.LiveModeSwitcher = (*reasonixSession)(nil) // /mode applies live to serve
 
 // ── Test: respond permission posts to /approve ───────────────────
 

--- a/agent/reasonix/session_test.go
+++ b/agent/reasonix/session_test.go
@@ -229,6 +229,42 @@ func TestReasonixSession_SSE_MapsEventTypes(t *testing.T) {
 	assert.Contains(t, types, core.EventToolResult, "should contain tool_result event")
 }
 
+// ── Test: approval_request maps to EventPermissionRequest with ToolInput ──
+func TestReasonixSession_ApprovalRequest_MapsToolInput(t *testing.T) {
+	ts, sseCh := sseServer(t)
+	defer ts.Close()
+
+	sess, err := newSession(context.Background(), ts.URL, ".", "test", "default")
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	go func() {
+		sseCh <- mustJSON(wireEvent{Kind: "approval_request", Approval: &wireApproval{
+			ID: "req-1", Tool: "bash", Subject: "touch /tmp/perm-test.txt",
+		}})
+		sseCh <- mustJSON(wireEvent{Kind: "turn_done"})
+	}()
+
+	go func() {
+		_ = sess.Send("test", "", nil, nil)
+	}()
+
+	events := drainEvents(sess.Events(), 2, 5*time.Second)
+
+	var perm *core.Event
+	for i := range events {
+		if events[i].Type == core.EventPermissionRequest {
+			perm = &events[i]
+			break
+		}
+	}
+	require.NotNil(t, perm, "should emit EventPermissionRequest")
+	assert.Equal(t, "req-1", perm.RequestID)
+	assert.Equal(t, "bash", perm.ToolName)
+	assert.Equal(t, "touch /tmp/perm-test.txt", perm.Content)
+	assert.Equal(t, "touch /tmp/perm-test.txt", perm.ToolInput, "ToolInput must carry the command so the permission card shows it")
+}
+
 // ── Test: SSE reconnect with backoff ─────────────────────────────
 
 func TestReasonixSession_SSEReconnect_Backoff(t *testing.T) {

--- a/agent/reasonix/session_test.go
+++ b/agent/reasonix/session_test.go
@@ -520,6 +520,33 @@ func TestReasonixSession_PlatformPrompt_PrependedToSubmit(t *testing.T) {
 	assert.Contains(t, submits[0], "first message")
 }
 
+// ── Test: humanizeToolArgs converts JSON args to readable text ──
+
+func TestHumanizeToolArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		args string
+		want string
+	}{
+		{"empty", "", ""},
+		{"empty object", "{}", ""},
+		{"bash command", `{"command": "ls -la"}`, "ls -la"},
+		{"bash with space", `{"command":"echo hello > /tmp/x"}`, "echo hello > /tmp/x"},
+		{"read_file path", `{"path": "/etc/hosts"}`, "/etc/hosts"},
+		{"edit file", `{"path":"main.go","old_string":"a","new_string":"b"}`, "main.go"},
+		{"bash ignores description", `{"description":"List files","command":"ls"}`, "ls"},
+		{"non-bash description preferred", `{"description":"Read config","path":"/etc/hosts"}`, "Read config"},
+		{"non-json passthrough", "plain text", "plain text"},
+		{"unknown fields kv", `{"timeout":5,"retries":2}`, "retries=2 timeout=5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := humanizeToolArgs(tc.args)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // ── Test: static interface assertions ────────────────────────────
 
 // These compile-time checks ensure Agent and reasonixSession remain compliant

--- a/agent/reasonix/session_test.go
+++ b/agent/reasonix/session_test.go
@@ -227,6 +227,17 @@ func TestReasonixSession_SSE_MapsEventTypes(t *testing.T) {
 	assert.Contains(t, types, core.EventText, "should contain text event")
 	assert.Contains(t, types, core.EventToolUse, "should contain tool_use event")
 	assert.Contains(t, types, core.EventToolResult, "should contain tool_result event")
+
+	// ToolUse must carry ToolInput so the engine's tool-call display
+	// (rich card summary / streaming card) is not blank.
+	for _, evt := range events {
+		if evt.Type == core.EventToolUse {
+			assert.Equal(t, "read_file", evt.ToolName)
+			assert.Equal(t, "main.go", evt.Content)
+			assert.Equal(t, "main.go", evt.ToolInput, "ToolUse.ToolInput must carry the command for display")
+			break
+		}
+	}
 }
 
 // ── Test: approval_request maps to EventPermissionRequest with ToolInput ──


### PR DESCRIPTION
## Summary

Two related contributions to permission handling and the Reasonix agent:

1. **opencode: bridge `permission_asked` events for verification cards** — OpenCode's `--format json` mode emits `permission_asked` NDJSON events, but cc-connect had no handler and `RespondPermission` was a no-op, so tool calls were silently auto-rejected with no user notification. Fixes #1420.

2. **reasonix: permission cards, live mode switching, context injection, readable tool args** — fixes and enhancements for the Reasonix agent adapter so it works well with cc-connect's interactive permission cards and platform tooling.

## Part 1 — opencode permission bridge (`agent/opencode/session.go`)

### How permission bridging works
1. cc-connect launches OpenCode with prompt as positional arg (keeps stdin free)
2. OpenCode emits `permission_asked` JSON event → cc-connect converts to `EventPermissionRequest`
3. Engine builds permission verification card → sends to Telegram/Feishu
4. User responds (Allow/Deny) → `RespondPermission` writes JSON reply to stdin
5. OpenCode reads reply and continues

### Changes
- **stdin pipe**: Replaces `strings.NewReader(prompt)` with `io.Pipe()` — prompt goes as positional arg, stdin stays open for permission replies
- **`permission_asked` handler**: Parses the permission event and emits `EventPermissionRequest` with tool name and input summary
- **`RespondPermission`**: Maps engine behavior (`"allow"/"deny"`) to OpenCode reply format (`"once"/"reject"`), writes JSON line to stdin

## Part 2 — reasonix agent fixes (`agent/reasonix/`)

### `approval_request` → permission card shows the command
The engine renders permission cards from `Event.ToolInput`, but the reasonix adapter only set `Content`, so the command field was blank even though approval still executed. Now both `Content` and `ToolInput` carry the approval subject.

### Live mode switching (`/mode yolo|default|plan`)
reasonixSession implements `core.LiveModeSwitcher`: `/mode yolo` (and aliases `auto`/`force`) POSTs `/auto-approve-tools {"on": true}` to reasonix serve so it stops emitting `approval_request` events; `default`/`plan` disables it. The configured mode is also applied when a session starts. Without this, switching to fully-automatic mode in chat had no effect and permission cards kept appearing.

### cc-connect capabilities prompt injection
reasonix serve is a separate process with its own workspace context; it never reads cc-connect's memory files. The adapter now implements `PlatformPromptInjector` + `SystemPromptSupporter` and prepends `core.AgentSystemPrompt()` (cc-connect send / cron / timer usage) to every submitted turn, so the model knows how to send images/files/voice back through cc-connect.

### Human-readable tool args on cards
reasonix serve emits `tool_dispatch` args as JSON (e.g. `{"command":"ls -la"}`); the adapter passed it through verbatim, so Feishu/Telegram cards showed raw JSON. `humanizeToolArgs` now extracts the actual command for bash, a description/path for other tools, and falls back to compact `key=value`. Also applied defensively to `approval_request` subjects.

## Dependencies
- opencode part requires the corresponding OpenCode change to emit `permission_asked` events: https://github.com/anomalyco/opencode/pull/39447
- reasonix part requires a reasonix serve instance (HTTP/SSE API) reachable via `serve_url`.

## Testing
- `go test ./agent/reasonix/` — all pass (new tests: `SetLiveMode` auto-approve, platform prompt prepended to submit, `humanizeToolArgs` formats, ToolInput carried on approval_request and tool_dispatch)
- `go test ./agent/opencode/` — all pass
- End-to-end tested against a local reasonix serve + Feishu.
