### PR TITLE
fix(dingtalk): forward inline images in richText messages

### DIFF
--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -239,16 +239,17 @@ func (p *Platform) onRawMessage(rawJSON string) {
 	// Parse the full "text" object from raw JSON to recover isReplyMsg/repliedMsg.
 	// The SDK's BotCallbackDataTextModel only has Content string, losing these fields.
 	var envelope struct {
-		Text richTextContent `json:"text"`
+		Text      richTextContent `json:"text"`
+		RobotCode string          `json:"robotCode"`
 	}
 	if err := json.Unmarshal([]byte(rawJSON), &envelope); err != nil {
 		slog.Warn("dingtalk: failed to parse rich text content", "error", err)
 	}
 
-	p.onMessage(&data, &envelope.Text)
+	p.onMessage(&data, &envelope.Text, envelope.RobotCode)
 }
 
-func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richTextContent) {
+func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richTextContent, callbackRobotCode string) {
 	slog.Debug("dingtalk: message received", "user", data.SenderNick, "msgtype", data.Msgtype)
 
 	if p.dedup.IsDuplicate(data.MsgId) {
@@ -288,11 +289,24 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 		return
 	}
 
-	// Handle richText messages — extract plain text from rich content
+	// Handle richText messages, including images embedded alongside text.
 	if data.Msgtype == "richText" {
-		text := extractRichText(data.Content)
-		if text == "" {
-			slog.Debug("dingtalk: richText message with no extractable text", "msg_id", data.MsgId)
+		text, pictureDownloads := extractRichText(data.Content)
+		images := make([]core.ImageAttachment, 0, len(pictureDownloads))
+		for _, picture := range pictureDownloads {
+			img, err := p.downloadImage(picture.DownloadCode, callbackRobotCode)
+			if err != nil && picture.FallbackCode != "" {
+				slog.Warn("dingtalk: retrying richText image with legacy download code", "error", err, "msg_id", data.MsgId)
+				img, err = p.downloadImage(picture.FallbackCode, callbackRobotCode)
+			}
+			if err != nil {
+				slog.Error("dingtalk: failed to download richText image", "error", err, "msg_id", data.MsgId)
+				continue
+			}
+			images = append(images, img)
+		}
+		if text == "" && len(images) == 0 {
+			slog.Debug("dingtalk: richText message with no extractable content", "msg_id", data.MsgId)
 			return
 		}
 		msg := &core.Message{
@@ -303,6 +317,7 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 			ChatName:   data.ConversationTitle,
 			Content:    text,
 			MessageID:  data.MsgId,
+			ChannelKey: data.ConversationId,
 			ReplyCtx: replyContext{
 				sessionWebhook: data.SessionWebhook,
 				conversationId: data.ConversationId,
@@ -310,6 +325,7 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 				messageID:      data.MsgId,
 				isGroup:        data.ConversationType == "2",
 			},
+			Images: images,
 		}
 		p.handler(p, msg)
 		return
@@ -377,19 +393,26 @@ func (p *Platform) replyUnauthorized(data *chatbot.BotCallbackDataModel) {
 	}
 }
 
-// extractRichText extracts plain text from a DingTalk richText content payload.
+type richTextImageDownload struct {
+	DownloadCode string
+	FallbackCode string
+}
+
+// extractRichText extracts plain text and embedded image download codes from a
+// DingTalk richText content payload. New callbacks use downloadCode with the
+// v1.0 API; pictureDownloadCode is retained as a legacy fallback.
 // The expected structure is: {"richText": [{"text": "..."}, {"text": "...", "attrs": {...}}, ...]}
-// Non-text elements (e.g. pictureDownloadCode) are skipped.
-func extractRichText(content interface{}) string {
+func extractRichText(content interface{}) (string, []richTextImageDownload) {
 	m, ok := content.(map[string]interface{})
 	if !ok {
-		return ""
+		return "", nil
 	}
 	parts, ok := m["richText"].([]interface{})
 	if !ok {
-		return ""
+		return "", nil
 	}
 	var b strings.Builder
+	var pictureDownloads []richTextImageDownload
 	for _, part := range parts {
 		item, ok := part.(map[string]interface{})
 		if !ok {
@@ -398,8 +421,23 @@ func extractRichText(content interface{}) string {
 		if text, ok := item["text"].(string); ok {
 			b.WriteString(text)
 		}
+		downloadCode, _ := item["downloadCode"].(string)
+		fallbackCode, _ := item["pictureDownloadCode"].(string)
+		downloadCode = strings.TrimSpace(downloadCode)
+		fallbackCode = strings.TrimSpace(fallbackCode)
+		if downloadCode == "" {
+			downloadCode, fallbackCode = fallbackCode, ""
+		} else if fallbackCode == downloadCode {
+			fallbackCode = ""
+		}
+		if downloadCode != "" {
+			pictureDownloads = append(pictureDownloads, richTextImageDownload{
+				DownloadCode: downloadCode,
+				FallbackCode: fallbackCode,
+			})
+		}
 	}
-	return strings.TrimSpace(b.String())
+	return strings.TrimSpace(b.String()), pictureDownloads
 }
 
 func (p *Platform) handleAudioMessage(data *chatbot.BotCallbackDataModel, sessionKey string) {
@@ -493,42 +531,11 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 		return
 	}
 
-	// Download image file using the same messageFiles/download API as audio
-	downloadURL, err := p.getDownloadURL(downloadCode)
-	if err != nil {
-		slog.Error("dingtalk: failed to get image download URL", "error", err)
-		return
-	}
-
-	resp, err := p.httpClient.Get(downloadURL)
+	img, err := p.downloadImage(downloadCode)
 	if err != nil {
 		slog.Error("dingtalk: failed to download image", "error", err)
 		return
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		slog.Error("dingtalk: image download returned status", "status", resp.StatusCode)
-		return
-	}
-
-	const maxImageBytes = 25 * 1024 * 1024 // 25 MiB, same cap as other platforms
-	imgBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxImageBytes+1))
-	if err != nil {
-		slog.Error("dingtalk: failed to read image data", "error", err)
-		return
-	}
-	if len(imgBytes) > maxImageBytes {
-		slog.Error("dingtalk: image too large, dropping", "size", len(imgBytes), "limit", maxImageBytes)
-		return
-	}
-
-	mimeType := resp.Header.Get("Content-Type")
-	if mimeType == "" {
-		mimeType = "image/png"
-	}
-
-	slog.Info("dingtalk: image downloaded successfully", "size", len(imgBytes), "mime", mimeType)
 
 	msg := &core.Message{
 		SessionKey: sessionKey,
@@ -543,13 +550,45 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 			messageID:      data.MsgId,
 			isGroup:        data.ConversationType == "2",
 		},
-		Images: []core.ImageAttachment{{
-			MimeType: mimeType,
-			Data:     imgBytes,
-		}},
+		Images: []core.ImageAttachment{img},
 	}
 
 	p.handler(p, msg)
+}
+
+func (p *Platform) downloadImage(downloadCode string, robotCodes ...string) (core.ImageAttachment, error) {
+	// Download image file using the same messageFiles/download API as audio.
+	downloadURL, err := p.getDownloadURL(downloadCode, robotCodes...)
+	if err != nil {
+		return core.ImageAttachment{}, fmt.Errorf("get download URL: %w", err)
+	}
+
+	resp, err := p.httpClient.Get(downloadURL)
+	if err != nil {
+		return core.ImageAttachment{}, fmt.Errorf("http get: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return core.ImageAttachment{}, fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	const maxImageBytes = 25 * 1024 * 1024 // 25 MiB, same cap as other platforms
+	imgBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxImageBytes+1))
+	if err != nil {
+		return core.ImageAttachment{}, fmt.Errorf("read image data: %w", err)
+	}
+	if len(imgBytes) > maxImageBytes {
+		return core.ImageAttachment{}, fmt.Errorf("image too large: size %d exceeds limit %d", len(imgBytes), maxImageBytes)
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+
+	slog.Info("dingtalk: image downloaded successfully", "size", len(imgBytes), "mime", mimeType)
+	return core.ImageAttachment{MimeType: mimeType, Data: imgBytes}, nil
 }
 
 // handleFileMessage downloads a file attachment (msgtype=file) and dispatches
@@ -636,9 +675,9 @@ func (p *Platform) handleFileMessage(data *chatbot.BotCallbackDataModel, session
 	p.handler(p, msg)
 }
 
-func (p *Platform) downloadAudio(downloadCode string) ([]byte, string, error) {
+func (p *Platform) downloadAudio(downloadCode string, robotCodes ...string) ([]byte, string, error) {
 	// Get download URL
-	downloadURL, err := p.getDownloadURL(downloadCode)
+	downloadURL, err := p.getDownloadURL(downloadCode, robotCodes...)
 	if err != nil {
 		return nil, "", fmt.Errorf("get download URL: %w", err)
 	}
@@ -668,15 +707,19 @@ func (p *Platform) downloadAudio(downloadCode string) ([]byte, string, error) {
 	return data, mimeType, nil
 }
 
-func (p *Platform) getDownloadURL(downloadCode string) (string, error) {
+func (p *Platform) getDownloadURL(downloadCode string, robotCodes ...string) (string, error) {
 	token, err := p.getAccessToken()
 	if err != nil {
 		return "", fmt.Errorf("get access token: %w", err)
 	}
 
+	robotCode := p.robotCode
+	if len(robotCodes) > 0 && strings.TrimSpace(robotCodes[0]) != "" {
+		robotCode = strings.TrimSpace(robotCodes[0])
+	}
 	reqBody := map[string]string{
 		"downloadCode": downloadCode,
-		"robotCode":    p.robotCode,
+		"robotCode":    robotCode,
 	}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
@@ -702,6 +745,10 @@ func (p *Platform) getDownloadURL(downloadCode string) (string, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
+		errorBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if detail := strings.TrimSpace(string(errorBody)); detail != "" {
+			return "", fmt.Errorf("api returned status %d: %s", resp.StatusCode, detail)
+		}
 		return "", fmt.Errorf("api returned status %d", resp.StatusCode)
 	}
 

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -688,9 +689,10 @@ func TestProactiveRouting_DirectSessionUsesDirectAPI(t *testing.T) {
 
 func TestExtractRichText(t *testing.T) {
 	tests := []struct {
-		name    string
-		content interface{}
-		want    string
+		name         string
+		content      interface{}
+		want         string
+		wantPictures []richTextImageDownload
 	}{
 		{
 			name:    "nil content",
@@ -739,15 +741,16 @@ func TestExtractRichText(t *testing.T) {
 			want: "normal bold",
 		},
 		{
-			name: "mixed text and picture elements — pictures skipped",
+			name: "mixed text and picture elements",
 			content: map[string]interface{}{
 				"richText": []interface{}{
 					map[string]interface{}{"text": "See image: "},
-					map[string]interface{}{"pictureDownloadCode": "abc123"},
+					map[string]interface{}{"downloadCode": "v1-code", "pictureDownloadCode": "legacy-code"},
 					map[string]interface{}{"text": "done"},
 				},
 			},
-			want: "See image: done",
+			want:         "See image: done",
+			wantPictures: []richTextImageDownload{{DownloadCode: "v1-code", FallbackCode: "legacy-code"}},
 		},
 		{
 			name: "missing richText key",
@@ -760,9 +763,12 @@ func TestExtractRichText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractRichText(tt.content)
+			got, pictures := extractRichText(tt.content)
 			if got != tt.want {
 				t.Errorf("extractRichText() = %q, want %q", got, tt.want)
+			}
+			if !slices.Equal(pictures, tt.wantPictures) {
+				t.Errorf("extractRichText() picture codes = %v, want %v", pictures, tt.wantPictures)
 			}
 		})
 	}
@@ -936,6 +942,76 @@ func TestStartTypingAndDoneReaction(t *testing.T) {
 	}
 }
 
+func TestOnRawMessage_RichTextForwardsInlineImage(t *testing.T) {
+	const imageBody = "fake-richtext-image"
+
+	imageSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte(imageBody))
+	}))
+	defer imageSrv.Close()
+
+	rt := &dingtalkDownloadRT{
+		accessToken:      "tok-richtext-image",
+		downloadURL:      imageSrv.URL,
+		failDownloadCode: "dc-v1-image",
+	}
+
+	captured := make(chan *core.Message, 1)
+	p := &Platform{
+		clientID:     "cid",
+		clientSecret: "csec",
+		robotCode:    "robot-1",
+		httpClient:   &http.Client{Transport: rt},
+		handler: func(_ core.Platform, msg *core.Message) {
+			captured <- msg
+		},
+	}
+
+	p.onRawMessage(`{
+		"msgtype": "richText",
+		"msgId": "msg-richtext-image-1",
+		"conversationType": "1",
+		"conversationId": "conv-1",
+		"conversationTitle": "test",
+		"senderStaffId": "user-1",
+		"senderNick": "Alice",
+		"robotCode": "robot-from-callback",
+		"sessionWebhook": "https://example.invalid/webhook",
+		"content": {
+			"richText": [
+				{"text": "Please inspect "},
+				{"type": "picture", "downloadCode": "dc-v1-image", "pictureDownloadCode": "dc-legacy-image"},
+				{"text": "this screenshot"}
+			]
+		}
+	}`)
+
+	select {
+	case msg := <-captured:
+		if msg.Content != "Please inspect this screenshot" {
+			t.Fatalf("Content = %q, want rich text", msg.Content)
+		}
+		if len(msg.Images) != 1 {
+			t.Fatalf("Images len = %d, want 1", len(msg.Images))
+		}
+		if got := string(msg.Images[0].Data); got != imageBody {
+			t.Errorf("image bytes = %q, want %q", got, imageBody)
+		}
+		if msg.Images[0].MimeType != "image/png" {
+			t.Errorf("image MIME type = %q, want image/png", msg.Images[0].MimeType)
+		}
+		if rt.requestRobotCode != "robot-from-callback" {
+			t.Errorf("download robotCode = %q, want callback robotCode", rt.requestRobotCode)
+		}
+		if !slices.Equal(rt.requestDownloadCodes, []string{"dc-v1-image", "dc-legacy-image"}) {
+			t.Errorf("download codes = %v, want v1 code then legacy fallback", rt.requestDownloadCodes)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never invoked with richText image message")
+	}
+}
+
 func TestOnRawMessage_PictureMsgTypeNotDroppedAsEmptyText(t *testing.T) {
 	// Regression test for #1128: DingTalk sometimes sends msgtype="picture"
 	// for image messages. Before the fix, this fell through to the text handler,
@@ -1028,7 +1104,7 @@ func TestHandleFileMessage_BuildsFileAttachmentWithName(t *testing.T) {
 	}))
 	defer fileSrv.Close()
 
-	rt := &dingtalkFileDownloadRT{
+	rt := &dingtalkDownloadRT{
 		accessToken: "tok-files",
 		downloadURL: fileSrv.URL,
 	}
@@ -1076,16 +1152,18 @@ func TestHandleFileMessage_BuildsFileAttachmentWithName(t *testing.T) {
 	}
 }
 
-// dingtalkFileDownloadRT mocks /v1.0/oauth2/accessToken and
+// dingtalkDownloadRT mocks /v1.0/oauth2/accessToken and
 // /v1.0/robot/messageFiles/download. The latter returns downloadURL pointing
-// to a test server that serves the actual file body. Used by
-// TestHandleFileMessage_BuildsFileAttachmentWithName.
-type dingtalkFileDownloadRT struct {
-	accessToken string
-	downloadURL string
+// to a test server that serves the actual attachment body.
+type dingtalkDownloadRT struct {
+	accessToken          string
+	downloadURL          string
+	failDownloadCode     string
+	requestRobotCode     string
+	requestDownloadCodes []string
 }
 
-func (f *dingtalkFileDownloadRT) RoundTrip(req *http.Request) (*http.Response, error) {
+func (f *dingtalkDownloadRT) RoundTrip(req *http.Request) (*http.Response, error) {
 	switch req.URL.Path {
 	case "/v1.0/oauth2/accessToken":
 		body := fmt.Sprintf(`{"accessToken":%q,"expireIn":7200}`, f.accessToken)
@@ -1096,6 +1174,21 @@ func (f *dingtalkFileDownloadRT) RoundTrip(req *http.Request) (*http.Response, e
 			Request:    req,
 		}, nil
 	case "/v1.0/robot/messageFiles/download":
+		var requestBody struct {
+			RobotCode    string `json:"robotCode"`
+			DownloadCode string `json:"downloadCode"`
+		}
+		_ = json.NewDecoder(req.Body).Decode(&requestBody)
+		f.requestRobotCode = requestBody.RobotCode
+		f.requestDownloadCodes = append(f.requestDownloadCodes, requestBody.DownloadCode)
+		if requestBody.DownloadCode == f.failDownloadCode {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader(`{"code":"unknownError","message":"未知错误"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
 		body := fmt.Sprintf(`{"downloadUrl":%q}`, f.downloadURL)
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -1206,7 +1299,7 @@ func TestOnMessageRepliesToUnauthorizedSender(t *testing.T) {
 		ConversationType: "1",
 		SessionWebhook:   sessionWebhook.URL,
 		Text:             chatbot.BotCallbackDataTextModel{Content: "hello"},
-	}, nil)
+	}, nil, "")
 
 	select {
 	case got := <-gotReply:


### PR DESCRIPTION
## Summary

Forward images embedded in DingTalk richText callbacks together with their surrounding text instead of silently dropping them. The download flow prefers the v1.0 `downloadCode`, falls back to legacy `pictureDownloadCode`, uses the callback robot code when available, and includes bounded API error details for diagnostics.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

### Automated tests added in this PR

- `TestOnRawMessage_RichTextForwardsInlineImage` in `platform/dingtalk/dingtalk_test.go` — verifies text and image bytes are forwarded in one message, callback robotCode is used, and v1 downloadCode falls back to pictureDownloadCode after an API failure.
- `TestExtractRichText` in `platform/dingtalk/dingtalk_test.go` — verifies richText text extraction and ordered v1/legacy image download candidates.

### For bug fixes only — regression test

- Regression test name: `TestOnRawMessage_RichTextForwardsInlineImage`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally; the regression test failed as expected with zero forwarded images.

### Critical User Journeys (CUJ) impact

- [x] No CUJ touched (platform-specific DingTalk callback parsing and attachment download)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

## Manual / user-visible behavior change

A DingTalk message containing text plus an inline screenshot now reaches the agent with both the text and image. Verified against a live DingTalk Stream bot: the pre-fix service logged `has_images=false` and the agent reported no attachment; after deploying this branch the user confirmed the image is visible.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (no new user-facing strings)
- [x] No secrets / credentials in source

## Related

- Issue: N/A
- Related PR: N/A