### PR TITLE
fix(feishu): preserve inbound interactive cards and merge forwards

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -505,6 +505,7 @@ type queuedMessage struct {
 	platform          Platform
 	replyCtx          any
 	content           string
+	cards             []InboundCard
 	images            []ImageAttachment
 	files             []FileAttachment
 	fromVoice         bool
@@ -2852,7 +2853,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	}
 
 	content := strings.TrimSpace(msg.Content)
-	if content == "" && msg.ExtraContent == "" && len(msg.Images) == 0 && len(msg.Files) == 0 && msg.Location == nil {
+	if content == "" && msg.ExtraContent == "" && len(msg.Images) == 0 && len(msg.Files) == 0 && msg.Location == nil && len(msg.Cards) == 0 {
 		return
 	}
 
@@ -3183,6 +3184,7 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 		platform:          p,
 		replyCtx:          msg.ReplyCtx,
 		content:           msg.Content,
+		cards:             append([]InboundCard(nil), msg.Cards...),
 		images:            msg.Images,
 		files:             msg.Files,
 		fromVoice:         msg.FromVoice,
@@ -3799,7 +3801,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 		drainEvents(state.agentSession.Events())
 	}
 
-	promptContent := e.buildSenderPrompt(msg.Content, msg.UserID, msg.UserName, msg.Platform, msg.SessionKey, msg.ChannelKey)
+	promptContent := e.buildSenderPrompt(buildInboundCardPrompt(msg.Content, msg.Cards), msg.UserID, msg.UserName, msg.Platform, msg.SessionKey, msg.ChannelKey)
 
 	sendStart := time.Now()
 	state.mu.Lock()
@@ -5917,7 +5919,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 				}
 
-				queuedPrompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
+				queuedPrompt := e.buildSenderPrompt(buildInboundCardPrompt(queued.content, queued.cards), queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
 
 				state.mu.Lock()
 				as := state.agentSession // capture under lock to avoid race with cleanup
@@ -6236,7 +6238,7 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 		state.mu.Unlock()
 
 		e.i18n.DetectAndSet(queued.content)
-		prompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
+		prompt := e.buildSenderPrompt(buildInboundCardPrompt(queued.content, queued.cards), queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
 
 		state.mu.Lock()
 		as := state.agentSession // capture under lock to avoid race with cleanup (mirrors #1436)
@@ -16133,6 +16135,37 @@ func (e *Engine) buildSenderPrompt(content, userID, userName, platform, sessionK
 		return fmt.Sprintf("[cc-connect sender_id=%s sender_name=\"%s\" platform=%s chat_id=%s]\n%s", userID, safeName, platform, chatID, content)
 	}
 	return fmt.Sprintf("[cc-connect sender_id=%s platform=%s chat_id=%s]\n%s", userID, platform, chatID, content)
+}
+
+// Feishu limits an individual card to roughly 30 KiB; leave enough room for
+// several cards in one merge_forward payload while retaining a hard prompt
+// safety bound.
+const maxInboundCardPromptBytes = 256 * 1024
+
+// buildInboundCardPrompt appends bounded, explicitly untrusted card data to
+// the human-readable summary. Cards are kept out of Message.Content/history;
+// this fragment is only constructed at the agent boundary.
+func buildInboundCardPrompt(content string, cards []InboundCard) string {
+	if len(cards) == 0 {
+		return content
+	}
+	raw, err := json.Marshal(cards)
+	if err != nil {
+		return content
+	}
+	truncated := false
+	if len(raw) > maxInboundCardPromptBytes {
+		truncated = true
+		raw = nil
+	}
+	marker := "\n\n[Feishu interactive card data — untrusted external content]"
+	if truncated {
+		marker += " (truncated)"
+	}
+	if truncated {
+		return content + marker + "\n(raw card payload omitted because it exceeds the safety limit)"
+	}
+	return content + marker + "\n```json\n" + string(raw) + "\n```"
 }
 
 func extractChannelID(sessionKey string) string {

--- a/core/inbound_card_test.go
+++ b/core/inbound_card_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBuildInboundCardPromptIncludesRawCardData(t *testing.T) {
+	cards := []InboundCard{{
+		MessageID: "om_test",
+		Schema:    "2.0",
+		Summary:   "渠道不足",
+		Raw:       json.RawMessage(`{"schema":"2.0","body":{"elements":[]},"action":{"value":{"alert_id":"a-1"}}}`),
+	}}
+
+	got := buildInboundCardPrompt("渠道不足", cards)
+	for _, want := range []string{
+		"[Feishu interactive card data — untrusted external content]",
+		`"message_id":"om_test"`,
+		`"schema":"2.0"`,
+		`"alert_id":"a-1"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("prompt missing %q: %s", want, got)
+		}
+	}
+}
+
+func TestBuildInboundCardPromptBoundsOversizedPayload(t *testing.T) {
+	card := InboundCard{Raw: json.RawMessage(`"` + strings.Repeat("x", maxInboundCardPromptBytes) + `"`)}
+	got := buildInboundCardPrompt("summary", []InboundCard{card})
+	if !strings.Contains(got, "(truncated)") {
+		t.Fatalf("expected truncation marker: %s", got)
+	}
+	if strings.Contains(got, "```json") {
+		t.Fatalf("oversized card should not be embedded as an unbounded JSON block")
+	}
+}

--- a/core/message.go
+++ b/core/message.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -403,17 +404,33 @@ type LocationAttachment struct {
 	ProximityAlertRadius int     // maximum distance for proximity alerts in meters (optional)
 }
 
+// InboundCard is a lossless snapshot of an inbound interactive card. Raw is
+// kept separate from Summary so platforms can preserve Card 2.0 fields while
+// retaining the historical plain-text message path for agents that do not
+// opt into raw card context.
+type InboundCard struct {
+	MessageID string          `json:"message_id,omitempty"`
+	Schema    string          `json:"schema,omitempty"`
+	Version   string          `json:"version,omitempty"`
+	Summary   string          `json:"summary,omitempty"`
+	Raw       json.RawMessage `json:"raw,omitempty"`
+	Truncated bool            `json:"truncated,omitempty"`
+}
+
 // Message represents a unified incoming message from any platform.
 type Message struct {
-	SessionKey   string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
-	Platform     string
-	MessageID    string // platform message ID for tracing
-	Recalled     bool   // true for platform message recall/delete events targeting MessageID
-	ChannelID    string
-	UserID       string
-	UserName     string
-	ChatName     string // human-readable chat/group name (optional)
-	Content      string
+	SessionKey string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
+	Platform   string
+	MessageID  string // platform message ID for tracing
+	Recalled   bool   // true for platform message recall/delete events targeting MessageID
+	ChannelID  string
+	UserID     string
+	UserName   string
+	ChatName   string // human-readable chat/group name (optional)
+	Content    string
+	// Cards contains lossless inbound interactive-card payloads. It is
+	// additive: existing platforms leave it empty and continue using Content.
+	Cards        []InboundCard
 	Images       []ImageAttachment   // attached images (if any)
 	Files        []FileAttachment    // attached files (if any)
 	Audio        *AudioAttachment    // voice message (if any)

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -110,6 +110,8 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # domain = "https://open.feishu.cn" # 可选：覆盖运行时 API/WebSocket 域名
 # enable_feishu_card = true  # 可选：关闭后统一回退纯文本回复
 # thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
+# inbound_card_mode = "both" # 可选：summary（默认）| raw | both；保留入站 Card 2.0 原始 JSON
+# inbound_card_max_bytes = 0  # 可选：单卡原始 JSON 上限，0 表示不截断
 # progress_style = "legacy"  # 可选：legacy | compact | card
 # done_emoji = "none"          # 可选：agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 # image_batch_window_ms = 500  # 可选：连续多图合批窗口（默认 500ms，详见下文）
@@ -122,6 +124,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
 > `done_emoji` 设置后，agent 每次完成回复时会在用户消息上添加指定表情（如 `"Done"` → ✅）。先移除 "OnIt" 表情（如果有），再添加 done 表情。在 quiet 模式下特别有用，因为飞书卡片原地更新不触发推送，done 表情可以通知用户 agent 已完成。设为 `"none"` 或不配置则禁用。
 > `image_batch_window_ms` 控制连续多张图片合并成一条 agent 消息的等待窗口（默认 500ms）。飞书手机端一次连发多张图时，每张图是独立事件；cc-connect 会在窗口内将它们合并成一条多图消息再分发给 agent。如果你的网络/设备发送间隔超过 500ms 且仍被拆成多轮回复（每张图独立处理），可调高到 800–1200ms；如果以单图为主、希望响应更快，可适当调低。设为 `0` 时回退到默认 500ms。
+> `inbound_card_mode = "both"` 只影响已经通过正常入站门控（群聊仍需真实 @ 机器人）的消息：`interactive` 和 `merge_forward` 中的交互卡会保留完整原始 JSON，并同时提供可读摘要；不会打开全群消息接收。`raw` 只把原始卡片交给 agent，`summary` 保持旧行为。
 
 ---
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -1521,8 +1521,18 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	// exception: earlier unmentioned messages were never dispatched to the
 	// agent, so bootstrap its context from the parent/root reply chain once.
 	var quoted quotedMessage
-	if parentID != "" && (!p.threadIsolation || !isThreadSessionKey(sessionKey) || rctx.bootstrapThread) {
-		quoted = p.fetchQuotedMessage(ctx, parentID)
+	if parentID != "" {
+		switch {
+		case !p.threadIsolation || !isThreadSessionKey(sessionKey) || rctx.bootstrapThread:
+			quoted = p.fetchQuotedMessage(ctx, parentID)
+		case p.threadIsolation && isThreadSessionKey(sessionKey):
+			// An engaged thread already has its text context in the agent
+			// session, but its root may be an interactive alert card that was
+			// never dispatched (the alert bot cannot @ this bot in the root
+			// message). Preserve only cards from the reply chain here; do not
+			// re-ingest ordinary group messages or attachments.
+			quoted = p.fetchQuotedCards(ctx, parentID)
+		}
 	}
 
 	switch msgType {
@@ -2119,6 +2129,17 @@ func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) quot
 		images: collectReplyChainImages(chain),
 		files:  collectReplyChainFiles(chain),
 	}
+}
+
+// fetchQuotedCards retrieves only interactive cards from a quoted reply chain.
+// It is used for already-engaged isolated threads so the root alert card remains
+// available without re-ingesting the thread's ordinary group messages.
+func (p *Platform) fetchQuotedCards(ctx context.Context, parentID string) quotedMessage {
+	chain := p.fetchReplyChain(ctx, parentID, maxReplyChainDepth)
+	if len(chain) == 0 {
+		return quotedMessage{}
+	}
+	return quotedMessage{cards: collectReplyChainCards(chain)}
 }
 
 // resolveBotSenderName returns a display name for a bot sender in a quoted

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -128,6 +128,8 @@ type Platform struct {
 	allowChat                  string
 	groupOnly                  bool
 	groupReplyAll              bool
+	inboundCardMode            string // summary (default), raw, or both
+	inboundCardMaxBytes        int
 	respondToAtEveryoneAndHere bool
 	shareSessionInChannel      bool
 	threadIsolation            bool
@@ -303,6 +305,31 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	allowChat, _ := opts["allow_chat"].(string)
 	groupOnly, _ := opts["group_only"].(bool)
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
+	inboundCardMode := "summary"
+	if v, ok := opts["inbound_card_mode"].(string); ok && strings.TrimSpace(v) != "" {
+		inboundCardMode = strings.ToLower(strings.TrimSpace(v))
+	}
+	if inboundCardMode != "summary" && inboundCardMode != "raw" && inboundCardMode != "both" {
+		return nil, fmt.Errorf("%s: invalid inbound_card_mode %q (want summary, raw, or both)", name, inboundCardMode)
+	}
+	// Zero means lossless/unbounded at the platform boundary. The engine still
+	// applies its prompt safety cap when serializing cards for the agent.
+	inboundCardMaxBytes := 0
+	if raw, ok := opts["inbound_card_max_bytes"]; ok {
+		switch v := raw.(type) {
+		case int:
+			inboundCardMaxBytes = v
+		case int64:
+			inboundCardMaxBytes = int(v)
+		case float64:
+			inboundCardMaxBytes = int(v)
+		default:
+			return nil, fmt.Errorf("%s: invalid inbound_card_max_bytes %v", name, raw)
+		}
+	}
+	if inboundCardMaxBytes < 0 {
+		return nil, fmt.Errorf("%s: inbound_card_max_bytes must be >= 0", name)
+	}
 	// require_mention = false is equivalent to group_reply_all = true:
 	// both mean "respond to all group messages without needing an @mention".
 	if v, ok := opts["require_mention"].(bool); ok && !v {
@@ -399,6 +426,8 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		allowChat:                  allowChat,
 		groupOnly:                  groupOnly,
 		groupReplyAll:              groupReplyAll,
+		inboundCardMode:            inboundCardMode,
+		inboundCardMaxBytes:        inboundCardMaxBytes,
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
 		shareSessionInChannel:      shareSessionInChannel,
 		threadIsolation:            threadIsolation,
@@ -1276,6 +1305,7 @@ func (p *Platform) dispatchImageBatchEntry(entry *imageBatchEntry) {
 		UserID:    entry.userID, UserName: entry.userName, ChatName: entry.chatName,
 		Content:           "",
 		ExtraContent:      entry.quoted.text,
+		Cards:             entry.quoted.cards,
 		Images:            append(entry.quoted.images, entry.images...),
 		ReplyCtx:          entry.rctx,
 		UserMessageTimeMs: entry.createTimeMs,
@@ -1419,7 +1449,7 @@ func (p *Platform) onMessage(ctx context.Context, event *larkim.P2MessageReceive
 		return nil
 	}
 
-	if msg.Content == nil && msgType != "merge_forward" {
+	if msg.Content == nil && msgType != "merge_forward" && msgType != "interactive" {
 		slog.Debug(p.tag()+": message content is nil", "message_id", messageID, "type", msgType)
 		return nil
 	}
@@ -1513,7 +1543,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		// zero file-resource API calls.
 		approvedFileMetas := p.filterQuotedFilesForUser(quoted.files, mentions, userID)
 		quotedFiles := p.downloadQuotedFiles(ctx, approvedFileMetas)
-		if text == "" && quoted.text == "" && len(quoted.images) == 0 && len(quotedFiles) == 0 {
+		if text == "" && quoted.text == "" && len(quoted.cards) == 0 && len(quoted.images) == 0 && len(quotedFiles) == 0 {
 			slog.Debug(p.tag()+": dropping empty text after mention stripping",
 				"message_id", messageID,
 				"raw_text_len", len(textBody.Text),
@@ -1529,7 +1559,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quoted.text, Images: quoted.images, Files: quotedFiles, ReplyCtx: rctx,
+			Content: text, ExtraContent: quoted.text, Cards: quoted.cards, Images: quoted.images, Files: quotedFiles, ReplyCtx: rctx,
 			UserMessageTimeMs: createTimeMs,
 		})
 
@@ -1576,6 +1606,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			UserID:    userID, UserName: userName, ChatName: chatName,
 			Content:           "",
 			ExtraContent:      quoted.text,
+			Cards:             quoted.cards,
 			Images:            append(quoted.images, core.ImageAttachment{MimeType: mimeType, Data: imgData}),
 			ReplyCtx:          rctx,
 			UserMessageTimeMs: createTimeMs,
@@ -1607,6 +1638,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
+			Cards: quoted.cards,
 			Audio: &core.AudioAttachment{
 				MimeType: "audio/opus",
 				Data:     audioData,
@@ -1620,7 +1652,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 	case "post":
 		textParts, images := p.parsePostContent(messageID, content)
 		text := stripMentions(strings.Join(textParts, "\n"), mentions, p.getBotOpenID())
-		if text == "" && len(images) == 0 && quoted.text == "" && len(quoted.images) == 0 {
+		if text == "" && len(images) == 0 && quoted.text == "" && len(quoted.cards) == 0 && len(quoted.images) == 0 {
 			return
 		}
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
@@ -1629,8 +1661,43 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quoted.text, Images: append(quoted.images, images...),
+			Content: text, ExtraContent: quoted.text, Cards: quoted.cards, Images: append(quoted.images, images...),
 			ReplyCtx:          rctx,
+			UserMessageTimeMs: createTimeMs,
+		})
+
+	case "interactive":
+		text := extractInteractiveCardText(content)
+		cards := append([]core.InboundCard(nil), quoted.cards...)
+		// Fetching through raw_card_content is necessary because the event
+		// payload may contain only a lossy card summary.
+		if fetched := p.fetchSingleMessage(ctx, messageID); fetched != nil {
+			if fetched.text != "" {
+				text = fetched.text
+			}
+			if fetched.card != nil && p.inboundCardMode != "summary" {
+				cards = append(cards, *fetched.card)
+			}
+		}
+		if len(cards) == 0 && p.inboundCardMode != "summary" {
+			if card, ok := parseInboundCard(content, messageID, p.inboundCardMaxBytes); ok {
+				card.Summary = text
+				cards = append(cards, card)
+			}
+		}
+		if p.inboundCardMode == "raw" {
+			text = "[interactive card]"
+		}
+		if text == "" || text == "[interactive card]" {
+			text = "[interactive card]"
+		}
+		p.flushImageBatchForSession(sessionKey)
+		p.dispatchCoreMessage(&core.Message{
+			SessionKey: sessionKey, Platform: p.platformName,
+			MessageID: messageID,
+			UserID:    userID, UserName: userName, ChatName: chatName,
+			Content: text, ExtraContent: quoted.text, Cards: cards,
+			Images: quoted.images, ReplyCtx: rctx,
 			UserMessageTimeMs: createTimeMs,
 		})
 
@@ -1670,8 +1737,9 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 		})
 
 	case "merge_forward":
-		text, images, files := p.parseMergeForward(messageID)
-		if text == "" && len(images) == 0 && len(files) == 0 {
+		text, images, files, cards := p.parseMergeForward(ctx, messageID)
+		cards = append(append([]core.InboundCard(nil), quoted.cards...), cards...)
+		if text == "" && len(images) == 0 && len(files) == 0 && len(cards) == 0 {
 			slog.Warn(p.tag()+": merge_forward produced no content", "message_id", messageID)
 			return
 		}
@@ -1682,6 +1750,8 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
 			Content:           text,
+			ExtraContent:      quoted.text,
+			Cards:             cards,
 			Images:            images,
 			Files:             files,
 			ReplyCtx:          rctx,
@@ -1707,7 +1777,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 				SessionKey: sessionKey, Platform: p.platformName,
 				MessageID: messageID,
 				UserID:    userID, UserName: userName, ChatName: chatName,
-				Content: "[sticker]", ExtraContent: quoted.text, ReplyCtx: rctx,
+				Content: "[sticker]", ExtraContent: quoted.text, Cards: quoted.cards, ReplyCtx: rctx,
 				UserMessageTimeMs: createTimeMs,
 			})
 			return
@@ -1718,6 +1788,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
+			Cards:             quoted.cards,
 			Images:            []core.ImageAttachment{{MimeType: mimeType, Data: imgData}},
 			ReplyCtx:          rctx,
 			UserMessageTimeMs: createTimeMs,
@@ -1757,7 +1828,7 @@ func (p *Platform) dispatchMessage(ctx context.Context, msgType, content string,
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quoted.text, Images: images, ReplyCtx: rctx,
+			Content: text, ExtraContent: quoted.text, Cards: quoted.cards, Images: images, ReplyCtx: rctx,
 			UserMessageTimeMs: createTimeMs,
 		})
 
@@ -1997,6 +2068,7 @@ type chainMessage struct {
 	senderID   string // Feishu open_id (or app_id for bots) — used by the caller
 	// to enforce same-user privacy when forwarding quoted files.
 	text     string
+	card     *core.InboundCard
 	images   []core.ImageAttachment
 	files    []quotedFileMeta
 	parentID string
@@ -2019,6 +2091,7 @@ type quotedFileMeta struct {
 
 type quotedMessage struct {
 	text   string
+	cards  []core.InboundCard
 	images []core.ImageAttachment
 	files  []quotedFileMeta
 }
@@ -2042,6 +2115,7 @@ func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) quot
 	}
 	return quotedMessage{
 		text:   formatReplyChain(chain),
+		cards:  collectReplyChainCards(chain),
 		images: collectReplyChainImages(chain),
 		files:  collectReplyChainFiles(chain),
 	}
@@ -2101,6 +2175,7 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 
 	// Extract plain text based on message type.
 	var text string
+	var card *core.InboundCard
 	var images []core.ImageAttachment
 	var files []quotedFileMeta
 	switch item.MsgType {
@@ -2170,13 +2245,23 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		}
 	case "interactive":
 		text = extractInteractiveCardText(content)
+		if parsedCard, ok := parseInboundCard(content, messageID, p.inboundCardMaxBytes); ok {
+			parsedCard.Summary = text
+			card = &parsedCard
+		}
+		if text == "" && card != nil {
+			text = "[interactive card]"
+		}
+		if p.inboundCardMode == "raw" {
+			text = "[interactive card]"
+		}
 	default:
 		text = fmt.Sprintf("[%s]", item.MsgType)
 	}
 	// Empty quoted payloads (no text, no images, no files) are dropped here:
 	// keeping a chainMessage with an empty text would otherwise produce an
 	// empty reply prefix and an empty files slice in the dispatch layer.
-	if text == "" && len(images) == 0 && len(files) == 0 {
+	if text == "" && card == nil && len(images) == 0 && len(files) == 0 {
 		return nil
 	}
 	if text == "" {
@@ -2204,6 +2289,7 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		senderType: item.Sender.SenderType,
 		senderID:   item.Sender.ID,
 		text:       text,
+		card:       card,
 		images:     images,
 		files:      files,
 		parentID:   item.ParentID,
@@ -2216,6 +2302,16 @@ func collectReplyChainImages(chain []chainMessage) []core.ImageAttachment {
 		images = append(images, msg.images...)
 	}
 	return images
+}
+
+func collectReplyChainCards(chain []chainMessage) []core.InboundCard {
+	var cards []core.InboundCard
+	for _, msg := range chain {
+		if msg.card != nil {
+			cards = append(cards, *msg.card)
+		}
+	}
+	return cards
 }
 
 // collectReplyChainFiles flattens file metadata from every chainMessage.
@@ -2370,11 +2466,16 @@ func extractPostPlainText(content string) string {
 func extractInteractiveCardText(content string) string {
 	// Try raw_card_content format: {"json_card": "<escaped JSON>", ...}
 	var wrapper struct {
-		JsonCard string `json:"json_card"`
+		JsonCard json.RawMessage `json:"json_card"`
 	}
 	cardJSON := content
-	if json.Unmarshal([]byte(content), &wrapper) == nil && wrapper.JsonCard != "" {
-		cardJSON = wrapper.JsonCard
+	if json.Unmarshal([]byte(content), &wrapper) == nil && len(wrapper.JsonCard) > 0 {
+		var nested string
+		if json.Unmarshal(wrapper.JsonCard, &nested) == nil {
+			cardJSON = nested
+		} else {
+			cardJSON = string(wrapper.JsonCard)
+		}
 	}
 
 	var card map[string]json.RawMessage
@@ -2456,9 +2557,12 @@ func extractInteractiveCardText(content string) string {
 func extractCardElements(elements []json.RawMessage, parts *[]string) {
 	for _, raw := range elements {
 		var elem struct {
-			Tag      string `json:"tag"`
-			Content  string `json:"content"`
-			Property struct {
+			Tag       string          `json:"tag"`
+			Content   string          `json:"content"`
+			Text      json.RawMessage `json:"text"`
+			Actions   json.RawMessage `json:"actions"`
+			Behaviors json.RawMessage `json:"behaviors"`
+			Property  struct {
 				Content   string            `json:"content"`
 				Contents  json.RawMessage   `json:"contents"`
 				Language  string            `json:"language"`
@@ -2478,6 +2582,14 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 			// Extract button label text and open_url from behaviors.
 			label := elem.Property.Content
 			if label == "" {
+				var textElem struct {
+					Content string `json:"content"`
+				}
+				if json.Unmarshal(elem.Text, &textElem) == nil {
+					label = textElem.Content
+				}
+			}
+			if label == "" {
 				// label may be in property.text.property.content
 				var textElem struct {
 					Property struct {
@@ -2489,15 +2601,25 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 				}
 			}
 			var openURL string
-			if len(elem.Property.Behaviors) > 0 {
+			behaviorsRaw := elem.Property.Behaviors
+			if len(behaviorsRaw) == 0 {
+				behaviorsRaw = elem.Behaviors
+			}
+			if len(behaviorsRaw) > 0 {
 				var behaviors []struct {
-					Type string `json:"type"`
-					URL  string `json:"url"`
+					Type       string `json:"type"`
+					URL        string `json:"url"`
+					DefaultURL string `json:"default_url"`
 				}
-				if json.Unmarshal(elem.Property.Behaviors, &behaviors) == nil {
+				if json.Unmarshal(behaviorsRaw, &behaviors) == nil {
 					for _, b := range behaviors {
-						if b.Type == "open_url" && b.URL != "" {
+						if b.Type == "open_url" {
 							openURL = b.URL
+							if openURL == "" {
+								openURL = b.DefaultURL
+							}
+						}
+						if openURL != "" {
 							break
 						}
 					}
@@ -2507,6 +2629,11 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 				*parts = append(*parts, fmt.Sprintf("[%s](%s)", label, openURL))
 			} else if label != "" {
 				*parts = append(*parts, label)
+			}
+		case "action":
+			var actions []json.RawMessage
+			if json.Unmarshal(elem.Actions, &actions) == nil {
+				extractCardElements(actions, parts)
 			}
 		case "code_block":
 			var lines []struct {
@@ -2547,6 +2674,14 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 			content := elem.Property.Content
 			if content == "" {
 				content = elem.Content
+			}
+			if content == "" && len(elem.Text) > 0 {
+				var textElem struct {
+					Content string `json:"content"`
+				}
+				if json.Unmarshal(elem.Text, &textElem) == nil {
+					content = textElem.Content
+				}
 			}
 			if content != "" {
 				*parts = append(*parts, content)
@@ -2630,24 +2765,35 @@ func extractCardListItems(itemsRaw json.RawMessage, parts *[]string) {
 }
 
 // parseMergeForward fetches sub-messages of a merge_forward message via the
-// GET /open-apis/im/v1/messages/{message_id} API, then formats them into
-// readable text. Returns combined text, images, and files from the sub-messages.
-func (p *Platform) parseMergeForward(rootMessageID string) (string, []core.ImageAttachment, []core.FileAttachment) {
-	resp, err := p.client.Im.Message.Get(context.Background(),
-		larkim.NewGetMessageReqBuilder().
-			MessageId(rootMessageID).
-			Build())
+// raw-card variant of GET /open-apis/im/v1/messages/{message_id}, then formats
+// them into readable text while retaining each interactive card's original
+// JSON. The generated SDK request does not expose card_msg_content_type, so the
+// raw client is intentional here.
+func (p *Platform) parseMergeForward(ctx context.Context, rootMessageID string) (string, []core.ImageAttachment, []core.FileAttachment, []core.InboundCard) {
+	apiPath := fmt.Sprintf("/open-apis/im/v1/messages/%s?card_msg_content_type=raw_card_content", rootMessageID)
+	apiResp, err := p.client.Get(ctx, apiPath, nil, larkcore.AccessTokenTypeTenant)
 	if err != nil {
 		slog.Error(p.tag()+": fetch merge_forward sub-messages failed", "error", err)
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
-	if !resp.Success() {
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			Items []*larkim.Message `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
+		slog.Error(p.tag()+": parse merge_forward response failed", "error", err)
+		return "", nil, nil, nil
+	}
+	if resp.Code != 0 {
 		slog.Error(p.tag()+": fetch merge_forward sub-messages failed", "code", resp.Code, "msg", resp.Msg)
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
-	if resp.Data == nil || len(resp.Data.Items) == 0 {
+	if len(resp.Data.Items) == 0 {
 		slog.Warn(p.tag()+": merge_forward has no sub-messages", "message_id", rootMessageID)
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
 
 	items := resp.Data.Items
@@ -2682,12 +2828,13 @@ func (p *Platform) parseMergeForward(rootMessageID string) (string, []core.Image
 
 	var allImages []core.ImageAttachment
 	var allFiles []core.FileAttachment
+	var allCards []core.InboundCard
 	var sb strings.Builder
 	sb.WriteString("<forwarded_messages>\n")
-	p.formatMergeForwardTree(rootMessageID, childrenMap, nameMap, &sb, &allImages, &allFiles, 0)
+	p.formatMergeForwardTree(ctx, rootMessageID, childrenMap, nameMap, &sb, &allImages, &allFiles, &allCards, 0)
 	sb.WriteString("</forwarded_messages>")
 
-	return sb.String(), allImages, allFiles
+	return sb.String(), allImages, allFiles, allCards
 }
 
 // replaceMentions replaces @_user_N placeholders with real names from the Mentions list.
@@ -2701,7 +2848,7 @@ func replaceMentions(text string, mentions []*larkim.Mention) string {
 }
 
 // formatMergeForwardTree recursively formats the sub-message tree.
-func (p *Platform) formatMergeForwardTree(parentID string, childrenMap map[string][]*larkim.Message, nameMap map[string]string, sb *strings.Builder, images *[]core.ImageAttachment, files *[]core.FileAttachment, depth int) {
+func (p *Platform) formatMergeForwardTree(ctx context.Context, parentID string, childrenMap map[string][]*larkim.Message, nameMap map[string]string, sb *strings.Builder, images *[]core.ImageAttachment, files *[]core.FileAttachment, cards *[]core.InboundCard, depth int) {
 	if depth > 10 {
 		sb.WriteString(strings.Repeat("    ", depth) + "[nested forwarding truncated]\n")
 		return
@@ -2798,7 +2945,35 @@ func (p *Platform) formatMergeForwardTree(parentID string, childrenMap map[strin
 
 		case "merge_forward":
 			sb.WriteString(fmt.Sprintf("%s[%s] %s: [forwarded messages]\n", indent, ts, senderName))
-			p.formatMergeForwardTree(msgID, childrenMap, nameMap, sb, images, files, depth+1)
+			p.formatMergeForwardTree(ctx, msgID, childrenMap, nameMap, sb, images, files, cards, depth+1)
+
+		case "interactive":
+			text := extractInteractiveCardText(content)
+			card, parsed := parseInboundCard(content, msgID, p.inboundCardMaxBytes)
+			if parsed {
+				if card.Summary != "" {
+					text = card.Summary
+				}
+				if p.inboundCardMode != "summary" {
+					*cards = append(*cards, card)
+				}
+			} else if fetched := p.fetchSingleMessage(ctx, msgID); fetched != nil {
+				if fetched.text != "" {
+					text = fetched.text
+				}
+				if fetched.card != nil && p.inboundCardMode != "summary" {
+					*cards = append(*cards, *fetched.card)
+				}
+			}
+			if p.inboundCardMode == "raw" {
+				text = "[interactive card]"
+			}
+			if text != "" {
+				sb.WriteString(fmt.Sprintf("%s[%s] %s:\n", indent, ts, senderName))
+				for _, line := range strings.Split(text, "\n") {
+					sb.WriteString(fmt.Sprintf("%s    %s\n", indent, line))
+				}
+			}
 
 		default:
 			sb.WriteString(fmt.Sprintf("%s[%s] %s: [%s message]\n", indent, ts, senderName, msgType))

--- a/platform/feishu/inbound_card.go
+++ b/platform/feishu/inbound_card.go
@@ -1,0 +1,65 @@
+package feishu
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// parseInboundCard unwraps Feishu's raw_card_content response and keeps the
+// original Card JSON separate from the readable summary. The raw payload is
+// intentionally omitted when it exceeds maxBytes; callers still receive the
+// summary and a truncation marker rather than invalid JSON.
+func parseInboundCard(content, messageID string, maxBytes int) (core.InboundCard, bool) {
+	raw := unwrapInboundCardJSON(content)
+	if len(raw) == 0 {
+		return core.InboundCard{}, false
+	}
+	var card map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &card); err != nil {
+		return core.InboundCard{}, false
+	}
+
+	var schema string
+	_ = json.Unmarshal(card["schema"], &schema)
+	version := "v1"
+	if schema == "2.0" {
+		version = "v2"
+	}
+	summary := extractInteractiveCardText(content)
+	if summary == "[interactive card]" || strings.TrimSpace(summary) == "" {
+		summary = extractInteractiveCardText(string(raw))
+	}
+
+	result := core.InboundCard{
+		MessageID: messageID,
+		Schema:    schema,
+		Version:   version,
+		Summary:   summary,
+	}
+	if maxBytes <= 0 || len(raw) <= maxBytes {
+		result.Raw = append(json.RawMessage(nil), raw...)
+	} else {
+		result.Truncated = true
+	}
+	return result, true
+}
+
+func unwrapInboundCardJSON(content string) []byte {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil
+	}
+	var wrapper struct {
+		JSONCard json.RawMessage `json:"json_card"`
+	}
+	if json.Unmarshal([]byte(content), &wrapper) == nil && len(wrapper.JSONCard) > 0 {
+		var nested string
+		if json.Unmarshal(wrapper.JSONCard, &nested) == nil {
+			return []byte(nested)
+		}
+		return append([]byte(nil), wrapper.JSONCard...)
+	}
+	return []byte(content)
+}

--- a/platform/feishu/inbound_card_dispatch_test.go
+++ b/platform/feishu/inbound_card_dispatch_test.go
@@ -1,0 +1,154 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+)
+
+const testCard20 = `{"schema":"2.0","body":{"elements":[{"tag":"div","text":{"tag":"plain_text","content":"告警正文"}},{"tag":"button","text":{"tag":"plain_text","content":"查看详情"},"behaviors":[{"type":"open_url","default_url":"https://example.test/alert"}],"value":{"alert_id":"alert-1"}}]}}`
+
+func TestDispatchInteractivePreservesRawCard(t *testing.T) {
+	got := make(chan *core.Message, 1)
+	var rawQuerySeen bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/open-apis/im/v1/messages/om_interactive" {
+			rawQuerySeen = r.URL.Query().Get("card_msg_content_type") == "raw_card_content"
+			writeInboundCardResponse(t, w, "om_interactive", testCard20)
+			return
+		}
+		writeInboundCardResponse(t, w, "", "")
+	}))
+	defer srv.Close()
+
+	p := newInboundCardTestPlatform(srv, "both", func(msg *core.Message) { got <- msg })
+	p.dispatchMessage(
+		context.Background(), "interactive", `{"title":"lossy event summary"}`, nil,
+		"om_interactive", "feishu:oc_chat:ou_user", "ou_user", "oc_chat",
+		replyContext{messageID: "om_interactive", chatID: "oc_chat", sessionKey: "feishu:oc_chat:ou_user"}, "", time.Now().UnixMilli(),
+	)
+
+	select {
+	case msg := <-got:
+		if len(msg.Cards) != 1 {
+			t.Fatalf("Cards = %d, want 1", len(msg.Cards))
+		}
+		if !strings.Contains(string(msg.Cards[0].Raw), `"alert_id":"alert-1"`) {
+			t.Fatalf("raw card lost action value: %s", msg.Cards[0].Raw)
+		}
+		if !strings.Contains(msg.Content, "告警正文") || !strings.Contains(msg.Content, "https://example.test/alert") {
+			t.Fatalf("summary = %q", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for interactive card")
+	}
+	if !rawQuerySeen {
+		t.Fatal("interactive fetch did not request raw_card_content")
+	}
+}
+
+func TestDispatchMergeForwardPreservesInteractiveChildren(t *testing.T) {
+	got := make(chan *core.Message, 1)
+	var rawQueries []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/open-apis/im/v1/messages/om_forward" {
+			rawQueries = append(rawQueries, r.URL.Query().Get("card_msg_content_type"))
+			writeMergeForwardResponse(t, w)
+			return
+		}
+		if r.URL.Path == "/open-apis/im/v1/messages/om_child_card" {
+			rawQueries = append(rawQueries, r.URL.Query().Get("card_msg_content_type"))
+			writeInboundCardResponse(t, w, "om_child_card", testCard20)
+			return
+		}
+		writeInboundCardResponse(t, w, "", "")
+	}))
+	defer srv.Close()
+
+	p := newInboundCardTestPlatform(srv, "both", func(msg *core.Message) { got <- msg })
+	p.dispatchMessage(
+		context.Background(), "merge_forward", "", nil,
+		"om_forward", "feishu:oc_chat:ou_user", "ou_user", "oc_chat",
+		replyContext{messageID: "om_forward", chatID: "oc_chat", sessionKey: "feishu:oc_chat:ou_user"}, "", time.Now().UnixMilli(),
+	)
+
+	select {
+	case msg := <-got:
+		if len(msg.Cards) != 1 {
+			t.Fatalf("Cards = %d, want 1", len(msg.Cards))
+		}
+		if !strings.Contains(string(msg.Cards[0].Raw), `"alert_id":"alert-1"`) {
+			t.Fatalf("merge-forward raw card lost action value: %s", msg.Cards[0].Raw)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for merge-forward card")
+	}
+	for _, value := range rawQueries {
+		if value != "raw_card_content" {
+			t.Fatalf("merge-forward fetch query = %q, want raw_card_content", value)
+		}
+	}
+	if len(rawQueries) < 1 {
+		t.Fatalf("raw queries = %d, want the merge-forward root fetch", len(rawQueries))
+	}
+}
+
+func newInboundCardTestPlatform(srv *httptest.Server, mode string, handler func(*core.Message)) *Platform {
+	return &Platform{
+		platformName:        "feishu",
+		domain:              srv.URL,
+		appID:               "cli_card_test",
+		appSecret:           "secret-card-test",
+		inboundCardMode:     mode,
+		inboundCardMaxBytes: 0,
+		client: lark.NewClient("cli_card_test", "secret-card-test",
+			lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+		handler: func(_ core.Platform, msg *core.Message) { handler(msg) },
+	}
+}
+
+func writeInboundCardResponse(t *testing.T, w http.ResponseWriter, messageID, card string) {
+	t.Helper()
+	items := []map[string]any{}
+	if messageID != "" {
+		items = append(items, map[string]any{
+			"message_id": messageID,
+			"msg_type":   "interactive",
+			"sender":     map[string]any{"id": "ou_sender", "sender_type": "app"},
+			"body":       map[string]any{"content": `{"json_card":` + quoteJSON(card) + `}`},
+		})
+	}
+	writeCardTestJSON(t, w, map[string]any{"code": 0, "msg": "success", "data": map[string]any{"items": items}})
+}
+
+func writeMergeForwardResponse(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	writeCardTestJSON(t, w, map[string]any{
+		"code": 0,
+		"msg":  "success",
+		"data": map[string]any{"items": []map[string]any{
+			{"message_id": "om_forward", "msg_type": "merge_forward", "sender": map[string]any{"id": "ou_sender", "sender_type": "app"}},
+			{"message_id": "om_child_card", "upper_message_id": "om_forward", "msg_type": "interactive", "sender": map[string]any{"id": "ou_sender", "sender_type": "app"}, "body": map[string]any{"content": `{"json_card":` + quoteJSON(testCard20) + `}`}},
+		}},
+	})
+}
+
+func quoteJSON(value string) string {
+	data, _ := json.Marshal(value)
+	return string(data)
+}
+
+func writeCardTestJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/platform/feishu/inbound_card_dispatch_test.go
+++ b/platform/feishu/inbound_card_dispatch_test.go
@@ -100,6 +100,40 @@ func TestDispatchMergeForwardPreservesInteractiveChildren(t *testing.T) {
 	}
 }
 
+func TestDispatchEngagedThreadStillPreservesQuotedCards(t *testing.T) {
+	got := make(chan *core.Message, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/open-apis/im/v1/messages/om_root_card" {
+			writeInboundCardResponse(t, w, "om_root_card", testCard20)
+			return
+		}
+		writeInboundCardResponse(t, w, "", "")
+	}))
+	defer srv.Close()
+
+	const sessionKey = "feishu:oc_chat:root:om_root_card"
+	p := newInboundCardTestPlatform(srv, "both", func(msg *core.Message) { got <- msg })
+	p.threadIsolation = true
+	p.activeThreadSessions.Store(sessionKey, time.Now())
+	p.dispatchMessage(
+		context.Background(), "text", `{"text":"你拿到卡片了吗"}`, nil,
+		"om_followup", sessionKey, "ou_user", "oc_chat",
+		replyContext{messageID: "om_followup", chatID: "oc_chat", sessionKey: sessionKey}, "om_root_card", time.Now().UnixMilli(),
+	)
+
+	select {
+	case msg := <-got:
+		if len(msg.Cards) != 1 {
+			t.Fatalf("Cards = %d, want 1 for an engaged thread quote", len(msg.Cards))
+		}
+		if !strings.Contains(string(msg.Cards[0].Raw), `"alert_id":"alert-1"`) {
+			t.Fatalf("quoted card raw payload lost: %s", msg.Cards[0].Raw)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for engaged-thread quoted card")
+	}
+}
+
 func newInboundCardTestPlatform(srv *httptest.Server, mode string, handler func(*core.Message)) *Platform {
 	return &Platform{
 		platformName:        "feishu",

--- a/platform/feishu/inbound_card_test.go
+++ b/platform/feishu/inbound_card_test.go
@@ -1,0 +1,66 @@
+package feishu
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseInboundCardPreservesCard20Raw(t *testing.T) {
+	card := `{"schema":"2.0","header":{"title":{"tag":"plain_text","content":"告警"}},"body":{"elements":[{"tag":"div","text":{"tag":"plain_text","content":"渠道不足"}},{"tag":"button","text":{"tag":"plain_text","content":"查看详情"},"behaviors":[{"type":"open_url","default_url":"https://example.test/alert"}],"value":{"alert_id":"alert-1"}}]}}`
+	content := `{"json_card":` + strconvQuote(card) + `}`
+
+	got, ok := parseInboundCard(content, "om_test", 64*1024)
+	if !ok {
+		t.Fatal("parseInboundCard returned false")
+	}
+	if got.Schema != "2.0" || got.Version != "v2" {
+		t.Fatalf("schema/version = %q/%q", got.Schema, got.Version)
+	}
+	if got.MessageID != "om_test" {
+		t.Fatalf("message id = %q", got.MessageID)
+	}
+	if !strings.Contains(got.Summary, "查看详情") || !strings.Contains(got.Summary, "https://example.test/alert") {
+		t.Fatalf("summary lost card text or action URL: %q", got.Summary)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(got.Raw, &decoded); err != nil {
+		t.Fatalf("raw card is not valid JSON: %v", err)
+	}
+	if decoded["schema"] != "2.0" {
+		t.Fatalf("raw schema = %v", decoded["schema"])
+	}
+}
+
+func TestParseInboundCardBoundsRawPayload(t *testing.T) {
+	card := `{"schema":"2.0","body":{"elements":[{"tag":"div","text":{"tag":"plain_text","content":"hello"}}]}}`
+	got, ok := parseInboundCard(card, "om_test", 16)
+	if !ok {
+		t.Fatal("parseInboundCard returned false")
+	}
+	if !got.Truncated || len(got.Raw) != 0 {
+		t.Fatalf("expected truncated raw payload, got truncated=%v raw=%d", got.Truncated, len(got.Raw))
+	}
+}
+
+func TestUnwrapInboundCardJSONAcceptsPlainAndWrapper(t *testing.T) {
+	plain := `{"schema":"2.0"}`
+	if string(unwrapInboundCardJSON(plain)) != plain {
+		t.Fatalf("plain card changed")
+	}
+	wrapper := `{"json_card":` + strconvQuote(plain) + `}`
+	if string(unwrapInboundCardJSON(wrapper)) != plain {
+		t.Fatalf("wrapped card was not unwrapped")
+	}
+	if got := extractInteractiveCardText(`{"json_card":{"schema":"2.0","body":{"elements":[{"tag":"div","text":{"content":"object wrapper"}}]}}}`); !strings.Contains(got, "object wrapper") {
+		t.Fatalf("object json_card wrapper was not parsed: %q", got)
+	}
+	if strings.TrimSpace(string(unwrapInboundCardJSON(""))) != "" {
+		t.Fatalf("empty card should remain empty")
+	}
+}
+
+func strconvQuote(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}


### PR DESCRIPTION
## Problem

Feishu alert cards can arrive as direct `interactive` messages or as `merge_forward` messages whose children are interactive cards. The inbound dispatcher currently ignores direct interactive messages, and merge-forward formatting reduces interactive children to a placeholder. The event payload can also be lossy unless the raw card content is fetched explicitly.

## What this changes

- Dispatch direct `interactive` messages through the normal Feishu inbound path.
- Fetch messages with `card_msg_content_type=raw_card_content` when reading interactive cards and merge-forward trees.
- Parse interactive children inside `merge_forward`, including Card 2.0 text, actions, URLs, values, and open-url behaviors.
- Add `core.InboundCard` to preserve the original Card 2.0 JSON alongside a readable summary.
- Add `inbound_card_mode = "summary" | "raw" | "both"` (default remains `summary`) and a per-card raw-size limit.
- Pass card payloads to the agent through an explicitly marked, bounded untrusted-content prompt section.
- Preserve the existing mention gate; this does not enable whole-group message intake.

## Validation

- `go test ./platform/feishu`
- Targeted core tests for inbound-card prompt handling
- Added tests covering direct interactive cards, merge-forward interactive children, raw-card query parameters, Card 2.0 action values/URLs, and payload bounds.

The implementation is intentionally additive: existing configurations keep summary behavior, while deployments that need lossless card context can opt into `raw` or `both`.
