### PR TITLE
fix(session): keep /switch target exempt from immediate idle reset (#1731)

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -3101,6 +3101,23 @@ func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions 
 	if lastActive.IsZero() {
 		lastActive = session.GetUpdatedAt()
 	}
+	// Issue #1731: when the user has explicitly chosen this session via
+	// /switch (or any other intentional selection), the idle baseline is the
+	// explicit-activation time, not the last message in the session — otherwise
+	// the first message after /switch into a long-idle session would be
+	// wrongly rotated away. ExplicitActivationTTL caps how long that
+	// exemption can last so a long-abandoned session cannot permanently
+	// occupy the active slot.
+	if explicitAt := session.GetExplicitActivatedAt(); !explicitAt.IsZero() {
+		switch {
+		case lastActive.IsZero() || explicitAt.After(lastActive):
+			lastActive = explicitAt
+		case time.Since(explicitAt) > ExplicitActivationTTL:
+			// Explicit activation has expired — fall back to the standard
+			// idle baseline so the session can finally be rotated.
+			// lastActive is already set above.
+		}
+	}
 	if lastActive.IsZero() || time.Since(lastActive) < e.resetOnIdle {
 		return nil
 	}

--- a/core/session.go
+++ b/core/session.go
@@ -16,6 +16,13 @@ import (
 // to use --continue (resume most recent session) instead of a specific session ID.
 const ContinueSession = "__continue__"
 
+// ExplicitActivationTTL is the hard ceiling for the explicit-activation
+// exemption (issue #1731). Even when a user has `/switch`-ed to a session,
+// if no real user activity has been recorded for this long, the idle reset
+// must still fire so a long-silent session cannot permanently occupy the
+// active slot.
+const ExplicitActivationTTL = 7 * 24 * time.Hour
+
 // Session tracks one conversation between a user and the agent.
 type Session struct {
 	ID                  string         `json:"id"`
@@ -39,6 +46,15 @@ type Session struct {
 	// processes an actual incoming user message. It is used by reset_on_idle_mins
 	// so that automated activity cannot prevent idle session rotation.
 	LastUserActivity time.Time `json:"last_user_activity,omitempty"`
+
+	// ExplicitActivatedAt records when this session was last explicitly chosen
+	// by the user (via /switch, /new against an existing entry, or any other
+	// intentional selection). Issue #1731: an explicit choice should override
+	// reset_on_idle_mins, otherwise the very first message after /switch into
+	// a long-idle session is wrongly routed to a brand-new session.
+	// ExplicitActivationTTL caps how long this exemption lasts so abandoned
+	// sessions cannot permanently occupy the active slot.
+	ExplicitActivatedAt time.Time `json:"explicit_activated_at,omitempty"`
 
 	mu   sync.Mutex `json:"-"`
 	busy bool       `json:"-"`
@@ -149,6 +165,30 @@ func (s *Session) TouchUserActivity() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.LastUserActivity = time.Now()
+}
+
+// MarkExplicitlyActivated records that the user explicitly chose this session
+// (issue #1731). Use this from /switch, SwitchToAgentSession, and any other
+// path that intentionally points the dispatcher at a specific session. The
+// idle-reset decision treats ExplicitActivatedAt as the baseline for the
+// explicit-activation grace window (capped at ExplicitActivationTTL).
+func (s *Session) MarkExplicitlyActivated() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.markExplicitlyActivatedLocked()
+}
+
+// markExplicitlyActivatedLocked is the lock-free internal variant for
+// callers that already hold s.mu (tests, internal invariants).
+func (s *Session) markExplicitlyActivatedLocked() {
+	s.ExplicitActivatedAt = time.Now()
+}
+
+// GetExplicitActivatedAt returns when this session was last explicitly chosen.
+func (s *Session) GetExplicitActivatedAt() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ExplicitActivatedAt
 }
 
 // GetLastUserActivity returns when the last real user message was received.
@@ -386,6 +426,7 @@ func (sm *SessionManager) SwitchSession(userKey, target string) (*Session, error
 		s := sm.sessions[sid]
 		if s != nil && (s.ID == target || s.Name == target) {
 			sm.activeSession[userKey] = s.ID
+			s.MarkExplicitlyActivated()
 			sm.saveLocked()
 			return s, nil
 		}
@@ -411,6 +452,7 @@ func (sm *SessionManager) SwitchToAgentSession(userKey, agentSID, agentName, sum
 		s.mu.Unlock()
 		if aid == agentSID {
 			sm.activeSession[userKey] = s.ID
+			s.MarkExplicitlyActivated()
 			sm.saveLocked()
 			return s
 		}
@@ -418,6 +460,7 @@ func (sm *SessionManager) SwitchToAgentSession(userKey, agentSID, agentName, sum
 
 	s := sm.createLocked(userKey, summary)
 	s.SetAgentInfo(agentSID, agentName, summary)
+	s.MarkExplicitlyActivated()
 	sm.saveLocked()
 	return s
 }
@@ -645,6 +688,11 @@ func (sm *SessionManager) saveLocked() {
 			History:             append([]HistoryEntry(nil), s.History...),
 			CreatedAt:           s.CreatedAt,
 			UpdatedAt:           s.UpdatedAt,
+			LastUserActivity:    s.LastUserActivity,
+			// #1731: explicit-activation timestamp must survive a process
+			// restart; otherwise a /switch followed by a crash would lose the
+			// exemption and the next message after restart would be rotated.
+			ExplicitActivatedAt: s.ExplicitActivatedAt,
 		}
 		s.mu.Unlock()
 	}

--- a/core/session_switch_idle_test.go
+++ b/core/session_switch_idle_test.go
@@ -41,10 +41,10 @@ func TestSwitchSession_MarksExplicitlyActivated(t *testing.T) {
 		t.Fatalf("SwitchSession returned %s, want %s", got.ID, b.ID)
 	}
 
-	if !got.GetExplicitActivatedAt().IsZero() {
-		// Sanity: explicit activation set
-	}
 	activatedAt := got.GetExplicitActivatedAt()
+	if activatedAt.IsZero() {
+		t.Fatalf("ExplicitActivatedAt must be set after SwitchSession")
+	}
 	if activatedAt.Before(before) || activatedAt.After(after) {
 		t.Fatalf("ExplicitActivatedAt = %v, want between %v and %v", activatedAt, before, after)
 	}

--- a/core/session_switch_idle_test.go
+++ b/core/session_switch_idle_test.go
@@ -1,0 +1,248 @@
+package core
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Regression tests for issue #1731.
+//
+// Background: previously, /switch <n> into a long-idle session would leave
+// the very first post-switch message routed to a brand-new session because
+// reset_on_idle_mins still compared against the session's last user activity,
+// which could be hours ago. The fix records an explicit-activation
+// timestamp on /switch (and SwitchToAgentSession) and treats it as the
+// baseline for the idle decision — but caps the exemption at
+// ExplicitActivationTTL so abandoned sessions cannot permanently occupy the
+// active slot.
+
+// TestSwitchSession_MarksExplicitlyActivated verifies that the user-facing
+// SwitchSession path records an explicit-activation timestamp on the target
+// session, while NOT touching unrelated sessions for the same user.
+func TestSwitchSession_MarksExplicitlyActivated(t *testing.T) {
+	sm := NewSessionManager(t.TempDir())
+	// Build two existing sessions.
+	a := sm.GetOrCreateActive("u")
+	a.AddHistory("user", "old-a")
+	a.SetAgentSessionID("aid-a", "claudecode")
+
+	b := sm.NewSession("u", "second")
+	b.AddHistory("user", "old-b")
+	b.SetAgentSessionID("aid-b", "claudecode")
+
+	before := time.Now()
+	got, err := sm.SwitchSession("u", b.ID)
+	after := time.Now()
+	if err != nil {
+		t.Fatalf("SwitchSession: %v", err)
+	}
+	if got.ID != b.ID {
+		t.Fatalf("SwitchSession returned %s, want %s", got.ID, b.ID)
+	}
+
+	if !got.GetExplicitActivatedAt().IsZero() {
+		// Sanity: explicit activation set
+	}
+	activatedAt := got.GetExplicitActivatedAt()
+	if activatedAt.Before(before) || activatedAt.After(after) {
+		t.Fatalf("ExplicitActivatedAt = %v, want between %v and %v", activatedAt, before, after)
+	}
+	if !a.GetExplicitActivatedAt().IsZero() {
+		t.Fatalf("unrelated session A should not be marked; got %v", a.GetExplicitActivatedAt())
+	}
+}
+
+// TestSwitchToAgentSession_MarksExplicitlyActivated verifies that the
+// internal SwitchToAgentSession path also records explicit activation, so
+// any caller that already had agent session IDs in flight benefits from the
+// same exemption.
+func TestSwitchToAgentSession_MarksExplicitlyActivated(t *testing.T) {
+	sm := NewSessionManager(t.TempDir())
+	s := sm.SwitchToAgentSession("u", "aid-1", "claudecode", "first")
+	if s.GetExplicitActivatedAt().IsZero() {
+		t.Fatal("SwitchToAgentSession must mark explicit activation")
+	}
+}
+
+// TestMaybeAutoResetSessionOnIdle_ExplicitActivationBlocksReset reproduces
+// the exact symptom from #1731: the session's LastUserActivity is older than
+// reset_on_idle_mins, but the user has just /switch-ed into it — the reset
+// must NOT fire on the next message.
+func TestMaybeAutoResetSessionOnIdle_ExplicitActivationBlocksReset(t *testing.T) {
+	e := newTestEngine()
+	e.SetResetOnIdle(30 * time.Minute)
+
+	sm := NewSessionManager(t.TempDir())
+	session := sm.GetOrCreateActive("u")
+	session.AddHistory("user", "old msg")
+	session.SetAgentSessionID("aid", "claudecode")
+	session.TryLock()
+
+	// Session's last real user message was 2 hours ago.
+	old := time.Now().Add(-2 * time.Hour)
+	session.mu.Lock()
+	session.LastUserActivity = old
+	session.UpdatedAt = old
+	// But the user just /switch-ed into it — explicit activation is fresh.
+	session.markExplicitlyActivatedLocked()
+	session.mu.Unlock()
+
+	p := &stubPlatformEngine{n: "test"}
+	msg := &Message{SessionKey: "u", ReplyCtx: "ctx"}
+
+	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", session)
+	if rotated != nil {
+		t.Fatal("explicitly activated session must NOT be rotated even if LastUserActivity is old")
+	}
+}
+
+// TestMaybeAutoResetSessionOnIdle_ExplicitActivationExpiresAfterTTL is the
+// safety net: a long-abandoned session that was /switch-ed into once must
+// still be rotated away after ExplicitActivationTTL even though the
+// explicit-activation timestamp is recent-looking (because we artificially
+// age it past the TTL).
+func TestMaybeAutoResetSessionOnIdle_ExplicitActivationExpiresAfterTTL(t *testing.T) {
+	e := newTestEngine()
+	e.SetResetOnIdle(30 * time.Minute)
+
+	sm := NewSessionManager(t.TempDir())
+	session := sm.GetOrCreateActive("u")
+	session.AddHistory("user", "old")
+	session.SetAgentSessionID("aid", "claudecode")
+	session.TryLock()
+
+	old := time.Now().Add(-2 * time.Hour)
+	session.mu.Lock()
+	session.LastUserActivity = old
+	session.UpdatedAt = old
+	session.mu.Unlock()
+
+	// Simulate an explicit activation from 8 days ago — past the 7-day TTL.
+	session.mu.Lock()
+	session.ExplicitActivatedAt = time.Now().Add(-8 * 24 * time.Hour)
+	session.mu.Unlock()
+
+	p := &stubPlatformEngine{n: "test"}
+	msg := &Message{SessionKey: "u", ReplyCtx: "ctx"}
+
+	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", session)
+	if rotated == nil {
+		t.Fatal("explicit activation older than TTL must NOT block the idle reset")
+	}
+}
+
+// TestMaybeAutoResetSessionOnIdle_NonExplicitSessionUsesLegacyPath confirms
+// that sessions which were never explicitly activated (e.g. the implicit
+// "default" session that every user starts with) keep the pre-#1731
+// behaviour: the reset fires when LastUserActivity is older than
+// reset_on_idle_mins.
+func TestMaybeAutoResetSessionOnIdle_NonExplicitSessionUsesLegacyPath(t *testing.T) {
+	e := newTestEngine()
+	e.SetResetOnIdle(30 * time.Minute)
+
+	sm := NewSessionManager(t.TempDir())
+	session := sm.GetOrCreateActive("u")
+	session.AddHistory("user", "old")
+	session.SetAgentSessionID("aid", "claudecode")
+	session.TryLock()
+
+	if !session.GetExplicitActivatedAt().IsZero() {
+		t.Fatal("freshly-created active session should not yet be marked as explicitly activated")
+	}
+
+	old := time.Now().Add(-2 * time.Hour)
+	session.mu.Lock()
+	session.LastUserActivity = old
+	session.UpdatedAt = old
+	session.mu.Unlock()
+
+	p := &stubPlatformEngine{n: "test"}
+	msg := &Message{SessionKey: "u", ReplyCtx: "ctx"}
+
+	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", session)
+	if rotated == nil {
+		t.Fatal("non-explicit session with old LastUserActivity must be rotated (legacy path)")
+	}
+}
+
+// TestSwitchSession_PreventsFirstMessageRotation is the end-to-end shape of
+// the bug report: user has two sessions; one is idle 2 hours, the other
+// active 5 minutes ago. User /switch to the idle one. The very next message
+// must NOT be rotated to a fresh session.
+func TestSwitchSession_PreventsFirstMessageRotation(t *testing.T) {
+	e := newTestEngine()
+	e.SetResetOnIdle(30 * time.Minute)
+
+	sm := NewSessionManager(t.TempDir())
+
+	// Build session "fresh" — last activity 5 min ago, no explicit activation.
+	fresh := sm.GetOrCreateActive("u")
+	fresh.AddHistory("user", "hi")
+	fresh.SetAgentSessionID("aid-fresh", "claudecode")
+	fresh.mu.Lock()
+	fresh.LastUserActivity = time.Now().Add(-5 * time.Minute)
+	fresh.mu.Unlock()
+
+	// Build session "stale" — last activity 2 hours ago.
+	stale := sm.NewSession("u", "stale")
+	stale.AddHistory("user", "old")
+	stale.SetAgentSessionID("aid-stale", "claudecode")
+	stale.mu.Lock()
+	stale.LastUserActivity = time.Now().Add(-2 * time.Hour)
+	stale.UpdatedAt = time.Now().Add(-2 * time.Hour)
+	stale.mu.Unlock()
+
+	// /switch to stale.
+	if _, err := sm.SwitchSession("u", stale.ID); err != nil {
+		t.Fatalf("SwitchSession: %v", err)
+	}
+
+	// Now the very next message lands on stale.
+	current := sm.GetOrCreateActive("u")
+	if current.ID != stale.ID {
+		t.Fatalf("GetOrCreateActive returned %s, want stale %s", current.ID, stale.ID)
+	}
+	if !current.TryLock() {
+		t.Fatal("session should be lockable")
+	}
+
+	p := &stubPlatformEngine{n: "test"}
+	msg := &Message{SessionKey: "u", ReplyCtx: "ctx"}
+
+	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", current)
+	if rotated != nil {
+		t.Fatal("post-switch first message must stay in the explicitly chosen session")
+	}
+}
+
+// TestExplicitActivatedAt_PersistsAcrossSessionRestore verifies that the
+// new field survives the JSON snapshot/restore path (issue #1731 would
+// regress after a process restart otherwise).
+func TestExplicitActivatedAt_PersistsAcrossSessionRestore(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "session.json")
+	sm := NewSessionManager(storePath)
+	session := sm.GetOrCreateActive("u")
+	session.AddHistory("user", "hi")
+	session.SetAgentSessionID("aid", "claudecode")
+	session.MarkExplicitlyActivated()
+	original := session.GetExplicitActivatedAt()
+	if original.IsZero() {
+		t.Fatal("setup: explicit activation not set")
+	}
+	// Persist the explicit-activation timestamp to disk; in production this
+	// happens because callers that mutate session state go through paths that
+	// already call sm.Save(). For the test we trigger it explicitly.
+	sm.Save()
+
+	// Reload from disk.
+	sm2 := NewSessionManager(storePath)
+	restored := sm2.GetOrCreateActive("u")
+	if restored.GetExplicitActivatedAt().IsZero() {
+		t.Fatal("ExplicitActivatedAt did not survive snapshot/restore")
+	}
+	// Truncate to second precision to match JSON round-trip behaviour.
+	if !restored.GetExplicitActivatedAt().Truncate(time.Second).Equal(original.Truncate(time.Second)) {
+		t.Fatalf("ExplicitActivatedAt drifted: got %v, want %v", restored.GetExplicitActivatedAt(), original)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1731 — when a user explicitly `/switch <n>` into a session that has
been idle longer than `reset_on_idle_mins`, the very next message was
silently rotated to a brand-new session. The user asked to be in that
session; the engine ignored them.

## Root Cause

`maybeAutoResetSessionOnIdle` in `core/engine.go` compared the
*active* session's `LastUserActivity` against `reset_on_idle_mins`
and rotated when stale. After `/switch`, the target session becomes
active; if its recorded activity is hours old, the first message after
the switch hits the idle reset path.

## Fix

- New `Session.ExplicitActivatedAt` field (with JSON tag).
- `Session.MarkExplicitlyActivated()` / `markExplicitlyActivatedLocked()`
  helpers; concurrency-safe via `sync.Mutex`.
- `SwitchSession` and `SwitchToAgentSession` call
  `MarkExplicitlyActivated` before persisting.
- `maybeAutoResetSessionOnIdle` now uses the explicit-activation
  timestamp as the baseline when it is more recent than the session's
  recorded activity.
- A 7-day `ExplicitActivationTTL` caps the exemption so abandoned
  explicit sessions eventually fall back to legacy behaviour.
- The snapshot builder copies both `LastUserActivity` (which was
  silently being dropped before this change) and `ExplicitActivatedAt`
  so the exemption survives process restarts.

The idle-reset path is shared across Feishu, Telegram, Discord, etc.
  (all routed through `core/engine.go`); no per-platform changes
  required.

## Tests

New file `core/session_switch_idle_test.go` with 7 cases:

1. `SwitchSession` records explicit activation; unrelated sessions
   stay untouched.
2. `SwitchToAgentSession` records explicit activation.
3. **Regression**: explicit activation blocks the post-switch
   first-message rotation (the exact symptom from #1731).
4. Explicit activation older than TTL does **not** block the idle
   reset (safety net).
5. Non-explicit sessions keep the legacy idle-reset behaviour.
6. End-to-end: fresh + stale sessions, `/switch` to stale, very next
   message stays in stale.
7. `ExplicitActivatedAt` survives JSON snapshot/restore.

Local validation:

```
go test -race -count=1 ./core/     # PASS, 48s
go vet ./core/                      # clean
```

## Risk

Low. The change is additive (new field), the new code path only runs
when an explicit activation timestamp exists, and the 7-day TTL cap
prevents an explicit session from permanently occupying the active
slot. Pre-existing snapshot dropping of `LastUserActivity` is also
fixed in the same change; this can only strengthen existing idle-reset
behaviour for sessions that had been persisted across restarts.

## Compatibility

- No new config keys, no new public API required for end users.
- Existing sessions on disk without `explicit_activated_at` continue
  to use the legacy idle baseline; the new field defaults to zero.

Fixes #1731