### PR TITLE
feat(codex): support max reasoning effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- **codex**: support `max` reasoning effort in project configuration and through `/reasoning max` (#1683).
 - **`agent_session_idle_timeout_mins`**: new per-project config option that closes an idle live agent process after a clean turn while preserving the cc-connect session and saved agent session ID. The next message starts a new agent process and resumes the same conversation. Set to `0` or leave unset to disable (#1338).
 - **Reasonix agent**: new agent adapter for Reasonix multi-model coding agent, bridging via HTTP serve API (POST /submit, SSE /events, POST /approve). Supports default/yolo/plan permission modes, SSE auto-reconnect with backoff, and thinking accumulator. (#1281)
 - **cloud_web platform**: 新增 self-hosted IM Gateway 作为 first-class platform 接入 (CWIP v1 协议,支持 websocket / long_poll / gateway 3 种 transport,完整 inbound/outbound + capability negotiation + graceful degradation)。 详见 docs/cloud-web.md + #1282。

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -51,6 +51,19 @@ type Agent struct {
 	mu              sync.RWMutex
 }
 
+type reasoningEffortDefinition struct {
+	name    string
+	aliases []string
+}
+
+var reasoningEffortDefinitions = []reasoningEffortDefinition{
+	{name: "low"},
+	{name: "medium", aliases: []string{"med"}},
+	{name: "high"},
+	{name: "xhigh", aliases: []string{"x-high", "very-high"}},
+	{name: "max", aliases: []string{"maximum"}},
+}
+
 func New(opts map[string]any) (core.Agent, error) {
 	workDir, _ := opts["work_dir"].(string)
 	if workDir == "" {
@@ -142,22 +155,21 @@ func normalizeMode(raw string) string {
 }
 
 func normalizeReasoningEffort(raw string) string {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "":
-		return ""
-	case "low":
-		return "low"
-	case "medium", "med":
-		return "medium"
-	case "high":
-		return "high"
-	case "xhigh", "x-high", "very-high":
-		return "xhigh"
-	case "max", "maximum":
-		return "max"
-	default:
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if normalized == "" {
 		return ""
 	}
+	for _, definition := range reasoningEffortDefinitions {
+		if normalized == definition.name {
+			return definition.name
+		}
+		for _, alias := range definition.aliases {
+			if normalized == alias {
+				return definition.name
+			}
+		}
+	}
+	return ""
 }
 
 func (a *Agent) Name() string { return "codex" }
@@ -202,7 +214,11 @@ func (a *Agent) GetReasoningEffort() string {
 }
 
 func (a *Agent) AvailableReasoningEfforts() []string {
-	return []string{"low", "medium", "high", "xhigh", "max"}
+	efforts := make([]string, len(reasoningEffortDefinitions))
+	for i, definition := range reasoningEffortDefinitions {
+		efforts[i] = definition.name
+	}
+	return efforts
 }
 
 func (a *Agent) configuredModels() []core.ModelOption {

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -153,6 +153,8 @@ func normalizeReasoningEffort(raw string) string {
 		return "high"
 	case "xhigh", "x-high", "very-high":
 		return "xhigh"
+	case "max", "maximum":
+		return "max"
 	default:
 		return ""
 	}
@@ -200,7 +202,7 @@ func (a *Agent) GetReasoningEffort() string {
 }
 
 func (a *Agent) AvailableReasoningEfforts() []string {
-	return []string{"low", "medium", "high", "xhigh"}
+	return []string{"low", "medium", "high", "xhigh", "max"}
 }
 
 func (a *Agent) configuredModels() []core.ModelOption {

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -23,10 +23,19 @@ func TestNormalizeReasoningEffort_RejectsMinimal(t *testing.T) {
 	}
 }
 
+func TestNormalizeReasoningEffort_AcceptsMax(t *testing.T) {
+	if got := normalizeReasoningEffort("max"); got != "max" {
+		t.Fatalf("normalizeReasoningEffort(max) = %q, want max", got)
+	}
+	if got := normalizeReasoningEffort("maximum"); got != "max" {
+		t.Fatalf("normalizeReasoningEffort(maximum) = %q, want max", got)
+	}
+}
+
 func TestAvailableReasoningEfforts_ExcludesMinimal(t *testing.T) {
 	agent := &Agent{}
 	got := agent.AvailableReasoningEfforts()
-	want := []string{"low", "medium", "high", "xhigh"}
+	want := []string{"low", "medium", "high", "xhigh", "max"}
 	if len(got) != len(want) {
 		t.Fatalf("AvailableReasoningEfforts len = %d, want %d, got=%v", len(got), len(want), got)
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -9768,7 +9768,7 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 				buttons = append(buttons, row)
 			}
 			sb.WriteString("\n")
-			sb.WriteString(e.i18n.T(MsgReasoningUsage))
+			sb.WriteString(e.reasoningUsage(efforts))
 			e.replyWithButtons(p, msg.ReplyCtx, sb.String(), buttons)
 			return
 		}
@@ -9790,7 +9790,7 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 		}
 	}
 	if !valid {
-		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgReasoningUsage))
+		e.reply(p, msg.ReplyCtx, e.reasoningUsage(efforts))
 		return
 	}
 
@@ -9803,6 +9803,10 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 	sessions.Save()
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgReasoningChanged, target))
+}
+
+func (e *Engine) reasoningUsage(efforts []string) string {
+	return e.i18n.Tf(MsgReasoningUsage, strings.Join(efforts, "|"))
 }
 
 func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
@@ -12917,7 +12921,7 @@ func (e *Engine) renderReasoningCard() *Card {
 		Markdown(sb.String()).
 		Select(e.i18n.T(MsgReasoningSelectPlaceholder), opts, initVal).
 		Buttons(e.cardBackButton())
-	cb.Note(e.i18n.T(MsgReasoningUsage))
+	cb.Note(e.reasoningUsage(efforts))
 	return cb.Build()
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -445,6 +445,7 @@ type stubModelModeAgent struct {
 	model           string
 	mode            string
 	reasoningEffort string
+	reasoningLevels []string
 	providers       []ProviderConfig
 	active          string
 }
@@ -545,6 +546,9 @@ func (a *stubModelModeAgent) GetReasoningEffort() string {
 }
 
 func (a *stubModelModeAgent) AvailableReasoningEfforts() []string {
+	if a.reasoningLevels != nil {
+		return a.reasoningLevels
+	}
 	return []string{"low", "medium", "high", "xhigh"}
 }
 
@@ -5503,6 +5507,22 @@ func TestCmdReasoning_RejectsMinimal(t *testing.T) {
 	}
 	if len(p.sent) != 1 || !strings.Contains(p.sent[0], "/reasoning <number>") || strings.Contains(p.sent[0], "minimal") {
 		t.Fatalf("sent = %v, want usage without minimal", p.sent)
+	}
+}
+
+func TestCmdReasoning_UsageListsOnlyAgentReasoningEfforts(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubModelModeAgent{reasoningLevels: []string{"off", "minimal", "low", "medium", "high", "xhigh"}}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+
+	e.cmdReasoning(p, msg, []string{"unsupported"})
+
+	if len(p.sent) != 1 || !strings.Contains(p.sent[0], "/reasoning <off|minimal|low|medium|high|xhigh>") {
+		t.Fatalf("sent = %v, want usage with agent-provided reasoning efforts", p.sent)
+	}
+	if strings.Contains(p.sent[0], "max") {
+		t.Fatalf("sent = %v, usage advertised an unavailable reasoning effort", p.sent)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -2483,11 +2483,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Niveles de razonamiento disponibles:\n",
 	},
 	MsgReasoningUsage: {
-		LangEnglish:            "Usage: `/reasoning <number>` or `/reasoning <low|medium|high|xhigh|max>`",
-		LangChinese:            "用法: `/reasoning <序号>` 或 `/reasoning <low|medium|high|xhigh|max>`",
-		LangTraditionalChinese: "用法: `/reasoning <序號>` 或 `/reasoning <low|medium|high|xhigh|max>`",
-		LangJapanese:           "使い方: `/reasoning <番号>` または `/reasoning <low|medium|high|xhigh|max>`",
-		LangSpanish:            "Uso: `/reasoning <número>` o `/reasoning <low|medium|high|xhigh|max>`",
+		LangEnglish:            "Usage: `/reasoning <number>` or `/reasoning <%s>`",
+		LangChinese:            "用法: `/reasoning <序号>` 或 `/reasoning <%s>`",
+		LangTraditionalChinese: "用法: `/reasoning <序號>` 或 `/reasoning <%s>`",
+		LangJapanese:           "使い方: `/reasoning <番号>` または `/reasoning <%s>`",
+		LangSpanish:            "Uso: `/reasoning <número>` o `/reasoning <%s>`",
 	},
 	MsgModeUsage: {
 		LangEnglish:            "\nUse `/mode <name>` to switch.\nAvailable: %s",

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -2483,11 +2483,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangSpanish:            "Niveles de razonamiento disponibles:\n",
 	},
 	MsgReasoningUsage: {
-		LangEnglish:            "Usage: `/reasoning <number>` or `/reasoning <low|medium|high|xhigh>`",
-		LangChinese:            "用法: `/reasoning <序号>` 或 `/reasoning <low|medium|high|xhigh>`",
-		LangTraditionalChinese: "用法: `/reasoning <序號>` 或 `/reasoning <low|medium|high|xhigh>`",
-		LangJapanese:           "使い方: `/reasoning <番号>` または `/reasoning <low|medium|high|xhigh>`",
-		LangSpanish:            "Uso: `/reasoning <número>` o `/reasoning <low|medium|high|xhigh>`",
+		LangEnglish:            "Usage: `/reasoning <number>` or `/reasoning <low|medium|high|xhigh|max>`",
+		LangChinese:            "用法: `/reasoning <序号>` 或 `/reasoning <low|medium|high|xhigh|max>`",
+		LangTraditionalChinese: "用法: `/reasoning <序號>` 或 `/reasoning <low|medium|high|xhigh|max>`",
+		LangJapanese:           "使い方: `/reasoning <番号>` または `/reasoning <low|medium|high|xhigh|max>`",
+		LangSpanish:            "Uso: `/reasoning <número>` o `/reasoning <low|medium|high|xhigh|max>`",
 	},
 	MsgModeUsage: {
 		LangEnglish:            "\nUse `/mode <name>` to switch.\nAvailable: %s",


### PR DESCRIPTION
## Summary

- accept `max` and `maximum` as Codex reasoning-effort values
- expose `max` through the `/reasoning` selector
- render `/reasoning` usage from each agent's `AvailableReasoningEfforts()` instead of a shared hardcoded list
- keep Codex reasoning levels and aliases in one ordered definition
- add an Unreleased changelog entry

## Why

Codex models such as GPT-5.6 support a `max` reasoning effort. cc-connect previously normalized that value to an empty string, so `reasoning_effort = "max"` silently fell back to the Codex default and `/reasoning max` was rejected.

The previous shared usage string was also inaccurate across agents: Pi exposes `off` and `minimal`, while Claude Code and Codex expose different level sets. Usage text now follows the current agent capability list.

## User impact

Codex projects can configure `reasoning_effort = "max"`, and users can select it through `/reasoning max`. Existing reasoning levels and session-reset behavior are unchanged. Other agents now show only the reasoning levels they actually advertise.

## Validation

Passed locally on Windows:

- `go test ./agent/codex -count=1`
- `go test ./core -run 'TestCmdReasoning|TestReasoning' -count=1`
- `go test ./core/ -run TestCUJ -count=1`
- `go vet ./agent/codex ./core`
- `go build ./agent/codex ./core`

`go build ./...` still reproduces the pre-existing Windows baseline failures outside this PR: duplicate `daemon.CheckLinger` definitions and an unused `os` import in `agent/pi/proc_windows.go`. The full test suite also contains pre-existing Windows-only failures that assume Unix executables, paths, symlink behavior, or file modes. Race tests could not be rerun locally because this Windows Go environment has CGO disabled; the previous CI run and maintainer review race runs passed.

## Compatibility notes

- The earlier `npm run build` was only a repository sanity check. The localized `/reasoning` strings are rendered by the Go backend and are not embedded in the web bundle, so it is omitted from the focused validation above.
- cc-connect has no per-model reasoning-effort capability metadata. As with existing model-dependent levels such as `xhigh`, the selected value is passed to Codex CLI/provider for validation. `max` is sent only when a user explicitly configures or selects it; unsupported model/provider combinations may reject it at runtime.