### PR TITLE
feat(core): accept TOML array form for agent cmd field (#1670)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1713,6 +1713,16 @@ app_secret = "your-feishu-app-secret"
 # Optional: specify a model tier / 可选：指定模型级别
 # model = "auto"  # "auto" | "ultimate" | "performance" | "efficient" | "lite"
 #
+# Optional: override the CLI invocation via the unified `cmd` field. Accepts
+# both a whitespace-separated string and a TOML array. Useful for passing
+# flags that the IM-platform user expects to take effect, e.g. forcing
+# permission bypass without a wrapper script.
+# 可选：通过统一的 `cmd` 字段覆盖 CLI 调用方式，同时接受空白分隔字符串
+# 和 TOML 数组两种写法。可用于让 IM 平台用户透传 CLI 参数，例如绕过权限
+# 检查而无需再用 wrapper 脚本。
+# cmd = "qodercli --permission-mode bypass_permissions"
+# cmd = ["qodercli", "--permission-mode", "bypass_permissions"]
+#
 # [[projects.platforms]]
 # type = "telegram"
 #

--- a/core/cmdopts.go
+++ b/core/cmdopts.go
@@ -8,20 +8,31 @@ import (
 // ParseCmdOpts extracts the command and extra args from agent options.
 //
 // Priority (first non-empty wins):
-//  1. "cmd" (canonical field, no warning)
-//  2. "cli_path" (deprecated — logs a warning)
-//  3. "command" (deprecated — logs a warning)
+//  1. "cmd" (canonical field, no warning). Accepts both:
+//     - a string (whitespace-separated, e.g. "my-cli code -t foo")
+//     - a TOML array of strings (e.g. ["my-cli", "code", "-t", "foo"])
+//  2. "cli_path" (deprecated — logs a warning). String only.
+//  3. "command" (deprecated — logs a warning). String only.
 //  4. defaultBin (fallback when nothing is configured)
 //
 // Examples:
 //
-//	"my-cli code -t foo" → cmd="my-cli", extraArgs=["code", "-t", "foo"]
-//	"claude"             → cmd="claude", extraArgs=nil
-//	"" (default "pi")    → cmd="pi", extraArgs=nil
+//	"my-cli code -t foo"             → cmd="my-cli", extraArgs=["code", "-t", "foo"]
+//	["my-cli", "code", "-t", "foo"] → cmd="my-cli", extraArgs=["code", "-t", "foo"]
+//	"claude"                          → cmd="claude", extraArgs=nil
+//	"" (default "pi")                 → cmd="pi", extraArgs=nil
 func ParseCmdOpts(opts map[string]any, defaultBin string) (cmd string, extraArgs []string) {
-	if v, ok := opts["cmd"].(string); ok && strings.TrimSpace(v) != "" {
-		parts := strings.Fields(v)
-		return parts[0], parts[1:]
+	if v, ok := opts["cmd"]; ok {
+		if s, ok := v.(string); ok {
+			if parts := splitCmdString(s); parts != nil {
+				return parts[0], parts[1:]
+			}
+		} else if arr, ok := toStringArray(v); ok {
+			if parts := filterNonEmpty(arr); len(parts) > 0 {
+				return parts[0], parts[1:]
+			}
+		}
+		// Non-string non-array types fall through to deprecated keys / default.
 	}
 
 	if v, ok := opts["cli_path"].(string); ok && strings.TrimSpace(v) != "" {
@@ -29,8 +40,9 @@ func ParseCmdOpts(opts map[string]any, defaultBin string) (cmd string, extraArgs
 			"deprecated_key", "cli_path",
 			"new_key", "cmd",
 			"value", v)
-		parts := strings.Fields(v)
-		return parts[0], parts[1:]
+		if parts := splitCmdString(v); parts != nil {
+			return parts[0], parts[1:]
+		}
 	}
 
 	if v, ok := opts["command"].(string); ok && strings.TrimSpace(v) != "" {
@@ -38,11 +50,64 @@ func ParseCmdOpts(opts map[string]any, defaultBin string) (cmd string, extraArgs
 			"deprecated_key", "command",
 			"new_key", "cmd",
 			"value", v)
-		parts := strings.Fields(v)
-		return parts[0], parts[1:]
+		if parts := splitCmdString(v); parts != nil {
+			return parts[0], parts[1:]
+		}
 	}
 
 	return defaultBin, nil
+}
+
+// splitCmdString splits a whitespace-separated cmd string into ordered parts.
+// Returns nil when the string is empty or whitespace-only so the caller can
+// fall through to the next priority.
+func splitCmdString(s string) []string {
+	parts := strings.Fields(strings.TrimSpace(s))
+	if len(parts) == 0 {
+		return nil
+	}
+	return parts
+}
+
+// toStringArray accepts the shape TOML produces for inline arrays
+// (i.e. []any of strings) as well as the []string shape some callers may
+// pass directly. Returns ok=false for any other type so the caller can
+// fall through to its next priority without logging a false-positive.
+func toStringArray(v any) ([]string, bool) {
+	switch arr := v.(type) {
+	case []string:
+		return arr, true
+	case []any:
+		out := make([]string, 0, len(arr))
+		for _, item := range arr {
+			s, ok := item.(string)
+			if !ok {
+				// Mixed-type or non-string arrays are an invalid cmd
+				// shape; let the caller fall through rather than panic
+				// or silently drop the user's config.
+				return nil, false
+			}
+			out = append(out, s)
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+// filterNonEmpty strips empty / whitespace-only entries from a cmd array.
+// TOML allows inline arrays with sparse entries (`["cli", "", "--flag"]`)
+// and we want the empty slots treated as if the user had not set them
+// rather than spawning the CLI with an empty argv entry.
+func filterNonEmpty(parts []string) []string {
+	out := parts[:0:0]
+	for _, p := range parts {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // ParseConfigEnv parses opts["env"] (set via [projects.agent.options.env]

--- a/core/cmdopts_test.go
+++ b/core/cmdopts_test.go
@@ -63,7 +63,7 @@ func TestParseCmdOpts_CmdField(t *testing.T) {
 			wantArgs:   nil,
 		},
 		{
-			name:       "cmd field non-string falls through to default",
+			name:       "cmd field non-string non-array falls through to default",
 			opts:       map[string]any{"cmd": 12345},
 			defaultBin: "fallback",
 			wantCmd:    "fallback",
@@ -83,6 +83,65 @@ func TestParseCmdOpts_CmdField(t *testing.T) {
 			wantCmd:    "gemini",
 			wantArgs:   []string{"--model", "pro"},
 		},
+		// Array form (issue #1670 regression: qoder agent must accept the
+		// unified cmd array shape so users can pass
+		// --permission-mode bypass_permissions without a wrapper script).
+		{
+			name:       "cmd array with no extra args",
+			opts:       map[string]any{"cmd": []any{"qodercli"}},
+			defaultBin: "fallback",
+			wantCmd:    "qodercli",
+			wantArgs:   nil,
+		},
+		{
+			name:       "cmd array with permission-mode args (qoder IM use case)",
+			opts:       map[string]any{"cmd": []any{"qodercli", "--permission-mode", "bypass_permissions"}},
+			defaultBin: "fallback",
+			wantCmd:    "qodercli",
+			wantArgs:   []string{"--permission-mode", "bypass_permissions"},
+		},
+		{
+			name:       "cmd []string form",
+			opts:       map[string]any{"cmd": []string{"claude", "--add-dir", "/parent"}},
+			defaultBin: "fallback",
+			wantCmd:    "claude",
+			wantArgs:   []string{"--add-dir", "/parent"},
+		},
+		{
+			name:       "cmd empty array falls through to default",
+			opts:       map[string]any{"cmd": []any{}},
+			defaultBin: "fallback",
+			wantCmd:    "fallback",
+			wantArgs:   nil,
+		},
+		{
+			name:       "cmd array of only whitespace falls through to default",
+			opts:       map[string]any{"cmd": []any{"", "  ", ""}},
+			defaultBin: "fallback",
+			wantCmd:    "fallback",
+			wantArgs:   nil,
+		},
+		{
+			name:       "cmd array with mixed empty entries skips them",
+			opts:       map[string]any{"cmd": []any{"qodercli", "", "--flag", "  "}},
+			defaultBin: "fallback",
+			wantCmd:    "qodercli",
+			wantArgs:   []string{"--flag"},
+		},
+		{
+			name:       "cmd array with non-string entry falls through to default",
+			opts:       map[string]any{"cmd": []any{"qodercli", 42, "--flag"}},
+			defaultBin: "fallback",
+			wantCmd:    "fallback",
+			wantArgs:   nil,
+		},
+		{
+			name:       "cmd array preserves order (argv order matters for some CLIs)",
+			opts:       map[string]any{"cmd": []any{"qodercli", "-p", "first", "--flag", "second"}},
+			defaultBin: "fallback",
+			wantCmd:    "qodercli",
+			wantArgs:   []string{"-p", "first", "--flag", "second"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -92,7 +151,10 @@ func TestParseCmdOpts_CmdField(t *testing.T) {
 			if gotCmd != tt.wantCmd {
 				t.Errorf("cmd: got %q, want %q", gotCmd, tt.wantCmd)
 			}
-			if !equalStrings(gotArgs, tt.wantArgs) {
+			// Order-sensitive check for the array form; the string form
+			// is also order-preserving via strings.Fields, so we just
+			// compare order here too.
+			if !slicesEqual(gotArgs, tt.wantArgs) {
 				t.Errorf("extraArgs: got %v, want %v", gotArgs, tt.wantArgs)
 			}
 			if buf.Len() != 0 {
@@ -312,6 +374,20 @@ func equalStrings(a, b []string) bool {
 	sort.Strings(bc)
 	for i := range ac {
 		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// slicesEqual compares two string slices in order. Used for argv-style
+// checks where position matters (e.g. ParseCmdOpts array form).
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

The qoder agent adapter routes through `core.ParseCmdOpts`, but the parser only accepted a whitespace-separated string for the unified `cmd` field. Users who tried the documented array form:

```toml
[projects.agent.options]
cmd = ["qodercli", "--permission-mode", "bypass_permissions"]
```

saw their extra args silently dropped because `opts["cmd"].(string)` type-asserted against `[]any` and the parser fell through to the default binary. WebSearch / WebFetch / Bash curl were then rejected by qodercli on IM platforms because `--permission-mode` never reached the spawned process.

## Fix

Extend `core.ParseCmdOpts` to also accept `[]any` (TOML inline array) and `[]string` shapes for the `cmd` field. Behavior for the string form, deprecated `cli_path` / `command` fields, and the default fallback is unchanged.

- New `toStringArray` helper returns `ok=false` for mixed-type arrays so invalid configs fall through instead of panicking.
- New `filterNonEmpty` drops empty / whitespace-only array slots (matches the string form's whitespace-only skip).
- Doc update in `config.example.toml` qoder section listing both forms.

## Acceptance criteria mapping

| Criterion | Status |
| --- | --- |
| `cmd = ["qodercli", "--permission-mode", "bypass_permissions"]` reaches the spawned process | ✅ unit-tested via `cmd_array_with_permission-mode_args_(qoder_IM_use_case)` |
| Backward compat: `cmd` 缺失 falls back to default `qodercli -p -f stream-json` | ✅ unchanged (existing tests still pass) |
| README/docs updated | ✅ `config.example.toml` qoder section |
| Existing wrapper-script users can switch | ✅ any valid `cmd` form (string or array) now reaches the spawn |

## Tests

- `go test ./core/ -v -run TestParseCmdOpts` — PASS (all subtests including 8 new array-form cases)
- `go test ./core/` — PASS (full suite, 47s)
- `go test ./agent/qoder/ ./agent/claudecode/ ./agent/codex/ ./agent/cursor/ ./agent/opencode/ ./agent/iflow/ ./agent/copilot/ ./agent/kimi/ ./agent/antigravity/ ./agent/acp/` — PASS (no regression in any agent using ParseCmdOpts)
- `go vet ./core/...` — clean
- `golangci-lint v2.11.4 run --new-from-rev origin/main ./core/... ./agent/qoder/...` — 0 issues (matches CI flag)

## Backward compatibility

Purely additive — existing string-form configs and the deprecated `cli_path` / `command` paths keep their behavior. The fix benefits all 10 agents that route through `core.ParseCmdOpts` (claudecode, codex, cursor, qoder, opencode, iflow, copilot, kimi, antigravity, acp), not just qoder.

## Refs

- Issue #1670