### PR TITLE
feat(core): attach existing agent sessions via local API

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -91,6 +91,7 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 	}
 	s.mux.HandleFunc("/send", s.handleSend)
 	s.mux.HandleFunc("/sessions", s.handleSessions)
+	s.mux.HandleFunc("/sessions/bind-agent", s.handleBindAgentSession)
 	s.mux.HandleFunc("/cron/add", s.handleCronAdd)
 	s.mux.HandleFunc("/cron/list", s.handleCronList)
 	s.mux.HandleFunc("/cron/info", s.handleCronInfo)
@@ -309,6 +310,152 @@ func (s *APIServer) handleSessions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	apiJSON(w, http.StatusOK, result)
+}
+
+// ── Local session attach API ────────────────────────────────────
+
+// BindAgentSessionRequest maps a platform conversation to a native session
+// that was created outside cc-connect (for example by a local IDE or CLI).
+// The endpoint is intentionally exposed only by the owner-only Unix socket.
+type BindAgentSessionRequest struct {
+	Project     string `json:"project"`
+	SessionKey  string `json:"session_key"`
+	SessionID   string `json:"session_id"`
+	SessionName string `json:"session_name,omitempty"`
+	WorkDir     string `json:"work_dir,omitempty"`
+}
+
+func (s *APIServer) resolveBindAgentEngine(project string) (*Engine, int, string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if project != "" {
+		if engine, ok := s.engines[project]; ok {
+			return engine, 0, ""
+		}
+		return nil, http.StatusNotFound, fmt.Sprintf("project %q not found", project)
+	}
+	if len(s.engines) == 0 {
+		return nil, http.StatusServiceUnavailable, "no projects configured"
+	}
+	if len(s.engines) > 1 {
+		return nil, http.StatusBadRequest, "project is required (multiple projects configured)"
+	}
+	for _, engine := range s.engines {
+		return engine, 0, ""
+	}
+	return nil, http.StatusServiceUnavailable, "no projects configured"
+}
+
+type bindAgentTarget struct {
+	agent             Agent
+	sessions          *SessionManager
+	bindingChannelKey string
+	bindingWorkDir    string
+}
+
+type bindAgentError struct {
+	status  int
+	message string
+}
+
+func resolveBindAgentTarget(engine *Engine, req BindAgentSessionRequest) (bindAgentTarget, *bindAgentError) {
+	if req.WorkDir == "" {
+		return bindAgentTarget{agent: engine.agent, sessions: engine.sessions}, nil
+	}
+	if !engine.multiWorkspace || engine.workspaceBindings == nil {
+		return bindAgentTarget{}, &bindAgentError{http.StatusConflict, "work_dir requires a multi-workspace project"}
+	}
+
+	resolved, err := resolveLocalDirPath(req.WorkDir, engine.baseDir)
+	if err != nil {
+		return bindAgentTarget{}, &bindAgentError{http.StatusUnprocessableEntity, "invalid work_dir: " + err.Error()}
+	}
+	base, err := filepath.Abs(engine.baseDir)
+	if err != nil {
+		return bindAgentTarget{}, &bindAgentError{http.StatusInternalServerError, "invalid project base_dir"}
+	}
+	if evaluated, evalErr := filepath.EvalSymlinks(base); evalErr == nil {
+		base = evaluated
+	}
+	rel, err := filepath.Rel(base, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return bindAgentTarget{}, &bindAgentError{http.StatusUnprocessableEntity, "work_dir is outside project base_dir"}
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return bindAgentTarget{}, &bindAgentError{http.StatusUnprocessableEntity, "work_dir does not exist or is not a directory"}
+	}
+
+	channelKey := extractWorkspaceChannelKey(req.SessionKey)
+	if channelKey == "" {
+		return bindAgentTarget{}, &bindAgentError{http.StatusBadRequest, "cannot derive workspace channel from session_key"}
+	}
+	agent, sessions, err := engine.getOrCreateWorkspaceAgent(resolved)
+	if err != nil {
+		return bindAgentTarget{}, &bindAgentError{http.StatusInternalServerError, "create workspace agent: " + err.Error()}
+	}
+	return bindAgentTarget{
+		agent:             agent,
+		sessions:          sessions,
+		bindingChannelKey: channelKey,
+		bindingWorkDir:    resolved,
+	}, nil
+}
+
+func (s *APIServer) handleBindAgentSession(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req BindAgentSessionRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	req.Project = strings.TrimSpace(req.Project)
+	req.SessionKey = strings.TrimSpace(req.SessionKey)
+	req.SessionID = strings.TrimSpace(req.SessionID)
+	req.SessionName = strings.TrimSpace(req.SessionName)
+	req.WorkDir = strings.TrimSpace(req.WorkDir)
+	if req.SessionKey == "" || req.SessionID == "" {
+		http.Error(w, "session_key and session_id are required", http.StatusBadRequest)
+		return
+	}
+
+	engine, status, message := s.resolveBindAgentEngine(req.Project)
+	if engine == nil {
+		http.Error(w, message, status)
+		return
+	}
+
+	name := req.SessionName
+	if name == "" {
+		name = req.SessionID
+	}
+	target, targetErr := resolveBindAgentTarget(engine, req)
+	if targetErr != nil {
+		http.Error(w, targetErr.message, targetErr.status)
+		return
+	}
+
+	if validator, supported := target.agent.(SessionIDValidator); supported && !validator.ValidateSessionID(r.Context(), req.SessionID) {
+		http.Error(w, "agent session not found in the configured project", http.StatusUnprocessableEntity)
+		return
+	}
+	if target.bindingChannelKey != "" {
+		engine.workspaceBindings.Bind("project:"+engine.name, target.bindingChannelKey, name, target.bindingWorkDir)
+	}
+	session := target.sessions.SwitchToAgentSession(req.SessionKey, req.SessionID, target.agent.Name(), name)
+
+	apiJSON(w, http.StatusOK, map[string]string{
+		"status":           "ok",
+		"session_key":      req.SessionKey,
+		"agent_session_id": req.SessionID,
+		"session_id":       session.ID,
+	})
 }
 
 // ── Cron API ───────────────────────────────────────────────────

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -150,6 +151,158 @@ func TestHandleSend_EmptyProjectFallsBackToSingleEngine(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleBindAgentSession_AttachesExistingNativeSession(t *testing.T) {
+	engine := NewEngine("projectA", &stubAgent{}, nil, "", LangEnglish)
+	api := &APIServer{engines: map[string]*Engine{"projectA": engine}}
+	body, err := json.Marshal(BindAgentSessionRequest{
+		Project:     "projectA",
+		SessionKey:  "test:channel:user",
+		SessionID:   "native-session-id",
+		SessionName: "local session",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sessions/bind-agent", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleBindAgentSession(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	session := engine.sessions.GetOrCreateActive("test:channel:user")
+	if got := session.GetAgentSessionID(); got != "native-session-id" {
+		t.Fatalf("agent session id = %q, want native-session-id", got)
+	}
+	if got := session.GetName(); got != "local session" {
+		t.Fatalf("session name = %q, want local session", got)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/sessions/bind-agent", bytes.NewReader(body))
+	secondRec := httptest.NewRecorder()
+	api.handleBindAgentSession(secondRec, secondReq)
+	if secondRec.Code != http.StatusOK {
+		t.Fatalf("repeated attach status = %d, want 200; body=%s", secondRec.Code, secondRec.Body.String())
+	}
+	if got := engine.sessions.ListSessions("test:channel:user"); len(got) != 1 {
+		t.Fatalf("repeated attach created %d sessions, want 1", len(got))
+	}
+}
+
+func TestHandleBindAgentSession_RejectsInvalidNativeSession(t *testing.T) {
+	agent := &validatingAgent{
+		controllableAgent: controllableAgent{},
+		validateFunc: func(_ context.Context, _ string) bool {
+			return false
+		},
+	}
+	engine := NewEngine("projectA", agent, nil, "", LangEnglish)
+	api := &APIServer{engines: map[string]*Engine{"projectA": engine}}
+	body, err := json.Marshal(BindAgentSessionRequest{
+		Project: "projectA", SessionKey: "test:channel:user", SessionID: "foreign-session",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sessions/bind-agent", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleBindAgentSession(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := engine.sessions.ListSessions("test:channel:user"); len(got) != 0 {
+		t.Fatalf("rejected attach mutated sessions: %#v", got)
+	}
+}
+
+func TestHandleBindAgentSession_BindsMultiWorkspace(t *testing.T) {
+	baseDir := t.TempDir()
+	workDir := filepath.Join(baseDir, "repo")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	engine := newTestEngineWithMultiWorkspaceAgent(t, baseDir)
+	engine.sessions = NewSessionManager(filepath.Join(t.TempDir(), "sessions.json"))
+	api := &APIServer{engines: map[string]*Engine{"test": engine}}
+	body, err := json.Marshal(BindAgentSessionRequest{
+		Project:     "test",
+		SessionKey:  "test:channel:user",
+		SessionID:   "native-session-id",
+		SessionName: "local session",
+		WorkDir:     workDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sessions/bind-agent", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleBindAgentSession(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	binding := engine.workspaceBindings.Lookup("project:test", "test:channel")
+	if binding == nil || binding.Workspace != normalizeWorkspacePath(workDir) {
+		t.Fatalf("workspace binding = %#v, want %q", binding, normalizeWorkspacePath(workDir))
+	}
+	_, sessions, err := engine.getOrCreateWorkspaceAgent(normalizeWorkspacePath(workDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sessions.GetOrCreateActive("test:channel:user").GetAgentSessionID(); got != "native-session-id" {
+		t.Fatalf("workspace agent session id = %q, want native-session-id", got)
+	}
+}
+
+func TestHandleBindAgentSession_RejectsWorkspaceOutsideBaseDir(t *testing.T) {
+	baseDir := t.TempDir()
+	outsideDir := t.TempDir()
+	engine := newTestEngineWithMultiWorkspaceAgent(t, baseDir)
+	api := &APIServer{engines: map[string]*Engine{"test": engine}}
+	body, err := json.Marshal(BindAgentSessionRequest{
+		Project: "test", SessionKey: "test:channel:user",
+		SessionID: "native-session-id", WorkDir: outsideDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sessions/bind-agent", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleBindAgentSession(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if binding := engine.workspaceBindings.Lookup("project:test", "test:channel"); binding != nil {
+		t.Fatalf("rejected attach created workspace binding: %#v", binding)
+	}
+}
+
+func TestHandleBindAgentSession_WorkDirRequiresMultiWorkspace(t *testing.T) {
+	engine := NewEngine("projectA", &stubAgent{}, nil, "", LangEnglish)
+	api := &APIServer{engines: map[string]*Engine{"projectA": engine}}
+	body, err := json.Marshal(BindAgentSessionRequest{
+		Project: "projectA", SessionKey: "test:channel:user",
+		SessionID: "native-session-id", WorkDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/sessions/bind-agent", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleBindAgentSession(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -991,6 +991,40 @@ type = "claudecode"
 
 ---
 
+## Attach an Existing Agent Session
+
+Local tools can bind a platform conversation to an Agent session that was
+created outside cc-connect, such as a Codex or Claude Code session started by
+an IDE. The API is available only on cc-connect's owner-only Unix socket:
+
+```bash
+curl --unix-socket ~/.cc-connect/run/api.sock \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "project": "my-project",
+    "session_key": "feishu:chat-id:user-id",
+    "session_id": "native-agent-session-id",
+    "session_name": "IDE session",
+    "work_dir": "/absolute/path/to/workspace"
+  }' \
+  http://unix/sessions/bind-agent
+```
+
+`project`, `session_key`, and `session_id` identify the cc-connect engine,
+platform conversation, and native Agent session. `project` may be omitted when
+exactly one engine is configured. `session_name` is optional.
+
+`work_dir` is optional and is accepted only for a `multi-workspace` project.
+It must be an existing directory inside that project's `base_dir`; a successful
+request also persists the conversation-to-workspace binding. If the Agent
+implements native session validation, cc-connect rejects IDs that do not
+belong to the selected project before changing the binding.
+
+Do not proxy this endpoint to TCP. The trust boundary is the mode-`0600` Unix
+socket, so any process that can connect to it can change active session routing.
+
+---
+
 ## Web Admin Dashboard (Beta)
 
 > **Status: Beta.** This feature is available since v1.2.2-beta.5. The UI and API may change in future releases.

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -904,6 +904,39 @@ type = "claudecode"
 
 ---
 
+## 绑定已有 Agent 会话
+
+本地工具可以把平台会话绑定到 cc-connect 之外创建的 Agent 会话，
+例如由 IDE 启动的 Codex 或 Claude Code 会话。该 API 仅通过 cc-connect
+的 owner-only Unix Socket 提供：
+
+```bash
+curl --unix-socket ~/.cc-connect/run/api.sock \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "project": "my-project",
+    "session_key": "feishu:chat-id:user-id",
+    "session_id": "native-agent-session-id",
+    "session_name": "IDE session",
+    "work_dir": "/absolute/path/to/workspace"
+  }' \
+  http://unix/sessions/bind-agent
+```
+
+`project`、`session_key` 和 `session_id` 分别标识 cc-connect engine、
+平台会话和 Agent 原生会话。仅配置一个 engine 时可以省略 `project`；
+`session_name` 为可选字段。
+
+`work_dir` 为可选字段，仅适用于 `multi-workspace` 项目。目录必须已存在
+且位于项目 `base_dir` 内；请求成功后还会持久化会话到工作区的绑定。
+如果 Agent 实现了原生会话校验，cc-connect 会在修改绑定前拒绝不属于
+所选项目的 session ID。
+
+不要将该端点反向代理到 TCP。它的信任边界是权限为 `0600` 的 Unix Socket；
+任何能连接该 Socket 的进程都可以修改活跃会话路由。
+
+---
+
 ## Web 管理后台（Beta）
 
 > **状态：Beta。** 此功能自 v1.2.2-beta.5 起可用，UI 和 API 在后续版本中可能调整。


### PR DESCRIPTION
## Motivation

cc-connect currently learns a native Agent session ID after a platform message starts the Agent. Local-first tools have the opposite ordering: an IDE or CLI has already created the Codex/Claude Code session, and a platform conversation needs to resume that exact session.

`SessionManager.SwitchToAgentSession` already provides the core mapping behavior, but it is not exposed to local integrations. This PR adds the smallest local-only API surface around that existing capability.

Addresses #1550. Related to the local socket/API direction discussed in #1542, while deliberately excluding message injection, response streaming, and queue semantics from this PR.

## What changed

- Add `POST /sessions/bind-agent` to the existing owner-only Unix socket API.
- Accept `project`, `session_key`, `session_id`, optional `session_name`, and optional `work_dir`.
- Use the existing `SessionIDValidator` capability before mutating a binding when an Agent supports validation.
- Make repeated requests idempotent through the existing `SwitchToAgentSession` behavior.
- Support `multi-workspace` projects by validating `work_dir` is an existing directory inside `base_dir`, persisting the conversation-to-workspace binding, and selecting that workspace session manager.
- Preserve the existing single-engine fallback, while refusing ambiguous or unknown projects.
- Document the endpoint and its security boundary in English and Chinese.

The implementation is platform- and Agent-agnostic: core contains no Feishu, Codex, or Claude-specific routing.

## Security

This endpoint is registered only on the existing Unix socket API. The socket is created with mode `0600`; the docs explicitly warn against proxying this route to TCP. Invalid native session IDs are rejected before binding mutation when the selected Agent implements `SessionIDValidator`, and multi-workspace paths are contained beneath the configured `base_dir` after symlink resolution.

## Compatibility

Existing configurations and platform-first session creation are unchanged. `work_dir` is optional and returns `409` unless the selected project uses `multi-workspace`. Agents without `SessionIDValidator` retain the same trust behavior they already use when resuming persisted IDs.

## Validation

- `GOMAXPROCS=1 go test -p 1 -tags no_web ./...`
- `go test -race ./core -run TestHandleBindAgentSession -count=1`
- `GOMAXPROCS=1 go test ./core -run "TestHandleBindAgentSession|TestCUJ" -count=1`
- `go vet ./core`
- `go build -tags no_web ./cmd/cc-connect`
- `git diff --check`

New tests cover successful and repeated attachment, optional native ID rejection without mutation, multi-workspace persistence, base directory containment, and the non-multi-workspace conflict path.