### PR TITLE
feat(codex): support fast mode

### DIFF
--- a/agent/codex/appserver_session.go
+++ b/agent/codex/appserver_session.go
@@ -145,6 +145,7 @@ type appServerSession struct {
 	workDir        string
 	model          string
 	effort         string
+	serviceTier    string
 	mode           string
 	baseURL        string
 	modelProvider  string
@@ -192,12 +193,17 @@ const (
 )
 
 func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string, systemPrompt string, appendPrompt string) (*appServerSession, error) {
+	return newAppServerSessionWithServiceTier(ctx, url, workDir, model, effort, "", mode, resumeID, baseURL, modelProvider, extraEnv, codexHome, systemPrompt, appendPrompt)
+}
+
+func newAppServerSessionWithServiceTier(ctx context.Context, url, workDir, model, effort, serviceTier, mode, resumeID, baseURL, modelProvider string, extraEnv []string, codexHome string, systemPrompt string, appendPrompt string) (*appServerSession, error) {
 	sessionCtx, cancel := context.WithCancel(ctx)
 	s := &appServerSession{
 		url:              url,
 		workDir:          workDir,
 		model:            model,
 		effort:           effort,
+		serviceTier:      normalizeServiceTier(serviceTier),
 		mode:             mode,
 		baseURL:          baseURL,
 		modelProvider:    modelProvider,
@@ -235,22 +241,7 @@ func newAppServerSession(ctx context.Context, url, workDir, model, effort, mode,
 }
 
 func (s *appServerSession) connect() error {
-	args := []string{"app-server"}
-	if strings.TrimSpace(s.url) != "" {
-		args = append(args, "--listen", strings.TrimSpace(s.url))
-	}
-	if model := strings.TrimSpace(s.model); model != "" {
-		args = append(args, "-c", fmt.Sprintf("model=%q", model))
-	}
-	if effort := strings.TrimSpace(s.effort); effort != "" {
-		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%q", effort))
-	}
-	if provider := strings.TrimSpace(s.modelProvider); provider != "" {
-		args = append(args, "-c", fmt.Sprintf("model_provider=%q", provider))
-	}
-	if baseURL := strings.TrimSpace(s.baseURL); baseURL != "" {
-		args = append(args, "-c", fmt.Sprintf("openai_base_url=%q", baseURL))
-	}
+	args := s.buildCommandArgs()
 	cmd := exec.CommandContext(s.ctx, "codex", args...)
 	cmd.Dir = s.workDir
 	env := append([]string(nil), s.extraEnv...)
@@ -289,6 +280,29 @@ func (s *appServerSession) connect() error {
 	go s.stderrLoop(stderr)
 	go s.waitLoop()
 	return nil
+}
+
+func (s *appServerSession) buildCommandArgs() []string {
+	args := []string{"app-server"}
+	if strings.TrimSpace(s.url) != "" {
+		args = append(args, "--listen", strings.TrimSpace(s.url))
+	}
+	if model := strings.TrimSpace(s.model); model != "" {
+		args = append(args, "-c", fmt.Sprintf("model=%q", model))
+	}
+	if effort := strings.TrimSpace(s.effort); effort != "" {
+		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%q", effort))
+	}
+	if serviceTier := normalizeServiceTier(s.serviceTier); serviceTier != "" {
+		args = append(args, "-c", fmt.Sprintf("service_tier=%q", serviceTier))
+	}
+	if provider := strings.TrimSpace(s.modelProvider); provider != "" {
+		args = append(args, "-c", fmt.Sprintf("model_provider=%q", provider))
+	}
+	if baseURL := strings.TrimSpace(s.baseURL); baseURL != "" {
+		args = append(args, "-c", fmt.Sprintf("openai_base_url=%q", baseURL))
+	}
+	return args
 }
 
 func (s *appServerSession) initialize() error {

--- a/agent/codex/appserver_session_test.go
+++ b/agent/codex/appserver_session_test.go
@@ -13,6 +13,23 @@ import (
 	"github.com/chenhg5/cc-connect/core"
 )
 
+func TestAppServerCommandArgs_IncludesFastServiceTier(t *testing.T) {
+	s := &appServerSession{url: "stdio://", serviceTier: "fast"}
+	args := s.buildCommandArgs()
+	if !containsSequence(args, []string{"-c", `service_tier="fast"`}) {
+		t.Fatalf("args missing fast service tier: %v", args)
+	}
+}
+
+func TestAppServerCommandArgs_OmitsUnsetServiceTier(t *testing.T) {
+	args := (&appServerSession{url: "stdio://"}).buildCommandArgs()
+	for _, arg := range args {
+		if strings.Contains(arg, "service_tier=") {
+			t.Fatalf("unset service tier should inherit Codex config, args=%v", args)
+		}
+	}
+}
+
 func TestAppServerSession_ApplyThreadRuntimeState(t *testing.T) {
 	s := &appServerSession{}
 	effort := "xhigh"

--- a/agent/codex/codex.go
+++ b/agent/codex/codex.go
@@ -37,6 +37,7 @@ type Agent struct {
 	workDir         string
 	model           string
 	reasoningEffort string
+	serviceTier     string // "fast" | "default" | "" (inherit Codex config)
 	mode            string // "suggest" | "auto-edit" | "full-auto" | "yolo"
 	backend         string // "exec" | "app_server"
 	appServerURL    string
@@ -59,6 +60,7 @@ func New(opts map[string]any) (core.Agent, error) {
 	}
 	model, _ := opts["model"].(string)
 	reasoningEffort, _ := opts["reasoning_effort"].(string)
+	serviceTier, _ := opts["service_tier"].(string)
 	mode, _ := opts["mode"].(string)
 	backend, _ := opts["backend"].(string)
 	appServerURL, _ := opts["app_server_url"].(string)
@@ -96,6 +98,7 @@ func New(opts map[string]any) (core.Agent, error) {
 		workDir:         workDir,
 		model:           model,
 		reasoningEffort: normalizeReasoningEffort(reasoningEffort),
+		serviceTier:     normalizeServiceTier(serviceTier),
 		mode:            mode,
 		backend:         backend,
 		appServerURL:    appServerURL,
@@ -107,6 +110,17 @@ func New(opts map[string]any) (core.Agent, error) {
 		configEnv:       configEnv,
 		activeIdx:       -1,
 	}, nil
+}
+
+func normalizeServiceTier(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "fast":
+		return "fast"
+	case "default":
+		return "default"
+	default:
+		return ""
+	}
 }
 
 func normalizeBackend(raw string) string {
@@ -204,6 +218,23 @@ func (a *Agent) GetReasoningEffort() string {
 
 func (a *Agent) AvailableReasoningEfforts() []string {
 	return []string{"low", "medium", "high", "xhigh", "max"}
+}
+
+func (a *Agent) SetFastMode(enabled bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if enabled {
+		a.serviceTier = "fast"
+	} else {
+		a.serviceTier = "default"
+	}
+	slog.Info("codex: fast mode changed", "enabled", enabled)
+}
+
+func (a *Agent) FastModeEnabled() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.serviceTier == "fast"
 }
 
 func (a *Agent) configuredModels() []core.ModelOption {
@@ -467,6 +498,7 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	mode := a.mode
 	model := a.model
 	reasoningEffort := a.reasoningEffort
+	serviceTier := a.serviceTier
 	backend := a.backend
 	appServerURL := a.appServerURL
 	codexHome := a.codexHome
@@ -502,13 +534,18 @@ func (a *Agent) StartSession(ctx context.Context, sessionID string) (core.AgentS
 	}
 
 	if backend == "app_server" {
-		return newAppServerSession(ctx, appServerURL, workDir, model, reasoningEffort, mode, sessionID, baseURL, provName, extraEnv, codexHome, systemPrompt, appendPrompt)
+		return newAppServerSessionWithServiceTier(ctx, appServerURL, workDir, model, reasoningEffort, serviceTier, mode, sessionID, baseURL, provName, extraEnv, codexHome, systemPrompt, appendPrompt)
 	}
 	if codexHome != "" {
 		extraEnv = append(extraEnv, "CODEX_HOME="+codexHome)
 	}
 
-	return newCodexSession(ctx, cliBin, cliExtraArgs, workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv, provName, systemPrompt, appendPrompt)
+	session, err := newCodexSession(ctx, cliBin, cliExtraArgs, workDir, model, reasoningEffort, mode, sessionID, baseURL, extraEnv, provName, systemPrompt, appendPrompt)
+	if err != nil {
+		return nil, err
+	}
+	session.serviceTier = serviceTier
+	return session, nil
 }
 
 func (a *Agent) ListSessions(_ context.Context) ([]core.AgentSessionInfo, error) {
@@ -566,6 +603,9 @@ func (a *Agent) WorkspaceAgentOptions() map[string]any {
 	}
 	if a.reasoningEffort != "" {
 		opts["reasoning_effort"] = a.reasoningEffort
+	}
+	if a.serviceTier != "" {
+		opts["service_tier"] = a.serviceTier
 	}
 	if a.appServerURL != "" {
 		opts["app_server_url"] = a.appServerURL

--- a/agent/codex/session.go
+++ b/agent/codex/session.go
@@ -27,6 +27,7 @@ type codexSession struct {
 	workDir        string
 	model          string
 	effort         string
+	serviceTier    string
 	mode           string
 	baseURL        string   // provider base URL; passed as -c openai_base_url=<url>
 	modelProvider  string   // Codex model_provider name; passed as -c model_provider=<name>
@@ -264,6 +265,9 @@ func (cs *codexSession) buildExecArgs(prompt string, imagePaths []string) []stri
 	}
 	if cs.effort != "" {
 		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%q", cs.effort))
+	}
+	if serviceTier := normalizeServiceTier(cs.serviceTier); serviceTier != "" {
+		args = append(args, "-c", fmt.Sprintf("service_tier=%q", serviceTier))
 	}
 
 	if isResume {

--- a/agent/codex/session_test.go
+++ b/agent/codex/session_test.go
@@ -31,6 +31,16 @@ func TestNormalizeReasoningEffort_AcceptsMax(t *testing.T) {
 	}
 }
 
+func TestNormalizeServiceTier(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{"fast", "fast"}, {" FAST ", "fast"}, {"default", "default"}, {"", ""}, {"priority", ""},
+	} {
+		if got := normalizeServiceTier(tc.input); got != tc.want {
+			t.Fatalf("normalizeServiceTier(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
 func TestAvailableReasoningEfforts_IncludesMax(t *testing.T) {
 	agent := &Agent{}
 	got := agent.AvailableReasoningEfforts()
@@ -76,6 +86,30 @@ func TestBuildExecArgs_IncludesReasoningEffort(t *testing.T) {
 		if args[i] != want[i] {
 			t.Fatalf("args[%d] = %q, want %q, args=%v", i, args[i], want[i], args)
 		}
+	}
+}
+
+func TestBuildExecArgs_IncludesFastServiceTier(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "suggest", "", "", nil, "", "", "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	cs.serviceTier = "fast"
+	args := cs.buildExecArgs("hello", nil)
+	if !containsSequence(args, []string{"-c", `service_tier="fast"`}) {
+		t.Fatalf("args missing fast service tier: %v", args)
+	}
+}
+
+func TestBuildExecArgs_IncludesExplicitDefaultServiceTier(t *testing.T) {
+	cs, err := newCodexSession(context.Background(), "codex", nil, "/tmp/project", "", "", "suggest", "", "", nil, "", "", "")
+	if err != nil {
+		t.Fatalf("newCodexSession: %v", err)
+	}
+	cs.serviceTier = "default"
+	args := cs.buildExecArgs("hello", nil)
+	if !containsSequence(args, []string{"-c", `service_tier="default"`}) {
+		t.Fatalf("args missing default service tier: %v", args)
 	}
 }
 

--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -932,6 +932,9 @@ func main() {
 		engine.SetModelSaveFunc(func(model string) error {
 			return config.SaveAgentModel(projName, model)
 		})
+		engine.SetFastModeSaveFunc(func(serviceTier string) error {
+			return config.SaveAgentServiceTier(projName, serviceTier)
+		})
 
 		// Wire config reload
 		capturedEngine := engine

--- a/config.example.toml
+++ b/config.example.toml
@@ -1635,6 +1635,7 @@ app_secret = "your-feishu-app-secret"
 #
 # Optional: specify Codex reasoning effort / 可选：指定 Codex 推理强度
 # reasoning_effort = "high"  # "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
+# service_tier = "default"   # "default" | "fast" (OpenAI Codex Fast mode)
 #
 # Optional: project system prompt / 可选：项目系统提示
 # Codex has no native system-prompt flag, so cc-connect injects this as a

--- a/config/config.go
+++ b/config/config.go
@@ -1296,6 +1296,12 @@ func SaveAgentModel(projectName, model string) error {
 	return patchProjectAgentOption(projectName, "model", model)
 }
 
+func SaveAgentServiceTier(projectName, serviceTier string) error {
+	configMu.Lock()
+	defer configMu.Unlock()
+	return patchProjectAgentOption(projectName, "service_tier", serviceTier)
+}
+
 // AddProviderToConfig adds a provider to a project's agent config and saves.
 func AddProviderToConfig(projectName string, provider ProviderConfig) error {
 	configMu.Lock()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -808,6 +808,17 @@ func TestSaveAgentModel(t *testing.T) {
 	}
 }
 
+func TestSaveAgentServiceTier(t *testing.T) {
+	writeTestConfig(t, providerConfigTOML)
+	if err := SaveAgentServiceTier("demo", "fast"); err != nil {
+		t.Fatalf("SaveAgentServiceTier() error: %v", err)
+	}
+	cfg := readTestConfig(t)
+	if got, _ := cfg.Projects[0].Agent.Options["service_tier"].(string); got != "fast" {
+		t.Fatalf("agent.options.service_tier = %q, want fast", got)
+	}
+}
+
 const providerConfigWithCommentsTOML = `# This is my config file
 # Very important - do not lose this!
 custom_top = "keep_me"

--- a/core/engine.go
+++ b/core/engine.go
@@ -376,6 +376,7 @@ type Engine struct {
 	providerRefsSaveFunc    func(refs []string) error
 	listGlobalProvidersFunc func(agentType string) ([]ProviderConfig, error)
 	modelSaveFunc           func(model string) error
+	fastModeSaveFunc        func(serviceTier string) error
 
 	ttsSaveFunc func(mode string) error
 
@@ -1082,6 +1083,10 @@ func (e *Engine) SetListGlobalProvidersFunc(fn func(agentType string) ([]Provide
 
 func (e *Engine) SetModelSaveFunc(fn func(model string) error) {
 	e.modelSaveFunc = fn
+}
+
+func (e *Engine) SetFastModeSaveFunc(fn func(serviceTier string) error) {
+	e.fastModeSaveFunc = fn
 }
 
 // AddPlatform appends a platform to the engine after construction.
@@ -3925,6 +3930,9 @@ func (e *Engine) getOrCreateWorkspaceAgent(workspace string) (Agent, *SessionMan
 		if m := e.projectState.WorkspaceModelOverride(workspace); m != "" {
 			opts["model"] = m
 		}
+		if tier := e.projectState.WorkspaceServiceTierOverride(workspace); tier != "" {
+			opts["service_tier"] = tier
+		}
 	}
 
 	// Copy model from original agent if possible
@@ -6515,6 +6523,7 @@ var builtinCommands = []struct {
 	{[]string{"allow"}, "allow"},
 	{[]string{"model"}, "model"},
 	{[]string{"reasoning", "effort"}, "reasoning"},
+	{[]string{"fast"}, "fast"},
 	{[]string{"mode"}, "mode"},
 	{[]string{"lang"}, "lang"},
 	{[]string{"quiet"}, "quiet"},
@@ -6725,6 +6734,8 @@ func (e *Engine) handleCommand(p Platform, msg *Message, raw string) bool {
 		e.cmdModel(p, msg, args)
 	case "reasoning":
 		e.cmdReasoning(p, msg, args)
+	case "fast":
+		e.cmdFast(p, msg, args)
 	case "mode":
 		e.cmdMode(p, msg, args)
 	case "lang":
@@ -8759,6 +8770,13 @@ func (e *Engine) cmdStatus(p Platform, msg *Message) {
 				modeStr = e.i18n.Tf(MsgStatusMode, mode)
 			}
 		}
+		if fs, ok := agent.(FastModeSwitcher); ok {
+			state := e.i18n.T(MsgDisabledShort)
+			if fs.FastModeEnabled() {
+				state = e.i18n.T(MsgEnabledShort)
+			}
+			modeStr += e.i18n.Tf(MsgStatusFastMode, state)
+		}
 		thinkingStr := e.i18n.T(MsgDisabledShort)
 		if e.display.ThinkingMessages {
 			thinkingStr = e.i18n.T(MsgEnabledShort)
@@ -9196,6 +9214,13 @@ func (e *Engine) renderStatusCard(sessionKey string, userID string) *Card {
 			modeStr = e.i18n.Tf(MsgStatusMode, mode)
 		}
 	}
+	if fs, ok := agent.(FastModeSwitcher); ok {
+		state := e.i18n.T(MsgDisabledShort)
+		if fs.FastModeEnabled() {
+			state = e.i18n.T(MsgEnabledShort)
+		}
+		modeStr += e.i18n.Tf(MsgStatusFastMode, state)
+	}
 	thinkingStr := e.i18n.T(MsgDisabledShort)
 	if e.display.ThinkingMessages {
 		thinkingStr = e.i18n.T(MsgEnabledShort)
@@ -9525,6 +9550,7 @@ func helpCardGroups() []helpCardGroup {
 			items: []helpCardItem{
 				{command: "/model", action: "nav:/model"},
 				{command: "/reasoning", action: "nav:/reasoning"},
+				{command: "/fast", action: "cmd:/fast"},
 				{command: "/mode", action: "nav:/mode"},
 				{command: "/lang", action: "nav:/lang"},
 				{command: "/provider", action: "nav:/provider"},
@@ -10076,6 +10102,58 @@ func (e *Engine) cmdReasoning(p Platform, msg *Message, args []string) {
 	sessions.Save()
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgReasoningChanged, target))
+}
+
+func (e *Engine) cmdFast(p Platform, msg *Message, args []string) {
+	agent, sessions, interactiveKey, err := e.commandContext(p, msg)
+	if err != nil {
+		e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgWsResolutionError, err))
+		return
+	}
+	switcher, ok := agent.(FastModeSwitcher)
+	if !ok {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFastNotSupported))
+		return
+	}
+	if len(args) == 0 {
+		if switcher.FastModeEnabled() {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFastEnabled))
+		} else {
+			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFastDisabled))
+		}
+		return
+	}
+	var enabled bool
+	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "on", "enable", "enabled", "true", "1":
+		enabled = true
+	case "off", "disable", "disabled", "false", "0":
+		enabled = false
+	default:
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFastUsage))
+		return
+	}
+	serviceTier := "default"
+	if enabled {
+		serviceTier = "fast"
+	}
+	if agent == e.agent && e.fastModeSaveFunc != nil {
+		if err := e.fastModeSaveFunc(serviceTier); err != nil {
+			e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgFastChangeFailed, err))
+			return
+		}
+	}
+	switcher.SetFastMode(enabled)
+	e.persistWorkspaceFastModeOverride(interactiveKey, msg.SessionKey, agent, serviceTier)
+	e.cleanupInteractiveState(interactiveKey)
+	// Keep the backend ID and local history so the next process resumes the
+	// conversation with the new service tier.
+	sessions.Save()
+	if enabled {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFastChangedOn))
+	} else {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgFastChangedOff))
+	}
 }
 
 func (e *Engine) cmdMode(p Platform, msg *Message, args []string) {
@@ -12277,6 +12355,18 @@ func (e *Engine) persistWorkspaceModelOverride(interactiveKey, sessionKey string
 		return
 	}
 	e.projectState.SetWorkspaceModelOverride(workspace, model)
+	e.projectState.Save()
+}
+
+func (e *Engine) persistWorkspaceFastModeOverride(interactiveKey, sessionKey string, agent Agent, serviceTier string) {
+	if e.projectState == nil || !e.multiWorkspace || agent == e.agent {
+		return
+	}
+	workspace := workspaceModelOverrideKey(interactiveKey, sessionKey, agent)
+	if workspace == "" {
+		return
+	}
+	e.projectState.SetWorkspaceServiceTierOverride(workspace, serviceTier)
 	e.projectState.Save()
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -445,6 +445,7 @@ type stubModelModeAgent struct {
 	model           string
 	mode            string
 	reasoningEffort string
+	fastMode        bool
 	providers       []ProviderConfig
 	active          string
 }
@@ -547,6 +548,9 @@ func (a *stubModelModeAgent) GetReasoningEffort() string {
 func (a *stubModelModeAgent) AvailableReasoningEfforts() []string {
 	return []string{"low", "medium", "high", "xhigh"}
 }
+
+func (a *stubModelModeAgent) SetFastMode(enabled bool) { a.fastMode = enabled }
+func (a *stubModelModeAgent) FastModeEnabled() bool    { return a.fastMode }
 
 type namedStubModelModeAgent struct {
 	stubModelModeAgent
@@ -5503,6 +5507,44 @@ func TestCmdReasoning_RejectsMinimal(t *testing.T) {
 	}
 	if len(p.sent) != 1 || !strings.Contains(p.sent[0], "/reasoning <number>") || strings.Contains(p.sent[0], "minimal") {
 		t.Fatalf("sent = %v, want usage without minimal", p.sent)
+	}
+}
+
+func TestCmdFast_SwitchesTierPersistsAndPreservesConversation(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	agent := &stubModelModeAgent{}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	msg := &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}
+	s := e.sessions.GetOrCreateActive(msg.SessionKey)
+	s.SetAgentSessionID("existing-session", "test")
+	s.AddHistory("user", "hello")
+	var saved string
+	e.SetFastModeSaveFunc(func(tier string) error { saved = tier; return nil })
+
+	e.cmdFast(p, msg, []string{"on"})
+
+	if !agent.FastModeEnabled() || saved != "fast" {
+		t.Fatalf("fast=%v saved=%q, want true/fast", agent.FastModeEnabled(), saved)
+	}
+	if got := s.GetAgentSessionID(); got != "existing-session" {
+		t.Fatalf("AgentSessionID = %q, want preserved", got)
+	}
+	if got := len(s.History); got != 1 {
+		t.Fatalf("history length = %d, want preserved", got)
+	}
+
+	e.cmdFast(p, msg, []string{"off"})
+	if agent.FastModeEnabled() || saved != "default" {
+		t.Fatalf("fast=%v saved=%q, want false/default", agent.FastModeEnabled(), saved)
+	}
+}
+
+func TestCmdFast_RejectsUnsupportedAgent(t *testing.T) {
+	p := &stubPlatformEngine{n: "plain"}
+	e := NewEngine("test", &stubAgent{}, []Platform{p}, "", LangEnglish)
+	e.cmdFast(p, &Message{SessionKey: "test:user1", ReplyCtx: "ctx"}, []string{"on"})
+	if len(p.sent) != 1 || !strings.Contains(p.sent[0], "does not support Fast mode") {
+		t.Fatalf("sent = %v", p.sent)
 	}
 }
 

--- a/core/i18n.go
+++ b/core/i18n.go
@@ -342,6 +342,13 @@ const (
 	MsgReasoningCurrent      MsgKey = "reasoning_current"
 	MsgReasoningChanged      MsgKey = "reasoning_changed"
 	MsgReasoningNotSupported MsgKey = "reasoning_not_supported"
+	MsgFastEnabled           MsgKey = "fast_enabled"
+	MsgFastDisabled          MsgKey = "fast_disabled"
+	MsgFastChangedOn         MsgKey = "fast_changed_on"
+	MsgFastChangedOff        MsgKey = "fast_changed_off"
+	MsgFastChangeFailed      MsgKey = "fast_change_failed"
+	MsgFastNotSupported      MsgKey = "fast_not_supported"
+	MsgFastUsage             MsgKey = "fast_usage"
 
 	MsgCompressNotSupported MsgKey = "compress_not_supported"
 	MsgCompressing          MsgKey = "compressing"
@@ -360,6 +367,7 @@ const (
 
 	// Inline strings previously hardcoded in engine.go
 	MsgStatusMode             MsgKey = "status_mode"
+	MsgStatusFastMode         MsgKey = "status_fast_mode"
 	MsgStatusSession          MsgKey = "status_session"
 	MsgStatusCron             MsgKey = "status_cron"
 	MsgStatusThinkingMessages MsgKey = "status_thinking_messages"
@@ -413,31 +421,31 @@ const (
 	MsgCronIDLabel               MsgKey = "cron_id_label"
 	MsgCronFailedSuffix          MsgKey = "cron_failed_suffix"
 
-	MsgTimerNotAvailable  MsgKey = "timer_not_available"
-	MsgTimerUsage         MsgKey = "timer_usage"
-	MsgTimerAddUsage      MsgKey = "timer_add_usage"
-	MsgTimerAdded         MsgKey = "timer_added"
-	MsgTimerAddedExec     MsgKey = "timer_added_exec"
-	MsgTimerAddExecUsage  MsgKey = "timer_addexec_usage"
-	MsgTimerEmpty         MsgKey = "timer_empty"
-	MsgTimerListTitle     MsgKey = "timer_list_title"
-	MsgTimerListFooter    MsgKey = "timer_list_footer"
-	MsgTimerDelUsage      MsgKey = "timer_del_usage"
-	MsgTimerMuteUsage     MsgKey = "timer_mute_usage"
-	MsgTimerDeleted       MsgKey = "timer_deleted"
-	MsgTimerNotFound      MsgKey = "timer_not_found"
-	MsgTimerMuted         MsgKey = "timer_muted"
-	MsgTimerUnmuted       MsgKey = "timer_unmuted"
-	MsgTimerCardHint      MsgKey = "timer_card_hint"
-	MsgTimerBtnMute       MsgKey = "timer_btn_mute"
-	MsgTimerBtnUnmute     MsgKey = "timer_btn_unmute"
-	MsgTimerBtnDelete     MsgKey = "timer_btn_delete"
-	MsgTimerIDLabel       MsgKey = "timer_id_label"
-	MsgTimerScheduledLabel MsgKey = "timer_scheduled_label"
-	MsgTimerFailedSuffix  MsgKey = "timer_failed_suffix"
-	MsgCommandsTagAgent          MsgKey = "commands_tag_agent"
-	MsgCommandsTagShell          MsgKey = "commands_tag_shell"
-	MsgUpgradeTimeoutSuffix      MsgKey = "upgrade_timeout_suffix"
+	MsgTimerNotAvailable    MsgKey = "timer_not_available"
+	MsgTimerUsage           MsgKey = "timer_usage"
+	MsgTimerAddUsage        MsgKey = "timer_add_usage"
+	MsgTimerAdded           MsgKey = "timer_added"
+	MsgTimerAddedExec       MsgKey = "timer_added_exec"
+	MsgTimerAddExecUsage    MsgKey = "timer_addexec_usage"
+	MsgTimerEmpty           MsgKey = "timer_empty"
+	MsgTimerListTitle       MsgKey = "timer_list_title"
+	MsgTimerListFooter      MsgKey = "timer_list_footer"
+	MsgTimerDelUsage        MsgKey = "timer_del_usage"
+	MsgTimerMuteUsage       MsgKey = "timer_mute_usage"
+	MsgTimerDeleted         MsgKey = "timer_deleted"
+	MsgTimerNotFound        MsgKey = "timer_not_found"
+	MsgTimerMuted           MsgKey = "timer_muted"
+	MsgTimerUnmuted         MsgKey = "timer_unmuted"
+	MsgTimerCardHint        MsgKey = "timer_card_hint"
+	MsgTimerBtnMute         MsgKey = "timer_btn_mute"
+	MsgTimerBtnUnmute       MsgKey = "timer_btn_unmute"
+	MsgTimerBtnDelete       MsgKey = "timer_btn_delete"
+	MsgTimerIDLabel         MsgKey = "timer_id_label"
+	MsgTimerScheduledLabel  MsgKey = "timer_scheduled_label"
+	MsgTimerFailedSuffix    MsgKey = "timer_failed_suffix"
+	MsgCommandsTagAgent     MsgKey = "commands_tag_agent"
+	MsgCommandsTagShell     MsgKey = "commands_tag_shell"
+	MsgUpgradeTimeoutSuffix MsgKey = "upgrade_timeout_suffix"
 
 	MsgCronScheduleLabel MsgKey = "cron_schedule_label"
 	MsgCronNextRunLabel  MsgKey = "cron_next_run_label"
@@ -596,6 +604,7 @@ const (
 	MsgBuiltinCmdAllow     MsgKey = "allow"
 	MsgBuiltinCmdModel     MsgKey = "model"
 	MsgBuiltinCmdReasoning MsgKey = "reasoning"
+	MsgBuiltinCmdFast      MsgKey = "fast"
 	MsgBuiltinCmdMode      MsgKey = "mode"
 	MsgBuiltinCmdLang      MsgKey = "lang"
 	MsgBuiltinCmdQuiet     MsgKey = "quiet"
@@ -688,8 +697,8 @@ const (
 	// send / cron / timer / relay tool documentation in their native
 	// language. Translation coverage is en + zh for this PR; additional
 	// languages fall back to en automatically.
-	MsgAgentSendToolPrompt MsgKey = "agent_send_tool_prompt"
-	MsgAgentCronToolPrompt MsgKey = "agent_cron_tool_prompt"
+	MsgAgentSendToolPrompt  MsgKey = "agent_send_tool_prompt"
+	MsgAgentCronToolPrompt  MsgKey = "agent_cron_tool_prompt"
 	MsgAgentTimerToolPrompt MsgKey = "agent_timer_tool_prompt"
 	MsgAgentRelayToolPrompt MsgKey = "agent_relay_tool_prompt"
 )
@@ -1050,6 +1059,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/allow <tool>\n  Pre-allow a tool (next session)\n\n" +
 			"/model [switch <name>]\n  View/switch model\n\n" +
 			"/reasoning [level]\n  View/switch reasoning effort\n\n" +
+			"/fast [on|off]\n  View/switch Codex Fast mode\n\n" +
 			"/mode [name]\n  View/switch permission mode\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  View/switch language\n\n" +
 			"/compress\n  Compress conversation context\n\n" +
@@ -1094,6 +1104,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/allow <工具名>\n  预授权工具（下次会话生效）\n\n" +
 			"/model [switch <名称>]\n  查看/切换模型\n\n" +
 			"/reasoning [级别]\n  查看/切换推理强度\n\n" +
+			"/fast [on|off]\n  查看/切换 Codex Fast 模式\n\n" +
 			"/mode [名称]\n  查看/切换权限模式\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  查看/切换语言\n\n" +
 			"/compress\n  压缩会话上下文\n\n" +
@@ -1138,6 +1149,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/allow <工具名>\n  預授權工具（下次會話生效）\n\n" +
 			"/model [switch <名稱>]\n  查看/切換模型\n\n" +
 			"/reasoning [級別]\n  查看/切換推理強度\n\n" +
+			"/fast [on|off]\n  查看/切換 Codex Fast 模式\n\n" +
 			"/mode [名稱]\n  查看/切換權限模式\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  查看/切換語言\n\n" +
 			"/compress\n  壓縮會話上下文\n\n" +
@@ -1180,6 +1192,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/allow <ツール名>\n  ツールを事前許可（次のセッションで有効）\n\n" +
 			"/model [switch <名前>]\n  モデルの表示/切り替え\n\n" +
 			"/reasoning [レベル]\n  推論レベルの表示/切り替え\n\n" +
+			"/fast [on|off]\n  Codex Fast モードの表示/切り替え\n\n" +
 			"/mode [名前]\n  権限モードの表示/切り替え\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  言語の表示/切り替え\n\n" +
 			"/compress\n  会話コンテキストを圧縮\n\n" +
@@ -1222,6 +1235,7 @@ var messages = map[MsgKey]map[Language]string{
 			"/allow <herramienta>\n  Pre-autorizar herramienta (próxima sesión)\n\n" +
 			"/model [switch <nombre>]\n  Ver/cambiar modelo\n\n" +
 			"/reasoning [nivel]\n  Ver/cambiar nivel de razonamiento\n\n" +
+			"/fast [on|off]\n  Ver/cambiar el modo Fast de Codex\n\n" +
 			"/mode [nombre]\n  Ver/cambiar modo de permisos\n\n" +
 			"/lang [en|zh|zh-TW|ja|es|auto]\n  Ver/cambiar idioma\n\n" +
 			"/compress\n  Comprimir contexto de conversación\n\n" +
@@ -2324,6 +2338,45 @@ var messages = map[MsgKey]map[Language]string{
 		LangJapanese:           "このエージェントは推論強度の切り替えをサポートしていません。",
 		LangSpanish:            "Este agente no soporta el cambio de esfuerzo de razonamiento.",
 	},
+	MsgFastEnabled: {
+		LangEnglish: "Fast mode is enabled.", LangChinese: "Fast 模式已开启。",
+		LangTraditionalChinese: "Fast 模式已開啟。", LangJapanese: "Fast モードは有効です。",
+		LangSpanish: "El modo Fast está activado.",
+	},
+	MsgFastDisabled: {
+		LangEnglish: "Fast mode is disabled.", LangChinese: "Fast 模式已关闭。",
+		LangTraditionalChinese: "Fast 模式已關閉。", LangJapanese: "Fast モードは無効です。",
+		LangSpanish: "El modo Fast está desactivado.",
+	},
+	MsgFastChangedOn: {
+		LangEnglish:            "Fast mode enabled. The next message will resume this conversation using the fast service tier.",
+		LangChinese:            "Fast 模式已开启。下一条消息将使用 fast 服务层恢复当前对话。",
+		LangTraditionalChinese: "Fast 模式已開啟。下一則訊息將使用 fast 服務層恢復目前對話。",
+		LangJapanese:           "Fast モードを有効にしました。次のメッセージから fast サービス階層でこの会話を再開します。",
+		LangSpanish:            "Modo Fast activado. El próximo mensaje reanudará esta conversación con el nivel de servicio fast.",
+	},
+	MsgFastChangedOff: {
+		LangEnglish:            "Fast mode disabled. The next message will resume this conversation using the default service tier.",
+		LangChinese:            "Fast 模式已关闭。下一条消息将使用 default 服务层恢复当前对话。",
+		LangTraditionalChinese: "Fast 模式已關閉。下一則訊息將使用 default 服務層恢復目前對話。",
+		LangJapanese:           "Fast モードを無効にしました。次のメッセージから default サービス階層でこの会話を再開します。",
+		LangSpanish:            "Modo Fast desactivado. El próximo mensaje reanudará esta conversación con el nivel de servicio default.",
+	},
+	MsgFastChangeFailed: {
+		LangEnglish: "Failed to change Fast mode: %v", LangChinese: "切换 Fast 模式失败：%v",
+		LangTraditionalChinese: "切換 Fast 模式失敗：%v", LangJapanese: "Fast モードの変更に失敗しました: %v",
+		LangSpanish: "No se pudo cambiar el modo Fast: %v",
+	},
+	MsgFastNotSupported: {
+		LangEnglish: "This agent does not support Fast mode.", LangChinese: "当前 Agent 不支持 Fast 模式。",
+		LangTraditionalChinese: "目前 Agent 不支援 Fast 模式。", LangJapanese: "このエージェントは Fast モードをサポートしていません。",
+		LangSpanish: "Este agente no admite el modo Fast.",
+	},
+	MsgFastUsage: {
+		LangEnglish: "Usage: /fast [on|off]", LangChinese: "用法：/fast [on|off]",
+		LangTraditionalChinese: "用法：/fast [on|off]", LangJapanese: "使用法: /fast [on|off]",
+		LangSpanish: "Uso: /fast [on|off]",
+	},
 	MsgMemoryNotSupported: {
 		LangEnglish:            "This agent does not support memory files.",
 		LangChinese:            "当前 Agent 不支持记忆文件。",
@@ -2443,6 +2496,11 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "權限模式: %s\n",
 		LangJapanese:           "権限モード: %s\n",
 		LangSpanish:            "Modo: %s\n",
+	},
+	MsgStatusFastMode: {
+		LangEnglish: "⚡ Fast mode: %s\n", LangChinese: "⚡ Fast 模式：%s\n",
+		LangTraditionalChinese: "⚡ Fast 模式：%s\n", LangJapanese: "⚡ Fast モード: %s\n",
+		LangSpanish: "⚡ Modo Fast: %s\n",
 	},
 	MsgStatusSession: {
 		LangEnglish:            "Session: %s (messages: %d)\n",
@@ -3689,6 +3747,13 @@ var messages = map[MsgKey]map[Language]string{
 		LangTraditionalChinese: "查看/切換推理強度，參數: [等級]",
 		LangJapanese:           "推論強度の表示/切り替え、引数: [レベル]",
 		LangSpanish:            "Ver/cambiar esfuerzo de razonamiento, arg: [nivel]",
+	},
+	MsgBuiltinCmdFast: {
+		LangEnglish:            "View/switch Codex Fast mode, arg: [on|off]",
+		LangChinese:            "查看/切换 Codex Fast 模式，参数: [on|off]",
+		LangTraditionalChinese: "查看/切換 Codex Fast 模式，參數: [on|off]",
+		LangJapanese:           "Codex Fast モードの表示/切り替え、引数: [on|off]",
+		LangSpanish:            "Ver/cambiar el modo Fast de Codex, arg: [on|off]",
 	},
 	MsgBuiltinCmdMode: {
 		LangEnglish:            "View/switch permission mode, arg: [name]",

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -443,6 +443,14 @@ type ReasoningEffortSwitcher interface {
 	AvailableReasoningEfforts() []string
 }
 
+// FastModeSwitcher is an optional capability for agents whose backend supports
+// a low-latency service tier. The engine recreates the current process after a
+// change while preserving the backend conversation ID for resume.
+type FastModeSwitcher interface {
+	SetFastMode(enabled bool)
+	FastModeEnabled() bool
+}
+
 // ModelOption describes a selectable model.
 type ModelOption struct {
 	Name  string // model identifier passed to CLI

--- a/core/projectstate.go
+++ b/core/projectstate.go
@@ -9,9 +9,10 @@ import (
 )
 
 type projectStateData struct {
-	WorkDirOverride         string            `json:"work_dir_override,omitempty"`
-	WorkspaceDirOverrides   map[string]string `json:"workspace_dir_overrides,omitempty"`
-	WorkspaceModelOverrides map[string]string `json:"workspace_model_overrides,omitempty"`
+	WorkDirOverride               string            `json:"work_dir_override,omitempty"`
+	WorkspaceDirOverrides         map[string]string `json:"workspace_dir_overrides,omitempty"`
+	WorkspaceModelOverrides       map[string]string `json:"workspace_model_overrides,omitempty"`
+	WorkspaceServiceTierOverrides map[string]string `json:"workspace_service_tier_overrides,omitempty"`
 }
 
 // ProjectStateStore persists lightweight runtime state for one project.
@@ -103,6 +104,21 @@ func (ps *ProjectStateStore) ClearWorkspaceModelOverride(workspace string) {
 	if len(ps.state.WorkspaceModelOverrides) == 0 {
 		ps.state.WorkspaceModelOverrides = nil
 	}
+}
+
+func (ps *ProjectStateStore) WorkspaceServiceTierOverride(workspace string) string {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	return ps.state.WorkspaceServiceTierOverrides[workspace]
+}
+
+func (ps *ProjectStateStore) SetWorkspaceServiceTierOverride(workspace, tier string) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if ps.state.WorkspaceServiceTierOverrides == nil {
+		ps.state.WorkspaceServiceTierOverrides = make(map[string]string)
+	}
+	ps.state.WorkspaceServiceTierOverrides[workspace] = tier
 }
 
 func (ps *ProjectStateStore) ClearWorkDirOverride() {

--- a/core/projectstate_test.go
+++ b/core/projectstate_test.go
@@ -95,3 +95,14 @@ func TestWorkspaceModelOverride(t *testing.T) {
 		t.Fatalf("WorkspaceModelOverride(%q) after clearing other workspace = %q, want %q", workspaceB, got, "sonnet")
 	}
 }
+
+func TestWorkspaceServiceTierOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store := NewProjectStateStore(path)
+	store.SetWorkspaceServiceTierOverride("/tmp/workspace", "fast")
+	store.Save()
+	reloaded := NewProjectStateStore(path)
+	if got := reloaded.WorkspaceServiceTierOverride("/tmp/workspace"); got != "fast" {
+		t.Fatalf("WorkspaceServiceTierOverride() = %q, want fast", got)
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,6 +44,7 @@ Each user gets an independent session with full conversation context. Manage ses
 | `/dir [path]` | Show or switch the agent work directory |
 | `/allow <tool>` | Pre-allow a tool (next session) |
 | `/reasoning [level]` | View or switch reasoning effort (Codex) |
+| `/fast [on|off]` | View or switch Codex Fast mode (`service_tier`) |
 | `/mode [name]` | View or switch permission mode |
 | `/stop` | Stop current execution |
 | `/help` | Show available commands |
@@ -85,6 +86,23 @@ All agents support permission modes switchable at runtime via `/mode`.
 | YOLO | `bypassPermissions` / `yolo` | All tools auto-approved |
 
 ### Codex Modes
+
+Codex Fast mode is separate from reasoning effort. Configure the project default
+with `service_tier = "fast"` (or `"default"`) under
+`[projects.agent.options]`, or switch it from chat:
+
+```text
+/fast       # show current state
+/fast on    # use service_tier="fast"
+/fast off   # use service_tier="default"
+```
+
+Switching restarts the agent process for the next message while preserving the
+Codex conversation ID so it can resume the existing conversation. Fast mode is
+subject to model, account, and provider availability. If `service_tier` is
+omitted, cc-connect inherits the native Codex configuration. Outside multi-workspace
+mode, this is a project-wide default and therefore affects every user of that
+project; multi-workspace selections are stored per workspace.
 
 | Mode | Config Value | Behavior |
 |------|-------------|----------|

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -46,6 +46,7 @@ cc-connect 完整功能使用指南。
 | `/show <引用>` | 按引用查看文件、目录或代码片段 |
 | `/allow <工具名>` | 预授权工具 |
 | `/reasoning [等级]` | 查看或切换推理强度（Codex）|
+| `/fast [on|off]` | 查看或切换 Codex Fast 模式（`service_tier`）|
 | `/mode [名称]` | 查看或切换权限模式 |
 | `/stop` | 停止当前执行 |
 | `/help` | 显示可用命令 |
@@ -83,6 +84,20 @@ reset_on_idle_mins = 60
 | YOLO | `bypassPermissions` / `yolo` | 全部自动通过 |
 
 ### Codex 模式
+
+Codex Fast 模式与推理强度相互独立。可以在 `[projects.agent.options]`
+中通过 `service_tier = "fast"`（或 `"default"`）设置项目默认值，也可以在聊天中切换：
+
+```text
+/fast       # 查看当前状态
+/fast on    # 使用 service_tier="fast"
+/fast off   # 使用 service_tier="default"
+```
+
+切换后，下一条消息会重启 Agent 进程，但保留 Codex 对话 ID 并恢复现有对话。
+Fast 模式是否可用取决于模型、账号和 Provider。未配置 `service_tier` 时，cc-connect
+会继承 Codex 自身的配置。非多工作区模式下，该设置是项目级默认值，
+会影响项目中的所有用户；多工作区模式会按工作区分别保存。
 
 | 模式 | 配置值 | 行为 |
 |------|--------|------|


### PR DESCRIPTION
## Summary

- add a /fast [on|off] chat command for Codex agents
- pass the selected service_tier to both exec and app-server backends
- persist project and multi-workspace selections while preserving the Codex conversation on process restart
- expose status/help text in all supported languages and document configuration
- inherit native Codex configuration when service_tier is omitted

## Validation

- go test ./... (4033 passed across 51 packages)
- go test ./core -run TestCUJ (55 passed)
- go vet ./...
- go build ./...