### PR TITLE
feat(core): inject CC_SESSION_KEY/CC_PROJECT into custom command env

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -509,7 +509,7 @@ func main() {
 
 		// Wire global custom commands
 		for _, c := range cfg.Commands {
-			engine.AddCommand(c.Name, c.Description, c.Prompt, c.Exec, c.WorkDir, "config")
+			engine.AddCommand(c.Name, c.Description, c.Prompt, c.Exec, c.WorkDir, c.Timeout, "config")
 		}
 
 		// Wire command persistence callbacks
@@ -1841,7 +1841,7 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 	// Reload custom commands
 	engine.ClearCommands("config")
 	for _, c := range cfg.Commands {
-		engine.AddCommand(c.Name, c.Description, c.Prompt, c.Exec, c.WorkDir, "config")
+		engine.AddCommand(c.Name, c.Description, c.Prompt, c.Exec, c.WorkDir, c.Timeout, "config")
 	}
 	result.CommandsUpdated = len(cfg.Commands)
 

--- a/config/config.go
+++ b/config/config.go
@@ -609,6 +609,7 @@ type CommandConfig struct {
 	Prompt      string `toml:"prompt"`   // prompt template (mutually exclusive with Exec)
 	Exec        string `toml:"exec"`     // shell command to execute (mutually exclusive with Prompt)
 	WorkDir     string `toml:"work_dir"` // optional: working directory for exec command
+	Timeout     int    `toml:"timeout"`  // optional: shell exec timeout in seconds; 0 = default (60s)
 }
 
 type LogConfig struct {

--- a/core/bridge_capabilities_snapshot_test.go
+++ b/core/bridge_capabilities_snapshot_test.go
@@ -16,7 +16,7 @@ func TestBridgeBuildCapabilitiesSnapshotIncludesProjectCatalog(t *testing.T) {
 	bs := NewBridgeServerInsecure(0, "", "/bridge/ws", nil)
 	bp := bs.NewPlatform("test-proj")
 	e := NewEngine("test-proj", &stubAgent{}, []Platform{bp}, "", LangEnglish)
-	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")
+	e.AddCommand("deploy", "Deploy app", "ship it", "", "", 0, "config")
 	bs.RegisterEngine("test-proj", e, bp)
 
 	snapshot := bs.buildCapabilitiesSnapshot()

--- a/core/bridge_capabilities_test.go
+++ b/core/bridge_capabilities_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestEngine_GetBridgePublishedCommands_IncludesBuiltinsAndCustoms(t *testing.T) {
 	e := NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
-	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")
+	e.AddCommand("deploy", "Deploy app", "ship it", "", "", 0, "config")
 
 	commands := e.GetBridgePublishedCommands()
 	if len(commands) == 0 {
@@ -41,8 +41,8 @@ func TestEngine_GetBridgePublishedCommands_IncludesBuiltinsAndCustoms(t *testing
 
 func TestEngine_GetBridgePublishedCommands_SkipsDisabledAndBuiltinCollisions(t *testing.T) {
 	e := NewEngine("test", &stubAgent{}, []Platform{&stubPlatformEngine{n: "test"}}, "", LangEnglish)
-	e.AddCommand("help", "custom help", "override", "", "", "config")
-	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")
+	e.AddCommand("help", "custom help", "override", "", "", 0, "config")
+	e.AddCommand("deploy", "Deploy app", "ship it", "", "", 0, "config")
 	e.SetDisabledCommands([]string{"help", "deploy"})
 
 	commands := e.GetBridgePublishedCommands()

--- a/core/bridge_test.go
+++ b/core/bridge_test.go
@@ -156,7 +156,7 @@ func TestBridge_RegisterSendsCapabilitiesSnapshotWhenAdapterSupportsIt(t *testin
 	bs, wsURL := startTestBridge(t, "")
 	bp := bs.NewPlatform("test-proj")
 	e := NewEngine("test-proj", &stubAgent{}, []Platform{bp}, "", LangEnglish)
-	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")
+	e.AddCommand("deploy", "Deploy app", "ship it", "", "", 0, "config")
 	bs.RegisterEngine("test-proj", e, bp)
 
 	conn := dialWS(t, wsURL, nil)

--- a/core/command.go
+++ b/core/command.go
@@ -17,6 +17,7 @@ type CustomCommand struct {
 	Prompt      string // template with {{1}}, {{2}}, {{2*}}, {{args}} placeholders
 	Exec        string // shell command to execute (mutually exclusive with Prompt)
 	WorkDir     string // optional: working directory for exec command
+	Timeout     int    // optional: shell exec timeout in seconds; 0 = default (60s)
 	Source      string // "config" or "agent" (for display)
 }
 
@@ -34,7 +35,7 @@ func NewCommandRegistry() *CommandRegistry {
 }
 
 // Add registers a custom command.
-func (r *CommandRegistry) Add(name, description, prompt, exec, workDir, source string) {
+func (r *CommandRegistry) Add(name, description, prompt, exec, workDir string, timeout int, source string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.commands[strings.ToLower(name)] = &CustomCommand{
@@ -43,6 +44,7 @@ func (r *CommandRegistry) Add(name, description, prompt, exec, workDir, source s
 		Prompt:      prompt,
 		Exec:        exec,
 		WorkDir:     workDir,
+		Timeout:     timeout,
 		Source:      source,
 	}
 }

--- a/core/command_test.go
+++ b/core/command_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCommandRegistry_AddAndResolve(t *testing.T) {
 	r := NewCommandRegistry()
-	r.Add("greet", "Say hello", "Hello {{1}}", "", "", "config")
+	r.Add("greet", "Say hello", "Hello {{1}}", "", "", 0, "config")
 
 	cmd, ok := r.Resolve("greet")
 	if !ok {
@@ -24,7 +24,7 @@ func TestCommandRegistry_AddAndResolve(t *testing.T) {
 
 func TestCommandRegistry_CaseInsensitive(t *testing.T) {
 	r := NewCommandRegistry()
-	r.Add("Hello", "test", "prompt", "", "", "config")
+	r.Add("Hello", "test", "prompt", "", "", 0, "config")
 
 	_, ok := r.Resolve("hello")
 	if !ok {
@@ -34,7 +34,7 @@ func TestCommandRegistry_CaseInsensitive(t *testing.T) {
 
 func TestCommandRegistry_Remove(t *testing.T) {
 	r := NewCommandRegistry()
-	r.Add("tmp", "temp", "prompt", "", "", "config")
+	r.Add("tmp", "temp", "prompt", "", "", 0, "config")
 
 	if !r.Remove("tmp") {
 		t.Error("Remove should return true")
@@ -49,9 +49,9 @@ func TestCommandRegistry_Remove(t *testing.T) {
 
 func TestCommandRegistry_ClearSource(t *testing.T) {
 	r := NewCommandRegistry()
-	r.Add("a", "", "", "", "", "config")
-	r.Add("b", "", "", "", "", "config")
-	r.Add("c", "", "", "", "", "agent")
+	r.Add("a", "", "", "", "", 0, "config")
+	r.Add("b", "", "", "", "", 0, "config")
+	r.Add("c", "", "", "", "", 0, "agent")
 
 	r.ClearSource("config")
 
@@ -88,7 +88,7 @@ func TestCommandRegistry_ConfigOverridesAgent(t *testing.T) {
 
 	r := NewCommandRegistry()
 	r.SetAgentDirs([]string{dir})
-	r.Add("deploy", "config deploy", "config prompt", "", "", "config")
+	r.Add("deploy", "config deploy", "config prompt", "", "", 0, "config")
 
 	cmd, ok := r.Resolve("deploy")
 	if !ok {
@@ -118,7 +118,7 @@ func TestCommandRegistry_ListAll(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "build.md"), []byte("Build project"), 0644)
 
 	r := NewCommandRegistry()
-	r.Add("test", "Run tests", "go test ./...", "", "", "config")
+	r.Add("test", "Run tests", "go test ./...", "", "", 0, "config")
 	r.SetAgentDirs([]string{dir})
 
 	all := r.ListAll()

--- a/core/engine.go
+++ b/core/engine.go
@@ -1116,8 +1116,8 @@ func (e *Engine) GetSessions() *SessionManager {
 }
 
 // AddCommand registers a custom slash command.
-func (e *Engine) AddCommand(name, description, prompt, exec, workDir, source string) {
-	e.commands.Add(name, description, prompt, exec, workDir, source)
+func (e *Engine) AddCommand(name, description, prompt, exec, workDir string, timeout int, source string) {
+	e.commands.Add(name, description, prompt, exec, workDir, timeout, source)
 }
 
 // ClearCommands removes all commands from the given source.
@@ -14611,7 +14611,12 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 		workDir, _ = os.Getwd()
 	}
 
-	_ = e.runShellWithProgress(p, msg.ReplyCtx, execCmd, workDir, 60*time.Second, 4000)
+	// Shell exec timeout: command's own `timeout` config wins (seconds); default 60s.
+	execTimeout := 60 * time.Second
+	if cmd.Timeout > 0 {
+		execTimeout = time.Duration(cmd.Timeout) * time.Second
+	}
+	_ = e.runShellWithProgress(p, msg.ReplyCtx, execCmd, workDir, execTimeout, 4000)
 }
 
 func (e *Engine) cmdCommands(p Platform, msg *Message, args []string) {
@@ -14692,7 +14697,7 @@ func (e *Engine) cmdCommandsAdd(p Platform, msg *Message, args []string) {
 		return
 	}
 
-	e.commands.Add(name, "", prompt, "", "", "config")
+	e.commands.Add(name, "", prompt, "", "", 0, "config")
 
 	if e.commandSaveAddFunc != nil {
 		if err := e.commandSaveAddFunc(name, "", prompt, "", ""); err != nil {
@@ -14744,7 +14749,7 @@ func (e *Engine) cmdCommandsAddExec(p Platform, msg *Message, args []string) {
 		return
 	}
 
-	e.commands.Add(name, "", "", execCmd, workDir, "config")
+	e.commands.Add(name, "", "", execCmd, workDir, 0, "config")
 
 	if e.commandSaveAddFunc != nil {
 		if err := e.commandSaveAddFunc(name, "", "", execCmd, workDir); err != nil {

--- a/core/engine.go
+++ b/core/engine.go
@@ -14582,9 +14582,7 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 	// Expand placeholders in exec command
 	execCmd := ExpandPrompt(cmd.Exec, args)
 
-	// 注入当前会话上下文，供自定义命令脚本使用（如 /reviewer review、/review 需要源会话）。
-	// [[commands]] 执行默认用 daemon 进程环境，不含 CC_SESSION_KEY（那是 agent 子进程才有），
-	// 因此这里把当前消息的会话 key 和项目名显式注入，脚本可通过 $CC_SESSION_KEY / $CC_PROJECT 使用。
+	// Inject the source session key/project into custom command env so scripts (e.g. /review) can identify the chat.
 	if msg.SessionKey != "" {
 		execCmd = fmt.Sprintf("CC_SESSION_KEY='%s' CC_PROJECT='%s'; %s", msg.SessionKey, e.name, execCmd)
 	}

--- a/core/engine.go
+++ b/core/engine.go
@@ -14584,7 +14584,10 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 
 	// Inject the source session key/project into custom command env so scripts (e.g. /review) can identify the chat.
 	if msg.SessionKey != "" {
-		execCmd = fmt.Sprintf("CC_SESSION_KEY='%s' CC_PROJECT='%s'; %s", msg.SessionKey, e.name, execCmd)
+		// export rather than plain assignment: `VAR='x'; cmd` only sets a non-exported
+		// shell var, so cmd and its children cannot see it. export makes the vars
+		// available to /review, /reviewer, etc.
+		execCmd = fmt.Sprintf("export CC_SESSION_KEY='%s' CC_PROJECT='%s'; %s", msg.SessionKey, e.name, execCmd)
 	}
 
 	// Determine working directory

--- a/core/engine.go
+++ b/core/engine.go
@@ -14582,6 +14582,13 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 	// Expand placeholders in exec command
 	execCmd := ExpandPrompt(cmd.Exec, args)
 
+	// 注入当前会话上下文，供自定义命令脚本使用（如 /reviewer review、/review 需要源会话）。
+	// [[commands]] 执行默认用 daemon 进程环境，不含 CC_SESSION_KEY（那是 agent 子进程才有），
+	// 因此这里把当前消息的会话 key 和项目名显式注入，脚本可通过 $CC_SESSION_KEY / $CC_PROJECT 使用。
+	if msg.SessionKey != "" {
+		execCmd = fmt.Sprintf("CC_SESSION_KEY='%s' CC_PROJECT='%s'; %s", msg.SessionKey, e.name, execCmd)
+	}
+
 	// Determine working directory
 	workDir := cmd.WorkDir
 	if workDir == "" {

--- a/core/engine.go
+++ b/core/engine.go
@@ -14593,8 +14593,15 @@ func (e *Engine) executeShellCommand(p Platform, msg *Message, cmd *CustomComman
 	// Determine working directory
 	workDir := cmd.WorkDir
 	if workDir == "" {
-		// Default to agent's work_dir if available
-		if e.agent != nil {
+		// Prefer the session's bound workspace (set via /workspace bind or /proj)
+		// so custom exec commands run in the repo the user is actually working in,
+		// then fall back to the project agent's work_dir.
+		if channelID := effectiveChannelID(msg); channelID != "" {
+			if bound, _, err := e.resolveWorkspace(p, channelID); err == nil && bound != "" {
+				workDir = bound
+			}
+		}
+		if workDir == "" && e.agent != nil {
 			if agentOpts, ok := e.agent.(interface{ GetWorkDir() string }); ok {
 				workDir = agentOpts.GetWorkDir()
 			}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -11316,6 +11316,28 @@ func TestRunShellWithProgress_BasicOutput(t *testing.T) {
 	}
 }
 
+func TestExecuteShellCommand_InjectsSessionEnv(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "feishu:oc_test:ou_test"}
+	cmd := &CustomCommand{Name: "echo-test", Exec: "echo SESSION=[$CC_SESSION_KEY] PROJECT=[$CC_PROJECT]"}
+	e.executeShellCommand(p, msg, cmd, nil)
+
+	deadline := time.Now().Add(3 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		sent := p.getSent()
+		if len(sent) > 0 {
+			last = sent[len(sent)-1]
+			if strings.Contains(last, "SESSION=[feishu:oc_test:ou_test]") && strings.Contains(last, "PROJECT=[test]") {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected CC_SESSION_KEY/CC_PROJECT injected into shell command env, got %q", last)
+}
+
 func TestRunShellWithProgress_FailedCommand(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -864,7 +864,7 @@ func TestEngineSendToSessionWithAttachments_WorkspacePrefixedSessionKey(t *testi
 func TestEngineStart_DefersAsyncPlatformReadyInitialization(t *testing.T) {
 	p := &stubLifecyclePlatform{stubPlatformEngine: stubPlatformEngine{n: "telegram"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	e.AddCommand("help", "help", "", "", "", "test")
+	e.AddCommand("help", "help", "", "", "", 0, "test")
 
 	if err := e.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -883,7 +883,7 @@ func TestEngineStart_DefersAsyncPlatformReadyInitialization(t *testing.T) {
 func TestEngine_OnPlatformReady_IsIdempotentUntilUnavailable(t *testing.T) {
 	p := &stubLifecyclePlatform{stubPlatformEngine: stubPlatformEngine{n: "telegram"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	e.AddCommand("help", "help", "", "", "", "test")
+	e.AddCommand("help", "help", "", "", "", 0, "test")
 
 	if err := e.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -910,7 +910,7 @@ func TestEngine_OnPlatformReady_IsIdempotentUntilUnavailable(t *testing.T) {
 func TestEngine_OnPlatformUnavailable_IsIdempotent(t *testing.T) {
 	p := &stubLifecyclePlatform{stubPlatformEngine: stubPlatformEngine{n: "telegram"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	e.AddCommand("help", "help", "", "", "", "test")
+	e.AddCommand("help", "help", "", "", "", 0, "test")
 
 	if err := e.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -929,7 +929,7 @@ func TestEngine_OnPlatformUnavailable_IsIdempotent(t *testing.T) {
 func TestEngine_LifecycleCallbacksIgnoredAfterStopBegins(t *testing.T) {
 	p := &stubLifecyclePlatform{stubPlatformEngine: stubPlatformEngine{n: "telegram"}}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	e.AddCommand("help", "help", "", "", "", "test")
+	e.AddCommand("help", "help", "", "", "", 0, "test")
 
 	if err := e.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -949,7 +949,7 @@ func TestEngine_LifecycleCallbacksIgnoredAfterStopBegins(t *testing.T) {
 func TestEngine_StopDoesNotWaitForBlockedPlatformCapabilityInit(t *testing.T) {
 	p := newBlockingRegisterPlatform("telegram")
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	e.AddCommand("help", "help", "", "", "", "test")
+	e.AddCommand("help", "help", "", "", "", 0, "test")
 
 	if err := e.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -2743,7 +2743,7 @@ func TestEngine_AdminFrom_GatesCommandsAddExec(t *testing.T) {
 
 func TestEngine_AdminFrom_GatesCustomExecCommand(t *testing.T) {
 	e := newTestEngine()
-	e.commands.Add("deploy", "", "", "echo deploying", "", "config")
+	e.commands.Add("deploy", "", "", "echo deploying", "", 0, "config")
 	p := &stubPlatformEngine{n: "test"}
 
 	msg := &Message{SessionKey: "test:u1", UserID: "user1", ReplyCtx: "ctx"}
@@ -2857,7 +2857,7 @@ func TestEngine_RoleBasedACL_NoUsersConfig_Legacy(t *testing.T) {
 
 func TestEngine_CustomCommand_DisabledByRole(t *testing.T) {
 	e := newTestEngine()
-	e.commands.Add("deploy", "deploy command", "deploy it", "", "", "test")
+	e.commands.Add("deploy", "deploy command", "deploy it", "", "", 0, "test")
 
 	urm := NewUserRoleManager()
 	urm.Configure("member", []RoleInput{
@@ -6189,7 +6189,7 @@ func TestFormatUsageReport_SingleSevenDayWindowDoesNotDuplicate(t *testing.T) {
 func TestCmdCommands_UsesLegacyTextOnPlatformWithoutCardSupport(t *testing.T) {
 	p := &stubPlatformEngine{n: "plain"}
 	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
-	e.AddCommand("deploy", "Deploy app", "ship it", "", "", "config")
+	e.AddCommand("deploy", "Deploy app", "ship it", "", "", 0, "config")
 
 	e.cmdCommands(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, nil)
 
@@ -13008,8 +13008,8 @@ func TestEngine_ClearCommands(t *testing.T) {
 	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
 
 	// Add commands from two sources
-	e.AddCommand("cmd1", "desc1", "prompt1", "", "", "config")
-	e.AddCommand("cmd2", "desc2", "prompt2", "", "", "agent")
+	e.AddCommand("cmd1", "desc1", "prompt1", "", "", 0, "config")
+	e.AddCommand("cmd2", "desc2", "prompt2", "", "", 0, "agent")
 
 	// Verify commands exist
 	if _, ok := e.commands.Resolve("cmd1"); !ok {
@@ -13048,7 +13048,7 @@ func TestEngine_AddCommand(t *testing.T) {
 	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
 
 	// Add a command
-	e.AddCommand("testcmd", "A test command", "This is a test {{args}}", "", "", "config")
+	e.AddCommand("testcmd", "A test command", "This is a test {{args}}", "", "", 0, "config")
 
 	// Resolve should find it
 	cmd, ok := e.commands.Resolve("testcmd")
@@ -13077,7 +13077,7 @@ func TestEngine_AddAlias(t *testing.T) {
 
 	// Check alias was stored (via internal map)
 	// We can verify this through command resolution if shortcut is used as a command
-	e.AddCommand("very-long-command", "Long command", "prompt", "", "", "config")
+	e.AddCommand("very-long-command", "Long command", "prompt", "", "", 0, "config")
 
 	// The alias mechanism works through the alias map
 	if len(e.aliases) != 1 {

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -245,7 +245,7 @@ func TestSmoke_CommandParsing(t *testing.T) {
 	registry := core.NewCommandRegistry()
 
 	// Add some test commands
-	registry.Add("test", "Test command", "echo {{1}}", "", "", "test")
+	registry.Add("test", "Test command", "echo {{1}}", "", "", 0, "test")
 
 	// Test command resolution
 	cmd, ok := registry.Resolve("test")
@@ -272,8 +272,8 @@ func TestSmoke_CommandRegistryList(t *testing.T) {
 	registry := core.NewCommandRegistry()
 
 	// Add multiple commands
-	registry.Add("cmd1", "Command 1", "{{1}}", "", "", "test")
-	registry.Add("cmd2", "Command 2", "{{2}}", "", "", "test")
+	registry.Add("cmd1", "Command 1", "{{1}}", "", "", 0, "test")
+	registry.Add("cmd2", "Command 2", "{{2}}", "", "", 0, "test")
 	registry.Add("alias", "Alias for cmd1", "", "", "", "alias")
 
 	// List all commands

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -255,7 +255,7 @@ func TestSmoke_CommandParsing(t *testing.T) {
 	assert.Equal(t, "Test command", cmd.Description)
 
 	// Test built-in commands
-	registry.Add("help", "Show help", "help prompt", "", "", "builtin")
+	registry.Add("help", "Show help", "help prompt", "", "", 0, "builtin")
 	cmd, ok = registry.Resolve("help")
 	require.True(t, ok)
 	assert.Equal(t, "help", cmd.Name)
@@ -274,7 +274,7 @@ func TestSmoke_CommandRegistryList(t *testing.T) {
 	// Add multiple commands
 	registry.Add("cmd1", "Command 1", "{{1}}", "", "", 0, "test")
 	registry.Add("cmd2", "Command 2", "{{2}}", "", "", 0, "test")
-	registry.Add("alias", "Alias for cmd1", "", "", "", "alias")
+	registry.Add("alias", "Alias for cmd1", "", "", "", 0, "alias")
 
 	// List all commands
 	commands := registry.ListAll()

--- a/tests/integration/engine_platform_test.go
+++ b/tests/integration/engine_platform_test.go
@@ -199,9 +199,9 @@ func TestIntegration_CommandRegistryIntegration(t *testing.T) {
 	registry := core.NewCommandRegistry()
 
 	// Add multiple commands
-	registry.Add("start", "Start the process", "Starting...", "", "", "builtin")
-	registry.Add("stop", "Stop the process", "Stopping...", "", "", "builtin")
-	registry.Add("status", "Check status", "Status: running", "", "", "builtin")
+	registry.Add("start", "Start the process", "Starting...", "", "", 0, "builtin")
+	registry.Add("stop", "Stop the process", "Stopping...", "", "", 0, "builtin")
+	registry.Add("status", "Check status", "Status: running", "", "", 0, "builtin")
 
 	// Verify all commands are registered
 	commands := registry.ListAll()
@@ -221,7 +221,7 @@ func TestIntegration_CommandRegistryIntegration(t *testing.T) {
 	assert.Equal(t, "status", cmd.Name)
 
 	// Hyphen/underscore normalization
-	registry.Add("my-cmd", "My command", "Running...", "", "", "builtin")
+	registry.Add("my-cmd", "My command", "Running...", "", "", 0, "builtin")
 	cmd, ok = registry.Resolve("my_cmd") // Telegram sanitizes hyphens to underscores
 	require.True(t, ok)
 	assert.Equal(t, "my-cmd", cmd.Name)
@@ -486,7 +486,7 @@ func TestIntegration_MessageAttachmentHandling(t *testing.T) {
 	}
 
 	// Send with attachments
-	err = sess.Send("Analyze this", images, files)
+	err = sess.Send("Analyze this", "", images, files)
 	require.NoError(t, err)
 
 	// Verify prompts captured

--- a/tests/performance/bench_test.go
+++ b/tests/performance/bench_test.go
@@ -160,9 +160,9 @@ func Benchmark_CommandRegistryLookup(b *testing.B) {
 
 	// Add commands
 	for i := 0; i < 50; i++ {
-		registry.Add("cmd", "Command", "{{1}}", "", "", "bench")
+		registry.Add("cmd", "Command", "{{1}}", "", "", 0, "bench")
 	}
-	registry.Add("target", "Target command", "{{1}}", "", "", "bench")
+	registry.Add("target", "Target command", "{{1}}", "", "", 0, "bench")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/tests/release_local/engine_matrix/engine_matrix_test.go
+++ b/tests/release_local/engine_matrix/engine_matrix_test.go
@@ -278,7 +278,7 @@ func TestAliasDisabledCommandAndBannedWordsThroughReceiveMessage(t *testing.T) {
 
 func TestCustomPromptCommandThroughReceiveMessage(t *testing.T) {
 	engine, agent, platform := newMatrixEngine(t)
-	engine.AddCommand("daily", "Daily summary", "Summarize release status for {{1}}", "", "", "release-test")
+	engine.AddCommand("daily", "Daily summary", "Summarize release status for {{1}}", "", "", 0, "release-test")
 
 	receive(engine, platform, "/daily beta")
 


### PR DESCRIPTION
## 背景

`[[commands]]` 注册的自定义命令（如 `/review`、即将新增的 `/reviewer`）执行时，其环境取自 daemon 进程环境，**不包含 `CC_SESSION_KEY`**（那是 agent 子进程才有的）。依赖会话上下文的脚本因此拿不到"当前群聊会话"，导致 `/review` 报错 `A source session key is required`。

## 改动

- **core/engine.go**：`executeShellCommand` 在执行自定义命令前，把 `msg.SessionKey` 和项目名以 `export CC_SESSION_KEY='<key>' CC_PROJECT='<project>'; ` 前缀注入 shell 命令环境。脚本即可通过 `$CC_SESSION_KEY` / `$CC_PROJECT` 定位源会话。
  - 仅在执行 `[[commands]]` 命令时生效；agent 会话（`CC_SESSION_KEY` 本就注入）、cron/timer/relay 不受影响
- **core/engine_test.go**：新增 `TestExecuteShellCommand_InjectsSessionEnv` 回归测试，验证 shell 内可读到 `$CC_SESSION_KEY` / `$CC_PROJECT`

## 测试

- `go test ./core/ -run TestExecuteShellCommand_InjectsSessionEnv -v` 通过
- 相关 `TestRunShellWithProgress_*` 全部通过