### PR TITLE
fix(core): render Feishu AskUserQuestion as flat action rows (fixes #1658)

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -11507,6 +11507,19 @@ func (e *Engine) sendAskQuestionPrompt(p Platform, replyCtx any, questions []Use
 			cb.Markdown(body)
 			cb.Note(e.i18n.T(MsgAskQuestionNoteMulti))
 		} else {
+			// Single-select path. Issue #1658: rendering each option as a
+			// column_set row (description column + button column) looked right
+			// on Feishu desktop but the button clicks never dispatched on
+			// Feishu mobile, and even on desktop the column_set > column >
+			// button layout was reported as unreliable. Permission cards use a
+			// flat action row (tag:"action") and their cmd: clicks dispatch
+			// reliably on both desktop and mobile. So mirror that pattern:
+			// description as markdown, then a per-option action row with a
+			// single button. Each click carries the askq:qIdx:optIdx value
+			// plus askq_label/askq_question extras so the Feishu callback
+			// handler can render the post-answer card. The Note still tells
+			// users how to fall back to numeric/text input if their client
+			// happens to ignore the button row.
 			cb.Markdown(body)
 			for i, opt := range q.Options {
 				desc := opt.Label
@@ -11514,9 +11527,15 @@ func (e *Engine) sendAskQuestionPrompt(p Platform, replyCtx any, questions []Use
 					desc += " — " + opt.Description
 				}
 				answerData := fmt.Sprintf("askq:%d:%d", qIdx, i+1)
-				cb.ListItemBtnExtra(desc, opt.Label, "default", answerData, map[string]string{
-					"askq_label":    opt.Label,
-					"askq_question": q.Question,
+				cb.Markdown("**" + desc + "**")
+				cb.Buttons(CardButton{
+					Text:  opt.Label,
+					Type:  "primary",
+					Value: answerData,
+					Extra: map[string]string{
+						"askq_label":    opt.Label,
+						"askq_question": q.Question,
+					},
 				})
 			}
 			cb.Note(e.i18n.T(MsgAskQuestionNote))

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -6625,6 +6625,64 @@ func TestSendAskQuestionPrompt_CardPlatform(t *testing.T) {
 	}
 }
 
+// TestSendAskQuestionPrompt_CardPlatform_SingleSelectUsesActionRows is a
+// regression for issue #1658 (Feishu pi ask_user_question card: button clicks
+// never dispatched on mobile/desktop). The old layout rendered each option
+// as a `column_set` row with the button nested inside a column; Feishu mobile
+// clients dropped those click events, and even on desktop the layout was
+// reported as unreliable. The fix renders each option as a markdown line +
+// a flat action row (tag:"action") whose single button carries the askq:
+// value and the askq_label/askq_question extras — the same shape that
+// permission cards use for their cmd: clicks, which the issue reporter
+// confirmed dispatch reliably.
+func TestSendAskQuestionPrompt_CardPlatform_SingleSelectUsesActionRows(t *testing.T) {
+	e := newTestEngine()
+	p := &stubCardPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	e.sendAskQuestionPrompt(p, "ctx", testQuestions(), 0)
+
+	if len(p.sentCards) != 1 {
+		t.Fatalf("expected 1 card, got %d", len(p.sentCards))
+	}
+	card := p.sentCards[0]
+
+	// Count askq action rows. We expect exactly 3 options, each rendered as
+	// its own CardActions (one button per row) — not as nested CardListItem.
+	var actionRows int
+	var askqButtons int
+	var sawCardListItem bool
+	for _, elem := range card.Elements {
+		switch e := elem.(type) {
+		case CardActions:
+			for _, btn := range e.Buttons {
+				if strings.HasPrefix(btn.Value, "askq:") {
+					askqButtons++
+					// Each button must carry the askq_label + askq_question
+					// extras so the Feishu callback handler can render the
+					// post-answer card without re-fetching the question.
+					if btn.Extra["askq_label"] == "" {
+						t.Errorf("askq button %q missing askq_label extra", btn.Text)
+					}
+					if btn.Extra["askq_question"] == "" {
+						t.Errorf("askq button %q missing askq_question extra", btn.Text)
+					}
+				}
+			}
+			actionRows++
+		case CardListItem:
+			sawCardListItem = true
+		}
+	}
+	if actionRows != 3 {
+		t.Errorf("expected 3 CardActions rows (one per option), got %d", actionRows)
+	}
+	if askqButtons != 3 {
+		t.Errorf("expected 3 askq buttons in action rows, got %d", askqButtons)
+	}
+	if sawCardListItem {
+		t.Errorf("CardListItem must not be used for single-select AskUserQuestion on Feishu (issue #1658)")
+	}
+}
+
 func TestSendAskQuestionPrompt_CardPlatform_MultiQuestion_ShowsIndex(t *testing.T) {
 	e := newTestEngine()
 	p := &stubCardPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}


### PR DESCRIPTION
## Summary

Fix #1658: Feishu + pi agent's AskUserQuestion card button clicks never dispatched on Feishu mobile, and were unreliable on desktop. Permission cards (cmd: actions) worked normally — the reporter's log showed zero card-action entries during the 08:00-08:25 ask_user_question test window while cmd= entries for permission cards appeared as expected.

## Root cause

`sendAskQuestionPrompt` (single-select path) rendered each option as a `CardListItem`, which the Feishu renderer serialises as a `column_set` with the description in a weighted column (weight:5) and the click button in an `auto` column. On Feishu mobile the button column is clipped/non-interactive, and even on desktop this nested layout doesn't reliably dispatch click events.

## Fix

Mirror the permission-card pattern (which the reporter confirmed dispatches reliably): each option becomes a markdown description line followed by a flat `CardActions` row with a single button. The `askq:qIdx:optIdx` value plus `askq_label` / `askq_question` extras are preserved so the Feishu callback handler still renders the post-answer card unchanged.

The Note line that nudges users toward numeric / text fallbacks is kept in place as a defensive fallback.

## Sibling

PR #1677 (issue #1659, pi ≥ 0.84.0 tool-call drop) — same reporter (Po1nt9), same pi + Feishu setup. Both fixes ship together so the pi + Feishu flow is fully usable end-to-end.

## Changes

- `core/engine.go` — switch single-select AskUserQuestion rendering from `cb.ListItemBtnExtra(...)` to `cb.Markdown("**desc**") + cb.Buttons(CardButton{...})`
- `core/engine_test.go` — new regression test asserting: 3 `CardActions` rows, 3 askq buttons, no `CardListItem`, and that every button carries `askq_label` + `askq_question` extras

## Validation

- `go test -race -count=1 ./core/` — PASS (48.7s)
- `go test -race -count=1 ./agent/pi/` — PASS (7.0s)
- `go test -race -count=1 ./platform/feishu/` — PASS (33.3s)
- `gofmt -l` — clean
- `go vet ./core/...` — clean
- `go build -tags no_web ./...` — clean
- `golangci-lint run --new-from-rev origin/main ./core/...` — 0 issues

## Risks

- **Card layout shift**: cards now show each option as a two-line row (description + button row) instead of one row with description-on-left + button-on-right. Same data, slightly different visual rhythm. This is intentional — the previous layout doesn't dispatch on mobile.
- **Backward compat for other AskUserQuestion callers**: `isAskQuestion` (`engine.go`) still treats `AskUserQuestion` and `extension_select` the same way and routes through the same `sendAskQuestionPrompt`. pi's `forwardSelect` carries `askq_label` / `askq_question` via `Extra` exactly as before.
- **No regression to permission cards**: those use `CardActions` directly, not via this path.