### PR TITLE
fix(cursor): preserve cmd and env across multi-workspace rebuilds

### DIFF
--- a/agent/cursor/cursor.go
+++ b/agent/cursor/cursor.go
@@ -84,6 +84,40 @@ func (a *Agent) Name() string           { return "cursor" }
 func (a *Agent) CLIBinaryName() string  { return "agent" }
 func (a *Agent) CLIDisplayName() string { return "Cursor Agent" }
 
+// WorkspaceAgentOptions implements core.WorkspaceAgentOptionSnapshotter so
+// multi-workspace reconstruction preserves cmd/env. Without this, the engine
+// rebuilds the agent with only work_dir/model/mode and defaults cmd to bare
+// "agent", which collides with other CLIs (e.g. Grok) that also install as
+// `agent` and interpret --print as --single.
+func (a *Agent) WorkspaceAgentOptions() map[string]any {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	opts := map[string]any{}
+	if cmd := joinCursorCommand(a.cmd, a.cliExtraArgs); cmd != "" {
+		opts["cmd"] = cmd
+	}
+	if len(a.configEnv) > 0 {
+		env := make(map[string]string, len(a.configEnv))
+		for _, pair := range a.configEnv {
+			if key, value, ok := strings.Cut(pair, "="); ok {
+				env[key] = value
+			}
+		}
+		opts["env"] = env
+	}
+	return opts
+}
+
+func joinCursorCommand(cmd string, args []string) string {
+	if cmd == "" {
+		return ""
+	}
+	if len(args) == 0 {
+		return cmd
+	}
+	return cmd + " " + strings.Join(args, " ")
+}
+
 func (a *Agent) SetWorkDir(dir string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -686,3 +720,5 @@ func countSessionMessages(dbPath, rootBlobID string) (int, string) {
 
 	return msgCount, firstUserMsg
 }
+
+var _ core.WorkspaceAgentOptionSnapshotter = (*Agent)(nil)

--- a/agent/cursor/workspace_opts_test.go
+++ b/agent/cursor/workspace_opts_test.go
@@ -1,0 +1,53 @@
+package cursor
+
+import (
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestWorkspaceAgentOptionsPreservesCmdAndEnv(t *testing.T) {
+	a := &Agent{
+		cmd:          "/custom/cursor-agent",
+		cliExtraArgs: []string{"--force"},
+		configEnv:    []string{"FOO=bar"},
+		model:        "cursor-grok-4.6-high",
+		mode:         "force",
+	}
+
+	snapshotter, ok := any(a).(core.WorkspaceAgentOptionSnapshotter)
+	if !ok {
+		t.Fatal("cursor agent does not implement WorkspaceAgentOptionSnapshotter")
+	}
+	opts := snapshotter.WorkspaceAgentOptions()
+	if got, _ := opts["cmd"].(string); got != "/custom/cursor-agent --force" {
+		t.Fatalf("cmd = %#v, want %q", opts["cmd"], "/custom/cursor-agent --force")
+	}
+	gotEnv, _ := opts["env"].(map[string]string)
+	if gotEnv["FOO"] != "bar" {
+		t.Fatalf("env = %#v, want FOO=bar", gotEnv)
+	}
+
+	// 多 workspace 重建必须带着自定义 cmd，不能回落到 PATH 上的裸 agent。
+	rebuilt := &Agent{}
+	cmd, extra := core.ParseCmdOpts(opts, "agent")
+	rebuilt.cmd = cmd
+	rebuilt.cliExtraArgs = extra
+	rebuilt.configEnv = core.ParseConfigEnv(opts)
+	again := rebuilt.WorkspaceAgentOptions()
+	if again["cmd"] != opts["cmd"] {
+		t.Fatalf("rebuilt cmd = %#v, want %#v", again["cmd"], opts["cmd"])
+	}
+}
+
+func TestJoinCursorCommand(t *testing.T) {
+	if got := joinCursorCommand("", nil); got != "" {
+		t.Fatalf("empty cmd = %q, want empty", got)
+	}
+	if got := joinCursorCommand("/bin/cursor-agent", nil); got != "/bin/cursor-agent" {
+		t.Fatalf("cmd only = %q", got)
+	}
+	if got := joinCursorCommand("/bin/cursor-agent", []string{"--force", "--yolo"}); got != "/bin/cursor-agent --force --yolo" {
+		t.Fatalf("cmd+args = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Cursor now implements `WorkspaceAgentOptionSnapshotter`, matching Claude / Codex / Grok / Pi / Copilot
- Per-workspace agent rebuilds keep the configured `cmd` and `env` instead of falling back to bare `agent`
- This avoids colliding with another CLI named `agent` on PATH (Grok Build installs as `agent` and treats `--print` as `--single`)

## Test plan
- [x] `go test ./agent/cursor -count=1 -run 'TestWorkspaceAgentOptions|TestJoinCursorCommand'`
- [ ] Multi-workspace project with `cmd = "/path/to/cursor-agent"`: switch workspace and confirm the child still uses that binary


Made with [Cursor](https://cursor.com)