### PR TITLE
fix(pi): fall back to models-store.json when enabledModels is unset

### DIFF
--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -350,6 +350,10 @@ type modelsJSON struct {
 // (e.g. "deepseek/deepseek-v4-pro") and the fully-qualified
 // provider/ID (e.g. "my-provider/my-model").
 // Returns nil on any error (caller falls back to 200K).
+//
+// Note: models.json is distinct from models-store.json — models.json carries
+// per-model context-window sizes, while models-store.json is the provider
+// catalog that readModelsStore uses to build the /model list.
 func loadModelsContextWindows() map[string]int {
 	dir := piSettingsDir()
 	if dir == "" {

--- a/agent/pi/pi.go
+++ b/agent/pi/pi.go
@@ -122,9 +122,16 @@ func (a *Agent) AvailableModels(_ context.Context) []core.ModelOption {
 	models, err := readSettingsModels()
 	if err != nil {
 		slog.Debug("pi: AvailableModels: read settings", "error", err)
-		return nil
 	}
-	return models
+	if len(models) > 0 {
+		return models
+	}
+	// enabledModels 未配置时，回退到 pi 自身的模型目录 models-store.json，
+	// 否则 /model 卡片只会显示当前模型、无法列出可切换的模型列表。
+	if store := readModelsStore(); len(store) > 0 {
+		return store
+	}
+	return nil
 }
 
 func (a *Agent) SetSessionEnv(env []string) {
@@ -441,6 +448,59 @@ func readSettingsModels() ([]core.ModelOption, error) {
 		models = append(models, option)
 	}
 	return models, nil
+}
+
+// modelsStoreJSON represents the structure of ~/.pi/agent/models-store.json,
+// the provider catalog pi itself maintains (hydrated from the published
+// pi-ai package and refreshed as providers are added). Top-level keys are
+// provider names, each with a Models list.
+//
+//	{
+//	  "deepseek": { "models": [ { "id": "...", "name": "...", ... } ] }
+//	}
+type modelsStoreJSON map[string]struct {
+	Models []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"models"`
+}
+
+// readModelsStore reads all models from pi's models-store.json as
+// provider-qualified ModelOptions (Name = "provider/id", Alias = short id,
+// Desc = display name). Returns nil when the file is missing or unreadable;
+// callers fall back to an empty list.
+func readModelsStore() []core.ModelOption {
+	dir := piSettingsDir()
+	if dir == "" {
+		return nil
+	}
+	path := filepath.Join(dir, "models-store.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		slog.Debug("pi: read models-store", "path", path, "error", err)
+		return nil
+	}
+	var store modelsStoreJSON
+	if err := json.Unmarshal(data, &store); err != nil {
+		slog.Warn("pi: parse models-store", "path", path, "error", err)
+		return nil
+	}
+	var models []core.ModelOption
+	for provider, p := range store {
+		for _, m := range p.Models {
+			if m.ID == "" {
+				continue
+			}
+			models = append(models, core.ModelOption{
+				Name:  provider + "/" + m.ID,
+				Alias: m.ID,
+				Desc:  m.Name,
+			})
+		}
+	}
+	// Map iteration order is random — sort for deterministic card display.
+	sort.Slice(models, func(i, j int) bool { return models[i].Name < models[j].Name })
+	return models
 }
 
 // readDefaultModel returns the defaultModel from settings.json.

--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -216,6 +216,41 @@ func TestAgent_AvailableModels(t *testing.T) {
 	}
 }
 
+func TestAgent_AvailableModels_FallsBackToStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", tmpDir)
+
+	// settings.json with empty enabledModels → readSettingsModels returns empty.
+	settings := map[string]any{"enabledModels": []string{}}
+	data, _ := json.Marshal(settings)
+	if err := os.WriteFile(filepath.Join(tmpDir, "settings.json"), data, 0o644); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	// models-store.json with two models.
+	store := map[string]any{
+		"deepseek": map[string]any{
+			"models": []any{
+				map[string]any{"id": "deepseek-chat", "name": "DeepSeek Chat"},
+				map[string]any{"id": "deepseek-reasoner", "name": "DeepSeek Reasoner"},
+			},
+		},
+	}
+	sdata, _ := json.Marshal(store)
+	if err := os.WriteFile(filepath.Join(tmpDir, "models-store.json"), sdata, 0o644); err != nil {
+		t.Fatalf("write models-store.json: %v", err)
+	}
+
+	a := &Agent{}
+	models := a.AvailableModels(context.Background())
+	if len(models) != 2 {
+		t.Fatalf("AvailableModels() = %d models, want 2 (fallback to models-store.json)", len(models))
+	}
+	if models[0].Name != "deepseek/deepseek-chat" || models[1].Name != "deepseek/deepseek-reasoner" {
+		t.Errorf("AvailableModels() = %+v, want store models in sorted order", models)
+	}
+}
+
 func TestReadSettingsModels(t *testing.T) {
 	// Save and restore settings path.
 	savedEnv := os.Getenv("PI_CODING_AGENT_DIR")
@@ -275,6 +310,86 @@ func TestReadSettingsModels(t *testing.T) {
 			t.Errorf("models[%d].Alias = %q, want %q", i, models[i].Alias, tt.alias)
 		}
 	}
+}
+
+func TestReadModelsStore(t *testing.T) {
+	writeStore := func(t *testing.T, store any) {
+		t.Helper()
+		tmpDir := t.TempDir()
+		t.Setenv("PI_CODING_AGENT_DIR", tmpDir)
+		data, _ := json.Marshal(store)
+		if err := os.WriteFile(filepath.Join(tmpDir, "models-store.json"), data, 0o644); err != nil {
+			t.Fatalf("write models-store.json: %v", err)
+		}
+	}
+
+	t.Run("missing file returns nil", func(t *testing.T) {
+		t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
+		if got := readModelsStore(); got != nil {
+			t.Errorf("readModelsStore() = %v, want nil for missing models-store.json", got)
+		}
+	})
+
+	t.Run("valid file returns sorted provider-qualified models", func(t *testing.T) {
+		writeStore(t, map[string]any{
+			"openai": map[string]any{
+				"models": []any{
+					map[string]any{"id": "gpt-4", "name": "GPT-4"},
+					map[string]any{"id": "gpt-4o", "name": "GPT-4o"},
+				},
+			},
+			"deepseek": map[string]any{
+				"models": []any{
+					map[string]any{"id": "deepseek-chat", "name": "DeepSeek Chat"},
+					map[string]any{"id": "deepseek-reasoner", "name": "DeepSeek Reasoner"},
+				},
+			},
+		})
+		got := readModelsStore()
+		want := []core.ModelOption{
+			{Name: "deepseek/deepseek-chat", Alias: "deepseek-chat", Desc: "DeepSeek Chat"},
+			{Name: "deepseek/deepseek-reasoner", Alias: "deepseek-reasoner", Desc: "DeepSeek Reasoner"},
+			{Name: "openai/gpt-4", Alias: "gpt-4", Desc: "GPT-4"},
+			{Name: "openai/gpt-4o", Alias: "gpt-4o", Desc: "GPT-4o"},
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %d models, want %d: %+v", len(got), len(want), got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("got[%d] = %+v, want %+v", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("empty id model is skipped", func(t *testing.T) {
+		writeStore(t, map[string]any{
+			"openai": map[string]any{
+				"models": []any{
+					map[string]any{"id": "", "name": "Empty"},
+					map[string]any{"id": "gpt-4", "name": "GPT-4"},
+				},
+			},
+		})
+		got := readModelsStore()
+		if len(got) != 1 {
+			t.Fatalf("got %d models, want 1 (empty-id skipped): %+v", len(got), got)
+		}
+		if got[0].Name != "openai/gpt-4" || got[0].Alias != "gpt-4" || got[0].Desc != "GPT-4" {
+			t.Errorf("got[0] = %+v, want openai/gpt-4", got[0])
+		}
+	})
+
+	t.Run("malformed json returns nil", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("PI_CODING_AGENT_DIR", tmpDir)
+		if err := os.WriteFile(filepath.Join(tmpDir, "models-store.json"), []byte("{invalid json"), 0o644); err != nil {
+			t.Fatalf("write models-store.json: %v", err)
+		}
+		if got := readModelsStore(); got != nil {
+			t.Errorf("readModelsStore() = %v, want nil for malformed models-store.json", got)
+		}
+	})
 }
 
 func TestReadDefaultModel(t *testing.T) {


### PR DESCRIPTION
## Problem

The pi agent's `AvailableModels` reads only `enabledModels` from `~/.pi/agent/settings.json`. When the user has not configured `enabledModels` (the default), it returns an empty list.

As a result, `/model` on card-capable platforms (Feishu) renders a model card whose select dropdown contains **only the current model** — there is no way to switch to any other model. On non-card platforms the list is also empty.

This is the gap left by #1178 (`fix(pi): read enabledModels from settings.json for /model`): it wired the *restricted* list but provided no fallback for the unrestricted default.

## Fix

When `enabledModels` is empty, fall back to pi's own model catalog at `~/.pi/agent/models-store.json`. That file is maintained by pi itself (hydrated from the published `@earendil-works/pi-ai` package and refreshed as providers are added), so the list stays accurate without extra configuration:

- `Name` = `provider/id` (what pi accepts via `--model`)
- `Alias` = short model id (for the `/model` button/select labels)
- `Desc` = display name from the catalog
- results sorted by name for deterministic card layout

If `enabledModels` is set, it still takes priority (restriction semantics preserved).

## Validation

- `go build -tags no_web ./...` passes
- `go test -tags no_web ./agent/pi/` passes
- Note: `go test ./core/` has one pre-existing failure (`TestRunShellWithProgress_NonexistentCommand`) unrelated to this change — it expects an English shell error string but the test machine's `zh_CN` locale produces a localized message.

## Related

- #1178 — current `enabledModels`-only implementation this fixes
- #890 — alternative approach using `pi --list-models` (still open)