### PR TITLE
fix(pi): handle pi ≥ 0.84.0 toolcall_end with toolCall field (fixes #1659)

### DIFF
--- a/agent/pi/pi_test.go
+++ b/agent/pi/pi_test.go
@@ -1175,6 +1175,167 @@ func TestHandleMessageUpdate_ToolcallEnd_NilMessage(t *testing.T) {
 	}
 }
 
+func TestHandleMessageUpdate_ToolcallEnd_NewProtocol(t *testing.T) {
+	// pi ≥ 0.84.0 ships the completed call directly on the event as
+	// assistantMessageEvent.toolCall. Without this branch every tool-call
+	// event from pi ≥ 0.84.0 is silently dropped (see issue #1659).
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_update",
+		"assistantMessageEvent": map[string]any{
+			"type": "toolcall_end",
+			"toolCall": map[string]any{
+				"name":      "bash",
+				"arguments": map[string]any{"command": "ls -la"},
+			},
+		},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1", len(evts))
+	}
+	if evts[0].Type != core.EventToolUse {
+		t.Errorf("type = %s", evts[0].Type)
+	}
+	if evts[0].ToolName != "bash" {
+		t.Errorf("toolName = %q", evts[0].ToolName)
+	}
+	if evts[0].ToolInput != "ls -la" {
+		t.Errorf("toolInput = %q", evts[0].ToolInput)
+	}
+}
+
+func TestHandleMessageUpdate_ToolcallEnd_NewProtocol_Description(t *testing.T) {
+	// extractToolInput prefers tool-specific fields like "description" over
+	// the JSON dump of the arguments map. Verify the new protocol honours
+	// the same priority so cc-connect's chat UX matches what callers saw
+	// from the legacy path.
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_update",
+		"assistantMessageEvent": map[string]any{
+			"type": "toolcall_end",
+			"toolCall": map[string]any{
+				"name":      "edit",
+				"arguments": map[string]any{"description": "Update README", "command": "ignored"},
+			},
+		},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1", len(evts))
+	}
+	if evts[0].ToolName != "edit" {
+		t.Errorf("toolName = %q", evts[0].ToolName)
+	}
+	if evts[0].ToolInput != "Update README" {
+		t.Errorf("toolInput = %q", evts[0].ToolInput)
+	}
+}
+
+func TestHandleMessageUpdate_ToolcallEnd_NewProtocol_NoArguments(t *testing.T) {
+	// pi may emit a toolCall with no arguments map; extractToolInput should
+	// still produce an empty string instead of "{}".
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_update",
+		"assistantMessageEvent": map[string]any{
+			"type":     "toolcall_end",
+			"toolCall": map[string]any{"name": "noargs"},
+		},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1", len(evts))
+	}
+	if evts[0].ToolName != "noargs" {
+		t.Errorf("toolName = %q", evts[0].ToolName)
+	}
+	if evts[0].ToolInput != "" {
+		t.Errorf("toolInput = %q, want empty", evts[0].ToolInput)
+	}
+}
+
+func TestHandleMessageUpdate_ToolcallEnd_NewProtocol_TakesPrecedenceOverLegacy(t *testing.T) {
+	// When both toolCall and message/partial are present (transitional or
+	// malformed events), trust the new protocol so we don't silently fall
+	// back to a stale snapshot from the legacy path.
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_update",
+		"assistantMessageEvent": map[string]any{
+			"type":         "toolcall_end",
+			"contentIndex": float64(0),
+			"toolCall": map[string]any{
+				"name":      "bash",
+				"arguments": map[string]any{"command": "new"},
+			},
+			"message": map[string]any{
+				"content": []any{
+					map[string]any{
+						"type":      "toolCall",
+						"name":      "bash",
+						"arguments": map[string]any{"command": "legacy"},
+					},
+				},
+			},
+		},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1", len(evts))
+	}
+	if evts[0].ToolInput != "new" {
+		t.Errorf("toolInput = %q, want \"new\" (new protocol should win)", evts[0].ToolInput)
+	}
+}
+
+func TestHandleMessageUpdate_ToolcallEnd_NewProtocol_WrongTypeIsIgnored(t *testing.T) {
+	// If "toolCall" exists but is not a map (e.g. accidentally a string),
+	// fall through to the legacy path. This mirrors the existing
+	// defensive-type-assertion style used elsewhere in this file.
+	s := newTestSession()
+	defer s.cancel()
+
+	s.handleEvent(map[string]any{
+		"type": "message_update",
+		"assistantMessageEvent": map[string]any{
+			"type":         "toolcall_end",
+			"contentIndex": float64(0),
+			"toolCall":     "not-a-map",
+			"message": map[string]any{
+				"content": []any{
+					map[string]any{
+						"type":      "toolCall",
+						"name":      "bash",
+						"arguments": map[string]any{"command": "fallback"},
+					},
+				},
+			},
+		},
+	})
+
+	evts := drainEvents(s)
+	if len(evts) != 1 {
+		t.Fatalf("got %d events, want 1", len(evts))
+	}
+	if evts[0].ToolInput != "fallback" {
+		t.Errorf("toolInput = %q, want legacy fallback", evts[0].ToolInput)
+	}
+}
+
 func TestHandleMessageUpdate_NilAssistantEvent(t *testing.T) {
 	s := newTestSession()
 	defer s.cancel()

--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -810,7 +810,22 @@ func (s *piSession) handleMessageUpdate(raw map[string]any) {
 		}
 
 	case "toolcall_end":
-		s.emitToolFromMessage(msg)
+		// pi ≥ 0.84.0 ships the completed call directly on the event
+		// (assistantMessageEvent.toolCall), avoiding the quadratic growth
+		// caused by sending the accumulated message/partial each tick.
+		// Fall back to the legacy message/partial + contentIndex path so
+		// pi < 0.84.0 keeps working.
+		if tc, ok := msg["toolCall"].(map[string]any); ok {
+			name, _ := tc["name"].(string)
+			input := extractToolInput(tc)
+			evt := core.Event{Type: core.EventToolUse, ToolName: name, ToolInput: input}
+			select {
+			case s.events <- evt:
+			case <-s.ctx.Done():
+			}
+		} else {
+			s.emitToolFromMessage(msg)
+		}
 	}
 }
 
@@ -1225,7 +1240,19 @@ func truncStr(s string, maxRunes int) string {
 func extractToolInput(item map[string]any) string {
 	args, hasArgs := item["arguments"].(map[string]any)
 	if !hasArgs {
-		args = item
+		// No arguments map — fall back to dumping the item itself, but
+		// strip fields that are surfaced elsewhere on the Event so the
+		// JSON doesn't repeat them in the tool-progress card. This branch
+		// is exercised by pi ≥ 0.84.0's new toolcall_end protocol, where
+		// the completed call is delivered directly on the event and may
+		// omit `arguments` when the tool takes no parameters.
+		args = make(map[string]any, len(item))
+		for k, v := range item {
+			if k == "name" || k == "type" || k == "id" {
+				continue
+			}
+			args[k] = v
+		}
 	}
 
 	if desc, ok := args["description"].(string); ok && desc != "" {


### PR DESCRIPTION
Fixes chenhg5/cc-connect#1659.

## Problem

pi 0.84.0 removed the accumulated `message` and `assistantMessageEvent.partial` fields from `message_update` events (to avoid quadratic output growth). The cc-connect pi adapter still relied on those fields to extract tool calls, so every `toolcall_end` from pi ≥ 0.84.0 was silently dropped — `tools=N` log was always 0 and tool-progress cards never rendered on Feishu/Telegram/Discord.

## Fix

In `agent/pi/session.go`, the `toolcall_end` case now:

1. Checks for `assistantMessageEvent.toolCall` first. When present (pi ≥ 0.84.0), it emits an `EventToolUse` directly with the tool name and `extractToolInput(tc)` result. **No more silent drop.**
2. Falls back to the existing `emitToolFromMessage` path (legacy `message`/`partial` + `contentIndex`) when `toolCall` is absent, so pi < 0.84.0 keeps working.

Also tightened `extractToolInput`'s no-`arguments` fallback: when the new protocol sends a bare `toolCall` without an `arguments` map, the JSON dump now skips `name`/`type`/`id` instead of repeating them (they're already surfaced as `ToolName` / discriminator / event-id).

## Changes

- `agent/pi/session.go`
  - `handleMessageUpdate` `toolcall_end` branch: new protocol path before legacy fallback.
  - `extractToolInput`: strip `name`/`type`/`id` when falling back to JSON of the whole item.
- `agent/pi/pi_test.go`
  - 5 new test cases covering:
    - new protocol with `toolCall` + `arguments.command`
    - new protocol: `extractToolInput` priority (`description` beats `command`)
    - new protocol: no `arguments` map (covered JSON skip)
    - new protocol takes precedence when both fields are present
    - non-map `toolCall` (defensive type assertion) falls through to legacy path

## Test results

- `go test ./agent/pi/... -race -count=1` — all pass (25 `toolcall_end` tests + full suite unchanged).
- `golangci-lint run --new-from-rev origin/main ./agent/pi/...` — 0 issues.
- `go build ./agent/pi/...` — clean.
- `go vet ./agent/pi/...` — clean.
- `go test ./...` — all unaffected packages pass; the two `[setup failed]` entries (`cmd/cc-connect`, `web`) are unrelated, pre-existing sandbox limitations (frontend `web/dist` not built locally; CI builds it via `pnpm build` per `.github/workflows/ci.yml` before Go tests).

## Acceptance criteria

- ✅ pi ≥ 0.84.0: every `toolcall_end` is processed (no silent drop).
- ✅ pi < 0.84.0: legacy `message` + `contentIndex` path still works (existing tests `TestHandleMessageUpdate_ToolcallEnd`, `TestHandleMessageUpdate_ToolcallEnd_UsesPartialFallback` cover this).
- ✅ `tools=N` will reflect the real count once pi 0.84+ is used.
- ✅ Tool-progress cards on Feishu/Telegram/Discord will render (downstream of `EventToolUse`; no platform changes).
- ✅ Unit tests cover both protocol paths and edge cases.

## Risks

- `assistantMessageEvent.toolCall` field shape is reverse-engineered from the pi 0.84.0 changelog plus the existing legacy schema; if pi renames the field in a future release cc-connect will silently drop again. The fallback path stays in place, so an unintended future protocol drift silently reverts to legacy behavior — preferable to a hard break.
- The `extractToolInput` JSON-skip change only affects the no-`arguments` branch, which the legacy path never exercised (legacy always had `arguments`). Existing `TestExtractToolInput` cases all pass unchanged.

## Sibling

- chenhg5/cc-connect#1658 (pi ask_user_question card broken on Feishu mobile) shares the same root-cause family (event handling chain) but is a separate bug. Not addressed here per the issue's "Out of scope" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
