### PR TITLE
feat(relay): support async relay send

### DIFF
--- a/cmd/cc-connect/relay.go
+++ b/cmd/cc-connect/relay.go
@@ -28,6 +28,7 @@ func runRelay(args []string) {
 
 func runRelaySend(args []string) {
 	var from, to, sessionKey, message, dataDir string
+	async := false
 
 	var positional []string
 	for i := 0; i < len(args); i++ {
@@ -57,6 +58,8 @@ func runRelaySend(args []string) {
 				i++
 				dataDir = args[i]
 			}
+		case "--async":
+			async = true
 		case "--help", "-h":
 			printRelaySendUsage()
 			return
@@ -103,7 +106,11 @@ func runRelaySend(args []string) {
 		"message":     message,
 	})
 
-	resp, err := apiPost(sockPath, "/relay/send", payload)
+	endpoint := "/relay/send"
+	if async {
+		endpoint = "/relay/send-async"
+	}
+	resp, err := apiPost(sockPath, endpoint, payload)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -111,19 +118,26 @@ func runRelaySend(args []string) {
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
+	accepted := resp.StatusCode == http.StatusOK || async && resp.StatusCode == http.StatusAccepted
+	if !accepted {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", strings.TrimSpace(string(body)))
 		os.Exit(1)
 	}
 
 	var result struct {
 		Response string `json:"response"`
+		Status   string `json:"status"`
+		Job      string `json:"job"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: decode response: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Print(result.Response)
+	if async {
+		fmt.Printf("queued relay job=%s\n", result.Job)
+	} else {
+		fmt.Print(result.Response)
+	}
 }
 
 func printRelayUsage() {
@@ -145,6 +159,7 @@ Options:
   -t, --to <project>         Target bot project name
   -s, --session-key <key>    Session key (auto-detected from CC_SESSION_KEY env)
   -m, --message <text>       Message to send
+      --async                Queue the relay and return immediately
       --data-dir <path>      Data directory (default: ~/.cc-connect)
   -h, --help                 Show this help
 

--- a/core/api.go
+++ b/core/api.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -103,6 +104,7 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 	s.mux.HandleFunc("/cron/exec", s.handleCronExec)
 	s.mux.HandleFunc("/cron/run", s.handleCronExec)
 	s.mux.HandleFunc("/relay/send", s.handleRelaySend)
+	s.mux.HandleFunc("/relay/send-async", s.handleRelaySendAsync)
 	s.mux.HandleFunc("/relay/bind", s.handleRelayBind)
 	s.mux.HandleFunc("/relay/binding", s.handleRelayBinding)
 
@@ -767,13 +769,9 @@ func (s *APIServer) handleRelaySend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req RelayRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	if req.To == "" || req.Message == "" || req.SessionKey == "" {
-		http.Error(w, "to, session_key, and message are required", http.StatusBadRequest)
+	req, err := decodeRelayRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -784,6 +782,46 @@ func (s *APIServer) handleRelaySend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	apiJSON(w, http.StatusOK, resp)
+}
+
+// handleRelaySendAsync accepts a relay request and executes it after returning.
+// The request context cannot be reused because clients may disconnect as soon
+// as the job is accepted.
+func (s *APIServer) handleRelaySendAsync(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.relay == nil {
+		http.Error(w, "relay not available", http.StatusServiceUnavailable)
+		return
+	}
+	req, err := decodeRelayRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	jobID := fmt.Sprintf("relay-%d", time.Now().UnixNano())
+	go func() {
+		if _, err := s.relay.Send(context.Background(), req); err != nil {
+			slog.Error("relay: async job failed", "job", jobID, "error", err)
+			return
+		}
+		slog.Info("relay: async job completed", "job", jobID)
+	}()
+	apiJSON(w, http.StatusAccepted, map[string]string{"status": "queued", "job": jobID})
+}
+
+func decodeRelayRequest(r *http.Request) (RelayRequest, error) {
+	var req RelayRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return req, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if req.To == "" || req.Message == "" || req.SessionKey == "" {
+		return req, fmt.Errorf("to, session_key, and message are required")
+	}
+	return req, nil
 }
 
 func (s *APIServer) handleRelayBind(w http.ResponseWriter, r *http.Request) {

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -91,6 +91,59 @@ func TestHandleSend_AllowsTTSTextOnly(t *testing.T) {
 	}
 }
 
+func TestHandleRelaySendAsync_AcceptsAndQueues(t *testing.T) {
+	api := &APIServer{relay: NewRelayManager("")}
+	body, err := json.Marshal(RelayRequest{
+		From:       "source",
+		To:         "target",
+		SessionKey: "feishu:chat:user",
+		Message:    "please work in the background",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/relay/send-async", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleRelaySendAsync(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got["status"] != "queued" {
+		t.Fatalf("status payload = %q, want queued", got["status"])
+	}
+	if !strings.HasPrefix(got["job"], "relay-") {
+		t.Fatalf("job = %q, want relay-*", got["job"])
+	}
+}
+
+func TestHandleRelaySendAsync_ValidatesRequest(t *testing.T) {
+	api := &APIServer{relay: NewRelayManager("")}
+	body, err := json.Marshal(RelayRequest{
+		To:         "target",
+		SessionKey: "feishu:chat:user",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/relay/send-async", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleRelaySendAsync(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "to, session_key, and message are required") {
+		t.Fatalf("body = %q, want validation error", rec.Body.String())
+	}
+}
+
 // TestHandleSend_UnknownProjectReturns404 ensures the API does NOT silently
 // fall back to the only registered engine when the caller named a different
 // project. Previously a typo'd project name routed messages to whatever


### PR DESCRIPTION
## Summary

- Add an async relay send mode for fire-and-return relay jobs.
- Add `/relay/send-async` to the local API; it validates the request, queues the relay job, and returns a job id with HTTP 202 while the daemon processes the relay in the background.
- Share relay request parsing and validation between the sync and async relay handlers.
- Update the `cc-connect relay send` CLI path to support async delivery.

## Verification

- `go test ./core -run 'TestHandleRelaySendAsync|TestHandleRelaySend' -count=1`
- `go test ./core -count=1`
- `GOOS=linux GOARCH=amd64 go build -tags no_web ./cmd/cc-connect`

## Overlap check

- Checked open PRs for relay async/send behavior; no existing PR implements this endpoint/CLI flag.
