### PR TITLE
fix(feishu): enforce allow_from on card actions

### DIFF
--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -161,7 +161,7 @@ type Platform struct {
 	chatNameCache    sync.Map          // chat_id -> chat name
 	chatMemberCache  sync.Map          // chatID -> *chatMemberEntry
 	recalledMu       sync.Mutex
-	recalledMsgIDs   map[string]time.Time // message_id -> recall time, short TTL race guard
+	recalledMsgIDs         map[string]time.Time // message_id -> recall time, short TTL race guard
 	// Webhook mode fields (for Lark international version)
 	server       *http.Server
 	port         string
@@ -778,6 +778,10 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 	userID := ""
 	if event.Event.Operator != nil {
 		userID = event.Event.Operator.OpenID
+	}
+	if !core.AllowList(p.allowFrom, userID) {
+		slog.Debug(p.tag()+": card action from unauthorized user", "user", userID)
+		return nil, nil
 	}
 	chatID := ""
 	messageID := ""

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -314,6 +314,47 @@ func TestInteractivePlatform_CardActionPassesCardSenderToHandler(t *testing.T) {
 	}
 }
 
+func TestInteractivePlatform_CardActionRejectsUnauthorizedUser(t *testing.T) {
+	platformAny, err := New(map[string]any{
+		"app_id":             "cli_xxx",
+		"app_secret":         "secret",
+		"enable_feishu_card": true,
+		"allow_from":         "ou_allowed",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	ip := platformAny.(*interactivePlatform)
+
+	invoked := make(chan struct{}, 1)
+	ip.handler = func(_ core.Platform, _ *core.Message) {
+		invoked <- struct{}{}
+	}
+	ip.cardNavHandler = func(_ string, _ string) *core.Card {
+		invoked <- struct{}{}
+		return core.NewCard().Markdown("unexpected").Build()
+	}
+
+	resp, err := ip.onCardAction(&callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_denied"},
+			Action:   &callback.CallBackAction{Value: map[string]any{"action": "cmd:/help"}},
+			Context:  &callback.Context{OpenChatID: "oc_test_chat", OpenMessageID: "om_test_message"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("onCardAction() error = %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("unauthorized card action response = %#v, want nil", resp)
+	}
+	select {
+	case <-invoked:
+		t.Fatal("unauthorized card action reached a handler")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func TestInteractivePlatform_CardActionActWithoutCardResponseDoesNotWarn(t *testing.T) {
 	platformAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": true})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Apply the configured allow_from check to every Feishu card callback before navigation, command, permission, or question handlers run.
- Keep empty and wildcard behavior aligned with normal inbound message routing.
- Add a regression test proving an unauthorized card actor cannot invoke message or navigation handlers.

## Why

Normal messages and bot-menu events enforce allow_from, but card actions only checked allow_chat. A user outside the configured allowlist could therefore execute actions on a card visible in an allowed group.

## Verification

- go test ./platform/feishu -run TestInteractivePlatform_CardActionRejectsUnauthorizedUser -count=1
- go test ./platform/feishu -count=1