### PR TITLE
build: derive version from git state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ MODULE     := github.com/chenhg5/cc-connect
 CMD        := ./cmd/cc-connect
 DIST       := dist
 
-VERSION := v1.3.3
-COMMIT     := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+# Derive the build version from the checked-out Git state.
+GIT_VERSION := $(if $(wildcard .git),$(shell git describe --tags --always --dirty))
+VERSION     := $(if $(strip $(GIT_VERSION)),$(GIT_VERSION),dev)
+COMMIT     := $(if $(wildcard .git),$(shell git rev-parse --short HEAD),none)
 BUILD_TIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 
 LDFLAGS := -s -w \


### PR DESCRIPTION
## Summary

- derive the embedded build version from `git describe --tags --always --dirty`
- keep exact release tags unchanged while development builds include commit distance and SHA
- fall back to `dev` outside a Git checkout
- derive commit metadata without shell redirection so Windows GNU Make works correctly

## Testing

- `GOOS=linux CGO_ENABLED=0 make build-noweb APP=cc-connect-version-test`
- `make -n build-noweb`
- `make -n build-noweb VERSION=v1.4.1`
- `git describe --tags --always v1.4.1`

`go test ./...` was also attempted on Windows; it reaches existing upstream Windows failures involving missing generated web assets, duplicate Windows symbols, and Unix-only test assumptions. CI provides the Linux test gate for this Makefile-only change.