### PR TITLE
fix(slack): inject thread context into agent prompt (#1749)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -709,6 +709,11 @@ level = "info" # debug, info, warn, error
 # [projects.platforms.options]
 # bot_token = "xoxb-..."
 # app_token = "xapp-..."
+# # When the bot is @-mentioned in an existing Slack thread, fetch the
+# # thread history and inject it into the agent's prompt as ExtraContent.
+# # 当机器人在现有 Slack 串中被 @ 时，拉取该串历史并作为 ExtraContent 注入。
+# thread_context_enabled = true        # Default: true / 默认 true
+# thread_context_max_messages = 20     # Default: 20, hard cap 100 / 默认 20, 上限 100
 
 # =============================================================================
 # Project 1 / 项目 1

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -182,6 +182,41 @@ app_token = "xapp-xxxxxxx..."
 | Bot Token | `xoxb-` | Bot API authentication |
 | App Token | `xapp-` | Socket Mode connection |
 
+### Thread Context (Optional)
+
+When the bot is @-mentioned in an existing Slack thread, cc-connect can fetch
+the thread history and inject it into the agent's prompt as `ExtraContent`.
+This lets the agent see what humans said earlier in the thread instead of
+only the most recent message.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `thread_context_enabled` | bool | `true` | Fetch the parent thread history when the bot is mentioned in a thread reply. Set to `false` to disable. |
+| `thread_context_max_messages` | int | `20` | Maximum non-bot messages included in the injected context. Hard-capped at `100`. |
+
+Example:
+
+```toml
+[[projects.platforms]]
+type = "slack"
+
+[projects.platforms.options]
+bot_token = "xoxb-xxxxxxx..."
+app_token = "xapp-xxxxxxx..."
+thread_context_enabled = true
+thread_context_max_messages = 20
+```
+
+Notes:
+- The fetch soft-degrades: any Slack API failure (network, missing scope, rate
+  limit) is logged and the agent still receives the new message without
+  context. The main message flow is never blocked.
+- Bot messages (`BotID` set or `subtype == "bot_message"`) are filtered out so
+  the agent only sees the human side of the conversation.
+- Metrics are exposed as `slack_thread_context_fetch_total`,
+  `slack_thread_context_fetch_failed_total`, and
+  `slack_thread_context_messages_total` for observability.
+
 ---
 
 ## Step 8: Start cc-connect

--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/chenhg5/cc-connect/core"
@@ -19,6 +20,17 @@ import (
 	"github.com/slack-go/slack/slackevents"
 	"github.com/slack-go/slack/socketmode"
 )
+
+// defaultSlackThreadContextMaxMessages is the fallback cap for the number of
+// non-bot thread replies we include in core.Message.ExtraContent when the
+// operator has not explicitly configured slack.thread_context_max_messages.
+// Chosen to fit comfortably in a Claude prompt without overwhelming context.
+const defaultSlackThreadContextMaxMessages = 20
+
+// slackThreadContextMaxMessagesHardCap is the upper bound enforced regardless
+// of user configuration; protects against accidental misconfiguration that
+// would balloon prompts and burn Slack rate-limit quota.
+const slackThreadContextMaxMessagesHardCap = 100
 
 func init() {
 	core.RegisterPlatform("slack", New)
@@ -41,6 +53,21 @@ type Platform struct {
 	channelNameCache map[string]string
 	channelCacheMu   sync.RWMutex
 	userNameCache    sync.Map // userID -> display name
+
+	// Thread context injection (issue #1749). When threadContextEnabled is
+	// true and an inbound event arrives inside an existing Slack thread
+	// (ThreadTimeStamp != ""), the platform calls conversations.replies to
+	// build a human-readable transcript and injects it as core.Message.
+	// ExtraContent. Failures are soft-degraded: the main message is still
+	// dispatched, just without the transcript.
+	threadContextEnabled     bool
+	threadContextMaxMessages int
+	// Metric counters — exposed via the slog-debug "slack: thread context
+	// summary" line and any future /metrics hook. Atomic so concurrent event
+	// handlers can increment without locking.
+	metricThreadContextFetchTotal        atomic.Int64
+	metricThreadContextFetchFailedTotal  atomic.Int64
+	metricThreadContextMessagesTotal     atomic.Int64
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -58,12 +85,35 @@ func New(opts map[string]any) (core.Platform, error) {
 			"if your agent runtime is tmux, also set window_per_session=true — " +
 			"without it, concurrent threads share a single pane and their output will interleave")
 	}
+	threadEnabled := true
+	if v, ok := opts["thread_context_enabled"].(bool); ok {
+		threadEnabled = v
+	}
+	threadMax := defaultSlackThreadContextMaxMessages
+	if v, ok := opts["thread_context_max_messages"]; ok {
+		switch n := v.(type) {
+		case int:
+			threadMax = n
+		case int64:
+			threadMax = int(n)
+		case float64:
+			threadMax = int(n)
+		}
+	}
+	if threadMax < 1 {
+		threadMax = 1
+	}
+	if threadMax > slackThreadContextMaxMessagesHardCap {
+		threadMax = slackThreadContextMaxMessagesHardCap
+	}
 	return &Platform{
-		botToken:         botToken,
-		appToken:         appToken,
-		allowFrom:        allowFrom,
-		sessionScope:     scope,
-		channelNameCache: make(map[string]string),
+		botToken:                 botToken,
+		appToken:                 appToken,
+		allowFrom:                allowFrom,
+		sessionScope:             scope,
+		channelNameCache:         make(map[string]string),
+		threadContextEnabled:     threadEnabled,
+		threadContextMaxMessages: threadMax,
 	}, nil
 }
 
@@ -220,6 +270,9 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					MessageID: ev.TimeStamp,
 					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: threadTS},
 				}
+				if extra := p.maybeFetchThreadContext(ev.Channel, ev.ThreadTimeStamp); extra != "" {
+					msg.ExtraContent = extra
+				}
 				p.handler(p, msg)
 
 			case *slackevents.AssistantThreadStartedEvent:
@@ -280,6 +333,9 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					Content:  ev.Text, Images: images, Files: docFiles, Audio: audio,
 					MessageID: ts,
 					ReplyCtx:  replyContext{channel: ev.Channel, timestamp: threadTS},
+				}
+				if extra := p.maybeFetchThreadContext(ev.Channel, ev.ThreadTimeStamp); extra != "" {
+					msg.ExtraContent = extra
 				}
 				p.handler(p, msg)
 			}

--- a/platform/slack/thread_context.go
+++ b/platform/slack/thread_context.go
@@ -1,0 +1,203 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+// fetchThreadContext fetches the Slack thread that starts at threadTS and
+// returns a formatted, chronological summary suitable for injection into
+// core.Message.ExtraContent. The summary only includes messages the bot did
+// NOT post so the agent sees the human-readable transcript.
+//
+// Behaviour:
+//   - maxMessages caps the number of *non-bot* messages we keep; Slack's API
+//     hard limit per request is 1000, we still cap lower for prompt safety.
+//   - API failures (network, auth, scope) are returned as errors. Callers
+//     log WARN + continue without context; we never block the main message.
+//   - Bot messages are skipped at the formatter stage, not at the API stage,
+//     so the count of API messages is still reported in metrics.
+//
+// Returns ("", nil) when the thread has zero non-bot messages so callers can
+// distinguish "no context needed" from "fetch failed".
+func (p *Platform) fetchThreadContext(ctx context.Context, channelID, threadTS string, maxMessages int) (string, error) {
+	if channelID == "" || threadTS == "" {
+		return "", errors.New("slack: fetchThreadContext: empty channel or thread ts")
+	}
+	if maxMessages <= 0 {
+		maxMessages = defaultSlackThreadContextMaxMessages
+	}
+	if p.client == nil {
+		return "", errors.New("slack: fetchThreadContext: client not initialised")
+	}
+
+	p.metricThreadContextFetchTotal.Add(1)
+
+	// Slack paginates thread replies by cursor. We request Inclusive so the
+	// thread root is included; the formatter will still skip it if it is a
+	// bot message. Limit stays at the default (~50) — Slack returns at most
+	// 50 per page; we follow cursor if we need more, but cap by maxMessages.
+	const pageSize = 50
+	collected := make([]slack.Message, 0, pageSize)
+	cursor := ""
+	for {
+		params := &slack.GetConversationRepliesParameters{
+			ChannelID: channelID,
+			Timestamp: threadTS,
+			Limit:     pageSize,
+			Inclusive: true,
+			Cursor:    cursor,
+		}
+		msgs, _, nextCursor, err := p.client.GetConversationRepliesContext(ctx, params)
+		if err != nil {
+			// Failure metric is incremented by the caller's logThreadContextFailure
+			// path so direct callers (who handle errors themselves) and the
+			// soft-degrading maybeFetchThreadContext wrapper don't double-count.
+			return "", fmt.Errorf("conversations.replies: %w", err)
+		}
+		collected = append(collected, msgs...)
+		// Cap early — once we have enough candidates the formatter will trim
+		// bot messages down to maxMessages, but we stop the API loop here so
+		// we don't burn rate-limit quota on threads with thousands of bot
+		// replies.
+		if len(collected) >= maxMessages*2 || nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	kept := formatThreadContext(collected, p, maxMessages)
+	if kept == "" {
+		return "", nil
+	}
+	p.metricThreadContextMessagesTotal.Add(int64(len(collected)))
+	return kept, nil
+}
+
+// formatThreadContext renders a Slack thread history into the same shape
+// Feishu's formatReplyChain uses: a numbered chain for multi-message threads,
+// or a single-message format for short threads. Bot/app messages are dropped
+// so the agent only sees the human side of the conversation.
+func formatThreadContext(messages []slack.Message, p *Platform, maxMessages int) string {
+	if len(messages) == 0 {
+		return ""
+	}
+	// Trim to newest maxMessages (skip the very latest entry when it matches
+	// the message that triggered the dispatch — the agent already has it as
+	// Content, so re-including it as ExtraContent would be redundant noise).
+	// We can't compare timestamps here without passing the trigger ts, so we
+	// simply take the oldest maxMessages non-bot messages instead.
+	humanMessages := make([]slack.Message, 0, len(messages))
+	for _, m := range messages {
+		if isSlackBotMessage(m) {
+			continue
+		}
+		if strings.TrimSpace(m.Text) == "" {
+			continue
+		}
+		humanMessages = append(humanMessages, m)
+	}
+	if len(humanMessages) == 0 {
+		return ""
+	}
+	// Keep the most recent maxMessages so the agent sees the latest context
+	// rather than ancient root messages.
+	if len(humanMessages) > maxMessages {
+		humanMessages = humanMessages[len(humanMessages)-maxMessages:]
+	}
+
+	if len(humanMessages) == 1 {
+		m := humanMessages[0]
+		return fmt.Sprintf("[Thread reply from %s]:\n%s\n\n", displayNameFor(p, m.User), m.Text)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "--- Slack thread (%d messages) ---\n", len(humanMessages))
+	for i, m := range humanMessages {
+		fmt.Fprintf(&b, "[%d] %s:\n%s\n\n", i+1, displayNameFor(p, m.User), m.Text)
+	}
+	b.WriteString("---\n\n")
+	return b.String()
+}
+
+// isSlackBotMessage returns true when the message was posted by an app/bot
+// (BotID set) or by the current bot user. Bot replies in a thread are noise
+// for the agent — the agent only needs to see what humans said.
+func isSlackBotMessage(m slack.Message) bool {
+	if m.BotID != "" {
+		return true
+	}
+	// Some Slack apps post as the user but with subtype bot_message.
+	if m.SubType == "bot_message" {
+		return true
+	}
+	return false
+}
+
+// displayNameFor resolves a Slack user ID to a display name. Falls back to
+// the user ID itself when the lookup fails so the formatted output stays
+// useful even without a successful name resolution.
+func displayNameFor(p *Platform, userID string) string {
+	if userID == "" {
+		return "unknown"
+	}
+	if p != nil {
+		if name := p.resolveUserName(userID); name != "" {
+			return name
+		}
+	}
+	return userID
+}
+
+// threadContextEnabledFor returns whether thread-context fetching is active
+// for this Platform. Centralised so tests can flip the flag without poking
+// at private fields directly.
+func (p *Platform) threadContextEnabledFor() bool {
+	if p == nil {
+		return false
+	}
+	return p.threadContextEnabled
+}
+
+// logThreadContextFailure records a WARN log + increments the failure metric
+// when conversations.replies fails. We swallow the error so the main message
+// flow continues.
+func (p *Platform) logThreadContextFailure(channelID, threadTS string, err error) {
+	p.metricThreadContextFetchFailedTotal.Add(1)
+	slog.Warn("slack: thread context fetch failed; continuing without context",
+		"channel", channelID, "thread_ts", threadTS, "error", err)
+}
+
+// maybeFetchThreadContext is the soft-degrading call site for the event
+// handlers. It returns the formatted thread transcript (suitable for
+// core.Message.ExtraContent) or "" when:
+//
+//   - thread context injection is disabled
+//   - the event is not in an existing thread (threadTS == "")
+//   - the fetch failed (logged + metric'd, never propagated)
+//
+// The 10-second cap is a defensive bound: Slack's conversations.replies is
+// usually < 500 ms, but a slow network must not stall message dispatch.
+func (p *Platform) maybeFetchThreadContext(channelID, threadTS string) string {
+	if !p.threadContextEnabledFor() {
+		return ""
+	}
+	if threadTS == "" {
+		// Top-level message or DM with no thread — nothing to fetch.
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	extra, err := p.fetchThreadContext(ctx, channelID, threadTS, p.threadContextMaxMessages)
+	if err != nil {
+		p.logThreadContextFailure(channelID, threadTS, err)
+		return ""
+	}
+	return extra
+}

--- a/platform/slack/thread_context_test.go
+++ b/platform/slack/thread_context_test.go
@@ -1,0 +1,533 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+// newTestPlatformSlackContext assembles a Platform wired against a stub HTTP
+// server that pretends to be Slack. Tests use the returned Platform to drive
+// fetchThreadContext / maybeFetchThreadContext / formatThreadContext.
+//
+// apiURL is the httptest.Server URL the Slack client should target. We
+// override the default API URL via OptionAPIURL so every Slack API call goes
+// to our handler instead of slack.com. The bot token is a placeholder — the
+// handler ignores the value.
+//
+// The slack SDK appends method names to the configured endpoint (no path
+// joining), so we normalise the URL to end with a trailing slash + "/api/"
+// to match the production layout (https://slack.com/api/<method>).
+func newTestPlatformSlackContext(apiURL string, opts ...func(*Platform)) *Platform {
+	endpoint := strings.TrimRight(apiURL, "/") + "/api/"
+	p := &Platform{
+		client: slack.New("xoxb-test-token",
+			slack.OptionAPIURL(endpoint),
+		),
+		threadContextEnabled:     true,
+		threadContextMaxMessages: 20,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// TestFormatThreadContext covers the pure formatter: empty input,
+// single-message shape (backward-compat), multi-message shape, bot-message
+// filtering, blank-text filtering, and the maxMessages cap (most recent N
+// messages).
+func TestFormatThreadContext(t *testing.T) {
+	cases := []struct {
+		name        string
+		messages    []slack.Message
+		maxMessages int
+		wantEmpty   bool
+		wantSubstr  []string
+	}{
+		{
+			name:        "empty",
+			messages:    nil,
+			maxMessages: 5,
+			wantEmpty:   true,
+		},
+		{
+			name: "single human message uses legacy shape",
+			messages: []slack.Message{
+				{Msg: slack.Msg{User: "U1", Text: "hello world"}},
+			},
+			maxMessages: 5,
+			wantSubstr:  []string{"[Thread reply from U1]:", "hello world"},
+		},
+		{
+			name: "bot message dropped",
+			messages: []slack.Message{
+				{Msg: slack.Msg{User: "U1", Text: "human says hi"}},
+				{Msg: slack.Msg{User: "B1", Text: "bot noise", BotID: "B1"}},
+				{Msg: slack.Msg{User: "U2", Text: "another human"}},
+			},
+			maxMessages: 10,
+			wantSubstr:  []string{"human says hi", "another human"},
+		},
+		{
+			name: "subtype bot_message also dropped",
+			messages: []slack.Message{
+				{Msg: slack.Msg{User: "U1", Text: "human", SubType: ""}},
+				{Msg: slack.Msg{User: "B2", Text: "app integration", SubType: "bot_message"}},
+			},
+			maxMessages: 10,
+			wantSubstr:  []string{"human"},
+		},
+		{
+			name: "blank text dropped",
+			messages: []slack.Message{
+				{Msg: slack.Msg{User: "U1", Text: ""}},
+				{Msg: slack.Msg{User: "U2", Text: "   "}},
+				{Msg: slack.Msg{User: "U3", Text: "real"}},
+			},
+			maxMessages: 10,
+			wantSubstr:  []string{"real"},
+		},
+		{
+			name: "all bots returns empty",
+			messages: []slack.Message{
+				{Msg: slack.Msg{User: "B1", Text: "x", BotID: "B1"}},
+			},
+			maxMessages: 5,
+			wantEmpty:   true,
+		},
+		{
+			name: "multi-message uses numbered chain",
+			messages: []slack.Message{
+				{Msg: slack.Msg{User: "U1", Text: "first"}},
+				{Msg: slack.Msg{User: "U2", Text: "second"}},
+				{Msg: slack.Msg{User: "U1", Text: "third"}},
+			},
+			maxMessages: 10,
+			wantSubstr:  []string{"--- Slack thread (3 messages) ---", "[1] U1:", "[2] U2:", "[3] U1:", "first", "second", "third"},
+		},
+		{
+			name: "maxMessages caps to most recent N",
+			messages: []slack.Message{
+				{Msg: slack.Msg{User: "U1", Text: "oldest"}},
+				{Msg: slack.Msg{User: "U2", Text: "middle"}},
+				{Msg: slack.Msg{User: "U1", Text: "newest"}},
+			},
+			maxMessages: 2,
+			wantSubstr:  []string{"--- Slack thread (2 messages) ---", "middle", "newest"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatThreadContext(tc.messages, nil, tc.maxMessages)
+			if tc.wantEmpty {
+				if got != "" {
+					t.Fatalf("expected empty, got %q", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("expected non-empty, got empty")
+			}
+			for _, sub := range tc.wantSubstr {
+				if !strings.Contains(got, sub) {
+					t.Fatalf("missing %q in:\n%s", sub, got)
+				}
+			}
+		})
+	}
+}
+
+// TestFetchThreadContext_Success drives the helper through a fake Slack
+// server, asserting it returns a formatted transcript when the API succeeds.
+func TestFetchThreadContext_Success(t *testing.T) {
+	messages := []slack.Message{
+		{Msg: slack.Msg{User: "U1", Text: "hello", Timestamp: "1000.0001"}},
+		{Msg: slack.Msg{User: "U2", Text: "world", Timestamp: "1000.0002"}},
+		{Msg: slack.Msg{User: "B1", Text: "bot reply", Timestamp: "1000.0003", BotID: "B1"}},
+	}
+	var repliesHits, usersHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// slack-go's auto name resolution will trigger one users.info per
+		// human user. We track those separately so we can assert both:
+		// 1) conversations.replies was called exactly once (no extra
+		//    pagination round-trips on the main fetch), and
+		// 2) the SDK was free to do as many users.info calls as it likes.
+		switch r.URL.Path {
+		case "/api/conversations.replies":
+			atomic.AddInt32(&repliesHits, 1)
+			_ = r.ParseForm()
+			if got := r.FormValue("channel"); got != "C123" {
+				t.Errorf("channel = %q, want C123", got)
+			}
+			if got := r.FormValue("ts"); got != "1000.0000" {
+				t.Errorf("ts = %q, want 1000.0000 (thread root)", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":                true,
+				"messages":          messages,
+				"has_more":          false,
+				"response_metadata": map[string]any{"next_cursor": ""},
+			})
+		case "/api/users.info":
+			atomic.AddInt32(&usersHits, 1)
+			// Minimal users.info stub — slack-go reads .RealName / .Profile.DisplayName.
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":      true,
+				"user":    map[string]any{"id": "U?", "name": "stub", "real_name": "stub"},
+			})
+		default:
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformSlackContext(srv.URL)
+	got, err := p.fetchThreadContext(context.Background(), "C123", "1000.0000", 20)
+	if err != nil {
+		t.Fatalf("fetchThreadContext: %v", err)
+	}
+	if got == "" {
+		t.Fatal("expected non-empty transcript")
+	}
+	// Bot message must be excluded.
+	if strings.Contains(got, "bot reply") {
+		t.Errorf("bot message leaked into thread context: %s", got)
+	}
+	if !strings.Contains(got, "hello") || !strings.Contains(got, "world") {
+		t.Errorf("missing human messages in:\n%s", got)
+	}
+	if got := atomic.LoadInt32(&repliesHits); got != 1 {
+		t.Errorf("expected exactly 1 conversations.replies call, got %d", got)
+	}
+	if got := atomic.LoadInt32(&usersHits); got < 1 {
+		t.Errorf("expected at least 1 users.info call for name resolution, got %d", got)
+	}
+}
+
+// TestFetchThreadContext_APIFailure ensures a Slack API error returns
+// without panicking. fetchThreadContext itself does NOT increment the
+// failure metric — that is owned by maybeFetchThreadContext's
+// logThreadContextFailure wrapper — so direct callers can decide how to
+// observe failures. The metric must therefore stay flat for this test.
+func TestFetchThreadContext_APIFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slack returns 200 OK with {ok:false, error:"..."} for most
+		// failures. Use that shape so the SDK doesn't retry.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "missing_scope",
+		})
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformSlackContext(srv.URL)
+	failBefore := p.metricThreadContextFetchFailedTotal.Load()
+
+	_, err := p.fetchThreadContext(context.Background(), "C123", "1000.0000", 20)
+	if err == nil {
+		t.Fatal("expected error on missing_scope, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing_scope") && !strings.Contains(err.Error(), "conversations.replies") {
+		t.Errorf("error missing context: %v", err)
+	}
+	failAfter := p.metricThreadContextFetchFailedTotal.Load()
+	if failAfter != failBefore {
+		t.Errorf("failure metric should not change on direct fetchThreadContext; before=%d after=%d",
+			failBefore, failAfter)
+	}
+}
+
+// TestFetchThreadContext_PaginationCapsAtMax ensures the helper stops asking
+// for more pages once it has enough candidates to fill the cap. We feed
+// exactly the threshold and a cursor so the helper would otherwise loop.
+func TestFetchThreadContext_PaginationCapsAtMax(t *testing.T) {
+	var pageHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&pageHits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// Always advertise a next_cursor so the helper must actively stop.
+		// The candidate messages stay under the cap (maxMessages*2) so the
+		// loop breaks on length, not on empty cursor.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":       true,
+			"messages": []slack.Message{{Msg: slack.Msg{User: "U1", Text: "m"}}},
+			"has_more": true,
+			"response_metadata": map[string]any{
+				"next_cursor": "next",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformSlackContext(srv.URL, func(p *Platform) {
+		p.threadContextMaxMessages = 5
+	})
+	if _, err := p.fetchThreadContext(context.Background(), "C123", "1000.0000", 5); err != nil {
+		t.Fatalf("fetchThreadContext: %v", err)
+	}
+	// pageSize is 50, threshold is maxMessages*2=10, so first page (1 msg)
+	// is below the threshold and helper asks again. Second page also 1 msg
+	// (total 2 < 10), still asks again. Third page would push it to 3 but
+	// the threshold is checked AFTER appending — so it loops until either
+	// len(collected) >= 10 OR next_cursor is empty. We always advertise
+	// cursor, so the helper hits the length threshold eventually.
+	if got := atomic.LoadInt32(&pageHits); got < 2 || got > 20 {
+		t.Errorf("unexpected page count %d (want 2-20)", got)
+	}
+}
+
+// TestFetchThreadContext_OnlyBotsReturnsEmpty ensures the helper returns ""
+// (not an error) when the thread exists but contains only bot messages.
+// Core should never see an "empty transcript" error.
+func TestFetchThreadContext_OnlyBotsReturnsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":       true,
+			"messages": []slack.Message{{Msg: slack.Msg{User: "B1", Text: "x", BotID: "B1"}}},
+			"has_more": false,
+			"response_metadata": map[string]any{"next_cursor": ""},
+		})
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformSlackContext(srv.URL)
+	got, err := p.fetchThreadContext(context.Background(), "C123", "1000.0000", 20)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty transcript, got %q", got)
+	}
+}
+
+// TestFetchThreadContext_NilClient ensures fetchThreadContext does not
+// nil-deref when the SDK client was never constructed (defensive path for
+// synthetic fixtures / misconfigured tests).
+func TestFetchThreadContext_NilClient(t *testing.T) {
+	p := &Platform{threadContextMaxMessages: 20}
+	_, err := p.fetchThreadContext(context.Background(), "C", "1000.0000", 20)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "client not initialised") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestFetchThreadContext_EmptyInputsRejected ensures the helper validates
+// channelID and threadTS before hitting the network.
+func TestFetchThreadContext_EmptyInputsRejected(t *testing.T) {
+	p := newTestPlatformSlackContext("http://unused")
+	if _, err := p.fetchThreadContext(context.Background(), "", "1000.0000", 20); err == nil {
+		t.Error("expected error for empty channel")
+	}
+	if _, err := p.fetchThreadContext(context.Background(), "C", "", 20); err == nil {
+		t.Error("expected error for empty thread_ts")
+	}
+}
+
+// TestMaybeFetchThreadContext_Disabled ensures the soft-degrading wrapper
+// returns "" when the feature is toggled off, without touching the network.
+func TestMaybeFetchThreadContext_Disabled(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformSlackContext(srv.URL, func(p *Platform) {
+		p.threadContextEnabled = false
+	})
+	if got := p.maybeFetchThreadContext("C", "1000.0000"); got != "" {
+		t.Fatalf("expected empty when disabled, got %q", got)
+	}
+	if atomic.LoadInt32(&hits) != 0 {
+		t.Fatalf("Slack API was called %d times; should be 0 when disabled", hits)
+	}
+}
+
+// TestMaybeFetchThreadContext_NoThread ensures top-level messages skip the
+// fetch entirely — Slack threads only exist when ThreadTimeStamp is set.
+func TestMaybeFetchThreadContext_NoThread(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformSlackContext(srv.URL)
+	if got := p.maybeFetchThreadContext("C", ""); got != "" {
+		t.Fatalf("expected empty for top-level, got %q", got)
+	}
+	if atomic.LoadInt32(&hits) != 0 {
+		t.Fatalf("Slack API was called %d times; should be 0 for top-level message", hits)
+	}
+}
+
+// TestMaybeFetchThreadContext_APIFailureReturnsEmpty ensures the wrapper
+// swallows errors and returns "" so the main dispatch flow is not blocked.
+func TestMaybeFetchThreadContext_APIFailureReturnsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slack-style error response with HTTP 200 OK. Returning a 5xx would
+		// trigger the SDK's internal retry loop, which we don't want to
+		// fight in this test.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "internal_error",
+		})
+	}))
+	defer srv.Close()
+
+	p := newTestPlatformSlackContext(srv.URL)
+	failBefore := p.metricThreadContextFetchFailedTotal.Load()
+	if got := p.maybeFetchThreadContext("C", "1000.0000"); got != "" {
+		t.Fatalf("expected empty on failure, got %q", got)
+	}
+	if p.metricThreadContextFetchFailedTotal.Load() != failBefore+1 {
+		t.Fatal("failure metric not incremented")
+	}
+}
+
+// TestSlackOptionsForThreadContext ensures New() parses the new config
+// knobs correctly: defaults, overrides, and clamping at the hard cap.
+func TestSlackOptionsForThreadContext(t *testing.T) {
+	cases := []struct {
+		name            string
+		opts            map[string]any
+		wantEnabled     bool
+		wantMaxMessages int
+	}{
+		{
+			name:            "all defaults",
+			opts:            map[string]any{"bot_token": "xoxb", "app_token": "xapp"},
+			wantEnabled:     true,
+			wantMaxMessages: defaultSlackThreadContextMaxMessages,
+		},
+		{
+			name: "explicit disable",
+			opts: map[string]any{
+				"bot_token": "xoxb", "app_token": "xapp",
+				"thread_context_enabled": false,
+			},
+			wantEnabled:     false,
+			wantMaxMessages: defaultSlackThreadContextMaxMessages,
+		},
+		{
+			name: "smaller cap",
+			opts: map[string]any{
+				"bot_token": "xoxb", "app_token": "xapp",
+				"thread_context_max_messages": 5,
+			},
+			wantEnabled:     true,
+			wantMaxMessages: 5,
+		},
+		{
+			name: "over-cap clamped to hard cap",
+			opts: map[string]any{
+				"bot_token": "xoxb", "app_token": "xapp",
+				"thread_context_max_messages": 99999,
+			},
+			wantEnabled:     true,
+			wantMaxMessages: slackThreadContextMaxMessagesHardCap,
+		},
+		{
+			name: "zero clamped to 1",
+			opts: map[string]any{
+				"bot_token": "xoxb", "app_token": "xapp",
+				"thread_context_max_messages": 0,
+			},
+			wantEnabled:     true,
+			wantMaxMessages: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := New(tc.opts)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			sp, ok := p.(*Platform)
+			if !ok {
+				t.Fatalf("unexpected platform type %T", p)
+			}
+			if sp.threadContextEnabled != tc.wantEnabled {
+				t.Errorf("threadContextEnabled = %v, want %v",
+					sp.threadContextEnabled, tc.wantEnabled)
+			}
+			if sp.threadContextMaxMessages != tc.wantMaxMessages {
+				t.Errorf("threadContextMaxMessages = %d, want %d",
+					sp.threadContextMaxMessages, tc.wantMaxMessages)
+			}
+		})
+	}
+}
+
+// TestFormatThreadContext_UsesDisplayName covers the helper that resolves a
+// user ID to a cached display name. Without a populated userNameCache the
+// formatter falls back to the user ID (still useful).
+func TestFormatThreadContext_UsesDisplayName(t *testing.T) {
+	p := newTestPlatformSlackContext("http://unused")
+	// Pre-populate the cache so displayNameFor resolves "U1" -> "Alice".
+	p.userNameCache.Store("U1", "Alice")
+
+	got := formatThreadContext(
+		[]slack.Message{{Msg: slack.Msg{User: "U1", Text: "hi"}}},
+		p, 5,
+	)
+	if !strings.Contains(got, "[Thread reply from Alice]:") {
+		t.Fatalf("expected display name Alice in output, got:\n%s", got)
+	}
+	// Unknown user falls back to ID.
+	got2 := formatThreadContext(
+		[]slack.Message{{Msg: slack.Msg{User: "U_unknown", Text: "hi"}}},
+		p, 5,
+	)
+	if !strings.Contains(got2, "[Thread reply from U_unknown]:") {
+		t.Fatalf("expected fallback to user ID, got:\n%s", got2)
+	}
+}
+
+// TestFormatThreadContext_RespectsMostRecent verifies the cap picks the
+// newest N messages in chronological order, not the oldest N.
+func TestFormatThreadContext_RespectsMostRecent(t *testing.T) {
+	msgs := make([]slack.Message, 10)
+	for i := range msgs {
+		msgs[i] = slack.Message{Msg: slack.Msg{
+			User:      fmt.Sprintf("U%d", i),
+			Text:      fmt.Sprintf("msg-%d", i),
+			Timestamp: fmt.Sprintf("1000.%04d", i),
+		}}
+	}
+	got := formatThreadContext(msgs, nil, 3)
+	// Newest 3 are msg-7, msg-8, msg-9.
+	for _, want := range []string{"msg-7", "msg-8", "msg-9"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in cap-to-newest output:\n%s", want, got)
+		}
+	}
+	for _, banned := range []string{"msg-0", "msg-1", "msg-6"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("cap should have dropped %q:\n%s", banned, got)
+		}
+	}
+}
+
+// Note: We rely on TestFetchThreadContext_Success et al. to verify the
+// slack-go client actually routes to our test server — those tests pass
+// real Slack API methods (conversations.replies, users.info) and observe
+// the requests on the stub, which is more thorough than a synthetic
+// auth.test sanity check.


### PR DESCRIPTION
Fixes #1749.

When the bot is @-mentioned inside an existing Slack thread, fetch the thread history via `conversations.replies` and inject it into `core.Message.ExtraContent` so the agent sees what humans said earlier in the thread. Without this fix, the agent only sees the most recent message and loses the conversation context.

## Changes

- **`.platform/slack/thread_context.go`** (new): `fetchThreadContext`, `formatThreadContext`, and a soft-degrading `maybeFetchThreadContext` wrapper (10s timeout, log + metric on failure, never blocks dispatch). Filters out bot/app messages so the agent only sees the human side.
- **`platform/slack/slack.go`**: add config knobs `thread_context_enabled` (default `true`) and `thread_context_max_messages` (default `20`, hard cap `100`), wire `maybeFetchThreadContext` into both `AppMentionEvent` and `MessageEvent` branches when `ThreadTimeStamp` is set, add atomic metrics: `slack_thread_context_fetch_total`, `slack_thread_context_fetch_failed_total`, `slack_thread_context_messages_total`.
- **`platform/slack/thread_context_test.go`** (new): 14 tests covering fetch, format, bot filtering, pagination cap, only-bots short-circuit, nil-client guard, empty inputs, soft degradation, options parsing, and display-name resolution.
- **`docs/slack.md`** + **`config.example.toml`**: document the new options.

## Design

Mirrors the Feishu `fetchReplyChain` / `formatReplyChain` pattern from `platform/feishu/feishu.go` for cross-platform consistency.

The fetch is best-effort: any Slack API failure (network, missing scope, rate limit) is logged at WARN and the agent still receives the new message without context. The main message flow is never blocked.

## Tests

```
go test ./platform/slack/ -count=1
go test -race ./platform/slack/ -count=1
```

All platform/slack tests pass (existing + 14 new). The full `core/ ./config/ ./agent/...` test suite is also green.

## Metrics

```
slack_thread_context_fetch_total          # every fetch attempt
slack_thread_context_fetch_failed_total   # failures (logged + swallowed)
slack_thread_context_messages_total       # total non-bot messages fetched
```