### PR TITLE
feat(web): support multi-workspace configuration in the management dashboard

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -1174,6 +1174,8 @@ func main() {
 				ReplyFooter:          u.ReplyFooter,
 				InjectSender:         u.InjectSender,
 				PlatformAllowFrom:    u.PlatformAllowFrom,
+				WorkspaceMode:        u.WorkspaceMode,
+				WorkspaceBaseDir:     u.WorkspaceBaseDir,
 			})
 		})
 		mgmtSrv.SetGetProjectConfig(config.GetProjectConfigDetails)

--- a/config/config.go
+++ b/config/config.go
@@ -3375,6 +3375,11 @@ type ProjectSettingsUpdate struct {
 	ReplyFooter          *bool
 	InjectSender         *bool
 	PlatformAllowFrom    map[string]string
+	// WorkspaceMode and WorkspaceBaseDir control the project-level
+	// multi-workspace feature (ProjectConfig.Mode/BaseDir), distinct from
+	// Mode above (which is the agent permission mode, e.g. yolo/plan).
+	WorkspaceMode    *string
+	WorkspaceBaseDir *string
 }
 
 // SaveProjectSettings persists project-level settings and the global language to config.toml.
@@ -3484,6 +3489,22 @@ func SaveProjectSettings(projectName string, update ProjectSettingsUpdate) error
 				proj.Agent.Options["mode"] = mode
 			}
 		}
+		if update.WorkspaceBaseDir != nil {
+			proj.BaseDir = strings.TrimSpace(*update.WorkspaceBaseDir)
+		}
+		if update.WorkspaceMode != nil {
+			mode := strings.TrimSpace(*update.WorkspaceMode)
+			if mode == "single" {
+				mode = ""
+			}
+			if mode != "" && mode != "multi-workspace" {
+				return fmt.Errorf("invalid workspace_mode %q", mode)
+			}
+			if mode == "multi-workspace" && proj.BaseDir == "" {
+				return fmt.Errorf("workspace_base_dir is required to enable multi-workspace mode")
+			}
+			proj.Mode = mode
+		}
 		if update.PlatformAllowFrom != nil {
 			for j := range proj.Platforms {
 				typ := strings.TrimSpace(proj.Platforms[j].Type)
@@ -3549,6 +3570,12 @@ func GetProjectConfigDetails(projectName string) map[string]any {
 		}
 		if p.InjectSender != nil {
 			result["inject_sender"] = *p.InjectSender
+		}
+		if strings.TrimSpace(p.Mode) != "" {
+			result["workspace_mode"] = p.Mode
+		}
+		if strings.TrimSpace(p.BaseDir) != "" {
+			result["workspace_base_dir"] = p.BaseDir
 		}
 		platConfigs := make([]map[string]any, len(p.Platforms))
 		for j, plat := range p.Platforms {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2801,6 +2801,59 @@ func TestSaveProjectSettings_ExtraFields(t *testing.T) {
 	}
 }
 
+func TestSaveProjectSettings_WorkspaceModeAndBaseDir(t *testing.T) {
+	configPath := writeConfigFixture(t, feishuConfigFixture)
+	patchConfigPath(t, configPath)
+
+	wsMode := "multi-workspace"
+	wsBaseDir := "/tmp/workspaces"
+	err := SaveProjectSettings("alpha", ProjectSettingsUpdate{
+		WorkspaceMode:    &wsMode,
+		WorkspaceBaseDir: &wsBaseDir,
+	})
+	if err != nil {
+		t.Fatalf("SaveProjectSettings: %v", err)
+	}
+
+	cfg := readConfigFixture(t, configPath)
+	proj := cfg.Projects[0]
+	if proj.Mode != wsMode {
+		t.Fatalf("Mode = %q, want %q", proj.Mode, wsMode)
+	}
+	if proj.BaseDir != wsBaseDir {
+		t.Fatalf("BaseDir = %q, want %q", proj.BaseDir, wsBaseDir)
+	}
+
+	details := GetProjectConfigDetails("alpha")
+	if details["workspace_mode"] != wsMode {
+		t.Fatalf("workspace_mode = %v, want %q", details["workspace_mode"], wsMode)
+	}
+	if details["workspace_base_dir"] != wsBaseDir {
+		t.Fatalf("workspace_base_dir = %v, want %q", details["workspace_base_dir"], wsBaseDir)
+	}
+
+	// Switching back to single mode clears Mode but leaves BaseDir untouched.
+	single := "single"
+	if err := SaveProjectSettings("alpha", ProjectSettingsUpdate{WorkspaceMode: &single}); err != nil {
+		t.Fatalf("SaveProjectSettings (single): %v", err)
+	}
+	cfg = readConfigFixture(t, configPath)
+	if cfg.Projects[0].Mode != "" {
+		t.Fatalf("Mode = %q, want empty after switching to single", cfg.Projects[0].Mode)
+	}
+}
+
+func TestSaveProjectSettings_WorkspaceModeRequiresBaseDir(t *testing.T) {
+	configPath := writeConfigFixture(t, feishuConfigFixture)
+	patchConfigPath(t, configPath)
+
+	wsMode := "multi-workspace"
+	err := SaveProjectSettings("alpha", ProjectSettingsUpdate{WorkspaceMode: &wsMode})
+	if err == nil {
+		t.Fatal("expected error enabling multi-workspace mode without base_dir, got nil")
+	}
+}
+
 func TestGetProjectConfigDetails(t *testing.T) {
 	configPath := writeConfigFixture(t, feishuConfigFixture)
 	patchConfigPath(t, configPath)

--- a/core/management.go
+++ b/core/management.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,6 +31,8 @@ type ProjectSettingsUpdate struct {
 	ReplyFooter          *bool
 	InjectSender         *bool
 	PlatformAllowFrom    map[string]string
+	WorkspaceMode        *string
+	WorkspaceBaseDir     *string
 }
 
 // ManagementServer provides an HTTP REST API for external management tools
@@ -646,6 +649,8 @@ func (m *ManagementServer) handleProjectRoutes(w http.ResponseWriter, r *http.Re
 		m.handleProjectHeartbeat(w, r, projName, rest)
 	case "users":
 		m.handleProjectUsers(w, r, engine)
+	case "workspaces":
+		m.handleProjectWorkspaces(w, r, projName, engine, rest)
 	default:
 		mgmtError(w, http.StatusNotFound, "not found")
 	}
@@ -750,6 +755,8 @@ func (m *ManagementServer) handleProjectDetail(w http.ResponseWriter, r *http.Re
 			ReplyFooter          *bool             `json:"reply_footer"`
 			InjectSender         *bool             `json:"inject_sender"`
 			PlatformAllowFrom    map[string]string `json:"platform_allow_from"`
+			WorkspaceMode        *string           `json:"workspace_mode"`
+			WorkspaceBaseDir     *string           `json:"workspace_base_dir"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			mgmtError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -762,6 +769,37 @@ func (m *ManagementServer) handleProjectDetail(w http.ResponseWriter, r *http.Re
 				return
 			}
 			*body.WorkDir = workDir
+		}
+		if body.WorkspaceBaseDir != nil {
+			baseDir, err := validateProjectWorkDir(*body.WorkspaceBaseDir)
+			if err != nil {
+				mgmtError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			*body.WorkspaceBaseDir = baseDir
+		}
+		if body.WorkspaceMode != nil {
+			wm := strings.TrimSpace(*body.WorkspaceMode)
+			if wm != "" && wm != "single" && wm != "multi-workspace" {
+				mgmtError(w, http.StatusBadRequest, fmt.Sprintf("invalid workspace_mode %q", wm))
+				return
+			}
+			if wm == "multi-workspace" {
+				effectiveBaseDir := ""
+				if body.WorkspaceBaseDir != nil {
+					effectiveBaseDir = *body.WorkspaceBaseDir
+				} else if m.getProjectConfig != nil {
+					if extra := m.getProjectConfig(name); extra != nil {
+						if bd, ok := extra["workspace_base_dir"].(string); ok {
+							effectiveBaseDir = bd
+						}
+					}
+				}
+				if strings.TrimSpace(effectiveBaseDir) == "" {
+					mgmtError(w, http.StatusBadRequest, "workspace_base_dir is required to enable multi-workspace mode")
+					return
+				}
+			}
 		}
 
 		if body.Language != nil {
@@ -823,6 +861,9 @@ func (m *ManagementServer) handleProjectDetail(w http.ResponseWriter, r *http.Re
 			}
 			restartRequired = true
 		}
+		if body.WorkspaceMode != nil || body.WorkspaceBaseDir != nil {
+			restartRequired = true
+		}
 
 		if m.saveProjectSettings != nil {
 			patch := ProjectSettingsUpdate{
@@ -837,6 +878,8 @@ func (m *ManagementServer) handleProjectDetail(w http.ResponseWriter, r *http.Re
 				ReplyFooter:          body.ReplyFooter,
 				InjectSender:         body.InjectSender,
 				PlatformAllowFrom:    body.PlatformAllowFrom,
+				WorkspaceMode:        body.WorkspaceMode,
+				WorkspaceBaseDir:     body.WorkspaceBaseDir,
 			}
 			if err := m.saveProjectSettings(name, patch); err != nil {
 				slog.Warn("management: failed to persist project settings", "project", name, "error", err)
@@ -937,6 +980,139 @@ func (m *ManagementServer) handleProjectUsers(w http.ResponseWriter, r *http.Req
 	default:
 		mgmtError(w, http.StatusMethodNotAllowed, "GET or PATCH only")
 	}
+}
+
+// ── Workspace endpoints ───────────────────────────────────────
+
+// handleProjectWorkspaces manages channel↔workspace bindings for a project
+// running in multi-workspace mode (see Engine.SetMultiWorkspace).
+func (m *ManagementServer) handleProjectWorkspaces(w http.ResponseWriter, r *http.Request, projName string, e *Engine, rest string) {
+	if !e.multiWorkspace || e.workspaceBindings == nil {
+		mgmtError(w, http.StatusBadRequest, fmt.Sprintf("project %q is not in multi-workspace mode", projName))
+		return
+	}
+	projectKey := "project:" + projName
+
+	if rest != "" {
+		if r.Method != http.MethodDelete {
+			mgmtError(w, http.StatusMethodNotAllowed, "DELETE only")
+			return
+		}
+		e.workspaceBindings.Unbind(projectKey, rest)
+		mgmtOK(w, "workspace binding removed")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		bindings := e.workspaceBindings.ListByProject(projectKey)
+		bound := make(map[string]bool, len(bindings))
+		list := make([]map[string]any, 0, len(bindings))
+		for channelKey, b := range bindings {
+			entry := map[string]any{
+				"channel_key":  channelKey,
+				"channel_name": b.ChannelName,
+				"workspace":    b.Workspace,
+				"bound_at":     b.BoundAt.Time,
+			}
+			if ws := e.workspacePool.Get(b.Workspace); ws != nil {
+				entry["active"] = ws.HasActiveTurn()
+				entry["last_activity"] = ws.LastActivity()
+			}
+			list = append(list, entry)
+			bound[normalizeWorkspacePath(b.Workspace)] = true
+		}
+
+		var suggestions []string
+		if e.baseDir != "" {
+			if entries, err := os.ReadDir(e.baseDir); err == nil {
+				for _, ent := range entries {
+					if !ent.IsDir() {
+						continue
+					}
+					candidate := filepath.Join(e.baseDir, ent.Name())
+					if bound[normalizeWorkspacePath(candidate)] {
+						continue
+					}
+					suggestions = append(suggestions, candidate)
+				}
+			}
+		}
+
+		mgmtJSON(w, http.StatusOK, map[string]any{
+			"base_dir":    e.baseDir,
+			"bindings":    list,
+			"suggestions": suggestions,
+		})
+
+	case http.MethodPost:
+		var body struct {
+			ChannelKey  string `json:"channel_key"`
+			ChannelName string `json:"channel_name"`
+			Workspace   string `json:"workspace"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			mgmtError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		channelKey := strings.TrimSpace(body.ChannelKey)
+		if channelKey == "" {
+			mgmtError(w, http.StatusBadRequest, "channel_key is required")
+			return
+		}
+		workspace, err := validateWorkspacePath(e.baseDir, body.Workspace)
+		if err != nil {
+			mgmtError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		channelName := strings.TrimSpace(body.ChannelName)
+		if channelName == "" {
+			channelName = channelKey
+		}
+		e.workspaceBindings.Bind(projectKey, channelKey, channelName, workspace)
+		mgmtJSON(w, http.StatusCreated, map[string]any{"message": "workspace bound", "workspace": workspace})
+
+	default:
+		mgmtError(w, http.StatusMethodNotAllowed, "GET or POST only")
+	}
+}
+
+// validateWorkspacePath ensures a workspace path is an existing directory
+// located under baseDir, rejecting traversal outside it.
+func validateWorkspacePath(baseDir, target string) (string, error) {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "" {
+		return "", fmt.Errorf("workspace path is required")
+	}
+	if baseDir == "" {
+		return "", fmt.Errorf("project has no base_dir configured")
+	}
+	if !filepath.IsAbs(trimmed) {
+		trimmed = filepath.Join(baseDir, trimmed)
+	}
+	cleaned := filepath.Clean(trimmed)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("workspace does not exist: %s", cleaned)
+		}
+		return "", fmt.Errorf("workspace is not accessible: %s: %w", cleaned, err)
+	}
+	cleanBase := filepath.Clean(baseDir)
+	if evalBase, err := filepath.EvalSymlinks(cleanBase); err == nil {
+		cleanBase = evalBase
+	}
+	if resolved != cleanBase && !strings.HasPrefix(resolved, cleanBase+string(filepath.Separator)) {
+		return "", fmt.Errorf("workspace path escapes base_dir")
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("workspace is not accessible: %s: %w", resolved, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("workspace is not a directory: %s", resolved)
+	}
+	return resolved, nil
 }
 
 // ── Session endpoints ─────────────────────────────────────────

--- a/core/management_test.go
+++ b/core/management_test.go
@@ -3010,3 +3010,104 @@ func TestMgmt_SetupWeixinPoll_RejectsMalformedAPIURL(t *testing.T) {
 		}
 	}
 }
+
+func TestMgmt_ProjectWorkspaces_NotMultiWorkspace(t *testing.T) {
+	_, ts, _ := testManagementServer(t, "tok")
+
+	r := mgmtGet(t, ts.URL+"/api/v1/projects/test-project/workspaces", "tok")
+	if r.OK {
+		t.Fatal("expected error for project not in multi-workspace mode")
+	}
+	if !strings.Contains(r.Error, "not in multi-workspace mode") {
+		t.Fatalf("error = %q, want not in multi-workspace mode", r.Error)
+	}
+}
+
+func TestMgmt_ProjectWorkspaces_ListBindUnbind(t *testing.T) {
+	_, ts, e := testManagementServer(t, "tok")
+
+	baseDir := t.TempDir()
+	sub := filepath.Join(baseDir, "repo-a")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+
+	// Initially empty, with the unbound subdirectory suggested.
+	r := mgmtGet(t, ts.URL+"/api/v1/projects/test-project/workspaces", "tok")
+	if !r.OK {
+		t.Fatalf("list workspaces: %s", r.Error)
+	}
+	var listed struct {
+		Bindings    []map[string]any `json:"bindings"`
+		Suggestions []string         `json:"suggestions"`
+	}
+	if err := json.Unmarshal(r.Data, &listed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(listed.Bindings) != 0 {
+		t.Fatalf("bindings = %#v, want empty", listed.Bindings)
+	}
+	if len(listed.Suggestions) != 1 || !strings.HasSuffix(listed.Suggestions[0], "repo-a") {
+		t.Fatalf("suggestions = %#v, want [.../repo-a]", listed.Suggestions)
+	}
+
+	// Bind the suggested directory to a channel.
+	r = mgmtPost(t, ts.URL+"/api/v1/projects/test-project/workspaces", "tok", map[string]string{
+		"channel_key":  "slack:C123",
+		"channel_name": "repo-a-channel",
+		"workspace":    sub,
+	})
+	if !r.OK {
+		t.Fatalf("bind workspace: %s", r.Error)
+	}
+
+	r = mgmtGet(t, ts.URL+"/api/v1/projects/test-project/workspaces", "tok")
+	if !r.OK {
+		t.Fatalf("list workspaces after bind: %s", r.Error)
+	}
+	if err := json.Unmarshal(r.Data, &listed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(listed.Bindings) != 1 {
+		t.Fatalf("bindings = %#v, want 1 entry", listed.Bindings)
+	}
+	if listed.Bindings[0]["channel_key"] != "slack:C123" {
+		t.Fatalf("channel_key = %v, want slack:C123", listed.Bindings[0]["channel_key"])
+	}
+	if len(listed.Suggestions) != 0 {
+		t.Fatalf("suggestions = %#v, want empty once bound", listed.Suggestions)
+	}
+
+	// Unbind and confirm it's gone.
+	r = mgmtDelete(t, ts.URL+"/api/v1/projects/test-project/workspaces/slack:C123", "tok")
+	if !r.OK {
+		t.Fatalf("unbind workspace: %s", r.Error)
+	}
+	r = mgmtGet(t, ts.URL+"/api/v1/projects/test-project/workspaces", "tok")
+	if err := json.Unmarshal(r.Data, &listed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(listed.Bindings) != 0 {
+		t.Fatalf("bindings after unbind = %#v, want empty", listed.Bindings)
+	}
+}
+
+func TestMgmt_ProjectWorkspaces_BindRejectsPathOutsideBaseDir(t *testing.T) {
+	_, ts, e := testManagementServer(t, "tok")
+
+	baseDir := t.TempDir()
+	outside := t.TempDir()
+	e.SetMultiWorkspace(baseDir, filepath.Join(t.TempDir(), "bindings.json"))
+
+	r := mgmtPost(t, ts.URL+"/api/v1/projects/test-project/workspaces", "tok", map[string]string{
+		"channel_key": "slack:C999",
+		"workspace":   outside,
+	})
+	if r.OK {
+		t.Fatal("expected error binding a workspace outside base_dir")
+	}
+	if !strings.Contains(r.Error, "escapes base_dir") {
+		t.Fatalf("error = %q, want escapes base_dir", r.Error)
+	}
+}

--- a/web/src/api/projects.ts
+++ b/web/src/api/projects.ts
@@ -27,6 +27,8 @@ export interface ProjectDetail {
   platforms: { type: string; connected: boolean }[];
   sessions_count: number;
   active_session_keys: string[];
+  workspace_mode?: string;
+  workspace_base_dir?: string;
   heartbeat: {
     enabled: boolean;
     paused: boolean;
@@ -52,6 +54,17 @@ export interface ProjectSettingsUpdate {
   reply_footer?: boolean;
   inject_sender?: boolean;
   platform_allow_from?: Record<string, string>;
+  workspace_mode?: string;
+  workspace_base_dir?: string;
+}
+
+export interface WorkspaceBinding {
+  channel_key: string;
+  channel_name: string;
+  workspace: string;
+  bound_at: string;
+  active?: boolean;
+  last_activity?: string;
 }
 
 export const listAgentTypes = () => api.get<{ agents: string[]; platforms: string[] }>('/agents');
@@ -66,3 +79,12 @@ export const addPlatformToProject = (projectName: string, body: {
 
 export const deleteProject = (name: string) =>
   api.delete<{ message: string; restart_required: boolean }>(`/projects/${name}`);
+
+export const listWorkspaces = (name: string) =>
+  api.get<{ base_dir: string; bindings: WorkspaceBinding[]; suggestions?: string[] }>(`/projects/${name}/workspaces`);
+
+export const bindWorkspace = (name: string, body: { channel_key: string; channel_name?: string; workspace: string }) =>
+  api.post<{ message: string; workspace: string }>(`/projects/${name}/workspaces`, body);
+
+export const unbindWorkspace = (name: string, channelKey: string) =>
+  api.delete(`/projects/${name}/workspaces/${encodeURIComponent(channelKey)}`);

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -56,8 +56,26 @@
       "overview": "Overview",
       "providers": "Providers",
       "heartbeat": "Heartbeat",
-      "settings": "Settings"
-    }
+      "settings": "Settings",
+      "workspaces": "Workspaces"
+    },
+    "workspaceMode": "Multi-workspace mode",
+    "workspaceModeHint": "Route different chat channels to different working directories under a shared base directory.",
+    "workspaceModeEnable": "Enable multi-workspace mode",
+    "workspaceModeWarning": "Switching modes requires a restart. The single work_dir is not used while multi-workspace mode is on.",
+    "workspaceBaseDir": "Base directory",
+    "workspaceBaseDirRequired": "Base directory is required to enable multi-workspace mode.",
+    "workspaceModeConfirm": "Changing workspace mode requires a service restart. Continue?",
+    "workspaceBindings": "Channel bindings",
+    "workspaceNoBindings": "No channels are bound to a workspace yet.",
+    "workspaceActive": "active",
+    "workspaceIdle": "idle",
+    "workspaceAddBinding": "Bind a channel",
+    "workspaceChannelKey": "Channel key",
+    "workspaceChannelName": "Channel name (optional)",
+    "workspacePath": "Workspace path",
+    "workspaceSuggestions": "Unbound directories in base_dir:",
+    "workspaceBind": "Bind"
   },
   "sessions": {
     "title": "Sessions",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -56,8 +56,26 @@
       "overview": "Resumen",
       "providers": "Proveedores",
       "heartbeat": "Latido",
-      "settings": "Ajustes"
-    }
+      "settings": "Ajustes",
+      "workspaces": "Espacios de trabajo"
+    },
+    "workspaceMode": "Modo multi-espacio",
+    "workspaceModeHint": "Enrutar diferentes canales de chat a diferentes directorios de trabajo bajo un directorio base compartido.",
+    "workspaceModeEnable": "Activar modo multi-espacio",
+    "workspaceModeWarning": "Cambiar de modo requiere reiniciar el servicio. El work_dir único no se usa mientras el modo multi-espacio esté activo.",
+    "workspaceBaseDir": "Directorio base",
+    "workspaceBaseDirRequired": "Se requiere un directorio base para activar el modo multi-espacio.",
+    "workspaceModeConfirm": "Cambiar el modo de espacio de trabajo requiere reiniciar el servicio. ¿Continuar?",
+    "workspaceBindings": "Vínculos de canal",
+    "workspaceNoBindings": "Todavía no hay canales vinculados a un espacio de trabajo.",
+    "workspaceActive": "activo",
+    "workspaceIdle": "inactivo",
+    "workspaceAddBinding": "Vincular un canal",
+    "workspaceChannelKey": "Clave de canal",
+    "workspaceChannelName": "Nombre de canal (opcional)",
+    "workspacePath": "Ruta del espacio de trabajo",
+    "workspaceSuggestions": "Directorios sin vincular en base_dir:",
+    "workspaceBind": "Vincular"
   },
   "sessions": {
     "title": "Sesiones",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -56,8 +56,26 @@
       "overview": "概要",
       "providers": "プロバイダー",
       "heartbeat": "ハートビート",
-      "settings": "設定"
-    }
+      "settings": "設定",
+      "workspaces": "ワークスペース"
+    },
+    "workspaceMode": "マルチワークスペースモード",
+    "workspaceModeHint": "共有のベースディレクトリの下で、異なるチャットチャンネルを異なる作業ディレクトリにルーティングします。",
+    "workspaceModeEnable": "マルチワークスペースモードを有効化",
+    "workspaceModeWarning": "モードの切り替えには再起動が必要です。マルチワークスペースモードが有効な間は単一の work_dir は使用されません。",
+    "workspaceBaseDir": "ベースディレクトリ",
+    "workspaceBaseDirRequired": "マルチワークスペースモードを有効にするにはベースディレクトリが必要です。",
+    "workspaceModeConfirm": "ワークスペースモードの変更にはサービスの再起動が必要です。続行しますか？",
+    "workspaceBindings": "チャンネルの紐付け",
+    "workspaceNoBindings": "まだワークスペースに紐付けられたチャンネルはありません。",
+    "workspaceActive": "実行中",
+    "workspaceIdle": "アイドル",
+    "workspaceAddBinding": "チャンネルを紐付け",
+    "workspaceChannelKey": "チャンネルキー",
+    "workspaceChannelName": "チャンネル名（任意）",
+    "workspacePath": "ワークスペースのパス",
+    "workspaceSuggestions": "base_dir 内の未紐付けディレクトリ:",
+    "workspaceBind": "紐付け"
   },
   "sessions": {
     "title": "セッション",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -56,8 +56,26 @@
       "overview": "개요",
       "providers": "제공업체",
       "heartbeat": "하트비트",
-      "settings": "설정"
-    }
+      "settings": "설정",
+      "workspaces": "워크스페이스"
+    },
+    "workspaceMode": "멀티 워크스페이스 모드",
+    "workspaceModeHint": "공유된 기본 디렉터리 아래에서 서로 다른 채팅 채널을 서로 다른 작업 디렉터리로 라우팅합니다.",
+    "workspaceModeEnable": "멀티 워크스페이스 모드 활성화",
+    "workspaceModeWarning": "모드를 전환하려면 재시작이 필요합니다. 멀티 워크스페이스 모드가 켜져 있는 동안에는 단일 work_dir이 사용되지 않습니다.",
+    "workspaceBaseDir": "기본 디렉터리",
+    "workspaceBaseDirRequired": "멀티 워크스페이스 모드를 활성화하려면 기본 디렉터리가 필요합니다.",
+    "workspaceModeConfirm": "워크스페이스 모드를 변경하려면 서비스를 재시작해야 합니다. 계속하시겠습니까?",
+    "workspaceBindings": "채널 바인딩",
+    "workspaceNoBindings": "아직 워크스페이스에 바인딩된 채널이 없습니다.",
+    "workspaceActive": "활성",
+    "workspaceIdle": "유휴",
+    "workspaceAddBinding": "채널 바인딩",
+    "workspaceChannelKey": "채널 키",
+    "workspaceChannelName": "채널 이름 (선택 사항)",
+    "workspacePath": "워크스페이스 경로",
+    "workspaceSuggestions": "base_dir 내 바인딩되지 않은 디렉터리:",
+    "workspaceBind": "바인딩"
   },
   "sessions": {
     "title": "세션",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -56,8 +56,26 @@
       "overview": "Обзор",
       "providers": "Провайдеры",
       "heartbeat": "Пульс",
-      "settings": "Настройки"
-    }
+      "settings": "Настройки",
+      "workspaces": "Рабочие области"
+    },
+    "workspaceMode": "Режим нескольких рабочих областей",
+    "workspaceModeHint": "Направлять разные чат-каналы в разные рабочие директории в пределах общей базовой директории.",
+    "workspaceModeEnable": "Включить режим нескольких рабочих областей",
+    "workspaceModeWarning": "Переключение режима требует перезапуска службы. Единый work_dir не используется, пока включён режим нескольких рабочих областей.",
+    "workspaceBaseDir": "Базовая директория",
+    "workspaceBaseDirRequired": "Для включения режима нескольких рабочих областей требуется базовая директория.",
+    "workspaceModeConfirm": "Изменение режима рабочей области требует перезапуска службы. Продолжить?",
+    "workspaceBindings": "Привязки каналов",
+    "workspaceNoBindings": "Пока ни один канал не привязан к рабочей области.",
+    "workspaceActive": "активен",
+    "workspaceIdle": "простой",
+    "workspaceAddBinding": "Привязать канал",
+    "workspaceChannelKey": "Ключ канала",
+    "workspaceChannelName": "Имя канала (необязательно)",
+    "workspacePath": "Путь рабочей области",
+    "workspaceSuggestions": "Непривязанные директории в base_dir:",
+    "workspaceBind": "Привязать"
   },
   "sessions": {
     "title": "Сессии",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -56,8 +56,26 @@
       "overview": "總覽",
       "providers": "供應商",
       "heartbeat": "心跳",
-      "settings": "設定"
-    }
+      "settings": "設定",
+      "workspaces": "工作區"
+    },
+    "workspaceMode": "多工作區模式",
+    "workspaceModeHint": "在共享的基礎目錄下，將不同的聊天頻道路由到不同的工作目錄。",
+    "workspaceModeEnable": "啟用多工作區模式",
+    "workspaceModeWarning": "切換模式需要重新啟動服務。多工作區模式開啟後，單一的 work_dir 將不再使用。",
+    "workspaceBaseDir": "基礎目錄",
+    "workspaceBaseDirRequired": "啟用多工作區模式需要設定基礎目錄。",
+    "workspaceModeConfirm": "修改工作區模式需要重新啟動服務，確定繼續嗎？",
+    "workspaceBindings": "頻道綁定",
+    "workspaceNoBindings": "尚無頻道綁定到工作區。",
+    "workspaceActive": "運行中",
+    "workspaceIdle": "閒置",
+    "workspaceAddBinding": "綁定頻道",
+    "workspaceChannelKey": "頻道 Key",
+    "workspaceChannelName": "頻道名稱（可選）",
+    "workspacePath": "工作區路徑",
+    "workspaceSuggestions": "base_dir 中未綁定的目錄：",
+    "workspaceBind": "綁定"
   },
   "sessions": {
     "title": "工作階段",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -56,8 +56,26 @@
       "overview": "概览",
       "providers": "服务商",
       "heartbeat": "心跳",
-      "settings": "设置"
-    }
+      "settings": "设置",
+      "workspaces": "工作区"
+    },
+    "workspaceMode": "多工作区模式",
+    "workspaceModeHint": "在共享的基础目录下，将不同的聊天频道路由到不同的工作目录。",
+    "workspaceModeEnable": "启用多工作区模式",
+    "workspaceModeWarning": "切换模式需要重启服务。多工作区模式开启后，单一的 work_dir 将不再使用。",
+    "workspaceBaseDir": "基础目录",
+    "workspaceBaseDirRequired": "启用多工作区模式需要设置基础目录。",
+    "workspaceModeConfirm": "修改工作区模式需要重启服务，确定继续吗？",
+    "workspaceBindings": "频道绑定",
+    "workspaceNoBindings": "尚无频道绑定到工作区。",
+    "workspaceActive": "运行中",
+    "workspaceIdle": "空闲",
+    "workspaceAddBinding": "绑定频道",
+    "workspaceChannelKey": "频道 Key",
+    "workspaceChannelName": "频道名称（可选）",
+    "workspacePath": "工作区路径",
+    "workspaceSuggestions": "base_dir 中未绑定的目录：",
+    "workspaceBind": "绑定"
   },
   "sessions": {
     "title": "会话",

--- a/web/src/pages/Projects/ProjectDetail.tsx
+++ b/web/src/pages/Projects/ProjectDetail.tsx
@@ -3,10 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import {
   ArrowLeft, Plug, Heart, Settings, Layers, Zap, Pause, Play,
-  Trash2, Plus, Check, Clock, ExternalLink, Link2,
+  Trash2, Plus, Check, Clock, ExternalLink, Link2, FolderTree, Folder,
 } from 'lucide-react';
 import { Card, Badge, Button, Input, Modal, EmptyState } from '@/components/ui';
-import { getProject, updateProject, deleteProject, listAgentTypes, type ProjectDetail as ProjectDetailType } from '@/api/projects';
+import {
+  getProject, updateProject, deleteProject, listAgentTypes,
+  listWorkspaces, bindWorkspace, unbindWorkspace,
+  type ProjectDetail as ProjectDetailType, type WorkspaceBinding,
+} from '@/api/projects';
 import { listProviders, addProvider, removeProvider, activateProvider, type Provider, listGlobalProviders, type GlobalProvider, saveProviderRefs } from '@/api/providers';
 import { getHeartbeat, pauseHeartbeat, resumeHeartbeat, triggerHeartbeat, setHeartbeatInterval, type HeartbeatStatus } from '@/api/heartbeat';
 import { restartSystem } from '@/api/status';
@@ -57,7 +61,7 @@ const MODE_OPTIONS_BY_AGENT: Record<string, { value: string; label: string }[]> 
 
 const isQRPlatform = (type: string) => type === 'feishu' || type === 'lark' || type === 'weixin';
 
-type Tab = 'overview' | 'providers' | 'heartbeat' | 'settings';
+type Tab = 'overview' | 'providers' | 'heartbeat' | 'workspaces' | 'settings';
 
 export default function ProjectDetail() {
   const { t } = useTranslation();
@@ -81,6 +85,18 @@ export default function ProjectDetail() {
   const [injectSender, setInjectSender] = useState(false);
   const [platformAllowFrom, setPlatformAllowFrom] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
+
+  // Workspace mode (multi-workspace) settings
+  const [workspaceMode, setWorkspaceMode] = useState('');
+  const [workspaceBaseDir, setWorkspaceBaseDir] = useState('');
+  const [savingWorkspaceMode, setSavingWorkspaceMode] = useState(false);
+  const [workspaceBindings, setWorkspaceBindings] = useState<WorkspaceBinding[]>([]);
+  const [workspaceSuggestions, setWorkspaceSuggestions] = useState<string[]>([]);
+  const [loadingWorkspaces, setLoadingWorkspaces] = useState(false);
+  const [newBindingChannelKey, setNewBindingChannelKey] = useState('');
+  const [newBindingChannelName, setNewBindingChannelName] = useState('');
+  const [newBindingPath, setNewBindingPath] = useState('');
+  const [bindingWorkspace, setBindingWorkspace] = useState(false);
 
   // Agent type
   const [agentTypes, setAgentTypes] = useState<string[]>([]);
@@ -174,6 +190,8 @@ export default function ProjectDetail() {
         setReplyFooter(proj.value.reply_footer !== false);
         setInjectSender(proj.value.inject_sender === true);
         setProviderRefs(proj.value.provider_refs || []);
+        setWorkspaceMode(proj.value.workspace_mode || '');
+        setWorkspaceBaseDir(proj.value.workspace_base_dir || '');
         const afMap: Record<string, string> = {};
         proj.value.platform_configs?.forEach(pc => {
           if (pc.allow_from !== undefined) afMap[pc.type] = pc.allow_from;
@@ -206,6 +224,27 @@ export default function ProjectDetail() {
     return () => window.removeEventListener('cc:refresh', handler);
   }, [fetchAll]);
 
+  const fetchWorkspaces = useCallback(async () => {
+    if (!name) return;
+    setLoadingWorkspaces(true);
+    try {
+      const res = await listWorkspaces(name);
+      setWorkspaceBindings(res.bindings || []);
+      setWorkspaceSuggestions(res.suggestions || []);
+    } catch {
+      setWorkspaceBindings([]);
+      setWorkspaceSuggestions([]);
+    } finally {
+      setLoadingWorkspaces(false);
+    }
+  }, [name]);
+
+  useEffect(() => {
+    if (tab === 'workspaces' && workspaceMode === 'multi-workspace') {
+      fetchWorkspaces();
+    }
+  }, [tab, workspaceMode, fetchWorkspaces]);
+
   const handleSaveSettings = async () => {
     if (!name) return;
     setSaving(true);
@@ -234,6 +273,57 @@ export default function ProjectDetail() {
     }
   };
 
+  const handleSaveWorkspaceMode = async () => {
+    if (!name) return;
+    const enabling = workspaceMode === 'multi-workspace';
+    if (enabling && !workspaceBaseDir.trim()) {
+      alert(t('projects.workspaceBaseDirRequired', 'Base directory is required to enable multi-workspace mode.'));
+      return;
+    }
+    if (!window.confirm(t('projects.workspaceModeConfirm', 'Changing workspace mode requires a service restart. Continue?'))) {
+      return;
+    }
+    setSavingWorkspaceMode(true);
+    try {
+      const res: any = await updateProject(name, {
+        workspace_mode: workspaceMode,
+        workspace_base_dir: workspaceBaseDir,
+      });
+      if (res && res.restart_required) {
+        setShowRestartModal(true);
+      }
+      await fetchAll();
+    } finally {
+      setSavingWorkspaceMode(false);
+    }
+  };
+
+  const handleBindWorkspace = async () => {
+    if (!name || !newBindingChannelKey.trim() || !newBindingPath.trim()) return;
+    setBindingWorkspace(true);
+    try {
+      await bindWorkspace(name, {
+        channel_key: newBindingChannelKey.trim(),
+        channel_name: newBindingChannelName.trim() || undefined,
+        workspace: newBindingPath.trim(),
+      });
+      setNewBindingChannelKey('');
+      setNewBindingChannelName('');
+      setNewBindingPath('');
+      await fetchWorkspaces();
+    } catch (e: any) {
+      alert(e?.message || String(e));
+    } finally {
+      setBindingWorkspace(false);
+    }
+  };
+
+  const handleUnbindWorkspace = async (channelKey: string) => {
+    if (!name) return;
+    await unbindWorkspace(name, channelKey);
+    await fetchWorkspaces();
+  };
+
   const handleAddProvider = async () => {
     if (!name || !newProvider.name) return;
     await addProvider(name, newProvider);
@@ -253,6 +343,7 @@ export default function ProjectDetail() {
     { key: 'overview', icon: Layers },
     { key: 'providers', icon: Zap },
     { key: 'heartbeat', icon: Heart },
+    { key: 'workspaces', icon: FolderTree },
     { key: 'settings', icon: Settings },
   ];
 
@@ -515,6 +606,104 @@ export default function ProjectDetail() {
               </div>
             </div>
           </Modal>
+        </div>
+      )}
+
+      {tab === 'workspaces' && project && (
+        <div className="space-y-4">
+          <Card>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-1">{t('projects.workspaceMode', 'Multi-workspace mode')}</h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+              {t('projects.workspaceModeHint', 'Route different chat channels to different working directories under a shared base directory.')}
+            </p>
+            <div className="space-y-4 max-w-lg">
+              <div className="flex items-center justify-between">
+                <div>
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300">{t('projects.workspaceModeEnable', 'Enable multi-workspace mode')}</label>
+                  <p className="text-[11px] text-amber-500 mt-0.5">{t('projects.workspaceModeWarning', 'Switching modes requires a restart. The single work_dir is not used while multi-workspace mode is on.')}</p>
+                </div>
+                <button
+                  onClick={() => setWorkspaceMode(workspaceMode === 'multi-workspace' ? '' : 'multi-workspace')}
+                  className={cn('w-10 h-6 rounded-full transition-colors shrink-0 ml-3', workspaceMode === 'multi-workspace' ? 'bg-accent' : 'bg-gray-300 dark:bg-gray-700')}
+                >
+                  <div className={cn('w-4 h-4 bg-white rounded-full transition-transform mx-1', workspaceMode === 'multi-workspace' ? 'translate-x-4' : 'translate-x-0')} />
+                </button>
+              </div>
+              <Input
+                label={t('projects.workspaceBaseDir', 'Base directory')}
+                value={workspaceBaseDir}
+                onChange={(e) => setWorkspaceBaseDir(e.target.value)}
+                placeholder="/path/to/workspaces"
+                disabled={workspaceMode !== 'multi-workspace'}
+              />
+              <Button loading={savingWorkspaceMode} onClick={handleSaveWorkspaceMode}>{t('common.save')}</Button>
+            </div>
+          </Card>
+
+          {workspaceMode === 'multi-workspace' && (
+            <>
+              <Card>
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">{t('projects.workspaceBindings', 'Channel bindings')}</h3>
+                {loadingWorkspaces ? (
+                  <p className="text-sm text-gray-400">{t('common.loading', 'Loading...')}</p>
+                ) : workspaceBindings.length === 0 ? (
+                  <EmptyState message={t('projects.workspaceNoBindings', 'No channels are bound to a workspace yet.')} />
+                ) : (
+                  <div className="space-y-2">
+                    {workspaceBindings.map((b) => (
+                      <div
+                        key={b.channel_key}
+                        className="flex items-center justify-between px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-700/60 bg-white dark:bg-gray-800/40"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-medium text-gray-900 dark:text-white">{b.channel_name}</span>
+                            <Badge variant={b.active ? 'success' : 'default'}>
+                              {b.active ? t('projects.workspaceActive', 'active') : t('projects.workspaceIdle', 'idle')}
+                            </Badge>
+                          </div>
+                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate">
+                            <Folder size={11} className="inline mr-1" />{b.workspace}
+                          </p>
+                        </div>
+                        <Button size="sm" variant="ghost" className="text-gray-400 hover:text-red-500 shrink-0 ml-3" onClick={() => handleUnbindWorkspace(b.channel_key)}>
+                          <Trash2 size={14} />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </Card>
+
+              <Card>
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">{t('projects.workspaceAddBinding', 'Bind a channel')}</h3>
+                <div className="space-y-3 max-w-lg">
+                  <Input label={t('projects.workspaceChannelKey', 'Channel key')} value={newBindingChannelKey} onChange={(e) => setNewBindingChannelKey(e.target.value)} placeholder="slack:C0123456" />
+                  <Input label={t('projects.workspaceChannelName', 'Channel name (optional)')} value={newBindingChannelName} onChange={(e) => setNewBindingChannelName(e.target.value)} placeholder="#general" />
+                  <Input label={t('projects.workspacePath', 'Workspace path')} value={newBindingPath} onChange={(e) => setNewBindingPath(e.target.value)} placeholder={workspaceBaseDir ? `${workspaceBaseDir}/...` : '/path/to/workspaces/...'} />
+                  {workspaceSuggestions.length > 0 && (
+                    <div>
+                      <p className="text-[11px] text-gray-400 mb-1.5">{t('projects.workspaceSuggestions', 'Unbound directories in base_dir:')}</p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {workspaceSuggestions.map((s) => (
+                          <button
+                            key={s}
+                            onClick={() => setNewBindingPath(s)}
+                            className="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 hover:border-accent/50 hover:bg-accent/5 transition-all text-gray-600 dark:text-gray-300"
+                          >
+                            {s}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  <Button loading={bindingWorkspace} onClick={handleBindWorkspace} disabled={!newBindingChannelKey.trim() || !newBindingPath.trim()}>
+                    <Plus size={14} /> {t('projects.workspaceBind', 'Bind')}
+                  </Button>
+                </div>
+              </Card>
+            </>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary / 概述

- Extends the management REST API with `workspace_mode` / `workspace_base_dir` on `GET/PATCH /api/v1/projects/{name}`, and new `GET/POST/DELETE /api/v1/projects/{name}/workspaces` endpoints to list, bind, and unbind channel↔workspace bindings (backed by the existing `WorkspaceBindingManager`/`workspacePool`).
  为管理 REST API 新增 `workspace_mode` / `workspace_base_dir` 字段（`GET/PATCH /api/v1/projects/{name}`），并新增 `GET/POST/DELETE /api/v1/projects/{name}/workspaces` 接口，用于列出、绑定、解绑「频道 ↔ 工作区目录」的映射关系（复用现有的 `WorkspaceBindingManager`/`workspacePool`）。
- Adds a new **"Workspaces" tab** in the project detail page of the web dashboard so operators can enable multi-workspace mode, set the base directory, and bind/unbind chat channels to working directories — without touching `config.toml` or chat slash commands.
  在 Web 管理后台的项目详情页新增 **「Workspaces」标签页**，运维人员可直接在页面上开启多工作区模式、设置基础目录，并绑定/解绑聊天频道对应的工作目录 —— 无需再手动编辑 `config.toml` 或使用聊天内命令。
- Workspace paths are validated against path traversal (must resolve under `base_dir`); switching `workspace_mode` surfaces `restart_required` like other config changes.
  绑定路径会做越权校验（必须位于 `base_dir` 之下，防止路径穿越）；切换 `workspace_mode` 时与其他配置变更一致，会返回 `restart_required` 提示需要重启服务。
- Translations added for all 7 supported locales (en, es, ja, ko, ru, zh, zh-TW).
  已为全部 7 种语言（en、es、ja、ko、ru、zh、zh-TW）补充翻译文案。

## Test plan / 测试计划

- [x] `go build ./...` and `go vet ./...` pass (with `web/dist` built) / 构建与 vet 检查通过（含前端产物）
- [x] New backend tests pass: `TestSaveProjectSettings_WorkspaceModeAndBaseDir`, `TestSaveProjectSettings_WorkspaceModeRequiresBaseDir`, `TestMgmt_ProjectWorkspaces_NotMultiWorkspace`, `TestMgmt_ProjectWorkspaces_ListBindUnbind`, `TestMgmt_ProjectWorkspaces_BindRejectsPathOutsideBaseDir`
  新增后端测试全部通过
- [x] `go test ./config/... ./core/...` — no regressions (one pre-existing, unrelated flaky test `TestCmdDiff_EmptyDiff` reproduces independently of this change)
  `go test ./config/... ./core/...` 无回归（`TestCmdDiff_EmptyDiff` 为既存的、与本次改动无关的偶发失败）
- [x] `cd web && npm run build` and `npx tsc -b --noEmit` pass / 前端构建与类型检查通过
- [ ] Manual click-through in a running browser (enable multi-workspace, bind/unbind a channel, confirm persistence to `~/.cc-connect/workspace_bindings.json`) — not done in this environment, recommend verifying before merge
  未在真实浏览器中进行完整点击验证（开启多工作区、绑定/解绑频道、确认持久化到 `~/.cc-connect/workspace_bindings.json`），建议合并前手动验证一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)