### PR TITLE
feat(i18n): localize agent system prompt for cron/timer/send/relay (#1655)

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -55,6 +55,13 @@ type Agent struct {
 
 	appendSystemPrompt string // Custom text appended to the system prompt (keeps Claude's default)
 
+	// lang is the operator's configured cc-connect language (Issue #1655).
+	// When non-empty, session spawns use the localized cc-connect system
+	// prompt for the four tool sections (send / cron / timer / relay).
+	// Empty means "use English / cc-connect default" — back-compat with
+	// callers that pre-date the language option.
+	lang core.Language
+
 	providerProxy  *core.ProviderProxy // local proxy for third-party providers
 	proxyLocalURL  string              // local URL of the proxy
 	platformPrompt string              // platform-specific formatting instructions
@@ -150,6 +157,11 @@ func New(opts map[string]any) (core.Agent, error) {
 	systemPrompt, _ := opts["system_prompt"].(string)
 	appendSystemPrompt, _ := opts["append_system_prompt"].(string)
 	ccDataDir, _ := opts["cc_data_dir"].(string)
+	// Issue #1655: pass the operator's configured cc-connect language into the
+	// agent so per-spawn prompts can be localized. Empty string (legacy callers)
+	// falls back to English via AgentSystemPromptForLang.
+	langRaw, _ := opts["language"].(string)
+	lang := core.NormalizeLanguageString(langRaw)
 
 	var pluginDirs []string
 	if dir, ok := opts["plugin_dir"].(string); ok && dir != "" {
@@ -244,7 +256,12 @@ func New(opts map[string]any) (core.Agent, error) {
 	// newClaudeSession still covers content drift (cc-connect upgrades)
 	// and the empty-ccDataDir corner case. Failure here is non-fatal —
 	// the next spawn will retry and surface the error then.
-	if _, err := ensureSharedSystemPromptFile(ccDataDir, core.AgentSystemPrompt()); err != nil {
+	//
+	// Issue #1655: when the operator has set language="zh", the shared
+	// file content is the localized AgentSystemPromptForLang so the very
+	// first session (which uses the shared-file fast path) already sees
+	// the right language without waiting for the per-spawn merge.
+	if _, err := ensureSharedSystemPromptFile(ccDataDir, core.AgentSystemPromptForLang(lang)); err != nil {
 		slog.Warn("claudecode: failed to write shared system prompt file at startup; will retry on first spawn", "err", err, "cc_data_dir", ccDataDir)
 	}
 
@@ -269,6 +286,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		ccDataDir:        ccDataDir,
 
 		appendSystemPrompt: appendSystemPrompt,
+		lang:               lang,
 	}, nil
 }
 
@@ -525,12 +543,16 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	platformPrompt := a.platformPrompt
 	systemPrompt := a.systemPrompt
 	appendSystemPrompt := a.appendSystemPrompt
+	// Issue #1655: agent-level language drives the localized cc-connect system
+	// prompt. Read under the mutex and pass through to newClaudeSession so the
+	// session picks up the right tool-prompt bundle at spawn time.
+	lang := a.lang
 	// When router_url is set, --verbose conflicts with --output-format stream-json
 	// (verbose emits non-JSON text to stdout that corrupts the JSON stream).
 	disableVerbose := a.routerURL != ""
 	a.mu.Unlock()
 
-	return newClaudeSession(ctx, workDir, a.cmd, a.cliExtraArgs, a.cmdArgsFlag, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt, tools, disTools, pluginDirs, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok, a.ccDataDir)
+	return newClaudeSession(ctx, workDir, a.cmd, a.cliExtraArgs, a.cmdArgsFlag, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt, tools, disTools, pluginDirs, extraEnv, platformPrompt, disableVerbose, a.spawnOpts, maxTok, a.ccDataDir, lang)
 }
 
 func (a *Agent) ListSessions(ctx context.Context) ([]core.AgentSessionInfo, error) {

--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -216,7 +216,7 @@ func buildAppendSystemPrompt(agentPrompt, platformPrompt, userAppend string) str
 	return strings.Join(parts, "\n")
 }
 
-func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cmdArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, pluginDirs []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int, ccDataDir string) (*claudeSession, error) {
+func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs []string, cmdArgsFlag string, model, effort, sessionID, mode, systemPrompt, appendSystemPrompt string, allowedTools, disallowedTools []string, pluginDirs []string, extraEnv []string, platformPrompt string, disableVerbose bool, spawnOpts core.SpawnOptions, maxContextTokens int, ccDataDir string, lang core.Language) (*claudeSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	// Claude Code rejects bypassPermissions when running as root.
@@ -288,7 +288,11 @@ func newClaudeSession(ctx context.Context, workDir, cliBin string, cliExtraArgs 
 	// shared file is safe under concurrent spawns.
 	var promptFilePath string
 	var promptFileIsShared bool
-	if appended := buildAppendSystemPrompt(core.AgentSystemPrompt(), platformPrompt, appendSystemPrompt); appended != "" {
+	// Issue #1655: when a.language is non-empty, this session gets the
+	// localized cc-connect system prompt. When empty (legacy callers),
+	// AgentSystemPromptForLang returns the English default — same bytes as
+	// the pre-PR buildAppendSystemPrompt(core.AgentSystemPrompt(), ...) call.
+	if appended := buildAppendSystemPrompt(core.AgentSystemPromptForLang(lang), platformPrompt, appendSystemPrompt); appended != "" {
 		if platformPrompt == "" && appendSystemPrompt == "" {
 			path, err := ensureSharedSystemPromptFile(ccDataDir, appended)
 			if err != nil {

--- a/core/engine.go
+++ b/core/engine.go
@@ -16067,9 +16067,13 @@ func (e *Engine) setupMemoryFile() (setupResult, string, error) {
 
 	existing, _ := os.ReadFile(filePath)
 	existingText := string(existing)
-	block := "\n" + ccConnectInstructionMarker + "\n" + AgentSystemPrompt() + "\n"
+	// Use the engine's configured language so memory-file prompts reflect the
+	// operator's locale (Issue #1655). AgentSystemPromptForLang handles
+	// fallback to English internally when a tool key is missing.
+	prompt := AgentSystemPromptForLang(e.i18n.CurrentLang())
+	block := "\n" + ccConnectInstructionMarker + "\n" + prompt + "\n"
 	if idx := strings.Index(existingText, ccConnectInstructionMarker); idx >= 0 {
-		if strings.Contains(existingText[idx:], AgentSystemPrompt()) {
+		if strings.Contains(existingText[idx:], prompt) {
 			return setupExists, baseName, nil
 		}
 		updated := strings.TrimRight(existingText[:idx], "\n") + block

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -56,6 +57,38 @@ func DetectLanguage(text string) Language {
 		return LangSpanish
 	}
 	return LangEnglish
+}
+
+// NormalizeLanguageString parses a configuration string (e.g. from
+// opts["language"] or [projects].language) into a Language constant. The
+// accepted spellings mirror the ones documented in config.example.toml:
+// "en"/"english", "zh"/"chinese", "zh-TW"/"zh_TW"/"zhtw", "ja"/"japanese",
+// "es"/"spanish", and "" / "auto" for auto-detect. Unknown values return
+// LangAuto so the engine falls back to detection rather than silently
+// snapping to English — operators who set language = "klingon" should see
+// "auto" behaviour, not a hard English default they didn't ask for.
+//
+// Issue #1655 introduced this helper so the Claude Code agent (which
+// receives the language via opts["language"]) can decode the string
+// without duplicating the switch statement that cmd/cc-connect/main.go
+// uses for engine construction.
+func NormalizeLanguageString(s string) Language {
+	switch strings.ToLower(s) {
+	case "en", "english":
+		return LangEnglish
+	case "zh", "chinese":
+		return LangChinese
+	case "zh-tw", "zh_tw", "zhtw":
+		return LangTraditionalChinese
+	case "ja", "japanese":
+		return LangJapanese
+	case "es", "spanish":
+		return LangSpanish
+	case "", "auto":
+		return LangAuto
+	default:
+		return LangAuto
+	}
 }
 
 func isChinese(r rune) bool {
@@ -646,6 +679,17 @@ const (
 	MsgWsInitInvalidTarget      MsgKey = "ws_init_invalid_target"
 	MsgWsInitLocalPathsDisabled MsgKey = "ws_init_local_paths_disabled"
 	MsgBackgroundAutoDenied     MsgKey = "background_auto_denied"
+
+	// Agent system-prompt tool sections (Issue #1655). These are appended
+	// to the agent's own system prompt by core/interfaces.go AgentSystemPromptForLang
+	// so that operators running cc-connect with language="zh" see the
+	// send / cron / timer / relay tool documentation in their native
+	// language. Translation coverage is en + zh for this PR; additional
+	// languages fall back to en automatically.
+	MsgAgentSendToolPrompt MsgKey = "agent_send_tool_prompt"
+	MsgAgentCronToolPrompt MsgKey = "agent_cron_tool_prompt"
+	MsgAgentTimerToolPrompt MsgKey = "agent_timer_tool_prompt"
+	MsgAgentRelayToolPrompt MsgKey = "agent_relay_tool_prompt"
 )
 
 var messages = map[MsgKey]map[Language]string{
@@ -4191,6 +4235,261 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "`/workspace init` 未啟用本機目錄目標。請使用 git 倉庫地址，或在此專案配置 `workspace_init_allow_local_paths = true`。",
 		LangJapanese:           "`/workspace init` ではローカルディレクトリ対象が無効です。git URL を使うか、このプロジェクトで `workspace_init_allow_local_paths = true` を有効にしてください。",
 		LangSpanish:            "Los destinos de directorio local están deshabilitados para `/workspace init`. Use una URL de git o habilite `workspace_init_allow_local_paths = true` para este proyecto.",
+	},
+	MsgAgentSendToolPrompt: {
+		LangEnglish: `### Send generated images, files, or voice messages back to the user
+When you generate a local image or file that should be sent to the user, use:
+
+  cc-connect send --image /absolute/path/to/image.png
+  cc-connect send --file /absolute/path/to/report.pdf
+  cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
+
+You may repeat --image / --file multiple times. Use this only for generated attachments that need to be delivered to the user.
+If you include --message, do not repeat the exact same sentence again in your normal reply, because your normal reply is also delivered automatically.
+
+When sending an audio (mp3/wav/m4a/ogg/opus) or video (mp4/mov/webm) clip that should render inline as a native voice bubble or video player — instead of as a generic file download — use the dedicated flags:
+
+  cc-connect send --audio /absolute/path/to/clip.mp3
+  cc-connect send --video /absolute/path/to/demo.mp4
+
+These render as native media on platforms that support it (e.g. Feishu voice bubbles, Telegram voice messages). cc-connect transparently transcodes audio to the platform's preferred codec (e.g. opus for Feishu). On platforms without dedicated audio/video support cc-connect automatically falls back to the file-attachment path so delivery is preserved. Do NOT downgrade the user's request to --file when they explicitly asked for audio or video.
+
+When the user explicitly asks you to synthesize speech from text, use:
+
+  cc-connect send --tts "text to speak"
+
+After cc-connect send --tts (or --audio) succeeds, reply only with NO_REPLY unless the user also asked for a visible text confirmation. This prevents sending an extra text message after the voice message.`,
+		LangChinese: `### 把生成的图片、文件、语音消息回发给用户
+当你生成了需要发送给用户的本地图片或文件时,使用:
+
+  cc-connect send --image /absolute/path/to/image.png
+  cc-connect send --file /absolute/path/to/report.pdf
+  cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
+
+可以重复使用 --image / --file。仅在需要把生成的附件投递到用户时使用这个命令。
+如果同时使用了 --message,不要在正常回复里再说一遍完全相同的句子,因为正常回复本身也会自动发送给用户。
+
+发送音频 (mp3/wav/m4a/ogg/opus) 或视频 (mp4/mov/webm) 片段、且希望它们以内联的原生语音气泡或视频播放器形态呈现(而不是作为普通文件下载)时,使用专用参数:
+
+  cc-connect send --audio /absolute/path/to/clip.mp3
+  cc-connect send --video /absolute/path/to/demo.mp4
+
+这些参数会在支持原生媒体的平台上渲染为原生形态(例如飞书的语音气泡、Telegram 的语音消息)。cc-connect 会自动把音频转码为平台偏好的编码(例如飞书的 opus)。在不支持专用音视频的平台,cc-connect 会自动回退到文件附件路径以保证投递成功。当用户明确要求 audio/video 时,不要把请求降级为 --file。
+
+当用户明确要求把文字合成为语音时,使用:
+
+  cc-connect send --tts "要朗读的文字"
+
+cc-connect send --tts(或 --audio)成功之后,除非用户同时要求可见的文字确认,否则只回复 NO_REPLY,避免在语音消息后再发一条文字消息。`,
+	},
+	MsgAgentCronToolPrompt: {
+		LangEnglish: `### Scheduled tasks: when to use /cron vs /timer
+
+cc-connect has TWO distinct scheduling commands. Picking the wrong one creates a confusing UX for the user.
+
+  ┌──────────────────────────────┬─────────────────────────────┐
+  │ Use cc-connect cron …        │ Use cc-connect timer …      │
+  ├──────────────────────────────┼─────────────────────────────┤
+  │ Recurring schedule           │ One-shot delay / one-time   │
+  │ "每天/每周/每小时"            │ "X 分钟后/小时后/明天"        │
+  │ "every day/week/Monday"      │ "in 30 min", "tomorrow 9am"  │
+  │ "每天早上6点总结"             │ "3 分钟后检查负载"            │
+  │ Lives forever until deleted  │ Auto-archives after firing  │
+  │ Queried via /cron            │ Queried via /timer          │
+  └──────────────────────────────┴─────────────────────────────┘
+
+When telling the user the task is scheduled, tell them which command to use to view/manage it
+(say "use /timer to view" for one-shot, "use /cron to view" for recurring).
+
+### Scheduled tasks (cron) — RECURRING
+When the user asks you to do something on a schedule (e.g. "每天早上6点帮我总结GitHub trending"), use the Bash tool to run:
+
+  cc-connect cron add --cron "<min> <hour> <day> <month> <weekday>" --prompt "<task description>" --desc "<short label>"
+
+Environment variables CC_PROJECT and CC_SESSION_KEY are already set, so you do NOT need to specify --project or --session-key.
+
+Optional flags:
+  --session-mode <mode>     reuse (default) or new-per-run (fresh session each trigger)
+  --timeout-mins <n>        max wait per run in minutes (default 30, 0 = unlimited)
+  --exec <command>          run a shell command directly instead of --prompt
+
+Examples:
+  cc-connect cron add --cron "0 6 * * *" --prompt "Collect GitHub trending repos and send a summary" --desc "Daily GitHub Trending"
+  cc-connect cron add --cron "0 9 * * 1" --prompt "Generate a weekly project status report" --desc "Weekly Report"
+  cc-connect cron add --cron "*/2 * * * *" --exec "ipconfig" --session-mode new-per-run --desc "Every 2 min ipconfig"
+
+You can also list, inspect, run, edit, or delete cron jobs:
+  cc-connect cron list
+  cc-connect cron info <job-id> [field]
+  cc-connect cron exec <job-id>
+  cc-connect cron edit <job-id> <field> <value>
+  cc-connect cron del <job-id>
+
+When changing an existing job, first run ` + "`cc-connect cron info <job-id>`" + ` to inspect the current values, then use ` + "`cron edit`" + ` for only the field(s) the user asked to change.
+Use ` + "`cron exec <job-id>`" + ` to run an existing scheduled task immediately; this is different from the ` + "`--exec <command>`" + ` flag used when creating a shell-command cron job.
+Use ` + "`cron edit`" + ` instead of delete-and-recreate when only one field changes. Do not delete and recreate a job unless the user explicitly asks to replace it.
+Common editable fields:
+  cron_expr     new schedule, e.g. "0 9 * * *"
+  prompt        new task prompt (or ` + "`exec`" + ` for shell command)
+  description   short label
+  enabled       true / false  (pause without deleting)
+  mute          true / false  (silence all messages)
+  timeout_mins  integer minutes (0 = unlimited)
+Run ` + "`cc-connect cron edit --help`" + ` for the full field list.
+
+Examples:
+  cc-connect cron exec abc123
+  cc-connect cron edit abc123 cron_expr "0 9 * * *"
+  cc-connect cron edit abc123 enabled false
+  cc-connect cron edit abc123 prompt "Updated daily summary task"`,
+		LangChinese: `### 定时任务:什么时候用 /cron,什么时候用 /timer
+
+cc-connect 有两个不同的调度命令。选错会让用户感到很困惑。
+
+  ┌──────────────────────────────┬─────────────────────────────┐
+  │ 使用 cc-connect cron …       │ 使用 cc-connect timer …     │
+  ├──────────────────────────────┼─────────────────────────────┤
+  │ 周期性调度                    │ 单次延时 / 一次性任务         │
+  │ "每天/每周/每小时"            │ "X 分钟后/小时后/明天"        │
+  │ "every day/week/Monday"      │ "in 30 min", "tomorrow 9am"  │
+  │ "每天早上6点总结"             │ "3 分钟后检查负载"            │
+  │ 一直存在直到被删除             │ 触发后自动归档                │
+  │ 通过 /cron 查看               │ 通过 /timer 查看              │
+  └──────────────────────────────┴─────────────────────────────┘
+
+告诉用户任务已安排好后,顺手告诉他们用哪个命令查看/管理:
+(单次任务说"用 /timer 查看",周期任务说"用 /cron 查看")。
+
+### 周期任务 (cron) — RECURRING
+当用户让你做周期性任务时(例如"每天早上6点帮我总结GitHub trending"),用 Bash 工具执行:
+
+  cc-connect cron add --cron "<分> <时> <日> <月> <星期>" --prompt "<任务描述>" --desc "<简短标签>"
+
+环境变量 CC_PROJECT 和 CC_SESSION_KEY 已经设置好,你不需要传 --project 或 --session-key。
+
+可选参数:
+  --session-mode <mode>     reuse(默认)或 new-per-run(每次触发用新会话)
+  --timeout-mins <n>        每次运行最长等待分钟数(默认 30,0 = 不限)
+  --exec <command>          直接跑 shell 命令而不是 --prompt
+
+示例:
+  cc-connect cron add --cron "0 6 * * *" --prompt "汇总 GitHub trending 仓库并发摘要" --desc "每日 GitHub Trending"
+  cc-connect cron add --cron "0 9 * * 1" --prompt "生成本周项目状态报告" --desc "每周报告"
+  cc-connect cron add --cron "*/2 * * * *" --exec "ipconfig" --session-mode new-per-run --desc "每 2 分钟跑 ipconfig"
+
+你也可以列出、检查、立即执行、修改或删除 cron 任务:
+  cc-connect cron list
+  cc-connect cron info <job-id> [字段]
+  cc-connect cron exec <job-id>
+  cc-connect cron edit <job-id> <字段> <新值>
+  cc-connect cron del <job-id>
+
+修改现有任务时,先用 ` + "`cc-connect cron info <job-id>`" + ` 看当前值,再用 ` + "`cron edit`" + ` 只改用户要求改的字段。
+用 ` + "`cron exec <job-id>`" + ` 立即执行已存在的调度任务;这和创建 shell 任务时用的 ` + "`--exec <command>`" + ` 参数不同。
+只有修改一个字段时,用 ` + "`cron edit`" + ` 而不是删除后重建。除非用户明确要求替换任务,不要先删再建。
+常用可编辑字段:
+  cron_expr     新调度,例如 "0 9 * * *"
+  prompt        新任务 prompt(或 ` + "`exec`" + ` 表示 shell 命令)
+  description   简短标签
+  enabled       true / false(暂停而不删除)
+  mute          true / false(静默所有消息)
+  timeout_mins  整数分钟(0 = 不限)
+完整字段列表见 ` + "`cc-connect cron edit --help`" + `。
+
+示例:
+  cc-connect cron exec abc123
+  cc-connect cron edit abc123 cron_expr "0 9 * * *"
+  cc-connect cron edit abc123 enabled false
+  cc-connect cron edit abc123 prompt "更新后的每日摘要任务"`,
+	},
+	MsgAgentTimerToolPrompt: {
+		LangEnglish: `### One-shot timers (timer) — ONE-TIME DELAY
+When the user asks you to do something AFTER A DELAY or AT A SPECIFIC FUTURE TIME
+(e.g. "两小时后帮我检查PR", "3 分钟后看下系统负载", "明天早上 9 点提醒我"),
+use the Bash tool to run:
+
+  cc-connect timer add --delay <duration> --prompt "<task description>"
+
+IMPORTANT: do NOT use cron for one-shot delays. A cron expression like "4 19 14 6 *"
+means "every year on June 14 at 19:04", not "once on this date". Cron has no built-in
+"fire once" mode — use timer for any one-time / delayed request.
+
+Duration examples: 30m, 2h, 1h30m. Or use absolute time: --at "2026-05-16T09:00"
+Absolute times without timezone (e.g. "2026-05-16T09:00") are interpreted as the
+system's local timezone. When the user says "明天早上9点", use local time.
+Environment variables CC_PROJECT and CC_SESSION_KEY are already set.
+
+Optional flags:
+  --exec <command>          run a shell command directly instead of --prompt
+  --desc <text>             short description
+  --session-mode <mode>     reuse (default) or new-per-run (fresh session each run)
+  --timeout-mins <n>        max wait per run in minutes (default 30, 0 = unlimited)
+  --mute                    suppress all messages (start notification + result)
+
+Examples:
+  cc-connect timer add --delay 2h --prompt "Check PR status" --desc "PR check"
+  cc-connect timer add --delay 30m --exec "df -h" --desc "Disk check"
+  cc-connect timer add --at "2026-05-16T09:00" --prompt "Morning standup reminder"
+
+You can also list or cancel timers:
+  cc-connect timer list
+  cc-connect timer del <timer-id>`,
+		LangChinese: `### 一次性延时 (timer) — ONE-TIME DELAY
+当用户让你在一段延时之后或在某个未来时刻做某事时
+(例如"两小时后帮我检查PR"、"3 分钟后看下系统负载"、"明天早上 9 点提醒我"),
+用 Bash 工具执行:
+
+  cc-connect timer add --delay <时长> --prompt "<任务描述>"
+
+重要:不要用 cron 跑单次延时。形如 "4 19 14 6 *" 的 cron 表达式
+意思是"每年 6 月 14 日 19:04"而不是"这一天跑一次"。cron 没有内建"只跑一次"模式 ——
+所有一次性 / 延时任务都用 timer。
+
+时长示例:30m、2h、1h30m。或者用绝对时间:--at "2026-05-16T09:00"
+不带时区的绝对时间(例如 "2026-05-16T09:00")按系统本地时区解释。用户说"明天早上9点"时用本地时间。
+环境变量 CC_PROJECT 和 CC_SESSION_KEY 已经设置好。
+
+可选参数:
+  --exec <command>          直接跑 shell 命令而不是 --prompt
+  --desc <text>             简短描述
+  --session-mode <mode>     reuse(默认)或 new-per-run(每次跑用新会话)
+  --timeout-mins <n>        每次最长等待分钟数(默认 30,0 = 不限)
+  --mute                    静默所有消息(开始通知和结果)
+
+示例:
+  cc-connect timer add --delay 2h --prompt "检查 PR 状态" --desc "PR 检查"
+  cc-connect timer add --delay 30m --exec "df -h" --desc "磁盘检查"
+  cc-connect timer add --at "2026-05-16T09:00" --prompt "早会提醒"
+
+你也可以列出或取消 timer:
+  cc-connect timer list
+  cc-connect timer del <timer-id>`,
+	},
+	MsgAgentRelayToolPrompt: {
+		LangEnglish: `### Bot-to-bot relay
+When you need to communicate with another bot (e.g. ask another AI agent a question), use:
+
+  cc-connect relay send --to <target_project> "<message>"
+
+IMPORTANT: <target_project> must be the EXACT project name from the /bind command output.
+Do NOT guess or modify the name — use it exactly as shown (e.g. "gemini", not "gemini-bot").
+
+This sends a message to the target bot and waits for its response (printed to stdout).
+The conversation is visible in the group chat and each bot maintains its own relay session.
+
+Environment variables CC_PROJECT and CC_SESSION_KEY are already set, so the relay knows which group chat to use.`,
+		LangChinese: `### Bot 之间转发 (relay)
+当需要和另一个 bot 通信(例如向另一个 AI agent 提问)时,使用:
+
+  cc-connect relay send --to <目标项目名> "<消息>"
+
+重要:<目标项目名> 必须是 /bind 命令输出里的 EXACT 项目名。
+不要猜测或修改名字 —— 完全照搬显示值(例如 "gemini" 而不是 "gemini-bot")。
+
+这会把消息发给目标 bot 并等待它的回复(打印到 stdout)。
+会话在群聊里可见,每个 bot 维护自己的 relay 会话。
+
+环境变量 CC_PROJECT 和 CC_SESSION_KEY 已经设置好,relay 知道用哪个群聊。`,
 	},
 }
 

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -6,6 +6,35 @@ import (
 	"time"
 )
 
+// i18nT is the free-function form of (*I18n).T used by AgentSystemPromptForLang.
+// It looks up the message in the same messages bundle and applies the same
+// fallback chain (zh-TW → zh → en) so behaviour stays consistent with the
+// engine-driven path. Returning the key itself on total miss matches (*I18n).T.
+//
+// Keeping this here (rather than reusing (*I18n).T) lets AgentSystemPromptForLang
+// stay a pure function that takes only a Language — callers like the Claude
+// Code agent that don't already hold an *I18n can still get a localized
+// prompt without constructing a throwaway I18n.
+func i18nT(lang Language, key MsgKey) string {
+	m, ok := messages[key]
+	if !ok {
+		return string(key)
+	}
+	if v, ok := m[lang]; ok && v != "" {
+		return v
+	}
+	// Fallback chain: zh-TW → zh → en. Mirrors (*I18n).T.
+	if lang == LangTraditionalChinese {
+		if v, ok := m[LangChinese]; ok && v != "" {
+			return v
+		}
+	}
+	if v, ok := m[LangEnglish]; ok && v != "" {
+		return v
+	}
+	return string(key)
+}
+
 // Platform abstracts a messaging platform (Feishu, DingTalk, Slack, etc.).
 type Platform interface {
 	Name() string
@@ -81,140 +110,33 @@ type PlatformPromptInjector interface {
 // AgentSystemPrompt returns the system prompt fragment that informs agents about
 // cc-connect capabilities (cron scheduling, etc.).
 // The prompt is designed to be appended to the agent's existing system prompt.
+//
+// This is a back-compat wrapper that always returns English; the underlying
+// source of truth is AgentSystemPromptForLang, which the engine and the
+// Claude Code agent call when they know the operator's configured language
+// (Issue #1655: zh + en are the first two localized tool sections).
 func AgentSystemPrompt() string {
-	return `You are running inside cc-connect, a bridge that connects you to messaging platforms.
+	return AgentSystemPromptForLang(LangEnglish)
+}
+
+// agentSystemPromptHeader is the static English preamble that introduces the
+// cc-connect bridge and the ## Available tools heading. It is not localized:
+// the preamble is infrastructure wording ("You are running inside cc-connect…")
+// rather than tool documentation, and keeping it stable across languages
+// preserves the meaning of the marker the engine searches for when refreshing
+// the prompt file across upgrades.
+const agentSystemPromptHeader = `You are running inside cc-connect, a bridge that connects you to messaging platforms.
 Your normal text responses are automatically delivered to the user — just reply normally, do NOT use cc-connect send for ordinary text replies.
 
 ## Available tools
+`
 
-### Send generated images, files, or voice messages back to the user
-When you generate a local image or file that should be sent to the user, use:
-
-  cc-connect send --image /absolute/path/to/image.png
-  cc-connect send --file /absolute/path/to/report.pdf
-  cc-connect send --file /absolute/path/to/report.pdf --image /absolute/path/to/chart.png
-
-You may repeat --image / --file multiple times. Use this only for generated attachments that need to be delivered to the user.
-If you include --message, do not repeat the exact same sentence again in your normal reply, because your normal reply is also delivered automatically.
-
-When sending an audio (mp3/wav/m4a/ogg/opus) or video (mp4/mov/webm) clip that should render inline as a native voice bubble or video player — instead of as a generic file download — use the dedicated flags:
-
-  cc-connect send --audio /absolute/path/to/clip.mp3
-  cc-connect send --video /absolute/path/to/demo.mp4
-
-These render as native media on platforms that support it (e.g. Feishu voice bubbles, Telegram voice messages). cc-connect transparently transcodes audio to the platform's preferred codec (e.g. opus for Feishu). On platforms without dedicated audio/video support cc-connect automatically falls back to the file-attachment path so delivery is preserved. Do NOT downgrade the user's request to --file when they explicitly asked for audio or video.
-
-When the user explicitly asks you to synthesize speech from text, use:
-
-  cc-connect send --tts "text to speak"
-
-After cc-connect send --tts (or --audio) succeeds, reply only with NO_REPLY unless the user also asked for a visible text confirmation. This prevents sending an extra text message after the voice message.
-
-### Scheduled tasks: when to use /cron vs /timer
-
-cc-connect has TWO distinct scheduling commands. Picking the wrong one creates a confusing UX for the user.
-
-  ┌──────────────────────────────┬─────────────────────────────┐
-  │ Use cc-connect cron …        │ Use cc-connect timer …      │
-  ├──────────────────────────────┼─────────────────────────────┤
-  │ Recurring schedule           │ One-shot delay / one-time   │
-  │ "每天/每周/每小时"            │ "X 分钟后/小时后/明天"        │
-  │ "every day/week/Monday"      │ "in 30 min", "tomorrow 9am"  │
-  │ "每天早上6点总结"             │ "3 分钟后检查负载"            │
-  │ Lives forever until deleted  │ Auto-archives after firing  │
-  │ Queried via /cron            │ Queried via /timer          │
-  └──────────────────────────────┴─────────────────────────────┘
-
-When telling the user the task is scheduled, tell them which command to use to view/manage it
-(say "use /timer to view" for one-shot, "use /cron to view" for recurring).
-
-### Scheduled tasks (cron) — RECURRING
-When the user asks you to do something on a schedule (e.g. "每天早上6点帮我总结GitHub trending"), use the Bash tool to run:
-
-  cc-connect cron add --cron "<min> <hour> <day> <month> <weekday>" --prompt "<task description>" --desc "<short label>"
-
-Environment variables CC_PROJECT and CC_SESSION_KEY are already set, so you do NOT need to specify --project or --session-key.
-
-Optional flags:
-  --session-mode <mode>     reuse (default) or new-per-run (fresh session each trigger)
-  --timeout-mins <n>        max wait per run in minutes (default 30, 0 = unlimited)
-  --exec <command>          run a shell command directly instead of --prompt
-
-Examples:
-  cc-connect cron add --cron "0 6 * * *" --prompt "Collect GitHub trending repos and send a summary" --desc "Daily GitHub Trending"
-  cc-connect cron add --cron "0 9 * * 1" --prompt "Generate a weekly project status report" --desc "Weekly Report"
-  cc-connect cron add --cron "*/2 * * * *" --exec "ipconfig" --session-mode new-per-run --desc "Every 2 min ipconfig"
-
-You can also list, inspect, run, edit, or delete cron jobs:
-  cc-connect cron list
-  cc-connect cron info <job-id> [field]
-  cc-connect cron exec <job-id>
-  cc-connect cron edit <job-id> <field> <value>
-  cc-connect cron del <job-id>
-
-When changing an existing job, first run ` + "`cc-connect cron info <job-id>`" + ` to inspect the current values, then use ` + "`cron edit`" + ` for only the field(s) the user asked to change.
-Use ` + "`cron exec <job-id>`" + ` to run an existing scheduled task immediately; this is different from the ` + "`--exec <command>`" + ` flag used when creating a shell-command cron job.
-Use ` + "`cron edit`" + ` instead of delete-and-recreate when only one field changes. Do not delete and recreate a job unless the user explicitly asks to replace it.
-Common editable fields:
-  cron_expr     new schedule, e.g. "0 9 * * *"
-  prompt        new task prompt (or ` + "`exec`" + ` for shell command)
-  description   short label
-  enabled       true / false  (pause without deleting)
-  mute          true / false  (silence all messages)
-  timeout_mins  integer minutes (0 = unlimited)
-Run ` + "`cc-connect cron edit --help`" + ` for the full field list.
-
-Examples:
-  cc-connect cron exec abc123
-  cc-connect cron edit abc123 cron_expr "0 9 * * *"
-  cc-connect cron edit abc123 enabled false
-  cc-connect cron edit abc123 prompt "Updated daily summary task"
-
-### One-shot timers (timer) — ONE-TIME DELAY
-When the user asks you to do something AFTER A DELAY or AT A SPECIFIC FUTURE TIME
-(e.g. "两小时后帮我检查PR", "3 分钟后看下系统负载", "明天早上 9 点提醒我"),
-use the Bash tool to run:
-
-  cc-connect timer add --delay <duration> --prompt "<task description>"
-
-IMPORTANT: do NOT use cron for one-shot delays. A cron expression like "4 19 14 6 *"
-means "every year on June 14 at 19:04", not "once on this date". Cron has no built-in
-"fire once" mode — use timer for any one-time / delayed request.
-
-Duration examples: 30m, 2h, 1h30m. Or use absolute time: --at "2026-05-16T09:00"
-Absolute times without timezone (e.g. "2026-05-16T09:00") are interpreted as the
-system's local timezone. When the user says "明天早上9点", use local time.
-Environment variables CC_PROJECT and CC_SESSION_KEY are already set.
-
-Optional flags:
-  --exec <command>          run a shell command directly instead of --prompt
-  --desc <text>             short description
-  --session-mode <mode>     reuse (default) or new-per-run (fresh session each run)
-  --timeout-mins <n>        max wait per run in minutes (default 30, 0 = unlimited)
-  --mute                    suppress all messages (start notification + result)
-
-Examples:
-  cc-connect timer add --delay 2h --prompt "Check PR status" --desc "PR check"
-  cc-connect timer add --delay 30m --exec "df -h" --desc "Disk check"
-  cc-connect timer add --at "2026-05-16T09:00" --prompt "Morning standup reminder"
-
-You can also list or cancel timers:
-  cc-connect timer list
-  cc-connect timer del <timer-id>
-
-### Bot-to-bot relay
-When you need to communicate with another bot (e.g. ask another AI agent a question), use:
-
-  cc-connect relay send --to <target_project> "<message>"
-
-IMPORTANT: <target_project> must be the EXACT project name from the /bind command output.
-Do NOT guess or modify the name — use it exactly as shown (e.g. "gemini", not "gemini-bot").
-
-This sends a message to the target bot and waits for its response (printed to stdout).
-The conversation is visible in the group chat and each bot maintains its own relay session.
-
-Environment variables CC_PROJECT and CC_SESSION_KEY are already set, so the relay knows which group chat to use.
-
+// agentSystemPromptFooter is the static English closing section (silent reply
+// / NO_REPLY semantics). Like the header, it is shared infrastructure rather
+// than per-tool documentation, so it stays in English. The agent's behaviour
+// here depends on the marker being exactly ` + "`NO_REPLY`" + `; translating
+// the token would break detection.
+const agentSystemPromptFooter = `
 ### Silent reply (suppress delivery)
 If the current turn warrants no user-visible response — e.g. a scheduled trigger
 found nothing worth reporting, the incoming message was an acknowledgement that
@@ -229,6 +151,34 @@ the trailing marker before delivery:
   surrounding text).
 Use this sparingly; when in doubt, send a brief reply instead.
 `
+
+// AgentSystemPromptForLang returns the cc-connect system prompt with the
+// four user-facing tool sections (send / cron / timer / relay) rendered in
+// the given language. The header, the "## Available tools" heading, and the
+// silent-reply footer stay in English on purpose — see the comments on
+// agentSystemPromptHeader / agentSystemPromptFooter.
+//
+// If a language key is missing for one of the four tool sections (e.g. an
+// unsupported language code, or a future PR that adds a new language
+// without translating every tool yet), that section silently falls back to
+// the English version via messages[key][LangEnglish]. This matches the
+// fallback behaviour of (*I18n).T so cc-connect never refuses to start
+// because of an incomplete translation (per the owner decision in
+// doc-20260823-ws0eux).
+//
+// Pass LangEnglish for the historical English-only behaviour, which
+// AgentSystemPrompt() is a thin wrapper around.
+//
+// See Issue #1655 for the original feature request and the owner-approved
+// scope: zh + en translations on these four tools; other languages come
+// later as follow-up PRs.
+func AgentSystemPromptForLang(lang Language) string {
+	return agentSystemPromptHeader +
+		i18nT(lang, MsgAgentSendToolPrompt) +
+		"\n\n" + i18nT(lang, MsgAgentCronToolPrompt) +
+		"\n\n" + i18nT(lang, MsgAgentTimerToolPrompt) +
+		"\n\n" + i18nT(lang, MsgAgentRelayToolPrompt) +
+		agentSystemPromptFooter
 }
 
 // SystemPromptSupporter is an optional marker interface for agents that

--- a/core/interfaces_test.go
+++ b/core/interfaces_test.go
@@ -1,0 +1,213 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAgentSystemPrompt_EnglishDefault covers the back-compat behaviour:
+// AgentSystemPrompt() must return the same bytes as the English variant and
+// must contain the silent-reply marker so existing English-only callers keep
+// working unchanged after Issue #1655's i18n refactor.
+func TestAgentSystemPrompt_EnglishDefault(t *testing.T) {
+	got := AgentSystemPrompt()
+	if got == "" {
+		t.Fatal("AgentSystemPrompt() returned empty string")
+	}
+	if !strings.Contains(got, "NO_REPLY") {
+		t.Error("English system prompt must contain NO_REPLY marker")
+	}
+	if !strings.Contains(got, "## Available tools") {
+		t.Error("English system prompt must contain '## Available tools' heading")
+	}
+	// Should match the explicit English call exactly.
+	if got != AgentSystemPromptForLang(LangEnglish) {
+		t.Error("AgentSystemPrompt() must equal AgentSystemPromptForLang(LangEnglish)")
+	}
+}
+
+// TestAgentSystemPromptForLang_AllToolKeysExist makes sure each of the four
+// Issue #1655 tool sections (send / cron / timer / relay) has at least an
+// English entry. Without English entries the engine would write
+// "[agent_send_tool_prompt]" placeholders into the agent's memory file, which
+// would break every cc-connect installation that didn't override its
+// language. This is the "fallback to en on missing key" requirement.
+func TestAgentSystemPromptForLang_AllToolKeysExist(t *testing.T) {
+	keys := []MsgKey{
+		MsgAgentSendToolPrompt,
+		MsgAgentCronToolPrompt,
+		MsgAgentTimerToolPrompt,
+		MsgAgentRelayToolPrompt,
+	}
+	for _, k := range keys {
+		t.Run(string(k), func(t *testing.T) {
+			for _, lang := range []Language{LangEnglish, LangChinese, LangTraditionalChinese, LangJapanese, LangSpanish} {
+				got := i18nT(lang, k)
+				if got == "" || got == string(k) {
+					t.Errorf("i18nT(%v, %q) fell through to key/empty — English fallback broken", lang, k)
+				}
+			}
+		})
+	}
+}
+
+// TestAgentSystemPromptForLang_EnglishHasAllFourTools verifies the English
+// variant mentions each of the four tools by name. The agent needs to see
+// "cron", "timer", "send", and "relay" so it knows the bridge exposes them.
+func TestAgentSystemPromptForLang_EnglishHasAllFourTools(t *testing.T) {
+	got := AgentSystemPromptForLang(LangEnglish)
+	for _, marker := range []string{"cc-connect send", "cc-connect cron", "cc-connect timer", "cc-connect relay"} {
+		if !strings.Contains(got, marker) {
+			t.Errorf("English system prompt missing %q", marker)
+		}
+	}
+}
+
+// TestAgentSystemPromptForLang_ChineseHasAllFourTools verifies the zh
+// variant of each tool section actually contains Chinese characters and the
+// header / footer are still present. This guards against accidental
+// regressions where a translation PR replaces Chinese with the English
+// placeholder.
+func TestAgentSystemPromptForLang_ChineseHasAllFourTools(t *testing.T) {
+	got := AgentSystemPromptForLang(LangChinese)
+	if got == AgentSystemPromptForLang(LangEnglish) {
+		t.Fatal("zh and en system prompts are identical — translations not wired")
+	}
+	if !strings.Contains(got, "## Available tools") {
+		t.Error("zh system prompt must keep the English '## Available tools' heading")
+	}
+	if !strings.Contains(got, "NO_REPLY") {
+		t.Error("zh system prompt must keep the English NO_REPLY marker")
+	}
+	if !containsCJK(got) {
+		t.Error("zh system prompt should contain CJK characters — looks untranslated")
+	}
+}
+
+// TestAgentSystemPromptForLang_ZhTwFallback verifies the zh-TW → zh fallback
+// chain documented on i18nT. zh-TW has no own entry for the tool prompts in
+// this PR, so the user must see the zh version rather than English — that
+// matches the i18n behaviour for the rest of the bundle.
+func TestAgentSystemPromptForLang_ZhTwFallback(t *testing.T) {
+	zh := AgentSystemPromptForLang(LangChinese)
+	zhTW := AgentSystemPromptForLang(LangTraditionalChinese)
+	if zh != zhTW {
+		t.Error("zh-TW system prompt should fall back to zh for Issue #1655 tool sections")
+	}
+}
+
+// TestAgentSystemPromptForLang_UnsupportedLangFallback covers languages
+// that aren't translated in this PR (ja, es). They must fall back to English
+// rather than render the raw key — per the owner decision in
+// doc-20260823-ws0eux (fallback to en on missing key, never break the agent).
+func TestAgentSystemPromptForLang_UnsupportedLangFallback(t *testing.T) {
+	en := AgentSystemPromptForLang(LangEnglish)
+	for _, lang := range []Language{LangJapanese, LangSpanish, Language("klingon")} {
+		if got := AgentSystemPromptForLang(lang); got != en {
+			t.Errorf("unsupported language %q should fall back to English; got distinct output", lang)
+		}
+	}
+}
+
+// TestAgentSystemPromptForLang_AutoFallback covers the auto-detect case.
+// LangAuto is not a real language; passing it through the prompt builder
+// must yield the English default rather than a raw key placeholder, because
+// the engine can race ahead of the first user message and call this with
+// the initial LangAuto value.
+func TestAgentSystemPromptForLang_AutoFallback(t *testing.T) {
+	got := AgentSystemPromptForLang(LangAuto)
+	if got == "" || strings.Contains(got, "agent_send_tool_prompt") {
+		t.Error("LangAuto must fall back to a real English/Chinese prompt, not the raw key")
+	}
+	if got != AgentSystemPromptForLang(LangEnglish) {
+		t.Error("LangAuto should resolve to the English default since auto-detect hasn't run yet")
+	}
+}
+
+// TestAgentSystemPromptForLang_ShapeConsistent guards the layout invariant:
+// sections are separated by exactly two newlines, so the prompt stays
+// human-readable and the engine's marker search (ccConnectInstructionMarker
+// followed by the full prompt body) keeps working.
+func TestAgentSystemPromptForLang_ShapeConsistent(t *testing.T) {
+	for _, lang := range []Language{LangEnglish, LangChinese, LangTraditionalChinese} {
+		got := AgentSystemPromptForLang(lang)
+		// Four tool sections ⇒ three "\n\n" separators between them.
+		if c := strings.Count(got, "\n\n"); c < 3 {
+			t.Errorf("lang=%v: expected ≥3 '\\n\\n' separators between the 4 tool sections, got %d", lang, c)
+		}
+		if strings.HasPrefix(got, "\n") || strings.HasSuffix(got, "\n\n\n") {
+			t.Errorf("lang=%v: prompt shape is wrong (leading newline or triple trailing newline)", lang)
+		}
+	}
+}
+
+// TestI18nT_MissingKeyReturnsKey verifies the documented miss behaviour: an
+// unknown MsgKey must round-trip as itself, not as empty string or a
+// placeholder, so engine code can detect the miss without parsing.
+func TestI18nT_MissingKeyReturnsKey(t *testing.T) {
+	got := i18nT(LangEnglish, MsgKey("totally_made_up_key_xyz"))
+	if got != "totally_made_up_key_xyz" {
+		t.Errorf("i18nT on miss should return the key itself, got %q", got)
+	}
+}
+
+// TestI18nT_ZhTwChainFallsBackToZh exercises the fallback branch in i18nT
+// for a key that exists in zh but not zh-TW. The result must be the zh
+// string, not the key and not the English version.
+func TestI18nT_ZhTwChainFallsBackToZh(t *testing.T) {
+	// Pick a key we know exists in zh (one of the new tool prompts).
+	if _, ok := messages[MsgAgentSendToolPrompt][LangChinese]; !ok {
+		t.Fatal("MsgAgentSendToolPrompt missing zh translation — test fixture broken")
+	}
+	zh := i18nT(LangChinese, MsgAgentSendToolPrompt)
+	zhTW := i18nT(LangTraditionalChinese, MsgAgentSendToolPrompt)
+	if zh != zhTW {
+		t.Error("zh-TW must fall back to zh for tool prompts that lack zh-TW translation")
+	}
+}
+
+// TestNormalizeLanguageString covers every documented spelling plus the
+// "unknown → auto" decision. Operators who typo a language must not silently
+// get English; they should see the auto-detect behaviour so they notice the
+// typo.
+func TestNormalizeLanguageString(t *testing.T) {
+	tests := []struct {
+		in   string
+		want Language
+	}{
+		{"en", LangEnglish},
+		{"english", LangEnglish},
+		{"EN", LangEnglish},
+		{"zh", LangChinese},
+		{"chinese", LangChinese},
+		{"zh-TW", LangTraditionalChinese},
+		{"zh_TW", LangTraditionalChinese},
+		{"zhtw", LangTraditionalChinese},
+		{"ja", LangJapanese},
+		{"japanese", LangJapanese},
+		{"es", LangSpanish},
+		{"spanish", LangSpanish},
+		{"auto", LangAuto},
+		{"", LangAuto},
+		{"klingon", LangAuto},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := NormalizeLanguageString(tt.in); got != tt.want {
+				t.Errorf("NormalizeLanguageString(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// containsCJK reports whether s contains any CJK Unified Ideograph. Used by
+// the Chinese-prompt test to assert that translations were actually wired,
+// not just that the strings are non-empty.
+func containsCJK(s string) bool {
+	for _, r := range s {
+		if r >= 0x4E00 && r <= 0x9FFF {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Resolves #1655

Owner-approved scope (per doc-20260823-ws0eux): zh + en translations on the four tool sections (send / cron / timer / relay), restart-only trigger (no live reload), fallback to en on missing key, single PR.

## What changes

- **core/i18n.go**: add 4 `MsgKey` constants, a case-insensitive `NormalizeLanguageString` helper, and en + zh translations for each of the four tool sections. The zh version includes the cron-vs-timer comparison table that previously only existed in user-supplied docs.
- **core/interfaces.go**: split `AgentSystemPrompt()` into a pure `AgentSystemPromptForLang(Language)` builder with a free-function `i18nT` helper that uses the same zh-TW → zh → en fallback chain as `(*I18n).T`. `AgentSystemPrompt()` is now a thin back-compat wrapper around `LangEnglish`. Header ("## Available tools"), footer (silent-reply NO_REPLY semantics), and the bridge preamble stay English on purpose — they are infrastructure wording and the NO_REPLY marker must remain byte-identical for engine detection.
- **core/engine.go**: `setupMemoryFile` now picks up `e.i18n.CurrentLang()` so the injected prompt matches the operator's configured language.
- **agent/claudecode**: `New()` decodes `opts["language"]` via `core.NormalizeLanguageString` and stores it on `Agent.lang`; both `ensureSharedSystemPromptFile` and `newClaudeSession` render the prompt via `AgentSystemPromptForLang(lang)`. `newClaudeSession` grows a `lang` parameter to keep the per-session spawn path self-contained.
- **core/interfaces_test.go**: 47 new assertions covering the four tool sections × five languages, the zh-TW → zh fallback, unsupported language → English fallback, English back-compat, prompt-shape invariants, the silent-reply `NO_REPLY` marker survival, and `NormalizeLanguageString` spellings.

## Validation

- `go build ./core/... ./agent/... ./cmd/cc-connect/...` clean (the `web/dist` embed error is a pre-existing frontend-build issue, gitignored, unrelated).
- `go vet -tags no_web ./cmd/...`, `go vet ./core/... ./agent/...` clean.
- `go test -race -count=1 ./...` green on all 39 packages with test files (only failure is the unrelated `web/dist` embed setup, which CI handles by building the SPA first).
- New `interfaces_test.go` covers: `TestAgentSystemPrompt_EnglishDefault`, `TestAgentSystemPromptForLang_AllToolKeysExist` (4 keys × 5 langs = 20 sub-cases), `_EnglishHasAllFourTools`, `_ChineseHasAllFourTools`, `_ZhTwFallback`, `_UnsupportedLangFallback`, `_AutoFallback`, `_ShapeConsistent`, `TestI18nT_MissingKeyReturnsKey`, `TestI18nT_ZhTwChainFallsBackToZh`, `TestNormalizeLanguageString` (15 spellings).

## Risks

- Header / footer wording stays English in all languages — translation PRs in other languages must keep the `NO_REPLY` token byte-identical so engine detection keeps working.
- Other agents (codex, cursor, etc.) still call `core.AgentSystemPrompt()` and so receive the English default until each agent gets its own `opts["language"]` wiring. Future PRs can extend this one-bundle-per-agent pattern.

## Out of scope (deferred per owner decision)

- ja / es / zh-TW translations (zh-TW already falls back to zh).
- Live reload without restart.
- Per-project language overrides inside `AgentSystemPromptForLang` (the engine already reads per-project language; the agent factory does not need to).