### PR TITLE
fix(weixin): 移除过时的纯文本提示，并改用围栏感知的消息分块

### DIFF
--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unicode/utf8"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -822,7 +821,7 @@ func (p *Platform) sendChunks(ctx context.Context, replyCtx any, content string,
 	if strings.TrimSpace(content) == "" {
 		return nil
 	}
-	chunks := splitUTF8(content, maxWeixinChunk)
+	chunks := core.SplitMessageCodeFenceAware(content, maxWeixinChunk)
 	total := len(chunks)
 	for i, chunk := range chunks {
 		// Add delay between chunks to avoid rate limiting (except for first chunk)
@@ -884,23 +883,6 @@ func truncatePreview(s string, max int) string {
 		return s
 	}
 	return s[:max] + "..."
-}
-
-func splitUTF8(s string, maxRunes int) []string {
-	if maxRunes <= 0 || utf8.RuneCountInString(s) <= maxRunes {
-		return []string{s}
-	}
-	var out []string
-	runes := []rune(s)
-	for len(runes) > 0 {
-		n := maxRunes
-		if len(runes) < n {
-			n = len(runes)
-		}
-		out = append(out, string(runes[:n]))
-		runes = runes[n:]
-	}
-	return out
 }
 
 // ReconstructReplyCtx implements core.ReplyContextReconstructor for cron / proactive sends.

--- a/platform/weixin/weixin.go
+++ b/platform/weixin/weixin.go
@@ -916,17 +916,17 @@ func (p *Platform) ReconstructReplyCtx(sessionKey string) (any, error) {
 	return &replyContext{peerUserID: peer, contextToken: tok}, nil
 }
 
-// FormattingInstructions implements core.FormattingInstructionProvider.
-func (p *Platform) FormattingInstructions() string {
-	return "Replies are delivered as plain text to Weixin. Avoid markdown tables; use short paragraphs."
-}
+// Weixin renders standard Markdown, so this platform intentionally does not
+// implement core.FormattingInstructionProvider. That optional interface exists
+// for platforms whose syntax deviates from standard Markdown (Slack mrkdwn,
+// Google Chat), and the majority of adapters — Feishu, Telegram, Discord,
+// DingTalk among them — likewise leave it unimplemented.
 
 var (
-	_ core.Platform                      = (*Platform)(nil)
-	_ core.ReplyContextReconstructor     = (*Platform)(nil)
-	_ core.FormattingInstructionProvider = (*Platform)(nil)
-	_ core.ImageSender                   = (*Platform)(nil)
-	_ core.FileSender                    = (*Platform)(nil)
-	_ core.TypingIndicator               = (*Platform)(nil)
-	_ core.AsyncRecoverablePlatform      = (*Platform)(nil)
+	_ core.Platform                  = (*Platform)(nil)
+	_ core.ReplyContextReconstructor = (*Platform)(nil)
+	_ core.ImageSender               = (*Platform)(nil)
+	_ core.FileSender                = (*Platform)(nil)
+	_ core.TypingIndicator           = (*Platform)(nil)
+	_ core.AsyncRecoverablePlatform  = (*Platform)(nil)
 )

--- a/platform/weixin/weixin_test.go
+++ b/platform/weixin/weixin_test.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/chenhg5/cc-connect/core"
 )
@@ -53,18 +54,39 @@ func TestBodyFromItemList_Quote(t *testing.T) {
 	}
 }
 
-func TestSplitUTF8(t *testing.T) {
-	s := string([]rune{'a', '啊', 'b', '吧', 'c'})
-	parts := splitUTF8(s, 2)
-	if len(parts) != 3 || parts[0] != "a啊" || parts[1] != "b吧" || parts[2] != "c" {
-		t.Fatalf("parts=%#v", parts)
+// TestChunkingKeepsCodeFencesBalanced is a regression test for the outbound
+// splitter. The previous implementation cut purely on rune count, so a chunk
+// boundary landing inside a fenced code block left the first message with an
+// unclosed fence and the second one starting as bare text. Worse, the trailing
+// fence then arrived alone and the client read it as the *start* of a new code
+// block, swallowing whatever followed.
+func TestChunkingKeepsCodeFencesBalanced(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("intro line\n\n```go\n")
+	for i := 0; i < 200; i++ {
+		fmt.Fprintf(&sb, "L%03d %s\n", i, strings.Repeat("x", 40))
+	}
+	sb.WriteString("```\ntrailing line")
+
+	chunks := core.SplitMessageCodeFenceAware(sb.String(), maxWeixinChunk)
+	if len(chunks) < 2 {
+		t.Fatalf("expected the sample to split, got %d chunk(s)", len(chunks))
+	}
+	for i, c := range chunks {
+		if n := strings.Count(c, "```"); n%2 != 0 {
+			t.Errorf("chunk %d/%d has %d fence markers, want an even count so the block is closed",
+				i+1, len(chunks), n)
+		}
+		if got := utf8.RuneCountInString(c); got > maxWeixinChunk {
+			t.Errorf("chunk %d/%d is %d runes, want <= %d", i+1, len(chunks), got, maxWeixinChunk)
+		}
 	}
 }
 
-func TestSplitUTF8Empty(t *testing.T) {
-	parts := splitUTF8("", maxWeixinChunk)
-	if len(parts) != 1 || parts[0] != "" {
-		t.Fatalf("parts=%#v", parts)
+func TestChunkingShortMessageStaysSingle(t *testing.T) {
+	chunks := core.SplitMessageCodeFenceAware("", maxWeixinChunk)
+	if len(chunks) != 1 || chunks[0] != "" {
+		t.Fatalf("chunks=%#v", chunks)
 	}
 }
 


### PR DESCRIPTION
## 背景

`platform/weixin` 每轮都会往 system prompt 里注入这句话：

> Replies are delivered as plain text to Weixin. Avoid markdown tables; use short paragraphs.

它从 #257（2026-03-22，微信个人号平台落地）起就在，五个月没有再被审视过。但它描述的行为已经不成立了：**当前微信客户端能正常渲染标准 Markdown**，围栏代码块甚至是一等公民——会自动识别语言、上语法高亮、并附带「复制」按钮。

这句过时的提示有实际代价：它明确禁止 agent 使用表格，而表格恰恰是在手机上呈现结构化信息最有效的形式，结果是回复质量被无谓地压低了。

## 改动一：移除 `FormattingInstructions`，而不是改写它

`FormattingInstructionProvider` 是可选接口，其文档注释写明用途是「语法偏离标准 Markdown 的平台」，并以 Slack mrkdwn 为例。仓库现状印证了这一设计意图：20 个平台适配器里只有 6 个实现它（slack、googlechat、max、tuitui、webex、weixin），而 **feishu、telegram、discord、dingtalk 等渲染标准 Markdown 的平台一概不实现**，此时 `engine.go` 注入的就是空字符串。

微信既然渲染标准 Markdown，就应该归入后一类。所以这里选择删除方法而非改写文案，顺带让每个会话少注入一段 prompt 片段。

### 验证

在真实客户端逐项测试了 12 类 Markdown 元素，如实记录如下：

| 元素 | 结果 |
|---|---|
| 粗体 / 斜体 / 粗斜体 / 删除线 | ✅ |
| 行内代码 | ✅ |
| 围栏代码块（无语言标注） | ✅ 带 `TEXT` 标签与复制按钮 |
| 围栏代码块（带语言标注） | ✅ 带 `GO` 标签、**语法高亮**、复制按钮 |
| 无序列表（含三层嵌套） | ✅ 缩进完整保留 |
| 有序列表 | ✅ |
| 引用块 | ✅ |
| 表格 | ✅ 表头、行分隔线、列对齐均正确 |
| 链接 / 分隔线 | ✅ |
| 转义字符 | ✅ |
| 标题 | ⚠️ `#` 被正确消费，但 H1/H2/H3 字号差异极小，视觉层级偏弱 |
| 任务列表 `- [ ]` | ❌ 不渲染复选框，退化为普通列表项 |

![Markdown 渲染测试](https://img.doufei.eu.org/file/web/1787926035075_img_1787924973842_0.jpg)

任务列表不支持这一点，我认为不构成保留提示的理由：它属于 GFM 扩展而非核心 Markdown，而**同样不渲染它的 Discord 也没有实现 `FormattingInstructions`**。仓库既有的处置方式就是不为这类边缘差异单独加提示。

## 改动二：外发分块改用 `core.SplitMessageCodeFenceAware`

这是一个独立的真实缺陷。`sendChunks` 此前使用 `splitUTF8`，纯按 rune 数硬切，完全不感知 Markdown 结构。当 3800 的切点落在围栏代码块内部时会造成双重破坏：

1. 第一条消息以未闭合的围栏结尾；
2. 第二条消息以裸文本开头，丢失等宽字体，长行被迫折行、行号与内容错位；
3. 更糟的是，收尾的 ` ``` ` 单独出现在后一条里，客户端会把它当作**新代码块的起始**，从而吞掉其后的正常文字。

下面这张截图是构造的复现：一条 82 行的代码块消息，切点落在 L079 中间。可以看到第二条完全失去代码块样式，且末尾我原本的说明文字被误吞进了一个 `TEXT` 代码块。

![分块破坏代码块](https://img.doufei.eu.org/file/web/1787926065409_img_1787925248407_0.jpg)

`core.SplitMessageCodeFenceAware` 正是为此而写：优先按行边界切分，在分块结尾补上闭合围栏、并在下一块开头重新打开，保证每一条消息自身都是合法的 Markdown。**telegram、discord、qqbot 以及 engine 自身都已在使用它**，weixin 是唯一还留着自研切分函数的适配器。

`splitUTF8` 没有其他调用方，一并删除，其原有测试替换为断言「各分块围栏数为偶数且不超过 `maxWeixinChunk`」的回归测试。

## 测试

```
go build ./...        通过
go vet ./platform/weixin/   通过
gofmt                 改动文件均已格式化
go test ./...         44 个包 ok
```

有 2 个包报 `[setup failed]`：`cmd/cc-connect` 和 `web`，原因均为 `web/embed.go:13:12: pattern all:dist: no matching files found`，即本地未构建前端产物。我用 `git stash` 回到未改动状态复现了同样的失败，**确认与本 PR 无关**。

## 需要说明的局限

上述渲染验证来自**单一环境**：一个微信个人号客户端、ilink 通道、2026-08-28。我无法证明所有客户端版本表现一致。如果维护者掌握与此不符的情况，改动一可以单独回退——两个 commit 是拆开的，**改动二不依赖任何渲染假设**（代码块被从中间劈开在任何客户端上都是错误行为），可以独立合入。

相关但不同的问题：#1326 讨论的是微信连续消息上限导致的截断，属于发送配额范畴，本 PR 不涉及。
