### PR TITLE
fix(opencode): connection drops when background subagent dispatched

### DIFF
--- a/agent/opencode/live_resume_test.go
+++ b/agent/opencode/live_resume_test.go
@@ -1,0 +1,198 @@
+package opencode
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// TestLivePromptAsyncAndSSE against the running opencode serve at localhost:4096.
+// Verifies: (1) prompt_async returns 204 quickly, (2) /event SSE delivers events,
+// (3) the SSE auto-reconnects after we forcibly close it server-side.
+//
+// Run with: OPENCODE_LIVE_RESUME_TEST=1 go test ./agent/opencode/ -run TestLivePromptAsync -v -timeout 60s
+func TestLivePromptAsync(t *testing.T) {
+	if os.Getenv("OPENCODE_LIVE_RESUME_TEST") == "" {
+		t.Skip("set OPENCODE_LIVE_RESUME_TEST=1 to run against local opencode serve")
+	}
+	url := os.Getenv("OPENCODE_LIVE_URL")
+	if url == "" {
+		url = "http://localhost:4096"
+	}
+	pw := os.Getenv("OPENCODE_SERVER_PASSWORD")
+	if pw == "" {
+		t.Skip("OPENCODE_SERVER_PASSWORD required for live test")
+	}
+
+	agent, err := New(map[string]any{
+		"cmd":            "/bin/false",
+		"work_dir":       "/tmp",
+		"connection_url": url,
+		"mode":           "default",
+		"model":          "zhipuai-coding-plan/glm-5.2",
+		"env":            map[string]any{"OPENCODE_SERVER_PASSWORD": pw},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = session.Close() }()
+
+	t.Logf("session id: %s", session.CurrentSessionID())
+
+	// Send a simple prompt. prompt_async should return 204 quickly.
+	start := time.Now()
+	sendErr := make(chan error, 1)
+	go func() { sendErr <- session.Send("Reply with exactly the word PONG, nothing else.", nil, nil) }()
+	select {
+	case err := <-sendErr:
+		if err != nil {
+			t.Fatalf("Send returned error: %v", err)
+		}
+		t.Logf("Send returned in %v (prompt_async 204 ack)", time.Since(start))
+	case <-time.After(10 * time.Second):
+		t.Fatal("Send did not return within 10s — prompt_async not fire-and-forget?")
+	}
+
+	// Wait for events: busy → step → text → idle. Collect text.
+	var textBuf strings.Builder
+	var gotResult atomic.Bool
+	deadline := time.After(60 * time.Second)
+	for !gotResult.Load() {
+		select {
+		case event := <-session.Events():
+			t.Logf("event: type=%q content=%q", event.Type, truncStr(event.Content, 80))
+			switch event.Type {
+			case core.EventText:
+				textBuf.WriteString(event.Content)
+			case core.EventResult:
+				gotResult.Store(true)
+			case core.EventError:
+				t.Fatalf("unexpected error event: %v", event.Error)
+			}
+		case <-deadline:
+			t.Fatal("did not receive EventResult within 60s")
+		}
+	}
+	if !strings.Contains(strings.ToUpper(textBuf.String()), "PONG") {
+		t.Logf("warning: response did not contain PONG: %q", textBuf.String())
+	} else {
+		t.Logf("PASS: got expected response containing PONG")
+	}
+}
+
+// TestLiveSSEReconnectAfterServerRestart verifies that cc-connect's SSE reconnects
+// after the opencode-server is briefly unavailable.
+//
+// Skipped unless OPENCODE_LIVE_RESUME_TEST=1 AND the user manually restarts opencode-server.
+// This is mostly a manual test stub — automated version requires controlling the server.
+func TestLiveSSEReconnectAfterServerRestart(t *testing.T) {
+	if os.Getenv("OPENCODE_LIVE_RESUME_TEST") == "" {
+		t.Skip("set OPENCODE_LIVE_RESUME_TEST=1 to run")
+	}
+	url := os.Getenv("OPENCODE_LIVE_URL")
+	if url == "" {
+		url = "http://localhost:4096"
+	}
+	pw := os.Getenv("OPENCODE_SERVER_PASSWORD")
+	if pw == "" {
+		t.Skip("OPENCODE_SERVER_PASSWORD required")
+	}
+
+	// Use a proxy that lets us kill the connection at will.
+	var killCount atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/event" && killCount.Add(1) == 1 {
+			// First SSE request: return immediately to force client reconnect.
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			return
+		}
+		// Otherwise, proxy through.
+		req, err := http.NewRequestWithContext(r.Context(), r.Method, url+r.URL.Path+"?"+r.URL.RawQuery, r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		req.Header = r.Header.Clone()
+		resp, err := http.DefaultTransport.RoundTrip(req)
+		if err != nil {
+			http.Error(w, err.Error(), 502)
+			return
+		}
+		defer resp.Body.Close()
+		for k, vs := range resp.Header {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		flusher, _ := w.(http.Flusher)
+		buf := make([]byte, 4096)
+		for {
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				w.Write(buf[:n])
+				if flusher != nil {
+					flusher.Flush()
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}))
+	defer proxy.Close()
+
+	agent, err := New(map[string]any{
+		"cmd":            "/bin/false",
+		"work_dir":       "/tmp",
+		"connection_url": proxy.URL,
+		"mode":           "default",
+		"model":          "anthropic/claude-haiku-4-5",
+		"env":            map[string]any{"OPENCODE_SERVER_PASSWORD": pw},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = session.Close() }()
+
+	t.Logf("session id: %s, kill count: %d", session.CurrentSessionID(), killCount.Load())
+	// Wait for reconnect to happen.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if killCount.Load() >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := killCount.Load(); got < 2 {
+		t.Fatalf("SSE did not reconnect: killCount=%d", got)
+	}
+	t.Logf("PASS: SSE reconnected after forced EOF (killCount=%d)", killCount.Load())
+}
+
+func truncStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return fmt.Sprintf("%s…(%d more)", s[:n], len(s)-n)
+}

--- a/agent/opencode/live_resume_test.go
+++ b/agent/opencode/live_resume_test.go
@@ -125,16 +125,16 @@ func TestLiveSSEReconnectAfterServerRestart(t *testing.T) {
 		// Otherwise, proxy through.
 		req, err := http.NewRequestWithContext(r.Context(), r.Method, url+r.URL.Path+"?"+r.URL.RawQuery, r.Body)
 		if err != nil {
-			http.Error(w, err.Error(), 500)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		req.Header = r.Header.Clone()
 		resp, err := http.DefaultTransport.RoundTrip(req)
 		if err != nil {
-			http.Error(w, err.Error(), 502)
+			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		for k, vs := range resp.Header {
 			for _, v := range vs {
 				w.Header().Add(k, v)
@@ -146,7 +146,7 @@ func TestLiveSSEReconnectAfterServerRestart(t *testing.T) {
 		for {
 			n, err := resp.Body.Read(buf)
 			if n > 0 {
-				w.Write(buf[:n])
+				_, _ = w.Write(buf[:n])
 				if flusher != nil {
 					flusher.Flush()
 				}

--- a/agent/opencode/live_resume_test.go
+++ b/agent/opencode/live_resume_test.go
@@ -54,7 +54,7 @@ func TestLivePromptAsync(t *testing.T) {
 	// Send a simple prompt. prompt_async should return 204 quickly.
 	start := time.Now()
 	sendErr := make(chan error, 1)
-	go func() { sendErr <- session.Send("Reply with exactly the word PONG, nothing else.", nil, nil) }()
+	go func() { sendErr <- session.Send("Reply with exactly the word PONG, nothing else.", "", nil, nil) }()
 	select {
 	case err := <-sendErr:
 		if err != nil {

--- a/agent/opencode/opencode.go
+++ b/agent/opencode/opencode.go
@@ -23,7 +23,7 @@ func init() {
 	core.RegisterAgent("opencode", New)
 }
 
-// Agent drives the OpenCode CLI in headless mode using `opencode run --format json`.
+// Agent drives OpenCode via the CLI or a persistent HTTP/SSE server connection.
 //
 // Modes:
 //   - "default": standard mode
@@ -34,8 +34,11 @@ type Agent struct {
 	mode                 string
 	cmd                  string   // CLI binary name, default "opencode"
 	cliExtraArgs         []string // extra args from cmd after the binary name
+	connectionURL        string
+	username             string
+	password             string
 	configEnv            []string // env vars from [projects.agent.options.env]
-	agentName            string // passed as --agent to opencode (for plugin-defined agents)
+	agentName            string   // passed as --agent to opencode (for plugin-defined agents)
 	providers            []core.ProviderConfig
 	activeIdx            int
 	sessionEnv           []string
@@ -70,6 +73,16 @@ func New(opts map[string]any) (core.Agent, error) {
 	mode, _ := opts["mode"].(string)
 	mode = normalizeMode(mode)
 	cmd, extraArgs := core.ParseCmdOpts(opts, "opencode")
+	connectionURL, _ := opts["connection_url"].(string)
+	if connectionURL != "" {
+		var err error
+		connectionURL, err = normalizeConnectionURL(connectionURL)
+		if err != nil {
+			return nil, err
+		}
+	}
+	username, _ := opts["username"].(string)
+	password, _ := opts["password"].(string)
 	agentName, _ := opts["agent"].(string) // --agent flag for plugin-defined agents (#1210)
 	ccDataDir, _ := opts["cc_data_dir"].(string)
 	ccProject, _ := opts["cc_project"].(string)
@@ -80,7 +93,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 
 	if _, err := exec.LookPath(cmd); err != nil {
-		return nil, fmt.Errorf("opencode: %q CLI not found in PATH, install from: https://github.com/opencode-ai/opencode", cmd)
+		return nil, fmt.Errorf("opencode: %q CLI not found in PATH, install from: https://github.com/anomalyco/opencode", cmd)
 	}
 
 	return &Agent{
@@ -89,6 +102,9 @@ func New(opts map[string]any) (core.Agent, error) {
 		mode:                 mode,
 		cmd:                  cmd,
 		cliExtraArgs:         extraArgs,
+		connectionURL:        connectionURL,
+		username:             username,
+		password:             password,
 		configEnv:            core.ParseConfigEnv(opts),
 		agentName:            agentName,
 		activeIdx:            -1,
@@ -466,6 +482,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	mode := a.mode
 	cmd := a.cmd
 	extraArgs := append([]string{}, a.cliExtraArgs...)
+	connectionURL := a.connectionURL
+	username := a.username
+	password := a.password
 	workDir := a.workDir
 	agentName := a.agentName
 	extraEnv := append([]string(nil), a.configEnv...)
@@ -478,6 +497,9 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 	a.mu.Unlock()
 
+	if connectionURL != "" {
+		return newOpencodeHTTPSession(ctx, connectionURL, username, password, workDir, model, mode, agentName, sessionID, extraEnv)
+	}
 	return newOpencodeSession(ctx, cmd, extraArgs, workDir, model, mode, agentName, sessionID, extraEnv)
 }
 

--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -47,6 +47,8 @@ type opencodeSession struct {
 	httpPartMu        sync.Mutex
 	httpPartText      map[string]string
 	httpAssistantMsg  map[string]struct{}
+	agentErrMu        sync.Mutex
+	agentErr          error
 }
 
 func newOpencodeSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
@@ -427,12 +429,35 @@ func (s *opencodeSession) handleReasoning(raw map[string]any) {
 func (s *opencodeSession) handleError(raw map[string]any) {
 	errMsg := extractErrorMessage(raw)
 	slog.Error("opencodeSession: agent error", "error", errMsg)
-	evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", errMsg)}
+	err := fmt.Errorf("%s", errMsg)
+	s.rememberAgentError(err)
+	evt := core.Event{Type: core.EventError, Error: err}
 	select {
 	case s.events <- evt:
 	case <-s.ctx.Done():
 		return
 	}
+}
+
+func (s *opencodeSession) rememberAgentError(err error) {
+	if err == nil {
+		return
+	}
+	s.agentErrMu.Lock()
+	s.agentErr = err
+	s.agentErrMu.Unlock()
+}
+
+func (s *opencodeSession) clearAgentError() {
+	s.agentErrMu.Lock()
+	s.agentErr = nil
+	s.agentErrMu.Unlock()
+}
+
+func (s *opencodeSession) currentAgentError() error {
+	s.agentErrMu.Lock()
+	defer s.agentErrMu.Unlock()
+	return s.agentErr
 }
 
 // extractErrorMessage tries to pull a human-readable message from various

--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -39,6 +39,7 @@ type opencodeSession struct {
 	expectingContinue atomic.Bool // true when compaction_continue received, waiting for next step
 	resultSent        atomic.Bool // true when EventResult has been sent for this turn
 	httpClient        *http.Client
+	streamClient      *http.Client // ponytail: separate no-timeout client for SSE event stream
 	connectionURL     string
 	username          string
 	password          string

--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,9 +21,7 @@ import (
 	"github.com/chenhg5/cc-connect/core"
 )
 
-// opencodeSession manages multi-turn conversations with the OpenCode CLI.
-// Each Send() launches a new `opencode run --format json` process
-// with --session for conversation continuity.
+// opencodeSession manages multi-turn conversations with OpenCode.
 type opencodeSession struct {
 	cmd               string
 	extraArgs         []string // extra args from cmd, prepended before opencode args
@@ -39,6 +38,15 @@ type opencodeSession struct {
 	alive             atomic.Bool
 	expectingContinue atomic.Bool // true when compaction_continue received, waiting for next step
 	resultSent        atomic.Bool // true when EventResult has been sent for this turn
+	httpClient        *http.Client
+	connectionURL     string
+	username          string
+	password          string
+	pendingMu         sync.Mutex
+	pendingQuestions  map[string][]core.UserQuestion
+	httpPartMu        sync.Mutex
+	httpPartText      map[string]string
+	httpAssistantMsg  map[string]struct{}
 }
 
 func newOpencodeSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
@@ -80,6 +88,9 @@ func (s *opencodeSession) Send(prompt string, messageID string, images []core.Im
 
 	s.resultSent.Store(false)
 	s.expectingContinue.Store(false)
+	if s.httpClient != nil {
+		return s.sendHTTP(prompt, imagePaths)
+	}
 
 	chatID := s.CurrentSessionID()
 	isResume := chatID != ""
@@ -487,7 +498,7 @@ func (s *opencodeSession) handleStepFinish(raw map[string]any) {
 	}
 	slog.Debug("opencodeSession: step finished", "reason", reason, "session_id", s.CurrentSessionID())
 
-	if reason == "stop" {
+	if reason == "stop" && s.httpClient == nil {
 		s.sendEventResult()
 	}
 }
@@ -506,8 +517,11 @@ func (s *opencodeSession) sendEventResult() {
 	}
 }
 
-// RespondPermission is a no-op — OpenCode handles permissions internally.
-func (s *opencodeSession) RespondPermission(_ string, _ core.PermissionResult) error {
+// RespondPermission is handled over HTTP in persistent-server mode.
+func (s *opencodeSession) RespondPermission(requestID string, result core.PermissionResult) error {
+	if s.httpClient != nil {
+		return s.respondHTTPPermission(requestID, result)
+	}
 	return nil
 }
 

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -216,6 +216,8 @@ func (s *opencodeSession) handleHTTPEvent(data []byte) {
 			s.resultSent.Store(false)
 		case "idle":
 			s.sendEventResult()
+		case "retry":
+			s.handleHTTPRetryStatus(status)
 		}
 	case "session.idle":
 		s.sendEventResult()
@@ -226,6 +228,37 @@ func (s *opencodeSession) handleHTTPEvent(data []byte) {
 	case "question.asked", "question.v2.asked":
 		s.handleHTTPQuestion(props)
 	}
+}
+
+func (s *opencodeSession) handleHTTPRetryStatus(status map[string]any) {
+	message := strings.TrimSpace(stringValue(status["message"]))
+	if message == "" || !isHTTPRetryFatal(message) {
+		return
+	}
+	err := fmt.Errorf("%s", message)
+	s.rememberAgentError(err)
+	s.emitHTTPEvent(core.Event{Type: core.EventError, Error: err})
+}
+
+func isHTTPRetryFatal(message string) bool {
+	lower := strings.ToLower(message)
+	for _, marker := range []string{
+		"usage limit",
+		"rate limit",
+		"quota",
+		"insufficient balance",
+		"payment required",
+		"429",
+		"使用上限",
+		"限额",
+		"余额不足",
+		"额度",
+	} {
+		if strings.Contains(lower, strings.ToLower(marker)) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *opencodeSession) handleHTTPPart(props map[string]any) {

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -1,0 +1,515 @@
+package opencode
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func normalizeConnectionURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", fmt.Errorf("opencode: invalid connection_url %q", raw)
+	}
+	return strings.TrimRight(raw, "/"), nil
+}
+
+func newOpencodeHTTPSession(ctx context.Context, connectionURL, username, password, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
+	s, err := newOpencodeSession(ctx, "", nil, workDir, model, mode, agentName, resumeID, extraEnv)
+	if err != nil {
+		return nil, err
+	}
+	s.httpClient = &http.Client{}
+	s.connectionURL = connectionURL
+	s.username = username
+	s.password = password
+	s.pendingQuestions = make(map[string][]core.UserQuestion)
+	s.httpPartText = make(map[string]string)
+	s.httpAssistantMsg = make(map[string]struct{})
+	if s.username == "" {
+		s.username = opencodeEnv(extraEnv, "OPENCODE_SERVER_USERNAME")
+		if s.username == "" {
+			s.username = "opencode"
+		}
+	}
+	if s.password == "" {
+		s.password = opencodeEnv(extraEnv, "OPENCODE_SERVER_PASSWORD")
+	}
+
+	if s.CurrentSessionID() == "" {
+		var created struct {
+			ID string `json:"id"`
+		}
+		if err := s.doHTTPJSON(http.MethodPost, "/session", map[string]any{}, &created); err != nil {
+			s.cancel()
+			return nil, fmt.Errorf("opencode: create HTTP session: %w", err)
+		}
+		if created.ID == "" {
+			s.cancel()
+			return nil, fmt.Errorf("opencode: create HTTP session: empty session ID")
+		}
+		s.chatID.Store(created.ID)
+	}
+
+	if err := s.startHTTPEventStream(); err != nil {
+		s.cancel()
+		return nil, err
+	}
+	return s, nil
+}
+
+func opencodeEnv(env []string, key string) string {
+	for i := len(env) - 1; i >= 0; i-- {
+		name, value, ok := strings.Cut(env[i], "=")
+		if ok && name == key {
+			return value
+		}
+	}
+	return os.Getenv(key)
+}
+
+func (s *opencodeSession) sendHTTP(prompt string, imagePaths []string) error {
+	parts := make([]map[string]any, 0, len(imagePaths)+1)
+	for _, path := range imagePaths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("opencode: read staged image: %w", err)
+		}
+		mimeType := mime.TypeByExtension(filepath.Ext(path))
+		if mimeType == "" {
+			mimeType = "image/png"
+		}
+		parts = append(parts, map[string]any{
+			"type":     "file",
+			"url":      "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(data),
+			"filename": filepath.Base(path),
+			"mime":     mimeType,
+		})
+	}
+	parts = append(parts, map[string]any{"type": "text", "text": prompt})
+
+	body := map[string]any{"parts": parts}
+	if s.agentName != "" {
+		body["agent"] = s.agentName
+	}
+	if providerID, modelID, ok := strings.Cut(s.model, "/"); ok && providerID != "" && modelID != "" {
+		body["model"] = map[string]any{"providerID": providerID, "modelID": modelID}
+	}
+	return s.doHTTPJSON(http.MethodPost, "/session/"+url.PathEscape(s.CurrentSessionID())+"/message", body, nil)
+}
+
+func (s *opencodeSession) startHTTPEventStream() error {
+	resp, err := s.doHTTPRequest(http.MethodGet, "/event", nil)
+	if err != nil {
+		return fmt.Errorf("opencode: connect event stream: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+		return s.httpStatusError(resp)
+	}
+	s.wg.Add(1)
+	go s.readHTTPEvents(resp.Body)
+	return nil
+}
+
+func (s *opencodeSession) readHTTPEvents(body io.ReadCloser) {
+	defer s.wg.Done()
+	defer body.Close()
+
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	var data strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if data.Len() > 0 {
+				s.handleHTTPEvent([]byte(data.String()))
+				data.Reset()
+			}
+			continue
+		}
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		if data.Len() > 0 {
+			data.WriteByte('\n')
+		}
+		data.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+	}
+	if s.ctx.Err() != nil {
+		return
+	}
+	s.alive.Store(false)
+	err := scanner.Err()
+	if err == nil {
+		err = io.EOF
+	}
+	s.emitHTTPEvent(core.Event{Type: core.EventError, Error: fmt.Errorf("opencode: event stream closed: %w", err)})
+}
+
+func (s *opencodeSession) handleHTTPEvent(data []byte) {
+	var event struct {
+		Type       string         `json:"type"`
+		Properties map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(data, &event); err != nil {
+		slog.Debug("opencode: invalid SSE event", "error", err)
+		return
+	}
+	props := event.Properties
+	sessionID, _ := props["sessionID"].(string)
+	if sessionID != "" && sessionID != s.CurrentSessionID() {
+		return
+	}
+
+	switch event.Type {
+	case "message.part.updated":
+		s.handleHTTPPart(props)
+	case "session.status":
+		status, _ := props["status"].(map[string]any)
+		switch statusType, _ := status["type"].(string); statusType {
+		case "busy":
+			s.resultSent.Store(false)
+		case "idle":
+			s.sendEventResult()
+		}
+	case "session.idle":
+		s.sendEventResult()
+	case "session.error":
+		s.handleError(map[string]any{"error": props["error"]})
+	case "permission.asked":
+		s.handleHTTPPermission(props)
+	case "question.asked", "question.v2.asked":
+		s.handleHTTPQuestion(props)
+	}
+}
+
+func (s *opencodeSession) handleHTTPPart(props map[string]any) {
+	part, _ := props["part"].(map[string]any)
+	if part == nil {
+		return
+	}
+	if sessionID, _ := part["sessionID"].(string); sessionID != s.CurrentSessionID() {
+		return
+	}
+	raw := map[string]any{"part": part}
+	switch partType, _ := part["type"].(string); partType {
+	case "text":
+		s.handleHTTPText(part)
+	case "reasoning":
+		s.handleHTTPReasoning(part)
+	case "tool":
+		state, _ := part["state"].(map[string]any)
+		status, _ := state["status"].(string)
+		if status == "completed" || status == "error" {
+			s.handleToolUse(raw)
+		}
+	case "step-start":
+		s.markHTTPAssistantMessage(part)
+		s.handleStepStart(raw)
+	case "step-finish":
+		s.handleStepFinish(raw)
+	}
+}
+
+func (s *opencodeSession) markHTTPAssistantMessage(part map[string]any) {
+	messageID := stringValue(part["messageID"])
+	if messageID == "" {
+		return
+	}
+	s.httpPartMu.Lock()
+	s.httpAssistantMsg[messageID] = struct{}{}
+	s.httpPartMu.Unlock()
+}
+
+func (s *opencodeSession) isHTTPAssistantPart(part map[string]any) bool {
+	messageID := stringValue(part["messageID"])
+	if messageID == "" {
+		return false
+	}
+	s.httpPartMu.Lock()
+	_, ok := s.httpAssistantMsg[messageID]
+	s.httpPartMu.Unlock()
+	return ok
+}
+
+func (s *opencodeSession) handleHTTPText(part map[string]any) {
+	if !s.isHTTPAssistantPart(part) {
+		return
+	}
+	text := s.httpPartDelta(part)
+	if text == "" {
+		return
+	}
+
+	metadata, _ := part["metadata"].(map[string]any)
+	synthetic, _ := part["synthetic"].(bool)
+	if synthetic && metadata != nil {
+		if cc, ok := metadata["compaction_continue"].(bool); ok && cc {
+			slog.Info("opencodeSession: compaction_continue detected, marking expectingContinue", "session_id", s.CurrentSessionID())
+			s.expectingContinue.Store(true)
+			return
+		}
+	}
+
+	s.emitHTTPEvent(core.Event{Type: core.EventText, Content: text, Metadata: metadata, Synthetic: synthetic})
+}
+
+func (s *opencodeSession) handleHTTPReasoning(part map[string]any) {
+	if !s.isHTTPAssistantPart(part) {
+		return
+	}
+	text := s.httpPartDelta(part)
+	if text == "" {
+		return
+	}
+	s.emitHTTPEvent(core.Event{Type: core.EventThinking, Content: text})
+}
+
+func (s *opencodeSession) httpPartDelta(part map[string]any) string {
+	text := stringValue(part["text"])
+	if text == "" {
+		return ""
+	}
+	key := httpPartKey(part)
+	if key == "" {
+		if opencodePartEnded(part) {
+			return text
+		}
+		return ""
+	}
+
+	s.httpPartMu.Lock()
+	defer s.httpPartMu.Unlock()
+	previous := s.httpPartText[key]
+	s.httpPartText[key] = text
+	if previous == "" {
+		return text
+	}
+	if strings.HasPrefix(text, previous) {
+		return text[len(previous):]
+	}
+	return text
+}
+
+func httpPartKey(part map[string]any) string {
+	if id := stringValue(part["id"]); id != "" {
+		return id
+	}
+	partType := stringValue(part["type"])
+	messageID := stringValue(part["messageID"])
+	if partType != "" && messageID != "" {
+		return messageID + ":" + partType
+	}
+	return ""
+}
+
+func opencodePartEnded(part map[string]any) bool {
+	timing, _ := part["time"].(map[string]any)
+	end, ok := timing["end"]
+	return ok && end != nil
+}
+
+func (s *opencodeSession) handleHTTPPermission(props map[string]any) {
+	requestID, _ := props["id"].(string)
+	permission, _ := props["permission"].(string)
+	patterns := opencodeStrings(props["patterns"])
+	if s.mode == "yolo" {
+		if err := s.RespondPermission(requestID, core.PermissionResult{Behavior: "allow"}); err != nil {
+			s.emitHTTPEvent(core.Event{Type: core.EventError, Error: err})
+		}
+		return
+	}
+	input := map[string]any{"patterns": patterns}
+	if metadata, ok := props["metadata"].(map[string]any); ok {
+		input["metadata"] = metadata
+	}
+	s.emitHTTPEvent(core.Event{
+		Type:         core.EventPermissionRequest,
+		RequestID:    requestID,
+		ToolName:     permission,
+		ToolInput:    strings.Join(patterns, ", "),
+		ToolInputRaw: input,
+	})
+}
+
+func (s *opencodeSession) handleHTTPQuestion(props map[string]any) {
+	requestID, _ := props["id"].(string)
+	if requestID == "" {
+		return
+	}
+	rawQuestions, _ := props["questions"].([]any)
+	questions := make([]core.UserQuestion, 0, len(rawQuestions))
+	for _, raw := range rawQuestions {
+		question, _ := raw.(map[string]any)
+		if question == nil {
+			continue
+		}
+		options := make([]core.UserQuestionOption, 0)
+		rawOptions, _ := question["options"].([]any)
+		for _, rawOption := range rawOptions {
+			option, _ := rawOption.(map[string]any)
+			if option == nil {
+				continue
+			}
+			options = append(options, core.UserQuestionOption{
+				Label:       stringValue(option["label"]),
+				Description: stringValue(option["description"]),
+			})
+		}
+		questions = append(questions, core.UserQuestion{
+			Question:    stringValue(question["question"]),
+			Header:      stringValue(question["header"]),
+			Options:     options,
+			MultiSelect: boolValue(question["multiple"]),
+		})
+	}
+	if len(questions) == 0 {
+		return
+	}
+	s.pendingMu.Lock()
+	s.pendingQuestions[requestID] = questions
+	s.pendingMu.Unlock()
+	s.emitHTTPEvent(core.Event{
+		Type:         core.EventPermissionRequest,
+		RequestID:    requestID,
+		ToolName:     "AskUserQuestion",
+		ToolInputRaw: map[string]any{"questions": rawQuestions},
+		Questions:    questions,
+	})
+}
+
+func (s *opencodeSession) respondHTTPPermission(requestID string, result core.PermissionResult) error {
+	s.pendingMu.Lock()
+	questions, isQuestion := s.pendingQuestions[requestID]
+	s.pendingMu.Unlock()
+	if isQuestion {
+		path := "/question/" + url.PathEscape(requestID)
+		if !strings.EqualFold(result.Behavior, "allow") {
+			return s.doHTTPJSON(http.MethodPost, path+"/reject", nil, nil)
+		}
+		answersByQuestion, _ := result.UpdatedInput["answers"].(map[string]any)
+		answers := make([][]string, 0, len(questions))
+		for _, question := range questions {
+			answer := strings.TrimSpace(stringValue(answersByQuestion[question.Question]))
+			if question.MultiSelect {
+				answers = append(answers, strings.FieldsFunc(answer, func(r rune) bool { return r == ',' || r == '，' }))
+			} else {
+				answers = append(answers, []string{answer})
+			}
+		}
+		if err := s.doHTTPJSON(http.MethodPost, path+"/reply", map[string]any{"answers": answers}, nil); err != nil {
+			return err
+		}
+		s.pendingMu.Lock()
+		delete(s.pendingQuestions, requestID)
+		s.pendingMu.Unlock()
+		return nil
+	}
+
+	reply := "reject"
+	if strings.EqualFold(result.Behavior, "allow") {
+		reply = "once"
+	}
+	return s.doHTTPJSON(http.MethodPost, "/permission/"+url.PathEscape(requestID)+"/reply", map[string]any{
+		"reply":   reply,
+		"message": result.Message,
+	}, nil)
+}
+
+func (s *opencodeSession) doHTTPJSON(method, path string, body, output any) error {
+	resp, err := s.doHTTPRequest(method, path, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return s.httpStatusError(resp)
+	}
+	if output == nil {
+		_, err = io.Copy(io.Discard, resp.Body)
+		return err
+	}
+	if err := json.NewDecoder(resp.Body).Decode(output); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+func (s *opencodeSession) doHTTPRequest(method, path string, body any) (*http.Response, error) {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(data)
+	}
+	u, err := url.Parse(s.connectionURL + path)
+	if err != nil {
+		return nil, err
+	}
+	if s.workDir != "" {
+		query := u.Query()
+		query.Set("directory", s.workDir)
+		u.RawQuery = query.Encode()
+	}
+	req, err := http.NewRequestWithContext(s.ctx, method, u.String(), reader)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if s.password != "" {
+		req.SetBasicAuth(s.username, s.password)
+	}
+	return s.httpClient.Do(req)
+}
+
+func (s *opencodeSession) httpStatusError(resp *http.Response) error {
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	return fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(data)))
+}
+
+func (s *opencodeSession) emitHTTPEvent(event core.Event) {
+	select {
+	case s.events <- event:
+	case <-s.ctx.Done():
+	}
+}
+
+func opencodeStrings(value any) []string {
+	items, _ := value.([]any)
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if text, ok := item.(string); ok {
+			result = append(result, text)
+		}
+	}
+	return result
+}
+
+func stringValue(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
+func boolValue(value any) bool {
+	result, _ := value.(bool)
+	return result
+}

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -83,6 +84,7 @@ func opencodeEnv(env []string, key string) string {
 }
 
 func (s *opencodeSession) sendHTTP(prompt string, imagePaths []string) error {
+	s.clearAgentError()
 	parts := make([]map[string]any, 0, len(imagePaths)+1)
 	for _, path := range imagePaths {
 		data, err := os.ReadFile(path)
@@ -109,7 +111,35 @@ func (s *opencodeSession) sendHTTP(prompt string, imagePaths []string) error {
 	if providerID, modelID, ok := strings.Cut(s.model, "/"); ok && providerID != "" && modelID != "" {
 		body["model"] = map[string]any{"providerID": providerID, "modelID": modelID}
 	}
-	return s.doHTTPJSON(http.MethodPost, "/session/"+url.PathEscape(s.CurrentSessionID())+"/message", body, nil)
+	if err := s.doHTTPJSON(http.MethodPost, "/session/"+url.PathEscape(s.CurrentSessionID())+"/message", body, nil); err != nil {
+		if agentErr := s.waitHTTPAgentError(750 * time.Millisecond); agentErr != nil {
+			return agentErr
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *opencodeSession) waitHTTPAgentError(timeout time.Duration) error {
+	if err := s.currentAgentError(); err != nil {
+		return err
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return nil
+		case <-timer.C:
+			return s.currentAgentError()
+		case <-ticker.C:
+			if err := s.currentAgentError(); err != nil {
+				return err
+			}
+		}
+	}
 }
 
 func (s *opencodeSession) startHTTPEventStream() error {

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -148,7 +148,7 @@ func (s *opencodeSession) startHTTPEventStream() error {
 		return fmt.Errorf("opencode: connect event stream: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		return s.httpStatusError(resp)
 	}
 	s.wg.Add(1)
@@ -158,7 +158,7 @@ func (s *opencodeSession) startHTTPEventStream() error {
 
 func (s *opencodeSession) readHTTPEvents(body io.ReadCloser) {
 	defer s.wg.Done()
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
@@ -466,7 +466,7 @@ func (s *opencodeSession) doHTTPJSON(method, path string, body, output any) erro
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return s.httpStatusError(resp)
 	}

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -116,11 +116,13 @@ func (s *opencodeSession) sendHTTP(prompt string, imagePaths []string) error {
 		body["model"] = map[string]any{"providerID": providerID, "modelID": modelID}
 	}
 
-	path := "/session/" + url.PathEscape(s.CurrentSessionID()) + "/message"
-	// ponytail: /message is NON-IDEMPOTENT (each call creates a new user message) and
-	// streams the entire turn. Retrying duplicates the prompt into the session; the
-	// 60s API timeout kills legit long turns. No timeout, no retry — like /event.
-	if err := s.doHTTPJSONWithRetryClient(s.streamClient, http.MethodPost, path, body, nil, 1); err != nil {
+	// /prompt_async is fire-and-forget (204); the whole turn flows via /event SSE.
+	// Decouples POST lifecycle from the agent turn so long turns (incl. background
+	// subagent dispatch) can't break the POST and vice versa.
+	path := "/session/" + url.PathEscape(s.CurrentSessionID()) + "/prompt_async"
+	if err := s.doHTTPJSONWithRetryClient(s.httpClient, http.MethodPost, path, body, nil, 1); err != nil {
+		// Surface any async session.error (quota, payment-required) emitted on /event
+		// before returning the POST-level failure.
 		if agentErr := s.waitHTTPAgentError(750 * time.Millisecond); agentErr != nil {
 			return agentErr
 		}
@@ -151,24 +153,83 @@ func (s *opencodeSession) waitHTTPAgentError(timeout time.Duration) error {
 	}
 }
 
+// initialSSEBackoff and maxSSEBackoff bound the reconnect retry cadence after
+// the /event SSE stream ends. The SSE is the only durable link to opencode's
+// turn output, so on EOF we reconnect instead of tearing the session down.
+const (
+	initialSSEBackoff = 500 * time.Millisecond
+	maxSSEBackoff     = 30 * time.Second
+)
+
 func (s *opencodeSession) startHTTPEventStream() error {
-	resp, err := s.doStreamRequest(http.MethodGet, "/event", nil)
+	resp, err := s.connectSSE()
 	if err != nil {
 		return fmt.Errorf("opencode: connect event stream: %w", err)
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		defer func() { _ = resp.Body.Close() }()
-		return s.httpStatusError(resp)
-	}
 	s.wg.Add(1)
-	go s.readHTTPEvents(resp.Body)
+	go s.readHTTPEventsLoop(resp)
 	return nil
 }
 
-func (s *opencodeSession) readHTTPEvents(body io.ReadCloser) {
-	defer s.wg.Done()
-	defer func() { _ = body.Close() }()
+func (s *opencodeSession) connectSSE() (*http.Response, error) {
+	resp, err := s.doStreamRequest(http.MethodGet, "/event", nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	return resp, nil
+}
 
+// readHTTPEventsLoop consumes the /event SSE forever, reconnecting with
+// exponential backoff (capped at maxSSEBackoff) whenever the stream ends.
+// It only returns when s.ctx is cancelled (session close). Transient stream
+// EOF — server restart, network blip, keepalive expiry — no longer kills the
+// session; the loop just reconnects.
+func (s *opencodeSession) readHTTPEventsLoop(initial *http.Response) {
+	defer s.wg.Done()
+
+	resp := initial
+	backoff := initialSSEBackoff
+	for {
+		s.readSSEBody(resp.Body)
+		_ = resp.Body.Close()
+		if s.ctx.Err() != nil {
+			return
+		}
+		slog.Info("opencode: /event stream ended, reconnecting", "backoff", backoff)
+
+		for attempts := 0; ; attempts++ {
+			if s.ctx.Err() != nil {
+				return
+			}
+			if attempts > 0 {
+				wait := backoff
+				backoff *= 2
+				if backoff > maxSSEBackoff {
+					backoff = maxSSEBackoff
+				}
+				s.sleepContext(wait)
+				if s.ctx.Err() != nil {
+					return
+				}
+			}
+			newResp, err := s.connectSSE()
+			if err != nil {
+				slog.Warn("opencode: /event reconnect failed", "error", err, "attempt", attempts+1)
+				continue
+			}
+			resp = newResp
+			backoff = initialSSEBackoff
+			break
+		}
+	}
+}
+
+func (s *opencodeSession) readSSEBody(body io.ReadCloser) {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
 	var data strings.Builder
@@ -189,15 +250,18 @@ func (s *opencodeSession) readHTTPEvents(body io.ReadCloser) {
 		}
 		data.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
 	}
-	if s.ctx.Err() != nil {
-		return
+	if err := scanner.Err(); err != nil && s.ctx.Err() == nil {
+		slog.Debug("opencode: /event scanner ended", "error", err)
 	}
-	s.alive.Store(false)
-	err := scanner.Err()
-	if err == nil {
-		err = io.EOF
+}
+
+func (s *opencodeSession) sleepContext(d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-s.ctx.Done():
+	case <-t.C:
 	}
-	s.emitHTTPEvent(core.Event{Type: core.EventError, Error: fmt.Errorf("opencode: event stream closed: %w", err)})
 }
 
 func (s *opencodeSession) handleHTTPEvent(data []byte) {

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -648,10 +648,6 @@ func isHTTPRetryableStatus(code int) bool {
 		code == http.StatusTooManyRequests || code == http.StatusBadGateway
 }
 
-func (s *opencodeSession) doHTTPRequest(method, path string, body any) (*http.Response, error) {
-	return s.doRequestWithClient(s.httpClient, method, path, body)
-}
-
 func (s *opencodeSession) doStreamRequest(method, path string, body any) (*http.Response, error) {
 	return s.doRequestWithClient(s.streamClient, method, path, body)
 }
@@ -685,11 +681,6 @@ func (s *opencodeSession) doRequestWithClient(client *http.Client, method, path 
 		req.SetBasicAuth(s.username, s.password)
 	}
 	return client.Do(req)
-}
-
-func (s *opencodeSession) httpStatusError(resp *http.Response) error {
-	data, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
-	return fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(data)))
 }
 
 func (s *opencodeSession) emitHTTPEvent(event core.Event) {

--- a/agent/opencode/session_http.go
+++ b/agent/opencode/session_http.go
@@ -34,7 +34,11 @@ func newOpencodeHTTPSession(ctx context.Context, connectionURL, username, passwo
 	if err != nil {
 		return nil, err
 	}
-	s.httpClient = &http.Client{}
+	// Regular API calls need a timeout so a hung opencode server doesn't
+	// block cc-connect forever. The event stream uses a separate client
+	// without a timeout because it is intentionally long-lived.
+	s.httpClient = &http.Client{Timeout: 60 * time.Second}
+	s.streamClient = &http.Client{}
 	s.connectionURL = connectionURL
 	s.username = username
 	s.password = password
@@ -111,7 +115,12 @@ func (s *opencodeSession) sendHTTP(prompt string, imagePaths []string) error {
 	if providerID, modelID, ok := strings.Cut(s.model, "/"); ok && providerID != "" && modelID != "" {
 		body["model"] = map[string]any{"providerID": providerID, "modelID": modelID}
 	}
-	if err := s.doHTTPJSON(http.MethodPost, "/session/"+url.PathEscape(s.CurrentSessionID())+"/message", body, nil); err != nil {
+
+	path := "/session/" + url.PathEscape(s.CurrentSessionID()) + "/message"
+	// ponytail: /message is NON-IDEMPOTENT (each call creates a new user message) and
+	// streams the entire turn. Retrying duplicates the prompt into the session; the
+	// 60s API timeout kills legit long turns. No timeout, no retry — like /event.
+	if err := s.doHTTPJSONWithRetryClient(s.streamClient, http.MethodPost, path, body, nil, 1); err != nil {
 		if agentErr := s.waitHTTPAgentError(750 * time.Millisecond); agentErr != nil {
 			return agentErr
 		}
@@ -143,7 +152,7 @@ func (s *opencodeSession) waitHTTPAgentError(timeout time.Duration) error {
 }
 
 func (s *opencodeSession) startHTTPEventStream() error {
-	resp, err := s.doHTTPRequest(http.MethodGet, "/event", nil)
+	resp, err := s.doStreamRequest(http.MethodGet, "/event", nil)
 	if err != nil {
 		return fmt.Errorf("opencode: connect event stream: %w", err)
 	}
@@ -207,6 +216,10 @@ func (s *opencodeSession) handleHTTPEvent(data []byte) {
 	}
 
 	switch event.Type {
+	case "session.next.step.started":
+		if assistantMessageID, _ := props["assistantMessageID"].(string); assistantMessageID != "" {
+			s.markHTTPAssistantMessageByID(assistantMessageID)
+		}
 	case "message.part.updated":
 		s.handleHTTPPart(props)
 	case "session.status":
@@ -291,6 +304,10 @@ func (s *opencodeSession) handleHTTPPart(props map[string]any) {
 
 func (s *opencodeSession) markHTTPAssistantMessage(part map[string]any) {
 	messageID := stringValue(part["messageID"])
+	s.markHTTPAssistantMessageByID(messageID)
+}
+
+func (s *opencodeSession) markHTTPAssistantMessageByID(messageID string) {
 	if messageID == "" {
 		return
 	}
@@ -495,25 +512,87 @@ func (s *opencodeSession) respondHTTPPermission(requestID string, result core.Pe
 }
 
 func (s *opencodeSession) doHTTPJSON(method, path string, body, output any) error {
-	resp, err := s.doHTTPRequest(method, path, body)
-	if err != nil {
-		return err
+	return s.doHTTPJSONWithRetry(method, path, body, output, 1)
+}
+
+func (s *opencodeSession) doHTTPJSONWithRetry(method, path string, body, output any, maxAttempts int) error {
+	return s.doHTTPJSONWithRetryClient(s.httpClient, method, path, body, output, maxAttempts)
+}
+
+func (s *opencodeSession) doHTTPJSONWithRetryClient(client *http.Client, method, path string, body, output any, maxAttempts int) error {
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			slog.Info("opencode: retrying HTTP request", "path", path, "attempt", attempt+1, "max", maxAttempts)
+			time.Sleep(time.Duration(attempt) * 500 * time.Millisecond)
+		}
+		resp, err := s.doRequestWithClient(client, method, path, body)
+		if err != nil {
+			lastErr = err
+			if !isHTTPRetryableError(err) {
+				return err
+			}
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			data, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(data)))
+			if !isHTTPRetryableStatus(resp.StatusCode) {
+				return lastErr
+			}
+			continue
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if output == nil {
+			_, err = io.Copy(io.Discard, resp.Body)
+			return err
+		}
+		if err := json.NewDecoder(resp.Body).Decode(output); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+		return nil
 	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return s.httpStatusError(resp)
+	return lastErr
+}
+
+func isHTTPRetryableError(err error) bool {
+	if err == nil {
+		return false
 	}
-	if output == nil {
-		_, err = io.Copy(io.Discard, resp.Body)
-		return err
+	if netErr, ok := err.(interface{ Timeout() bool }); ok && netErr.Timeout() {
+		return true
 	}
-	if err := json.NewDecoder(resp.Body).Decode(output); err != nil {
-		return fmt.Errorf("decode response: %w", err)
+	if netErr, ok := err.(interface{ Temporary() bool }); ok && netErr.Temporary() {
+		return true
 	}
-	return nil
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"econnreset", "econnrefused", "econnaborted", "enoent", "broken pipe",
+		"connection reset", "connection refused", "connection aborted",
+		"no such host", "i/o timeout", "tls handshake timeout",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHTTPRetryableStatus(code int) bool {
+	return code == http.StatusServiceUnavailable || code == http.StatusGatewayTimeout ||
+		code == http.StatusTooManyRequests || code == http.StatusBadGateway
 }
 
 func (s *opencodeSession) doHTTPRequest(method, path string, body any) (*http.Response, error) {
+	return s.doRequestWithClient(s.httpClient, method, path, body)
+}
+
+func (s *opencodeSession) doStreamRequest(method, path string, body any) (*http.Response, error) {
+	return s.doRequestWithClient(s.streamClient, method, path, body)
+}
+
+func (s *opencodeSession) doRequestWithClient(client *http.Client, method, path string, body any) (*http.Response, error) {
 	var reader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -541,7 +620,7 @@ func (s *opencodeSession) doHTTPRequest(method, path string, body any) (*http.Re
 	if s.password != "" {
 		req.SetBasicAuth(s.username, s.password)
 	}
-	return s.httpClient.Do(req)
+	return client.Do(req)
 }
 
 func (s *opencodeSession) httpStatusError(resp *http.Response) error {

--- a/agent/opencode/session_http_live_test.go
+++ b/agent/opencode/session_http_live_test.go
@@ -1,0 +1,94 @@
+package opencode
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestOpencodeHTTPModeLiveServer(t *testing.T) {
+	connectionURL := os.Getenv("OPENCODE_LIVE_URL")
+	if connectionURL == "" {
+		t.Skip("set OPENCODE_LIVE_URL to run against a local opencode serve")
+	}
+
+	agent, err := New(map[string]any{
+		"work_dir":       t.TempDir(),
+		"connection_url": connectionURL,
+		"username":       os.Getenv("OPENCODE_LIVE_USERNAME"),
+		"password":       os.Getenv("OPENCODE_LIVE_PASSWORD"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	if session.CurrentSessionID() == "" {
+		t.Fatal("expected live HTTP session ID")
+	}
+	if os.Getenv("OPENCODE_LIVE_SEND") == "" {
+		return
+	}
+
+	sendDone := make(chan error, 1)
+	startedAt := time.Now()
+	go func() {
+		sendDone <- session.Send("Reply exactly with CC_CONNECT_LIVE_OK.", nil, nil)
+	}()
+
+	var text strings.Builder
+	firstTextAt := time.Time{}
+	sendDoneAt := time.Time{}
+	var sendErr error
+	deadline := time.After(2 * time.Minute)
+	for {
+		select {
+		case err := <-sendDone:
+			sendDoneAt = time.Now()
+			sendErr = err
+		case event := <-session.Events():
+			switch event.Type {
+			case core.EventText:
+				if firstTextAt.IsZero() {
+					firstTextAt = time.Now()
+				}
+				text.WriteString(event.Content)
+			case core.EventResult:
+				if sendDoneAt.IsZero() {
+					select {
+					case sendErr = <-sendDone:
+						sendDoneAt = time.Now()
+					case <-time.After(10 * time.Second):
+						t.Fatal("timed out waiting for prompt response after EventResult")
+					}
+				}
+				if sendErr != nil {
+					t.Fatal(sendErr)
+				}
+				if firstTextAt.IsZero() {
+					t.Fatal("expected at least one streamed text event")
+				}
+				if !strings.Contains(text.String(), "CC_CONNECT_LIVE_OK") {
+					t.Fatalf("live response text = %q, want CC_CONNECT_LIVE_OK", text.String())
+				}
+				if strings.Contains(text.String(), "Reply exactly") {
+					t.Fatalf("live response echoed user prompt: %q", text.String())
+				}
+				t.Logf("first_text_after=%s prompt_response_after=%s total=%s", firstTextAt.Sub(startedAt), sendDoneAt.Sub(startedAt), time.Since(startedAt))
+				return
+			case core.EventError:
+				t.Fatal(event.Error)
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for live response; text so far: %q", text.String())
+		}
+	}
+}

--- a/agent/opencode/session_http_live_test.go
+++ b/agent/opencode/session_http_live_test.go
@@ -29,7 +29,7 @@ func TestOpencodeHTTPModeLiveServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	if session.CurrentSessionID() == "" {
 		t.Fatal("expected live HTTP session ID")

--- a/agent/opencode/session_http_live_test.go
+++ b/agent/opencode/session_http_live_test.go
@@ -41,7 +41,7 @@ func TestOpencodeHTTPModeLiveServer(t *testing.T) {
 	sendDone := make(chan error, 1)
 	startedAt := time.Now()
 	go func() {
-		sendDone <- session.Send("Reply exactly with CC_CONNECT_LIVE_OK.", nil, nil)
+		sendDone <- session.Send("Reply exactly with CC_CONNECT_LIVE_OK.", "", nil, nil)
 	}()
 
 	var text strings.Builder

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -402,7 +402,7 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	select {
 	case <-sseConnected:
@@ -550,7 +550,7 @@ func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
 	select {
 	case <-sseConnected:

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -505,6 +505,68 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 	}
 }
 
+func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails(t *testing.T) {
+	events := make(chan string, 4)
+	sseConnected := make(chan struct{})
+	var connectedOnce sync.Once
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /session", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"ses_http"}`))
+	})
+	mux.HandleFunc("GET /event", func(w http.ResponseWriter, r *http.Request) {
+		flusher := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		connectedOnce.Do(func() { close(sseConnected) })
+		for {
+			select {
+			case event := <-events:
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
+	mux.HandleFunc("POST /session/ses_http/message", func(w http.ResponseWriter, _ *http.Request) {
+		events <- `{"type":"session.error","properties":{"sessionID":"ses_http","error":{"name":"PaymentRequiredError","data":{"message":"Insufficient balance. Please recharge your account."}}}}`
+		http.Error(w, `{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"err_quota"}}`, http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	agent, err := New(map[string]any{
+		"cmd":            "/bin/false",
+		"work_dir":       t.TempDir(),
+		"connection_url": server.URL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	select {
+	case <-sseConnected:
+	case <-time.After(time.Second):
+		t.Fatal("SSE was not connected before Send")
+	}
+
+	err = session.Send("hello", nil, nil)
+	if err == nil {
+		t.Fatal("Send returned nil, want quota error")
+	}
+	if got := err.Error(); !strings.Contains(got, "PaymentRequiredError") || !strings.Contains(got, "Insufficient balance") {
+		t.Fatalf("Send error = %q, want SSE quota error", got)
+	}
+}
+
 func waitOpencodeEvent(t *testing.T, events <-chan core.Event) core.Event {
 	t.Helper()
 	select {

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -567,6 +567,27 @@ func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails(t *testing
 	}
 }
 
+func TestOpencodeHTTPMode_RetryStatusWithUsageLimitEmitsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{
+		events:        make(chan core.Event, 4),
+		ctx:           ctx,
+		connectionURL: "http://localhost:4096",
+	}
+	s.chatID.Store("ses_http")
+
+	s.handleHTTPEvent([]byte(`{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"retry","attempt":1,"message":"已达到 5 小时的使用上限。您的限额将在 2026-07-14 20:40:01 重置。"}}}`))
+
+	event := waitOpencodeEvent(t, s.Events())
+	if event.Type != core.EventError {
+		t.Fatalf("event type = %q, want EventError", event.Type)
+	}
+	if event.Error == nil || !strings.Contains(event.Error.Error(), "使用上限") {
+		t.Fatalf("event error = %v, want usage limit message", event.Error)
+	}
+}
+
 func waitOpencodeEvent(t *testing.T, events <-chan core.Event) core.Event {
 	t.Helper()
 	select {

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -3,12 +3,17 @@ package opencode
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -331,6 +336,192 @@ func TestHandleToolUseErrorNoMessageNoText(t *testing.T) {
 		if evt.Type == core.EventText {
 			t.Errorf("unexpected EventText for error with no message: %q", evt.Content)
 		}
+	}
+}
+
+func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *testing.T) {
+	events := make(chan string, 16)
+	sseConnected := make(chan struct{})
+	promptStarted := make(chan struct{})
+	releasePrompt := make(chan struct{})
+	permissionReply := make(chan map[string]any, 1)
+	questionReply := make(chan map[string]any, 1)
+	var connectedOnce sync.Once
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /session", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"ses_http"}`))
+	})
+	mux.HandleFunc("GET /event", func(w http.ResponseWriter, r *http.Request) {
+		flusher := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		connectedOnce.Do(func() { close(sseConnected) })
+		for {
+			select {
+			case event := <-events:
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
+	mux.HandleFunc("POST /session/ses_http/message", func(w http.ResponseWriter, _ *http.Request) {
+		close(promptStarted)
+		<-releasePrompt
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"info":{},"parts":[]}`))
+	})
+	mux.HandleFunc("POST /permission/per_1/reply", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		permissionReply <- body
+		_, _ = w.Write([]byte(`true`))
+	})
+	mux.HandleFunc("POST /question/que_1/reply", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		questionReply <- body
+		_, _ = w.Write([]byte(`true`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	agent, err := New(map[string]any{
+		"cmd":            "/bin/false",
+		"work_dir":       t.TempDir(),
+		"connection_url": server.URL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	select {
+	case <-sseConnected:
+	case <-time.After(time.Second):
+		t.Fatal("SSE was not connected before Send")
+	}
+
+	sendDone := make(chan error, 1)
+	go func() { sendDone <- session.Send("hello", nil, nil) }()
+	select {
+	case <-promptStarted:
+	case <-time.After(time.Second):
+		t.Fatal("prompt request did not start")
+	}
+
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_user","messageID":"msg_user","type":"text","sessionID":"ses_http","text":"hello"}}}`
+	assertNoOpencodeEvent(t, session.Events())
+
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"busy"}}}`
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_step","messageID":"msg_assistant","type":"step-start","sessionID":"ses_http"}}}`
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_1","messageID":"msg_assistant","type":"text","sessionID":"ses_http","text":"fi"}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventText || event.Content != "fi" {
+		t.Fatalf("first event = %#v, want streamed text", event)
+	}
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_1","messageID":"msg_assistant","type":"text","sessionID":"ses_http","text":"first","time":{"end":1}}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventText || event.Content != "rst" {
+		t.Fatalf("text delta = %#v, want streamed delta", event)
+	}
+	select {
+	case err := <-sendDone:
+		t.Fatalf("Send returned before prompt response: %v", err)
+	default:
+	}
+
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"idle"}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventResult {
+		t.Fatalf("idle event = %#v, want EventResult", event)
+	}
+	close(releasePrompt)
+	if err := <-sendDone; err != nil {
+		t.Fatal(err)
+	}
+
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"busy"}}}`
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_bg_step","messageID":"msg_background","type":"step-start","sessionID":"ses_http"}}}`
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_bg_text","messageID":"msg_background","type":"text","sessionID":"ses_http","text":"background done","time":{"end":1}}}}`
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"idle"}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventText || event.Content != "background done" {
+		t.Fatalf("background event = %#v, want unsolicited text", event)
+	}
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventResult {
+		t.Fatalf("background idle = %#v, want EventResult", event)
+	}
+
+	events <- `{"type":"permission.asked","properties":{"id":"per_1","sessionID":"ses_http","permission":"bash","patterns":["git status"],"metadata":{},"always":[]}}`
+	permission := waitOpencodeEvent(t, session.Events())
+	if permission.Type != core.EventPermissionRequest || permission.RequestID != "per_1" || permission.ToolName != "bash" {
+		t.Fatalf("permission event = %#v", permission)
+	}
+	if err := session.RespondPermission("per_1", core.PermissionResult{Behavior: "allow"}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case body := <-permissionReply:
+		if body["reply"] != "once" {
+			t.Fatalf("permission reply = %#v, want once", body)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("permission reply was not posted")
+	}
+
+	events <- `{"type":"question.asked","properties":{"id":"que_1","sessionID":"ses_http","questions":[{"question":"Pick a path","header":"Decision","options":[{"label":"A","description":"Alpha"},{"label":"B","description":"Beta"}],"multiple":false}]}}`
+	question := waitOpencodeEvent(t, session.Events())
+	if question.Type != core.EventPermissionRequest || question.RequestID != "que_1" || question.ToolName != "AskUserQuestion" {
+		t.Fatalf("question event = %#v", question)
+	}
+	if len(question.Questions) != 1 || question.Questions[0].Question != "Pick a path" || len(question.Questions[0].Options) != 2 {
+		t.Fatalf("parsed questions = %#v", question.Questions)
+	}
+	if err := session.RespondPermission("que_1", core.PermissionResult{
+		Behavior: "allow",
+		UpdatedInput: map[string]any{
+			"answers": map[string]any{"Pick a path": "A"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case body := <-questionReply:
+		answers, ok := body["answers"].([]any)
+		if !ok || len(answers) != 1 {
+			t.Fatalf("question reply = %#v, want one answer row", body)
+		}
+		firstAnswer, ok := answers[0].([]any)
+		if !ok || len(firstAnswer) != 1 || firstAnswer[0] != "A" {
+			t.Fatalf("question answers = %#v, want [[A]]", body["answers"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("question reply was not posted")
+	}
+}
+
+func waitOpencodeEvent(t *testing.T, events <-chan core.Event) core.Event {
+	t.Helper()
+	select {
+	case event := <-events:
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OpenCode event")
+		return core.Event{}
+	}
+}
+
+func assertNoOpencodeEvent(t *testing.T, events <-chan core.Event) {
+	t.Helper()
+	select {
+	case event := <-events:
+		t.Fatalf("unexpected OpenCode event: %#v", event)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -409,7 +409,7 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 	}
 
 	sendDone := make(chan error, 1)
-	go func() { sendDone <- session.Send("hello", nil, nil) }()
+	go func() { sendDone <- session.Send("hello", "", nil, nil) }()
 	select {
 	case <-promptStarted:
 	case <-time.After(time.Second):
@@ -556,7 +556,7 @@ func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenPromptAsyncFails(t *testing.T) 
 		t.Fatal("SSE was not connected before Send")
 	}
 
-	err = session.Send("hello", nil, nil)
+	err = session.Send("hello", "", nil, nil)
 	if err == nil {
 		t.Fatal("Send returned nil, want quota error")
 	}

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -343,7 +343,6 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 	events := make(chan string, 16)
 	sseConnected := make(chan struct{})
 	promptStarted := make(chan struct{})
-	releasePrompt := make(chan struct{})
 	permissionReply := make(chan map[string]any, 1)
 	questionReply := make(chan map[string]any, 1)
 	var connectedOnce sync.Once
@@ -369,11 +368,10 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 			}
 		}
 	})
-	mux.HandleFunc("POST /session/ses_http/message", func(w http.ResponseWriter, _ *http.Request) {
+	// prompt_async is fire-and-forget (204). The turn output flows via /event.
+	mux.HandleFunc("POST /session/ses_http/prompt_async", func(w http.ResponseWriter, _ *http.Request) {
 		close(promptStarted)
-		<-releasePrompt
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"info":{},"parts":[]}`))
+		w.WriteHeader(http.StatusNoContent)
 	})
 	mux.HandleFunc("POST /permission/per_1/reply", func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any
@@ -415,7 +413,16 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 	select {
 	case <-promptStarted:
 	case <-time.After(time.Second):
-		t.Fatal("prompt request did not start")
+		t.Fatal("prompt_async request did not start")
+	}
+	// With fire-and-forget prompt_async, Send returns as soon as the 204 is received.
+	select {
+	case err := <-sendDone:
+		if err != nil {
+			t.Fatalf("Send returned %v, want nil after prompt_async 204", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Send did not return after prompt_async 204")
 	}
 
 	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_user","messageID":"msg_user","type":"text","sessionID":"ses_http","text":"hello"}}}`
@@ -431,19 +438,10 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventText || event.Content != "rst" {
 		t.Fatalf("text delta = %#v, want streamed delta", event)
 	}
-	select {
-	case err := <-sendDone:
-		t.Fatalf("Send returned before prompt response: %v", err)
-	default:
-	}
 
 	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"idle"}}}`
 	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventResult {
 		t.Fatalf("idle event = %#v, want EventResult", event)
-	}
-	close(releasePrompt)
-	if err := <-sendDone; err != nil {
-		t.Fatal(err)
 	}
 
 	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"busy"}}}`
@@ -505,7 +503,7 @@ func TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents(t *
 	}
 }
 
-func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails(t *testing.T) {
+func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenPromptAsyncFails(t *testing.T) {
 	events := make(chan string, 4)
 	sseConnected := make(chan struct{})
 	var connectedOnce sync.Once
@@ -531,7 +529,7 @@ func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails(t *testing
 			}
 		}
 	})
-	mux.HandleFunc("POST /session/ses_http/message", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("POST /session/ses_http/prompt_async", func(w http.ResponseWriter, _ *http.Request) {
 		events <- `{"type":"session.error","properties":{"sessionID":"ses_http","error":{"name":"PaymentRequiredError","data":{"message":"Insufficient balance. Please recharge your account."}}}}`
 		http.Error(w, `{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"err_quota"}}`, http.StatusInternalServerError)
 	})
@@ -564,6 +562,91 @@ func TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails(t *testing
 	}
 	if got := err.Error(); !strings.Contains(got, "PaymentRequiredError") || !strings.Contains(got, "Insufficient balance") {
 		t.Fatalf("Send error = %q, want SSE quota error", got)
+	}
+}
+
+// TestOpencodeHTTPMode_SSEReconnectsAfterEOF verifies the central fix: when
+// the /event SSE stream ends (server restart, network blip, keepalive expiry),
+// cc-connect reconnects instead of tearing the session down. The session must
+// stay alive and keep delivering events after reconnect.
+func TestOpencodeHTTPMode_SSEReconnectsAfterEOF(t *testing.T) {
+	events := make(chan string, 16)
+	firstConnect := make(chan struct{})
+	secondConnect := make(chan struct{})
+	var connectCount atomic.Int32
+	var firstOnce, secondOnce sync.Once
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /session", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"ses_http"}`))
+	})
+	mux.HandleFunc("GET /event", func(w http.ResponseWriter, r *http.Request) {
+		n := connectCount.Add(1)
+		flusher := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		if n == 1 {
+			firstOnce.Do(func() { close(firstConnect) })
+			return // close immediately — simulates server restart / connection drop
+		}
+		secondOnce.Do(func() { close(secondConnect) })
+		for {
+			select {
+			case event := <-events:
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
+	mux.HandleFunc("POST /session/ses_http/prompt_async", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	agent, err := New(map[string]any{
+		"cmd":            "/bin/false",
+		"work_dir":       t.TempDir(),
+		"connection_url": server.URL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := agent.StartSession(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = session.Close() }()
+
+	select {
+	case <-firstConnect:
+	case <-time.After(time.Second):
+		t.Fatal("first SSE connection was not established")
+	}
+	// First connection returns immediately, simulating EOF. Wait for reconnect.
+	select {
+	case <-secondConnect:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("SSE did not reconnect after EOF (connectCount=%d)", connectCount.Load())
+	}
+
+	// Session must still be alive and deliver events on the new connection.
+	if !session.Alive() {
+		t.Fatal("session is not alive after SSE reconnect")
+	}
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"busy"}}}`
+	events <- `{"type":"session.next.step.started","properties":{"sessionID":"ses_http","assistantMessageID":"msg_post"}}`
+	events <- `{"type":"message.part.updated","properties":{"part":{"id":"prt_post","messageID":"msg_post","type":"text","sessionID":"ses_http","text":"after reconnect","time":{"end":1}}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventText || event.Content != "after reconnect" {
+		t.Fatalf("post-reconnect text = %#v, want 'after reconnect'", event)
+	}
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_http","status":{"type":"idle"}}}`
+	if event := waitOpencodeEvent(t, session.Events()); event.Type != core.EventResult {
+		t.Fatalf("post-reconnect idle = %#v, want EventResult", event)
 	}
 }
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1768,10 +1768,10 @@ app_secret = "your-feishu-app-secret"
 # =============================================================================
 # Project 6: Using OpenCode / 项目 6：使用 OpenCode (uncomment to enable / 取消注释以启用)
 # =============================================================================
-# Requires: OpenCode CLI — https://github.com/opencode-ai/opencode
+# Requires: OpenCode CLI — https://github.com/anomalyco/opencode
 # 需要安装：OpenCode CLI
-# Uses `opencode run --format json` under the hood.
-# 底层使用 `opencode run --format json` 命令。
+# By default, uses `opencode run --format json` under the hood.
+# 默认底层使用 `opencode run --format json` 命令。
 
 # [[projects]]
 # name = "my-opencode-project"
@@ -1782,6 +1782,14 @@ app_secret = "your-feishu-app-secret"
 # [projects.agent.options]
 # work_dir = "/path/to/project"
 # mode = "default"  # "default" | "yolo"
+#
+# Optional: connect to `opencode serve` instead of starting short-lived CLI runs.
+# This keeps `/event` SSE connected before each prompt, so streaming steps,
+# background callbacks, and permission/question prompts continue to reach cc-connect.
+# 可选：连接到 `opencode serve`，保持 `/event` SSE 长连接，以支持后台回调和决策提示。
+# connection_url = "http://127.0.0.1:4096"
+# username = "opencode"
+# password = "your-opencode-server-password"
 #
 # Mode options / 模式说明:
 # - "default": Standard mode / 标准模式

--- a/core/engine.go
+++ b/core/engine.go
@@ -4822,6 +4822,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			state.eventsNeedResync = true
 			p := state.platform
 			state.mu.Unlock()
+			agentName := e.agent.Name()
+			if state.agent != nil {
+				agentName = state.agent.Name()
+			}
+			session.SetAgentSessionID("", agentName)
+			sessions.Save()
 			e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), "agent session timed out (no response)"))
 			e.cleanupInteractiveState(sessionKey, state)
 			return

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -10879,6 +10879,7 @@ func TestEventIdleTimeout_CleansUpSession(t *testing.T) {
 	e.interactiveMu.Unlock()
 
 	session := e.sessions.GetOrCreateActive(key)
+	session.SetAgentSessionID("idle-test", agent.Name())
 	session.TryLock()
 
 	done := make(chan struct{})
@@ -10902,6 +10903,9 @@ func TestEventIdleTimeout_CleansUpSession(t *testing.T) {
 	}
 	if !foundTimeout {
 		t.Fatalf("expected timeout error message, got %v", sent)
+	}
+	if got := session.GetAgentSessionID(); got != "" {
+		t.Fatalf("agent session ID = %q, want cleared after idle timeout", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

When `cc-connect` talks to official `opencode serve` and the LLM dispatches a background subagent (`task(background=true)`), the connection drops — the user sees no response to the background completion.

Symptom reported: \"现在官方的cc-connect和官方的opencode配合使用时，一旦派发后台任务就断了\".

## Root cause

`agent/opencode/session_http.go` had two load-bearing failure modes:

### 1. Blocking `POST /session/{id}/message`

The POST held the connection open for the entire agent turn. When the LLM dispatched a background subagent, the parent turn ended immediately (the tool returns \"Background task started\" → parent loop goes idle), so the blocking POST returned. cc-connect then treated the turn as done — but the actual work (background completion, parent-session injection) was still pending.

### 2. Fatal `GET /event` SSE EOF

Any `/event` SSE stream termination (server restart, network blip, keepalive expiry) marked the session dead:

```go
s.alive.Store(false)
s.emitHTTPEvent(core.Event{Type: core.EventError, Error: ...})
```

The engine received the error → tore down the session → cancelled `s.ctx` → killed the in-flight turn. No reconnect logic existed.

## Fix — align with opencode's official streaming pattern

The official TUI client (`packages/opencode/src/cli/cmd/run/stream.transport.ts`) uses four rules. This PR adopts the two cc-connect was missing:

| # | Official pattern | This PR |
|---|---|---|
| 1 | One long-lived SSE subscription for the whole session | `readHTTPEventsLoop` reconnects with exponential backoff (500ms → 30s cap) on stream EOF; only exits when session ctx is cancelled |
| 2 | Fire-and-forget prompt POSTs | `sendHTTP` switched from `POST /message` (blocking) to `POST /prompt_async` (204 No Content) |
| 3 | `session.status: idle` events as turn-completion signal | Already in place — unchanged |
| 4 | Track child sessions | Analyzed and **intentionally omitted** — opencode injects background completion into the **parent sessionID**, so the existing filter is correct (see `TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents`). Child session events are intermediate noise the user doesn't need. |

## Server compatibility

Verified against `opencode serve` v1.18.14 (current release):
- `POST /session/{id}/prompt_async` ✓ exists, returns 204 fire-and-forget
- `GET /event` ✓ exists, real SSE global stream
- `/api/session/{id}/event?after=` ✗ dev-branch only, not on this version (so no cursor/replay; reconnect is blind but sufficient because the SSE stays open across background runs)

## Verification

### Unit tests

```
=== RUN   TestOpencodeHTTPMode_SSEReconnectsAfterEOF
2026/08/06 15:20:42 INFO opencode: /event stream ended, reconnecting backoff=500ms
--- PASS: TestOpencodeHTTPMode_SSEReconnectsAfterEOF (0.00s)

ok  github.com/chenhg5/cc-connect/agent/opencode  8.828s  # all 6 HTTP-mode tests pass, race-clean
ok  github.com/chenhg5/cc-connect/core            3.014s  # CUJ tests pass
```

### Live end-to-end against `opencode serve` v1.18.14

```
TestLivePromptAsync:
  session id: ses_02a0a1c81ffe4wAkMHMC1f6ebc
  Send returned in 3.370805ms (prompt_async 204 ack)   # OLD: would block ~38s
  event: type="text" content="PONG"
  event: type="result" content=""
  PASS (37.78s — full turn duration, all via SSE)

TestLiveSSEReconnectAfterServerRestart:
  INFO opencode: /event stream ended, reconnecting backoff=500ms
  PASS: SSE reconnected after forced EOF (killCount=2)
```

### Test changes

- **NEW** `TestOpencodeHTTPMode_SSEReconnectsAfterEOF` — regression for the central fix
- **NEW** `TestLivePromptAsync`, `TestLiveSSEReconnectAfterServerRestart` — env-gated live tests
- **UPDATED** `TestOpencodeHTTPMode_StreamsBeforePromptReturnsAndKeepsBackgroundEvents` — adapted for prompt_async (Send returns immediately; no more `releasePrompt` synchronization)
- **RENAMED** `TestOpencodeHTTPMode_SendReturnsSSEErrorWhenMessageEndpointFails` → `...PromptAsyncFails` — endpoint follow rename

## Commit-by-commit

1. `23036102` — fix opencode background streaming over HTTP *(baseline)*
2. `5145e134` — fix opencode HTTP agent error reporting *(baseline)*
3. `9787dab0` — fix opencode HTTP lint errors *(baseline)*
4. `7204f7d0` — surface opencode HTTP retry limit errors *(baseline)*
5. `5e14fe5e` — reset agent session after idle timeout *(baseline)*
6. `3f081e26` — split HTTP client (60s API) from streamClient (no-timeout SSE)
7. `165743b9` — **core fix**: prompt_async + SSE auto-reconnect

## Out of scope (YAGNI)

- **dev-branch `?after=<seq>` cursor replay** — server v1.18.14 doesn't expose it
- **Child session event forwarding** — opencode injects background results into the parent session; existing filter is correct
- **CLI subprocess mode** — only HTTP/SSE mode touches this issue

## Pre-merge checklist

- [x] Build passes: `go build ./...`
- [x] Tests pass: `go test ./agent/opencode/ -race`
- [x] CUJ tests pass: `go test ./core/ -run TestCUJ`
- [x] Bug fix has regression test: `TestOpencodeHTTPMode_SSEReconnectsAfterEOF`
- [x] No new hardcoded platform/agent names in core
- [x] No new user-facing strings
- [x] No secrets in code