### PR TITLE
fix(codex): show file diffs in approval prompts

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -178,6 +178,7 @@ type appServerSession struct {
 
 	stateMu      sync.Mutex
 	pendingMsgs  []string
+	fileChanges  map[string]string
 	currentTurn  string
 	preambleSent bool
 
@@ -209,6 +210,7 @@ func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode,
 		cancel:           cancel,
 		pending:          make(map[int64]chan rpcResponseEnvelope),
 		pendingApprovals: make(map[string]chan core.PermissionResult),
+		fileChanges:      make(map[string]string),
 		preambleSent:     resumeID != "" && resumeID != core.ContinueSession,
 	}
 	s.alive.Store(true)
@@ -585,7 +587,7 @@ func (s *appServerSession) handleApprovalRequest(rawID json.RawMessage, method s
 		return
 	}
 
-	toolName, toolInput := method, appServerJSON(params)
+	toolName, toolInput := method, ""
 	switch method {
 	case "item/commandExecution/requestApproval":
 		toolName = "Bash"
@@ -597,8 +599,18 @@ func (s *appServerSession) handleApprovalRequest(rawID json.RawMessage, method s
 		}
 	case "item/fileChange/requestApproval":
 		toolName = "Patch"
+		if itemID, _ := params["itemId"].(string); itemID != "" {
+			toolInput = s.fileChangeInput(itemID)
+		}
+		if toolInput != "" {
+			break
+		}
 		if reason, _ := params["reason"].(string); reason != "" {
 			toolInput = reason
+		} else if grantRoot, _ := params["grantRoot"].(string); grantRoot != "" {
+			toolInput = grantRoot
+		} else {
+			toolInput = "File changes"
 		}
 	}
 
@@ -659,7 +671,7 @@ func (s *appServerSession) handlePermissionsApproval(rawID json.RawMessage, para
 		Type:         core.EventPermissionRequest,
 		RequestID:    requestID,
 		ToolName:     "Permissions",
-		ToolInput:    appServerJSON(params),
+		ToolInput:    appServerPermissionsInput(params),
 		ToolInputRaw: params,
 	})
 
@@ -694,6 +706,26 @@ func (s *appServerSession) handlePermissionsApproval(rawID json.RawMessage, para
 			})
 		}
 	}()
+}
+
+func appServerPermissionsInput(params map[string]any) string {
+	parts := make([]string, 0, 2)
+	if permissions := appServerJSON(params["permissions"]); permissions != "" {
+		parts = append(parts, permissions)
+	}
+	if cwd, _ := params["cwd"].(string); cwd != "" {
+		parts = append(parts, "(in "+cwd+")")
+	}
+	if len(parts) == 0 {
+		return "Additional permissions"
+	}
+	return strings.Join(parts, "\n")
+}
+
+func (s *appServerSession) fileChangeInput(itemID string) string {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	return s.fileChanges[itemID]
 }
 
 func (s *appServerSession) handleRequestUserInput(rawID json.RawMessage, paramsRaw json.RawMessage) {
@@ -1107,6 +1139,7 @@ func (s *appServerSession) handleNotification(method string, paramsRaw json.RawM
 			s.stateMu.Lock()
 			s.currentTurn = notif.Turn.ID
 			s.pendingMsgs = s.pendingMsgs[:0]
+			clear(s.fileChanges)
 			s.stateMu.Unlock()
 			s.storeContextUsage(nil)
 		}
@@ -1194,14 +1227,70 @@ func (s *appServerSession) handleItemStarted(item map[string]any) {
 		s.emit(core.Event{Type: core.EventToolUse, ToolName: tool, ToolInput: appServerJSON(item["arguments"])})
 
 	case "fileChange":
-		s.emit(core.Event{Type: core.EventToolUse, ToolName: "Patch", ToolInput: appServerJSON(item["changes"])})
+		changes := appServerFileChangesInput(item["changes"])
+		if itemID, _ := item["id"].(string); itemID != "" && changes != "" {
+			s.stateMu.Lock()
+			if s.fileChanges == nil {
+				s.fileChanges = make(map[string]string)
+			}
+			s.fileChanges[itemID] = changes
+			s.stateMu.Unlock()
+		}
+		s.emit(core.Event{Type: core.EventToolUse, ToolName: "Patch", ToolInput: changes})
 	}
+}
+
+func appServerFileChangesInput(raw any) string {
+	changes, ok := raw.([]any)
+	if !ok || len(changes) == 0 {
+		return appServerJSON(raw)
+	}
+
+	parts := make([]string, 0, len(changes))
+	for _, rawChange := range changes {
+		change, ok := rawChange.(map[string]any)
+		if !ok {
+			continue
+		}
+		path, _ := change["path"].(string)
+		diff, _ := change["diff"].(string)
+		path = strings.TrimSpace(path)
+		diff = strings.TrimSpace(diff)
+		if path == "" && diff == "" {
+			continue
+		}
+
+		var part strings.Builder
+		if path != "" {
+			part.WriteString(path)
+		}
+		if diff != "" {
+			if part.Len() > 0 {
+				part.WriteByte('\n')
+			}
+			part.WriteString("```diff\n")
+			part.WriteString(diff)
+			part.WriteString("\n```")
+		}
+		parts = append(parts, part.String())
+	}
+	if len(parts) == 0 {
+		return appServerJSON(raw)
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 func (s *appServerSession) handleItemCompleted(item map[string]any) {
 	itemType, _ := item["type"].(string)
 	if itemType == "" {
 		return
+	}
+	if itemType == "fileChange" {
+		if itemID, _ := item["id"].(string); itemID != "" {
+			s.stateMu.Lock()
+			delete(s.fileChanges, itemID)
+			s.stateMu.Unlock()
+		}
 	}
 
 	switch itemType {

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -274,6 +274,116 @@ func TestAppServerSession_HandleRequestUserInputEmitsAskQuestion(t *testing.T) {
 	}
 }
 
+func TestAppServerSession_FileChangeApprovalWithNullReasonDoesNotExposeMetadata(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &appServerSession{
+		events:           make(chan core.Event, 1),
+		ctx:              ctx,
+		pendingApprovals: make(map[string]chan core.PermissionResult),
+		stdin:            &lockedWriteCloser{},
+	}
+	s.handleServerRequest(serverRequestProbe(t, `"patch-1"`, "item/fileChange/requestApproval", map[string]any{
+		"threadId":    "thread-1",
+		"turnId":      "turn-1",
+		"itemId":      "exec-1",
+		"reason":      nil,
+		"grantRoot":   nil,
+		"startedAtMs": 1787724290697,
+	}))
+
+	event := <-s.events
+	if event.ToolName != "Patch" {
+		t.Fatalf("tool name = %q, want Patch", event.ToolName)
+	}
+	if event.ToolInput != "File changes" {
+		t.Fatalf("tool input = %q, want friendly fallback", event.ToolInput)
+	}
+	for _, internalField := range []string{"threadId", "turnId", "itemId", "startedAtMs"} {
+		if strings.Contains(event.ToolInput, internalField) {
+			t.Fatalf("tool input %q exposes internal field %q", event.ToolInput, internalField)
+		}
+	}
+}
+
+func TestAppServerSession_FileChangeApprovalShowsChangesFromStartedItem(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &appServerSession{
+		events:           make(chan core.Event, 2),
+		ctx:              ctx,
+		pendingApprovals: make(map[string]chan core.PermissionResult),
+		stdin:            &lockedWriteCloser{},
+	}
+	s.handleItemStarted(map[string]any{
+		"id":   "exec-1",
+		"type": "fileChange",
+		"changes": []any{
+			map[string]any{
+				"path": "/workspace/restart.sh",
+				"kind": "update",
+				"diff": "+export https_proxy=http://0.0.0.0:1087",
+			},
+		},
+	})
+	<-s.events
+
+	s.handleServerRequest(serverRequestProbe(t, `"patch-with-changes"`, "item/fileChange/requestApproval", map[string]any{
+		"threadId":  "thread-1",
+		"turnId":    "turn-1",
+		"itemId":    "exec-1",
+		"reason":    nil,
+		"grantRoot": nil,
+	}))
+
+	event := <-s.events
+	want := "/workspace/restart.sh\n```diff\n+export https_proxy=http://0.0.0.0:1087\n```"
+	if event.ToolInput != want {
+		t.Fatalf("tool input = %q, want %q", event.ToolInput, want)
+	}
+	for _, internalField := range []string{"threadId", "turnId", "itemId"} {
+		if strings.Contains(event.ToolInput, internalField) {
+			t.Fatalf("tool input %q exposes internal field %q", event.ToolInput, internalField)
+		}
+	}
+}
+
+func TestAppServerSession_PermissionsApprovalDoesNotExposeMetadata(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &appServerSession{
+		events:           make(chan core.Event, 1),
+		ctx:              ctx,
+		pendingApprovals: make(map[string]chan core.PermissionResult),
+		stdin:            &lockedWriteCloser{},
+	}
+	s.handleServerRequest(serverRequestProbe(t, `"permissions-1"`, "item/permissions/requestApproval", map[string]any{
+		"threadId": "thread-1",
+		"turnId":   "turn-1",
+		"itemId":   "exec-1",
+		"cwd":      "/workspace",
+		"permissions": map[string]any{
+			"disk": map[string]any{"write": []any{"/workspace"}},
+		},
+	}))
+
+	event := <-s.events
+	if event.ToolName != "Permissions" {
+		t.Fatalf("tool name = %q, want Permissions", event.ToolName)
+	}
+	if !strings.Contains(event.ToolInput, `"write":["/workspace"]`) || !strings.Contains(event.ToolInput, "(in /workspace)") {
+		t.Fatalf("tool input = %q, want permissions and working directory", event.ToolInput)
+	}
+	for _, internalField := range []string{"threadId", "turnId", "itemId"} {
+		if strings.Contains(event.ToolInput, internalField) {
+			t.Fatalf("tool input %q exposes internal field %q", event.ToolInput, internalField)
+		}
+	}
+}
+
 func TestAppServerSession_HandleRequestUserInputWritesCodexResponse(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill in the sections below.
The reviewer will use the checklist at the bottom to gate merge.
-->

## Summary

<!-- 1-3 sentences explaining WHAT this PR does and WHY. -->

## Type of change

<!-- Mark all that apply: -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

<!-- Explain how you verified the change. Be specific. -->

### Automated tests added in this PR

<!-- List the test functions you added or modified. -->

- `TestX_Y_Z` in `path/to/file_test.go` — what it asserts

### For bug fixes only — regression test

<!-- A bug fix PR MUST include a regression test that:
     (1) fails on the pre-fix code, and
     (2) passes on the fixed code.
     Name it so the bug is searchable later. -->

- Regression test name: `Test...`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

<!-- See AGENTS.md → "Critical User Journeys (CUJ)" and the inventory in
     projects/cc-connect/agents/qa-cursor/release-gate/CUJ-INVENTORY.md.
     Mark which CUJ groups this PR touches: -->

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

<!-- Describe what a user will see or do differently after this PR.
     If none, write "None". -->

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [ ] No new hardcoded platform/agent names in `core/`
- [ ] i18n strings have all-language translations (if any new user-facing text)
- [ ] No secrets / credentials in source

## Related

<!-- Link to issue, RFC, design doc, prior PR, etc. -->

- Issue:
- Related PR:
