### PR TITLE
fix(core): trailing NO_REPLY must not suppress text already delivered before a tool call (#1614)

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -5598,17 +5598,47 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				}
 			}
 
+			// Text already surfaced to the user in earlier segments: every tool /
+			// thinking / permission boundary flushes textParts[segmentStart:] (as a
+			// detached frozen preview or as sent chunks) and advances segmentStart,
+			// so textParts[:segmentStart] is committed user-facing output. On the
+			// rich-card / streaming-card paths segmentStart stays 0 and the card
+			// keeps the body itself, so they are left untouched.
+			committedText := ""
+			if segmentStart > 0 && segmentStart <= len(textParts) && !hasRichCard {
+				committed := strings.Join(textParts[:segmentStart], "")
+				if stripped, ok := stripTrailingSilent(committed); ok {
+					committed = stripped
+				}
+				committed = strings.TrimRight(committed, " \t\r\n")
+				if strings.TrimSpace(committed) != "" {
+					committedText = committed
+				}
+			}
+
 			// Detect NO_REPLY marker on the base response (before indicators/footer are appended).
-			// Three cases:
-			//   1. bare marker (isSilentReply)               → fully silent
-			//   2. trailing marker with non-empty reasoning  → strip marker, deliver reasoning
-			//   3. trailing marker with empty strip result   → fully silent
+			// Four cases:
+			//   1. bare marker with committed text           → marker only closes the trailing
+			//                                                  continuation; the committed body
+			//                                                  is the turn response
+			//   2. bare marker, nothing committed            → fully silent
+			//   3. trailing marker with non-empty reasoning  → strip marker, deliver reasoning
+			//   4. trailing marker with empty strip result   → fully silent
 			// History records the ORIGINAL baseResponse so the agent retains context of its own
 			// decision; only the outbound platform text gets rewritten/suppressed.
+			isSilent := isSilentReply(baseResponse)
+			if isSilent && committedText != "" {
+				// Case 1: event.Content only carries the last assistant segment
+				// ("NO_REPLY"). Suppressing the turn here would drop the body the
+				// user already saw and collapse history to the marker.
+				baseResponse = committedText
+				cleanResponse = committedText
+				isSilent = false
+			}
+
 			session.AddHistory("assistant", baseResponse)
 			sessions.Save()
 
-			isSilent := isSilentReply(baseResponse)
 			if !isSilent {
 				if stripped, ok := stripTrailingSilent(baseResponse); ok {
 					if strings.TrimSpace(stripped) == "" {
@@ -5816,6 +5846,12 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 				sp.discard()
 				if segmentStart < len(textParts) {
 					unsent := strings.Join(textParts[segmentStart:], "")
+					// The remainder is raw agent text, so it can still carry the
+					// trailing NO_REPLY marker (baseResponse was stripped above but
+					// is not what gets sent here). Never leak the marker.
+					if stripped, ok := stripTrailingSilent(unsent); ok {
+						unsent = strings.TrimRight(stripped, " \t\r\n")
+					}
 					if unsent != "" {
 						if !sendChunksWithStatusFooter(e.ctx, p, replyCtx, unsent, statusFooter, sendWorkspaceWithError) {
 							return

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1373,6 +1373,105 @@ func TestProcessInteractiveEvents_ToolSegmentsKeepFinalFooter(t *testing.T) {
 	}
 }
 
+// TestProcessInteractiveEvents_TrailingNoReplyPreservesTextBeforeTool covers
+// the claudecode shape where the agent emits substantive user-facing text,
+// issues a tool call in the same turn, and then closes the trailing
+// continuation with a bare NO_REPLY (EventResult.Content = "NO_REPLY").
+// The marker only ends that continuation: the text already committed to the
+// user before the tool call must stay the turn response and must survive in
+// session history instead of collapsing to the marker.
+func TestProcessInteractiveEvents_TrailingNoReplyPreservesTextBeforeTool(t *testing.T) {
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{ThinkingMessages: true, ThinkingMaxLen: 300, ToolMaxLen: 500, ToolMessages: true})
+
+	sessionKey := "telegram:user-trailing-noreply"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-trailing-noreply")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-trailing-noreply",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	const report = "结论：三处风险，已按优先级排序。"
+	agentSession.events <- Event{Type: EventText, Content: "先检查一下。"}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "pwd"}
+	agentSession.events <- Event{Type: EventText, Content: report}
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "TaskUpdate", ToolInput: "completed"}
+	agentSession.events <- Event{Type: EventText, Content: "NO_REPLY"}
+	agentSession.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-trailing-noreply", time.Now(), nil, nil, state.replyCtx)
+
+	history := session.GetHistory(0)
+	if len(history) == 0 {
+		t.Fatal("history is empty, want the assistant turn recorded")
+	}
+	last := history[len(history)-1]
+	if last.Role != "assistant" {
+		t.Fatalf("last history role = %q, want assistant", last.Role)
+	}
+	if !strings.Contains(last.Content, report) {
+		t.Fatalf("history lost the committed body: %q", last.Content)
+	}
+	if strings.Contains(last.Content, "NO_REPLY") {
+		t.Fatalf("history collapsed to the NO_REPLY marker: %q", last.Content)
+	}
+
+	sent := p.getSent()
+	delivered := false
+	for _, msg := range sent {
+		if strings.Contains(msg, "NO_REPLY") {
+			t.Fatalf("NO_REPLY marker leaked to the platform: %q (all sent = %#v)", msg, sent)
+		}
+		if strings.Contains(msg, report) {
+			delivered = true
+		}
+	}
+	if !delivered {
+		t.Fatalf("committed body was never delivered, sent = %#v", sent)
+	}
+}
+
+// TestProcessInteractiveEvents_BareNoReplyWithToolsStaysSilent is the
+// regression guard for the case above: a turn whose only assistant text is the
+// marker stays fully silent even when tool calls happened.
+func TestProcessInteractiveEvents_BareNoReplyWithToolsStaysSilent(t *testing.T) {
+	p := &stubPlatformEngine{n: "telegram"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.SetDisplayConfig(DisplayCfg{ThinkingMessages: true, ThinkingMaxLen: 300, ToolMaxLen: 500, ToolMessages: true})
+
+	sessionKey := "telegram:user-bare-noreply"
+	session := e.sessions.GetOrCreateActive(sessionKey)
+	agentSession := newControllableSession("s-bare-noreply")
+	state := &interactiveState{
+		agentSession: agentSession,
+		platform:     p,
+		replyCtx:     "ctx-bare-noreply",
+	}
+	e.interactiveStates[sessionKey] = state
+
+	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "pwd"}
+	agentSession.events <- Event{Type: EventText, Content: "NO_REPLY"}
+	agentSession.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-bare-noreply", time.Now(), nil, nil, state.replyCtx)
+
+	history := session.GetHistory(0)
+	if len(history) == 0 {
+		t.Fatal("history is empty, want the assistant turn recorded")
+	}
+	last := history[len(history)-1]
+	if strings.TrimSpace(last.Content) != "NO_REPLY" {
+		t.Fatalf("history = %q, want the bare NO_REPLY marker preserved", last.Content)
+	}
+	for _, msg := range p.getSent() {
+		if strings.Contains(msg, "NO_REPLY") {
+			t.Fatalf("NO_REPLY marker leaked to the platform: %q", msg)
+		}
+	}
+}
+
 func TestProcessInteractiveEvents_DropsStandaloneEllipsisProgress(t *testing.T) {
 	p := &stubPlatformEngine{n: "telegram"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)


### PR DESCRIPTION
Fixes #1614.

## Root cause

In `processInteractiveEvents`, `EventResult.Content` only carries the **last** assistant segment — `"NO_REPLY"` in the issue's scenario. `isSilentReply` then silences the whole turn and `AddHistory` records the bare marker, even though every tool/thinking/permission boundary had already flushed `textParts[:segmentStart]` to the user as committed output. The marker was being applied retroactively to the entire turn instead of to its own trailing segment — exactly the granularity bug identified in the triage comment.

## Fix

- Before the silent check, reconstruct the committed body (`textParts[:segmentStart]`, marker-stripped). If the final segment is a bare marker **and** committed text exists, the marker only closes the trailing continuation: the committed body becomes the turn response and history keeps it instead of `"NO_REPLY"`.
- Guarded with `segmentStart > 0 && !hasRichCard` — rich-card/streaming-card paths keep `segmentStart == 0` and are untouched.
- A turn consisting of nothing but `NO_REPLY` (with or without tool calls) stays fully silent, locked by a regression test.
- The `toolCount > 0` remainder-send branch now also strips a trailing marker so it can never leak to the platform.

## Tests

- `TestProcessInteractiveEvents_TrailingNoReplyPreservesTextBeforeTool` — reproduces the issue sequence (text → tool → body → tool → `NO_REPLY`); fails before the fix with the exact symptoms from the report (`tools=2 response_len=8 silent=true`, history collapsed to the marker), passes after.
- `TestProcessInteractiveEvents_BareNoReplyWithToolsStaysSilent` — regression guard for the intentional silent path.

`go test ./core/ -count=1` passes (full package, no regressions); `go vet ./core/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)