### PR TITLE
fix(feishu): expand merge_forward content when quoting a reply

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -2178,9 +2178,10 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		Code int `json:"code"`
 		Data struct {
 			Items []struct {
-				MsgType  string `json:"msg_type"`
-				ParentID string `json:"parent_id"`
-				Sender   struct {
+				MessageID string `json:"message_id"`
+				MsgType   string `json:"msg_type"`
+				ParentID  string `json:"parent_id"`
+				Sender    struct {
 					ID         string `json:"id"`
 					SenderType string `json:"sender_type"`
 				} `json:"sender"`
@@ -2196,9 +2197,21 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		return nil
 	}
 
+	// Prefer the item matching the requested message ID. Get-message for a
+	// merge_forward root returns the root plus all sub-messages; Items[0] may
+	// be a child, which would make the quote look like a random sub-message.
 	item := resp.Data.Items[0]
+	for _, candidate := range resp.Data.Items {
+		if candidate.MessageID == messageID {
+			item = candidate
+			break
+		}
+	}
+
 	content := item.Body.Content
-	if content == "" {
+	// merge_forward body is a fixed placeholder ("Merged and Forwarded Message");
+	// real content lives in sub-messages and must be fetched separately.
+	if content == "" && item.MsgType != "merge_forward" {
 		return nil
 	}
 
@@ -2273,6 +2286,16 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		}
 	case "interactive":
 		text = extractInteractiveCardText(content)
+	case "merge_forward":
+		// Expanding the forward is required when the user replies to a
+		// merge_forward: the reply arrives with a newer create_time and can
+		// set the engine watermark before the async merge_forward dispatch
+		// finishes, causing the standalone forward event to be dropped as
+		// stale. Without this expansion the agent only sees "[merge_forward]".
+		text, images, _ = p.parseMergeForward(messageID)
+		if text == "" {
+			text = "[merge_forward]"
+		}
 	default:
 		text = fmt.Sprintf("[%s]", item.MsgType)
 	}

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1985,9 +1985,10 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		Code int `json:"code"`
 		Data struct {
 			Items []struct {
-				MsgType  string `json:"msg_type"`
-				ParentID string `json:"parent_id"`
-				Sender   struct {
+				MessageID string `json:"message_id"`
+				MsgType   string `json:"msg_type"`
+				ParentID  string `json:"parent_id"`
+				Sender    struct {
 					ID         string `json:"id"`
 					SenderType string `json:"sender_type"`
 				} `json:"sender"`
@@ -2003,9 +2004,21 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		return nil
 	}
 
+	// Prefer the item matching the requested message ID. Get-message for a
+	// merge_forward root returns the root plus all sub-messages; Items[0] may
+	// be a child, which would make the quote look like a random sub-message.
 	item := resp.Data.Items[0]
+	for _, candidate := range resp.Data.Items {
+		if candidate.MessageID == messageID {
+			item = candidate
+			break
+		}
+	}
+
 	content := item.Body.Content
-	if content == "" {
+	// merge_forward body is a fixed placeholder ("Merged and Forwarded Message");
+	// real content lives in sub-messages and must be fetched separately.
+	if content == "" && item.MsgType != "merge_forward" {
 		return nil
 	}
 
@@ -2042,6 +2055,16 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		}
 	case "interactive":
 		text = extractInteractiveCardText(content)
+	case "merge_forward":
+		// Expanding the forward is required when the user replies to a
+		// merge_forward: the reply arrives with a newer create_time and can
+		// set the engine watermark before the async merge_forward dispatch
+		// finishes, causing the standalone forward event to be dropped as
+		// stale. Without this expansion the agent only sees "[merge_forward]".
+		text, images, _ = p.parseMergeForward(messageID)
+		if text == "" {
+			text = "[merge_forward]"
+		}
 	default:
 		text = fmt.Sprintf("[%s]", item.MsgType)
 	}

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -429,6 +429,144 @@ func TestOnMessageThreadIsolationBootstrapsExistingThreadContext(t *testing.T) {
 	}
 }
 
+// TestDispatchMessageExpandsQuotedMergeForward ensures that when a user replies
+// to a merge_forward message, the quoted ExtraContent contains the forwarded
+// sub-message text — not a bare "[merge_forward]" placeholder.
+//
+// Regression: Feishu delivers the merge_forward event and the reply text nearly
+// together. The reply has a newer create_time, so the engine watermark can drop
+// the slower async merge_forward dispatch as stale. If the quote path only
+// emits "[merge_forward]", the agent never sees the forwarded content.
+func TestDispatchMessageExpandsQuotedMergeForward(t *testing.T) {
+	const appID = "cli_quote_merge_forward"
+	const appSecret = "secret-quote-merge-forward"
+	const parentMessageID = "om_parent_merge_forward"
+	const subMessageID = "om_sub_liangchen"
+
+	got := make(chan *core.Message, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID:
+			// Get-message for a merge_forward root returns the root plus
+			// sub-messages. Put a sub-message first so Items[0] is not the
+			// root — fetchSingleMessage must select by message_id.
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"items": []map[string]any{
+						{
+							"message_id":        subMessageID,
+							"msg_type":          "text",
+							"upper_message_id":  parentMessageID,
+							"parent_id":         "",
+							"create_time":       "1786522200000",
+							"sender": map[string]any{
+								"id":          "ou_liangchen",
+								"id_type":     "open_id",
+								"sender_type": "user",
+							},
+							"body": map[string]any{
+								"content": `{"text":"需要用飞书表格做信息调度，单聊成本太高"}`,
+							},
+						},
+						{
+							"message_id":  parentMessageID,
+							"msg_type":    "merge_forward",
+							"parent_id":   "",
+							"create_time": "1786522271011",
+							"sender": map[string]any{
+								"id":          "ou_xigu",
+								"id_type":     "open_id",
+								"sender_type": "user",
+							},
+							"body": map[string]any{
+								"content": "Merged and Forwarded Message",
+							},
+						},
+					},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/contact/v3/users/"):
+			w.Header().Set("Content-Type", "application/json")
+			name := "梁辰"
+			if strings.Contains(r.URL.Path, "ou_xigu") {
+				name = "西顾"
+			}
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"user": map[string]any{"name": name},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/im/v1/chats/"):
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		botOpenID:    "ou_bot",
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			got <- msg
+		},
+	}
+
+	p.dispatchMessage(
+		context.Background(),
+		"text",
+		`{"text":"总结梁辰提的这些需求"}`,
+		nil,
+		"om_child_reply",
+		"feishu:oc_chat:ou_xigu",
+		"ou_xigu",
+		"oc_chat",
+		replyContext{messageID: "om_child_reply", sessionKey: "feishu:oc_chat:ou_xigu"},
+		parentMessageID,
+		1786522271347,
+	)
+
+	select {
+	case msg := <-got:
+		if msg.Content != "总结梁辰提的这些需求" {
+			t.Fatalf("Content = %q, want reply text", msg.Content)
+		}
+		if strings.Contains(msg.ExtraContent, "[merge_forward]") &&
+			!strings.Contains(msg.ExtraContent, "需要用飞书表格做信息调度") {
+			t.Fatalf("ExtraContent still has bare [merge_forward] placeholder: %q", msg.ExtraContent)
+		}
+		if !strings.Contains(msg.ExtraContent, "需要用飞书表格做信息调度") {
+			t.Fatalf("ExtraContent = %q, want expanded merge_forward sub-message text", msg.ExtraContent)
+		}
+		if !strings.Contains(msg.ExtraContent, "<forwarded_messages>") {
+			t.Fatalf("ExtraContent = %q, want <forwarded_messages> wrapper", msg.ExtraContent)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reply with expanded merge_forward quote")
+	}
+}
+
 func TestOnMessageRepliesToUnauthorizedMention(t *testing.T) {
 	const appID = "cli_unauthorized"
 	const appSecret = "secret-unauthorized"

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -304,6 +304,144 @@ func TestDispatchMessageKeepsMentionOnlyQuotedText(t *testing.T) {
 	}
 }
 
+// TestDispatchMessageExpandsQuotedMergeForward ensures that when a user replies
+// to a merge_forward message, the quoted ExtraContent contains the forwarded
+// sub-message text — not a bare "[merge_forward]" placeholder.
+//
+// Regression: Feishu delivers the merge_forward event and the reply text nearly
+// together. The reply has a newer create_time, so the engine watermark can drop
+// the slower async merge_forward dispatch as stale. If the quote path only
+// emits "[merge_forward]", the agent never sees the forwarded content.
+func TestDispatchMessageExpandsQuotedMergeForward(t *testing.T) {
+	const appID = "cli_quote_merge_forward"
+	const appSecret = "secret-quote-merge-forward"
+	const parentMessageID = "om_parent_merge_forward"
+	const subMessageID = "om_sub_liangchen"
+
+	got := make(chan *core.Message, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case r.URL.Path == "/open-apis/im/v1/messages/"+parentMessageID:
+			// Get-message for a merge_forward root returns the root plus
+			// sub-messages. Put a sub-message first so Items[0] is not the
+			// root — fetchSingleMessage must select by message_id.
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"items": []map[string]any{
+						{
+							"message_id":        subMessageID,
+							"msg_type":          "text",
+							"upper_message_id":  parentMessageID,
+							"parent_id":         "",
+							"create_time":       "1786522200000",
+							"sender": map[string]any{
+								"id":          "ou_liangchen",
+								"id_type":     "open_id",
+								"sender_type": "user",
+							},
+							"body": map[string]any{
+								"content": `{"text":"需要用飞书表格做信息调度，单聊成本太高"}`,
+							},
+						},
+						{
+							"message_id":  parentMessageID,
+							"msg_type":    "merge_forward",
+							"parent_id":   "",
+							"create_time": "1786522271011",
+							"sender": map[string]any{
+								"id":          "ou_xigu",
+								"id_type":     "open_id",
+								"sender_type": "user",
+							},
+							"body": map[string]any{
+								"content": "Merged and Forwarded Message",
+							},
+						},
+					},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/contact/v3/users/"):
+			w.Header().Set("Content-Type", "application/json")
+			name := "梁辰"
+			if strings.Contains(r.URL.Path, "ou_xigu") {
+				name = "西顾"
+			}
+			writeJSON(t, w, map[string]any{
+				"code": 0,
+				"msg":  "success",
+				"data": map[string]any{
+					"user": map[string]any{"name": name},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/open-apis/im/v1/chats/"):
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		botOpenID:    "ou_bot",
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			got <- msg
+		},
+	}
+
+	p.dispatchMessage(
+		context.Background(),
+		"text",
+		`{"text":"总结梁辰提的这些需求"}`,
+		nil,
+		"om_child_reply",
+		"feishu:oc_chat:ou_xigu",
+		"ou_xigu",
+		"oc_chat",
+		replyContext{messageID: "om_child_reply", sessionKey: "feishu:oc_chat:ou_xigu"},
+		parentMessageID,
+		1786522271347,
+	)
+
+	select {
+	case msg := <-got:
+		if msg.Content != "总结梁辰提的这些需求" {
+			t.Fatalf("Content = %q, want reply text", msg.Content)
+		}
+		if strings.Contains(msg.ExtraContent, "[merge_forward]") &&
+			!strings.Contains(msg.ExtraContent, "需要用飞书表格做信息调度") {
+			t.Fatalf("ExtraContent still has bare [merge_forward] placeholder: %q", msg.ExtraContent)
+		}
+		if !strings.Contains(msg.ExtraContent, "需要用飞书表格做信息调度") {
+			t.Fatalf("ExtraContent = %q, want expanded merge_forward sub-message text", msg.ExtraContent)
+		}
+		if !strings.Contains(msg.ExtraContent, "<forwarded_messages>") {
+			t.Fatalf("ExtraContent = %q, want <forwarded_messages> wrapper", msg.ExtraContent)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reply with expanded merge_forward quote")
+	}
+}
+
 func TestOnMessageRepliesToUnauthorizedMention(t *testing.T) {
 	const appID = "cli_unauthorized"
 	const appSecret = "secret-unauthorized"


### PR DESCRIPTION
## Summary
- When a user **replies to** a Feishu `merge_forward` message, `fetchSingleMessage` only produced a bare `[merge_forward]` placeholder instead of expanding sub-message text via `parseMergeForward`.
- Combined with the create_time watermark: Feishu delivers the forward and the reply nearly together; the newer reply can mark the slower async forward dispatch as stale and drop it — so the agent never sees the forwarded content even though the UI shows a non-empty forward.
- Also select the Get-message item by `message_id` when the response includes merge_forward sub-messages (Items[0] may be a child).

## Root cause
1. Reply text (`parent_id` → merge_forward) goes through `fetchQuotedMessage` → `fetchSingleMessage`, which fell into `default` and set text to `[merge_forward]`.
2. The standalone `merge_forward` event was parsed successfully (`content_len` > 0) but often dropped as stale because the reply had a newer `create_time` and set the watermark first.

## Reproduction
1. In Feishu P2P with the bot, merge-forward a multi-message conversation.
2. Immediately reply to that forward (e.g. “总结这些需求”).
3. Before this fix: agent says it only received empty `[merge_forward]`; logs show `merge_forward sub-messages fetched` then `stale user message dropped` for the forward, while the reply is handled with no expanded quote.

## Test plan
- [x] `go test ./platform/feishu/ -run TestDispatchMessageExpandsQuotedMergeForward -count=1`
- [x] `go test ./platform/feishu/ -count=1`
- [ ] Manual: merge-forward a chat to the bot, reply asking to summarize — agent should see `<forwarded_messages>` content in context


Made with [Cursor](https://cursor.com)