### PR TITLE
fix(agent/pi): support pi v0.84.0 toolcall_end without cumulative message

### DIFF
--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1111,6 +1111,115 @@ func TestHandleMessageUpdate_ToolcallEnd_UsesPartialFallback(t *testing.T) {
 	}
 }
 
+// TestHandleMessageUpdate_ToolcallEnd_DirectToolCall covers the pi v0.84.0
+// breaking change: message_update emits only assistantMessageEvent deltas,
+// with the cumulative message and assistantMessageEvent.partial removed.
+// toolcall_end now carries the complete toolCall object; without the
+// toolCall branch, EventToolUse is never emitted and tool calls are lost.
+func TestHandleMessageUpdate_ToolcallEnd_DirectToolCall(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_update",
+		"assistantMessageEvent": map[string]any{
+			"type": "toolcall_end",
+			"toolCall": map[string]any{
+				"type":      "toolCall",
+				"name":      "read",
+				"arguments": map[string]any{"file_path": "/tmp/foo.txt"},
+			},
+		},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1", len(evts))
+	}
+	if evts[0].Type != core.EventToolUse || evts[0].ToolName != "read" || evts[0].ToolInput != "/tmp/foo.txt" {
+		t.Errorf("event = %+v", evts[0])
+	}
+}
+
+// TestHandleMessageUpdate_ToolcallEnd_CoexistsWithPartial pins the dedup
+// semantics: on v0.83.0 the wire carried BOTH toolCall and partial (they
+// reference the same finalized content block). The fast path must win and
+// emit exactly one EventToolUse — a future refactor that removes the early
+// return would double-emit, and one that breaks the fast path would emit 0.
+func TestHandleMessageUpdate_ToolcallEnd_CoexistsWithPartial(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_update",
+		"assistantMessageEvent": map[string]any{
+			"type":         "toolcall_end",
+			"contentIndex": float64(0),
+			"toolCall": map[string]any{
+				"type":      "toolCall",
+				"name":      "read",
+				"arguments": map[string]any{"file_path": "/tmp/foo.txt"},
+			},
+			"partial": map[string]any{
+				"content": []any{
+					map[string]any{
+						"type":      "toolCall",
+						"name":      "bash",
+						"arguments": map[string]any{"command": "ls"},
+					},
+				},
+			},
+		},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want exactly 1 (no double-emit)", len(evts))
+	}
+	if evts[0].Type != core.EventToolUse || evts[0].ToolName != "read" || evts[0].ToolInput != "/tmp/foo.txt" {
+		t.Errorf("event = %+v (want the toolCall fast-path event, not the partial one)", evts[0])
+	}
+}
+
+// TestHandleMessageUpdate_ToolcallEnd_NonToolCallType exercises the
+// toolCall-present-but-wrong-type path: it must fall through to the
+// message/partial snapshot path rather than emit from the toolCall fast
+// path. The partial carries a real toolCall so the fixture can observe the
+// fall-through — an unconditional early return (the M1 bug) would emit 0.
+func TestHandleMessageUpdate_ToolcallEnd_NonToolCallType(t *testing.T) {
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_update",
+		"assistantMessageEvent": map[string]any{
+			"type":         "toolcall_end",
+			"contentIndex": float64(0),
+			"toolCall": map[string]any{
+				"type": "text",
+				"text": "hello",
+			},
+			"partial": map[string]any{
+				"content": []any{
+					map[string]any{
+						"type":      "toolCall",
+						"name":      "read",
+						"arguments": map[string]any{"file_path": "/tmp/foo.txt"},
+					},
+				},
+			},
+		},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1 from the message/partial fallback", len(evts))
+	}
+	if evts[0].Type != core.EventToolUse || evts[0].ToolName != "read" || evts[0].ToolInput != "/tmp/foo.txt" {
+		t.Errorf("event = %+v (want the partial-path event)", evts[0])
+	}
+}
+
 func TestHandleMessageUpdate_ToolcallEnd_NonToolCallItem(t *testing.T) {
 	s := newTestSession()
 	defer s.cancel()

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -815,6 +815,28 @@ func (s *piSession) handleMessageUpdate(raw map[string]any) {
 }
 
 func (s *piSession) emitToolFromMessage(ame map[string]any) {
+	// pi >= 0.84.0: message_update emits only assistantMessageEvent deltas
+	// (the cumulative message and assistantMessageEvent.partial were removed
+	// to make JSON/RPC streaming output linear). toolcall_end now carries the
+	// complete toolCall object directly, so read it before falling back to
+	// the pre-0.84.0 message/partial snapshots. (toolCall has carried the
+	// same finalized block on every released pi version, so the fast path
+	// always wins; the fallback is a defensive safety net.)
+	if tc, ok := ame["toolCall"].(map[string]any); ok {
+		if itemType, _ := tc["type"].(string); itemType == "toolCall" {
+			name, _ := tc["name"].(string)
+			input := extractToolInput(tc)
+			evt := core.Event{Type: core.EventToolUse, ToolName: name, ToolInput: input}
+			select {
+			case s.events <- evt:
+			case <-s.ctx.Done():
+			}
+			return
+		}
+		// type != "toolCall" cannot happen on the real pi wire; fall through
+		// to the pre-0.84.0 snapshot path rather than silently dropping.
+	}
+
 	msg, _ := ame["message"].(map[string]any)
 	if msg == nil {
 		msg, _ = ame["partial"].(map[string]any)


### PR DESCRIPTION
## Summary

Fixes #1659 — tool-call events are silently dropped when the user upgrades pi to ≥ 0.84.0.

pi 0.84.0 ([earendil-works/pi#7290](https://github.com/earendil-works/pi/issues/7290)) removed the cumulative `message` and `assistantMessageEvent.partial` fields from JSON/RPC `message_update` events to make streaming output linear. `emitToolFromMessage` in `agent/pi/session.go` still parsed `toolcall_end` exclusively through those removed fields, so every `toolcall_end` hit `msg == nil → return` and no `EventToolUse` was ever emitted — no tool progress shown on any platform, and the engine logs `tools=0` for every turn.

## Changes

`agent/pi/session.go` — in the `toolcall_end` path:

- **Fast path (pi ≥ 0.84.0):** read the completed `toolCall` object delivered directly on the event (`assistantMessageEvent.toolCall`), validate `type == "toolCall"`, extract name + input via the existing `extractToolInput`, and emit `EventToolUse`.
- **Fallback (pi < 0.84.0):** keep the legacy `message`/`partial` + `contentIndex` snapshot path unchanged.
- **Safety net:** if `toolCall` is present but its `type` is not `"toolCall"` (cannot happen on the real wire), fall through to the legacy path instead of silently dropping the event.

`agent/pi/pi_test.go` — 3 regression tests:

- `TestHandleMessageUpdate_ToolcallEnd_DirectToolCall` — new v0.84.0 wire format emits exactly one `EventToolUse`.
- `TestHandleMessageUpdate_ToolcallEnd_CoexistsWithPartial` — on pre-0.84.0 wire where both `toolCall` and `partial` are present, the fast path wins and exactly one event is emitted (no double-emit).
- `TestHandleMessageUpdate_ToolcallEnd_NonToolCallType` — a wrong-typed `toolCall` falls through to the legacy path rather than being dropped.

## Backward compatibility

Fully backward compatible: pre-0.84.0 pi still sends the old fields, and the legacy path is untouched. The fast path always wins when `toolCall` is present (it has carried the finalized block on every released pi version).

## Testing

```bash
go test ./agent/pi/ -run 'TestHandleMessageUpdate_ToolcallEnd' -v   # all 9 cases pass
go test ./agent/pi/
```
