### PR TITLE
fix(daemon): fall back to ~/.cc-connect/config.toml in daemon install

### DIFF
--- a/cmd/cc-connect/daemon.go
+++ b/cmd/cc-connect/daemon.go
@@ -50,16 +50,20 @@ func daemonInstall(args []string) {
 		os.Exit(1)
 	}
 
-	if err := daemon.Resolve(&cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+	// Fall back to the standard ~/.cc-connect location before resolving,
+	// so that daemon.Resolve's env capture (including ${ENV} placeholder
+	// scanning of the config file) and the installed service's
+	// WorkingDirectory are consistent with the config actually in use.
+	// This matches the lookup behavior of other subcommands (see main.go
+	// config resolution: ./config.toml first, then ~/.cc-connect/config.toml).
+	workDir := cfg.WorkDir
+	if workDir == "" {
+		if wd, gerr := os.Getwd(); gerr == nil {
+			workDir = wd
+		}
 	}
-
-	configPath := cfg.WorkDir + "/config.toml"
+	configPath := filepath.Join(workDir, "config.toml")
 	if _, err := os.Stat(configPath); err != nil {
-		// Fall back to the standard ~/.cc-connect location before giving up,
-		// matching the lookup behavior of other subcommands (see main.go
-		// config resolution: ./config.toml first, then ~/.cc-connect/config.toml).
 		if home, herr := os.UserHomeDir(); herr == nil {
 			homeConfig := filepath.Join(home, ".cc-connect", "config.toml")
 			if _, serr := os.Stat(homeConfig); serr == nil {
@@ -71,10 +75,15 @@ func daemonInstall(args []string) {
 			}
 		}
 		if _, err := os.Stat(configPath); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: config.toml not found in %s\n", cfg.WorkDir)
+			fmt.Fprintf(os.Stderr, "Warning: config.toml not found in %s\n", workDir)
 			fmt.Fprintf(os.Stderr, "  Use --work-dir to specify the config directory or --config to point to the config file\n")
 			os.Exit(1)
 		}
+	}
+
+	if err := daemon.Resolve(&cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
 	}
 
 	mgr, err := daemon.NewManager()

--- a/cmd/cc-connect/daemon.go
+++ b/cmd/cc-connect/daemon.go
@@ -57,9 +57,24 @@ func daemonInstall(args []string) {
 
 	configPath := cfg.WorkDir + "/config.toml"
 	if _, err := os.Stat(configPath); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: config.toml not found in %s\n", cfg.WorkDir)
-		fmt.Fprintf(os.Stderr, "  Use --work-dir to specify the config directory or --config to point to the config file\n")
-		os.Exit(1)
+		// Fall back to the standard ~/.cc-connect location before giving up,
+		// matching the lookup behavior of other subcommands (see main.go
+		// config resolution: ./config.toml first, then ~/.cc-connect/config.toml).
+		if home, herr := os.UserHomeDir(); herr == nil {
+			homeConfig := filepath.Join(home, ".cc-connect", "config.toml")
+			if _, serr := os.Stat(homeConfig); serr == nil {
+				configPath = homeConfig
+				if cfg.WorkDir == "" {
+					cfg.WorkDir = filepath.Join(home, ".cc-connect")
+				}
+				fmt.Fprintf(os.Stderr, "Note: using config from %s\n", homeConfig)
+			}
+		}
+		if _, err := os.Stat(configPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: config.toml not found in %s\n", cfg.WorkDir)
+			fmt.Fprintf(os.Stderr, "  Use --work-dir to specify the config directory or --config to point to the config file\n")
+			os.Exit(1)
+		}
 	}
 
 	mgr, err := daemon.NewManager()


### PR DESCRIPTION
## Summary
- `cc-connect daemon install` previously only checked `./config.toml` in the CWD and exited with a warning even when the standard `~/.cc-connect/config.toml` existed — inconsistent with every other subcommand, which resolves both locations.
- This PR adds the fallback: when the work-dir lookup misses, install tries `~/.cc-connect/config.toml`, prints a `Note: using config from ...`, and only warns when neither location has a config.

Fixes #1783

## Testing
Built and verified all three paths:
- CWD without config + `~/.cc-connect/config.toml` present → `Note: using config from ...` + proceeds
- Different empty CWD → same fallback, proceeds
- Neither location has a config (HOME pointed at empty dir) → original warning + exit 1 preserved

```
$ cd ~ && cc-connect daemon install
Note: using config from /home/user/.cc-connect/config.toml
Service already installed. Use --force to reinstall.
```