### PR TITLE
feat(feishu): add workspace_thread_isolation for topic-level workspace binding

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1023,6 +1023,8 @@ app_secret = "your-feishu-app-secret"
 #                                   # 设为 true 时，群聊内所有用户共享同一个 Agent 会话
 # thread_isolation = false  # If true, group messages use Feishu reply threads as session boundaries (one thread/root = one agent session and, in multi-workspace mode, one workspace binding)
 #                           # 设为 true 时，群聊按飞书话题/根消息隔离会话；multi-workspace 模式下每个话题也独立绑定 workspace
+# workspace_thread_isolation = false  # Multi-workspace only: each Feishu topic binds its own workspace without auto-creating topics.
+#                                     # multi-workspace 模式下每个话题独立绑定 workspace，但不自动创建话题（需 thread_isolation 配合）。
 # reply_to_trigger = true   # Default: bot uses “reply to message” API (quotes the user’s message). Set false to post plain chat messages instead.
 #                           # 默认 true：用「回复消息」API（引用用户消息）。设为 false 则在会话里发普通消息、不引用触发消息。
 # progress_style = "legacy" # Progress rendering style: legacy | compact | card

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -110,6 +110,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # domain = "https://open.feishu.cn" # 可选：覆盖运行时 API/WebSocket 域名
 # enable_feishu_card = true  # 可选：关闭后统一回退纯文本回复
 # thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
+# workspace_thread_isolation = true  # 可选：multi-workspace 模式下按话题隔离 workspace（不自动开话题）
 # progress_style = "legacy"  # 可选：legacy | compact | card
 # done_emoji = "none"          # 可选：agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 # image_batch_window_ms = 500  # 可选：连续多图合批窗口（默认 500ms，详见下文）
@@ -118,6 +119,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
 > 如果开启 `thread_isolation = true`，群聊里每个根消息 / reply thread 会对应一个独立 agent session；私聊行为保持原样。
 > 在 multi-workspace 模式下，`thread_isolation = true` 也会让每个话题独立绑定 workspace；在话题内执行 `/workspace bind <name>` 不会影响同群的其他话题。已有的群级 binding 会保留为默认值，由尚未显式绑定的话题继承，因此回退到旧版本时仍可使用。
+> 如果只想在 multi-workspace 模式下按话题隔离 workspace，但不希望 bot 回复时自动创建话题，可单独开启 `workspace_thread_isolation = true`。此时 bot 回复不会开话题；用户在已有话题内 @bot 时，该话题会绑定独立的 workspace。
 > `progress_style = "compact"` 会把思考/工具进度合并到一条可更新消息里，减少刷屏；`legacy` 保持原有逐条发送；`card` 会使用结构化卡片（标题 + 进度块）持续更新同一条消息，观感比纯文本更清晰。
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
 > `done_emoji` 设置后，agent 每次完成回复时会在用户消息上添加指定表情（如 `"Done"` → ✅）。先移除 "OnIt" 表情（如果有），再添加 done 表情。在 quiet 模式下特别有用，因为飞书卡片原地更新不触发推送，done 表情可以通知用户 agent 已完成。设为 `"none"` 或不配置则禁用。

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -110,6 +110,7 @@ type replyContext struct {
 	messageID  string
 	chatID     string
 	sessionKey string
+	rootID     string // topic root message ID (from msg.RootId); used by workspace_thread_isolation
 }
 
 type Platform struct {
@@ -130,6 +131,7 @@ type Platform struct {
 	respondToAtEveryoneAndHere bool
 	shareSessionInChannel      bool
 	threadIsolation            bool
+	workspaceThreadIsolation   bool
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
 	noReplyToTrigger bool
 	resolveMentions  bool
@@ -310,6 +312,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
+	workspaceThreadIsolation, _ := opts["workspace_thread_isolation"].(bool)
 	resolveMentionsOpt, _ := opts["resolve_mentions"].(bool)
 	noReplyToTrigger := false
 	if v, ok := opts["reply_to_trigger"].(bool); ok && !v {
@@ -401,6 +404,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
 		shareSessionInChannel:      shareSessionInChannel,
 		threadIsolation:            threadIsolation,
+		workspaceThreadIsolation:   workspaceThreadIsolation,
 		resolveMentions:            resolveMentionsOpt,
 		noReplyToTrigger:           noReplyToTrigger,
 		client:                     lark.NewClient(appID, appSecret, clientOpts...),
@@ -1100,6 +1104,11 @@ func (p *Platform) dispatchCoreMessage(msg *core.Message) {
 // populateWorkspaceChannelKeys keeps workspace binding scope aligned with the
 // session scope. In Feishu topic mode the session key contains the root message
 // ID, while the legacy chat-level binding remains the default for new topics.
+//
+// When workspace_thread_isolation is enabled (even without thread_isolation),
+// messages inside a topic get a topic-scoped ChannelKey so each topic can bind
+// an independent workspace. The session key and reply behaviour remain
+// unchanged — only the workspace routing key is affected.
 func (p *Platform) populateWorkspaceChannelKeys(msg *core.Message) {
 	if msg == nil || msg.ChannelKey != "" {
 		return
@@ -1109,15 +1118,23 @@ func (p *Platform) populateWorkspaceChannelKeys(msg *core.Message) {
 		return
 	}
 	msg.ChannelKey = rctx.chatID
-	if !p.threadIsolation {
+
+	if !p.threadIsolation && !p.workspaceThreadIsolation {
 		return
 	}
-	parts := strings.SplitN(rctx.sessionKey, ":", 3)
-	if len(parts) != 3 || parts[0] != p.platformName || parts[1] != rctx.chatID {
-		return
+
+	// Determine the topic root ID.  Prefer the rootID captured from the
+	// inbound event (works for both thread_isolation and
+	// workspace_thread_isolation); fall back to parsing the session key
+	// (covers card-action paths where rootID may not be set directly).
+	rootID := rctx.rootID
+	if rootID == "" && p.threadIsolation {
+		parts := strings.SplitN(rctx.sessionKey, ":", 3)
+		if len(parts) == 3 && parts[0] == p.platformName && parts[1] == rctx.chatID {
+			rootID, _ = parseThreadRootID(parts[2])
+		}
 	}
-	rootID, ok := parseThreadRootID(parts[2])
-	if !ok {
+	if rootID == "" {
 		return
 	}
 	msg.ChannelKey = rctx.chatID + ":topic:" + rootID
@@ -1403,7 +1420,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	mentions := msg.Mentions
 	parentID := stringValue(msg.ParentId)
 
-	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey, rootID: stringValue(msg.RootId)}
 	slog.Debug(p.tag()+": routed inbound message",
 		"message_id", messageID,
 		"session_key", sessionKey,

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -1397,6 +1397,117 @@ func TestResolveRichCardMarkdownUploadsRemoteImages(t *testing.T) {
 	}
 }
 
+func TestPopulateWorkspaceChannelKeys_WorkspaceThreadIsolation(t *testing.T) {
+	tests := []struct {
+		name           string
+		platform       *Platform
+		msg            *core.Message
+		wantChannelKey string
+		wantLegacyKey  string
+	}{
+		{
+			name:     "thread_isolation sets topic-scoped key from session key",
+			platform: &Platform{platformName: "feishu", threadIsolation: true},
+			msg: &core.Message{
+				ReplyCtx: replyContext{
+					chatID:     "oc_chat",
+					sessionKey: "feishu:oc_chat:root:om_root",
+				},
+			},
+			wantChannelKey: "oc_chat:topic:om_root",
+			wantLegacyKey:  "oc_chat",
+		},
+		{
+			name:     "workspace_thread_isolation sets topic-scoped key from rootID",
+			platform: &Platform{platformName: "feishu", workspaceThreadIsolation: true},
+			msg: &core.Message{
+				ReplyCtx: replyContext{
+					chatID:     "oc_chat",
+					sessionKey: "feishu:oc_chat:ou_user",
+					rootID:     "om_topic_root",
+				},
+			},
+			wantChannelKey: "oc_chat:topic:om_topic_root",
+			wantLegacyKey:  "oc_chat",
+		},
+		{
+			name:     "workspace_thread_isolation without rootID keeps chat-level key",
+			platform: &Platform{platformName: "feishu", workspaceThreadIsolation: true},
+			msg: &core.Message{
+				ReplyCtx: replyContext{
+					chatID:     "oc_chat",
+					sessionKey: "feishu:oc_chat:ou_user",
+				},
+			},
+			wantChannelKey: "oc_chat",
+			wantLegacyKey:  "",
+		},
+		{
+			name:     "neither flag set keeps chat-level key",
+			platform: &Platform{platformName: "feishu"},
+			msg: &core.Message{
+				ReplyCtx: replyContext{
+					chatID:     "oc_chat",
+					sessionKey: "feishu:oc_chat:ou_user",
+					rootID:     "om_topic_root",
+				},
+			},
+			wantChannelKey: "oc_chat",
+			wantLegacyKey:  "",
+		},
+		{
+			name:     "thread_isolation fallback to session key when rootID is empty",
+			platform: &Platform{platformName: "feishu", threadIsolation: true},
+			msg: &core.Message{
+				ReplyCtx: replyContext{
+					chatID:     "oc_chat",
+					sessionKey: "feishu:oc_chat:root:om_from_session",
+					rootID:     "",
+				},
+			},
+			wantChannelKey: "oc_chat:topic:om_from_session",
+			wantLegacyKey:  "oc_chat",
+		},
+		{
+			name:     "workspace_thread_isolation prefers rootID over session key",
+			platform: &Platform{platformName: "feishu", workspaceThreadIsolation: true, threadIsolation: true},
+			msg: &core.Message{
+				ReplyCtx: replyContext{
+					chatID:     "oc_chat",
+					sessionKey: "feishu:oc_chat:root:om_from_session",
+					rootID:     "om_from_event",
+				},
+			},
+			wantChannelKey: "oc_chat:topic:om_from_event",
+			wantLegacyKey:  "oc_chat",
+		},
+		{
+			name:     "p2p chat without rootID keeps chat-level key",
+			platform: &Platform{platformName: "feishu", workspaceThreadIsolation: true},
+			msg: &core.Message{
+				ReplyCtx: replyContext{
+					chatID:     "oc_p2p",
+					sessionKey: "feishu:oc_p2p:ou_user",
+				},
+			},
+			wantChannelKey: "oc_p2p",
+			wantLegacyKey:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.platform.populateWorkspaceChannelKeys(tt.msg)
+			if tt.msg.ChannelKey != tt.wantChannelKey {
+				t.Errorf("ChannelKey = %q, want %q", tt.msg.ChannelKey, tt.wantChannelKey)
+			}
+			if tt.msg.LegacyChannelKey != tt.wantLegacyKey {
+				t.Errorf("LegacyChannelKey = %q, want %q", tt.msg.LegacyChannelKey, tt.wantLegacyKey)
+			}
+		})
+	}
+}
+
 func TestResolveRichCardMarkdownStreamingStartsUploadWithoutWaiting(t *testing.T) {
 	p := &Platform{platformName: "feishu"}
 	started := make(chan struct{})


### PR DESCRIPTION
## Summary

Add `workspace_thread_isolation` config for Feishu platform, enabling topic-level workspace binding in multi-workspace mode without auto-creating reply topics. This allows users to keep bot replies in the main chat (no auto-topic) while still isolating workspaces per topic when users reply inside existing topics.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

### Automated tests added in this PR

- `TestPopulateWorkspaceChannelKeys_WorkspaceThreadIsolation` in `platform/feishu/platform_test.go` — 7 sub-cases covering all config combinations (thread_isolation only, workspace_thread_isolation only, both, neither, rootID priority, fallback to session key, p2p chat)

### For bug fixes only — regression test

N/A — this is a new feature, not a bug fix.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [x] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

- [x] `go test ./core/ -run TestCUJ` passes locally (TestCUJ_H4_FeishuTopicsKeepWorkspaceBindingsIsolated passes).
- [ ] N/A — the new `workspace_thread_isolation` config is additive and does not alter the existing `thread_isolation` flow tested by CUJ_H4.

## Manual / user-visible behavior change

| `thread_isolation` | `workspace_thread_isolation` | auto-topic on reply | session isolation | workspace isolation |
|---|---|---|---|---|
| `true` | any | yes | per-topic | per-topic |
| `false` | `true` | no  | per-user/chat | **per-topic** (new) |
| `false` | `false` | no | per-user/chat | per-chat |

Users who previously couldn't use `thread_isolation` (because auto-creating topics was undesirable) can now enable `workspace_thread_isolation` alone to get per-topic workspace binding when users reply inside existing topics.

## Checklist

- [x] `go build ./...` passes (web dist missing is pre-existing)
- [x] `go test ./...` passes (pre-existing Windows path failures unrelated)
- [x] AGENTS.md Pre-Commit Checklist items satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings — no new user-facing text added (config key only)
- [x] No secrets / credentials in source


FIX: #1644 