### PR TITLE
fix(daemon): remove duplicate CheckLinger stub on darwin

### DIFF
--- a/daemon/check_linger_other.go
+++ b/daemon/check_linger_other.go
@@ -1,9 +1,0 @@
-//go:build !linux
-
-package daemon
-
-// CheckLinger is a stub for non-Linux platforms where systemd linger does not
-// apply. Returns (true, "") so callers skip the linger warning.
-func CheckLinger() (enabled bool, user string) {
-	return true, ""
-}


### PR DESCRIPTION
## Summary
- remove the non-linux CheckLinger stub that conflicts with launchd.go on darwin
- keep the Linux linger implementation and launchd-specific stub as the only platform definitions

## Tests
- go test ./daemon -count=1
- go build -tags no_web -o /tmp/cc-connect-darwin-build-check ./cmd/cc-connect