### PR TITLE
fix(feishu): bootstrap context for first thread mention（修复机器人第一次进入话题，读不到话题内容的问题）

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -107,9 +107,10 @@ func init() {
 }
 
 type replyContext struct {
-	messageID  string
-	chatID     string
-	sessionKey string
+	messageID       string
+	chatID          string
+	sessionKey      string
+	bootstrapThread bool
 }
 
 type Platform struct {
@@ -1411,8 +1412,13 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	)
 
 	// Mark this thread as bot-engaged so subsequent attachment-only messages
-	// in the same thread can pass through without re-mentioning the bot.
-	p.markThreadSessionActive(sessionKey)
+	// in the same thread can pass through without re-mentioning the bot. When
+	// this is the first accepted message in an existing thread, remember that
+	// dispatch must bootstrap the agent context from the parent/root message.
+	rctx.bootstrapThread = p.markThreadSessionActive(sessionKey)
+	if rctx.bootstrapThread && parentID == "" {
+		parentID = stringValue(msg.RootId)
+	}
 
 	// Dispatch message handling asynchronously so the SDK event loop is not
 	// blocked by IO-heavy operations (image/audio download, handler HTTP calls).
@@ -1451,10 +1457,13 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	// If this message is a reply to another message, fetch the quoted content
 	// and prepend it so the agent has full context.
 	// Skip quote injection when thread_isolation is enabled and the message is
-	// inside a thread — the thread already provides conversational context, and
-	// long quoted prefixes can drown out the user's actual text (issue #764).
+	// inside an already-engaged thread — the thread provides conversational
+	// context, and long quoted prefixes can drown out the user's actual text
+	// (issue #764). The first accepted message in a pre-existing thread is the
+	// exception: earlier unmentioned messages were never dispatched to the
+	// agent, so bootstrap its context from the parent/root reply chain once.
 	var quoted quotedMessage
-	if parentID != "" && !(p.threadIsolation && isThreadSessionKey(sessionKey)) {
+	if parentID != "" && (!(p.threadIsolation && isThreadSessionKey(sessionKey)) || rctx.bootstrapThread) {
 		quoted = p.fetchQuotedMessage(ctx, parentID)
 	}
 
@@ -3330,12 +3339,17 @@ func isAttachmentMsgType(msgType string) bool {
 
 // markThreadSessionActive records that a thread sessionKey has been engaged
 // by an @bot message, enabling attachment-only follow-ups inside the thread.
-// No-op when thread isolation is disabled or sessionKey is not a thread key.
-func (p *Platform) markThreadSessionActive(sessionKey string) {
+// It reports whether this call activated the thread for the first time. It is
+// a no-op when thread isolation is disabled or sessionKey is not a thread key.
+func (p *Platform) markThreadSessionActive(sessionKey string) bool {
 	if !p.threadIsolation || !isThreadSessionKey(sessionKey) {
-		return
+		return false
 	}
-	p.activeThreadSessions.Store(sessionKey, time.Now())
+	_, loaded := p.activeThreadSessions.LoadOrStore(sessionKey, time.Now())
+	if loaded {
+		p.activeThreadSessions.Store(sessionKey, time.Now())
+	}
+	return !loaded
 }
 
 // isActiveThreadSession reports whether the given sessionKey corresponds to a

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1463,7 +1463,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	// exception: earlier unmentioned messages were never dispatched to the
 	// agent, so bootstrap its context from the parent/root reply chain once.
 	var quoted quotedMessage
-	if parentID != "" && (!(p.threadIsolation && isThreadSessionKey(sessionKey)) || rctx.bootstrapThread) {
+	if parentID != "" && (!p.threadIsolation || !isThreadSessionKey(sessionKey) || rctx.bootstrapThread) {
 		quoted = p.fetchQuotedMessage(ctx, parentID)
 	}
 

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -304,6 +304,131 @@ func TestDispatchMessageKeepsMentionOnlyQuotedText(t *testing.T) {
 	}
 }
 
+// TestOnMessageThreadIsolationBootstrapsExistingThreadContext covers the case
+// where a thread root was posted without mentioning the bot. The root is not
+// dispatched, so the first later @bot reply must fetch the parent/root once
+// instead of assuming the new thread session already contains that context.
+func TestOnMessageThreadIsolationBootstrapsExistingThreadContext(t *testing.T) {
+	const (
+		appID        = "cli_thread_bootstrap"
+		appSecret    = "secret-thread-bootstrap"
+		botOpenID    = "ou_bot"
+		userOpenID   = "ou_user"
+		chatID       = "oc_chat"
+		rootMsgID    = "om_root"
+		triggerMsgID = "om_trigger"
+	)
+
+	got := make(chan *core.Message, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages/"+rootMsgID:
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"items": []map[string]any{
+						{
+							"msg_type":  "post",
+							"parent_id": "",
+							"sender": map[string]any{
+								"id":          "ou_root_author",
+								"sender_type": "user",
+							},
+							"body": map[string]any{
+								"content": `{"title":"环境信息","content":[[{"tag":"text","text":"审核 PBS: yingshi_video_i2v_input-text-cn"}]]}`,
+							},
+						},
+					},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/contact/v3/users/"):
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/im/v1/chats/"):
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:    "feishu",
+		domain:          srv.URL,
+		appID:           appID,
+		appSecret:       appSecret,
+		botOpenID:       botOpenID,
+		threadIsolation: true,
+		dedup:           &core.MessageDedup{},
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			got <- msg
+		},
+	}
+
+	chatType := "group"
+	senderType := "user"
+	msgType := "text"
+	content := `{"text":"@_user_1 看看这个"}`
+	createTime := strconv.FormatInt(time.Now().Add(time.Second).UnixMilli(), 10)
+	threadID := "omt_thread"
+
+	err := p.onMessage(context.Background(), &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: strPtr(userOpenID)},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   strPtr(triggerMsgID),
+				RootId:      strPtr(rootMsgID),
+				ThreadId:    &threadID,
+				ChatId:      strPtr(chatID),
+				ChatType:    &chatType,
+				MessageType: &msgType,
+				Content:     &content,
+				CreateTime:  &createTime,
+				Mentions: []*larkim.MentionEvent{
+					{
+						Key:  strPtr("@_user_1"),
+						Id:   &larkim.UserId{OpenId: strPtr(botOpenID)},
+						Name: strPtr("Bot"),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onMessage() error = %v", err)
+	}
+
+	select {
+	case msg := <-got:
+		if msg.SessionKey != "feishu:"+chatID+":root:"+rootMsgID {
+			t.Fatalf("SessionKey = %q, want thread root session", msg.SessionKey)
+		}
+		if msg.Content != "看看这个" {
+			t.Fatalf("Content = %q, want trigger text", msg.Content)
+		}
+		if !strings.Contains(msg.ExtraContent, "审核 PBS: yingshi_video_i2v_input-text-cn") {
+			t.Fatalf("ExtraContent = %q, want existing thread root content", msg.ExtraContent)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for bootstrapped thread message")
+	}
+}
+
 func TestOnMessageRepliesToUnauthorizedMention(t *testing.T) {
 	const appID = "cli_unauthorized"
 	const appSecret = "secret-unauthorized"
@@ -1036,7 +1161,9 @@ func TestMarkAndIsActiveThreadSession(t *testing.T) {
 
 	t.Run("thread isolation disabled is no-op", func(t *testing.T) {
 		p := &Platform{threadIsolation: false}
-		p.markThreadSessionActive(threadKey)
+		if p.markThreadSessionActive(threadKey) {
+			t.Fatal("disabled thread isolation must not report activation")
+		}
 		if p.isActiveThreadSession(threadKey) {
 			t.Fatal("expected no-op when thread_isolation is off")
 		}
@@ -1044,7 +1171,9 @@ func TestMarkAndIsActiveThreadSession(t *testing.T) {
 
 	t.Run("non-thread sessionKey is ignored", func(t *testing.T) {
 		p := &Platform{threadIsolation: true}
-		p.markThreadSessionActive(directKey)
+		if p.markThreadSessionActive(directKey) {
+			t.Fatal("non-thread session must not report activation")
+		}
 		if p.isActiveThreadSession(directKey) {
 			t.Fatal("expected non-thread sessionKey to be ignored")
 		}
@@ -1055,9 +1184,14 @@ func TestMarkAndIsActiveThreadSession(t *testing.T) {
 		if p.isActiveThreadSession(threadKey) {
 			t.Fatal("thread should not be active before mark")
 		}
-		p.markThreadSessionActive(threadKey)
+		if !p.markThreadSessionActive(threadKey) {
+			t.Fatal("first mark should report activation")
+		}
 		if !p.isActiveThreadSession(threadKey) {
 			t.Fatal("thread should be active after mark")
+		}
+		if p.markThreadSessionActive(threadKey) {
+			t.Fatal("subsequent mark must not report a second activation")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fix Feishu thread bootstrap when `thread_isolation = true`.

If a thread root is posted without mentioning the bot, cc-connect does not dispatch that message. When the bot is mentioned later in the same thread, the isolated agent session therefore starts empty and sees only the trigger text (for example, “看看这个”). This change detects the first accepted message in an existing isolated thread and injects its parent/root reply context once.

Later messages preserve the quote-skip behavior introduced for #764, avoiding repeated context and oversized quoted prefixes. This change is intentionally narrower than full thread-history synchronization: it bootstraps the parent/root context once and does not fetch every sibling message or other bots' replies.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

- `go test ./...` — passed for the functional change before the lint-only follow-up.
- GitHub Actions `lint` — passes after simplifying the condition flagged by staticcheck QF1001.
- The lint follow-up only applies De Morgan's law to an existing condition; behavior is unchanged.

### Automated tests added in this PR

- `TestOnMessageThreadIsolationBootstrapsExistingThreadContext` in `platform/feishu/feishu_test.go`
  - creates a pre-existing Feishu thread whose root did not mention the bot;
  - sends the first later `@bot` trigger with `thread_isolation = true`;
  - verifies the session key is scoped to the thread root;
  - verifies the trigger text remains the user content;
  - verifies the existing thread-root content is injected into `ExtraContent`.
- `TestMarkAndIsActiveThreadSession` now verifies that only the first activation reports a bootstrap and subsequent activations do not.

### For bug fixes only — regression test

- Regression test name: `TestOnMessageThreadIsolationBootstrapsExistingThreadContext`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [x] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [x] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [x] If the change alters an existing user-visible flow, corresponding regression coverage was added.

## Manual / user-visible behavior change

Before:

1. A user posts the content or attachment that starts a Feishu topic without mentioning the bot.
2. Later, the user sends `@bot 看看这个` in that topic.
3. The bot receives only “看看这个” and asks the user to send the content again.

After:

1. The first accepted bot mention activates the isolated thread session.
2. cc-connect fetches and injects the parent/root message context once.
3. Subsequent messages reuse the agent session and continue to skip repeated quote injection.

`thread_isolation = true` remains enabled, so unrelated topics stay isolated.

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [x] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (no new user-facing strings)
- [x] No secrets / credentials in source

## Related

- Fixes #1453
- Related to #1610 and #764
- Similar prior approach: #525 (closed without merge)

Unlike #525, this implementation reuses the existing `activeThreadSessions` state and is narrowly scoped to bootstrapping the first accepted mention in an unengaged isolated thread; it does not introduce separate message-to-session or root-context maps.
