### PR TITLE
fix(config): expand ~ in work_dir and base_dir

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -627,6 +627,7 @@ func load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 	resolveEnvInConfig(cfg)
+	expandHomeInConfig(cfg)
 	if cfg.DataDir == "" {
 		if home, err := os.UserHomeDir(); err == nil {
 			cfg.DataDir = filepath.Join(home, ".cc-connect")
@@ -671,6 +672,38 @@ var envPlaceholderPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 
 func resolveEnvInConfig(cfg *Config) {
 	resolveEnvValue(reflect.ValueOf(cfg))
+}
+
+// expandHomeInConfig expands a leading ~ / ~/ in path-like agent options
+// (work_dir, base_dir) to the user's home directory. Without this, a config
+// like work_dir = "~/.codex/workspace" is passed literally to exec.Cmd.Dir,
+// which fails at spawn time with a misleading "fork/exec ...: no such file
+// or directory" that points at the agent binary instead of the directory.
+func expandHomeInConfig(cfg *Config) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return
+	}
+	for i := range cfg.Projects {
+		proj := &cfg.Projects[i]
+		proj.BaseDir = expandLeadingHome(proj.BaseDir, home)
+		if v, ok := proj.Agent.Options["work_dir"]; ok {
+			if s, ok := v.(string); ok {
+				proj.Agent.Options["work_dir"] = expandLeadingHome(s, home)
+			}
+		}
+	}
+}
+
+// expandLeadingHome expands "~" and "~/" at the start of a path to home.
+func expandLeadingHome(s, home string) string {
+	if s == "~" {
+		return home
+	}
+	if strings.HasPrefix(s, "~/") {
+		return filepath.Join(home, s[2:])
+	}
+	return s
 }
 
 func resolveEnvValue(v reflect.Value) {

--- a/config/tilde_expand_integration_test.go
+++ b/config/tilde_expand_integration_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExpandHomeInConfig_LoadsAndExpandsWorkDir is a regression test for
+// issue #1782: a config with work_dir = "~/.codex/workspace" must load with
+// the tilde expanded, not passed literally to exec.Cmd.Dir.
+func TestExpandHomeInConfig_LoadsAndExpandsWorkDir(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	content := `[[projects]]
+name = "tilde-test"
+base_dir = "~/projects"
+
+[projects.agent]
+type = "codex"
+
+[projects.agent.options]
+work_dir = "~/.codex/workspace"
+
+[[projects.platforms]]
+type = "feishu"
+
+[projects.platforms.options]
+app_id = "x"
+app_secret = "y"
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadPermissive(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadPermissive: %v", err)
+	}
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("want 1 project, got %d", len(cfg.Projects))
+	}
+	proj := cfg.Projects[0]
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	wantWorkDir := filepath.Join(home, ".codex/workspace")
+	gotWorkDir, _ := proj.Agent.Options["work_dir"].(string)
+	if gotWorkDir != wantWorkDir {
+		t.Errorf("work_dir = %q, want %q", gotWorkDir, wantWorkDir)
+	}
+
+	wantBaseDir := filepath.Join(home, "projects")
+	if proj.BaseDir != wantBaseDir {
+		t.Errorf("base_dir = %q, want %q", proj.BaseDir, wantBaseDir)
+	}
+}

--- a/config/tilde_expand_test.go
+++ b/config/tilde_expand_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandLeadingHome(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	cases := map[string]string{
+		"~":                      home,
+		"~/.codex/workspace":     filepath.Join(home, ".codex/workspace"),
+		"/abs/path":              "/abs/path",
+		"relative/path":          "relative/path",
+		"/not/a/tilde~/path":     "/not/a/tilde~/path",
+	}
+	for in, want := range cases {
+		if got := expandLeadingHome(in, home); got != want {
+			t.Errorf("expandLeadingHome(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- A config like `work_dir = "~/.codex/workspace"` was previously passed **literally** to `exec.Cmd.Dir`. Go reports a missing cwd as `fork/exec <binary>: no such file or directory`, so the error pointed at the agent binary (which exists and works) instead of the working directory — users end up debugging their codex/claude installation instead of the config value. See #1782 for the full misdirection chain.
- This PR expands a leading `~` / `~/` in project `work_dir` (agent options) and `base_dir` to the user's home at config load time, right after the existing `${ENV}` resolution pass.

Fixes #1782

## Testing
- New unit test `TestExpandLeadingHome` covers `~`, `~/path`, absolute paths, relative paths, and `~` appearing mid-path (not expanded).
- End-to-end check: config with `work_dir = "~/.codex/workspace"` → loaded value is `/home/<user>/.codex/workspace`.
- `go test ./config/` passes (existing suite unaffected).