### PR TITLE
feat(acp): support model switching for Trae CLI ACP agent

### DIFF
--- a/agent/acp/agent.go
+++ b/agent/acp/agent.go
@@ -2,8 +2,10 @@ package acp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -28,6 +30,7 @@ type Agent struct {
 	sessionEnv   []string
 	authMethod   string // optional, e.g. "cursor_login" for Cursor CLI (see authenticate RPC)
 	displayName  string // optional, for doctor (default "ACP")
+	model        string // optional, for Trae CLI ACP only
 
 	// mode is the pending permission mode to apply to new sessions.
 	// When set, StartSession applies it via session/set_mode right after
@@ -45,9 +48,9 @@ type Agent struct {
 	// handshake so that future PermissionModes() calls can reflect the
 	// actual modes this specific ACP agent offers (rather than a
 	// hard-coded fallback that may not match).
-	modesMu       sync.RWMutex
-	modesCache    []core.PermissionModeInfo
-	modesCurrent  string
+	modesMu      sync.RWMutex
+	modesCache   []core.PermissionModeInfo
+	modesCurrent string
 
 	mu sync.RWMutex
 }
@@ -93,18 +96,25 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 	mode, _ := opts["mode"].(string)
 	mode = strings.TrimSpace(mode)
+	model, _ := opts["model"].(string)
+	model = strings.TrimSpace(model)
 
-	return &Agent{
-		workDir:     workDir,
+	agent := &Agent{
+		workDir:      workDir,
 		cmd:          cmdStr,
 		cliExtraArgs: cliExtraArgs,
-		args:        args,
-		staticEnv:   staticEnv,
-		extraEnv:    extra,
-		authMethod:  authMethod,
-		displayName: displayName,
-		mode:        mode,
-	}, nil
+		args:         args,
+		staticEnv:    staticEnv,
+		extraEnv:     extra,
+		authMethod:   authMethod,
+		displayName:  displayName,
+		mode:         mode,
+		model:        model,
+	}
+	if isTraeCLICommand(cmdStr) {
+		return &TraeAgent{Agent: agent}, nil
+	}
+	return agent, nil
 }
 
 func envMapFromOpts(opts map[string]any) map[string]string {
@@ -213,6 +223,9 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	if a.displayName != "" {
 		opts["display_name"] = a.displayName
 	}
+	if a.model != "" {
+		opts["model"] = a.model
+	}
 	return opts
 }
 
@@ -226,6 +239,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	a.mu.RLock()
 	command := a.cmd
 	allArgs := append(append([]string{}, a.cliExtraArgs...), a.args...)
+	if model := a.traeModelOverrideLocked(); model != "" {
+		allArgs = append([]string{"-c", fmt.Sprintf("model=%q", model)}, allArgs...)
+	}
 	workDir := a.workDir
 	authMethod := a.authMethod
 	pendingMode := a.mode
@@ -246,6 +262,122 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 }
 
 func (a *Agent) Stop() error { return nil }
+
+// TraeAgent wraps the generic ACP adapter with Trae CLI-specific model
+// discovery and selection. ACP itself has no generic model-switch RPC, but
+// Trae exposes `models --json` and accepts `-c model=...` before `acp serve`.
+type TraeAgent struct {
+	*Agent
+}
+
+// -- ModelSwitcher for Trae CLI ACP --
+//
+// ACP itself does not define a generic model-list/model-set RPC. Trae CLI exposes
+// models through its local CLI and accepts model overrides before `acp serve`, so
+// cc-connect can provide IM-side model cards for Trae without affecting other ACP
+// agents such as Cursor, Copilot, Devin, or OpenClaw.
+
+func (a *TraeAgent) SetModel(model string) {
+	model = strings.TrimSpace(model)
+	a.mu.Lock()
+	a.model = model
+	a.mu.Unlock()
+	slog.Info("acp: Trae CLI model changed for future sessions", "model", model)
+}
+
+func (a *TraeAgent) GetModel() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.model
+}
+
+func (a *TraeAgent) AvailableModels(ctx context.Context) []core.ModelOption {
+	a.mu.RLock()
+	cmd := a.cmd
+	extra := append([]string(nil), a.extraEnv...)
+	extra = append(extra, a.sessionEnv...)
+	workDir := a.workDir
+	a.mu.RUnlock()
+	return fetchTraeModels(ctx, cmd, workDir, extra)
+}
+
+func (a *Agent) traeModelOverrideLocked() string {
+	if !isTraeCLICommand(a.cmd) {
+		return ""
+	}
+	return strings.TrimSpace(a.model)
+}
+
+func isTraeCLICommand(cmd string) bool {
+	base := strings.ToLower(filepath.Base(strings.TrimSpace(cmd)))
+	return base == "traecli" || base == "traex"
+}
+
+type traeModelJSON struct {
+	Name        string `json:"name"`
+	RealName    string `json:"real_name"`
+	Description string `json:"description"`
+}
+
+func fetchTraeModels(ctx context.Context, cmd, workDir string, extraEnv []string) []core.ModelOption {
+	c := exec.CommandContext(ctx, cmd, "models", "--json")
+	c.Dir = workDir
+	c.Env = core.MergeEnv(os.Environ(), extraEnv)
+	out, err := c.Output()
+	if err != nil {
+		slog.Debug("acp: Trae CLI models failed", "error", err)
+		return nil
+	}
+	var raw []traeModelJSON
+	if err := json.Unmarshal(out, &raw); err != nil {
+		slog.Debug("acp: parse Trae CLI models failed", "error", err)
+		return parseTraeModelLines(string(out))
+	}
+	models := make([]core.ModelOption, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for _, m := range raw {
+		name := strings.TrimSpace(m.Name)
+		if name == "" {
+			name = strings.TrimSpace(m.RealName)
+		}
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		desc := strings.TrimSpace(m.Description)
+		if real := strings.TrimSpace(m.RealName); real != "" && !strings.EqualFold(real, name) {
+			if desc != "" {
+				desc = real + " — " + desc
+			} else {
+				desc = real
+			}
+		}
+		models = append(models, core.ModelOption{Name: name, Desc: desc})
+	}
+	return models
+}
+
+func parseTraeModelLines(out string) []core.ModelOption {
+	var models []core.ModelOption
+	seen := map[string]struct{}{}
+	for _, line := range strings.Split(out, "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || strings.HasPrefix(name, "WARNING:") {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		models = append(models, core.ModelOption{Name: name})
+	}
+	return models
+}
 
 // -- AgentDoctorInfo --
 

--- a/agent/acp/agent_test.go
+++ b/agent/acp/agent_test.go
@@ -1,10 +1,30 @@
 package acp
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
 )
+
+// fakeTraeCLIOnPath creates a stub "traecli" executable in a temp dir and
+// prepends that dir to PATH for the duration of the test. New() only needs the
+// command to be resolvable via exec.LookPath (and named "traecli"/"traex") to
+// construct a *TraeAgent; the stub is never actually run by these unit tests.
+func fakeTraeCLIOnPath(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake CLI stub uses a POSIX shebang; skip on Windows")
+	}
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "traecli")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
 
 func TestNew_DisplayNameDefault(t *testing.T) {
 	a, err := New(map[string]any{"command": "true"})
@@ -68,5 +88,51 @@ func TestWorkspaceAgentOptions(t *testing.T) {
 	}
 	if got, _ := opts["display_name"].(string); got != "Copilot ACP" {
 		t.Fatalf("display_name = %q, want Copilot ACP", got)
+	}
+}
+
+func TestNew_TraeCLIImplementsModelSwitcher(t *testing.T) {
+	fakeTraeCLIOnPath(t)
+	a, err := New(map[string]any{
+		"command": "traecli",
+		"args":    []any{"acp", "serve"},
+		"model":   "test-model-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := a.(*TraeAgent); !ok {
+		t.Fatalf("New(traecli) returned %T, want *TraeAgent", a)
+	}
+	switcher, ok := a.(core.ModelSwitcher)
+	if !ok {
+		t.Fatalf("TraeAgent does not implement ModelSwitcher")
+	}
+	if got := switcher.GetModel(); got != "test-model-a" {
+		t.Fatalf("GetModel = %q, want test-model-a", got)
+	}
+	switcher.SetModel("test-model-b")
+	if got := switcher.GetModel(); got != "test-model-b" {
+		t.Fatalf("GetModel after SetModel = %q, want test-model-b", got)
+	}
+	opts := a.(core.WorkspaceAgentOptionSnapshotter).WorkspaceAgentOptions()
+	if got, _ := opts["model"].(string); got != "test-model-b" {
+		t.Fatalf("snapshot model = %q, want test-model-b", got)
+	}
+}
+
+func TestNew_GenericACPDoesNotImplementModelSwitcher(t *testing.T) {
+	a, err := New(map[string]any{
+		"command": "true",
+		"args":    []any{"acp", "serve"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := a.(*Agent); !ok {
+		t.Fatalf("New(true) returned %T, want *Agent", a)
+	}
+	if _, ok := a.(core.ModelSwitcher); ok {
+		t.Fatalf("generic ACP agent unexpectedly implements ModelSwitcher")
 	}
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -6427,7 +6427,9 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 	case "allow":
 		e.cmdAllow(p, msg, args)
 	case "model":
-		e.cmdModel(p, msg, args)
+		if !e.cmdModel(p, msg, args) {
+			return false
+		}
 	case "reasoning":
 		e.cmdReasoning(p, msg, args)
 	case "mode":
@@ -9463,17 +9465,20 @@ func sanitizeTelegramMenuCommand(cmd string) string {
 	return result
 }
 
-func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
+func (e *Engine) cmdModel(p Platform, msg *Message, args []string) bool {
 	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
-		return
+		return true
 	}
 
 	switcher, ok := agent.(ModelSwitcher)
 	if !ok {
+		if agent != nil && agent.Name() == "acp" {
+			return false
+		}
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgModelNotSupported))
-		return
+		return true
 	}
 
 	if len(args) == 0 {
@@ -9530,16 +9535,16 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 			sb.WriteString("\n")
 			sb.WriteString(e.i18n.T(MsgModelUsage))
 			e.replyWithButtons(p, msg.ReplyCtx, sb.String(), buttons)
-			return
+			return true
 		}
 		e.replyWithCard(p, msg.ReplyCtx, e.renderModelCard(msg.SessionKey))
-		return
+		return true
 	}
 
 	targetInput, ok := parseModelSwitchArgs(args)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgModelUsage))
-		return
+		return true
 	}
 
 	target := strings.TrimSpace(targetInput)
@@ -9553,7 +9558,7 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 	target, err = e.switchModelOnAgent(agent, target, agent == e.agent)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChangeFailed, err))
-		return
+		return true
 	}
 	e.persistWorkspaceModelOverride(interactiveKey, msg.SessionKey, agent, target)
 	e.cleanupInteractiveState(interactiveKey)
@@ -9564,6 +9569,7 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 	sessions.Save()
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChanged, target))
+	return true
 }
 
 // resolveModelAlias resolves a user-supplied string to a model name.

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -52,6 +52,15 @@ func (s *recordingAgentSession) RespondPermission(id string, res PermissionResul
 	return nil
 }
 
+type stubNamedAgent struct {
+	stubAgent
+	name string
+}
+
+func (a *stubNamedAgent) Name() string {
+	return a.name
+}
+
 type stubPlatformEngine struct {
 	n    string
 	sent []string
@@ -2567,6 +2576,40 @@ func TestEngine_DisabledCommandsWildcard(t *testing.T) {
 	}
 	if !strings.Contains(p.sent[0], "disabled") && !strings.Contains(p.sent[0], "禁用") {
 		t.Errorf("expected disabled message, got: %s", p.sent[0])
+	}
+}
+
+func TestHandleCommand_ModelPassesThroughForACPAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubNamedAgent{name: "acp"}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:u1", UserID: "user1", ReplyCtx: "ctx"}
+
+	handled := e.handleCommand(p, msg, "/model")
+
+	if handled {
+		t.Fatal("expected /model on ACP agent to fall through to the agent")
+	}
+	if got := p.getSent(); len(got) != 0 {
+		t.Fatalf("expected no cc-connect reply before fallthrough, got %#v", got)
+	}
+}
+
+func TestHandleCommand_ModelUnsupportedForNonACPAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:u1", UserID: "user1", ReplyCtx: "ctx"}
+
+	handled := e.handleCommand(p, msg, "/model")
+
+	if !handled {
+		t.Fatal("expected /model on non-ACP agent to be handled by cc-connect")
+	}
+	got := p.getSent()
+	if len(got) != 1 {
+		t.Fatalf("expected one unsupported-model reply, got %#v", got)
+	}
+	if !strings.Contains(got[0], "does not support model switching") {
+		t.Fatalf("expected unsupported-model reply, got %q", got[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a Trae-specific ACP wrapper so `/model` works with the Trae CLI (`traecli acp serve`) agent, and lets generic ACP agents pass `/model` through when they do not implement cc-connect model switching.

## Motivation

When bridging to an ACP agent launched via `traecli acp serve`, `/model` reported "model switching not supported by the current agent" even though the underlying CLI does support switching models. Generic ACP agents had no way to discover available models or apply a selected model override at session start.

## Changes

- Add a `TraeAgent` ACP wrapper that:
  - discovers available models through the Trae CLI, and
  - injects the selected model override when starting ACP sessions.
- Implement `core.ModelSwitcher` (and the workspace-options snapshot) for the Trae agent so `/model` and per-workspace model overrides work end to end.
- Keep generic ACP agents unchanged: they do not implement `ModelSwitcher`, so `/model` passes through instead of erroring.

## Testing

- `go build -tags no_web ./...`
- `go test -tags no_web ./agent/acp/ ./core/`
  - `TestNew_TraeCLIImplementsModelSwitcher` verifies discovery, `GetModel`/`SetModel`, and the workspace-options snapshot.
  - `TestNew_GenericACPDoesNotImplementModelSwitcher` verifies generic ACP agents are untouched.
