### PR TITLE
fix(core): suppress /stop context-canceled error cards

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -4695,8 +4695,13 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 
 			case EventError:
 				if event.Error != nil {
-					slog.Error("unsolicited agent error", "error", event.Error, "session", sessionKey)
-					e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), event.Error))
+					errMsg := event.Error.Error()
+					if isIntentionalTurnCancel(errMsg) {
+						slog.Info("unsolicited agent turn cancelled", "error", errMsg, "session", sessionKey)
+					} else {
+						slog.Error("unsolicited agent error", "error", event.Error, "session", sessionKey)
+						e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), event.Error))
+					}
 				}
 				state.mu.Lock()
 				state.eventsNeedResync = true
@@ -4714,6 +4719,22 @@ type agentErrorHandler struct {
 
 var agentErrorHandlers = []agentErrorHandler{
 	{"Session not found", MsgSessionNotFound},
+}
+
+// isIntentionalTurnCancel reports errors emitted when /stop (or CancelTurn)
+// aborts the current headless turn. Grok and similar agents surface this as
+// EventError("…turn stopped: context canceled"); /stop already replied with
+// MsgExecutionStopped, so we must not also spam the IM user with an error card.
+func isIntentionalTurnCancel(errMsg string) bool {
+	if errMsg == "" {
+		return false
+	}
+	// Keep timeouts (deadline exceeded) as real errors.
+	if strings.Contains(errMsg, "deadline exceeded") {
+		return false
+	}
+	return strings.Contains(errMsg, "turn stopped") &&
+		(strings.Contains(errMsg, "context canceled") || strings.Contains(errMsg, "context cancelled"))
 }
 
 func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, msgID string, turnStart time.Time, stopTypingFn func(), sendDone <-chan error, replyCtx any) {
@@ -6015,21 +6036,26 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			}
 			if event.Error != nil {
 				errMsg := event.Error.Error()
-				slog.Error("agent error", "error", event.Error)
-				e.hooks.Emit(HookEvent{
-					Event:      HookEventError,
-					SessionKey: sessionKey,
-					Platform:   p.Name(),
-					Error:      event.Error.Error(),
-				})
-				userMsg := fmt.Sprintf(e.i18n.T(MsgError), errMsg)
-				for _, h := range agentErrorHandlers {
-					if strings.Contains(errMsg, h.contains) {
-						userMsg = e.i18n.T(h.msgKey)
-						break
+				if isIntentionalTurnCancel(errMsg) {
+					// /stop already notified the user; suppress the noisy error.
+					slog.Info("agent turn cancelled", "error", errMsg, "session_key", sessionKey)
+				} else {
+					slog.Error("agent error", "error", event.Error)
+					e.hooks.Emit(HookEvent{
+						Event:      HookEventError,
+						SessionKey: sessionKey,
+						Platform:   p.Name(),
+						Error:      event.Error.Error(),
+					})
+					userMsg := fmt.Sprintf(e.i18n.T(MsgError), errMsg)
+					for _, h := range agentErrorHandlers {
+						if strings.Contains(errMsg, h.contains) {
+							userMsg = e.i18n.T(h.msgKey)
+							break
+						}
 					}
+					e.send(p, replyCtx, userMsg)
 				}
-				e.send(p, replyCtx, userMsg)
 			}
 			// Only drop queued messages if the agent session is dead.
 			// Some agents (e.g. Codex) emit EventError for per-turn failures

--- a/core/turn_cancel_test.go
+++ b/core/turn_cancel_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestIsIntentionalTurnCancel(t *testing.T) {
+	cases := []struct {
+		name string
+		err  string
+		want bool
+	}{
+		{name: "empty", err: "", want: false},
+		{name: "grok stop", err: "grok: turn stopped: context canceled", want: true},
+		{name: "british spelling", err: "turn stopped: context cancelled", want: true},
+		{name: "timeout stays an error", err: "grok: turn stopped: context deadline exceeded", want: false},
+		{name: "unrelated cancel", err: "context canceled", want: false},
+		{name: "unrelated stop", err: "turn stopped by user", want: false},
+		{name: "generic failure", err: "something broke", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isIntentionalTurnCancel(tc.err); got != tc.want {
+				t.Fatalf("isIntentionalTurnCancel(%q) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `/stop` already replies with the stopped message; Grok then emits `EventError("…turn stopped: context canceled")` and the engine posted a second error card
- Treat that specific cancel as an intentional abort in both the interactive loop and the unsolicited reader
- Leave `deadline exceeded` and other failures as real errors

## Test plan
- [x] `go test ./core -count=1 -run 'TestIsIntentionalTurnCancel|TestUnsolicitedReader_SetsResyncOnEventError'`
- [ ] On a live Grok session, `/stop` mid-turn: user sees the stopped notice once, no extra error card
- [ ] A real agent failure still posts an error card


Made with [Cursor](https://cursor.com)