### PR TITLE
test(core): cover DirHistory move-to-front, trim, persistence, bounds

### DIFF
--- a/core/dir_history_test.go
+++ b/core/dir_history_test.go
@@ -1,0 +1,181 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestDirHistory_Add_MovesToFrontAndDedups(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	dh.Add("proj", "/a")
+	dh.Add("proj", "/b")
+	dh.Add("proj", "/a")
+
+	got := dh.List("proj")
+	want := []string{"/a", "/b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("List = %v, want %v (re-adding /a must move it to front)", got, want)
+	}
+}
+
+func TestDirHistory_Add_IgnoresEmpty(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	dh.Add("proj", "")
+	if got := dh.List("proj"); got != nil {
+		t.Fatalf("Add with empty dir should be a no-op, got %v", got)
+	}
+}
+
+func TestDirHistory_Add_TrimsToMaxSize(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	dh.SetMaxSize(3)
+	for _, d := range []string{"/a", "/b", "/c", "/d", "/e"} {
+		dh.Add("proj", d)
+	}
+	got := dh.List("proj")
+	// Newest first, trimmed to the three most recent: /e, /d, /c.
+	want := []string{"/e", "/d", "/c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("List = %v, want %v (history should be capped at maxSize)", got, want)
+	}
+}
+
+func TestDirHistory_SetMaxSize_AppliesToNextAdd(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	for _, d := range []string{"/a", "/b", "/c"} {
+		dh.Add("proj", d)
+	}
+	// Shrinking maxSize does not retroactively drop entries; the next Add
+	// must trim according to the new cap.
+	dh.SetMaxSize(2)
+	dh.Add("proj", "/d")
+	got := dh.List("proj")
+	want := []string{"/d", "/c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("List = %v, want %v after SetMaxSize(2)+Add", got, want)
+	}
+}
+
+func TestDirHistory_SetMaxSize_ClampsToAtLeastOne(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	dh.SetMaxSize(0)
+	dh.Add("proj", "/a")
+	dh.Add("proj", "/b")
+	got := dh.List("proj")
+	want := []string{"/b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("List = %v, want %v (maxSize must be clamped to >=1)", got, want)
+	}
+}
+
+func TestDirHistory_Get_OneBasedAndBoundsCheck(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	dh.Add("proj", "/a")
+	dh.Add("proj", "/b")
+
+	if got := dh.Get("proj", 1); got != "/b" {
+		t.Errorf("Get(1) = %q, want %q (index 1 is most recent)", got, "/b")
+	}
+	if got := dh.Get("proj", 2); got != "/a" {
+		t.Errorf("Get(2) = %q, want %q", got, "/a")
+	}
+	if got := dh.Get("proj", 0); got != "" {
+		t.Errorf("Get(0) = %q, want empty (out of range)", got)
+	}
+	if got := dh.Get("proj", 3); got != "" {
+		t.Errorf("Get(3) = %q, want empty (out of range)", got)
+	}
+	if got := dh.Get("other", 1); got != "" {
+		t.Errorf("Get on unknown project = %q, want empty", got)
+	}
+}
+
+func TestDirHistory_PreviousReturnsIndexTwo(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	dh.Add("proj", "/a")
+	dh.Add("proj", "/b")
+	if got := dh.Previous("proj"); got != "/a" {
+		t.Fatalf("Previous = %q, want %q", got, "/a")
+	}
+}
+
+func TestDirHistory_Contains(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	dh.Add("proj", "/a")
+	if !dh.Contains("proj", "/a") {
+		t.Errorf("Contains(/a) = false, want true")
+	}
+	if dh.Contains("proj", "/missing") {
+		t.Errorf("Contains(/missing) = true, want false")
+	}
+	if dh.Contains("other", "/a") {
+		t.Errorf("Contains on unknown project = true, want false")
+	}
+}
+
+func TestDirHistory_List_ReturnsDefensiveCopy(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	dh.Add("proj", "/a")
+
+	first := dh.List("proj")
+	first[0] = "/mutated"
+
+	again := dh.List("proj")
+	if again[0] != "/a" {
+		t.Fatalf("List returned a slice aliasing internal state; got %q after mutation, want /a", again[0])
+	}
+}
+
+func TestDirHistory_PerProjectIsolation(t *testing.T) {
+	dh := NewDirHistory(t.TempDir())
+	dh.Add("proj-a", "/a1")
+	dh.Add("proj-b", "/b1")
+
+	if got := dh.List("proj-a"); !reflect.DeepEqual(got, []string{"/a1"}) {
+		t.Fatalf("proj-a = %v, want [/a1]", got)
+	}
+	if got := dh.List("proj-b"); !reflect.DeepEqual(got, []string{"/b1"}) {
+		t.Fatalf("proj-b = %v, want [/b1]", got)
+	}
+}
+
+func TestDirHistory_PersistsAcrossInstances(t *testing.T) {
+	dataDir := t.TempDir()
+	dh1 := NewDirHistory(dataDir)
+	dh1.Add("proj", "/a")
+	dh1.Add("proj", "/b")
+
+	// New instance pointing at the same data dir must rehydrate from disk.
+	dh2 := NewDirHistory(dataDir)
+	got := dh2.List("proj")
+	want := []string{"/b", "/a"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("after reload List = %v, want %v", got, want)
+	}
+}
+
+func TestDirHistory_Load_MissingFileIsNotAnError(t *testing.T) {
+	// NewDirHistory on an empty data dir must not panic and List must
+	// return nil rather than a zero-length slice with stale data.
+	dh := NewDirHistory(t.TempDir())
+	if got := dh.List("proj"); got != nil {
+		t.Fatalf("List on empty history = %v, want nil", got)
+	}
+}
+
+func TestDirHistory_Load_CorruptFileIsIgnored(t *testing.T) {
+	dataDir := t.TempDir()
+	store := filepath.Join(dataDir, dirHistoryFileName)
+	if err := os.WriteFile(store, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+
+	dh := NewDirHistory(dataDir)
+	// Corrupt file should be logged and ignored; Add must still work.
+	dh.Add("proj", "/a")
+	if got := dh.List("proj"); !reflect.DeepEqual(got, []string{"/a"}) {
+		t.Fatalf("List after corrupt load = %v, want [/a]", got)
+	}
+}


### PR DESCRIPTION
## Summary

`core/dir_history.go` tracks per-project recently-used directories (backing the `/cd`-style switch history). Its six exported methods carry non-trivial logic — move-to-front dedup on `Add`, trim-to-`maxSize`, 1-based indexing on `Get` with bounds checking, `Previous` fixed at index 2, defensive-copy on `List`, JSON persistence across instances — but the package had no `dir_history_test.go`. Existing coverage only instantiated `NewDirHistory` as setup in `engine_test.go`, so any regression in the history behavior itself would have gone unnoticed.

## Change

No production code changes — this PR adds `core/dir_history_test.go` with 13 table-driven tests covering every exported method plus the load/reload and corrupt-file paths.

## Type of change

- [x] Internal refactor / chore (no user-visible change) — tests only

## Testing

### Automated tests added in this PR

`core/dir_history_test.go`:

- `TestDirHistory_Add_MovesToFrontAndDedups` — re-adding a directory moves it to the front and does not duplicate.
- `TestDirHistory_Add_IgnoresEmpty` — empty dir is a no-op.
- `TestDirHistory_Add_TrimsToMaxSize` — history is capped at the most recent N entries.
- `TestDirHistory_SetMaxSize_AppliesToNextAdd` — shrinking `maxSize` does not retroactively drop entries but trims on the next `Add`.
- `TestDirHistory_SetMaxSize_ClampsToAtLeastOne` — `SetMaxSize(0)` clamps to 1.
- `TestDirHistory_Get_OneBasedAndBoundsCheck` — index 1 is the most recent, index 0/out-of-range returns "".
- `TestDirHistory_PreviousReturnsIndexTwo` — `Previous` is hard-wired to the second-most-recent entry.
- `TestDirHistory_Contains` — true / false / unknown project cases.
- `TestDirHistory_List_ReturnsDefensiveCopy` — mutating the returned slice does not affect internal state.
- `TestDirHistory_PerProjectIsolation` — two projects do not share entries.
- `TestDirHistory_PersistsAcrossInstances` — a second `NewDirHistory` on the same data dir rehydrates from disk in most-recent-first order.
- `TestDirHistory_Load_MissingFileIsNotAnError` — empty data dir is not an error and `List` returns nil.
- `TestDirHistory_Load_CorruptFileIsIgnored` — malformed JSON is logged and ignored; subsequent `Add` still works.

### For bug fixes only — regression test

Not applicable — test-only change with no production fix.

### Critical User Journeys (CUJ) impact

- [x] No CUJ touched (test-only change).

## Manual / user-visible behavior change

None.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./core/ -run TestDirHistory` passes (all 13 new tests)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] No new i18n strings
- [x] No secrets / credentials in source

## Related

None.
