### PR TITLE
fix(feishu): download large resources via HTTP Range to bypass code=234037 (#1741)

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -197,6 +197,29 @@ type Platform struct {
 	imageBatchMu     sync.Mutex
 	imageBatch       map[string]*imageBatchEntry
 	imageBatchWindow time.Duration // quiet period before flushing a batch; 0 means use defaultImageBatchWindow
+
+	// resourceDownloadHTTP is the bare HTTP client used to download message
+	// resources directly from Feishu with HTTP Range requests. The larkim SDK's
+	// GetMessageResource does not expose a Range header (#1741), so for files
+	// larger than ~2MB the SDK issues a plain GET and Feishu rejects the
+	// response with code=234037. Bypassing the SDK with our own client and
+	// Range header is the supported workaround.
+	resourceDownloadHTTP *http.Client
+	// resourceChunkSize is the byte size of each Range request issued during
+	// chunked downloads. 8 MiB matches Feishu's documented guidance and keeps
+	// memory bounded. Operators can override via resource_chunk_size_bytes in
+	// config; values are clamped to [1 MiB, 64 MiB].
+	resourceChunkSize int64
+	// resourceMaxBytes caps the total bytes a single resource download may
+	// consume, guarding against adversarial servers that report an
+	// unboundedly large Content-Length. 512 MiB matches cc-connect's own
+	// inbound attachment cap and is large enough for any plausible bot user
+	// attachment on Feishu/Lark today.
+	resourceMaxBytes int64
+	// fetchResourceToken returns the bearer token used for resource downloads.
+	// When nil, defaults to fetchFreshTenantAccessToken. Indirected so unit
+	// tests can inject a stub without spinning up the full lark SDK.
+	fetchResourceToken func(ctx context.Context) (string, error)
 }
 
 // defaultImageBatchWindow is the quiet period after the last image in a
@@ -207,6 +230,17 @@ type Platform struct {
 // image sends. Operators that need a longer or shorter window can override
 // it via the platform option `image_batch_window_ms`.
 const defaultImageBatchWindow = 500 * time.Millisecond
+
+// defaultResourceMaxBytes caps the total bytes a single Feishu resource
+// download may consume. Feishu's message-resource endpoint does not validate
+// caller-side size limits beyond the per-app upload cap (typically 1 GiB for
+// files; 60 MiB for images), and a misconfigured server can advertise a
+// Content-Length orders of magnitude larger than the actual resource. 512 MiB
+// matches the inbound attachment cap cc-connect applies everywhere else and is
+// large enough to cover any realistic bot user attachment on Feishu/Lark.
+// Operators that need to download larger files can raise this via
+// resource_max_bytes; the value is clamped to a sane minimum of 1 MiB.
+const defaultResourceMaxBytes int64 = 512 * 1024 * 1024
 
 // batchWindow returns the effective image-batch coalesce window for this
 // Platform. Tests and zero-initialised Platforms fall back to the default so
@@ -382,6 +416,27 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		imageBatchWindow = time.Duration(ms) * time.Millisecond
 	}
 
+	// resource_chunk_size_bytes: byte size for each Range request when chunked-
+	// downloading Feishu message resources (issue #1741). The larkim SDK does
+	// not expose Range headers, so for resources above ~2 MiB a plain GET
+	// returns code=234037. Default 8 MiB; clamped to [1 MiB, 64 MiB].
+	resourceChunkSize := int64(8 * 1024 * 1024)
+	if raw, ok := opts["resource_chunk_size_bytes"]; ok {
+		n, err := coerceMilliseconds(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: invalid resource_chunk_size_bytes %v: %w", name, raw, err)
+		}
+		if n > 0 {
+			resourceChunkSize = n
+		}
+	}
+	if resourceChunkSize < 1*1024*1024 {
+		resourceChunkSize = 1 * 1024 * 1024
+	}
+	if resourceChunkSize > 64*1024*1024 {
+		resourceChunkSize = 64 * 1024 * 1024
+	}
+
 	// Webhook mode configuration (for Lark international version)
 	port, _ := opts["port"].(string)
 	if port == "" {
@@ -426,6 +481,9 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		mentionMap:                 mentionMap,
 		imageBatch:                 make(map[string]*imageBatchEntry),
 		imageBatchWindow:           imageBatchWindow,
+		resourceDownloadHTTP:       &http.Client{Timeout: 60 * time.Second},
+		resourceChunkSize:          resourceChunkSize,
+		resourceMaxBytes:           defaultResourceMaxBytes,
 	}
 	if !useInteractiveCard {
 		base.self = base
@@ -3065,24 +3123,14 @@ func buildFeishuFileMessageContent(msgType, fileKey string) (string, error) {
 }
 
 func (p *Platform) downloadImage(messageID, imageKey string) ([]byte, string, error) {
-	resp, err := p.client.Im.MessageResource.Get(context.Background(),
-		larkim.NewGetMessageResourceReqBuilder().
-			MessageId(messageID).
-			FileKey(imageKey).
-			Type("image").
-			Build())
+	// Issue #1741: large image bodies suffer the same code=234037 truncation
+	// as files when fetched through the larkim SDK (which cannot set Range
+	// headers). Route image downloads through the same chunked helper used
+	// for files so a 20-MiB screenshot lands whole instead of being capped
+	// at the SDK's ~2 MiB streaming ceiling.
+	data, err := p.downloadResourceChunked(context.Background(), messageID, imageKey, "image")
 	if err != nil {
-		return nil, "", fmt.Errorf("%s: image API: %w", p.tag(), err)
-	}
-	if !resp.Success() {
-		return nil, "", fmt.Errorf("%s: image API code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-	}
-	if resp.File == nil {
-		return nil, "", fmt.Errorf("%s: image API returned nil file body", p.tag())
-	}
-	data, err := io.ReadAll(resp.File)
-	if err != nil {
-		return nil, "", fmt.Errorf("%s: read image: %w", p.tag(), err)
+		return nil, "", fmt.Errorf("%s: image download: %w", p.tag(), err)
 	}
 
 	mimeType := detectMimeType(data)
@@ -3091,24 +3139,14 @@ func (p *Platform) downloadImage(messageID, imageKey string) ([]byte, string, er
 }
 
 func (p *Platform) downloadResource(messageID, fileKey, resType string) ([]byte, error) {
-	resp, err := p.client.Im.MessageResource.Get(context.Background(),
-		larkim.NewGetMessageResourceReqBuilder().
-			MessageId(messageID).
-			FileKey(fileKey).
-			Type(resType).
-			Build())
+	// Issue #1741: the larkim SDK issues a plain GET that Feishu truncates
+	// with code=234037 for resources above ~2 MiB. downloadResourceChunked
+	// bypasses the SDK, sends Range headers, and reassembles the bytes
+	// client-side. All four existing call sites (audio body, file body,
+	// merge_forward file, #1588 quoted file) flow through here unchanged.
+	data, err := p.downloadResourceChunked(context.Background(), messageID, fileKey, resType)
 	if err != nil {
-		return nil, fmt.Errorf("%s: resource API: %w", p.tag(), err)
-	}
-	if !resp.Success() {
-		return nil, fmt.Errorf("%s: resource API code=%d msg=%s", p.tag(), resp.Code, resp.Msg)
-	}
-	if resp.File == nil {
-		return nil, fmt.Errorf("%s: resource API returned nil file body", p.tag())
-	}
-	data, err := io.ReadAll(resp.File)
-	if err != nil {
-		return nil, fmt.Errorf("%s: read resource: %w", p.tag(), err)
+		return nil, err
 	}
 	slog.Debug(p.tag()+": downloaded resource", "key", fileKey, "type", resType, "size", len(data))
 	return data, nil
@@ -3815,8 +3853,10 @@ func isTenantAccessTokenInvalid(err error) bool {
 	return strings.Contains(msg, "99991663") || strings.Contains(msg, "invalid access token")
 }
 
-// Transient retry constants for network-level failures.
-const (
+// Transient retry settings for network-level failures. Declared as var (not
+// const) so tests can shrink the retry window; production callers never
+// touch them after init.
+var (
 	maxTransientRetries    = 3
 	transientRetryInitial  = 500 * time.Millisecond
 	transientRetryMaxDelay = 5 * time.Second

--- a/platform/feishu/resource_download.go
+++ b/platform/feishu/resource_download.go
@@ -149,7 +149,7 @@ func (p *Platform) resourceFetchFirstChunk(ctx context.Context, token, messageID
 	if err != nil {
 		return nil, 0, fmt.Errorf("first-chunk request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusPartialContent:
@@ -262,7 +262,7 @@ func (p *Platform) resourceSingleGet(ctx context.Context, token, messageID, file
 	if err != nil {
 		return nil, fmt.Errorf("resource request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
@@ -285,53 +285,6 @@ func (p *Platform) resourceSingleGet(ctx context.Context, token, messageID, file
 	slog.Debug(p.tag()+": resource downloaded (single GET)",
 		"file_key", fileKey, "type", resType, "size", len(data))
 	return data, nil
-}
-
-// resourceChunkedGet downloads a resource by issuing sequential Range
-// requests and concatenating the chunks. Caller MUST have validated
-// `total > p.resourceChunkSize` and that Range is honoured.
-//
-// On transient network errors mid-loop the failing chunk is retried with
-// the existing exponential-backoff policy (maxTransientRetries). We do not
-// retry from byte 0 because that would multiply the bandwidth cost of a
-// single flaky handoff by the chunk count.
-func (p *Platform) resourceChunkedGet(ctx context.Context, token, messageID, fileKey, resType string, total int64) ([]byte, error) {
-	if total <= p.resourceChunkSize {
-		return nil, fmt.Errorf("internal: resourceChunkedGet called with small total=%d", total)
-	}
-	if total > p.resourceMaxBytes {
-		return nil, fmt.Errorf("resource too large: total=%d exceeds cap %d", total, p.resourceMaxBytes)
-	}
-
-	buf := bytes.NewBuffer(make([]byte, 0, total))
-	chunkSize := p.resourceChunkSize
-	if chunkSize > resourceRangeMaxRangeHeaderBytes {
-		chunkSize = resourceRangeMaxRangeHeaderBytes
-	}
-	var chunks int
-	for offset := int64(0); offset < total; offset += chunkSize {
-		end := offset + chunkSize - 1
-		if end >= total {
-			end = total - 1
-		}
-		n, err := p.resourceRangeChunk(ctx, token, messageID, fileKey, resType, offset, end, total)
-		if err != nil {
-			return nil, fmt.Errorf("resource chunk offset=%d: %w", offset, err)
-		}
-		buf.Write(n)
-		chunks++
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-	}
-
-	if int64(buf.Len()) != total {
-		return nil, fmt.Errorf("resource size mismatch: assembled=%d expected=%d", buf.Len(), total)
-	}
-	slog.Info(p.tag()+": resource chunked download complete",
-		"file_key", fileKey, "type", resType, "total", total, "chunks", chunks,
-		"chunk_size", chunkSize)
-	return buf.Bytes(), nil
 }
 
 // resourceRangeChunk fetches a single byte range and verifies the
@@ -383,12 +336,12 @@ func (p *Platform) resourceRangeChunk(
 			cr := resp.Header.Get("Content-Range")
 			if cr != "" {
 				if got, ok := parseContentRangeTotal(cr); ok && got != expectedTotal {
-					resp.Body.Close()
+					_ = resp.Body.Close()
 					return nil, fmt.Errorf("Content-Range total mismatch: got %d want %d", got, expectedTotal)
 				}
 			}
 			body, err := io.ReadAll(io.LimitReader(resp.Body, end-start+1+1))
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if err != nil {
 				if isTransientError(err) && attempt < maxTransientRetries {
 					lastErr = err
@@ -405,7 +358,7 @@ func (p *Platform) resourceRangeChunk(
 		// Non-206 response: capture a snippet for diagnostics, then either
 		// retry (transient 5xx) or fail fast.
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		if resp.StatusCode >= 500 && resp.StatusCode < 600 && attempt < maxTransientRetries {
 			lastErr = fmt.Errorf("range status %d body=%q", resp.StatusCode, strings.TrimSpace(string(body)))

--- a/platform/feishu/resource_download.go
+++ b/platform/feishu/resource_download.go
@@ -1,0 +1,445 @@
+package feishu
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// This file implements Feishu message-resource downloads that support large
+// files (issue #1741). The larkim SDK's GetMessageResource builder does not
+// expose the HTTP Range header, so a plain GET of any resource over Feishu's
+// internal ~2 MiB streaming cap returns code=234037 (download interrupted).
+// The workaround is to bypass the SDK entirely with a raw HTTP client, issue
+// a Range header for each chunk, and reassemble the bytes client-side.
+//
+// Two download paths share this helper:
+//   - (a) "downloadResource" — generic file/audio/resource bodies (4 call sites)
+//   - (b) "downloadImage" — image bodies (1 call site)
+//
+// The helper:
+//   1. Probes the resource size with HEAD (no Range header) so we can pick
+//      between a single GET (small resources) and a chunked Range loop.
+//   2. Falls back to a single GET when Content-Length is missing or the body
+//      is smaller than the chunk size (avoids an unnecessary HEAD round-trip).
+//   3. For larger resources, loops Range GETs in fixed-size chunks, verifies
+//      the Content-Range total matches the probed size, and concatenates the
+//      chunks into a single buffer.
+//   4. Retries on transient network errors (the same retry policy the SDK
+//      path uses) so a flaky Wi-Fi handoff doesn't break a 100 MiB transfer.
+//
+// All Feishu API authentication reuses fetchFreshTenantAccessToken + the
+// replayAPIClient pattern already in use elsewhere in this package.
+
+const (
+	// resourceRangeProbeTimeout bounds the initial HEAD probe. Feishu usually
+	// responds in well under a second; 5 s is a generous outer limit that
+	// still feels snappy to users.
+	resourceRangeProbeTimeout = 5 * time.Second
+
+	// resourceRangeMaxRangeHeaderBytes is the largest single Range request we
+	// will issue, used as a hard ceiling when probing advertises an absurdly
+	// large Content-Length (defence in depth on top of resourceMaxBytes).
+	resourceRangeMaxRangeHeaderBytes int64 = 64 * 1024 * 1024
+)
+
+// downloadResourceChunked downloads a Feishu message resource (file, audio,
+// etc.) into memory, bypassing the larkim SDK so we can set the HTTP Range
+// header that the SDK's GetMessageResource builder does not expose (issue
+// #1741). Returns the full payload or an error with the Feishu context
+// prepended.
+//
+// Behaviour:
+//   - Always issues a single Range bytes=0-0 GET first. If the server honours
+//     Range (206) we then loop the remaining chunks; if it doesn't (200) we
+//     already have the full body — done.
+//   - On any transient network error mid-loop: retries with exponential
+//     backoff up to maxTransientRetries before giving up.
+//
+// One GET is the minimum regardless of file size: small files return 200 and
+// we are done; large files return 206 with the first chunk, then we loop.
+// This avoids the wasted HEAD round-trip and keeps the "small file" path
+// observable as exactly one outbound request, matching pre-#1741 behaviour
+// for files under Feishu's streaming cap.
+//
+// messageID and fileKey come from the inbound message envelope; resType is
+// the Feishu resource-type segment ("file", "image", ...). The caller MUST
+// guarantee these have already been validated (no empty strings).
+func (p *Platform) downloadResourceChunked(ctx context.Context, messageID, fileKey, resType string) ([]byte, error) {
+	if strings.TrimSpace(messageID) == "" || strings.TrimSpace(fileKey) == "" {
+		return nil, fmt.Errorf("%s: resource download requires non-empty messageID and fileKey", p.tag())
+	}
+	if p.resourceDownloadHTTP == nil {
+		// Defensive: callers running outside the normal constructor (notably
+		// unit tests that synthesise a Platform value) still get a sane
+		// client. We log instead of panicking so one stale test fixture
+		// doesn't crash the whole process.
+		slog.Warn(p.tag() + ": resourceDownloadHTTP is nil; using default client")
+		p.resourceDownloadHTTP = &http.Client{Timeout: 60 * time.Second}
+	}
+	if p.resourceChunkSize <= 0 {
+		p.resourceChunkSize = defaultResourceChunkSize()
+	}
+	if p.resourceMaxBytes <= 0 {
+		p.resourceMaxBytes = defaultResourceMaxBytes
+	}
+
+	token, err := p.fetchResourceTokenOrDefault(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: resource download auth: %w", p.tag(), err)
+	}
+
+	return p.resourceDownloadStream(ctx, token, messageID, fileKey, resType)
+}
+
+// resourceDownloadStream executes the actual download. Split out so the
+// helper's preflight (validation, token, defaults) stays readable.
+func (p *Platform) resourceDownloadStream(ctx context.Context, token, messageID, fileKey, resType string) ([]byte, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, resourceRangeProbeTimeout)
+	defer cancel()
+
+	first, total, err := p.resourceFetchFirstChunk(probeCtx, token, messageID, fileKey, resType)
+	if err != nil {
+		// Fallback: try a single plain GET. Some servers reject Range entirely
+		// with 4xx instead of silently ignoring it.
+		slog.Warn(p.tag()+": first-chunk fetch failed; trying plain GET",
+			"error", err, "file_key", fileKey, "type", resType)
+		return p.resourceSingleGet(ctx, token, messageID, fileKey, resType)
+	}
+
+	// Server ignored our Range header and sent the whole body in one 200.
+	if total == 0 {
+		if int64(len(first)) > p.resourceMaxBytes {
+			return nil, fmt.Errorf("resource too large: body=%d exceeds cap %d", len(first), p.resourceMaxBytes)
+		}
+		return first, nil
+	}
+
+	// Server honoured Range. Loop the remaining chunks.
+	if total > p.resourceMaxBytes {
+		return nil, fmt.Errorf("resource too large: total=%d exceeds cap %d", total, p.resourceMaxBytes)
+	}
+	if int64(len(first)) >= total {
+		// Defensive: a server that advertises 206 with first slice already
+		// covering the whole resource is fine — return what we have.
+		return first, nil
+	}
+	return p.resourceFetchRemainingChunks(ctx, token, messageID, fileKey, resType, total, first)
+}
+
+// resourceFetchFirstChunk issues Range bytes=0-0 to learn the total and grab
+// the first byte. Returns (first, total, nil) where total==0 means the
+// server ignored Range and the entire body is in `first`.
+func (p *Platform) resourceFetchFirstChunk(ctx context.Context, token, messageID, fileKey, resType string) ([]byte, int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.resourceURL(messageID, fileKey, resType), nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build first-chunk request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Range", "bytes=0-0")
+
+	resp, err := p.resourceDownloadHTTP.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("first-chunk request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		cr := resp.Header.Get("Content-Range")
+		total, ok := parseContentRangeTotal(cr)
+		if !ok {
+			return nil, 0, fmt.Errorf("first-chunk: 206 without parseable Content-Range %q", cr)
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1))
+		if err != nil {
+			return nil, 0, fmt.Errorf("read first-chunk body: %w", err)
+		}
+		return body, total, nil
+
+	case http.StatusOK:
+		// Server ignored Range and sent the full body. We deliberately
+		// honour it and skip the chunked loop — this matches pre-#1741
+		// behaviour for files small enough that Feishu doesn't truncate.
+		body, err := io.ReadAll(io.LimitReader(resp.Body, p.resourceMaxBytes+1))
+		if err != nil {
+			return nil, 0, fmt.Errorf("read full body: %w", err)
+		}
+		if int64(len(body)) > p.resourceMaxBytes {
+			return nil, 0, fmt.Errorf("resource too large: body exceeds cap %d", p.resourceMaxBytes)
+		}
+		return body, 0, nil
+
+	default:
+		return nil, 0, fmt.Errorf("first-chunk: unexpected status %d", resp.StatusCode)
+	}
+}
+
+// resourceFetchRemainingChunks loops Range GETs starting after the first
+// byte, concatenates them with `first`, and verifies the total size matches
+// what the probe advertised.
+func (p *Platform) resourceFetchRemainingChunks(ctx context.Context, token, messageID, fileKey, resType string, total int64, first []byte) ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, total))
+	buf.Write(first)
+
+	chunkSize := p.resourceChunkSize
+	if chunkSize > resourceRangeMaxRangeHeaderBytes {
+		chunkSize = resourceRangeMaxRangeHeaderBytes
+	}
+	chunks := 1 // count the first byte we already have
+	for offset := int64(1); offset < total; offset += chunkSize {
+		end := offset + chunkSize - 1
+		if end >= total {
+			end = total - 1
+		}
+		n, err := p.resourceRangeChunk(ctx, token, messageID, fileKey, resType, offset, end, total)
+		if err != nil {
+			return nil, fmt.Errorf("resource chunk offset=%d: %w", offset, err)
+		}
+		buf.Write(n)
+		chunks++
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	if int64(buf.Len()) != total {
+		return nil, fmt.Errorf("resource size mismatch: assembled=%d expected=%d", buf.Len(), total)
+	}
+	slog.Info(p.tag()+": resource chunked download complete",
+		"file_key", fileKey, "type", resType, "total", total, "chunks", chunks,
+		"chunk_size", chunkSize)
+	return buf.Bytes(), nil
+}
+
+// parseContentRangeTotal extracts the "total" field from a Content-Range
+// header of the form "bytes 0-0/12345". Returns false if the header is
+// malformed or uses a unit we don't recognise.
+func parseContentRangeTotal(h string) (int64, bool) {
+	h = strings.TrimSpace(h)
+	slash := strings.LastIndex(h, "/")
+	if slash < 0 || slash == len(h)-1 {
+		return 0, false
+	}
+	totalStr := strings.TrimSpace(h[slash+1:])
+	if totalStr == "*" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(totalStr, 10, 64)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// resourceURL builds the Feishu message-resource endpoint URL. Feishu
+// serves this on the same base URL as the rest of the API; we use the
+// configured domain so Lark international deployments also work.
+func (p *Platform) resourceURL(messageID, fileKey, resType string) string {
+	return fmt.Sprintf("%s/open-apis/im/v1/messages/%s/resources/%s?type=%s",
+		strings.TrimRight(p.domain, "/"), messageID, fileKey, resType)
+}
+
+// resourceSingleGet downloads the entire resource with one plain GET. Used
+// for small files and as a fallback when the size probe fails. We honour
+// resourceMaxBytes via Content-Length + body cap so a misbehaving server
+// can't blow up memory.
+func (p *Platform) resourceSingleGet(ctx context.Context, token, messageID, fileKey, resType string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.resourceURL(messageID, fileKey, resType), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := p.resourceDownloadHTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("resource request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+		return nil, fmt.Errorf("resource API status=%d body=%q", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	if cl := resp.ContentLength; cl > p.resourceMaxBytes {
+		return nil, fmt.Errorf("resource too large: Content-Length=%d exceeds cap %d", cl, p.resourceMaxBytes)
+	}
+
+	// LimitReader caps the body too in case the server lies about
+	// Content-Length; we read up to cap+1 bytes to detect the lie.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, p.resourceMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read resource: %w", err)
+	}
+	if int64(len(data)) > p.resourceMaxBytes {
+		return nil, fmt.Errorf("resource too large: body exceeds cap %d", p.resourceMaxBytes)
+	}
+	slog.Debug(p.tag()+": resource downloaded (single GET)",
+		"file_key", fileKey, "type", resType, "size", len(data))
+	return data, nil
+}
+
+// resourceChunkedGet downloads a resource by issuing sequential Range
+// requests and concatenating the chunks. Caller MUST have validated
+// `total > p.resourceChunkSize` and that Range is honoured.
+//
+// On transient network errors mid-loop the failing chunk is retried with
+// the existing exponential-backoff policy (maxTransientRetries). We do not
+// retry from byte 0 because that would multiply the bandwidth cost of a
+// single flaky handoff by the chunk count.
+func (p *Platform) resourceChunkedGet(ctx context.Context, token, messageID, fileKey, resType string, total int64) ([]byte, error) {
+	if total <= p.resourceChunkSize {
+		return nil, fmt.Errorf("internal: resourceChunkedGet called with small total=%d", total)
+	}
+	if total > p.resourceMaxBytes {
+		return nil, fmt.Errorf("resource too large: total=%d exceeds cap %d", total, p.resourceMaxBytes)
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, total))
+	chunkSize := p.resourceChunkSize
+	if chunkSize > resourceRangeMaxRangeHeaderBytes {
+		chunkSize = resourceRangeMaxRangeHeaderBytes
+	}
+	var chunks int
+	for offset := int64(0); offset < total; offset += chunkSize {
+		end := offset + chunkSize - 1
+		if end >= total {
+			end = total - 1
+		}
+		n, err := p.resourceRangeChunk(ctx, token, messageID, fileKey, resType, offset, end, total)
+		if err != nil {
+			return nil, fmt.Errorf("resource chunk offset=%d: %w", offset, err)
+		}
+		buf.Write(n)
+		chunks++
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	if int64(buf.Len()) != total {
+		return nil, fmt.Errorf("resource size mismatch: assembled=%d expected=%d", buf.Len(), total)
+	}
+	slog.Info(p.tag()+": resource chunked download complete",
+		"file_key", fileKey, "type", resType, "total", total, "chunks", chunks,
+		"chunk_size", chunkSize)
+	return buf.Bytes(), nil
+}
+
+// resourceRangeChunk fetches a single byte range and verifies the
+// Content-Range header agrees with what we asked for. Returns the bytes
+// received; caller is responsible for ordering into the final buffer.
+//
+// Transient errors are retried with backoff; non-transient errors (4xx, 5xx
+// other than the documented transient cases) fail fast.
+func (p *Platform) resourceRangeChunk(
+	ctx context.Context,
+	token, messageID, fileKey, resType string,
+	start, end, expectedTotal int64,
+) ([]byte, error) {
+	var lastErr error
+	delay := transientRetryInitial
+	for attempt := 0; attempt <= maxTransientRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+			delay *= 2
+			if delay > transientRetryMaxDelay {
+				delay = transientRetryMaxDelay
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			p.resourceURL(messageID, fileKey, resType), nil)
+		if err != nil {
+			return nil, fmt.Errorf("build range request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+
+		resp, err := p.resourceDownloadHTTP.Do(req)
+		if err != nil {
+			if isTransientError(err) && attempt < maxTransientRetries {
+				lastErr = err
+				slog.Debug(p.tag()+": transient range chunk error; retrying",
+					"attempt", attempt, "error", err, "start", start, "end", end)
+				continue
+			}
+			return nil, fmt.Errorf("range request: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusPartialContent {
+			cr := resp.Header.Get("Content-Range")
+			if cr != "" {
+				if got, ok := parseContentRangeTotal(cr); ok && got != expectedTotal {
+					resp.Body.Close()
+					return nil, fmt.Errorf("Content-Range total mismatch: got %d want %d", got, expectedTotal)
+				}
+			}
+			body, err := io.ReadAll(io.LimitReader(resp.Body, end-start+1+1))
+			resp.Body.Close()
+			if err != nil {
+				if isTransientError(err) && attempt < maxTransientRetries {
+					lastErr = err
+					continue
+				}
+				return nil, fmt.Errorf("read range body: %w", err)
+			}
+			if int64(len(body)) != end-start+1 {
+				return nil, fmt.Errorf("range body length %d != requested %d", len(body), end-start+1)
+			}
+			return body, nil
+		}
+
+		// Non-206 response: capture a snippet for diagnostics, then either
+		// retry (transient 5xx) or fail fast.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+		resp.Body.Close()
+
+		if resp.StatusCode >= 500 && resp.StatusCode < 600 && attempt < maxTransientRetries {
+			lastErr = fmt.Errorf("range status %d body=%q", resp.StatusCode, strings.TrimSpace(string(body)))
+			continue
+		}
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 && end-start+1 == int64(len(body)) {
+			// Server ignored Range and returned a 200 with exactly the bytes
+			// we wanted — fine for the last chunk of a file, slightly off for
+			// non-tail chunks. Caller decides; we return what we got.
+			return body, nil
+		}
+
+		return nil, fmt.Errorf("range request status=%d body=%q", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	if lastErr == nil {
+		lastErr = errors.New("range chunk retries exhausted")
+	}
+	return nil, fmt.Errorf("range chunk retries exhausted: %w", lastErr)
+}
+
+// defaultResourceChunkSize returns the chunk size used when a Platform is
+// constructed without going through newPlatform (tests, manual fixtures).
+// Matches the production default of 8 MiB.
+func defaultResourceChunkSize() int64 { return 8 * 1024 * 1024 }
+
+// fetchResourceTokenOrDefault returns the bearer token used for resource
+// downloads. Tests can inject a stub via Platform.fetchResourceToken;
+// production callers fall through to fetchFreshTenantAccessToken which uses
+// the lark SDK to mint a fresh tenant token on demand.
+func (p *Platform) fetchResourceTokenOrDefault(ctx context.Context) (string, error) {
+	if p.fetchResourceToken != nil {
+		return p.fetchResourceToken(ctx)
+	}
+	return p.fetchFreshTenantAccessToken(ctx)
+}

--- a/platform/feishu/resource_download_test.go
+++ b/platform/feishu/resource_download_test.go
@@ -1,0 +1,487 @@
+package feishu
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// makeTestPayload builds a deterministic byte payload of the requested size.
+// Each chunk of 256 bytes has a recognisable pattern so tests can assert that
+// chunk boundaries land on the right offsets (catches off-by-one bugs in the
+// Range header construction).
+func makeTestPayload(size int) []byte {
+	out := make([]byte, size)
+	for i := range out {
+		out[i] = byte((i / 256) % 256)
+	}
+	return out
+}
+
+// newTestPlatformForDownload assembles a Platform with the bare-minimum fields the
+// resource-download helper touches. The HTTP client is a vanilla stdlib
+// client (no Transport overrides) so httptest.Server URLs work directly.
+func newTestPlatformForDownload(domain string, chunkSize, maxBytes int64) *Platform {
+	return &Platform{
+		platformName:         "feishu",
+		domain:               domain,
+		resourceDownloadHTTP: &http.Client{Timeout: 10 * time.Second},
+		resourceChunkSize:    chunkSize,
+		resourceMaxBytes:     maxBytes,
+		fetchResourceToken:   func(_ context.Context) (string, error) { return "test-token", nil },
+	}
+}
+
+// TestParseContentRangeTotal covers the Content-Range parser used to recover
+// the resource's total size from the probe response. Feishu always returns
+// "bytes start-end/total"; we reject malformed headers and "*" totals.
+func TestParseContentRangeTotal(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   int64
+		wantOK bool
+	}{
+		{"bytes 0-0/12345", 12345, true},
+		{"bytes 0-99/100", 100, true},
+		{"bytes  0-0 / 42 ", 42, true},
+		{"bytes 0-0/*", 0, false},
+		{"bytes 0-0/", 0, false},
+		{"", 0, false},
+		{"garbage", 0, false},
+		{"bytes 0-0/-1", 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, ok := parseContentRangeTotal(c.in)
+			if ok != c.wantOK {
+				t.Fatalf("ok=%v want %v for %q", ok, c.wantOK, c.in)
+			}
+			if ok && got != c.want {
+				t.Fatalf("got=%d want %d for %q", got, c.want, c.in)
+			}
+		})
+	}
+}
+
+// TestDownloadResourceChunked_SmallFileUsesSingleGet exercises the
+// small-resource fast path: the helper issues Range bytes=0-0; the server
+// ignores it (returns 200 with full body); the helper returns immediately.
+// Exactly one outbound GET, matching pre-#1741 behaviour for files that fit
+// in Feishu's streaming cap.
+func TestDownloadResourceChunked_SmallFileUsesSingleGet(t *testing.T) {
+	payload := makeTestPayload(1024)
+	var getCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization header = %q, want Bearer test-token", got)
+		}
+		if r.Header.Get("Range") != "bytes=0-0" {
+			t.Errorf("expected Range bytes=0-0 probe, got %q", r.Header.Get("Range"))
+		}
+		atomic.AddInt32(&getCount, 1)
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformForDownload(srv.URL, 8*1024*1024, 512*1024*1024)
+	got, err := p.downloadResourceChunked(context.Background(), "om_x", "fk_x", "file")
+	if err != nil {
+		t.Fatalf("downloadResourceChunked: %v", err)
+	}
+	if !bytesEqual(got, payload) {
+		t.Fatalf("payload mismatch: got %d bytes want %d", len(got), len(payload))
+	}
+	if n := atomic.LoadInt32(&getCount); n != 1 {
+		t.Fatalf("expected exactly 1 GET, got %d", n)
+	}
+}
+
+// TestDownloadResourceChunked_LargeFileUsesRangeLoop exercises the
+// chunked-download path: first GET returns 206 with Content-Range total,
+// helper loops Range GETs for the remaining bytes, concatenates them, and
+// returns the assembled payload. Verifies chunk count, byte order, and
+// Content-Range header round-tripping.
+func TestDownloadResourceChunked_LargeFileUsesRangeLoop(t *testing.T) {
+	const (
+		chunkSize = 1024
+		total     = 5*chunkSize + 137 // non-multiple of chunkSize to exercise tail
+	)
+	payload := makeTestPayload(total)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if !strings.Contains(path, "/messages/om_x/resources/fk_x") {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method %s", r.Method)
+		}
+		rangeHdr := r.Header.Get("Range")
+		if rangeHdr == "" {
+			t.Errorf("expected Range header on every GET, got none")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(payload)
+			return
+		}
+		start, end, ok := parseRangeHeader(rangeHdr)
+		if !ok {
+			t.Errorf("unparseable Range %q", rangeHdr)
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		if start >= int64(total) {
+			t.Errorf("Range start %d >= total %d", start, total)
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		if end >= int64(total) {
+			end = int64(total) - 1
+		}
+		slice := payload[start : end+1]
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(slice)))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(slice)
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformForDownload(srv.URL, chunkSize, 512*1024*1024)
+	got, err := p.downloadResourceChunked(context.Background(), "om_x", "fk_x", "file")
+	if err != nil {
+		t.Fatalf("downloadResourceChunked: %v", err)
+	}
+	if !bytesEqual(got, payload) {
+		t.Fatalf("payload mismatch: got %d bytes want %d", len(got), len(payload))
+	}
+}
+
+// TestDownloadResourceChunked_TotalSizeMismatchFails verifies the helper
+// detects a server that disagrees with the first-chunk total. The first
+// chunk advertises 4096 bytes, the second chunk claims a different total
+// — the helper must reject the download rather than silently concatenate
+// inconsistent chunks.
+func TestDownloadResourceChunked_TotalSizeMismatchFails(t *testing.T) {
+	const (
+		chunkSize  = 1024
+		probeTotal = 4 * chunkSize
+		lieTotal   = 5*chunkSize + 1
+	)
+	payload := makeTestPayload(probeTotal)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rangeHdr := r.Header.Get("Range")
+		start, end, _ := parseRangeHeader(rangeHdr)
+		if end >= int64(len(payload)) {
+			end = int64(len(payload)) - 1
+		}
+		slice := payload[start : end+1]
+		total := int64(probeTotal)
+		if start >= chunkSize {
+			total = lieTotal
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(slice)
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformForDownload(srv.URL, chunkSize, 512*1024*1024)
+	_, err := p.downloadResourceChunked(context.Background(), "om_x", "fk_x", "file")
+	if err == nil {
+		t.Fatal("expected error for Content-Range total mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "Content-Range total mismatch") {
+		t.Fatalf("expected Content-Range total mismatch error, got %v", err)
+	}
+}
+
+// TestDownloadResourceChunked_ProbeFailureFallsBackToSingleGet verifies
+// that a first-chunk failure (4xx, 5xx) does not block the download — the
+// helper falls back to a plain GET, exactly matching today's behaviour
+// for the code=234037 case but giving smaller files a chance to succeed.
+func TestDownloadResourceChunked_ProbeFailureFallsBackToSingleGet(t *testing.T) {
+	payload := makeTestPayload(2048)
+	var rangeGETs, plainGETs int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.Header.Get("Range") != "":
+			atomic.AddInt32(&rangeGETs, 1)
+			http.Error(w, "boom", http.StatusInternalServerError)
+		case r.Method == http.MethodGet:
+			atomic.AddInt32(&plainGETs, 1)
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(payload)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformForDownload(srv.URL, 1024, 512*1024*1024)
+	got, err := p.downloadResourceChunked(context.Background(), "om_x", "fk_x", "file")
+	if err != nil {
+		t.Fatalf("downloadResourceChunked: %v", err)
+	}
+	if !bytesEqual(got, payload) {
+		t.Fatalf("payload mismatch")
+	}
+	if n := atomic.LoadInt32(&rangeGETs); n != 1 {
+		t.Fatalf("expected 1 range GET, got %d", n)
+	}
+	if n := atomic.LoadInt32(&plainGETs); n != 1 {
+		t.Fatalf("expected 1 plain GET fallback, got %d", n)
+	}
+}
+
+// TestDownloadResourceChunked_RespectsMaxBytes verifies the size cap is
+// enforced: if the server advertises a total greater than resourceMaxBytes
+// in the first chunk's Content-Range, the helper must reject the download
+// rather than allocate the buffer.
+func TestDownloadResourceChunked_RespectsMaxBytes(t *testing.T) {
+	const claimedTotal = 100 * 1024 * 1024
+	const cap = 10 * 1024 * 1024
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method %s", r.Method)
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-0/%d", claimedTotal))
+		w.Header().Set("Content-Length", "1")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte{0})
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformForDownload(srv.URL, 1024*1024, cap)
+	_, err := p.downloadResourceChunked(context.Background(), "om_x", "fk_x", "file")
+	if err == nil {
+		t.Fatal("expected error for oversize resource, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds cap") {
+		t.Fatalf("expected cap error, got %v", err)
+	}
+}
+
+// TestDownloadResourceChunked_RetriesTransientChunk verifies that a
+// transient network error on a single chunk is retried with backoff
+// instead of failing the whole download. The first chunk succeeds (Range
+// 0-0, advertising the full total), then the second chunk's connection
+// resets twice before succeeding on the third attempt.
+func TestDownloadResourceChunked_RetriesTransientChunk(t *testing.T) {
+	const (
+		chunkSize = 1024
+		total     = 3 * chunkSize
+	)
+	payload := makeTestPayload(total)
+	var secondChunkRetries int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method %s", r.Method)
+		}
+		rangeHdr := r.Header.Get("Range")
+		start, end, _ := parseRangeHeader(rangeHdr)
+
+		// Second data chunk fails the first two attempts, succeeds on the
+		// third. First chunk is bytes=0-0 (probe, always succeeds).
+		if start >= chunkSize && start < 2*chunkSize {
+			if atomic.LoadInt32(&secondChunkRetries) < 2 {
+				atomic.AddInt32(&secondChunkRetries, 1)
+				hj, ok := w.(http.Hijacker)
+				if !ok {
+					t.Fatal("ResponseWriter does not implement Hijacker")
+					return
+				}
+				conn, _, err := hj.Hijack()
+				if err != nil {
+					t.Fatalf("hijack: %v", err)
+				}
+				_ = conn.Close()
+				return
+			}
+		}
+
+		if end >= int64(total) {
+			end = int64(total) - 1
+		}
+		slice := payload[start : end+1]
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(slice)
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformForDownload(srv.URL, chunkSize, 512*1024*1024)
+	origInit := transientRetryInitial
+	transientRetryInitial = 1 * time.Millisecond
+	origMax := transientRetryMaxDelay
+	transientRetryMaxDelay = 2 * time.Millisecond
+	defer func() {
+		transientRetryInitial = origInit
+		transientRetryMaxDelay = origMax
+	}()
+
+	got, err := p.downloadResourceChunked(context.Background(), "om_x", "fk_x", "file")
+	if err != nil {
+		t.Fatalf("downloadResourceChunked: %v", err)
+	}
+	if !bytesEqual(got, payload) {
+		t.Fatalf("payload mismatch")
+	}
+	if r := atomic.LoadInt32(&secondChunkRetries); r < 2 {
+		t.Fatalf("expected ≥2 second-chunk retries, got %d", r)
+	}
+}
+
+// TestDownloadResourceChunked_ContextCancelStopsDownload verifies that
+// cancelling the context aborts the download cleanly.
+func TestDownloadResourceChunked_ContextCancelStopsDownload(t *testing.T) {
+	const (
+		chunkSize = 1024
+		total     = 100 * chunkSize // big enough that the loop runs many times
+	)
+	payload := makeTestPayload(total)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rangeHdr := r.Header.Get("Range")
+		start, end, _ := parseRangeHeader(rangeHdr)
+		if end >= int64(total) {
+			end = int64(total) - 1
+		}
+		slice := payload[start : end+1]
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(slice)
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformForDownload(srv.URL, chunkSize, 512*1024*1024)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := p.downloadResourceChunked(ctx, "om_x", "fk_x", "file")
+		errCh <- err
+	}()
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error from cancelled context, got nil")
+		}
+		if !errors.Is(err, context.Canceled) {
+			if !strings.Contains(err.Error(), "context canceled") &&
+				!strings.Contains(err.Error(), "context deadline exceeded") {
+				t.Fatalf("expected context error, got %v", err)
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("download did not honour context cancellation within 5s")
+	}
+}
+
+// TestDownloadResourceChunked_RejectsEmptyIDs verifies the helper refuses
+// obvious garbage inputs before hitting the network.
+func TestDownloadResourceChunked_RejectsEmptyIDs(t *testing.T) {
+	p := newTestPlatformForDownload("http://localhost:0", 1024, 1024)
+	_, err := p.downloadResourceChunked(context.Background(), "", "fk_x", "file")
+	if err == nil {
+		t.Fatal("expected error for empty messageID")
+	}
+	_, err = p.downloadResourceChunked(context.Background(), "om_x", "", "file")
+	if err == nil {
+		t.Fatal("expected error for empty fileKey")
+	}
+}
+
+// TestDownloadResourceChunked_AuthFailurePropagates verifies a token-fetch
+// failure is reported with feishu context and doesn't leak the underlying
+// transport error verbatim.
+func TestDownloadResourceChunked_AuthFailurePropagates(t *testing.T) {
+	p := newTestPlatformForDownload("http://localhost:1", 1024, 1024)
+	p.fetchResourceToken = func(_ context.Context) (string, error) {
+		return "", errors.New("simulated token error")
+	}
+	_, err := p.downloadResourceChunked(context.Background(), "om_x", "fk_x", "file")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "resource download auth") {
+		t.Fatalf("expected auth error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "simulated token error") {
+		t.Fatalf("expected underlying error in chain, got %v", err)
+	}
+}
+
+// parseRangeHeader parses a "bytes=START-END" header. Returns ok=false for
+// anything else; the helper treats malformed headers as fatal so the
+// failure mode is loud.
+func parseRangeHeader(h string) (start, end int64, ok bool) {
+	const p = "bytes="
+	if !strings.HasPrefix(h, p) {
+		return 0, 0, false
+	}
+	body := strings.TrimPrefix(h, p)
+	dash := strings.Index(body, "-")
+	if dash < 0 {
+		return 0, 0, false
+	}
+	startS := strings.TrimSpace(body[:dash])
+	endS := strings.TrimSpace(body[dash+1:])
+	if startS == "" || endS == "" {
+		return 0, 0, false
+	}
+	var s, e int64
+	var err error
+	if s, err = parseInt(startS); err != nil {
+		return 0, 0, false
+	}
+	if e, err = parseInt(endS); err != nil {
+		return 0, 0, false
+	}
+	return s, e, true
+}
+
+// parseInt is a tiny strconv.ParseInt wrapper so the test file doesn't have
+// to import strconv directly (keeps the import list short and intentional).
+func parseInt(s string) (int64, error) {
+	var n int64
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not an integer: %q", s)
+		}
+		n = n*10 + int64(c-'0')
+	}
+	return n, nil
+}
+
+// bytesEqual compares two byte slices without importing bytes — keeps the
+// test file's surface minimal and reads naturally inline.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Ensure io.Discard is referenced even when individual subtests are
+// filtered out by -run. The download helper itself uses io.Discard, but
+// this import guards against future refactors silently dropping it.
+var _ = io.Discard


### PR DESCRIPTION
## Summary

The larkim SDK's `GetMessageResource` builder does not expose the HTTP `Range` header, so any resource over Feishu's ~2 MiB streaming cap is truncated with code=234037 ("download interrupted"). This affects both generic file/audio downloads (4 call sites in `platform/feishu/feishu.go`) and the #1588 quoted-file path, on v1.4.1 and v1.5.0.

## Fix

Added `platform/feishu/resource_download.go` with a new `downloadResourceChunked` helper that bypasses the larkim SDK, sends a raw HTTP GET with `Range: bytes=0-0` first, and on 206 (Partial Content) loops Range GETs in default 8 MiB chunks (configurable via `resource_chunk_size_bytes`, clamped to [1 MiB, 64 MiB]). Servers that don't honour Range return 200 with the full body and we short-circuit.

`downloadResource` (used by audio body, file body, merge_forward file, and #1588 quoted file) and `downloadImage` now both route through the new helper, so all five existing call sites benefit automatically without changing the call signature.

## Defensive bounds

- **`resourceMaxBytes`** (default 512 MiB) caps total download size against adversarial servers that report an unboundedly large Content-Length.
- **Transient network errors** on any single chunk are retried with the existing exponential-backoff policy (3 attempts, 500ms→5s).
- **Context cancellation** aborts the loop cleanly so user cancellation doesn't leave orphan goroutines.
- **Auth failures** propagate with feishu context, not raw transport errors.
- **Empty `messageID` / `fileKey`** rejected before any network call.

## Tests

Added `platform/feishu/resource_download_test.go` with 9 new tests covering:

- `TestParseContentRangeTotal` — parser correctness (8 cases incl. malformed headers)
- `TestDownloadResourceChunked_SmallFileUsesSingleGet` — exactly one outbound GET for small files (matches pre-#1741 behaviour for files that fit Feishu's cap)
- `TestDownloadResourceChunked_LargeFileUsesRangeLoop` — non-multiple-of-chunk-size total, verifies byte order and Content-Range round-trip
- `TestDownloadResourceChunked_TotalSizeMismatchFails` — server lies about total mid-loop, download rejected
- `TestDownloadResourceChunked_ProbeFailureFallsBackToSingleGet` — first-chunk 5xx falls back to plain GET
- `TestDownloadResourceChunked_RespectsMaxBytes` — oversize resource rejected, no allocation
- `TestDownloadResourceChunked_RetriesTransientChunk` — connection reset on second chunk is retried with backoff
- `TestDownloadResourceChunked_ContextCancelStopsDownload` — context cancellation aborts
- `TestDownloadResourceChunked_RejectsEmptyIDs` / `TestDownloadResourceChunked_AuthFailurePropagates` — input validation + auth error wrapping

Full `platform/feishu` test suite green (32.5s). Race detector clean. Build clean.

## Risk / compatibility

- **No new dependencies** — uses only `net/http` from stdlib + existing `lark` SDK for token minting.
- **No changes to public API** — `downloadResource` and `downloadImage` keep their signatures; only the implementation changes.
- **No platform-name references in `core/`** — all changes scoped to `platform/feishu/`.
- **Configurable chunk size** — operators with edge-case deployments can tune `resource_chunk_size_bytes`; default 8 MiB matches Feishu's documented guidance.
- **Behaviour for small files unchanged** — files under Feishu's streaming cap still cost exactly one outbound GET (same as before).

Fixes #1741