### PR TITLE
fix(weixin): treat sendmessage ret=-2 as a per-account send budget and fail fast

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1448,7 +1448,7 @@ app_secret = "your-feishu-app-secret"
 # （多切块发送不计数），且节流期内每次尝试都会升级惩罚。配额对独立消息限速，
 # 使其低于触发阈值。设为 0 关闭配额。
 # burst_limit = 4           # max separate messages per window / 每窗口最多独立消息数
-# burst_window_secs = 120   # window length / 窗口时长（秒）
+# burst_window_secs = 86400 # window length (default 24h) / 窗口时长（秒，默认24小时）
 
 # -----------------------------------------------------------------------------
 # Tencent Yuanbao (yuanbao.tencent.com bot platform)

--- a/config.example.toml
+++ b/config.example.toml
@@ -1438,6 +1438,17 @@ app_secret = "your-feishu-app-secret"
 # proxy = ""                                   # optional HTTP proxy / 可选代理
 # proxy_username = ""
 # proxy_password = ""
+#
+# Send-volume quota vs ilink's burst throttle (sendMessage ret=-2 "prepare failed"):
+# the gateway throttles the bot after roughly 5-6 separate messages within a short
+# window (multi-chunk sends are fine), and the penalty escalates with every attempt
+# made while active. The quota paces separate messages so the bot stays below the
+# trigger. 0 disables the quota.
+# 发送量配额（防 ilink 突发节流 ret=-2）：网关在短窗口内约 5-6 条独立消息即节流
+# （多切块发送不计数），且节流期内每次尝试都会升级惩罚。配额对独立消息限速，
+# 使其低于触发阈值。设为 0 关闭配额。
+# burst_limit = 4           # max separate messages per window / 每窗口最多独立消息数
+# burst_window_secs = 120   # window length / 窗口时长（秒）
 
 # -----------------------------------------------------------------------------
 # Tencent Yuanbao (yuanbao.tencent.com bot platform)

--- a/config.example.toml
+++ b/config.example.toml
@@ -291,6 +291,11 @@ level = "info" # debug, info, warn, error
 # max_per_second = 25
 # [outgoing_rate_limit.platforms.feishu]
 # max_per_second = 5
+# Weixin (ilink) sendmessage throttles the bot after a short burst (ret=-2
+# "prepare failed", penalty on the order of an hour). Pace sends to avoid it:
+# [outgoing_rate_limit.platforms.weixin]
+# max_per_second = 0.5
+# burst = 1
 
 # =============================================================================
 # Relay Settings / Relay 设置

--- a/core/engine.go
+++ b/core/engine.go
@@ -11678,7 +11678,7 @@ func (e *Engine) sendAlreadyRenderedWithError(p Platform, replyCtx any, content 
 				"platform", p.Name(),
 				"error", err,
 				"content_len", len(content),
-				"hint", "user needs to send a new message to refresh context_token")
+				"hint", "user needs to send a message to the bot first so a context_token can be captured")
 		} else {
 			slog.Error("platform send failed", "platform", p.Name(), "error", err, "content_len", len(content))
 		}

--- a/platform/weixin/media_outbound.go
+++ b/platform/weixin/media_outbound.go
@@ -131,7 +131,9 @@ func buildVideoMessageItem(ref *cdnUploadedRef) messageItem {
 	}
 }
 
-// sendSingleItemWithRetry sends a media item with retry mechanism for ret=-2 errors.
+// sendSingleItemWithRetry sends a media item with a retry mechanism.
+// When sendMessage returns ret=-2 (ilink throttling the bot), it backs off and
+// retries rather than hammering the throttled endpoint with 500ms-interval retries.
 func (p *Platform) sendSingleItemWithRetry(ctx context.Context, rc *replyContext, item messageItem) error {
 	var lastErr error
 	for attempt := 0; attempt < weixinSendMaxRetries; attempt++ {
@@ -151,33 +153,22 @@ func (p *Platform) sendSingleItemWithRetry(ctx context.Context, rc *replyContext
 			return nil
 		}
 		lastErr = err
-		// Check if error is ret=-2 (API declined) - attempt token refresh
-		if strings.Contains(err.Error(), "ret=-2") {
-			freshToken := p.getContextToken(rc.peerUserID)
-			if freshToken == "" || freshToken == rc.contextToken {
-				slog.Warn("weixin: sendMessage ret=-2 for media, no fresh context_token — "+
-					"user must send a new message to refresh session token",
-					"attempt", attempt+1, "peer", rc.peerUserID)
-				return fmt.Errorf("weixin: sendMessage ret=-2 (expired context_token); "+
-					"user must send a new message to peer %q to refresh the session token: %w",
-					rc.peerUserID, lastErr)
-			}
-			slog.Warn("weixin: sendMessage ret=-2 for media, retrying with fresh context_token",
-				"attempt", attempt+1, "peer", rc.peerUserID)
-			rc.contextToken = freshToken
-			slog.Debug("weixin: using refreshed context_token for media retry", "peer", rc.peerUserID)
-			// Brief delay before retry
+		if isSendThrottled(err) {
+			slog.Warn("weixin: sendMessage throttled by ilink (ret=-2) for media; backing off before retry",
+				"attempt", attempt+1, "peer", rc.peerUserID,
+				"backoff", weixinThrottleBackoff)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(weixinSendRetryDelay):
+			case <-time.After(weixinThrottleBackoff):
 			}
 			continue
 		}
 		// For other errors, don't retry
 		return err
 	}
-	return lastErr
+	return fmt.Errorf("weixin: sendMessage throttled (ret=-2) after %d attempts; "+
+		"ilink is rate-limiting the bot, retry later: %w", weixinSendMaxRetries, lastErr)
 }
 
 // SendImage implements core.ImageSender.

--- a/platform/weixin/media_outbound.go
+++ b/platform/weixin/media_outbound.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -109,8 +108,31 @@ func (p *Platform) uploadToWeixinCDN(ctx context.Context, to string, plaintext [
 	}, nil
 }
 
+// sendSingleItem sends a media item. If ilink throttles the send (ret=-2
+// "prepare failed"), it fails fast instead of retrying: the penalty is escalated
+// by every send attempt made while it is active, so retrying only prolongs the
+// outage.
 func (p *Platform) sendSingleItem(ctx context.Context, rc *replyContext, item messageItem) error {
-	return p.sendSingleItemWithRetry(ctx, rc, item)
+	msg := sendMessageReq{
+		Msg: weixinOutboundMsg{
+			FromUserID:   "",
+			ToUserID:     rc.peerUserID,
+			ClientID:     "cc-" + randomHex(8),
+			MessageType:  messageTypeBot,
+			MessageState: messageStateFinish,
+			ItemList:     []messageItem{item},
+			ContextToken: rc.contextToken,
+		},
+	}
+	err := p.api.sendMessage(ctx, &msg)
+	if err == nil {
+		return nil
+	}
+	if isSendThrottled(err) {
+		return fmt.Errorf("weixin: sendMessage throttled by ilink (ret=-2); "+
+			"the bot is rate-limited and sending during the penalty escalates it, retry the message later: %w", err)
+	}
+	return err
 }
 
 func mediaFromUploadRef(ref *cdnUploadedRef) *cdnMedia {
@@ -131,45 +153,6 @@ func buildVideoMessageItem(ref *cdnUploadedRef) messageItem {
 	}
 }
 
-// sendSingleItemWithRetry sends a media item with a retry mechanism.
-// When sendMessage returns ret=-2 (ilink throttling the bot), it backs off and
-// retries rather than hammering the throttled endpoint with 500ms-interval retries.
-func (p *Platform) sendSingleItemWithRetry(ctx context.Context, rc *replyContext, item messageItem) error {
-	var lastErr error
-	for attempt := 0; attempt < weixinSendMaxRetries; attempt++ {
-		msg := sendMessageReq{
-			Msg: weixinOutboundMsg{
-				FromUserID:   "",
-				ToUserID:     rc.peerUserID,
-				ClientID:     "cc-" + randomHex(8),
-				MessageType:  messageTypeBot,
-				MessageState: messageStateFinish,
-				ItemList:     []messageItem{item},
-				ContextToken: rc.contextToken,
-			},
-		}
-		err := p.api.sendMessage(ctx, &msg)
-		if err == nil {
-			return nil
-		}
-		lastErr = err
-		if isSendThrottled(err) {
-			slog.Warn("weixin: sendMessage throttled by ilink (ret=-2) for media; backing off before retry",
-				"attempt", attempt+1, "peer", rc.peerUserID,
-				"backoff", weixinThrottleBackoff)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(weixinThrottleBackoff):
-			}
-			continue
-		}
-		// For other errors, don't retry
-		return err
-	}
-	return fmt.Errorf("weixin: sendMessage throttled (ret=-2) after %d attempts; "+
-		"ilink is rate-limiting the bot, retry later: %w", weixinSendMaxRetries, lastErr)
-}
 
 // SendImage implements core.ImageSender.
 func (p *Platform) SendImage(ctx context.Context, replyCtx any, img core.ImageAttachment) error {

--- a/platform/weixin/media_outbound.go
+++ b/platform/weixin/media_outbound.go
@@ -113,6 +113,9 @@ func (p *Platform) uploadToWeixinCDN(ctx context.Context, to string, plaintext [
 // by every send attempt made while it is active, so retrying only prolongs the
 // outage.
 func (p *Platform) sendSingleItem(ctx context.Context, rc *replyContext, item messageItem) error {
+	if err := p.waitSendQuota(ctx); err != nil {
+		return err
+	}
 	msg := sendMessageReq{
 		Msg: weixinOutboundMsg{
 			FromUserID:   "",

--- a/platform/weixin/media_outbound.go
+++ b/platform/weixin/media_outbound.go
@@ -113,7 +113,7 @@ func (p *Platform) uploadToWeixinCDN(ctx context.Context, to string, plaintext [
 // by every send attempt made while it is active, so retrying only prolongs the
 // outage.
 func (p *Platform) sendSingleItem(ctx context.Context, rc *replyContext, item messageItem) error {
-	if err := p.waitSendQuota(ctx); err != nil {
+	if err := p.checkSendQuota(ctx); err != nil {
 		return err
 	}
 	msg := sendMessageReq{

--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -27,7 +27,7 @@ const (
 	sessionKeyPrefix = "weixin:dm:"
 	maxWeixinChunk   = 3800 // stay under typical IM limits
 
-	// weixinSendMaxRetries is the maximum number of retries for sendMessage when API returns ret=-2.
+	// weixinSendMaxRetries is the maximum number of attempts for sendMessage.
 	weixinSendMaxRetries = 3
 	// weixinSendRetryDelay is the delay between retries when sendMessage fails.
 	weixinSendRetryDelay = 500 * time.Millisecond
@@ -38,6 +38,12 @@ const (
 	// typingRepeatInterval is how often to resend the typing status to keep it alive.
 	typingRepeatInterval = 5 * time.Second
 )
+
+// weixinThrottleBackoff is how long to wait before retrying a send that ilink
+// throttled with ret=-2 "prepare failed". The penalty is bot-wide and long
+// (~1h); a short backoff only adds more refused sends to the window.
+// A var (not const) so tests can shrink it.
+var weixinThrottleBackoff = 15 * time.Second
 
 type replyContext struct {
 	peerUserID   string
@@ -651,8 +657,8 @@ func (p *Platform) sendChunks(ctx context.Context, replyCtx any, content string)
 		slog.Error("weixin: cannot send message - missing context_token",
 			"peer", rc.peerUserID,
 			"content_preview", truncatePreview(content, 100),
-			"hint", "user needs to send a new message to refresh context_token")
-		return fmt.Errorf("weixin: missing context_token for peer %q - user must send a new message first", rc.peerUserID)
+			"hint", "user needs to send a message to the bot first so a context_token can be captured")
+		return fmt.Errorf("weixin: missing context_token for peer %q - user must send a message to the bot first", rc.peerUserID)
 	}
 	if strings.TrimSpace(content) == "" {
 		return nil
@@ -675,12 +681,15 @@ func (p *Platform) sendChunks(ctx context.Context, replyCtx any, content string)
 				"peer", rc.peerUserID,
 				"failed_chunk", fmt.Sprintf("%d/%d", i+1, total),
 				"error", err)
-			// Notify user that message delivery was incomplete.
-			// Use a short message that is unlikely to fail itself.
-			notice := "⚠️ 消息发送不完整，请在终端查看完整结果。"
-			noticeID := "cc-" + randomHex(6)
-			if nerr := p.api.sendText(ctx, rc.peerUserID, notice, rc.contextToken, noticeID); nerr != nil {
-				slog.Warn("weixin: failed to send incomplete-delivery notice", "peer", rc.peerUserID, "error", nerr)
+			// Notify user that message delivery was incomplete, unless the failure
+			// is the ilink throttle: the notice send would be refused too, only
+			// adding another throttled request.
+			if !isSendThrottled(err) {
+				notice := "⚠️ 消息发送不完整，请在终端查看完整结果。"
+				noticeID := "cc-" + randomHex(6)
+				if nerr := p.api.sendText(ctx, rc.peerUserID, notice, rc.contextToken, noticeID); nerr != nil {
+					slog.Warn("weixin: failed to send incomplete-delivery notice", "peer", rc.peerUserID, "error", nerr)
+				}
 			}
 			return fmt.Errorf("weixin: send chunk %d/%d: %w", i+1, total, err)
 		}
@@ -688,11 +697,17 @@ func (p *Platform) sendChunks(ctx context.Context, replyCtx any, content string)
 	return nil
 }
 
-// sendChunkWithRetry sends a single chunk with retry mechanism.
-// When sendMessage returns ret=-2, it tries to refresh the context_token from
-// storage (which is updated by every inbound message) before retrying.
-// If the stored token is the same as the current one (no refresh possible),
-// it fails fast rather than burning retries on a stale token.
+// isSendThrottled reports whether err is ilink sendmessage's burst-throttle
+// response (ret=-2 "prepare failed"). This is a bot-wide rate-limit penalty, not a
+// context_token problem: the gateway accepts any (or no) context_token on sends.
+func isSendThrottled(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "ret=-2")
+}
+
+// sendChunkWithRetry sends a single chunk with a retry mechanism.
+// When sendMessage returns ret=-2 (ilink throttling the bot), it backs off and
+// retries rather than hammering the throttled endpoint with 500ms-interval retries
+// (which only adds more refused sends to the penalty window).
 // chunkIdx and totalChunks are 1-based indices used for logging context.
 func (p *Platform) sendChunkWithRetry(ctx context.Context, rc *replyContext, chunk string, chunkIdx, totalChunks int) error {
 	var lastErr error
@@ -703,47 +718,24 @@ func (p *Platform) sendChunkWithRetry(ctx context.Context, rc *replyContext, chu
 			return nil
 		}
 		lastErr = err
-		// Check if error is ret=-2 (API declined) - attempt token refresh
-		if strings.Contains(err.Error(), "ret=-2") {
-			preview := []rune(chunk)
-			if len(preview) > 50 {
-				preview = preview[:50]
-			}
-			// Refresh context_token from stored tokens (may have been updated by a
-			// concurrent inbound message while we were waiting).
-			freshToken := p.getContextToken(rc.peerUserID)
-			if freshToken == "" || freshToken == rc.contextToken {
-				// No fresh token available — further retries would use the same stale
-				// token and all fail. Fail fast with an actionable error.
-				slog.Warn("weixin: sendMessage ret=-2, no fresh context_token available — "+
-					"user must send a new message to refresh the session token",
-					"attempt", attempt+1, "peer", rc.peerUserID,
-					"chunk", fmt.Sprintf("%d/%d", chunkIdx, totalChunks),
-					"chunk_runes", utf8.RuneCountInString(chunk),
-					"preview", string(preview))
-				return fmt.Errorf("weixin: sendMessage ret=-2 (expired context_token); "+
-					"user must send a new message to peer %q to refresh the session token: %w",
-					rc.peerUserID, lastErr)
-			}
-			slog.Warn("weixin: sendMessage ret=-2, retrying with fresh context_token",
+		if isSendThrottled(err) {
+			slog.Warn("weixin: sendMessage throttled by ilink (ret=-2); backing off before retry",
 				"attempt", attempt+1, "peer", rc.peerUserID,
 				"chunk", fmt.Sprintf("%d/%d", chunkIdx, totalChunks),
 				"chunk_runes", utf8.RuneCountInString(chunk),
-				"preview", string(preview))
-			rc.contextToken = freshToken
-			slog.Debug("weixin: using refreshed context_token for retry", "peer", rc.peerUserID)
-			// Brief delay before retry
+				"backoff", weixinThrottleBackoff)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(weixinSendRetryDelay):
+			case <-time.After(weixinThrottleBackoff):
 			}
 			continue
 		}
-		// For other errors, don't retry
+		// For other errors, don't retry.
 		return err
 	}
-	return lastErr
+	return fmt.Errorf("weixin: sendMessage throttled (ret=-2) after %d attempts; "+
+		"ilink is rate-limiting the bot, retry later: %w", weixinSendMaxRetries, lastErr)
 }
 
 func truncatePreview(s string, max int) string {

--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -37,8 +37,8 @@ const (
 	// active. We pace separate messages (not chunks: multi-chunk sends are fine)
 	// to stay well below the trigger. Configurable via burst_limit /
 	// burst_window_secs platform options.
-	defaultBurstLimit      = 4  // max separate messages per window
-	defaultBurstWindowSecs = 120 // window length
+	defaultBurstLimit      = 4     // max separate messages per window
+	defaultBurstWindowSecs = 86400 // window length (24h: ilink budgets ~5-6 sends/day)
 	// typingTicketTTL is how long a cached typing ticket remains valid.
 	typingTicketTTL = 10 * time.Minute
 	// typingRepeatInterval is how often to resend the typing status to keep it alive.
@@ -670,14 +670,18 @@ func (p *Platform) refreshTypingTicket(ctx context.Context, peerID, contextToken
 	}()
 }
 
-// waitSendQuota blocks until the bot's recent separate-message volume is under
-// the burst window quota, so ilink's sendmessage throttle (ret=-2 "prepare
-// failed") is not triggered. Live testing showed the gateway throttles after
-// roughly 5-6 separate messages within a short window and that attempts made
-// during the penalty escalate it, so we pace separate messages (not chunks —
-// multi-chunk sends are fine) to stay safely below the trigger. A limit of 0
-// disables the quota.
-func (p *Platform) waitSendQuota(ctx context.Context) error {
+// checkSendQuota enforces the bot's separate-message budget so ilink's
+// sendmessage throttle (ret=-2 "prepare failed") is not triggered. Live testing
+// showed the gateway throttles a bot after roughly 5-6 separate messages per
+// long window (about a day; matches the 24h context TTL), regardless of pacing,
+// and that attempts made during the penalty escalate it. Multi-chunk sends do
+// not count (a chunked message is one logical message). This quota counts
+// logical messages in a sliding window and FAILS FAST once the budget is
+// exhausted — waiting for the window to slide (up to a day) is useless, and the
+// fail-fast philosophy (see sendChunk) applies: do not keep hammering a
+// throttled bot. Configure via burst_limit / burst_window_secs platform
+// options. A limit of 0 disables the quota.
+func (p *Platform) checkSendQuota(ctx context.Context) error {
 	if p.sendQuotaLimit <= 0 || p.sendQuotaWindow <= 0 {
 		return nil
 	}
@@ -692,18 +696,9 @@ func (p *Platform) waitSendQuota(ctx context.Context) error {
 	}
 	p.sendQuotaTimes = kept
 	if len(p.sendQuotaTimes) >= p.sendQuotaLimit {
-		oldest := p.sendQuotaTimes[0]
-		wait := oldest.Add(p.sendQuotaWindow).Sub(now)
 		p.sendQuotaMu.Unlock()
-		if wait <= 0 {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(wait):
-		}
-		return p.waitSendQuota(ctx)
+		return fmt.Errorf("weixin: send budget exhausted (%d messages in the last %s); "+
+			"ilink throttles the bot after roughly 5-6 sends per window — reduce messages or re-login later", p.sendQuotaLimit, p.sendQuotaWindow)
 	}
 	p.sendQuotaTimes = append(p.sendQuotaTimes, now)
 	p.sendQuotaMu.Unlock()
@@ -715,7 +710,7 @@ func (p *Platform) sendChunks(ctx context.Context, replyCtx any, content string)
 	if !ok || rc == nil {
 		return fmt.Errorf("weixin: invalid reply context")
 	}
-	if err := p.waitSendQuota(ctx); err != nil {
+	if err := p.checkSendQuota(ctx); err != nil {
 		return err
 	}
 	if strings.TrimSpace(rc.contextToken) == "" {

--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -27,10 +27,6 @@ const (
 	sessionKeyPrefix = "weixin:dm:"
 	maxWeixinChunk   = 3800 // stay under typical IM limits
 
-	// weixinSendMaxRetries is the maximum number of attempts for sendMessage.
-	weixinSendMaxRetries = 3
-	// weixinSendRetryDelay is the delay between retries when sendMessage fails.
-	weixinSendRetryDelay = 500 * time.Millisecond
 	// weixinChunkSendDelay is the delay between sending message chunks to avoid rate limiting.
 	weixinChunkSendDelay = 100 * time.Millisecond
 	// typingTicketTTL is how long a cached typing ticket remains valid.
@@ -38,12 +34,6 @@ const (
 	// typingRepeatInterval is how often to resend the typing status to keep it alive.
 	typingRepeatInterval = 5 * time.Second
 )
-
-// weixinThrottleBackoff is how long to wait before retrying a send that ilink
-// throttled with ret=-2 "prepare failed". The penalty is bot-wide and long
-// (~1h); a short backoff only adds more refused sends to the window.
-// A var (not const) so tests can shrink it.
-var weixinThrottleBackoff = 15 * time.Second
 
 type replyContext struct {
 	peerUserID   string
@@ -674,8 +664,7 @@ func (p *Platform) sendChunks(ctx context.Context, replyCtx any, content string)
 			case <-time.After(weixinChunkSendDelay):
 			}
 		}
-		// Retry sendText with context_token refresh on failure
-		err := p.sendChunkWithRetry(ctx, rc, chunk, i+1, total)
+		err := p.sendChunk(ctx, rc, chunk)
 		if err != nil {
 			slog.Error("weixin: chunk send failed, message incomplete",
 				"peer", rc.peerUserID,
@@ -704,38 +693,21 @@ func isSendThrottled(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "ret=-2")
 }
 
-// sendChunkWithRetry sends a single chunk with a retry mechanism.
-// When sendMessage returns ret=-2 (ilink throttling the bot), it backs off and
-// retries rather than hammering the throttled endpoint with 500ms-interval retries
-// (which only adds more refused sends to the penalty window).
-// chunkIdx and totalChunks are 1-based indices used for logging context.
-func (p *Platform) sendChunkWithRetry(ctx context.Context, rc *replyContext, chunk string, chunkIdx, totalChunks int) error {
-	var lastErr error
-	for attempt := 0; attempt < weixinSendMaxRetries; attempt++ {
-		clientID := "cc-" + randomHex(6)
-		err := p.api.sendText(ctx, rc.peerUserID, chunk, rc.contextToken, clientID)
-		if err == nil {
-			return nil
-		}
-		lastErr = err
-		if isSendThrottled(err) {
-			slog.Warn("weixin: sendMessage throttled by ilink (ret=-2); backing off before retry",
-				"attempt", attempt+1, "peer", rc.peerUserID,
-				"chunk", fmt.Sprintf("%d/%d", chunkIdx, totalChunks),
-				"chunk_runes", utf8.RuneCountInString(chunk),
-				"backoff", weixinThrottleBackoff)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(weixinThrottleBackoff):
-			}
-			continue
-		}
-		// For other errors, don't retry.
-		return err
+// sendChunk sends a single chunk. If ilink throttles the send (ret=-2
+// "prepare failed"), it fails fast instead of retrying: live testing showed the
+// penalty is escalated by every send attempt made while it is active, so retrying
+// (e.g. the old 3×500ms loop plus the extra notice send) only prolongs the outage.
+func (p *Platform) sendChunk(ctx context.Context, rc *replyContext, chunk string) error {
+	clientID := "cc-" + randomHex(6)
+	err := p.api.sendText(ctx, rc.peerUserID, chunk, rc.contextToken, clientID)
+	if err == nil {
+		return nil
 	}
-	return fmt.Errorf("weixin: sendMessage throttled (ret=-2) after %d attempts; "+
-		"ilink is rate-limiting the bot, retry later: %w", weixinSendMaxRetries, lastErr)
+	if isSendThrottled(err) {
+		return fmt.Errorf("weixin: sendMessage throttled by ilink (ret=-2); "+
+			"the bot is rate-limited and sending during the penalty escalates it, retry the message later: %w", err)
+	}
+	return err
 }
 
 func truncatePreview(s string, max int) string {

--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -29,6 +29,16 @@ const (
 
 	// weixinChunkSendDelay is the delay between sending message chunks to avoid rate limiting.
 	weixinChunkSendDelay = 100 * time.Millisecond
+
+	// Send-volume quota that keeps the bot under ilink's burst throttle
+	// (sendMessage ret=-2 "prepare failed"). Live testing showed the gateway
+	// throttles the bot after roughly 5-6 separate messages within a short window,
+	// and that the penalty is escalated by every send attempt made while it is
+	// active. We pace separate messages (not chunks: multi-chunk sends are fine)
+	// to stay well below the trigger. Configurable via burst_limit /
+	// burst_window_secs platform options.
+	defaultBurstLimit      = 4  // max separate messages per window
+	defaultBurstWindowSecs = 120 // window length
 	// typingTicketTTL is how long a cached typing ticket remains valid.
 	typingTicketTTL = 10 * time.Minute
 	// typingRepeatInterval is how often to resend the typing status to keep it alive.
@@ -83,6 +93,12 @@ type Platform struct {
 
 	typingMu      sync.RWMutex
 	typingTickets map[string]typingTicketEntry // peerUserID → cached ticket
+
+	// Send-volume quota guarding against ilink's burst throttle (see constants).
+	sendQuotaMu     sync.Mutex
+	sendQuotaTimes  []time.Time
+	sendQuotaLimit  int
+	sendQuotaWindow time.Duration
 }
 
 type typingTicketEntry struct {
@@ -131,6 +147,16 @@ func New(opts map[string]any) (core.Platform, error) {
 	}
 	lp := pickInt(opts["long_poll_timeout_ms"])
 
+	// Send-volume quota (see defaultBurstLimit constants). 0 disables the quota.
+	burstLimit := pickInt(opts["burst_limit"])
+	if burstLimit < 0 {
+		burstLimit = 0
+	}
+	burstWindow := pickInt(opts["burst_window_secs"])
+	if burstWindow < 0 {
+		burstWindow = 0
+	}
+
 	dataDir, _ := opts["cc_data_dir"].(string)
 	project, _ := opts["cc_project"].(string)
 	stateDir := ""
@@ -163,20 +189,29 @@ func New(opts map[string]any) (core.Platform, error) {
 		Transport: &http.Transport{Proxy: nil},
 	}
 
+	if burstLimit <= 0 {
+		burstLimit = defaultBurstLimit
+	}
+	if burstWindow <= 0 {
+		burstWindow = defaultBurstWindowSecs
+	}
+
 	p := &Platform{
-		token:         token,
-		baseURL:       baseURL,
-		cdnBaseURL:    cdnBaseURL,
-		allowFrom:     allowFrom,
-		routeTag:      routeTag,
-		stateDir:      stateDir,
-		longPollMS:    lp,
-		accountLabel:  accountLabel,
-		httpClient:    httpClient,
-		cdnHttpClient: cdnHttpClient,
-		tokens:        make(map[string]string),
-		dedup:         make(map[string]time.Time),
-		typingTickets: make(map[string]typingTicketEntry),
+		token:           token,
+		baseURL:         baseURL,
+		cdnBaseURL:      cdnBaseURL,
+		allowFrom:       allowFrom,
+		routeTag:        routeTag,
+		stateDir:        stateDir,
+		longPollMS:      lp,
+		accountLabel:    accountLabel,
+		httpClient:      httpClient,
+		cdnHttpClient:   cdnHttpClient,
+		tokens:          make(map[string]string),
+		dedup:           make(map[string]time.Time),
+		typingTickets:   make(map[string]typingTicketEntry),
+		sendQuotaLimit:  burstLimit,
+		sendQuotaWindow: time.Duration(burstWindow) * time.Second,
 	}
 	p.api = newAPIClient(baseURL, token, routeTag, httpClient)
 
@@ -635,10 +670,53 @@ func (p *Platform) refreshTypingTicket(ctx context.Context, peerID, contextToken
 	}()
 }
 
+// waitSendQuota blocks until the bot's recent separate-message volume is under
+// the burst window quota, so ilink's sendmessage throttle (ret=-2 "prepare
+// failed") is not triggered. Live testing showed the gateway throttles after
+// roughly 5-6 separate messages within a short window and that attempts made
+// during the penalty escalate it, so we pace separate messages (not chunks —
+// multi-chunk sends are fine) to stay safely below the trigger. A limit of 0
+// disables the quota.
+func (p *Platform) waitSendQuota(ctx context.Context) error {
+	if p.sendQuotaLimit <= 0 || p.sendQuotaWindow <= 0 {
+		return nil
+	}
+	p.sendQuotaMu.Lock()
+	now := time.Now()
+	cutoff := now.Add(-p.sendQuotaWindow)
+	kept := p.sendQuotaTimes[:0]
+	for _, t := range p.sendQuotaTimes {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	p.sendQuotaTimes = kept
+	if len(p.sendQuotaTimes) >= p.sendQuotaLimit {
+		oldest := p.sendQuotaTimes[0]
+		wait := oldest.Add(p.sendQuotaWindow).Sub(now)
+		p.sendQuotaMu.Unlock()
+		if wait <= 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+		return p.waitSendQuota(ctx)
+	}
+	p.sendQuotaTimes = append(p.sendQuotaTimes, now)
+	p.sendQuotaMu.Unlock()
+	return nil
+}
+
 func (p *Platform) sendChunks(ctx context.Context, replyCtx any, content string) error {
 	rc, ok := replyCtx.(*replyContext)
 	if !ok || rc == nil {
 		return fmt.Errorf("weixin: invalid reply context")
+	}
+	if err := p.waitSendQuota(ctx); err != nil {
+		return err
 	}
 	if strings.TrimSpace(rc.contextToken) == "" {
 		rc.contextToken = p.getContextToken(rc.peerUserID)

--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -456,5 +457,88 @@ func TestReconstructReplyCtx_MissingToken(t *testing.T) {
 	}
 	if !containsStr(err.Error(), "no stored context_token") {
 		t.Errorf("error = %q, want it to mention 'no stored context_token'", err.Error())
+	}
+}
+
+// TestIsSendThrottled verifies ret=-2 (ilink sendmessage burst throttle) is
+// recognized as a throttle and other errors are not.
+func TestIsSendThrottled(t *testing.T) {
+	if !isSendThrottled(fmt.Errorf("weixin: sendMessage: ret=-2 errcode=0 errmsg=prepare failed")) {
+		t.Fatal("ret=-2 should be recognized as a throttle")
+	}
+	if isSendThrottled(fmt.Errorf("weixin: sendMessage: connection reset by peer")) {
+		t.Fatal("non-ret=-2 error should not be treated as a throttle")
+	}
+	if isSendThrottled(nil) {
+		t.Fatal("nil error should not be treated as a throttle")
+	}
+}
+
+// TestSendChunkWithRetry_RecoversFromThrottle verifies the send path backs off
+// and retries when ilink returns ret=-2, succeeding once the throttle clears.
+func TestSendChunkWithRetry_RecoversFromThrottle(t *testing.T) {
+	var sendCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sendCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if sendCalls.Load() <= 2 {
+			_, _ = w.Write([]byte(`{"ret":-2,"errmsg":"prepare failed"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"message_id":123}`))
+	}))
+	defer srv.Close()
+
+	old := weixinThrottleBackoff
+	weixinThrottleBackoff = time.Millisecond
+	defer func() { weixinThrottleBackoff = old }()
+
+	p := &Platform{httpClient: &http.Client{}}
+	p.api = newAPIClient(srv.URL, "tok", "", p.httpClient)
+	rc := &replyContext{peerUserID: "peer-1", contextToken: "tok-1"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.sendChunkWithRetry(ctx, rc, "hello", 1, 1); err != nil {
+		t.Fatalf("sendChunkWithRetry failed: %v", err)
+	}
+	if got := sendCalls.Load(); got < 3 {
+		t.Fatalf("sendmessage calls = %d, want >= 3 (2 throttled + 1 success)", got)
+	}
+}
+
+// TestSendChunkWithRetry_FailsAfterThrottleAttempts verifies a persistently
+// throttled bot gives up after weixinSendMaxRetries attempts with a clear error
+// instead of hammering the endpoint indefinitely.
+func TestSendChunkWithRetry_FailsAfterThrottleAttempts(t *testing.T) {
+	var sendCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sendCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ret":-2,"errmsg":"prepare failed"}`))
+	}))
+	defer srv.Close()
+
+	old := weixinThrottleBackoff
+	weixinThrottleBackoff = time.Millisecond
+	defer func() { weixinThrottleBackoff = old }()
+
+	p := &Platform{httpClient: &http.Client{}}
+	p.api = newAPIClient(srv.URL, "tok", "", p.httpClient)
+	rc := &replyContext{peerUserID: "peer-1", contextToken: "tok-1"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := p.sendChunkWithRetry(ctx, rc, "hello", 1, 1)
+	if err == nil {
+		t.Fatal("expected a throttled error, got nil")
+	}
+	if !isSendThrottled(err) {
+		t.Fatalf("error should be recognized as a throttle, got: %v", err)
+	}
+	if got := sendCalls.Load(); got != weixinSendMaxRetries {
+		t.Fatalf("sendmessage calls = %d, want %d (bounded retries)", got, weixinSendMaxRetries)
 	}
 }

--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -474,44 +474,10 @@ func TestIsSendThrottled(t *testing.T) {
 	}
 }
 
-// TestSendChunkWithRetry_RecoversFromThrottle verifies the send path backs off
-// and retries when ilink returns ret=-2, succeeding once the throttle clears.
-func TestSendChunkWithRetry_RecoversFromThrottle(t *testing.T) {
-	var sendCalls atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sendCalls.Add(1)
-		w.Header().Set("Content-Type", "application/json")
-		if sendCalls.Load() <= 2 {
-			_, _ = w.Write([]byte(`{"ret":-2,"errmsg":"prepare failed"}`))
-			return
-		}
-		_, _ = w.Write([]byte(`{"message_id":123}`))
-	}))
-	defer srv.Close()
-
-	old := weixinThrottleBackoff
-	weixinThrottleBackoff = time.Millisecond
-	defer func() { weixinThrottleBackoff = old }()
-
-	p := &Platform{httpClient: &http.Client{}}
-	p.api = newAPIClient(srv.URL, "tok", "", p.httpClient)
-	rc := &replyContext{peerUserID: "peer-1", contextToken: "tok-1"}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := p.sendChunkWithRetry(ctx, rc, "hello", 1, 1); err != nil {
-		t.Fatalf("sendChunkWithRetry failed: %v", err)
-	}
-	if got := sendCalls.Load(); got < 3 {
-		t.Fatalf("sendmessage calls = %d, want >= 3 (2 throttled + 1 success)", got)
-	}
-}
-
-// TestSendChunkWithRetry_FailsAfterThrottleAttempts verifies a persistently
-// throttled bot gives up after weixinSendMaxRetries attempts with a clear error
-// instead of hammering the endpoint indefinitely.
-func TestSendChunkWithRetry_FailsAfterThrottleAttempts(t *testing.T) {
+// TestSendChunk_FailsFastOnThrottle verifies a throttled send fails immediately
+// with a single sendmessage call — no retries, because every attempt made during
+// the ilink penalty window escalates it.
+func TestSendChunk_FailsFastOnThrottle(t *testing.T) {
 	var sendCalls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sendCalls.Add(1)
@@ -520,9 +486,35 @@ func TestSendChunkWithRetry_FailsAfterThrottleAttempts(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := weixinThrottleBackoff
-	weixinThrottleBackoff = time.Millisecond
-	defer func() { weixinThrottleBackoff = old }()
+	p := &Platform{httpClient: &http.Client{}}
+	p.api = newAPIClient(srv.URL, "tok", "", p.httpClient)
+	rc := &replyContext{peerUserID: "peer-1", contextToken: "tok-1"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := p.sendChunk(ctx, rc, "hello")
+	if err == nil {
+		t.Fatal("expected a throttled error, got nil")
+	}
+	if !isSendThrottled(err) {
+		t.Fatalf("error should be recognized as a throttle, got: %v", err)
+	}
+	if got := sendCalls.Load(); got != 1 {
+		t.Fatalf("sendmessage calls = %d, want 1 (fail fast, no retries)", got)
+	}
+}
+
+// TestSendChunk_Succeeds verifies a normal send returns nil and issues exactly
+// one sendmessage call.
+func TestSendChunk_Succeeds(t *testing.T) {
+	var sendCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sendCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message_id":123}`))
+	}))
+	defer srv.Close()
 
 	p := &Platform{httpClient: &http.Client{}}
 	p.api = newAPIClient(srv.URL, "tok", "", p.httpClient)
@@ -531,14 +523,10 @@ func TestSendChunkWithRetry_FailsAfterThrottleAttempts(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err := p.sendChunkWithRetry(ctx, rc, "hello", 1, 1)
-	if err == nil {
-		t.Fatal("expected a throttled error, got nil")
+	if err := p.sendChunk(ctx, rc, "hello"); err != nil {
+		t.Fatalf("sendChunk failed: %v", err)
 	}
-	if !isSendThrottled(err) {
-		t.Fatalf("error should be recognized as a throttle, got: %v", err)
-	}
-	if got := sendCalls.Load(); got != weixinSendMaxRetries {
-		t.Fatalf("sendmessage calls = %d, want %d (bounded retries)", got, weixinSendMaxRetries)
+	if got := sendCalls.Load(); got != 1 {
+		t.Fatalf("sendmessage calls = %d, want 1", got)
 	}
 }

--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -531,48 +531,48 @@ func TestSendChunk_Succeeds(t *testing.T) {
 	}
 }
 
-// TestWaitSendQuota_AllowsUnderLimit verifies sends under the window limit pass
-// through without blocking.
-func TestWaitSendQuota_AllowsUnderLimit(t *testing.T) {
+// TestCheckSendQuota_AllowsUnderLimit verifies sends under the window limit pass
+// through without error.
+func TestCheckSendQuota_AllowsUnderLimit(t *testing.T) {
 	p := &Platform{sendQuotaLimit: 4, sendQuotaWindow: time.Hour}
 	ctx := context.Background()
 	for i := 0; i < 4; i++ {
-		if err := p.waitSendQuota(ctx); err != nil {
-			t.Fatalf("waitSendQuota(%d) unexpectedly failed: %v", i, err)
+		if err := p.checkSendQuota(ctx); err != nil {
+			t.Fatalf("checkSendQuota(%d) unexpectedly failed: %v", i, err)
 		}
 	}
 }
 
-// TestWaitSendQuota_BlocksWhenOverLimit verifies the quota paces sends once the
-// window is full, waiting until the oldest send falls outside the window.
-func TestWaitSendQuota_BlocksWhenOverLimit(t *testing.T) {
-	p := &Platform{sendQuotaLimit: 1, sendQuotaWindow: 300 * time.Millisecond}
+// TestCheckSendQuota_FailsWhenOverLimit verifies the quota fails fast (no
+// waiting) once the window budget is exhausted.
+func TestCheckSendQuota_FailsWhenOverLimit(t *testing.T) {
+	p := &Platform{sendQuotaLimit: 1, sendQuotaWindow: time.Hour}
 	ctx := context.Background()
-	if err := p.waitSendQuota(ctx); err != nil {
+	if err := p.checkSendQuota(ctx); err != nil {
 		t.Fatalf("first send should pass: %v", err)
 	}
 	start := time.Now()
-	if err := p.waitSendQuota(ctx); err != nil {
-		t.Fatalf("second send should be allowed after window expires: %v", err)
+	if err := p.checkSendQuota(ctx); err == nil {
+		t.Fatal("second send should fail (budget exhausted)")
 	}
-	if elapsed := time.Since(start); elapsed < 250*time.Millisecond {
-		t.Fatalf("expected to block ~300ms, got %v", elapsed)
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("over-budget send should fail fast, took %v", elapsed)
 	}
 }
 
-// TestWaitSendQuota_DisabledWhenZero verifies limit 0 disables the quota entirely.
-func TestWaitSendQuota_DisabledWhenZero(t *testing.T) {
+// TestCheckSendQuota_DisabledWhenZero verifies limit 0 disables the quota entirely.
+func TestCheckSendQuota_DisabledWhenZero(t *testing.T) {
 	p := &Platform{sendQuotaLimit: 0, sendQuotaWindow: time.Hour}
 	ctx := context.Background()
 	for i := 0; i < 10; i++ {
-		if err := p.waitSendQuota(ctx); err != nil {
-			t.Fatalf("disabled quota should never block: %v", err)
+		if err := p.checkSendQuota(ctx); err != nil {
+			t.Fatalf("disabled quota should never fail: %v", err)
 		}
 	}
 }
 
-// TestSendChunks_AppliesQuota verifies a burst of separate messages is paced by
-// the window quota end-to-end through sendChunks (httptest server).
+// TestSendChunks_AppliesQuota verifies the budget is enforced end-to-end through
+// sendChunks (httptest server): under budget sends succeed, over budget fails.
 func TestSendChunks_AppliesQuota(t *testing.T) {
 	var sendCalls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -582,7 +582,7 @@ func TestSendChunks_AppliesQuota(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := &Platform{httpClient: &http.Client{}, sendQuotaLimit: 1, sendQuotaWindow: 200 * time.Millisecond}
+	p := &Platform{httpClient: &http.Client{}, sendQuotaLimit: 1, sendQuotaWindow: time.Hour}
 	p.api = newAPIClient(srv.URL, "tok", "", p.httpClient)
 	rc := &replyContext{peerUserID: "peer-1", contextToken: "tok-1"}
 
@@ -592,14 +592,10 @@ func TestSendChunks_AppliesQuota(t *testing.T) {
 	if err := p.sendChunks(ctx, rc, "first"); err != nil {
 		t.Fatalf("first send failed: %v", err)
 	}
-	start := time.Now()
-	if err := p.sendChunks(ctx, rc, "second"); err != nil {
-		t.Fatalf("second send failed: %v", err)
+	if err := p.sendChunks(ctx, rc, "second"); err == nil {
+		t.Fatal("second send should fail (budget exhausted)")
 	}
-	if elapsed := time.Since(start); elapsed < 150*time.Millisecond {
-		t.Fatalf("second send should have been paced ~200ms, got %v", elapsed)
-	}
-	if got := sendCalls.Load(); got != 2 {
-		t.Fatalf("sendmessage calls = %d, want 2", got)
+	if got := sendCalls.Load(); got != 1 {
+		t.Fatalf("sendmessage calls = %d, want 1 (over-budget send not attempted)", got)
 	}
 }

--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -530,3 +530,76 @@ func TestSendChunk_Succeeds(t *testing.T) {
 		t.Fatalf("sendmessage calls = %d, want 1", got)
 	}
 }
+
+// TestWaitSendQuota_AllowsUnderLimit verifies sends under the window limit pass
+// through without blocking.
+func TestWaitSendQuota_AllowsUnderLimit(t *testing.T) {
+	p := &Platform{sendQuotaLimit: 4, sendQuotaWindow: time.Hour}
+	ctx := context.Background()
+	for i := 0; i < 4; i++ {
+		if err := p.waitSendQuota(ctx); err != nil {
+			t.Fatalf("waitSendQuota(%d) unexpectedly failed: %v", i, err)
+		}
+	}
+}
+
+// TestWaitSendQuota_BlocksWhenOverLimit verifies the quota paces sends once the
+// window is full, waiting until the oldest send falls outside the window.
+func TestWaitSendQuota_BlocksWhenOverLimit(t *testing.T) {
+	p := &Platform{sendQuotaLimit: 1, sendQuotaWindow: 300 * time.Millisecond}
+	ctx := context.Background()
+	if err := p.waitSendQuota(ctx); err != nil {
+		t.Fatalf("first send should pass: %v", err)
+	}
+	start := time.Now()
+	if err := p.waitSendQuota(ctx); err != nil {
+		t.Fatalf("second send should be allowed after window expires: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 250*time.Millisecond {
+		t.Fatalf("expected to block ~300ms, got %v", elapsed)
+	}
+}
+
+// TestWaitSendQuota_DisabledWhenZero verifies limit 0 disables the quota entirely.
+func TestWaitSendQuota_DisabledWhenZero(t *testing.T) {
+	p := &Platform{sendQuotaLimit: 0, sendQuotaWindow: time.Hour}
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		if err := p.waitSendQuota(ctx); err != nil {
+			t.Fatalf("disabled quota should never block: %v", err)
+		}
+	}
+}
+
+// TestSendChunks_AppliesQuota verifies a burst of separate messages is paced by
+// the window quota end-to-end through sendChunks (httptest server).
+func TestSendChunks_AppliesQuota(t *testing.T) {
+	var sendCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sendCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message_id":123}`))
+	}))
+	defer srv.Close()
+
+	p := &Platform{httpClient: &http.Client{}, sendQuotaLimit: 1, sendQuotaWindow: 200 * time.Millisecond}
+	p.api = newAPIClient(srv.URL, "tok", "", p.httpClient)
+	rc := &replyContext{peerUserID: "peer-1", contextToken: "tok-1"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	if err := p.sendChunks(ctx, rc, "first"); err != nil {
+		t.Fatalf("first send failed: %v", err)
+	}
+	start := time.Now()
+	if err := p.sendChunks(ctx, rc, "second"); err != nil {
+		t.Fatalf("second send failed: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 150*time.Millisecond {
+		t.Fatalf("second send should have been paced ~200ms, got %v", elapsed)
+	}
+	if got := sendCalls.Load(); got != 2 {
+		t.Fatalf("sendmessage calls = %d, want 2", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes weixin (ilink) `sendMessage ret=-2 "prepare failed"` failures that blocked proactive
pushes (cron/timer). Ref issue #1640.

**Root cause (empirically verified on a live bot, differs from the original diagnosis):**
the ilink gateway does **not** validate `context_token` on sends — fake and tokenless sends
both return HTTP 200 and are delivered. So this is **not a token-expiry bug**. `ret=-2
"prepare failed"` is a **per-account send budget / burst throttle**:
- Roughly **5-6 separate messages per 24h window** trip it (sends spread over hours count,
  so rate-based pacing alone does not help). Multi-chunk messages do **not** count (a
  chunked reply is one logical message).
- **Every send attempt made while the penalty is active escalates it** — the original
  incident recovered in ~1h with no attempts; sending probes kept a bot throttled for 15h+.
  So the old `3×500ms` retry loop plus the "incomplete delivery notice" send actively
  prolonged outages.

## Changes

1. **`platform/weixin` — fail fast on throttle** (`sendChunk`, `sendSingleItem`): on
   `ret=-2`, return a clear throttled error after a single sendmessage call. No retries
   (every attempt escalates the penalty). The "incomplete delivery notice" send is skipped
   when throttled.
2. **`platform/weixin` — 24h message budget** (`burst_limit` / `burst_window_secs`, default
   4 per 86400s): a sliding-window counter that **fails fast** (no waiting) once the budget
   is exhausted, so the bot never approaches the throttle. The `checkSendQuota` is applied
   to both the text (`sendChunks`) and media (`sendSingleItem`) paths, keeping the push and
   reply paths consistent.
3. **Fix misleading logs/errors** — "user must send a new message to refresh the session
   token" described a mechanism that doesn't exist; replaced with accurate throttle-aware
   messages.
4. **`config.example.toml`** — document the weixin burst quota options and the
   `[outgoing_rate_limit.platforms.weixin]` rate-limit example.

## Acceptance criteria (from the maintainer's plan) — how this maps

1. *ret=-2 self-heal by retrying once* — **reinterpreted**: retrying during the penalty
   escalates it (shown live), so the correct behavior is fail-fast + wait for the ~1h base
   penalty / next retry, plus QR re-login as recovery. The budget prevents triggering.
2. *context_tokens.json refresh* — **not applicable**: the gateway does not validate the
   token (proven), so refreshing it cannot change behavior. The file still updates on
   inbound messages (unchanged, harmless).
3. *Fix misleading log* — done (accurate throttle messaging).
4. *cron and reply paths consistent* — done: both go through `sendChunks`/`sendSingleItem`
   and share fail-fast + the budget.
5. *No regression* — ret=0 path untouched; `errcode -14` (pauseSession) untouched; only the
   `ret=-2` path changed.

## Tests

- New unit tests: `TestIsSendThrottled`, `TestSendChunk_FailsFastOnThrottle` (asserts a
  single sendmessage call), `TestSendChunk_Succeeds`, `TestCheckSendQuota_AllowsUnderLimit`,
  `TestCheckSendQuota_FailsWhenOverLimit`, `TestCheckSendQuota_DisabledWhenZero`,
  `TestSendChunks_AppliesQuota`.
- `go build -tags no_web ./...`, `go vet`, and `go test -tags no_web ./platform/weixin/
  ./core/` pass. The full suite's only failures are pre-existing and unrelated
  (`platform/cloud-web` needs a reachable gateway; `platform/feishu` has one flaky test),
  reproducible on `main`.

## Live verification (2026-08-05)

- Confirmed the throttle is a 24h per-account budget (a bot throttled at ~5-6 messages sent
  over several hours, not a burst).
- After deploying fail-fast + the 24h budget, the daily-report push succeeded end-to-end.
- Recovery when a bot does get throttled: QR re-login (`cc-connect weixin new`) yields a
  fresh account with a fresh budget — the only reliable immediate recovery.

Refs #1640
