### PR TITLE
fix(acp): make session resume robust against restart, giant history, and slow start

### DIFF
--- a/agent/acp/session.go
+++ b/agent/acp/session.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -21,6 +22,12 @@ import (
 // toolInputCacheMaxEntries caps toolInputByID growth; beyond this we evict
 // roughly half the map (iteration order is arbitrary) to bound memory.
 const toolInputCacheMaxEntries = 1000
+
+// sessionLoadTimeout bounds a single ACP session/load call. Resuming a very
+// large saved session (history replayed as many tool calls) can otherwise
+// hang indefinitely and wedge the whole topic. When it fires we surface
+// core.ErrSessionResumeTimeout instead of silently starting a fresh session.
+var sessionLoadTimeout = 90 * time.Second
 
 type acpSession struct {
 	workDir string
@@ -211,8 +218,22 @@ func (s *acpSession) handshake(resumeSessionID string, authMethod string) error 
 			"cwd":        s.workDir,
 			"mcpServers": []any{},
 		}
-		loadRes, err := s.tr.call(s.ctx, "session/load", loadParams)
+		// Bound session/load so a giant history replay cannot hang the topic
+		// forever. Some sessions (e.g. ones stuffed with huge tool outputs)
+		// take many minutes to reload and, combined with a slow-first-token
+		// model, effectively wedge the whole conversation. On timeout we do
+		// NOT silently fall through to session/new — that would overwrite the
+		// saved session ID and truncate history. Instead return a distinct
+		// error so the engine preserves the ID and tells the user to /new.
+		loadCtx, cancelLoad := context.WithTimeout(s.ctx, sessionLoadTimeout)
+		loadRes, err := s.tr.call(loadCtx, "session/load", loadParams)
+		cancelLoad()
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) && s.ctx.Err() == nil {
+				slog.Error("acp: session/load timed out, preserving saved session id",
+					"session_id", resumeSessionID, "timeout", sessionLoadTimeout)
+				return fmt.Errorf("acp: session/load: %w", core.ErrSessionResumeTimeout)
+			}
 			slog.Warn("acp: session/load failed, starting new session", "error", err)
 		} else {
 			var lr struct {

--- a/agent/acp/session_load_timeout_test.go
+++ b/agent/acp/session_load_timeout_test.go
@@ -1,0 +1,72 @@
+package acp
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// TestHandshake_SessionLoadTimeout verifies that when a resume's session/load
+// stalls past sessionLoadTimeout, handshake returns core.ErrSessionResumeTimeout
+// instead of silently falling through to session/new (which would overwrite the
+// saved session ID and truncate history).
+func TestHandshake_SessionLoadTimeout(t *testing.T) {
+	// Shorten the budget so the test is fast; restore afterwards.
+	prev := sessionLoadTimeout
+	sessionLoadTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { sessionLoadTimeout = prev })
+
+	s, wResp, rReq := newTestSession(t, &fakeCallbacks{})
+
+	// Mock server: answer initialize (loadSession=true), then deliberately
+	// never respond to session/load. It must also never receive session/new.
+	sawSessionNew := make(chan struct{}, 1)
+	go func() {
+		sc := bufio.NewScanner(rReq)
+		for sc.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(sc.Bytes(), &req); err != nil {
+				continue
+			}
+			switch req.Method {
+			case "initialize":
+				_, _ = fmt.Fprintf(wResp,
+					`{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}`+"\n",
+					req.ID)
+			case "session/load":
+				// Stall forever — the client's per-call timeout must fire.
+			case "session/new":
+				select {
+				case sawSessionNew <- struct{}{}:
+				default:
+				}
+				_, _ = fmt.Fprintf(wResp,
+					`{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"fresh-should-not-happen"}}`+"\n",
+					req.ID)
+			}
+		}
+	}()
+
+	err := s.handshake("big-session-id", "")
+	if err == nil {
+		t.Fatal("handshake returned nil, want ErrSessionResumeTimeout")
+	}
+	if !errors.Is(err, core.ErrSessionResumeTimeout) {
+		t.Fatalf("handshake err = %v, want ErrSessionResumeTimeout", err)
+	}
+
+	// Ensure we did NOT fall back to session/new (which would clobber the id).
+	select {
+	case <-sawSessionNew:
+		t.Fatal("handshake started a fresh session/new after load timeout — must preserve saved id")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -95,6 +95,12 @@ var CurrentVersion string
 // ErrAttachmentSendDisabled indicates that side-channel image/file delivery is disabled by config.
 var ErrAttachmentSendDisabled = errors.New("attachment send is disabled by config")
 
+// ErrSessionResumeTimeout indicates that resuming a saved agent session
+// (e.g. ACP session/load replaying a very large history) exceeded the
+// allowed time budget. The saved session ID must be preserved so the
+// conversation is not truncated; the user is told to /new to start fresh.
+var ErrSessionResumeTimeout = errors.New("agent session resume timed out")
+
 // RestartRequest carries info needed to send a post-restart notification.
 type RestartRequest struct {
 	SessionKey string `json:"session_key"`
@@ -539,6 +545,12 @@ type interactiveState struct {
 	// the next turn (e.g. after an abnormal exit). Defaults to true (safe);
 	// cleared to false only after a clean EventResult.
 	eventsNeedResync bool
+
+	// resumeTimedOut is true when the last attempt to resume this session's
+	// saved agent session exceeded the load budget (ErrSessionResumeTimeout).
+	// The saved session ID is preserved; the caller uses this to tell the user
+	// to /new rather than emitting the generic "failed to start" error.
+	resumeTimedOut bool
 
 	// lastCompletedUserMessageTimeMs is the max platform user-message create time
 	// (ms) for which an agent turn has finished with EventResult.
@@ -3661,6 +3673,25 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	// on the turn completing without a process crash).
 	sessions.Save()
 
+	// Start the typing indicator (e.g. Feishu "processing" reaction) BEFORE
+	// obtaining the interactive state. getOrCreateInteractiveStateWith may block
+	// for a long time when it resumes a large/slow agent session (session/load
+	// replays the whole history), so adding the reaction here guarantees the user
+	// gets immediate "received, working on it" feedback even when resume is slow.
+	// Ownership is transferred to processInteractiveEvents which manages
+	// stopping/restarting it across queued message turns.
+	var stopTyping func()
+	if ti, ok := p.(TypingIndicator); ok {
+		stopTyping = ti.StartTyping(e.ctx, msg.ReplyCtx)
+	}
+	defer func() {
+		// Stop typing if ownership was NOT transferred to processInteractiveEvents
+		// (i.e. an early return before that call).
+		if stopTyping != nil {
+			stopTyping()
+		}
+	}()
+
 	// Use the agent override when available (multi-workspace mode)
 	var agentOverride Agent
 	if agent != e.agent {
@@ -3691,7 +3722,14 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	defer stopRecallMonitor()
 
 	if state.agentSession == nil {
-		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFailedToStartAgentSession))
+		state.mu.Lock()
+		timedOut := state.resumeTimedOut
+		state.mu.Unlock()
+		if timedOut {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgSessionResumeTimeout))
+		} else {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFailedToStartAgentSession))
+		}
 		return
 	}
 	e.cancelAgentSessionIdleClose(state)
@@ -3719,21 +3757,6 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 			}
 		}
 	}
-
-	// Start typing indicator if platform supports it.
-	// Ownership is transferred to processInteractiveEvents which manages
-	// stopping/restarting it across queued message turns.
-	var stopTyping func()
-	if ti, ok := p.(TypingIndicator); ok {
-		stopTyping = ti.StartTyping(e.ctx, msg.ReplyCtx)
-	}
-	defer func() {
-		// Stop typing if ownership was NOT transferred to processInteractiveEvents
-		// (i.e. an early return before that call).
-		if stopTyping != nil {
-			stopTyping()
-		}
-	}()
 
 	// Stop the unsolicited reader (if running) and hand off event channel
 	// ownership to this foreground turn. Only drain events when the previous
@@ -4055,6 +4078,36 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	agentSession, err := agent.StartSession(e.ctx, startSessionID)
 	startElapsed := time.Since(startAt)
 	if err != nil {
+		// Shutdown/restart guard: if the engine context was canceled (e.g.
+		// cc-connect is restarting) a resume can fail with context.Canceled
+		// mid-flight. That is NOT a stale/invalid session id, so clearing it
+		// here would permanently truncate the conversation's history chain and
+		// the next message would start a blank session. Preserve the saved id
+		// and bail out with a resync placeholder; the next message re-loads the
+		// original session cleanly.
+		if errors.Is(err, context.Canceled) || e.ctx.Err() != nil {
+			slog.Warn("session start canceled (shutdown/restart), preserving saved session id",
+				"session_key", sessionKey, "saved_session_id", startSessionID, "elapsed", startElapsed)
+			newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true}
+			adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
+			state = newState
+			e.interactiveStates[sessionKey] = state
+			return state
+		}
+		// Resume timeout guard: a very large saved session can make the agent's
+		// session/load hang past its budget. Like the shutdown case, this is NOT
+		// a stale/invalid id — clearing it would truncate history. Preserve the
+		// id, tell the user to /new, and bail out. The placeholder state has a
+		// nil agentSession so the caller replies MsgSessionResumeTimeout below.
+		if errors.Is(err, ErrSessionResumeTimeout) {
+			slog.Error("session resume timed out, preserving saved session id",
+				"session_key", sessionKey, "saved_session_id", startSessionID, "elapsed", startElapsed)
+			newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true, resumeTimedOut: true}
+			adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
+			state = newState
+			e.interactiveStates[sessionKey] = state
+			return state
+		}
 		// If resume/continue failed, try a fresh session as fallback.
 		if startSessionID != "" {
 			slog.Error("session resume failed, falling back to fresh session",
@@ -15670,6 +15723,13 @@ func (e *Engine) HandleRelay(ctx context.Context, fromProject, sourceSessionKey,
 	// timeout only controls how long we *wait* for the response.
 	agentSession, err := agent.StartSession(e.ctx, session.GetAgentSessionID())
 	if err != nil {
+		// Shutdown/restart guard (see interactive path above): a resume that
+		// fails with context.Canceled is a restart artifact, not a stale id.
+		// Preserve the saved id so the relay reconnects to the same
+		// conversation on the next attempt instead of losing history.
+		if errors.Is(err, context.Canceled) || e.ctx.Err() != nil {
+			return "", fmt.Errorf("start relay session canceled (shutdown/restart): %w", err)
+		}
 		// Resume failed — fall back to a fresh session so the relay is not
 		// permanently broken by a corrupted/stale session ID.
 		if session.GetAgentSessionID() != "" {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -7549,6 +7549,104 @@ func TestSessionMismatch_RecyclesStaleAgent(t *testing.T) {
 	}
 }
 
+// TestSessionResume_CanceledPreservesSavedID verifies the shutdown/restart guard:
+// when StartSession fails with context.Canceled (cc-connect restarting mid-resume),
+// the saved AgentSessionID must be preserved (NOT cleared) so the next message
+// re-loads the same conversation. Clearing it would permanently truncate history.
+func TestSessionResume_CanceledPreservesSavedID(t *testing.T) {
+	agent := &controllableAgent{
+		startSessionFn: func(_ context.Context, _ string) (AgentSession, error) {
+			return nil, context.Canceled
+		},
+	}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	session := &Session{AgentSessionID: "saved-agent-id"}
+
+	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+
+	if got := session.GetAgentSessionID(); got != "saved-agent-id" {
+		t.Fatalf("AgentSessionID = %q, want %q — canceled resume must not wipe the saved id", got, "saved-agent-id")
+	}
+	if state == nil || !state.eventsNeedResync {
+		t.Fatal("expected a resync placeholder state after canceled resume")
+	}
+	if state.agentSession != nil {
+		t.Fatal("expected no live agent session after canceled resume")
+	}
+}
+
+// TestSessionResume_RealFailureClearsID verifies that a genuine (non-cancel)
+// resume failure still falls back to a fresh session by clearing the stale id,
+// preserving the pre-existing recovery behavior.
+func TestSessionResume_RealFailureClearsID(t *testing.T) {
+	freshSess := newControllableSession("fresh-after-failure")
+	calls := 0
+	agent := &controllableAgent{
+		startSessionFn: func(_ context.Context, sessionID string) (AgentSession, error) {
+			calls++
+			if sessionID != "" {
+				return nil, fmt.Errorf("resume: no such session")
+			}
+			return freshSess, nil
+		},
+	}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	session := &Session{AgentSessionID: "stale-id"}
+
+	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+
+	if calls != 2 {
+		t.Fatalf("StartSession calls = %d, want 2 (resume then fresh)", calls)
+	}
+	if state.agentSession != freshSess {
+		t.Fatal("expected fresh agent session after real resume failure")
+	}
+	if got := session.GetAgentSessionID(); got != "fresh-after-failure" {
+		t.Fatalf("AgentSessionID = %q, want %q — fresh id should be written back", got, "fresh-after-failure")
+	}
+}
+
+// TestSessionResume_TimeoutPreservesSavedID verifies the resume-timeout guard:
+// when StartSession fails with ErrSessionResumeTimeout (a giant session/load that
+// exceeded its budget), the saved AgentSessionID must be preserved (NOT cleared)
+// and no fresh session should be started. Clearing it would truncate history; the
+// placeholder is flagged resumeTimedOut so the caller tells the user to /new.
+func TestSessionResume_TimeoutPreservesSavedID(t *testing.T) {
+	calls := 0
+	agent := &controllableAgent{
+		startSessionFn: func(_ context.Context, _ string) (AgentSession, error) {
+			calls++
+			return nil, fmt.Errorf("acp: session/load: %w", ErrSessionResumeTimeout)
+		},
+	}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	session := &Session{AgentSessionID: "big-session-id"}
+
+	state := e.getOrCreateInteractiveStateWith(key, p, "ctx", session, e.sessions, nil, "")
+
+	if calls != 1 {
+		t.Fatalf("StartSession calls = %d, want 1 — timeout must NOT retry a fresh session", calls)
+	}
+	if got := session.GetAgentSessionID(); got != "big-session-id" {
+		t.Fatalf("AgentSessionID = %q, want %q — timed-out resume must not wipe the saved id", got, "big-session-id")
+	}
+	if state == nil || !state.resumeTimedOut {
+		t.Fatal("expected a placeholder state flagged resumeTimedOut after resume timeout")
+	}
+	if state.agentSession != nil {
+		t.Fatal("expected no live agent session after resume timeout")
+	}
+}
+
 // TestSessionClearedAfterNew_RecyclesAliveAgent verifies issue #238: after /new the
 // Session's AgentSessionID is empty but an older Claude process may still be alive;
 // it must be recycled instead of reused (which would keep prior --resume context).

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -182,6 +182,7 @@ const (
 	MsgToolAllowedNew            MsgKey = "tool_allowed_new"
 	MsgError                     MsgKey = "error"
 	MsgSessionNotFound           MsgKey = "session_not_found"
+	MsgSessionResumeTimeout      MsgKey = "session_resume_timeout"
 	MsgFailedToStartAgentSession MsgKey = "failed_to_start_agent_session"
 	MsgFailedToDeleteSession     MsgKey = "failed_to_delete_session"
 	MsgEmptyResponse             MsgKey = "empty_response"
@@ -813,6 +814,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "⚠️ 會話已過期，請發送 /new 開始新會話",
 		LangJapanese:           "⚠️ セッションが期限切れです。/new で新しい会話を開始してください。",
 		LangSpanish:            "⚠️ Sesión expirada. Usa /new para iniciar una nueva conversación.",
+	},
+	MsgSessionResumeTimeout: {
+		LangEnglish:            "⚠️ This conversation is too large to resume (timed out). Its history is kept — use /new to start a fresh conversation.",
+		LangChinese:            "⚠️ 该会话历史过大，恢复超时。历史已保留，请发送 /new 开始新会话。",
+		LangTraditionalChinese: "⚠️ 該會話歷史過大，恢復逾時。歷史已保留，請發送 /new 開始新會話。",
+		LangJapanese:           "⚠️ この会話は履歴が大きすぎて再開できませんでした（タイムアウト）。履歴は保持されています。/new で新しい会話を開始してください。",
+		LangSpanish:            "⚠️ Esta conversación es demasiado grande para reanudarse (tiempo agotado). Su historial se conserva; usa /new para iniciar una nueva conversación.",
 	},
 	MsgFailedToStartAgentSession: {
 		LangEnglish:            "❌ Error: failed to start agent session",


### PR DESCRIPTION
## Problem

Resuming a saved agent session could either **silently truncate history** or **wedge an entire topic/conversation**:

- On restart, `StartSession` can fail mid-resume with `context.Canceled`. The old code treated that like a stale/invalid session ID and fell back to a fresh session, permanently breaking the conversation's history chain — the next message started blank.
- A very large saved session (long history replayed as many tool calls) combined with a slow-first-token model could make ACP `session/load` hang effectively forever, blocking every subsequent message in that topic with no feedback and no recovery path.
- The typing indicator (e.g. the Feishu "processing" reaction) was only started *after* the resume, so during a slow resume the user got no acknowledgement at all.

## Changes

1. **Restart guard** — when `StartSession` fails with `context.Canceled` (or the engine context is already canceled), preserve the saved session ID instead of clearing it. Applied to both the interactive path and the inter-bot relay path.

2. **Resume timeout** — bound a single ACP `session/load` to 90s. On timeout, return a distinct `ErrSessionResumeTimeout` instead of silently falling through to `session/new`, so the saved ID is preserved and the user is told to `/new` (new i18n message, 5 languages). This never truncates history silently.

3. **Immediate feedback** — start the typing indicator *before* resuming the session, so the user sees "received, working on it" even when the resume is slow. Ownership is still handed off to the event loop for the actual turn.

## Tests

- `TestSessionResume_CanceledPreservesSavedID` — canceled resume keeps the saved ID and yields a resync placeholder.
- `TestSessionResume_RealFailureClearsID` — a genuine resume failure still falls back to a fresh session (preserves existing recovery behavior).
- `TestSessionResume_TimeoutPreservesSavedID` — timeout keeps the saved ID, does not retry a fresh session, and flags the placeholder for the `/new` prompt.
- `TestHandshake_SessionLoadTimeout` (ACP layer) — a stalled `session/load` returns `ErrSessionResumeTimeout` and never calls `session/new`.

`go vet` and `go build -tags no_web ./...` pass.
