### PR TITLE
fix(codex): persist session ID on thread start

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -381,6 +381,12 @@ func (cs *codexSession) handleEvent(raw map[string]any) {
 			cs.contextUsage = nil
 			cs.contextMu.Unlock()
 			slog.Debug("codexSession: thread started", "thread_id", tid)
+			// 立即通知 Engine 持久化新会话 ID，避免首轮尚未完成时重启导致无法恢复。
+			select {
+			case cs.events <- core.Event{Type: core.EventText, SessionID: tid}:
+			case <-cs.ctx.Done():
+				return
+			}
 		}
 
 	case "turn.started":

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -437,6 +437,36 @@ func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 	}
 }
 
+// TestCodexSession_ThreadStartedEmitsSessionID 验证首轮启动时立即上报会话 ID，
+// 使 Engine 可以在 turn.completed 之前持久化绑定关系。
+func TestCodexSession_ThreadStartedEmitsSessionID(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "codex", nil, t.TempDir(), "", "", "", "", "", nil, "", "", "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	cs.handleEvent(map[string]any{
+		"type":      "thread.started",
+		"thread_id": "thread-before-turn-completed",
+	})
+
+	select {
+	case event := <-cs.Events():
+		if event.Type != core.EventText {
+			t.Fatalf("event type = %q, want %q", event.Type, core.EventText)
+		}
+		if event.SessionID != "thread-before-turn-completed" {
+			t.Fatalf("event session ID = %q, want thread-before-turn-completed", event.SessionID)
+		}
+		if event.Content != "" {
+			t.Fatalf("event content = %q, want empty", event.Content)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("thread.started did not emit session ID event")
+	}
+}
+
 func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
 	workDir := t.TempDir()
 	binDir := filepath.Join(workDir, "bin")
@@ -877,6 +907,14 @@ func TestClose_ForceKillsProcessGroupAfterGracefulTimeout(t *testing.T) {
 	}
 
 	waitForThreadID(t, cs, "thread-close")
+	select {
+	case event := <-cs.Events():
+		if event.Type != core.EventText || event.SessionID != "thread-close" {
+			t.Fatalf("startup event = %#v, want session ID event for thread-close", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for startup session ID event")
+	}
 
 	closeStarted := time.Now()
 	if err := cs.Close(); err != nil {


### PR DESCRIPTION
## Background

A fresh Codex CLI session exposes its thread ID in `thread.started`. Previously the adapter retained that ID only in memory and did not emit it until `turn.completed`. If cc-connect restarted during the first turn, the session binding was never persisted, so the next user message started a new Codex conversation instead of resuming the existing rollout.

## Changes

- Emit an empty `EventText` carrying the session ID as soon as Codex emits `thread.started`, allowing the Engine to persist the binding immediately.
- Add a regression test proving the session ID event arrives before `turn.completed`.
- Update the close lifecycle test to consume the expected startup session-ID event before asserting that shutdown suppresses delayed child output.

## Validation

- `go test -race ./agent/codex -count=1`
- `go build ./...`
- `go vet ./agent/codex`
- `golangci-lint run --new-from-rev upstream/main ./...`
- `go test ./...` was run; only pre-existing local macOS environment failures remain: `TestCUJ_A5_FileReachesAgent` temporary-directory cleanup and `TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable` without a launchd GUI domain.