### PR TITLE
fix(core,relay,codex): restore async relay, workspace invalidation, and codex retries

### DIFF
--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -408,14 +408,17 @@ func (cs *codexSession) handleEvent(raw map[string]any) {
 
 	case "turn.failed":
 		errMsg := ""
+		errInfo := ""
 		if errObj, ok := raw["error"].(map[string]any); ok {
 			errMsg, _ = errObj["message"].(string)
+			errInfo, _ = errObj["codex_error_info"].(string)
 		}
 		if errMsg == "" {
 			errMsg = "turn failed (no details)"
 		}
-		slog.Warn("codexSession: turn failed", "error", errMsg)
-		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", errMsg)}
+		errKind := codexErrorKind(errInfo, errMsg)
+		slog.Warn("codexSession: turn failed", "error", errMsg, "codex_error_info", errInfo, "error_kind", errKind)
+		evt := core.Event{Type: core.EventError, Error: fmt.Errorf("%s", errMsg), ErrorKind: errKind}
 		select {
 		case cs.events <- evt:
 		case <-cs.ctx.Done():
@@ -433,6 +436,24 @@ func (cs *codexSession) handleEvent(raw map[string]any) {
 	default:
 		slog.Debug("codexSession: unhandled event type", "type", eventType)
 	}
+}
+
+func codexErrorKind(errorInfo string, message string) core.ErrorKind {
+	switch strings.TrimSpace(errorInfo) {
+	case "server_overloaded":
+		return core.ErrorKindOverloaded
+	case "rate_limit_exceeded", "rate_limit":
+		return core.ErrorKindRateLimit
+	}
+
+	msg := strings.ToLower(message)
+	if strings.Contains(msg, "at capacity") || strings.Contains(msg, "overloaded") {
+		return core.ErrorKindOverloaded
+	}
+	if strings.Contains(msg, "rate limit") || strings.Contains(msg, "rate_limit") {
+		return core.ErrorKindRateLimit
+	}
+	return core.ErrorKindUnknown
 }
 
 // flushPendingAsThinking emits all buffered agent_messages as EventThinking.

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -349,7 +349,7 @@ func TestRefreshContextUsageFromRollout_UsesLastTokenCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	cs.refreshContextUsageFromRollout()
 
@@ -400,7 +400,7 @@ func TestSend_WithImages_PassesImageArgsAndDefaultPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	img := core.ImageAttachment{
 		MimeType: "image/png",
@@ -461,7 +461,7 @@ func TestSend_ResumeWithImages_PlacesSessionBeforeImageFlags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	if err := cs.Send("describe this", "", []core.ImageAttachment{{MimeType: "image/jpeg", Data: []byte("jpg")}}, nil); err != nil {
 		t.Fatalf("Send: %v", err)
@@ -514,7 +514,7 @@ func TestSend_UsesStdinForMultilinePrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	prompt := "line1\nline2"
 	if err := cs.Send(prompt, "", nil, nil); err != nil {
@@ -609,7 +609,7 @@ func TestSend_HandlesLargeJSONLines(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	if err := cs.Send("hello", "", nil, nil); err != nil {
 		t.Fatalf("Send: %v", err)
@@ -664,7 +664,7 @@ func TestSend_TurnFailedServerOverloadedIsRetriable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	if err := cs.Send("hello", "", nil, nil); err != nil {
 		t.Fatalf("Send: %v", err)

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -644,6 +644,52 @@ func TestSend_HandlesLargeJSONLines(t *testing.T) {
 	}
 }
 
+func TestSend_TurnFailedServerOverloadedIsRetriable(t *testing.T) {
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+
+	shellScript := "#!/bin/sh\n" +
+		"printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"thread-overloaded\"}'\n" +
+		"printf '%s\\n' '{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity. Please try a different model.\",\"codex_error_info\":\"server_overloaded\"}}'\n"
+	powershellScript := "[Console]::Out.WriteLine('{\"type\":\"thread.started\",\"thread_id\":\"thread-overloaded\"}')\n" +
+		"[Console]::Out.WriteLine('{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity. Please try a different model.\",\"codex_error_info\":\"server_overloaded\"}}')\n"
+	writeFakeCodexScript(t, binDir, shellScript, powershellScript)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cs, err := newCodexSession(context.Background(), "codex", nil, workDir, "", "", "", "", "", nil, "", "", "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	defer cs.Close()
+
+	if err := cs.Send("hello", "", nil, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case evt := <-cs.Events():
+			if evt.Type != core.EventError {
+				continue
+			}
+			if evt.ErrorKind != core.ErrorKindOverloaded {
+				t.Fatalf("ErrorKind = %q, want %q", evt.ErrorKind, core.ErrorKindOverloaded)
+			}
+			if evt.Error == nil || !strings.Contains(evt.Error.Error(), "Selected model is at capacity") {
+				t.Fatalf("Error = %v, want capacity message", evt.Error)
+			}
+			return
+		case <-timeout:
+			t.Fatal("timed out waiting for retriable error event")
+		}
+	}
+}
+
 func TestWaitForArgsFile_WaitsForNonEmptyContent(t *testing.T) {
 	workDir := t.TempDir()
 	argsFile := filepath.Join(workDir, "args.txt")

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -315,7 +315,7 @@ while (($line = [Console]::In.ReadLine()) -ne $null) {
 	if err != nil {
 		t.Fatalf("newCodexSession: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	if got := cs.GetModel(); got != "gpt-5.4" {
 		t.Fatalf("GetModel() = %q, want gpt-5.4", got)

--- a/cmd/cc-connect/relay.go
+++ b/cmd/cc-connect/relay.go
@@ -28,6 +28,7 @@ func runRelay(args []string) {
 
 func runRelaySend(args []string) {
 	var from, to, sessionKey, message, dataDir string
+	async := false
 
 	var positional []string
 	for i := 0; i < len(args); i++ {
@@ -57,6 +58,8 @@ func runRelaySend(args []string) {
 				i++
 				dataDir = args[i]
 			}
+		case "--async":
+			async = true
 		case "--help", "-h":
 			printRelaySendUsage()
 			return
@@ -103,7 +106,11 @@ func runRelaySend(args []string) {
 		"message":     message,
 	})
 
-	resp, err := apiPost(sockPath, "/relay/send", payload)
+	endpoint := "/relay/send"
+	if async {
+		endpoint = "/relay/send-async"
+	}
+	resp, err := apiPost(sockPath, endpoint, payload)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -111,19 +118,26 @@ func runRelaySend(args []string) {
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
+	accepted := resp.StatusCode == http.StatusOK || async && resp.StatusCode == http.StatusAccepted
+	if !accepted {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", strings.TrimSpace(string(body)))
 		os.Exit(1)
 	}
 
 	var result struct {
 		Response string `json:"response"`
+		Status   string `json:"status"`
+		Job      string `json:"job"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: decode response: %v\n", err)
 		os.Exit(1)
 	}
-	fmt.Print(result.Response)
+	if async {
+		fmt.Printf("queued relay job=%s\n", result.Job)
+	} else {
+		fmt.Print(result.Response)
+	}
 }
 
 func printRelayUsage() {
@@ -145,6 +159,7 @@ Options:
   -t, --to <project>         Target bot project name
   -s, --session-key <key>    Session key (auto-detected from CC_SESSION_KEY env)
   -m, --message <text>       Message to send
+      --async                Queue the relay and return immediately
       --data-dir <path>      Data directory (default: ~/.cc-connect)
   -h, --help                 Show this help
 

--- a/cmd/cc-connect/relay_test.go
+++ b/cmd/cc-connect/relay_test.go
@@ -27,7 +27,7 @@ func TestRunRelaySendAsyncUsesAsyncEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen unix socket: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	gotPath := make(chan string, 1)
 	gotBody := make(chan string, 1)
@@ -45,7 +45,7 @@ func TestRunRelaySendAsyncUsesAsyncEndpoint(t *testing.T) {
 	go func() {
 		_ = srv.Serve(ln)
 	}()
-	defer srv.Close()
+	defer func() { _ = srv.Close() }()
 
 	oldStdout := os.Stdout
 	rOut, wOut, err := os.Pipe()

--- a/cmd/cc-connect/relay_test.go
+++ b/cmd/cc-connect/relay_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRelaySendAsyncUsesAsyncEndpoint(t *testing.T) {
+	dataDir, err := os.MkdirTemp("/tmp", "cc-connect-relay-")
+	if err != nil {
+		t.Fatalf("mkdir temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dataDir) })
+	runDir := filepath.Join(dataDir, "run")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir run dir: %v", err)
+	}
+	sockPath := filepath.Join(runDir, "api.sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	defer ln.Close()
+
+	gotPath := make(chan string, 1)
+	gotBody := make(chan string, 1)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotPath <- r.URL.Path
+		gotBody <- string(body)
+		if r.URL.Path != "/relay/send-async" {
+			http.Error(w, "wrong endpoint", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = io.WriteString(w, `{"status":"queued","job":"relay-123"}`)
+	})}
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+	defer srv.Close()
+
+	oldStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = wOut
+	defer func() { os.Stdout = oldStdout }()
+
+	outDone := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, rOut)
+		outDone <- buf.String()
+	}()
+
+	runRelaySend([]string{
+		"--data-dir", dataDir,
+		"--from", "source",
+		"--to", "target",
+		"--session-key", "feishu:chat:user",
+		"--message", "please work in the background",
+		"--async",
+	})
+
+	_ = wOut.Close()
+	out := <-outDone
+
+	if got := <-gotPath; got != "/relay/send-async" {
+		t.Fatalf("path = %q, want /relay/send-async", got)
+	}
+	if got := <-gotBody; !strings.Contains(got, `"message":"please work in the background"`) {
+		t.Fatalf("body = %q, want relay payload", got)
+	}
+	if out != "queued relay job=relay-123\n" {
+		t.Fatalf("stdout = %q, want queued job output", out)
+	}
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -412,7 +412,8 @@ level = "info" # debug, info, warn, error
 #
 # Supported events / 支持的事件:
 #   message.received   — user message arrives / 用户消息到达
-#   message.sent       — agent reply sent / Agent 回复发送完成
+#   message.sent       — legacy pre-delivery agent reply hook / 兼容旧版发送前事件
+#   message.finalized  — final reply send completed / 最终回复发送完成
 #   session.started    — agent session spawned / Agent 会话启动
 #   session.ended      — agent session stopped / Agent 会话结束
 #   cron.triggered     — cron job fires / 定时任务触发

--- a/config/config.go
+++ b/config/config.go
@@ -467,7 +467,7 @@ type ReferenceConfig struct {
 	EnclosureStyle  string   `toml:"enclosure_style,omitempty"`
 }
 
-// ProjectConfig binds one agent (with a specific work_dir) to one or more platforms.
+// ProjectConfig binds one agent (with a specific work_dir) to zero or more platforms.
 type ProjectConfig struct {
 	Name    string `toml:"name"`
 	Mode    string `toml:"mode,omitempty"`     // "" or "multi-workspace"
@@ -1030,9 +1030,6 @@ func (c *Config) validateInternal(permissive bool) error {
 		}
 		if proj.Agent.Type == "" {
 			return fmt.Errorf("config: %s.agent.type is required", prefix)
-		}
-		if len(proj.Platforms) == 0 && !permissive {
-			return fmt.Errorf("config: %s needs at least one [[projects.platforms]]", prefix)
 		}
 		for j, p := range proj.Platforms {
 			if p.Type == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,7 +44,7 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: `projects[0].agent.type is required`,
 		},
 		{
-			name: "requires at least one platform",
+			name: "allows projects without platforms",
 			cfg: Config{
 				Projects: []ProjectConfig{
 					func() ProjectConfig {
@@ -54,7 +54,6 @@ func TestConfigValidate(t *testing.T) {
 					}(),
 				},
 			},
-			wantErr: `projects[0] needs at least one [[projects.platforms]]`,
 		},
 		{
 			name: "requires platform type",

--- a/core/api.go
+++ b/core/api.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -103,6 +104,7 @@ func NewAPIServer(dataDir string) (*APIServer, error) {
 	s.mux.HandleFunc("/cron/exec", s.handleCronExec)
 	s.mux.HandleFunc("/cron/run", s.handleCronExec)
 	s.mux.HandleFunc("/relay/send", s.handleRelaySend)
+	s.mux.HandleFunc("/relay/send-async", s.handleRelaySendAsync)
 	s.mux.HandleFunc("/relay/bind", s.handleRelayBind)
 	s.mux.HandleFunc("/relay/binding", s.handleRelayBinding)
 
@@ -767,13 +769,9 @@ func (s *APIServer) handleRelaySend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req RelayRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	if req.To == "" || req.Message == "" || req.SessionKey == "" {
-		http.Error(w, "to, session_key, and message are required", http.StatusBadRequest)
+	req, err := decodeRelayRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -784,6 +782,46 @@ func (s *APIServer) handleRelaySend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	apiJSON(w, http.StatusOK, resp)
+}
+
+// handleRelaySendAsync accepts a relay request and executes it after returning.
+// The request context cannot be reused because clients may disconnect as soon
+// as the job is accepted.
+func (s *APIServer) handleRelaySendAsync(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.relay == nil {
+		http.Error(w, "relay not available", http.StatusServiceUnavailable)
+		return
+	}
+	req, err := decodeRelayRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	jobID := fmt.Sprintf("relay-%d", time.Now().UnixNano())
+	go func() {
+		if _, err := s.relay.Send(context.Background(), req); err != nil {
+			slog.Error("relay: async job failed", "job", jobID, "error", err)
+			return
+		}
+		slog.Info("relay: async job completed", "job", jobID)
+	}()
+	apiJSON(w, http.StatusAccepted, map[string]string{"status": "queued", "job": jobID})
+}
+
+func decodeRelayRequest(r *http.Request) (RelayRequest, error) {
+	var req RelayRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return req, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if req.To == "" || req.Message == "" || req.SessionKey == "" {
+		return req, fmt.Errorf("to, session_key, and message are required")
+	}
+	return req, nil
 }
 
 func (s *APIServer) handleRelayBind(w http.ResponseWriter, r *http.Request) {

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -91,6 +91,66 @@ func TestHandleSend_AllowsTTSTextOnly(t *testing.T) {
 	}
 }
 
+func TestHandleRelaySendAsync_AcceptsAndQueues(t *testing.T) {
+	relay := NewRelayManager("")
+	relay.Bind("feishu", "chat-1", map[string]string{
+		"source": "source-bot",
+		"target": "target-bot",
+	})
+	relay.RegisterEngine("source", NewEngine("source", &stubAgent{}, []Platform{&stubPlatformEngine{n: "feishu"}}, "", LangEnglish))
+	relay.RegisterEngine("target", NewEngine("target", &resultAgent{session: newResultAgentSession("relay response")}, []Platform{&stubPlatformEngine{n: "feishu"}}, "", LangEnglish))
+	api := &APIServer{relay: relay}
+	body, err := json.Marshal(RelayRequest{
+		From:       "source",
+		To:         "target",
+		SessionKey: "feishu:chat-1:user",
+		Message:    "please work in the background",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/relay/send-async", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleRelaySendAsync(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got["status"] != "queued" {
+		t.Fatalf("status payload = %q, want queued", got["status"])
+	}
+	if !strings.HasPrefix(got["job"], "relay-") {
+		t.Fatalf("job = %q, want relay-*", got["job"])
+	}
+}
+
+func TestHandleRelaySendAsync_ValidatesRequest(t *testing.T) {
+	api := &APIServer{relay: NewRelayManager("")}
+	body, err := json.Marshal(RelayRequest{
+		To:         "target",
+		SessionKey: "feishu:chat:user",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/relay/send-async", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	api.handleRelaySendAsync(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "to, session_key, and message are required") {
+		t.Fatalf("body = %q, want validation error", rec.Body.String())
+	}
+}
+
 // TestHandleSend_UnknownProjectReturns404 ensures the API does NOT silently
 // fall back to the only registered engine when the caller named a different
 // project. Previously a typo'd project name routed messages to whatever

--- a/core/engine.go
+++ b/core/engine.go
@@ -526,6 +526,7 @@ type interactiveState struct {
 	lastRecallProbeAt        time.Time
 	recallProbeInFlight      bool
 	workspaceDir             string
+	ccSessionKey             string // raw platform:chat:user key for hooks and agent env
 	agent                    Agent
 	mu                       sync.Mutex
 	stopCh                   chan struct{}
@@ -3773,59 +3774,15 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 		}
 	}
 
-	// Start typing indicator if platform supports it.
-	// Ownership is transferred to processInteractiveEvents which manages
-	// stopping/restarting it across queued message turns.
-	var stopTyping func()
-	if ti, ok := p.(TypingIndicator); ok {
-		stopTyping = ti.StartTyping(e.ctx, msg.ReplyCtx)
-	}
-	defer func() {
-		// Stop typing if ownership was NOT transferred to processInteractiveEvents
-		// (i.e. an early return before that call).
-		if stopTyping != nil {
-			stopTyping()
-		}
-	}()
-
-	// Stop the unsolicited reader (if running) and hand off event channel
-	// ownership to this foreground turn. Only drain events when the previous
-	// turn ended abnormally (eventsNeedResync=true, the default).
-	e.stopUnsolicitedReader(state)
-	state.mu.Lock()
-	needResync := state.eventsNeedResync
-	state.mu.Unlock()
-	if needResync {
-		drainEvents(state.agentSession.Events())
-	}
-
 	promptContent := e.buildSenderPrompt(msg.Content, msg.UserID, msg.UserName, msg.Platform, msg.SessionKey, msg.ChannelKey)
 
-	sendStart := time.Now()
 	state.mu.Lock()
 	state.currentMessageID = msg.MessageID
 	state.fromVoice = msg.FromVoice
 	state.sideText = ""
-	as := state.agentSession // capture under lock to avoid race with cleanup
 	state.mu.Unlock()
 
-	// Run Send concurrently with processInteractiveEvents. Some agents block inside
-	// Send until the prompt turn finishes (e.g. ACP session/prompt); they may emit
-	// EventPermissionRequest while blocked — the event loop must run in parallel.
-	sendDone := make(chan error, 1)
-	go func() {
-		if as == nil {
-			sendDone <- fmt.Errorf("agent session became nil")
-			return
-		}
-		sendDone <- as.Send(promptContent, msg.MessageID, msg.Images, msg.Files)
-	}()
-
-	e.processInteractiveEvents(state, session, sessions, interactiveKey, msg.MessageID, turnStart, stopTyping, sendDone, msg.ReplyCtx)
-	if elapsed := time.Since(sendStart); elapsed >= slowAgentSend {
-		slog.Warn("slow agent send", "elapsed", elapsed, "session", msg.SessionKey, "content_len", len(msg.Content))
-	}
-	stopTyping = nil // ownership transferred; prevent defer from double-stopping
+	e.processInteractiveTurnWithRetry(state, session, sessions, interactiveKey, promptContent, msg.MessageID, msg.Images, msg.Files, msg.ReplyCtx, turnStart, msg.SessionKey, len(msg.Content))
 
 	// Start unsolicited reader and arm the idle close timer BEFORE draining
 	// queued messages. drainPendingMessages releases the session lock, and
@@ -3850,6 +3807,140 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	// the message to queueMessageForBusySession). Drain any such orphans.
 	if e.drainPendingMessages(state, session, sessions, interactiveKey) {
 		unlocked = true
+	}
+}
+
+type interactiveRetryTurn struct {
+	kind          ErrorKind
+	err           error
+	promptContent string
+	msgID         string
+	images        []ImageAttachment
+	files         []FileAttachment
+	replyCtx      any
+	logSessionKey string
+	contentLen    int
+}
+
+func (e *Engine) processInteractiveTurnWithRetry(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, promptContent string, msgID string, images []ImageAttachment, files []FileAttachment, replyCtx any, turnStart time.Time, logSessionKey string, contentLen int) {
+	maxAttempts := RetriableErrorMaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	var stopTyping func()
+	defer func() {
+		if stopTyping != nil {
+			stopTyping()
+		}
+	}()
+
+	for attempt := 1; ; attempt++ {
+		if state.isStopped() {
+			return
+		}
+
+		state.mu.Lock()
+		p := state.platform
+		as := state.agentSession // capture under lock to avoid race with cleanup
+		needResync := state.eventsNeedResync
+		state.mu.Unlock()
+
+		if as == nil || !as.Alive() {
+			if stopTyping != nil {
+				stopTyping()
+				stopTyping = nil
+			}
+			e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), "agent session ended"))
+			return
+		}
+
+		if needResync {
+			drainEvents(as.Events())
+		}
+
+		if stopTyping == nil {
+			if ti, ok := p.(TypingIndicator); ok {
+				stopTyping = ti.StartTyping(e.ctx, replyCtx)
+			}
+		}
+
+		sendStart := time.Now()
+		sendDone := make(chan error, 1)
+		go func(agentSession AgentSession) {
+			if agentSession == nil {
+				sendDone <- fmt.Errorf("agent session became nil")
+				return
+			}
+			sendDone <- agentSession.Send(promptContent, msgID, images, files)
+		}(as)
+
+		retryTurn := e.processInteractiveEvents(state, session, sessions, sessionKey, msgID, turnStart, stopTyping, sendDone, replyCtx)
+		stopTyping = nil // ownership transferred; prevent defer from double-stopping
+
+		if elapsed := time.Since(sendStart); elapsed >= slowAgentSend {
+			slog.Warn("slow agent send", "elapsed", elapsed, "session", logSessionKey, "content_len", contentLen, "attempt", attempt)
+		}
+
+		if retryTurn == nil || !retryTurn.kind.IsRetriable() {
+			return
+		}
+		retryKind := retryTurn.kind
+		retryErr := retryTurn.err
+		if retryTurn.promptContent != "" {
+			promptContent = retryTurn.promptContent
+			msgID = retryTurn.msgID
+			images = retryTurn.images
+			files = retryTurn.files
+			replyCtx = retryTurn.replyCtx
+			logSessionKey = retryTurn.logSessionKey
+			contentLen = retryTurn.contentLen
+		}
+
+		if attempt >= maxAttempts {
+			slog.Error("retriable agent error exhausted", "error", retryErr, "kind", retryKind, "session", logSessionKey, "attempts", attempt)
+			state.mu.Lock()
+			p := state.platform
+			state.mu.Unlock()
+			if retryErr == nil {
+				retryErr = fmt.Errorf("agent returned retriable error: %s", retryKind)
+			}
+			if retryErr != nil {
+				e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgError), retryErr))
+			}
+			return
+		}
+
+		delay := RetriableErrorDelay(attempt)
+		slog.Warn("retrying agent turn after retriable error", "error", retryErr, "kind", retryKind, "session", logSessionKey, "attempt", attempt, "max_attempts", maxAttempts, "delay", delay)
+		if attempt == 1 || attempt%5 == 0 {
+			state.mu.Lock()
+			p := state.platform
+			state.mu.Unlock()
+			e.send(p, replyCtx, fmt.Sprintf(e.i18n.T(MsgRetriableAgentError), delay.Round(time.Second), attempt+1, maxAttempts))
+		}
+
+		timer := time.NewTimer(delay)
+		stopCh := state.stopSignal()
+		select {
+		case <-timer.C:
+		case <-e.ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		case <-stopCh:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		}
 	}
 }
 
@@ -3939,11 +4030,17 @@ func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionMan
 		}
 	}
 
-	// Create per-workspace session manager
-	h := sha256.Sum256([]byte(workspace))
-	sessionFile := filepath.Join(filepath.Dir(e.sessions.StorePath()),
-		fmt.Sprintf("%s_ws_%s.json", e.name, hex.EncodeToString(h[:4])))
+	// Create per-workspace session manager. Preserve the base manager's
+	// no-persistence mode; deriving filepath.Dir("") would otherwise write
+	// runtime state into the current working directory (including test trees).
+	sessionFile := ""
+	if baseStorePath := e.sessions.StorePath(); baseStorePath != "" {
+		h := sha256.Sum256([]byte(workspace))
+		sessionFile = filepath.Join(filepath.Dir(baseStorePath),
+			fmt.Sprintf("%s_ws_%s.json", e.name, hex.EncodeToString(h[:4])))
+	}
 	sessions := NewSessionManager(sessionFile)
+	sessions.InvalidateForAgent(agent.Name())
 
 	ws.agent = agent
 	ws.sessions = sessions
@@ -4000,6 +4097,11 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 
 	state, ok := e.interactiveStates[sessionKey]
 	if ok && state.agentSession != nil && state.agentSession.Alive() {
+		if ccSessionKey != "" {
+			state.mu.Lock()
+			state.ccSessionKey = ccSessionKey
+			state.mu.Unlock()
+		}
 		// Verify the running agent session matches the current active session.
 		// After /new or /switch the active session changes, but the old agent
 		// process may still be alive. Reusing it would send messages to the
@@ -4075,7 +4177,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	// Check if context is already canceled (e.g. during shutdown/restart)
 	if e.ctx.Err() != nil {
 		slog.Debug("skipping session start: context canceled", "session_key", sessionKey)
-		newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true}
+		newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, ccSessionKey: ccKey, eventsNeedResync: true}
 		adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
 		state = newState
 		e.interactiveStates[sessionKey] = state
@@ -4139,7 +4241,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 				Platform:   p.Name(),
 				Error:      fmt.Sprintf("failed to start session: %v", err),
 			})
-			newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true}
+			newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, ccSessionKey: ccKey, eventsNeedResync: true}
 			adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
 			state = newState
 			e.interactiveStates[sessionKey] = state
@@ -4181,6 +4283,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		platform:         p,
 		replyCtx:         replyCtx,
 		agent:            agent,
+		ccSessionKey:     ccKey,
 		eventsNeedResync: true,
 	}
 	adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
@@ -4640,10 +4743,47 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 					fullResponse = strings.Join(textParts, "")
 				}
 
+				finalized := fullResponse != ""
 				if fullResponse != "" {
 					for _, chunk := range SplitMessageCodeFenceAware(fullResponse, maxPlatformMessageLen) {
-						e.send(p, replyCtx, chunk)
+						if err := e.sendWithErrorForWorkspace(p, replyCtx, chunk, workspaceDir); err != nil {
+							finalized = false
+							break
+						}
 					}
+				}
+				if finalized {
+					state.mu.Lock()
+					hookSessionKey := state.ccSessionKey
+					hookWorkspace := state.workspaceDir
+					hookAgent := state.agent
+					state.mu.Unlock()
+					if hookSessionKey == "" {
+						hookSessionKey = sessionKey
+					}
+					if hookWorkspace == "" {
+						hookWorkspace = workspaceDir
+					}
+					if hookWorkspace == "" {
+						if hookAgent == nil {
+							hookAgent = e.agent
+						}
+						if wd, ok := hookAgent.(WorkDirSwitcher); ok {
+							hookWorkspace = wd.GetWorkDir()
+						}
+					}
+					turnID := fmt.Sprintf("background-%d", time.Now().UnixNano())
+					e.hooks.Emit(HookEvent{
+						Event:      HookEventMessageFinalized,
+						TurnID:     turnID,
+						SessionKey: hookSessionKey,
+						Workspace:  hookWorkspace,
+						Platform:   p.Name(),
+						Source:     "agent.background_reply",
+						Internal:   false,
+						ReplyKind:  "text",
+						Content:    fullResponse,
+					})
 				}
 
 				// Safety note: concurrent writes to session.History by the
@@ -4747,7 +4887,7 @@ var agentErrorHandlers = []agentErrorHandler{
 	{"Session not found", MsgSessionNotFound},
 }
 
-func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, msgID string, turnStart time.Time, stopTypingFn func(), sendDone <-chan error, replyCtx any) {
+func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, msgID string, turnStart time.Time, stopTypingFn func(), sendDone <-chan error, replyCtx any) (retryTurn *interactiveRetryTurn) {
 	if msgID != "" {
 		state.mu.Lock()
 		state.currentMessageID = msgID
@@ -4767,6 +4907,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	var partialText string
 	triggerAutoCompress := false
 	pendingSend := sendDone
+	var currentRetryTurn *interactiveRetryTurn
 
 	// stopTyping tracks the current turn's typing indicator so it can be
 	// stopped when a queued message starts a new turn.
@@ -4785,9 +4926,19 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 	state.mu.Lock()
 	workspaceDir := state.workspaceDir
+	hookSessionKey := state.ccSessionKey
 	replyAgent := state.agent
 	if replyAgent == nil {
 		replyAgent = e.agent
+	}
+	if hookSessionKey == "" {
+		hookSessionKey = sessionKey
+	}
+	hookWorkspace := workspaceDir
+	if hookWorkspace == "" {
+		if wd, ok := replyAgent.(WorkDirSwitcher); ok {
+			hookWorkspace = wd.GetWorkDir()
+		}
 	}
 	workspaceRenderer := func(content string) string {
 		return e.renderOutgoingContentForWorkspace(state.platform, content, workspaceDir)
@@ -5680,9 +5831,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			state.mu.Unlock()
 
 			replyStart := time.Now()
+			finalized := false
+			replyKind := "text"
 
 			// --- StreamingCard path ---
 			if streamCard != nil && !streamCard.Failed() {
+				replyKind = "card"
 				sp.finish("", "") // cleanup preview (should be no-op if card was active)
 				// Silent reply: never render the NO_REPLY marker into the card.
 				// cardAnswerText holds only the text streamed BEFORE the marker
@@ -5697,6 +5851,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 				finalContent := buildCardContent(cardThinkingText, cardToolCalls, cardBody)
 				if err := streamCard.Finalize(e.ctx, finalContent); err != nil {
+					replyKind = "fallback"
 					slog.Error("streaming card finalize failed, sending fallback", "error", err)
 					// Fallback: send the response as a normal message — but never
 					// for a silent reply, which has no deliverable content.
@@ -5706,7 +5861,10 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 								return
 							}
 						}
+						finalized = true
 					}
+				} else {
+					finalized = true
 				}
 				if isSilent {
 					slog.Info("silent reply suppressed", "session", session.ID)
@@ -5752,6 +5910,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 				slog.Info("silent reply suppressed", "session", session.ID)
 			} else if hasRichCard {
+				replyKind = "card"
 				parts := []string{fullResponse}
 				if splitter, ok := p.(MarkdownTableSplitter); ok {
 					parts = splitter.SplitMarkdownByTables(fullResponse, 5)
@@ -5782,6 +5941,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 								return
 							}
 						}
+					} else if err := p.Send(e.ctx, replyCtx, finalCard); err != nil {
+						slog.Error("failed to send rich card reply without updater", "error", err)
+						return
 					}
 				} else {
 					if err := p.Send(e.ctx, replyCtx, finalCard); err != nil {
@@ -5797,6 +5959,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 						return
 					}
 				}
+				finalized = true
 			} else if toolCount > 0 && segmentStart > 0 {
 				// When tool calls happened and prior text was already surfaced in segments,
 				// only send the unsent remainder. When tool progress is hidden, tool events don't surface
@@ -5810,6 +5973,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 						}
 					}
 				}
+				finalized = true
 			} else if suppressDuplicate {
 				sp.discard()
 				metaOnly := strings.TrimSpace(strings.TrimPrefix(fullResponse, baseResponse))
@@ -5819,13 +5983,30 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 				}
 				slog.Debug("EventResult: suppressed duplicate side-channel text", "response_len", len(fullResponse))
+				finalized = true
 			} else if sp.finish(fullResponse, statusFooter) {
 				slog.Debug("EventResult: finalized via stream preview", "response_len", len(fullResponse), "footer_len", len(statusFooter))
+				finalized = true
 			} else {
 				slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "footer_len", len(statusFooter))
 				if !sendChunksWithStatusFooter(e.ctx, p, replyCtx, fullResponse, statusFooter, sendWorkspaceWithError) {
 					return
 				}
+				finalized = true
+			}
+
+			if finalized && !isSilent {
+				e.hooks.Emit(HookEvent{
+					Event:      HookEventMessageFinalized,
+					TurnID:     msgID,
+					SessionKey: hookSessionKey,
+					Workspace:  hookWorkspace,
+					Platform:   p.Name(),
+					Source:     "agent.final_reply",
+					Internal:   false,
+					ReplyKind:  replyKind,
+					Content:    fullResponse,
+				})
 			}
 
 			if elapsed := time.Since(replyStart); elapsed >= slowPlatformSend {
@@ -5923,6 +6104,15 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 
 				queuedPrompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
+				currentRetryTurn = &interactiveRetryTurn{
+					promptContent: queuedPrompt,
+					msgID:         queued.messageID,
+					images:        queued.images,
+					files:         queued.files,
+					replyCtx:      queued.replyCtx,
+					logSessionKey: sessionKey,
+					contentLen:    len(queued.content),
+				}
 
 				state.mu.Lock()
 				as := state.agentSession // capture under lock to avoid race with cleanup
@@ -6036,11 +6226,27 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			return
 
 		case EventError:
-			cp.Finalize(ProgressCardStateFailed)
-			sp.discard()
 			state.mu.Lock()
 			state.eventsNeedResync = true
 			state.mu.Unlock()
+			if event.ErrorKind.IsRetriable() {
+				sp.discard()
+				if pendingSend != nil {
+					if err := <-pendingSend; err != nil {
+						slog.Debug("async send error after retriable EventError", "error", err)
+					}
+				}
+				slog.Warn("agent retriable error", "error", event.Error, "kind", event.ErrorKind, "session_key", sessionKey)
+				retryTurn := &interactiveRetryTurn{kind: event.ErrorKind, err: event.Error}
+				if currentRetryTurn != nil {
+					*retryTurn = *currentRetryTurn
+					retryTurn.kind = event.ErrorKind
+					retryTurn.err = event.Error
+				}
+				return retryTurn
+			}
+			cp.Finalize(ProgressCardStateFailed)
+			sp.discard()
 			if hasRichCard && cardMessageID != nil {
 				errCard := buildResolvedRichCard(CardStatusError, "", toolSteps, partialText, false, e.composeRichStatusFooter(false, turnStart, e.agent, state.agentSession, state.workspaceDir))
 				if updater, ok := p.(MessageUpdater); ok {
@@ -6119,6 +6325,8 @@ channelClosed:
 			Content:    fullResponse,
 		})
 
+		finalized := false
+		replyKind := "text"
 		if toolCount > 0 && segmentStart > 0 {
 			sp.discard()
 			if segmentStart < len(textParts) {
@@ -6131,16 +6339,34 @@ channelClosed:
 					}
 				}
 			}
+			finalized = true
 		} else if sp.finish(fullResponse, "") {
 			slog.Debug("stream preview: finalized in-place (process exited)")
+			finalized = true
 		} else {
 			for _, chunk := range SplitMessageCodeFenceAware(fullResponse, maxPlatformMessageLen) {
 				if err := sendWorkspaceWithError(p, replyCtx, chunk); err != nil {
 					return
 				}
 			}
+			finalized = true
+		}
+		if finalized {
+			e.hooks.Emit(HookEvent{
+				Event:      HookEventMessageFinalized,
+				TurnID:     msgID,
+				SessionKey: hookSessionKey,
+				Workspace:  hookWorkspace,
+				Platform:   p.Name(),
+				Source:     "agent.final_reply",
+				Internal:   false,
+				ReplyKind:  replyKind,
+				Content:    fullResponse,
+			})
 		}
 	}
+
+	return
 }
 
 func mergeRichToolResult(steps []ToolStep, event Event, result string, maxLen int) []ToolStep {
@@ -6256,22 +6482,8 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 
 		session.AddHistory("user", queued.content)
 
-		sendDone := make(chan error, 1)
-		go func() {
-			if as == nil {
-				sendDone <- fmt.Errorf("agent session became nil")
-				return
-			}
-			sendDone <- as.Send(prompt, queued.messageID, queued.images, queued.files)
-		}()
-
-		var stopTyping func()
-		if ti, ok := queued.platform.(TypingIndicator); ok {
-			stopTyping = ti.StartTyping(e.ctx, queued.replyCtx)
-		}
-
 		slog.Info("processing queued message", "session", sessionKey)
-		e.processInteractiveEvents(state, session, sessions, sessionKey, queued.messageID, time.Now(), stopTyping, sendDone, queued.replyCtx)
+		e.processInteractiveTurnWithRetry(state, session, sessions, sessionKey, prompt, queued.messageID, queued.images, queued.files, queued.replyCtx, time.Now(), sessionKey, len(queued.content))
 	}
 }
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -5214,8 +5214,13 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				// the rich-card path. event.ToolInput itself is left untouched.
 				cardToolInput := truncateIf(toolInput, e.display.ToolMaxLen)
 				if !cp.AppendEvent(ProgressEntryToolUse, cardToolInput, event.ToolName, toolMsg) {
-					for _, chunk := range SplitMessageCodeFenceAware(toolMsg, maxPlatformMessageLen) {
-						sendWorkspace(p, replyCtx, chunk)
+					// Compact/card progress is best-effort. If its editable card
+					// fails, do not turn every subsequent tool event into a new
+					// chat message; the final answer remains authoritative.
+					if progressStyleForTarget(p, replyCtx) == progressStyleLegacy {
+						for _, chunk := range SplitMessageCodeFenceAware(toolMsg, maxPlatformMessageLen) {
+							sendWorkspace(p, replyCtx, chunk)
+						}
 					}
 				}
 			}
@@ -5260,7 +5265,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 						Success:  event.ToolSuccess,
 					}
 					if !cp.AppendStructured(entry, resultMsg) {
-						if !SuppressStandaloneToolResultEvent(p) {
+						if progressStyleForTarget(p, replyCtx) == progressStyleLegacy && !SuppressStandaloneToolResultEvent(p) {
 							e.sendRaw(p, replyCtx, resultMsg)
 						}
 					}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -14363,7 +14363,7 @@ func TestUnsolicitedReader_EmitsFinalizedHookAfterReplySend(t *testing.T) {
 		marker:             sentMarker,
 	}
 	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, filepath.Join(dir, "sessions.json"), LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 	e.SetHooks(NewHookManager("my-project", []HookConfig{{
 		Event:   string(HookEventMessageFinalized),
 		Type:    "command",
@@ -14408,7 +14408,7 @@ func TestUnsolicitedReader_DoesNotEmitFinalizedHookWhenReplySendFails(t *testing
 		marker:             sendAttemptMarker,
 	}
 	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, filepath.Join(dir, "sessions.json"), LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 	e.SetHooks(NewHookManager("my-project", []HookConfig{{
 		Event:   string(HookEventMessageFinalized),
 		Type:    "command",

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -58,6 +58,30 @@ type stubPlatformEngine struct {
 	mu   sync.Mutex
 }
 
+type finalizedOrderPlatform struct {
+	stubPlatformEngine
+	marker string
+}
+
+func (p *finalizedOrderPlatform) Send(ctx context.Context, replyCtx any, content string) error {
+	if err := os.WriteFile(p.marker, []byte("sent\n"), 0600); err != nil {
+		return err
+	}
+	return p.stubPlatformEngine.Send(ctx, replyCtx, content)
+}
+
+type failedSendPlatform struct {
+	stubPlatformEngine
+	marker string
+}
+
+func (p *failedSendPlatform) Send(_ context.Context, _ any, _ string) error {
+	if err := os.WriteFile(p.marker, []byte("attempted\n"), 0600); err != nil {
+		return err
+	}
+	return errors.New("platform send failed")
+}
+
 func (p *stubPlatformEngine) Name() string               { return p.n }
 func (p *stubPlatformEngine) Start(MessageHandler) error { return nil }
 func (p *stubPlatformEngine) Reply(_ context.Context, _ any, content string) error {
@@ -1026,6 +1050,47 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelText(t *testing.
 	}
 }
 
+func TestProcessInteractiveEvents_FinalizedHookRunsAfterReplySend(t *testing.T) {
+	dir := t.TempDir()
+	sentMarker := filepath.Join(dir, "sent")
+	hookMarker := filepath.Join(dir, "hook")
+	p := &finalizedOrderPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		marker:             sentMarker,
+	}
+	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetHooks(NewHookManager("my-project", []HookConfig{{
+		Event:   string(HookEventMessageFinalized),
+		Type:    "command",
+		Command: "test -f '" + sentMarker + "' && touch '" + hookMarker + "'",
+		Async:   boolPtr(false),
+	}}, "sh", "-c", ""))
+
+	sessionKey := "feishu:chat:user"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-finalized")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-finalized",
+		ccSessionKey: sessionKey,
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "final reply", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "turn-1", time.Now(), nil, nil, state.replyCtx)
+
+	if _, err := os.Stat(sentMarker); err != nil {
+		t.Fatalf("final reply was not sent: %v", err)
+	}
+	if _, err := os.Stat(hookMarker); err != nil {
+		t.Fatalf("message.finalized hook did not run after send: %v", err)
+	}
+	if got := p.getSent(); len(got) != 1 || got[0] != "final reply" {
+		t.Fatalf("sent replies = %#v, want one final reply", got)
+	}
+}
+
 func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelTextWithContextIndicator(t *testing.T) {
 	p := &stubMediaPlatform{stubPlatformEngine: stubPlatformEngine{n: "test"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
@@ -1086,6 +1151,181 @@ func TestProcessInteractiveEvents_DoesNotSuppressDifferentFinalText(t *testing.T
 	}
 	if got := p.getSent()[1]; got != finalText {
 		t.Fatalf("final sent text = %q, want %q", got, finalText)
+	}
+}
+
+func TestProcessInteractiveEvents_ReturnsRetriableErrorWithoutSendingRawError(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s1")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{
+		Type:      EventError,
+		Error:     errors.New("Selected model is at capacity. Please try a different model."),
+		ErrorKind: ErrorKindOverloaded,
+	}
+	retryTurn := e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil)
+
+	if retryTurn == nil {
+		t.Fatal("retryTurn = nil, want retriable turn")
+	}
+	if retryTurn.kind != ErrorKindOverloaded {
+		t.Fatalf("retryKind = %q, want %q", retryTurn.kind, ErrorKindOverloaded)
+	}
+	if retryTurn.err == nil || !strings.Contains(retryTurn.err.Error(), "capacity") {
+		t.Fatalf("retryErr = %v, want capacity error", retryTurn.err)
+	}
+	if sent := p.getSent(); len(sent) != 0 {
+		t.Fatalf("sent = %#v, want no raw error sent before retry", sent)
+	}
+	state.mu.Lock()
+	needResync := state.eventsNeedResync
+	state.mu.Unlock()
+	if !needResync {
+		t.Fatal("eventsNeedResync = false, want true after retriable error")
+	}
+}
+
+func TestProcessInteractiveTurnWithRetry_ReplaysQueuedPromptAfterOverloaded(t *testing.T) {
+	oldInitialDelay := RetriableErrorInitialDelay
+	oldRetryDelay := RetriableErrorRetryDelay
+	oldMaxAttempts := RetriableErrorMaxAttempts
+	RetriableErrorInitialDelay = time.Millisecond
+	RetriableErrorRetryDelay = time.Millisecond
+	RetriableErrorMaxAttempts = 3
+	t.Cleanup(func() {
+		RetriableErrorInitialDelay = oldInitialDelay
+		RetriableErrorRetryDelay = oldRetryDelay
+		RetriableErrorMaxAttempts = oldMaxAttempts
+	})
+
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newQueuedRetryAgentSession("s1")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1",
+		pendingMessages: []queuedMessage{
+			{platform: p, replyCtx: "ctx-queued", content: "queued-msg", messageID: "queued-1"},
+		},
+	}
+	e.interactiveStates[sessionKey] = state
+
+	e.processInteractiveTurnWithRetry(state, session, e.sessions, sessionKey, "initial-msg", "m1", nil, nil, "ctx-1", time.Now(), sessionKey, len("initial-msg"))
+
+	calls := agentSession.prompts()
+	if len(calls) != 3 {
+		t.Fatalf("prompts = %#v, want initial + queued + queued retry", calls)
+	}
+	if calls[0] != "initial-msg" {
+		t.Fatalf("first prompt = %q, want initial-msg", calls[0])
+	}
+	if !strings.Contains(calls[1], "queued-msg") || !strings.Contains(calls[2], "queued-msg") {
+		t.Fatalf("queued prompts = %#v, want both retries to target queued-msg", calls[1:])
+	}
+	if strings.Contains(calls[2], "initial-msg") {
+		t.Fatalf("retry prompt = %q, should not replay initial prompt", calls[2])
+	}
+}
+
+func TestProcessInteractiveTurnWithRetry_StopCancelsRetryDelay(t *testing.T) {
+	oldInitialDelay := RetriableErrorInitialDelay
+	oldRetryDelay := RetriableErrorRetryDelay
+	oldMaxAttempts := RetriableErrorMaxAttempts
+	RetriableErrorInitialDelay = time.Hour
+	RetriableErrorRetryDelay = time.Hour
+	RetriableErrorMaxAttempts = 3
+	t.Cleanup(func() {
+		RetriableErrorInitialDelay = oldInitialDelay
+		RetriableErrorRetryDelay = oldRetryDelay
+		RetriableErrorMaxAttempts = oldMaxAttempts
+	})
+
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newAlwaysRetryAgentSession("s1")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-1",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveTurnWithRetry(state, session, e.sessions, sessionKey, "hello", "m1", nil, nil, "ctx-1", time.Now(), sessionKey, len("hello"))
+		close(done)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for agentSession.sendCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	state.markStopped()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry delay did not stop after state.markStopped")
+	}
+	if got := agentSession.sendCount(); got != 1 {
+		t.Fatalf("sendCount = %d, want no retry after stop", got)
+	}
+}
+
+func TestProcessInteractiveTurnWithRetry_ReplaysPromptAfterOverloaded(t *testing.T) {
+	oldInitialDelay := RetriableErrorInitialDelay
+	oldRetryDelay := RetriableErrorRetryDelay
+	oldMaxAttempts := RetriableErrorMaxAttempts
+	RetriableErrorInitialDelay = time.Millisecond
+	RetriableErrorRetryDelay = time.Millisecond
+	RetriableErrorMaxAttempts = 2
+	t.Cleanup(func() {
+		RetriableErrorInitialDelay = oldInitialDelay
+		RetriableErrorRetryDelay = oldRetryDelay
+		RetriableErrorMaxAttempts = oldMaxAttempts
+	})
+
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	sessionKey := "test:user1"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newRetryOnceAgentSession("s1")
+	state := &interactiveState{
+		agentSession:     agentSession,
+		platform:         p,
+		replyCtx:         "ctx-1",
+		eventsNeedResync: true,
+	}
+	e.interactiveStates[sessionKey] = state
+
+	e.processInteractiveTurnWithRetry(state, session, e.sessions, sessionKey, "hello", "m1", nil, nil, "ctx-1", time.Now(), sessionKey, len("hello"))
+
+	if got := agentSession.sendCount(); got != 2 {
+		t.Fatalf("sendCount = %d, want 2", got)
+	}
+	sent := p.getSent()
+	if len(sent) != 2 {
+		t.Fatalf("sent = %#v, want retry notice and final response", sent)
+	}
+	if !strings.Contains(sent[0], "Retrying") {
+		t.Fatalf("retry notice = %q, want English retry notice", sent[0])
+	}
+	if sent[1] != "ok after retry" {
+		t.Fatalf("final response = %q, want ok after retry", sent[1])
 	}
 }
 
@@ -7269,6 +7509,149 @@ func (s *controllableAgentSession) Close() error {
 		close(s.closed)
 	}
 	return nil
+}
+
+type retryOnceAgentSession struct {
+	sessionID string
+	events    chan Event
+	sends     int
+	mu        sync.Mutex
+}
+
+type queuedRetryAgentSession struct {
+	sessionID  string
+	events     chan Event
+	promptList []string
+	queuedSeen int
+	mu         sync.Mutex
+}
+
+type alwaysRetryAgentSession struct {
+	sessionID string
+	events    chan Event
+	sends     int
+	mu        sync.Mutex
+}
+
+func newRetryOnceAgentSession(id string) *retryOnceAgentSession {
+	return &retryOnceAgentSession{
+		sessionID: id,
+		events:    make(chan Event, 8),
+	}
+}
+
+func newQueuedRetryAgentSession(id string) *queuedRetryAgentSession {
+	return &queuedRetryAgentSession{
+		sessionID: id,
+		events:    make(chan Event, 8),
+	}
+}
+
+func newAlwaysRetryAgentSession(id string) *alwaysRetryAgentSession {
+	return &alwaysRetryAgentSession{
+		sessionID: id,
+		events:    make(chan Event, 8),
+	}
+}
+
+func (s *retryOnceAgentSession) Send(_ string, _ string, _ []ImageAttachment, _ []FileAttachment) error {
+	s.mu.Lock()
+	s.sends++
+	sendNo := s.sends
+	s.mu.Unlock()
+	if sendNo == 1 {
+		s.events <- Event{
+			Type:      EventError,
+			Error:     errors.New("Selected model is at capacity. Please try a different model."),
+			ErrorKind: ErrorKindOverloaded,
+		}
+		return nil
+	}
+	s.events <- Event{Type: EventResult, Content: "ok after retry", Done: true}
+	return nil
+}
+
+func (s *retryOnceAgentSession) RespondPermission(_ string, _ PermissionResult) error { return nil }
+func (s *retryOnceAgentSession) Events() <-chan Event                                 { return s.events }
+func (s *retryOnceAgentSession) CurrentSessionID() string                             { return s.sessionID }
+func (s *retryOnceAgentSession) Alive() bool                                          { return true }
+func (s *retryOnceAgentSession) Close() error {
+	close(s.events)
+	return nil
+}
+
+func (s *retryOnceAgentSession) sendCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sends
+}
+
+func (s *queuedRetryAgentSession) Send(prompt string, _ string, _ []ImageAttachment, _ []FileAttachment) error {
+	s.mu.Lock()
+	s.promptList = append(s.promptList, prompt)
+	isQueued := strings.Contains(prompt, "queued-msg")
+	if isQueued {
+		s.queuedSeen++
+	}
+	queuedSeen := s.queuedSeen
+	s.mu.Unlock()
+
+	if !isQueued {
+		s.events <- Event{Type: EventResult, Content: "initial ok", Done: true}
+		return nil
+	}
+	if queuedSeen == 1 {
+		s.events <- Event{
+			Type:      EventError,
+			Error:     errors.New("Selected model is at capacity. Please try a different model."),
+			ErrorKind: ErrorKindOverloaded,
+		}
+		return nil
+	}
+	s.events <- Event{Type: EventResult, Content: "queued ok", Done: true}
+	return nil
+}
+
+func (s *queuedRetryAgentSession) RespondPermission(_ string, _ PermissionResult) error { return nil }
+func (s *queuedRetryAgentSession) Events() <-chan Event                                 { return s.events }
+func (s *queuedRetryAgentSession) CurrentSessionID() string                             { return s.sessionID }
+func (s *queuedRetryAgentSession) Alive() bool                                          { return true }
+func (s *queuedRetryAgentSession) Close() error {
+	close(s.events)
+	return nil
+}
+
+func (s *queuedRetryAgentSession) prompts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.promptList...)
+}
+
+func (s *alwaysRetryAgentSession) Send(_ string, _ string, _ []ImageAttachment, _ []FileAttachment) error {
+	s.mu.Lock()
+	s.sends++
+	s.mu.Unlock()
+	s.events <- Event{
+		Type:      EventError,
+		Error:     errors.New("Selected model is at capacity. Please try a different model."),
+		ErrorKind: ErrorKindOverloaded,
+	}
+	return nil
+}
+
+func (s *alwaysRetryAgentSession) RespondPermission(_ string, _ PermissionResult) error { return nil }
+func (s *alwaysRetryAgentSession) Events() <-chan Event                                 { return s.events }
+func (s *alwaysRetryAgentSession) CurrentSessionID() string                             { return s.sessionID }
+func (s *alwaysRetryAgentSession) Alive() bool                                          { return true }
+func (s *alwaysRetryAgentSession) Close() error {
+	close(s.events)
+	return nil
+}
+
+func (s *alwaysRetryAgentSession) sendCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sends
 }
 
 func waitForInteractiveStateRemoved(t *testing.T, e *Engine, key string) {
@@ -13968,6 +14351,99 @@ func TestUnsolicitedReader_RelaysEventResult(t *testing.T) {
 	state.mu.Unlock()
 	if resync {
 		t.Error("expected eventsNeedResync=false after clean unsolicited EventResult")
+	}
+}
+
+func TestUnsolicitedReader_EmitsFinalizedHookAfterReplySend(t *testing.T) {
+	dir := t.TempDir()
+	sentMarker := filepath.Join(dir, "sent")
+	hookMarker := filepath.Join(dir, "hook")
+	p := &finalizedOrderPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		marker:             sentMarker,
+	}
+	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, filepath.Join(dir, "sessions.json"), LangEnglish)
+	defer e.Stop()
+	e.SetHooks(NewHookManager("my-project", []HookConfig{{
+		Event:   string(HookEventMessageFinalized),
+		Type:    "command",
+		Command: "test -f '" + sentMarker + "' && touch '" + hookMarker + "'",
+		Async:   boolPtr(false),
+	}}, "sh", "-c", ""))
+
+	sessionKey := "feishu:chat:user"
+	sessions := e.sessions
+	session := sessions.GetOrCreateActive(sessionKey)
+	sess := newControllableSession("unsol-finalized")
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+		ccSessionKey: sessionKey,
+	}
+
+	e.startUnsolicitedReader(state, session, sessions, sessionKey, "")
+	defer e.stopUnsolicitedReader(state)
+	sess.events <- Event{Type: EventResult, Content: "background reply", Done: true}
+
+	if sent := waitForPlatformSend(&p.stubPlatformEngine, 1, 5*time.Second); len(sent) != 1 || sent[0] != "background reply" {
+		t.Fatalf("sent replies = %#v, want one background reply", sent)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(hookMarker); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("message.finalized hook did not run after background reply send")
+}
+
+func TestUnsolicitedReader_DoesNotEmitFinalizedHookWhenReplySendFails(t *testing.T) {
+	dir := t.TempDir()
+	sendAttemptMarker := filepath.Join(dir, "send-attempt")
+	hookMarker := filepath.Join(dir, "hook")
+	p := &failedSendPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		marker:             sendAttemptMarker,
+	}
+	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, filepath.Join(dir, "sessions.json"), LangEnglish)
+	defer e.Stop()
+	e.SetHooks(NewHookManager("my-project", []HookConfig{{
+		Event:   string(HookEventMessageFinalized),
+		Type:    "command",
+		Command: "touch '" + hookMarker + "'",
+		Async:   boolPtr(false),
+	}}, "sh", "-c", ""))
+
+	sessionKey := "feishu:chat:user"
+	sessions := e.sessions
+	session := sessions.GetOrCreateActive(sessionKey)
+	sess := newControllableSession("unsol-finalized-failure")
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+		ccSessionKey: sessionKey,
+	}
+
+	e.startUnsolicitedReader(state, session, sessions, sessionKey, "")
+	defer e.stopUnsolicitedReader(state)
+	sess.events <- Event{Type: EventResult, Content: "background reply", Done: true}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sendAttemptMarker); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(sendAttemptMarker); err != nil {
+		t.Fatalf("background reply send was not attempted: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if _, err := os.Stat(hookMarker); !os.IsNotExist(err) {
+		t.Fatalf("message.finalized hook ran after failed background send: err=%v", err)
 	}
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -14308,7 +14308,7 @@ func TestUnsolicitedReader_RelaysEventResult(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newControllableSession("unsol-relay")
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 
 	sessions := e.sessions
 	session := sessions.GetOrCreateActive("test:ch1:u1")
@@ -14533,7 +14533,7 @@ func TestUnsolicitedReader_StopsOnCancel(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newControllableSession("unsol-cancel")
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 
 	sessions := e.sessions
 	session := sessions.GetOrCreateActive("test:ch1:u1")
@@ -14579,7 +14579,7 @@ func TestUnsolicitedReader_SetsResyncOnChannelClose(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newControllableSession("unsol-close")
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 
 	sessions := e.sessions
 	session := sessions.GetOrCreateActive("test:close:u1")
@@ -14621,7 +14621,7 @@ func TestUnsolicitedReader_SetsResyncOnEventError(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newControllableSession("unsol-error")
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 
 	sessions := e.sessions
 	session := sessions.GetOrCreateActive("test:error:u1")
@@ -14674,7 +14674,7 @@ func TestUnsolicitedReader_SetsResyncOnEventError(t *testing.T) {
 func TestUnsolicitedReader_PermissionDeny(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 
 	sess := newControllableSession("unsol-perm")
 	permRecorder := &permRecordingSession{
@@ -14749,7 +14749,7 @@ func (s *permRecordingSession) RespondPermission(_ string, res PermissionResult)
 func TestEventsNeedResync_DefaultTrue(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 
 	e.ensureInteractiveStateForQueueing("key1", p, "ctx")
 
@@ -14771,7 +14771,7 @@ func TestEventsNeedResync_ClearedOnCleanResult(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newControllableSession("resync-clean")
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 
 	sessions := e.sessions
 	session := sessions.GetOrCreateActive("test:resync:u1")
@@ -14808,7 +14808,7 @@ func TestCleanupInteractiveState_StopsUnsolicitedReader(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newControllableSession("cleanup-unsol")
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 
 	sessions := e.sessions
 	session := sessions.GetOrCreateActive("test:cleanup:u1")
@@ -14848,7 +14848,7 @@ func TestCleanupInteractiveState_StopsUnsolicitedReader(t *testing.T) {
 func TestWorkspaceIdleTimeout_Configurable(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	defer e.Stop()
+	defer func() { _ = e.Stop() }()
 
 	tmpDir := t.TempDir()
 	e.SetMultiWorkspace(tmpDir, filepath.Join(tmpDir, "bindings.json"))

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -17,14 +17,15 @@ import (
 type HookEventType string
 
 const (
-	HookEventMessageReceived    HookEventType = "message.received"
-	HookEventMessageSent        HookEventType = "message.sent"
-	HookEventSessionStarted     HookEventType = "session.started"
-	HookEventSessionEnded       HookEventType = "session.ended"
-	HookEventCronTriggered      HookEventType = "cron.triggered"
-	HookEventTimerTriggered     HookEventType = "timer.triggered"
+	HookEventMessageReceived     HookEventType = "message.received"
+	HookEventMessageSent         HookEventType = "message.sent"
+	HookEventMessageFinalized    HookEventType = "message.finalized"
+	HookEventSessionStarted      HookEventType = "session.started"
+	HookEventSessionEnded        HookEventType = "session.ended"
+	HookEventCronTriggered       HookEventType = "cron.triggered"
+	HookEventTimerTriggered      HookEventType = "timer.triggered"
 	HookEventPermissionRequested HookEventType = "permission.requested"
-	HookEventError              HookEventType = "error"
+	HookEventError               HookEventType = "error"
 )
 
 // HookHandlerType is the execution strategy for a hook.
@@ -38,7 +39,7 @@ const (
 // HookConfig is the user-facing configuration for a single hook rule.
 type HookConfig struct {
 	Event   string `toml:"event" json:"event"`
-	Type    string `toml:"type" json:"type"`       // "command" or "http"
+	Type    string `toml:"type" json:"type"` // "command" or "http"
 	Command string `toml:"command" json:"command,omitempty"`
 	URL     string `toml:"url" json:"url,omitempty"`
 	Timeout int    `toml:"timeout" json:"timeout,omitempty"` // seconds; 0 = default (10s cmd, 5s http)
@@ -64,10 +65,15 @@ type HookEvent struct {
 	Event      HookEventType  `json:"event"`
 	Timestamp  time.Time      `json:"timestamp"`
 	Project    string         `json:"project"`
+	TurnID     string         `json:"turn_id,omitempty"`
 	SessionKey string         `json:"session_key,omitempty"`
+	Workspace  string         `json:"workspace,omitempty"`
 	Platform   string         `json:"platform,omitempty"`
 	UserID     string         `json:"user_id,omitempty"`
 	UserName   string         `json:"user_name,omitempty"`
+	Source     string         `json:"source,omitempty"`
+	Internal   bool           `json:"internal"`
+	ReplyKind  string         `json:"reply_kind,omitempty"`
 	Content    string         `json:"content,omitempty"`
 	Error      string         `json:"error,omitempty"`
 	Extra      map[string]any `json:"extra,omitempty"`
@@ -75,13 +81,13 @@ type HookEvent struct {
 
 // HookManager dispatches lifecycle events to configured hook handlers.
 type HookManager struct {
-	hooks       []HookConfig
-	project     string
-	shell       string // shell binary (e.g. "sh", "/bin/zsh")
-	shellFlag   string // shell flag (e.g. "-c", "-Command")
+	hooks        []HookConfig
+	project      string
+	shell        string // shell binary (e.g. "sh", "/bin/zsh")
+	shellFlag    string // shell flag (e.g. "-c", "-Command")
 	shellProfile string // prepended to every command
-	mu          sync.RWMutex
-	client      *http.Client
+	mu           sync.RWMutex
+	client       *http.Client
 }
 
 // NewHookManager creates a manager for the given project name.
@@ -95,12 +101,12 @@ func NewHookManager(project string, hooks []HookConfig, shell, shellFlag, shellP
 		valid = append(valid, h)
 	}
 	return &HookManager{
-		hooks:       valid,
-		project:     project,
-		shell:       shell,
-		shellFlag:   shellFlag,
+		hooks:        valid,
+		project:      project,
+		shell:        shell,
+		shellFlag:    shellFlag,
 		shellProfile: shellProfile,
-		client:      &http.Client{},
+		client:       &http.Client{},
 	}
 }
 
@@ -249,6 +255,12 @@ func eventToEnv(e HookEvent) []string {
 	if e.SessionKey != "" {
 		env = append(env, "CC_HOOK_SESSION_KEY="+e.SessionKey)
 	}
+	if e.TurnID != "" {
+		env = append(env, "CC_HOOK_TURN_ID="+e.TurnID)
+	}
+	if e.Workspace != "" {
+		env = append(env, "CC_HOOK_WORKSPACE="+e.Workspace)
+	}
 	if e.Platform != "" {
 		env = append(env, "CC_HOOK_PLATFORM="+e.Platform)
 	}
@@ -257,6 +269,13 @@ func eventToEnv(e HookEvent) []string {
 	}
 	if e.UserName != "" {
 		env = append(env, "CC_HOOK_USER_NAME="+e.UserName)
+	}
+	if e.Source != "" {
+		env = append(env, "CC_HOOK_SOURCE="+e.Source)
+	}
+	env = append(env, fmt.Sprintf("CC_HOOK_INTERNAL=%t", e.Internal))
+	if e.ReplyKind != "" {
+		env = append(env, "CC_HOOK_REPLY_KIND="+e.ReplyKind)
 	}
 	if e.Content != "" {
 		env = append(env, "CC_HOOK_CONTENT="+e.Content)

--- a/core/hooks_test.go
+++ b/core/hooks_test.go
@@ -20,11 +20,11 @@ func boolPtr(v bool) *bool { return &v }
 func TestNewHookManager_ValidatesConfig(t *testing.T) {
 	hooks := []HookConfig{
 		{Event: "message.received", Type: "command", Command: "echo ok"},
-		{Event: "", Type: "command", Command: "echo bad"},         // missing event
-		{Event: "error", Type: "http", URL: ""},                   // missing url
-		{Event: "error", Type: "http", URL: "ftp://bad"},          // bad url scheme
-		{Event: "error", Type: "unknown", Command: "echo"},        // bad type
-		{Event: "error", Type: "command", Command: ""},            // missing command
+		{Event: "", Type: "command", Command: "echo bad"},  // missing event
+		{Event: "error", Type: "http", URL: ""},            // missing url
+		{Event: "error", Type: "http", URL: "ftp://bad"},   // bad url scheme
+		{Event: "error", Type: "unknown", Command: "echo"}, // bad type
+		{Event: "error", Type: "command", Command: ""},     // missing command
 		{Event: "message.sent", Type: "http", URL: "http://ok.com"},
 	}
 	hm := NewHookManager("test", hooks, "sh", "-c", "")
@@ -384,10 +384,15 @@ func TestEventToEnv(t *testing.T) {
 		Event:      HookEventCronTriggered,
 		Timestamp:  time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC),
 		Project:    "myproj",
+		TurnID:     "turn-123",
 		SessionKey: "tg:1:1",
+		Workspace:  "/tmp/project",
 		Platform:   "telegram",
 		UserID:     "U123",
 		UserName:   "alice",
+		Source:     "agent.final_reply",
+		Internal:   true,
+		ReplyKind:  "card",
 		Content:    "hello world",
 		Error:      "oops",
 	}
@@ -403,10 +408,15 @@ func TestEventToEnv(t *testing.T) {
 	checks := map[string]string{
 		"CC_HOOK_EVENT":       "cron.triggered",
 		"CC_HOOK_PROJECT":     "myproj",
+		"CC_HOOK_TURN_ID":     "turn-123",
 		"CC_HOOK_SESSION_KEY": "tg:1:1",
+		"CC_HOOK_WORKSPACE":   "/tmp/project",
 		"CC_HOOK_PLATFORM":    "telegram",
 		"CC_HOOK_USER_ID":     "U123",
 		"CC_HOOK_USER_NAME":   "alice",
+		"CC_HOOK_SOURCE":      "agent.final_reply",
+		"CC_HOOK_INTERNAL":    "true",
+		"CC_HOOK_REPLY_KIND":  "card",
 		"CC_HOOK_CONTENT":     "hello world",
 		"CC_HOOK_ERROR":       "oops",
 	}
@@ -417,6 +427,12 @@ func TestEventToEnv(t *testing.T) {
 	}
 	if _, ok := m["CC_HOOK_TIMESTAMP"]; !ok {
 		t.Error("expected CC_HOOK_TIMESTAMP in env")
+	}
+}
+
+func TestMessageFinalizedEventType(t *testing.T) {
+	if string(HookEventMessageFinalized) != "message.finalized" {
+		t.Fatalf("HookEventMessageFinalized = %q, want message.finalized", HookEventMessageFinalized)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -181,6 +181,7 @@ const (
 	MsgToolAllowFailed           MsgKey = "tool_allow_failed"
 	MsgToolAllowedNew            MsgKey = "tool_allowed_new"
 	MsgError                     MsgKey = "error"
+	MsgRetriableAgentError       MsgKey = "retriable_agent_error"
 	MsgSessionNotFound           MsgKey = "session_not_found"
 	MsgFailedToStartAgentSession MsgKey = "failed_to_start_agent_session"
 	MsgFailedToDeleteSession     MsgKey = "failed_to_delete_session"
@@ -378,31 +379,31 @@ const (
 	MsgCronIDLabel               MsgKey = "cron_id_label"
 	MsgCronFailedSuffix          MsgKey = "cron_failed_suffix"
 
-	MsgTimerNotAvailable  MsgKey = "timer_not_available"
-	MsgTimerUsage         MsgKey = "timer_usage"
-	MsgTimerAddUsage      MsgKey = "timer_add_usage"
-	MsgTimerAdded         MsgKey = "timer_added"
-	MsgTimerAddedExec     MsgKey = "timer_added_exec"
-	MsgTimerAddExecUsage  MsgKey = "timer_addexec_usage"
-	MsgTimerEmpty         MsgKey = "timer_empty"
-	MsgTimerListTitle     MsgKey = "timer_list_title"
-	MsgTimerListFooter    MsgKey = "timer_list_footer"
-	MsgTimerDelUsage      MsgKey = "timer_del_usage"
-	MsgTimerMuteUsage     MsgKey = "timer_mute_usage"
-	MsgTimerDeleted       MsgKey = "timer_deleted"
-	MsgTimerNotFound      MsgKey = "timer_not_found"
-	MsgTimerMuted         MsgKey = "timer_muted"
-	MsgTimerUnmuted       MsgKey = "timer_unmuted"
-	MsgTimerCardHint      MsgKey = "timer_card_hint"
-	MsgTimerBtnMute       MsgKey = "timer_btn_mute"
-	MsgTimerBtnUnmute     MsgKey = "timer_btn_unmute"
-	MsgTimerBtnDelete     MsgKey = "timer_btn_delete"
-	MsgTimerIDLabel       MsgKey = "timer_id_label"
-	MsgTimerScheduledLabel MsgKey = "timer_scheduled_label"
-	MsgTimerFailedSuffix  MsgKey = "timer_failed_suffix"
-	MsgCommandsTagAgent          MsgKey = "commands_tag_agent"
-	MsgCommandsTagShell          MsgKey = "commands_tag_shell"
-	MsgUpgradeTimeoutSuffix      MsgKey = "upgrade_timeout_suffix"
+	MsgTimerNotAvailable    MsgKey = "timer_not_available"
+	MsgTimerUsage           MsgKey = "timer_usage"
+	MsgTimerAddUsage        MsgKey = "timer_add_usage"
+	MsgTimerAdded           MsgKey = "timer_added"
+	MsgTimerAddedExec       MsgKey = "timer_added_exec"
+	MsgTimerAddExecUsage    MsgKey = "timer_addexec_usage"
+	MsgTimerEmpty           MsgKey = "timer_empty"
+	MsgTimerListTitle       MsgKey = "timer_list_title"
+	MsgTimerListFooter      MsgKey = "timer_list_footer"
+	MsgTimerDelUsage        MsgKey = "timer_del_usage"
+	MsgTimerMuteUsage       MsgKey = "timer_mute_usage"
+	MsgTimerDeleted         MsgKey = "timer_deleted"
+	MsgTimerNotFound        MsgKey = "timer_not_found"
+	MsgTimerMuted           MsgKey = "timer_muted"
+	MsgTimerUnmuted         MsgKey = "timer_unmuted"
+	MsgTimerCardHint        MsgKey = "timer_card_hint"
+	MsgTimerBtnMute         MsgKey = "timer_btn_mute"
+	MsgTimerBtnUnmute       MsgKey = "timer_btn_unmute"
+	MsgTimerBtnDelete       MsgKey = "timer_btn_delete"
+	MsgTimerIDLabel         MsgKey = "timer_id_label"
+	MsgTimerScheduledLabel  MsgKey = "timer_scheduled_label"
+	MsgTimerFailedSuffix    MsgKey = "timer_failed_suffix"
+	MsgCommandsTagAgent     MsgKey = "commands_tag_agent"
+	MsgCommandsTagShell     MsgKey = "commands_tag_shell"
+	MsgUpgradeTimeoutSuffix MsgKey = "upgrade_timeout_suffix"
 
 	MsgCronScheduleLabel MsgKey = "cron_schedule_label"
 	MsgCronNextRunLabel  MsgKey = "cron_next_run_label"
@@ -799,6 +800,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "❌ 錯誤: %v",
 		LangJapanese:           "❌ エラー: %v",
 		LangSpanish:            "❌ Error: %v",
+	},
+	MsgRetriableAgentError: {
+		LangEnglish:            "⚠️ Upstream model is busy or rate-limited. Retrying in %s (attempt %d/%d).",
+		LangChinese:            "⚠️ 上游模型繁忙或限流，将在 %s 后自动重试（第 %d/%d 次）。",
+		LangTraditionalChinese: "⚠️ 上游模型繁忙或限流，將在 %s 後自動重試（第 %d/%d 次）。",
+		LangJapanese:           "⚠️ 上流モデルが混雑またはレート制限中です。%s 後に自動再試行します（%d/%d 回目）。",
+		LangSpanish:            "⚠️ El modelo upstream está ocupado o limitado. Reintentando en %s (intento %d/%d).",
 	},
 	MsgBackgroundAutoDenied: {
 		LangEnglish:            "⚠️ Background task requested permission for `%s` but was auto-denied (no active user turn). Send a message or use `/yolo` to approve future requests.",

--- a/core/message.go
+++ b/core/message.go
@@ -414,6 +414,24 @@ const (
 	EventThinking          EventType = "thinking"           // thinking/processing status
 )
 
+// ErrorKind classifies agent errors that need special handling by the engine.
+type ErrorKind string
+
+const (
+	ErrorKindUnknown    ErrorKind = ""
+	ErrorKindRateLimit  ErrorKind = "rate_limit"
+	ErrorKindOverloaded ErrorKind = "overloaded"
+)
+
+func (k ErrorKind) IsRetriable() bool {
+	switch k {
+	case ErrorKindRateLimit, ErrorKindOverloaded:
+		return true
+	default:
+		return false
+	}
+}
+
 // UserQuestion represents a structured question from AskUserQuestion.
 type UserQuestion struct {
 	Question    string               `json:"question"`
@@ -444,6 +462,7 @@ type Event struct {
 	Questions                []UserQuestion // populated when ToolName == "AskUserQuestion"
 	Done                     bool
 	Error                    error
+	ErrorKind                ErrorKind
 	InputTokens              int // token usage from agent result events
 	OutputTokens             int
 	CacheCreationInputTokens int            // cache-write tokens (new content written to cache)

--- a/core/multi_workspace_test.go
+++ b/core/multi_workspace_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -345,6 +346,81 @@ func TestSessionContextForKey_SharedBinding(t *testing.T) {
 	}
 }
 
+func TestGetOrCreateWorkspaceAgent_InvalidatesStaleSessionIDs(t *testing.T) {
+	baseDir := t.TempDir()
+	dataDir := t.TempDir()
+	sessionPath := filepath.Join(dataDir, "sessions.json")
+	bindingPath := filepath.Join(dataDir, "bindings.json")
+	agentName := "test-multiworkspace-invalidate-agent"
+
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		return &namedTestAgent{name: agentName}, nil
+	})
+
+	e := NewEngine("test", &namedTestAgent{name: agentName}, nil, sessionPath, LangEnglish)
+	e.SetMultiWorkspace(baseDir, bindingPath)
+
+	workspaceDir := normalizeWorkspacePath(filepath.Join(baseDir, "workspace"))
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	h := sha256.Sum256([]byte(workspaceDir))
+	workspaceSessionPath := filepath.Join(dataDir, fmt.Sprintf("%s_ws_%x.json", e.name, h[:4]))
+	t.Cleanup(func() {
+		_ = os.Remove(workspaceSessionPath)
+	})
+
+	store := NewSessionManager(workspaceSessionPath)
+	stale := store.GetOrCreateActive("feishu:channel1:user1")
+	stale.SetAgentSessionID("old-claudecode-session", "claudecode")
+	keep := store.NewSession("feishu:channel1:user1", "keep")
+	keep.SetAgentSessionID("keep-opencode-session", agentName)
+	store.Save()
+
+	agent, sessions, err := e.getOrCreateWorkspaceAgent(workspaceDir)
+	if err != nil {
+		t.Fatalf("getOrCreateWorkspaceAgent: %v", err)
+	}
+	if agent == nil || sessions == nil {
+		t.Fatalf("expected workspace agent and session manager, got agent=%v sessions=%v", agent, sessions)
+	}
+
+	loadedStale := sessions.FindByID(stale.ID)
+	if loadedStale == nil {
+		t.Fatalf("stale session %q not loaded", stale.ID)
+	}
+	if got := loadedStale.AgentSessionID; got != "" {
+		t.Fatalf("stale session id = %q, want cleared", got)
+	}
+	if got := loadedStale.AgentType; got != agentName {
+		t.Fatalf("stale session agent type = %q, want %q", got, agentName)
+	}
+
+	loadedKeep := sessions.FindByID(keep.ID)
+	if loadedKeep == nil {
+		t.Fatalf("kept session %q not loaded", keep.ID)
+	}
+	if got := loadedKeep.AgentSessionID; got != "keep-opencode-session" {
+		t.Fatalf("kept session id = %q, want preserved", got)
+	}
+	if got := loadedKeep.AgentType; got != agentName {
+		t.Fatalf("kept session agent type = %q, want %q", got, agentName)
+	}
+
+	reloaded := NewSessionManager(workspaceSessionPath)
+	reloadedStale := reloaded.FindByID(stale.ID)
+	if reloadedStale == nil {
+		t.Fatalf("stale session %q not persisted", stale.ID)
+	}
+	if got := reloadedStale.AgentSessionID; got != "" {
+		t.Fatalf("persisted stale session id = %q, want cleared", got)
+	}
+	if got := reloadedStale.AgentType; got != agentName {
+		t.Fatalf("persisted stale session agent type = %q, want %q", got, agentName)
+	}
+}
+
 func TestExtractRepoName(t *testing.T) {
 	tests := []struct {
 		input string
@@ -645,6 +721,32 @@ func TestMultiWorkspaceAgent_NoPropagationWhenParentHasNoRunAs(t *testing.T) {
 	}
 	if _, exists := opts["run_as_env"]; exists {
 		t.Errorf("run_as_env should not be present in opts when parent has no isolation; got %v", opts["run_as_env"])
+	}
+}
+
+// An empty base session path means persistence is disabled. Workspace session
+// managers must preserve that mode instead of deriving a file in the test or
+// process working directory.
+func TestMultiWorkspaceAgent_EmptySessionStoreDoesNotPersistWorkspaceState(t *testing.T) {
+	baseDir := t.TempDir()
+	workspaceDir := filepath.Join(baseDir, "workspace")
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	agentName := "empty-session-store-test-agent"
+	RegisterAgent(agentName, func(opts map[string]any) (Agent, error) {
+		return &namedTestAgent{name: agentName}, nil
+	})
+	e := NewEngine("test", &namedTestAgent{name: agentName}, nil, "", LangEnglish)
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+
+	_, sessions, err := e.getOrCreateWorkspaceAgent(workspaceDir)
+	if err != nil {
+		t.Fatalf("getOrCreateWorkspaceAgent: %v", err)
+	}
+	if got := sessions.StorePath(); got != "" {
+		t.Fatalf("workspace session store path = %q, want empty persistence path", got)
 	}
 }
 

--- a/core/retriable_error.go
+++ b/core/retriable_error.go
@@ -1,0 +1,16 @@
+package core
+
+import "time"
+
+var (
+	RetriableErrorInitialDelay = 30 * time.Second
+	RetriableErrorRetryDelay   = 60 * time.Second
+	RetriableErrorMaxAttempts  = 30
+)
+
+func RetriableErrorDelay(attempt int) time.Duration {
+	if attempt <= 1 {
+		return RetriableErrorInitialDelay
+	}
+	return RetriableErrorRetryDelay
+}

--- a/daemon/check_linger_other.go
+++ b/daemon/check_linger_other.go
@@ -1,9 +1,0 @@
-//go:build !linux
-
-package daemon
-
-// CheckLinger is a stub for non-Linux platforms where systemd linger does not
-// apply. Returns (true, "") so callers skip the linger warning.
-func CheckLinger() (enabled bool, user string) {
-	return true, ""
-}

--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	launchdLabel = "com.cc-connect.service"
+	launchdLabel       = "com.cc-connect.service"
+	legacyLaunchdLabel = "com.cc-connect.retry"
 )
 
 var runLaunchctl = func(args ...string) (string, error) {
@@ -52,6 +53,7 @@ func (m *launchdManager) Install(cfg Config) error {
 	// Unload existing service first (ignore errors) so we do not leave a stale
 	// job behind when switching between GUI and headless sessions.
 	bootoutLaunchdTargets()
+	removeLegacyLaunchdPlist()
 
 	plist := buildPlist(cfg)
 	// 0600: plist may contain captured secret values (config.toml ${ENV}
@@ -81,20 +83,24 @@ func (m *launchdManager) Install(cfg Config) error {
 func (m *launchdManager) Uninstall() error {
 	bootoutLaunchdTargets()
 
-	plistPath := launchdPlistPath()
-	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove plist: %w", err)
+	for _, plistPath := range launchdPlistPaths() {
+		if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove plist: %w", err)
+		}
 	}
 	return nil
 }
 
 func (*launchdManager) Start() error {
-	if _, target, _, ok := loadedLaunchdTarget(); ok {
+	if _, target, _, ok := loadedLaunchdTargetForLabel(launchdLabel); ok {
 		out, err := runLaunchctl("kickstart", "-kp", target)
 		if err != nil {
 			return fmt.Errorf("start: %s (%w)", out, err)
 		}
 		return nil
+	}
+	if _, _, _, ok := loadedLaunchdTargetForLabel(legacyLaunchdLabel); ok {
+		bootoutLaunchdTargets()
 	}
 
 	domain := preferredLaunchdDomain()
@@ -134,6 +140,7 @@ func (*launchdManager) Restart() error {
 	}
 	target := launchdTarget(domain)
 	bootoutLaunchdTargets()
+	removeLegacyLaunchdPlist()
 
 	plistPath := launchdPlistPath()
 
@@ -162,8 +169,7 @@ func (*launchdManager) Restart() error {
 func (*launchdManager) Status() (*Status, error) {
 	st := &Status{Platform: "launchd"}
 
-	plistPath := launchdPlistPath()
-	if _, err := os.Stat(plistPath); err != nil {
+	if !launchdAnyPlistExists() {
 		return st, nil
 	}
 	st.Installed = true
@@ -175,14 +181,20 @@ func (*launchdManager) Status() (*Status, error) {
 
 	for _, line := range strings.Split(out, "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "pid = ") {
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if indent > 1 {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "pid = "):
 			if pid, err := strconv.Atoi(strings.TrimPrefix(trimmed, "pid = ")); err == nil && pid > 0 {
 				st.PID = pid
 				st.Running = true
 			}
-		}
-		if strings.Contains(trimmed, "state = running") {
-			st.Running = true
+		case strings.HasPrefix(trimmed, "state = "):
+			if strings.Contains(trimmed, "state = running") {
+				st.Running = true
+			}
 		}
 	}
 	return st, nil
@@ -193,6 +205,15 @@ func (*launchdManager) Status() (*Status, error) {
 func launchdPlistPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist")
+}
+
+func legacyLaunchdPlistPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "LaunchAgents", legacyLaunchdLabel+".plist")
+}
+
+func launchdPlistPaths() []string {
+	return []string{launchdPlistPath(), legacyLaunchdPlistPath()}
 }
 
 func launchdUserDomain() string {
@@ -225,18 +246,23 @@ func launchdTarget(domain string) string {
 	return fmt.Sprintf("%s/%s", domain, launchdLabel)
 }
 
+func legacyLaunchdTarget(domain string) string {
+	return fmt.Sprintf("%s/%s", domain, legacyLaunchdLabel)
+}
+
 func launchdTargets() []string {
 	domains := launchdDomains()
-	targets := make([]string, 0, len(domains))
+	targets := make([]string, 0, len(domains)*2)
 	for _, domain := range domains {
 		targets = append(targets, launchdTarget(domain))
+		targets = append(targets, legacyLaunchdTarget(domain))
 	}
 	return targets
 }
 
-func loadedLaunchdTarget() (string, string, string, bool) {
+func loadedLaunchdTargetForLabel(label string) (string, string, string, bool) {
 	for _, domain := range launchdDomains() {
-		target := launchdTarget(domain)
+		target := fmt.Sprintf("%s/%s", domain, label)
 		out, err := runLaunchctl("print", target)
 		if err == nil {
 			return domain, target, out, true
@@ -245,10 +271,30 @@ func loadedLaunchdTarget() (string, string, string, bool) {
 	return "", "", "", false
 }
 
+func loadedLaunchdTarget() (string, string, string, bool) {
+	if domain, target, out, ok := loadedLaunchdTargetForLabel(launchdLabel); ok {
+		return domain, target, out, true
+	}
+	return loadedLaunchdTargetForLabel(legacyLaunchdLabel)
+}
+
+func launchdAnyPlistExists() bool {
+	for _, plistPath := range launchdPlistPaths() {
+		if _, err := os.Stat(plistPath); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 func bootoutLaunchdTargets() {
 	for _, target := range launchdTargets() {
 		_, _ = runLaunchctl("bootout", target)
 	}
+}
+
+func removeLegacyLaunchdPlist() {
+	_ = os.Remove(legacyLaunchdPlistPath())
 }
 
 // templateOwnedEnvKeys are keys the plist template renders directly; if
@@ -350,4 +396,3 @@ func buildPlist(cfg Config) string {
 </plist>
 `, launchdLabel, xmlEscape(cfg.BinaryPath), xmlEscape(cfg.WorkDir), xmlEscape(cfg.LogFile), cfg.LogMaxSize, cfg.LogMaxBackups, xmlEscape(envPATH), envExtra)
 }
-

--- a/daemon/launchd_test.go
+++ b/daemon/launchd_test.go
@@ -103,6 +103,106 @@ func TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable(t *testing.T) {
 	}
 }
 
+func TestLaunchdStatusRecognizesLegacyRetryLabel(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	legacyGUI := legacyLaunchdTarget(guiDomain)
+	legacyUser := legacyLaunchdTarget(userDomain)
+	legacyPlist := legacyLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPlist), 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(legacyPlist, []byte("plist"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	runLaunchctl = func(args ...string) (string, error) {
+		if len(args) < 2 || args[0] != "print" {
+			return "", nil
+		}
+		switch args[1] {
+		case guiDomain, launchdGUIDomain() + "/" + launchdLabel:
+			return "Bootstrap failed: 125: Domain does not support specified action", fmt.Errorf("exit status 125")
+		case userDomain:
+			return "subsystem", nil
+		case legacyGUI, legacyUser:
+			return "\tstate = running\n\tpid = 9001", nil
+		default:
+			return "", fmt.Errorf("unexpected target %q", args[1])
+		}
+	}
+
+	mgr := &launchdManager{}
+	st, err := mgr.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if !st.Installed {
+		t.Fatal("Status().Installed = false, want true")
+	}
+	if !st.Running {
+		t.Fatal("Status().Running = false, want true")
+	}
+	if st.PID != 9001 {
+		t.Fatalf("Status().PID = %d, want 9001", st.PID)
+	}
+}
+
+func TestLaunchdStatusIgnoresNestedActiveState(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	currentGUI := launchdTarget(guiDomain)
+	currentUser := launchdTarget(userDomain)
+	currentPlist := launchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(currentPlist), 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(currentPlist, []byte("plist"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	runLaunchctl = func(args ...string) (string, error) {
+		if len(args) < 2 || args[0] != "print" {
+			return "", nil
+		}
+		switch args[1] {
+		case guiDomain, userDomain:
+			return "subsystem", nil
+		case currentGUI, currentUser:
+			return "state = spawn scheduled\n\t\tstate = active", nil
+		default:
+			return "", fmt.Errorf("unexpected target %q", args[1])
+		}
+	}
+
+	mgr := &launchdManager{}
+	st, err := mgr.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if !st.Installed {
+		t.Fatal("Status().Installed = false, want true")
+	}
+	if st.Running {
+		t.Fatalf("Status().Running = true, want false")
+	}
+	if st.PID != 0 {
+		t.Fatalf("Status().PID = %d, want 0", st.PID)
+	}
+}
+
 func TestRestartPrefersGUIDomainWhenAvailable(t *testing.T) {
 	orig := runLaunchctl
 	t.Cleanup(func() { runLaunchctl = orig })
@@ -510,5 +610,40 @@ func TestInstallLaunchd_TightensExistingPlistFrom0644(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Errorf("plist mode after reinstall = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestInstallLaunchd_RemovesLegacyRetryPlist(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+	runLaunchctl = func(args ...string) (string, error) { return "", nil }
+
+	legacyPath := legacyLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("<plist>legacy</plist>\n"), 0o644); err != nil {
+		t.Fatalf("seed legacy plist: %v", err)
+	}
+
+	mgr := &launchdManager{}
+	cfg := Config{
+		BinaryPath: "/bin/true",
+		WorkDir:    t.TempDir(),
+		LogFile:    filepath.Join(t.TempDir(), "cc.log"),
+		LogMaxSize: 1024,
+		EnvPATH:    "/usr/bin",
+	}
+	if err := mgr.Install(cfg); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy plist still exists after install: %v", err)
+	}
+	if _, err := os.Stat(launchdPlistPath()); err != nil {
+		t.Fatalf("current plist missing after install: %v", err)
 	}
 }

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -430,6 +430,10 @@ func (p *Platform) ProgressStyle() string { return p.progressStyle }
 
 func (p *Platform) SupportsProgressCardPayload() bool { return true }
 
+// ProgressUpdateInterval limits card edits so a burst of tool events does not
+// exhaust Feishu PATCH capacity or turn a transient timeout into fallback spam.
+func (p *Platform) ProgressUpdateInterval() time.Duration { return 1500 * time.Millisecond }
+
 func (p *Platform) tag() string { return p.platformName }
 
 func (p *Platform) dispatchPlatform() core.Platform {


### PR DESCRIPTION
This PR restores the current cc-connect fixes on top of the existing reviewer/platformless branch.

Includes:
- restore async relay send (`#1700`)
- invalidate stale workspace sessions (`#1699`)
- retry Codex overloaded / rate-limited turns (`#1641`)
- keep the compact fallback spam throttle already carried on this branch

Validation:
- go test ./agent/codex ./core ./cmd/cc-connect
- go test ./... (still has unrelated pre-existing failures in agent/antigravity, agent/iflow, and agent/opencode)
