### PR TITLE
feat(wecom): streaming instant reply with auto-recall

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -617,9 +617,14 @@ func main() {
 
 		// Wire instant reply
 		if cfg.InstantReply.Enabled != nil && *cfg.InstantReply.Enabled {
+			autoRecall := true // default: recall when real response arrives
+			if cfg.InstantReply.AutoRecall != nil {
+				autoRecall = *cfg.InstantReply.AutoRecall
+			}
 			engine.SetInstantReply(core.InstantReplyCfg{
-				Enabled: true,
-				Content: cfg.InstantReply.Content,
+				Enabled:    true,
+				Content:    cfg.InstantReply.Content,
+				AutoRecall: autoRecall,
 			})
 		}
 
@@ -1807,9 +1812,14 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 
 	// Reload instant reply
 	if cfg.InstantReply.Enabled != nil && *cfg.InstantReply.Enabled {
+		autoRecall := true
+		if cfg.InstantReply.AutoRecall != nil {
+			autoRecall = *cfg.InstantReply.AutoRecall
+		}
 		engine.SetInstantReply(core.InstantReplyCfg{
-			Enabled: true,
-			Content: cfg.InstantReply.Content,
+			Enabled:    true,
+			Content:    cfg.InstantReply.Content,
+			AutoRecall: autoRecall,
 		})
 	} else {
 		engine.SetInstantReply(core.InstantReplyCfg{})

--- a/config/config.go
+++ b/config/config.go
@@ -217,8 +217,9 @@ type StreamPreviewConfig struct {
 // is received, before the agent starts processing. This gives users quick feedback
 // that their message was received (e.g. "🤔 Thinking...").
 type InstantReplyConfig struct {
-	Enabled *bool  `toml:"enabled"` // default false
-	Content string `toml:"content"` // custom reply text; empty = use i18n default ("⏳ Processing...")
+	Enabled    *bool  `toml:"enabled"`     // default false
+	Content    string `toml:"content"`     // custom reply text; empty = use i18n default ("⏳ Processing...")
+	AutoRecall *bool  `toml:"auto_recall"` // default true when enabled; recall instant reply when real response arrives
 }
 
 // RateLimitConfig controls per-session message rate limiting.

--- a/core/engine.go
+++ b/core/engine.go
@@ -334,8 +334,9 @@ type DisplayCfg struct {
 // InstantReplyCfg controls the immediate confirmation reply sent when a message
 // is received, before the agent starts processing.
 type InstantReplyCfg struct {
-	Enabled bool
-	Content string // custom reply text; empty = use i18n MsgStarting default
+	Enabled    bool
+	Content    string // custom reply text; empty = use i18n MsgStarting default
+	AutoRecall bool   // recall instant reply message when real response arrives
 }
 
 // RateLimitCfg controls per-session message rate limiting.
@@ -4820,12 +4821,27 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	// Send instant confirmation reply if enabled and no streaming card is active.
 	// Streaming cards provide their own "processing" indicator, so instant reply
 	// is only needed when the platform doesn't support cards or card creation failed.
+	var instantReplyMsgID string
 	if e.instantReply.Enabled && streamCard == nil {
 		replyContent := e.instantReply.Content
 		if replyContent == "" {
 			replyContent = e.i18n.T(MsgStarting)
 		}
-		e.send(state.platform, state.replyCtx, replyContent)
+		if e.instantReply.AutoRecall {
+			if sender, ok := state.platform.(MessageRecallSender); ok {
+				msgID, err := sender.SendAndRecall(e.ctx, state.replyCtx, replyContent)
+				if err != nil {
+					slog.Warn("instant reply send failed, falling back to plain send", "error", err)
+					e.send(state.platform, state.replyCtx, replyContent)
+				} else {
+					instantReplyMsgID = msgID
+				}
+			} else {
+				e.send(state.platform, state.replyCtx, replyContent)
+			}
+		} else {
+			e.send(state.platform, state.replyCtx, replyContent)
+		}
 	}
 
 	// Idle timeout: resets on every received event (0 = disabled)
@@ -4865,6 +4881,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			if err != nil {
 				slog.Error("failed to send prompt", "error", err, "session_key", sessionKey)
 				sp.discard()
+				if instantReplyMsgID != "" {
+					if sender, ok := state.platform.(MessageRecallSender); ok {
+						_ = sender.RecallMessage(e.ctx, instantReplyMsgID)
+						instantReplyMsgID = ""
+					}
+				}
 				if stopTyping != nil {
 					stopTyping()
 					stopTyping = nil
@@ -4885,6 +4907,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				"session_key", sessionKey, "timeout", e.eventIdleTimeout, "elapsed", time.Since(turnStart))
 			cp.Finalize(ProgressCardStateFailed)
 			sp.discard()
+			if instantReplyMsgID != "" {
+				if sender, ok := state.platform.(MessageRecallSender); ok {
+					_ = sender.RecallMessage(e.ctx, instantReplyMsgID)
+					instantReplyMsgID = ""
+				}
+			}
 			state.mu.Lock()
 			state.eventsNeedResync = true
 			p := state.platform
@@ -4898,6 +4926,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				"session_key", sessionKey, "max_turn_time", e.maxTurnTime, "elapsed", elapsed)
 			cp.Finalize(ProgressCardStateFailed)
 			sp.discard()
+			if instantReplyMsgID != "" {
+				if sender, ok := state.platform.(MessageRecallSender); ok {
+					_ = sender.RecallMessage(e.ctx, instantReplyMsgID)
+					instantReplyMsgID = ""
+				}
+			}
 			state.mu.Lock()
 			p := state.platform
 			state.mu.Unlock()
@@ -4941,6 +4975,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			e.cleanupInteractiveState(sessionKey, state)
 			return
 		case <-e.ctx.Done():
+			if instantReplyMsgID != "" {
+				if sender, ok := state.platform.(MessageRecallSender); ok {
+					_ = sender.RecallMessage(e.ctx, instantReplyMsgID)
+					instantReplyMsgID = ""
+				}
+			}
 			state.mu.Lock()
 			state.eventsNeedResync = true
 			state.mu.Unlock()
@@ -5273,6 +5313,17 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				content = stripAgentFooterLines(content)
 			}
 			if content != "" && !isEllipsisOnly(content) {
+				// Recall instant reply when real response starts arriving.
+				if instantReplyMsgID != "" {
+					if sender, ok := p.(MessageRecallSender); ok {
+						if err := sender.RecallMessage(e.ctx, instantReplyMsgID); err != nil {
+							slog.Debug("failed to recall instant reply", "error", err, "msgid", instantReplyMsgID)
+						} else {
+							slog.Debug("instant reply recalled", "msgid", instantReplyMsgID)
+						}
+					}
+					instantReplyMsgID = ""
+				}
 				// Pre-compute silentHold transition including this chunk so the
 				// rich-card path doesn't leak a preview that gets recalled at
 				// end-of-stream when the text resolves to bare NO_REPLY (Lark
@@ -5514,6 +5565,19 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				continue
 			}
 			cp.Finalize(ProgressCardStateCompleted)
+			// Recall instant reply as soon as we know the turn is done and real
+			// response is about to be sent. Must happen before any send path
+			// (streaming card, rich card, plain text, etc.).
+			if instantReplyMsgID != "" {
+				if sender, ok := p.(MessageRecallSender); ok {
+					if err := sender.RecallMessage(e.ctx, instantReplyMsgID); err != nil {
+						slog.Debug("failed to recall instant reply on EventResult", "error", err, "msgid", instantReplyMsgID)
+					} else {
+						slog.Info("instant reply recalled", "msgid", instantReplyMsgID)
+					}
+				}
+				instantReplyMsgID = ""
+			}
 			// Use state.agentSession.CurrentSessionID() instead of event.SessionID.
 			// event.SessionID may be empty in some cases, causing the agent_session_id
 			// to not be persisted to disk, breaking session resume on next startup.
@@ -5982,14 +6046,28 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 				}
 
-				// Send instant reply for queued turn if no streaming card is active.
-				if e.instantReply.Enabled && streamCard == nil {
-					replyContent := e.instantReply.Content
-					if replyContent == "" {
-						replyContent = e.i18n.T(MsgStarting)
+			// Send instant reply for queued turn if no streaming card is active.
+			if e.instantReply.Enabled && streamCard == nil {
+				replyContent := e.instantReply.Content
+				if replyContent == "" {
+					replyContent = e.i18n.T(MsgStarting)
+				}
+				if e.instantReply.AutoRecall {
+					if sender, ok := queued.platform.(MessageRecallSender); ok {
+						msgID, err := sender.SendAndRecall(e.ctx, queued.replyCtx, replyContent)
+						if err != nil {
+							slog.Warn("instant reply send failed for queued turn, falling back to plain send", "error", err)
+							e.send(queued.platform, queued.replyCtx, replyContent)
+						} else {
+							instantReplyMsgID = msgID
+						}
+					} else {
+						e.send(queued.platform, queued.replyCtx, replyContent)
 					}
+				} else {
 					e.send(queued.platform, queued.replyCtx, replyContent)
 				}
+			}
 
 				session.AddHistory("user", queued.content)
 				// Persist queued user message immediately (mirror of the
@@ -6075,6 +6153,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 channelClosed:
 	// Channel closed - process exited unexpectedly
 	slog.Warn("agent process exited", "session_key", sessionKey)
+	// Recall any pending instant reply on abnormal exit.
+	if instantReplyMsgID != "" {
+		if sender, ok := state.platform.(MessageRecallSender); ok {
+			if err := sender.RecallMessage(e.ctx, instantReplyMsgID); err != nil {
+				slog.Debug("failed to recall instant reply on channel close", "error", err)
+			}
+			instantReplyMsgID = ""
+		}
+	}
 	state.mu.Lock()
 	state.eventsNeedResync = true
 	state.mu.Unlock()

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -47,6 +47,20 @@ type MessageRecallDetector interface {
 	IsMessageRecalled(ctx context.Context, replyCtx any) (bool, error)
 }
 
+// MessageRecallSender is an optional interface for platforms that support
+// sending a message and later recalling (deleting) it by message ID.
+// This is used for instant reply auto-recall: the bot sends a "thinking..."
+// placeholder, then recalls it when the real response arrives.
+type MessageRecallSender interface {
+	// SendAndRecall sends a message and returns its platform message ID
+	// for later recall. The returned msgID is non-empty only when the
+	// platform supports recall (e.g. WeChat Work within 24h).
+	SendAndRecall(ctx context.Context, replyCtx any, content string) (msgID string, err error)
+	// RecallMessage recalls (deletes) a previously sent message by its ID.
+	// Returns nil if recall is not supported or the message was already recalled.
+	RecallMessage(ctx context.Context, msgID string) error
+}
+
 // CronReplyTargetResolver is an optional interface for platforms that need to
 // map a logical cron session key to the actual reply target used at execution
 // time. This is useful for platforms where proactive replies may need to create

--- a/platform/wecom/websocket.go
+++ b/platform/wecom/websocket.go
@@ -36,7 +36,8 @@ type WSPlatform struct {
 	dedup       core.MessageDedup
 	reqSeq      atomic.Int64 // monotonic counter for generating unique req_id
 	missedPong  atomic.Int32 // consecutive heartbeat acks not received
-	pendingAcks sync.Map     // req_id -> chan wsAckResult, for sequential send with ack waiting
+	pendingAcks   sync.Map // req_id -> chan wsAckResult, for sequential send with ack waiting
+	pendingStreams sync.Map // chatID -> pendingStreamInfo, for streaming instant reply (finish=false → finish=true)
 }
 
 const (
@@ -48,10 +49,15 @@ var errWSAckTimeout = errors.New("wecom-ws: ack timeout")
 
 // wsReplyContext holds the context needed to reply to a specific message.
 type wsReplyContext struct {
-	reqID    string // req_id from headers of aibot_msg_callback
-	chatID   string // chatid for aibot_send_msg
-	chatType string // chattype: "single" or "group"
-	userID   string // from.userid
+	reqID  string // req_id from headers of aibot_msg_callback
+	chatID string // chatid for aibot_send_msg
+	userID string // from.userid
+}
+
+// pendingStreamInfo tracks a streaming instant reply that needs to be finished.
+type pendingStreamInfo struct {
+	reqID    string // original req_id from the callback (for aibot_respond_msg header)
+	streamID string // stream ID used in the initial finish=false frame
 }
 
 // --- WebSocket protocol frame types (matching official SDK) ---
@@ -383,10 +389,9 @@ func (p *WSPlatform) handleMsgCallback(frame wsFrame) {
 		chatID = body.From.UserID
 	}
 	rctx := wsReplyContext{
-		reqID:    reqID,
-		chatID:   chatID,
-		chatType: body.ChatType,
-		userID:   body.From.UserID,
+		reqID:  reqID,
+		chatID: chatID,
+		userID: body.From.UserID,
 	}
 
 	if !core.AllowList(p.allowFrom, body.From.UserID) {
@@ -464,6 +469,8 @@ func (p *WSPlatform) handleMsgCallback(frame wsFrame) {
 // The stream content field is a full-replacement (not incremental append), so we
 // send the complete content in one frame with finish=true.
 // Markdown is natively supported by the stream reply format.
+// If there's a pending streaming instant reply (from SendAndRecall), this method
+// finishes it with the real response content (finish=true on the same stream).
 func (p *WSPlatform) Reply(ctx context.Context, rctx any, content string) error {
 	rc, ok := rctx.(wsReplyContext)
 	if !ok {
@@ -473,6 +480,30 @@ func (p *WSPlatform) Reply(ctx context.Context, rctx any, content string) error 
 		return nil
 	}
 
+	// Check if there's a pending streaming instant reply to finish
+	if psVal, ok := p.pendingStreams.LoadAndDelete(rc.chatID); ok {
+		ps := psVal.(*pendingStreamInfo)
+		frame := map[string]any{
+			"cmd":     "aibot_respond_msg",
+			"headers": map[string]string{"req_id": ps.reqID},
+			"body": map[string]any{
+				"msgtype": "stream",
+				"stream": map[string]any{
+					"id":      ps.streamID,
+					"finish":  true,
+					"content": content,
+				},
+			},
+		}
+		if err := p.writeJSON(frame); err != nil {
+			slog.Error("wecom-ws: reply (finish stream) failed", "user", rc.userID, "error", err)
+			return err
+		}
+		slog.Debug("wecom-ws: reply sent (finished streaming instant reply)", "user", rc.userID, "len", len(content))
+		return nil
+	}
+
+	// Normal reply (no pending stream)
 	streamID := p.generateReqID("stream")
 	frame := map[string]any{
 		"cmd":     "aibot_respond_msg",
@@ -497,6 +528,9 @@ func (p *WSPlatform) Reply(ctx context.Context, rctx any, content string) error 
 // Send sends a proactive message via aibot_send_msg (markdown format).
 // Used for follow-up messages and cron-triggered messages where no req_id is available.
 // Markdown is natively supported.
+// If there's a pending streaming instant reply (from SendAndRecall), this method
+// finishes it with the real response content via aibot_respond_msg (finish=true)
+// instead of sending a new aibot_send_msg — the stream replaces the placeholder.
 func (p *WSPlatform) Send(ctx context.Context, rctx any, content string) error {
 	rc, ok := rctx.(wsReplyContext)
 	if !ok {
@@ -507,6 +541,30 @@ func (p *WSPlatform) Send(ctx context.Context, rctx any, content string) error {
 	}
 	if rc.chatID == "" {
 		return fmt.Errorf("wecom-ws: chatID is empty, cannot send proactive message")
+	}
+
+	// Finish any pending streaming instant reply with the real content
+	if psVal, ok := p.pendingStreams.LoadAndDelete(rc.chatID); ok {
+		ps := psVal.(*pendingStreamInfo)
+		finishFrame := map[string]any{
+			"cmd":     "aibot_respond_msg",
+			"headers": map[string]string{"req_id": ps.reqID},
+			"body": map[string]any{
+				"msgtype": "stream",
+				"stream": map[string]any{
+					"id":      ps.streamID,
+					"finish":  true,
+					"content": content,
+				},
+			},
+		}
+		if err := p.writeJSON(finishFrame); err != nil {
+			slog.Error("wecom-ws: finish pending stream failed", "user", rc.userID, "error", err)
+			// Fall through to send via aibot_send_msg as backup
+		} else {
+			slog.Debug("wecom-ws: finished streaming instant reply with real content", "user", rc.userID, "len", len(content))
+			return nil
+		}
 	}
 
 	chunks := splitByBytes(content, 2000)
@@ -631,4 +689,50 @@ func (p *WSPlatform) writeAndWaitResult(ctx context.Context, frame map[string]an
 		p.pendingAcks.Delete(reqID)
 		return wsAckResult{}, errWSAckTimeout
 	}
+}
+
+// SendAndRecall sends an instant reply via WebSocket streaming (finish=false)
+// and stores the stream info for later finishing by Reply() or Send().
+// This avoids the IP whitelist issue with REST API (error 60020).
+// The returned "msgID" is actually the reqID, used as key for RecallMessage.
+func (p *WSPlatform) SendAndRecall(ctx context.Context, rctx any, content string) (string, error) {
+	rc, ok := rctx.(wsReplyContext)
+	if !ok {
+		return "", fmt.Errorf("wecom-ws: SendAndRecall: invalid reply context type %T", rctx)
+	}
+	if content == "" {
+		return "", nil
+	}
+
+	streamID := p.generateReqID("stream")
+	frame := map[string]any{
+		"cmd":     "aibot_respond_msg",
+		"headers": map[string]string{"req_id": rc.reqID},
+		"body": map[string]any{
+			"msgtype": "stream",
+			"stream": map[string]any{
+				"id":      streamID,
+				"finish":  false,
+				"content": content,
+			},
+		},
+	}
+	if err := p.writeJSON(frame); err != nil {
+		slog.Error("wecom-ws: SendAndRecall: send failed", "user", rc.userID, "error", err)
+		return "", err
+	}
+
+	// Store stream info keyed by chatID (both Reply and Send can look it up)
+	p.pendingStreams.Store(rc.chatID, &pendingStreamInfo{reqID: rc.reqID, streamID: streamID})
+	slog.Debug("wecom-ws: SendAndRecall: instant reply sent via streaming", "user", rc.userID, "chat_id", rc.chatID, "req_id", rc.reqID, "stream_id", streamID)
+	return rc.reqID, nil
+}
+
+// RecallMessage is a no-op in streaming mode.
+// The instant reply stream will be finished by the next Reply() call
+// with the real response content (finish=true on the same stream).
+// msgID is actually the reqID from SendAndRecall.
+func (p *WSPlatform) RecallMessage(ctx context.Context, msgID string) error {
+	slog.Debug("wecom-ws: RecallMessage: stream will be finished by next Reply", "req_id", msgID)
+	return nil
 }

--- a/platform/wecom/wecom.go
+++ b/platform/wecom/wecom.go
@@ -450,44 +450,98 @@ func (p *Platform) handleMessage(w http.ResponseWriter, r *http.Request, msgSig,
 }
 
 func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
+	_, err := p.replyWithMsgID(ctx, rctx, content)
+	return err
+}
+
+func (p *Platform) replyWithMsgID(ctx context.Context, rctx any, content string) (string, error) {
 	rc, ok := rctx.(replyContext)
 	if !ok {
-		return fmt.Errorf("wecom: invalid reply context type %T", rctx)
+		return "", fmt.Errorf("wecom: invalid reply context type %T", rctx)
 	}
 	if content == "" {
-		return nil
+		return "", nil
 	}
 
 	accessToken, err := p.getAccessToken()
 	if err != nil {
 		slog.Error("wecom: get access_token failed", "error", err)
-		return fmt.Errorf("wecom: get access_token: %w", err)
+		return "", fmt.Errorf("wecom: get access_token: %w", err)
 	}
 
 	if !p.enableMarkdown {
 		content = core.StripMarkdown(content)
 	}
 
+	var lastMsgID string
 	chunks := splitByBytes(content, 2000)
 	for i, chunk := range chunks {
+		var msgID string
 		var sendErr error
 		if p.enableMarkdown {
-			sendErr = p.sendMarkdown(accessToken, rc.userID, chunk)
+			msgID, sendErr = p.sendMarkdown(accessToken, rc.userID, chunk)
 		} else {
-			sendErr = p.sendText(accessToken, rc.userID, chunk)
+			msgID, sendErr = p.sendText(accessToken, rc.userID, chunk)
+		}
+		if msgID != "" {
+			lastMsgID = msgID
 		}
 		if sendErr != nil {
 			slog.Error("wecom: send failed", "user", rc.userID, "chunk", i, "error", sendErr)
-			return sendErr
+			return lastMsgID, sendErr
 		}
 	}
 	slog.Debug("wecom: message sent", "user", rc.userID, "chunks", len(chunks), "total_len", len(content))
-	return nil
+	return lastMsgID, nil
 }
 
 // Send sends a new message (same as Reply for WeChat Work)
 func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 	return p.Reply(ctx, rctx, content)
+}
+
+// SendAndRecall sends a message and returns its msgID for later recall.
+// Implements core.MessageRecallSender.
+func (p *Platform) SendAndRecall(ctx context.Context, rctx any, content string) (string, error) {
+	return p.replyWithMsgID(ctx, rctx, content)
+}
+
+// RecallMessage recalls (deletes) a previously sent message by msgID.
+// WeChat Work allows recalling messages within 24 hours.
+// Implements core.MessageRecallSender.
+func (p *Platform) RecallMessage(ctx context.Context, msgID string) error {
+	if msgID == "" {
+		return nil
+	}
+	accessToken, err := p.getAccessToken()
+	if err != nil {
+		slog.Warn("wecom: recall: get access_token failed", "error", err)
+		return fmt.Errorf("wecom: recall: get access_token: %w", err)
+	}
+	payload := map[string]string{"msgid": msgID}
+	body, _ := json.Marshal(payload)
+	apiURL := p.wecomAPIURL("/cgi-bin/message/recall", url.Values{
+		"access_token": []string{accessToken},
+	})
+	resp, err := p.apiClient.Post(apiURL, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		slog.Warn("wecom: recall: request failed", "error", err)
+		return fmt.Errorf("wecom: recall: request: %w", err)
+	}
+	defer resp.Body.Close()
+	var result struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("wecom: recall: decode response: %w", err)
+	}
+	if result.ErrCode != 0 {
+		slog.Warn("wecom: recall failed", "errcode", result.ErrCode, "errmsg", result.ErrMsg, "msgid", msgID)
+		return fmt.Errorf("wecom: recall failed: %d %s", result.ErrCode, result.ErrMsg)
+	}
+	slog.Debug("wecom: message recalled", "msgid", msgID)
+	return nil
 }
 
 // SendImage uploads and sends an image to the user.
@@ -589,7 +643,7 @@ func (p *Platform) uploadImageMedia(accessToken string, img core.ImageAttachment
 
 var _ core.ImageSender = (*Platform)(nil)
 
-func (p *Platform) sendMarkdown(accessToken, toUser, content string) error {
+func (p *Platform) sendMarkdown(accessToken, toUser, content string) (string, error) {
 	payload := map[string]any{
 		"touser":   toUser,
 		"msgtype":  "markdown",
@@ -604,24 +658,25 @@ func (p *Platform) sendMarkdown(accessToken, toUser, content string) error {
 
 	resp, err := p.apiClient.Post(apiURL, "application/json", strings.NewReader(string(body)))
 	if err != nil {
-		return fmt.Errorf("wecom: send markdown: %w", err)
+		return "", fmt.Errorf("wecom: send markdown: %w", err)
 	}
 	defer resp.Body.Close()
 
 	var result struct {
 		ErrCode int    `json:"errcode"`
 		ErrMsg  string `json:"errmsg"`
+		MsgID   string `json:"msgid"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("wecom: decode send response: %w", err)
+		return "", fmt.Errorf("wecom: decode send response: %w", err)
 	}
 	if result.ErrCode != 0 {
-		return fmt.Errorf("wecom: send markdown failed: %d %s", result.ErrCode, result.ErrMsg)
+		return "", fmt.Errorf("wecom: send markdown failed: %d %s", result.ErrCode, result.ErrMsg)
 	}
-	return nil
+	return result.MsgID, nil
 }
 
-func (p *Platform) sendText(accessToken, toUser, text string) error {
+func (p *Platform) sendText(accessToken, toUser, text string) (string, error) {
 	payload := map[string]any{
 		"touser":  toUser,
 		"msgtype": "text",
@@ -637,21 +692,22 @@ func (p *Platform) sendText(accessToken, toUser, text string) error {
 
 	resp, err := p.apiClient.Post(apiURL, "application/json", strings.NewReader(string(body)))
 	if err != nil {
-		return fmt.Errorf("wecom: send message: %w", err)
+		return "", fmt.Errorf("wecom: send message: %w", err)
 	}
 	defer resp.Body.Close()
 
 	var result struct {
 		ErrCode int    `json:"errcode"`
 		ErrMsg  string `json:"errmsg"`
+		MsgID   string `json:"msgid"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("wecom: decode send response: %w", err)
+		return "", fmt.Errorf("wecom: decode send response: %w", err)
 	}
 	if result.ErrCode != 0 {
-		return fmt.Errorf("wecom: send failed: %d %s", result.ErrCode, result.ErrMsg)
+		return "", fmt.Errorf("wecom: send failed: %d %s", result.ErrCode, result.ErrMsg)
 	}
-	return nil
+	return result.MsgID, nil
 }
 
 func (p *Platform) getAccessToken() (string, error) {


### PR DESCRIPTION
Add MessageRecallSender interface and instant reply auto-recall support for WeChat Work platforms.

## Changes

### WebSocket Mode (WSPlatform)
- `SendAndRecall()` sends instant reply via streaming (`finish=false`)
- `RecallMessage()` is a no-op (stream replaced, not recalled)
- `Reply()`/`Send()` detect pending streams and finish them (`finish=true`) with the real response content, replacing the placeholder

### REST API Mode (Platform)
- `SendAndRecall()` sends message and returns msgID
- `RecallMessage()` recalls the message via `/cgi-bin/message/recall`

### Config
- Add `auto_recall` option to `[instant_reply]` section (default: true)
- When enabled, platforms implementing `MessageRecallSender` will use the recall/replace flow instead of showing two separate messages

## Motivation

This avoids the IP whitelist issue (error 60020) for WebSocket mode by using the streaming protocol instead of REST API for message replacement. The bot sends a placeholder message (finish=false) and replaces it with the real response (finish=true) using the same stream ID.

## How it works

```
User sends message
    ↓
SendAndRecall() → sends "🤔 Thinking..." (finish=false, stream_id=X)
    ↓
AI processes...
    ↓
Reply()/Send() → sends real response (finish=true, same stream_id=X)
    ↓
Enterprise WeChat replaces placeholder with real content (single message)
```
