### PR TITLE
fix(core): lock CommandRegistry.agentDirs in SetAgentDirs and Resolve

### DIFF
--- a/core/command.go
+++ b/core/command.go
@@ -71,8 +71,12 @@ func (r *CommandRegistry) Remove(name string) bool {
 }
 
 // SetAgentDirs sets the directories to scan for agent command files.
+// Safe for concurrent use with Resolve / ListAll.
 func (r *CommandRegistry) SetAgentDirs(dirs []string) {
-	r.agentDirs = dirs
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Copy so later mutations of the caller's slice don't race with readers.
+	r.agentDirs = append([]string(nil), dirs...)
 }
 
 // Resolve looks up a command by name. Config commands take priority, then
@@ -96,6 +100,9 @@ func (r *CommandRegistry) Resolve(name string) (*CustomCommand, bool) {
 			return c, true
 		}
 	}
+	// Snapshot agentDirs under the lock so we don't hold it across file IO
+	// while still avoiding a data race with SetAgentDirs.
+	agentDirs := append([]string(nil), r.agentDirs...)
 	r.mu.RUnlock()
 
 	// Scan agent command directories; try both original name and hyphenated variant
@@ -103,7 +110,7 @@ func (r *CommandRegistry) Resolve(name string) (*CustomCommand, bool) {
 	if alt := strings.ReplaceAll(name, "_", "-"); alt != name {
 		candidates = append(candidates, alt)
 	}
-	for _, dir := range r.agentDirs {
+	for _, dir := range agentDirs {
 		absDir, err := filepath.Abs(dir)
 		if err != nil {
 			continue

--- a/core/command_race_test.go
+++ b/core/command_race_test.go
@@ -1,0 +1,69 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// Regression: CommandRegistry.SetAgentDirs wrote r.agentDirs without holding
+// r.mu, and Resolve read r.agentDirs after releasing r.mu.RLock(), so a
+// concurrent re-bind raced on the slice header. ListAll already accessed the
+// same field under the lock, which made the inconsistency obvious.
+//
+// Run with `go test -race ./core/ -run TestCommandRegistry_ConcurrentDirSwap`.
+func TestCommandRegistry_ConcurrentDirSwap(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dirA, "alpha.md"), []byte("alpha prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirB, "beta.md"), []byte("beta prompt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewCommandRegistry()
+	r.Add("config-cmd", "", "from config", "", "", "config")
+	r.SetAgentDirs([]string{dirA})
+
+	const writers = 8
+	const readers = 16
+	const iters = 50
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for w := 0; w < writers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			dirs := []string{dirA}
+			if id%2 == 0 {
+				dirs = []string{dirB}
+			}
+			for i := 0; i < iters; i++ {
+				r.SetAgentDirs(dirs)
+			}
+		}(w)
+	}
+
+	for rd := 0; rd < readers; rd++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				// Config command must always resolve.
+				if _, ok := r.Resolve("config-cmd"); !ok {
+					t.Errorf("config-cmd failed to resolve")
+					return
+				}
+				// Agent commands may or may not resolve depending on the
+				// active dir set; just ensure no panic / race.
+				_, _ = r.Resolve("alpha")
+				_, _ = r.Resolve("beta")
+				_ = r.ListAll()
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

`core/command.go` guards the `commands` map with `r.mu`, but access to `r.agentDirs` was inconsistent: `ListAll` reads it under `RLock`, `SetAgentDirs` wrote it with no lock at all, and `Resolve` released the read lock before ranging over it. Today `SetAgentDirs` is only called at engine construction (`engine.go:749`), so there is no live crash, but the locking contract is misleading — any future runtime re-bind (or a `go test -race` run that overlaps setup with message handling) races on the slice header. `ListAll` in the same file already treats `agentDirs` as lock-guarded, so this just makes the other two methods follow that contract.

## Change

- `SetAgentDirs`: take `r.mu.Lock()` and copy the incoming slice before storing it, so later mutations by the caller do not leak into the registry under a reader.
- `Resolve`: snapshot `r.agentDirs` under `RLock` before doing file IO, so the slice header is read safely without holding the lock across disk reads.
- No behavior change for callers.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Internal refactor / chore (no user-visible change)

## Testing

### Automated tests added in this PR

- `core/command_race_test.go`
  - `TestCommandRegistry_ConcurrentDirSwap` — spawns writers that repeatedly swap `agentDirs` between two temp directories while readers call `Resolve` on a config command, agent commands, and `ListAll`. Fails under `-race` if either the write or the post-unlock read is unlocked.

### For bug fixes only — regression test

- Regression test name: `TestCommandRegistry_ConcurrentDirSwap`.
- Manual verification this test catches the regression:
  - [x] Reverted the production fix locally; `go test -race -run TestCommandRegistry_ConcurrentDirSwap ./core/` failed with `race detected during execution of test` pointing at the unlocked `SetAgentDirs` write and the unlocked `Resolve` read.

### Critical User Journeys (CUJ) impact

- [x] No CUJ touched (locking-only change; no behavior change).

## Manual / user-visible behavior change

None.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes, including `go test -race -run TestCommandRegistry_ConcurrentDirSwap ./core/`
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (no user-facing strings added)
- [x] No secrets / credentials in source

## Related

- `ListAll` in the same file already reads `agentDirs` under `RLock`; this PR makes `SetAgentDirs` and `Resolve` follow that same contract.
