### PR TITLE
fix(codex): propagate failed app-server turns

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -1126,7 +1126,18 @@ func (s *appServerSession) handleNotification(method string, paramsRaw json.RawM
 	case "turn/completed":
 		var notif turnNotification
 		if err := json.Unmarshal(paramsRaw, &notif); err == nil {
-			s.completeTurn()
+			if strings.EqualFold(strings.TrimSpace(notif.Turn.Status), "failed") || notif.Turn.Error != nil {
+				errMsg := ""
+				if notif.Turn.Error != nil {
+					errMsg = strings.TrimSpace(notif.Turn.Error.Message)
+				}
+				if errMsg == "" {
+					errMsg = "turn failed (no details)"
+				}
+				s.failTurn(fmt.Errorf("%s", errMsg))
+			} else {
+				s.completeTurn()
+			}
 		}
 
 	case "thread/status/changed":
@@ -1518,6 +1529,18 @@ func (s *appServerSession) completeTurn() {
 	s.stateMu.Unlock()
 	s.flushPendingAsText()
 	s.emit(core.Event{Type: core.EventResult, SessionID: s.CurrentSessionID(), Done: true})
+}
+
+func (s *appServerSession) failTurn(err error) {
+	s.stateMu.Lock()
+	if s.currentTurn == "" {
+		s.stateMu.Unlock()
+		return
+	}
+	s.currentTurn = ""
+	s.pendingMsgs = s.pendingMsgs[:0]
+	s.stateMu.Unlock()
+	s.emitError(err)
 }
 
 func (s *appServerSession) flushPendingAsThinking() {

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -131,6 +131,57 @@ func TestAppServerSession_HandleThreadTokenUsageUpdatedCachesContextUsage(t *tes
 	}
 }
 
+func TestAppServerSession_FailedTurnEmitsError(t *testing.T) {
+	s := &appServerSession{
+		events:      make(chan core.Event, 2),
+		currentTurn: "turn-1",
+		pendingMsgs: []string{"partial reasoning"},
+	}
+
+	raw, err := json.Marshal(map[string]any{
+		"threadId": "thread-1",
+		"turn": map[string]any{
+			"id":     "turn-1",
+			"status": "failed",
+			"error":  map[string]any{"message": "service unavailable"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal notification: %v", err)
+	}
+	s.handleNotification("turn/completed", raw)
+
+	event := <-s.events
+	if event.Type != core.EventError || event.Error == nil || event.Error.Error() != "service unavailable" {
+		t.Fatalf("event = %#v, want EventError with service unavailable", event)
+	}
+
+	s.stateMu.Lock()
+	currentTurn := s.currentTurn
+	pendingCount := len(s.pendingMsgs)
+	s.stateMu.Unlock()
+	if currentTurn != "" {
+		t.Fatalf("current turn = %q after failure, want empty", currentTurn)
+	}
+	if pendingCount != 0 {
+		t.Fatalf("pending message count = %d after failure, want 0", pendingCount)
+	}
+
+	idleRaw, err := json.Marshal(map[string]any{
+		"threadId": "thread-1",
+		"status":   map[string]any{"type": "idle"},
+	})
+	if err != nil {
+		t.Fatalf("marshal idle notification: %v", err)
+	}
+	s.handleNotification("thread/status/changed", idleRaw)
+	select {
+	case duplicate := <-s.events:
+		t.Fatalf("idle notification emitted duplicate event %#v", duplicate)
+	default:
+	}
+}
+
 func TestAppServerSession_RequestTimeoutIncludesBlockedStdinWrite(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Supersedes #1599.

This is a same-patch replacement rebased onto the latest `main`.

## Summary

- inspect `turn/completed` status and error data from Codex app-server
- emit `EventError` instead of a successful empty `EventResult` when the turn failed
- clear failed-turn state so the later idle notification cannot emit a duplicate completion

## Why

Codex app-server can report a failed turn through `turn/completed` with `turn.status = "failed"` and an error object. The adapter currently ignores both fields and always completes successfully. Scheduled jobs then render `(empty response)` and are recorded as completed, hiding the upstream error.

## Tests

- `go test -race ./agent/codex -run 'TestAppServerSession_FailedTurnEmitsError$' -count=1`
- `git diff --check`
