### PR TITLE
fix(claudecode): add claude-fable-5 to the /model fallback list (#1642)

### DIFF
--- a/agent/claudecode/claudecode.go
+++ b/agent/claudecode/claudecode.go
@@ -393,6 +393,7 @@ func (a *Agent) AvailableModels(ctx context.Context) []core.ModelOption {
 		{Name: "sonnet[1m]", Desc: "Claude Sonnet (1M context)"},
 		{Name: "opus", Desc: "Claude Opus (most capable)"},
 		{Name: "opus[1m]", Desc: "Claude Opus (1M context)"},
+		{Name: "claude-fable-5", Desc: "Claude Fable 5 (frontier)"},
 		{Name: "haiku", Desc: "Claude Haiku (fastest)"},
 	}
 }


### PR DESCRIPTION
Fixes #1642.

The hardcoded fallback list in `AvailableModels()` predates the Claude 5 family, so subscription-auth users (where the dynamic listing is unavailable) cannot pick `claude-fable-5` from `/model`.

One-line fix: add `{Name: "claude-fable-5", Desc: "Claude Fable 5 (frontier)"}` to the fallback list, between `opus[1m]` and `haiku` to keep the existing capability ordering.

Deliberately minimal:
- The issue and triage only name `fable` as missing; `opus`/`sonnet`/`haiku` aliases already roll forward to the latest generation in the CLI, so no redundant `claude-opus-5`/`claude-sonnet-5` entries.
- Full id `claude-fable-5` rather than a short alias — the reporter verified end-to-end that this id passes through `--model` correctly.
- No entries removed.

Verification: `go build ./agent/...` and `go test ./agent/claudecode/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)