### PR TITLE
fix(cloud-web): TestGatewayWebhook fails on IPv6 dual-stack hosts

### DIFF
--- a/platform/cloud-web/gateway_test.go
+++ b/platform/cloud-web/gateway_test.go
@@ -32,7 +32,11 @@ func TestGatewayWebhook(t *testing.T) {
 	if gt.listener == nil {
 		t.Fatal("gateway listener not started")
 	}
-	url := "http://" + gt.listener.Addr().String() + gt.webhookPath
+	// listener.Addr() returns the IPv6 wildcard "[::]:port" on dual-stack
+	// systems. The wildcard address is not dialable — the test client must
+	// use the loopback form to actually reach the listener.
+	addr := strings.Replace(gt.listener.Addr().String(), "[::]", "[::1]", 1)
+	url := "http://" + addr + gt.webhookPath
 	body, _ := json.Marshal(wireInboundMessage{
 		Type: "message", MsgID: "g1", SessionKey: "cloud_web:x:y",
 		UserID: "y", Content: "from gateway", ReplyCtx: "ctx",


### PR DESCRIPTION
## Problem

`TestGatewayWebhook` fails deterministically on IPv6 dual-stack hosts (most modern Linux distros / containers) with:

```
gateway_test.go:44: webhook post: Post "http://[::]:36233/hook": EOF
```

## Root cause

Minimal reproducer:

```go
ln, _ := net.Listen("tcp", ":0")
// ln.Addr().String() == "[::]:<random>" on dual-stack systems
http.Post("http://"+ln.Addr().String()+"/hook", ...)  // EOF
```

`net.Listen("tcp", ":0")` returns an IPv6 wildcard listener whose address string is `[::]:<port>`. The IPv6 wildcard `::` (like IPv4 `0.0.0.0`) is **not dialable** — the test client must use the loopback form `[::1]:<port>` to reach the listener.

## Scope

- **Production**: zero impact. Real deployments configure concrete IPs (`0.0.0.0:8099`, public IP, reverse-proxy domain); the literal `::` only appears in this test.
- **CI / dev**: real impact. Any IPv6-enabled host fails this test, which can mask real regressions.

## Fix

One-line rewrite in `gateway_test.go`: replace `[::]` with the dialable loopback `[::1]`. Comment included to prevent future maintainers from deleting the `strings.Replace` as "redundant".

```go
addr := strings.Replace(gt.listener.Addr().String(), "[::]", "[::1]", 1)
url := "http://" + addr + gt.webhookPath
```

## Verification

Before (3 consecutive runs on the same host):

```
--- FAIL: TestGatewayWebhook (1.07s)
    gateway_test.go:44: webhook post: Post "http://[::]:36669/hook": EOF
```

After (3 consecutive runs):

```
ok  github.com/chenhg5/cc-connect/platform/cloud-web  0.004s
ok  github.com/chenhg5/cc-connect/platform/cloud-web  0.004s
ok  github.com/chenhg5/cc-connect/platform/cloud-web  0.004s
```

Reproduced on `origin/main` — predates any other work.

## Checklist

- [x] Build passes: `go build ./...`
- [x] Tests pass: `go test ./platform/cloud-web/`
- [x] Bug fix has a regression test (the fix flips `TestGatewayWebhook` from FAIL to PASS — it was already the regression test)
- [x] No new hardcoded platform/agent names in core
- [x] No new user-facing strings
- [x] No secrets in code