### PR TITLE
fix(dingtalk): handle richText and replied media attachments

### DIFF
--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -288,11 +288,12 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 		return
 	}
 
-	// Handle richText messages — extract plain text from rich content
+	// Handle richText messages — extract text and download embedded pictures.
 	if data.Msgtype == "richText" {
-		text := extractRichText(data.Content)
-		if text == "" {
-			slog.Debug("dingtalk: richText message with no extractable text", "msg_id", data.MsgId)
+		text, pictureDownloadCodes := parseRichText(data.Content)
+		images := p.downloadRichTextImages(pictureDownloadCodes, data.MsgId)
+		if text == "" && len(images) == 0 {
+			slog.Debug("dingtalk: richText message with no extractable content", "msg_id", data.MsgId)
 			return
 		}
 		msg := &core.Message{
@@ -303,6 +304,7 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 			ChatName:   data.ConversationTitle,
 			Content:    text,
 			MessageID:  data.MsgId,
+			ChannelKey: data.ConversationId,
 			ReplyCtx: replyContext{
 				sessionWebhook: data.SessionWebhook,
 				conversationId: data.ConversationId,
@@ -310,6 +312,7 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 				messageID:      data.MsgId,
 				isGroup:        data.ConversationType == "2",
 			},
+			Images: images,
 		}
 		p.handler(p, msg)
 		return
@@ -377,19 +380,19 @@ func (p *Platform) replyUnauthorized(data *chatbot.BotCallbackDataModel) {
 	}
 }
 
-// extractRichText extracts plain text from a DingTalk richText content payload.
-// The expected structure is: {"richText": [{"text": "..."}, {"text": "...", "attrs": {...}}, ...]}
-// Non-text elements (e.g. pictureDownloadCode) are skipped.
-func extractRichText(content interface{}) string {
+// parseRichText extracts plain text and embedded picture download codes from a
+// DingTalk richText payload while preserving the picture order.
+func parseRichText(content interface{}) (string, []string) {
 	m, ok := content.(map[string]interface{})
 	if !ok {
-		return ""
+		return "", nil
 	}
 	parts, ok := m["richText"].([]interface{})
 	if !ok {
-		return ""
+		return "", nil
 	}
 	var b strings.Builder
+	var pictureDownloadCodes []string
 	for _, part := range parts {
 		item, ok := part.(map[string]interface{})
 		if !ok {
@@ -398,8 +401,28 @@ func extractRichText(content interface{}) string {
 		if text, ok := item["text"].(string); ok {
 			b.WriteString(text)
 		}
+		if code, ok := item["pictureDownloadCode"].(string); ok {
+			code = strings.TrimSpace(code)
+			if code != "" {
+				pictureDownloadCodes = append(pictureDownloadCodes, code)
+			}
+		}
 	}
-	return strings.TrimSpace(b.String())
+	return strings.TrimSpace(b.String()), pictureDownloadCodes
+}
+
+func (p *Platform) downloadRichTextImages(downloadCodes []string, messageID string) []core.ImageAttachment {
+	images := make([]core.ImageAttachment, 0, len(downloadCodes))
+	for i, downloadCode := range downloadCodes {
+		image, err := p.downloadImage(downloadCode)
+		if err != nil {
+			slog.Warn("dingtalk: failed to download richText image",
+				"error", err, "image_index", i, "msg_id", messageID)
+			continue
+		}
+		images = append(images, image)
+	}
+	return images
 }
 
 func (p *Platform) handleAudioMessage(data *chatbot.BotCallbackDataModel, sessionKey string) {
@@ -493,42 +516,13 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 		return
 	}
 
-	// Download image file using the same messageFiles/download API as audio
-	downloadURL, err := p.getDownloadURL(downloadCode)
-	if err != nil {
-		slog.Error("dingtalk: failed to get image download URL", "error", err)
-		return
-	}
-
-	resp, err := p.httpClient.Get(downloadURL)
+	image, err := p.downloadImage(downloadCode)
 	if err != nil {
 		slog.Error("dingtalk: failed to download image", "error", err)
 		return
 	}
-	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		slog.Error("dingtalk: image download returned status", "status", resp.StatusCode)
-		return
-	}
-
-	const maxImageBytes = 25 * 1024 * 1024 // 25 MiB, same cap as other platforms
-	imgBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxImageBytes+1))
-	if err != nil {
-		slog.Error("dingtalk: failed to read image data", "error", err)
-		return
-	}
-	if len(imgBytes) > maxImageBytes {
-		slog.Error("dingtalk: image too large, dropping", "size", len(imgBytes), "limit", maxImageBytes)
-		return
-	}
-
-	mimeType := resp.Header.Get("Content-Type")
-	if mimeType == "" {
-		mimeType = "image/png"
-	}
-
-	slog.Info("dingtalk: image downloaded successfully", "size", len(imgBytes), "mime", mimeType)
+	slog.Info("dingtalk: image downloaded successfully", "size", len(image.Data), "mime", image.MimeType)
 
 	msg := &core.Message{
 		SessionKey: sessionKey,
@@ -543,13 +537,43 @@ func (p *Platform) handleImageMessage(data *chatbot.BotCallbackDataModel, sessio
 			messageID:      data.MsgId,
 			isGroup:        data.ConversationType == "2",
 		},
-		Images: []core.ImageAttachment{{
-			MimeType: mimeType,
-			Data:     imgBytes,
-		}},
+		Images: []core.ImageAttachment{image},
 	}
 
 	p.handler(p, msg)
+}
+
+const maxDingTalkImageBytes = 25 * 1024 * 1024
+
+func (p *Platform) downloadImage(downloadCode string) (core.ImageAttachment, error) {
+	downloadURL, err := p.getDownloadURL(downloadCode)
+	if err != nil {
+		return core.ImageAttachment{}, fmt.Errorf("get download URL: %w", err)
+	}
+
+	resp, err := p.httpClient.Get(downloadURL)
+	if err != nil {
+		return core.ImageAttachment{}, fmt.Errorf("http get: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return core.ImageAttachment{}, fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	imageBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxDingTalkImageBytes+1))
+	if err != nil {
+		return core.ImageAttachment{}, fmt.Errorf("read response: %w", err)
+	}
+	if len(imageBytes) > maxDingTalkImageBytes {
+		return core.ImageAttachment{}, fmt.Errorf("image too large: size %d exceeds limit %d", len(imageBytes), maxDingTalkImageBytes)
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+	return core.ImageAttachment{MimeType: mimeType, Data: imageBytes}, nil
 }
 
 // handleFileMessage downloads a file attachment (msgtype=file) and dispatches

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -54,12 +54,20 @@ type repliedTextContent struct {
 	Text string `json:"text"`
 }
 
+type repliedMediaContent struct {
+	DownloadCode string `json:"downloadCode"`
+	FileName     string `json:"fileName"`
+}
+
 const maxQuotedMessageRunes = 4000
 
 const (
 	defaultReactionEmoji        = "🤔Thinking"
 	customTextEmotionID         = "2659900"
 	customTextEmotionBackground = "im_bg_1"
+	// maxDingTalkFileBytes limits attachment memory usage while keeping common
+	// documents within the supported range.
+	maxDingTalkFileBytes = 50 * 1024 * 1024
 )
 
 type downloadResponse struct {
@@ -336,9 +344,15 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 
 	// Extract message content, recovering quoted/reply info from richText.
 	messageContent := data.Text.Content
+	var images []core.ImageAttachment
+	var files []core.FileAttachment
 	if richText != nil && richText.IsReplyMsg && richText.RepliedMsg != nil {
 		slog.Debug("dingtalk: reply message detected", "msgType", richText.RepliedMsg.MsgType)
 		messageContent = p.formatReplyContent(richText, messageContent)
+		mediaContent, ok := p.extractQuotedMediaContent(richText.RepliedMsg.Content)
+		if ok {
+			images, files = p.downloadQuotedMedia(richText.RepliedMsg.MsgType, mediaContent, data.MsgId)
+		}
 	}
 
 	// Handle text messages (default)
@@ -351,6 +365,8 @@ func (p *Platform) onMessage(data *chatbot.BotCallbackDataModel, richText *richT
 		Content:    messageContent,
 		MessageID:  data.MsgId,
 		ChannelKey: data.ConversationId,
+		Images:     images,
+		Files:      files,
 		ReplyCtx: replyContext{
 			sessionWebhook: data.SessionWebhook,
 			conversationId: data.ConversationId,
@@ -602,43 +618,13 @@ func (p *Platform) handleFileMessage(data *chatbot.BotCallbackDataModel, session
 
 	fileName, _ := fileData["fileName"].(string)
 
-	downloadURL, err := p.getDownloadURL(downloadCode)
+	file, err := p.downloadFile(downloadCode, fileName)
 	if err != nil {
-		slog.Error("dingtalk: failed to get file download URL", "error", err)
+		slog.Error("dingtalk: failed to download file", "error", err, "file_name", fileName)
 		return
 	}
 
-	resp, err := p.httpClient.Get(downloadURL)
-	if err != nil {
-		slog.Error("dingtalk: failed to download file", "error", err)
-		return
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		slog.Error("dingtalk: file download returned status", "status", resp.StatusCode)
-		return
-	}
-
-	// DingTalk caps single file at 100 MiB; 50 MiB is plenty for agent inputs
-	// and matches what other platforms accept without OOM risk.
-	const maxFileBytes = 50 * 1024 * 1024
-	fileBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxFileBytes+1))
-	if err != nil {
-		slog.Error("dingtalk: failed to read file data", "error", err)
-		return
-	}
-	if len(fileBytes) > maxFileBytes {
-		slog.Error("dingtalk: file too large, dropping", "size", len(fileBytes), "limit", maxFileBytes, "file_name", fileName)
-		return
-	}
-
-	mimeType := resp.Header.Get("Content-Type")
-	if mimeType == "" {
-		mimeType = "application/octet-stream"
-	}
-
-	slog.Info("dingtalk: file downloaded successfully", "size", len(fileBytes), "mime", mimeType, "file_name", fileName)
+	slog.Info("dingtalk: file downloaded successfully", "size", len(file.Data), "mime", file.MimeType, "file_name", file.FileName)
 
 	msg := &core.Message{
 		SessionKey: sessionKey,
@@ -655,14 +641,68 @@ func (p *Platform) handleFileMessage(data *chatbot.BotCallbackDataModel, session
 			messageID:      data.MsgId,
 			isGroup:        data.ConversationType == "2",
 		},
-		Files: []core.FileAttachment{{
-			MimeType: mimeType,
-			Data:     fileBytes,
-			FileName: fileName,
-		}},
+		Files: []core.FileAttachment{file},
 	}
 
 	p.handler(p, msg)
+}
+
+func (p *Platform) downloadFile(downloadCode, fileName string) (core.FileAttachment, error) {
+	downloadURL, err := p.getDownloadURL(downloadCode)
+	if err != nil {
+		return core.FileAttachment{}, fmt.Errorf("get download URL: %w", err)
+	}
+
+	resp, err := p.httpClient.Get(downloadURL)
+	if err != nil {
+		return core.FileAttachment{}, fmt.Errorf("http get: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return core.FileAttachment{}, fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	fileBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxDingTalkFileBytes+1))
+	if err != nil {
+		return core.FileAttachment{}, fmt.Errorf("read response: %w", err)
+	}
+	if len(fileBytes) > maxDingTalkFileBytes {
+		return core.FileAttachment{}, fmt.Errorf("file too large: size %d exceeds limit %d", len(fileBytes), maxDingTalkFileBytes)
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	return core.FileAttachment{MimeType: mimeType, Data: fileBytes, FileName: fileName}, nil
+}
+
+func (p *Platform) downloadQuotedMedia(msgType string, media repliedMediaContent, messageID string) ([]core.ImageAttachment, []core.FileAttachment) {
+	if msgType == "picture" || msgType == "image" {
+		image, err := p.downloadImage(media.DownloadCode)
+		if err != nil {
+			slog.Warn("dingtalk: failed to download quoted image", "error", err, "msg_type", msgType, "msg_id", messageID)
+			return nil, nil
+		}
+		slog.Info("dingtalk: quoted image downloaded successfully", "size", len(image.Data), "mime", image.MimeType, "msg_type", msgType)
+		return []core.ImageAttachment{image}, nil
+	}
+
+	// Unknown downloadable reply types are retained as files. If DingTalk sends
+	// a new image msgType, MIME detection still promotes it to an image.
+	file, err := p.downloadFile(media.DownloadCode, media.FileName)
+	if err != nil {
+		slog.Warn("dingtalk: failed to download quoted attachment", "error", err, "file_name", media.FileName, "msg_type", msgType, "msg_id", messageID)
+		return nil, nil
+	}
+	if strings.HasPrefix(strings.ToLower(file.MimeType), "image/") {
+		image := core.ImageAttachment{MimeType: file.MimeType, Data: file.Data, FileName: file.FileName}
+		slog.Info("dingtalk: quoted attachment detected as image", "size", len(image.Data), "mime", image.MimeType, "msg_type", msgType)
+		return []core.ImageAttachment{image}, nil
+	}
+	slog.Info("dingtalk: quoted attachment downloaded successfully", "size", len(file.Data), "mime", file.MimeType, "file_name", file.FileName, "msg_type", msgType)
+	return nil, []core.FileAttachment{file}
 }
 
 func (p *Platform) downloadAudio(downloadCode string) ([]byte, string, error) {
@@ -1471,12 +1511,32 @@ func (p *Platform) extractQuotedMessageText(msg *repliedMessage) string {
 	switch msg.MsgType {
 	case "text":
 		return p.extractQuotedTextMessageText(msg.Content)
+	case "file":
+		mediaContent, ok := p.extractQuotedMediaContent(msg.Content)
+		if !ok {
+			return ""
+		}
+		return "文件: " + mediaContent.FileName
+	case "picture", "image":
+		return "图片"
 	case "interactiveCard":
 		return p.extractInteractiveCardQuotedText(msg.Content)
 	default:
 		slog.Debug("dingtalk: quoted message type not supported", "type", msg.MsgType)
 		return ""
 	}
+}
+
+func (p *Platform) extractQuotedMediaContent(raw json.RawMessage) (repliedMediaContent, bool) {
+	var mediaContent repliedMediaContent
+	if err := json.Unmarshal(raw, &mediaContent); err != nil {
+		slog.Debug("dingtalk: failed to parse replied media content", "error", err)
+		return repliedMediaContent{}, false
+	}
+	if mediaContent.DownloadCode == "" {
+		return repliedMediaContent{}, false
+	}
+	return mediaContent, true
 }
 
 func (p *Platform) extractQuotedTextMessageText(raw json.RawMessage) string {

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -380,8 +380,10 @@ func (p *Platform) replyUnauthorized(data *chatbot.BotCallbackDataModel) {
 	}
 }
 
-// parseRichText extracts plain text and embedded picture download codes from a
-// DingTalk richText payload while preserving the picture order.
+// parseRichText extracts plain text and embedded image download codes from a
+// DingTalk richText payload while preserving the image order. DingTalk may
+// provide both downloadCode and pictureDownloadCode; the download API expects
+// downloadCode, while pictureDownloadCode is retained as a compatibility fallback.
 func parseRichText(content interface{}) (string, []string) {
 	m, ok := content.(map[string]interface{})
 	if !ok {
@@ -392,7 +394,7 @@ func parseRichText(content interface{}) (string, []string) {
 		return "", nil
 	}
 	var b strings.Builder
-	var pictureDownloadCodes []string
+	var imageDownloadCodes []string
 	for _, part := range parts {
 		item, ok := part.(map[string]interface{})
 		if !ok {
@@ -401,14 +403,17 @@ func parseRichText(content interface{}) (string, []string) {
 		if text, ok := item["text"].(string); ok {
 			b.WriteString(text)
 		}
-		if code, ok := item["pictureDownloadCode"].(string); ok {
+		code, _ := item["downloadCode"].(string)
+		code = strings.TrimSpace(code)
+		if code == "" {
+			code, _ = item["pictureDownloadCode"].(string)
 			code = strings.TrimSpace(code)
-			if code != "" {
-				pictureDownloadCodes = append(pictureDownloadCodes, code)
-			}
+		}
+		if code != "" {
+			imageDownloadCodes = append(imageDownloadCodes, code)
 		}
 	}
-	return strings.TrimSpace(b.String()), pictureDownloadCodes
+	return strings.TrimSpace(b.String()), imageDownloadCodes
 }
 
 func (p *Platform) downloadRichTextImages(downloadCodes []string, messageID string) []core.ImageAttachment {

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -697,7 +697,7 @@ func (p *Platform) downloadQuotedMedia(msgType string, media repliedMediaContent
 		return nil, nil
 	}
 	if strings.HasPrefix(strings.ToLower(file.MimeType), "image/") {
-		image := core.ImageAttachment{MimeType: file.MimeType, Data: file.Data, FileName: file.FileName}
+		image := core.ImageAttachment(file)
 		slog.Info("dingtalk: quoted attachment detected as image", "size", len(image.Data), "mime", image.MimeType, "msg_type", msgType)
 		return []core.ImageAttachment{image}, nil
 	}

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -328,6 +328,44 @@ func TestFormatReplyContent_EmptyContent_UsesFallback(t *testing.T) {
 	}
 }
 
+func TestFormatReplyContent_WithQuotedFile(t *testing.T) {
+	p := &Platform{}
+	repliedContent, _ := json.Marshal(repliedMediaContent{
+		DownloadCode: "download-code",
+		FileName:     "AGENTS.user.md",
+	})
+	richText := &richTextContent{
+		Content:    "这个文件你能看得见吗",
+		IsReplyMsg: true,
+		RepliedMsg: &repliedMessage{
+			MsgType: "file",
+			Content: repliedContent,
+		},
+	}
+	result := p.formatReplyContent(richText, "fallback")
+	expected := "引用: \"文件: AGENTS.user.md\"\n\n这个文件你能看得见吗"
+	if result != expected {
+		t.Errorf("formatReplyContent() = %q, want %q", result, expected)
+	}
+}
+
+func TestFormatReplyContent_WithQuotedPicture(t *testing.T) {
+	p := &Platform{}
+	richText := &richTextContent{
+		Content:    "这个呢",
+		IsReplyMsg: true,
+		RepliedMsg: &repliedMessage{
+			MsgType: "picture",
+			Content: json.RawMessage(`{"downloadCode":"download-code"}`),
+		},
+	}
+	result := p.formatReplyContent(richText, "fallback")
+	expected := "引用: \"图片\"\n\n这个呢"
+	if result != expected {
+		t.Errorf("formatReplyContent() = %q, want %q", result, expected)
+	}
+}
+
 func TestFormatReplyContent_TextQuotePreservesWhitespace(t *testing.T) {
 	p := &Platform{}
 	repliedContent, _ := json.Marshal(repliedTextContent{Text: "  original message  "})
@@ -365,7 +403,7 @@ func TestFormatReplyContent_NonTextMsgType(t *testing.T) {
 		Content:    "user reply",
 		IsReplyMsg: true,
 		RepliedMsg: &repliedMessage{
-			MsgType: "image",
+			MsgType: "video",
 			Content: json.RawMessage(`{}`),
 		},
 	}
@@ -1256,6 +1294,144 @@ func TestHandleFileMessage_BuildsFileAttachmentWithName(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("handler never invoked with file message")
+	}
+}
+
+func TestReplyToFileMessage_BuildsTextAndFileAttachment(t *testing.T) {
+	const fileBody = "quoted dingtalk file"
+	const fileName = "AGENTS.user.md"
+
+	fileSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown")
+		_, _ = w.Write([]byte(fileBody))
+	}))
+	defer fileSrv.Close()
+
+	rt := &dingtalkFileDownloadRT{
+		accessToken: "tok-replied-file",
+		downloadURL: fileSrv.URL,
+	}
+	captured := make(chan *core.Message, 1)
+	p := &Platform{
+		clientID:     "cid",
+		clientSecret: "csec",
+		robotCode:    "robot-1",
+		httpClient:   &http.Client{Transport: rt},
+		handler: func(_ core.Platform, msg *core.Message) {
+			captured <- msg
+		},
+	}
+
+	p.onRawMessage(`{
+		"msgtype": "text",
+		"msgId": "msg-replied-file-1",
+		"conversationType": "2",
+		"conversationId": "conv-1",
+		"conversationTitle": "test group",
+		"senderStaffId": "user-1",
+		"senderNick": "Alice",
+		"sessionWebhook": "https://example.invalid/webhook",
+		"text": {
+			"isReplyMsg": true,
+			"repliedMsg": {
+				"msgType": "file",
+				"content": {
+					"spaceId": "space-1",
+					"fileName": "` + fileName + `",
+					"downloadCode": "dc-replied-file",
+					"fileId": "file-1"
+				}
+			},
+			"content": "这个文件你能看得见吗"
+		}
+	}`)
+
+	select {
+	case msg := <-captured:
+		expectedContent := "引用: \"文件: " + fileName + "\"\n\n这个文件你能看得见吗"
+		if msg.Content != expectedContent {
+			t.Errorf("Content = %q, want %q", msg.Content, expectedContent)
+		}
+		if len(msg.Files) != 1 {
+			t.Fatalf("Files len = %d, want 1", len(msg.Files))
+		}
+		file := msg.Files[0]
+		if file.FileName != fileName {
+			t.Errorf("FileName = %q, want %q", file.FileName, fileName)
+		}
+		if string(file.Data) != fileBody {
+			t.Errorf("file bytes = %q, want %q", file.Data, fileBody)
+		}
+		if file.MimeType != "text/markdown" {
+			t.Errorf("MimeType = %q, want %q", file.MimeType, "text/markdown")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never invoked for reply-to-file message")
+	}
+}
+
+func TestReplyToPictureMessage_BuildsTextAndImageAttachment(t *testing.T) {
+	imageBody := []byte("fake png bytes")
+	imageSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(imageBody)
+	}))
+	defer imageSrv.Close()
+
+	rt := &dingtalkFileDownloadRT{
+		accessToken: "tok-replied-picture",
+		downloadURL: imageSrv.URL,
+	}
+	captured := make(chan *core.Message, 1)
+	p := &Platform{
+		clientID:     "cid",
+		clientSecret: "csec",
+		robotCode:    "robot-1",
+		httpClient:   &http.Client{Transport: rt},
+		handler: func(_ core.Platform, msg *core.Message) {
+			captured <- msg
+		},
+	}
+
+	p.onRawMessage(`{
+		"msgtype": "text",
+		"msgId": "msg-replied-picture-1",
+		"conversationType": "2",
+		"conversationId": "conv-1",
+		"conversationTitle": "test group",
+		"senderStaffId": "user-1",
+		"senderNick": "Alice",
+		"sessionWebhook": "https://example.invalid/webhook",
+		"text": {
+			"isReplyMsg": true,
+			"repliedMsg": {
+				"msgType": "picture",
+				"content": {"downloadCode": "dc-replied-picture"}
+			},
+			"content": "这个呢"
+		}
+	}`)
+
+	select {
+	case msg := <-captured:
+		if msg.Content != "引用: \"图片\"\n\n这个呢" {
+			t.Errorf("Content = %q", msg.Content)
+		}
+		if len(msg.Images) != 1 {
+			t.Fatalf("Images len = %d, want 1", len(msg.Images))
+		}
+		if len(msg.Files) != 0 {
+			t.Fatalf("Files len = %d, want 0", len(msg.Files))
+		}
+		image := msg.Images[0]
+		if string(image.Data) != string(imageBody) {
+			t.Errorf("image bytes = %q, want %q", image.Data, imageBody)
+		}
+		if image.MimeType != "image/png" {
+			t.Errorf("MimeType = %q, want image/png", image.MimeType)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never invoked for reply-to-picture message")
 	}
 }
 

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -688,10 +688,10 @@ func TestProactiveRouting_DirectSessionUsesDirectAPI(t *testing.T) {
 
 func TestParseRichText(t *testing.T) {
 	tests := []struct {
-		name             string
-		content          interface{}
-		wantText         string
-		wantPictureCodes []string
+		name              string
+		content           interface{}
+		wantText          string
+		wantDownloadCodes []string
 	}{
 		{
 			name:     "nil content",
@@ -744,14 +744,14 @@ func TestParseRichText(t *testing.T) {
 			content: map[string]interface{}{
 				"richText": []interface{}{
 					map[string]interface{}{"text": "See image: "},
-					map[string]interface{}{"pictureDownloadCode": "abc123"},
+					map[string]interface{}{"pictureDownloadCode": "preview-abc123", "downloadCode": "abc123"},
 					map[string]interface{}{"pictureDownloadCode": "  "},
 					map[string]interface{}{"pictureDownloadCode": "def456"},
 					map[string]interface{}{"text": "done"},
 				},
 			},
-			wantText:         "See image: done",
-			wantPictureCodes: []string{"abc123", "def456"},
+			wantText:          "See image: done",
+			wantDownloadCodes: []string{"abc123", "def456"},
 		},
 		{
 			name: "missing richText key",
@@ -764,12 +764,12 @@ func TestParseRichText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotText, gotPictureCodes := parseRichText(tt.content)
+			gotText, gotDownloadCodes := parseRichText(tt.content)
 			if gotText != tt.wantText {
 				t.Errorf("parseRichText() text = %q, want %q", gotText, tt.wantText)
 			}
-			if got, want := strings.Join(gotPictureCodes, ","), strings.Join(tt.wantPictureCodes, ","); got != want {
-				t.Errorf("parseRichText() picture codes = %q, want %q", got, want)
+			if got, want := strings.Join(gotDownloadCodes, ","), strings.Join(tt.wantDownloadCodes, ","); got != want {
+				t.Errorf("parseRichText() download codes = %q, want %q", got, want)
 			}
 		})
 	}
@@ -811,7 +811,7 @@ func TestOnRawMessage_RichTextWithPicture_DownloadsImage(t *testing.T) {
 		"content": {
 			"richText": [
 				{"text": "Please inspect "},
-				{"pictureDownloadCode": "picture-code-1"},
+				{"pictureDownloadCode": "preview-picture-code-1", "downloadCode": "picture-code-1", "type": "picture"},
 				{"text": "this image"}
 			]
 		}
@@ -922,9 +922,9 @@ func TestOnRawMessage_RichTextPictures_PreservesUsableContent(t *testing.T) {
 		"senderStaffId": "user-1",
 		"content": {
 			"richText": [
-				{"pictureDownloadCode": "picture-a"},
-				{"pictureDownloadCode": "broken-picture"},
-				{"pictureDownloadCode": "picture-b"}
+				{"pictureDownloadCode": "preview-a", "downloadCode": "picture-a", "type": "picture"},
+				{"pictureDownloadCode": "preview-broken", "downloadCode": "broken-picture", "type": "picture"},
+				{"pictureDownloadCode": "preview-b", "downloadCode": "picture-b", "type": "picture"}
 			]
 		}
 	}`)

--- a/platform/dingtalk/dingtalk_test.go
+++ b/platform/dingtalk/dingtalk_test.go
@@ -683,31 +683,32 @@ func TestProactiveRouting_DirectSessionUsesDirectAPI(t *testing.T) {
 }
 
 // ──────────────────────────────────────────────────────────────
-// extractRichText tests (from main: richText message type support)
+// parseRichText tests
 // ──────────────────────────────────────────────────────────────
 
-func TestExtractRichText(t *testing.T) {
+func TestParseRichText(t *testing.T) {
 	tests := []struct {
-		name    string
-		content interface{}
-		want    string
+		name             string
+		content          interface{}
+		wantText         string
+		wantPictureCodes []string
 	}{
 		{
-			name:    "nil content",
-			content: nil,
-			want:    "",
+			name:     "nil content",
+			content:  nil,
+			wantText: "",
 		},
 		{
-			name:    "non-map content",
-			content: "not a map",
-			want:    "",
+			name:     "non-map content",
+			content:  "not a map",
+			wantText: "",
 		},
 		{
 			name: "empty richText array",
 			content: map[string]interface{}{
 				"richText": []interface{}{},
 			},
-			want: "",
+			wantText: "",
 		},
 		{
 			name: "single text element",
@@ -716,7 +717,7 @@ func TestExtractRichText(t *testing.T) {
 					map[string]interface{}{"text": "Hello World"},
 				},
 			},
-			want: "Hello World",
+			wantText: "Hello World",
 		},
 		{
 			name: "multiple text elements",
@@ -726,7 +727,7 @@ func TestExtractRichText(t *testing.T) {
 					map[string]interface{}{"text": "World"},
 				},
 			},
-			want: "Hello World",
+			wantText: "Hello World",
 		},
 		{
 			name: "text with attrs (bold etc) — attrs ignored, text extracted",
@@ -736,35 +737,217 @@ func TestExtractRichText(t *testing.T) {
 					map[string]interface{}{"text": "bold", "attrs": map[string]interface{}{"bold": true}},
 				},
 			},
-			want: "normal bold",
+			wantText: "normal bold",
 		},
 		{
-			name: "mixed text and picture elements — pictures skipped",
+			name: "mixed text and picture elements",
 			content: map[string]interface{}{
 				"richText": []interface{}{
 					map[string]interface{}{"text": "See image: "},
 					map[string]interface{}{"pictureDownloadCode": "abc123"},
+					map[string]interface{}{"pictureDownloadCode": "  "},
+					map[string]interface{}{"pictureDownloadCode": "def456"},
 					map[string]interface{}{"text": "done"},
 				},
 			},
-			want: "See image: done",
+			wantText:         "See image: done",
+			wantPictureCodes: []string{"abc123", "def456"},
 		},
 		{
 			name: "missing richText key",
 			content: map[string]interface{}{
 				"other": "data",
 			},
-			want: "",
+			wantText: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractRichText(tt.content)
-			if got != tt.want {
-				t.Errorf("extractRichText() = %q, want %q", got, tt.want)
+			gotText, gotPictureCodes := parseRichText(tt.content)
+			if gotText != tt.wantText {
+				t.Errorf("parseRichText() text = %q, want %q", gotText, tt.wantText)
+			}
+			if got, want := strings.Join(gotPictureCodes, ","), strings.Join(tt.wantPictureCodes, ","); got != want {
+				t.Errorf("parseRichText() picture codes = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestOnRawMessage_RichTextWithPicture_DownloadsImage(t *testing.T) {
+	const imageBody = "rich-text-image"
+
+	imageSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte(imageBody))
+	}))
+	defer imageSrv.Close()
+
+	p := &Platform{
+		clientID:     "cid",
+		clientSecret: "csec",
+		robotCode:    "robot-1",
+		httpClient: &http.Client{Transport: &dingtalkFileDownloadRT{
+			accessToken: "tok-rich-text-image",
+			downloadURL: imageSrv.URL,
+		}},
+	}
+
+	captured := make(chan *core.Message, 1)
+	p.handler = func(_ core.Platform, msg *core.Message) {
+		captured <- msg
+	}
+
+	p.onRawMessage(`{
+		"msgtype": "richText",
+		"msgId": "msg-rich-text-image",
+		"conversationType": "2",
+		"conversationId": "conv-group",
+		"conversationTitle": "test group",
+		"senderStaffId": "user-1",
+		"senderNick": "Alice",
+		"sessionWebhook": "https://example.invalid/webhook",
+		"content": {
+			"richText": [
+				{"text": "Please inspect "},
+				{"pictureDownloadCode": "picture-code-1"},
+				{"text": "this image"}
+			]
+		}
+	}`)
+
+	select {
+	case msg := <-captured:
+		if msg.Content != "Please inspect this image" {
+			t.Fatalf("Content = %q, want %q", msg.Content, "Please inspect this image")
+		}
+		if len(msg.Images) != 1 {
+			t.Fatalf("Images len = %d, want 1", len(msg.Images))
+		}
+		if got := string(msg.Images[0].Data); got != imageBody {
+			t.Fatalf("image bytes = %q, want %q", got, imageBody)
+		}
+		if msg.Images[0].MimeType != "image/png" {
+			t.Fatalf("image MIME = %q, want image/png", msg.Images[0].MimeType)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler was not invoked for richText image message")
+	}
+}
+
+type richTextImageResponse struct {
+	body     string
+	mimeType string
+}
+
+type richTextImageDownloadRT struct {
+	images      map[string]richTextImageResponse
+	failedCodes map[string]bool
+}
+
+func (r *richTextImageDownloadRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path == "/v1.0/robot/messageFiles/download" {
+		var payload struct {
+			DownloadCode string `json:"downloadCode"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			return nil, err
+		}
+		if r.failedCodes[payload.DownloadCode] {
+			return &http.Response{
+				StatusCode: http.StatusBadGateway,
+				Body:       io.NopCloser(strings.NewReader(`{"message":"download unavailable"}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		body := fmt.Sprintf(`{"downloadUrl":"https://richtext-images.invalid/%s"}`, payload.DownloadCode)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}
+
+	if req.URL.Host == "richtext-images.invalid" {
+		code := strings.TrimPrefix(req.URL.Path, "/")
+		image, ok := r.images[code]
+		if !ok {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader("not found")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		header := make(http.Header)
+		header.Set("Content-Type", image.mimeType)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(image.body)),
+			Header:     header,
+			Request:    req,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unexpected request: %s", req.URL)
+}
+
+func TestOnRawMessage_RichTextPictures_PreservesUsableContent(t *testing.T) {
+	rt := &richTextImageDownloadRT{
+		images: map[string]richTextImageResponse{
+			"picture-a": {body: "image-a", mimeType: "image/jpeg"},
+			"picture-b": {body: "image-b", mimeType: "image/png"},
+		},
+		failedCodes: map[string]bool{"broken-picture": true},
+	}
+	p := &Platform{
+		clientID:     "cid",
+		clientSecret: "csec",
+		robotCode:    "robot-1",
+		httpClient:   &http.Client{Transport: rt},
+		accessToken:  "tok-rich-text-images",
+		tokenExpiry:  time.Now().Add(time.Hour),
+	}
+
+	captured := make(chan *core.Message, 1)
+	p.handler = func(_ core.Platform, msg *core.Message) { captured <- msg }
+	p.onRawMessage(`{
+		"msgtype": "richText",
+		"msgId": "msg-rich-text-multiple-images",
+		"conversationType": "2",
+		"conversationId": "conv-group",
+		"senderStaffId": "user-1",
+		"content": {
+			"richText": [
+				{"pictureDownloadCode": "picture-a"},
+				{"pictureDownloadCode": "broken-picture"},
+				{"pictureDownloadCode": "picture-b"}
+			]
+		}
+	}`)
+
+	select {
+	case msg := <-captured:
+		if msg.Content != "" {
+			t.Fatalf("Content = %q, want empty for picture-only richText", msg.Content)
+		}
+		if len(msg.Images) != 2 {
+			t.Fatalf("Images len = %d, want 2 usable images", len(msg.Images))
+		}
+		if got := string(msg.Images[0].Data); got != "image-a" {
+			t.Fatalf("first image = %q, want image-a", got)
+		}
+		if got := string(msg.Images[1].Data); got != "image-b" {
+			t.Fatalf("second image = %q, want image-b", got)
+		}
+		if msg.ChannelKey != "conv-group" {
+			t.Fatalf("ChannelKey = %q, want conv-group", msg.ChannelKey)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler was not invoked for picture-only richText message")
 	}
 }
 


### PR DESCRIPTION
## Summary

- parse both text and embedded image download codes from DingTalk `richText` callbacks
- prefer the working `downloadCode` field and retain `pictureDownloadCode` as a compatibility fallback
- download multiple embedded pictures and pass them with text in the same `core.Message`
- recover media metadata from `text.repliedMsg.content` when users reply to a group file or picture and @mention the robot
- route quoted `picture` / `image` messages to `Images` and quoted files to `Files`; use MIME detection as a fallback for new downloadable reply types
- keep usable text and successfully downloaded attachments when one media download fails
- reuse bounded download helpers: 25 MiB for images and 50 MiB for files

## Problem

DingTalk group media reaches Stream robots in more than one callback shape:

1. An @mention mixed with text and pictures arrives as `msgtype=richText`, with image download codes inside `content.richText[]`.
2. A user can first send a file or picture, then reply to it and @mention the robot. DingTalk sends this as top-level `msgtype=text`; the referenced media is nested under `text.repliedMsg` with `msgType` and `content.downloadCode`.

The adapter previously handled the outer text but silently dropped media in both shapes. It also selected `pictureDownloadCode` when both rich-text code fields were present, while the real download API requires `downloadCode` for these callbacks.

## Behavior

- rich-text text and pictures are delivered together
- reply-to-file messages preserve the user text and add a named `FileAttachment`
- reply-to-picture messages preserve the user text and add an `ImageAttachment`
- unknown replied message types that expose a download code are downloaded as bounded attachments and promoted to images when their MIME type starts with `image/`
- download failures are logged without dropping the remaining text or other usable pictures

## Tests

- `go test ./platform/dingtalk -count=1`
- `go test -race ./platform/dingtalk -count=1`
- `go vet ./platform/dingtalk`
- `go build ./cmd/cc-connect`

Regression coverage includes mixed rich text, multiple pictures with partial download failure, download-code precedence, reply-to-file, reply-to-picture, standalone picture aliases, file names, MIME types, and attachment bytes.