### PR TITLE
fix(daemon): drop redundant CheckLinger stub that breaks all non-Linux builds

### DIFF
--- a/daemon/check_linger_other.go
+++ b/daemon/check_linger_other.go
@@ -1,9 +1,0 @@
-//go:build !linux
-
-package daemon
-
-// CheckLinger is a stub for non-Linux platforms where systemd linger does not
-// apply. Returns (true, "") so callers skip the linger warning.
-func CheckLinger() (enabled bool, user string) {
-	return true, ""
-}


### PR DESCRIPTION
## Problem

`main` does not compile on macOS (or Windows):

```
# github.com/chenhg5/cc-connect/daemon
daemon/launchd.go:32:6: CheckLinger redeclared in this block
	daemon/check_linger_other.go:7:6: other declaration of CheckLinger
```

`daemon/check_linger_other.go` declares `CheckLinger` under `//go:build !linux`,
but each platform already has its own definition:

| file | build tag |
| --- | --- |
| `daemon/systemd.go` | `linux` |
| `daemon/launchd.go` | `darwin` |
| `daemon/windows.go` | `windows` |
| `daemon/unsupported.go` | `!linux && !darwin && !windows` |

`!linux` overlaps darwin, windows **and** the catch-all case, so the package
only compiles on Linux. `v1.5.0` builds fine; the stub was added afterwards.

## Fix

The stub is fully redundant — `unsupported.go` already covers every platform
that lacks a native implementation. Removing the file restores the build.

## Verification

`go build -tags no_web ./cmd/cc-connect`

- darwin/arm64 — OK
- darwin/amd64 — OK
- linux/amd64 (`CGO_ENABLED=0`) — OK

Unrelated pre-existing issue spotted while checking windows/amd64, not touched
by this PR: `agent/pi/proc_windows.go:6:2: "os" imported and not used`.

## Why not just narrow the build tag?

Tested: retagging the stub to `!linux && !darwin && !windows` simply moves the collision to `daemon/unsupported.go`, which carries the same tag and already defines `CheckLinger`:

```
daemon/unsupported.go:15:6: CheckLinger redeclared in this block
	daemon/check_linger_other.go:7:6: other declaration of CheckLinger
```

Since the four files above partition every GOOS, there is **no possible build tag** under which this stub compiles anywhere — deletion is the only fix. (Semantics also favor `unsupported.go`: it returns `false` where the stub returns `true`.)

Related: #1738 fixes the remaining windows-only break in `agent/pi`; with both, darwin/arm64, darwin/amd64, windows/amd64, linux/amd64 and freebsd/amd64 all compile cleanly.