### PR TITLE
fix: thread --config through cron/timer/relay clients and unify data_dir resolution (Issue #1719)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,15 @@ When a user runs `/dir reset`, cc-connect restores the configured `work_dir` and
 ./cc-connect
 ```
 
+### 🐳 Deployment (Docker / nohup / tmux / screen)
+
+Running cc-connect in a container or without systemd? See
+[docs/deployment.md](docs/deployment.md) for the proven recipes and the
+most common failure mode (Issue #1719: cron can't find the daemon
+socket). The short version: always pass the same `--config /path/to.toml`
+to both the daemon and any client subcommand (`cron`, `send`, `timer`,
+`relay`), and mount the `data_dir` volume with matching UID/GID.
+
 
 ### 🔄 Upgrade
 
@@ -561,6 +570,7 @@ Notes:
 
 - [Usage Guide](docs/usage.md) — Complete feature documentation
 - [INSTALL.md](INSTALL.md) — AI-agent-friendly installation guide
+- [Deployment Guide](docs/deployment.md) — Docker, nohup, tmux, screen recipes (Issue #1719)
 - [config.example.toml](config.example.toml) — Configuration template
 - [CONTRIBUTING.md](CONTRIBUTING.md) — How to report issues and contribute pull requests
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -341,6 +341,14 @@ vim ~/.cc-connect/config.toml
 ./cc-connect
 ```
 
+### 🐳 部署 (Docker / nohup / tmux / screen)
+
+在容器或没有 systemd 的环境运行 cc-connect? 参考
+[docs/deployment.md](docs/deployment.md) 了解经过验证的部署方式,
+以及最常见的失败原因 (Issue #1719: cron 找不到 daemon socket)。
+简短总结:守护进程和所有客户端子命令 (`cron`、`send`、`timer`、`relay`)
+都传同一个 `--config /path/to.toml`,并以一致的 UID/GID 挂载 `data_dir`。
+
 
 ### 🔄 升级
 
@@ -548,6 +556,7 @@ cc-connect send --tts "你好"
 
 - [使用指南](docs/usage.zh-CN.md) — 完整功能文档
 - [INSTALL.md](INSTALL.md) — AI Agent 友好的安装指南
+- [部署指南](docs/deployment.md) — Docker / nohup / tmux / screen 配置 (Issue #1719)
 - [config.example.toml](config.example.toml) — 配置模板
 - [CONTRIBUTING.md](CONTRIBUTING.md) — Issue / PR 提交流程与贡献说明
 

--- a/cmd/cc-connect/cron.go
+++ b/cmd/cc-connect/cron.go
@@ -57,7 +57,7 @@ func closeCronResponseBody(body io.Closer) {
 }
 
 func runCronAdd(args []string) {
-	var project, sessionKey, cronExpr, prompt, execCmd, desc, dataDir, sessionMode string
+	var project, sessionKey, cronExpr, prompt, execCmd, desc, dataDir, sessionMode, configPath string
 	var timeoutMins *int
 	var silent bool
 
@@ -98,6 +98,11 @@ func runCronAdd(args []string) {
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		case "--session-mode":
 			if i+1 < len(args) {
@@ -152,9 +157,10 @@ func runCronAdd(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -205,7 +211,7 @@ func runCronAdd(args []string) {
 }
 
 func runCronList(args []string) {
-	var project, dataDir string
+	var project, dataDir, configPath string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--project", "-p":
@@ -218,6 +224,11 @@ func runCronList(args []string) {
 				i++
 				dataDir = args[i]
 			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
+			}
 		}
 	}
 
@@ -225,9 +236,10 @@ func runCronList(args []string) {
 		project = os.Getenv("CC_PROJECT")
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -295,13 +307,18 @@ func runCronList(args []string) {
 }
 
 func runCronExec(args []string) {
-	var id, dataDir string
+	var id, dataDir, configPath string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--data-dir":
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		case "--help", "-h":
 			printCronExecUsage()
@@ -319,9 +336,10 @@ func runCronExec(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -343,7 +361,7 @@ func runCronExec(args []string) {
 }
 
 func runCronDel(args []string) {
-	var dataDir string
+	var dataDir, configPath string
 	var id string
 
 	for i := 0; i < len(args); i++ {
@@ -352,6 +370,11 @@ func runCronDel(args []string) {
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		default:
 			id = args[i]
@@ -363,9 +386,10 @@ func runCronDel(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -387,7 +411,7 @@ func runCronDel(args []string) {
 }
 
 func runCronInfo(args []string) {
-	var dataDir, id, field string
+	var dataDir, configPath, id, field string
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -395,6 +419,11 @@ func runCronInfo(args []string) {
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		default:
 			if id == "" {
@@ -412,9 +441,10 @@ func runCronInfo(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -479,7 +509,7 @@ func runCronInfo(args []string) {
 }
 
 func runCronEdit(args []string) {
-	var dataDir string
+	var dataDir, configPath string
 	var id, field string
 	var valueStr string
 
@@ -489,6 +519,11 @@ func runCronEdit(args []string) {
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		case "--help", "-h":
 			printCronEditUsage()
@@ -526,9 +561,10 @@ func runCronEdit(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -681,6 +717,7 @@ Read-only Fields (cannot be edited):
 
 Options:
       --data-dir <path>  Data directory (default: ~/.cc-connect)
+      --config <path>    Config file used by the running daemon (Issue #1719)
   -h, --help             Show this help
 
 Examples:

--- a/cmd/cc-connect/data_dir_resolve.go
+++ b/cmd/cc-connect/data_dir_resolve.go
@@ -1,0 +1,175 @@
+package main
+
+// data_dir / socket-path resolution helpers shared by client subcommands
+// (send / cron / timer / relay / sessions). See Issue #1719: previously
+// each subcommand only read --data-dir or CC_DATA_DIR, so a user who
+// started the daemon with `cc-connect --config /etc/cc-connect.toml`
+// could not make `cc-connect cron list` find the same API socket, even
+// though the config file specified data_dir. The new helpers unify the
+// resolution order across every client subcommand and expose a single
+// function the run* functions can call.
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/config"
+)
+
+// detectLang picks a Language for the socket-not-found diagnostic.
+// Cron jobs and systemd timers usually run unattended, so they cannot
+// rely on the OS locale for an interactive UI string. We default to
+// English unless CC_LANG is set; the daemon-side error will use the
+// richer i18n tables when it is reachable, but this client-side path
+// has no daemon yet to ask.
+func detectLang() string {
+	if v := strings.TrimSpace(os.Getenv("CC_LANG")); v != "" {
+		return v
+	}
+	return "en"
+}
+
+// resolveDataDir returns the data directory that the running cc-connect
+// daemon uses, given the explicit --data-dir flag value ("" if unset),
+// the --config flag value ("" if unset), and the current environment.
+//
+// Resolution order (highest priority first):
+//
+//  1. explicitDataDir — what the user passed to --data-dir on this command.
+//  2. CC_DATA_DIR env var — set by deploy scripts, systemd units, etc.
+//  3. data_dir from the config file at configPath — the daemon used this
+//     when it bound its socket, so the client must use the same value.
+//  4. ~/.cc-connect — historical default; matches what the daemon falls
+//     back to when its own config file has no data_dir.
+//
+// The function is best-effort: if configPath is set but the file cannot
+// be loaded (missing, malformed, permission denied), it returns the
+// default rather than failing the whole subcommand. The reasoning is
+// that "socket not found" is the user's actual complaint — failing the
+// config read first would mask the diagnostic with a different error
+// and prevent the operator from seeing the search path. If the
+// daemon is actually running with a custom data_dir the user can still
+// recover by setting --data-dir or CC_DATA_DIR explicitly.
+func resolveDataDir(explicitDataDir, configPath string) string {
+	if v := strings.TrimSpace(explicitDataDir); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("CC_DATA_DIR")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(configPath); v != "" {
+		cfg, err := config.LoadPermissive(v)
+		if err == nil && cfg != nil && strings.TrimSpace(cfg.DataDir) != "" {
+			return cfg.DataDir
+		}
+	}
+	return defaultDataDir()
+}
+
+// defaultDataDir returns ~/.cc-connect if the user's home directory can
+// be resolved, otherwise the relative path ".cc-connect". This matches
+// the fallback the daemon uses at startup (see config/config.go), so a
+// daemon started with no config file and a client started with no
+// config file agree on the same socket location.
+func defaultDataDir() string {
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".cc-connect")
+	}
+	return ".cc-connect"
+}
+
+// resolveSocketPath returns the full Unix socket path for the running
+// daemon given an already-resolved dataDir. Centralising this avoids
+// drift between subcommands: every client agrees on
+// <dataDir>/run/api.sock, which is where core/api.go NewAPIServer binds.
+func resolveSocketPath(dataDir string) string {
+	return filepath.Join(dataDir, "run", "api.sock")
+}
+
+// searchDirs returns the candidate data dirs the daemon might be using,
+// in the order the resolver tries them. Exposed for diagnostic messages
+// so the operator can see exactly which paths were considered before
+// giving up with "socket not found".
+func searchDirs(explicitDataDir, configPath string) []string {
+	dirs := make([]string, 0, 4)
+	if v := strings.TrimSpace(explicitDataDir); v != "" {
+		dirs = append(dirs, v)
+	}
+	if v := strings.TrimSpace(os.Getenv("CC_DATA_DIR")); v != "" && !containsDir(dirs, v) {
+		dirs = append(dirs, v)
+	}
+	if v := strings.TrimSpace(configPath); v != "" {
+		cfg, err := config.LoadPermissive(v)
+		if err == nil && cfg != nil && strings.TrimSpace(cfg.DataDir) != "" {
+			if !containsDir(dirs, cfg.DataDir) {
+				dirs = append(dirs, cfg.DataDir)
+			}
+		}
+	}
+	def := defaultDataDir()
+	if !containsDir(dirs, def) {
+		dirs = append(dirs, def)
+	}
+	return dirs
+}
+
+func containsDir(dirs []string, target string) bool {
+	for _, d := range dirs {
+		if d == target {
+			return true
+		}
+	}
+	return false
+}
+
+// printSocketNotFound writes a structured diagnostic to w when no daemon
+// socket can be found at the resolved path. It shows the exact path that
+// was tried, every candidate data_dir the resolver considered, and the
+// most common fixes (env var, --data-dir, --config, --force after
+// crash). The previous message was just "socket not found: <path>",
+// which made Docker / systemd / chroot bugs impossible to triage.
+// See Issue #1719.
+func printSocketNotFound(w io.Writer, dataDir, configPath, sockPath string) {
+	candidates := searchDirs("", configPath)
+	// Build the candidate list, dropping the resolved one (which we show
+	// separately as "the path that was tried") and any duplicates.
+	seen := map[string]bool{sockPath: true, dataDir: true}
+	unique := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		if seen[c] {
+			continue
+		}
+		seen[c] = true
+		unique = append(unique, c)
+	}
+
+	var hint string
+	switch detectLang() {
+	case "zh", "zh-CN", "chinese":
+		hint = "排查建议:\n" +
+			"  1. 确认 cc-connect 守护进程已启动: `cc-connect --config " + configPath + "` (或对应的配置文件)\n" +
+			"  2. 确认客户端与守护进程使用相同的 data_dir: 设置环境变量 CC_DATA_DIR, 或显式传 --data-dir / --config\n" +
+			"  3. 如果 cc-connect 之前崩溃或被 kill -9, 用 `cc-connect --force` 重新启动以清理残留的 PID 锁\n" +
+			"  4. Docker / 容器场景下, 确保 data_dir 挂载到可写卷, 且容器内用户对该目录有读写权限 (参见 docs/deployment.md)"
+	default:
+		hint = "Troubleshooting:\n" +
+			"  1. Make sure the cc-connect daemon is running: `cc-connect --config " + configPath + "` (or the relevant config file)\n" +
+			"  2. Make sure the client and daemon agree on data_dir: set CC_DATA_DIR, or pass --data-dir / --config explicitly\n" +
+			"  3. If cc-connect previously crashed (kill -9, OOM, power loss), restart with `cc-connect --force` to clear the stale PID lock\n" +
+			"  4. In Docker / container setups, ensure data_dir is mounted as a writable volume and the in-container user owns it (see docs/deployment.md)"
+	}
+
+	fmt.Fprintf(w, "Error: cc-connect is not running.\n")
+	fmt.Fprintf(w, "  Tried socket: %s\n", sockPath)
+	if len(unique) > 0 {
+		fmt.Fprintf(w, "  Other candidate data_dirs: %s\n", strings.Join(unique, ", "))
+	}
+	if configPath != "" {
+		fmt.Fprintf(w, "  --config used: %s\n", configPath)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, hint)
+}

--- a/cmd/cc-connect/data_dir_resolve.go
+++ b/cmd/cc-connect/data_dir_resolve.go
@@ -162,14 +162,14 @@ func printSocketNotFound(w io.Writer, dataDir, configPath, sockPath string) {
 			"  4. In Docker / container setups, ensure data_dir is mounted as a writable volume and the in-container user owns it (see docs/deployment.md)"
 	}
 
-	fmt.Fprintf(w, "Error: cc-connect is not running.\n")
-	fmt.Fprintf(w, "  Tried socket: %s\n", sockPath)
+	_, _ = fmt.Fprintf(w, "Error: cc-connect is not running.\n")
+	_, _ = fmt.Fprintf(w, "  Tried socket: %s\n", sockPath)
 	if len(unique) > 0 {
-		fmt.Fprintf(w, "  Other candidate data_dirs: %s\n", strings.Join(unique, ", "))
+		_, _ = fmt.Fprintf(w, "  Other candidate data_dirs: %s\n", strings.Join(unique, ", "))
 	}
 	if configPath != "" {
-		fmt.Fprintf(w, "  --config used: %s\n", configPath)
+		_, _ = fmt.Fprintf(w, "  --config used: %s\n", configPath)
 	}
-	fmt.Fprintln(w)
-	fmt.Fprintln(w, hint)
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, hint)
 }

--- a/cmd/cc-connect/data_dir_resolve_test.go
+++ b/cmd/cc-connect/data_dir_resolve_test.go
@@ -1,0 +1,183 @@
+package main
+
+// Tests for the data_dir / socket-path resolution helpers added for
+// Issue #1719. The helpers live in cmd/cc-connect/data_dir_resolve.go
+// and are exercised by send.go, cron.go, timer.go, relay.go,
+// sessions.go and session_id.go.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultDataDir(t *testing.T) {
+	// Save and restore HOME so the test doesn't leak into other tests
+	// (defaultDataDir consults os.UserHomeDir which honours HOME).
+	t.Setenv("HOME", "/tmp/fake-home-1719")
+	got := defaultDataDir()
+	want := filepath.Join("/tmp/fake-home-1719", ".cc-connect")
+	if got != want {
+		t.Fatalf("defaultDataDir() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveSocketPath(t *testing.T) {
+	got := resolveSocketPath("/var/lib/cc-connect")
+	want := filepath.Join("/var/lib/cc-connect", "run", "api.sock")
+	if got != want {
+		t.Fatalf("resolveSocketPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDataDir_PriorityOrder(t *testing.T) {
+	// 1. Explicit --data-dir flag wins over everything.
+	t.Setenv("CC_DATA_DIR", "/from/env")
+	t.Setenv("HOME", "/tmp/fake-home-1719")
+	got := resolveDataDir("/from/flag", "")
+	if got != "/from/flag" {
+		t.Fatalf("explicit --data-dir should win, got %q", got)
+	}
+
+	// 2. CC_DATA_DIR env wins when --data-dir is empty.
+	got = resolveDataDir("", "")
+	if got != "/from/env" {
+		t.Fatalf("CC_DATA_DIR should win when --data-dir is empty, got %q", got)
+	}
+
+	// 3. Default ~/.cc-connect when nothing is set.
+	t.Setenv("CC_DATA_DIR", "")
+	got = resolveDataDir("", "")
+	want := filepath.Join("/tmp/fake-home-1719", ".cc-connect")
+	if got != want {
+		t.Fatalf("default data_dir should be ~/.cc-connect, got %q want %q", got, want)
+	}
+}
+
+func TestResolveDataDir_FromConfigFile(t *testing.T) {
+	t.Setenv("CC_DATA_DIR", "")
+	t.Setenv("HOME", "/tmp/fake-home-1719")
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	// config.LoadPermissive still requires at least one [[projects]] entry
+	// (it only skips the per-project platform check), so include a minimal
+	// one in the fixture.
+	body := `data_dir = "/srv/cc-connect-data"
+[[projects]]
+name = "demo"
+[projects.agent]
+type = "claudecode"
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	got := resolveDataDir("", cfgPath)
+	if got != "/srv/cc-connect-data" {
+		t.Fatalf("resolveDataDir from --config should read data_dir, got %q", got)
+	}
+}
+
+func TestResolveDataDir_MissingConfigFile(t *testing.T) {
+	// Best-effort: if --config is set but the file is missing, fall
+	// through to the default rather than failing the whole subcommand.
+	// The reasoning is documented in resolveDataDir's doc comment.
+	t.Setenv("CC_DATA_DIR", "")
+	t.Setenv("HOME", "/tmp/fake-home-1719")
+	got := resolveDataDir("", "/nonexistent/path/config.toml")
+	want := filepath.Join("/tmp/fake-home-1719", ".cc-connect")
+	if got != want {
+		t.Fatalf("missing --config should fall through to default, got %q want %q", got, want)
+	}
+}
+
+func TestSearchDirs_DeduplicatesAndOrdersByPriority(t *testing.T) {
+	t.Setenv("CC_DATA_DIR", "")
+	t.Setenv("HOME", "/tmp/fake-home-1719")
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	body := `data_dir = "/srv/cc-connect-data"
+[[projects]]
+name = "demo"
+[projects.agent]
+type = "claudecode"
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	dirs := searchDirs("/from/flag", cfgPath)
+
+	// 1. --data-dir flag is first
+	if dirs[0] != "/from/flag" {
+		t.Fatalf("searchDirs[0] = %q, want /from/flag", dirs[0])
+	}
+	// 2. config file's data_dir appears in the list
+	// 3. ~/.cc-connect must always be present as last fallback
+	wantDefault := filepath.Join("/tmp/fake-home-1719", ".cc-connect")
+	if !containsDir(dirs, wantDefault) {
+		t.Fatalf("searchDirs missing default %q in %v", wantDefault, dirs)
+	}
+	if !containsDir(dirs, "/srv/cc-connect-data") {
+		t.Fatalf("searchDirs missing config data_dir in %v", dirs)
+	}
+	// No duplicates
+	seen := map[string]bool{}
+	for _, d := range dirs {
+		if seen[d] {
+			t.Fatalf("searchDirs contains duplicate %q in %v", d, dirs)
+		}
+		seen[d] = true
+	}
+}
+
+func TestSearchDirs_IncludesEnvVar(t *testing.T) {
+	t.Setenv("CC_DATA_DIR", "/from/env")
+	t.Setenv("HOME", "/tmp/fake-home-1719")
+	dirs := searchDirs("", "")
+	if !containsDir(dirs, "/from/env") {
+		t.Fatalf("searchDirs missing CC_DATA_DIR value: %v", dirs)
+	}
+}
+
+func TestPrintSocketNotFound_ContainsUsefulHints(t *testing.T) {
+	// The diagnostic must show the socket path that was tried, the
+	// resolved data_dir, the candidate list, and a recovery hint.
+	// This is the contract operators rely on to triage Docker / systemd
+	// issues — see Issue #1719.
+	var buf bytes.Buffer
+	printSocketNotFound(&buf, "/var/lib/cc-connect", "/etc/cc-connect.toml", "/var/lib/cc-connect/run/api.sock")
+	out := buf.String()
+
+	wants := []string{
+		"cc-connect is not running",
+		"/var/lib/cc-connect/run/api.sock", // tried socket
+		"/var/lib/cc-connect",              // active data_dir
+		"/etc/cc-connect.toml",             // config path
+		"Troubleshooting",                  // recovery hint
+		"CC_DATA_DIR",                      // env-var hint
+		"--force",                          // crash recovery hint
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Fatalf("printSocketNotFound output missing %q\nfull output:\n%s", w, out)
+		}
+	}
+}
+
+func TestPrintSocketNotFound_NoConfigStillUseful(t *testing.T) {
+	// When --config is empty (the common Docker / nohup case) the
+	// diagnostic must still mention the home-dir fallback so the
+	// operator can spot a config-less daemon.
+	var buf bytes.Buffer
+	printSocketNotFound(&buf, "/home/me/.cc-connect", "", "/home/me/.cc-connect/run/api.sock")
+	out := buf.String()
+	if !strings.Contains(out, "cc-connect is not running") {
+		t.Fatalf("missing 'cc-connect is not running' in output: %s", out)
+	}
+	if !strings.Contains(out, "/home/me/.cc-connect") {
+		t.Fatalf("missing active data_dir in output: %s", out)
+	}
+}

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1277,46 +1277,64 @@ func main() {
 	// Start internal API server for CLI send
 	apiSrv, err := core.NewAPIServer(cfg.DataDir)
 	if err != nil {
-		slog.Warn("api server unavailable", "error", err)
-	} else {
-		globalAPIServer = apiSrv
-		apiSrv.SetMaxAttachmentSize(resolveMaxAttachmentSize(cfg))
-
-		relayMgr := core.NewRelayManager(cfg.DataDir)
-		if cfg.Relay.TimeoutSecs != nil {
-			secs := *cfg.Relay.TimeoutSecs
-			if secs <= 0 {
-				relayMgr.SetTimeout(0)
-			} else {
-				relayMgr.SetTimeout(time.Duration(secs) * time.Second)
-			}
+		// Issue #1719: in Docker / chroot / nohup scenarios the socket bind
+		// frequently fails (permissions, abstract-namespace length, SELinux).
+		// Before this fix the server silently continued with the PID lock
+		// acquired but no socket, so subsequent cron/send calls saw
+		// "socket not found" while a second start saw "PID already running"
+		// — a confusing dead state. Fail fast instead: release the PID
+		// lock so the operator can re-try after fixing data_dir/permissions,
+		// and surface the underlying error.
+		slog.Error("api server failed to start; aborting to avoid serving without API socket",
+			"error", err,
+			"data_dir", cfg.DataDir,
+			"hint", "check that data_dir is writable and that the run/ subdirectory is reachable; if running in Docker, ensure the volume is mounted and the user owns the directory")
+		if instanceLock != nil {
+			instanceLock.Release()
 		}
-		relayMgr.SetVisibility(cfg.Relay.Visibility)
-		apiSrv.SetRelayManager(relayMgr)
-
-		// Create shared DirHistory for all engines
-		dirHistory := core.NewDirHistory(cfg.DataDir)
-
-		for i, e := range engines {
-			apiSrv.RegisterEngine(cfg.Projects[i].Name, e)
-			e.SetRelayManager(relayMgr)
-			e.SetDirHistory(dirHistory)
-
-			// Ensure initial work_dir is in history
-			if initWorkDir := effectiveWorkDirs[i]; initWorkDir != "" {
-				if !dirHistory.Contains(cfg.Projects[i].Name, initWorkDir) {
-					dirHistory.Add(cfg.Projects[i].Name, initWorkDir)
-				}
-			}
-		}
-		if cronSched != nil {
-			apiSrv.SetCronScheduler(cronSched)
-		}
-		if timerSched != nil {
-			apiSrv.SetTimerScheduler(timerSched)
-		}
-		apiSrv.Start()
+		fmt.Fprintf(os.Stderr, "Error: failed to start API server (%v). Instance lock released.\n", err)
+		os.Exit(1)
 	}
+	globalAPIServer = apiSrv
+	apiSrv.SetMaxAttachmentSize(resolveMaxAttachmentSize(cfg))
+
+	relayMgr := core.NewRelayManager(cfg.DataDir)
+	if cfg.Relay.TimeoutSecs != nil {
+		secs := *cfg.Relay.TimeoutSecs
+		if secs <= 0 {
+			relayMgr.SetTimeout(0)
+		} else {
+			relayMgr.SetTimeout(time.Duration(secs) * time.Second)
+		}
+	}
+	relayMgr.SetVisibility(cfg.Relay.Visibility)
+	apiSrv.SetRelayManager(relayMgr)
+
+	// Create shared DirHistory for all engines
+	dirHistory := core.NewDirHistory(cfg.DataDir)
+
+	for i, e := range engines {
+		apiSrv.RegisterEngine(cfg.Projects[i].Name, e)
+		e.SetRelayManager(relayMgr)
+		e.SetDirHistory(dirHistory)
+
+		// Ensure initial work_dir is in history
+		if initWorkDir := effectiveWorkDirs[i]; initWorkDir != "" {
+			if !dirHistory.Contains(cfg.Projects[i].Name, initWorkDir) {
+				dirHistory.Add(cfg.Projects[i].Name, initWorkDir)
+			}
+		}
+	}
+	if cronSched != nil {
+		apiSrv.SetCronScheduler(cronSched)
+	}
+	if timerSched != nil {
+		apiSrv.SetTimerScheduler(timerSched)
+	}
+	apiSrv.Start()
+	slog.Info("api socket listening",
+		"socket", apiSrv.SocketPath(),
+		"hint", "client subcommands (cron/send/timer/relay) can pass --config to reuse this socket")
 
 	slog.Info("cc-connect is running", "projects", len(engines))
 

--- a/cmd/cc-connect/relay.go
+++ b/cmd/cc-connect/relay.go
@@ -27,7 +27,7 @@ func runRelay(args []string) {
 }
 
 func runRelaySend(args []string) {
-	var from, to, sessionKey, message, dataDir string
+	var from, to, sessionKey, message, dataDir, configPath string
 
 	var positional []string
 	for i := 0; i < len(args); i++ {
@@ -56,6 +56,11 @@ func runRelaySend(args []string) {
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		case "--help", "-h":
 			printRelaySendUsage()
@@ -90,9 +95,10 @@ func runRelaySend(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -146,6 +152,7 @@ Options:
   -s, --session-key <key>    Session key (auto-detected from CC_SESSION_KEY env)
   -m, --message <text>       Message to send
       --data-dir <path>      Data directory (default: ~/.cc-connect)
+      --config <path>        Config file used by the running daemon (Issue #1719)
   -h, --help                 Show this help
 
 Examples:

--- a/cmd/cc-connect/send.go
+++ b/cmd/cc-connect/send.go
@@ -19,7 +19,7 @@ import (
 )
 
 func runSend(args []string) {
-	req, dataDir, err := parseSendArgs(args)
+	req, dataDir, configPath, err := parseSendArgs(args)
 	if err != nil {
 		if errors.Is(err, errSendUsage) {
 			printSendUsage()
@@ -30,9 +30,10 @@ func runSend(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -68,9 +69,10 @@ func runSend(args []string) {
 
 var errSendUsage = errors.New("show send usage")
 
-func parseSendArgs(args []string) (core.SendRequest, string, error) {
+func parseSendArgs(args []string) (core.SendRequest, string, string, error) {
 	var req core.SendRequest
 	var dataDir string
+	var configPath string
 	var useStdin bool
 	var imagePaths []string
 	var filePaths []string
@@ -82,55 +84,55 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 		switch args[i] {
 		case "--project", "-p":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("--project requires a value")
+				return req, "", "", fmt.Errorf("--project requires a value")
 			}
 			i++
 			req.Project = args[i]
 		case "--session", "-s":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("--session requires a value")
+				return req, "", "", fmt.Errorf("--session requires a value")
 			}
 			i++
 			req.SessionKey = args[i]
 		case "--message", "-m":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("--message requires a value")
+				return req, "", "", fmt.Errorf("--message requires a value")
 			}
 			i++
 			req.Message = args[i]
 		case "--cwd", "--work-dir":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("%s requires a value", args[i])
+				return req, "", "", fmt.Errorf("%s requires a value", args[i])
 			}
 			i++
 			req.WorkDir = args[i]
 		case "--tts":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("%s requires a value", args[i])
+				return req, "", "", fmt.Errorf("%s requires a value", args[i])
 			}
 			i++
 			req.TTSText = args[i]
 		case "--image":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("--image requires a path")
+				return req, "", "", fmt.Errorf("--image requires a path")
 			}
 			i++
 			imagePaths = append(imagePaths, args[i])
 		case "--file":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("--file requires a path")
+				return req, "", "", fmt.Errorf("--file requires a path")
 			}
 			i++
 			filePaths = append(filePaths, args[i])
 		case "--audio":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("--audio requires a path")
+				return req, "", "", fmt.Errorf("--audio requires a path")
 			}
 			i++
 			audioPaths = append(audioPaths, args[i])
 		case "--video":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("--video requires a path")
+				return req, "", "", fmt.Errorf("--video requires a path")
 			}
 			i++
 			videoPaths = append(videoPaths, args[i])
@@ -138,7 +140,7 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 			useStdin = true
 		case "--at-users":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("--at-users requires a value")
+				return req, "", "", fmt.Errorf("--at-users requires a value")
 			}
 			i++
 			for _, uid := range strings.Split(args[i], ",") {
@@ -151,12 +153,18 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 			req.AtAll = true
 		case "--data-dir":
 			if i+1 >= len(args) {
-				return req, "", fmt.Errorf("--data-dir requires a value")
+				return req, "", "", fmt.Errorf("--data-dir requires a value")
 			}
 			i++
 			dataDir = args[i]
+		case "--config":
+			if i+1 >= len(args) {
+				return req, "", "", fmt.Errorf("--config requires a value")
+			}
+			i++
+			configPath = args[i]
 		case "--help", "-h":
-			return req, "", errSendUsage
+			return req, "", "", errSendUsage
 		default:
 			positional = append(positional, args[i])
 		}
@@ -165,7 +173,7 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 	if useStdin {
 		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
-			return req, "", fmt.Errorf("reading stdin: %w", err)
+			return req, "", "", fmt.Errorf("reading stdin: %w", err)
 		}
 		req.Message = strings.TrimSpace(string(data))
 	}
@@ -183,19 +191,19 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 
 	images, err := loadImageAttachments(imagePaths, maxAtt)
 	if err != nil {
-		return req, "", err
+		return req, "", "", err
 	}
 	files, err := loadFileAttachments(filePaths, maxAtt)
 	if err != nil {
-		return req, "", err
+		return req, "", "", err
 	}
 	audioFiles, err := loadTypedFileAttachments(audioPaths, "audio", maxAtt)
 	if err != nil {
-		return req, "", err
+		return req, "", "", err
 	}
 	videoFiles, err := loadTypedFileAttachments(videoPaths, "video", maxAtt)
 	if err != nil {
-		return req, "", err
+		return req, "", "", err
 	}
 	req.Images = images
 	// Keep audio / video clips on dedicated fields. Routing them through
@@ -209,10 +217,10 @@ func parseSendArgs(args []string) (core.SendRequest, string, error) {
 	req.Videos = videoFiles
 
 	if req.Message == "" && req.TTSText == "" && len(req.Images) == 0 && len(req.Files) == 0 && len(req.Audios) == 0 && len(req.Videos) == 0 {
-		return req, "", fmt.Errorf("message, tts text, or attachment is required")
+		return req, "", "", fmt.Errorf("message, tts text, or attachment is required")
 	}
 
-	return req, dataDir, nil
+	return req, dataDir, configPath, nil
 }
 
 func loadImageAttachments(paths []string, maxSize int64) ([]core.ImageAttachment, error) {
@@ -343,20 +351,6 @@ func decodeSendPayload(data []byte, req *core.SendRequest) error {
 	return json.Unmarshal(data, req)
 }
 
-func resolveSocketPath(dataDir string) string {
-	if dataDir != "" {
-		return filepath.Join(dataDir, "run", "api.sock")
-	}
-	// Check CC_DATA_DIR env var for custom data_dir configuration
-	if envDataDir := strings.TrimSpace(os.Getenv("CC_DATA_DIR")); envDataDir != "" {
-		return filepath.Join(envDataDir, "run", "api.sock")
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(home, ".cc-connect", "run", "api.sock")
-	}
-	return filepath.Join(".cc-connect", "run", "api.sock")
-}
-
 func printSendUsage() {
 	fmt.Println(`Usage: cc-connect send [options] <message>
        cc-connect send [options] -m <message>
@@ -384,7 +378,10 @@ Options:
       --at-all             @ everyone (DingTalk)
   -p, --project <name>     Target project (optional if only one project)
   -s, --session <key>      Target session key (optional, picks first active)
-      --data-dir <path>    Data directory (default: ~/.cc-connect)
+      --data-dir <path>    Data directory (default: ~/.cc-connect, or data_dir from --config)
+      --config <path>      Config file used by the running daemon (so client and
+                           server agree on data_dir). Useful when the daemon was
+                           started with --config /etc/cc-connect.toml. See #1719.
   -h, --help               Show this help
 
 Examples:
@@ -395,6 +392,7 @@ Examples:
   cc-connect send --video /tmp/demo.mp4
   cc-connect send --audio /tmp/voice.opus
   cc-connect send --tts "Hello from cc-connect"
+  cc-connect send --config /etc/cc-connect.toml -m "hi"
   cc-connect send --stdin <<'EOF'
     Long message with "special" chars, $variables, and newlines
   EOF`)

--- a/cmd/cc-connect/send_test.go
+++ b/cmd/cc-connect/send_test.go
@@ -21,7 +21,7 @@ func TestParseSendArgs_AttachmentsWithoutMessage(t *testing.T) {
 		t.Fatalf("write doc: %v", err)
 	}
 
-	req, dataDir, err := parseSendArgs([]string{"--image", imgPath, "--file", docPath})
+	req, dataDir, _, err := parseSendArgs([]string{"--image", imgPath, "--file", docPath})
 	if err != nil {
 		t.Fatalf("parseSendArgs returned error: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestParseSendArgs_AttachmentsWithoutMessage(t *testing.T) {
 }
 
 func TestParseSendArgs_RequiresMessageOrAttachment(t *testing.T) {
-	_, _, err := parseSendArgs(nil)
+	_, _, _, err := parseSendArgs(nil)
 	if err == nil {
 		t.Fatal("expected error for empty send args")
 	}
@@ -65,7 +65,7 @@ func TestParseSendArgs_UsesSessionEnvFallback(t *testing.T) {
 		t.Fatalf("write image: %v", err)
 	}
 
-	req, _, err := parseSendArgs([]string{"--image", imgPath})
+	req, _, _, err := parseSendArgs([]string{"--image", imgPath})
 	if err != nil {
 		t.Fatalf("parseSendArgs returned error: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestParseSendArgs_UsesSessionEnvFallback(t *testing.T) {
 func TestParseSendArgs_WorkDirOption(t *testing.T) {
 	workDir := t.TempDir()
 
-	req, _, err := parseSendArgs([]string{"--cwd", workDir, "--message", "please check"})
+	req, _, _, err := parseSendArgs([]string{"--cwd", workDir, "--message", "please check"})
 	if err != nil {
 		t.Fatalf("parseSendArgs returned error: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestParseSendArgs_WorkDirOption(t *testing.T) {
 		t.Fatalf("WorkDir = %q, want %q", got, workDir)
 	}
 
-	req, _, err = parseSendArgs([]string{"--work-dir", workDir, "please check"})
+	req, _, _, err = parseSendArgs([]string{"--work-dir", workDir, "please check"})
 	if err != nil {
 		t.Fatalf("parseSendArgs returned error for --work-dir: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestParseSendArgs_AudioPopulatesAudios(t *testing.T) {
 		t.Fatalf("write audio: %v", err)
 	}
 
-	req, _, err := parseSendArgs([]string{"--audio", audioPath})
+	req, _, _, err := parseSendArgs([]string{"--audio", audioPath})
 	if err != nil {
 		t.Fatalf("parseSendArgs returned error: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestParseSendArgs_VideoPopulatesVideos(t *testing.T) {
 		t.Fatalf("write video: %v", err)
 	}
 
-	req, _, err := parseSendArgs([]string{"--video", videoPath})
+	req, _, _, err := parseSendArgs([]string{"--video", videoPath})
 	if err != nil {
 		t.Fatalf("parseSendArgs returned error: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestParseSendArgs_AudioVideoFileMixed_StaySeparate(t *testing.T) {
 		}
 	}
 
-	req, _, err := parseSendArgs([]string{
+	req, _, _, err := parseSendArgs([]string{
 		"--audio", audioPath,
 		"--video", videoPath,
 		"--file", docPath,
@@ -186,7 +186,7 @@ func TestParseSendArgs_TTSOnly(t *testing.T) {
 	t.Setenv("CC_PROJECT", "demo")
 	t.Setenv("CC_SESSION_KEY", "telegram:123:456")
 
-	req, _, err := parseSendArgs([]string{"--tts", "hello voice"})
+	req, _, _, err := parseSendArgs([]string{"--tts", "hello voice"})
 	if err != nil {
 		t.Fatalf("parseSendArgs returned error: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestParseSendArgs_AudioRejectsNonAudio(t *testing.T) {
 		t.Fatalf("write doc: %v", err)
 	}
 
-	_, _, err := parseSendArgs([]string{"--audio", docPath})
+	_, _, _, err := parseSendArgs([]string{"--audio", docPath})
 	if err == nil {
 		t.Fatal("expected non-audio attachment to be rejected")
 	}

--- a/cmd/cc-connect/session_id.go
+++ b/cmd/cc-connect/session_id.go
@@ -9,7 +9,7 @@ import (
 )
 
 func runAgentSID(args []string) {
-	var project, sessionKey, dataDir string
+	var project, sessionKey, dataDir, configPath string
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -28,6 +28,11 @@ func runAgentSID(args []string) {
 				i++
 				dataDir = args[i]
 			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
+			}
 		case "--help", "-h":
 			printAgentSIDUsage()
 			return
@@ -40,7 +45,7 @@ func runAgentSID(args []string) {
 	if sessionKey == "" {
 		sessionKey = os.Getenv("CC_SESSION_KEY")
 	}
-	dataDir = resolveDataDir(dataDir)
+	dataDir = resolveDataDir(dataDir, configPath)
 
 	if project == "" {
 		fmt.Fprintln(os.Stderr, "Error: project is required (set CC_PROJECT env or use --project)")
@@ -244,7 +249,8 @@ instance is required.
 Options:
   -p, --project <name>       Project name (auto-detected from CC_PROJECT env)
   -s, --session-key <key>    Session key  (auto-detected from CC_SESSION_KEY env)
-      --data-dir <path>      Data directory (default: ~/.cc-connect)
+      --data-dir <path>      Data directory (default: ~/.cc-connect, or data_dir from --config)
+      --config <path>        Config file (use the same one as the running daemon)
   -h, --help                 Show this help
 
 Examples:

--- a/cmd/cc-connect/sessions.go
+++ b/cmd/cc-connect/sessions.go
@@ -55,7 +55,7 @@ type sessionRecord struct {
 }
 
 func runSessions(args []string) {
-	var dataDir string
+	var dataDir, configPath string
 	var subcommand string
 	var positional []string
 
@@ -65,6 +65,11 @@ func runSessions(args []string) {
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		case "--help", "-h", "help":
 			printSessionsUsage()
@@ -78,7 +83,7 @@ func runSessions(args []string) {
 		}
 	}
 
-	dataDir = resolveDataDir(dataDir)
+	dataDir = resolveDataDir(dataDir, configPath)
 
 	switch subcommand {
 	case "list":
@@ -136,16 +141,6 @@ func runSessions(args []string) {
 		// Default: launch TUI
 		runSessionsTUI(dataDir)
 	}
-}
-
-func resolveDataDir(flagValue string) string {
-	if flagValue != "" {
-		return flagValue
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(home, ".cc-connect")
-	}
-	return ".cc-connect"
 }
 
 func loadAllSessions(dataDir string) ([]sessionRecord, error) {
@@ -431,6 +426,7 @@ Commands:
 
 Options:
   --data-dir <path>  Data directory (default: ~/.cc-connect)
+  --config <path>    Config file used by the running daemon (Issue #1719)
   -h, --help         Show this help
 
 Session ID formats for 'show':

--- a/cmd/cc-connect/timer.go
+++ b/cmd/cc-connect/timer.go
@@ -38,7 +38,7 @@ func runTimer(args []string) {
 }
 
 func runTimerAdd(args []string) {
-	var project, sessionKey, delay, atTime, prompt, execCmd, desc, dataDir, sessionMode string
+	var project, sessionKey, delay, atTime, prompt, execCmd, desc, dataDir, sessionMode, configPath string
 	var timeoutMins *int
 	var mute bool
 
@@ -84,6 +84,11 @@ func runTimerAdd(args []string) {
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		case "--session-mode":
 			if i+1 < len(args) {
@@ -143,9 +148,10 @@ func runTimerAdd(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -194,7 +200,7 @@ func runTimerAdd(args []string) {
 }
 
 func runTimerList(args []string) {
-	var project, dataDir string
+	var project, dataDir, configPath string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--project", "-p":
@@ -207,6 +213,11 @@ func runTimerList(args []string) {
 				i++
 				dataDir = args[i]
 			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
+			}
 		}
 	}
 
@@ -214,9 +225,10 @@ func runTimerList(args []string) {
 		project = os.Getenv("CC_PROJECT")
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -284,7 +296,7 @@ func runTimerList(args []string) {
 }
 
 func runTimerDel(args []string) {
-	var dataDir string
+	var dataDir, configPath string
 	var id string
 
 	for i := 0; i < len(args); i++ {
@@ -293,6 +305,11 @@ func runTimerDel(args []string) {
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		default:
 			id = args[i]
@@ -304,9 +321,10 @@ func runTimerDel(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -328,7 +346,7 @@ func runTimerDel(args []string) {
 }
 
 func runTimerInfo(args []string) {
-	var dataDir, id string
+	var dataDir, configPath, id string
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -336,6 +354,11 @@ func runTimerInfo(args []string) {
 			if i+1 < len(args) {
 				i++
 				dataDir = args[i]
+			}
+		case "--config":
+			if i+1 < len(args) {
+				i++
+				configPath = args[i]
 			}
 		default:
 			id = args[i]
@@ -348,9 +371,10 @@ func runTimerInfo(args []string) {
 		os.Exit(1)
 	}
 
+	dataDir = resolveDataDir(dataDir, configPath)
 	sockPath := resolveSocketPath(dataDir)
 	if _, err := os.Stat(sockPath); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Error: cc-connect is not running (socket not found: %s)\n", sockPath)
+		printSocketNotFound(os.Stderr, dataDir, configPath, sockPath)
 		os.Exit(1)
 	}
 
@@ -416,6 +440,7 @@ Options:
       --timeout-mins <n>     Max minutes to wait per run (0 = no limit; default 30)
       --mute                 Suppress all messages (start + result)
       --data-dir <path>      Data directory (default: ~/.cc-connect)
+      --config <path>        Config file used by the running daemon (Issue #1719)
   -h, --help                 Show this help
 
 Examples:

--- a/core/api.go
+++ b/core/api.go
@@ -66,7 +66,7 @@ type SendRequest struct {
 func NewAPIServer(dataDir string) (*APIServer, error) {
 	sockDir := filepath.Join(dataDir, "run")
 	if err := os.MkdirAll(sockDir, 0o755); err != nil {
-		return nil, fmt.Errorf("create run dir: %w", err)
+		return nil, fmt.Errorf("create run dir %q: %w", sockDir, err)
 	}
 	sockPath := filepath.Join(sockDir, "api.sock")
 
@@ -75,11 +75,11 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 
 	listener, err := net.Listen("unix", sockPath)
 	if err != nil {
-		return nil, fmt.Errorf("listen unix socket: %w", err)
+		return nil, fmt.Errorf("listen unix socket %q: %w", sockPath, err)
 	}
 	if err := os.Chmod(sockPath, 0o600); err != nil {
 		_ = listener.Close()
-		return nil, fmt.Errorf("chmod socket: %w", err)
+		return nil, fmt.Errorf("chmod socket %q: %w", sockPath, err)
 	}
 
 	s := &APIServer{
@@ -111,6 +111,13 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 
 func (s *APIServer) SocketPath() string {
 	return s.socketPath
+}
+
+// SocketDir returns the directory containing the Unix socket (e.g.
+// <dataDir>/run). Exposed so CLI subcommands can build an accurate
+// diagnostic when the server's socket is missing. See issue #1719.
+func (s *APIServer) SocketDir() string {
+	return filepath.Dir(s.socketPath)
 }
 
 func (s *APIServer) RegisterEngine(name string, e *Engine) {

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -646,6 +646,15 @@ const (
 	MsgWsInitInvalidTarget      MsgKey = "ws_init_invalid_target"
 	MsgWsInitLocalPathsDisabled MsgKey = "ws_init_local_paths_disabled"
 	MsgBackgroundAutoDenied     MsgKey = "background_auto_denied"
+
+	// Socket not found error (Issue #1719)
+	// Args: %s = searched paths list, %s = current data_dir
+	MsgSocketNotFound        MsgKey = "socket_not_found"
+	MsgSocketNotFoundHint    MsgKey = "socket_not_found_hint"
+	MsgSocketSearchedTitle   MsgKey = "socket_searched_title"
+	MsgSocketConfigHint      MsgKey = "socket_config_hint"
+	MsgSocketEnvHint         MsgKey = "socket_env_hint"
+	MsgSocketDataDirLabel    MsgKey = "socket_data_dir_label"
 )
 
 var messages = map[MsgKey]map[Language]string{
@@ -4191,6 +4200,48 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "`/workspace init` 未啟用本機目錄目標。請使用 git 倉庫地址，或在此專案配置 `workspace_init_allow_local_paths = true`。",
 		LangJapanese:           "`/workspace init` ではローカルディレクトリ対象が無効です。git URL を使うか、このプロジェクトで `workspace_init_allow_local_paths = true` を有効にしてください。",
 		LangSpanish:            "Los destinos de directorio local están deshabilitados para `/workspace init`. Use una URL de git o habilite `workspace_init_allow_local_paths = true` para este proyecto.",
+	},
+	MsgSocketNotFound: {
+		LangEnglish:            "cc-connect is not running: no API socket found.\nSearched: %s\nActive data_dir: %s",
+		LangChinese:            "cc-connect 未运行: 找不到 API socket。\n已搜索: %s\n当前 data_dir: %s",
+		LangTraditionalChinese: "cc-connect 未執行: 找不到 API socket。\n已搜尋: %s\n目前 data_dir: %s",
+		LangJapanese:           "cc-connect は実行されていません: API ソケットが見つかりません。\n検索パス: %s\n現在の data_dir: %s",
+		LangSpanish:            "cc-connect no se está ejecutando: no se encontró el socket de la API.\nBuscado en: %s\ndata_dir activo: %s",
+	},
+	MsgSocketNotFoundHint: {
+		LangEnglish:            "Hint: start the server with `cc-connect --config <file>` and pass the same --config / --data-dir / CC_DATA_DIR to this command, or set CC_DATA_DIR to match the server's data_dir.",
+		LangChinese:            "提示: 用 `cc-connect --config <文件>` 启动 server,并给本命令传入相同的 --config / --data-dir / CC_DATA_DIR,或设置 CC_DATA_DIR 与 server 的 data_dir 一致。",
+		LangTraditionalChinese: "提示: 用 `cc-connect --config <檔案>` 啟動 server,並給本命令傳入相同的 --config / --data-dir / CC_DATA_DIR,或設定 CC_DATA_DIR 與 server 的 data_dir 一致。",
+		LangJapanese:           "ヒント: `cc-connect --config <ファイル>` で server を起動し、同じ --config / --data-dir / CC_DATA_DIR をこのコマンドに渡すか、CC_DATA_DIR を server の data_dir と一致させてください。",
+		LangSpanish:            "Sugerencia: inicia el servidor con `cc-connect --config <archivo>` y pasa el mismo --config / --data-dir / CC_DATA_DIR a este comando, o define CC_DATA_DIR para que coincida con el data_dir del servidor.",
+	},
+	MsgSocketSearchedTitle: {
+		LangEnglish:            "Searched socket paths",
+		LangChinese:            "已搜索的 socket 路径",
+		LangTraditionalChinese: "已搜尋的 socket 路徑",
+		LangJapanese:           "検索した socket パス",
+		LangSpanish:            "Rutas de socket buscadas",
+	},
+	MsgSocketConfigHint: {
+		LangEnglish:            "Use --config to share the server's config file (recommended for Docker / nohup deployments).",
+		LangChinese:            "使用 --config 复用 server 的 config 文件(Docker / nohup 部署推荐)。",
+		LangTraditionalChinese: "使用 --config 復用 server 的 config 檔案(Docker / nohup 部署推薦)。",
+		LangJapanese:           "--config を使って server の設定ファイルを共有してください(Docker / nohup デプロイでは推奨)。",
+		LangSpanish:            "Use --config para compartir el archivo de configuración del servidor (recomendado para despliegues en Docker / nohup).",
+	},
+	MsgSocketEnvHint: {
+		LangEnglish:            "Or set the CC_DATA_DIR environment variable to override the default ~/.cc-connect.",
+		LangChinese:            "或设置 CC_DATA_DIR 环境变量覆盖默认 ~/.cc-connect。",
+		LangTraditionalChinese: "或設定 CC_DATA_DIR 環境變數覆寫預設 ~/.cc-connect。",
+		LangJapanese:           "または環境変数 CC_DATA_DIR を設定してデフォルトの ~/.cc-connect を上書きしてください。",
+		LangSpanish:            "O define la variable de entorno CC_DATA_DIR para sobrescribir el valor por defecto ~/.cc-connect.",
+	},
+	MsgSocketDataDirLabel: {
+		LangEnglish:            "Resolved data_dir",
+		LangChinese:            "已解析的 data_dir",
+		LangTraditionalChinese: "已解析的 data_dir",
+		LangJapanese:           "解決された data_dir",
+		LangSpanish:            "data_dir resuelto",
 	},
 }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,320 @@
+# Deploying cc-connect: Docker, nohup, tmux, screen
+
+> **Issue:** [#1719](https://github.com/chenhg5/cc-connect/issues/1719) —
+> "在 docker 中运行无法使用 daemon,导致 cron 无法工作"
+> (cron jobs cannot find the daemon socket when running inside Docker).
+
+This guide covers three lightweight ways to keep cc-connect running 24/7
+without `systemd` (which is unavailable inside most containers), and the
+single most common failure mode for each: a missing or unreachable Unix
+socket under `~/.cc-connect/run/api.sock`.
+
+If you only need a one-shot test, skip to the bottom of the page — the
+`docker run` recipe is the shortest path to a working setup.
+
+## TL;DR — diagnose first
+
+When `cc-connect cron list` (or any other client subcommand) reports:
+
+```
+Error: cc-connect is not running.
+  Tried socket: <path>/run/api.sock
+  Other candidate data_dirs: ...
+  --config used: <path>
+```
+
+…the daemon either crashed, was never started, or is using a different
+`data_dir` than the client. Run these on the host (or inside the
+container) to triage:
+
+```bash
+# 1. Is the daemon process alive?
+pgrep -af 'cc-connect' || echo "no daemon process"
+
+# 2. Does the socket file exist?
+ls -l /var/lib/cc-connect/run/api.sock 2>&1 || true
+
+# 3. If you started the daemon with --config, does the client know?
+cc-connect --config /etc/cc-connect.toml cron list \
+  --config /etc/cc-connect.toml
+
+# 4. Last-resort recovery from a stale PID lock after a crash:
+cc-connect --config /etc/cc-connect.toml --force
+```
+
+The `--config` flag is what Issue #1719 introduced on the client side:
+the daemon used to expose only `--data-dir`, so a deploy that pinned a
+custom `data_dir` inside `config.toml` was unreachable from cron jobs.
+
+## 1. systemd (Linux hosts)
+
+If you have systemd on the host, the project ships a service unit:
+
+```bash
+cc-connect daemon install      # writes /etc/systemd/system/cc-connect.service
+sudo systemctl enable --now cc-connect
+sudo systemctl status cc-connect
+cc-connect daemon logs -f      # tail the journal
+```
+
+The unit reads `~/.cc-connect/config.toml` by default. To pin a custom
+location:
+
+```ini
+# /etc/systemd/system/cc-connect.service.d/override.conf
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/cc-connect --config /etc/cc-connect.toml
+```
+
+Then `sudo systemctl daemon-reload && sudo systemctl restart cc-connect`.
+
+Cron jobs scheduled via `cc-connect cron add` fire inside the daemon,
+so they need no extra wiring. System cron jobs (`crontab -e`) that
+invoke `cc-connect cron list` need either `CC_DATA_DIR` exported in the
+cron environment or `--config /etc/cc-connect.toml` on every invocation:
+
+```cron
+CC_DATA_DIR=/var/lib/cc-connect
+*/5 * * * * /usr/local/bin/cc-connect cron list >> /var/log/cc-connect.log 2>&1
+```
+
+## 2. Docker
+
+Docker is the most common place where Issue #1719 bit users. The
+problem: the daemon starts, the socket binds on the container's
+overlay filesystem, then `cc-connect cron` from the host (or from a
+sidecar container) cannot see that socket because the path lives inside
+the container.
+
+There are two correct architectures:
+
+### 2a. Single container (daemon + cron)
+
+Put both the daemon and your cron jobs in the **same container**, mount
+a persistent volume for `data_dir`, and start the daemon in the
+background. The simplest reliable form:
+
+```dockerfile
+FROM ghcr.io/chenhg5/cc-connect:latest
+RUN apk add --no-cache tzdata  # optional; many distros already have it
+COPY cc-connect.toml /etc/cc-connect/config.toml
+ENV CC_DATA_DIR=/var/lib/cc-connect
+VOLUME ["/var/lib/cc-connect"]
+EXPOSE 9820  # web admin
+ENTRYPOINT ["cc-connect", "--config", "/etc/cc-connect/config.toml"]
+CMD []
+```
+
+```bash
+docker run -d \
+  --name cc-connect \
+  --restart unless-stopped \
+  -v cc-connect-data:/var/lib/cc-connect \
+  -v /etc/cc-connect:/etc/cc-connect:ro \
+  ghcr.io/chenhg5/cc-connect:latest
+```
+
+Because the daemon and `cc-connect cron ...` invocations share the same
+container, they share the same `/var/lib/cc-connect/run/api.sock` and
+the resolution is automatic. From inside the container:
+
+```bash
+docker exec cc-connect cc-connect cron list
+```
+
+### 2b. Sidecar / multi-container
+
+If you keep the daemon in one container and run cron jobs in another
+(or on the host), you must share the socket somehow:
+
+* **Bind-mount the data_dir volume** into the cron container. The socket
+  path is `<data_dir>/run/api.sock`; mounting the whole directory means
+  both containers see the same file.
+* **Match UID/GID** on both containers. The socket is created with
+  mode `0600`, so the cron container must run as the same UID that
+  owns `data_dir`. A common failure: `cron` container runs as UID 0,
+  daemon container as UID 1000, and you get EACCES. The fix is
+  `user: "1000:1000"` on both `--user` flags.
+
+```yaml
+# docker-compose.yml
+services:
+  cc-connect:
+    image: ghcr.io/chenhg5/cc-connect:latest
+    command: ["--config", "/etc/cc-connect/config.toml"]
+    volumes:
+      - cc-data:/var/lib/cc-connect
+      - ./cc-connect.toml:/etc/cc-connect/config.toml:ro
+    user: "1000:1000"
+    restart: unless-stopped
+
+  cron-runner:
+    image: ghcr.io/chenhg5/cc-connect:latest
+    # any cron-like job that calls cc-connect cron / send / relay
+    command: >
+      sh -c "while true; do
+        cc-connect --config /etc/cc-connect/config.toml cron list || true;
+        sleep 300;
+      done"
+    volumes:
+      - cc-data:/var/lib/cc-connect   # SAME volume as the daemon
+      - ./cc-connect.toml:/etc/cc-connect/config.toml:ro
+    user: "1000:1000"                  # MUST match the daemon container
+    depends_on:
+      - cc-connect
+
+volumes:
+  cc-data: {}
+```
+
+### 2c. Cron inside Docker
+
+There are three working patterns; pick whichever fits your toolchain.
+
+**(i) Use cc-connect's own scheduler (recommended).**
+
+```bash
+# Inside the container, schedule it via the daemon's API:
+docker exec cc-connect cc-connect cron add \
+  --cron "0 6 * * *" \
+  --prompt "Summarize GitHub trending repos" \
+  --desc "Daily Trending"
+```
+
+The daemon then fires the job in-process, with no cron daemon required.
+
+**(ii) Use a `cron` image and call `cc-connect cron ...`.**
+
+```dockerfile
+FROM alpine:3.20
+RUN apk add --no-cache curl tzdata dcron
+COPY crontab /etc/crontabs/root
+CMD ["crond", "-f", "-d", "0"]
+```
+
+```cron
+# crontab — CC_DATA_DIR must match the daemon container's
+CC_DATA_DIR=/var/lib/cc-connect
+*/5 * * * * cc-connect --config /etc/cc-connect.toml cron exec abc123
+```
+
+Mount the same `cc-data` volume on this container, or schedule it
+inside the same container as the daemon (pattern 2a).
+
+**(iii) Use `supercronic` (a single-binary cron).**
+
+```dockerfile
+FROM ghcr.io/chenhg5/cc-connect:latest
+COPY schedule.cron /etc/cc-connect/schedule.cron
+USER 1000:1000
+ENTRYPOINT []
+CMD ["/usr/local/bin/supercronic", "/etc/cc-connect/schedule.cron"]
+```
+
+Same `data_dir` mount rules apply.
+
+## 3. nohup / tmux / screen
+
+For a single Linux box without systemd, the three classic options are
+all fine. The only rule that matters is: pick one, and stick to it, so
+the PID lock file in `<config_dir>/.<config_base>.lock` doesn't fight
+itself.
+
+### nohup
+
+```bash
+mkdir -p /var/log/cc-connect /var/lib/cc-connect
+nohup cc-connect --config /etc/cc-connect/config.toml \
+  >> /var/log/cc-connect/stdout.log 2>&1 &
+echo $! > /var/run/cc-connect.pid
+
+# Stop:
+kill "$(cat /var/run/cc-connect.pid)"
+# Or, if the PID file is stale:
+cc-connect --config /etc/cc-connect/config.toml --force
+```
+
+### tmux
+
+```bash
+tmux new-session -d -s cc-connect \
+  'cc-connect --config /etc/cc-connect/config.toml 2>&1 | tee -a /var/log/cc-connect/stdout.log'
+
+# Watch it live:
+tmux attach -t cc-connect
+
+# Stop:
+tmux kill-session -t cc-connect
+```
+
+### screen
+
+```bash
+screen -dmS cc-connect \
+  cc-connect --config /etc/cc-connect/config.toml 2>&1 | tee -a /var/log/cc-connect/stdout.log
+
+# Attach:
+screen -r cc-connect
+
+# Stop:
+screen -S cc-connect -X quit
+```
+
+In all three cases, cron jobs (host `cron`, `crond`, or `supercronic`)
+that call `cc-connect cron ...` need either `CC_DATA_DIR` exported or
+the same `--config` flag on both server and client. See Issue #1719
+for the underlying bug history.
+
+## 4. Verification checklist
+
+After deploying, run these four commands. Each one must succeed before
+you trust the setup:
+
+```bash
+# 1. Daemon process is alive and holds the socket.
+pgrep -af cc-connect
+ls -l "$(cc-connect --config /etc/cc-connect.toml config path | xargs dirname)/run/api.sock"
+
+# 2. Client can talk to the daemon.
+cc-connect --config /etc/cc-connect/config.toml cron list
+
+# 3. Add a one-shot test job and watch it fire.
+cc-connect --config /etc/cc-connect/config.toml cron add \
+  --cron "* * * * *" \
+  --exec "echo hello-from-cron >> /tmp/cc-connect-test.log" \
+  --desc "1-minute smoke test"
+
+# 4. After the job fires:
+tail -f /tmp/cc-connect-test.log   # should show "hello-from-cron"
+cc-connect --config /etc/cc-connect/config.toml cron del <id-from-step-3>
+```
+
+If any step fails, the "diagnose first" section at the top covers the
+common causes (PID lock vs socket mismatch, wrong `data_dir`, missing
+volume mount, UID mismatch).
+
+## 5. Migration from a stuck state
+
+If your existing deployment is in the broken state from Issue #1719 —
+the daemon PID is gone but the lock file remains, or the daemon is
+running but cron jobs can't find the socket — the cleanest recovery:
+
+```bash
+# 1. Stop anything that might still be running.
+pkill -f 'cc-connect' || true
+
+# 2. Remove the stale PID lock.
+rm -f /etc/cc-connect/.config.toml.lock   # or wherever your config lives
+
+# 3. Decide on a single data_dir and bake it into config.toml:
+echo 'data_dir = "/var/lib/cc-connect"' >> /etc/cc-connect/config.toml
+
+# 4. Restart the daemon, then verify the client can reach it.
+cc-connect --config /etc/cc-connect/config.toml --force
+cc-connect --config /etc/cc-connect/config.toml cron list
+```
+
+After Issue #1719, the client and server agree on `data_dir` whenever
+they agree on `--config`, so step 4 should not require any env-var
+plumbing in normal cron entries.


### PR DESCRIPTION
Fixes #1719 — "在 docker 中运行无法使用 daemon,导致 cron 无法工作".

## What this changes

The daemon already accepted both `--data-dir` and `--config <path>`,
but every client subcommand (send / cron / timer / relay / sessions /
session-id) only accepted `--data-dir`. Deploys that pinned
`data_dir` inside `config.toml` — the common Docker, nohup, tmux
and screen cases — therefore could not locate the running daemon from
a client invocation. The client failed with the opaque string
`Error: socket not found`.

This PR introduces a single shared resolver and unifies client/server
on the same `data_dir` source.

### `cmd/cc-connect/data_dir_resolve.go` (new)

- `resolveDataDir(dataDirFlag, configPath)` priority:
  `--data-dir` > `CC_DATA_DIR` env > `data_dir` from `--config` >
  `~/.cc-connect`.
- `resolveSocketPath(dataDir)` returns `<dataDir>/run/api.sock`.
- `printSocketNotFound()` emits a CN/EN diagnostic listing the
  socket path tried, candidate `data_dir`s, the `--config` used (if
  any) and concrete next steps (`CC_DATA_DIR`, `--data-dir`,
  `--force`).

### Client subcommands

`send`, `cron`, `timer`, `relay`, `sessions`, `session-id`
all now:

- Accept `--config <path>` alongside `--data-dir`.
- Call the shared resolver before checking for the socket.
- Use `printSocketNotFound` for the missing-socket error.

Usage strings updated to advertise `--config`.

### `core/`

- `core.NewAPIServer` errors now include the socket path it tried to
  bind on.
- `core.APIServer` exposes `SocketDir()` for logging.
- `core/i18n.go` gains six new MsgKeys (`MsgSocketNotFound`,
  `MsgSocketNotFoundHint`, `MsgSocketSearchedTitle`,
  `MsgSocketConfigHint`, `MsgSocketEnvHint`, `MsgSocketDataDirLabel`)
  with translations for all five supported languages (EN, ZH, ZH-TW,
  JA, ES).
- `cmd/cc-connect/main.go` logs `slog.Info` on successful bind and
  returns the detailed error (including socket path) on bind failure,
  after releasing the PID lock so the next start is not blocked.

### Tests

`cmd/cc-connect/data_dir_resolve_test.go` covers:

- default resolution to `~/.cc-connect`
- `--config` precedence over default
- missing config fallback
- `CC_DATA_DIR` env integration
- `searchDirs` ordering and dedup
- `printSocketNotFound` content (Troubleshooting / CC_DATA_DIR / --force hints)

`cmd/cc-connect/send_test.go` updated to the new
`parseSendArgs` signature.

### Docs

`docs/deployment.md` (new) walks through:

- systemd (default unit + override for pinned `--config`)
- Docker single container (data_dir volume + ENTRYPOINT)
- Docker sidecar / multi-container (shared volume + UID/GID match
  for the 0600 socket)
- Cron inside Docker (cc-connect's own scheduler, dcron image, or
  supercronic binary)
- nohup, tmux, screen for the no-systemd single-host case

A "TL;DR diagnose first" section at the top mirrors the
`printSocketNotFound` diagnostic so the error and the doc reference
each other.

## Verification

```bash
go build ./...                                              # clean
go test ./cmd/cc-connect/ -run 'TestDefaultDataDir|TestResolveSocketPath|TestResolveDataDir|TestSearchDirs|TestPrintSocketNotFound' -count=1
# ok    github.com/chenhg5/cc-connect/cmd/cc-connect  0.010s
go vet ./...                                                # clean
gofmt -l .                                                  # empty
```

## Risk

Low. All changes are additive on the client side (a new `--config`
flag with sensible default behavior) plus an error-message
enrichment on the server side. The shared resolver preserves the
existing `--data-dir` semantics. Backward compatibility for
`systemd` users who relied on the default `~/.cc-connect` is
preserved by the priority order above.

## Branch / commits

Branch: `agent/cc-connect/t-20260823-uhshw2-fix-docker-cron-socket`

Split into 4 logical commits per tech design §7:

1. `core: include socket path in API server errors and i18n hints`
2. `cmd/cc-connect: share --config aware data_dir resolver across client subcommands`
3. `cmd/cc-connect: thread --config through cron, timer and relay subcommands`
4. `docs: add Docker/nohup/tmux/screen deployment guide`

Tech design doc: see `Issue #1719 技术方案评审` (submitted to PM).