### PR TITLE
fix(preset): correct Kimi API registration link (#1611)

### DIFF
--- a/provider-presets.json
+++ b/provider-presets.json
@@ -5,7 +5,7 @@
     {
       "name": "kimi",
       "display_name": "Kimi",
-      "invite_url": "https://platform.kimi.ai?track_id=track-dd37b0bea7a64b99b3fe2217b398e20b&aff=cc-connect",
+      "invite_url": "https://platform.kimi.ai/?aff=cc-connect",
       "description": "Kimi K2.7 Code — coding-focused open-source agentic model from Moonshot AI. Reduces thinking-token usage by ~30% vs K2.6. cc-connect brings Kimi CLI to Feishu/DingTalk/Telegram/Slack/Discord/WeChat Work.",
       "description_zh": "Kimi K2.7 Code — Moonshot AI 推出的编程专用开源智能体模型,相比 K2.6 平均减少约 30% 的推理 Token 消耗。cc-connect 可将本地 Kimi CLI 接入飞书/钉钉/Telegram/Slack/Discord/企业微信。",
       "features": ["K2.7 Code", "30% Less Tokens", "Sponsor", "cc-connect Native"],


### PR DESCRIPTION
Fixes #1611.

Per the triage comment, the Kimi preset invite link pointed at the wrong product (Kimi Code subscription vs Platform API). This updates `provider-presets.json` to the confirmed target `https://platform.kimi.ai/?aff=cc-connect` (verified reachable, lands on the Moonshot AI open platform / pay-as-you-go API page).

`base_url` values (`https://api.moonshot.ai/v1`) across agents were already correct and are untouched. The CN-site preset suggestion from the reporter is intentionally left out, as triaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)