### PR TITLE
feat(core): add message.finalized hook event for post-reply automation

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -412,7 +412,8 @@ level = "info" # debug, info, warn, error
 #
 # Supported events / 支持的事件:
 #   message.received   — user message arrives / 用户消息到达
-#   message.sent       — agent reply sent / Agent 回复发送完成
+#   message.sent       — legacy pre-delivery agent reply hook / 兼容旧版发送前事件
+#   message.finalized  — final reply send completed / 最终回复发送完成
 #   session.started    — agent session spawned / Agent 会话启动
 #   session.ended      — agent session stopped / Agent 会话结束
 #   cron.triggered     — cron job fires / 定时任务触发

--- a/config.example.toml
+++ b/config.example.toml
@@ -414,6 +414,16 @@ level = "info" # debug, info, warn, error
 #   message.received   — user message arrives / 用户消息到达
 #   message.sent       — legacy pre-delivery agent reply hook / 兼容旧版发送前事件
 #   message.finalized  — final reply send completed / 最终回复发送完成
+#                       (CC_HOOK_CHANGED=true only when the turn actually
+#                       modified the git working tree. Semantics: false does NOT
+#                       mean "no change" — non-git workspaces, fresh repos
+#                       without commits, or git failures always report false.
+#                       Fingerprint windows are serialized per workspace, so
+#                       concurrent turns cannot pollute each other's flag.)
+#                       (CC_HOOK_CHANGED 仅在该轮确实改动 git 工作树时为 true。
+#                       注意：false 不等于"无改动"——非 git 工作区、无提交的
+#                       新仓库或 git 失败时恒为 false。指纹窗口按工作区互斥，
+#                       并发轮次不会互相污染该标志。)
 #   session.started    — agent session spawned / Agent 会话启动
 #   session.ended      — agent session stopped / Agent 会话结束
 #   cron.triggered     — cron job fires / 定时任务触发

--- a/core/engine.go
+++ b/core/engine.go
@@ -455,10 +455,15 @@ type Engine struct {
 	workspaceInitAllowLocalPaths bool
 	workspaceBindings            *WorkspaceBindingManager
 	workspacePool                *workspacePool
-	initFlows                    map[string]*workspaceInitFlow // workspace channel key → init state
-	initFlowsMu                  sync.Mutex
-	sendWorkDirMu                sync.RWMutex
-	sendWorkDirs                 map[string]string // sessionKey → work_dir assigned by send --cwd
+	// workspaceFpMu/workspaceFpLocks serialize the git fingerprint window per
+	// workspace, so a turn's Changed flag cannot be polluted by concurrent turns
+	// (foreground-foreground or foreground-background) in the same directory.
+	workspaceFpMu    sync.Mutex
+	workspaceFpLocks map[string]*sync.Mutex        // workdir -> fingerprint window lock
+	initFlows        map[string]*workspaceInitFlow // workspace channel key → init state
+	initFlowsMu      sync.Mutex
+	sendWorkDirMu    sync.RWMutex
+	sendWorkDirs     map[string]string // sessionKey → work_dir assigned by send --cwd
 
 	// Terminal observation (--observe)
 	observeEnabled    bool
@@ -4757,10 +4762,6 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 
 	events := agentSession.Events()
 
-	// Record workspace git state at reader start so background replies can report
-	// whether the working tree changed during this reader's lifetime.
-	readerStartGitFingerprint := workspaceGitFingerprint(workspaceDir)
-
 	var turnActive bool // true after first event, cleared on EventResult
 	defer func() {
 		if turnActive {
@@ -4859,6 +4860,39 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 					"status", event.ToolStatus)
 
 			case EventResult:
+				// Resolve hook context first so the fingerprint window lock uses
+				// the same effective workspace key as the foreground path.
+				state.mu.Lock()
+				hookSessionKey := state.ccSessionKey
+				hookWorkspace := state.workspaceDir
+				hookAgent := state.agent
+				state.mu.Unlock()
+				if hookSessionKey == "" {
+					hookSessionKey = sessionKey
+				}
+				if hookWorkspace == "" {
+					hookWorkspace = workspaceDir
+				}
+				if hookWorkspace == "" {
+					if hookAgent == nil {
+						hookAgent = e.agent
+					}
+					if wd, ok := hookAgent.(WorkDirSwitcher); ok {
+						hookWorkspace = wd.GetWorkDir()
+					}
+				}
+
+				// Serialize the fingerprint window per workspace: baseline is
+				// sampled inside the lock, so concurrent turns in the same
+				// directory cannot pollute this background turn's Changed flag.
+				// The lock also refreshes the baseline per background turn —
+				// a single reader may relay multiple EventResult turns.
+				fpLock := e.workspaceFingerprintLock(hookWorkspace)
+				if fpLock != nil {
+					fpLock.Lock()
+				}
+				turnStartGitFingerprint := workspaceGitFingerprint(e.ctx, hookWorkspace)
+
 				fullResponse := event.Content
 				if fullResponse == "" && len(textParts) > 0 {
 					fullResponse = strings.Join(textParts, "")
@@ -4874,25 +4908,6 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 					}
 				}
 				if finalized {
-					state.mu.Lock()
-					hookSessionKey := state.ccSessionKey
-					hookWorkspace := state.workspaceDir
-					hookAgent := state.agent
-					state.mu.Unlock()
-					if hookSessionKey == "" {
-						hookSessionKey = sessionKey
-					}
-					if hookWorkspace == "" {
-						hookWorkspace = workspaceDir
-					}
-					if hookWorkspace == "" {
-						if hookAgent == nil {
-							hookAgent = e.agent
-						}
-						if wd, ok := hookAgent.(WorkDirSwitcher); ok {
-							hookWorkspace = wd.GetWorkDir()
-						}
-					}
 					turnID := fmt.Sprintf("background-%d", time.Now().UnixNano())
 					e.hooks.Emit(HookEvent{
 						Event:      HookEventMessageFinalized,
@@ -4903,9 +4918,12 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 						Source:     "agent.background_reply",
 						Internal:   false,
 						ReplyKind:  "text",
-						Changed:    readerStartGitFingerprint != "" && readerStartGitFingerprint != workspaceGitFingerprint(hookWorkspace),
+						Changed:    turnStartGitFingerprint != "" && turnStartGitFingerprint != workspaceGitFingerprint(e.ctx, hookWorkspace),
 						Content:    fullResponse,
 					})
+				}
+				if fpLock != nil {
+					fpLock.Unlock()
 				}
 
 				// Safety note: concurrent writes to session.History by the
@@ -5089,9 +5107,20 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	cp := newCompactProgressWriter(e.ctx, state.platform, state.replyCtx, e.agent.Name(), e.i18n.CurrentLang(), workspaceRenderer)
 	state.mu.Unlock()
 
+	// Serialize the git fingerprint window per workspace: hold the lock from
+	// baseline sampling through the finalized emit so concurrent turns in the
+	// same directory (other sessions / background reader) cannot pollute this
+	// turn's Changed flag. Queued messages processed later in this call share
+	// the same window and re-sample their own baseline (see the queued branch).
+	fpLock := e.workspaceFingerprintLock(hookWorkspace)
+	if fpLock != nil {
+		fpLock.Lock()
+		defer fpLock.Unlock()
+	}
+
 	// Record the workspace git state at the start of this turn so post-reply
 	// hooks can tell whether this turn actually changed the working tree.
-	turnStartGitFingerprint := workspaceGitFingerprint(hookWorkspace)
+	turnStartGitFingerprint := workspaceGitFingerprint(e.ctx, hookWorkspace)
 
 	// Send instant confirmation reply if enabled and no streaming card is active.
 	// Streaming cards provide their own "processing" indicator, so instant reply
@@ -5826,6 +5855,11 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			} else if fullResponse == "" && len(textParts) > 0 {
 				fullResponse = strings.Join(textParts, "")
 			}
+			// Record whether the agent produced no content at all before the
+			// localized empty-response placeholder replaces it: an empty reply
+			// must not fire message.finalized (matches the background path,
+			// where an empty EventResult emits nothing).
+			hadEmptyReply := fullResponse == ""
 			if fullResponse == "" {
 				fullResponse = e.i18n.T(MsgEmptyResponse)
 			}
@@ -6123,7 +6157,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				finalized = true
 			}
 
-			if finalized && !isSilent {
+			if finalized && !isSilent && !hadEmptyReply {
 				e.hooks.Emit(HookEvent{
 					Event:      HookEventMessageFinalized,
 					TurnID:     msgID,
@@ -6133,7 +6167,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					Source:     "agent.final_reply",
 					Internal:   false,
 					ReplyKind:  replyKind,
-					Changed:    turnStartGitFingerprint != "" && turnStartGitFingerprint != workspaceGitFingerprint(hookWorkspace),
+					Changed:    turnStartGitFingerprint != "" && turnStartGitFingerprint != workspaceGitFingerprint(e.ctx, hookWorkspace),
 					Content:    fullResponse,
 				})
 			}
@@ -6233,6 +6267,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 
 				queuedPrompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
+
+				// Re-sample the turn baseline before this queued message's agent
+				// turn starts: earlier queued messages may have changed the tree,
+				// and this message's Changed flag must not inherit their edits.
+				// The fingerprint window lock is already held for this call.
+				turnStartGitFingerprint = workspaceGitFingerprint(e.ctx, hookWorkspace)
 
 				state.mu.Lock()
 				as := state.agentSession // capture under lock to avoid race with cleanup
@@ -12018,23 +12058,53 @@ func (e *Engine) sendForWorkspace(p Platform, replyCtx any, content, workspaceDi
 	_ = e.sendWithErrorForWorkspace(p, replyCtx, content, workspaceDir)
 }
 
+// workspaceGitFingerprintTimeout bounds each git fingerprint scan. The scan runs
+// synchronously in the engine's event loop (per turn start and per finalized emit),
+// so an unbounded git (huge tree, network filesystem, hung process) would stall
+// every session; the timeout caps the worst-case blocking.
+const workspaceGitFingerprintTimeout = 5 * time.Second
+
 // workspaceGitFingerprint returns a fingerprint of the git working tree at workDir
 // (porcelain status + HEAD). Empty when workDir is not a git repo or git fails.
 // Used to detect whether a turn actually changed the workspace, so post-reply
 // hooks (e.g. auto-review) can skip turns that made no code change.
-func workspaceGitFingerprint(workDir string) string {
+func workspaceGitFingerprint(ctx context.Context, workDir string) string {
 	if workDir == "" {
 		return ""
 	}
-	status, err := exec.Command("git", "-C", workDir, "status", "--porcelain").Output()
+	ctx, cancel := context.WithTimeout(ctx, workspaceGitFingerprintTimeout)
+	defer cancel()
+	status, err := exec.CommandContext(ctx, "git", "-C", workDir, "status", "--porcelain").Output()
 	if err != nil {
 		return ""
 	}
-	head, err := exec.Command("git", "-C", workDir, "rev-parse", "HEAD").Output()
+	head, err := exec.CommandContext(ctx, "git", "-C", workDir, "rev-parse", "HEAD").Output()
 	if err != nil {
 		return ""
 	}
 	return string(status) + "\x00" + string(head)
+}
+
+// workspaceFingerprintLock returns the per-workspace mutex that serializes git
+// fingerprint windows for workDir (nil when workDir is empty — no workspace, no
+// fingerprint, nothing to protect). The lock is held from baseline sampling
+// through the end-of-turn sampling so no other turn in the same directory can
+// interleave its own changes into this turn's fingerprint delta.
+func (e *Engine) workspaceFingerprintLock(workDir string) *sync.Mutex {
+	if workDir == "" {
+		return nil
+	}
+	e.workspaceFpMu.Lock()
+	defer e.workspaceFpMu.Unlock()
+	if e.workspaceFpLocks == nil {
+		e.workspaceFpLocks = make(map[string]*sync.Mutex)
+	}
+	m, ok := e.workspaceFpLocks[workDir]
+	if !ok {
+		m = &sync.Mutex{}
+		e.workspaceFpLocks[workDir] = m
+	}
+	return m
 }
 
 func (e *Engine) renderCardForPlatform(p Platform, card *Card) *Card {

--- a/core/engine.go
+++ b/core/engine.go
@@ -545,6 +545,7 @@ type interactiveState struct {
 	lastRecallProbeAt        time.Time
 	recallProbeInFlight      bool
 	workspaceDir             string
+	ccSessionKey             string // raw platform:chat:user key for hooks and agent env
 	agent                    Agent
 	mu                       sync.Mutex
 	stopCh                   chan struct{}
@@ -4044,6 +4045,11 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 
 	state, ok := e.interactiveStates[sessionKey]
 	if ok && state.agentSession != nil && state.agentSession.Alive() {
+		if ccSessionKey != "" {
+			state.mu.Lock()
+			state.ccSessionKey = ccSessionKey
+			state.mu.Unlock()
+		}
 		// Verify the running agent session matches the current active session.
 		// After /new or /switch the active session changes, but the old agent
 		// process may still be alive. Reusing it would send messages to the
@@ -4119,7 +4125,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	// Check if context is already canceled (e.g. during shutdown/restart)
 	if e.ctx.Err() != nil {
 		slog.Debug("skipping session start: context canceled", "session_key", sessionKey)
-		newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true}
+		newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, ccSessionKey: ccKey, eventsNeedResync: true}
 		adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
 		state = newState
 		e.interactiveStates[sessionKey] = state
@@ -4196,7 +4202,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 				Platform:   p.Name(),
 				Error:      fmt.Sprintf("failed to start session: %v", err),
 			})
-			newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true}
+			newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, ccSessionKey: ccKey, eventsNeedResync: true}
 			adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
 			state = newState
 			e.interactiveStates[sessionKey] = state
@@ -4238,6 +4244,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		platform:         p,
 		replyCtx:         replyCtx,
 		agent:            agent,
+		ccSessionKey:     ccKey,
 		eventsNeedResync: true,
 	}
 	adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
@@ -4853,10 +4860,47 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 					fullResponse = strings.Join(textParts, "")
 				}
 
+				finalized := fullResponse != ""
 				if fullResponse != "" {
 					for _, chunk := range SplitMessageCodeFenceAware(fullResponse, maxPlatformMessageLen) {
-						e.send(p, replyCtx, chunk)
+						if err := e.sendWithErrorForWorkspace(p, replyCtx, chunk, workspaceDir); err != nil {
+							finalized = false
+							break
+						}
 					}
+				}
+				if finalized {
+					state.mu.Lock()
+					hookSessionKey := state.ccSessionKey
+					hookWorkspace := state.workspaceDir
+					hookAgent := state.agent
+					state.mu.Unlock()
+					if hookSessionKey == "" {
+						hookSessionKey = sessionKey
+					}
+					if hookWorkspace == "" {
+						hookWorkspace = workspaceDir
+					}
+					if hookWorkspace == "" {
+						if hookAgent == nil {
+							hookAgent = e.agent
+						}
+						if wd, ok := hookAgent.(WorkDirSwitcher); ok {
+							hookWorkspace = wd.GetWorkDir()
+						}
+					}
+					turnID := fmt.Sprintf("background-%d", time.Now().UnixNano())
+					e.hooks.Emit(HookEvent{
+						Event:      HookEventMessageFinalized,
+						TurnID:     turnID,
+						SessionKey: hookSessionKey,
+						Workspace:  hookWorkspace,
+						Platform:   p.Name(),
+						Source:     "agent.background_reply",
+						Internal:   false,
+						ReplyKind:  "text",
+						Content:    fullResponse,
+					})
 				}
 
 				// Safety note: concurrent writes to session.History by the
@@ -4998,9 +5042,19 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 	state.mu.Lock()
 	workspaceDir := state.workspaceDir
+	hookSessionKey := state.ccSessionKey
 	replyAgent := state.agent
 	if replyAgent == nil {
 		replyAgent = e.agent
+	}
+	if hookSessionKey == "" {
+		hookSessionKey = sessionKey
+	}
+	hookWorkspace := workspaceDir
+	if hookWorkspace == "" {
+		if wd, ok := replyAgent.(WorkDirSwitcher); ok {
+			hookWorkspace = wd.GetWorkDir()
+		}
 	}
 	workspaceRenderer := func(content string) string {
 		return e.renderOutgoingContentForWorkspace(state.platform, content, workspaceDir)
@@ -5899,9 +5953,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 			state.mu.Unlock()
 
 			replyStart := time.Now()
+			finalized := false
+			replyKind := "text"
 
 			// --- StreamingCard path ---
 			if streamCard != nil && !streamCard.Failed() {
+				replyKind = "card"
 				sp.finish("", "") // cleanup preview (should be no-op if card was active)
 				// Silent reply: never render the NO_REPLY marker into the card.
 				// cardAnswerText holds only the text streamed BEFORE the marker
@@ -5916,6 +5973,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 				finalContent := buildCardContent(cardThinkingText, cardToolCalls, cardBody)
 				if err := streamCard.Finalize(e.ctx, finalContent); err != nil {
+					replyKind = "fallback"
 					slog.Error("streaming card finalize failed, sending fallback", "error", err)
 					// Fallback: send the response as a normal message — but never
 					// for a silent reply, which has no deliverable content.
@@ -5925,7 +5983,10 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 								return
 							}
 						}
+						finalized = true
 					}
+				} else {
+					finalized = true
 				}
 				if isSilent {
 					slog.Info("silent reply suppressed", "session", session.ID)
@@ -5971,6 +6032,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 				slog.Info("silent reply suppressed", "session", session.ID)
 			} else if hasRichCard {
+				replyKind = "card"
 				parts := []string{fullResponse}
 				if splitter, ok := p.(MarkdownTableSplitter); ok {
 					parts = splitter.SplitMarkdownByTables(fullResponse, 5)
@@ -6016,6 +6078,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 						return
 					}
 				}
+				finalized = true
 			} else if toolCount > 0 && segmentStart > 0 {
 				// When tool calls happened and prior text was already surfaced in segments,
 				// only send the unsent remainder. When tool progress is hidden, tool events don't surface
@@ -6029,6 +6092,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 						}
 					}
 				}
+				finalized = true
 			} else if suppressDuplicate {
 				sp.discard()
 				metaOnly := strings.TrimSpace(strings.TrimPrefix(fullResponse, baseResponse))
@@ -6038,13 +6102,30 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 				}
 				slog.Debug("EventResult: suppressed duplicate side-channel text", "response_len", len(fullResponse))
+				finalized = true
 			} else if sp.finish(fullResponse, statusFooter) {
 				slog.Debug("EventResult: finalized via stream preview", "response_len", len(fullResponse), "footer_len", len(statusFooter))
+				finalized = true
 			} else {
 				slog.Debug("EventResult: sending via p.Send (preview inactive or failed)", "response_len", len(fullResponse), "footer_len", len(statusFooter))
 				if !sendChunksWithStatusFooter(e.ctx, p, replyCtx, fullResponse, statusFooter, sendWorkspaceWithError) {
 					return
 				}
+				finalized = true
+			}
+
+			if finalized && !isSilent {
+				e.hooks.Emit(HookEvent{
+					Event:      HookEventMessageFinalized,
+					TurnID:     msgID,
+					SessionKey: hookSessionKey,
+					Workspace:  hookWorkspace,
+					Platform:   p.Name(),
+					Source:     "agent.final_reply",
+					Internal:   false,
+					ReplyKind:  replyKind,
+					Content:    fullResponse,
+				})
 			}
 
 			if elapsed := time.Since(replyStart); elapsed >= slowPlatformSend {

--- a/core/engine.go
+++ b/core/engine.go
@@ -4757,6 +4757,10 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 
 	events := agentSession.Events()
 
+	// Record workspace git state at reader start so background replies can report
+	// whether the working tree changed during this reader's lifetime.
+	readerStartGitFingerprint := workspaceGitFingerprint(workspaceDir)
+
 	var turnActive bool // true after first event, cleared on EventResult
 	defer func() {
 		if turnActive {
@@ -4899,6 +4903,7 @@ func (e *Engine) runUnsolicitedReader(ctx context.Context, cancel context.Cancel
 						Source:     "agent.background_reply",
 						Internal:   false,
 						ReplyKind:  "text",
+						Changed:    readerStartGitFingerprint != "" && readerStartGitFingerprint != workspaceGitFingerprint(hookWorkspace),
 						Content:    fullResponse,
 					})
 				}
@@ -5083,6 +5088,10 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 	sp := newStreamPreview(e.streamPreview, state.platform, state.replyCtx, e.ctx, workspaceRenderer)
 	cp := newCompactProgressWriter(e.ctx, state.platform, state.replyCtx, e.agent.Name(), e.i18n.CurrentLang(), workspaceRenderer)
 	state.mu.Unlock()
+
+	// Record the workspace git state at the start of this turn so post-reply
+	// hooks can tell whether this turn actually changed the working tree.
+	turnStartGitFingerprint := workspaceGitFingerprint(hookWorkspace)
 
 	// Send instant confirmation reply if enabled and no streaming card is active.
 	// Streaming cards provide their own "processing" indicator, so instant reply
@@ -6124,6 +6133,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					Source:     "agent.final_reply",
 					Internal:   false,
 					ReplyKind:  replyKind,
+					Changed:    turnStartGitFingerprint != "" && turnStartGitFingerprint != workspaceGitFingerprint(hookWorkspace),
 					Content:    fullResponse,
 				})
 			}
@@ -12006,6 +12016,25 @@ func (e *Engine) sendWithErrorForWorkspace(p Platform, replyCtx any, content, wo
 
 func (e *Engine) sendForWorkspace(p Platform, replyCtx any, content, workspaceDir string) {
 	_ = e.sendWithErrorForWorkspace(p, replyCtx, content, workspaceDir)
+}
+
+// workspaceGitFingerprint returns a fingerprint of the git working tree at workDir
+// (porcelain status + HEAD). Empty when workDir is not a git repo or git fails.
+// Used to detect whether a turn actually changed the workspace, so post-reply
+// hooks (e.g. auto-review) can skip turns that made no code change.
+func workspaceGitFingerprint(workDir string) string {
+	if workDir == "" {
+		return ""
+	}
+	status, err := exec.Command("git", "-C", workDir, "status", "--porcelain").Output()
+	if err != nil {
+		return ""
+	}
+	head, err := exec.Command("git", "-C", workDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return string(status) + "\x00" + string(head)
 }
 
 func (e *Engine) renderCardForPlatform(p Platform, card *Card) *Card {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1050,6 +1050,39 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelText(t *testing.
 	}
 }
 
+func TestWorkspaceGitFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	// non-git directory -> empty
+	if got := workspaceGitFingerprint(dir); got != "" {
+		t.Errorf("non-git dir: want empty, got %q", got)
+	}
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init")
+	runGit("config", "user.email", "t@t")
+	runGit("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v1"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "a.txt")
+	runGit("commit", "-qm", "init")
+	fp := workspaceGitFingerprint(dir)
+	if fp == "" {
+		t.Fatal("git repo should have a fingerprint")
+	}
+	// working tree change -> fingerprint changes
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v2"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if workspaceGitFingerprint(dir) == fp {
+		t.Error("working tree change should change the fingerprint")
+	}
+}
+
 func TestProcessInteractiveEvents_FinalizedHookRunsAfterReplySend(t *testing.T) {
 	dir := t.TempDir()
 	sentMarker := filepath.Join(dir, "sent")

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -2,8 +2,12 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1053,7 +1057,7 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelText(t *testing.
 func TestWorkspaceGitFingerprint(t *testing.T) {
 	dir := t.TempDir()
 	// non-git directory -> empty
-	if got := workspaceGitFingerprint(dir); got != "" {
+	if got := workspaceGitFingerprint(context.Background(), dir); got != "" {
 		t.Errorf("non-git dir: want empty, got %q", got)
 	}
 	runGit := func(args ...string) {
@@ -1070,7 +1074,7 @@ func TestWorkspaceGitFingerprint(t *testing.T) {
 	}
 	runGit("add", "a.txt")
 	runGit("commit", "-qm", "init")
-	fp := workspaceGitFingerprint(dir)
+	fp := workspaceGitFingerprint(context.Background(), dir)
 	if fp == "" {
 		t.Fatal("git repo should have a fingerprint")
 	}
@@ -1078,7 +1082,7 @@ func TestWorkspaceGitFingerprint(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v2"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if workspaceGitFingerprint(dir) == fp {
+	if workspaceGitFingerprint(context.Background(), dir) == fp {
 		t.Error("working tree change should change the fingerprint")
 	}
 }
@@ -1121,6 +1125,311 @@ func TestProcessInteractiveEvents_FinalizedHookRunsAfterReplySend(t *testing.T) 
 	}
 	if got := p.getSent(); len(got) != 1 || got[0] != "final reply" {
 		t.Fatalf("sent replies = %#v, want one final reply", got)
+	}
+}
+
+// newFinalizedHookServer starts an HTTP hook receiver for message.finalized and
+// returns the server plus a channel that receives each emitted event.
+func newFinalizedHookServer(t *testing.T) (*httptest.Server, chan HookEvent) {
+	t.Helper()
+	events := make(chan HookEvent, 16)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var ev HookEvent
+		_ = json.Unmarshal(body, &ev)
+		events <- ev
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, events
+}
+
+// TestProcessInteractiveEvents_EmptyReplyDoesNotEmitFinalizedHook verifies that
+// an agent reply with no content does not fire message.finalized even though the
+// localized empty-response placeholder is still delivered to the platform. The
+// PR description promises "empty replies do not trigger"; the placeholder send
+// must not be conflated with a real final reply.
+func TestProcessInteractiveEvents_EmptyReplyDoesNotEmitFinalizedHook(t *testing.T) {
+	p := &stubPlatformEngine{n: "feishu"}
+	srv, hookEvents := newFinalizedHookServer(t)
+	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetHooks(NewHookManager("my-project", []HookConfig{{
+		Event: string(HookEventMessageFinalized),
+		Type:  "http",
+		URL:   srv.URL,
+		Async: boolPtr(false),
+	}}, "sh", "-c", ""))
+
+	sessionKey := "feishu:chat:user"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-empty")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-empty",
+		ccSessionKey: sessionKey,
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "turn-1", time.Now(), nil, nil, state.replyCtx)
+
+	// The empty reply is replaced by the localized placeholder and delivered.
+	if got := p.getSent(); len(got) != 1 {
+		t.Fatalf("sent replies = %#v, want the empty-response placeholder", got)
+	}
+	// ... but message.finalized must NOT fire for an empty reply.
+	select {
+	case ev := <-hookEvents:
+		t.Fatalf("message.finalized fired for empty reply: %#v", ev)
+	default:
+	}
+}
+
+// TestProcessInteractiveEvents_QueuedMessageGetsFreshBaseline verifies that a
+// queued message re-samples its turn-start git baseline instead of inheriting
+// the baseline captured for the first message of the call. Without the
+// re-sample, changes made during the first message's turn would make the second
+// message report changed=true even though it modified nothing itself.
+//
+// Timeline (synchronous engine call driven by a helper goroutine):
+//  1. turnStart baseline A captured (clean tree)
+//  2. engine goroutine then blocks on events; test writes file x (strictly
+//     after A — see the fingerprint-lock wait below) → first EventResult emits
+//     changed=true
+//  3. queued branch drains stale events and re-samples baseline B (tree now
+//     contains x)
+//  4. test feeds second EventResult after the first emit's marker → emits
+//     changed=false (B vs unchanged tree)
+//
+// If the queued branch failed to re-sample, step 4 would compare A vs B and
+// wrongly report changed=true.
+func TestProcessInteractiveEvents_QueuedMessageGetsFreshBaseline(t *testing.T) {
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init")
+	runGit("config", "user.email", "t@t")
+	runGit("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(dir, "base.txt"), []byte("v1"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "base.txt")
+	runGit("commit", "-qm", "init")
+
+	changedLog := filepath.Join(dir, "changed.log")
+	firstEmitMarker := filepath.Join(dir, "first-emit")
+	hookCmd := "echo \"$CC_HOOK_CHANGED\" >> '" + changedLog + "'; touch '" + firstEmitMarker + "'"
+
+	p := &stubPlatformEngine{n: "feishu"}
+	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetHooks(NewHookManager("my-project", []HookConfig{{
+		Event:   string(HookEventMessageFinalized),
+		Type:    "command",
+		Command: hookCmd,
+		Async:   boolPtr(false),
+	}}, "sh", "-c", ""))
+
+	sessionKey := "feishu:chat:user"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-queued")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-queued",
+		ccSessionKey: sessionKey,
+		workspaceDir: dir,
+		pendingMessages: []queuedMessage{
+			{messageID: "msg-2", platform: p, replyCtx: "ctx-queued", content: "second"},
+		},
+	}
+	e.interactiveStates[sessionKey] = state
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		e.processInteractiveEvents(state, session, e.sessions, sessionKey, "msg-1", time.Now(), nil, nil, state.replyCtx)
+	}()
+
+	// Wait until the engine goroutine holds the fingerprint window lock
+	// (baseline A is sampled right after acquisition), plus a settle window for
+	// the git scan itself, so the tree change below lands strictly after A.
+	fpLock := e.workspaceFingerprintLock(dir)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if !fpLock.TryLock() {
+			time.Sleep(500 * time.Millisecond)
+			break
+		}
+		fpLock.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("engine goroutine did not acquire the fingerprint lock")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "x.txt"), []byte("change"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	agentSession.events <- Event{Type: EventResult, Content: "first", Done: true}
+
+	// Wait for the first finalized emit (marker touched by the sync hook), then
+	// let the queued branch finish its stale-event drain and baseline re-sample
+	// before queuing EventResult #2 — feeding it earlier would get it dropped by
+	// drainEvents and the second turn would never start.
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(firstEmitMarker); err == nil {
+			time.Sleep(300 * time.Millisecond)
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("first finalized emit did not run")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	agentSession.events <- Event{Type: EventResult, Content: "second", Done: true}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processInteractiveEvents did not finish")
+	}
+
+	logData, err := os.ReadFile(changedLog)
+	if err != nil {
+		t.Fatalf("read changed log: %v", err)
+	}
+	lines := strings.Fields(string(logData))
+	if len(lines) != 2 {
+		t.Fatalf("changed log = %q, want 2 emits", lines)
+	}
+	if lines[0] != "true" {
+		t.Errorf("first message changed = %q, want true (it modified the tree after baseline A)", lines[0])
+	}
+	if lines[1] != "false" {
+		t.Errorf("second message changed = %q, want false (queued message must re-sample its baseline, otherwise the first message's change leaks into it)", lines[1])
+	}
+}
+
+// TestWorkspaceFingerprintLock_SerializesConcurrentTurns verifies that
+// concurrent turns in the same workspace serialize their git fingerprint
+// windows: the second turn's Changed flag must not be polluted by the first
+// turn's edits. Without the per-workspace lock the second turn could sample its
+// baseline before the first turn's change and then report changed=true.
+func TestWorkspaceFingerprintLock_SerializesConcurrentTurns(t *testing.T) {
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init")
+	runGit("config", "user.email", "t@t")
+	runGit("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(dir, "base.txt"), []byte("v1"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "base.txt")
+	runGit("commit", "-qm", "init")
+
+	p := &stubPlatformEngine{n: "feishu"}
+	srv, hookEvents := newFinalizedHookServer(t)
+	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetHooks(NewHookManager("my-project", []HookConfig{{
+		Event: string(HookEventMessageFinalized),
+		Type:  "http",
+		URL:   srv.URL,
+		Async: boolPtr(false),
+	}}, "sh", "-c", ""))
+
+	newState := func(sessID, sk string) (*interactiveState, *Session) {
+		session := e.sessions.GetOrCreateActive(sk)
+		as := newControllableSession(sessID)
+		st := &interactiveState{
+			agentSession: as,
+			platform:     p,
+			replyCtx:     "ctx-" + sk,
+			ccSessionKey: sk,
+			workspaceDir: dir,
+		}
+		e.interactiveStates[sk] = st
+		return st, session
+	}
+	state1, session1 := newState("s1", "feishu:chat:u1")
+	state2, session2 := newState("s2", "feishu:chat:u2")
+
+	done1 := make(chan struct{})
+	done2 := make(chan struct{})
+	go func() {
+		defer close(done1)
+		e.processInteractiveEvents(state1, session1, e.sessions, "feishu:chat:u1", "t1", time.Now(), nil, nil, state1.replyCtx)
+	}()
+	// Wait until turn 1 holds the fingerprint window lock, then start turn 2 —
+	// it must block on the lock instead of sampling concurrently with turn 1.
+	// Once the lock is held we still wait for the git scan itself to settle
+	// (baseline A is sampled right after lock acquisition; `git status` takes a
+	// few tens of ms), so the tree change below lands strictly after A.
+	fpLock := e.workspaceFingerprintLock(dir)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if !fpLock.TryLock() {
+			time.Sleep(500 * time.Millisecond)
+			break
+		}
+		fpLock.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("turn 1 did not acquire the fingerprint lock")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	go func() {
+		defer close(done2)
+		e.processInteractiveEvents(state2, session2, e.sessions, "feishu:chat:u2", "t2", time.Now(), nil, nil, state2.replyCtx)
+	}()
+
+	// Turn 1 modifies the tree, then completes.
+	if err := os.WriteFile(filepath.Join(dir, "y.txt"), []byte("change"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	state1.agentSession.(*controllableAgentSession).events <- Event{Type: EventResult, Content: "one", Done: true}
+	select {
+	case <-done1:
+	case <-time.After(5 * time.Second):
+		t.Fatal("turn 1 did not finish")
+	}
+
+	// Turn 2 makes no further change; its Changed must be false.
+	state2.agentSession.(*controllableAgentSession).events <- Event{Type: EventResult, Content: "two", Done: true}
+	select {
+	case <-done2:
+	case <-time.After(5 * time.Second):
+		t.Fatal("turn 2 did not finish")
+	}
+
+	var ev1, ev2 HookEvent
+	deadline = time.Now().Add(5 * time.Second)
+	for ev1.Event == "" || ev2.Event == "" {
+		select {
+		case ev := <-hookEvents:
+			if ev.SessionKey == "feishu:chat:u1" && ev1.Event == "" {
+				ev1 = ev
+			} else if ev.SessionKey == "feishu:chat:u2" && ev2.Event == "" {
+				ev2 = ev
+			}
+		case <-time.After(time.Until(deadline)):
+			t.Fatal("finalized events not received")
+		}
+	}
+	if !ev1.Changed {
+		t.Errorf("turn 1 changed = false, want true (it modified the tree)")
+	}
+	if ev2.Changed {
+		t.Errorf("turn 2 changed = true, want false (fingerprint window must be serialized per workspace)")
 	}
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -88,6 +88,30 @@ func (p *stubPlatformEngine) clearSent() {
 	p.mu.Unlock()
 }
 
+type finalizedOrderPlatform struct {
+	stubPlatformEngine
+	marker string
+}
+
+func (p *finalizedOrderPlatform) Send(ctx context.Context, replyCtx any, content string) error {
+	if err := os.WriteFile(p.marker, []byte("sent\n"), 0600); err != nil {
+		return err
+	}
+	return p.stubPlatformEngine.Send(ctx, replyCtx, content)
+}
+
+type failedSendPlatform struct {
+	stubPlatformEngine
+	marker string
+}
+
+func (p *failedSendPlatform) Send(_ context.Context, _ any, _ string) error {
+	if err := os.WriteFile(p.marker, []byte("attempted\n"), 0600); err != nil {
+		return err
+	}
+	return errors.New("platform send failed")
+}
+
 type recallCheckingPlatform struct {
 	stubPlatformEngine
 	recalled bool
@@ -1023,6 +1047,47 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelText(t *testing.
 
 	if got := p.getSent(); len(got) != 1 || got[0] != sideText {
 		t.Fatalf("sent text = %#v, want one side-channel message", got)
+	}
+}
+
+func TestProcessInteractiveEvents_FinalizedHookRunsAfterReplySend(t *testing.T) {
+	dir := t.TempDir()
+	sentMarker := filepath.Join(dir, "sent")
+	hookMarker := filepath.Join(dir, "hook")
+	p := &finalizedOrderPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		marker:             sentMarker,
+	}
+	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetHooks(NewHookManager("my-project", []HookConfig{{
+		Event:   string(HookEventMessageFinalized),
+		Type:    "command",
+		Command: "test -f '" + sentMarker + "' && touch '" + hookMarker + "'",
+		Async:   boolPtr(false),
+	}}, "sh", "-c", ""))
+
+	sessionKey := "feishu:chat:user"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-finalized")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-finalized",
+		ccSessionKey: sessionKey,
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventResult, Content: "final reply", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "turn-1", time.Now(), nil, nil, state.replyCtx)
+
+	if _, err := os.Stat(sentMarker); err != nil {
+		t.Fatalf("final reply was not sent: %v", err)
+	}
+	if _, err := os.Stat(hookMarker); err != nil {
+		t.Fatalf("message.finalized hook did not run after send: %v", err)
+	}
+	if got := p.getSent(); len(got) != 1 || got[0] != "final reply" {
+		t.Fatalf("sent replies = %#v, want one final reply", got)
 	}
 }
 
@@ -14048,6 +14113,99 @@ func waitForPlatformSend(p *stubPlatformEngine, n int, timeout time.Duration) []
 
 // TestUnsolicitedReader_RelaysEventResult verifies that the unsolicited reader
 // goroutine relays EventResult content to the platform.
+func TestUnsolicitedReader_EmitsFinalizedHookAfterReplySend(t *testing.T) {
+	dir := t.TempDir()
+	sentMarker := filepath.Join(dir, "sent")
+	hookMarker := filepath.Join(dir, "hook")
+	p := &finalizedOrderPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		marker:             sentMarker,
+	}
+	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, filepath.Join(dir, "sessions.json"), LangEnglish)
+	defer func() { _ = e.Stop() }()
+	e.SetHooks(NewHookManager("my-project", []HookConfig{{
+		Event:   string(HookEventMessageFinalized),
+		Type:    "command",
+		Command: "test -f '" + sentMarker + "' && touch '" + hookMarker + "'",
+		Async:   boolPtr(false),
+	}}, "sh", "-c", ""))
+
+	sessionKey := "feishu:chat:user"
+	sessions := e.sessions
+	session := sessions.GetOrCreateActive(sessionKey)
+	sess := newControllableSession("unsol-finalized")
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+		ccSessionKey: sessionKey,
+	}
+
+	e.startUnsolicitedReader(state, session, sessions, sessionKey, "")
+	defer e.stopUnsolicitedReader(state)
+	sess.events <- Event{Type: EventResult, Content: "background reply", Done: true}
+
+	if sent := waitForPlatformSend(&p.stubPlatformEngine, 1, 5*time.Second); len(sent) != 1 || sent[0] != "background reply" {
+		t.Fatalf("sent replies = %#v, want one background reply", sent)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(hookMarker); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("message.finalized hook did not run after background reply send")
+}
+
+func TestUnsolicitedReader_DoesNotEmitFinalizedHookWhenReplySendFails(t *testing.T) {
+	dir := t.TempDir()
+	sendAttemptMarker := filepath.Join(dir, "send-attempt")
+	hookMarker := filepath.Join(dir, "hook")
+	p := &failedSendPlatform{
+		stubPlatformEngine: stubPlatformEngine{n: "feishu"},
+		marker:             sendAttemptMarker,
+	}
+	e := NewEngine("my-project", &stubAgent{}, []Platform{p}, filepath.Join(dir, "sessions.json"), LangEnglish)
+	defer func() { _ = e.Stop() }()
+	e.SetHooks(NewHookManager("my-project", []HookConfig{{
+		Event:   string(HookEventMessageFinalized),
+		Type:    "command",
+		Command: "touch '" + hookMarker + "'",
+		Async:   boolPtr(false),
+	}}, "sh", "-c", ""))
+
+	sessionKey := "feishu:chat:user"
+	sessions := e.sessions
+	session := sessions.GetOrCreateActive(sessionKey)
+	sess := newControllableSession("unsol-finalized-failure")
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+		ccSessionKey: sessionKey,
+	}
+
+	e.startUnsolicitedReader(state, session, sessions, sessionKey, "")
+	defer e.stopUnsolicitedReader(state)
+	sess.events <- Event{Type: EventResult, Content: "background reply", Done: true}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sendAttemptMarker); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(sendAttemptMarker); err != nil {
+		t.Fatalf("background reply send was not attempted: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if _, err := os.Stat(hookMarker); !os.IsNotExist(err) {
+		t.Fatalf("message.finalized hook ran after failed background send: err=%v", err)
+	}
+}
+
 func TestUnsolicitedReader_RelaysEventResult(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newControllableSession("unsol-relay")

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -17,14 +17,15 @@ import (
 type HookEventType string
 
 const (
-	HookEventMessageReceived    HookEventType = "message.received"
-	HookEventMessageSent        HookEventType = "message.sent"
-	HookEventSessionStarted     HookEventType = "session.started"
-	HookEventSessionEnded       HookEventType = "session.ended"
-	HookEventCronTriggered      HookEventType = "cron.triggered"
-	HookEventTimerTriggered     HookEventType = "timer.triggered"
+	HookEventMessageReceived     HookEventType = "message.received"
+	HookEventMessageSent         HookEventType = "message.sent"
+	HookEventMessageFinalized    HookEventType = "message.finalized"
+	HookEventSessionStarted      HookEventType = "session.started"
+	HookEventSessionEnded        HookEventType = "session.ended"
+	HookEventCronTriggered       HookEventType = "cron.triggered"
+	HookEventTimerTriggered      HookEventType = "timer.triggered"
 	HookEventPermissionRequested HookEventType = "permission.requested"
-	HookEventError              HookEventType = "error"
+	HookEventError               HookEventType = "error"
 )
 
 // HookHandlerType is the execution strategy for a hook.
@@ -38,7 +39,7 @@ const (
 // HookConfig is the user-facing configuration for a single hook rule.
 type HookConfig struct {
 	Event   string `toml:"event" json:"event"`
-	Type    string `toml:"type" json:"type"`       // "command" or "http"
+	Type    string `toml:"type" json:"type"` // "command" or "http"
 	Command string `toml:"command" json:"command,omitempty"`
 	URL     string `toml:"url" json:"url,omitempty"`
 	Timeout int    `toml:"timeout" json:"timeout,omitempty"` // seconds; 0 = default (10s cmd, 5s http)
@@ -64,10 +65,15 @@ type HookEvent struct {
 	Event      HookEventType  `json:"event"`
 	Timestamp  time.Time      `json:"timestamp"`
 	Project    string         `json:"project"`
+	TurnID     string         `json:"turn_id,omitempty"`
 	SessionKey string         `json:"session_key,omitempty"`
+	Workspace  string         `json:"workspace,omitempty"`
 	Platform   string         `json:"platform,omitempty"`
 	UserID     string         `json:"user_id,omitempty"`
 	UserName   string         `json:"user_name,omitempty"`
+	Source     string         `json:"source,omitempty"`
+	Internal   bool           `json:"internal"`
+	ReplyKind  string         `json:"reply_kind,omitempty"`
 	Content    string         `json:"content,omitempty"`
 	Error      string         `json:"error,omitempty"`
 	Extra      map[string]any `json:"extra,omitempty"`
@@ -75,13 +81,13 @@ type HookEvent struct {
 
 // HookManager dispatches lifecycle events to configured hook handlers.
 type HookManager struct {
-	hooks       []HookConfig
-	project     string
-	shell       string // shell binary (e.g. "sh", "/bin/zsh")
-	shellFlag   string // shell flag (e.g. "-c", "-Command")
+	hooks        []HookConfig
+	project      string
+	shell        string // shell binary (e.g. "sh", "/bin/zsh")
+	shellFlag    string // shell flag (e.g. "-c", "-Command")
 	shellProfile string // prepended to every command
-	mu          sync.RWMutex
-	client      *http.Client
+	mu           sync.RWMutex
+	client       *http.Client
 }
 
 // NewHookManager creates a manager for the given project name.
@@ -95,12 +101,12 @@ func NewHookManager(project string, hooks []HookConfig, shell, shellFlag, shellP
 		valid = append(valid, h)
 	}
 	return &HookManager{
-		hooks:       valid,
-		project:     project,
-		shell:       shell,
-		shellFlag:   shellFlag,
+		hooks:        valid,
+		project:      project,
+		shell:        shell,
+		shellFlag:    shellFlag,
 		shellProfile: shellProfile,
-		client:      &http.Client{},
+		client:       &http.Client{},
 	}
 }
 
@@ -249,6 +255,12 @@ func eventToEnv(e HookEvent) []string {
 	if e.SessionKey != "" {
 		env = append(env, "CC_HOOK_SESSION_KEY="+e.SessionKey)
 	}
+	if e.TurnID != "" {
+		env = append(env, "CC_HOOK_TURN_ID="+e.TurnID)
+	}
+	if e.Workspace != "" {
+		env = append(env, "CC_HOOK_WORKSPACE="+e.Workspace)
+	}
 	if e.Platform != "" {
 		env = append(env, "CC_HOOK_PLATFORM="+e.Platform)
 	}
@@ -257,6 +269,13 @@ func eventToEnv(e HookEvent) []string {
 	}
 	if e.UserName != "" {
 		env = append(env, "CC_HOOK_USER_NAME="+e.UserName)
+	}
+	if e.Source != "" {
+		env = append(env, "CC_HOOK_SOURCE="+e.Source)
+	}
+	env = append(env, fmt.Sprintf("CC_HOOK_INTERNAL=%t", e.Internal))
+	if e.ReplyKind != "" {
+		env = append(env, "CC_HOOK_REPLY_KIND="+e.ReplyKind)
 	}
 	if e.Content != "" {
 		env = append(env, "CC_HOOK_CONTENT="+e.Content)

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -74,6 +74,7 @@ type HookEvent struct {
 	Source     string         `json:"source,omitempty"`
 	Internal   bool           `json:"internal"`
 	ReplyKind  string         `json:"reply_kind,omitempty"`
+	Changed    bool           `json:"changed,omitempty"`
 	Content    string         `json:"content,omitempty"`
 	Error      string         `json:"error,omitempty"`
 	Extra      map[string]any `json:"extra,omitempty"`
@@ -274,6 +275,7 @@ func eventToEnv(e HookEvent) []string {
 		env = append(env, "CC_HOOK_SOURCE="+e.Source)
 	}
 	env = append(env, fmt.Sprintf("CC_HOOK_INTERNAL=%t", e.Internal))
+	env = append(env, fmt.Sprintf("CC_HOOK_CHANGED=%t", e.Changed))
 	if e.ReplyKind != "" {
 		env = append(env, "CC_HOOK_REPLY_KIND="+e.ReplyKind)
 	}

--- a/core/hooks_test.go
+++ b/core/hooks_test.go
@@ -20,11 +20,11 @@ func boolPtr(v bool) *bool { return &v }
 func TestNewHookManager_ValidatesConfig(t *testing.T) {
 	hooks := []HookConfig{
 		{Event: "message.received", Type: "command", Command: "echo ok"},
-		{Event: "", Type: "command", Command: "echo bad"},         // missing event
-		{Event: "error", Type: "http", URL: ""},                   // missing url
-		{Event: "error", Type: "http", URL: "ftp://bad"},          // bad url scheme
-		{Event: "error", Type: "unknown", Command: "echo"},        // bad type
-		{Event: "error", Type: "command", Command: ""},            // missing command
+		{Event: "", Type: "command", Command: "echo bad"},  // missing event
+		{Event: "error", Type: "http", URL: ""},            // missing url
+		{Event: "error", Type: "http", URL: "ftp://bad"},   // bad url scheme
+		{Event: "error", Type: "unknown", Command: "echo"}, // bad type
+		{Event: "error", Type: "command", Command: ""},     // missing command
 		{Event: "message.sent", Type: "http", URL: "http://ok.com"},
 	}
 	hm := NewHookManager("test", hooks, "sh", "-c", "")
@@ -384,10 +384,15 @@ func TestEventToEnv(t *testing.T) {
 		Event:      HookEventCronTriggered,
 		Timestamp:  time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC),
 		Project:    "myproj",
+		TurnID:     "turn-123",
 		SessionKey: "tg:1:1",
+		Workspace:  "/tmp/project",
 		Platform:   "telegram",
 		UserID:     "U123",
 		UserName:   "alice",
+		Source:     "agent.final_reply",
+		Internal:   true,
+		ReplyKind:  "card",
 		Content:    "hello world",
 		Error:      "oops",
 	}
@@ -403,10 +408,15 @@ func TestEventToEnv(t *testing.T) {
 	checks := map[string]string{
 		"CC_HOOK_EVENT":       "cron.triggered",
 		"CC_HOOK_PROJECT":     "myproj",
+		"CC_HOOK_TURN_ID":     "turn-123",
 		"CC_HOOK_SESSION_KEY": "tg:1:1",
+		"CC_HOOK_WORKSPACE":   "/tmp/project",
 		"CC_HOOK_PLATFORM":    "telegram",
 		"CC_HOOK_USER_ID":     "U123",
 		"CC_HOOK_USER_NAME":   "alice",
+		"CC_HOOK_SOURCE":      "agent.final_reply",
+		"CC_HOOK_INTERNAL":    "true",
+		"CC_HOOK_REPLY_KIND":  "card",
 		"CC_HOOK_CONTENT":     "hello world",
 		"CC_HOOK_ERROR":       "oops",
 	}
@@ -417,6 +427,12 @@ func TestEventToEnv(t *testing.T) {
 	}
 	if _, ok := m["CC_HOOK_TIMESTAMP"]; !ok {
 		t.Error("expected CC_HOOK_TIMESTAMP in env")
+	}
+}
+
+func TestMessageFinalizedEventType(t *testing.T) {
+	if string(HookEventMessageFinalized) != "message.finalized" {
+		t.Fatalf("HookEventMessageFinalized = %q, want message.finalized", HookEventMessageFinalized)
 	}
 }
 

--- a/core/hooks_test.go
+++ b/core/hooks_test.go
@@ -416,6 +416,7 @@ func TestEventToEnv(t *testing.T) {
 		"CC_HOOK_USER_NAME":   "alice",
 		"CC_HOOK_SOURCE":      "agent.final_reply",
 		"CC_HOOK_INTERNAL":    "true",
+		"CC_HOOK_CHANGED":     "false",
 		"CC_HOOK_REPLY_KIND":  "card",
 		"CC_HOOK_CONTENT":     "hello world",
 		"CC_HOOK_ERROR":       "oops",


### PR DESCRIPTION
## 背景

实现 Agent 完成一轮代码改动后的自动代码审核（AI review）需要"最终回复发送完成"这一生命周期事件。当前只有 `message.sent`（发送前），无法在回复完成后触发外部脚本。

## 改动

- **core/hooks.go**：新增 `message.finalized` 事件类型；`HookEvent` 增加 `turn_id` / `workspace` / `source` / `internal` / `reply_kind` 字段；`eventToEnv` 导出对应 `CC_HOOK_*` 环境变量
- **core/engine.go**：
  - 前台最终回复（rich card / stream preview / 普通分片 / suppress-duplicate / fallback 路径）完整发送成功后 Emit，`source=agent.final_reply`
  - 后台回复（unsolicited reader）发送成功后 Emit，`source=agent.background_reply`
  - 静默回复（NO_REPLY）、空回复、发送失败不触发
  - `interactiveState` 持久化 `ccSessionKey` 供 hook 上下文使用
- **core/hooks_test.go / core/engine_test.go**：事件类型、env 变量、发送后触发顺序、后台回复触发、发送失败不触发等测试
- **daemon/check_linger_other.go**：build tag 从 `!linux` 改为 `!linux && !darwin`，修复 macOS 上与 `launchd.go` 的 `CheckLinger` 重复声明导致的本地构建失败

## 测试

- `go build ./...` 通过
- 新增测试全部通过（`TestMessageFinalizedEventType`、`TestEventToEnv`、`TestProcessInteractiveEvents_FinalizedHookRunsAfterReplySend`、`TestUnsolicitedReader_EmitsFinalizedHookAfterReplySend`、`TestUnsolicitedReader_DoesNotEmitFinalizedHookWhenReplySendFails`）
- hooks 相关测试全部通过