### PR TITLE
fix(dingtalk): add opt-in AI Card preview message

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1098,6 +1098,8 @@ app_secret = "your-feishu-app-secret"
 #                                 # 收到消息时添加的表情回复（默认 "🤔Thinking"）；设为 "none" 可禁用
 # done_emoji = "none"             # Emotion when agent finishes a reply (e.g. "🥳Done"); set to "none" to disable
 #                                 # Agent 完成回复后添加的表情回复（如 "🥳Done"）；设为 "none" 可禁用
+# card_final_preview_message = false # After an AI Card turn, send a separate Markdown summary
+#                                    # AI 卡片完成后额外发送一条普通 Markdown 摘要，用于刷新会话列表预览
 
 # WPS Xiezuo / WPS 协作 (uncomment to enable / 取消注释以启用)
 # 1. Create a WPS Open Platform app and enable event WebSocket delivery

--- a/platform/dingtalk/card.go
+++ b/platform/dingtalk/card.go
@@ -22,6 +22,7 @@ type aiCard struct {
 	outTrackId     string
 	templateKey    string // 卡片模板变量名，默认 "content"
 	platform       *Platform
+	replyCtx       replyContext
 
 	mu              sync.Mutex
 	state           string // "processing" | "finished" | "failed"
@@ -209,6 +210,7 @@ func (p *Platform) createAICard(ctx context.Context, rc replyContext) (*aiCard, 
 		outTrackId:     resolvedOutTrackId,
 		templateKey:    p.cardTemplateKey,
 		platform:       p,
+		replyCtx:       rc,
 		state:          "processing",
 		throttleMs:     p.cardThrottleMs,
 		done:           make(chan struct{}),
@@ -429,7 +431,19 @@ func (c *aiCard) Finalize(ctx context.Context, content string) error {
 	}
 	c.mu.Unlock()
 
-	return err
+	if err != nil {
+		return err
+	}
+	// DingTalk does not refresh the conversation-list preview when an AI Card
+	// is finalized. Opt-in to a separate normal message to refresh it.
+	if c.platform.cardFinalPreviewMessage {
+		if sendErr := c.platform.Reply(ctx, c.replyCtx, content); sendErr != nil {
+			slog.Warn("dingtalk: final preview message failed", "error", sendErr, "outTrackId", c.outTrackId)
+		} else {
+			slog.Info("dingtalk: final preview message sent", "outTrackId", c.outTrackId)
+		}
+	}
+	return nil
 }
 
 // Failed returns true if the card has entered a failed state.

--- a/platform/dingtalk/card_preview_message_test.go
+++ b/platform/dingtalk/card_preview_message_test.go
@@ -1,0 +1,114 @@
+package dingtalk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestCardFinalPreviewMessage_DefaultsOff(t *testing.T) {
+	p, err := New(map[string]any{
+		"client_id":        "cid",
+		"client_secret":    "secret",
+		"card_template_id": "template.schema",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if p.(*Platform).cardFinalPreviewMessage {
+		t.Fatal("card_final_preview_message defaults to true")
+	}
+}
+
+func TestCardFinalPreviewMessage_OptIn(t *testing.T) {
+	p, err := New(map[string]any{
+		"client_id":                  "cid",
+		"client_secret":              "secret",
+		"card_template_id":           "template.schema",
+		"card_final_preview_message": true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !p.(*Platform).cardFinalPreviewMessage {
+		t.Fatal("card_final_preview_message = false, want true")
+	}
+}
+
+func TestAICardFinalize_FinalPreviewMessageIsOptIn(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		enabled    bool
+		wantNormal bool
+	}{
+		{name: "disabled", enabled: false, wantNormal: false},
+		{name: "enabled", enabled: true, wantNormal: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var streamRequests int
+			cardClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				streamRequests++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(nil)),
+					Header:     make(http.Header),
+				}, nil
+			})}
+
+			var normalRequests int
+			var normalPayload map[string]any
+			normalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				normalRequests++
+				if err := json.NewDecoder(r.Body).Decode(&normalPayload); err != nil {
+					t.Fatalf("decode normal message: %v", err)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer normalServer.Close()
+
+			previousHTTPClient := core.HTTPClient
+			core.HTTPClient = normalServer.Client()
+			defer func() { core.HTTPClient = previousHTTPClient }()
+
+			card := &aiCard{
+				outTrackId:  "test-track",
+				templateKey: "content",
+				platform: &Platform{
+					httpClient:              cardClient,
+					accessToken:             "test-token",
+					tokenExpiry:             time.Now().Add(time.Hour),
+					cardFinalPreviewMessage: tt.enabled,
+				},
+				replyCtx: replyContext{sessionWebhook: normalServer.URL},
+				state:    "processing",
+				done:     make(chan struct{}),
+			}
+
+			if err := card.Finalize(context.Background(), "final content"); err != nil {
+				t.Fatalf("Finalize: %v", err)
+			}
+			if streamRequests != 1 {
+				t.Fatalf("stream requests = %d, want 1", streamRequests)
+			}
+			if got := normalRequests > 0; got != tt.wantNormal {
+				t.Fatalf("normal message sent = %v, want %v", got, tt.wantNormal)
+			}
+			if tt.wantNormal && normalPayload["msgtype"] != "markdown" {
+				t.Fatalf("normal message msgtype = %v, want markdown", normalPayload["msgtype"])
+			}
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/platform/dingtalk/dingtalk.go
+++ b/platform/dingtalk/dingtalk.go
@@ -90,8 +90,11 @@ type Platform struct {
 	cardTemplateID  string
 	cardTemplateKey string
 	cardThrottleMs  int
-	degradeUntil    time.Time
-	degradeMu       sync.Mutex
+	// cardFinalPreviewMessage sends a normal Markdown message after an AI Card
+	// turn so DingTalk refreshes the conversation-list preview.
+	cardFinalPreviewMessage bool
+	degradeUntil            time.Time
+	degradeMu               sync.Mutex
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -152,20 +155,22 @@ func New(opts map[string]any) (core.Platform, error) {
 	} else if v, ok := opts["card_throttle_ms"].(int); ok && v > 0 {
 		cardThrottleMs = v
 	}
+	cardFinalPreviewMessage, _ := opts["card_final_preview_message"].(bool)
 
 	return &Platform{
-		clientID:              clientID,
-		clientSecret:          clientSecret,
-		robotCode:             robotCode,
-		agentID:               agentID,
-		allowFrom:             allowFrom,
-		shareSessionInChannel: shareSessionInChannel,
-		httpClient:            &http.Client{Timeout: 30 * time.Second},
-		reactionEmoji:         reactionEmoji,
-		doneEmoji:             doneEmoji,
-		cardTemplateID:        cardTemplateID,
-		cardTemplateKey:       cardTemplateKey,
-		cardThrottleMs:        cardThrottleMs,
+		clientID:                clientID,
+		clientSecret:            clientSecret,
+		robotCode:               robotCode,
+		agentID:                 agentID,
+		allowFrom:               allowFrom,
+		shareSessionInChannel:   shareSessionInChannel,
+		httpClient:              &http.Client{Timeout: 30 * time.Second},
+		reactionEmoji:           reactionEmoji,
+		doneEmoji:               doneEmoji,
+		cardTemplateID:          cardTemplateID,
+		cardTemplateKey:         cardTemplateKey,
+		cardThrottleMs:          cardThrottleMs,
+		cardFinalPreviewMessage: cardFinalPreviewMessage,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

This PR implements option 2 for DingTalk AI Card conversation-list previews.

After an AI Card is successfully finalized, it can optionally send one separate normal Markdown message using the original reply context. DingTalk then refreshes the conversation-list preview from that normal message.

## Scope and behavior

- Added `card_final_preview_message`, defaulting to `false`.
- The extra message is sent only from the DingTalk AI Card `Finalize` path.
- Normal Markdown replies do not send an additional message.
- If the optional preview message fails, the completed AI Card is still treated as successful; the failure is logged as a warning.
- The tradeoff is one additional summary message in the chat when the option is enabled.

This intentionally does not attempt to update the AI Card's unsupported conversation-list fields. If the author agrees with this independent-message approach, the PR can be merged; if not, it can be closed or discarded.

## Validation

- `go test ./platform/dingtalk -count=1`
- `go build -tags no_web ./...`
- `go vet -tags no_web ./...`
- Added tests covering both disabled and enabled behavior, including verification that the extra request is Markdown.

Full CI should run on Ubuntu. The local Windows environment cannot run the repository's race tests because no C compiler is installed, and the full web build requires CI's frontend asset build step.