### PR TITLE
feat(cursor): deliver image attachments to the Cursor CLI via on-disk paths

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -962,7 +962,7 @@ func (cs *claudeSession) Send(prompt string, messageID string, images []core.Ima
 
 	// Save and encode images
 	for i, img := range images {
-		ext := extFromMime(img.MimeType)
+		ext := core.ExtFromMime(img.MimeType)
 		fname := fmt.Sprintf("img_%d_%d%s", time.Now().UnixMilli(), i, ext)
 		fpath := filepath.Join(attachDir, fname)
 		if err := os.WriteFile(fpath, img.Data, 0o644); err != nil {
@@ -1008,19 +1008,6 @@ func (cs *claudeSession) Send(prompt string, messageID string, images []core.Ima
 		"type":    "user",
 		"message": map[string]any{"role": "user", "content": parts},
 	})
-}
-
-func extFromMime(mime string) string {
-	switch mime {
-	case "image/jpeg":
-		return ".jpg"
-	case "image/gif":
-		return ".gif"
-	case "image/webp":
-		return ".webp"
-	default:
-		return ".png"
-	}
 }
 
 // RespondPermission writes a control_response to the Claude process stdin.

--- a/agent/cursor/session.go
+++ b/agent/cursor/session.go
@@ -77,7 +77,25 @@ func newCursorSession(ctx context.Context, cmd string, extraArgs []string, workD
 
 func (cs *cursorSession) Send(prompt string, messageID string, images []core.ImageAttachment, files []core.FileAttachment) error {
 	if len(images) > 0 {
-		slog.Warn("cursorSession: images not yet supported in CLI mode, ignoring")
+		// The Cursor Agent CLI has no image flag, but it can open image files
+		// from disk and see their content. So route images through the same
+		// on-disk channel as files instead of dropping them.
+		imgFiles := make([]core.FileAttachment, 0, len(images))
+		for i, im := range images {
+			name := im.FileName
+			if name == "" {
+				// Feishu image messages carry no filename — synthesise one so
+				// the file lands with a correct extension.
+				name = fmt.Sprintf("img_%d_%d%s", time.Now().UnixMilli(), i, core.ExtFromMime(im.MimeType))
+			}
+			imgFiles = append(imgFiles, core.FileAttachment{
+				MimeType: im.MimeType,
+				Data:     im.Data,
+				FileName: name,
+			})
+		}
+		imagePaths := core.SaveFilesToDisk(cs.workDir, messageID, imgFiles)
+		prompt = core.AppendImageRefs(prompt, imagePaths)
 	}
 	if len(files) > 0 {
 		filePaths := core.SaveFilesToDisk(cs.workDir, messageID, files)

--- a/core/message.go
+++ b/core/message.go
@@ -341,6 +341,50 @@ func AppendFileRefs(prompt string, filePaths []string) string {
 	return prompt + "\n\n(Files saved locally, please read them: " + strings.Join(abs, ", ") + ")"
 }
 
+// ExtFromMime maps an image MIME type to a file extension. Attachments that
+// arrive without a filename (Feishu image messages carry only bytes + MIME)
+// must still land on disk with a usable extension, otherwise downstream agents
+// have to guess the format from the bytes.
+func ExtFromMime(mime string) string {
+	switch mime {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/bmp":
+		return ".bmp"
+	default:
+		return ".png"
+	}
+}
+
+// AppendImageRefs appends saved image paths to the prompt. Kept separate from
+// AppendFileRefs so the wording tells the agent these are images the user sent
+// and that it should open them to see the content.
+func AppendImageRefs(prompt string, imagePaths []string) string {
+	if len(imagePaths) == 0 {
+		return prompt
+	}
+	if prompt == "" {
+		prompt = "Please look at the attached image(s)."
+	}
+	abs := make([]string, len(imagePaths))
+	for i, p := range imagePaths {
+		if filepath.IsAbs(p) {
+			abs[i] = p
+			continue
+		}
+		if a, err := filepath.Abs(p); err == nil {
+			abs[i] = a
+		} else {
+			abs[i] = p
+		}
+	}
+	return prompt + "\n\n(The user attached image(s), saved locally — read the file(s) to view them: " + strings.Join(abs, ", ") + ")"
+}
+
 // AudioAttachment represents a voice/audio message sent by the user.
 type AudioAttachment struct {
 	MimeType string // e.g. "audio/amr", "audio/ogg", "audio/mp4"

--- a/core/message_image_test.go
+++ b/core/message_image_test.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtFromMime(t *testing.T) {
+	cases := map[string]string{
+		"image/jpeg": ".jpg",
+		"image/gif":  ".gif",
+		"image/webp": ".webp",
+		"image/bmp":  ".bmp",
+		"image/png":  ".png",
+		"":           ".png", // unknown / missing MIME falls back to png
+	}
+	for mime, want := range cases {
+		if got := ExtFromMime(mime); got != want {
+			t.Errorf("ExtFromMime(%q) = %q, want %q", mime, got, want)
+		}
+	}
+}
+
+func TestAppendImageRefs(t *testing.T) {
+	if got := AppendImageRefs("hi", nil); got != "hi" {
+		t.Errorf("no paths should leave prompt untouched, got %q", got)
+	}
+
+	got := AppendImageRefs("", []string{"/tmp/a.png"})
+	if !strings.Contains(got, "/tmp/a.png") {
+		t.Errorf("path missing from prompt: %q", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "image") {
+		t.Errorf("prompt should tell the agent these are images: %q", got)
+	}
+}
+
+// Images arriving without a filename (Feishu sends bytes + MIME only) must
+// still land on disk with a usable extension.
+func TestSaveFilesToDisk_ImageWithoutFileName(t *testing.T) {
+	dir := t.TempDir()
+	saved := SaveFilesToDisk(dir, "msg1", []FileAttachment{
+		{MimeType: "image/png", Data: []byte("\x89PNG fake"), FileName: "img_1_0" + ExtFromMime("image/png")},
+	})
+	if len(saved) != 1 {
+		t.Fatalf("expected 1 saved file, got %d", len(saved))
+	}
+	if filepath.Ext(saved[0]) != ".png" {
+		t.Errorf("saved image lost its extension: %q", saved[0])
+	}
+	if _, err := os.Stat(saved[0]); err != nil {
+		t.Errorf("saved image not on disk: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`cursorSession.Send()` discarded every image:

```go
if len(images) > 0 {
    slog.Warn("cursorSession: images not yet supported in CLI mode, ignoring")
}
```

The drop is silent from the agent's point of view — no placeholder, nothing
appended to the prompt. A user who sends a screenshot plus "what's in here?"
gets an answer that quietly resolves the pronoun against unrelated
conversation history, which reads as a confident hallucination.

## Why it can work

The Cursor Agent CLI has no image flag, but it **can open image files from disk
and see their content**. Verified directly:

```
$ agent --print --workspace <dir> -- "read this image and quote the text: /tmp/shot.png"
```

returns an accurate transcription of the screenshot, watermarks included.

## Change

Route images through the same on-disk channel the file attachments already
use (`core.SaveFilesToDisk` + a path reference appended to the prompt).

Feishu image messages carry only bytes + MIME and **no filename**, so a name is
synthesised with an extension derived from the MIME type. Without this the
attachment lands as an extension-less blob and the agent has to guess the
format.

Two small helpers move into `core` so both backends share them:

- `core.ExtFromMime` — lifted out of `agent/claudecode` (was private, now shared;
  claudecode calls the shared one, behaviour unchanged, plus `image/bmp`)
- `core.AppendImageRefs` — like `AppendFileRefs`, but the wording tells the
  agent the paths are images the user attached

## Tests

- `core/message_image_test.go` — MIME→extension mapping, prompt wording, and
  that an image without a filename still lands with a usable extension
- `go test ./core/... ./agent/...` passes

## End-to-end

Running this build behind Feishu + cursor: sending a screenshot now logs the
attachment instead of the warning, and the agent reads the image content
correctly.