### PR TITLE
fix(daemon): set HOME in systemd system units so the default data_dir resolves (#1634)

### DIFF
--- a/daemon/systemd.go
+++ b/daemon/systemd.go
@@ -7,6 +7,9 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	// aliased: checkSystemdRunning / CheckLinger already bind a local
+	// identifier named "user".
+	osuser "os/user"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -182,6 +185,18 @@ func (m *systemdManager) buildUnit(cfg Config) string {
 	fmt.Fprintf(&sb, "WorkingDirectory=%s\n", cfg.WorkDir)
 	sb.WriteString("Restart=on-failure\n")
 	sb.WriteString("RestartSec=10\n")
+	// System units inherit almost nothing from the installing shell, so
+	// HOME is undefined unless the unit sets it. Without it
+	// os.UserHomeDir() fails and the default data_dir degrades to the
+	// relative "./.cc-connect", which then resolves against whatever
+	// working directory each consumer happens to have. User units are
+	// started by the per-user systemd manager, which already exports a
+	// correct HOME, so they are left alone.
+	if m.system {
+		if home := systemUnitHome(cfg); home != "" {
+			fmt.Fprintf(&sb, "Environment=\"HOME=%s\"\n", escapeSystemdEnvValue(home))
+		}
+	}
 	fmt.Fprintf(&sb, "Environment=\"CC_LOG_FILE=%s\"\n", cfg.LogFile)
 	fmt.Fprintf(&sb, "Environment=\"CC_LOG_MAX_SIZE=%d\"\n", cfg.LogMaxSize)
 	fmt.Fprintf(&sb, "Environment=\"CC_LOG_MAX_BACKUPS=%d\"\n", cfg.LogMaxBackups)
@@ -214,6 +229,44 @@ func (m *systemdManager) buildUnit(cfg Config) string {
 		sb.WriteString("WantedBy=default.target\n")
 	}
 	return sb.String()
+}
+
+// lookupUserHome is a var (not a func) so tests can stub the passwd
+// lookup without depending on the accounts of the test host.
+var lookupUserHome = func(uid int) (string, error) {
+	u, err := osuser.LookupId(strconv.Itoa(uid))
+	if err != nil {
+		return "", err
+	}
+	return u.HomeDir, nil
+}
+
+// systemUnitHome resolves the HOME value to bake into a system-level unit.
+//
+// The generated unit carries no User=, so systemd runs the service as the
+// account that installed it — root, since newPlatformManager only selects
+// system mode for uid 0. The home directory is read from the passwd
+// database rather than hardcoded to /root so that a relocated root home,
+// or a service account installing on root's behalf, gets its own home
+// instead of one belonging to another user.
+//
+// Returns "" when the caller already emits HOME from cfg.EnvExtra (a
+// ${HOME} placeholder captured out of config.toml): an operator's explicit
+// value wins and must not be written twice.
+func systemUnitHome(cfg Config) string {
+	if cfg.EnvExtra["HOME"] != "" {
+		return ""
+	}
+	if home, err := lookupUserHome(os.Getuid()); err == nil && filepath.IsAbs(home) {
+		return home
+	}
+	// Passwd lookup can fail in minimal images with no /etc/passwd entry
+	// for uid 0. Fall back to the installing shell's HOME, then to the
+	// conventional root home so the unit never ships a relative path.
+	if home := os.Getenv("HOME"); filepath.IsAbs(home) {
+		return home
+	}
+	return "/root"
 }
 
 // escapeSystemdEnvValue prepares a value for inclusion inside the double

--- a/daemon/systemd_test.go
+++ b/daemon/systemd_test.go
@@ -72,6 +72,83 @@ func TestBuildUnit_DropsEmptyValue(t *testing.T) {
 	}
 }
 
+// stubUserHome makes systemUnitHome deterministic regardless of the
+// accounts present on the test host.
+func stubUserHome(t *testing.T, home string, err error) {
+	t.Helper()
+	orig := lookupUserHome
+	t.Cleanup(func() { lookupUserHome = orig })
+	lookupUserHome = func(int) (string, error) { return home, err }
+}
+
+func systemUnitCfg() Config {
+	return Config{
+		BinaryPath: "/usr/local/bin/cc-connect",
+		WorkDir:    "/srv/cc-connect",
+		LogFile:    "/var/log/cc-connect.log",
+		LogMaxSize: 1024,
+		EnvPATH:    "/usr/bin",
+	}
+}
+
+// TestBuildUnit_SystemSetsHOME covers issue #1634: a system unit inherits
+// no HOME, so os.UserHomeDir() fails and the default data_dir degrades to
+// the relative ".cc-connect".
+func TestBuildUnit_SystemSetsHOME(t *testing.T) {
+	stubUserHome(t, "/root", nil)
+	out := (&systemdManager{system: true}).buildUnit(systemUnitCfg())
+	if !strings.Contains(out, `Environment="HOME=/root"`) {
+		t.Errorf("system unit missing HOME; got:\n%s", out)
+	}
+}
+
+// A relocated service-account home must be used verbatim rather than the
+// hardcoded /root.
+func TestBuildUnit_SystemUsesAccountHome(t *testing.T) {
+	stubUserHome(t, "/var/lib/ccbot", nil)
+	out := (&systemdManager{system: true}).buildUnit(systemUnitCfg())
+	if !strings.Contains(out, `Environment="HOME=/var/lib/ccbot"`) {
+		t.Errorf("system unit did not use the account home; got:\n%s", out)
+	}
+}
+
+// User units are started by the per-user systemd manager, which already
+// exports HOME; the unit must not pin one.
+func TestBuildUnit_UserDoesNotSetHOME(t *testing.T) {
+	stubUserHome(t, "/root", nil)
+	out := (&systemdManager{system: false}).buildUnit(systemUnitCfg())
+	if strings.Contains(out, "HOME=") {
+		t.Errorf("user unit should not pin HOME; got:\n%s", out)
+	}
+}
+
+// An explicit HOME captured from config.toml wins and is written once.
+func TestBuildUnit_SystemHOMENotDuplicated(t *testing.T) {
+	stubUserHome(t, "/root", nil)
+	cfg := systemUnitCfg()
+	cfg.EnvExtra = map[string]string{"HOME": "/opt/ccdata"}
+	out := (&systemdManager{system: true}).buildUnit(cfg)
+	if n := strings.Count(out, "HOME="); n != 1 {
+		t.Errorf("want exactly 1 HOME line, got %d:\n%s", n, out)
+	}
+	if !strings.Contains(out, `Environment="HOME=/opt/ccdata"`) {
+		t.Errorf("explicit HOME should win; got:\n%s", out)
+	}
+}
+
+// A failed passwd lookup must still yield an absolute HOME.
+func TestSystemUnitHome_FallbackIsAbsolute(t *testing.T) {
+	stubUserHome(t, "", os.ErrNotExist)
+	t.Setenv("HOME", "relative/path")
+	if got := systemUnitHome(Config{}); got != "/root" {
+		t.Errorf("systemUnitHome() = %q, want /root", got)
+	}
+	t.Setenv("HOME", "/home/installer")
+	if got := systemUnitHome(Config{}); got != "/home/installer" {
+		t.Errorf("systemUnitHome() = %q, want /home/installer", got)
+	}
+}
+
 // TestSystemdInstall_TightensExistingUnitFrom0644 covers the upgrade
 // path: os.WriteFile would truncate-in-place and KEEP the old 0644
 // permissions of a unit file left over from earlier cc-connect


### PR DESCRIPTION
Fixes #1634.

## Problem

System-level units inherit almost nothing from the installing shell, so the generated unit runs with no `HOME`. `os.UserHomeDir()` then fails and the default `data_dir` degrades to the relative `./.cc-connect`, breaking Claude session discovery (and anything else that resolves `~`). User units are unaffected — the per-user systemd manager exports a correct `HOME`.

## Fix

`buildUnit` now emits `Environment="HOME=..."` for **system units only**, resolved by `systemUnitHome`:

1. If the operator already provides `HOME` via config (`EnvExtra`), that value wins and no duplicate line is written.
2. Otherwise the passwd database is queried for the current uid (`os/user`) — not hardcoded `/root`, so a relocated root home resolves correctly.
3. Fallback to the installing shell's absolute `$HOME`, then `/root`, so the unit never ships a relative path.

The unit carries no `User=` and system mode is only selected for uid 0, so "current uid" is the service account by construction; if `User=` is ever introduced, only the uid passed to the lookup needs to change.

## Tests

5 new tests in `daemon/systemd_test.go` covering: system unit gets `HOME`, relocated home respected, user unit never gets `HOME`, explicit config `HOME` not duplicated, fallback stays absolute. Passwd lookup is stubbed via a package-level var (same pattern as `runSystemctl`).

Verification: `CGO_ENABLED=0 GOOS=linux go build ./...`, `GOOS=linux go vet ./daemon/...`, and the test binary compile all pass (host is darwin; the linux-tagged tests were additionally executed in a tag-stripped scratch copy — all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)