### PR TITLE
feat(feishu): share group chat context on mention

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1028,6 +1028,10 @@ app_secret = "your-feishu-app-secret"
 #                                   # 设为 true 时，群聊内所有用户共享同一个 Agent 会话
 # thread_isolation = false  # If true, group messages use Feishu reply threads as session boundaries (one thread/root = one agent session and, in multi-workspace mode, one workspace binding)
 #                           # 设为 true 时，群聊按飞书话题/根消息隔离会话；multi-workspace 模式下每个话题也独立绑定 workspace
+# Share non-mentioned group messages as context with the next bot-triggered turn.
+# Messages themselves do not trigger a reply.
+# group_chat_history_share = false
+# 将未 @ 机器人的群消息作为下一次触发的上下文共享；消息本身不会触发回复。
 # reply_to_trigger = true   # Default: bot uses “reply to message” API (quotes the user’s message). Set false to post plain chat messages instead.
 #                           # 默认 true：用「回复消息」API（引用用户消息）。设为 false 则在会话里发普通消息、不引用触发消息。
 # progress_style = "legacy" # Progress rendering style: legacy | compact | card

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -110,6 +110,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # domain = "https://open.feishu.cn" # 可选：覆盖运行时 API/WebSocket 域名
 # enable_feishu_card = true  # 可选：关闭后统一回退纯文本回复
 # thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
+# group_chat_history_share = false  # 可选：共享未 @ 机器人的群消息作为下一次触发的上下文；消息本身不会触发回复
 # progress_style = "legacy"  # 可选：legacy | compact | card
 # done_emoji = "none"          # 可选：agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 # image_batch_window_ms = 500  # 可选：连续多图合批窗口（默认 500ms，详见下文）
@@ -117,6 +118,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
 > 如果开启 `thread_isolation = true`，群聊里每个根消息 / reply thread 会对应一个独立 agent session；私聊行为保持原样。
+> `group_chat_history_share = true` 时，cc-connect 只在内存中保留当前进程观察到的、允许访问的群聊 text/post 消息，并在下一次明确 @ 机器人且真正进入 agent turn 时注入；未 @ 的消息不会触发回复。`/status` 等由 cc-connect 处理的命令不会消费这段待处理上下文，`/new` 会清空对应主频道或话题的上下文。
 > 在 multi-workspace 模式下，`thread_isolation = true` 也会让每个话题独立绑定 workspace；在话题内执行 `/workspace bind <name>` 不会影响同群的其他话题。已有的群级 binding 会保留为默认值，由尚未显式绑定的话题继承，因此回退到旧版本时仍可使用。
 > `progress_style = "compact"` 会把思考/工具进度合并到一条可更新消息里，减少刷屏；`legacy` 保持原有逐条发送；`card` 会使用结构化卡片（标题 + 进度块）持续更新同一条消息，观感比纯文本更清晰。
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
@@ -164,6 +166,8 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 ### 4.3 发布权限申请
 
 配置完权限后，点击「申请发布」使权限生效。
+
+如果启用了 `group_chat_history_share`，必须为应用申请并发布 `im:message.group_msg`，否则飞书只会向机器人推送被 @ 的群消息，未提及消息无法进入共享上下文。该功能不会回溯 cc-connect 启动前的历史，也不会持久化待处理消息。
 
 ---
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -131,6 +131,7 @@ type Platform struct {
 	respondToAtEveryoneAndHere bool
 	shareSessionInChannel      bool
 	threadIsolation            bool
+	groupChatHistoryShare      bool
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
 	noReplyToTrigger bool
 	resolveMentions  bool
@@ -169,6 +170,14 @@ type Platform struct {
 	// without requiring another @bot mention. Value is the last-seen time so
 	// stale entries can be expired by a future TTL sweep if needed.
 	activeThreadSessions sync.Map // sessionKey -> time.Time
+
+	// pendingGroupHistory keeps text/post messages that were observed in an
+	// allowed group chat without an explicit bot trigger. It is deliberately
+	// platform-local and in-memory: the next accepted agent turn consumes the
+	// snapshot, while slash commands that are handled by core leave it intact.
+	groupHistoryMu      sync.Mutex
+	pendingGroupHistory map[string][]groupHistoryEntry
+	nextGroupHistoryID  uint64
 
 	richCardImageMu         sync.Mutex
 	richCardImageResolved   map[string]string
@@ -244,6 +253,7 @@ type imageBatchEntry struct {
 	chatName     string
 	rctx         replyContext
 	quoted       quotedMessage
+	onAccepted   func()
 	images       []core.ImageAttachment
 	messageIDs   []string
 	createTimeMs int64
@@ -311,6 +321,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
+	groupChatHistoryShare, _ := opts["group_chat_history_share"].(bool)
 	resolveMentionsOpt, _ := opts["resolve_mentions"].(bool)
 	noReplyToTrigger := false
 	if v, ok := opts["reply_to_trigger"].(bool); ok && !v {
@@ -402,6 +413,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
 		shareSessionInChannel:      shareSessionInChannel,
 		threadIsolation:            threadIsolation,
+		groupChatHistoryShare:      groupChatHistoryShare,
 		resolveMentions:            resolveMentionsOpt,
 		noReplyToTrigger:           noReplyToTrigger,
 		client:                     lark.NewClient(appID, appSecret, clientOpts...),
@@ -1276,6 +1288,7 @@ func (p *Platform) dispatchImageBatchEntry(entry *imageBatchEntry) {
 		UserID:    entry.userID, UserName: entry.userName, ChatName: entry.chatName,
 		Content:           "",
 		ExtraContent:      entry.quoted.text,
+		OnAccepted:        entry.onAccepted,
 		Images:            append(entry.quoted.images, entry.images...),
 		ReplyCtx:          entry.rctx,
 		UserMessageTimeMs: entry.createTimeMs,
@@ -1299,6 +1312,7 @@ func (p *Platform) onMessageRecalled(_ context.Context, event *larkim.P2MessageR
 	}
 
 	p.markMessageRecalled(messageID)
+	p.removeGroupHistory(messageID)
 	slog.Info(p.tag()+": message recalled",
 		"message_id", messageID,
 		"chat_id", chatID,
@@ -1318,6 +1332,213 @@ func (p *Platform) onMessageRecalled(_ context.Context, event *larkim.P2MessageR
 	return nil
 }
 
+func isGroupHistoryMessageType(msgType string) bool {
+	return msgType == "text" || msgType == "post"
+}
+
+// groupHistoryScope deliberately differs from makeSessionKey. With
+// thread_isolation enabled, a main-channel mention creates a root-scoped
+// agent session, but later main-channel messages must remain in the chat-level
+// history rather than being attached to that forked session.
+func (p *Platform) groupHistoryScope(msg *larkim.EventMessage, chatID string) string {
+	if chatID == "" {
+		return ""
+	}
+	if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
+		if rootID := stringValue(msg.RootId); rootID != "" {
+			return "thread:" + chatID + ":" + rootID
+		}
+	}
+	return "chat:" + chatID
+}
+
+func (p *Platform) historyText(msgType, content string, mentions []*larkim.MentionEvent) string {
+	if content == "" {
+		return ""
+	}
+	switch msgType {
+	case "text":
+		var textBody struct {
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal([]byte(content), &textBody); err != nil {
+			return ""
+		}
+		return stripMentions(textBody.Text, mentions, p.getBotOpenID())
+	case "post":
+		return strings.TrimSpace(extractPostPlainText(content))
+	default:
+		return ""
+	}
+}
+
+func (p *Platform) rememberGroupHistory(scope, messageID, msgType, content string, mentions []*larkim.MentionEvent, senderID, senderType string) {
+	if !p.groupChatHistoryShare || scope == "" || !isGroupHistoryMessageType(msgType) {
+		return
+	}
+	text := p.historyText(msgType, content, mentions)
+	if text == "" {
+		return
+	}
+
+	p.groupHistoryMu.Lock()
+	defer p.groupHistoryMu.Unlock()
+	p.nextGroupHistoryID++
+	entry := groupHistoryEntry{
+		id:         p.nextGroupHistoryID,
+		messageID:  messageID,
+		senderID:   senderID,
+		senderType: senderType,
+		text:       text,
+	}
+	history := append(p.pendingGroupHistory[scope], entry)
+	if len(history) > maxPendingGroupHistoryEntries {
+		history = history[len(history)-maxPendingGroupHistoryEntries:]
+	}
+	if p.pendingGroupHistory == nil {
+		p.pendingGroupHistory = make(map[string][]groupHistoryEntry)
+	}
+	p.pendingGroupHistory[scope] = history
+}
+
+func (p *Platform) removeGroupHistory(messageID string) {
+	if messageID == "" {
+		return
+	}
+	p.groupHistoryMu.Lock()
+	defer p.groupHistoryMu.Unlock()
+	for scope, history := range p.pendingGroupHistory {
+		kept := history[:0]
+		for _, entry := range history {
+			if entry.messageID != messageID {
+				kept = append(kept, entry)
+			}
+		}
+		if len(kept) == 0 {
+			delete(p.pendingGroupHistory, scope)
+		} else {
+			p.pendingGroupHistory[scope] = kept
+		}
+	}
+}
+
+func (p *Platform) snapshotGroupHistory(scope string) groupHistoryContext {
+	if !p.groupChatHistoryShare || scope == "" {
+		return groupHistoryContext{}
+	}
+
+	p.groupHistoryMu.Lock()
+	history := append([]groupHistoryEntry(nil), p.pendingGroupHistory[scope]...)
+	p.groupHistoryMu.Unlock()
+	if len(history) == 0 {
+		return groupHistoryContext{}
+	}
+
+	maxID := history[len(history)-1].id
+	var once sync.Once
+	return groupHistoryContext{
+		entries: history,
+		onAccepted: func() {
+			once.Do(func() { p.consumeGroupHistory(scope, maxID) })
+		},
+	}
+}
+
+func (p *Platform) consumeGroupHistory(scope string, maxID uint64) {
+	p.groupHistoryMu.Lock()
+	defer p.groupHistoryMu.Unlock()
+	history := p.pendingGroupHistory[scope]
+	kept := history[:0]
+	for _, entry := range history {
+		if entry.id > maxID {
+			kept = append(kept, entry)
+		}
+	}
+	if len(kept) == 0 {
+		delete(p.pendingGroupHistory, scope)
+		return
+	}
+	p.pendingGroupHistory[scope] = kept
+}
+
+func (p *Platform) resetGroupHistory(scope string) {
+	if scope == "" {
+		return
+	}
+	p.groupHistoryMu.Lock()
+	delete(p.pendingGroupHistory, scope)
+	p.groupHistoryMu.Unlock()
+}
+
+func (p *Platform) historySenderName(entry groupHistoryEntry) string {
+	if strings.EqualFold(entry.senderType, "app") {
+		return p.resolveBotSenderName(entry.senderID)
+	}
+	if entry.senderID == "" {
+		return "User"
+	}
+	if cached, ok := p.userNameCache.Load(entry.senderID); ok {
+		if name, ok := cached.(string); ok && name != "" {
+			return name
+		}
+	}
+	if p.client != nil {
+		if name := p.resolveUserName(entry.senderID); name != "" && name != entry.senderID {
+			return name
+		}
+	}
+	return entry.senderID
+}
+
+func (p *Platform) formatGroupHistory(ctx groupHistoryContext) string {
+	if len(ctx.entries) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	formatted := 0
+	for _, entry := range ctx.entries {
+		if entry.messageID != "" && p.isMessageRecalled(entry.messageID) {
+			continue
+		}
+		if formatted == 0 {
+			b.WriteString("--- Recent Feishu group messages (context only) ---\n")
+		}
+		name := strings.NewReplacer("\n", " ", "\r", "").Replace(p.historySenderName(entry))
+		fmt.Fprintf(&b, "%s:\n%s\n\n", name, entry.text)
+		formatted++
+	}
+	if formatted == 0 {
+		return ""
+	}
+	b.WriteString("---\n\n")
+	return b.String()
+}
+
+func joinFeishuExtraContent(parts ...string) string {
+	var nonEmpty []string
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			nonEmpty = append(nonEmpty, strings.TrimSpace(part))
+		}
+	}
+	return strings.Join(nonEmpty, "\n\n")
+}
+
+func (p *Platform) isGroupHistoryNewCommand(msgType, content string, mentions []*larkim.MentionEvent) bool {
+	if msgType != "text" {
+		return false
+	}
+	var textBody struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal([]byte(content), &textBody) != nil {
+		return false
+	}
+	text := strings.TrimSpace(stripMentions(textBody.Text, mentions, p.getBotOpenID()))
+	fields := strings.Fields(text)
+	return len(fields) > 0 && strings.EqualFold(fields[0], "/new")
+}
+
 func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
 	msg := event.Event.Message
 	sender := event.Event.Sender
@@ -1332,6 +1553,10 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 		chatID = *msg.ChatId
 	}
 	userID := userIDFromEvent(sender.SenderId)
+	senderType := ""
+	if sender.SenderType != nil {
+		senderType = *sender.SenderType
+	}
 	// userName and chatName are resolved in dispatchMessage to avoid blocking
 	// the SDK dispatcher goroutine with synchronous HTTP calls.
 
@@ -1382,12 +1607,36 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	// Pre-compute sessionKey so the @bot filter below can consult the active
 	// thread set; sessionKey is also used downstream for dispatch.
 	sessionKey := p.makeSessionKey(msg, chatID, userID)
+	botOpenID := ""
+	if chatType == "group" && !p.groupReplyAll {
+		botOpenID = p.getBotOpenID()
+	}
+	botMentioned := botOpenID != "" && isBotMentioned(msg.Mentions, botOpenID)
+	atEveryone := p.respondToAtEveryoneAndHere && msg.Content != nil && strings.Contains(*msg.Content, "@_all")
 
-	if chatType == "group" && !p.groupReplyAll && p.getBotOpenID() != "" {
-		if !isBotMentioned(msg.Mentions, p.getBotOpenID()) {
+	// With history sharing enabled, observe ordinary text/post messages only
+	// after the chat-level allow list has admitted the chat. Do this before the
+	// existing mention filter and before allow_from: the chat controls whether
+	// cc-connect may observe the conversation, while allow_from controls who may
+	// trigger an agent turn.
+	if p.groupChatHistoryShare && chatType == "group" && !p.groupReplyAll && botOpenID != "" &&
+		!botMentioned && !atEveryone && isGroupHistoryMessageType(msgType) {
+		if !core.AllowList(p.allowChat, chatID) {
+			slog.Debug(p.tag()+": group history ignored for unauthorized chat", "chat_id", chatID)
+			return nil
+		}
+		p.rememberGroupHistory(
+			p.groupHistoryScope(msg, chatID), messageID, msgType, stringValue(msg.Content), msg.Mentions,
+			userID, senderType,
+		)
+		return nil
+	}
+
+	if chatType == "group" && !p.groupReplyAll && botOpenID != "" {
+		if !botMentioned {
 			switch {
 			// Feishu @all sends {"text":"@_all"} with 0 mentions.
-			case p.respondToAtEveryoneAndHere && msg.Content != nil && strings.Contains(*msg.Content, "@_all"):
+			case atEveryone:
 				slog.Debug(p.tag()+": responding to @all message", "chat_id", chatID)
 			// Once a thread has been engaged via @bot, allow follow-up
 			// attachment-only messages (image/file/audio) in the same thread
@@ -1433,6 +1682,15 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	parentID := stringValue(msg.ParentId)
 
 	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+	var groupHistoryCtx groupHistoryContext
+	if p.groupChatHistoryShare && chatType == "group" && !p.groupReplyAll && botOpenID != "" && (botMentioned || atEveryone) {
+		scope := p.groupHistoryScope(msg, chatID)
+		if p.isGroupHistoryNewCommand(msgType, content, mentions) {
+			p.resetGroupHistory(scope)
+		} else {
+			groupHistoryCtx = p.snapshotGroupHistory(scope)
+		}
+	}
 	slog.Debug(p.tag()+": routed inbound message",
 		"message_id", messageID,
 		"session_key", sessionKey,
@@ -1452,7 +1710,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	// blocked by IO-heavy operations (image/audio download, handler HTTP calls).
 	// The dedup and old-message checks above remain synchronous to guarantee
 	// correctness before spawning the goroutine.
-	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID, createTimeMs)
+	go p.dispatchMessageWithHistory(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID, createTimeMs, groupHistoryCtx)
 
 	return nil
 }
@@ -1470,6 +1728,10 @@ func (p *Platform) replyUnauthorizedAccess(ctx context.Context, rctx replyContex
 // handler invocation. It runs in its own goroutine so that onMessage returns
 // quickly and does not block the SDK event loop.
 func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, chatID string, rctx replyContext, parentID string, createTimeMs int64) {
+	p.dispatchMessageWithHistory(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID, createTimeMs, groupHistoryContext{})
+}
+
+func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, chatID string, rctx replyContext, parentID string, createTimeMs int64, groupHistoryCtx groupHistoryContext) {
 	if p.isMessageRecalled(messageID) {
 		slog.Debug(p.tag()+": recalled message ignored in async dispatch", "message_id", messageID)
 		return
@@ -1494,6 +1756,14 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	if parentID != "" && (!p.threadIsolation || !isThreadSessionKey(sessionKey) || rctx.bootstrapThread) {
 		quoted = p.fetchQuotedMessage(ctx, parentID)
 	}
+	historyText := p.formatGroupHistory(groupHistoryCtx)
+	dispatchCore := func(msg *core.Message) {
+		if historyText != "" {
+			msg.ExtraContent = joinFeishuExtraContent(historyText, msg.ExtraContent)
+			msg.OnAccepted = groupHistoryCtx.onAccepted
+		}
+		p.dispatchCoreMessage(msg)
+	}
 
 	switch msgType {
 	case "text":
@@ -1513,7 +1783,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		// zero file-resource API calls.
 		approvedFileMetas := p.filterQuotedFilesForUser(quoted.files, mentions, userID)
 		quotedFiles := p.downloadQuotedFiles(ctx, approvedFileMetas)
-		if text == "" && quoted.text == "" && len(quoted.images) == 0 && len(quotedFiles) == 0 {
+		if text == "" && historyText == "" && quoted.text == "" && len(quoted.images) == 0 && len(quotedFiles) == 0 {
 			slog.Debug(p.tag()+": dropping empty text after mention stripping",
 				"message_id", messageID,
 				"raw_text_len", len(textBody.Text),
@@ -1525,7 +1795,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		// reaches the engine before the text message advances the user-message
 		// watermark (#1686 P1-B, related #1395).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1563,6 +1833,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 				userName:     userName,
 				chatName:     chatName,
 				rctx:         rctx,
+				quoted:       quotedMessage{text: historyText, images: quoted.images},
+				onAccepted:   groupHistoryCtx.onAccepted,
 				images:       []core.ImageAttachment{{MimeType: mimeType, Data: imgData}},
 				messageIDs:   []string{messageID},
 				createTimeMs: createTimeMs,
@@ -1570,7 +1842,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			})
 			return
 		}
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1603,7 +1875,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		// reaches the engine before this audio message advances the user-message
 		// watermark (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1620,12 +1892,12 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	case "post":
 		textParts, images := p.parsePostContent(messageID, content)
 		text := stripMentions(strings.Join(textParts, "\n"), mentions, p.getBotOpenID())
-		if text == "" && len(images) == 0 && quoted.text == "" && len(quoted.images) == 0 {
+		if text == "" && historyText == "" && len(images) == 0 && quoted.text == "" && len(quoted.images) == 0 {
 			return
 		}
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1656,7 +1928,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		mimeType := detectMimeType(fileData)
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1687,7 +1959,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			ReplyCtx:          rctx,
 			UserMessageTimeMs: createTimeMs,
 		}
-		p.dispatchCoreMessage(coreMsg)
+		dispatchCore(coreMsg)
 
 	case "sticker":
 		var stickerBody struct {
@@ -1703,7 +1975,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			slog.Warn(p.tag()+": download sticker failed, falling back to placeholder", "error", err)
 			// Flush any image batch buffered earlier in this session (#1686 P1-B).
 			p.flushImageBatchForSession(sessionKey)
-			p.dispatchCoreMessage(&core.Message{
+			dispatchCore(&core.Message{
 				SessionKey: sessionKey, Platform: p.platformName,
 				MessageID: messageID,
 				UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1714,7 +1986,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1753,7 +2025,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -2021,6 +2293,28 @@ type quotedMessage struct {
 	text   string
 	images []core.ImageAttachment
 	files  []quotedFileMeta
+}
+
+// maxPendingGroupHistoryEntries bounds the per-scope in-memory buffer. The
+// feature is intentionally a small recent-context window rather than a chat
+// history store.
+const maxPendingGroupHistoryEntries = 50
+
+type groupHistoryEntry struct {
+	id         uint64
+	messageID  string
+	senderID   string
+	senderType string
+	text       string
+}
+
+// groupHistoryContext is captured synchronously when a triggering event is
+// received, before its asynchronous dispatch can race with later events.
+// onAccepted consumes only that captured prefix once the core accepts a real
+// agent turn. Recognized slash commands return before OnAccepted is called.
+type groupHistoryContext struct {
+	entries    []groupHistoryEntry
+	onAccepted func()
 }
 
 // maxReplyChainDepth is the maximum number of parent messages to traverse

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -131,6 +131,7 @@ type Platform struct {
 	respondToAtEveryoneAndHere bool
 	shareSessionInChannel      bool
 	threadIsolation            bool
+	groupChatHistoryShare      bool
 	// noReplyToTrigger: when true, send via Create instead of Im.Message.Reply (no quote to the user's message).
 	noReplyToTrigger bool
 	resolveMentions  bool
@@ -150,18 +151,18 @@ type Platform struct {
 	// Issue #1618: previous behavior treated botOpenID=="" as "filter off", which
 	// silently turned the bot into a loud responder for the rest of the process
 	// lifetime when the bot-info API failed.
-	groupFilterDegraded     bool
-	groupFilterDegradedAt   time.Time
-	groupFilterDegradedErr  string
-	groupFilterRetryCancel  context.CancelFunc
-	groupFilterRetryStop    chan struct{}
-	peerBots                map[string]string // app_id -> friendly alias, for quoted-reply attribution
-	mentionMap       map[string]string // agent name -> open_id (for outbound @ resolution)
-	userNameCache    sync.Map          // open_id -> display name
-	chatNameCache    sync.Map          // chat_id -> chat name
-	chatMemberCache  sync.Map          // chatID -> *chatMemberEntry
-	recalledMu       sync.Mutex
-	recalledMsgIDs   map[string]time.Time // message_id -> recall time, short TTL race guard
+	groupFilterDegraded    bool
+	groupFilterDegradedAt  time.Time
+	groupFilterDegradedErr string
+	groupFilterRetryCancel context.CancelFunc
+	groupFilterRetryStop   chan struct{}
+	peerBots               map[string]string // app_id -> friendly alias, for quoted-reply attribution
+	mentionMap             map[string]string // agent name -> open_id (for outbound @ resolution)
+	userNameCache          sync.Map          // open_id -> display name
+	chatNameCache          sync.Map          // chat_id -> chat name
+	chatMemberCache        sync.Map          // chatID -> *chatMemberEntry
+	recalledMu             sync.Mutex
+	recalledMsgIDs         map[string]time.Time // message_id -> recall time, short TTL race guard
 	// Webhook mode fields (for Lark international version)
 	server       *http.Server
 	port         string
@@ -181,6 +182,14 @@ type Platform struct {
 	// without requiring another @bot mention. Value is the last-seen time so
 	// stale entries can be expired by a future TTL sweep if needed.
 	activeThreadSessions sync.Map // sessionKey -> time.Time
+
+	// pendingGroupHistory keeps text/post messages that were observed in an
+	// allowed group chat without an explicit bot trigger. It is deliberately
+	// platform-local and in-memory: the next accepted agent turn consumes the
+	// snapshot, while slash commands that are handled by core leave it intact.
+	groupHistoryMu      sync.Mutex
+	pendingGroupHistory map[string][]groupHistoryEntry
+	nextGroupHistoryID  uint64
 
 	richCardImageMu         sync.Mutex
 	richCardImageResolved   map[string]string
@@ -290,6 +299,7 @@ type imageBatchEntry struct {
 	chatName     string
 	rctx         replyContext
 	quoted       quotedMessage
+	onAccepted   func()
 	images       []core.ImageAttachment
 	messageIDs   []string
 	createTimeMs int64
@@ -357,6 +367,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	respondToAtEveryoneAndHere, _ := opts["respond_to_at_everyone_and_here"].(bool)
 	shareSessionInChannel, _ := opts["share_session_in_channel"].(bool)
 	threadIsolation, _ := opts["thread_isolation"].(bool)
+	groupChatHistoryShare, _ := opts["group_chat_history_share"].(bool)
 	resolveMentionsOpt, _ := opts["resolve_mentions"].(bool)
 	noReplyToTrigger := false
 	if v, ok := opts["reply_to_trigger"].(bool); ok && !v {
@@ -469,6 +480,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
 		shareSessionInChannel:      shareSessionInChannel,
 		threadIsolation:            threadIsolation,
+		groupChatHistoryShare:      groupChatHistoryShare,
 		resolveMentions:            resolveMentionsOpt,
 		noReplyToTrigger:           noReplyToTrigger,
 		client:                     lark.NewClient(appID, appSecret, clientOpts...),
@@ -1360,6 +1372,7 @@ func (p *Platform) dispatchImageBatchEntry(entry *imageBatchEntry) {
 		UserID:    entry.userID, UserName: entry.userName, ChatName: entry.chatName,
 		Content:           "",
 		ExtraContent:      entry.quoted.text,
+		OnAccepted:        entry.onAccepted,
 		Images:            append(entry.quoted.images, entry.images...),
 		ReplyCtx:          entry.rctx,
 		UserMessageTimeMs: entry.createTimeMs,
@@ -1383,6 +1396,7 @@ func (p *Platform) onMessageRecalled(_ context.Context, event *larkim.P2MessageR
 	}
 
 	p.markMessageRecalled(messageID)
+	p.removeGroupHistory(messageID)
 	slog.Info(p.tag()+": message recalled",
 		"message_id", messageID,
 		"chat_id", chatID,
@@ -1402,6 +1416,213 @@ func (p *Platform) onMessageRecalled(_ context.Context, event *larkim.P2MessageR
 	return nil
 }
 
+func isGroupHistoryMessageType(msgType string) bool {
+	return msgType == "text" || msgType == "post"
+}
+
+// groupHistoryScope deliberately differs from makeSessionKey. With
+// thread_isolation enabled, a main-channel mention creates a root-scoped
+// agent session, but later main-channel messages must remain in the chat-level
+// history rather than being attached to that forked session.
+func (p *Platform) groupHistoryScope(msg *larkim.EventMessage, chatID string) string {
+	if chatID == "" {
+		return ""
+	}
+	if p.threadIsolation && msg != nil && stringValue(msg.ChatType) == "group" {
+		if rootID := stringValue(msg.RootId); rootID != "" {
+			return "thread:" + chatID + ":" + rootID
+		}
+	}
+	return "chat:" + chatID
+}
+
+func (p *Platform) historyText(msgType, content string, mentions []*larkim.MentionEvent) string {
+	if content == "" {
+		return ""
+	}
+	switch msgType {
+	case "text":
+		var textBody struct {
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal([]byte(content), &textBody); err != nil {
+			return ""
+		}
+		return stripMentions(textBody.Text, mentions, p.getBotOpenID())
+	case "post":
+		return strings.TrimSpace(extractPostPlainText(content))
+	default:
+		return ""
+	}
+}
+
+func (p *Platform) rememberGroupHistory(scope, messageID, msgType, content string, mentions []*larkim.MentionEvent, senderID, senderType string) {
+	if !p.groupChatHistoryShare || scope == "" || !isGroupHistoryMessageType(msgType) {
+		return
+	}
+	text := p.historyText(msgType, content, mentions)
+	if text == "" {
+		return
+	}
+
+	p.groupHistoryMu.Lock()
+	defer p.groupHistoryMu.Unlock()
+	p.nextGroupHistoryID++
+	entry := groupHistoryEntry{
+		id:         p.nextGroupHistoryID,
+		messageID:  messageID,
+		senderID:   senderID,
+		senderType: senderType,
+		text:       text,
+	}
+	history := append(p.pendingGroupHistory[scope], entry)
+	if len(history) > maxPendingGroupHistoryEntries {
+		history = history[len(history)-maxPendingGroupHistoryEntries:]
+	}
+	if p.pendingGroupHistory == nil {
+		p.pendingGroupHistory = make(map[string][]groupHistoryEntry)
+	}
+	p.pendingGroupHistory[scope] = history
+}
+
+func (p *Platform) removeGroupHistory(messageID string) {
+	if messageID == "" {
+		return
+	}
+	p.groupHistoryMu.Lock()
+	defer p.groupHistoryMu.Unlock()
+	for scope, history := range p.pendingGroupHistory {
+		kept := history[:0]
+		for _, entry := range history {
+			if entry.messageID != messageID {
+				kept = append(kept, entry)
+			}
+		}
+		if len(kept) == 0 {
+			delete(p.pendingGroupHistory, scope)
+		} else {
+			p.pendingGroupHistory[scope] = kept
+		}
+	}
+}
+
+func (p *Platform) snapshotGroupHistory(scope string) groupHistoryContext {
+	if !p.groupChatHistoryShare || scope == "" {
+		return groupHistoryContext{}
+	}
+
+	p.groupHistoryMu.Lock()
+	history := append([]groupHistoryEntry(nil), p.pendingGroupHistory[scope]...)
+	p.groupHistoryMu.Unlock()
+	if len(history) == 0 {
+		return groupHistoryContext{}
+	}
+
+	maxID := history[len(history)-1].id
+	var once sync.Once
+	return groupHistoryContext{
+		entries: history,
+		onAccepted: func() {
+			once.Do(func() { p.consumeGroupHistory(scope, maxID) })
+		},
+	}
+}
+
+func (p *Platform) consumeGroupHistory(scope string, maxID uint64) {
+	p.groupHistoryMu.Lock()
+	defer p.groupHistoryMu.Unlock()
+	history := p.pendingGroupHistory[scope]
+	kept := history[:0]
+	for _, entry := range history {
+		if entry.id > maxID {
+			kept = append(kept, entry)
+		}
+	}
+	if len(kept) == 0 {
+		delete(p.pendingGroupHistory, scope)
+		return
+	}
+	p.pendingGroupHistory[scope] = kept
+}
+
+func (p *Platform) resetGroupHistory(scope string) {
+	if scope == "" {
+		return
+	}
+	p.groupHistoryMu.Lock()
+	delete(p.pendingGroupHistory, scope)
+	p.groupHistoryMu.Unlock()
+}
+
+func (p *Platform) historySenderName(entry groupHistoryEntry) string {
+	if strings.EqualFold(entry.senderType, "app") {
+		return p.resolveBotSenderName(entry.senderID)
+	}
+	if entry.senderID == "" {
+		return "User"
+	}
+	if cached, ok := p.userNameCache.Load(entry.senderID); ok {
+		if name, ok := cached.(string); ok && name != "" {
+			return name
+		}
+	}
+	if p.client != nil {
+		if name := p.resolveUserName(entry.senderID); name != "" && name != entry.senderID {
+			return name
+		}
+	}
+	return entry.senderID
+}
+
+func (p *Platform) formatGroupHistory(ctx groupHistoryContext) string {
+	if len(ctx.entries) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	formatted := 0
+	for _, entry := range ctx.entries {
+		if entry.messageID != "" && p.isMessageRecalled(entry.messageID) {
+			continue
+		}
+		if formatted == 0 {
+			b.WriteString("--- Recent Feishu group messages (context only) ---\n")
+		}
+		name := strings.NewReplacer("\n", " ", "\r", "").Replace(p.historySenderName(entry))
+		fmt.Fprintf(&b, "%s:\n%s\n\n", name, entry.text)
+		formatted++
+	}
+	if formatted == 0 {
+		return ""
+	}
+	b.WriteString("---\n\n")
+	return b.String()
+}
+
+func joinFeishuExtraContent(parts ...string) string {
+	var nonEmpty []string
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			nonEmpty = append(nonEmpty, strings.TrimSpace(part))
+		}
+	}
+	return strings.Join(nonEmpty, "\n\n")
+}
+
+func (p *Platform) isGroupHistoryNewCommand(msgType, content string, mentions []*larkim.MentionEvent) bool {
+	if msgType != "text" {
+		return false
+	}
+	var textBody struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal([]byte(content), &textBody) != nil {
+		return false
+	}
+	text := strings.TrimSpace(stripMentions(textBody.Text, mentions, p.getBotOpenID()))
+	fields := strings.Fields(text)
+	return len(fields) > 0 && strings.EqualFold(fields[0], "/new")
+}
+
 func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
 	msg := event.Event.Message
 	sender := event.Event.Sender
@@ -1416,6 +1637,10 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 		chatID = *msg.ChatId
 	}
 	userID := userIDFromEvent(sender.SenderId)
+	senderType := ""
+	if sender.SenderType != nil {
+		senderType = *sender.SenderType
+	}
 	// userName and chatName are resolved in dispatchMessage to avoid blocking
 	// the SDK dispatcher goroutine with synchronous HTTP calls.
 
@@ -1466,6 +1691,28 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	// Pre-compute sessionKey so the @bot filter below can consult the active
 	// thread set; sessionKey is also used downstream for dispatch.
 	sessionKey := p.makeSessionKey(msg, chatID, userID)
+	botOpenID := p.getBotOpenID()
+	filterActive := botOpenID != "" || p.IsGroupFilterDegraded()
+	botMentioned := botOpenID != "" && isBotMentioned(msg.Mentions, botOpenID)
+	atEveryone := p.respondToAtEveryoneAndHere && msg.Content != nil && strings.Contains(*msg.Content, "@_all")
+
+	// With history sharing enabled, observe ordinary text/post messages only
+	// after the chat-level allow list has admitted the chat. Do this before the
+	// existing mention filter and before allow_from: the chat controls whether
+	// cc-connect may observe the conversation, while allow_from controls who may
+	// trigger an agent turn.
+	if p.groupChatHistoryShare && chatType == "group" && !p.groupReplyAll && botOpenID != "" &&
+		!botMentioned && !atEveryone && isGroupHistoryMessageType(msgType) {
+		if !core.AllowList(p.allowChat, chatID) {
+			slog.Debug(p.tag()+": group history ignored for unauthorized chat", "chat_id", chatID)
+			return nil
+		}
+		p.rememberGroupHistory(
+			p.groupHistoryScope(msg, chatID), messageID, msgType, stringValue(msg.Content), msg.Mentions,
+			userID, senderType,
+		)
+		return nil
+	}
 
 	// Issue #1618: the mention filter used to gate on `botOpenID != ""`,
 	// which silently *disabled* filtering when bot discovery had failed
@@ -1473,13 +1720,11 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	// rest of the process lifetime. We now consult both flags: when
 	// the filter is degraded we fail closed (drop the message) and
 	// emit a periodic warning, instead of failing open.
-	botOpenID := p.getBotOpenID()
-	filterActive := botOpenID != "" || p.IsGroupFilterDegraded()
 	if chatType == "group" && !p.groupReplyAll && filterActive {
-		if !isBotMentioned(msg.Mentions, botOpenID) {
+		if !botMentioned {
 			switch {
 			// Feishu @all sends {"text":"@_all"} with 0 mentions.
-			case p.respondToAtEveryoneAndHere && msg.Content != nil && strings.Contains(*msg.Content, "@_all"):
+			case atEveryone:
 				slog.Debug(p.tag()+": responding to @all message", "chat_id", chatID)
 			// Once a thread has been engaged via @bot, allow follow-up
 			// attachment-only messages (image/file/audio) in the same thread
@@ -1536,6 +1781,15 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	parentID := stringValue(msg.ParentId)
 
 	rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+	var groupHistoryCtx groupHistoryContext
+	if p.groupChatHistoryShare && chatType == "group" && !p.groupReplyAll && botOpenID != "" && (botMentioned || atEveryone) {
+		scope := p.groupHistoryScope(msg, chatID)
+		if p.isGroupHistoryNewCommand(msgType, content, mentions) {
+			p.resetGroupHistory(scope)
+		} else {
+			groupHistoryCtx = p.snapshotGroupHistory(scope)
+		}
+	}
 	slog.Debug(p.tag()+": routed inbound message",
 		"message_id", messageID,
 		"session_key", sessionKey,
@@ -1555,7 +1809,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 	// blocked by IO-heavy operations (image/audio download, handler HTTP calls).
 	// The dedup and old-message checks above remain synchronous to guarantee
 	// correctness before spawning the goroutine.
-	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID, createTimeMs)
+	go p.dispatchMessageWithHistory(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID, createTimeMs, groupHistoryCtx)
 
 	return nil
 }
@@ -1573,6 +1827,10 @@ func (p *Platform) replyUnauthorizedAccess(ctx context.Context, rctx replyContex
 // handler invocation. It runs in its own goroutine so that onMessage returns
 // quickly and does not block the SDK event loop.
 func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, chatID string, rctx replyContext, parentID string, createTimeMs int64) {
+	p.dispatchMessageWithHistory(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID, createTimeMs, groupHistoryContext{})
+}
+
+func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, content string, mentions []*larkim.MentionEvent, messageID, sessionKey, userID, chatID string, rctx replyContext, parentID string, createTimeMs int64, groupHistoryCtx groupHistoryContext) {
 	if p.isMessageRecalled(messageID) {
 		slog.Debug(p.tag()+": recalled message ignored in async dispatch", "message_id", messageID)
 		return
@@ -1597,6 +1855,14 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	if parentID != "" && (!p.threadIsolation || !isThreadSessionKey(sessionKey) || rctx.bootstrapThread) {
 		quoted = p.fetchQuotedMessage(ctx, parentID)
 	}
+	historyText := p.formatGroupHistory(groupHistoryCtx)
+	dispatchCore := func(msg *core.Message) {
+		if historyText != "" {
+			msg.ExtraContent = joinFeishuExtraContent(historyText, msg.ExtraContent)
+			msg.OnAccepted = groupHistoryCtx.onAccepted
+		}
+		p.dispatchCoreMessage(msg)
+	}
 
 	switch msgType {
 	case "text":
@@ -1616,7 +1882,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		// zero file-resource API calls.
 		approvedFileMetas := p.filterQuotedFilesForUser(quoted.files, mentions, userID)
 		quotedFiles := p.downloadQuotedFiles(ctx, approvedFileMetas)
-		if text == "" && quoted.text == "" && len(quoted.images) == 0 && len(quotedFiles) == 0 {
+		if text == "" && historyText == "" && quoted.text == "" && len(quoted.images) == 0 && len(quotedFiles) == 0 {
 			slog.Debug(p.tag()+": dropping empty text after mention stripping",
 				"message_id", messageID,
 				"raw_text_len", len(textBody.Text),
@@ -1628,7 +1894,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		// reaches the engine before the text message advances the user-message
 		// watermark (#1686 P1-B, related #1395).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1666,6 +1932,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 				userName:     userName,
 				chatName:     chatName,
 				rctx:         rctx,
+				quoted:       quotedMessage{text: historyText, images: quoted.images},
+				onAccepted:   groupHistoryCtx.onAccepted,
 				images:       []core.ImageAttachment{{MimeType: mimeType, Data: imgData}},
 				messageIDs:   []string{messageID},
 				createTimeMs: createTimeMs,
@@ -1673,7 +1941,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			})
 			return
 		}
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1706,7 +1974,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		// reaches the engine before this audio message advances the user-message
 		// watermark (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1723,12 +1991,12 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	case "post":
 		textParts, images := p.parsePostContent(messageID, content)
 		text := stripMentions(strings.Join(textParts, "\n"), mentions, p.getBotOpenID())
-		if text == "" && len(images) == 0 && quoted.text == "" && len(quoted.images) == 0 {
+		if text == "" && historyText == "" && len(images) == 0 && quoted.text == "" && len(quoted.images) == 0 {
 			return
 		}
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1759,7 +2027,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		mimeType := detectMimeType(fileData)
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1790,7 +2058,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			ReplyCtx:          rctx,
 			UserMessageTimeMs: createTimeMs,
 		}
-		p.dispatchCoreMessage(coreMsg)
+		dispatchCore(coreMsg)
 
 	case "sticker":
 		var stickerBody struct {
@@ -1806,7 +2074,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			slog.Warn(p.tag()+": download sticker failed, falling back to placeholder", "error", err)
 			// Flush any image batch buffered earlier in this session (#1686 P1-B).
 			p.flushImageBatchForSession(sessionKey)
-			p.dispatchCoreMessage(&core.Message{
+			dispatchCore(&core.Message{
 				SessionKey: sessionKey, Platform: p.platformName,
 				MessageID: messageID,
 				UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1817,7 +2085,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -1856,7 +2124,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		}
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
 		p.flushImageBatchForSession(sessionKey)
-		p.dispatchCoreMessage(&core.Message{
+		dispatchCore(&core.Message{
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
@@ -2124,6 +2392,28 @@ type quotedMessage struct {
 	text   string
 	images []core.ImageAttachment
 	files  []quotedFileMeta
+}
+
+// maxPendingGroupHistoryEntries bounds the per-scope in-memory buffer. The
+// feature is intentionally a small recent-context window rather than a chat
+// history store.
+const maxPendingGroupHistoryEntries = 50
+
+type groupHistoryEntry struct {
+	id         uint64
+	messageID  string
+	senderID   string
+	senderType string
+	text       string
+}
+
+// groupHistoryContext is captured synchronously when a triggering event is
+// received, before its asynchronous dispatch can race with later events.
+// onAccepted consumes only that captured prefix once the core accepts a real
+// agent turn. Recognized slash commands return before OnAccepted is called.
+type groupHistoryContext struct {
+	entries    []groupHistoryEntry
+	onAccepted func()
 }
 
 // maxReplyChainDepth is the maximum number of parent messages to traverse

--- a/platform/feishu/group_history_test.go
+++ b/platform/feishu/group_history_test.go
@@ -1,0 +1,323 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+func newGroupHistoryTestPlatform(handler core.MessageHandler) *Platform {
+	p := &Platform{
+		platformName:          "feishu",
+		botOpenID:             "ou_bot",
+		groupChatHistoryShare: true,
+		dedup:                 &core.MessageDedup{},
+		handler:               handler,
+	}
+	for id, name := range map[string]string{
+		"ou_alice": "Alice",
+		"ou_bob":   "Bob",
+		"ou_john":  "John",
+		"ou_other": "Other",
+	} {
+		p.userNameCache.Store(id, name)
+	}
+	p.chatNameCache.Store("oc_main", "Main group")
+	p.chatNameCache.Store("oc_allowed", "Allowed group")
+	p.chatNameCache.Store("oc_forbidden", "Forbidden group")
+	return p
+}
+
+func makeGroupHistoryEvent(t *testing.T, messageID, userID, msgType, rawContent, chatID, rootID string, mentioned bool) *larkim.P2MessageReceiveV1 {
+	t.Helper()
+	chatType := "group"
+	senderType := "user"
+	content := rawContent
+	mentions := []*larkim.MentionEvent(nil)
+	if mentioned {
+		if msgType != "text" {
+			t.Fatalf("mentioned test event must be text, got %q", msgType)
+		}
+		var body struct {
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal([]byte(rawContent), &body); err != nil {
+			t.Fatalf("decode text content: %v", err)
+		}
+		body.Text = "@_bot " + body.Text
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("encode text content: %v", err)
+		}
+		content = string(encoded)
+		mentions = []*larkim.MentionEvent{{
+			Key:  stringPtr("@_bot"),
+			Id:   &larkim.UserId{OpenId: stringPtr("ou_bot")},
+			Name: stringPtr("cc-connect"),
+		}}
+	}
+	// The event API uses Unix milliseconds as a decimal string. Keep each test
+	// event current so the restart-age guard does not discard it.
+	createTime := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	return &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: stringPtr(userID)},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   stringPtr(messageID),
+				RootId:      optionalString(rootID),
+				ChatId:      stringPtr(chatID),
+				ChatType:    &chatType,
+				MessageType: stringPtr(msgType),
+				Content:     stringPtr(content),
+				Mentions:    mentions,
+				CreateTime:  &createTime,
+			},
+		},
+	}
+}
+
+func optionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return stringPtr(value)
+}
+
+func sendGroupHistoryText(t *testing.T, p *Platform, messageID, userID, text, chatID, rootID string, mentioned bool) {
+	t.Helper()
+	content, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		t.Fatalf("marshal text: %v", err)
+	}
+	if err := p.onMessage(context.Background(), makeGroupHistoryEvent(t, messageID, userID, "text", string(content), chatID, rootID, mentioned)); err != nil {
+		t.Fatalf("onMessage(%s): %v", messageID, err)
+	}
+}
+
+func sendGroupHistoryPost(t *testing.T, p *Platform, messageID, userID, text, chatID, rootID string) {
+	t.Helper()
+	content := `{"content":[[{"tag":"text","text":"` + text + `"}]]}`
+	if err := p.onMessage(context.Background(), makeGroupHistoryEvent(t, messageID, userID, "post", content, chatID, rootID, false)); err != nil {
+		t.Fatalf("onMessage(%s): %v", messageID, err)
+	}
+}
+
+func awaitGroupHistoryMessage(t *testing.T, messages <-chan *core.Message) *core.Message {
+	t.Helper()
+	select {
+	case msg := <-messages:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Feishu handler message")
+		return nil
+	}
+}
+
+func assertNoGroupHistoryMessage(t *testing.T, messages <-chan *core.Message) {
+	t.Helper()
+	select {
+	case msg := <-messages:
+		t.Fatalf("unexpected handler message: %#v", msg)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestFeishuGroupHistory_DisabledPreservesMentionFilter(t *testing.T) {
+	messages := make(chan *core.Message, 1)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+	p.groupChatHistoryShare = false
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "ordinary context", "oc_main", "", false)
+	assertNoGroupHistoryMessage(t, messages)
+}
+
+func TestFeishuGroupHistory_ConfigDefaultsOffAndCanBeEnabled(t *testing.T) {
+	defaultPlatform, err := New(map[string]any{"app_id": "cli_history_default", "app_secret": "secret"})
+	if err != nil {
+		t.Fatalf("New(default) error: %v", err)
+	}
+	if base := extractBasePlatform(defaultPlatform); base.groupChatHistoryShare {
+		t.Fatal("group_chat_history_share should default to false")
+	}
+
+	enabledPlatform, err := New(map[string]any{
+		"app_id":                   "cli_history_enabled",
+		"app_secret":               "secret",
+		"group_chat_history_share": true,
+	})
+	if err != nil {
+		t.Fatalf("New(enabled) error: %v", err)
+	}
+	if base := extractBasePlatform(enabledPlatform); !base.groupChatHistoryShare {
+		t.Fatal("group_chat_history_share=true was not applied")
+	}
+}
+
+func TestFeishuGroupHistory_MainChannelSharesOrderedMessagesAndConsumesOnce(t *testing.T) {
+	messages := make(chan *core.Message, 4)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "I think the return data is wrong", "oc_main", "", false)
+	sendGroupHistoryPost(t, p, "m2", "ou_bob", "Web store looks especially strange", "oc_main", "")
+	sendGroupHistoryText(t, p, "m3", "ou_alice", "SU may have the same issue", "oc_main", "", false)
+	assertNoGroupHistoryMessage(t, messages)
+
+	sendGroupHistoryText(t, p, "m4", "ou_john", "check this", "oc_main", "", true)
+	first := awaitGroupHistoryMessage(t, messages)
+	if first.Content != "check this" {
+		t.Fatalf("trigger content = %q, want check this", first.Content)
+	}
+	for _, want := range []string{"Alice:\nI think the return data is wrong", "Bob:\nWeb store looks especially strange", "Alice:\nSU may have the same issue"} {
+		if !strings.Contains(first.ExtraContent, want) {
+			t.Fatalf("history missing %q: %q", want, first.ExtraContent)
+		}
+	}
+	if strings.Index(first.ExtraContent, "Alice:\nI think") > strings.Index(first.ExtraContent, "Bob:\nWeb") {
+		t.Fatalf("history order was not preserved: %q", first.ExtraContent)
+	}
+	if first.OnAccepted == nil {
+		t.Fatal("trigger should have a delayed history-consumption callback")
+	}
+	first.OnAccepted()
+
+	sendGroupHistoryText(t, p, "m5", "ou_john", "nothing old should repeat", "oc_main", "", true)
+	second := awaitGroupHistoryMessage(t, messages)
+	if second.ExtraContent != "" {
+		t.Fatalf("consumed history repeated: %q", second.ExtraContent)
+	}
+}
+
+func TestFeishuGroupHistory_StatusDoesNotConsumePendingContext(t *testing.T) {
+	messages := make(chan *core.Message, 2)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "keep this for the next real turn", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "m2", "ou_john", "/status", "oc_main", "", true)
+	status := awaitGroupHistoryMessage(t, messages)
+	if status.Content != "/status" || !strings.Contains(status.ExtraContent, "keep this for the next real turn") {
+		t.Fatalf("status message lost pending context: content=%q extra=%q", status.Content, status.ExtraContent)
+	}
+	if status.OnAccepted == nil {
+		t.Fatal("status snapshot should retain a consumption callback for a later real turn")
+	}
+
+	sendGroupHistoryText(t, p, "m3", "ou_john", "real turn", "oc_main", "", true)
+	realTurn := awaitGroupHistoryMessage(t, messages)
+	if !strings.Contains(realTurn.ExtraContent, "keep this for the next real turn") {
+		t.Fatalf("pending context was consumed by /status: %q", realTurn.ExtraContent)
+	}
+	realTurn.OnAccepted()
+}
+
+func TestFeishuGroupHistory_NewResetsPendingContext(t *testing.T) {
+	messages := make(chan *core.Message, 2)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "old context", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "m2", "ou_john", "/new", "oc_main", "", true)
+	newMessage := awaitGroupHistoryMessage(t, messages)
+	if newMessage.ExtraContent != "" {
+		t.Fatalf("/new received stale context: %q", newMessage.ExtraContent)
+	}
+
+	sendGroupHistoryText(t, p, "m3", "ou_bob", "new context", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "m4", "ou_john", "continue", "oc_main", "", true)
+	continueMessage := awaitGroupHistoryMessage(t, messages)
+	if strings.Contains(continueMessage.ExtraContent, "old context") || !strings.Contains(continueMessage.ExtraContent, "new context") {
+		t.Fatalf("/new did not reset the main history scope: %q", continueMessage.ExtraContent)
+	}
+}
+
+func TestFeishuGroupHistory_ThreadScopesDoNotLeakAndMainDoesNotFollowFork(t *testing.T) {
+	messages := make(chan *core.Message, 8)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+	p.threadIsolation = true
+
+	// A main-channel mention forks an agent session, but does not become
+	// pending history for the next main-channel mention.
+	sendGroupHistoryText(t, p, "main-trigger-a", "ou_john", "task A", "oc_main", "", true)
+	mainA := awaitGroupHistoryMessage(t, messages)
+	if mainA.ExtraContent != "" {
+		t.Fatalf("first main trigger unexpectedly had context: %q", mainA.ExtraContent)
+	}
+	sendGroupHistoryText(t, p, "main-context-1", "ou_alice", "context B1", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "main-context-2", "ou_bob", "context B2", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "main-trigger-b", "ou_john", "task B", "oc_main", "", true)
+	mainB := awaitGroupHistoryMessage(t, messages)
+	if !strings.Contains(mainB.ExtraContent, "context B1") || !strings.Contains(mainB.ExtraContent, "context B2") || strings.Contains(mainB.ExtraContent, "task A") {
+		t.Fatalf("main-channel history attached to the forked session: %q", mainB.ExtraContent)
+	}
+	mainB.OnAccepted()
+
+	// Thread roots each have an independent pending queue.
+	// Upstream bootstraps a pre-existing thread's reply chain on first
+	// engagement. Mark these synthetic threads active so this scope test does
+	// not require a Feishu API client; bootstrap behavior has dedicated tests.
+	p.markThreadSessionActive("feishu:oc_main:root:root-a")
+	p.markThreadSessionActive("feishu:oc_main:root:root-b")
+	sendGroupHistoryText(t, p, "thread-a-context", "ou_alice", "thread A context", "oc_main", "root-a", false)
+	sendGroupHistoryText(t, p, "thread-b-context", "ou_bob", "thread B context", "oc_main", "root-b", false)
+	sendGroupHistoryText(t, p, "thread-a-trigger", "ou_john", "continue A", "oc_main", "root-a", true)
+	threadA := awaitGroupHistoryMessage(t, messages)
+	if !strings.Contains(threadA.ExtraContent, "thread A context") || strings.Contains(threadA.ExtraContent, "thread B context") {
+		t.Fatalf("thread A received leaked history: %q", threadA.ExtraContent)
+	}
+	threadA.OnAccepted()
+
+	sendGroupHistoryText(t, p, "thread-b-trigger", "ou_john", "continue B", "oc_main", "root-b", true)
+	threadB := awaitGroupHistoryMessage(t, messages)
+	if !strings.Contains(threadB.ExtraContent, "thread B context") || strings.Contains(threadB.ExtraContent, "thread A context") {
+		t.Fatalf("thread B received leaked history: %q", threadB.ExtraContent)
+	}
+}
+
+func TestFeishuGroupHistory_PostAndSenderTypeFormatting(t *testing.T) {
+	p := newGroupHistoryTestPlatform(nil)
+	p.peerBots = map[string]string{"cli_peer": "PeerBot"}
+	p.rememberGroupHistory("chat:oc_main", "post-1", "post", `{"title":"Topic","content":[[{"tag":"text","text":"post body"}]]}`, nil, "ou_alice", "user")
+	p.rememberGroupHistory("chat:oc_main", "text-1", "text", `{"text":"bot observation"}`, nil, "cli_peer", "app")
+	ctx := p.snapshotGroupHistory("chat:oc_main")
+	formatted := p.formatGroupHistory(ctx)
+	if !strings.Contains(formatted, "Alice:\nTopic\npost body") {
+		t.Fatalf("post history was not formatted with sender name: %q", formatted)
+	}
+	if !strings.Contains(formatted, "PeerBot:\nbot observation") {
+		t.Fatalf("app sender was not resolved: %q", formatted)
+	}
+}
+
+func TestFeishuGroupHistory_ChatAndTriggerPermissionsRemainSeparate(t *testing.T) {
+	messages := make(chan *core.Message, 1)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+	p.allowChat = "oc_allowed"
+	p.allowFrom = "ou_john"
+
+	sendGroupHistoryText(t, p, "forbidden-context", "ou_alice", "must not be observed", "oc_forbidden", "", false)
+	sendGroupHistoryText(t, p, "allowed-context", "ou_alice", "allowed chat context", "oc_allowed", "", false)
+	sendGroupHistoryText(t, p, "allowed-trigger", "ou_john", "use context", "oc_allowed", "", true)
+	msg := awaitGroupHistoryMessage(t, messages)
+	if strings.Contains(msg.ExtraContent, "must not be observed") || !strings.Contains(msg.ExtraContent, "allowed chat context") {
+		t.Fatalf("chat permission boundary was not respected: %q", msg.ExtraContent)
+	}
+}
+
+func TestFeishuGroupHistory_GroupReplyAllRemainsImmediate(t *testing.T) {
+	messages := make(chan *core.Message, 1)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+	p.groupReplyAll = true
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "reply immediately", "oc_main", "", false)
+	msg := awaitGroupHistoryMessage(t, messages)
+	if msg.Content != "reply immediately" || msg.ExtraContent != "" {
+		t.Fatalf("group_reply_all behavior changed: content=%q extra=%q", msg.Content, msg.ExtraContent)
+	}
+}

--- a/platform/feishu/group_history_test.go
+++ b/platform/feishu/group_history_test.go
@@ -1,0 +1,336 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+func newGroupHistoryTestPlatform(handler core.MessageHandler) *Platform {
+	p := &Platform{
+		platformName:          "feishu",
+		botOpenID:             "ou_bot",
+		groupChatHistoryShare: true,
+		dedup:                 &core.MessageDedup{},
+		handler:               handler,
+	}
+	for id, name := range map[string]string{
+		"ou_alice": "Alice",
+		"ou_bob":   "Bob",
+		"ou_john":  "John",
+		"ou_other": "Other",
+	} {
+		p.userNameCache.Store(id, name)
+	}
+	p.chatNameCache.Store("oc_main", "Main group")
+	p.chatNameCache.Store("oc_allowed", "Allowed group")
+	p.chatNameCache.Store("oc_forbidden", "Forbidden group")
+	return p
+}
+
+func makeGroupHistoryEvent(t *testing.T, messageID, userID, msgType, rawContent, chatID, rootID string, mentioned bool) *larkim.P2MessageReceiveV1 {
+	t.Helper()
+	chatType := "group"
+	senderType := "user"
+	content := rawContent
+	mentions := []*larkim.MentionEvent(nil)
+	if mentioned {
+		if msgType != "text" {
+			t.Fatalf("mentioned test event must be text, got %q", msgType)
+		}
+		var body struct {
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal([]byte(rawContent), &body); err != nil {
+			t.Fatalf("decode text content: %v", err)
+		}
+		body.Text = "@_bot " + body.Text
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("encode text content: %v", err)
+		}
+		content = string(encoded)
+		mentions = []*larkim.MentionEvent{{
+			Key:  stringPtr("@_bot"),
+			Id:   &larkim.UserId{OpenId: stringPtr("ou_bot")},
+			Name: stringPtr("cc-connect"),
+		}}
+	}
+	// The event API uses Unix milliseconds as a decimal string. Keep each test
+	// event current so the restart-age guard does not discard it.
+	createTime := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	return &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId:   &larkim.UserId{OpenId: stringPtr(userID)},
+				SenderType: &senderType,
+			},
+			Message: &larkim.EventMessage{
+				MessageId:   stringPtr(messageID),
+				RootId:      optionalString(rootID),
+				ChatId:      stringPtr(chatID),
+				ChatType:    &chatType,
+				MessageType: stringPtr(msgType),
+				Content:     stringPtr(content),
+				Mentions:    mentions,
+				CreateTime:  &createTime,
+			},
+		},
+	}
+}
+
+func optionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return stringPtr(value)
+}
+
+func sendGroupHistoryText(t *testing.T, p *Platform, messageID, userID, text, chatID, rootID string, mentioned bool) {
+	t.Helper()
+	content, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		t.Fatalf("marshal text: %v", err)
+	}
+	if err := p.onMessage(context.Background(), makeGroupHistoryEvent(t, messageID, userID, "text", string(content), chatID, rootID, mentioned)); err != nil {
+		t.Fatalf("onMessage(%s): %v", messageID, err)
+	}
+}
+
+func sendGroupHistoryPost(t *testing.T, p *Platform, messageID, userID, text, chatID, rootID string) {
+	t.Helper()
+	content := `{"content":[[{"tag":"text","text":"` + text + `"}]]}`
+	if err := p.onMessage(context.Background(), makeGroupHistoryEvent(t, messageID, userID, "post", content, chatID, rootID, false)); err != nil {
+		t.Fatalf("onMessage(%s): %v", messageID, err)
+	}
+}
+
+func awaitGroupHistoryMessage(t *testing.T, messages <-chan *core.Message) *core.Message {
+	t.Helper()
+	select {
+	case msg := <-messages:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Feishu handler message")
+		return nil
+	}
+}
+
+func assertNoGroupHistoryMessage(t *testing.T, messages <-chan *core.Message) {
+	t.Helper()
+	select {
+	case msg := <-messages:
+		t.Fatalf("unexpected handler message: %#v", msg)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestFeishuGroupHistory_DisabledPreservesMentionFilter(t *testing.T) {
+	messages := make(chan *core.Message, 1)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+	p.groupChatHistoryShare = false
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "ordinary context", "oc_main", "", false)
+	assertNoGroupHistoryMessage(t, messages)
+}
+
+func TestFeishuGroupHistory_DegradedMentionFilterDoesNotCapture(t *testing.T) {
+	messages := make(chan *core.Message, 1)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+	p.botOpenID = ""
+	p.groupFilterDegraded = true
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "must not be captured", "oc_main", "", false)
+	assertNoGroupHistoryMessage(t, messages)
+	if history := p.snapshotGroupHistory("chat:oc_main"); len(history.entries) != 0 {
+		t.Fatalf("degraded mention filtering captured group history: %#v", history.entries)
+	}
+}
+
+func TestFeishuGroupHistory_ConfigDefaultsOffAndCanBeEnabled(t *testing.T) {
+	defaultPlatform, err := New(map[string]any{"app_id": "cli_history_default", "app_secret": "secret"})
+	if err != nil {
+		t.Fatalf("New(default) error: %v", err)
+	}
+	if base := extractBasePlatform(defaultPlatform); base.groupChatHistoryShare {
+		t.Fatal("group_chat_history_share should default to false")
+	}
+
+	enabledPlatform, err := New(map[string]any{
+		"app_id":                   "cli_history_enabled",
+		"app_secret":               "secret",
+		"group_chat_history_share": true,
+	})
+	if err != nil {
+		t.Fatalf("New(enabled) error: %v", err)
+	}
+	if base := extractBasePlatform(enabledPlatform); !base.groupChatHistoryShare {
+		t.Fatal("group_chat_history_share=true was not applied")
+	}
+}
+
+func TestFeishuGroupHistory_MainChannelSharesOrderedMessagesAndConsumesOnce(t *testing.T) {
+	messages := make(chan *core.Message, 4)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "I think the return data is wrong", "oc_main", "", false)
+	sendGroupHistoryPost(t, p, "m2", "ou_bob", "Web store looks especially strange", "oc_main", "")
+	sendGroupHistoryText(t, p, "m3", "ou_alice", "SU may have the same issue", "oc_main", "", false)
+	assertNoGroupHistoryMessage(t, messages)
+
+	sendGroupHistoryText(t, p, "m4", "ou_john", "check this", "oc_main", "", true)
+	first := awaitGroupHistoryMessage(t, messages)
+	if first.Content != "check this" {
+		t.Fatalf("trigger content = %q, want check this", first.Content)
+	}
+	for _, want := range []string{"Alice:\nI think the return data is wrong", "Bob:\nWeb store looks especially strange", "Alice:\nSU may have the same issue"} {
+		if !strings.Contains(first.ExtraContent, want) {
+			t.Fatalf("history missing %q: %q", want, first.ExtraContent)
+		}
+	}
+	if strings.Index(first.ExtraContent, "Alice:\nI think") > strings.Index(first.ExtraContent, "Bob:\nWeb") {
+		t.Fatalf("history order was not preserved: %q", first.ExtraContent)
+	}
+	if first.OnAccepted == nil {
+		t.Fatal("trigger should have a delayed history-consumption callback")
+	}
+	first.OnAccepted()
+
+	sendGroupHistoryText(t, p, "m5", "ou_john", "nothing old should repeat", "oc_main", "", true)
+	second := awaitGroupHistoryMessage(t, messages)
+	if second.ExtraContent != "" {
+		t.Fatalf("consumed history repeated: %q", second.ExtraContent)
+	}
+}
+
+func TestFeishuGroupHistory_StatusDoesNotConsumePendingContext(t *testing.T) {
+	messages := make(chan *core.Message, 2)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "keep this for the next real turn", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "m2", "ou_john", "/status", "oc_main", "", true)
+	status := awaitGroupHistoryMessage(t, messages)
+	if status.Content != "/status" || !strings.Contains(status.ExtraContent, "keep this for the next real turn") {
+		t.Fatalf("status message lost pending context: content=%q extra=%q", status.Content, status.ExtraContent)
+	}
+	if status.OnAccepted == nil {
+		t.Fatal("status snapshot should retain a consumption callback for a later real turn")
+	}
+
+	sendGroupHistoryText(t, p, "m3", "ou_john", "real turn", "oc_main", "", true)
+	realTurn := awaitGroupHistoryMessage(t, messages)
+	if !strings.Contains(realTurn.ExtraContent, "keep this for the next real turn") {
+		t.Fatalf("pending context was consumed by /status: %q", realTurn.ExtraContent)
+	}
+	realTurn.OnAccepted()
+}
+
+func TestFeishuGroupHistory_NewResetsPendingContext(t *testing.T) {
+	messages := make(chan *core.Message, 2)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "old context", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "m2", "ou_john", "/new", "oc_main", "", true)
+	newMessage := awaitGroupHistoryMessage(t, messages)
+	if newMessage.ExtraContent != "" {
+		t.Fatalf("/new received stale context: %q", newMessage.ExtraContent)
+	}
+
+	sendGroupHistoryText(t, p, "m3", "ou_bob", "new context", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "m4", "ou_john", "continue", "oc_main", "", true)
+	continueMessage := awaitGroupHistoryMessage(t, messages)
+	if strings.Contains(continueMessage.ExtraContent, "old context") || !strings.Contains(continueMessage.ExtraContent, "new context") {
+		t.Fatalf("/new did not reset the main history scope: %q", continueMessage.ExtraContent)
+	}
+}
+
+func TestFeishuGroupHistory_ThreadScopesDoNotLeakAndMainDoesNotFollowFork(t *testing.T) {
+	messages := make(chan *core.Message, 8)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+	p.threadIsolation = true
+
+	// A main-channel mention forks an agent session, but does not become
+	// pending history for the next main-channel mention.
+	sendGroupHistoryText(t, p, "main-trigger-a", "ou_john", "task A", "oc_main", "", true)
+	mainA := awaitGroupHistoryMessage(t, messages)
+	if mainA.ExtraContent != "" {
+		t.Fatalf("first main trigger unexpectedly had context: %q", mainA.ExtraContent)
+	}
+	sendGroupHistoryText(t, p, "main-context-1", "ou_alice", "context B1", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "main-context-2", "ou_bob", "context B2", "oc_main", "", false)
+	sendGroupHistoryText(t, p, "main-trigger-b", "ou_john", "task B", "oc_main", "", true)
+	mainB := awaitGroupHistoryMessage(t, messages)
+	if !strings.Contains(mainB.ExtraContent, "context B1") || !strings.Contains(mainB.ExtraContent, "context B2") || strings.Contains(mainB.ExtraContent, "task A") {
+		t.Fatalf("main-channel history attached to the forked session: %q", mainB.ExtraContent)
+	}
+	mainB.OnAccepted()
+
+	// Thread roots each have an independent pending queue.
+	// Upstream bootstraps a pre-existing thread's reply chain on first
+	// engagement. Mark these synthetic threads active so this scope test does
+	// not require a Feishu API client; bootstrap behavior has dedicated tests.
+	p.markThreadSessionActive("feishu:oc_main:root:root-a")
+	p.markThreadSessionActive("feishu:oc_main:root:root-b")
+	sendGroupHistoryText(t, p, "thread-a-context", "ou_alice", "thread A context", "oc_main", "root-a", false)
+	sendGroupHistoryText(t, p, "thread-b-context", "ou_bob", "thread B context", "oc_main", "root-b", false)
+	sendGroupHistoryText(t, p, "thread-a-trigger", "ou_john", "continue A", "oc_main", "root-a", true)
+	threadA := awaitGroupHistoryMessage(t, messages)
+	if !strings.Contains(threadA.ExtraContent, "thread A context") || strings.Contains(threadA.ExtraContent, "thread B context") {
+		t.Fatalf("thread A received leaked history: %q", threadA.ExtraContent)
+	}
+	threadA.OnAccepted()
+
+	sendGroupHistoryText(t, p, "thread-b-trigger", "ou_john", "continue B", "oc_main", "root-b", true)
+	threadB := awaitGroupHistoryMessage(t, messages)
+	if !strings.Contains(threadB.ExtraContent, "thread B context") || strings.Contains(threadB.ExtraContent, "thread A context") {
+		t.Fatalf("thread B received leaked history: %q", threadB.ExtraContent)
+	}
+}
+
+func TestFeishuGroupHistory_PostAndSenderTypeFormatting(t *testing.T) {
+	p := newGroupHistoryTestPlatform(nil)
+	p.peerBots = map[string]string{"cli_peer": "PeerBot"}
+	p.rememberGroupHistory("chat:oc_main", "post-1", "post", `{"title":"Topic","content":[[{"tag":"text","text":"post body"}]]}`, nil, "ou_alice", "user")
+	p.rememberGroupHistory("chat:oc_main", "text-1", "text", `{"text":"bot observation"}`, nil, "cli_peer", "app")
+	ctx := p.snapshotGroupHistory("chat:oc_main")
+	formatted := p.formatGroupHistory(ctx)
+	if !strings.Contains(formatted, "Alice:\nTopic\npost body") {
+		t.Fatalf("post history was not formatted with sender name: %q", formatted)
+	}
+	if !strings.Contains(formatted, "PeerBot:\nbot observation") {
+		t.Fatalf("app sender was not resolved: %q", formatted)
+	}
+}
+
+func TestFeishuGroupHistory_ChatAndTriggerPermissionsRemainSeparate(t *testing.T) {
+	messages := make(chan *core.Message, 1)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+	p.allowChat = "oc_allowed"
+	p.allowFrom = "ou_john"
+
+	sendGroupHistoryText(t, p, "forbidden-context", "ou_alice", "must not be observed", "oc_forbidden", "", false)
+	sendGroupHistoryText(t, p, "allowed-context", "ou_alice", "allowed chat context", "oc_allowed", "", false)
+	sendGroupHistoryText(t, p, "allowed-trigger", "ou_john", "use context", "oc_allowed", "", true)
+	msg := awaitGroupHistoryMessage(t, messages)
+	if strings.Contains(msg.ExtraContent, "must not be observed") || !strings.Contains(msg.ExtraContent, "allowed chat context") {
+		t.Fatalf("chat permission boundary was not respected: %q", msg.ExtraContent)
+	}
+}
+
+func TestFeishuGroupHistory_GroupReplyAllRemainsImmediate(t *testing.T) {
+	messages := make(chan *core.Message, 1)
+	p := newGroupHistoryTestPlatform(func(_ core.Platform, msg *core.Message) { messages <- msg })
+	p.groupReplyAll = true
+
+	sendGroupHistoryText(t, p, "m1", "ou_alice", "reply immediately", "oc_main", "", false)
+	msg := awaitGroupHistoryMessage(t, messages)
+	if msg.Content != "reply immediately" || msg.ExtraContent != "" {
+		t.Fatalf("group_reply_all behavior changed: content=%q extra=%q", msg.Content, msg.ExtraContent)
+	}
+}


### PR DESCRIPTION
## Summary

Add optional Feishu group-chat history sharing via `group_chat_history_share`.

When enabled, non-mentioned group messages are retained as context for the next explicit bot mention, while ordinary messages still do not trigger an agent turn or reply. This preserves the conversation leading up to a bot request without changing the default behavior.

## Type of change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing behavior to change)
* [ ] Documentation only
* [ ] Internal refactor / chore (no user-visible change)

## Testing

Verified with the full repository test suite, race detector, build, and a live Feishu group using the patched binary.

### Automated tests added in this PR

Added `platform/feishu/group_history_test.go` with:

* `TestFeishuGroupHistory_DisabledPreservesMentionFilter` — verifies the feature defaults to the existing mention-filter behavior when disabled.
* `TestFeishuGroupHistory_ConfigDefaultsOffAndCanBeEnabled` — verifies the config defaults to `false` and can be enabled.
* `TestFeishuGroupHistory_MainChannelSharesOrderedMessagesAndConsumesOnce` — verifies main-channel messages are preserved in sender/order sequence and consumed only once after an accepted turn.
* `TestFeishuGroupHistory_StatusDoesNotConsumePendingContext` — verifies `/status` does not consume pending conversation context.
* `TestFeishuGroupHistory_NewResetsPendingContext` — verifies `/new` resets pending context.
* `TestFeishuGroupHistory_ThreadScopesDoNotLeakAndMainDoesNotFollowFork` — verifies isolated threads do not leak history and main-channel context does not follow a previous forked thread.
* `TestFeishuGroupHistory_PostAndSenderTypeFormatting` — verifies post content and user/app sender attribution.
* `TestFeishuGroupHistory_ChatAndTriggerPermissionsRemainSeparate` — verifies `allow_chat` controls observable chats while `allow_from` continues to control who may trigger the agent.
* `TestFeishuGroupHistory_GroupReplyAllRemainsImmediate` — verifies existing `group_reply_all=true` behavior is unchanged.

Commands run successfully:

```bash
go test ./...
go test -race ./...
make test-full
make build
```

The patched binary was also manually verified in a live Feishu group: non-mentioned messages were retained and supplied to the next explicit bot mention without triggering replies themselves.

### For bug fixes only — regression test

Not applicable — this PR adds an opt-in feature and does not change the default behavior.

### Critical User Journeys (CUJ) impact

* [ ] No CUJ touched (small refactor, doc change, etc.)
* [x] A — basic conversation
* [x] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
* [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
* [x] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
* [ ] E — scheduled tasks (`/cron` `/timer`)
* [ ] F — config switching (`/lang` `/provider` `/model` reload)
* [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
* [ ] H — multi-platform / multi-project isolation
* [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

* [x] `go test ./core/ -run TestCUJ` passes locally.
* [ ] If the change alters an existing user-visible flow, the corresponding CUJ test was updated (or a new CUJ added) to cover the new behavior.

No core CUJ was added because this is a new opt-in Feishu-adapter behavior, disabled by default, and its end-to-end message capture semantics are covered directly in `platform/feishu/group_history_test.go`.

## Manual / user-visible behavior change

With:

```toml
group_chat_history_share = true
```

allowed Feishu group `text`/`post` messages that do not mention the bot are retained in bounded in-memory context instead of being discarded.

They do not invoke the agent or produce a reply.

On the next explicit bot mention:

* pending messages from the same main-channel or thread scope are injected through the existing `ExtraContent` path;
* sender names and message ordering are preserved;
* the history is consumed only after a real agent turn is accepted;
* `/status` and similar non-agent commands do not consume it;
* `/new` resets the relevant pending context;
* isolated threads do not share pending context.

The feature defaults to `false`, so existing deployments are unaffected.

The implementation does not fetch Feishu history or persist context across process restarts. It reuses messages already delivered to the Feishu adapter.

Receiving non-mentioned group messages requires the appropriate Feishu group-message permission (`im:message.group_msg`).

## Checklist (reviewer will verify)

* [x] `go build ./...` passes
* [x] `go test ./...` passes (with `-race` if touching concurrency)
* [x] AGENTS.md Pre-Commit Checklist items are satisfied
* [x] No new hardcoded platform/agent names in `core/`
* [x] i18n strings have all-language translations (if any new user-facing text)
* [x] No secrets / credentials in source

## Related

* Issue: #1610
* Related PR: None
