### PR TITLE
feat(wecom): add interactive card sending and callback feedback

### DIFF
--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -287,7 +287,7 @@ func (p *WSPlatform) handleFrame(frame wsFrame) {
 	case "aibot_msg_callback":
 		p.handleMsgCallback(frame)
 	case "aibot_event_callback":
-		slog.Debug("wecom-ws: event callback received (ignored)", "req_id", frame.Headers.ReqID)
+		p.handleEventCallback(frame)
 	case "":
 		// Response frame (no cmd): identify by req_id prefix
 		reqID := frame.Headers.ReqID
@@ -530,6 +530,125 @@ func (p *WSPlatform) Send(ctx context.Context, rctx any, content string) error {
 	}
 	slog.Debug("wecom-ws: message sent", "user", rc.userID, "chunks", len(chunks), "total_len", len(content))
 	return nil
+}
+
+var _ core.CardSender = (*WSPlatform)(nil)
+
+// SendCard sends a structured card via aibot_send_msg. Implements core.CardSender.
+func (p *WSPlatform) SendCard(ctx context.Context, rctx any, card *core.Card) error {
+	rc, ok := rctx.(wsReplyContext)
+	if !ok {
+		return fmt.Errorf("wecom-ws: send card: invalid reply context type %T", rctx)
+	}
+	if rc.chatID == "" {
+		return fmt.Errorf("wecom-ws: chatID is empty, cannot send proactive card")
+	}
+
+	cardPayload, err := buildWeComTemplateCard(card)
+	if err != nil {
+		return fmt.Errorf("wecom-ws: build template card: %w", err)
+	}
+
+	reqID := p.generateReqID("aibot_send_msg")
+	frame := map[string]any{
+		"cmd":     "aibot_send_msg",
+		"headers": map[string]string{"req_id": reqID},
+		"body": map[string]any{
+			"chatid":        rc.chatID,
+			"msgtype":       "template_card",
+			"template_card": cardPayload,
+		},
+	}
+	if err := p.writeAndWaitAck(ctx, frame, reqID); err != nil {
+		slog.Error("wecom-ws: send card failed", "user", rc.userID, "error", err)
+		return err
+	}
+	slog.Debug("wecom-ws: card sent", "user", rc.userID)
+	return nil
+}
+
+// ReplyCard replies with a structured card via aibot_respond_msg. Implements core.CardSender.
+func (p *WSPlatform) ReplyCard(ctx context.Context, rctx any, card *core.Card) error {
+	rc, ok := rctx.(wsReplyContext)
+	if !ok {
+		return fmt.Errorf("wecom-ws: reply card: invalid reply context type %T", rctx)
+	}
+	if rc.reqID == "" {
+		return p.SendCard(ctx, rctx, card)
+	}
+
+	cardPayload, err := buildWeComTemplateCard(card)
+	if err != nil {
+		return fmt.Errorf("wecom-ws: build template card: %w", err)
+	}
+
+	frame := map[string]any{
+		"cmd":     "aibot_respond_msg",
+		"headers": map[string]string{"req_id": rc.reqID},
+		"body": map[string]any{
+			"msgtype":       "template_card",
+			"template_card": cardPayload,
+		},
+	}
+	if err := p.writeJSON(frame); err != nil {
+		slog.Error("wecom-ws: reply card failed", "user", rc.userID, "error", err)
+		return err
+	}
+	slog.Debug("wecom-ws: card reply sent", "user", rc.userID)
+	return nil
+}
+
+func (p *WSPlatform) handleEventCallback(frame wsFrame) {
+	var body struct {
+		MsgID      string `json:"msgid"`
+		CreateTime int64  `json:"create_time"`
+		AibotID    string `json:"aibotid"`
+		ChatID     string `json:"chatid"`
+		From       struct {
+			UserID string `json:"userid"`
+		} `json:"from"`
+		MsgType string `json:"msgtype"`
+		Event   struct {
+			EventType string `json:"eventtype"`
+			EventKey  string `json:"event_key"`
+			TaskID    string `json:"task_id"`
+		} `json:"event"`
+	}
+
+	if err := json.Unmarshal(frame.Body, &body); err != nil {
+		slog.Warn("wecom-ws: parse event_callback body failed", "error", err)
+		return
+	}
+
+	if body.Event.EventType == "template_card_event" {
+		slog.Info("wecom-ws: template_card_event received", "user", body.From.UserID, "event_key", body.Event.EventKey, "task_id", body.Event.TaskID)
+		if !core.AllowList(p.allowFrom, body.From.UserID) {
+			slog.Warn("wecom-ws: event rejected by allow_from", "user", body.From.UserID)
+			return
+		}
+		chatID := body.ChatID
+		if chatID == "" {
+			chatID = body.From.UserID
+		}
+		sessionKey := fmt.Sprintf("wecom:%s:%s", chatID, body.From.UserID)
+		chatName := chatID
+		rctx := wsReplyContext{reqID: frame.Headers.ReqID, userID: body.From.UserID, chatID: chatID}
+
+		responseText, isPerm := parseWeComPermissionResponse(body.Event.EventKey)
+		go p.handler(p, &core.Message{
+			SessionKey:           sessionKey,
+			Platform:             "wecom",
+			MessageID:            body.MsgID,
+			UserID:               body.From.UserID,
+			UserName:             body.From.UserID,
+			ChatName:             chatName,
+			Content:              responseText,
+			ReplyCtx:             rctx,
+			IsPermissionResponse: isPerm,
+		})
+	} else {
+		slog.Debug("wecom-ws: event callback received (ignored)", "req_id", frame.Headers.ReqID, "event_type", body.Event.EventType)
+	}
 }
 
 // ReconstructReplyCtx rebuilds a reply context from a session key.

--- a/platform/wecom/wecom.go
+++ b/platform/wecom/wecom.go
@@ -46,6 +46,9 @@ type xmlMessage struct {
 	FromUserName string   `xml:"FromUserName"`
 	CreateTime   int64    `xml:"CreateTime"`
 	MsgType      string   `xml:"MsgType"`
+	Event        string   `xml:"Event"`
+	EventKey     string   `xml:"EventKey"`
+	TaskId       string   `xml:"TaskId"`
 	Content      string   `xml:"Content"`
 	PicUrl       string   `xml:"PicUrl"`
 	MediaId      string   `xml:"MediaId"`
@@ -441,6 +444,24 @@ func (p *Platform) handleMessage(w http.ResponseWriter, r *http.Request, msgSig,
 			})
 		}()
 
+	case "event":
+		if msg.Event == "template_card_event" {
+			slog.Info("wecom: template_card_event received", "user", msg.FromUserName, "event_key", msg.EventKey, "task_id", msg.TaskId)
+			responseText, isPerm := parseWeComPermissionResponse(msg.EventKey)
+			go p.handler(p, &core.Message{
+				SessionKey:           sessionKey,
+				Platform:             "wecom",
+				MessageID:            strconv.FormatInt(msg.MsgId, 10),
+				UserID:               msg.FromUserName,
+				UserName:             p.resolveUserName(msg.FromUserName),
+				Content:              responseText,
+				ReplyCtx:             rctx,
+				IsPermissionResponse: isPerm,
+			})
+		} else {
+			slog.Debug("wecom: unhandled event type", "event", msg.Event)
+		}
+
 	default:
 		slog.Warn("wecom: unsupported inbound message type (no handler)",
 			"msg_type", msg.MsgType,
@@ -588,6 +609,64 @@ func (p *Platform) uploadImageMedia(accessToken string, img core.ImageAttachment
 }
 
 var _ core.ImageSender = (*Platform)(nil)
+var _ core.CardSender = (*Platform)(nil)
+
+// SendCard sends a structured card to the user. Implements core.CardSender.
+func (p *Platform) SendCard(ctx context.Context, rctx any, card *core.Card) error {
+	return p.sendCardInternal(ctx, rctx, card)
+}
+
+// ReplyCard replies with a structured card to the user. Implements core.CardSender.
+func (p *Platform) ReplyCard(ctx context.Context, rctx any, card *core.Card) error {
+	return p.sendCardInternal(ctx, rctx, card)
+}
+
+func (p *Platform) sendCardInternal(ctx context.Context, rctx any, card *core.Card) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return fmt.Errorf("wecom: send card: invalid reply context type %T", rctx)
+	}
+
+	cardPayload, err := buildWeComTemplateCard(card)
+	if err != nil {
+		return fmt.Errorf("wecom: build template card: %w", err)
+	}
+
+	accessToken, err := p.getAccessToken()
+	if err != nil {
+		return fmt.Errorf("wecom: send card: %w", err)
+	}
+
+	payload := map[string]any{
+		"touser":        rc.userID,
+		"msgtype":       "template_card",
+		"agentid":       p.agentID,
+		"template_card": cardPayload,
+	}
+
+	body, _ := json.Marshal(payload)
+	apiURL := p.wecomAPIURL("/cgi-bin/message/send", url.Values{
+		"access_token": []string{accessToken},
+	})
+
+	resp, err := p.apiClient.Post(apiURL, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return fmt.Errorf("wecom: send template card: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("wecom: decode send template card response: %w", err)
+	}
+	if result.ErrCode != 0 {
+		return fmt.Errorf("wecom: send template card failed: %d %s", result.ErrCode, result.ErrMsg)
+	}
+	return nil
+}
 
 func (p *Platform) sendMarkdown(accessToken, toUser, content string) error {
 	payload := map[string]any{

--- a/platform/wecom/wecom.go
+++ b/platform/wecom/wecom.go
@@ -653,7 +653,7 @@ func (p *Platform) sendCardInternal(ctx context.Context, rctx any, card *core.Ca
 	if err != nil {
 		return fmt.Errorf("wecom: send template card: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var result struct {
 		ErrCode int    `json:"errcode"`

--- a/platform/wecom/wecom_card.go
+++ b/platform/wecom/wecom_card.go
@@ -1,0 +1,110 @@
+package wecom
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// buildWeComTemplateCard converts a core.Card into a WeCom template_card payload.
+func buildWeComTemplateCard(card *core.Card) (map[string]any, error) {
+	if card == nil {
+		return nil, fmt.Errorf("wecom: nil card")
+	}
+
+	payload := make(map[string]any)
+
+	// Main Title
+	if card.Header != nil && card.Header.Title != "" {
+		payload["main_title"] = map[string]string{
+			"title": card.Header.Title,
+		}
+	}
+
+	var subTexts []string
+	var buttons []map[string]any
+	var horizontalList []map[string]string
+
+	for _, elem := range card.Elements {
+		switch e := elem.(type) {
+		case core.CardMarkdown:
+			if strings.TrimSpace(e.Content) != "" {
+				subTexts = append(subTexts, e.Content)
+			}
+		case core.CardNote:
+			if strings.TrimSpace(e.Text) != "" {
+				subTexts = append(subTexts, e.Text)
+			}
+		case core.CardListItem:
+			item := map[string]string{}
+			if e.Text != "" {
+				item["keyname"] = e.Text
+			}
+			if e.BtnText != "" {
+				item["value"] = e.BtnText
+			}
+			if len(item) > 0 {
+				horizontalList = append(horizontalList, item)
+			}
+		case core.CardActions:
+			for _, btn := range e.Buttons {
+				style := 2 // default
+				switch btn.Type {
+				case "primary":
+					style = 1
+				case "danger":
+					style = 3
+				}
+				buttons = append(buttons, map[string]any{
+					"text":  btn.Text,
+					"style": style,
+					"key":   btn.Value,
+				})
+			}
+		}
+	}
+
+	if len(subTexts) > 0 {
+		payload["sub_title_text"] = strings.Join(subTexts, "\n\n")
+	}
+
+	if len(horizontalList) > 0 {
+		payload["horizontal_content_list"] = horizontalList
+	}
+
+	// Always add card_action default
+	payload["card_action"] = map[string]any{
+		"type": 0,
+	}
+
+	if len(buttons) > 0 {
+		payload["card_type"] = "button_interaction"
+		payload["button_list"] = buttons
+	} else {
+		payload["card_type"] = "text_notice"
+		// text_notice requires sub_title_text or main_title
+		if payload["main_title"] == nil && payload["sub_title_text"] == nil {
+			payload["sub_title_text"] = " "
+		}
+	}
+
+	return payload, nil
+}
+
+// parseWeComPermissionResponse converts WeCom button event_key (e.g. perm:allow, perm:deny)
+// into standard permission response strings ("allow", "deny", "allow all", "deny all").
+// Returns response text and whether it was a permission response.
+func parseWeComPermissionResponse(eventKey string) (string, bool) {
+	switch eventKey {
+	case "perm:allow":
+		return "allow", true
+	case "perm:deny":
+		return "deny", true
+	case "perm:allow_all":
+		return "allow all", true
+	case "perm:deny_all":
+		return "deny all", true
+	}
+	return eventKey, false
+}

--- a/platform/wecom/wecom_card_test.go
+++ b/platform/wecom/wecom_card_test.go
@@ -1,0 +1,160 @@
+package wecom
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestBuildWeComTemplateCard(t *testing.T) {
+	card := core.NewCard().
+		Title("Permission Request", "red").
+		Markdown("Agent requests to run `rm -rf /tmp/test`").
+		Buttons(
+			core.PrimaryBtn("Allow", "perm:allow"),
+			core.DangerBtn("Deny", "perm:deny"),
+		).
+		Build()
+
+	payload, err := buildWeComTemplateCard(card)
+	if err != nil {
+		t.Fatalf("buildWeComTemplateCard error: %v", err)
+	}
+
+	if payload["card_type"] != "button_interaction" {
+		t.Errorf("expected card_type=button_interaction, got %v", payload["card_type"])
+	}
+
+	mainTitle, ok := payload["main_title"].(map[string]string)
+	if !ok || mainTitle["title"] != "Permission Request" {
+		t.Errorf("expected main_title.title='Permission Request', got %v", payload["main_title"])
+	}
+
+	subTitle, ok := payload["sub_title_text"].(string)
+	if !ok || !strings.Contains(subTitle, "rm -rf /tmp/test") {
+		t.Errorf("expected sub_title_text containing markdown, got %v", payload["sub_title_text"])
+	}
+
+	buttons, ok := payload["button_list"].([]map[string]any)
+	if !ok || len(buttons) != 2 {
+		t.Fatalf("expected 2 buttons, got %v", payload["button_list"])
+	}
+
+	if buttons[0]["text"] != "Allow" || buttons[0]["key"] != "perm:allow" || buttons[0]["style"] != 1 {
+		t.Errorf("button 0 mismatch: %+v", buttons[0])
+	}
+	if buttons[1]["text"] != "Deny" || buttons[1]["key"] != "perm:deny" || buttons[1]["style"] != 3 {
+		t.Errorf("button 1 mismatch: %+v", buttons[1])
+	}
+}
+
+func TestBuildWeComTemplateCard_TextNotice(t *testing.T) {
+	card := core.NewCard().
+		Title("Notice", "blue").
+		Markdown("Simple text notice without buttons").
+		Build()
+
+	payload, err := buildWeComTemplateCard(card)
+	if err != nil {
+		t.Fatalf("buildWeComTemplateCard error: %v", err)
+	}
+
+	if payload["card_type"] != "text_notice" {
+		t.Errorf("expected card_type=text_notice, got %v", payload["card_type"])
+	}
+}
+
+func TestParseWeComPermissionResponse(t *testing.T) {
+	tests := []struct {
+		key      string
+		wantText string
+		wantPerm bool
+	}{
+		{"perm:allow", "allow", true},
+		{"perm:deny", "deny", true},
+		{"perm:allow_all", "allow all", true},
+		{"perm:deny_all", "deny all", true},
+		{"act:/stop", "act:/stop", false},
+		{"custom_key", "custom_key", false},
+	}
+
+	for _, tt := range tests {
+		gotText, gotPerm := parseWeComPermissionResponse(tt.key)
+		if gotText != tt.wantText || gotPerm != tt.wantPerm {
+			t.Errorf("parseWeComPermissionResponse(%q) = (%q, %v), want (%q, %v)",
+				tt.key, gotText, gotPerm, tt.wantText, tt.wantPerm)
+		}
+	}
+}
+
+func TestWSEventCallback_TemplateCardEvent(t *testing.T) {
+	var handledMsg *core.Message
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	p := &WSPlatform{
+		botID: "bot_123",
+		handler: func(platform core.Platform, msg *core.Message) {
+			handledMsg = msg
+			wg.Done()
+		},
+	}
+
+	eventJSON := `{
+		"msgid": "msg_event_1",
+		"create_time": 1700000000,
+		"aibotid": "bot_123",
+		"chatid": "chat_456",
+		"from": {"userid": "user_789"},
+		"msgtype": "event",
+		"event": {
+			"eventtype": "template_card_event",
+			"event_key": "perm:allow",
+			"task_id": "task_abc"
+		}
+	}`
+
+	frame := wsFrame{
+		Cmd:     "aibot_event_callback",
+		Headers: wsFrameHeaders{ReqID: "req_evt_1"},
+		Body:    json.RawMessage(eventJSON),
+	}
+
+	p.handleEventCallback(frame)
+
+	if waitTimeout(&wg, 2*time.Second) {
+		t.Fatal("timed out waiting for event callback handler")
+	}
+
+	if handledMsg == nil {
+		t.Fatal("expected handledMsg to be set")
+	}
+
+	if handledMsg.UserID != "user_789" {
+		t.Errorf("UserID = %q, want user_789", handledMsg.UserID)
+	}
+	if handledMsg.Content != "allow" {
+		t.Errorf("Content = %q, want allow", handledMsg.Content)
+	}
+	if !handledMsg.IsPermissionResponse {
+		t.Errorf("IsPermissionResponse = false, want true")
+	}
+}
+
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed
+	case <-time.After(timeout):
+		return true // timed out
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds interactive card sending (`core.CardSender`) and callback feedback (`template_card_event`) support to the WeChat Work (WeCom / 企业微信) platform adapter in `cc-connect`, covering both **HTTP Webhook** mode (`wecom.go`) and **WebSocket** mode (`websocket.go`).

## Problem & Motivation

Previously, the WeCom platform adapter in `cc-connect` only supported plain text, markdown, image, voice, and file messages. Incoming `template_card_event` callbacks (button interactions) were either logged as unsupported or ignored (`aibot_event_callback`). As a result, interactive features like permission approval prompts (`perm:allow` / `perm:deny`), action buttons, and structured cards could not be rendered or interacted with on Enterprise WeChat.

## Changes

### 1. Template Card Renderer (`platform/wecom/wecom_card.go`)
- Added `buildWeComTemplateCard(card *core.Card)` to convert `*core.Card` into WeCom's official `template_card` format (`button_interaction` when buttons are present, and `text_notice` when text/title only).
- Maps button labels, types (`primary` -> 1, `danger` -> 3, `default` -> 2), and callback keys (`btn.Value`).
- Added `parseWeComPermissionResponse` helper to handle permission decision keys (`perm:allow`, `perm:deny`, `perm:allow_all`, `perm:deny_all`) and set `IsPermissionResponse: true` on `core.Message`.

### 2. HTTP Webhook Mode (`platform/wecom/wecom.go`)
- Implemented `core.CardSender` (`SendCard`, `ReplyCard`) for `Platform` by sending `msgtype: "template_card"` to `/cgi-bin/message/send`.
- Updated XML callback handler to parse `MsgType == "event"` and `Event == "template_card_event"`, extracting `EventKey` and `TaskId` to dispatch user actions.

### 3. WebSocket Mode (`platform/wecom/websocket.go`)
- Implemented `core.CardSender` (`SendCard`, `ReplyCard`) for `WSPlatform` via `aibot_send_msg` and `aibot_respond_msg`.
- Updated `handleFrame` for `cmd: "aibot_event_callback"` to handle `template_card_event` and dispatch the user button interaction.

### 4. Unit Tests (`platform/wecom/wecom_card_test.go`)
- Added unit tests covering:
  - `TestBuildWeComTemplateCard`: `button_interaction` mapping.
  - `TestBuildWeComTemplateCard_TextNotice`: `text_notice` fallback mapping.
  - `TestParseWeComPermissionResponse`: Permission response detection.
  - `TestWSEventCallback_TemplateCardEvent`: WebSocket frame parsing and `IsPermissionResponse` flag handling.

## Verification

Ran all unit tests for the `wecom` package:
```bash
go test -v ./platform/wecom/...
```
All 48 tests in `platform/wecom` passed cleanly.

## Wecom ref

https://developer.work.weixin.qq.com/document/path/101032

https://developer.work.weixin.qq.com/document/path/101027
