### PR TITLE
fix(core): use real context window for reply footer ctx indicator (Fixes #1672)

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -5625,11 +5625,26 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			var statusFooter string
 			var legacyStatusFooter string
 			if !isSilent {
-				footerContext := replyFooterContextText(replyFooterSessionContextUsage(state.agentSession), e.i18n)
+				footerUsage := replyFooterSessionContextUsage(state.agentSession)
+				footerContext := replyFooterContextText(footerUsage, e.i18n)
 				if e.showContextIndicator {
 					if sdkPlausible {
-						if text := contextIndicatorText(event.InputTokens); text != "" {
-							footerContext = text
+						// Use the real ContextWindow from the active session
+						// instead of the previous hardcoded 200k fallback (see
+						// issue #1672). Prefer ContextUsage.UsedTokens (which
+						// already includes cache-read tokens) over the raw
+						// event.InputTokens to avoid inflating the ratio.
+						// When the session does NOT expose a real window we
+						// deliberately emit nothing rather than fall back to
+						// a misleading percentage.
+						if footerUsage != nil && footerUsage.ContextWindow > 0 {
+							used := footerUsage.UsedTokens
+							if used <= 0 {
+								used = event.InputTokens
+							}
+							if text := contextIndicatorText(used, footerUsage.ContextWindow); text != "" {
+								footerContext = text
+							}
 						}
 					} else if selfPct > 0 {
 						footerContext = fmt.Sprintf("[ctx: ~%d%%]", selfPct)
@@ -16808,13 +16823,21 @@ func gitClone(repoURL, dest string) error {
 
 // ── Context usage indicator ──────────────────────────────────
 
-const modelContextWindow = 200_000 // generic fallback window for heuristic context estimates
-
-func contextIndicatorText(inputTokens int) string {
-	if inputTokens <= 0 {
+// contextIndicatorText formats a "[ctx: ~N%]" reply footer marker.
+//
+// contextWindow is the active model's real context window in tokens
+// (sourced from ContextUsage.ContextWindow). Callers must pass a positive
+// value; when the agent session does not report a real window, callers
+// should NOT fall back to a hardcoded constant — returning "" is
+// preferred to emitting a misleading percentage. The fallback heuristic
+// was the source of the v1.4.1 regression tracked in issue #1672 where
+// any model with a window larger than 200k (e.g. deepseek-v4-flash[1M])
+// displayed a flat 100% once input_tokens crossed the hardcoded ceiling.
+func contextIndicatorText(inputTokens, contextWindow int) string {
+	if inputTokens <= 0 || contextWindow <= 0 {
 		return ""
 	}
-	pct := inputTokens * 100 / modelContextWindow
+	pct := inputTokens * 100 / contextWindow
 	if pct > 100 {
 		pct = 100
 	}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1309,6 +1309,14 @@ func TestProcessInteractiveEvents_AppendsContextIndicatorInsideReplyFooter(t *te
 	sessionKey := "telegram:user-footer-context"
 	session := e.sessions.GetOrCreateActive(sessionKey)
 	agentSession := newControllableSession("s-footer-context")
+	// glm-5.1 has a 200k context window — set it so the indicator can be
+	// computed against the real window instead of the previous 200k fallback
+	// (regression test for issue #1672).
+	agentSession.contextUsage = &ContextUsage{
+		ContextWindow: 200_000,
+		UsedTokens:    28000,
+		InputTokens:   28000,
+	}
 	state := &interactiveState{
 		agentSession: agentSession,
 		platform:     p,
@@ -1348,6 +1356,14 @@ func TestProcessInteractiveEvents_ToolSegmentsKeepFinalFooter(t *testing.T) {
 	sessionKey := "telegram:user-tool-footer"
 	session := e.sessions.GetOrCreateActive(sessionKey)
 	agentSession := newControllableSession("s-tool-footer")
+	// glm-5.1 has a 200k context window — set it so the indicator can be
+	// computed against the real window instead of the previous 200k fallback
+	// (regression test for issue #1672).
+	agentSession.contextUsage = &ContextUsage{
+		ContextWindow: 200_000,
+		UsedTokens:    28000,
+		InputTokens:   28000,
+	}
 	state := &interactiveState{
 		agentSession: agentSession,
 		platform:     p,
@@ -8489,6 +8505,161 @@ func TestParseSelfReportedCtx(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("parseSelfReportedCtx(%q) = %d, want %d", tt.input, got, tt.want)
 		}
+	}
+}
+
+// TestContextIndicatorText covers the indicator computation for issue #1672.
+// The function used to divide against a hardcoded 200_000 constant which made
+// it display ~100% for any model whose window was larger than 200k. The fix
+// requires the caller to pass the real context window, so these tests pin
+// the new contract: positive inputs + positive window => "[ctx: ~N%]"; zero
+// or negative inputs/windows => empty string.
+func TestContextIndicatorText(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputTokens   int
+		contextWindow int
+		want          string
+	}{
+		// 200k default model — behavior must match the previous 200k hardcoded path.
+		{"200k model small usage", 28_000, 200_000, "[ctx: ~14%]"},
+		{"200k model half full", 100_000, 200_000, "[ctx: ~50%]"},
+		{"200k model over full clamped to 100", 250_000, 200_000, "[ctx: ~100%]"},
+
+		// 1M window model — the headline regression from issue #1672.
+		// 360527 / 1_000_000 = 36%, NOT 100% as the buggy hardcoded path produced.
+		{"1M model 360k tokens shows 36%", 360_527, 1_000_000, "[ctx: ~36%]"},
+		{"1M model small usage", 50_000, 1_000_000, "[ctx: ~5%]"},
+		{"1M model fully saturated", 1_500_000, 1_000_000, "[ctx: ~100%]"},
+
+		// Edge cases: no real window or no tokens => no indicator.
+		{"no context window returns empty", 28_000, 0, ""},
+		{"negative context window returns empty", 28_000, -1, ""},
+		{"no input tokens returns empty", 0, 200_000, ""},
+		{"negative input tokens returns empty", -1, 200_000, ""},
+		{"both zero returns empty", 0, 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := contextIndicatorText(tt.inputTokens, tt.contextWindow)
+			if got != tt.want {
+				t.Errorf("contextIndicatorText(%d, %d) = %q, want %q",
+					tt.inputTokens, tt.contextWindow, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestContextIndicatorText_OneMillionWindowRegression is the headline scenario
+// from issue #1672: deepseek-v4-flash[1M] with input_tokens=360527 used to
+// display ~100% because the indicator was hardcoded to a 200k denominator.
+// With the real 1M context window in hand it must display ~36%.
+func TestContextIndicatorText_OneMillionWindowRegression(t *testing.T) {
+	const (
+		inputTokens   = 360_527
+		contextWindow = 1_000_000
+	)
+	got := contextIndicatorText(inputTokens, contextWindow)
+	if got != "[ctx: ~36%]" {
+		t.Fatalf("360527/1M must display ~36%% (issue #1672 regression); got %q", got)
+	}
+}
+
+// TestReplyFooterUsesRealContextWindowForOneMillionModel is the integration
+// regression for issue #1672: the full reply footer path must read the
+// active session's ContextWindow rather than the previous 200k hardcoded
+// constant, and prefer ContextUsage.UsedTokens over event.InputTokens when
+// cache-read tokens would otherwise inflate the percentage.
+func TestReplyFooterUsesRealContextWindowForOneMillionModel(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	workDir := filepath.Join(homeDir, "code", "TechStudio", "projects", "core", "agents", "ceo")
+	agent := &stubReplyFooterAgent{
+		stubModelModeAgent: stubModelModeAgent{model: "deepseek-v4-flash[1m]"},
+		workDir:            workDir,
+	}
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetReplyFooterEnabled(true)
+
+	sessionKey := "telegram:user-ctx-1m"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-ctx-1m")
+	// Real session reports a 1M window. UsedTokens already includes
+	// cache-read tokens; event.InputTokens is just the new prompt slice
+	// (smaller than UsedTokens).
+	agentSession.contextUsage = &ContextUsage{
+		ContextWindow: 1_000_000,
+		UsedTokens:    360_527,
+		InputTokens:   5_000,
+	}
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1m",
+		agent:        agent,
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "answer", InputTokens: 5_000, Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-ctx-1m", time.Now(), nil, nil, state.replyCtx)
+
+	sent := p.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent = %#v, want one final reply", sent)
+	}
+	// Must reflect the real 1M window — 360527/1M ~= 36%, NOT 100%.
+	want := "answer\n\n*[ctx: ~36%] · deepseek-v4-flash[1m] · " + compactReplyFooterPath(workDir) + "*"
+	if sent[0] != want {
+		t.Fatalf("final reply = %q, want %q", sent[0], want)
+	}
+}
+
+// TestReplyFooterHidesIndicatorWhenContextWindowUnknown pins the contract
+// that without a real context window the engine must NOT fall back to a
+// hardcoded percentage — it must drop the misleading indicator instead.
+func TestReplyFooterHidesIndicatorWhenContextWindowUnknown(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+
+	workDir := filepath.Join(homeDir, "code", "TechStudio", "projects", "core", "agents", "ceo")
+	agent := &stubReplyFooterAgent{
+		stubModelModeAgent: stubModelModeAgent{model: "mystery-model"},
+		workDir:            workDir,
+	}
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetReplyFooterEnabled(true)
+
+	sessionKey := "telegram:user-ctx-unknown"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-ctx-unknown")
+	// Deliberately leave contextUsage == nil so the engine sees no real
+	// context window. event.InputTokens alone must NOT trigger an
+	// indicator (that was the buggy path).
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-unknown",
+		agent:        agent,
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "answer", InputTokens: 50_000, Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-ctx-unknown", time.Now(), nil, nil, state.replyCtx)
+
+	sent := p.getSent()
+	if len(sent) != 1 {
+		t.Fatalf("sent = %#v, want one final reply", sent)
+	}
+	// No real context window => no "[ctx: ~N%]" marker; the rest of the
+	// footer still renders.
+	want := "answer\n\n*mystery-model · " + compactReplyFooterPath(workDir) + "*"
+	if sent[0] != want {
+		t.Fatalf("final reply = %q, want %q", sent[0], want)
 	}
 }
 

--- a/tests/release_local/turn_contract/turn_contract_test.go
+++ b/tests/release_local/turn_contract/turn_contract_test.go
@@ -44,15 +44,16 @@ func (a *turnAgent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, er
 func (a *turnAgent) Stop() error                                                     { return a.session.Close() }
 
 type turnSession struct {
-	mu         sync.Mutex
-	id         string
-	alive      bool
-	records    []turnRecord
-	events     chan core.Event
-	blockFirst bool
-	blocked    bool
-	result     core.Event
-	permCalls  []permissionCall
+	mu           sync.Mutex
+	id           string
+	alive        bool
+	records      []turnRecord
+	events       chan core.Event
+	blockFirst   bool
+	blocked      bool
+	result       core.Event
+	permCalls    []permissionCall
+	contextUsage *core.ContextUsage
 }
 
 type permissionCall struct {
@@ -141,6 +142,23 @@ func (s *turnSession) releaseFirstResult(event core.Event) {
 	}
 	s.events <- event
 	s.blocked = false
+}
+
+// setContextUsage lets a test make the session report a real context
+// window so the engine's reply-footer ctx indicator can be computed
+// against the model (issue #1672). When left unset, the engine treats
+// the session as not having any context-window info and omits the
+// "[ctx: ~N%]" marker instead of falling back to a hardcoded 200k value.
+func (s *turnSession) setContextUsage(u *core.ContextUsage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.contextUsage = u
+}
+
+func (s *turnSession) GetContextUsage() *core.ContextUsage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.contextUsage
 }
 
 func (s *turnSession) emit(event core.Event) {
@@ -293,6 +311,13 @@ func TestBasicUserTurnContractAcrossInputModalities(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			engine, agent, platform := newTurnEngine(t)
 			engine.SetReplyFooterEnabled(true)
+			// Provide a real context window so the engine emits a
+			// meaningful "[ctx: ~N%]" marker (issue #1672).
+			agent.session.setContextUsage(&core.ContextUsage{
+				ContextWindow: 200_000,
+				UsedTokens:    52000,
+				InputTokens:   52000,
+			})
 			agent.session.setResult(core.Event{Type: core.EventResult, Content: "final answer", InputTokens: 52000, Done: true})
 
 			msg := turnMessage(tt.content)
@@ -606,6 +631,13 @@ func TestStreamingPreviewConfigurationMatrix(t *testing.T) {
 				engine.Stop()
 				_ = agent.Stop()
 			})
+			// Provide a real context window so the engine can compute a
+			// meaningful "[ctx: ~N%]" marker (issue #1672).
+			agent.session.setContextUsage(&core.ContextUsage{
+				ContextWindow: 200_000,
+				UsedTokens:    52000,
+				InputTokens:   52000,
+			})
 			agent.session.blockFirstResult()
 
 			msg := turnMessage("streaming config matrix")
@@ -722,6 +754,14 @@ func TestReplyMetadataConfigurationMatrix(t *testing.T) {
 			agent.workDir = "/tmp/release-agent"
 			engine.SetShowContextIndicator(tt.showCtx)
 			engine.SetReplyFooterEnabled(tt.showFooter)
+			// glm-5.1 has a 200k context window — make the session report
+			// it so the indicator is computed against the real window
+			// instead of the previous 200k hardcoded fallback (#1672).
+			agent.session.setContextUsage(&core.ContextUsage{
+				ContextWindow: 200_000,
+				UsedTokens:    28000,
+				InputTokens:   28000,
+			})
 			agent.session.setResult(core.Event{Type: core.EventResult, Content: "answer", InputTokens: 28000, Done: true})
 
 			engine.ReceiveMessage(platform, turnMessage("metadata matrix"))
@@ -750,6 +790,14 @@ func TestLongFinalResponseKeepsMetadataOnceAtTail(t *testing.T) {
 	agent.model = "glm-5.1"
 	agent.workDir = "/tmp/release-agent"
 	engine.SetReplyFooterEnabled(true)
+	// glm-5.1 has a 200k context window — make the session report it so
+	// the indicator is computed against the real window instead of the
+	// previous 200k hardcoded fallback (#1672).
+	agent.session.setContextUsage(&core.ContextUsage{
+		ContextWindow: 200_000,
+		UsedTokens:    28000,
+		InputTokens:   28000,
+	})
 
 	body := strings.Repeat("long-response ", 420)
 	agent.session.setResult(core.Event{Type: core.EventResult, Content: body, InputTokens: 28000, Done: true})
@@ -842,6 +890,14 @@ func TestRichCardModeKeepsToolStepsAndFinalMetadataInOneCard(t *testing.T) {
 		ToolMessages:     true,
 		ThinkingMaxLen:   300,
 		ToolMaxLen:       500,
+	})
+	// glm-5.1 has a 200k context window — make the session report it so
+	// the indicator is computed against the real window instead of the
+	// previous 200k hardcoded fallback (#1672).
+	agent.session.setContextUsage(&core.ContextUsage{
+		ContextWindow: 200_000,
+		UsedTokens:    28000,
+		InputTokens:   28000,
 	})
 	t.Cleanup(func() {
 		engine.Stop()


### PR DESCRIPTION
Fixes #1672

## Problem

The reply footer `[ctx: ~N%]` marker used a hardcoded 200k denominator (`const modelContextWindow = 200_000` in `core/engine.go`). For models whose context window was larger than 200k (e.g. `deepseek-v4-flash[1M]` with a 1M window), the indicator saturated at 100% the moment input tokens crossed 200k, masking the real consumption.

Reported by @shengbuding with a complete root cause, line numbers, and reproduction (`input=360527` on a 1M model displayed `[ctx: ~100%]` instead of `[ctx: ~36%]`).

## Fix

- Replace `const modelContextWindow = 200_000` with a `contextWindow` parameter on `contextIndicatorText`. When `contextWindow <= 0` the helper returns `""` rather than emitting a misleading percentage.
- The reply footer call site (`processInteractiveEvents` in `core/engine.go`) now reads the real `ContextWindow` from `replyFooterSessionContextUsage(state.agentSession)` and prefers `ContextUsage.UsedTokens` (which already includes cache-read tokens) over the raw `event.InputTokens` to avoid inflating the ratio.
- When the session exposes no real window, we intentionally leave the existing `replyFooterContextText` ("X% left") fallback untouched instead of substituting a hardcoded 200k percentage.

Mirrors the pattern already used by `replyFooterContextText` (L7452).

## Regression tests added (`core/engine_test.go`)

- `TestContextIndicatorText` — table-driven covering 200k/1M windows, saturation clamp at 100%, and zero/negative inputs and windows.
- `TestContextIndicatorText_OneMillionWindowRegression` — pins the headline case: `360527/1M` → `[ctx: ~36%]`, not 100%.
- `TestReplyFooterUsesRealContextWindowForOneMillionModel` — end-to-end integration test asserting that a session reporting `ContextWindow=1_000_000` and `UsedTokens=360_527` (with smaller `event.InputTokens=5000` to simulate cache reads) renders `[ctx: ~36%]` in the final reply footer.
- `TestReplyFooterHidesIndicatorWhenContextWindowUnknown` — pins the contract that without a real `ContextWindow` the engine does NOT emit a misleading percentage based on raw `event.InputTokens`.
- Updated two existing tests that relied on the previous 200k hardcoded fallback to set an explicit `ContextWindow: 200_000` on the stub session.

## Verification

- `go vet -tags no_web ./...` clean
- `go build -tags no_web ./core/... ./cmd/...` clean
- `go test -tags no_web ./core/ -count=1` — all tests pass (47s)

## Risk

Low. The change only affects the path that emits `[ctx: ~N%]` in the reply footer and:
- preserves the existing 200k default-model behavior (verified by `TestProcessInteractiveEvents_AppendsContextIndicatorInsideReplyFooter`),
- intentionally suppresses the misleading indicator instead of falling back to a hardcoded constant when no real window is reported (reporter-requested behavior),
- leaves the `replyFooterContextText` "X% left" branch untouched for sessions that do not implement `ContextUsageReporter`.

## Link

- Issue: https://github.com/chenhg5/cc-connect/issues/1672
- PM triage context: doc-20260818-00j9j8