### PR TITLE
feat(wecom): add outbound burst_limit sliding-window quota

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1423,6 +1423,16 @@ app_secret = "your-feishu-app-secret"
 #             # 示例："http://你的VPS-IP:8888" — 将 VPS IP 加入可信 IP 列表
 # proxy_username = ""  # optional: proxy authentication username / 代理认证用户名
 # proxy_password = ""  # optional: proxy authentication password / 代理认证密码
+# burst_limit = 0           # Max outbound messages per sliding window; 0 = unlimited (default)
+#                            # 滑动窗口内最大出站消息数；0 = 不限（默认）
+#                            # WeChat Work throttles apps at ~20-30 msgs/min; set e.g. 20 to stay safe.
+#                            # 企业微信应用消息频率约 20-30 条/分钟；例如设 20 以留余量。
+# burst_window_secs = 60     # Sliding window length in seconds (default 60)
+#                            # 滑动窗口长度（秒，默认 60）
+#                            # Counts per API request: a long reply split into chunks consumes multiple slots.
+#                            # 按 API 请求计数：长回复被切分后每段占一个配额。阻塞等待，不丢消息。
+#                            # Stacks with [outgoing_rate_limit.platforms.wecom] (token bucket = per-second pacing).
+#                            # 与 [outgoing_rate_limit.platforms.wecom] 令牌桶叠加（令牌桶管每秒匀速）。
 
 # WeChat Work WebSocket / 企业微信长连接模式 (uncomment to enable / 取消注释以启用)
 # No public URL, no message encryption, no IP allowlist needed!
@@ -1442,6 +1452,14 @@ app_secret = "your-feishu-app-secret"
 # bot_id = "your-bot-id"
 # bot_secret = "your-bot-secret"
 # allow_from = "*"  # Allowed user IDs / 允许的用户 ID
+# burst_limit = 0           # Max outbound messages per sliding window; 0 = unlimited (default)
+#                            # 滑动窗口内最大出站消息数；0 = 不限（默认）
+#                            # WeChat Work throttles apps at ~20-30 msgs/min; set e.g. 20 to stay safe.
+#                            # 企业微信应用消息频率约 20-30 条/分钟；例如设 20 以留余量。
+# burst_window_secs = 60     # Sliding window length in seconds (default 60)
+#                            # 滑动窗口长度（秒，默认 60）
+#                            # Counts per API request: a long reply split into chunks consumes multiple slots.
+#                            # 按 API 请求计数：长回复被切分后每段占一个配额。阻塞等待，不丢消息。
 
 # Weixin personal (ilink bot) / 微信个人号（ilink 机器人网关）
 # Same HTTP API as OpenClaw @tencent-weixin/openclaw-weixin: long-poll getUpdates + sendMessage.

--- a/config.example.toml
+++ b/config.example.toml
@@ -1427,6 +1427,16 @@ app_secret = "your-feishu-app-secret"
 #             # 示例："http://你的VPS-IP:8888" — 将 VPS IP 加入可信 IP 列表
 # proxy_username = ""  # optional: proxy authentication username / 代理认证用户名
 # proxy_password = ""  # optional: proxy authentication password / 代理认证密码
+# burst_limit = 0           # Max outbound messages per sliding window; 0 = unlimited (default)
+#                            # 滑动窗口内最大出站消息数；0 = 不限（默认）
+#                            # WeChat Work throttles apps at ~20-30 msgs/min; set e.g. 20 to stay safe.
+#                            # 企业微信应用消息频率约 20-30 条/分钟；例如设 20 以留余量。
+# burst_window_secs = 60     # Sliding window length in seconds (default 60)
+#                            # 滑动窗口长度（秒，默认 60）
+#                            # Counts per API request: a long reply split into chunks consumes multiple slots.
+#                            # 按 API 请求计数：长回复被切分后每段占一个配额。阻塞等待，不丢消息。
+#                            # Stacks with [outgoing_rate_limit.platforms.wecom] (token bucket = per-second pacing).
+#                            # 与 [outgoing_rate_limit.platforms.wecom] 令牌桶叠加（令牌桶管每秒匀速）。
 
 # WeChat Work WebSocket / 企业微信长连接模式 (uncomment to enable / 取消注释以启用)
 # No public URL, no message encryption, no IP allowlist needed!
@@ -1446,6 +1456,14 @@ app_secret = "your-feishu-app-secret"
 # bot_id = "your-bot-id"
 # bot_secret = "your-bot-secret"
 # allow_from = "*"  # Allowed user IDs / 允许的用户 ID
+# burst_limit = 0           # Max outbound messages per sliding window; 0 = unlimited (default)
+#                            # 滑动窗口内最大出站消息数；0 = 不限（默认）
+#                            # WeChat Work throttles apps at ~20-30 msgs/min; set e.g. 20 to stay safe.
+#                            # 企业微信应用消息频率约 20-30 条/分钟；例如设 20 以留余量。
+# burst_window_secs = 60     # Sliding window length in seconds (default 60)
+#                            # 滑动窗口长度（秒，默认 60）
+#                            # Counts per API request: a long reply split into chunks consumes multiple slots.
+#                            # 按 API 请求计数：长回复被切分后每段占一个配额。阻塞等待，不丢消息。
 
 # Weixin personal (ilink bot) / 微信个人号（ilink 机器人网关）
 # Same HTTP API as OpenClaw @tencent-weixin/openclaw-weixin: long-poll getUpdates + sendMessage.

--- a/platform/wecom/sendquota_test.go
+++ b/platform/wecom/sendquota_test.go
@@ -1,0 +1,261 @@
+package wecom
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// withNow overrides the package-level nowFunc for the duration of a test and
+// restores it afterwards. Returns a setter to advance the clock.
+func withNow(t *testing.T) func(time.Time) {
+	t.Helper()
+	prev := nowFunc
+	mu := sync.Mutex{}
+	current := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	}
+	set := func(t2 time.Time) {
+		mu.Lock()
+		current = t2
+		mu.Unlock()
+	}
+	t.Cleanup(func() { nowFunc = prev })
+	return set
+}
+
+func TestSendQuota_Disabled(t *testing.T) {
+	withNow(t)
+	q := sendQuota{limit: 0, window: time.Second} // disabled
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Should return immediately no matter how many times called.
+	for i := 0; i < 100; i++ {
+		if err := q.wait(ctx); err != nil {
+			t.Fatalf("call %d: wait = %v, want nil", i, err)
+		}
+	}
+}
+
+func TestSendQuota_AllowsUnderLimit(t *testing.T) {
+	withNow(t)
+	q := sendQuota{limit: 3, window: time.Minute}
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if err := q.wait(ctx); err != nil {
+			t.Fatalf("call %d: wait = %v, want nil", i, err)
+		}
+	}
+}
+
+func TestSendQuota_BlocksThenReleasesAfterWindow(t *testing.T) {
+	set := withNow(t)
+	q := sendQuota{limit: 1, window: 100 * time.Millisecond}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// First send: immediate.
+	if err := q.wait(ctx); err != nil {
+		t.Fatalf("first wait = %v, want nil", err)
+	}
+
+	// Second send: should block. Run it in a goroutine and confirm it does not
+	// return before the window slides. We advance the injected clock to release it.
+	done := make(chan error, 1)
+	go func() {
+		done <- q.wait(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("second wait returned before window slid: %v", err)
+	case <-time.After(20 * time.Millisecond):
+		// still blocked, as expected.
+	}
+
+	// Advance the clock past the window so wait() can proceed.
+	set(time.Date(2025, 1, 1, 0, 0, 0, 200_000_000, time.UTC))
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("second wait = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second wait did not return after window slid")
+	}
+}
+
+func TestSendQuota_ContextCancel(t *testing.T) {
+	withNow(t)
+	q := sendQuota{limit: 1, window: time.Minute}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Fill the only slot.
+	if err := q.wait(ctx); err != nil {
+		t.Fatalf("first wait = %v, want nil", err)
+	}
+
+	// Second wait should block; cancel ctx to abort it.
+	done := make(chan error, 1)
+	go func() {
+		done <- q.wait(ctx)
+	}()
+
+	// Give the goroutine time to enter the blocked select.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("wait = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked wait did not return after ctx cancel")
+	}
+}
+
+func TestSendQuota_SlidingWindowEvicts(t *testing.T) {
+	set := withNow(t)
+	// limit 2 per 1s. Send 2, advance 1s+, send 2 more — all should pass.
+	q := sendQuota{limit: 2, window: time.Second}
+	ctx := context.Background()
+
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	set(base)
+	if err := q.wait(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.wait(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Advance well past the window; old timestamps must be evicted.
+	set(base.Add(2 * time.Second))
+	if err := q.wait(ctx); err != nil {
+		t.Fatalf("after window: %v", err)
+	}
+	if err := q.wait(ctx); err != nil {
+		t.Fatalf("after window 2: %v", err)
+	}
+}
+
+func TestNew_BurstLimitParsed(t *testing.T) {
+	pf, err := New(map[string]any{
+		"corp_id":          "ww_test",
+		"corp_secret":      "sec_test",
+		"agent_id":         "1000002",
+		"callback_token":   "cb_token",
+		"callback_aes_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"burst_limit":      20,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p := pf.(*Platform)
+	if p.sendQuota.limit != 20 {
+		t.Errorf("limit = %d, want 20", p.sendQuota.limit)
+	}
+	if p.sendQuota.window != 60*time.Second {
+		t.Errorf("window = %v, want 60s (default)", p.sendQuota.window)
+	}
+}
+
+func TestNew_BurstLimitDisabledByDefault(t *testing.T) {
+	pf, err := New(map[string]any{
+		"corp_id":          "ww_test",
+		"corp_secret":      "sec_test",
+		"agent_id":         "1000002",
+		"callback_token":   "cb_token",
+		"callback_aes_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p := pf.(*Platform)
+	if p.sendQuota.limit != 0 {
+		t.Errorf("limit = %d, want 0 (disabled by default)", p.sendQuota.limit)
+	}
+}
+
+func TestNew_BurstLimitCustomWindow(t *testing.T) {
+	pf, err := New(map[string]any{
+		"corp_id":           "ww_test",
+		"corp_secret":       "sec_test",
+		"agent_id":          "1000002",
+		"callback_token":    "cb_token",
+		"callback_aes_key":  "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"burst_limit":       5,
+		"burst_window_secs": 120,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p := pf.(*Platform)
+	if p.sendQuota.limit != 5 {
+		t.Errorf("limit = %d, want 5", p.sendQuota.limit)
+	}
+	if p.sendQuota.window != 120*time.Second {
+		t.Errorf("window = %v, want 120s", p.sendQuota.window)
+	}
+}
+
+func TestNewWebSocket_BurstLimitParsed(t *testing.T) {
+	pf, err := New(map[string]any{
+		"mode":              "websocket",
+		"bot_id":            "bot_test",
+		"bot_secret":        "sec_test",
+		"burst_limit":       10,
+		"burst_window_secs": 30,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p := pf.(*WSPlatform)
+	if p.sendQuota.limit != 10 {
+		t.Errorf("limit = %d, want 10", p.sendQuota.limit)
+	}
+	if p.sendQuota.window != 30*time.Second {
+		t.Errorf("window = %v, want 30s", p.sendQuota.window)
+	}
+}
+
+func TestNewWebSocket_BurstLimitDisabledByDefault(t *testing.T) {
+	pf, err := New(map[string]any{
+		"mode":       "websocket",
+		"bot_id":     "bot_test",
+		"bot_secret": "sec_test",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p := pf.(*WSPlatform)
+	if p.sendQuota.limit != 0 {
+		t.Errorf("limit = %d, want 0 (disabled by default)", p.sendQuota.limit)
+	}
+}
+
+func TestPickInt(t *testing.T) {
+	cases := []struct {
+		in   any
+		want int
+	}{
+		{int(7), 7},
+		{int64(8), 8},
+		{float64(9.9), 9},
+		{"10", 0},
+		{nil, 0},
+	}
+	for _, c := range cases {
+		if got := pickInt(c.in); got != c.want {
+			t.Errorf("pickInt(%v) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -37,6 +37,7 @@ type WSPlatform struct {
 	reqSeq      atomic.Int64 // monotonic counter for generating unique req_id
 	missedPong  atomic.Int32 // consecutive heartbeat acks not received
 	pendingAcks sync.Map     // req_id -> chan wsAckResult, for sequential send with ack waiting
+	sendQuota   sendQuota    // outbound sliding-window quota (burst_limit/burst_window_secs)
 }
 
 const (
@@ -125,10 +126,31 @@ func newWebSocket(opts map[string]any) (core.Platform, error) {
 	}
 	allowFrom, _ := opts["allow_from"].(string)
 
+	// Outbound sliding-window quota (see sendQuota). 0 disables the quota.
+	burstLimit := pickInt(opts["burst_limit"])
+	if burstLimit < 0 {
+		burstLimit = 0
+	}
+	burstWindow := pickInt(opts["burst_window_secs"])
+	if burstWindow < 0 {
+		burstWindow = 0
+	}
+	quotaWindow := time.Duration(0)
+	if burstLimit > 0 {
+		if burstWindow <= 0 {
+			burstWindow = 60
+		}
+		quotaWindow = time.Duration(burstWindow) * time.Second
+	}
+
 	return &WSPlatform{
 		botID:     botID,
 		secret:    secret,
 		allowFrom: allowFrom,
+		sendQuota: sendQuota{
+			limit:  burstLimit,
+			window: quotaWindow,
+		},
 	}, nil
 }
 
@@ -473,6 +495,12 @@ func (p *WSPlatform) Reply(ctx context.Context, rctx any, content string) error 
 		return nil
 	}
 
+	// Throttle: a stream reply is one WS frame / WeCom send.
+	if err := p.sendQuota.wait(ctx); err != nil {
+		slog.Error("wecom-ws: reply quota wait cancelled", "user", rc.userID, "error", err)
+		return fmt.Errorf("wecom-ws: reply quota: %w", err)
+	}
+
 	streamID := p.generateReqID("stream")
 	frame := map[string]any{
 		"cmd":     "aibot_respond_msg",
@@ -511,6 +539,11 @@ func (p *WSPlatform) Send(ctx context.Context, rctx any, content string) error {
 
 	chunks := splitByBytes(content, 2000)
 	for i, chunk := range chunks {
+		// Throttle per API request: each chunk is a separate WS send.
+		if err := p.sendQuota.wait(ctx); err != nil {
+			slog.Error("wecom-ws: send quota wait cancelled", "user", rc.userID, "chunk", i, "error", err)
+			return fmt.Errorf("wecom-ws: send quota: %w", err)
+		}
 		reqID := p.generateReqID("aibot_send_msg")
 		frame := map[string]any{
 			"cmd":     "aibot_send_msg",

--- a/platform/wecom/wecom.go
+++ b/platform/wecom/wecom.go
@@ -82,6 +82,7 @@ type Platform struct {
 	tokenCache     tokenCache
 	dedup          msgDedup
 	userNameCache  sync.Map // userID -> display name
+	sendQuota      sendQuota // outbound sliding-window quota (burst_limit/burst_window_secs)
 }
 
 const defaultAPIBaseURL = "https://qyapi.weixin.qq.com"
@@ -113,6 +114,86 @@ func (d *msgDedup) isDuplicate(msgID int64) bool {
 	}
 	d.seen[msgID] = now
 	return false
+}
+
+// nowFunc returns the current time. It is a package-level variable so tests
+// can override it to drive sendQuota without real sleeps.
+var nowFunc = time.Now
+
+// sendQuota enforces a sliding-window cap on outbound messages to stay under
+// WeChat Work's app-message frequency limit (~20-30 msgs/min for private
+// deployments; excess triggers throttling/account restrictions). Unlike
+// weixin's fail-fast quota (ilink escalates on retry), wecom's limit is a
+// cumulative frequency gate, so this BLOCKS until the window slides — no
+// messages are dropped, matching the engine-level token-bucket semantics.
+//
+// Counting granularity is per API request: a long reply split by splitByBytes
+// into N chunks consumes N slots, because each chunk is a separate WeCom API
+// call and WeCom counts API calls. Configure via the burst_limit /
+// burst_window_secs platform options. A limit of 0 disables the quota.
+type sendQuota struct {
+	mu     sync.Mutex
+	times  []time.Time // send timestamps still inside the window
+	limit  int         // max sends per window; 0 = disabled
+	window time.Duration
+}
+
+// wait blocks until one send slot is available within the sliding window, then
+// records it. Returns nil on success, or ctx.Err() if ctx is cancelled while
+// waiting. When disabled (limit <= 0 or window <= 0) it returns immediately.
+func (q *sendQuota) wait(ctx context.Context) error {
+	if q.limit <= 0 || q.window <= 0 {
+		return nil
+	}
+	for {
+		now := nowFunc()
+		cutoff := now.Add(-q.window)
+		q.mu.Lock()
+		// Drop timestamps that have slid out of the window.
+		kept := q.times[:0]
+		for _, t := range q.times {
+			if t.After(cutoff) {
+				kept = append(kept, t)
+			}
+		}
+		q.times = kept
+		if len(q.times) < q.limit {
+			q.times = append(q.times, now)
+			q.mu.Unlock()
+			return nil
+		}
+		// Window full: wait until the oldest send slides out.
+		oldest := q.times[0]
+		q.mu.Unlock()
+
+		waitFor := oldest.Add(q.window).Sub(now)
+		if waitFor <= 0 {
+			continue // window already slid; retry immediately
+		}
+		timer := time.NewTimer(waitFor)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+			// Loop back to re-check and consume a slot.
+		}
+	}
+}
+
+// pickInt extracts an int from a map value, tolerating the int/int64/float64
+// types TOML decoding may produce. Returns 0 for missing/unsupported values.
+func pickInt(v any) int {
+	switch x := v.(type) {
+	case int:
+		return x
+	case int64:
+		return int(x)
+	case float64:
+		return int(x)
+	default:
+		return 0
+	}
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -183,6 +264,23 @@ func New(opts map[string]any) (core.Platform, error) {
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom("wecom", allowFrom)
 
+	// Outbound sliding-window quota (see sendQuota). 0 disables the quota.
+	burstLimit := pickInt(opts["burst_limit"])
+	if burstLimit < 0 {
+		burstLimit = 0
+	}
+	burstWindow := pickInt(opts["burst_window_secs"])
+	if burstWindow < 0 {
+		burstWindow = 0
+	}
+	quotaWindow := time.Duration(0)
+	if burstLimit > 0 {
+		if burstWindow <= 0 {
+			burstWindow = 60
+		}
+		quotaWindow = time.Duration(burstWindow) * time.Second
+	}
+
 	return &Platform{
 		corpID:         corpID,
 		corpSecret:     corpSecret,
@@ -195,6 +293,10 @@ func New(opts map[string]any) (core.Platform, error) {
 		callbackPath:   path,
 		enableMarkdown: enableMarkdown,
 		apiClient:      apiClient,
+		sendQuota: sendQuota{
+			limit:  burstLimit,
+			window: quotaWindow,
+		},
 	}, nil
 }
 
@@ -470,6 +572,11 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 
 	chunks := splitByBytes(content, 2000)
 	for i, chunk := range chunks {
+		// Throttle per API request: each chunk is a separate WeCom send call.
+		if err := p.sendQuota.wait(ctx); err != nil {
+			slog.Error("wecom: send quota wait cancelled", "user", rc.userID, "chunk", i, "error", err)
+			return fmt.Errorf("wecom: send quota: %w", err)
+		}
 		var sendErr error
 		if p.enableMarkdown {
 			sendErr = p.sendMarkdown(accessToken, rc.userID, chunk)
@@ -501,6 +608,11 @@ func (p *Platform) SendImage(ctx context.Context, rctx any, img core.ImageAttach
 	accessToken, err := p.getAccessToken()
 	if err != nil {
 		return fmt.Errorf("wecom: send image: %w", err)
+	}
+
+	// Throttle: an image send is one WeCom API call.
+	if err := p.sendQuota.wait(ctx); err != nil {
+		return fmt.Errorf("wecom: send image quota: %w", err)
 	}
 
 	mediaID, err := p.uploadImageMedia(accessToken, img)


### PR DESCRIPTION
## Summary

Add a platform-local outbound rate-limiting quota to the WeChat Work (wecom) platform via two new config options — `burst_limit` and `burst_window_secs` — mirroring the existing `weixin` convention. WeChat Work throttles app messages at ~20-30 msgs/min; the wecom platform previously had no platform-local send throttling, relying solely on the engine-level token bucket (`[outgoing_rate_limit]`), which is disabled by default and cannot express a minute-level total cap.

The quota uses a sliding window that **blocks** (rather than failing fast like weixin, since wecom's limit is a cumulative frequency gate, not a retry-penalty one) until the window slides — no messages dropped. Counts per API request, so a long reply split into N chunks consumes N slots. Applied to both HTTP (`Reply`/`SendImage`) and WebSocket (`Reply`/`Send`) send paths. Disabled by default (`burst_limit=0`) for backward compatibility; stacks with the engine token bucket (per-second pacing + minute cap).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

Verified via build, vet, targeted unit tests, race detector, and the existing wecom package suite.

### Automated tests added in this PR

- `TestSendQuota_Disabled` in `platform/wecom/sendquota_test.go` — `limit=0` returns immediately, never blocks.
- `TestSendQuota_AllowsUnderLimit` — sends under the cap pass instantly.
- `TestSendQuota_BlocksThenReleasesAfterWindow` — at cap, the call blocks; advancing the injected clock past the window releases it.
- `TestSendQuota_ContextCancel` — a blocked `wait` returns `context.Canceled` when ctx is cancelled.
- `TestSendQuota_SlidingWindowEvicts` — timestamps older than the window are evicted, allowing fresh sends.
- `TestNew_BurstLimitParsed` / `TestNew_BurstLimitCustomWindow` / `TestNew_BurstLimitDisabledByDefault` — `New()` (HTTP mode) parses `burst_limit`/`burst_window_secs`, defaults window to 60s, and is disabled by default.
- `TestNewWebSocket_BurstLimitParsed` / `TestNewWebSocket_BurstLimitDisabledByDefault` — same for WebSocket mode.
- `TestPickInt` — the int/int64/float64 TOML coercion helper.

### Critical User Journeys (CUJ) impact

- [x] No CUJ touched (small refactor, doc change, etc.)

This PR adds an opt-in (disabled by default) throttle inside the wecom platform send path. It does not alter any existing user-visible flow — with `burst_limit=0` (default), behavior is byte-for-byte identical to before. No CUJ test updates required.

## Manual / user-visible behavior change

Users can now add to a wecom platform's `[projects.platforms.options]`:

```toml
burst_limit = 20          # max outbound messages per sliding window; 0 = unlimited (default)
burst_window_secs = 60    # sliding window length in seconds (default 60)
```

With the defaults (`burst_limit = 0`) there is **no change**. When enabled, sends that would exceed `burst_limit` within the last `burst_window_secs` block (with context cancellation honored) until the window slides — no messages are dropped. This stacks with the engine-level `[outgoing_rate_limit.platforms.wecom]` token bucket (per-second pacing); the two are independent and complementary.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes (with `-race` if touching concurrency)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (if any new user-facing text)
- [x] No secrets / credentials in source

> Notes for reviewer:
>
> - `go build ./...`: passes. (`web/embed.go` reports a missing `all:dist` embed pattern, but that is a pre-existing, unrelated issue — this PR touches only `platform/wecom/` and `config.example.toml`.)
> - Concurrency: `go test -race ./platform/wecom/` passes clean. The `sendQuota` mutex guards the timestamp slice; the blocking `wait` uses `time.NewTimer` + `ctx.Done()` select with no shared-state access outside the lock.
> - `go vet ./platform/wecom/`: clean. (Initial draft copied a `sendQuota` value through a local var, tripping vet's lock-copy check; fixed by initializing the field directly in the struct literal.)
> - No `core/` changes — the throttle lives entirely in `platform/wecom/`. AGENTS.md notes rate limiting as a cross-cutting concern that "lives in core/", and indeed the **generic** engine-level outgoing limiter already does (`core/outgoing_ratelimit.go`, untouched here). This PR adds a **platform-local** sliding-window quota, not a new cross-cutting mechanism — mirroring the existing `weixin` `burst_limit`/`burst_window_secs` convention (`platform/weixin/weixin.go`). wecom's ~20-30 msgs/min cumulative cap is platform-specific behavior, so it belongs in `platform/wecom/` alongside the weixin precedent, not in the platform-agnostic core.
> - No new user-facing i18n strings — new error text appears only in `slog` logs and returned `error` values, not in user-visible UI.
> - `go test ./...`: wecom package passes (including `-race`). One unrelated failure exists on `main` independently of this PR: `core/TestCUJ_A5_FileReachesAgent` fails on a macOS TempDir cleanup race (`unlinkat ... directory not empty`) during session `.tmp` persistence — this PR does not touch `core/`.

## Related

- Issue:
- Related PR: