### PR TITLE
fix(pi): remove unused "os" import that breaks windows builds

### DIFF
--- a/agent/pi/proc_windows.go
+++ b/agent/pi/proc_windows.go
@@ -3,7 +3,6 @@
 package pi
 
 import (
-	"os"
 	"os/exec"
 	"syscall"
 )


### PR DESCRIPTION
## Problem

`GOOS=windows go build ./...` fails:

```
agent/pi/proc_windows.go:6:2: "os" imported and not used
```

The windows build-constrained file only uses `os/exec` and `syscall` — the bare `"os"` import is stray, and since the file is behind `//go:build windows`, the breakage is invisible to Linux/macOS CI and local builds.

## Fix

Drop the unused import. One line.

## Verification

```
GOOS=windows GOARCH=amd64 go build ./agent/pi/...   # fails before, passes after
```

Note: a full `GOOS=windows go build ./...` additionally requires #1710 (duplicate `CheckLinger` in the daemon package also breaks windows). The two fixes are independent; together all of darwin/arm64, darwin/amd64, windows/amd64, linux/amd64, freebsd/amd64 compile cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)