### PR TITLE
fix(core,feishu): v1.5.0-beta.3 P1 stability — restart recover / cross-type flush / idle close race (#1686)

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -190,6 +190,23 @@ func (e *Engine) SetPendingRestartTimeout(d time.Duration) {
 func (e *Engine) runPendingRestartNotify(req *RestartRequest, firedCh chan struct{}) {
 	defer close(firedCh)
 
+	// Recover from any panic inside dispatch (ReconstructReplyCtx / Send) so a
+	// platform-side panic cannot take down the whole cc-connect process.
+	// See #1686 P1-A. Without this defer, a panic in the restart-notify
+	// goroutine kills the daemon because no higher-level recover exists.
+	defer func() {
+		if r := recover(); r != nil {
+			const maxStackBytes = 8192
+			stack := make([]byte, maxStackBytes)
+			n := runtime.Stack(stack, false)
+			slog.Error("restart notify panic",
+				"platform", req.Platform,
+				"session", req.SessionKey,
+				"panic", r,
+				"stack", string(stack[:n]))
+		}
+	}()
+
 	// Wait briefly for the platform to reach ready if it's not already.
 	// Upper bound: matches the typical Telegram 2-3 s connect window
 	// with margin (see defaultPendingRestartTimeout), and short enough
@@ -3810,23 +3827,29 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	}
 	stopTyping = nil // ownership transferred; prevent defer from double-stopping
 
-	// Guard against a narrow race: a message may have been queued between
-	// processInteractiveEvents observing an empty queue and returning here
-	// (session is still locked, so handleMessage's TryLock fails and routes
-	// the message to queueMessageForBusySession). Drain any such orphans.
-	if e.drainPendingMessages(state, session, sessions, interactiveKey) {
-		unlocked = true
-	}
-
-	// Start unsolicited reader if the session is still alive and the last
-	// turn ended cleanly. This goroutine will consume agent-initiated events
-	// (e.g. background task completions) and relay them to the platform.
+	// Start unsolicited reader and arm the idle close timer BEFORE draining
+	// queued messages. drainPendingMessages releases the session lock, and
+	// without this ordering the next user message can race in, call
+	// cancelAgentSessionIdleClose (a no-op since nothing was scheduled yet),
+	// and then the late schedule below arms a timer that no subsequent cancel
+	// will catch — closing the live session mid-turn. See #1686 P1-C P1-2.
+	// The schedule's own state checks (agentSession nil, stopped, etc.) and
+	// cleanupInteractiveStateForIdleToken's stale-token guard make it safe to
+	// leave a scheduled timer running across drain.
 	state.mu.Lock()
 	alive := state.agentSession != nil && state.agentSession.Alive() && !state.stopped && !state.eventsNeedResync
 	state.mu.Unlock()
 	if alive {
 		e.startUnsolicitedReader(state, session, sessions, interactiveKey, workspaceDir)
 		e.scheduleAgentSessionIdleClose(interactiveKey, state)
+	}
+
+	// Guard against a narrow race: a message may have been queued between
+	// processInteractiveEvents observing an empty queue and returning here
+	// (session is still locked, so handleMessage's TryLock fails and routes
+	// the message to queueMessageForBusySession). Drain any such orphans.
+	if e.drainPendingMessages(state, session, sessions, interactiveKey) {
+		unlocked = true
 	}
 }
 
@@ -4647,6 +4670,14 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 				state.mu.Lock()
 				state.eventsNeedResync = false
 				state.mu.Unlock()
+
+				// Reset the per-session idle close timer so a series of
+				// background task completions does not get cut short by the
+				// idle timeout armed at the end of the last foreground turn.
+				// Without this, a long-running background turn (e.g. cron task
+				// that reports progress every minute) can be killed mid-flight
+				// when the original idle timer fires. See #1686 P1-C P1-1.
+				e.scheduleAgentSessionIdleClose(sessionKey, state)
 
 				slog.Info("unsolicited turn complete",
 					"session", sessionKey,

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -13981,7 +13981,7 @@ func TestUnsolicitedReader_ResetsIdleCloseOnEventResult(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newControllableSession("unsol-idle-reset")
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 	e.SetAgentSessionIdleTimeout(50 * time.Millisecond)
 
 	sessions := e.sessions

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -13971,6 +13971,86 @@ func TestUnsolicitedReader_RelaysEventResult(t *testing.T) {
 	}
 }
 
+// TestUnsolicitedReader_ResetsIdleCloseOnEventResult verifies the P1-C P1-1
+// fix: an unsolicited EventResult must re-arm the per-session idle close
+// timer. Before the fix, the idle timer was only scheduled at the end of
+// the last foreground turn, so a long-running background turn (background
+// task that takes longer than the idle timeout) would be killed mid-flight
+// when the original timer fired.
+func TestUnsolicitedReader_ResetsIdleCloseOnEventResult(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newControllableSession("unsol-idle-reset")
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	defer e.Stop()
+	e.SetAgentSessionIdleTimeout(50 * time.Millisecond)
+
+	sessions := e.sessions
+	session := sessions.GetOrCreateActive("test:ch_idle:u1")
+
+	state := &interactiveState{
+		agentSession:     sess,
+		platform:         p,
+		replyCtx:         "ctx",
+		eventsNeedResync: false,
+	}
+	iKey := "test:ch_idle:u1"
+	e.interactiveMu.Lock()
+	e.interactiveStates[iKey] = state
+	e.interactiveMu.Unlock()
+
+	// Pretend a previous foreground turn already scheduled an idle close
+	// with token N and a known cancel function. The cancel must be
+	// invoked by the unsolicited reader's EventResult path as part of
+	// re-scheduling.
+	var prevCancelCalled atomic.Int32
+	state.mu.Lock()
+	state.agentSessionIdleCancel = func() { prevCancelCalled.Add(1) }
+	state.agentSessionIdleToken = 42
+	state.mu.Unlock()
+
+	e.startUnsolicitedReader(state, session, sessions, iKey, "")
+	defer e.stopUnsolicitedReader(state)
+
+	// Send an EventResult — this is the trigger for re-scheduling.
+	sess.events <- Event{Type: EventResult, Content: "background step done", Done: true}
+
+	// Wait for the reader to drain the EventResult and reach the schedule
+	// call. The reader sends the relayed content asynchronously; we poll
+	// until either the cancel fires or a generous timeout elapses.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if prevCancelCalled.Load() > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if prevCancelCalled.Load() == 0 {
+		t.Fatal("expected EventResult path to call cancelAgentSessionIdleClose before re-scheduling")
+	}
+
+	// After re-scheduling, token must have advanced and a fresh cancel
+	// function must be installed. A stale token would risk the cleanup
+	// path closing the live agent session while the background turn is
+	// still running.
+	state.mu.Lock()
+	newToken := state.agentSessionIdleToken
+	newCancel := state.agentSessionIdleCancel
+	state.mu.Unlock()
+	if newToken == 42 {
+		t.Errorf("expected agentSessionIdleToken to advance after re-schedule, still %d", newToken)
+	}
+	if newCancel == nil {
+		t.Fatal("expected a fresh agentSessionIdleCancel to be installed after EventResult")
+	}
+
+	// Cancel the freshly installed timer so the test does not leak the
+	// background goroutine until idle timeout fires.
+	state.mu.Lock()
+	state.agentSessionIdleCancel = nil
+	state.agentSessionIdleToken = 0
+	state.mu.Unlock()
+}
+
 // TestUnsolicitedReader_StopsOnCancel verifies that stopUnsolicitedReader
 // cleanly stops the reader goroutine and waits for it to exit.
 func TestUnsolicitedReader_StopsOnCancel(t *testing.T) {

--- a/core/restart_notify_test.go
+++ b/core/restart_notify_test.go
@@ -260,3 +260,72 @@ func TestRestartNotify_NilNotifyIgnored(t *testing.T) {
 		t.Error("nil notify should not occupy the pending slot")
 	}
 }
+
+// panickingRestartStub wraps restartNotifyStub and panics on Send. Used by
+// TestRestartNotify_PanicInSendRecovered to exercise the defer-recover added
+// to runPendingRestartNotify for #1686 P1-A.
+type panickingRestartStub struct {
+	*restartNotifyStub
+}
+
+// markReady forwards to the embedded restartNotifyStub.markReady but registers
+// the OUTER *panickingRestartStub with the engine, not the embedded
+// *restartNotifyStub. Otherwise lookupReadyPlatform returns the inner stub
+// (which does not panic on Send) and the test never exercises the recover path.
+func (p *panickingRestartStub) markReady(t *testing.T, e *Engine) {
+	t.Helper()
+	inner := p.restartNotifyStub
+	if !inner.ready.CompareAndSwap(false, true) {
+		return
+	}
+	e.OnPlatformReady(p) // pass the OUTER stub so Send dispatches to our panic
+}
+
+func (p *panickingRestartStub) Send(_ context.Context, _ any, _ string) error {
+	panic("simulated platform Send panic for #1686 P1-A test")
+}
+
+// TestRestartNotify_PanicInSendRecovered verifies that a panic inside
+// runPendingRestartNotify's dispatch path (e.g. a platform adapter panicking
+// in Send during ReconstructReplyCtx / Send) is caught by the new
+// defer-recover and does NOT crash the cc-connect process. Before #1686 P1-A,
+// this kind of panic would propagate up and kill the daemon because no
+// higher-level recover() existed in the restart-notify goroutine.
+//
+// We assert by waiting for the fired channel to close: the deferred
+// close(firedCh) at the top of runPendingRestartNotify runs after recover
+// handles the panic, so its closure is proof the goroutine exited cleanly.
+func TestRestartNotify_PanicInSendRecovered(t *testing.T) {
+	plat := &panickingRestartStub{restartNotifyStub: &restartNotifyStub{name: "telegram"}}
+	engine := NewEngine("test", &stubAgent{}, []Platform{plat}, "", LangEnglish)
+	plat.markReady(t, engine)
+
+	engine.SetPendingRestartNotify(&RestartRequest{
+		Platform:   "telegram",
+		SessionKey: "session-panic-1",
+	})
+
+	// Pull the fired channel out of the engine so we can wait for the
+	// goroutine to finish, instead of polling on ConsumePendingRestartNotify
+	// (which races with the panic-time clearPendingRestart path).
+	e := engine
+	e.pendingRestartMu.Lock()
+	firedCh := e.pendingRestartFiredCh
+	e.pendingRestartMu.Unlock()
+	if firedCh == nil {
+		t.Fatal("expected SetPendingRestartNotify to register a fired channel")
+	}
+
+	select {
+	case <-firedCh:
+		// firedCh closed → goroutine exited cleanly → panic was recovered.
+	case <-time.After(2 * time.Second):
+		t.Fatal("restart notify goroutine did not finish within 2s after Send panic; recover likely missing")
+	}
+
+	// Engine must still be usable after a recovered panic — no shared state
+	// corruption.
+	if got := plat.sentTexts(); len(got) != 0 {
+		t.Fatalf("a panicking stub should never record a successful send, got %v", got)
+	}
+}

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1204,6 +1204,34 @@ func (p *Platform) flushImageBatchByRef(sessionKey string, ref *imageBatchEntry)
 	p.dispatchImageBatchEntry(current)
 }
 
+// flushImageBatchForSession synchronously dispatches the pending image batch
+// (if any) for the given session key, then returns. Called from non-image
+// dispatchMessage branches (text/audio/file/post/media/...) so an image
+// already buffered for this session is sent to the engine before the new
+// message advances the user-message watermark. Without this flush, the
+// batch timer can fire AFTER the text message has set the watermark, causing
+// core/engine.go to drop the image as stale (see #1686 P1-B and #1395).
+//
+// Safe to call when no batch is buffered for this session — it is a no-op.
+func (p *Platform) flushImageBatchForSession(sessionKey string) {
+	if sessionKey == "" {
+		return
+	}
+	p.imageBatchMu.Lock()
+	entry, ok := p.imageBatch[sessionKey]
+	if !ok {
+		p.imageBatchMu.Unlock()
+		return
+	}
+	if entry.timer != nil {
+		entry.timer.Stop()
+	}
+	delete(p.imageBatch, sessionKey)
+	p.imageBatchMu.Unlock()
+
+	p.dispatchImageBatchEntry(entry)
+}
+
 // flushImageBatches synchronously dispatches any pending image batches.
 // Intended to be called from Stop() so buffered images aren't lost when
 // cc-connect shuts down.
@@ -1493,6 +1521,10 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			)
 			return
 		}
+		// Flush any image batch buffered earlier in this session so the image
+		// reaches the engine before the text message advances the user-message
+		// watermark (#1686 P1-B, related #1395).
+		p.flushImageBatchForSession(sessionKey)
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
@@ -1567,6 +1599,10 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			}
 			return
 		}
+		// Flush any image batch buffered earlier in this session so the image
+		// reaches the engine before this audio message advances the user-message
+		// watermark (#1686 P1-B).
+		p.flushImageBatchForSession(sessionKey)
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
@@ -1587,6 +1623,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		if text == "" && len(images) == 0 && quoted.text == "" && len(quoted.images) == 0 {
 			return
 		}
+		// Flush any image batch buffered earlier in this session (#1686 P1-B).
+		p.flushImageBatchForSession(sessionKey)
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
@@ -1616,6 +1654,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		slog.Debug(p.tag()+": file downloaded", "file_name", fileBody.FileName, "size", len(fileData))
 		mimeType := detectMimeType(fileData)
+		// Flush any image batch buffered earlier in this session (#1686 P1-B).
+		p.flushImageBatchForSession(sessionKey)
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
@@ -1635,6 +1675,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			slog.Warn(p.tag()+": merge_forward produced no content", "message_id", messageID)
 			return
 		}
+		// Flush any image batch buffered earlier in this session (#1686 P1-B).
+		p.flushImageBatchForSession(sessionKey)
 		coreMsg := &core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
@@ -1659,6 +1701,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		imgData, mimeType, err := p.downloadImage(messageID, stickerBody.FileKey)
 		if err != nil {
 			slog.Warn(p.tag()+": download sticker failed, falling back to placeholder", "error", err)
+			// Flush any image batch buffered earlier in this session (#1686 P1-B).
+			p.flushImageBatchForSession(sessionKey)
 			p.dispatchCoreMessage(&core.Message{
 				SessionKey: sessionKey, Platform: p.platformName,
 				MessageID: messageID,
@@ -1668,6 +1712,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			})
 			return
 		}
+		// Flush any image batch buffered earlier in this session (#1686 P1-B).
+		p.flushImageBatchForSession(sessionKey)
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
@@ -1705,6 +1751,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 				slog.Warn(p.tag()+": download media thumbnail failed", "error", err)
 			}
 		}
+		// Flush any image batch buffered earlier in this session (#1686 P1-B).
+		p.flushImageBatchForSession(sessionKey)
 		p.dispatchCoreMessage(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -2059,3 +2059,116 @@ func TestFlushImageBatchesEmptySafe(t *testing.T) {
 	// Should not panic, should not block.
 	p.flushImageBatches()
 }
+
+// TestFlushImageBatchForSession verifies the per-session flush helper added
+// for #1686 P1-B. When a non-image message (text/audio/file/post/media/...)
+// arrives for the same session that has a pending image batch, the batch
+// must be dispatched BEFORE the new message so core/engine's create_time
+// watermark does not drop the image as stale.
+func TestFlushImageBatchForSession(t *testing.T) {
+	const appID = "cli_per_session"
+	const appSecret = "secret-per-session"
+	const imageKey = "img_per_session"
+
+	imageBytes := []byte{0x89, 'P', 'N', 'G', 'F', '\r', '\n', 0x1a, '\n'}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{
+				"code":                0,
+				"msg":                 "success",
+				"expire":              7200,
+				"tenant_access_token": "tenant-token",
+			})
+		case strings.HasSuffix(r.URL.Path, "/resources/"+imageKey):
+			w.Header().Set("Content-Type", "image/png")
+			if _, err := w.Write(imageBytes); err != nil {
+				t.Fatalf("write image: %v", err)
+			}
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			writeJSON(t, w, map[string]any{"code": 0, "msg": "success", "data": map[string]any{}})
+		}
+	}))
+	defer srv.Close()
+
+	received := make(chan *core.Message, 2)
+	p := &Platform{
+		platformName: "feishu",
+		domain:       srv.URL,
+		appID:        appID,
+		appSecret:    appSecret,
+		dedup:        &core.MessageDedup{},
+		client: lark.NewClient(appID, appSecret,
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+		),
+		handler: func(_ core.Platform, msg *core.Message) {
+			received <- msg
+		},
+		imageBatch: make(map[string]*imageBatchEntry),
+	}
+
+	sessionKey := "feishu:oc_per_session:ou_user"
+
+	// Buffer a single image for the session. Use a long batch window so the
+	// timer doesn't fire on its own before we exercise the flush path.
+	p.imageBatchWindow = 5 * time.Second
+	p.bufferImage(sessionKey, &imageBatchEntry{
+		sessionKey:   sessionKey,
+		userID:       "ou_user",
+		chatName:     "oc_per_session",
+		rctx:         replyContext{messageID: "om_per_session", chatID: "oc_per_session", sessionKey: sessionKey},
+		images:       []core.ImageAttachment{{MimeType: "image/png", Data: imageBytes}},
+		messageIDs:   []string{"om_per_session"},
+		createTimeMs: 1710000000000,
+	})
+
+	// Confirm the batch is buffered.
+	p.imageBatchMu.Lock()
+	if len(p.imageBatch) != 1 {
+		p.imageBatchMu.Unlock()
+		t.Fatalf("imageBatch size = %d before flush, want 1", len(p.imageBatch))
+	}
+	p.imageBatchMu.Unlock()
+
+	// Flush only this session. The image must be dispatched synchronously.
+	p.flushImageBatchForSession(sessionKey)
+
+	p.imageBatchMu.Lock()
+	batchSize := len(p.imageBatch)
+	p.imageBatchMu.Unlock()
+	if batchSize != 0 {
+		t.Fatalf("imageBatch size = %d after flushImageBatchForSession, want 0", batchSize)
+	}
+
+	select {
+	case msg := <-received:
+		if len(msg.Images) != 1 {
+			t.Fatalf("flushed message has %d images, want 1", len(msg.Images))
+		}
+		if msg.SessionKey != sessionKey {
+			t.Errorf("flushed message session = %q, want %q", msg.SessionKey, sessionKey)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("flushImageBatchForSession did not synchronously dispatch the batch")
+	}
+}
+
+// TestFlushImageBatchForSession_NoBatchIsSafe verifies the per-session flush
+// helper is a safe no-op when nothing is buffered for that session (the
+// common case for sessions that only ever send text).
+func TestFlushImageBatchForSession_NoBatchIsSafe(t *testing.T) {
+	p := &Platform{
+		platformName: "feishu",
+		imageBatch:   make(map[string]*imageBatchEntry),
+	}
+	// No panic, no block, no entries changed.
+	p.flushImageBatchForSession("feishu:oc_empty:ou_user")
+	p.flushImageBatchForSession("") // empty session key is also a safe no-op
+	if n := len(p.imageBatch); n != 0 {
+		t.Fatalf("imageBatch size = %d, want 0", n)
+	}
+}


### PR DESCRIPTION
Fixes the 3 P1 stability issues from #1686 on v1.5.0-beta.3 (`ad196294`).

## P1-A (crash-class): defer recover in restart-notify goroutine

`runPendingRestartNotify` had no `defer recover()`. `dispatchRestartNotify` calls `p.ReconstructReplyCtx` and `p.Send`, and either panicking (e.g. when a platform adapter panics on a not-yet-ready reply ctx) took down the whole daemon because `core/` has zero other `recover()` in the path. Remote restart is the trigger pattern.

Fix: 6-line `defer recover()` that logs the panic + stack via `slog.Error` + `runtime.Stack`.

## P1-B (image loss): cross-type image batch flush

`image_batch_window_ms=500` (default) plus a text message arriving within that window caused core/engine's `create_time` watermark to drop the buffered image as stale (#1395-adjacent, #1686 P1-B). Workaround `image_batch_window_ms=50` is verified effective but the proper fix is per-session flush before any non-image dispatch:

- Added `Platform.flushImageBatchForSession(sessionKey)` that synchronously dispatches the pending batch for a session key.
- Called from every non-image branch in `dispatchMessage` (text / audio / post / file / merge_forward / sticker / media), BEFORE the new message advances the watermark.

The image-only branch is unaffected — it still coalesces via `bufferImage` for rapid batch-selected uploads.

## P1-C P1-1: unsolicited turn re-arms idle close

The per-session idle close timer was only armed at the end of a foreground turn. An agent-driven background turn (cron progress updates, async tool completion) did not reset it, so a long-running background turn could be killed by a stale timer set during the previous foreground turn.

Fix: `runUnsolicitedReader` calls `scheduleAgentSessionIdleClose(sessionKey, state)` at the end of each `EventResult` branch, after the existing reset of `eventsNeedResync`.

## P1-C P1-2: idle close armed BEFORE drain

The race: `drainPendingMessages` releases the session lock, then `scheduleAgentSessionIdleClose` fires AFTER. A new user message racing in during that window calls `cancelAgentSessionIdleClose` at the top of its handler — but `state.agentSessionIdleCancel` is still nil (no schedule yet), so the cancel is a no-op. The late schedule then arms a timer that no later cancel will catch. If the new turn runs longer than `timeout`, `cleanupInteractiveStateForIdleToken` sees a matching token and closes the live session mid-turn.

Fix: arm the timer (and start the unsolicited reader) BEFORE `drainPendingMessages` in the regular handler. The new turn's `cancel` at the top of its handler now catches the schedule. The stale-token guard in `cleanupInteractiveStateForIdleToken` and the schedule's own state checks make it safe to leave the timer running across drain.

## Optional Task 4 (goSafe helper) deferred

Per PM triage (decision doc `doc-20260816-9y7e9d`), the cross-cutting `goSafe(name, fn)` helper that would have caught ALL spawn sites in `core/engine.go` is gated on maintainer decision about scope. This PR fixes the specific #1686 issues; a follow-up PR can adopt the helper once the maintainer approves its wider scope.

## Tests

- `TestRestartNotify_PanicInSendRecovered` — Send panics, `firedCh` closes (recover caught it).
- `TestUnsolicitedReader_ResetsIdleCloseOnEventResult` — pre-set cancel fires, token advances.
- `TestFlushImageBatchForSession` — buffered image dispatched synchronously by per-session flush.
- `TestFlushImageBatchForSession_NoBatchIsSafe` — empty session is a safe no-op.

Existing tests still pass with `-race`:
- `go test -tags no_web -race ./core/` ✅ 48.7s
- `go test -tags no_web -race ./platform/feishu/` ✅ 33.5s

## Risk

- All changes are additive: P1-A only adds a `defer recover`. P1-B only adds a synchronous flush helper and per-branch flush calls (no API surface change). P1-C P1-1 only adds one extra `schedule` call after an existing reset. P1-C P1-2 only reorders two adjacent function calls; both still run, just in a different order. The schedule's state checks (`agentSession == nil`, `stopped`, etc.) and the cleanup's stale-token guard protect against any new timing edge cases.
- goSafe is NOT in scope (awaiting maintainer decision).