### PR TITLE
fix(codex): don't pass --listen for stdio app-server transport

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -234,10 +234,30 @@ func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode,
 	return s, nil
 }
 
+// appServerListenURL returns the --listen value for the spawn. A stdio
+// transport ("stdio" / "stdio://") must not open a listener: on codex 0.152+
+// any --listen value switches the app-server to serve the protocol over the
+// listener only, leaving stdio unresponsive and timing out every initialize
+// (see #1781).
+func appServerListenURL(url string) string {
+	listenURL := strings.TrimSpace(url)
+	if listenURL == "stdio://" || listenURL == "stdio" {
+		return ""
+	}
+	return listenURL
+}
+
 func (s *appServerSession) connect() error {
 	args := []string{"app-server"}
-	if strings.TrimSpace(s.url) != "" {
-		args = append(args, "--listen", strings.TrimSpace(s.url))
+	// With url "stdio://" the session speaks JSON-RPC over the stdio pipes.
+	// Pass no --listen flag in that case: on codex 0.152+ a --listen value
+	// (including ws://) switches the app-server to serve the protocol over
+	// the listener only, leaving stdio unresponsive and causing every
+	// initialize request to time out (see #1781). --listen stdio:// is kept
+	// for explicitness on older codex versions where it is a no-op, but a
+	// bare stdio transport should simply not open a listener.
+	if listenURL := appServerListenURL(s.url); listenURL != "" {
+		args = append(args, "--listen", listenURL)
 	}
 	if model := strings.TrimSpace(s.model); model != "" {
 		args = append(args, "-c", fmt.Sprintf("model=%q", model))

--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -235,13 +235,14 @@ func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode,
 }
 
 // appServerListenURL returns the --listen value for the spawn. A stdio
-// transport ("stdio" / "stdio://") must not open a listener: on codex 0.152+
-// any --listen value switches the app-server to serve the protocol over the
-// listener only, leaving stdio unresponsive and timing out every initialize
-// (see #1781).
+// transport ("stdio" / "stdio://", case-insensitive, matching
+// normalizeAppServerURL's EqualFold handling) must not open a listener:
+// on codex 0.152+ any --listen value switches the app-server to serve the
+// protocol over the listener only, leaving stdio unresponsive and timing
+// out every initialize (see #1781).
 func appServerListenURL(url string) string {
 	listenURL := strings.TrimSpace(url)
-	if listenURL == "stdio://" || listenURL == "stdio" {
+	if strings.EqualFold(listenURL, "stdio://") || strings.EqualFold(listenURL, "stdio") {
 		return ""
 	}
 	return listenURL

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -512,6 +512,10 @@ func TestAppServerListenURL(t *testing.T) {
 		"ws://127.0.0.1:3845":    "ws://127.0.0.1:3845",
 		"ws://localhost:9000":    "ws://localhost:9000",
 		"ws://127.0.0.1:3845 ":   "ws://127.0.0.1:3845",
+		" stdio ":                 "",
+		" stdio:// ":               "",
+		"STDIO":                    "",
+		"STDIO://":                 "",
 	}
 	for in, want := range cases {
 		if got := appServerListenURL(in); got != want {

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -502,3 +502,20 @@ func waitForWrittenJSONLine(t *testing.T, w *lockedWriteCloser) string {
 		}
 	}
 }
+
+func TestAppServerListenURL(t *testing.T) {
+	cases := map[string]string{
+		"":                       "",
+		"  ":                     "",
+		"stdio://":               "",
+		"stdio":                  "",
+		"ws://127.0.0.1:3845":    "ws://127.0.0.1:3845",
+		"ws://localhost:9000":    "ws://localhost:9000",
+		"ws://127.0.0.1:3845 ":   "ws://127.0.0.1:3845",
+	}
+	for in, want := range cases {
+		if got := appServerListenURL(in); got != want {
+			t.Errorf("appServerListenURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -121,7 +121,11 @@ func normalizeBackend(raw string) string {
 func normalizeAppServerURL(raw string) string {
 	url := strings.TrimSpace(raw)
 	if url == "" {
-		return "ws://127.0.0.1:3845"
+		// Default to the stdio transport: cc-connect's app_server backend
+		// speaks JSON-RPC over the stdio pipes, and on codex 0.152+ a ws://
+		// --listen value leaves stdio unresponsive (see #1781). Users who
+		// need a WebSocket listener can still set app_server_url explicitly.
+		return "stdio://"
 	}
 	if strings.EqualFold(url, "stdio") {
 		return "stdio://"

--- a/agent/codex/codex_model_test.go
+++ b/agent/codex/codex_model_test.go
@@ -64,9 +64,9 @@ func TestNormalizeAppServerURL_StdIOIsExplicit(t *testing.T) {
 	}
 }
 
-func TestNormalizeAppServerURL_EmptyKeepsWebSocketDefault(t *testing.T) {
-	if got := normalizeAppServerURL(""); got != "ws://127.0.0.1:3845" {
-		t.Fatalf("normalizeAppServerURL(empty) = %q, want ws://127.0.0.1:3845", got)
+func TestNormalizeAppServerURL_EmptyDefaultsToStdio(t *testing.T) {
+	if got := normalizeAppServerURL(""); got != "stdio://" {
+		t.Fatalf("normalizeAppServerURL(empty) = %q, want stdio://", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- On codex 0.152+, any `--listen` value (including `ws://127.0.0.1:3845`, the previous default for `app_server_url`) switches `codex app-server` to serve JSON-RPC **over the listener only** and stops responding on stdio. Since `connect()` speaks the protocol over the stdio pipes, every `initialize` timed out after 2 minutes: `codex app-server initialize: initialize timed out` (#1781).
- Two changes:
  1. A stdio transport (`app_server_url = "stdio"` / `"stdio://"`) spawns plain `codex app-server` with **no `--listen` flag** (which is also codex's own default transport), restoring stdio JSON-RPC.
  2. **The default `app_server_url` is now `stdio://`** — the previous ws:// default was broken out of the box on codex 0.152+ for every user. No documented contract depends on the ws default (verified absent from docs/ and config.example.toml). Users who want a real WebSocket listener can still set a `ws://` URL explicitly.

Fixes #1781

## Testing
- Unit tests: `TestAppServerListenURL` (transport mapping) and updated `TestNormalizeAppServerURL_EmptyDefaultsToStdio` (new default).
- `go test ./agent/codex/` passes.
- End-to-end spawn verification against a stub codex binary, **both with explicit `app_server_url = "stdio"` and with no `app_server_url` at all**: spawn args are plain `app-server` (no `--listen`), vs. the previous `app-server --listen ws://127.0.0.1:3845`.
- Verified against real codex-cli 0.152.0 over Feishu: session starts and replies in seconds (previously timed out every time).

## Notes for reviewers
- Alternative direction (kept out to stay minimal): making cc-connect actually connect over WebSocket/UnixSocket when such a URL is configured. `codex app-server` also supports a `unix://` transport on 0.152+ which could enable a single resident app-server shared across sessions — that's an architecture decision better suited to a separate discussion.