### PR TITLE
feat(acp): support reasoning-effort switching for Trae CLI ACP agent

### DIFF
--- a/agent/acp/agent.go
+++ b/agent/acp/agent.go
@@ -2,8 +2,10 @@ package acp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -28,6 +30,7 @@ type Agent struct {
 	sessionEnv   []string
 	authMethod   string // optional, e.g. "cursor_login" for Cursor CLI (see authenticate RPC)
 	displayName  string // optional, for doctor (default "ACP")
+	model        string // optional, for Trae CLI ACP only
 
 	// mode is the pending permission mode to apply to new sessions.
 	// When set, StartSession applies it via session/set_mode right after
@@ -45,9 +48,9 @@ type Agent struct {
 	// handshake so that future PermissionModes() calls can reflect the
 	// actual modes this specific ACP agent offers (rather than a
 	// hard-coded fallback that may not match).
-	modesMu       sync.RWMutex
-	modesCache    []core.PermissionModeInfo
-	modesCurrent  string
+	modesMu      sync.RWMutex
+	modesCache   []core.PermissionModeInfo
+	modesCurrent string
 
 	mu sync.RWMutex
 }
@@ -93,18 +96,25 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 	mode, _ := opts["mode"].(string)
 	mode = strings.TrimSpace(mode)
+	model, _ := opts["model"].(string)
+	model = strings.TrimSpace(model)
 
-	return &Agent{
-		workDir:     workDir,
+	agent := &Agent{
+		workDir:      workDir,
 		cmd:          cmdStr,
 		cliExtraArgs: cliExtraArgs,
-		args:        args,
-		staticEnv:   staticEnv,
-		extraEnv:    extra,
-		authMethod:  authMethod,
-		displayName: displayName,
-		mode:        mode,
-	}, nil
+		args:         args,
+		staticEnv:    staticEnv,
+		extraEnv:     extra,
+		authMethod:   authMethod,
+		displayName:  displayName,
+		mode:         mode,
+		model:        model,
+	}
+	if isTraeCLICommand(cmdStr) {
+		return &TraeAgent{Agent: agent}, nil
+	}
+	return agent, nil
 }
 
 func envMapFromOpts(opts map[string]any) map[string]string {
@@ -213,6 +223,9 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	if a.displayName != "" {
 		opts["display_name"] = a.displayName
 	}
+	if a.model != "" {
+		opts["model"] = a.model
+	}
 	return opts
 }
 
@@ -226,6 +239,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	a.mu.RLock()
 	command := a.cmd
 	allArgs := append(append([]string{}, a.cliExtraArgs...), a.args...)
+	if model := a.traeModelOverrideLocked(); model != "" {
+		allArgs = append([]string{"-c", fmt.Sprintf("model=%q", model)}, allArgs...)
+	}
 	workDir := a.workDir
 	authMethod := a.authMethod
 	pendingMode := a.mode
@@ -246,6 +262,122 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 }
 
 func (a *Agent) Stop() error { return nil }
+
+// TraeAgent wraps the generic ACP adapter with Trae CLI-specific model
+// discovery and selection. ACP itself has no generic model-switch RPC, but
+// Trae exposes `models --json` and accepts `-c model=...` before `acp serve`.
+type TraeAgent struct {
+	*Agent
+}
+
+// -- ModelSwitcher for Trae CLI ACP --
+//
+// ACP itself does not define a generic model-list/model-set RPC. Trae CLI exposes
+// models through its local CLI and accepts model overrides before `acp serve`, so
+// cc-connect can provide IM-side model cards for Trae without affecting other ACP
+// agents such as Cursor, Copilot, Devin, or OpenClaw.
+
+func (a *TraeAgent) SetModel(model string) {
+	model = strings.TrimSpace(model)
+	a.mu.Lock()
+	a.model = model
+	a.mu.Unlock()
+	slog.Info("acp: Trae CLI model changed for future sessions", "model", model)
+}
+
+func (a *TraeAgent) GetModel() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.model
+}
+
+func (a *TraeAgent) AvailableModels(ctx context.Context) []core.ModelOption {
+	a.mu.RLock()
+	cmd := a.cmd
+	extra := append([]string(nil), a.extraEnv...)
+	extra = append(extra, a.sessionEnv...)
+	workDir := a.workDir
+	a.mu.RUnlock()
+	return fetchTraeModels(ctx, cmd, workDir, extra)
+}
+
+func (a *Agent) traeModelOverrideLocked() string {
+	if !isTraeCLICommand(a.cmd) {
+		return ""
+	}
+	return strings.TrimSpace(a.model)
+}
+
+func isTraeCLICommand(cmd string) bool {
+	base := strings.ToLower(filepath.Base(strings.TrimSpace(cmd)))
+	return base == "traecli" || base == "traex"
+}
+
+type traeModelJSON struct {
+	Name        string `json:"name"`
+	RealName    string `json:"real_name"`
+	Description string `json:"description"`
+}
+
+func fetchTraeModels(ctx context.Context, cmd, workDir string, extraEnv []string) []core.ModelOption {
+	c := exec.CommandContext(ctx, cmd, "models", "--json")
+	c.Dir = workDir
+	c.Env = core.MergeEnv(os.Environ(), extraEnv)
+	out, err := c.Output()
+	if err != nil {
+		slog.Debug("acp: Trae CLI models failed", "error", err)
+		return nil
+	}
+	var raw []traeModelJSON
+	if err := json.Unmarshal(out, &raw); err != nil {
+		slog.Debug("acp: parse Trae CLI models failed", "error", err)
+		return parseTraeModelLines(string(out))
+	}
+	models := make([]core.ModelOption, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for _, m := range raw {
+		name := strings.TrimSpace(m.Name)
+		if name == "" {
+			name = strings.TrimSpace(m.RealName)
+		}
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		desc := strings.TrimSpace(m.Description)
+		if real := strings.TrimSpace(m.RealName); real != "" && !strings.EqualFold(real, name) {
+			if desc != "" {
+				desc = real + " — " + desc
+			} else {
+				desc = real
+			}
+		}
+		models = append(models, core.ModelOption{Name: name, Desc: desc})
+	}
+	return models
+}
+
+func parseTraeModelLines(out string) []core.ModelOption {
+	var models []core.ModelOption
+	seen := map[string]struct{}{}
+	for _, line := range strings.Split(out, "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || strings.HasPrefix(name, "WARNING:") {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		models = append(models, core.ModelOption{Name: name})
+	}
+	return models
+}
 
 // -- AgentDoctorInfo --
 

--- a/agent/acp/agent.go
+++ b/agent/acp/agent.go
@@ -31,6 +31,9 @@ type Agent struct {
 	authMethod   string // optional, e.g. "cursor_login" for Cursor CLI (see authenticate RPC)
 	displayName  string // optional, for doctor (default "ACP")
 	model        string // optional, for Trae CLI ACP only
+	// reasoningEffort is the pending reasoning effort to apply to new
+	// sessions (Trae CLI ACP only). Empty means "use the agent default".
+	reasoningEffort string
 
 	// mode is the pending permission mode to apply to new sessions.
 	// When set, StartSession applies it via session/set_mode right after
@@ -70,7 +73,7 @@ var _ sessionCallbacks = (*Agent)(nil)
 // New builds an acp agent from project options.
 // Required: options["command"] — executable name or path for the ACP agent.
 // Optional: options["args"], options["env"], options["auth_method"],
-// options["display_name"], options["mode"].
+// options["display_name"], options["mode"], options["reasoning_effort"].
 func New(opts map[string]any) (core.Agent, error) {
 	workDir, _ := opts["work_dir"].(string)
 	if workDir == "" {
@@ -98,18 +101,21 @@ func New(opts map[string]any) (core.Agent, error) {
 	mode = strings.TrimSpace(mode)
 	model, _ := opts["model"].(string)
 	model = strings.TrimSpace(model)
+	reasoningEffort, _ := opts["reasoning_effort"].(string)
+	reasoningEffort = normalizeTraeReasoningEffort(reasoningEffort)
 
 	agent := &Agent{
-		workDir:      workDir,
-		cmd:          cmdStr,
-		cliExtraArgs: cliExtraArgs,
-		args:         args,
-		staticEnv:    staticEnv,
-		extraEnv:     extra,
-		authMethod:   authMethod,
-		displayName:  displayName,
-		mode:         mode,
-		model:        model,
+		workDir:         workDir,
+		cmd:             cmdStr,
+		cliExtraArgs:    cliExtraArgs,
+		args:            args,
+		staticEnv:       staticEnv,
+		extraEnv:        extra,
+		authMethod:      authMethod,
+		displayName:     displayName,
+		mode:            mode,
+		model:           model,
+		reasoningEffort: reasoningEffort,
 	}
 	if isTraeCLICommand(cmdStr) {
 		return &TraeAgent{Agent: agent}, nil
@@ -226,6 +232,9 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	if a.model != "" {
 		opts["model"] = a.model
 	}
+	if a.reasoningEffort != "" {
+		opts["reasoning_effort"] = a.reasoningEffort
+	}
 	return opts
 }
 
@@ -239,6 +248,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	a.mu.RLock()
 	command := a.cmd
 	allArgs := append(append([]string{}, a.cliExtraArgs...), a.args...)
+	if effort := a.traeReasoningEffortOverrideLocked(); effort != "" {
+		allArgs = append([]string{"-c", fmt.Sprintf("model_reasoning_effort=%q", effort)}, allArgs...)
+	}
 	if model := a.traeModelOverrideLocked(); model != "" {
 		allArgs = append([]string{"-c", fmt.Sprintf("model=%q", model)}, allArgs...)
 	}
@@ -299,6 +311,58 @@ func (a *TraeAgent) AvailableModels(ctx context.Context) []core.ModelOption {
 	workDir := a.workDir
 	a.mu.RUnlock()
 	return fetchTraeModels(ctx, cmd, workDir, extra)
+}
+
+// -- ReasoningEffortSwitcher for Trae CLI ACP --
+//
+// ACP has no generic reasoning-effort RPC either. Trae CLI reads the effort
+// from `model_reasoning_effort` in traecli.toml and accepts an override via
+// `-c model_reasoning_effort=...` before `acp serve` (same mechanism as the
+// model override above). Only TraeAgent exposes this so other ACP agents are
+// unaffected.
+
+func (a *TraeAgent) SetReasoningEffort(effort string) {
+	effort = normalizeTraeReasoningEffort(effort)
+	a.mu.Lock()
+	a.reasoningEffort = effort
+	a.mu.Unlock()
+	slog.Info("acp: Trae CLI reasoning effort changed for future sessions", "reasoning_effort", effort)
+}
+
+func (a *TraeAgent) GetReasoningEffort() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.reasoningEffort
+}
+
+func (a *TraeAgent) AvailableReasoningEfforts() []string {
+	return []string{"low", "medium", "high", "xhigh"}
+}
+
+func (a *Agent) traeReasoningEffortOverrideLocked() string {
+	if !isTraeCLICommand(a.cmd) {
+		return ""
+	}
+	return strings.TrimSpace(a.reasoningEffort)
+}
+
+// normalizeTraeReasoningEffort maps user input to a Trae-accepted effort value.
+// Unknown values return "" so the agent falls back to its configured default.
+func normalizeTraeReasoningEffort(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return ""
+	case "low":
+		return "low"
+	case "medium", "med":
+		return "medium"
+	case "high":
+		return "high"
+	case "xhigh", "x-high", "very-high":
+		return "xhigh"
+	default:
+		return ""
+	}
 }
 
 func (a *Agent) traeModelOverrideLocked() string {

--- a/agent/acp/agent_test.go
+++ b/agent/acp/agent_test.go
@@ -1,10 +1,30 @@
 package acp
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/chenhg5/cc-connect/core"
 )
+
+// fakeTraeCLIOnPath creates a stub "traecli" executable in a temp dir and
+// prepends that dir to PATH for the duration of the test. New() only needs the
+// command to be resolvable via exec.LookPath (and named "traecli"/"traex") to
+// construct a *TraeAgent; the stub is never actually run by these unit tests.
+func fakeTraeCLIOnPath(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake CLI stub uses a POSIX shebang; skip on Windows")
+	}
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "traecli")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
 
 func TestNew_DisplayNameDefault(t *testing.T) {
 	a, err := New(map[string]any{"command": "true"})
@@ -68,5 +88,51 @@ func TestWorkspaceAgentOptions(t *testing.T) {
 	}
 	if got, _ := opts["display_name"].(string); got != "Copilot ACP" {
 		t.Fatalf("display_name = %q, want Copilot ACP", got)
+	}
+}
+
+func TestNew_TraeCLIImplementsModelSwitcher(t *testing.T) {
+	fakeTraeCLIOnPath(t)
+	a, err := New(map[string]any{
+		"command": "traecli",
+		"args":    []any{"acp", "serve"},
+		"model":   "test-model-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := a.(*TraeAgent); !ok {
+		t.Fatalf("New(traecli) returned %T, want *TraeAgent", a)
+	}
+	switcher, ok := a.(core.ModelSwitcher)
+	if !ok {
+		t.Fatalf("TraeAgent does not implement ModelSwitcher")
+	}
+	if got := switcher.GetModel(); got != "test-model-a" {
+		t.Fatalf("GetModel = %q, want test-model-a", got)
+	}
+	switcher.SetModel("test-model-b")
+	if got := switcher.GetModel(); got != "test-model-b" {
+		t.Fatalf("GetModel after SetModel = %q, want test-model-b", got)
+	}
+	opts := a.(core.WorkspaceAgentOptionSnapshotter).WorkspaceAgentOptions()
+	if got, _ := opts["model"].(string); got != "test-model-b" {
+		t.Fatalf("snapshot model = %q, want test-model-b", got)
+	}
+}
+
+func TestNew_GenericACPDoesNotImplementModelSwitcher(t *testing.T) {
+	a, err := New(map[string]any{
+		"command": "true",
+		"args":    []any{"acp", "serve"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := a.(*Agent); !ok {
+		t.Fatalf("New(true) returned %T, want *Agent", a)
+	}
+	if _, ok := a.(core.ModelSwitcher); ok {
+		t.Fatalf("generic ACP agent unexpectedly implements ModelSwitcher")
 	}
 }

--- a/agent/acp/agent_test.go
+++ b/agent/acp/agent_test.go
@@ -136,3 +136,51 @@ func TestNew_GenericACPDoesNotImplementModelSwitcher(t *testing.T) {
 		t.Fatalf("generic ACP agent unexpectedly implements ModelSwitcher")
 	}
 }
+
+func TestNew_TraeCLIImplementsReasoningEffortSwitcher(t *testing.T) {
+	a, err := New(map[string]any{
+		"command":          "traecli",
+		"args":             []any{"acp", "serve"},
+		"reasoning_effort": "high",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	switcher, ok := a.(core.ReasoningEffortSwitcher)
+	if !ok {
+		t.Fatalf("TraeAgent does not implement ReasoningEffortSwitcher")
+	}
+	if got := switcher.GetReasoningEffort(); got != "high" {
+		t.Fatalf("GetReasoningEffort = %q, want high", got)
+	}
+	if efforts := switcher.AvailableReasoningEfforts(); len(efforts) != 4 || efforts[0] != "low" || efforts[3] != "xhigh" {
+		t.Fatalf("AvailableReasoningEfforts = %#v, want [low medium high xhigh]", efforts)
+	}
+	// unknown value falls back to "" (use agent default)
+	switcher.SetReasoningEffort("bogus")
+	if got := switcher.GetReasoningEffort(); got != "" {
+		t.Fatalf("GetReasoningEffort after bogus = %q, want empty", got)
+	}
+	// alias normalization
+	switcher.SetReasoningEffort("x-high")
+	if got := switcher.GetReasoningEffort(); got != "xhigh" {
+		t.Fatalf("GetReasoningEffort after x-high = %q, want xhigh", got)
+	}
+	opts := a.(core.WorkspaceAgentOptionSnapshotter).WorkspaceAgentOptions()
+	if got, _ := opts["reasoning_effort"].(string); got != "xhigh" {
+		t.Fatalf("snapshot reasoning_effort = %q, want xhigh", got)
+	}
+}
+
+func TestNew_GenericACPDoesNotImplementReasoningEffortSwitcher(t *testing.T) {
+	a, err := New(map[string]any{
+		"command": "true",
+		"args":    []any{"acp", "serve"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := a.(core.ReasoningEffortSwitcher); ok {
+		t.Fatalf("generic ACP agent unexpectedly implements ReasoningEffortSwitcher")
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -6427,7 +6427,9 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 	case "allow":
 		e.cmdAllow(p, msg, args)
 	case "model":
-		e.cmdModel(p, msg, args)
+		if !e.cmdModel(p, msg, args) {
+			return false
+		}
 	case "reasoning":
 		e.cmdReasoning(p, msg, args)
 	case "mode":
@@ -9463,17 +9465,20 @@ func sanitizeTelegramMenuCommand(cmd string) string {
 	return result
 }
 
-func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
+func (e *Engine) cmdModel(p Platform, msg *Message, args []string) bool {
 	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
-		return
+		return true
 	}
 
 	switcher, ok := agent.(ModelSwitcher)
 	if !ok {
+		if agent != nil && agent.Name() == "acp" {
+			return false
+		}
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgModelNotSupported))
-		return
+		return true
 	}
 
 	if len(args) == 0 {
@@ -9530,16 +9535,16 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 			sb.WriteString("\n")
 			sb.WriteString(e.i18n.T(MsgModelUsage))
 			e.replyWithButtons(p, msg.ReplyCtx, sb.String(), buttons)
-			return
+			return true
 		}
 		e.replyWithCard(p, msg.ReplyCtx, e.renderModelCard(msg.SessionKey))
-		return
+		return true
 	}
 
 	targetInput, ok := parseModelSwitchArgs(args)
 	if !ok {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgModelUsage))
-		return
+		return true
 	}
 
 	target := strings.TrimSpace(targetInput)
@@ -9553,7 +9558,7 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 	target, err = e.switchModelOnAgent(agent, target, agent == e.agent)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChangeFailed, err))
-		return
+		return true
 	}
 	e.persistWorkspaceModelOverride(interactiveKey, msg.SessionKey, agent, target)
 	e.cleanupInteractiveState(interactiveKey)
@@ -9564,6 +9569,7 @@ func (e *Engine) cmdModel(p Platform, msg *Message, args []string) {
 	sessions.Save()
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgModelChanged, target))
+	return true
 }
 
 // resolveModelAlias resolves a user-supplied string to a model name.

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -52,6 +52,15 @@ func (s *recordingAgentSession) RespondPermission(id string, res PermissionResul
 	return nil
 }
 
+type stubNamedAgent struct {
+	stubAgent
+	name string
+}
+
+func (a *stubNamedAgent) Name() string {
+	return a.name
+}
+
 type stubPlatformEngine struct {
 	n    string
 	sent []string
@@ -2567,6 +2576,40 @@ func TestEngine_DisabledCommandsWildcard(t *testing.T) {
 	}
 	if !strings.Contains(p.sent[0], "disabled") && !strings.Contains(p.sent[0], "禁用") {
 		t.Errorf("expected disabled message, got: %s", p.sent[0])
+	}
+}
+
+func TestHandleCommand_ModelPassesThroughForACPAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubNamedAgent{name: "acp"}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:u1", UserID: "user1", ReplyCtx: "ctx"}
+
+	handled := e.handleCommand(p, msg, "/model")
+
+	if handled {
+		t.Fatal("expected /model on ACP agent to fall through to the agent")
+	}
+	if got := p.getSent(); len(got) != 0 {
+		t.Fatalf("expected no cc-connect reply before fallthrough, got %#v", got)
+	}
+}
+
+func TestHandleCommand_ModelUnsupportedForNonACPAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:u1", UserID: "user1", ReplyCtx: "ctx"}
+
+	handled := e.handleCommand(p, msg, "/model")
+
+	if !handled {
+		t.Fatal("expected /model on non-ACP agent to be handled by cc-connect")
+	}
+	got := p.getSent()
+	if len(got) != 1 {
+		t.Fatalf("expected one unsupported-model reply, got %#v", got)
+	}
+	if !strings.Contains(got[0], "does not support model switching") {
+		t.Fatalf("expected unsupported-model reply, got %q", got[0])
 	}
 }
 


### PR DESCRIPTION
## Depends on #1617

This is **stacked on top of #1617** (Trae CLI model switching). The first commit in this PR is #1617's commit; please review/merge #1617 first. Once #1617 lands, this branch rebases down to a single commit (the reasoning-effort change below). The net new diff here is `agent/acp/agent.go` + `agent/acp/agent_test.go` only.

## Problem

`ReasoningEffortSwitcher` (the `/model`-style reasoning-effort chooser) is already implemented for Codex and the `pi` agent, but the ACP agent did not expose it, so Trae CLI users could pick a model but not its reasoning effort.

## Changes

Trae CLI reads its reasoning effort from `model_reasoning_effort` in `traecli.toml` and accepts an override via `-c model_reasoning_effort=...` before `acp serve` — the same mechanism the model override already uses. This wires that into the ACP agent:

- add a `reasoning_effort` project option, parsed and normalized in `New`
- expose it in the `WorkspaceAgentOptions` snapshot
- prepend `-c model_reasoning_effort=%q` in `StartSession` when set
- implement `ReasoningEffortSwitcher` on `TraeAgent` only (`low` / `medium` / `high` / `xhigh`), with alias normalization and a fallback to the agent default on unknown input

Generic ACP agents are unaffected — the interface is exposed only by `TraeAgent`.

## Tests

- `TestNew_TraeCLIImplementsReasoningEffortSwitcher` — Trae agent implements the interface, exposes the four efforts, normalizes aliases (`x-high` → `xhigh`), and falls back to `""` on unknown input; snapshot round-trips.
- `TestNew_GenericACPDoesNotImplementReasoningEffortSwitcher` — a non-Trae ACP command does not implement the interface.

`go vet` and `go build -tags no_web ./...` pass.
