### PR TITLE
fix(weixin): let burst_limit = 0 actually disable the send quota (#1716)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1475,13 +1475,17 @@ app_secret = "your-feishu-app-secret"
 # proxy_password = ""
 #
 # Send-volume quota vs ilink's burst throttle (sendMessage ret=-2 "prepare failed"):
-# the gateway throttles the bot after roughly 5-6 separate messages within a short
-# window (multi-chunk sends are fine), and the penalty escalates with every attempt
-# made while active. The quota paces separate messages so the bot stays below the
-# trigger. 0 disables the quota.
-# 发送量配额（防 ilink 突发节流 ret=-2）：网关在短窗口内约 5-6 条独立消息即节流
+# the gateway throttles the bot after roughly 5-6 separate messages per window
+# (multi-chunk sends are fine), and the penalty escalates with every attempt made
+# while active. The quota paces separate messages so the bot stays below the
+# trigger. Note the default window is 24h, so the defaults below cap the bot at 4
+# outbound messages per day — raise burst_limit / shorten burst_window_secs for
+# interactive deployments, or set burst_limit = 0 to disable the quota entirely.
+# 发送量配额（防 ilink 突发节流 ret=-2）：网关在单个窗口内约 5-6 条独立消息即节流
 # （多切块发送不计数），且节流期内每次尝试都会升级惩罚。配额对独立消息限速，
-# 使其低于触发阈值。设为 0 关闭配额。
+# 使其低于触发阈值。注意默认窗口为 24 小时，即下方默认值会将机器人限制为
+# 每天 4 条外发消息；交互式部署请调大 burst_limit 或调小 burst_window_secs，
+# 或设 burst_limit = 0 完全关闭配额。
 # burst_limit = 4           # max separate messages per window / 每窗口最多独立消息数
 # burst_window_secs = 86400 # window length (default 24h) / 窗口时长（秒，默认24小时）
 #

--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -151,12 +151,20 @@ func New(opts map[string]any) (core.Platform, error) {
 	}
 	lp := pickInt(opts["long_poll_timeout_ms"])
 
-	// Send-volume quota (see defaultBurstLimit constants). 0 disables the quota.
-	burstLimit := pickInt(opts["burst_limit"])
+	// Send-volume quota (see defaultBurstLimit constants). An explicitly
+	// configured 0 disables the quota as documented in config.example.toml;
+	// only an absent key falls back to the default (issue #1716).
+	burstLimit := defaultBurstLimit
+	if v, ok := opts["burst_limit"]; ok {
+		burstLimit = pickInt(v)
+	}
 	if burstLimit < 0 {
 		burstLimit = 0
 	}
-	burstWindow := pickInt(opts["burst_window_secs"])
+	burstWindow := defaultBurstWindowSecs
+	if v, ok := opts["burst_window_secs"]; ok {
+		burstWindow = pickInt(v)
+	}
 	if burstWindow < 0 {
 		burstWindow = 0
 	}
@@ -191,13 +199,6 @@ func New(opts map[string]any) (core.Platform, error) {
 	cdnHttpClient := &http.Client{
 		Timeout:   60 * time.Second,
 		Transport: &http.Transport{Proxy: nil},
-	}
-
-	if burstLimit <= 0 {
-		burstLimit = defaultBurstLimit
-	}
-	if burstWindow <= 0 {
-		burstWindow = defaultBurstWindowSecs
 	}
 
 	// dedup_enabled (default true) and dedup_window_seconds (default 300s, the

--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -571,6 +571,77 @@ func TestCheckSendQuota_DisabledWhenZero(t *testing.T) {
 	}
 }
 
+// TestNew_BurstQuotaOptions verifies how burst_limit / burst_window_secs are
+// resolved from platform options (issue #1716): an absent key falls back to the
+// documented default, while an explicit 0 disables the quota as config.example.toml
+// promises. Before the fix an explicit 0 was indistinguishable from "unset" and
+// silently became the default, capping bots at 4 messages/24h with no escape hatch.
+func TestNew_BurstQuotaOptions(t *testing.T) {
+	cases := []struct {
+		name       string
+		opts       map[string]any
+		wantLimit  int
+		wantWindow time.Duration
+	}{
+		{
+			name:       "unset falls back to defaults",
+			opts:       map[string]any{"token": "tok"},
+			wantLimit:  defaultBurstLimit,
+			wantWindow: time.Duration(defaultBurstWindowSecs) * time.Second,
+		},
+		{
+			name:       "explicit zero limit disables the quota",
+			opts:       map[string]any{"token": "tok", "burst_limit": 0},
+			wantLimit:  0,
+			wantWindow: time.Duration(defaultBurstWindowSecs) * time.Second,
+		},
+		{
+			name:       "explicit zero window disables the quota",
+			opts:       map[string]any{"token": "tok", "burst_window_secs": 0},
+			wantLimit:  defaultBurstLimit,
+			wantWindow: 0,
+		},
+		{
+			name:       "negative values are clamped to disabled",
+			opts:       map[string]any{"token": "tok", "burst_limit": -1, "burst_window_secs": -5},
+			wantLimit:  0,
+			wantWindow: 0,
+		},
+		{
+			name:       "explicit values are honored",
+			opts:       map[string]any{"token": "tok", "burst_limit": 30, "burst_window_secs": 600},
+			wantLimit:  30,
+			wantWindow: 600 * time.Second,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plat, err := New(tc.opts)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			p, ok := plat.(*Platform)
+			if !ok {
+				t.Fatalf("New returned %T, want *Platform", plat)
+			}
+			if p.sendQuotaLimit != tc.wantLimit {
+				t.Errorf("sendQuotaLimit = %d, want %d", p.sendQuotaLimit, tc.wantLimit)
+			}
+			if p.sendQuotaWindow != tc.wantWindow {
+				t.Errorf("sendQuotaWindow = %v, want %v", p.sendQuotaWindow, tc.wantWindow)
+			}
+			// The quota must actually be off when it is configured off.
+			if tc.wantLimit == 0 || tc.wantWindow == 0 {
+				for i := 0; i < defaultBurstLimit+5; i++ {
+					if err := p.checkSendQuota(context.Background()); err != nil {
+						t.Fatalf("disabled quota rejected send %d: %v", i, err)
+					}
+				}
+			}
+		})
+	}
+}
+
 // TestSendChunks_AppliesQuota verifies the budget is enforced end-to-end through
 // sendChunks (httptest server): under budget sends succeed, over budget fails.
 func TestSendChunks_AppliesQuota(t *testing.T) {


### PR DESCRIPTION
Fixes #1716. Also unblocks #1712 and #1742.

## The bug

`New()` reads both quota options through `pickInt()`, which returns `0` for an
absent key **and** for an explicitly configured `0`. Forty lines later:

```go
if burstLimit <= 0 {
	burstLimit = defaultBurstLimit
}
if burstWindow <= 0 {
	burstWindow = defaultBurstWindowSecs
}
```

So `burst_limit = 0` was rewritten back to `4`, and the quota stayed on.

That matters because `0` is the only documented way out. `config.example.toml`
says, in both languages:

> `0 disables the quota.`
> `设为 0 关闭配额。`

With the shipped defaults (`burst_limit = 4`, `burst_window_secs = 86400`) a
bot stops sending after four outbound messages per 24h. The send is dropped,
not queued — the only trace is a local `level=ERROR` line, so the person
chatting just stops getting answers. Three reports so far (#1712, #1716,
#1742), and each one hit the same wall: setting `burst_limit = 0` and
restarting changed nothing.

## The fix

Resolve both options by key presence, matching the `dedup_enabled` idiom
already used a few lines below:

- key absent → default (unchanged behaviour)
- explicit `0` → quota disabled, as documented
- negative → clamped to disabled (unchanged)
- explicit positive → honoured (unchanged)

The `<= 0` fallback block is removed since the defaults are now applied at
the point of parsing.

Second commit hunk corrects the `config.example.toml` prose: it described the
gateway throttle as firing on "5-6 separate messages within a **short**
window", while the default window is 86400s. As written the two halves
contradict each other, which is what led #1716 to read the daily cap as a
bug in itself. The note now states plainly that the shipped defaults are a
cap of 4 outbound messages per day.

## Not changed here — needs your call

#1742 argues the quota should apply to the proactive-push path only, not to
replies, with log evidence from a pre-v1.5.0 account: 36 replies delivered in
one day with a single throttle episode, versus every proactive send tripping
`ret=-2` on a day with zero inbound messages. #1643 applied it to both paths
deliberately ("keeping the push and reply paths consistent"), and the
`~5-6/window` figure is your measurement, so I did not touch either the
push/reply split or the `86400` default. Happy to follow up in a separate PR
if you want the reply path exempted or the default window shortened.

## Tests

`TestNew_BurstQuotaOptions` covers all five resolution cases and asserts the
quota is genuinely off (via `checkSendQuota`) whenever it is configured off.

Verified against `golang:1.25`:

- before the fix, the new test fails on `explicit zero limit`, `explicit zero
  window` and `negative values` — e.g. `sendQuotaLimit = 4, want 0`
- after the fix, `go vet ./platform/weixin/` is clean and
  `go test ./platform/weixin/` passes

(`go build ./...` fails on `web/embed.go: pattern all:dist: no matching files
found` on a fresh checkout without a frontend build — pre-existing and
unrelated to this change.)

---

## 中文摘要

`pickInt()` 无法区分「未配置」与「显式配置为 0」，随后的 `<= 0` 回退把显式的
`0` 改回默认值 4，导致 `config.example.toml` 中承诺的「设为 0 关闭配额」完全
失效。默认配置下机器人每 24 小时只能外发 4 条消息，超出后直接丢弃（仅本地
`ERROR` 日志），用户侧毫无提示 —— 已有 #1712、#1716、#1742 三份报告。

本 PR 改为按 key 是否存在来解析（与下方 `dedup_enabled` 写法一致）：未配置走
默认值，显式 `0` 或负数关闭配额，正数按配置生效。同时修正
`config.example.toml` 中「短窗口」与 86400 秒默认值自相矛盾的说明。

#1742 提出的「配额应只作用于主动推送、不作用于回复」涉及 #1643 的既定设计
选择，本 PR 未改动，留待您决定。
