### PR TITLE
fix(dingtalk): session-list preview for text replies and AI cards (#1591)

### DIFF
--- a/platform/dingtalk/card.go
+++ b/platform/dingtalk/card.go
@@ -10,10 +10,18 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/chenhg5/cc-connect/core"
+)
+
+const (
+	lastMsgProcessingZH = "处理中…"
+	lastMsgProcessingEN = "Thinking…"
+	lastMsgMaxRunes     = 80
 )
 
 // aiCard implements core.StreamingCard for DingTalk AI Card streaming.
@@ -22,6 +30,7 @@ type aiCard struct {
 	outTrackId     string
 	templateKey    string // 卡片模板变量名，默认 "content"
 	platform       *Platform
+	isGroup        bool
 
 	mu              sync.Mutex
 	state           string // "processing" | "finished" | "failed"
@@ -75,10 +84,22 @@ func (p *Platform) createAICard(ctx context.Context, rc replyContext) (*aiCard, 
 		openSpaceId = fmt.Sprintf("dtv1.card//IM_ROBOT.%s", rc.senderStaffId)
 	}
 
-	// Build card data
+	// Build card data. Session-list preview uses lastMessageI18n (space model)
+	// and/or sys_lastMessageI18n (cardParamMap). Without these DingTalk shows
+	// the fixed placeholder "[交互卡片消息]". See #1591.
+	processingLastMsg := processingLastMessageI18n()
+	sysLastMsg, _ := json.Marshal(map[string]string{
+		"zh_CN": lastMsgProcessingZH,
+		"en_US": lastMsgProcessingEN,
+	})
 	cardParamMap := map[string]string{
-		"config":          `{"autoLayout":true,"enableForward":true}`,
-		p.cardTemplateKey: "",
+		"config":             `{"autoLayout":true,"enableForward":true}`,
+		p.cardTemplateKey:    "",
+		"sys_lastMessageI18n": string(sysLastMsg),
+	}
+	spaceModel := map[string]any{
+		"supportForward":  true,
+		"lastMessageI18n": processingLastMsg,
 	}
 
 	payload := map[string]any{
@@ -88,8 +109,8 @@ func (p *Platform) createAICard(ctx context.Context, rc replyContext) (*aiCard, 
 			"cardParamMap": cardParamMap,
 		},
 		"callbackType":          "STREAM",
-		"imGroupOpenSpaceModel": map[string]any{"supportForward": true},
-		"imRobotOpenSpaceModel": map[string]any{"supportForward": true},
+		"imGroupOpenSpaceModel": spaceModel,
+		"imRobotOpenSpaceModel": spaceModel,
 		"openSpaceId":           openSpaceId,
 		"userIdType":            1,
 	}
@@ -209,12 +230,120 @@ func (p *Platform) createAICard(ctx context.Context, rc replyContext) (*aiCard, 
 		outTrackId:     resolvedOutTrackId,
 		templateKey:    p.cardTemplateKey,
 		platform:       p,
+		isGroup:        isGroup,
 		state:          "processing",
 		throttleMs:     p.cardThrottleMs,
 		done:           make(chan struct{}),
 	}
 
 	return card, nil
+}
+
+func processingLastMessageI18n() map[string]string {
+	return map[string]string{
+		"ZH_CN": lastMsgProcessingZH,
+		"EN_US": lastMsgProcessingEN,
+	}
+}
+
+// truncateLastMessage collapses whitespace and truncates for session-list preview.
+func truncateLastMessage(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return lastMsgProcessingZH
+	}
+	s = strings.Join(strings.Fields(s), " ")
+	if utf8.RuneCountInString(s) <= lastMsgMaxRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:lastMsgMaxRunes]) + "…"
+}
+
+// updateLastMessagePreview refreshes the conversation-list preview after
+// Finalize. Streaming cannot set this field. Create may set both space-model
+// lastMessageI18n and cardParamMap.sys_lastMessageI18n; DingTalk can keep
+// showing the create-time sys_ value unless both are updated.
+func (c *aiCard) updateLastMessagePreview(ctx context.Context, text string) error {
+	token, err := c.platform.getAccessToken()
+	if err != nil {
+		return fmt.Errorf("get access token: %w", err)
+	}
+
+	preview := truncateLastMessage(text)
+	lastMsg := map[string]string{
+		"ZH_CN": preview,
+		"EN_US": preview,
+	}
+	space := map[string]any{
+		"supportForward":  true,
+		"lastMessageI18n": lastMsg,
+	}
+	// Match createAndDeliver: set both space models so DM/group clients
+	// that read either field both pick up the final preview.
+	spacesPayload := map[string]any{
+		"outTrackId":            c.outTrackId,
+		"imGroupOpenSpaceModel": space,
+		"imRobotOpenSpaceModel": space,
+	}
+	if err := c.putJSON(ctx, token, "https://api.dingtalk.com/v1.0/card/instances/spaces", spacesPayload); err != nil {
+		return fmt.Errorf("spaces: %w", err)
+	}
+
+	sysLastMsg, _ := json.Marshal(map[string]string{
+		"zh_CN": preview,
+		"en_US": preview,
+	})
+	cardPayload := map[string]any{
+		"outTrackId": c.outTrackId,
+		"cardData": map[string]any{
+			"cardParamMap": map[string]string{
+				"sys_lastMessageI18n": string(sysLastMsg),
+			},
+		},
+		"cardUpdateOptions": map[string]any{
+			"updateCardDataByKey": true,
+		},
+	}
+	if err := c.putJSON(ctx, token, "https://api.dingtalk.com/v1.0/card/instances", cardPayload); err != nil {
+		return fmt.Errorf("card instances: %w", err)
+	}
+
+	slog.Info("dingtalk: AI card lastMessageI18n updated",
+		"outTrackId", c.outTrackId,
+		"preview", preview,
+		"preview_len", utf8.RuneCountInString(preview),
+		"isGroup", c.isGroup)
+	return nil
+}
+
+func (c *aiCard) putJSON(ctx context.Context, token, url string, payload map[string]any) error {
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPut, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-acs-dingtalk-access-token", token)
+
+	resp, err := c.platform.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
 }
 
 // Update replaces the card content with the given markdown.
@@ -429,7 +558,16 @@ func (c *aiCard) Finalize(ctx context.Context, content string) error {
 	}
 	c.mu.Unlock()
 
-	return err
+	if err != nil {
+		return err
+	}
+	// Best-effort: refresh session-list preview with the final reply snippet.
+	if updateErr := c.updateLastMessagePreview(ctx, content); updateErr != nil {
+		slog.Warn("dingtalk: AI card lastMessageI18n update failed",
+			"error", updateErr,
+			"outTrackId", c.outTrackId)
+	}
+	return nil
 }
 
 // Failed returns true if the card has entered a failed state.

--- a/platform/dingtalk/card_test.go
+++ b/platform/dingtalk/card_test.go
@@ -1,0 +1,222 @@
+package dingtalk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTruncateLastMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty falls back to processing", in: "  ", want: lastMsgProcessingZH},
+		{name: "collapse whitespace", in: "hello\n\n  world", want: "hello world"},
+		{name: "short chinese kept", in: "处理完成", want: "处理完成"},
+		{
+			name: "long truncated with ellipsis",
+			in:   strings.Repeat("测", lastMsgMaxRunes+5),
+			want: strings.Repeat("测", lastMsgMaxRunes) + "…",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateLastMessage(tt.in); got != tt.want {
+				t.Fatalf("truncateLastMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateAICard_SetsLastMessageI18n(t *testing.T) {
+	var createBody map[string]any
+	rt := &cardAPIRoundTrip{
+		onCreate: func(body map[string]any) {
+			createBody = body
+		},
+	}
+	p := &Platform{
+		clientID:        "cid",
+		clientSecret:    "csec",
+		robotCode:       "robot-1",
+		cardTemplateID:  "tmpl.schema",
+		cardTemplateKey: "content",
+		cardThrottleMs:  50,
+		httpClient:      &http.Client{Transport: rt},
+	}
+
+	card, err := p.createAICard(context.Background(), replyContext{
+		conversationId: "conv-1",
+		senderStaffId:  "user-1",
+		isGroup:        false,
+	})
+	if err != nil {
+		t.Fatalf("createAICard: %v", err)
+	}
+	if card == nil || card.outTrackId == "" {
+		t.Fatal("expected card with outTrackId")
+	}
+
+	space, ok := createBody["imRobotOpenSpaceModel"].(map[string]any)
+	if !ok {
+		t.Fatalf("imRobotOpenSpaceModel missing: %#v", createBody["imRobotOpenSpaceModel"])
+	}
+	last, ok := space["lastMessageI18n"].(map[string]any)
+	if !ok {
+		t.Fatalf("lastMessageI18n missing: %#v", space)
+	}
+	if last["ZH_CN"] != lastMsgProcessingZH {
+		t.Errorf("ZH_CN = %v, want %q", last["ZH_CN"], lastMsgProcessingZH)
+	}
+	if last["EN_US"] != lastMsgProcessingEN {
+		t.Errorf("EN_US = %v, want %q", last["EN_US"], lastMsgProcessingEN)
+	}
+
+	cardData, _ := createBody["cardData"].(map[string]any)
+	paramMap, _ := cardData["cardParamMap"].(map[string]any)
+	sysRaw, _ := paramMap["sys_lastMessageI18n"].(string)
+	if sysRaw == "" {
+		t.Fatal("sys_lastMessageI18n missing from cardParamMap")
+	}
+	var sys map[string]string
+	if err := json.Unmarshal([]byte(sysRaw), &sys); err != nil {
+		t.Fatalf("sys_lastMessageI18n json: %v", err)
+	}
+	if sys["zh_CN"] != lastMsgProcessingZH {
+		t.Errorf("sys zh_CN = %q, want %q", sys["zh_CN"], lastMsgProcessingZH)
+	}
+}
+
+func TestFinalize_UpdatesSpaceLastMessage(t *testing.T) {
+	var spacesBody, cardBody map[string]any
+	rt := &cardAPIRoundTrip{
+		onSpaces: func(body map[string]any) {
+			spacesBody = body
+		},
+		onCardUpdate: func(body map[string]any) {
+			cardBody = body
+		},
+	}
+	p := &Platform{
+		clientID:        "cid",
+		clientSecret:    "csec",
+		robotCode:       "robot-1",
+		cardTemplateID:  "tmpl.schema",
+		cardTemplateKey: "content",
+		cardThrottleMs:  1,
+		httpClient:      &http.Client{Transport: rt},
+		accessToken:     "tok-cached",
+		tokenExpiry:     time.Now().Add(time.Hour),
+	}
+	card := &aiCard{
+		outTrackId:  "card_track_1",
+		templateKey: "content",
+		platform:    p,
+		isGroup:     false,
+		state:       "processing",
+		done:        make(chan struct{}),
+	}
+
+	if err := card.Finalize(context.Background(), "最终答复：已修好 lastMessageI18n"); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	if spacesBody == nil {
+		t.Fatal("expected PUT /card/instances/spaces call")
+	}
+	if spacesBody["outTrackId"] != "card_track_1" {
+		t.Errorf("outTrackId = %v", spacesBody["outTrackId"])
+	}
+	for _, key := range []string{"imRobotOpenSpaceModel", "imGroupOpenSpaceModel"} {
+		space, ok := spacesBody[key].(map[string]any)
+		if !ok {
+			t.Fatalf("%s missing: %#v", key, spacesBody)
+		}
+		last, ok := space["lastMessageI18n"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s.lastMessageI18n missing: %#v", key, space)
+		}
+		if !strings.Contains(fmtString(last["ZH_CN"]), "最终答复") {
+			t.Errorf("%s preview = %v, want final reply snippet", key, last["ZH_CN"])
+		}
+	}
+
+	if cardBody == nil {
+		t.Fatal("expected PUT /card/instances call for sys_lastMessageI18n")
+	}
+	cardData, _ := cardBody["cardData"].(map[string]any)
+	paramMap, _ := cardData["cardParamMap"].(map[string]any)
+	sysRaw, _ := paramMap["sys_lastMessageI18n"].(string)
+	if !strings.Contains(sysRaw, "最终答复") {
+		t.Errorf("sys_lastMessageI18n = %q, want final reply", sysRaw)
+	}
+	opts, _ := cardBody["cardUpdateOptions"].(map[string]any)
+	if opts["updateCardDataByKey"] != true {
+		t.Errorf("updateCardDataByKey = %v, want true", opts["updateCardDataByKey"])
+	}
+}
+
+func fmtString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+// cardAPIRoundTrip mocks DingTalk card create / stream / spaces endpoints.
+type cardAPIRoundTrip struct {
+	onCreate     func(map[string]any)
+	onSpaces     func(map[string]any)
+	onCardUpdate func(map[string]any)
+}
+
+func (f *cardAPIRoundTrip) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, _ := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+
+	switch {
+	case req.URL.Path == "/v1.0/oauth2/accessToken":
+		return jsonResp(req, http.StatusOK, `{"accessToken":"tok-card","expireIn":7200}`)
+	case req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/card/instances/createAndDeliver"):
+		var payload map[string]any
+		_ = json.Unmarshal(body, &payload)
+		if f.onCreate != nil {
+			f.onCreate(payload)
+		}
+		outTrack, _ := payload["outTrackId"].(string)
+		resp := fmt.Sprintf(`{"result":{"cardInstanceId":"inst-1","outTrackId":%q,"deliverResults":[{"success":true}]}}`, outTrack)
+		return jsonResp(req, http.StatusOK, resp)
+	case req.Method == http.MethodPut && strings.HasSuffix(req.URL.Path, "/card/streaming"):
+		return jsonResp(req, http.StatusOK, `{}`)
+	case req.Method == http.MethodPut && strings.HasSuffix(req.URL.Path, "/card/instances/spaces"):
+		var payload map[string]any
+		_ = json.Unmarshal(body, &payload)
+		if f.onSpaces != nil {
+			f.onSpaces(payload)
+		}
+		return jsonResp(req, http.StatusOK, `{}`)
+	case req.Method == http.MethodPut && req.URL.Path == "/v1.0/card/instances":
+		var payload map[string]any
+		_ = json.Unmarshal(body, &payload)
+		if f.onCardUpdate != nil {
+			f.onCardUpdate(payload)
+		}
+		return jsonResp(req, http.StatusOK, `{"success":true}`)
+	default:
+		return jsonResp(req, http.StatusNotFound, `{"message":"unexpected path `+req.URL.Path+`"}`)
+	}
+}
+
+func jsonResp(req *http.Request, status int, body string) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/chenhg5/cc-connect/core"
 
@@ -847,11 +848,13 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 
 	atUserIds := extractAtUserIds(content)
 
+	title := markdownTitle(content)
 	content = preprocessDingTalkMarkdown(content)
 
+	// DingTalk conversation-list preview for markdown uses "title", not body text.
 	payload := map[string]any{
 		"msgtype":  "markdown",
-		"markdown": map[string]string{"title": "reply", "text": content},
+		"markdown": map[string]string{"title": title, "text": content},
 	}
 	if len(atUserIds) > 0 {
 		payload["at"] = map[string]any{
@@ -1643,6 +1646,7 @@ func (p *Platform) sendProactiveMessage(ctx context.Context, rc replyContext, co
 		return fmt.Errorf("dingtalk: get access token for proactive send: %w", err)
 	}
 
+	title := markdownTitle(content)
 	content = preprocessDingTalkMarkdown(content)
 
 	var apiURL string
@@ -1651,7 +1655,7 @@ func (p *Platform) sendProactiveMessage(ctx context.Context, rc replyContext, co
 	if rc.isGroup && rc.conversationId != "" {
 		// Group message via /v1.0/robot/groupMessages/send
 		apiURL = "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
-		msgParam, _ := json.Marshal(map[string]string{"text": content})
+		msgParam, _ := json.Marshal(map[string]string{"title": title, "text": content})
 		requestBody = map[string]any{
 			"robotCode":          p.robotCode,
 			"openConversationId": rc.conversationId,
@@ -1661,7 +1665,7 @@ func (p *Platform) sendProactiveMessage(ctx context.Context, rc replyContext, co
 	} else if rc.senderStaffId != "" {
 		// Direct message via /v1.0/robot/oToMessages/batchSend
 		apiURL = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend"
-		msgParam, _ := json.Marshal(map[string]string{"title": "reply", "text": content})
+		msgParam, _ := json.Marshal(map[string]string{"title": title, "text": content})
 		requestBody = map[string]any{
 			"robotCode": p.robotCode,
 			"userIds":   []string{rc.senderStaffId},
@@ -1714,6 +1718,42 @@ func extractAtUserIds(content string) []string {
 		}
 	}
 	return ids
+}
+
+// markdownTitle builds the DingTalk markdown title used as conversation-list
+// preview. Strip light markup so the list shows readable reply text.
+func markdownTitle(content string) string {
+	s := strings.TrimSpace(content)
+	if s == "" {
+		return "reply"
+	}
+	for {
+		start := strings.Index(s, "```")
+		if start < 0 {
+			break
+		}
+		rest := s[start+3:]
+		end := strings.Index(rest, "```")
+		if end < 0 {
+			s = s[:start]
+			break
+		}
+		s = s[:start] + " " + rest[end+3:]
+	}
+	replacer := strings.NewReplacer(
+		"**", "", "*", "", "__", "", "_", "", "`", "",
+		"# ", "", "## ", "", "### ", "", "> ", "",
+	)
+	s = replacer.Replace(s)
+	s = strings.Join(strings.Fields(s), " ")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "reply"
+	}
+	if utf8.RuneCountInString(s) <= lastMsgMaxRunes {
+		return s
+	}
+	return string([]rune(s)[:lastMsgMaxRunes]) + "…"
 }
 
 // preprocessDingTalkMarkdown adapts content for DingTalk's markdown renderer:

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -1255,6 +1255,58 @@ func TestExtractAtUserIds(t *testing.T) {
 	}
 }
 
+func TestMarkdownTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty falls back", in: "  ", want: "reply"},
+		{name: "plain chinese kept", in: "你好，需要我帮你做什么？", want: "你好，需要我帮你做什么？"},
+		{name: "strip bold markers", in: "**你好**，世界", want: "你好，世界"},
+		{name: "collapse whitespace", in: "hello\n\n  world", want: "hello world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := markdownTitle(tt.in); got != tt.want {
+				t.Fatalf("markdownTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReply_UsesContentAsMarkdownTitle(t *testing.T) {
+	gotPayload := make(chan map[string]any, 1)
+	sessionWebhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode reply payload: %v", err)
+		}
+		gotPayload <- payload
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sessionWebhook.Close()
+
+	p := &Platform{}
+	rc := replyContext{sessionWebhook: sessionWebhook.URL}
+	if err := p.Reply(context.Background(), rc, "你好，需要我帮你做什么？"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	select {
+	case payload := <-gotPayload:
+		md, ok := payload["markdown"].(map[string]any)
+		if !ok {
+			t.Fatalf("markdown missing: %#v", payload)
+		}
+		if md["title"] != "你好，需要我帮你做什么？" {
+			t.Fatalf("title = %v, want Chinese reply snippet", md["title"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reply")
+	}
+}
+
 func TestReply_IncludesExtractedAtUserIds(t *testing.T) {
 	gotPayload := make(chan map[string]any, 1)
 	sessionWebhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- **Normal markdown replies**: use a truncated reply snippet as the markdown `title` instead of the hardcoded `reply` string. DingTalk session-list preview reads `title`, so users now see meaningful text when AI Card mode is off.
- **AI Card streaming** (#1591): set `lastMessageI18n` / `sys_lastMessageI18n` on create (`处理中…` / `Thinking…`) and best-effort refresh after `Finalize` via `PUT /card/instances/spaces` plus `PUT /card/instances` (`sys_lastMessageI18n`).
- Non-AI-Card reply path behavior unchanged aside from the title fix; no new config knobs.

Closes #1591

## Test plan
- [x] `go test ./platform/dingtalk/ -run 'TestMarkdownTitle|TestReply_UsesContent|TestTruncateLastMessage|TestCreateAICard|TestFinalize_Updates'`
- [x] Manual: DingTalk DM without `card_template_id` — session list shows reply snippet after turn completes
- [ ] Manual: DingTalk DM with `card_template_id` — session list shows processing copy on create (finalize refresh may vary by client)


Made with [Cursor](https://cursor.com)