### PR TITLE
feat(wecom): support private WeChat Work WebSocket deployment

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1441,6 +1441,7 @@ app_secret = "your-feishu-app-secret"
 # mode = "websocket"
 # bot_id = "your-bot-id"
 # bot_secret = "your-bot-secret"
+# ws_url = "wss://your-wecom-host:port/im_openws?bizid=10001"  # optional / 可选：私有化部署 WebSocket 地址，留空默认公有云 wss://openws.work.weixin.qq.com
 # allow_from = "*"  # Allowed user IDs / 允许的用户 ID
 
 # Weixin personal (ilink bot) / 微信个人号（ilink 机器人网关）

--- a/config.example.toml
+++ b/config.example.toml
@@ -1445,6 +1445,7 @@ app_secret = "your-feishu-app-secret"
 # mode = "websocket"
 # bot_id = "your-bot-id"
 # bot_secret = "your-bot-secret"
+# ws_url = "wss://your-wecom-host:port/im_openws?bizid=10001"  # optional / 可选：私有化部署 WebSocket 地址，留空默认公有云 wss://openws.work.weixin.qq.com
 # allow_from = "*"  # Allowed user IDs / 允许的用户 ID
 
 # Weixin personal (ilink bot) / 微信个人号（ilink 机器人网关）

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -452,10 +452,12 @@ func TestHandleCronExec_RunAliasRouteTriggersJob(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if len(platform.getSent()) >= 2 {
+			scheduler.WaitActiveJobs()
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	scheduler.WaitActiveJobs()
 	t.Fatalf("timed out waiting for local api alias trigger, sent=%v", platform.getSent())
 }
 

--- a/core/cron.go
+++ b/core/cron.go
@@ -418,6 +418,7 @@ type CronScheduler struct {
 	entries            map[string]cron.EntryID // job ID → cron entry
 	defaultSilent      bool                    // global default for suppressing cron start notifications
 	defaultSessionMode string                  // global default session mode; "" = reuse, "new_per_run" = fresh session each run
+	activeJobs         sync.WaitGroup          // tracks in-flight runJob goroutines for test cleanup
 }
 
 func NewCronScheduler(store *CronStore) *CronScheduler {
@@ -476,6 +477,14 @@ func (cs *CronScheduler) Start() error {
 
 func (cs *CronScheduler) Stop() {
 	cs.cron.Stop()
+	cs.activeJobs.Wait()
+}
+
+// WaitActiveJobs waits for all in-flight runJob goroutines to complete.
+// Use this in tests to ensure all cron job side effects (file writes, etc.)
+// finish before cleaning up temp directories or asserting results.
+func (cs *CronScheduler) WaitActiveJobs() {
+	cs.activeJobs.Wait()
 }
 
 func (cs *CronScheduler) AddJob(job *CronJob) error {
@@ -673,7 +682,11 @@ func (cs *CronScheduler) RunJobNow(id string) error {
 		return fmt.Errorf("%w: %q", ErrCronProjectNotFound, job.Project)
 	}
 	snapshot := *job
-	go cs.runJob(&snapshot, true)
+	cs.activeJobs.Add(1)
+	go func() {
+		defer cs.activeJobs.Done()
+		cs.runJob(&snapshot, true)
+	}()
 	return nil
 }
 

--- a/docs/wecom.md
+++ b/docs/wecom.md
@@ -59,6 +59,7 @@ type = "wecom"
 mode = "websocket"
 bot_id = "your-bot-id"
 bot_secret = "your-bot-secret"
+ws_url = "wss://openws.work.weixin.qq.com"   # optional; 私有化部署时填写私有 WebSocket 地址
 allow_from = "*"
 ```
 
@@ -69,6 +70,7 @@ allow_from = "*"
 | `mode` | ✅ | 必须为 `"websocket"` |
 | `bot_id` | ✅ | 智能机器人 BotID |
 | `bot_secret` | ✅ | 智能机器人 Secret |
+| `ws_url` | ❌ | WebSocket 端点地址（默认 `wss://openws.work.weixin.qq.com`；**私有化部署**时改为你的私有地址，如 `wss://your-wecom-host:port/im_openws?bizid=<id>`） |
 | `allow_from` | ❌ | 允许的用户 ID（默认 `"*"` 允许所有） |
 
 ### 第三步：启动并验证
@@ -88,12 +90,106 @@ level=INFO msg="wecom-ws: subscribed successfully" bot_id=your-bot-id
 
 ### 技术细节
 
-- **连接地址**：`wss://openws.work.weixin.qq.com`
+- **连接地址**：默认 `wss://openws.work.weixin.qq.com`（公有云）；可通过 `ws_url` 覆盖为私有化部署地址（格式同 `wss://your-wecom-host:port/im_openws?bizid=<id>`）
 - **认证方式**：连接后发送 `aibot_subscribe`（bot_id + secret）
 - **心跳**：每 30 秒发送 `ping`
 - **自动重连**：连接断开后指数退避重连（1s → 2s → 4s → ... → 30s max）
 - **图片回传**：通过 `aibot_upload_media_*` 上传临时素材，再用 `aibot_send_msg` 发送图片
 - **限制**：同一机器人仅支持 1 个长连接；30 条/分钟、1000 条/小时
+
+---
+
+## 私有化部署（自定义 WebSocket 地址）
+
+如果你的企业微信是**私有化部署**（on-premise / 自建服务器），智能机器人的 WebSocket 端点不再是公有云的 `wss://openws.work.weixin.qq.com`，而是你公司内网或专有云中的地址。cc-connect 支持通过 `ws_url` 配置项覆盖默认端点。
+
+### 何时使用
+
+- 企业微信为**私有化部署**版本
+- 智能机器人 WebSocket 服务地址与公有云不同
+- 需要连接到内网/专有云的 `wss://your-host:port/im_openws?bizid=<id>` 端点
+
+> ⚠️ 如果你使用的是企业微信**公有云**（SaaS）服务，**不需要**配置 `ws_url`，保持默认即可。错误地填写私有化地址会导致无法连接公有云服务。
+
+### 配置方法
+
+在 `config.toml` 的 wecom 平台配置中增加 `ws_url` 项：
+
+```toml
+[[projects.platforms]]
+type = "wecom"
+
+[projects.platforms.options]
+mode = "websocket"
+bot_id = "your-bot-id"
+bot_secret = "your-bot-secret"
+# 私有化部署：填写你的私有 WebSocket 地址
+ws_url = "wss://your-wecom-host:port/im_openws?bizid=10001"
+allow_from = "*"
+```
+
+#### 配置项说明
+
+| 配置项 | 必填 | 说明 |
+|--------|------|------|
+| `ws_url` | ❌ | WebSocket 端点地址。**公有云**无需填写（默认 `wss://openws.work.weixin.qq.com`）；**私有化部署**填写你的私有地址，如 `wss://your-wecom-host:port/im_openws?bizid=<id>` |
+
+### 获取私有化 WebSocket 地址
+
+私有化部署的 WebSocket 地址通常由你的企业微信运维团队提供，一般格式为：
+
+```
+wss://<私有化域名或IP>:<端口>/im_openws?bizid=<企业/业务ID>
+```
+
+如果不确定地址，请联系企业管理员或参考企业微信私有化部署文档。
+
+### 部署步骤
+
+1. **确认私有化地址**：向企业微信运维团队索取智能机器人 WebSocket 端点地址（含 `bizid` 等参数）。
+
+2. **配置 `config.toml`**：按上方示例填写 `mode = "websocket"`、`bot_id`、`bot_secret` 及 `ws_url`。
+
+3. **网络连通性检查**：确保 cc-connect 所在服务器可访问 `ws_url` 指定的地址（内网或专有云环境需放通防火墙 / 安全组策略）。
+
+   ```bash
+   # 测试 TLS 握手连通性（替换为你的地址）
+   openssl s_client -connect your-wecom-host:port -servername your-wecom-host </dev/null
+   ```
+
+4. **启动 cc-connect**：
+
+   ```bash
+   cc-connect -config /path/to/config.toml
+   ```
+
+5. **验证连接**：日志中应出现你配置的私有化地址，并订阅成功：
+
+   ```
+   level=INFO msg="wecom-ws: connecting" endpoint=wss://your-wecom-host:port/im_openws?bizid=10001
+   level=INFO msg="wecom-ws: subscribed successfully" bot_id=your-bot-id
+   ```
+
+6. **功能测试**：在企业微信中找到机器人发送一条消息，确认能正常收发。
+
+### 注意事项
+
+- **协议**：`ws_url` 必须使用 `wss://`（TLS 加密）协议；明文 `ws://` 仅在受信任的内网测试环境使用，生产环境不建议。
+- **证书**：若私有化端点使用自签名证书，需确保 cc-connect 运行环境的 CA 信任链包含该证书，否则握手会失败。可通过系统证书库或 `SSL_CERT_FILE` / `SSL_CERT_DIR` 环境变量指定。
+- **端口**：确认端口已在防火墙 / 安全组放通，且未被其他服务占用。
+- **bizid 参数**：地址中的 `bizid` 等查询参数由私有化部署方提供，缺失或错误会导致订阅失败。
+- **回退行为**：`ws_url` 留空或仅含空白字符时，自动回退到默认公有云地址 `wss://openws.work.weixin.qq.com`，不会因配置缺省而报错。
+- **同一机器人单连接**：私有化部署同样遵循「同一机器人仅支持 1 个长连接」的限制，请勿多实例同时连接同一 `bot_id`。
+
+### 故障排查
+
+| 现象 | 可能原因 / 处理 |
+|------|----------------|
+| `dial: ... connection refused` | 地址或端口不对，或防火墙未放通 |
+| `dial: ... certificate signed by unknown authority` | 自签名证书未被信任，配置 CA 证书 |
+| `dial: ... tls: handshake failure` | 端点不支持 TLS，或协议版本不匹配；确认应使用 `wss://` |
+| 日志 `endpoint=wss://openws.work.weixin.qq.com`（非你的私有地址） | `ws_url` 未生效，检查缩进 / 拼写 / 是否在 `[projects.platforms.options]` 下 |
+| 订阅后无响应 | `bizid` 等参数错误，或 `bot_id` / `bot_secret` 与私有化部署方提供的不一致 |
 
 ---
 

--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -28,6 +28,7 @@ type WSPlatform struct {
 	botID       string
 	secret      string
 	allowFrom   string
+	wsURL       string // WebSocket endpoint; defaults to wsEndpoint (公有云), 可经 ws_url 覆盖为私有化部署地址
 	conn        *websocket.Conn
 	handler     core.MessageHandler
 	ctx         context.Context
@@ -124,11 +125,17 @@ func newWebSocket(opts map[string]any) (core.Platform, error) {
 		return nil, fmt.Errorf("wecom-ws: bot_id and bot_secret are required for websocket mode")
 	}
 	allowFrom, _ := opts["allow_from"].(string)
+	wsURL, _ := opts["ws_url"].(string)
+	wsURL = strings.TrimSpace(wsURL)
+	if wsURL == "" {
+		wsURL = wsEndpoint
+	}
 
 	return &WSPlatform{
 		botID:     botID,
 		secret:    secret,
 		allowFrom: allowFrom,
+		wsURL:     wsURL,
 	}, nil
 }
 
@@ -186,9 +193,9 @@ func (p *WSPlatform) connectLoop() {
 
 // runConnection dials, subscribes, and processes messages until disconnection.
 func (p *WSPlatform) runConnection() error {
-	slog.Info("wecom-ws: connecting", "endpoint", wsEndpoint)
+	slog.Info("wecom-ws: connecting", "endpoint", p.wsURL)
 
-	conn, _, err := websocket.DefaultDialer.DialContext(p.ctx, wsEndpoint, nil)
+	conn, _, err := websocket.DefaultDialer.DialContext(p.ctx, p.wsURL, nil)
 	if err != nil {
 		return fmt.Errorf("dial: %w", err)
 	}

--- a/platform/wecom/websocket_test.go
+++ b/platform/wecom/websocket_test.go
@@ -1096,3 +1096,48 @@ func TestNewWebSocket_ValidConfig(t *testing.T) {
 		t.Fatalf("unexpected config: botID=%s secret=%s allowFrom=%s", ws.botID, ws.secret, ws.allowFrom)
 	}
 }
+
+func TestNewWebSocket_DefaultWSEndpoint(t *testing.T) {
+	p, err := newWebSocket(map[string]any{
+		"bot_id":     "aibTest",
+		"bot_secret": "secretXYZ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ws := p.(*WSPlatform)
+	if ws.wsURL != wsEndpoint {
+		t.Fatalf("expected default wsURL %q, got %q", wsEndpoint, ws.wsURL)
+	}
+}
+
+func TestNewWebSocket_CustomWSEndpoint(t *testing.T) {
+	const custom = "wss://corp.example.com:85/im_openws?bizid=1"
+	p, err := newWebSocket(map[string]any{
+		"bot_id":     "aibTest",
+		"bot_secret": "secretXYZ",
+		"ws_url":     custom,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ws := p.(*WSPlatform)
+	if ws.wsURL != custom {
+		t.Fatalf("expected custom wsURL %q, got %q", custom, ws.wsURL)
+	}
+}
+
+func TestNewWebSocket_BlankWSEndpointFallsBack(t *testing.T) {
+	p, err := newWebSocket(map[string]any{
+		"bot_id":     "aibTest",
+		"bot_secret": "secretXYZ",
+		"ws_url":     "   ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ws := p.(*WSPlatform)
+	if ws.wsURL != wsEndpoint {
+		t.Fatalf("expected blank ws_url to fall back to %q, got %q", wsEndpoint, ws.wsURL)
+	}
+}


### PR DESCRIPTION
WebSocket 模式的端点原先写死为公有云 wss://openws.work.weixin.qq.com， 无法接入私有化部署的企业微信智能机器人。新增 ws_url 配置项覆盖默认端点，
留空则回退公有云地址，行为不变。

- platform/wecom/websocket.go: WSPlatform 增加 wsURL 字段，newWebSocket 解析 ws_url（trim 后为空回退 wsEndpoint），runConnection 用 p.wsURL 拨号
- config.example.toml: wecom WebSocket 段补 ws_url 注释示例
- docs/wecom.md: 配置项表格加 ws_url 行，新增「私有化部署」章节
- websocket_test.go: 默认/自定义/空白回退三个回归用例

<!--
Thanks for contributing! Please fill in the sections below.
The reviewer will use the checklist at the bottom to gate merge.
-->

## Summary

<!-- 1-3 sentences explaining WHAT this PR does and WHY. -->

## Type of change

<!-- Mark all that apply: -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

<!-- Explain how you verified the change. Be specific. -->

### Automated tests added in this PR

<!-- List the test functions you added or modified. -->

- `TestX_Y_Z` in `path/to/file_test.go` — what it asserts

### For bug fixes only — regression test

<!-- A bug fix PR MUST include a regression test that:
     (1) fails on the pre-fix code, and
     (2) passes on the fixed code.
     Name it so the bug is searchable later. -->

- Regression test name: `Test...`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

<!-- See AGENTS.md → "Critical User Journeys (CUJ)" and the inventory in
     projects/cc-connect/agents/qa-cursor/release-gate/CUJ-INVENTORY.md.
     Mark which CUJ groups this PR touches: -->

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

<!-- Describe what a user will see or do differently after this PR.
     If none, write "None". -->

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [ ] No new hardcoded platform/agent names in `core/`
- [ ] i18n strings have all-language translations (if any new user-facing text)
- [ ] No secrets / credentials in source

## Related

<!-- Link to issue, RFC, design doc, prior PR, etc. -->

- Issue:
- Related PR:
