### PR TITLE
fix(codex,claudecode): surface scanner.Err in JSONL session readers

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -671,6 +672,16 @@ func scanSessionMeta(path string) (string, int) {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		if errors.Is(err, bufio.ErrTooLong) {
+			slog.Warn("claudecode: session transcript line exceeded scanner buffer; summary may be incomplete",
+				"path", path, "error", err)
+		} else {
+			slog.Warn("claudecode: failed to scan session transcript",
+				"path", path, "error", err)
+		}
+	}
+
 	summary := customTitle
 	if summary == "" {
 		summary = aiTitle
@@ -745,6 +756,13 @@ func (a *Agent) GetSessionHistory(_ context.Context, sessionID string, limit int
 			Content:   text,
 			Timestamp: ts,
 		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		if errors.Is(err, bufio.ErrTooLong) {
+			return entries, fmt.Errorf("claudecode: session history line exceeds %d-byte scanner buffer (history truncated): %w", 256*1024, err)
+		}
+		return entries, fmt.Errorf("claudecode: scan session transcript: %w", err)
 	}
 
 	if limit > 0 && len(entries) > limit {

--- a/agent/claudecode/session_scanner_test.go
+++ b/agent/claudecode/session_scanner_test.go
@@ -1,0 +1,104 @@
+package claudecode
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression: a JSONL line larger than the 256 KB scanner buffer used to
+// silently truncate history — GetSessionHistory returned the entries parsed
+// before the oversized line with a nil error. It must now surface
+// bufio.ErrTooLong so callers know the result is incomplete.
+func TestGetSessionHistory_OversizedLineReturnsError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	workDir := t.TempDir()
+
+	projectDir := filepath.Join(home, ".claude", "projects", encodeClaudeProjectKey(workDir))
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+
+	sessionID := "oversize-session"
+	path := filepath.Join(projectDir, sessionID+".jsonl")
+	big := strings.Repeat("x", 300*1024) // > 256 KB scanner cap
+	lines := []string{
+		`{"type":"user","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"` + big + `"}}`,
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:01Z","message":{"role":"assistant","content":"hi"}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	a := &Agent{workDir: workDir}
+	_, err := a.GetSessionHistory(context.Background(), sessionID, 0)
+	if err == nil {
+		t.Fatalf("expected error when a line exceeds scanner buffer, got nil")
+	}
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Fatalf("expected bufio.ErrTooLong, got %v", err)
+	}
+}
+
+// Regression: scanSessionMeta must not panic when the scanner hits
+// ErrTooLong. It previously scanned a partial file and returned a misleading
+// count/summary; the fix adds an error log and keeps returning the partial
+// result (caller listSessions tolerates best-effort summaries).
+func TestScanSessionMeta_OversizedLineDoesNotPanic(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "oversize.jsonl")
+
+	big := strings.Repeat("y", 300*1024)
+	lines := []string{
+		`{"type":"user","message":{"content":"` + big + `"}}`,
+		`{"type":"assistant","message":{"content":"hi"}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Must return without panicking; partial count is acceptable.
+	summary, count := scanSessionMeta(path)
+	if count < 0 {
+		t.Fatalf("count must be non-negative, got %d", count)
+	}
+	_ = summary
+}
+
+// Sanity: happy path still parses fine after the scanner.Err() check is added.
+func TestGetSessionHistory_HappyPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	workDir := t.TempDir()
+
+	projectDir := filepath.Join(home, ".claude", "projects", encodeClaudeProjectKey(workDir))
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+
+	sessionID := "happy-session"
+	path := filepath.Join(projectDir, sessionID+".jsonl")
+	lines := []string{
+		`{"type":"user","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"hello"}}`,
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:01Z","message":{"role":"assistant","content":"hi"}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	a := &Agent{workDir: workDir}
+	entries, err := a.GetSessionHistory(context.Background(), sessionID, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 history entries, got %d", len(entries))
+	}
+}

--- a/agent/codex/list.go
+++ b/agent/codex/list.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -146,6 +148,17 @@ func parseCodexSessionFile(path, filterCwd string) *core.AgentSessionInfo {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		if errors.Is(err, bufio.ErrTooLong) {
+			slog.Warn("codex: session transcript line exceeded scanner buffer; skipping session",
+				"path", path, "error", err)
+		} else {
+			slog.Warn("codex: failed to scan session transcript",
+				"path", path, "error", err)
+		}
+		return nil
+	}
+
 	// Filter by cwd
 	if filterCwd != "" && sessionCwd != "" && sessionCwd != filterCwd {
 		return nil
@@ -255,6 +268,13 @@ func getSessionHistory(sessionID, codexHome string, limit int) ([]core.HistoryEn
 		case item.Type == "reasoning" && item.Text != "":
 			// skip reasoning items
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		if errors.Is(err, bufio.ErrTooLong) {
+			return entries, fmt.Errorf("codex: session history line exceeds %d-byte scanner buffer (history truncated): %w", 256*1024, err)
+		}
+		return entries, fmt.Errorf("codex: scan session transcript: %w", err)
 	}
 
 	if limit > 0 && len(entries) > limit {

--- a/agent/codex/list_scanner_test.go
+++ b/agent/codex/list_scanner_test.go
@@ -1,0 +1,96 @@
+package codex
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression: a JSONL line larger than the 256 KB scanner buffer used to
+// silently truncate history — getSessionHistory returned whatever entries
+// preceded the oversized line with a nil error. It must now surface
+// bufio.ErrTooLong so callers know the result is incomplete.
+func TestGetSessionHistory_OversizedLineReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	codexHome := filepath.Join(tmpDir, ".codex")
+	sessionsDir := filepath.Join(codexHome, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	sessionID := "oversize-session"
+	path := filepath.Join(sessionsDir, "rollout-"+sessionID+".jsonl")
+
+	big := strings.Repeat("x", 300*1024) // > 256 KB scanner cap
+	lines := []string{
+		`{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"id":"` + sessionID + `","cwd":"/tmp"}}`,
+		`{"timestamp":"2026-01-01T00:00:01Z","type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"` + big + `"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := getSessionHistory(sessionID, codexHome, 0)
+	if err == nil {
+		t.Fatalf("expected error when a line exceeds scanner buffer, got nil")
+	}
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Fatalf("expected bufio.ErrTooLong, got %v", err)
+	}
+}
+
+// Regression: parseCodexSessionFile must not return a session with a
+// misleading message count / summary when the underlying scanner hits
+// ErrTooLong. Previously it returned the partial result silently; it must
+// now return nil so listCodexSessions skips the unreadable file.
+func TestParseCodexSessionFile_OversizedLineReturnsNil(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "rollout-oversize.jsonl")
+
+	big := strings.Repeat("y", 300*1024)
+	lines := []string{
+		`{"type":"session_meta","payload":{"id":"s1","cwd":"/tmp"}}`,
+		`{"type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"` + big + `"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := parseCodexSessionFile(path, ""); got != nil {
+		t.Fatalf("expected nil on oversized line, got session %+v (summary=%q count=%d)",
+			got, got.Summary, got.MessageCount)
+	}
+}
+
+// Sanity: the existing happy path still parses fine and returns both entries
+// once the scanner err check is added.
+func TestGetSessionHistory_HappyPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	codexHome := filepath.Join(tmpDir, ".codex")
+	sessionsDir := filepath.Join(codexHome, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	sessionID := "happy-session"
+	path := filepath.Join(sessionsDir, "rollout-"+sessionID+".jsonl")
+	lines := []string{
+		`{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"id":"` + sessionID + `","cwd":"/tmp"}}`,
+		`{"timestamp":"2026-01-01T00:00:01Z","type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"hello"}]}}`,
+		`{"timestamp":"2026-01-01T00:00:02Z","type":"response_item","payload":{"role":"assistant","content":[{"type":"output_text","text":"hi"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	entries, err := getSessionHistory(sessionID, codexHome, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 history entries, got %d", len(entries))
+	}
+}


### PR DESCRIPTION
## Summary

The session transcript readers in `agent/codex/list.go` and `agent/claudecode/claudecode.go` all use `bufio.Scanner` with a fixed 256 KB buffer but never checked `scanner.Err()` after the loop. When a single JSONL line (a large tool output, pasted file content, image data) exceeded the buffer, `Scan()` returned `false` with `bufio.ErrTooLong` and the function quietly returned whatever it had parsed so far with a `nil` error — so the session list showed a wrong message count / empty summary, and `/history` returned a truncated conversation without telling the caller.

The correct pattern already exists in this repo at `agent/codex/context_usage.go:258`, which checks `scanner.Err()` and propagates it; these four readers were the inconsistent ones.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

### Automated tests added in this PR

- `agent/codex/list_scanner_test.go`
  - `TestGetSessionHistory_OversizedLineReturnsError` — writes a 300 KB JSONL line, expects `errors.Is(err, bufio.ErrTooLong)`.
  - `TestParseCodexSessionFile_OversizedLineReturnsNil` — expects the unreadable session to be skipped.
  - `TestGetSessionHistory_HappyPath` — sanity check that normal files still parse.
- `agent/claudecode/session_scanner_test.go`
  - `TestGetSessionHistory_OversizedLineReturnsError` — same for `Agent.GetSessionHistory`.
  - `TestScanSessionMeta_OversizedLineDoesNotPanic` — verifies the best-effort summary path.
  - `TestGetSessionHistory_HappyPath`.

### For bug fixes only — regression test

- Regression tests: `TestGetSessionHistory_OversizedLineReturnsError` (codex + claudecode), `TestParseCodexSessionFile_OversizedLineReturnsNil`.
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally; the regression tests failed as expected (`expected error when a line exceeds scanner buffer, got nil`).

### Critical User Journeys (CUJ) impact

- [x] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.): the bug surfaces in `/list` summaries and `/history` output.

- [x] `go test ./core/ -run TestCUJ` passes locally.
- [x] No existing user-visible flow is altered beyond surfacing a previously-silent error.

## Manual / user-visible behavior change

When a session transcript contains a line larger than 256 KB, `/history` now returns an explicit error rather than a silently truncated conversation, and the offending session is omitted from `/list` (codex) with a warning log instead of appearing with a wrong message count.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes (with `-race` where concurrency is touched — not applicable to this change; package tests run with `-tags no_web` matching the Makefile default)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (no new user-facing strings)
- [x] No secrets / credentials in source

## Related

- Same-class fix elsewhere in this repo: `agent/codex/context_usage.go:258` already checks `scanner.Err()`.
