### PR TITLE
fix(multi-workspace): honor per-key /dir in card session context

### DIFF
--- a/core/cuj_test.go
+++ b/core/cuj_test.go
@@ -274,6 +274,35 @@ func (p *cujReplyCtxPlatform) ReconstructReplyCtx(sessionKey string) (any, error
 	return "reconstructed:" + sessionKey, nil
 }
 
+type cujCardPlatform struct {
+	stubPlatformEngine
+}
+
+func (p *cujCardPlatform) ReplyCard(ctx context.Context, replyCtx any, card *Card) error {
+	return p.Reply(ctx, replyCtx, card.RenderText())
+}
+
+func (p *cujCardPlatform) SendCard(ctx context.Context, replyCtx any, card *Card) error {
+	return p.Send(ctx, replyCtx, card.RenderText())
+}
+
+type cujWorkspaceListAgent struct {
+	cujAgent
+	name     string
+	workDir  string
+	sessions []AgentSessionInfo
+}
+
+func (a *cujWorkspaceListAgent) Name() string { return a.name }
+
+func (a *cujWorkspaceListAgent) SetWorkDir(dir string) { a.workDir = dir }
+
+func (a *cujWorkspaceListAgent) GetWorkDir() string { return a.workDir }
+
+func (a *cujWorkspaceListAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) {
+	return append([]AgentSessionInfo(nil), a.sessions...), nil
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a
@@ -1273,6 +1302,101 @@ func TestCUJ_B2_ListShowsAllSessions(t *testing.T) {
 	list := env.engine.sessions.ListSessions(key)
 	if len(list) < 3 {
 		t.Fatalf("SessionManager.ListSessions = %d, want ≥3", len(list))
+	}
+}
+
+func TestCUJ_B13_CardListHonorsPerKeyDir(t *testing.T) {
+	baseDir := t.TempDir()
+	parentDir := filepath.Join(baseDir, "parent")
+	childDir := filepath.Join(parentDir, "child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("mkdir child workspace: %v", err)
+	}
+	parentDir = normalizeWorkspacePath(parentDir)
+	childDir = normalizeWorkspacePath(childDir)
+
+	parentSession := AgentSessionInfo{ID: "parent-session", Summary: "Parent workspace session"}
+	childSession := AgentSessionInfo{ID: "child-session", Summary: "Child workspace session"}
+	agentName := "cuj-card-list-per-key-dir"
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		workDir, _ := opts["work_dir"].(string)
+		workDir = normalizeWorkspacePath(workDir)
+		sessions := []AgentSessionInfo{parentSession}
+		if workDir == childDir {
+			sessions = []AgentSessionInfo{childSession}
+		}
+		return &cujWorkspaceListAgent{
+			name:     agentName,
+			workDir:  workDir,
+			sessions: sessions,
+		}, nil
+	})
+
+	platform := &cujCardPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	globalAgent := &cujWorkspaceListAgent{
+		name:     agentName,
+		workDir:  parentDir,
+		sessions: []AgentSessionInfo{parentSession},
+	}
+	e := NewEngine("test", globalAgent, []Platform{platform}, filepath.Join(t.TempDir(), "sessions.json"), LangEnglish)
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+	e.SetProjectStateStore(NewProjectStateStore(filepath.Join(t.TempDir(), "project-state.json")))
+	e.SetAdminFrom("ou_user")
+
+	channelID := "oc_cuj_card_list"
+	sessionKey := "feishu:" + channelID + ":ou_user"
+	e.workspaceBindings.Bind("project:test", workspaceChannelKey("feishu", channelID), "card-list", parentDir)
+	send := func(content string) {
+		e.ReceiveMessage(platform, &Message{
+			SessionKey: sessionKey,
+			ChannelKey: channelID,
+			Platform:   "feishu",
+			MessageID:  "msg-" + content[:min(8, len(content))],
+			UserID:     "ou_user",
+			UserName:   "user",
+			Content:    content,
+			ReplyCtx:   "ctx",
+		})
+	}
+
+	// 1. The user applies a per-key child directory and sees that directory.
+	send("/dir " + childDir)
+	if got := platform.getSent(); len(got) == 0 || !strings.Contains(got[len(got)-1], childDir) {
+		t.Fatalf("/dir card did not show child workspace: %v", got)
+	}
+
+	// 2. A normal message still uses the effective child workspace.
+	platform.clearSent()
+	send("hello child workspace")
+	deadline := time.Now().Add(2 * time.Second)
+	for len(platform.getSent()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := platform.getSent(); len(got) == 0 || !strings.Contains(got[len(got)-1], "ok") {
+		t.Fatalf("normal child-workspace message did not complete: %v", got)
+	}
+
+	// 3. Card /list shows only sessions from the child workspace.
+	platform.clearSent()
+	send("/list")
+	listReply := platform.getSent()
+	if len(listReply) == 0 || !strings.Contains(listReply[len(listReply)-1], childSession.Summary) {
+		t.Fatalf("card /list missing child session: %v", listReply)
+	}
+	if strings.Contains(listReply[len(listReply)-1], parentSession.Summary) {
+		t.Fatalf("card /list leaked parent session: %v", listReply)
+	}
+
+	// 4. Switching and then viewing the current card stay in the child context.
+	platform.clearSent()
+	send("/switch 1")
+	if got := platform.getSent(); len(got) == 0 || !strings.Contains(got[len(got)-1], childSession.Summary) {
+		t.Fatalf("/switch did not select child session: %v", got)
+	}
+	platform.clearSent()
+	send("/current")
+	if got := platform.getSent(); len(got) == 0 || !strings.Contains(got[len(got)-1], childSession.ID) {
+		t.Fatalf("/current did not stay on child session: %v", got)
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -6343,7 +6343,7 @@ func (e *Engine) cmdPs(p Platform, msg *Message, args []string) {
 	// When the session is idle, injecting via agentSession.Send bypasses the
 	// session lock and races with concurrent normal messages on the CLI's
 	// stdin, so reject instead.
-	_, sessions := e.sessionContextForKey(msg.SessionKey)
+	_, sessions := e.sessionContextForKey(iKey, msg.SessionKey)
 	if session := sessions.GetOrCreateActive(msg.SessionKey); !session.Busy() {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPsNoSession))
 		return
@@ -6909,7 +6909,7 @@ const listPageSize = 20
 const dirCardPageSize = 20
 
 func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
-	agent, sessions, _, err := e.commandContext(p, msg)
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
 		return
@@ -6992,7 +6992,7 @@ func (e *Engine) cmdList(p Platform, msg *Message, args []string) {
 			page = n
 		}
 	}
-	card, err := e.renderListCard(msg.SessionKey, page)
+	card, err := e.renderListCard(interactiveKey, msg.SessionKey, page)
 	if err != nil {
 		e.reply(p, msg.ReplyCtx, err.Error())
 		return
@@ -8911,10 +8911,10 @@ func (e *Engine) simpleCard(title, color, content string) *Card {
 }
 
 // renderListCardSafe wraps renderListCard and returns an error card on failure.
-func (e *Engine) renderListCardSafe(sessionKey string, page int) *Card {
-	card, err := e.renderListCard(sessionKey, page)
+func (e *Engine) renderListCardSafe(interactiveKey, sessionKey string, page int) *Card {
+	card, err := e.renderListCard(interactiveKey, sessionKey, page)
 	if err != nil {
-		agent, _ := e.sessionContextForKey(sessionKey)
+		agent, _ := e.sessionContextForKey(interactiveKey, sessionKey)
 		return e.simpleCard(e.i18n.Tf(MsgCardTitleSessions, agent.Name(), 0), "red", err.Error())
 	}
 	return card
@@ -8930,7 +8930,8 @@ func (e *Engine) renderDirCardSafe(sessionKey string, page int) *Card {
 }
 
 func (e *Engine) renderStatusCard(sessionKey string, userID string) *Card {
-	agent, sessions := e.sessionContextForKey(sessionKey)
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 	platNames := make([]string, len(e.platforms))
 	for i, pl := range e.platforms {
 		platNames[i] = pl.Name()
@@ -11902,6 +11903,7 @@ func (e *Engine) handleCardNav(action string, sessionKey string) *Card {
 		cmd = body[:i]
 		args = strings.TrimSpace(body[i+1:])
 	}
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 
 	if prefix == "act" && cmd == "/model" {
 		return e.handleModelCardAction(args, sessionKey)
@@ -11931,7 +11933,7 @@ func (e *Engine) handleCardNav(action string, sessionKey string) *Card {
 				page = n
 			}
 		}
-		return e.renderListCardSafe(sessionKey, page)
+		return e.renderListCardSafe(interactiveKey, sessionKey, page)
 	case "/dir":
 		page := 1
 		if args != "" {
@@ -11975,10 +11977,10 @@ func (e *Engine) handleCardNav(action string, sessionKey string) *Card {
 	case "/new":
 		return e.renderCurrentCard(sessionKey)
 	case "/switch":
-		return e.renderListCardSafe(sessionKey, 1)
+		return e.renderListCardSafe(interactiveKey, sessionKey, 1)
 	case "/delete-mode":
 		if strings.HasPrefix(args, "cancel") {
-			return e.renderListCardSafe(sessionKey, 1)
+			return e.renderListCardSafe(interactiveKey, sessionKey, 1)
 		}
 		return e.renderDeleteModeCard(sessionKey)
 	case "/stop":
@@ -11990,7 +11992,8 @@ func (e *Engine) handleCardNav(action string, sessionKey string) *Card {
 }
 
 func (e *Engine) handleModelCardAction(args, sessionKey string) *Card {
-	agent, sessions := e.sessionContextForKey(sessionKey)
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 	switcher, ok := agent.(ModelSwitcher)
 	if !ok {
 		return e.simpleCard(e.i18n.T(MsgCardTitleModel), "indigo", e.i18n.T(MsgModelNotSupported))
@@ -12009,7 +12012,6 @@ func (e *Engine) handleModelCardAction(args, sessionKey string) *Card {
 	}
 
 	resolved, err := e.switchModelOnAgent(agent, target, agent == e.agent)
-	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
 	if err == nil {
 		e.persistWorkspaceModelOverride(interactiveKey, sessionKey, agent, resolved)
 	}
@@ -12066,7 +12068,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		if args == "" {
 			return
 		}
-		agent, sessions := e.sessionContextForKey(sessionKey)
+		agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 		switcher, ok := agent.(ModelSwitcher)
 		if !ok {
 			return
@@ -12233,7 +12235,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		e.executeProviderLink(sessionKey, args)
 
 	case "/new":
-		_, sessions := e.sessionContextForKey(sessionKey)
+		_, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 		e.cleanupInteractiveState(interactiveKey)
 		sessions.NewSession(sessionKey, "")
 
@@ -12244,7 +12246,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		if args == "" {
 			return
 		}
-		agent, sessions := e.sessionContextForKey(sessionKey)
+		agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 		agentSessions, err := agent.ListSessions(e.ctx)
 		if err != nil || len(agentSessions) == 0 {
 			return
@@ -12263,8 +12265,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		if len(fields) == 0 {
 			return
 		}
-		agent, sessions := e.sessionContextForKey(sessionKey)
-		ik := e.interactiveKeyForSessionKey(sessionKey)
+		agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 		var applyArgs []string
 		switch fields[0] {
 		case "select":
@@ -12279,7 +12280,7 @@ func (e *Engine) executeCardAction(cmd, args, sessionKey string) {
 		default:
 			return
 		}
-		errMsg, _ := e.dirApply(agent, sessions, ik, sessionKey, applyArgs)
+		errMsg, _ := e.dirApply(agent, sessions, interactiveKey, sessionKey, applyArgs)
 		if errMsg != "" {
 			slog.Debug("dir card action failed", "message", errMsg)
 		}
@@ -12417,7 +12418,8 @@ func (e *Engine) getModelSwitchState(sessionKey string) *modelSwitchState {
 }
 
 func (e *Engine) renderDeleteModeCard(sessionKey string) *Card {
-	agent, sessions := e.sessionContextForKey(sessionKey)
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 	agentSessions, err := agent.ListSessions(e.ctx)
 	if err != nil {
 		return e.simpleCard(e.i18n.T(MsgDeleteModeTitle), "red", err.Error())
@@ -12782,7 +12784,8 @@ func parseDeleteModeSelectedIDs(args []string) map[string]struct{} {
 }
 
 func (e *Engine) submitDeleteModeSelection(sessionKey string, selectedIDs map[string]struct{}) []string {
-	agent, sessions := e.sessionContextForKey(sessionKey)
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 	deleter, ok := agent.(SessionDeleter)
 	if !ok {
 		return []string{e.i18n.T(MsgDeleteNotSupported)}
@@ -12852,7 +12855,8 @@ func (e *Engine) renderModelCard(sessionKey string) *Card {
 
 	agent := e.agent
 	if sessionKey != "" {
-		agent, _ = e.sessionContextForKey(sessionKey)
+		interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+		agent, _ = e.sessionContextForKey(interactiveKey, sessionKey)
 	}
 
 	switcher, ok := agent.(ModelSwitcher)
@@ -12997,8 +13001,8 @@ func (e *Engine) renderModeCard() *Card {
 	return cb.Build()
 }
 
-func (e *Engine) renderListCard(sessionKey string, page int) (*Card, error) {
-	agent, sessions := e.sessionContextForKey(sessionKey)
+func (e *Engine) renderListCard(interactiveKey, sessionKey string, page int) (*Card, error) {
+	agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 	agentSessions, err := agent.ListSessions(e.ctx)
 	if err != nil {
 		return nil, fmt.Errorf(e.i18n.T(MsgListError), err)
@@ -13090,7 +13094,8 @@ func dirCardTruncPath(absPath string) string {
 }
 
 func (e *Engine) renderDirCard(sessionKey string, page int) (*Card, error) {
-	agent, _ := e.sessionContextForKey(sessionKey)
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+	agent, _ := e.sessionContextForKey(interactiveKey, sessionKey)
 	switcher, ok := agent.(WorkDirSwitcher)
 	if !ok {
 		return nil, fmt.Errorf("%s", e.i18n.T(MsgDirNotSupported))
@@ -13201,7 +13206,8 @@ func (e *Engine) currentSessionDisplayName(agent Agent, sessions *SessionManager
 }
 
 func (e *Engine) renderCurrentCard(sessionKey string) *Card {
-	agent, sessions := e.sessionContextForKey(sessionKey)
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 	s := sessions.GetOrCreateActive(sessionKey)
 	agentID := s.GetAgentSessionID()
 	if agentID == "" {
@@ -13217,7 +13223,8 @@ func (e *Engine) renderCurrentCard(sessionKey string) *Card {
 }
 
 func (e *Engine) renderHistoryCard(sessionKey string) *Card {
-	agent, sessions := e.sessionContextForKey(sessionKey)
+	interactiveKey := e.interactiveKeyForSessionKey(sessionKey)
+	agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
 	s := sessions.GetOrCreateActive(sessionKey)
 	entries := s.GetHistory(10)
 
@@ -15478,7 +15485,8 @@ func (e *Engine) deleteSingleSessionReply(msg *Message, deleter SessionDeleter, 
 	}
 
 	// Prevent deleting the currently active session
-	_, sessions := e.sessionContextForKey(msg.SessionKey)
+	interactiveKey := e.interactiveKeyForSessionKey(msg.SessionKey)
+	_, sessions := e.sessionContextForKey(interactiveKey, msg.SessionKey)
 	activeSession := sessions.GetOrCreateActive(msg.SessionKey)
 	if activeSession.GetAgentSessionID() == matched.ID {
 		return e.i18n.T(MsgDeleteActiveDenied)
@@ -16269,9 +16277,9 @@ func (e *Engine) commandContextWithWorkspace(p Platform, msg *Message) (Agent, *
 	return agent, sessions, interactiveKey, effectiveDir, nil
 }
 
-// sessionContextForKey resolves the agent and session manager for a sessionKey.
-// It uses existing workspace bindings and falls back to global context if unresolved.
-func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager) {
+// sessionContextForKey resolves the agent and session manager for an interactiveKey/sessionKey pair.
+// It applies a persisted per-key /dir override before falling back to workspace bindings.
+func (e *Engine) sessionContextForKey(interactiveKey, sessionKey string) (Agent, *SessionManager) {
 	if workspace := e.sendWorkDirForSession(sessionKey); workspace != "" {
 		if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(workspace); err == nil {
 			return wsAgent, wsSessions
@@ -16280,9 +16288,19 @@ func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager
 	if !e.multiWorkspace || e.workspaceBindings == nil {
 		return e.agent, e.sessions
 	}
+	if workspace := workspaceFromInteractiveKey(interactiveKey, sessionKey); workspace != "" {
+		workspace = normalizeWorkspacePath(workspace)
+		effectiveDir := e.resolveChannelWorkDir(workspace, interactiveKey)
+		if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(effectiveDir); err == nil {
+			return wsAgent, wsSessions
+		}
+	}
 	if channelKey := extractWorkspaceChannelKey(sessionKey); channelKey != "" {
 		if b, _, usable := e.lookupEffectiveWorkspaceBinding(channelKey); usable {
-			if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(normalizeWorkspacePath(b.Workspace)); err == nil {
+			workspace := normalizeWorkspacePath(b.Workspace)
+			bindingInteractiveKey := workspace + ":" + sessionKey
+			effectiveDir := e.resolveChannelWorkDir(workspace, bindingInteractiveKey)
+			if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(effectiveDir); err == nil {
 				return wsAgent, wsSessions
 			}
 		}
@@ -16295,7 +16313,9 @@ func (e *Engine) sessionContextForKey(sessionKey string) (Agent, *SessionManager
 	// returns the workspace-prefixed key, allowing concurrent unlocked sends
 	// to the same agent session.
 	if workspace := e.workspaceFromLiveState(sessionKey); workspace != "" {
-		if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(workspace); err == nil {
+		liveInteractiveKey := workspace + ":" + sessionKey
+		effectiveDir := e.resolveChannelWorkDir(workspace, liveInteractiveKey)
+		if wsAgent, wsSessions, err := e.getOrCreateWorkspaceAgent(effectiveDir); err == nil {
 			return wsAgent, wsSessions
 		}
 	}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -611,6 +611,18 @@ func (a *namedStubWorkDirAgent) Name() string {
 	return a.name
 }
 
+type namedStubWorkDirListAgent struct {
+	stubWorkDirAgent
+	name     string
+	sessions []AgentSessionInfo
+}
+
+func (a *namedStubWorkDirListAgent) Name() string { return a.name }
+
+func (a *namedStubWorkDirListAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) {
+	return append([]AgentSessionInfo(nil), a.sessions...), nil
+}
+
 type stubListAgent struct {
 	stubAgent
 	sessions []AgentSessionInfo
@@ -3271,7 +3283,7 @@ func TestSessionContextForKey_RecoversWorkspaceFromLiveState(t *testing.T) {
 	e.interactiveStates[storedKey] = &interactiveState{}
 	e.interactiveMu.Unlock()
 
-	agent, sessions := e.sessionContextForKey(threadSessionKey)
+	agent, sessions := e.sessionContextForKey(threadSessionKey, threadSessionKey)
 	if agent == e.agent {
 		t.Fatal("sessionContextForKey returned the global agent; live-state recovery did not engage")
 	}
@@ -6368,7 +6380,7 @@ func TestRenderListCard_MakesEveryVisibleSessionClickable(t *testing.T) {
 	// Switch active to the session mapped to sessions[5] (agent-session-F).
 	e.sessions.SwitchSession("test:user1", internalIDs[5])
 
-	card, err := e.renderListCard("test:user1", 1)
+	card, err := e.renderListCard("test:user1", "test:user1", 1)
 	if err != nil {
 		t.Fatalf("renderListCard returned error: %v", err)
 	}
@@ -6437,6 +6449,101 @@ func TestHandleCardNav_DirSelectSwitchesWorkDir(t *testing.T) {
 	card := e.handleCardNav("nav:/dir 1", sk)
 	if card == nil {
 		t.Fatal("expected dir card after nav")
+	}
+}
+
+func TestCardList_AfterPerKeyDirUsesChildWorkspaceAndSwitchesChildSession(t *testing.T) {
+	baseDir := t.TempDir()
+	parentDir := filepath.Join(baseDir, "parent")
+	childDir := filepath.Join(parentDir, "child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("mkdir child workspace: %v", err)
+	}
+	parentDir = normalizeWorkspacePath(parentDir)
+	childDir = normalizeWorkspacePath(childDir)
+
+	parentSession := AgentSessionInfo{ID: "parent-session", Summary: "Parent workspace session"}
+	childSession := AgentSessionInfo{ID: "child-session", Summary: "Child workspace session"}
+	agentName := "test-card-list-per-key-dir"
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		workDir, _ := opts["work_dir"].(string)
+		workDir = normalizeWorkspacePath(workDir)
+		sessions := []AgentSessionInfo{parentSession}
+		if workDir == childDir {
+			sessions = []AgentSessionInfo{childSession}
+		}
+		return &namedStubWorkDirListAgent{
+			stubWorkDirAgent: stubWorkDirAgent{workDir: workDir},
+			name:             agentName,
+			sessions:         sessions,
+		}, nil
+	})
+
+	platform := &stubCardPlatform{stubPlatformEngine: stubPlatformEngine{n: "feishu"}}
+	globalAgent := &namedStubWorkDirListAgent{
+		stubWorkDirAgent: stubWorkDirAgent{workDir: parentDir},
+		name:             agentName,
+		sessions:         []AgentSessionInfo{parentSession},
+	}
+	e := NewEngine("test", globalAgent, []Platform{platform}, filepath.Join(t.TempDir(), "sessions.json"), LangEnglish)
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+	e.SetProjectStateStore(NewProjectStateStore(filepath.Join(t.TempDir(), "project-state.json")))
+
+	channelID := "oc_card_list"
+	sessionKey := "feishu:" + channelID + ":ou_user"
+	e.workspaceBindings.Bind("project:test", workspaceChannelKey("feishu", channelID), "card-list", parentDir)
+	msg := &Message{
+		SessionKey: sessionKey,
+		ChannelKey: channelID,
+		Platform:   "feishu",
+		ReplyCtx:   "ctx",
+	}
+
+	e.cmdDir(platform, msg, []string{childDir})
+	interactiveKey := parentDir + ":" + sessionKey
+	if got := e.projectState.WorkspaceDirOverride(interactiveKey); got != childDir {
+		t.Fatalf("workspace dir override = %q, want %q", got, childDir)
+	}
+
+	platform.mu.Lock()
+	platform.repliedCards = nil
+	platform.mu.Unlock()
+	e.cmdList(platform, msg, nil)
+
+	platform.mu.Lock()
+	if len(platform.repliedCards) != 1 {
+		got := len(platform.repliedCards)
+		platform.mu.Unlock()
+		t.Fatalf("replied cards = %d, want 1", got)
+	}
+	listCard := platform.repliedCards[0]
+	platform.mu.Unlock()
+	listText := listCard.RenderText()
+	if !strings.Contains(listText, childSession.Summary) {
+		t.Fatalf("card /list missing child session:\n%s", listText)
+	}
+	if strings.Contains(listText, parentSession.Summary) {
+		t.Fatalf("card /list leaked parent session:\n%s", listText)
+	}
+
+	resultCard := e.handleCardNav("act:/switch 1", sessionKey)
+	if resultCard == nil || !strings.Contains(resultCard.RenderText(), childSession.Summary) {
+		t.Fatalf("card /switch did not stay in child workspace: %#v", resultCard)
+	}
+	childState := e.workspacePool.Get(childDir)
+	if childState == nil || childState.sessions == nil {
+		t.Fatal("child workspace session manager was not created")
+	}
+	if got := childState.sessions.GetOrCreateActive(sessionKey).GetAgentSessionID(); got != childSession.ID {
+		t.Fatalf("active child session = %q, want %q", got, childSession.ID)
+	}
+
+	agent, _, _, effectiveDir, err := e.commandContextWithWorkspace(platform, msg)
+	if err != nil {
+		t.Fatalf("commandContextWithWorkspace: %v", err)
+	}
+	if agent == nil || effectiveDir != childDir {
+		t.Fatalf("normal message context dir = %q, want %q", effectiveDir, childDir)
 	}
 }
 
@@ -14691,7 +14798,7 @@ func TestRenderListCard_AllSessionsVisibleAfterRepeatedNew(t *testing.T) {
 	}
 	e.sessions.Save()
 
-	card, err := e.renderListCard(userKey, 1)
+	card, err := e.renderListCard(userKey, userKey, 1)
 	if err != nil {
 		t.Fatalf("renderListCard error: %v", err)
 	}
@@ -15078,7 +15185,7 @@ func TestFilterExternalSessions_DeleteByIndex(t *testing.T) {
 func TestFilterExternalSessions_RenderListCard(t *testing.T) {
 	t.Run("disabled: card shows all sessions", func(t *testing.T) {
 		e, _, userKey, agentSessions := setupFilterTestEngine(t, false)
-		card, err := e.renderListCard(userKey, 1)
+		card, err := e.renderListCard(userKey, userKey, 1)
 		if err != nil {
 			t.Fatalf("renderListCard: %v", err)
 		}
@@ -15090,7 +15197,7 @@ func TestFilterExternalSessions_RenderListCard(t *testing.T) {
 
 	t.Run("enabled: card hides external sessions", func(t *testing.T) {
 		e, _, userKey, _ := setupFilterTestEngine(t, true)
-		card, err := e.renderListCard(userKey, 1)
+		card, err := e.renderListCard(userKey, userKey, 1)
 		if err != nil {
 			t.Fatalf("renderListCard: %v", err)
 		}

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -304,7 +304,8 @@ func TestSessionContextForKey_MissingSharedBindingFallsBack(t *testing.T) {
 	e := newTestEngineWithMultiWorkspaceAgent(t, baseDir)
 	e.workspaceBindings.Bind(sharedWorkspaceBindingsKey, channelID, "shared-channel", missingDir)
 
-	agent, sessions := e.sessionContextForKey("mock:" + channelID + ":user")
+	sessionKey := "mock:" + channelID + ":user"
+	agent, sessions := e.sessionContextForKey(sessionKey, sessionKey)
 	if agent != e.agent {
 		t.Fatal("expected base agent for missing shared binding")
 	}
@@ -327,7 +328,8 @@ func TestSessionContextForKey_SharedBinding(t *testing.T) {
 	e := newTestEngineWithMultiWorkspaceAgent(t, baseDir)
 	e.workspaceBindings.Bind(sharedWorkspaceBindingsKey, channelID, "shared-channel", wsDir)
 
-	agent, sessions := e.sessionContextForKey("mock:" + channelID + ":user")
+	sessionKey := "mock:" + channelID + ":user"
+	agent, sessions := e.sessionContextForKey(sessionKey, sessionKey)
 	if agent == nil {
 		t.Fatal("expected workspace agent, got nil")
 	}
@@ -342,6 +344,45 @@ func TestSessionContextForKey_SharedBinding(t *testing.T) {
 	}
 	if got := e.workspacePool.Get(normalizeWorkspacePath(wsDir)); got == nil || got.agent == nil || got.sessions == nil {
 		t.Fatal("expected workspace pool entry to be created for shared binding")
+	}
+}
+
+func TestSessionContextForKey_ExplicitTopicKeyKeepsPerKeyDirOverride(t *testing.T) {
+	baseDir := t.TempDir()
+	chatDir := filepath.Join(baseDir, "chat")
+	topicDir := filepath.Join(baseDir, "topic")
+	childDir := filepath.Join(topicDir, "child")
+	for _, dir := range []string{chatDir, childDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	chatDir = normalizeWorkspacePath(chatDir)
+	topicDir = normalizeWorkspacePath(topicDir)
+	childDir = normalizeWorkspacePath(childDir)
+
+	e := newTestEngineWithMultiWorkspaceAgent(t, baseDir)
+	channelID := "C-topic"
+	sessionKey := "mock:" + channelID + ":root:R-topic"
+	e.workspaceBindings.Bind(
+		sharedWorkspaceBindingsKey,
+		workspaceChannelKey("mock", channelID),
+		"chat-default",
+		chatDir,
+	)
+
+	interactiveKey := topicDir + ":" + sessionKey
+	store := NewProjectStateStore(filepath.Join(t.TempDir(), "project-state.json"))
+	store.SetWorkspaceDirOverride(interactiveKey, childDir)
+	e.SetProjectStateStore(store)
+
+	agent, sessions := e.sessionContextForKey(interactiveKey, sessionKey)
+	childState := e.workspacePool.Get(childDir)
+	if childState == nil || childState.agent != agent || childState.sessions != sessions {
+		t.Fatal("explicit topic interactive key did not resolve the child workspace override")
+	}
+	if e.workspacePool.Get(chatDir) != nil {
+		t.Fatal("chat-level fallback should not win over an explicit topic interactive key")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Resolve card session context from the current interactive key before falling back to chat-level workspace bindings, so persisted per-key `/dir` overrides select the effective child workspace.
- Thread the interactive key through card `/list` rendering and card actions, while preserving explicit topic-scoped keys for compatibility with #1616.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

### Automated tests added in this PR

- `TestCardList_AfterPerKeyDirUsesChildWorkspaceAndSwitchesChildSession` in `core/engine_test.go` — covers `/dir child -> card /list -> card /switch`, rejects parent-session leakage, and verifies the normal message context stays on the child directory.
- `TestSessionContextForKey_ExplicitTopicKeyKeepsPerKeyDirOverride` in `core/multi_workspace_test.go` — verifies an explicit topic interactive key wins over chat-level fallback and still applies its per-key directory override.
- `TestCUJ_B13_CardListHonorsPerKeyDir` in `core/cuj_test.go` — drives the real Engine through `ReceiveMessage` for `/dir`, a normal message, card `/list`, `/switch`, and `/current`.

Passing commands:

- `go test ./core -skip '^TestCUJ' -count=1`
- `go test ./core -run TestCUJ -count=1 -v`
- `go test -race ./core -run '^(TestCUJ_B13_CardListHonorsPerKeyDir|TestCardList_AfterPerKeyDirUsesChildWorkspaceAndSwitchesChildSession|TestSessionContextForKey_)' -count=1`
- `go test ./platform/feishu -count=1`
- `go vet ./core`
- `GOOS=linux CGO_ENABLED=0 go build -tags no_web ./...`

### For bug fixes only — regression test

- Regression test name: `TestCardList_AfterPerKeyDirUsesChildWorkspaceAndSwitchesChildSession`
- Manual verification this test catches the regression:
  - [x] Added and ran it against the pre-fix code first; it failed because the card showed only `Parent workspace session`.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [x] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [x] H — multi-platform / multi-project isolation
- [x] I — UI rendering correctness (cards, streaming, display modes)

- [x] `go test ./core/ -run TestCUJ` passes locally.
- [x] Added a CUJ for the changed user-visible flow.

## Manual / user-visible behavior change

After a user runs `/dir <child>` in a multi-workspace Feishu chat, card `/list`, card session selection, `/current`, and other session-context card paths stay on that user's effective child workspace instead of falling back to the parent binding.

Real-client Feishu QA was not run; card behavior is covered through the platform card boundary and Engine CUJ.

## Full-suite baseline limitations

The exact full-repository commands are not marked passing locally:

- `go build ./...` stops at the clean-checkout `web/dist` embed prerequisite; `go build -tags no_web ./...` then reaches the existing Darwin duplicate `daemon.CheckLinger` declarations.
- `go test ./...` reaches the same unchanged build prerequisites, local Cursor/ACP integration tests that require CLI login, and an existing asynchronous TempDir cleanup flake in `TestCUJ_A3_ImageReachesAgent` / `TestCUJ_A5_FileReachesAgent`. The complete CUJ command passes in isolation.

None of `web/`, `daemon/`, `agent/acp/`, or `agent/cursor/` is changed by this PR.

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [x] Relevant AGENTS.md pre-commit checks and CUJ coverage are satisfied
- [x] No new hardcoded platform/agent names in production `core/` code
- [x] No new user-facing strings; i18n is unchanged
- [x] No secrets / credentials in source

## Related

- Closes #1653
- Related PR: #1616
