### PR TITLE
fix(opencode): first message dequeued from a busy-session queue loses its reply ("(empty response)")

### DIFF
--- a/agent/opencode/session.go
+++ b/agent/opencode/session.go
@@ -37,8 +37,9 @@ type opencodeSession struct {
 	cancel            context.CancelFunc
 	wg                sync.WaitGroup
 	alive             atomic.Bool
-	expectingContinue atomic.Bool // true when compaction_continue received, waiting for next step
-	resultSent        atomic.Bool // true when EventResult has been sent for this turn
+	expectingContinue atomic.Bool  // true when compaction_continue received, waiting for next step
+	resultSent        atomic.Bool  // true when EventResult has been sent for this turn
+	turnGen           atomic.Int64 // incremented by each Send; a previous turn's readLoop must not emit terminal events into the current turn
 }
 
 func newOpencodeSession(ctx context.Context, cmd string, extraArgs []string, workDir, model, mode, agentName, resumeID string, extraEnv []string) (*opencodeSession, error) {
@@ -80,6 +81,12 @@ func (s *opencodeSession) Send(prompt string, messageID string, images []core.Im
 
 	s.resultSent.Store(false)
 	s.expectingContinue.Store(false)
+	// Each Send starts a new turn. The previous turn's process may still be
+	// running (its readLoop lingers until the process exits, often hundreds of
+	// milliseconds after it emitted step_finish reason=stop). Its EOF fallback
+	// must not send an EventResult for THIS turn — that would terminate the new
+	// turn before any output arrives, delivering an empty response.
+	gen := s.turnGen.Add(1)
 
 	chatID := s.CurrentSessionID()
 	isResume := chatID != ""
@@ -110,7 +117,7 @@ func (s *opencodeSession) Send(prompt string, messageID string, images []core.Im
 	}
 
 	s.wg.Add(1)
-	go s.readLoop(cmd, stdout, &stderrBuf)
+	go s.readLoop(cmd, stdout, &stderrBuf, gen)
 
 	return nil
 }
@@ -191,9 +198,8 @@ func (s *opencodeSession) buildRunArgs(prompt string, imagePaths []string, chatI
 	return args
 }
 
-func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer) {
+func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBuf *bytes.Buffer, gen int64) {
 	defer s.wg.Done()
-	defer func() { _ = cmd.Wait() }()
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
@@ -210,11 +216,27 @@ func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBu
 			continue
 		}
 
-		s.handleEvent(raw)
+		s.handleEvent(raw, gen)
 	}
 
+	// Reap the process before reading stderrBuf: cmd.Wait joins the exec
+	// goroutine that copies the child's stderr into stderrBuf, so reading the
+	// buffer any earlier races with that copy (and may see partial output).
+	// All stdout reads are complete here (scanner hit EOF or errored), which
+	// is the precondition os/exec documents for calling Wait.
+	_ = cmd.Wait()
+
+	// Terminal emissions below must be skipped if a newer turn has started:
+	// this readLoop belongs to a process whose turn already completed (the
+	// engine consumed its step_finish EventResult and moved on), so its EOF
+	// bookkeeping must not leak into the turn that is now in flight.
+	stale := s.turnGen.Load() != gen
+
 	if err := scanner.Err(); err != nil {
-		slog.Error("opencodeSession: scanner error", "error", err)
+		slog.Error("opencodeSession: scanner error", "error", err, "stale", stale)
+		if stale {
+			return
+		}
 		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("read stdout: %w", err)}
 		select {
 		case s.events <- evt:
@@ -226,7 +248,10 @@ func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBu
 
 	stderrMsg := stderrBuf.String()
 	if stderrMsg != "" {
-		slog.Error("opencodeSession: process error", "stderr", truncate(stderrMsg, 500))
+		slog.Error("opencodeSession: process error", "stderr", truncate(stderrMsg, 500), "stale", stale)
+		if stale {
+			return
+		}
 		if strings.Contains(stderrMsg, "Session not found") {
 			s.chatID.Store("")
 			slog.Warn("opencodeSession: cleared stale session ID")
@@ -249,14 +274,14 @@ func (s *opencodeSession) readLoop(cmd *exec.Cmd, stdout io.ReadCloser, stderrBu
 	}
 
 	slog.Debug("opencodeSession: readLoop complete, sending fallback EventResult", "session_id", s.CurrentSessionID())
-	s.sendEventResult()
+	s.sendEventResult(gen)
 }
 
 // OpenCode NDJSON event structure:
 //
 //	{ "type": "text|tool_use|reasoning|step_start|step_finish",
 //	  "part": { "type": "text|tool|reasoning|step-start|step-finish", ... } }
-func (s *opencodeSession) handleEvent(raw map[string]any) {
+func (s *opencodeSession) handleEvent(raw map[string]any, gen int64) {
 	eventType, _ := raw["type"].(string)
 
 	switch eventType {
@@ -269,7 +294,7 @@ func (s *opencodeSession) handleEvent(raw map[string]any) {
 	case "step_start":
 		s.handleStepStart(raw)
 	case "step_finish":
-		s.handleStepFinish(raw)
+		s.handleStepFinish(raw, gen)
 	case "error":
 		s.handleError(raw)
 	default:
@@ -479,7 +504,7 @@ func (s *opencodeSession) handleStepStart(raw map[string]any) {
 	}
 }
 
-func (s *opencodeSession) handleStepFinish(raw map[string]any) {
+func (s *opencodeSession) handleStepFinish(raw map[string]any, gen int64) {
 	part, _ := raw["part"].(map[string]any)
 	reason := ""
 	if part != nil {
@@ -488,11 +513,16 @@ func (s *opencodeSession) handleStepFinish(raw map[string]any) {
 	slog.Debug("opencodeSession: step finished", "reason", reason, "session_id", s.CurrentSessionID())
 
 	if reason == "stop" {
-		s.sendEventResult()
+		s.sendEventResult(gen)
 	}
 }
 
-func (s *opencodeSession) sendEventResult() {
+func (s *opencodeSession) sendEventResult(gen int64) {
+	if s.turnGen.Load() != gen {
+		slog.Warn("opencodeSession: suppressing stale EventResult from a previous turn's process",
+			"session_id", s.CurrentSessionID())
+		return
+	}
 	if s.resultSent.Load() {
 		slog.Debug("opencodeSession: EventResult already sent, skipping", "session_id", s.CurrentSessionID())
 		return

--- a/agent/opencode/session_test.go
+++ b/agent/opencode/session_test.go
@@ -3,12 +3,15 @@ package opencode
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -170,7 +173,7 @@ func TestHandleStepStopSendsEventResult(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s := &opencodeSession{events: make(chan core.Event, 1), ctx: ctx}
-	s.handleStepFinish(raw)
+	s.handleStepFinish(raw, s.turnGen.Load())
 
 	select {
 	case evt := <-s.events:
@@ -199,7 +202,7 @@ func TestHandleStepToolCallsNoEventResult(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s := &opencodeSession{events: make(chan core.Event, 1), ctx: ctx}
-	s.handleStepFinish(raw)
+	s.handleStepFinish(raw, s.turnGen.Load())
 
 	select {
 	case evt := <-s.events:
@@ -227,8 +230,8 @@ func TestHandleStepDuplicateEventResultPrevented(t *testing.T) {
 		resultSent: atomic.Bool{},
 	}
 
-	s.handleStepFinish(raw)
-	s.handleStepFinish(raw)
+	s.handleStepFinish(raw, s.turnGen.Load())
+	s.handleStepFinish(raw, s.turnGen.Load())
 
 	count := 0
 	for len(s.events) > 0 {
@@ -331,6 +334,151 @@ func TestHandleToolUseErrorNoMessageNoText(t *testing.T) {
 		if evt.Type == core.EventText {
 			t.Errorf("unexpected EventText for error with no message: %q", evt.Content)
 		}
+	}
+}
+
+// TestStaleFallbackEventResultSuppressed reproduces the "(empty response)"
+// bug for the first message dequeued from a busy-session queue.
+//
+// Sequence (as observed in production):
+//  1. Turn 1's process emits step_finish reason=stop → EventResult. The
+//     engine consumes it and immediately dequeues the next queued message.
+//  2. The engine calls Send() for turn 2, which resets resultSent and spawns
+//     a new process. Turn 1's process is still alive — its readLoop lingers
+//     until the process exits, typically hundreds of milliseconds later.
+//  3. Turn 1's process exits. Its readLoop's EOF fallback calls
+//     sendEventResult. Because resultSent was reset by turn 2's Send, the
+//     old guard let a stale EventResult through, terminating turn 2 before
+//     any of its output arrived → "(空响应)" placeholder.
+//
+// With the turn-generation guard, step 3 must emit nothing.
+func TestStaleFallbackEventResultSuppressed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &opencodeSession{events: make(chan core.Event, 4), ctx: ctx}
+
+	// Turn 1 begins (mimic Send's per-turn reset).
+	s.resultSent.Store(false)
+	gen1 := s.turnGen.Add(1)
+
+	// Turn 1's process emits step_finish reason=stop.
+	s.sendEventResult(gen1)
+	evt := <-s.events
+	if evt.Type != core.EventResult {
+		t.Fatalf("turn 1: event type = %q, want EventResult", evt.Type)
+	}
+
+	// Engine dequeues the queued message and calls Send for turn 2.
+	s.resultSent.Store(false)
+	gen2 := s.turnGen.Add(1)
+
+	// Turn 1's process exits now; its readLoop EOF fallback fires with gen1.
+	s.sendEventResult(gen1)
+	select {
+	case evt := <-s.events:
+		t.Fatalf("stale EventResult from turn 1's process leaked into turn 2: %+v", evt)
+	default:
+	}
+
+	// Turn 2's own completion must still go through.
+	s.sendEventResult(gen2)
+	select {
+	case evt := <-s.events:
+		if evt.Type != core.EventResult {
+			t.Fatalf("turn 2: event type = %q, want EventResult", evt.Type)
+		}
+	default:
+		t.Fatal("turn 2's own EventResult was not sent")
+	}
+}
+
+// TestQueuedTurnNotTerminatedByLingeringPreviousProcess is an integration
+// repro of the same bug through the real Send/readLoop path, using this test
+// binary as a fake agent CLI (see TestHelperProcess).
+//
+// Turn 1's fake process emits its final event, then lingers 400ms before
+// exiting — like the real CLI, which flushes/tears down after printing the
+// result. Turn 2 is sent as soon as turn 1's EventResult is consumed
+// (exactly what the engine's queue-drain path does), and its fake process
+// takes 700ms to produce output. Without the fix, turn 1's exit produces a
+// stale EventResult at ~400ms and turn 2 completes "empty".
+func TestQueuedTurnNotTerminatedByLingeringPreviousProcess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s, err := newOpencodeSession(ctx, os.Args[0],
+		[]string{"-test.run=TestHelperProcess", "--"},
+		t.TempDir(), "", "default", "", "", []string{"GO_OC_HELPER=1"})
+	if err != nil {
+		t.Fatalf("newOpencodeSession: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if err := s.Send("turn1", "msg1", nil, nil); err != nil {
+		t.Fatalf("Send turn1: %v", err)
+	}
+	waitForResult(t, s, "turn 1", nil)
+
+	// Engine behavior after EventResult: dequeue and Send immediately,
+	// while turn 1's process is still lingering.
+	if err := s.Send("turn2", "msg2", nil, nil); err != nil {
+		t.Fatalf("Send turn2: %v", err)
+	}
+	var texts []string
+	waitForResult(t, s, "turn 2", &texts)
+
+	joined := strings.Join(texts, "")
+	if !strings.Contains(joined, "reply two") {
+		t.Fatalf("turn 2 completed without its reply text (stale EventResult ended the turn early); got text %q", joined)
+	}
+}
+
+// waitForResult consumes events until EventResult, collecting EventText
+// content into texts if non-nil. Fails the test on EventError or timeout.
+func waitForResult(t *testing.T, s *opencodeSession, label string, texts *[]string) {
+	t.Helper()
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case evt := <-s.events:
+			switch evt.Type {
+			case core.EventResult:
+				return
+			case core.EventError:
+				t.Fatalf("%s: unexpected EventError: %v", label, evt.Error)
+			case core.EventText:
+				if texts != nil {
+					*texts = append(*texts, evt.Content)
+				}
+			}
+		case <-deadline:
+			t.Fatalf("%s: timed out waiting for EventResult", label)
+		}
+	}
+}
+
+// TestHelperProcess acts as a fake agent CLI for the integration test above.
+// It is only active when GO_OC_HELPER=1; the prompt arrives on stdin.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_OC_HELPER") != "1" {
+		return
+	}
+	defer os.Exit(0)
+	in, _ := io.ReadAll(os.Stdin)
+	prompt := string(in)
+	switch {
+	case strings.Contains(prompt, "turn1"):
+		fmt.Println(`{"type":"step_start","sessionID":"ses_helper"}`)
+		fmt.Println(`{"type":"text","part":{"text":"reply one"}}`)
+		fmt.Println(`{"type":"step_finish","part":{"reason":"stop"}}`)
+		_ = os.Stdout.Sync()
+		// Linger after the final event, like the real CLI's teardown.
+		time.Sleep(400 * time.Millisecond)
+	case strings.Contains(prompt, "turn2"):
+		// Simulate LLM latency before any output.
+		time.Sleep(700 * time.Millisecond)
+		fmt.Println(`{"type":"text","part":{"text":"reply two"}}`)
+		fmt.Println(`{"type":"step_finish","part":{"reason":"stop"}}`)
 	}
 }
 


### PR DESCRIPTION

## Symptom

With the OpenCode agent (one `opencode run --format json --session <id>` process per turn), when a user sends multiple messages in quick succession:

- the first message is processed normally;
- follow-up messages are queued (`message queued for busy session`);
- **the first message dequeued from the queue always completes with the "(空响应)" / "(empty response)" placeholder** — its real reply is lost. Messages after it behave normally.

Observed timeline from production logs (2026-08-15, times local +08:00):

```
13:10:45.418  msg="processing queued message" remaining_queue=0
13:10:45.486  (agent-side log) new opencode process wrote its first stdout byte
13:10:45.946  msg="turn complete" ... tools=0 response_len=11   ← len("(空响应)") in UTF-8
```

The gap between dequeue and the bogus "turn complete" was 704 ms / 1090 ms / 528 ms across three occurrences — no correlation with any timeout, and making the agent emit its first byte 68 ms after startup did not help. The freshly spawned agent process kept running (its work completed) and was later killed without receiving a normal completion.

## Root cause

`opencodeSession.Send()` spawns a new process per turn, and every process's `readLoop` feeds the **same** `s.events` channel. A turn normally ends when the process prints `step_finish reason=stop` → `sendEventResult()`. But the process does **not** exit at that moment — it lingers for teardown, typically several hundred milliseconds, and its `readLoop` stays alive until stdout EOF, where it calls the EOF **fallback** `sendEventResult()` (meant to cover processes that die without a `step_finish`).

The duplicate-suppression flag `resultSent` is per-session and is **reset by the next `Send()`**. That is exactly what happens on the busy-queue path: the engine consumes turn N's `EventResult` and immediately dequeues the next message and calls `Send()` for turn N+1 — while turn N's process is still lingering. Sequence:

1. Turn N's process emits `step_finish reason=stop` → `EventResult` (`resultSent = true`). Engine consumes it, dequeues, drains stale events, calls `Send()` for turn N+1 → `resultSent = false`, new process spawned.
2. Turn N's process finally exits (0.5–1 s later). Its `readLoop` hits EOF and fires the fallback `sendEventResult()`. The guard was already reset, so a **stale `EventResult` is emitted into turn N+1**.
3. The engine treats it as turn N+1's completion. No text has arrived yet (the model is still working), so the response is empty → "(empty response)" placeholder. Turn N+1's real output is later discarded / its process torn down.

This explains every observed detail: only the first dequeued message is affected (it is the only turn started inside the previous process's linger window), the irregular 0.5–1 s "give-up" delay (= the previous process's exit lag), and why early first-byte output from the new process doesn't help (its stdout *is* read — the turn is just terminated from outside before the reply text arrives).

The same hole applies to the EOF-path `EventError` emissions (scanner error / non-empty stderr of a stale process failing the *current* turn).

## Fix

Add a per-`Send()` turn generation counter (`turnGen atomic.Int64`). Each `Send()` increments it and hands the value to the spawned `readLoop`. Terminal emissions — the EOF fallback `EventResult`, the `step_finish`-driven `EventResult`, and the EOF-path `EventError`s (scanner error / stderr) — are dropped (with a log line) if a newer turn has started since. In-turn behavior is unchanged; the existing `resultSent` duplicate guard is kept.

No new dependencies, no API changes outside the `agent/opencode` package, ~30 lines.

## Tests

- `TestStaleFallbackEventResultSuppressed` — unit test of the exact race ordering (result → next Send resets state → stale fallback fires → must emit nothing; the new turn's own result must still pass).
- `TestQueuedTurnNotTerminatedByLingeringPreviousProcess` — integration repro through the real `Send`/`readLoop` path using the test binary as a fake agent CLI: turn 1 prints its final event then lingers 400 ms before exiting; turn 2 is sent immediately after turn 1's `EventResult` (as the engine's queue-drain path does) and produces output after 700 ms. Red/green verified: with the generation guard disabled, the test fails with exactly the production symptom (turn 2 completes with no text at ~400 ms); with the guard it passes (3/3 runs).

Existing `agent/opencode` tests pass. (The `opencode_model_test.go` fake-CLI discovery tests fail on Windows with or without this change — pre-existing, unrelated: the fixtures are extension-less Unix scripts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
