### PR TITLE
feat(cloud_web): support extra_headers on websocket transport

### DIFF
--- a/platform/cloud-web/cloudweb.go
+++ b/platform/cloud-web/cloudweb.go
@@ -102,7 +102,7 @@ func New(opts map[string]any) (core.Platform, error) {
 		if strings.TrimSpace(resolved) == "" {
 			return nil, fmt.Errorf("cloud_web: ws_url or base_url is required for websocket transport")
 		}
-		tp = newWSTransport(resolved, token, name, project)
+		tp = newWSTransport(resolved, token, name, project, pickStringMap(opts["extra_headers"]))
 	case "long_poll":
 		if strings.TrimSpace(baseURL) == "" {
 			return nil, fmt.Errorf("cloud_web: base_url is required for long_poll transport")
@@ -152,6 +152,25 @@ func pickInt(v any) int {
 		}
 	}
 	return 0
+}
+
+// pickStringMap converts a TOML inline table to map[string]string.
+// Used for extra_headers: [projects.platforms.options.extra_headers].
+func pickStringMap(v any) map[string]string {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, val := range m {
+		if s, ok := val.(string); ok {
+			out[k] = s
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (p *Platform) Name() string { return p.name }

--- a/platform/cloud-web/ws.go
+++ b/platform/cloud-web/ws.go
@@ -27,6 +27,12 @@ type wsTransport struct {
 	name    string
 	project string
 
+	// extraHeaders are injected into the WebSocket upgrade request, in
+	// addition to the standard Authorization/X-Cloud-Web-Token headers.
+	// Used for upstreams that require bespoke auth (e.g. IAP AK/SK via
+	// X-Brain-Authorization).
+	extraHeaders map[string]string
+
 	mu        sync.RWMutex
 	caps      map[string]bool
 	conn      *websocket.Conn
@@ -40,12 +46,13 @@ type wsTransport struct {
 	previewRequests map[string]chan string
 }
 
-func newWSTransport(wsURL, token, name, project string) *wsTransport {
+func newWSTransport(wsURL, token, name, project string, extraHeaders map[string]string) *wsTransport {
 	return &wsTransport{
 		wsURL:           wsURL,
 		token:           token,
 		name:            name,
 		project:         project,
+		extraHeaders:    extraHeaders,
 		caps:            defaultCapabilities(),
 		previewRequests: make(map[string]chan string),
 	}
@@ -130,6 +137,11 @@ func (t *wsTransport) connectOnce(ctx context.Context) error {
 	if t.token != "" {
 		header.Set("Authorization", "Bearer "+t.token)
 		header.Set("X-Cloud-Web-Token", t.token)
+	}
+	for k, v := range t.extraHeaders {
+		if v != "" {
+			header.Set(k, v)
+		}
 	}
 
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, u.String(), header)

--- a/platform/cloud-web/ws_test.go
+++ b/platform/cloud-web/ws_test.go
@@ -123,3 +123,67 @@ func TestAllowFromFilter(t *testing.T) {
 		t.Fatal("expected blocked user")
 	}
 }
+
+// TestExtraHeadersInjected verifies that extra_headers from the platform
+// options are injected into the WebSocket upgrade request, alongside the
+// standard Authorization/X-Cloud-Web-Token headers.
+func TestExtraHeadersInjected(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	var gotAuth, gotCloudWeb, gotCustom, gotEmpty string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotCloudWeb = r.Header.Get("X-Cloud-Web-Token")
+		gotCustom = r.Header.Get("X-Brain-Authorization")
+		gotEmpty = r.Header.Get("X-Empty")
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _, _ = conn.ReadMessage() // register
+		_ = conn.WriteJSON(wireRegisterAck{Type: "register_ack", OK: true, Capabilities: []string{"text"}})
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	p := mustNew(t, map[string]any{
+		"token":     "secret",
+		"transport": "websocket",
+		"ws_url":    wsURL,
+		"extra_headers": map[string]any{
+			"X-Brain-Authorization": "Basic abc123",
+			"X-Empty":               "",
+		},
+	})
+	if err := p.Start(func(_ core.Platform, _ *core.Message) {}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Stop() }()
+
+	// Give the transport a moment to dial + complete the handshake.
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for websocket handshake")
+		default:
+		}
+		if gotCustom != "" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if gotAuth != "Bearer secret" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer secret")
+	}
+	if gotCloudWeb != "secret" {
+		t.Errorf("X-Cloud-Web-Token = %q, want %q", gotCloudWeb, "secret")
+	}
+	if gotCustom != "Basic abc123" {
+		t.Errorf("X-Brain-Authorization = %q, want %q", gotCustom, "Basic abc123")
+	}
+	if gotEmpty != "" {
+		t.Errorf("X-Empty should not be set for empty value, got %q", gotEmpty)
+	}
+}


### PR DESCRIPTION
## Summary

Allow injecting custom HTTP headers into the `cloud_web` websocket upgrade request via the `[projects.platforms.options.extra_headers]` TOML table.

This is needed for upstreams that require bespoke auth headers beyond the standard `Authorization`/`X-Cloud-Web-Token` pair — notably **IAP (Identity-Aware Proxy) AK/SK auth**, which requires `X-Brain-Authorization: Basic <base64(ak:sk)>`.

## Problem

cc-connect's `cloud_web` websocket transport only sends two fixed headers (`Authorization: Bearer <token>` and `X-Cloud-Web-Token: <token>`). There is no way to add custom headers to the WebSocket upgrade request.

When deploying a cloud_web relay behind an IAP internal domain (e.g. `*.iap-rjob-internal.platform.shaipower.com`), the IAP gateway requires an `X-Brain-Authorization` header for AK/SK authentication. Without custom header support, cc-connect cannot directly reach such a relay — forcing users to run a local sidecar proxy that injects the header, which is an unnecessary operational burden.

## Solution

Add an optional `extra_headers` map to the cloud_web platform options. Each key-value pair is injected into the WebSocket upgrade request's HTTP headers, alongside the existing `Authorization`/`X-Cloud-Web-Token` headers.

### Config example

```toml
[[projects.platforms]]
type = "cloud_web"

[projects.platforms.options]
transport = "websocket"
token = "relay-token"
ws_url = "wss://my-relay.iap-rjob-internal.example.com/cloud-web/ws"

[projects.platforms.options.extra_headers]
X-Brain-Authorization = "Basic <base64(accesskey:secretkey)>"
X-Custom-Header = "any-value"
```

## Changes

- **`platform/cloud-web/ws.go`**: `wsTransport` gains an `extraHeaders map[string]string` field; `connectOnce` iterates it and calls `header.Set(k, v)` (empty values are skipped).
- **`platform/cloud-web/cloudweb.go`**: `New()` reads `extra_headers` from opts via new `pickStringMap` helper (converts TOML inline table `map[string]any` → `map[string]string`); passes it to `newWSTransport`.
- **`platform/cloud-web/ws_test.go`**: `TestExtraHeadersInjected` — spins up a test WS server, configures `extra_headers`, and asserts the custom header (`X-Brain-Authorization`), the standard headers (`Authorization`, `X-Cloud-Web-Token`), and the empty-value-skip behavior.

## Backward compatibility

**No breaking changes.** `extra_headers` is entirely optional. Omitting it yields the exact prior behavior (only `Authorization` + `X-Cloud-Web-Token` are sent). The new `pickStringMap` helper returns `nil` for missing/non-table values, and the `wsTransport` loop is a no-op when `extraHeaders` is `nil`.

## Testing

- `go test ./platform/cloud-web/` — all tests pass, including the new `TestExtraHeadersInjected`.
- Verified end-to-end: built cc-connect with this change, configured `extra_headers` with a real IAP AK/SK, and confirmed cc-connect connects directly to a relay behind `*.iap-rjob-internal.platform.shaipower.com` and registers successfully (`cloud_web: websocket connected` + `platform ready`).

```
go test ./platform/cloud-web/ -run TestExtraHeadersInjected -v
=== RUN   TestExtraHeadersInjected
--- PASS: TestExtraHeadersInjected (0.02s)
PASS
```

## Notes

- Pre-existing test failures in `daemon/`, `cmd/cc-connect/`, and `web/` are unrelated to this change (they fail on `main` too: `daemon` is a macOS launchd env issue; `cmd/cc-connect`/`web` need the embedded `dist/` frontend assets which require a separate build step).