### PR TITLE
fix(core): never write temp files in target directory (fixes t.TempDir cleanup)

### DIFF
--- a/core/atomicwrite.go
+++ b/core/atomicwrite.go
@@ -5,12 +5,26 @@ import (
 	"path/filepath"
 )
 
-// AtomicWriteFile writes data to a file atomically by first writing to a
-// temporary file in the same directory, syncing, then renaming over the target.
-// This prevents data loss / corruption on crash.
+// AtomicWriteFile writes data to a file atomically when possible by first
+// writing to a temporary file in the system temp directory, syncing, then
+// renaming over the target.  On the same filesystem the rename is fully
+// atomic.
+//
+// When os.TempDir() and the target directory are on different filesystems
+// the rename will fail with EXDEV; in that case we fall back to writing
+// directly to the target path.  We never create temp files in the target
+// directory so that callers which write from background goroutines (e.g.
+// the session manager's saveLocked) never leave orphan temp files behind —
+// this avoids spurious "t.TempDir() cleanup: directory not empty" failures
+// during parallel tests.
 func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	dstDir := filepath.Dir(path)
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return err
+	}
+
+	// Write to system temp dir for atomic rename.
+	tmp, err := os.CreateTemp("", "cc-atomic-*")
 	if err != nil {
 		return err
 	}
@@ -34,17 +48,14 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		// Rename can fail when the destination is a directory, the
-		// destination's filesystem differs from the temp dir's (rare given
-		// CreateTemp uses the same dir, but possible with bind mounts), or
-		// the destination is locked by another process on Windows. In any
-		// of those cases the temp file is now an orphaned `.tmp-*` we
-		// created — clean it up so repeated failures don't litter the
-		// directory and confuse later directory scans (e.g. cron / session
-		// stores that walk their parent dir).
-		os.Remove(tmpPath)
-		return err
+
+	// Try atomic rename (works when temp and target are on the same fs).
+	if err := os.Rename(tmpPath, path); err == nil {
+		return nil
 	}
-	return nil
+
+	// Rename failed (likely EXDEV on different mount points).
+	// Fall back to direct write — safe, no orphan temp files.
+	_ = os.Remove(tmpPath)
+	return os.WriteFile(path, data, perm)
 }


### PR DESCRIPTION
## Problem

`AtomicWriteFile` 在目标目录中创建临时文件（如 `.tmp-...`)。当 session manager 的 `saveLocked()` 通过后台 goroutine（`ReceiveMessage` → `processInteractiveMessageWith` 触发）在 tests 中使用 `t.TempDir()` 时被调用，这些孤立的临时文件阻止了 Go test framework 清理 temp 目录：

```
--- FAIL: TestCUJ_A3_ImageReachesAgent (0.02s)
    testing.go:1617: TempDir RemoveAll cleanup: unlinkat .../001: directory not empty
```

## Solution

重写 `AtomicWriteFile`：**始终**将初始临时文件写入系统临时目录 (`os.TempDir()`)，而非目标目录。确保目标目录中永远不会创建临时文件。

- **同文件系统**（macOS 常见）：atomic rename 成功，完全原子写入
- **跨设备**（EXDEV，如 NFS/mount points）：fallback 到 `os.WriteFile` 直接写入 — 非原子但无孤立文件

## Changes

- `core/atomicwrite.go` — rewrite: always start with system temp dir, fallback to direct write

🤖 Generated with [Claude Code](https://claude.com/claude-code)