### PR TITLE
fix(codex): allow listing sessions across workdirs

### DIFF
--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -41,6 +41,7 @@ type Agent struct {
 	backend         string // "exec" | "app_server"
 	appServerURL    string
 	codexHome       string
+	listAllWorkdirs bool
 	systemPrompt    string
 	appendPrompt    string
 	cmd             string   // CLI binary name, default "codex"
@@ -63,6 +64,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	backend, _ := opts["backend"].(string)
 	appServerURL, _ := opts["app_server_url"].(string)
 	codexHome, _ := opts["codex_home"].(string)
+	listAllWorkdirs, _ := opts["list_all_workdirs"].(bool)
 	systemPrompt, _ := opts["system_prompt"].(string)
 	appendPrompt, _ := opts["append_system_prompt"].(string)
 	mode = normalizeMode(mode)
@@ -100,6 +102,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		backend:         backend,
 		appServerURL:    appServerURL,
 		codexHome:       strings.TrimSpace(codexHome),
+		listAllWorkdirs: listAllWorkdirs,
 		systemPrompt:    strings.TrimSpace(systemPrompt),
 		appendPrompt:    strings.TrimSpace(appendPrompt),
 		cmd:             cmd,
@@ -515,7 +518,11 @@ func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error)
 	a.mu.RLock()
 	codexHome := a.codexHome
 	workDir := a.workDir
+	listAllWorkdirs := a.listAllWorkdirs
 	a.mu.RUnlock()
+	if listAllWorkdirs {
+		workDir = ""
+	}
 	return listCodexSessions(workDir, codexHome)
 }
 
@@ -558,8 +565,9 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	defer a.mu.RUnlock()
 
 	opts := map[string]any{
-		"mode":    a.mode,
-		"backend": a.backend,
+		"mode":              a.mode,
+		"backend":           a.backend,
+		"list_all_workdirs": a.listAllWorkdirs,
 	}
 	if a.model != "" {
 		opts["model"] = a.model

--- a/agent/codex/codex_model_test.go
+++ b/agent/codex/codex_model_test.go
@@ -82,6 +82,15 @@ func TestWorkspaceAgentOptions_PreservesStdIOAppServerURL(t *testing.T) {
 	}
 }
 
+func TestWorkspaceAgentOptions_PreservesListAllWorkdirs(t *testing.T) {
+	a := &Agent{listAllWorkdirs: true}
+
+	opts := a.WorkspaceAgentOptions()
+	if got := opts["list_all_workdirs"]; got != true {
+		t.Fatalf("WorkspaceAgentOptions()[list_all_workdirs] = %#v, want true", got)
+	}
+}
+
 func TestIsCodexChatModel(t *testing.T) {
 	tests := []struct {
 		id   string

--- a/agent/codex/list.go
+++ b/agent/codex/list.go
@@ -31,12 +31,16 @@ func resolveCodexHomeDir(explicit string) string {
 	return filepath.Join(homeDir, ".codex")
 }
 
-// listCodexSessions scans the codex sessions directory for JSONL transcript
-// files whose cwd matches workDir.
+// listCodexSessions scans Codex JSONL transcripts. An empty workDir lists all
+// work directories instead of filtering by cwd.
 func listCodexSessions(workDir, codexHome string) ([]core.AgentSessionInfo, error) {
-	absWorkDir, err := filepath.Abs(workDir)
-	if err != nil {
-		absWorkDir = workDir
+	absWorkDir := strings.TrimSpace(workDir)
+	if absWorkDir != "" {
+		var err error
+		absWorkDir, err = filepath.Abs(absWorkDir)
+		if err != nil {
+			absWorkDir = workDir
+		}
 	}
 
 	sessionsDir := filepath.Join(resolveCodexHomeDir(codexHome), "sessions")

--- a/agent/codex/list_test.go
+++ b/agent/codex/list_test.go
@@ -50,6 +50,65 @@ func TestAgentListSessions_ExcludesSubagentRollouts(t *testing.T) {
 	}
 }
 
+func TestAgentListSessions_ListAllWorkdirs(t *testing.T) {
+	codexHome := t.TempDir()
+	workDir := t.TempDir()
+	otherWorkDir := t.TempDir()
+
+	writeTestCodexRollout(t, codexHome, "rollout-main.jsonl", "main-session", workDir)
+	writeTestCodexRollout(t, codexHome, "rollout-other.jsonl", "other-session", otherWorkDir)
+
+	agent := &Agent{workDir: workDir, codexHome: codexHome, listAllWorkdirs: true}
+	sessions, err := agent.ListSessions(context.Background())
+	if err != nil {
+		t.Fatalf("ListSessions() error: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("ListSessions() returned %d sessions, want 2", len(sessions))
+	}
+
+	got := map[string]bool{}
+	for _, session := range sessions {
+		got[session.ID] = true
+	}
+	for _, want := range []string{"main-session", "other-session"} {
+		if !got[want] {
+			t.Fatalf("ListSessions() missing session %q; got %#v", want, got)
+		}
+	}
+}
+
+func TestListCodexSessions_EmptyWorkDirDoesNotFilterByProcessDir(t *testing.T) {
+	codexHome := t.TempDir()
+	sessionWorkDir := t.TempDir()
+	processWorkDir := t.TempDir()
+	writeTestCodexRollout(t, codexHome, "rollout-session.jsonl", "all-workdirs-session", sessionWorkDir)
+
+	originalWorkDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get current working directory: %v", err)
+	}
+	if err := os.Chdir(processWorkDir); err != nil {
+		t.Fatalf("change process working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWorkDir); err != nil {
+			t.Fatalf("restore process working directory: %v", err)
+		}
+	}()
+
+	sessions, err := listCodexSessions("", codexHome)
+	if err != nil {
+		t.Fatalf("listCodexSessions() error: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("listCodexSessions() returned %d sessions, want 1", len(sessions))
+	}
+	if sessions[0].ID != "all-workdirs-session" {
+		t.Fatalf("listCodexSessions()[0].ID = %q, want all-workdirs-session", sessions[0].ID)
+	}
+}
+
 func TestAgentListSessions_ExcludesSubagentRolloutWithCopiedParentMeta(t *testing.T) {
 	workDir := t.TempDir()
 	codexHome := t.TempDir()
@@ -161,5 +220,25 @@ func TestAgentListSessions_LongThreadNameTruncated(t *testing.T) {
 	want := strings.Repeat("会", 60) + "..."
 	if sessions[0].Summary != want {
 		t.Fatalf("ListSessions()[0].Summary = %q, want %q", sessions[0].Summary, want)
+	}
+}
+
+func writeTestCodexRollout(t *testing.T, codexHome, name, sessionID, workDir string) {
+	t.Helper()
+
+	sessionsDir := filepath.Join(codexHome, "sessions", "2026", "08", "31")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("create sessions directory: %v", err)
+	}
+
+	workDirJSON, err := json.Marshal(workDir)
+	if err != nil {
+		t.Fatalf("encode work directory: %v", err)
+	}
+
+	body := `{"type":"session_meta","payload":{"id":"` + sessionID + `","cwd":` + string(workDirJSON) + `,"source":"vscode"}}` + "\n" +
+		`{"type":"response_item","payload":{"role":"user","content":[{"type":"input_text","text":"test prompt"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessionsDir, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write rollout %s: %v", name, err)
 	}
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -1618,6 +1618,9 @@ app_secret = "your-feishu-app-secret"
 #
 # [projects.agent.options]
 # work_dir = "/path/to/project"
+# Show Codex sessions from all cwd values in /list.
+# /list 显示所有 cwd 的 Codex 会话。
+# list_all_workdirs = false
 # mode = "suggest"  # "suggest" | "auto-edit" | "full-auto" | "yolo"
 #
 # Mode options / 模式说明:


### PR DESCRIPTION
## Summary

Fixes Codex session listing when workDir filtering is intentionally disabled. Previously `filepath.Abs("")` turned an empty workDir into the cc-connect process cwd, so a list-all mode still filtered out Codex sessions from other cwd values.

This PR also adds a Codex agent option, `list_all_workdirs`, and documents it in `config.example.toml`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

Not run locally. I only ran `gofmt` and `git diff --check` before opening the PR.

### Automated tests added in this PR

- `TestAgentListSessions_ListAllWorkdirs` in `agent/codex/list_test.go` — verifies the Codex agent can list sessions from multiple cwd values when `list_all_workdirs` is enabled.
- `TestListCodexSessions_EmptyWorkDirDoesNotFilterByProcessDir` in `agent/codex/list_test.go` — verifies an empty workDir means no cwd filter instead of the current process directory.
- `TestWorkspaceAgentOptions_PreservesListAllWorkdirs` in `agent/codex/codex_model_test.go` — verifies workspace agent clones preserve the option.

### For bug fixes only — regression test

- Regression test name: `TestListCodexSessions_EmptyWorkDirDoesNotFilterByProcessDir`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [x] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

Codex users can set:

```toml
[projects.agent.options]
list_all_workdirs = true
```

Then `/list` shows Codex sessions from all cwd values under the configured Codex home instead of only the project `work_dir`.

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/`
- [x] i18n strings have all-language translations (if any new user-facing text)
- [x] No secrets / credentials in source

## Related

- Issue: Fixes #1773
- Related PR: