### PR TITLE
fix(windows): run daemon without console window

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -801,8 +801,9 @@ Logs auto-rotate at the configured max size and keep one backup.
 
 On Windows, `daemon install` creates a native Task Scheduler task named `cc-connect`.
 The task runs at user logon and is also started immediately after installation. The
-installer writes a small PowerShell launcher under `~/.cc-connect` so the scheduled
-task uses the selected config directory, log file, PATH, and proxy environment.
+installer writes a windowless Windows Script Host launcher under `~/.cc-connect` so
+the scheduled task uses the selected config directory, log file, PATH, and proxy
+environment without opening a console window.
 
 ### Uninstall
 

--- a/agent/pi/proc_windows.go
+++ b/agent/pi/proc_windows.go
@@ -3,7 +3,6 @@
 package pi
 
 import (
-	"os"
 	"os/exec"
 	"syscall"
 )

--- a/daemon/check_linger_other.go
+++ b/daemon/check_linger_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !windows
 
 package daemon
 

--- a/daemon/windows.go
+++ b/daemon/windows.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	windowsTaskName   = ServiceName
-	windowsScriptName = "cc-connect-daemon.ps1"
+	windowsTaskName         = ServiceName
+	windowsScriptName       = "cc-connect-daemon.vbs"
+	legacyWindowsScriptName = "cc-connect-daemon.ps1"
 )
 
 var runPowerShell = func(script string) (string, error) {
@@ -40,6 +41,9 @@ func newPlatformManager() (Manager, error) {
 func (*schtasksManager) Platform() string { return "schtasks" }
 
 func (m *schtasksManager) Install(cfg Config) error {
+	if _, err := exec.LookPath("wscript.exe"); err != nil {
+		return fmt.Errorf("wscript.exe not found: Windows daemon launcher requires Windows Script Host")
+	}
 	if err := os.MkdirAll(DefaultDataDir(), 0755); err != nil {
 		return fmt.Errorf("create data dir: %w", err)
 	}
@@ -81,6 +85,9 @@ func (m *schtasksManager) Install(cfg Config) error {
 	if err := m.Start(); err != nil {
 		return fmt.Errorf("start task: %w", err)
 	}
+	if err := removeWindowsTaskScript(legacyWindowsTaskScriptPath()); err != nil {
+		slog.Warn("schtasks: remove legacy PowerShell launcher failed", "error", err)
+	}
 	return nil
 }
 
@@ -91,8 +98,10 @@ func (*schtasksManager) Uninstall() error {
 	if err := deleteWindowsTask(); err != nil {
 		return err
 	}
-	if err := os.Remove(windowsTaskScriptPath()); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove task script: %w", err)
+	for _, scriptPath := range []string{windowsTaskScriptPath(), legacyWindowsTaskScriptPath()} {
+		if err := removeWindowsTaskScript(scriptPath); err != nil {
+			return fmt.Errorf("remove task script: %w", err)
+		}
 	}
 	return nil
 }
@@ -139,17 +148,28 @@ func windowsTaskScriptPath() string {
 	return filepath.Join(DefaultDataDir(), windowsScriptName)
 }
 
+func legacyWindowsTaskScriptPath() string {
+	return filepath.Join(DefaultDataDir(), legacyWindowsScriptName)
+}
+
+func removeWindowsTaskScript(scriptPath string) error {
+	if err := os.Remove(scriptPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 func windowsTaskAction(scriptPath string) string {
-	return fmt.Sprintf(`powershell.exe %s`, windowsTaskActionArgs(scriptPath))
+	return fmt.Sprintf(`wscript.exe %s`, windowsTaskActionArgs(scriptPath))
 }
 
 func windowsTaskActionArgs(scriptPath string) string {
-	return fmt.Sprintf(`-WindowStyle Hidden -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "%s"`, scriptPath)
+	return fmt.Sprintf(`//B //NoLogo "%s"`, scriptPath)
 }
 
 func createWindowsTask(scriptPath string) error {
 	out, err := runPowerShell(fmt.Sprintf(`
-$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument %s
+$action = New-ScheduledTaskAction -Execute 'wscript.exe' -Argument %s
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
 $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
 Register-ScheduledTask -TaskName %s -Action $action -Trigger $trigger -Principal $principal -Force | Out-Null
@@ -166,7 +186,7 @@ $task = Get-ScheduledTask -TaskName %s -ErrorAction SilentlyContinue
 if ($null -eq $task) { exit 1 }
 $expectedArgs = %s
 foreach ($action in $task.Actions) {
-	if (($action.Execute -ieq 'powershell.exe') -and ($action.Arguments -eq $expectedArgs)) {
+	if (($action.Execute -ieq 'wscript.exe') -and ($action.Arguments -eq $expectedArgs)) {
 		Write-Output 'true'
 		exit 0
 	}
@@ -178,12 +198,15 @@ exit 1
 
 func buildWindowsTaskScript(cfg Config) string {
 	var sb strings.Builder
-	sb.WriteString("$ErrorActionPreference = 'Stop'\r\n")
-	writePowerShellEnv(&sb, "CC_LOG_FILE", cfg.LogFile)
-	writePowerShellEnv(&sb, "CC_LOG_MAX_SIZE", strconv.FormatInt(cfg.LogMaxSize, 10))
-	writePowerShellEnv(&sb, "CC_LOG_MAX_BACKUPS", strconv.Itoa(cfg.LogMaxBackups))
+	sb.WriteString("Option Explicit\r\n")
+	sb.WriteString("Dim shell, processEnv, exitCode\r\n")
+	sb.WriteString("Set shell = CreateObject(\"WScript.Shell\")\r\n")
+	sb.WriteString("Set processEnv = shell.Environment(\"Process\")\r\n")
+	writeVBScriptEnv(&sb, "CC_LOG_FILE", cfg.LogFile)
+	writeVBScriptEnv(&sb, "CC_LOG_MAX_SIZE", strconv.FormatInt(cfg.LogMaxSize, 10))
+	writeVBScriptEnv(&sb, "CC_LOG_MAX_BACKUPS", strconv.Itoa(cfg.LogMaxBackups))
 	if cfg.EnvPATH != "" {
-		writePowerShellEnv(&sb, "PATH", cfg.EnvPATH)
+		writeVBScriptEnv(&sb, "PATH", cfg.EnvPATH)
 	}
 	if len(cfg.EnvExtra) > 0 {
 		keys := make([]string, 0, len(cfg.EnvExtra))
@@ -201,21 +224,27 @@ func buildWindowsTaskScript(cfg Config) string {
 			if value == "" {
 				continue
 			}
-			writePowerShellEnv(&sb, key, value)
+			writeVBScriptEnv(&sb, key, value)
 		}
 	}
-	fmt.Fprintf(&sb, "Set-Location -LiteralPath %s\r\n", powerShellLiteral(cfg.WorkDir))
-	sb.WriteString("while ($true) {\r\n")
-	fmt.Fprintf(&sb, "  & %s\r\n", powerShellLiteral(cfg.BinaryPath))
-	sb.WriteString("  $exitCode = $LASTEXITCODE\r\n")
-	sb.WriteString("  if ($exitCode -eq 0) { exit 0 }\r\n")
-	sb.WriteString("  Start-Sleep -Seconds 10\r\n")
-	sb.WriteString("}\r\n")
+	fmt.Fprintf(&sb, "shell.CurrentDirectory = %s\r\n", vbScriptLiteral(cfg.WorkDir))
+	sb.WriteString("Do\r\n")
+	// Window style 0 keeps the console-subsystem cc-connect binary off the interactive desktop.
+	fmt.Fprintf(&sb, "  exitCode = shell.Run(Chr(34) & %s & Chr(34), 0, True)\r\n", vbScriptLiteral(cfg.BinaryPath))
+	sb.WriteString("  If exitCode = 0 Then WScript.Quit 0\r\n")
+	sb.WriteString("  WScript.Sleep 10000\r\n")
+	sb.WriteString("Loop\r\n")
 	return sb.String()
 }
 
-func writePowerShellEnv(sb *strings.Builder, key, value string) {
-	fmt.Fprintf(sb, "$env:%s = %s\r\n", key, powerShellLiteral(value))
+func writeVBScriptEnv(sb *strings.Builder, key, value string) {
+	fmt.Fprintf(sb, "processEnv(%s) = %s\r\n", vbScriptLiteral(key), vbScriptLiteral(value))
+}
+
+func vbScriptLiteral(value string) string {
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
 }
 
 func powerShellLiteral(value string) string {
@@ -225,24 +254,81 @@ func powerShellLiteral(value string) string {
 }
 
 func stopWindowsTask() error {
+	lockedProcessID, expectedBinary := installedWindowsProcess()
 	out, err := runPowerShell(fmt.Sprintf(`
+$currentScript = %s
+$legacyScript = %s
+$lockedProcessId = %d
+$expectedBinary = %s
+$launcherPids = @(
+	Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+		$commandLine = [string]$_.CommandLine
+		($_.Name -ieq 'wscript.exe' -or $_.Name -ieq 'powershell.exe') -and
+		($commandLine.IndexOf($currentScript, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+		 $commandLine.IndexOf($legacyScript, [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
+	} | Select-Object -ExpandProperty ProcessId
+)
 $task = Get-ScheduledTask -TaskName %s -ErrorAction SilentlyContinue
-if ($null -eq $task) { exit 0 }
-if ($task.State -eq 'Running') {
+
+if ($null -ne $task -and $task.State -eq 'Running') {
 	Stop-ScheduledTask -TaskName %s
 }
-for ($i = 0; $i -lt 20; $i++) {
+
+$taskStopped = $null -eq $task
+for ($i = 0; -not $taskStopped -and $i -lt 20; $i++) {
 	$task = Get-ScheduledTask -TaskName %s -ErrorAction SilentlyContinue
-	if ($null -eq $task -or $task.State -ne 'Running') { exit 0 }
-	Start-Sleep -Milliseconds 500
+	$taskStopped = $null -eq $task -or $task.State -ne 'Running'
+	if (-not $taskStopped) { Start-Sleep -Milliseconds 500 }
 }
-Write-Error 'scheduled task did not stop within timeout'
-exit 1
-`, powerShellLiteral(windowsTaskName), powerShellLiteral(windowsTaskName), powerShellLiteral(windowsTaskName)))
+if (-not $taskStopped) {
+	Write-Error 'scheduled task did not stop within timeout'
+	exit 1
+}
+
+$childPids = @(
+	Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+		$launcherPids -contains $_.ParentProcessId
+	} | Select-Object -ExpandProperty ProcessId
+)
+foreach ($processId in ($childPids | Sort-Object -Unique)) {
+	Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
+	Wait-Process -Id $processId -Timeout 5 -ErrorAction SilentlyContinue
+}
+
+if ($lockedProcessId -gt 0) {
+	$lockedProcess = Get-CimInstance Win32_Process -Filter "ProcessId = $lockedProcessId" -ErrorAction SilentlyContinue
+	$binaryMatches = $null -ne $lockedProcess -and (
+		$lockedProcess.Name -ieq 'cc-connect.exe' -and
+		($expectedBinary -eq '' -or ([string]$lockedProcess.ExecutablePath).Equals($expectedBinary, [System.StringComparison]::OrdinalIgnoreCase))
+	)
+	if ($binaryMatches) {
+		Stop-Process -Id $lockedProcessId -Force -ErrorAction SilentlyContinue
+		Wait-Process -Id $lockedProcessId -Timeout 5 -ErrorAction SilentlyContinue
+	}
+}
+`, powerShellLiteral(windowsTaskScriptPath()), powerShellLiteral(legacyWindowsTaskScriptPath()), lockedProcessID,
+		powerShellLiteral(expectedBinary), powerShellLiteral(windowsTaskName), powerShellLiteral(windowsTaskName),
+		powerShellLiteral(windowsTaskName)))
 	if err != nil {
 		return fmt.Errorf("stop scheduled task: %s (%w)", out, err)
 	}
 	return nil
+}
+
+func installedWindowsProcess() (int, string) {
+	meta, err := LoadMeta()
+	if err != nil || meta.WorkDir == "" {
+		return 0, ""
+	}
+	data, err := os.ReadFile(filepath.Join(meta.WorkDir, ".config.toml.lock"))
+	if err != nil {
+		return 0, meta.BinaryPath
+	}
+	processID, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || processID <= 0 {
+		return 0, meta.BinaryPath
+	}
+	return processID, meta.BinaryPath
 }
 
 func startWindowsTask() error {

--- a/daemon/windows_test.go
+++ b/daemon/windows_test.go
@@ -33,16 +33,18 @@ func TestBuildWindowsTaskScript(t *testing.T) {
 
 	script := buildWindowsTaskScript(cfg)
 	for _, want := range []string{
-		`$env:CC_LOG_FILE = 'C:\Users\me\.cc-connect\logs\cc-connect.log'`,
-		`$env:CC_LOG_MAX_SIZE = '10485760'`,
-		`$env:PATH = 'C:\Program Files\nodejs;C:\Users\me\AppData\Local\Programs'`,
-		`$env:HTTPS_PROXY = 'http://127.0.0.1:7890'`,
-		`$env:http_proxy = 'http://127.0.0.1:7890'`,
-		`Set-Location -LiteralPath 'C:\Users\me\.cc-connect'`,
-		`while ($true) {`,
-		`& 'C:\Program Files\cc-connect\cc-connect.exe'`,
-		`if ($exitCode -eq 0) { exit 0 }`,
-		`Start-Sleep -Seconds 10`,
+		`Option Explicit`,
+		`Set shell = CreateObject("WScript.Shell")`,
+		`Set processEnv = shell.Environment("Process")`,
+		`processEnv("CC_LOG_FILE") = "C:\Users\me\.cc-connect\logs\cc-connect.log"`,
+		`processEnv("CC_LOG_MAX_SIZE") = "10485760"`,
+		`processEnv("PATH") = "C:\Program Files\nodejs;C:\Users\me\AppData\Local\Programs"`,
+		`processEnv("HTTPS_PROXY") = "http://127.0.0.1:7890"`,
+		`processEnv("http_proxy") = "http://127.0.0.1:7890"`,
+		`shell.CurrentDirectory = "C:\Users\me\.cc-connect"`,
+		`exitCode = shell.Run(Chr(34) & "C:\Program Files\cc-connect\cc-connect.exe" & Chr(34), 0, True)`,
+		`If exitCode = 0 Then WScript.Quit 0`,
+		`WScript.Sleep 10000`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing %q:\n%s", want, script)
@@ -50,19 +52,20 @@ func TestBuildWindowsTaskScript(t *testing.T) {
 	}
 }
 
-func TestWindowsTaskActionRunsHidden(t *testing.T) {
-	got := windowsTaskAction(`C:\Users\me\.cc-connect\cc-connect-daemon.ps1`)
+func TestWindowsTaskActionUsesWindowlessScriptHost(t *testing.T) {
+	got := windowsTaskAction(`C:\Users\me\.cc-connect\cc-connect-daemon.vbs`)
 	for _, want := range []string{
-		`powershell.exe`,
-		`-WindowStyle Hidden`,
-		`-NoProfile`,
-		`-NonInteractive`,
-		`-ExecutionPolicy Bypass`,
-		`-File "C:\Users\me\.cc-connect\cc-connect-daemon.ps1"`,
+		`wscript.exe`,
+		`//B`,
+		`//NoLogo`,
+		`"C:\Users\me\.cc-connect\cc-connect-daemon.vbs"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("windowsTaskAction() missing %q: %q", want, got)
 		}
+	}
+	if strings.Contains(strings.ToLower(got), "powershell") {
+		t.Fatalf("windowsTaskAction() still launches a console host: %q", got)
 	}
 }
 
@@ -76,16 +79,17 @@ func TestWindowsTaskCreateUsesLimitedInteractivePrincipal(t *testing.T) {
 		return "", nil
 	}
 
-	if err := createWindowsTask(`C:\Users\me\.cc-connect\cc-connect-daemon.ps1`); err != nil {
+	if err := createWindowsTask(`C:\Users\me\.cc-connect\cc-connect-daemon.vbs`); err != nil {
 		t.Fatalf("createWindowsTask() error = %v", err)
 	}
 	for _, want := range []string{
 		`New-ScheduledTaskAction`,
 		`Register-ScheduledTask`,
+		`-Execute 'wscript.exe'`,
 		`-LogonType Interactive`,
 		`-RunLevel Limited`,
-		`-WindowStyle Hidden`,
-		`C:\Users\me\.cc-connect\cc-connect-daemon.ps1`,
+		`//B //NoLogo`,
+		`C:\Users\me\.cc-connect\cc-connect-daemon.vbs`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("create script missing %q:\n%s", want, script)
@@ -103,12 +107,12 @@ func TestWindowsTaskMatchesActionRequiresExactAction(t *testing.T) {
 		return "true", nil
 	}
 
-	if !windowsTaskMatchesAction(`C:\Users\me\.cc-connect\cc-connect-daemon.ps1`) {
+	if !windowsTaskMatchesAction(`C:\Users\me\.cc-connect\cc-connect-daemon.vbs`) {
 		t.Fatal("windowsTaskMatchesAction() = false, want true")
 	}
 	for _, want := range []string{
-		`$expectedArgs = '-WindowStyle Hidden -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "C:\Users\me\.cc-connect\cc-connect-daemon.ps1"'`,
-		`$action.Execute -ieq 'powershell.exe'`,
+		`$expectedArgs = '//B //NoLogo "C:\Users\me\.cc-connect\cc-connect-daemon.vbs"'`,
+		`$action.Execute -ieq 'wscript.exe'`,
 		`$action.Arguments -eq $expectedArgs`,
 	} {
 		if !strings.Contains(script, want) {
@@ -125,6 +129,14 @@ func TestPowerShellLiteralEscapesSingleQuotes(t *testing.T) {
 	}
 }
 
+func TestVBScriptLiteralEscapesDoubleQuotes(t *testing.T) {
+	got := vbScriptLiteral(`C:\Users\Jane "quoted"`)
+	want := `"C:\Users\Jane ""quoted"""`
+	if got != want {
+		t.Fatalf("vbScriptLiteral() = %q, want %q", got, want)
+	}
+}
+
 func TestBuildWindowsTaskScript_DropsInvalidEnvName(t *testing.T) {
 	cfg := Config{
 		BinaryPath: "x", WorkDir: "y", LogFile: "l", LogMaxSize: 1, EnvPATH: "p",
@@ -134,7 +146,7 @@ func TestBuildWindowsTaskScript_DropsInvalidEnvName(t *testing.T) {
 	if strings.Contains(script, "FOO BAR") {
 		t.Errorf("invalid env name leaked: %s", script)
 	}
-	if !strings.Contains(script, "$env:OK = 'ok'") {
+	if !strings.Contains(script, `processEnv("OK") = "ok"`) {
 		t.Errorf("valid env missing: %s", script)
 	}
 }
@@ -145,8 +157,70 @@ func TestBuildWindowsTaskScript_DropsEmptyValue(t *testing.T) {
 		EnvExtra: map[string]string{"EMPTY": "", "OK": "ok"},
 	}
 	script := buildWindowsTaskScript(cfg)
-	if strings.Contains(script, "$env:EMPTY") {
+	if strings.Contains(script, `processEnv("EMPTY")`) {
 		t.Errorf("empty value should be skipped: %s", script)
+	}
+}
+
+func TestSchtasksInstallRemovesLegacyPowerShellLauncher(t *testing.T) {
+	t.Setenv("USERPROFILE", t.TempDir())
+
+	orig := runPowerShell
+	t.Cleanup(func() { runPowerShell = orig })
+	runPowerShell = func(script string) (string, error) { return "", nil }
+
+	if err := os.MkdirAll(DefaultDataDir(), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	legacyPath := legacyWindowsTaskScriptPath()
+	if err := os.WriteFile(legacyPath, []byte("legacy\r\n"), 0o600); err != nil {
+		t.Fatalf("seed legacy launcher: %v", err)
+	}
+
+	mgr := &schtasksManager{}
+	cfg := Config{BinaryPath: "C:\\cc.exe", WorkDir: t.TempDir(), LogFile: "C:\\cc.log", LogMaxSize: 1024, EnvPATH: "C:\\bin"}
+	if err := mgr.Install(cfg); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy launcher still exists or cannot be inspected: %v", err)
+	}
+}
+
+func TestStopWindowsTaskKillsLauncherChildrenAndLockedInstance(t *testing.T) {
+	t.Setenv("USERPROFILE", t.TempDir())
+
+	workDir := t.TempDir()
+	if err := os.WriteFile(workDir+`\.config.toml.lock`, []byte("4242\n"), 0o600); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+	if err := SaveMeta(&Meta{WorkDir: workDir, BinaryPath: `C:\Tools\cc-connect.exe`}); err != nil {
+		t.Fatalf("SaveMeta: %v", err)
+	}
+
+	orig := runPowerShell
+	t.Cleanup(func() { runPowerShell = orig })
+	var script string
+	runPowerShell = func(s string) (string, error) {
+		script = s
+		return "", nil
+	}
+
+	if err := stopWindowsTask(); err != nil {
+		t.Fatalf("stopWindowsTask: %v", err)
+	}
+	for _, want := range []string{
+		`cc-connect-daemon.vbs`,
+		`cc-connect-daemon.ps1`,
+		`Get-CimInstance Win32_Process`,
+		`$launcherPids -contains $_.ParentProcessId`,
+		`$lockedProcessId = 4242`,
+		`$expectedBinary = 'C:\Tools\cc-connect.exe'`,
+		`Stop-Process -Id $lockedProcessId -Force`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("stop script missing %q:\n%s", want, script)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Replace the Windows Scheduled Task PowerShell launcher with a `wscript.exe //B //NoLogo` VBScript launcher. The launcher starts the console-subsystem binary with window style `0`, so daemon startup and restart no longer leave a PowerShell console visible.

It preserves the configured log and environment variables, retry behavior, and working directory; removes legacy `.ps1` launchers on reinstall or uninstall; and stops launcher children plus a verified lock-file process as a safe orphan fallback. This PR also includes the two minimal Windows source-build fixes required for the current `main` branch to compile on Windows.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

- Passed: `go test ./daemon -run '^(TestBuildWindowsTaskScript|TestBuildWindowsTaskScript_DropsInvalidEnvName|TestBuildWindowsTaskScript_DropsEmptyValue|TestWindowsTaskActionUsesWindowlessScriptHost|TestWindowsTaskCreateUsesLimitedInteractivePrincipal|TestWindowsTaskMatchesActionRequiresExactAction|TestPowerShellLiteralEscapesSingleQuotes|TestVBScriptLiteralEscapesDoubleQuotes|TestSchtasksInstallRemovesLegacyPowerShellLauncher|TestStopWindowsTaskKillsLauncherChildrenAndLockedInstance)$' -count=1`
- Passed: `go test ./agent/pi -run '^$' -count=1`
- Passed: `go build -tags no_web ./...`
- Manual Windows verification: reinstalled and restarted the local scheduled task; confirmed its action is `wscript.exe //B //NoLogo ...cc-connect-daemon.vbs`, with both `wscript.exe` and `cc-connect.exe` reporting `MainWindowHandle = 0`. Feishu reached `platform ready` and `engine started`.
- `go build ./...` requires generated `web/dist` assets, which this clean local worktree does not contain; CI builds those assets before its normal build step.
- `go test ./daemon -count=1` still fails the existing Windows-only precondition in `TestSchtasksInstall_TightensExistingScriptFrom0644` because this filesystem reports a seeded mode of `0666`, not `0644`.
- Full `go test -tags no_web ./...` has existing Windows-only failures in path, shell, PTY, and file-mode assumptions outside this change.

### Automated tests added in this PR

- `TestWindowsTaskActionUsesWindowlessScriptHost` in `daemon/windows_test.go` - verifies the scheduled task uses `wscript.exe //B //NoLogo` instead of PowerShell.
- `TestVBScriptLiteralEscapesDoubleQuotes` in `daemon/windows_test.go` - verifies safe VBScript string generation.
- `TestSchtasksInstallRemovesLegacyPowerShellLauncher` in `daemon/windows_test.go` - verifies upgrade cleanup of the old PowerShell launcher.
- `TestStopWindowsTaskKillsLauncherChildrenAndLockedInstance` in `daemon/windows_test.go` - verifies launcher-child and verified lock-PID cleanup are emitted.

### For bug fixes only - regression test

- Regression test name: `TestWindowsTaskActionUsesWindowlessScriptHost`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

- [x] No CUJ touched (Windows daemon lifecycle only)

## Manual / user-visible behavior change

On Windows, `cc-connect daemon install` and `cc-connect daemon restart` now run the service with no visible PowerShell console window. Existing installations migrate away from the old PowerShell launcher on reinstall.

## Checklist

- [x] Focused Windows daemon regression tests pass
- [x] `go build -tags no_web ./...` passes
- [x] No secrets / credentials in source
- [x] No new hardcoded platform/agent names in `core/`
- [ ] `go test ./...` passes locally (see Windows-only baseline failures above)

## Related

- Issue: none