### PR TITLE
fix(daemon): tighten launchd status handling (legacy plist cleanup, bootout)

### DIFF
--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	launchdLabel = "com.cc-connect.service"
+	launchdLabel       = "com.cc-connect.service"
+	legacyLaunchdLabel = "com.cc-connect.retry"
 )
 
 var runLaunchctl = func(args ...string) (string, error) {
@@ -52,6 +53,7 @@ func (m *launchdManager) Install(cfg Config) error {
 	// Unload existing service first (ignore errors) so we do not leave a stale
 	// job behind when switching between GUI and headless sessions.
 	bootoutLaunchdTargets()
+	removeLegacyLaunchdPlist()
 
 	plist := buildPlist(cfg)
 	// 0600: plist may contain captured secret values (config.toml ${ENV}
@@ -81,20 +83,24 @@ func (m *launchdManager) Install(cfg Config) error {
 func (m *launchdManager) Uninstall() error {
 	bootoutLaunchdTargets()
 
-	plistPath := launchdPlistPath()
-	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove plist: %w", err)
+	for _, plistPath := range launchdPlistPaths() {
+		if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove plist: %w", err)
+		}
 	}
 	return nil
 }
 
 func (*launchdManager) Start() error {
-	if _, target, _, ok := loadedLaunchdTarget(); ok {
+	if _, target, _, ok := loadedLaunchdTargetForLabel(launchdLabel); ok {
 		out, err := runLaunchctl("kickstart", "-kp", target)
 		if err != nil {
 			return fmt.Errorf("start: %s (%w)", out, err)
 		}
 		return nil
+	}
+	if _, _, _, ok := loadedLaunchdTargetForLabel(legacyLaunchdLabel); ok {
+		bootoutLaunchdTargets()
 	}
 
 	domain := preferredLaunchdDomain()
@@ -134,6 +140,7 @@ func (*launchdManager) Restart() error {
 	}
 	target := launchdTarget(domain)
 	bootoutLaunchdTargets()
+	removeLegacyLaunchdPlist()
 
 	plistPath := launchdPlistPath()
 
@@ -162,8 +169,7 @@ func (*launchdManager) Restart() error {
 func (*launchdManager) Status() (*Status, error) {
 	st := &Status{Platform: "launchd"}
 
-	plistPath := launchdPlistPath()
-	if _, err := os.Stat(plistPath); err != nil {
+	if !launchdAnyPlistExists() {
 		return st, nil
 	}
 	st.Installed = true
@@ -175,14 +181,20 @@ func (*launchdManager) Status() (*Status, error) {
 
 	for _, line := range strings.Split(out, "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "pid = ") {
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if indent > 1 {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "pid = "):
 			if pid, err := strconv.Atoi(strings.TrimPrefix(trimmed, "pid = ")); err == nil && pid > 0 {
 				st.PID = pid
 				st.Running = true
 			}
-		}
-		if strings.Contains(trimmed, "state = running") {
-			st.Running = true
+		case strings.HasPrefix(trimmed, "state = "):
+			if strings.Contains(trimmed, "state = running") {
+				st.Running = true
+			}
 		}
 	}
 	return st, nil
@@ -193,6 +205,15 @@ func (*launchdManager) Status() (*Status, error) {
 func launchdPlistPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist")
+}
+
+func legacyLaunchdPlistPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "LaunchAgents", legacyLaunchdLabel+".plist")
+}
+
+func launchdPlistPaths() []string {
+	return []string{launchdPlistPath(), legacyLaunchdPlistPath()}
 }
 
 func launchdUserDomain() string {
@@ -225,18 +246,23 @@ func launchdTarget(domain string) string {
 	return fmt.Sprintf("%s/%s", domain, launchdLabel)
 }
 
+func legacyLaunchdTarget(domain string) string {
+	return fmt.Sprintf("%s/%s", domain, legacyLaunchdLabel)
+}
+
 func launchdTargets() []string {
 	domains := launchdDomains()
-	targets := make([]string, 0, len(domains))
+	targets := make([]string, 0, len(domains)*2)
 	for _, domain := range domains {
 		targets = append(targets, launchdTarget(domain))
+		targets = append(targets, legacyLaunchdTarget(domain))
 	}
 	return targets
 }
 
-func loadedLaunchdTarget() (string, string, string, bool) {
+func loadedLaunchdTargetForLabel(label string) (string, string, string, bool) {
 	for _, domain := range launchdDomains() {
-		target := launchdTarget(domain)
+		target := fmt.Sprintf("%s/%s", domain, label)
 		out, err := runLaunchctl("print", target)
 		if err == nil {
 			return domain, target, out, true
@@ -245,10 +271,30 @@ func loadedLaunchdTarget() (string, string, string, bool) {
 	return "", "", "", false
 }
 
+func loadedLaunchdTarget() (string, string, string, bool) {
+	if domain, target, out, ok := loadedLaunchdTargetForLabel(launchdLabel); ok {
+		return domain, target, out, true
+	}
+	return loadedLaunchdTargetForLabel(legacyLaunchdLabel)
+}
+
+func launchdAnyPlistExists() bool {
+	for _, plistPath := range launchdPlistPaths() {
+		if _, err := os.Stat(plistPath); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 func bootoutLaunchdTargets() {
 	for _, target := range launchdTargets() {
 		_, _ = runLaunchctl("bootout", target)
 	}
+}
+
+func removeLegacyLaunchdPlist() {
+	_ = os.Remove(legacyLaunchdPlistPath())
 }
 
 // templateOwnedEnvKeys are keys the plist template renders directly; if
@@ -350,4 +396,3 @@ func buildPlist(cfg Config) string {
 </plist>
 `, launchdLabel, xmlEscape(cfg.BinaryPath), xmlEscape(cfg.WorkDir), xmlEscape(cfg.LogFile), cfg.LogMaxSize, cfg.LogMaxBackups, xmlEscape(envPATH), envExtra)
 }
-

--- a/daemon/launchd_test.go
+++ b/daemon/launchd_test.go
@@ -103,6 +103,106 @@ func TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable(t *testing.T) {
 	}
 }
 
+func TestLaunchdStatusRecognizesLegacyRetryLabel(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	legacyGUI := legacyLaunchdTarget(guiDomain)
+	legacyUser := legacyLaunchdTarget(userDomain)
+	legacyPlist := legacyLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPlist), 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(legacyPlist, []byte("plist"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	runLaunchctl = func(args ...string) (string, error) {
+		if len(args) < 2 || args[0] != "print" {
+			return "", nil
+		}
+		switch args[1] {
+		case guiDomain, launchdGUIDomain() + "/" + launchdLabel:
+			return "Bootstrap failed: 125: Domain does not support specified action", fmt.Errorf("exit status 125")
+		case userDomain:
+			return "subsystem", nil
+		case legacyGUI, legacyUser:
+			return "\tstate = running\n\tpid = 9001", nil
+		default:
+			return "", fmt.Errorf("unexpected target %q", args[1])
+		}
+	}
+
+	mgr := &launchdManager{}
+	st, err := mgr.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if !st.Installed {
+		t.Fatal("Status().Installed = false, want true")
+	}
+	if !st.Running {
+		t.Fatal("Status().Running = false, want true")
+	}
+	if st.PID != 9001 {
+		t.Fatalf("Status().PID = %d, want 9001", st.PID)
+	}
+}
+
+func TestLaunchdStatusIgnoresNestedActiveState(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	currentGUI := launchdTarget(guiDomain)
+	currentUser := launchdTarget(userDomain)
+	currentPlist := launchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(currentPlist), 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(currentPlist, []byte("plist"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	runLaunchctl = func(args ...string) (string, error) {
+		if len(args) < 2 || args[0] != "print" {
+			return "", nil
+		}
+		switch args[1] {
+		case guiDomain, userDomain:
+			return "subsystem", nil
+		case currentGUI, currentUser:
+			return "state = spawn scheduled\n\t\tstate = active", nil
+		default:
+			return "", fmt.Errorf("unexpected target %q", args[1])
+		}
+	}
+
+	mgr := &launchdManager{}
+	st, err := mgr.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if !st.Installed {
+		t.Fatal("Status().Installed = false, want true")
+	}
+	if st.Running {
+		t.Fatalf("Status().Running = true, want false")
+	}
+	if st.PID != 0 {
+		t.Fatalf("Status().PID = %d, want 0", st.PID)
+	}
+}
+
 func TestRestartPrefersGUIDomainWhenAvailable(t *testing.T) {
 	orig := runLaunchctl
 	t.Cleanup(func() { runLaunchctl = orig })
@@ -510,5 +610,40 @@ func TestInstallLaunchd_TightensExistingPlistFrom0644(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Errorf("plist mode after reinstall = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestInstallLaunchd_RemovesLegacyRetryPlist(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+	runLaunchctl = func(args ...string) (string, error) { return "", nil }
+
+	legacyPath := legacyLaunchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("<plist>legacy</plist>\n"), 0o644); err != nil {
+		t.Fatalf("seed legacy plist: %v", err)
+	}
+
+	mgr := &launchdManager{}
+	cfg := Config{
+		BinaryPath: "/bin/true",
+		WorkDir:    t.TempDir(),
+		LogFile:    filepath.Join(t.TempDir(), "cc.log"),
+		LogMaxSize: 1024,
+		EnvPATH:    "/usr/bin",
+	}
+	if err := mgr.Install(cfg); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy plist still exists after install: %v", err)
+	}
+	if _, err := os.Stat(launchdPlistPath()); err != nil {
+		t.Fatalf("current plist missing after install: %v", err)
 	}
 }


### PR DESCRIPTION
从原 #1641 分支拆出的独立改动（b044db29 的 daemon 部分）。

- 清理旧版 launchd plist（com.cc-connect.retry 遗留）
- bootout 旧 launchd target
- 状态检查收紧

> 注意：daemon/check_linger_other.go 的删除不在本 PR（与 #1701/#1710 重复，由它们处理）。
