### PR TITLE
fix(copilot): send enableConfigDiscovery so skills load (#1769)

### DIFF
--- a/agent/copilot/session.go
+++ b/agent/copilot/session.go
@@ -73,6 +73,12 @@ type copilotSessionConfig struct {
 	Streaming                      *bool                      `json:"streaming,omitempty"`
 	IncludeSubAgentStreamingEvents *bool                      `json:"includeSubAgentStreamingEvents,omitempty"`
 	EnvValueMode                   string                     `json:"envValueMode,omitempty"`
+	// EnableConfigDiscovery must be sent explicitly: Copilot CLI's
+	// session.create/session.resume path defaults it to false, and derives
+	// enableSkills from it. Omitting it disables every environment-discovered
+	// skill source (.github/skills, .agents/skills, .claude/skills,
+	// ~/.copilot/skills, ~/.agents/skills), leaving only builtin skills.
+	EnableConfigDiscovery *bool `json:"enableConfigDiscovery,omitempty"`
 }
 
 type copilotPermissionResult struct {
@@ -214,6 +220,7 @@ func (cs *copilotSession) sessionConfig(sessionID string) copilotSessionConfig {
 	requestPermission := true
 	streaming := true
 	includeSubAgentStreaming := true
+	enableConfigDiscovery := true
 	return copilotSessionConfig{
 		SessionID:                      sessionID,
 		ClientName:                     "cc-connect",
@@ -224,6 +231,7 @@ func (cs *copilotSession) sessionConfig(sessionID string) copilotSessionConfig {
 		Streaming:                      &streaming,
 		IncludeSubAgentStreamingEvents: &includeSubAgentStreaming,
 		EnvValueMode:                   "direct",
+		EnableConfigDiscovery:          &enableConfigDiscovery,
 	}
 }
 

--- a/agent/copilot/session_test.go
+++ b/agent/copilot/session_test.go
@@ -419,6 +419,51 @@ func TestSessionConfig_MatchesCopilotCreateResumeShape(t *testing.T) {
 	}
 }
 
+// TestSessionConfig_SendsEnableConfigDiscoveryForSkills is a regression test
+// for skills under ~/.agents/skills (and every other discovered source) never
+// loading in cc-connect sessions.
+//
+// Copilot CLI's session.create/session.resume config builder defaults
+// enableConfigDiscovery to false and derives enableSkills from it
+// (`enableSkills: t.enableSkills ?? t.enableConfigDiscovery`). Note the
+// asymmetry that made this easy to miss: the lower-level skill discovery
+// helpers default the same flag to true, so interactive `copilot` and
+// `copilot -p` load skills fine — only the programmatic session.create path
+// defaults it off. Omitting the field therefore left cc-connect sessions with
+// builtin skills only, while `copilot skill list` in the same directory
+// listed all of them.
+func TestSessionConfig_SendsEnableConfigDiscoveryForSkills(t *testing.T) {
+	cs := &copilotSession{model: "gpt-5.2", workDir: "/work/project"}
+	cfg := cs.sessionConfig("sess-1")
+
+	if cfg.EnableConfigDiscovery == nil {
+		t.Fatal("EnableConfigDiscovery = nil (field omitted from session.create); " +
+			"Copilot CLI then defaults it to false and disables all skill discovery")
+	}
+	if !*cfg.EnableConfigDiscovery {
+		t.Fatalf("EnableConfigDiscovery = %v, want true", *cfg.EnableConfigDiscovery)
+	}
+
+	// The wire payload must actually carry the flag — `omitempty` on a *bool
+	// only elides a nil pointer, but assert it to pin the serialized shape
+	// Copilot CLI reads.
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal session config: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal session config: %v", err)
+	}
+	got, ok := wire["enableConfigDiscovery"]
+	if !ok {
+		t.Fatalf("session.create payload has no enableConfigDiscovery key: %s", raw)
+	}
+	if got != true {
+		t.Fatalf("enableConfigDiscovery = %v, want true, payload: %s", got, raw)
+	}
+}
+
 func TestRespondPermission_RPCUsesCopilotResultShape(t *testing.T) {
 	var buf bytes.Buffer
 	cs := &copilotSession{


### PR DESCRIPTION
## Summary

With `type = "copilot"`, every environment-discovered skill is silently dropped — the agent sees only the 2 builtin skills, while `copilot skill list` in the same directory lists all of them. `copilotSessionConfig` had no field for `enableConfigDiscovery`, so `session.create` / `session.resume` never sent it, and Copilot CLI defaults it to `false` on that path while deriving `enableSkills` from it. This adds the field and sets it to `true`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Root cause

Copilot CLI 1.0.81's session-config builder:

```js
enableConfigDiscovery: t.enableConfigDiscovery ?? !1,
enableSkills: t.enableSkills ?? t.enableConfigDiscovery,
```

The asymmetry that made this easy to miss: Copilot's lower-level discovery helpers default the same flag to `?? !0` (**true**), so interactive `copilot` and `copilot -p` load skills normally. Only the programmatic `session.create` path defaults it off, so any client omitting the field gets skill discovery silently disabled. Affects `.github/skills`, `.agents/skills`, `.claude/skills`, `~/.copilot/skills`, `~/.agents/skills`.

Since `sessionConfig()` backs both create and resume, one change covers resumed sessions too.

Alternatives that do **not** work, for the record: `enableSkills: true` alone (derived from this flag), `trustWorkingDirectory: "session"`, `--add-dir` (only covers `.github/skills`), `COPILOT_SKILLS_DIRS` (read inside the gated path). `cmd`/extra-args can't help either — it's a JSON-RPC param with no CLI-flag equivalent.

## Testing

Verified against Copilot CLI 1.0.81 — two `--headless --stdio` sessions differing **only** by this param, skill count parsed from Copilot's own `<available_skills>` prompt block in `~/.copilot/logs/process-*.log`:

| `session.create` params | skills injected |
|---|---|
| `{clientName, workingDirectory, model}` — pre-fix | **2** (both `builtin`) |
| same + `"enableConfigDiscovery": true` | **35** (33 `project` + 2 `builtin`) |

Reproduced twice in independent process pairs, attributed by matching each log's own `session.create` blob rather than by mtime.

### Automated tests added in this PR

- `TestSessionConfig_SendsEnableConfigDiscoveryForSkills` in `agent/copilot/session_test.go` — asserts `sessionConfig()` sets `EnableConfigDiscovery` to `true`, and that the marshaled `session.create` payload actually carries `"enableConfigDiscovery": true` (`omitempty` on a `*bool` only elides a nil pointer, so the wire shape is pinned explicitly).

### For bug fixes only — regression test

- Regression test name: `TestSessionConfig_SendsEnableConfigDiscoveryForSkills`
- Manual verification this test catches the regression:
  - [x] Reverted the fix locally; the regression test failed as expected.

Verified it fails for the right reason rather than on a compile error — with the struct field kept but the assignment removed (the true pre-fix behavior), it fails on the assertion:

```
--- FAIL: TestSessionConfig_SendsEnableConfigDiscoveryForSkills
    session_test.go:440: EnableConfigDiscovery = nil (field omitted from session.create);
    Copilot CLI then defaults it to false and disables all skill discovery
```

### Critical User Journeys (CUJ) impact

- [x] No CUJ touched (change is confined to `agent/copilot`; no files under `core/` are modified)

Ran it anyway for safety: `go test ./core/ -run TestCUJ` → `ok ... 4.917s`.

## Manual / user-visible behavior change

Skills placed in any Copilot-discovered directory now actually load in cc-connect sessions. In my setup the agent went from 2 skills to 35.

Note this fixes Copilot's *own runtime* skill loading. The `copilot` adapter separately doesn't implement cc-connect's `SkillProvider` (`SkillDirs()`), so the `/skills` command surface still won't list them — a distinct gap, not addressed here.

## Checklist (reviewer will verify)

- [x] `go build ./...` passes — clean with `-tags no_web`. Untagged, it fails on `web/embed.go:13:12: pattern all:dist: no matching files found`, which is the gitignored generated frontend `dist/` missing from a fresh clone; reproduced identically on unmodified `origin/main`.
- [x] `go test ./...` passes — `./agent/copilot/` green. Two pre-existing failures unrelated to this change, both reproduced on unmodified `origin/main`:
  - `cmd/cc-connect` and `web`: the same missing `dist/` above.
  - Flaky tests in `core` under full-suite parallel load — a *different* test failed on each run (`TestCUJ_G3_PlatformReconnectReinitializesAndDelivers`, then `TestCUJ_G5_ToolFailureSurfacesToUser` + `TestCmdCronExec_TriggersJob`), mostly `TempDir RemoveAll cleanup: directory not empty`. All pass in isolation, and a clean `go test ./core/` on unmodified `origin/main` fails the same way. `core` does not import `agent/copilot` (`go list -deps ./core/` → no match), so this change cannot reach it. CI's `unit-test` job is green, consistent with a local-environment race.
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/` — no `core/` files touched
- [x] i18n strings have all-language translations — no new user-facing strings
- [x] No secrets / credentials in source
- [x] `gofmt` / `go vet` clean on both changed files (`gofmt -l` also flags `agent/copilot/copilot.go` and `copilot_test.go`, but those are pre-existing on `origin/main` and left untouched)

## Related

- Issue: Closes #1769
- Related PR: —
- Related policy discussion: #1244 (ACP-first). Switching to `type = "acp"` with `args = ["--acp", "--stdio"]` also loads all 35 skills and is a reasonable workaround, but it costs the native adapter's optional interfaces — `/model` (`ModelSwitcher`), `/compress` (`CompressCommand`), `GetSessionHistory`, `DeleteSession`, provider switching — which `agent/acp` doesn't implement. So ACP isn't a full substitute for fixing this.

Per your routing note in #1769: the fix follows the three points you listed (add the field mirroring `RequestPermission`/`Streaming`, set it in `cs.sessionConfig()`, regression test asserting the `session.create` params). I left the `skills = false` opt-out out of scope as you suggested. On your "ideally also" fourth item — a fixture-driven test parsing `<available_skills>` out of `~/.copilot/logs/process-*.log` — I did use exactly that as the verification method above, but didn't add it to the suite since it needs a real authenticated Copilot CLI process and reads the user's home directory. Happy to add it behind a build tag or as an opt-in integration test if you'd prefer it committed.
