### PR TITLE
fix(readme): restore working star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,11 +706,11 @@ We accept the following commercial collaborations:
 
 ## ⭐ Star History
 
-<a href="https://www.star-history.com/#chenhg5/cc-connect&Date">
+<a href="https://star-history.dera.page/#chenhg5/cc-connect&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=chenhg5/cc-connect&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=chenhg5/cc-connect&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=chenhg5/cc-connect&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=chenhg5/cc-connect&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=chenhg5/cc-connect&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=chenhg5/cc-connect&type=Date" />
  </picture>
 </a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -692,11 +692,11 @@ cc-connect send --tts "你好"
 
 ## ⭐ Star History
 
-<a href="https://www.star-history.com/#chenhg5/cc-connect&Date">
+<a href="https://star-history.dera.page/#chenhg5/cc-connect&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=chenhg5/cc-connect&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=chenhg5/cc-connect&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=chenhg5/cc-connect&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=chenhg5/cc-connect&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=chenhg5/cc-connect&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=chenhg5/cc-connect&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart on the README is broken and shows nothing, which hides the project's popularity from visitors landing on the repo. This change fixes the chart in both README.md and README.zh-CN.md by pointing it at the current star-history host so the graph renders correctly again. No other content is modified.