### PR TITLE
fix(pi): reference non-image attachments by plain path, not @<path> (#1767)

### DIFF
--- a/agent/pi/session.go
+++ b/agent/pi/session.go
@@ -333,38 +333,48 @@ func (s *piSession) Send(msg string, messageID string, images []core.ImageAttach
 	}
 	cleanAttachments(attachDir)
 
-	var atFiles []string
+	// Issue #1723: images are passed via pi's @<path> argv / message-text
+	// mechanism. pi's processImage loads them as visual inputs and the
+	// bytes never enter our prompt text.
+	//
+	// Issue #1767: non-image files are NOT passed via @<path>. pi's
+	// processFileArguments reads every @<path> file's full UTF-8 contents
+	// and inlines them into the prompt the model sees. For a >~1MB text
+	// attachment this can blow the model's context and trigger a 400 from
+	// the provider. Mirror the claudecode behaviour: save non-image files
+	// to disk and tell the model where they live via a plain path
+	// reference; pi's own file-reading tools will load only the bytes the
+	// model actually needs.
+	var imageAtFiles []string
 	if len(images) > 0 {
-		atFiles = append(atFiles, saveImagesToDisk(attachDir, images)...)
+		imageAtFiles = append(imageAtFiles, saveImagesToDisk(attachDir, images)...)
 	}
+	var filePaths []string
 	if len(files) > 0 {
-		atFiles = append(atFiles, saveFilesToDisk(attachDir, files)...)
+		filePaths = append(filePaths, saveFilesToDisk(attachDir, files)...)
 	}
 
-	// Issue #1723: do NOT inline attachment bytes back into the prompt.
-	// json mode passes the prompt via -p <argv>, so embedding raw image
-	// bytes triggers execve EINVAL on NUL bytes and the pi process never
-	// starts (model never sees the image). rpc mode goes through stdin
-	// so it doesn't crash, but the model still gets image bytes as text
-	// rather than a real visual input. Both paths must hand pi the saved
-	// paths via pi's @<path> mechanism — sendJSON appends them as argv
-	// entries; sendRPC embeds them in the message text, which pi parses
-	// the same way.
 	if s.rpc {
-		return s.sendRPC(msg, atFiles)
+		return s.sendRPC(msg, imageAtFiles, filePaths)
 	}
-	return s.sendJSON(msg, atFiles)
+	return s.sendJSON(msg, imageAtFiles, filePaths)
 }
 
 // sendJSON spawns `pi --mode json -p <prompt>` as a one-shot process,
 // reads all output events, and sends them to the events channel.
 //
-// Issue #1723: attachment paths are passed as @<path> argv entries (Pi's
-// standard mechanism). Embedding the file bytes into -p would crash
+// Issue #1723: image paths are passed as @<path> argv entries (Pi's
+// standard mechanism). Embedding the image bytes into -p would crash
 // execve on NUL bytes, and would also break pi's vision pipeline which
 // needs to know the file is on disk rather than be handed raw bytes.
-func (s *piSession) sendJSON(prompt string, atFiles []string) error {
-	args := buildJSONArgs(s.extraArgs, prompt, s.CurrentSessionID(), s.model, s.thinking, atFiles)
+//
+// Issue #1767: filePaths (non-image attachments) are NOT passed as
+// @<path>. We append a plain "Files saved locally, please read them: …"
+// trailer to the prompt instead — pi's processFileArguments would
+// otherwise inline the entire UTF-8 contents into the prompt the model
+// sees, which triggers a 400 for files larger than the model's context.
+func (s *piSession) sendJSON(prompt string, imageAtFiles []string, filePaths []string) error {
+	args := buildJSONArgs(s.extraArgs, promptWithFileRefs(prompt, filePaths), s.CurrentSessionID(), s.model, s.thinking, imageAtFiles)
 
 	slog.Debug("piSession: spawning json mode", "cmd", s.cmd, "sessionID", s.CurrentSessionID())
 
@@ -458,19 +468,45 @@ func (s *piSession) writeRPCCommand(cmd map[string]any) error {
 // Events are read asynchronously by readLoopRPC, including agent_end which
 // triggers EventResult.
 //
-// Issue #1723: attachment paths are embedded into the message text as
+// Issue #1723: image paths are embedded into the message text as
 // @<path> references (pi's standard mechanism, parsed the same way as in
 // json mode). The rpc stdin pipe doesn't crash on NUL bytes, but the
-// model still needs to load the files from disk — embedding raw bytes
+// model still needs to load the images from disk — embedding raw bytes
 // in the message field would give the model text-shaped garbage instead
-// of a real visual/file input.
-func (s *piSession) sendRPC(prompt string, atFiles []string) error {
+// of a real visual input.
+//
+// Issue #1767: filePaths (non-image attachments) are NOT @<path>'d.
+// pi's processFileArguments would inline their full UTF-8 contents into
+// the message text the model sees; we append a plain "Files saved
+// locally, please read them: …" trailer instead so pi's own file
+// tools load only what the model actually needs.
+func (s *piSession) sendRPC(prompt string, imageAtFiles []string, filePaths []string) error {
 	cmd := map[string]any{
 		"type":    "prompt",
-		"message": composeRPCPrompt(prompt, atFiles),
+		"message": composeRPCPrompt(promptWithFileRefs(prompt, filePaths), imageAtFiles),
 	}
 	slog.Debug("piSession: sending RPC prompt", "bytes", len(prompt))
 	return s.writeRPCCommand(cmd)
+}
+
+// promptWithFileRefs appends a plain-text trailer that tells the model
+// where non-image attachments were saved on disk. Pulled out of Send()
+// so the Issue #1767 regression test can assert that the path strings
+// appear in the prompt without inlining file bytes.
+//
+// The trailer mirrors the wording cc-connect uses for the claudecode
+// agent so users see consistent phrasing across runtimes. Paths are
+// joined with ", " and wrapped in parentheses to make the boundary with
+// the original prompt text unambiguous.
+//
+// Returns prompt unchanged when filePaths is empty — we do NOT emit an
+// empty "Files saved locally" trailer because an assistant model could
+// interpret that as a request to attach something that isn't there.
+func promptWithFileRefs(prompt string, filePaths []string) string {
+	if len(filePaths) == 0 {
+		return prompt
+	}
+	return prompt + "\n\n(Files saved locally, please read them: " + strings.Join(filePaths, ", ") + ")"
 }
 
 // composeRPCPrompt builds the rpc-mode message text, appending

--- a/agent/pi/session_test.go
+++ b/agent/pi/session_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
 )
 
 // ── buildJSONArgs (Issue #1723) ────────────────────────────────
@@ -342,5 +344,276 @@ func TestComposeRPCPrompt_AcceptsNULInOriginalPrompt(t *testing.T) {
 	got := composeRPCPrompt(prompt, []string{"/tmp/x.png"})
 	if !strings.Contains(got, "hi\x00there") {
 		t.Errorf("NUL stripped from prompt: %q", got)
+	}
+}
+
+// ── promptWithFileRefs (Issue #1767) ───────────────────────────
+//
+// Issue #1767 regression coverage: the old code passed non-image files
+// through the same @<path> mechanism as images. pi's processFileArguments
+// reads every @<path> file's full UTF-8 contents and inlines them into
+// the prompt the model sees; for a >~1MB attachment this triggered a 400
+// from the model provider. The fix splits images (still @<path>) from
+// non-image files (now referenced by plain path trailer). These tests
+// pin the new contract so a future refactor cannot quietly re-introduce
+// the bug.
+
+func TestPromptWithFileRefs_NoFilesKeepsPrompt(t *testing.T) {
+	// When there are no non-image attachments, the prompt must be
+	// returned unchanged — we do NOT want to inject an empty "Files
+	// saved locally" trailer that would confuse the model.
+	got := promptWithFileRefs("just a plain question", nil)
+	if got != "just a plain question" {
+		t.Errorf("prompt mutated: got %q", got)
+	}
+	got = promptWithFileRefs("another", []string{})
+	if got != "another" {
+		t.Errorf("empty slice still mutated prompt: got %q", got)
+	}
+}
+
+func TestPromptWithFileRefs_AppendsPlainPathRefs(t *testing.T) {
+	// File paths must appear as plain text references, NOT prefixed
+	// with '@' (which is the pi mechanism that would re-trigger the
+	// #1767 inlining). Mirrors the wording claudecode uses so users
+	// see consistent phrasing across runtimes.
+	paths := []string{"/tmp/a.pdf", "/tmp/b.docx"}
+	got := promptWithFileRefs("please review", paths)
+
+	if !strings.HasPrefix(got, "please review") {
+		t.Errorf("original prompt text lost: %q", got)
+	}
+	for _, p := range paths {
+		if !strings.Contains(got, p) {
+			t.Errorf("path %q missing from prompt: %q", p, got)
+		}
+		if strings.Contains(got, "@"+p) {
+			t.Errorf("path %q must NOT be @-prefixed (would re-trigger Issue #1767): %q", p, got)
+		}
+	}
+}
+
+func TestPromptWithFileRefs_PreservesOrder(t *testing.T) {
+	// Order matters: multi-file reviews rely on the agent seeing
+	// attachments in the same order as the sender uploaded them.
+	paths := []string{"/tmp/first.pdf", "/tmp/second.pdf", "/tmp/third.pdf"}
+	got := promptWithFileRefs("p", paths)
+
+	prev := -1
+	for _, p := range paths {
+		idx := strings.Index(got, p)
+		if idx == -1 {
+			t.Fatalf("missing %s in prompt %q", p, got)
+		}
+		if idx <= prev {
+			t.Errorf("paths not in order: %s came after previous", p)
+		}
+		prev = idx
+	}
+}
+
+func TestPromptWithFileRefs_DoesNotInlineFileBytes(t *testing.T) {
+	// Core regression guard for #1767: a recognizable byte sequence
+	// saved to disk must never be inlined into the prompt.
+	marker := []byte("SECRET-INLINE-MARKER-1767")
+	tmp := t.TempDir()
+	docPath := tmp + "/report.pdf"
+	if err := os.WriteFile(docPath, marker, 0o644); err != nil {
+		t.Fatalf("seed attachment: %v", err)
+	}
+
+	got := promptWithFileRefs("review this", []string{docPath})
+	if strings.Contains(got, string(marker)) {
+		t.Errorf("file bytes inlined into prompt — #1767 regression: %q", got)
+	}
+	// The path itself may legitimately appear (as a plain reference);
+	// the marker check above is the real assertion.
+	if !strings.Contains(got, docPath) {
+		t.Errorf("path reference missing from prompt: %q", got)
+	}
+}
+
+func TestPromptWithFileRefs_LargeNonImageFileDoesNotInline(t *testing.T) {
+	// Spec-grade regression: a >1MB non-image attachment must NOT
+	// have its contents inlined into the prompt. The 1MB threshold
+	// matches the size mentioned in the upstream #1767 bug report
+	// that triggered model 400s. We seed a 1.5MB file with a
+	// recognizable marker scattered through it and assert the marker
+	// never appears in the prompt the model receives.
+	const size = 1_500_000
+	marker := []byte("ISSUE-1767-MUST-NOT-APPEAR-IN-PROMPT-ABCDEF")
+
+	tmp := t.TempDir()
+	docPath := tmp + "/big-log.txt"
+	f, err := os.Create(docPath)
+	if err != nil {
+		t.Fatalf("create big file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Fill with repeating marker so the byte sequence is dense and
+	// any inlining (even partial) is caught.
+	buf := make([]byte, 0, size+len(marker)*4)
+	for len(buf) < size {
+		buf = append(buf, marker...)
+		buf = append(buf, bytes.Repeat([]byte{'x'}, 4096)...)
+	}
+	buf = buf[:size]
+	if _, err := f.Write(buf); err != nil {
+		t.Fatalf("write big file: %v", err)
+	}
+
+	// Confirm we wrote >1MB and that the marker is actually present
+	// on disk (so a false-negative test can't pass trivially).
+	info, err := os.Stat(docPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() <= 1_000_000 {
+		t.Fatalf("seed file too small: %d", info.Size())
+	}
+	written, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Contains(written, marker) {
+		t.Fatalf("marker missing from seed file — test is meaningless")
+	}
+
+	// The fix: promptWithFileRefs must contain the path as plain text
+	// reference, but the marker bytes from inside the file must NOT
+	// appear anywhere in the returned prompt.
+	got := promptWithFileRefs("see attached", []string{docPath})
+
+	if strings.Contains(got, string(marker)) {
+		t.Fatalf("file bytes (marker) leaked into prompt for >1MB attachment — #1767 regression: %q (len=%d)", got, len(got))
+	}
+	if !strings.Contains(got, docPath) {
+		t.Errorf("path reference missing from prompt trailer: %q", got)
+	}
+}
+
+// ── Image vs file separation (Issue #1767) ───────────────────
+//
+// These tests pin the contract that Send() splits image attachments
+// from non-image attachments and hands only the image paths to
+// buildJSONArgs / composeRPCPrompt as @<path> argv entries. They use
+// the helpers directly (buildJSONArgs + composeRPCPrompt + a fake
+// caller's separation logic) because Send() itself spawns a pi
+// subprocess and is tested via the helpers.
+
+func TestBuildJSONArgs_OnlyImageAtFilesBecomeAtPath(t *testing.T) {
+	// Doc-level invariant: after the #1767 split, the @-args emitted
+	// by buildJSONArgs must contain ONLY image paths. Non-image file
+	// paths must travel through promptWithFileRefs instead, never as
+	// argv entries. The test mirrors what Send() now passes to
+	// buildJSONArgs.
+	imagePaths := []string{
+		"/tmp/cc-connect/attach/img1.png",
+		"/tmp/cc-connect/attach/img2.jpg",
+	}
+	promptWithTrailer := promptWithFileRefs("describe", []string{
+		"/tmp/cc-connect/attach/log.txt",
+		"/tmp/cc-connect/attach/report.pdf",
+	})
+	args := buildJSONArgs(nil, promptWithTrailer, "", "", "", imagePaths)
+
+	// Every image path must appear as @<path>; no non-image path may.
+	var got []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "@") {
+			got = append(got, a)
+		}
+	}
+	want := []string{"@" + imagePaths[0], "@" + imagePaths[1]}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d @-args (images only), got %d: %v", len(want), len(got), args)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("@-arg[%d]: got %q, want %q", i, got[i], w)
+		}
+	}
+	for _, f := range []string{"/tmp/cc-connect/attach/log.txt", "/tmp/cc-connect/attach/report.pdf"} {
+		// The non-image path may appear once in the prompt trailer
+		// (plain text reference), but never as a @<path> argv entry.
+		count := 0
+		for _, a := range args {
+			if a == "@"+f {
+				count++
+			}
+		}
+		if count != 0 {
+			t.Errorf("non-image path %q leaked into @-argv %d times", f, count)
+		}
+	}
+}
+
+func TestComposeRPCPrompt_OnlyImagesBecomeAtPathRefs(t *testing.T) {
+	// RPC-mode twin of TestBuildJSONArgs_OnlyImageAtFilesBecomeAtPath.
+	imagePaths := []string{"/tmp/img1.png"}
+	nonImagePaths := []string{"/tmp/notes.txt"}
+	got := composeRPCPrompt(promptWithFileRefs("look", nonImagePaths), imagePaths)
+
+	if !strings.Contains(got, "@"+imagePaths[0]) {
+		t.Errorf("image @<path> ref missing: %q", got)
+	}
+	if strings.Contains(got, "@"+nonImagePaths[0]) {
+		t.Errorf("non-image path must NOT be @-prefixed in RPC prompt: %q", got)
+	}
+	// Non-image path appears as plain text reference.
+	if !strings.Contains(got, nonImagePaths[0]) {
+		t.Errorf("non-image path reference missing from prompt: %q", got)
+	}
+}
+
+// ── saveFilesToDisk + ImageAtFiles invariants (Issue #1767) ────
+
+func TestSaveFilesToDisk_LargeFileRoundTrip(t *testing.T) {
+	// Doc-level invariant: saveFilesToDisk must handle >1MB non-image
+	// attachments without truncation (the file path is what we hand to
+	// the model, so the file on disk must be the FULL payload the
+	// platform sent us).
+	const size = 1_200_000
+	marker := []byte("LARGE-FILE-MARKER-XYZZY")
+	payload := make([]byte, size)
+	for i := 0; i < size; i++ {
+		payload[i] = byte('a' + (i % 26))
+	}
+	copy(payload[size-len(marker):], marker)
+
+	tmp := t.TempDir()
+	paths := saveFilesToDisk(tmp, []core.FileAttachment{
+		{MimeType: "text/plain", FileName: "big.txt", Data: payload},
+	})
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 saved path, got %d", len(paths))
+	}
+	written, err := os.ReadFile(paths[0])
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if len(written) != size {
+		t.Errorf("saved file truncated: wrote %d, read %d", size, len(written))
+	}
+	if !bytes.Contains(written, marker) {
+		t.Errorf("marker missing from saved file — round-trip failed")
+	}
+}
+
+func TestSaveImagesToDisk_DoesNotConsumeFileSlots(t *testing.T) {
+	// Defensive guard: after the #1767 split, saveImagesToDisk is the
+	// only producer of @<path> argv entries. A future refactor that
+	// accidentally feeds FileAttachment bytes through saveImagesToDisk
+	// (or vice versa) must be caught: image paths must end in image
+	// extensions and not look like arbitrary docs.
+	paths := saveImagesToDisk(t.TempDir(), []core.ImageAttachment{
+		{MimeType: "image/png", FileName: "shot.png", Data: []byte("\x89PNG\r\n\x1a\nfakepng")},
+	})
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 image path, got %d", len(paths))
+	}
+	if !strings.HasSuffix(paths[0], ".png") {
+		t.Errorf("image path missing .png suffix: %q", paths[0])
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1767: pi's `processFileArguments` inlines the full UTF-8 contents of every `@<path>` attachment into the prompt the model sees. For a >~1MB non-image attachment this triggers a 400 from the model provider. The `agent/pi` adapter was passing both images AND non-image files through the same single `atFiles` slice, so every non-image file hit the inliner.

Mirrors the `claudecode` behaviour:

- **Images** continue to use pi's `@<path>` argv / message-text mechanism. `pi`'s `processImage` handles them correctly and the bytes never enter our prompt text.
- **Non-image files** are saved to disk (unchanged) but referenced by **plain path** in a trailer appended to the prompt: `(Files saved locally, please read them: <paths>)`. Pi's own file-reading tools then load only the bytes the model actually needs.

The `agent/pi.Send()` pipeline now separates the two streams:

```
imageAtFiles  → buildJSONArgs / composeRPCPrompt → @<path> argv or message-text refs (Issue #1723 path)
filePaths     → promptWithFileRefs(prompt, filePaths) → plain trailer appended to prompt (Issue #1767 path)
```

Both `sendJSON` and `sendRPC` route through the new `promptWithFileRefs` helper so the trailer wording stays identical across modes.

## Root cause (Issue #1767)

Before this PR the `atFiles` slice in `Send()` aggregated both `saveImagesToDisk(...)` and `saveFilesToDisk(...)` into one bucket:

```go
var atFiles []string
if len(images) > 0 {
    atFiles = append(atFiles, saveImagesToDisk(attachDir, images)...)
}
if len(files) > 0 {
    atFiles = append(atFiles, saveFilesToDisk(attachDir, files)...)
}
```

Both `sendJSON` (via `buildJSONArgs`) and `sendRPC` (via `composeRPCPrompt`) then treated every entry as a `@<path>` reference. For images this is correct; for non-image files pi's `processFileArguments` reads the file contents and inlines them as UTF-8 text into the prompt.

## Changes

- `agent/pi/session.go`
  - `Send()`: split the single `atFiles` slice into `imageAtFiles` (only images) and `filePaths` (only non-image files). Comments now document the two distinct mechanisms.
  - `sendJSON(prompt, imageAtFiles, filePaths)`: pass `imageAtFiles` to `buildJSONArgs` and prepend the trailer produced by `promptWithFileRefs(prompt, filePaths)` to the prompt before it goes into `-p`. The trailer wording mirrors the `claudecode` agent so users see consistent phrasing across runtimes.
  - `sendRPC(prompt, imageAtFiles, filePaths)`: same pattern via `composeRPCPrompt`.
  - New `promptWithFileRefs(prompt, filePaths) string` helper: returns the original prompt when `filePaths` is empty (no spurious "Files saved locally" trailer), otherwise appends `"\n\n(Files saved locally, please read them: <paths>)"`.

- `agent/pi/session_test.go` (+273 lines)
  - 9 new tests pinning the new contract:
    - `TestPromptWithFileRefs_NoFilesKeepsPrompt` — empty `filePaths` → no trailer (matches the `composeRPCPrompt` invariant on the image side).
    - `TestPromptWithFileRefs_AppendsPlainPathRefs` — paths appear in trailer, **never** `@`-prefixed (would re-trigger #1767).
    - `TestPromptWithFileRefs_PreservesOrder` — multi-file reviews keep upload order.
    - `TestPromptWithFileRefs_DoesNotInlineFileBytes` — recognisable marker bytes written to disk must NOT appear in the returned prompt.
    - `TestPromptWithFileRefs_LargeNonImageFileDoesNotInline` — **spec-grade regression**: 1.5MB file with a recognisable marker scattered through it; assert the marker never appears in the prompt and the path is referenced as plain text.
    - `TestBuildJSONArgs_OnlyImageAtFilesBecomeAtPath` — JSON-mode invariant: `@`-args contain only image paths, never non-image paths.
    - `TestComposeRPCPrompt_OnlyImagesBecomeAtPathRefs` — RPC-mode twin.
    - `TestSaveFilesToDisk_LargeFileRoundTrip` — `saveFilesToDisk` must round-trip a 1.2MB file without truncation.
    - `TestSaveImagesToDisk_DoesNotConsumeFileSlots` — defensive guard against future refactors that mix the two producers.

## Tests

```
go test ./agent/pi/ -count=1
go test -race ./agent/pi/ -count=1
golangci-lint run ./agent/pi/...
```

All existing `agent/pi` tests still pass (the only `errcheck` items lint reports on the touched files are the pre-existing ones in `pi.go` / `pi_test.go`, untouched by this PR). 9 new tests added.

## Risk / compatibility

- Behaviour change: image attachments still work exactly as before (Issue #1723 path). Non-image attachments now arrive at the model as path references rather than inlined bytes — the model will need to call its file-reading tool to load them, which is the same behaviour as the `claudecode` agent. This is the intended fix.
- File bytes still land on disk exactly as the platform sent them (`saveFilesToDisk` unchanged); the only change is how those bytes reach the model.
- No public API changes; `Send()` signature is unchanged.

## Related

- Issue #1767
- Issue #1723 (predecessor: pass attachments as `@<path>` argv instead of inlining bytes — preserved for images)