### PR TITLE
fix(feishu): retry bot open_id discovery instead of permanently disabling group chat filtering

### DIFF
--- a/platform/feishu/bot_openid_retry_test.go
+++ b/platform/feishu/bot_openid_retry_test.go
@@ -1,0 +1,150 @@
+package feishu
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+)
+
+// newBotInfoTestServer serves the tenant-access-token endpoint plus the bot
+// info endpoint. botInfoStatus decides, per attempt, whether the bot info call
+// fails; attempts counts how many times bot info was hit.
+func newBotInfoTestServer(t *testing.T, openID string, failFirst int64) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var attempts atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal" {
+			_, _ = w.Write([]byte(`{"code":0,"msg":"ok","tenant_access_token":"t-test","expire":7200}`))
+			return
+		}
+		if r.URL.Path == "/open-apis/bot/v3/info" {
+			n := attempts.Add(1)
+			if failFirst < 0 || n <= failFirst {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"code":500,"msg":"internal error"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"code":0,"msg":"ok","bot":{"open_id":"` + openID + `"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &attempts
+}
+
+func newBotOpenIDRetryPlatform(srv *httptest.Server, initial, maxDelay time.Duration) *Platform {
+	return &Platform{
+		platformName: "feishu",
+		client: lark.NewClient("app-id", "app-secret",
+			lark.WithOpenBaseUrl(srv.URL),
+			lark.WithHttpClient(srv.Client()),
+			lark.WithEnableTokenCache(false),
+		),
+		botOpenIDRetryInitialDelay: initial,
+		botOpenIDRetryMaxDelay:     maxDelay,
+	}
+}
+
+// TestStartBotOpenIDRetry_RecoversAfterFailure covers the startup race that
+// motivated this retry loop: the first fetch fails (network not ready yet) and
+// a later attempt succeeds, restoring group chat filtering.
+func TestStartBotOpenIDRetry_RecoversAfterFailure(t *testing.T) {
+	srv, attempts := newBotInfoTestServer(t, "ou_bot_recovered", 2)
+	p := newBotOpenIDRetryPlatform(srv, 10*time.Millisecond, 40*time.Millisecond)
+	defer p.stopBotOpenIDRetry()
+
+	p.startBotOpenIDRetry()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for p.getBotOpenID() == "" && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := p.getBotOpenID(); got != "ou_bot_recovered" {
+		t.Fatalf("botOpenID = %q after %d attempts, want %q", got, attempts.Load(), "ou_bot_recovered")
+	}
+	if n := attempts.Load(); n < 3 {
+		t.Fatalf("attempts = %d, want at least 3 (two failures then success)", n)
+	}
+}
+
+// TestStartBotOpenIDRetry_OnlyOneGoroutine ensures a second call while a retry
+// loop is already running does not spawn a duplicate goroutine: a single stop
+// must then silence all retry traffic.
+func TestStartBotOpenIDRetry_OnlyOneGoroutine(t *testing.T) {
+	srv, attempts := newBotInfoTestServer(t, "ou_bot", -1) // always fails
+	p := newBotOpenIDRetryPlatform(srv, 10*time.Millisecond, 20*time.Millisecond)
+	defer p.stopBotOpenIDRetry()
+
+	p.startBotOpenIDRetry()
+	p.startBotOpenIDRetry()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for attempts.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	p.stopBotOpenIDRetry()
+
+	settled := attempts.Load()
+	time.Sleep(200 * time.Millisecond)
+	if after := attempts.Load(); after > settled+1 {
+		t.Fatalf("a second retry goroutine survived the single stop: attempts %d -> %d", settled, after)
+	}
+}
+
+// TestStopBotOpenIDRetry_StopsGoroutine verifies the retry goroutine exits on
+// shutdown instead of leaking and hammering the API forever.
+func TestStopBotOpenIDRetry_StopsGoroutine(t *testing.T) {
+	srv, attempts := newBotInfoTestServer(t, "ou_bot", -1) // always fails
+	p := newBotOpenIDRetryPlatform(srv, 10*time.Millisecond, 20*time.Millisecond)
+
+	p.startBotOpenIDRetry()
+
+	// Wait until the loop has actually made at least one attempt.
+	deadline := time.Now().Add(5 * time.Second)
+	for attempts.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if attempts.Load() == 0 {
+		t.Fatal("retry goroutine never called the bot info API")
+	}
+
+	p.stopBotOpenIDRetry()
+	if p.botOpenIDRetryCancel != nil {
+		t.Fatal("botOpenIDRetryCancel not cleared after stop")
+	}
+
+	// Give any surviving goroutine several backoff windows to prove itself.
+	settled := attempts.Load()
+	time.Sleep(200 * time.Millisecond)
+	after := attempts.Load()
+	if after > settled+1 { // +1 tolerates one attempt already in flight
+		t.Fatalf("retry goroutine still running after stop: attempts %d -> %d", settled, after)
+	}
+
+	// Stop must be idempotent.
+	p.stopBotOpenIDRetry()
+}
+
+// TestStop_CancelsBotOpenIDRetry verifies Platform.Stop wires through to the
+// retry goroutine, so shutdown does not leak it.
+func TestStop_CancelsBotOpenIDRetry(t *testing.T) {
+	srv, _ := newBotInfoTestServer(t, "ou_bot", -1) // always fails
+	p := newBotOpenIDRetryPlatform(srv, 10*time.Millisecond, 20*time.Millisecond)
+
+	p.startBotOpenIDRetry()
+	if p.botOpenIDRetryCancel == nil {
+		t.Fatal("retry loop did not start")
+	}
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop() error: %v", err)
+	}
+	if p.botOpenIDRetryCancel != nil {
+		t.Fatal("Stop() did not cancel the bot open_id retry goroutine")
+	}
+}

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -150,6 +150,15 @@ type Platform struct {
 	chatMemberCache  sync.Map          // chatID -> *chatMemberEntry
 	recalledMu       sync.Mutex
 	recalledMsgIDs   map[string]time.Time // message_id -> recall time, short TTL race guard
+
+	// botOpenIDRetryCancel cancels the background goroutine that keeps retrying
+	// bot open_id discovery after the eager startup fetch failed. Guarded by p.mu.
+	botOpenIDRetryCancel context.CancelFunc
+	// botOpenIDRetryInitialDelay / botOpenIDRetryMaxDelay override the retry
+	// backoff bounds. Zero means the package defaults; set only in tests.
+	botOpenIDRetryInitialDelay time.Duration
+	botOpenIDRetryMaxDelay     time.Duration
+
 	// Webhook mode fields (for Lark international version)
 	server       *http.Server
 	port         string
@@ -478,8 +487,13 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 	// can still receive events and operate correctly. We therefore only attempt
 	// bot open_id discovery eagerly for WebSocket mode.
 	if !p.shouldUseWebhookMode() {
-		if openID, err := p.fetchBotOpenID(); err != nil {
-			slog.Warn(p.platformName+": failed to get bot open_id, group chat filtering disabled", "error", err)
+		if openID, err := p.fetchBotOpenID(context.Background()); err != nil {
+			// A transient failure here (DNS/network not ready yet when the
+			// process is launched at boot or after a laptop wakes from sleep)
+			// must not permanently disable group chat filtering, so keep
+			// retrying in the background until it succeeds or we shut down.
+			slog.Warn(p.platformName+": failed to get bot open_id, group chat filtering disabled until retry succeeds", "error", err)
+			p.startBotOpenIDRetry()
 		} else {
 			p.mu.Lock()
 			p.botOpenID = openID
@@ -3435,8 +3449,8 @@ func findSingleAsterisk(s string) int {
 }
 
 // fetchBotOpenID retrieves the bot's open_id via the Feishu bot info API.
-func (p *Platform) fetchBotOpenID() (string, error) {
-	resp, err := p.client.Get(context.Background(),
+func (p *Platform) fetchBotOpenID(ctx context.Context) (string, error) {
+	resp, err := p.client.Get(ctx,
 		"/open-apis/bot/v3/info", nil, larkcore.AccessTokenTypeTenant)
 	if err != nil {
 		return "", fmt.Errorf("api call: %w", err)
@@ -3454,6 +3468,88 @@ func (p *Platform) fetchBotOpenID() (string, error) {
 		return "", fmt.Errorf("api code=%d", result.Code)
 	}
 	return result.Bot.OpenID, nil
+}
+
+const (
+	// botOpenIDRetryInitial is the first backoff delay after the eager bot
+	// open_id fetch failed at startup.
+	botOpenIDRetryInitial = 2 * time.Second
+	// botOpenIDRetryMax caps the exponential backoff between retries.
+	botOpenIDRetryMax = 60 * time.Second
+)
+
+// startBotOpenIDRetry launches a background goroutine that retries bot open_id
+// discovery with exponential backoff until it succeeds or the platform stops.
+// Without it a single startup-time network hiccup leaves p.botOpenID empty for
+// the whole process lifetime, which silently disables group @-mention filtering.
+func (p *Platform) startBotOpenIDRetry() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	p.mu.Lock()
+	if p.botOpenIDRetryCancel != nil {
+		// A retry loop is already running; keep it and drop the new context.
+		p.mu.Unlock()
+		cancel()
+		return
+	}
+	p.botOpenIDRetryCancel = cancel
+	initialDelay, maxDelay := p.botOpenIDRetryInitialDelay, p.botOpenIDRetryMaxDelay
+	p.mu.Unlock()
+
+	if initialDelay <= 0 {
+		initialDelay = botOpenIDRetryInitial
+	}
+	if maxDelay <= 0 {
+		maxDelay = botOpenIDRetryMax
+	}
+
+	go func() {
+		delay := initialDelay
+		for attempt := 1; ; attempt++ {
+			select {
+			case <-ctx.Done():
+				slog.Debug(p.platformName + ": bot open_id retry cancelled")
+				return
+			case <-time.After(delay):
+			}
+
+			openID, err := p.fetchBotOpenID(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					slog.Debug(p.platformName + ": bot open_id retry cancelled")
+					return
+				}
+				delay = min(delay*2, maxDelay)
+				slog.Warn(p.platformName+": bot open_id retry failed",
+					"attempt", attempt,
+					"next_delay", delay,
+					"error", err,
+				)
+				continue
+			}
+
+			p.mu.Lock()
+			p.botOpenID = openID
+			p.mu.Unlock()
+			slog.Info(p.platformName+": bot identified after retry, group chat filtering restored",
+				"open_id", openID,
+				"attempt", attempt,
+			)
+			return
+		}
+	}()
+}
+
+// stopBotOpenIDRetry cancels the background bot open_id retry goroutine, if any.
+// Safe to call when no retry is running and safe to call more than once.
+func (p *Platform) stopBotOpenIDRetry() {
+	p.mu.Lock()
+	cancel := p.botOpenIDRetryCancel
+	p.botOpenIDRetryCancel = nil
+	p.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 }
 
 func isBotMentioned(mentions []*larkim.MentionEvent, botOpenID string) bool {
@@ -4830,6 +4926,7 @@ func (p *Platform) updateCardEntity(ctx context.Context, h *feishuPreviewHandle,
 }
 
 func (p *Platform) Stop() error {
+	p.stopBotOpenIDRetry()
 	if p.isWSPrimary {
 		remaining := unregisterSharedWS(p)
 		if remaining > 0 {


### PR DESCRIPTION
# fix(feishu): retry bot open_id discovery instead of permanently disabling group chat filtering

> **Baseline:** branched from `main` (`580df5ea`), a single commit touching only
> `platform/feishu/`. No unrelated changes are bundled in.

## Symptom

When `cc-connect` starts in WebSocket mode and the very first Feishu API call fails,
the bot's own `open_id` is never learned — for the entire lifetime of the process.
The only trace is a single `WARN` at startup:

```
level=WARN msg="feishu: failed to get bot open_id, group chat filtering disabled"
```

The process then keeps running, looks healthy, serves DMs correctly, and gives no
further indication that anything is wrong. In the incident that prompted this PR the
daemon ran degraded for **43 minutes** until it was manually restarted.

## Reproduction conditions

Any transient failure of the *first* `/open-apis/bot/v3/info` call reproduces it:

- the process is launched at boot / by `launchd` / by systemd **before** the network
  stack or DNS resolver is ready;
- a laptop wakes from sleep and the supervisor restarts the service before Wi-Fi
  reassociates (this is the observed case — macOS `launchd` + wake-from-sleep);
- a brief DNS outage, captive portal, or proxy hiccup at the moment of startup.

The window is small, but the consequence is permanent, so over a long-running
deployment it is hit reliably.

## Real-world log

```
time=2026-08-25T13:52:32.693+08:00 level=WARN
  msg="feishu: failed to get bot open_id, group chat filtering disabled"
  error="api call: Post \"https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal\": dial tcp: lookup ..."
```

## Root cause

`Platform.Start` (`platform/feishu/feishu.go`) treats bot identity discovery as a
one-shot, best-effort operation:

```go
if !p.shouldUseWebhookMode() {
    if openID, err := p.fetchBotOpenID(); err != nil {
        slog.Warn(p.platformName+": failed to get bot open_id, group chat filtering disabled", "error", err)
    } else {
        p.mu.Lock()
        p.botOpenID = openID
        p.mu.Unlock()
        slog.Info(p.platformName+": bot identified", "open_id", openID)
    }
}
```

There is no retry. A transient error is converted into a permanent capability loss —
a classic startup race, where the recovery path (the network coming up a few seconds
later) exists but is never taken.

## Security impact — this fails **open**, not closed

`p.botOpenID` is not merely used to *match* mentions; its emptiness disables the
mention gate altogether. From `onMessage`:

```go
if chatType == "group" && !p.groupReplyAll && p.getBotOpenID() != "" {
    if !isBotMentioned(msg.Mentions, p.getBotOpenID()) {
        // ... drop the message
    }
}
```

When `getBotOpenID()` returns `""` the entire condition is skipped, so **every message
in every group chat is dispatched to the agent**, including messages that never
mentioned the bot. For a deployment that relies on `@bot` as the activation gate, this
means unrelated group chatter silently triggers agent runs — burning tokens, and
exposing conversation content the operator did not intend to route to an agent.

This PR does not change that fallback behaviour (a separate decision about whether an
unknown bot identity should fail closed), but it does shrink the exposure window from
"until someone notices and restarts" to "until the network comes back".

Two other consumers of `getBotOpenID()` degrade more benignly and are likewise
untouched: `filterQuotedFilesForUser` fails closed (drops quoted files), and
`stripMentions` merely leaves the `@bot` prefix in the forwarded text.

## Fix

When the eager fetch fails, start a background goroutine that retries with
exponential backoff until it succeeds or the platform shuts down:

- backoff starts at **2s**, doubles, and is capped at **60s**; retries are unbounded,
  because the condition being waited on (network availability) has no deadline;
- on success the value is written under the existing `p.mu` and an `INFO` line records
  the recovery, so operators can tell degraded-then-recovered from degraded-forever;
- the goroutine owns a `context.CancelFunc` stored on the `Platform` and cancelled
  from `Stop()`, so it cannot leak and an in-flight HTTP request is cancelled too;
- `startBotOpenIDRetry` is idempotent — a second call while a loop is running is a
  no-op rather than a duplicate goroutine;
- `fetchBotOpenID` now takes a `context.Context` instead of hard-coding
  `context.Background()`, which is what makes cancellation actually reach the request.

**Webhook mode is deliberately unchanged.** The existing comment explains why startup
there must not depend on a bot-info call, and that reasoning still holds — the retry
only applies to the WebSocket path that already performed eager discovery.

## Scope of change

| File | Change |
| --- | --- |
| `platform/feishu/feishu.go` | +101 / −4 — three new `Platform` fields, two new methods, `fetchBotOpenID` takes a ctx, `Start`/`Stop` wiring |
| `platform/feishu/bot_openid_retry_test.go` | new — 4 tests |

No behaviour changes on the success path: when the first fetch works, the code runs
exactly as before and no goroutine is started.

## Testing

**Unit tests** — `go test -count=1 -race ./platform/feishu/...` is green on a clean
`main` checkout (34.7s), as are `gofmt -l` and `go vet ./platform/feishu/`:

- `TestStartBotOpenIDRetry_RecoversAfterFailure` — `httptest` server fails the first
  two `/open-apis/bot/v3/info` calls, then succeeds; asserts `botOpenID` is populated
  and that it took ≥3 attempts.
- `TestStartBotOpenIDRetry_OnlyOneGoroutine` — two `start` calls, one `stop`; asserts
  API traffic ceases, proving no duplicate goroutine.
- `TestStopBotOpenIDRetry_StopsGoroutine` — always-failing server; asserts the attempt
  counter freezes after `stop`, and that `stop` is idempotent.
- `TestStop_CancelsBotOpenIDRetry` — asserts `Platform.Stop()` cancels the loop.

Both new code paths were mutation-checked: neutering the goroutine launch fails two
tests, and neutering the `cancel()` call fails two others — the tests are not vacuous.

**End-to-end against the live Feishu API.** The built binary was started behind a
`CONNECT` proxy that was *not yet listening*, reproducing the original failure, then
the proxy was brought up mid-backoff:

```
15:08:53 WARN  feishu: failed to get bot open_id, group chat filtering disabled until retry succeeds
               error="... proxyconnect tcp: dial tcp 127.0.0.1:18080: connect: connection refused"
15:08:55 WARN  feishu: bot open_id retry failed  attempt=1 next_delay=4s
15:08:59 WARN  feishu: bot open_id retry failed  attempt=2 next_delay=8s
15:09:07 WARN  feishu: bot open_id retry failed  attempt=3 next_delay=16s
        <-- proxy started here -->
15:09:23 INFO  feishu: bot identified after retry, group chat filtering restored
               open_id=ou_b3b9... attempt=4
```

Backoff progression (2s → 4s → 8s → 16s) and recovery both behave as designed. On the
previous binary this scenario stays degraded indefinitely.

**Happy path unaffected:** the new binary was installed over the running service and
restarted via `launchctl`; startup logs the unchanged `feishu: bot identified` line
and no retry goroutine is created.

## Note on scope of verification

This PR does not touch `daemon/`. On non-Linux hosts a whole-repo `go build ./...`
currently trips over a duplicate `CheckLinger` declaration in that package, which
predates and is unrelated to this change, so verification here is reported at package
level: `go test -count=1 -race ./platform/feishu/...` passes on a clean `main`
baseline.
