### PR TITLE
feat(feishu): AskUserQuestion card 2.0 with option buttons + free-form input

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -11799,6 +11799,30 @@ func (e *Engine) sendAskQuestionPrompt(p Platform, replyCtx any, questions []Use
 		titleSuffix = fmt.Sprintf(" (%d/%d)", qIdx+1, total)
 	}
 
+	// Try native rich ask-question card (Feishu schema 2.0: option buttons +
+	// free-form input in one card). Single-select only — for multiSelect,
+	// buttons would resolve on the first click and prevent selecting multiple.
+	if !q.MultiSelect {
+		if aqs, ok := p.(AskQuestionCardSender); ok {
+			body := "**" + q.Question + "**\n\n"
+			for i, opt := range q.Options {
+				body += fmt.Sprintf("%d. **%s**", i+1, opt.Label)
+				if opt.Description != "" {
+					body += " — " + opt.Description
+				}
+				body += "\n"
+			}
+			err := aqs.SendAskQuestionCard(context.Background(), replyCtx,
+				e.i18n.T(MsgAskQuestionTitle)+titleSuffix, body,
+				e.i18n.T(MsgAskQuestionNoteFreeform), q, qIdx)
+			if err == nil {
+				return
+			}
+			slog.Debug("sendAskQuestionPrompt: native card unavailable, falling back",
+				"platform", p.Name(), "error", err)
+		}
+	}
+
 	// Try card (Feishu/Lark)
 	if supportsCards(p) {
 		cb := NewCard().Title(e.i18n.T(MsgAskQuestionTitle)+titleSuffix, "blue")

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -413,31 +413,31 @@ const (
 	MsgCronIDLabel               MsgKey = "cron_id_label"
 	MsgCronFailedSuffix          MsgKey = "cron_failed_suffix"
 
-	MsgTimerNotAvailable  MsgKey = "timer_not_available"
-	MsgTimerUsage         MsgKey = "timer_usage"
-	MsgTimerAddUsage      MsgKey = "timer_add_usage"
-	MsgTimerAdded         MsgKey = "timer_added"
-	MsgTimerAddedExec     MsgKey = "timer_added_exec"
-	MsgTimerAddExecUsage  MsgKey = "timer_addexec_usage"
-	MsgTimerEmpty         MsgKey = "timer_empty"
-	MsgTimerListTitle     MsgKey = "timer_list_title"
-	MsgTimerListFooter    MsgKey = "timer_list_footer"
-	MsgTimerDelUsage      MsgKey = "timer_del_usage"
-	MsgTimerMuteUsage     MsgKey = "timer_mute_usage"
-	MsgTimerDeleted       MsgKey = "timer_deleted"
-	MsgTimerNotFound      MsgKey = "timer_not_found"
-	MsgTimerMuted         MsgKey = "timer_muted"
-	MsgTimerUnmuted       MsgKey = "timer_unmuted"
-	MsgTimerCardHint      MsgKey = "timer_card_hint"
-	MsgTimerBtnMute       MsgKey = "timer_btn_mute"
-	MsgTimerBtnUnmute     MsgKey = "timer_btn_unmute"
-	MsgTimerBtnDelete     MsgKey = "timer_btn_delete"
-	MsgTimerIDLabel       MsgKey = "timer_id_label"
-	MsgTimerScheduledLabel MsgKey = "timer_scheduled_label"
-	MsgTimerFailedSuffix  MsgKey = "timer_failed_suffix"
-	MsgCommandsTagAgent          MsgKey = "commands_tag_agent"
-	MsgCommandsTagShell          MsgKey = "commands_tag_shell"
-	MsgUpgradeTimeoutSuffix      MsgKey = "upgrade_timeout_suffix"
+	MsgTimerNotAvailable    MsgKey = "timer_not_available"
+	MsgTimerUsage           MsgKey = "timer_usage"
+	MsgTimerAddUsage        MsgKey = "timer_add_usage"
+	MsgTimerAdded           MsgKey = "timer_added"
+	MsgTimerAddedExec       MsgKey = "timer_added_exec"
+	MsgTimerAddExecUsage    MsgKey = "timer_addexec_usage"
+	MsgTimerEmpty           MsgKey = "timer_empty"
+	MsgTimerListTitle       MsgKey = "timer_list_title"
+	MsgTimerListFooter      MsgKey = "timer_list_footer"
+	MsgTimerDelUsage        MsgKey = "timer_del_usage"
+	MsgTimerMuteUsage       MsgKey = "timer_mute_usage"
+	MsgTimerDeleted         MsgKey = "timer_deleted"
+	MsgTimerNotFound        MsgKey = "timer_not_found"
+	MsgTimerMuted           MsgKey = "timer_muted"
+	MsgTimerUnmuted         MsgKey = "timer_unmuted"
+	MsgTimerCardHint        MsgKey = "timer_card_hint"
+	MsgTimerBtnMute         MsgKey = "timer_btn_mute"
+	MsgTimerBtnUnmute       MsgKey = "timer_btn_unmute"
+	MsgTimerBtnDelete       MsgKey = "timer_btn_delete"
+	MsgTimerIDLabel         MsgKey = "timer_id_label"
+	MsgTimerScheduledLabel  MsgKey = "timer_scheduled_label"
+	MsgTimerFailedSuffix    MsgKey = "timer_failed_suffix"
+	MsgCommandsTagAgent     MsgKey = "commands_tag_agent"
+	MsgCommandsTagShell     MsgKey = "commands_tag_shell"
+	MsgUpgradeTimeoutSuffix MsgKey = "upgrade_timeout_suffix"
 
 	MsgCronScheduleLabel MsgKey = "cron_schedule_label"
 	MsgCronNextRunLabel  MsgKey = "cron_next_run_label"
@@ -450,12 +450,13 @@ const (
 	MsgPermCardBody    MsgKey = "perm_card_body"
 	MsgPermCardNote    MsgKey = "perm_card_note"
 
-	MsgAskQuestionTitle     MsgKey = "ask_question_title"
-	MsgAskQuestionNote      MsgKey = "ask_question_note"
-	MsgAskQuestionNoteMulti MsgKey = "ask_question_note_multi"
-	MsgAskQuestionMulti     MsgKey = "ask_question_multi"
-	MsgAskQuestionPrompt    MsgKey = "ask_question_prompt"
-	MsgAskQuestionAnswered  MsgKey = "ask_question_answered"
+	MsgAskQuestionTitle        MsgKey = "ask_question_title"
+	MsgAskQuestionNote         MsgKey = "ask_question_note"
+	MsgAskQuestionNoteMulti    MsgKey = "ask_question_note_multi"
+	MsgAskQuestionNoteFreeform MsgKey = "ask_question_note_freeform"
+	MsgAskQuestionMulti        MsgKey = "ask_question_multi"
+	MsgAskQuestionPrompt       MsgKey = "ask_question_prompt"
+	MsgAskQuestionAnswered     MsgKey = "ask_question_answered"
 
 	MsgCommandsTitle        MsgKey = "commands_title"
 	MsgCommandsEmpty        MsgKey = "commands_empty"
@@ -688,8 +689,8 @@ const (
 	// send / cron / timer / relay tool documentation in their native
 	// language. Translation coverage is en + zh for this PR; additional
 	// languages fall back to en automatically.
-	MsgAgentSendToolPrompt MsgKey = "agent_send_tool_prompt"
-	MsgAgentCronToolPrompt MsgKey = "agent_cron_tool_prompt"
+	MsgAgentSendToolPrompt  MsgKey = "agent_send_tool_prompt"
+	MsgAgentCronToolPrompt  MsgKey = "agent_cron_tool_prompt"
 	MsgAgentTimerToolPrompt MsgKey = "agent_timer_tool_prompt"
 	MsgAgentRelayToolPrompt MsgKey = "agent_relay_tool_prompt"
 )
@@ -2786,6 +2787,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "請回覆逗號分隔的選項編號（如 1,3）或直接輸入你的回答",
 		LangJapanese:           "カンマ区切りの番号（例: 1,3）で返信するか、直接回答を入力してください",
 		LangSpanish:            "Responda con los números de opción separados por comas (ej. 1,3) o escriba su respuesta",
+	},
+	MsgAskQuestionNoteFreeform: {
+		LangEnglish:            "None of the options fit? Type your answer in the input box below — it is passed back to the agent as-is",
+		LangChinese:            "选项不合适？直接在下方输入框输入你的想法，会原样作为回答传回",
+		LangTraditionalChinese: "選項不合適？直接在下方輸入框輸入你的想法，會原樣作為回答傳回",
+		LangJapanese:           "選択肢が合わない場合は、下の入力欄に直接回答を入力してください（そのまま agent に渡されます）",
+		LangSpanish:            "¿Ninguna opción encaja? Escribe tu respuesta en el cuadro de abajo; se pasa al agente tal cual",
 	},
 	MsgAskQuestionMulti: {
 		LangEnglish:            " (multiple selections allowed, separate with commas)",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -299,6 +299,18 @@ type CardSender interface {
 	ReplyCard(ctx context.Context, replyCtx any, card *Card) error
 }
 
+// AskQuestionCardSender is an optional interface for platforms that can render
+// an AskUserQuestion prompt as a native rich card combining option buttons
+// with a free-form text input (e.g. Feishu card schema 2.0 with an input +
+// form_submit pair). title/body/note are pre-rendered, localized strings;
+// q carries the structured options; qIdx identifies the question batch for
+// the "askq:<qIdx>:<optIdx>" callback value. Implementations should return an
+// error (e.g. for MultiSelect, where buttons would resolve on first click)
+// so the engine falls back to the generic card path.
+type AskQuestionCardSender interface {
+	SendAskQuestionCard(ctx context.Context, replyCtx any, title, body, note string, q UserQuestion, qIdx int) error
+}
+
 // CardNavigationHandler is called by platforms to render a card for in-place
 // card updates (e.g. Feishu card.action.trigger callback). The action string
 // uses prefixes like "nav:/model" or "act:/model 3".

--- a/platform/feishu/askq_card_v2_test.go
+++ b/platform/feishu/askq_card_v2_test.go
@@ -2,6 +2,7 @@ package feishu
 
 import (
 	"testing"
+	"time"
 
 	"github.com/chenhg5/cc-connect/core"
 	larkcallback "github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
@@ -140,7 +141,7 @@ func TestOnCardActionAskqTextFormSubmit(t *testing.T) {
 		if msg.IsPermissionResponse {
 			t.Fatal("free-form answer must not be flagged as permission response")
 		}
-	default:
+	case <-time.After(2 * time.Second):
 		t.Fatal("expected the answer to be dispatched as a user message")
 	}
 }

--- a/platform/feishu/askq_card_v2_test.go
+++ b/platform/feishu/askq_card_v2_test.go
@@ -1,0 +1,183 @@
+package feishu
+
+import (
+	"testing"
+
+	"github.com/chenhg5/cc-connect/core"
+	larkcallback "github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+)
+
+func TestBuildAskQuestionCard2(t *testing.T) {
+	q := core.UserQuestion{
+		Question: "TJ 订单何时置已完成？",
+		Header:   "TJ状态语义",
+		Options: []core.UserQuestionOption{
+			{Label: "出码即完成", Description: "PRD 字面"},
+			{Label: "CK 发货才完成", Description: "兼容现有状态机"},
+		},
+	}
+	card := buildAskQuestionCard2("❓ 问题 (1/2)", "**TJ 订单何时置已完成？**", "选项不合适？直接输入", q, 0, "sess-1")
+
+	if card["schema"] != "2.0" {
+		t.Fatalf("schema = %v, want 2.0", card["schema"])
+	}
+	header, ok := card["header"].(map[string]any)
+	if !ok {
+		t.Fatal("missing header")
+	}
+	if header["title"] == nil {
+		t.Fatal("missing header title")
+	}
+	body, ok := card["body"].(map[string]any)
+	if !ok {
+		t.Fatal("missing body")
+	}
+	elements, ok := body["elements"].([]map[string]any)
+	if !ok {
+		t.Fatal("missing body elements")
+	}
+
+	buttons := 0
+	foundForm := false
+	for _, el := range elements {
+		switch el["tag"] {
+		case "button":
+			buttons++
+			behaviors, ok := el["behaviors"].([]map[string]any)
+			if !ok || len(behaviors) == 0 {
+				t.Fatalf("button %d missing behaviors", buttons)
+			}
+			value, ok := behaviors[0]["value"].(map[string]any)
+			if !ok {
+				t.Fatalf("button %d behaviors value has wrong type", buttons)
+			}
+			wantAction := "askq:0:" + itoa(buttons)
+			if value["action"] != wantAction {
+				t.Fatalf("button %d action = %v, want %q", buttons, value["action"], wantAction)
+			}
+			if value["session_key"] != "sess-1" {
+				t.Fatalf("button %d session_key = %v, want sess-1", buttons, value["session_key"])
+			}
+			if value["askq_label"] == "" {
+				t.Fatalf("button %d missing askq_label", buttons)
+			}
+		case "form":
+			foundForm = true
+			formEls, ok := el["elements"].([]map[string]any)
+			if !ok || len(formEls) != 2 {
+				t.Fatal("form should contain an input and a submit button")
+			}
+			if formEls[0]["tag"] != "input" || formEls[0]["name"] != "answer" {
+				t.Fatalf("form element[0] = %v, want input named answer", formEls[0]["tag"])
+			}
+			if formEls[1]["tag"] != "button" || formEls[1]["action_type"] != "form_submit" {
+				t.Fatalf("form element[1] = %v, want form_submit button", formEls[1]["tag"])
+			}
+		}
+	}
+	if buttons != 2 {
+		t.Fatalf("buttons = %d, want 2 (one per option)", buttons)
+	}
+	if !foundForm {
+		t.Fatal("missing free-form answer form")
+	}
+}
+
+func itoa(n int) string {
+	if n == 1 {
+		return "1"
+	}
+	if n == 2 {
+		return "2"
+	}
+	if n == 3 {
+		return "3"
+	}
+	if n == 4 {
+		return "4"
+	}
+	return "?"
+}
+
+func TestOnCardActionAskqTextFormSubmit(t *testing.T) {
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip, ok := platformAny.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *interactivePlatform", platformAny)
+	}
+
+	msgCh := make(chan *core.Message, 1)
+	ip.handler = func(p core.Platform, msg *core.Message) {
+		msgCh <- msg
+	}
+
+	resp, err := ip.onCardAction(&larkcallback.CardActionTriggerEvent{
+		Event: &larkcallback.CardActionTriggerRequest{
+			Operator: &larkcallback.Operator{OpenID: "ou_test_user"},
+			Action: &larkcallback.CallBackAction{
+				Name:      "submit",
+				FormValue: map[string]any{"answer": "先出码后置完成，但要加对账补偿"},
+				Value:     map[string]any{},
+			},
+			Context: &larkcallback.Context{OpenChatID: "oc_test_chat", OpenMessageID: "om_test_message"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp == nil || resp.Card == nil {
+		t.Fatal("expected a confirmation card response")
+	}
+
+	select {
+	case msg := <-msgCh:
+		if msg.Content != "先出码后置完成，但要加对账补偿" {
+			t.Fatalf("forwarded content = %q, want the raw answer text", msg.Content)
+		}
+		if msg.IsPermissionResponse {
+			t.Fatal("free-form answer must not be flagged as permission response")
+		}
+	default:
+		t.Fatal("expected the answer to be dispatched as a user message")
+	}
+}
+
+func TestOnCardActionFormSubmitWithoutAnswerIsIgnored(t *testing.T) {
+	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip, ok := platformAny.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *interactivePlatform", platformAny)
+	}
+
+	called := false
+	ip.handler = func(p core.Platform, msg *core.Message) {
+		called = true
+	}
+
+	resp, err := ip.onCardAction(&larkcallback.CardActionTriggerEvent{
+		Event: &larkcallback.CardActionTriggerRequest{
+			Operator: &larkcallback.Operator{OpenID: "ou_test_user"},
+			Action: &larkcallback.CallBackAction{
+				Name:      "submit",
+				FormValue: map[string]any{"answer": "   "},
+				Value:     map[string]any{},
+			},
+			Context: &larkcallback.Context{OpenChatID: "oc_test_chat"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp != nil {
+		t.Fatal("expected nil response when no answer text is present")
+	}
+	if called {
+		t.Fatal("no message should be dispatched for a blank answer")
+	}
+}

--- a/platform/feishu/card.go
+++ b/platform/feishu/card.go
@@ -462,3 +462,122 @@ func renderCard(card *core.Card, sessionKey string) string {
 	}
 	return string(b)
 }
+
+// SendAskQuestionCard renders an AskUserQuestion prompt as a Feishu card with
+// schema 2.0, combining option buttons with a free-form text input:
+//   - option buttons use a behaviors callback whose value reuses the legacy
+//     "askq:<qIdx>:<optIdx>" action contract, so the existing onCardAction
+//     askq path (and its confirmation card) works unchanged;
+//   - the input lives in a form whose form_submit button puts the typed text
+//     into the "answer" field; onCardAction forwards that text as the user's
+//     answer (resolved by the engine's resolveAskQuestionAnswer free-form path).
+func (p *interactivePlatform) SendAskQuestionCard(ctx context.Context, rctx any, title, body, note string, q core.UserQuestion, qIdx int) error {
+	rc, ok := rctx.(replyContext)
+	if !ok {
+		return fmt.Errorf("%s: invalid reply context type %T", p.tag(), rctx)
+	}
+	if rc.chatID == "" {
+		return fmt.Errorf("%s: chatID is empty, cannot send ask-question card", p.tag())
+	}
+	cardJSON, err := json.Marshal(buildAskQuestionCard2(title, body, note, q, qIdx, rc.sessionKey))
+	if err != nil {
+		return fmt.Errorf("%s: marshal ask-question card: %w", p.tag(), err)
+	}
+	if !p.noReplyToTrigger && p.shouldReplyInThread(rc) {
+		return p.replyMessage(ctx, rc, larkim.MsgTypeInteractive, string(cardJSON))
+	}
+	return p.createMessage(ctx, rc.chatID, larkim.MsgTypeInteractive, string(cardJSON), "send ask-question card")
+}
+
+// buildAskQuestionCard2 builds the Feishu card schema 2.0 map for an
+// AskUserQuestion prompt: option buttons (behaviors callback reusing the
+// legacy "askq:<qIdx>:<optIdx>" value contract) plus a free-form input whose
+// form_submit puts the typed text into the "answer" field.
+func buildAskQuestionCard2(title, body, note string, q core.UserQuestion, qIdx int, sessionKey string) map[string]any {
+
+	elements := []map[string]any{
+		{"tag": "div", "text": map[string]any{"tag": "lark_md", "content": body}},
+	}
+	for i, opt := range q.Options {
+		btnType := "default"
+		if i == 0 {
+			btnType = "primary"
+		}
+		value := map[string]any{
+			"action":        fmt.Sprintf("askq:%d:%d", qIdx, i+1),
+			"askq_label":    opt.Label,
+			"askq_question": q.Question,
+		}
+		if sessionKey != "" {
+			value["session_key"] = sessionKey
+		}
+		elements = append(elements, map[string]any{
+			"tag":  "button",
+			"name": fmt.Sprintf("askq_opt_%d", i+1),
+			"text": plainText(opt.Label),
+			"type": btnType,
+			"size": "medium",
+			"behaviors": []map[string]any{
+				{"type": "callback", "value": value},
+			},
+		})
+	}
+	elements = append(elements,
+		map[string]any{"tag": "hr"},
+		map[string]any{"tag": "div", "text": map[string]any{"tag": "lark_md", "content": note}},
+		map[string]any{
+			"tag":  "form",
+			"name": "askq_answer_form",
+			"elements": []map[string]any{
+				{
+					"tag":            "input",
+					"name":           "answer",
+					"placeholder":    plainText("输入你的想法… / Type your answer…"),
+					"label":          plainText("自由回答 / Free-form answer"),
+					"label_position": "top",
+					"max_length":     500,
+				},
+				{
+					"tag":         "button",
+					"action_type": "form_submit",
+					"name":        "submit",
+					"text":        plainText("发送 / Send"),
+					"type":        "primary",
+					"size":        "medium",
+				},
+			},
+		},
+	)
+
+	card := map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{"update_multi": true},
+		"header": map[string]any{
+			"title":    plainText(title),
+			"template": "blue",
+		},
+		"body": map[string]any{"elements": elements},
+	}
+	return card
+}
+
+// simpleCard2 builds a minimal Feishu card schema 2.0 with a colored header
+// and one markdown element. Callback responses for actions triggered on a
+// schema 2.0 card must themselves be schema 2.0 — a v1 response card is
+// rejected by Feishu with error 200830.
+func simpleCard2(title, markdown, color string) map[string]any {
+	if color == "" {
+		color = "blue"
+	}
+	return map[string]any{
+		"schema": "2.0",
+		"config": map[string]any{"update_multi": true},
+		"header": map[string]any{
+			"title":    plainText(title),
+			"template": color,
+		},
+		"body": map[string]any{"elements": []map[string]any{
+			{"tag": "div", "text": map[string]any{"tag": "lark_md", "content": markdown}},
+		}},
+	}
+}

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -150,18 +150,18 @@ type Platform struct {
 	// Issue #1618: previous behavior treated botOpenID=="" as "filter off", which
 	// silently turned the bot into a loud responder for the rest of the process
 	// lifetime when the bot-info API failed.
-	groupFilterDegraded     bool
-	groupFilterDegradedAt   time.Time
-	groupFilterDegradedErr  string
-	groupFilterRetryCancel  context.CancelFunc
-	groupFilterRetryStop    chan struct{}
-	peerBots                map[string]string // app_id -> friendly alias, for quoted-reply attribution
-	mentionMap       map[string]string // agent name -> open_id (for outbound @ resolution)
-	userNameCache    sync.Map          // open_id -> display name
-	chatNameCache    sync.Map          // chat_id -> chat name
-	chatMemberCache  sync.Map          // chatID -> *chatMemberEntry
-	recalledMu       sync.Mutex
-	recalledMsgIDs   map[string]time.Time // message_id -> recall time, short TTL race guard
+	groupFilterDegraded    bool
+	groupFilterDegradedAt  time.Time
+	groupFilterDegradedErr string
+	groupFilterRetryCancel context.CancelFunc
+	groupFilterRetryStop   chan struct{}
+	peerBots               map[string]string // app_id -> friendly alias, for quoted-reply attribution
+	mentionMap             map[string]string // agent name -> open_id (for outbound @ resolution)
+	userNameCache          sync.Map          // open_id -> display name
+	chatNameCache          sync.Map          // chat_id -> chat name
+	chatMemberCache        sync.Map          // chatID -> *chatMemberEntry
+	recalledMu             sync.Mutex
+	recalledMsgIDs         map[string]time.Time // message_id -> recall time, short TTL race guard
 	// Webhook mode fields (for Lark international version)
 	server       *http.Server
 	port         string
@@ -775,6 +775,15 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		}
 	}
 
+	// Card schema 2.0 free-form input: the ask-question card's form_submit
+	// button ("submit") carries the typed text in the "answer" form field.
+	// Route it as an askq free-form answer.
+	if actionVal == "" && event.Event.Action.Name == "submit" {
+		if ans, _ := event.Event.Action.FormValue["answer"].(string); strings.TrimSpace(ans) != "" {
+			actionVal = "askq_text:" + ans
+		}
+	}
+
 	userID := ""
 	if event.Event.Operator != nil {
 		userID = event.Event.Operator.OpenID
@@ -916,15 +925,44 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		if answerLabel == "" {
 			answerLabel = actionVal
 		}
-		cb := core.NewCard().Title("✅ "+answerLabel, "green")
+		md := ""
 		if askqQuestion != "" {
-			cb.Markdown(askqQuestion)
+			md = askqQuestion + "\n"
 		}
-		cb.Markdown("**→ " + answerLabel + "**")
+		md += "**→ " + answerLabel + "**"
 		return &callback.CardActionTriggerResponse{
 			Card: &callback.Card{
 				Type: "raw",
-				Data: renderCardMap(cb.Build(), sessionKey),
+				Data: simpleCard2("✅ "+answerLabel, md, "green"),
+			},
+		}, nil
+	}
+
+	// askq_text: — AskUserQuestion free-form answer submitted via the card
+	// schema 2.0 input box. Forward the raw text as a user message; while an
+	// askq prompt is pending the engine resolves non-numeric text as a
+	// free-form answer (resolveAskQuestionAnswer returns it as-is).
+	if strings.HasPrefix(actionVal, "askq_text:") {
+		answer := strings.TrimPrefix(actionVal, "askq_text:")
+		rctx := replyContext{messageID: messageID, chatID: chatID, sessionKey: sessionKey}
+		go p.dispatchCoreMessage(&core.Message{
+			SessionKey: sessionKey,
+			Platform:   p.platformName,
+			UserID:     userID,
+			UserName:   p.resolveUserName(userID),
+			ChatName:   p.resolveChatName(chatID),
+			Content:    answer,
+			ReplyCtx:   rctx,
+		})
+
+		title := answer
+		if len(title) > 50 {
+			title = title[:50] + "…"
+		}
+		return &callback.CardActionTriggerResponse{
+			Card: &callback.Card{
+				Type: "raw",
+				Data: simpleCard2("✅ "+title, "**→ "+answer+"**", "green"),
 			},
 		}, nil
 	}


### PR DESCRIPTION
## Problem

The Feishu AskUserQuestion card only renders option buttons. When none of the options fit, the user has no way to type a custom answer — the CLI UI has an "Other" free-text input, but Feishu had no equivalent. The card note ("reply with the option number or type your answer") suggests typing is possible, and the engine's `resolveAskQuestionAnswer` does pass free text through, but nothing on the card makes that discoverable.

## Solution

Render the ask-question prompt as a Feishu **card schema 2.0** with both interaction modes in one card:

- **Option buttons** — one `behaviors`-callback button per option. The callback value reuses the legacy `"action": "askq:<qIdx>:<optIdx>"` contract, so dispatch, confirmation card, and session tracking all work unchanged.
- **Free-form input** — an `input` field (max 500 chars) inside a `form`, with a `form_submit` "Send" button. `onCardAction` routes the submitted `answer` field as `askq_text:` and forwards the raw text as a user message; the engine's existing free-form answer path resolves it (non-numeric input returned as-is).
- **Confirmation cards** for actions on a schema 2.0 card must themselves be schema 2.0 — a v1 response card is rejected with Feishu error `200830`. Added a `simpleCard2` helper for that.

## Compatibility

- `MultiSelect` prompts keep the numbered-list card (buttons would resolve on first click).
- The rich card lives behind the new optional `core.AskQuestionCardSender` interface (same pattern as `InlineButtonSender`); platforms without it keep the generic card fallback, and core stays platform-agnostic.
- Free-form hint text is localized for all 5 supported languages (en, zh-CN, zh-TW, ja, es).
- `sendAskQuestionPrompt` falls back to the generic path if the platform implementation errors.

## Testing

- [x] `go test ./...` — new tests in `platform/feishu/askq_card_v2_test.go`: card structure (schema/buttons/behaviors value/form fields), form-submit dispatch, blank-answer ignored
- [x] End-to-end on a live Feishu bot: card renders, button clicks return the option label, typed input ("hello，123" / a Chinese sentence) is forwarded verbatim to the agent, and the agent re-asks when a submitted answer is meaningless

🤖 Generated with [Claude Code](https://claude.com/claude-code)