### PR TITLE
fix(claudecode): implement graceful CancelTurn via control_request interrupt so /stop keeps the session alive

### DIFF
--- a/agent/claudecode/session.go
+++ b/agent/claudecode/session.go
@@ -1191,6 +1191,42 @@ func (cs *claudeSession) Alive() bool {
 	return cs.alive.Load()
 }
 
+// CancelTurn implements core.AgentSessionCanceller. Asks Claude Code
+// to interrupt the current generation over the existing stream-json
+// stdin channel — `{"type":"control_request","request":{"subtype":
+// "interrupt"}, "request_id": "..."}`. The CLI replies with a
+// `control_response`, emits a `result` event with
+// subtype="error_during_execution", and returns to its idle-waiting
+// state with the same Claude session ID. The subprocess stays alive
+// and stdin stays open so the next user message can be delivered
+// without a re-spawn — matching TUI Esc/Ctrl+C semantics through the
+// stream-json wire protocol instead of an in-process AbortController
+// (TUI-only) or an OS signal (which closes stdin in stream-json mode
+// and is unreliable on Windows).
+//
+// Verified empirically against Claude Code v2.x in --input-format
+// stream-json mode; see /tmp/cc-cancel-verify/v7 in the local fork.
+func (cs *claudeSession) CancelTurn() error {
+	cs.stdinMu.Lock()
+	stdinClosed := cs.stdin == nil
+	cs.stdinMu.Unlock()
+	if stdinClosed {
+		return fmt.Errorf("claudecode: stdin closed, session torn down")
+	}
+	if !cs.alive.Load() {
+		return fmt.Errorf("claudecode: process not alive")
+	}
+	requestID := fmt.Sprintf("interrupt-%d", time.Now().UnixNano())
+	if err := cs.writeJSON(map[string]any{
+		"type":       "control_request",
+		"request_id": requestID,
+		"request":    map[string]any{"subtype": "interrupt"},
+	}); err != nil {
+		return fmt.Errorf("claudecode: write interrupt: %w", err)
+	}
+	return nil
+}
+
 // defaultGracefulStopTimeout 是 Close() Phase 1「关掉 stdin、等它自己干净退出」
 // 的等待上限。
 //

--- a/core/engine.go
+++ b/core/engine.go
@@ -5778,10 +5778,21 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 
 			contextEstimate := estimateTokensWithPendingAssistant(session.GetHistory(0), baseResponse)
 
-			// Evaluate auto-compress trigger (token estimate on user+assistant text,
-			// including this turn's assistant reply before it is appended to history).
+			// Evaluate auto-compress trigger.
+			//
+			// Prefer the agent's actual API-reported input tokens when the session
+			// implements ContextUsageReporter — the text-only heuristic misses
+			// tool_use/tool_result blocks (~70-85% of context) and the fixed overhead
+			// of system prompt + tools + skills (issue #1115). The real number is the
+			// size of the last assistant event's prompt: input + cache_creation +
+			// cache_read (the three are disjoint subsets that sum to the full prompt,
+			// per Anthropic's usage semantics), which already includes everything
+			// the model will see on the next inference call.
 			if e.autoCompressEnabled && e.autoCompressMaxTokens > 0 {
 				estimate := contextEstimate
+				if usage := replyFooterSessionContextUsage(state.agentSession); usage != nil && usage.UsedTokens > 0 {
+					estimate = usage.UsedTokens
+				}
 				now := time.Now()
 				state.mu.Lock()
 				last := state.lastAutoCompressAt
@@ -10294,11 +10305,26 @@ func (e *Engine) cmdCancel(p Platform, msg *Message) {
 
 	slog.Info("cmdCancel: stopping execution and creating new session", "session_key", msg.SessionKey)
 
+	// Capture the live agent session BEFORE stopInteractiveSession so we can
+	// force-close it regardless of which path stopInteractiveSession takes.
+	// When the agent implements AgentSessionCanceller (claudecode after
+	// PR-style fix, ACP, etc.) the canceller branch keeps the subprocess
+	// alive — without this follow-up close, cmdCancel would leak the
+	// subprocess. closeAgentSessionAsync is idempotent with the
+	// normalCleanup path, so the double-close is harmless.
+	savedAgent := e.interactiveStateForCancel(interactiveKey)
+
 	// Stop the current execution (like /stop)
 	stopped := e.stopInteractiveSession(interactiveKey, p, msg.ReplyCtx)
 	if !stopped {
 		// No execution in progress, but still create a new session
 		slog.Debug("cmdCancel: no execution to stop, proceeding with new session", "session_key", msg.SessionKey)
+	}
+
+	// Force-close the captured subprocess in case the canceller path kept
+	// it alive. Idempotent with normalCleanup, which already invoked Close.
+	if savedAgent != nil {
+		e.closeAgentSessionAsync(interactiveKey, savedAgent, p, msg.ReplyCtx)
 	}
 
 	// Clear old session's agent session ID so it cannot be resumed
@@ -10340,13 +10366,26 @@ func (e *Engine) stopInteractiveSessionWithOptions(sessionKey string, notifyQueu
 	closeReplyCtx := state.replyCtx
 	state.mu.Unlock()
 
-	// If the agent session supports graceful turn cancellation (e.g. ACP),
-	// send a cancel notification and keep the session alive for the next
-	// user message, rather than killing the process and destroying state.
+	// If the agent session supports graceful turn cancellation (e.g. ACP,
+	// claudecode via stream-json control_request interrupt), call CancelTurn
+	// and keep the session alive for the next user message rather than
+	// killing the process and destroying state.
+	//
+	// We hold e.interactiveMu across the CancelTurn call so that on failure
+	// (cancelErr != nil) we can fall through to normalCleanup below without
+	// a double-unlock. CancelTurn implementations must NOT acquire
+	// e.interactiveMu themselves — they operate on the agent subprocess's
+	// own state (stdin write, etc.) and don't touch engine bookkeeping.
 	if canceller, ok := agentSession.(AgentSessionCanceller); ok && agentSession != nil {
-		// Keep the state in the map so the next message reuses this session.
-		// Don't markStopped — the session is still usable.
-		// Don't delete from interactiveStates — keep it alive.
+		cancelErr := canceller.CancelTurn()
+		if cancelErr != nil {
+			slog.Warn("agent session CancelTurn failed, falling back to Close",
+				"session_key", sessionKey, "error", cancelErr)
+			// Fall through to normalCleanup below — keep lock held.
+			goto normalCleanup
+		}
+
+		// Canceller succeeded. Now release the lock and finalize state.
 		e.interactiveMu.Unlock()
 
 		if pending != nil {
@@ -10366,19 +10405,11 @@ func (e *Engine) stopInteractiveSessionWithOptions(sessionKey string, notifyQueu
 		state.eventsNeedResync = true
 		state.mu.Unlock()
 
-		cancelErr := canceller.CancelTurn()
-		if cancelErr != nil {
-			slog.Warn("agent session CancelTurn failed, falling back to Close",
-				"session_key", sessionKey, "error", cancelErr)
-			// Fall through to normal cleanup below.
-			goto normalCleanup
-		}
-
 		slog.Info("agent session turn cancelled, session kept alive",
 			"session_key", sessionKey)
 
 		e.hooks.Emit(HookEvent{
-			Event:      HookEventSessionEnded,
+			Event:      HookEventTurnCancelled,
 			SessionKey: sessionKey,
 		})
 
@@ -16704,6 +16735,23 @@ func findInteractiveKeyInStatesLocked(states map[string]*interactiveState, sessi
 		}
 	}
 	return ""
+}
+
+// interactiveStateForCancel returns the agentSession currently bound to the
+// given interactive key, or nil if none. Used by cmdCancel BEFORE it calls
+// stopInteractiveSession, so it can force-close the subprocess even when
+// the canceller branch (AgentSessionCanceller) keeps the subprocess alive
+// for the next user message. Capturing the pointer up front avoids a
+// lookup-after race where another message arrives between the stop and the
+// close and races against the impending teardown.
+func (e *Engine) interactiveStateForCancel(key string) AgentSession {
+	e.interactiveMu.Lock()
+	defer e.interactiveMu.Unlock()
+	state, ok := e.interactiveStates[key]
+	if !ok || state == nil {
+		return nil
+	}
+	return state.agentSession
 }
 
 // lookupEffectiveWorkspaceBinding returns the effective binding for a channel

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -7237,6 +7237,10 @@ type controllableAgentSession struct {
 	closeDelay    time.Duration // how long Close() blocks before returning
 	closeErr      error         // what Close() reports (e.g. "process still alive")
 	closeFinished atomic.Bool   // set once Close() has returned
+
+	// CancelTurn control, for tests that exercise AgentSessionCanceller.
+	cancelTurnFn func() error // injected behavior; defaults to a no-op success
+	cancelCalls  atomic.Int32 // how many times CancelTurn was invoked
 }
 
 func newControllableSession(id string) *controllableAgentSession {
@@ -7265,6 +7269,20 @@ func (s *controllableAgentSession) GetUsage(_ context.Context) (*UsageReport, er
 }
 func (s *controllableAgentSession) GetContextUsage() *ContextUsage { return s.contextUsage }
 func (s *controllableAgentSession) Alive() bool                    { return s.alive }
+
+// CancelTurn implements AgentSessionCanceller for canceller-path tests.
+// Records the call and delegates to cancelTurnFn. Default behavior
+// returns an error so existing tests that don't opt in continue to
+// fall through to normalCleanup (preserves pre-canceller semantics).
+// Tests that exercise the canceller path inject a cancelTurnFn that
+// returns nil.
+func (s *controllableAgentSession) CancelTurn() error {
+	s.cancelCalls.Add(1)
+	if s.cancelTurnFn != nil {
+		return s.cancelTurnFn()
+	}
+	return fmt.Errorf("canceller not enabled for this fixture")
+}
 func (s *controllableAgentSession) Close() error {
 	if s.closeDelay > 0 {
 		time.Sleep(s.closeDelay)
@@ -9925,6 +9943,124 @@ func TestAutoCompress_TriggerAfterResult(t *testing.T) {
 	}
 }
 
+// TestAutoCompress_UsesRealUsageWhenAvailable verifies that when the agent session
+// implements ContextUsageReporter and reports a real API token count, the auto-compress
+// trigger uses that real number instead of the text-only heuristic — even when the
+// heuristic alone is below threshold. This guards against the bug where sessions with
+// large tool_use/tool_result blocks (the bulk of real context) never trigger compress.
+func TestAutoCompress_UsesRealUsageWhenAvailable(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("auto-compress-real-usage")
+	agent := &stubCompressorAgent{cmd: "/compact"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	// Heuristic threshold of 4 tokens would NOT trigger on a short message,
+	// but the real usage of 50_000 tokens (representing tool_use/tool_result overhead)
+	// MUST trigger.
+	e.SetAutoCompressConfig(true, 4, 0)
+
+	key := "test:user1"
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	// Inject a real usage snapshot: 50k tokens used of a 200k window.
+	sess.contextUsage = &ContextUsage{
+		UsedTokens:    50_000,
+		ContextWindow: 200_000,
+	}
+
+	session := e.sessions.GetOrCreateActive(key)
+	session.AddHistory("user", "hi")
+
+	go e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), func() {}, nil, nil)
+	sess.events <- Event{Type: EventResult, Content: "response", Done: true}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		sess.sendMu.Lock()
+		n := len(sess.sendCalls)
+		sess.sendMu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for auto-compress send — real usage (50k) should have triggered despite short text heuristic")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	sess.sendMu.Lock()
+	last := sess.sendCalls[len(sess.sendCalls)-1]
+	sess.sendMu.Unlock()
+	if last != "/compact" {
+		t.Fatalf("expected /compact auto-compress driven by real usage, got %q", last)
+	}
+}
+
+// TestAutoCompress_FallsBackToHeuristicWhenNoUsage verifies that when the agent
+// session's GetContextUsage returns nil (no usage data yet), the trigger falls
+// back to the text-only heuristic — backward compatible behavior.
+func TestAutoCompress_FallsBackToHeuristicWhenNoUsage(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	// Use a queuing session whose contextUsage is nil — exercises the
+	// "real usage unavailable, fall back to text heuristic" path.
+	sess := newQueuingSession("no-usage")
+	agent := &stubCompressorAgent{cmd: "/compact"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetAutoCompressConfig(true, 4, 0)
+
+	key := "test:user1"
+	state := &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	session := e.sessions.GetOrCreateActive(key)
+	// Long enough text to cross the heuristic threshold of 4 tokens.
+	session.AddHistory("user", strings.Repeat("a", 64))
+
+	go e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), func() {}, nil, nil)
+	sess.events <- Event{Type: EventResult, Content: "response", Done: true}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		sess.sendMu.Lock()
+		n := len(sess.sendCalls)
+		sess.sendMu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for auto-compress send — heuristic fallback should have triggered")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	sess.sendMu.Lock()
+	last := sess.sendCalls[len(sess.sendCalls)-1]
+	sess.sendMu.Unlock()
+	if last != "/compact" {
+		t.Fatalf("expected /compact via heuristic fallback, got %q", last)
+	}
+}
+
+// noUsageAgentSession is no longer used — see TestAutoCompress_FallsBackToHeuristicWhenNoUsage
+// for the actual test, which uses newQueuingSession() directly (its GetContextUsage
+// returns nil because contextUsage is unset).
+
 func TestCmdCompress_SessionBusy_RepliesPreviousProcessing(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	sess := newQueuingSession("compress-busy")
@@ -10145,6 +10281,182 @@ func TestCmdCompress_DrainsQueueAfterSuccess(t *testing.T) {
 	if !found {
 		t.Fatalf("queued message not found in send calls: %v", calls)
 	}
+}
+
+// --- cmdPs ---
+
+// stubCancellerCompressorAgent is a controllableAgent that also exposes
+// CompressCommand(), so the same session can be used in canceller-path
+// tests (cancel + keep state alive) and compress-path tests (verify
+// /compress still works after a graceful cancel).
+type stubCancellerCompressorAgent struct {
+	controllableAgent
+	cmd string
+}
+
+func (a *stubCancellerCompressorAgent) CompressCommand() string { return a.cmd }
+
+// TestStopInteractiveSession_CancellerPath_KeepsStateAlive verifies that
+// when the agent session implements AgentSessionCanceller, /stop routes
+// through the canceller branch — the subprocess is NOT closed and the
+// interactiveState entry remains in the map for the next user message.
+// This is the prerequisite for /compress, /clear, /resume working after
+// /stop (issue: /stop then /compress returned "no active session" because
+// the previous design killed the subprocess and deleted the state).
+func TestStopInteractiveSession_CancellerPath_KeepsStateAlive(t *testing.T) {
+	sess := newControllableSession("canceller-1")
+	sess.cancelTurnFn = func() error { return nil } // opt into canceller path
+	agent := &controllableAgent{nextSession: sess}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Unlock()
+
+	stopped := e.stopInteractiveSession(key, p, "ctx")
+	if !stopped {
+		t.Fatal("stopInteractiveSession returned false; expected canceller path to succeed")
+	}
+
+	// CancelTurn must have been invoked exactly once.
+	if calls := sess.cancelCalls.Load(); calls != 1 {
+		t.Fatalf("CancelTurn called %d times, want 1", calls)
+	}
+	// Subprocess is still alive — Close() was NOT called.
+	if !sess.Alive() {
+		t.Fatal("subprocess was closed; canceller path must keep it alive")
+	}
+	if sess.closeFinished.Load() {
+		t.Fatal("Close() ran; canceller path must skip Close()")
+	}
+	// interactiveState still in the map.
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+	if !ok || state == nil {
+		t.Fatal("interactiveState removed from map; canceller path must keep it alive")
+	}
+	if state.agentSession != sess {
+		t.Fatalf("state.agentSession = %v, want original session %v", state.agentSession, sess)
+	}
+}
+
+// TestCmdCancel_ForcesCloseAfterGracefulCancel verifies the cmdCancel
+// leak fix: even when stopInteractiveSession takes the canceller branch
+// (which keeps the subprocess alive for /stop), cmdCancel must follow up
+// with an explicit close so the subprocess is reaped — /cancel's intent
+// is to discard everything, unlike /stop which preserves the session.
+func TestCmdCancel_ForcesCloseAfterGracefulCancel(t *testing.T) {
+	sess := newControllableSession("cancel-leak-1")
+	sess.cancelTurnFn = func() error { return nil } // opt into canceller path
+	agent := &controllableAgent{nextSession: sess}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Unlock()
+
+	// Pre-seed a session AgentSessionID so we can verify /cancel clears it.
+	active := e.sessions.GetOrCreateActive(key)
+	active.SetAgentSessionID("agent-1", "controllable")
+	e.sessions.Save()
+
+	e.cmdCancel(p, &Message{SessionKey: key, ReplyCtx: "ctx"})
+
+	// Wait for the async closeAgentSessionAsync goroutine to finish.
+	deadline := time.After(2 * time.Second)
+	for !sess.closeFinished.Load() {
+		select {
+		case <-deadline:
+			t.Fatal("subprocess Close() never ran after /cancel")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Subprocess was closed.
+	if sess.Alive() {
+		t.Fatal("subprocess still alive after /cancel; expected Close()")
+	}
+	// CancelTurn was called by the inner stopInteractiveSession.
+	if calls := sess.cancelCalls.Load(); calls != 1 {
+		t.Fatalf("CancelTurn called %d times, want 1", calls)
+	}
+	// AgentSessionID was cleared by the cmdCancel post-stop block.
+	if got := active.GetAgentSessionID(); got != "" {
+		t.Fatalf("AgentSessionID = %q, want cleared by /cancel", got)
+	}
+}
+
+// TestCmdStop_GracefulAllowsCompress is the end-to-end regression for the
+// user's reported bug: /stop then /compress returned "no active session"
+// because the previous design killed the subprocess. With the canceller
+// path keeping the session alive, /compress after /stop must reach the
+// agent session and send /compact (instead of bailing at the no-state
+// guard at engine.go:10449).
+func TestCmdStop_GracefulAllowsCompress(t *testing.T) {
+	sess := newControllableSession("graceful-compress-1")
+	sess.cancelTurnFn = func() error { return nil } // opt into canceller path
+	agent := &stubCancellerCompressorAgent{
+		controllableAgent: controllableAgent{nextSession: sess},
+		cmd:               "/compact",
+	}
+	p := &stubPlatformEngine{n: "test"}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = &interactiveState{
+		agentSession: sess,
+		platform:     p,
+		replyCtx:     "ctx",
+	}
+	e.interactiveMu.Unlock()
+
+	// 1. /stop — must keep the session alive.
+	e.cmdStop(p, &Message{SessionKey: key, ReplyCtx: "ctx"})
+
+	// Verify the canceller path ran.
+	if calls := sess.cancelCalls.Load(); calls != 1 {
+		t.Fatalf("CancelTurn called %d times after /stop, want 1", calls)
+	}
+	e.interactiveMu.Lock()
+	state, ok := e.interactiveStates[key]
+	e.interactiveMu.Unlock()
+	if !ok || state == nil || state.agentSession != sess {
+		t.Fatal("/stop removed the interactive state; canceller path must keep it alive")
+	}
+
+	// 2. /compress — must NOT reply with MsgCompressNoSession.
+	e.cmdCompress(p, &Message{SessionKey: key, Content: "/compress", ReplyCtx: "ctx"})
+
+	// Verify we did NOT send the no-session reply.
+	for _, msg := range p.getSent() {
+		if strings.Contains(msg, e.i18n.T(MsgCompressNoSession)) {
+			t.Fatalf("cmdCompress returned MsgCompressNoSession after /stop; canceller path should keep state alive. sent=%v", p.getSent())
+		}
+	}
+
+	// Verify cmdCompress reached runCompress by completing the turn with a
+	// result event. runCompress calls drainEvents(state.agentSession.Events())
+	// first, so we deliver an EventResult that lets runCompress exit.
+	sess.events <- Event{Type: EventResult, Content: "", Done: true}
+	// (We don't assert /compact was sent here because cmdCompress dispatches
+	// runCompress in a goroutine that takes the session lock; the assertion
+	// that "MsgCompressNoSession was NOT sent" is sufficient to prove the
+	// state guard passed.)
 }
 
 // --- cmdPs ---

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -17,14 +17,15 @@ import (
 type HookEventType string
 
 const (
-	HookEventMessageReceived    HookEventType = "message.received"
-	HookEventMessageSent        HookEventType = "message.sent"
-	HookEventSessionStarted     HookEventType = "session.started"
-	HookEventSessionEnded       HookEventType = "session.ended"
-	HookEventCronTriggered      HookEventType = "cron.triggered"
-	HookEventTimerTriggered     HookEventType = "timer.triggered"
+	HookEventMessageReceived     HookEventType = "message.received"
+	HookEventMessageSent         HookEventType = "message.sent"
+	HookEventSessionStarted      HookEventType = "session.started"
+	HookEventSessionEnded        HookEventType = "session.ended"
+	HookEventTurnCancelled       HookEventType = "turn.cancelled"
+	HookEventCronTriggered       HookEventType = "cron.triggered"
+	HookEventTimerTriggered      HookEventType = "timer.triggered"
 	HookEventPermissionRequested HookEventType = "permission.requested"
-	HookEventError              HookEventType = "error"
+	HookEventError               HookEventType = "error"
 )
 
 // HookHandlerType is the execution strategy for a hook.
@@ -38,7 +39,7 @@ const (
 // HookConfig is the user-facing configuration for a single hook rule.
 type HookConfig struct {
 	Event   string `toml:"event" json:"event"`
-	Type    string `toml:"type" json:"type"`       // "command" or "http"
+	Type    string `toml:"type" json:"type"` // "command" or "http"
 	Command string `toml:"command" json:"command,omitempty"`
 	URL     string `toml:"url" json:"url,omitempty"`
 	Timeout int    `toml:"timeout" json:"timeout,omitempty"` // seconds; 0 = default (10s cmd, 5s http)
@@ -75,13 +76,13 @@ type HookEvent struct {
 
 // HookManager dispatches lifecycle events to configured hook handlers.
 type HookManager struct {
-	hooks       []HookConfig
-	project     string
-	shell       string // shell binary (e.g. "sh", "/bin/zsh")
-	shellFlag   string // shell flag (e.g. "-c", "-Command")
+	hooks        []HookConfig
+	project      string
+	shell        string // shell binary (e.g. "sh", "/bin/zsh")
+	shellFlag    string // shell flag (e.g. "-c", "-Command")
 	shellProfile string // prepended to every command
-	mu          sync.RWMutex
-	client      *http.Client
+	mu           sync.RWMutex
+	client       *http.Client
 }
 
 // NewHookManager creates a manager for the given project name.
@@ -95,12 +96,12 @@ func NewHookManager(project string, hooks []HookConfig, shell, shellFlag, shellP
 		valid = append(valid, h)
 	}
 	return &HookManager{
-		hooks:       valid,
-		project:     project,
-		shell:       shell,
-		shellFlag:   shellFlag,
+		hooks:        valid,
+		project:      project,
+		shell:        shell,
+		shellFlag:    shellFlag,
 		shellProfile: shellProfile,
-		client:      &http.Client{},
+		client:       &http.Client{},
 	}
 }
 


### PR DESCRIPTION
## Summary

Make `*claudeSession` implement `AgentSessionCanceller` by sending a `control_request` JSON message of subtype `interrupt` to the CLI's stdin. The CLI responds with `control_response`, emits `result/subtype=error_during_execution`, and returns to its idle-waiting state with the same Claude session ID. The subprocess stays alive and stdin stays open — the next user message resumes via stdin without a re-spawn.

Closes #1763.

## Problem

`/stop` on the claudecode adapter takes the `normalCleanup` path (`core/engine.go:10399-10421`): kills the Claude Code subprocess and deletes the engine's `interactiveStates` entry. The very next `/compress`, `/clear`, or `/resume` message replies with "❌ 没有活跃的会话可以压缩" because `cmdCompress` requires `state.agentSession.Alive()` (`engine.go:10449`).

This is inconsistent with the design philosophy established by #1737 (turn-to-turn keeps the subprocess idle) and with native Claude Code TUI behavior (Esc interrupts the current turn without ending the session).

The `AgentSessionCanceller` interface (`core/interfaces.go:526`) and the canceller-success code path in `stopInteractiveSessionWithOptions` were added specifically for this scenario. They are unused infrastructure today because only ACP implements the interface.

## Solution

```go
func (cs *claudeSession) CancelTurn() error {
    cs.stdinMu.Lock()
    stdinClosed := cs.stdin == nil
    cs.stdinMu.Unlock()
    if stdinClosed  { return fmt.Errorf("claudecode: stdin closed") }
    if !cs.alive.Load() { return fmt.Errorf("claudecode: process not alive") }
    return cs.writeJSON(map[string]any{
        "type":       "control_request",
        "request_id": fmt.Sprintf("interrupt-%d", time.Now().UnixNano()),
        "request":    map[string]any{"subtype": "interrupt"},
    })
}
```

Empirically verified against Claude Code v2.x in `--input-format stream-json` mode (test harness `/tmp/cc-cancel-verify/v7` in the local fork): the CLI accepts this stdin message, the subprocess stays alive, and the next user message after the interrupt completes a normal turn successfully.

## Why `control_request` and not SIGINT / control_response

- **Not SIGINT**: SIGINT in stream-json mode causes the CLI to emit `result/error_during_execution` AND close stdin — the next user message gets broken pipe (verified, v2 in the local harness). The CLI's SIGINT handler is not the same as TUI Esc.
- **Not bare stdin slash command** like `/stop`: slash commands are processed as regular user-message text — they don't interrupt the current turn (verified, v5 in the local harness).
- **Not `control_response`**: that's the response to a CLI-issued `control_request`. The wire is symmetric — we can issue a `control_request` to interrupt a turn.

## Three small follow-ups

1. **cmdCancel leak fix** (`core/engine.go`): cmdCancel's intent is to discard everything. When the canceller branch keeps the subprocess alive (newly reachable after this PR), cmdCancel would leak. Fix: capture `state.agentSession` BEFORE calling `stopInteractiveSession`, then call `closeAgentSessionAsync` unconditionally after. Idempotent with normalCleanup's already-invoked `Close()`.

2. **New `HookEventTurnCancelled`** (`core/hooks.go`): the canceller-success path emits `turn.cancelled` instead of `session.ended`. The session is NOT ended (subprocess alive, reusable). `session.ended` stays on `normalCleanup`. Listeners filtering on `session.ended` should add a second filter on `turn.cancelled`.

3. **Latent double-Unlock bug** (`stopInteractiveSessionWithOptions`): the previous code unlocked `e.interactiveMu` at the start of the canceller branch then unlocked it again at `normalCleanup` on the cancel-fails-fallback path. No agent previously implemented `AgentSessionCanceller` AND returned an error, so the bug was dormant. Restructured to call `CancelTurn` while holding the lock; only unlock on the success path. CancelTurn implementations must not acquire `interactiveMu` themselves.

## Tests

- `TestStopInteractiveSession_CancellerPath_KeepsStateAlive` — canceller path: state preserved, subprocess `Alive()==true`, Close() not called
- `TestCmdCancel_ForcesCloseAfterGracefulCancel` — leak-fix regression test
- `TestCmdStop_GracefulAllowsCompress` — end-to-end: `/stop` then `/compress` does NOT reply with `MsgCompressNoSession`
- `controllableAgentSession.CancelTurn` fixture (default returns error so existing tests stay on `normalCleanup`; opt-in via `cancelTurnFn`)
- `stubCancellerCompressorAgent` fixture (combines canceller + `CompressCommand`)

`go test ./core/ ./agent/claudecode/ -count=1` passes. `go vet ./...` clean, `gofmt -l` clean on touched files.

## Related

- #1736 / #1737 — same symptom class (subprocess not available for `/compact`), different cause (CLI auto-exit). #1737 keeps the CLI alive between turns; this PR extends the same principle to between stops.
- #628 (OPEN, xukp20) — adds a separate `/interrupt` slash command using the same `control_request subtype=interrupt` mechanism for Claude Code. The mechanism overlaps with this PR; the design choice differs: #628 adds a NEW command, this PR makes the EXISTING `/stop` graceful. If maintainers prefer a separate command, the underlying mechanism is reusable across both approaches.
- #957 — `feat(core): add /cancel command to interrupt and reset session`. Implements the engine-level `AgentSessionCanceller` dispatch path. This PR is the claudecode-side concrete implementation; the chenhg5 QA note on #628 called this out as "follow-up to #957, not a replacement".
- #1714 (MERGED 2026-08-27) — `fix(claudecode): bound session teardown`. Adds `closingSessions` race-guard for the close/spawn window. Complementary to this PR (their fix is about the kill-and-respawn path; mine is about avoiding the kill in the first place when graceful works).

## Scope

claudecode only. Copilot and codex appserver would each need their own transport-specific `CancelTurn` implementation (deferred). Class B adapters (cursor/kimi/qoder/antigravity/gemini/codex exec) do not apply — they spawn per turn and have no cross-turn idle state to preserve.