### PR TITLE
fix(core): normalize workspace path separators for cross-platform key consistency

### DIFF
--- a/core/workspace_state.go
+++ b/core/workspace_state.go
@@ -11,16 +11,22 @@ import (
 // mismatches caused by trailing slashes, symlinks, or relative segments.
 // If the path cannot be resolved (e.g. doesn't exist yet), falls back to
 // filepath.Clean only.
+//
+// The result is always returned with forward-slash separators so that it can
+// be used as a stable, cross-platform key (workspace bindings, agent cache,
+// interactive session keys, etc.). On Windows, filepath.Clean/EvalSymlinks emit
+// backslashes, which would otherwise make the same logical path collide with
+// itself depending on which caller supplied the separators.
 func normalizeWorkspacePath(path string) string {
 	cleaned := filepath.Clean(path)
 	resolved, err := filepath.EvalSymlinks(cleaned)
 	if err != nil {
-		return cleaned
+		return filepath.ToSlash(cleaned)
 	}
 	if resolved != path {
 		slog.Debug("workspace path normalized", "original", path, "normalized", resolved)
 	}
-	return resolved
+	return filepath.ToSlash(resolved)
 }
 
 // workspaceState holds the runtime state for a single workspace.

--- a/core/workspace_state_test.go
+++ b/core/workspace_state_test.go
@@ -88,11 +88,14 @@ func TestNormalizeWorkspacePath(t *testing.T) {
 	}
 
 	// Resolve the expected path through EvalSymlinks so that the test works
-	// on macOS where /var is a symlink to /private/var.
-	resolvedRealDir, err := filepath.EvalSymlinks(realDir)
+	// on macOS where /var is a symlink to /private/var. Normalize to forward
+	// slashes to match normalizeWorkspacePath's separator-consistent output,
+	// keeping the expectation portable across Windows/Linux/macOS.
+	resolved, err := filepath.EvalSymlinks(realDir)
 	if err != nil {
 		t.Fatal(err)
 	}
+	resolvedRealDir := filepath.ToSlash(resolved)
 
 	tests := []struct {
 		name  string


### PR DESCRIPTION
### Problem

`normalizeWorkspacePath` returns whatever `filepath.Clean` / `filepath.EvalSymlinks` produce. On Windows that is backslash-separated, on Linux/macOS forward-slash. The result is used as a **map key** in several places: workspace bindings, the agent/workspace state cache, and interactive session keys. Because callers feed the same logical path from different origins (config, filesystem, platform messages), separators can differ, so the same workspace can produce two different keys on Windows (e.g. `C:/a/b` vs `C:\a\b`) -> duplicate workspace states / agent instances and missed bindings. The repo's own footer code already normalizes to forward slashes at display time (`compactReplyFooterPath` calls `filepath.ToSlash`), confirming forward-slash is the intended canonical form.

### Reproduction (on Windows)

```
go test ./core/ -run TestNormalizeWorkspacePath -v
```

Fails:

```
normalizeWorkspacePath("/nonexistent/path/./foo/../bar") = "\nonexistent\path\bar", want "/nonexistent/path/bar"
```

### Fix

Return `filepath.ToSlash(...)` from `normalizeWorkspacePath` in both branches. On Linux/macOS `ToSlash` is a no-op, so behavior there is unchanged (CI stays green); on Windows the key becomes separator-consistent. The test expectation is normalized with `filepath.ToSlash` as well so it is portable across platforms.

### Verification

- `go test ./core/ -run 'TestNormalizeWorkspacePath|TestNormalizeBeforePoolProducesSameKey|TestInteractiveKeyForSessionKey_NormalizesWorkspace|TestWorkspacePool' -v` -> `nonexistent uses Clean only` now PASS; other workspace-key tests PASS.
- Full `go test ./core/` on Windows: no new failures vs. baseline (remaining failures are pre-existing platform differences, e.g. symlink evaluation needing elevated privileges, unrelated to this change).
- On Linux/macOS the change is a no-op, so CI results are unaffected.

### Files changed

- `core/workspace_state.go` - `normalizeWorkspacePath` now returns forward-slash-normalized paths in both the symlink-resolved and Clean-only branches.
- `core/workspace_state_test.go` - expected value in `TestNormalizeWorkspacePath` normalized to forward slashes for portability.
