### PR TITLE
feat(feishu): pass through Card 2.0 VChart responses

### DIFF
--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -131,6 +131,39 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 > `done_emoji` 设置后，agent 每次完成回复时会在用户消息上添加指定表情（如 `"Done"` → ✅）。先清理临时处理表情（与接收确认相同的表情会保留），再添加 done 表情。在 quiet 模式下特别有用，因为飞书卡片原地更新不触发推送，done 表情可以通知用户 agent 已完成。设为 `"none"` 或不配置则禁用。
 > `image_batch_window_ms` 控制连续多张图片合并成一条 agent 消息的等待窗口（默认 500ms）。飞书手机端一次连发多张图时，每张图是独立事件；cc-connect 会在窗口内将它们合并成一条多图消息再分发给 agent。如果你的网络/设备发送间隔超过 500ms 且仍被拆成多轮回复（每张图独立处理），可调高到 800–1200ms；如果以单图为主、希望响应更快，可适当调低。设为 `0` 时回退到默认 500ms。
 
+### Agent 返回 Card 2.0 / VChart
+
+启用交互卡片后，如果 agent 的整条回复是完整的飞书 Card 2.0 JSON，cc-connect 会将其作为原生卡片发送，不再包裹为 Markdown。卡片元素（包括 `chart` 的 `chart_spec`）由飞书负责解析和渲染。例如：
+
+```json
+{
+  "schema": "2.0",
+  "body": {
+    "elements": [
+      {
+        "tag": "chart",
+        "chart_spec": {
+          "type": "bar",
+          "data": [
+            {
+              "id": "sales",
+              "values": [
+                {"month": "一月", "value": 12},
+                {"month": "二月", "value": 18}
+              ]
+            }
+          ],
+          "xField": "month",
+          "yField": "value"
+        }
+      }
+    ]
+  }
+}
+```
+
+回复必须是裸 JSON：第一个非空白字符为 `{`，最后一个非空白字符为 `}`，并包含 `schema: "2.0"` 和 `body.elements`。Markdown 代码围栏、JSON 前后的说明文字以及不完整的 JSON 都不会被当作原生卡片。cc-connect 不生成或转换 `chart_spec`，只负责透传完整卡片。
+
 ---
 
 ## 第三步：配置应用能力

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -3264,8 +3264,7 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 		return fmt.Errorf("%s: invalid reply context type %T", p.tag(), rctx)
 	}
 
-	content = p.resolveMentionsInContent(ctx, rc.chatID, content)
-	msgType, msgBody := buildReplyContent(content)
+	msgType, msgBody := p.buildReplyContent(ctx, rc.chatID, content)
 
 	if !p.shouldUseThreadOrReplyAPI(rc) {
 		return p.sendNewMessageToChat(ctx, rc, msgType, msgBody)
@@ -3286,8 +3285,7 @@ func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 		return p.Reply(ctx, rctx, content)
 	}
 
-	content = p.resolveMentionsInContent(ctx, rc.chatID, content)
-	msgType, msgBody := buildReplyContent(content)
+	msgType, msgBody := p.buildReplyContent(ctx, rc.chatID, content)
 	return p.sendNewMessageToChat(ctx, rc, msgType, msgBody)
 }
 
@@ -3301,6 +3299,12 @@ func (p *Platform) SendWithStatusFooter(ctx context.Context, rctx any, content, 
 	rc, ok := rctx.(replyContext)
 	if !ok {
 		return fmt.Errorf("%s: invalid reply context type %T", p.tag(), rctx)
+	}
+	if cardJSON, ok := normalizeCardJSON(content); ok && p.useInteractiveCard {
+		if p.shouldUseThreadOrReplyAPI(rc) {
+			return p.replyMessage(ctx, rc, larkim.MsgTypeInteractive, cardJSON)
+		}
+		return p.sendNewMessageToChat(ctx, rc, larkim.MsgTypeInteractive, cardJSON)
 	}
 	// Resolve mentions first so we can detect whether a real @mention is
 	content = p.resolveMentionsInContent(ctx, rc.chatID, content)
@@ -3539,6 +3543,13 @@ func buildReplyContent(content string) (msgType string, body string) {
 		return larkim.MsgTypePost, buildPostMdJSON(content)
 	}
 	return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)))
+}
+
+func (p *Platform) buildReplyContent(ctx context.Context, chatID, content string) (msgType string, body string) {
+	if cardJSON, ok := normalizeCardJSON(content); ok && p.useInteractiveCard {
+		return larkim.MsgTypeInteractive, cardJSON
+	}
+	return buildReplyContent(p.resolveMentionsInContent(ctx, chatID, content))
 }
 
 // hasComplexMarkdown detects code blocks or tables that require card rendering.
@@ -5091,6 +5102,9 @@ func buildPreviewCardJSON(content string) string {
 	if payload, ok := core.ParseProgressCardPayload(content); ok {
 		return buildProgressCardJSONFromPayload(payload)
 	}
+	if isIncompleteJSONObject(content) {
+		return buildCardJSON(" ")
+	}
 	return buildCardJSON(sanitizeMarkdownURLs(content))
 }
 
@@ -5098,17 +5112,15 @@ func buildPreviewCardJSON(content string) string {
 // Using card (interactive) type for both preview and final message so updates
 // are in-place without needing to delete and resend.
 //
-// Card 2.0 + cardkit-v1 path (when content is a rich card JSON and we're NOT
-// in thread/reply mode): runs a two-step flow that captures a card_id usable
-// for streaming text updates:
+// Card 2.0 + cardkit-v1 path (when content is a rich card JSON): runs a
+// two-step flow that captures a card_id usable for streaming text updates:
 //
 //  1. POST /open-apis/cardkit/v1/cards with {type:"card_json", data:<cardJSON>}
 //     → returns card_id (numeric string, 14-day TTL).
 //  2. Im.Message.Create with content {"type":"card","data":{"card_id":"..."}}
 //     → returns message_id; both ids are stored on feishuPreviewHandle.
 //
-// If step (1) fails OR we're in thread/reply mode (Reply API doesn't accept
-// card_id reference), we fall back to the inline-card-JSON path. The handle's
+// If step (1) fails, we fall back to the inline-card-JSON path. The handle's
 // cardID stays empty in that case and the engine routes EventText through the
 // full-card Patch path (= original #657 behavior, no typewriter).
 func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content string) (any, error) {
@@ -5130,8 +5142,8 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 	var cardJSON string
 	var sendContent string // what goes into the Im.Message.Create / Reply content field
 	var cardID string      // cardkit-v1 entity id (empty = no streaming text path)
-	if isCardJSON(content) {
-		cardJSON = content
+	if normalized, ok := normalizeCardJSON(content); ok {
+		cardJSON = normalized
 		// Try cardkit-v1 two-step flow regardless of Reply vs Create. Both
 		// Im.Message.Reply and Im.Message.Create accept the {type:card,data:{card_id}}
 		// content schema (verified by direct API call); skipping Reply mode would
@@ -5277,6 +5289,16 @@ func (p *Platform) StreamRichCardText(ctx context.Context, previewHandle any, fu
 	if h.cardID == "" {
 		return core.ErrNotSupported
 	}
+	if isCardJSON(fullText) {
+		// A complete Card 2.0 payload must replace the whole entity; putting it
+		// into the streaming markdown element would display the JSON as text.
+		return core.ErrNotSupported
+	}
+	if isIncompleteJSONObject(fullText) {
+		// Agent output may arrive in chunks. Keep the existing card unchanged
+		// until the complete Card 2.0 object can be applied atomically.
+		return nil
+	}
 
 	h.sequence++
 	apiPath := fmt.Sprintf("/open-apis/cardkit/v1/cards/%s/elements/%s/content",
@@ -5328,12 +5350,14 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 	}
 
 	cardJSON := ""
-	if isCardJSON(content) {
+	if normalized, ok := normalizeCardJSON(content); ok {
 		// Card 2.0: engine passes full card JSON directly, skip all processing.
-		cardJSON = content
+		cardJSON = normalized
 		h.mu.Lock()
-		h.lastContent = content
+		h.lastContent = normalized
 		h.mu.Unlock()
+	} else if isIncompleteJSONObject(content) {
+		return nil
 	} else if payload, ok := core.ParseProgressCardPayload(content); ok {
 		cardJSON = buildProgressCardJSONFromPayload(payload)
 	} else {
@@ -5362,6 +5386,9 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 func (p *Platform) UpdateMessageWithStatusFooter(ctx context.Context, previewHandle any, content, footer string) error {
 	if !p.useInteractiveCard {
 		return core.ErrNotSupported
+	}
+	if isCardJSON(content) {
+		return p.UpdateMessage(ctx, previewHandle, content)
 	}
 	if strings.TrimSpace(footer) == "" {
 		return p.UpdateMessage(ctx, previewHandle, content)
@@ -6483,6 +6510,9 @@ var blockedRichCardImagePrefixes = []netip.Prefix{
 // Streaming frames start uploads and strip unresolved images; final frames wait
 // briefly so resolved images can be embedded before the Done update.
 func (p *Platform) ResolveRichCardMarkdown(ctx context.Context, markdown string, final bool) string {
+	if cardJSON, ok := normalizeCardJSON(markdown); ok {
+		return cardJSON
+	}
 	if !strings.Contains(markdown, "![") {
 		return markdown
 	}
@@ -6978,13 +7008,47 @@ func richStepBody(step core.ToolStep) string {
 	return strings.Join(lines, "\n")
 }
 
-// isCardJSON returns true if content looks like a complete Feishu card JSON
-// (has "schema" and "body"). Used to avoid double-wrapping rich card output.
+// normalizeCardJSON validates and trims a complete Feishu Card 2.0 payload.
+// Agent-provided cards are otherwise opaque: their body elements, including
+// native chart/chart_spec elements, are passed to Feishu unchanged.
+func normalizeCardJSON(content string) (string, bool) {
+	trimmed := strings.TrimSpace(content)
+	if len(trimmed) < 2 || trimmed[0] != '{' {
+		return "", false
+	}
+	var card struct {
+		Schema string `json:"schema"`
+		Body   struct {
+			Elements json.RawMessage `json:"elements"`
+		} `json:"body"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &card); err != nil || card.Schema != "2.0" || len(card.Body.Elements) == 0 {
+		return "", false
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(card.Body.Elements, &elements); err != nil || elements == nil {
+		return "", false
+	}
+	return trimmed, true
+}
+
+// isCardJSON reports whether content is a complete Feishu Card 2.0 payload.
 func isCardJSON(content string) bool {
-	if len(content) < 10 || content[0] != '{' {
+	_, ok := normalizeCardJSON(content)
+	return ok
+}
+
+// isIncompleteJSONObject identifies a streamed JSON object that has not
+// reached its closing tokens yet. Feishu preview paths use this to avoid
+// exposing partial Card 2.0 JSON as user-visible markdown.
+func isIncompleteJSONObject(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" || trimmed[0] != '{' || json.Valid([]byte(trimmed)) {
 		return false
 	}
-	return strings.Contains(content, `"schema"`) && strings.Contains(content, `"body"`)
+	var value any
+	err := json.Unmarshal([]byte(trimmed), &value)
+	return err != nil && strings.Contains(err.Error(), "unexpected end of JSON input")
 }
 
 // buildCardJSONWithStatus builds a Feishu card JSON with a colored header
@@ -7125,6 +7189,12 @@ const maxRichCardJSONBytes = 28000
 // reasoning/tool panels, streaming markdown body, status-colored header, and a
 // pre-composed multi-line statusFooter (engine-owned, includes elapsed).
 func buildRichCard(status core.CardStatus, _ string, steps []core.ToolStep, markdown string, streaming bool, statusFooter string) string {
+	if cardJSON, ok := normalizeCardJSON(markdown); ok {
+		return cardJSON
+	}
+	if isIncompleteJSONObject(markdown) {
+		markdown = ""
+	}
 	b, err := buildRichCardJSONBytes(status, steps, markdown, streaming, statusFooter)
 	if err != nil {
 		slog.Debug("feishu: build rich card marshal failed, fallback to basic card", "error", err)
@@ -7371,6 +7441,11 @@ func (p *Platform) SetPreviewStatus(previewHandle any, status core.CardStatus) {
 	h.mu.Unlock()
 
 	if lastContent == "" {
+		return
+	}
+	if isCardJSON(lastContent) {
+		// Agent-provided Card 2.0 payloads own their header and visual status.
+		// Rebuilding them as markdown here would discard native chart elements.
 		return
 	}
 	cardJSON := buildCardJSONWithStatus(lastContent, status)

--- a/platform/feishu/vchart_test.go
+++ b/platform/feishu/vchart_test.go
@@ -1,0 +1,368 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+const testVChartCardJSON = `{
+  "schema": "2.0",
+  "config": {"width_mode": "fill"},
+  "body": {
+    "elements": [
+      {"tag": "markdown", "content": "Weekly requests"},
+      {
+        "tag": "chart",
+        "chart_spec": {
+          "type": "bar",
+          "data": [{"id": "requests", "values": [{"day": "Mon", "value": 12}]}],
+          "xField": "day",
+          "yField": "value"
+        },
+        "aspect_ratio": "2:1"
+      }
+    ]
+  }
+}`
+
+type capturedMessageRequest struct {
+	MsgType string `json:"msg_type"`
+	Content string `json:"content"`
+}
+
+func newVChartSendTestPlatform(t *testing.T, capture func(capturedMessageRequest)) (*Platform, *httptest.Server) {
+	t.Helper()
+	const appID = "cli_vchart_test"
+	const appSecret = "secret"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{"code": 0, "expire": 7200, "tenant_access_token": "t"})
+		case r.URL.Path == "/open-apis/im/v1/messages" && r.Method == http.MethodPost:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read message request: %v", err)
+				return
+			}
+			var req capturedMessageRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Errorf("unmarshal message request: %v", err)
+				return
+			}
+			capture(req)
+			writeJSON(t, w, map[string]any{"code": 0, "data": map[string]any{"message_id": "om_vchart"}})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			writeJSON(t, w, map[string]any{"code": 1, "msg": "unexpected request"})
+		}
+	}))
+
+	p := &Platform{
+		platformName:       "feishu",
+		domain:             srv.URL,
+		appID:              appID,
+		appSecret:          appSecret,
+		useInteractiveCard: true,
+		client:             lark.NewClient(appID, appSecret, lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+		replayClient:       lark.NewClient(appID, appSecret, lark.WithEnableTokenCache(false), lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+	}
+	return p, srv
+}
+
+func assertRawVChartRequest(t *testing.T, req capturedMessageRequest) {
+	t.Helper()
+	if req.MsgType != larkim.MsgTypeInteractive {
+		t.Fatalf("msg_type = %q, want %q", req.MsgType, larkim.MsgTypeInteractive)
+	}
+	if req.Content != strings.TrimSpace(testVChartCardJSON) {
+		t.Fatalf("card content was rewritten\n got: %s\nwant: %s", req.Content, strings.TrimSpace(testVChartCardJSON))
+	}
+}
+
+func TestRawVChartCard_SendPathsPreserveCardJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		send func(*Platform) error
+	}{
+		{
+			name: "send",
+			send: func(p *Platform) error {
+				return p.Send(context.Background(), replyContext{chatID: "oc_vchart"}, "\n"+testVChartCardJSON+"\n")
+			},
+		},
+		{
+			name: "send with status footer",
+			send: func(p *Platform) error {
+				return p.SendWithStatusFooter(context.Background(), replyContext{chatID: "oc_vchart"}, testVChartCardJSON, "model · ctx")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured capturedMessageRequest
+			p, srv := newVChartSendTestPlatform(t, func(req capturedMessageRequest) { captured = req })
+			defer srv.Close()
+
+			if err := tt.send(p); err != nil {
+				t.Fatalf("send raw VChart card: %v", err)
+			}
+			assertRawVChartRequest(t, captured)
+		})
+	}
+}
+
+func TestBuildRichCard_PreservesRawVChartCardJSON(t *testing.T) {
+	got := buildRichCard(core.CardStatusDone, "", nil, "\n"+testVChartCardJSON+"\n", false, "model · ctx")
+	if got != strings.TrimSpace(testVChartCardJSON) {
+		t.Fatalf("rich card wrapped raw VChart card\n got: %s\nwant: %s", got, strings.TrimSpace(testVChartCardJSON))
+	}
+}
+
+func TestUpdateMessageWithStatusFooter_PreservesRawVChartCardJSON(t *testing.T) {
+	const appID = "cli_vchart_update"
+	const appSecret = "secret"
+	var captured string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{"code": 0, "expire": 7200, "tenant_access_token": "t"})
+		case r.URL.Path == "/open-apis/im/v1/messages/om_preview" && r.Method == http.MethodPatch:
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				Content string `json:"content"`
+			}
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Errorf("unmarshal patch request: %v", err)
+				return
+			}
+			captured = req.Content
+			writeJSON(t, w, map[string]any{"code": 0})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			writeJSON(t, w, map[string]any{"code": 1, "msg": "unexpected request"})
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:       "feishu",
+		domain:             srv.URL,
+		appID:              appID,
+		appSecret:          appSecret,
+		useInteractiveCard: true,
+		client:             lark.NewClient(appID, appSecret, lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+		replayClient:       lark.NewClient(appID, appSecret, lark.WithEnableTokenCache(false), lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+	}
+
+	err := p.UpdateMessageWithStatusFooter(
+		context.Background(),
+		&feishuPreviewHandle{messageID: "om_preview", chatID: "oc_vchart"},
+		testVChartCardJSON,
+		"model · ctx",
+	)
+	if err != nil {
+		t.Fatalf("UpdateMessageWithStatusFooter: %v", err)
+	}
+	if captured != strings.TrimSpace(testVChartCardJSON) {
+		t.Fatalf("patched card content was rewritten\n got: %s\nwant: %s", captured, strings.TrimSpace(testVChartCardJSON))
+	}
+}
+
+func TestIsCardJSON_RequiresCompleteCard2Body(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "VChart card", content: " \n" + testVChartCardJSON + "\n", want: true},
+		{name: "ordinary JSON", content: `{"schema":"2.0","message":"body"}`, want: false},
+		{name: "legacy schema", content: `{"schema":"1.0","body":{"elements":[]}}`, want: false},
+		{name: "missing elements", content: `{"schema":"2.0","body":{}}`, want: false},
+		{name: "incomplete JSON", content: `{"schema":"2.0","body":{"elements":[`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCardJSON(tt.content); got != tt.want {
+				t.Fatalf("isCardJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSendPreviewStart_VChartCardEntityFailureFallsBackInline(t *testing.T) {
+	const appID = "cli_vchart_fallback"
+	const appSecret = "secret"
+	var captured capturedMessageRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{"code": 0, "expire": 7200, "tenant_access_token": "t"})
+		case r.URL.Path == "/open-apis/cardkit/v1/cards" && r.Method == http.MethodPost:
+			writeJSON(t, w, map[string]any{"code": 400, "msg": "card entity unavailable"})
+		case r.URL.Path == "/open-apis/im/v1/messages" && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &captured); err != nil {
+				t.Errorf("unmarshal fallback message request: %v", err)
+				return
+			}
+			writeJSON(t, w, map[string]any{"code": 0, "data": map[string]any{"message_id": "om_inline_vchart"}})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			writeJSON(t, w, map[string]any{"code": 1, "msg": "unexpected request"})
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:       "feishu",
+		domain:             srv.URL,
+		appID:              appID,
+		appSecret:          appSecret,
+		useInteractiveCard: true,
+		client:             lark.NewClient(appID, appSecret, lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+		replayClient:       lark.NewClient(appID, appSecret, lark.WithEnableTokenCache(false), lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+	}
+
+	handleAny, err := p.SendPreviewStart(context.Background(), replyContext{chatID: "oc_vchart"}, testVChartCardJSON)
+	if err != nil {
+		t.Fatalf("SendPreviewStart: %v", err)
+	}
+	handle, ok := handleAny.(*feishuPreviewHandle)
+	if !ok {
+		t.Fatalf("preview handle type = %T, want *feishuPreviewHandle", handleAny)
+	}
+	if handle.cardID != "" {
+		t.Fatalf("fallback handle cardID = %q, want empty", handle.cardID)
+	}
+	assertRawVChartRequest(t, captured)
+}
+
+func TestSendPreviewStart_VChartCardUsesCardEntity(t *testing.T) {
+	const appID = "cli_vchart_entity"
+	const appSecret = "secret"
+	var (
+		entityType string
+		entityData string
+		message    capturedMessageRequest
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
+			writeJSON(t, w, map[string]any{"code": 0, "expire": 7200, "tenant_access_token": "t"})
+		case r.URL.Path == "/open-apis/cardkit/v1/cards" && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				Type string `json:"type"`
+				Data string `json:"data"`
+			}
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Errorf("unmarshal card entity request: %v", err)
+				return
+			}
+			entityType = req.Type
+			entityData = req.Data
+			writeJSON(t, w, map[string]any{"code": 0, "data": map[string]any{"card_id": "card_vchart"}})
+		case r.URL.Path == "/open-apis/im/v1/messages" && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &message); err != nil {
+				t.Errorf("unmarshal card message request: %v", err)
+				return
+			}
+			writeJSON(t, w, map[string]any{"code": 0, "data": map[string]any{"message_id": "om_entity_vchart"}})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			writeJSON(t, w, map[string]any{"code": 1, "msg": "unexpected request"})
+		}
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:       "feishu",
+		domain:             srv.URL,
+		appID:              appID,
+		appSecret:          appSecret,
+		useInteractiveCard: true,
+		client:             lark.NewClient(appID, appSecret, lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+		replayClient:       lark.NewClient(appID, appSecret, lark.WithEnableTokenCache(false), lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+	}
+
+	handleAny, err := p.SendPreviewStart(context.Background(), replyContext{chatID: "oc_vchart"}, "\n"+testVChartCardJSON+"\n")
+	if err != nil {
+		t.Fatalf("SendPreviewStart: %v", err)
+	}
+	handle, ok := handleAny.(*feishuPreviewHandle)
+	if !ok {
+		t.Fatalf("preview handle type = %T, want *feishuPreviewHandle", handleAny)
+	}
+	if handle.cardID != "card_vchart" {
+		t.Fatalf("preview handle cardID = %q, want card_vchart", handle.cardID)
+	}
+	if entityType != "card_json" {
+		t.Fatalf("card entity type = %q, want card_json", entityType)
+	}
+	if entityData != strings.TrimSpace(testVChartCardJSON) {
+		t.Fatalf("card entity data was rewritten\n got: %s\nwant: %s", entityData, strings.TrimSpace(testVChartCardJSON))
+	}
+	if message.MsgType != larkim.MsgTypeInteractive {
+		t.Fatalf("message msg_type = %q, want interactive", message.MsgType)
+	}
+	if message.Content != `{"type":"card","data":{"card_id":"card_vchart"}}` {
+		t.Fatalf("message content = %s, want card_id reference", message.Content)
+	}
+}
+
+func TestRawVChartCard_StreamingWaitsForCompleteJSON(t *testing.T) {
+	partial := `{"schema":"2.0","body":{"elements":[`
+	if !isIncompleteJSONObject(partial) {
+		t.Fatal("partial Card 2.0 JSON was not recognized as incomplete")
+	}
+
+	preview := buildPreviewCardJSON(partial)
+	if strings.Contains(preview, partial) {
+		t.Fatalf("preview exposed partial Card 2.0 JSON: %s", preview)
+	}
+	rich := buildRichCard(core.CardStatusWorking, "", nil, partial, true, "")
+	if strings.Contains(rich, partial) {
+		t.Fatalf("rich preview exposed partial Card 2.0 JSON: %s", rich)
+	}
+
+	p := &Platform{platformName: "feishu", useInteractiveCard: true}
+	handle := &feishuPreviewHandle{messageID: "om_preview", cardID: "card_vchart"}
+	if err := p.StreamRichCardText(context.Background(), handle, partial); err != nil {
+		t.Fatalf("partial StreamRichCardText error = %v, want suppressed frame", err)
+	}
+	if err := p.UpdateMessage(context.Background(), handle, partial); err != nil {
+		t.Fatalf("partial UpdateMessage error = %v, want no-op", err)
+	}
+	if err := p.StreamRichCardText(context.Background(), handle, testVChartCardJSON); !errors.Is(err, core.ErrNotSupported) {
+		t.Fatalf("complete card StreamRichCardText error = %v, want ErrNotSupported for full-card update", err)
+	}
+}
+
+func TestResolveRichCardMarkdown_PreservesRawVChartCardJSON(t *testing.T) {
+	p := &Platform{platformName: "feishu"}
+	got := p.ResolveRichCardMarkdown(context.Background(), "\n"+testVChartCardJSON+"\n", true)
+	if got != strings.TrimSpace(testVChartCardJSON) {
+		t.Fatalf("markdown resolver rewrote raw VChart card\n got: %s\nwant: %s", got, strings.TrimSpace(testVChartCardJSON))
+	}
+}


### PR DESCRIPTION
## Summary

Pass complete Feishu Card 2.0 JSON responses through the Feishu adapter unchanged so native elements such as `chart` / VChart `chart_spec` render correctly. Suppress incomplete streamed JSON until it can be applied atomically, while preserving the existing CardKit-to-inline-card fallback.

This intentionally does not add agent prompt/skill injection, VChart conversion, or new configuration. The agent owns the complete Card 2.0 payload; cc-connect treats its body elements as opaque.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

### Automated tests added in this PR

- `TestRawVChartCard_SendPathsPreserveCardJSON` — verifies regular send and status-footer paths preserve the raw card.
- `TestBuildRichCard_PreservesRawVChartCardJSON` — verifies rich-card rendering does not wrap the agent card as Markdown.
- `TestUpdateMessageWithStatusFooter_PreservesRawVChartCardJSON` — verifies final preview updates preserve the card.
- `TestIsCardJSON_RequiresCompleteCard2Body` — verifies strict Card 2.0 recognition and rejects incomplete/unrelated JSON.
- `TestSendPreviewStart_VChartCardUsesCardEntity` — verifies the CardKit `card_json` and `card_id` path.
- `TestSendPreviewStart_VChartCardEntityFailureFallsBackInline` — verifies inline-card fallback keeps the original payload.
- `TestRawVChartCard_StreamingWaitsForCompleteJSON` — verifies partial streamed JSON is hidden and the complete card takes the full-card update path.
- `TestResolveRichCardMarkdown_PreservesRawVChartCardJSON` — verifies Markdown image resolution does not rewrite a complete card.

Commands run successfully:

```text
go build ./...
go test ./...
go test ./platform/feishu -count=1
go test -race ./platform/feishu -count=1
go test ./core/ -run TestCUJ -count=1
git diff --check
```

### For bug fixes only — regression test

Not applicable — this PR adds an output capability.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [x] I — UI rendering correctness (cards, streaming, display modes)

- [x] `go test ./core/ -run TestCUJ` passes locally.
- [x] Adapter-level tests cover the new user-visible flow; no core engine behavior changed.

## Manual / user-visible behavior change

When interactive cards are enabled and an agent's entire response is a complete raw Card 2.0 JSON object (`schema: "2.0"` with `body.elements`), Feishu renders it as the supplied native card instead of displaying or wrapping the JSON as Markdown. Code fences or surrounding prose remain ordinary content.

Live verification used the patched binary with a real Feishu bot. A Card 2.0 payload containing a native `chart` element rendered as an interactive bar chart, and the service remained healthy.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes (with `-race` if touching concurrency)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (no new runtime user-facing strings)
- [x] No secrets / credentials in source

## Real-world validation

Tested the rebased branch with a real Feishu agent workflow.

The agent performed business-data analysis and returned a complete Card 2.0 response containing native VChart specs. cc-connect passed the card through successfully, and Feishu rendered the charts correctly.


<img width="1065" height="3203" alt="vchart-example" src="https://github.com/user-attachments/assets/d5b6f8cf-fce4-4b88-ba6c-95cdf745ae06" />
