### PR TITLE
fix: preserve inbound Feishu alert cards

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1012,6 +1012,10 @@ app_secret = "your-feishu-app-secret"
 # domain = "https://open.feishu.cn"  # Optional runtime API/WebSocket base URL override / 可选：运行时 API/WebSocket 域名覆盖
 # enable_feishu_card = true  # Enable Feishu interactive cards (default: true); set false to force plain-text replies
 #                              # 启用飞书交互式卡片（默认 true）；设为 false 时强制回退纯文本回复
+# inbound_card_mode = "both"  # Inbound card payload: summary (default), raw, or both
+#                              # 入站卡片内容：summary（默认）、raw 或 both
+# inbound_card_max_bytes = 0   # Maximum raw card JSON bytes; 0 = no truncation
+#                              # 单卡原始 JSON 最大字节数；0 表示不截断
 # allow_from = "*"          # Allowed user open_ids, comma-separated; "*" = all (default). Use /whoami to get your open_id.
 #                              # 允许的用户 open_id，逗号分隔；"*" 表示所有（默认）。发送 /whoami 获取你的 open_id。
 # allow_chat = "*"          # Allowed group chat_ids, comma-separated; "*" = all (default). Find chat_id in group settings.
@@ -1078,6 +1082,8 @@ app_secret = "your-feishu-app-secret"
 # callback_path = "/feishu/webhook"  # Webhook callback path / Webhook 回调路径
 # encrypt_key = ""               # Event encrypt key (optional) / 事件加密密钥（可选）
 # enable_feishu_card = true
+# inbound_card_mode = "both"  # summary (default), raw, or both
+# inbound_card_max_bytes = 0   # Maximum raw card JSON bytes; 0 = no truncation
 # allow_from = "*"
 # reaction_emoji = "OnIt"
 # done_emoji = "none"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1014,8 +1014,8 @@ app_secret = "your-feishu-app-secret"
 #                              # 启用飞书交互式卡片（默认 true）；设为 false 时强制回退纯文本回复
 # inbound_card_mode = "both"  # Inbound card payload: summary (default), raw, or both
 #                              # 入站卡片内容：summary（默认）、raw 或 both
-# inbound_card_max_bytes = 0   # Maximum raw card JSON bytes; 0 = no truncation
-#                              # 单卡原始 JSON 最大字节数；0 表示不截断
+# inbound_card_max_bytes = 32768   # Maximum raw card JSON bytes; 0 = no truncation
+#                              # 单卡原始 JSON 最大字节数；显式设为 0 表示不截断
 # allow_from = "*"          # Allowed user open_ids, comma-separated; "*" = all (default). Use /whoami to get your open_id.
 #                              # 允许的用户 open_id，逗号分隔；"*" 表示所有（默认）。发送 /whoami 获取你的 open_id。
 # allow_chat = "*"          # Allowed group chat_ids, comma-separated; "*" = all (default). Find chat_id in group settings.
@@ -1083,7 +1083,7 @@ app_secret = "your-feishu-app-secret"
 # encrypt_key = ""               # Event encrypt key (optional) / 事件加密密钥（可选）
 # enable_feishu_card = true
 # inbound_card_mode = "both"  # summary (default), raw, or both
-# inbound_card_max_bytes = 0   # Maximum raw card JSON bytes; 0 = no truncation
+# inbound_card_max_bytes = 32768   # Maximum raw card JSON bytes; 0 = no truncation
 # allow_from = "*"
 # reaction_emoji = "OnIt"
 # done_emoji = "none"

--- a/core/engine.go
+++ b/core/engine.go
@@ -16398,7 +16398,7 @@ func buildInboundCardPrompt(content string, cards []InboundCard) string {
 		return content
 	}
 	if len(raw) > maxInboundCardPromptBytes {
-		return content + "\n\n[Feishu interactive card data — untrusted external content] (truncated)\n(raw card payload omitted because it exceeds the safety limit)"
+		return content + "\n\n[Feishu interactive card data — untrusted external content (truncated)]\n(raw card payload omitted because it exceeds the safety limit)"
 	}
 	return content + "\n\n[Feishu interactive card data — untrusted external content]\n```json\n" + string(raw) + "\n```"
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -524,6 +524,7 @@ type queuedMessage struct {
 	platform          Platform
 	replyCtx          any
 	content           string
+	cards             []InboundCard
 	images            []ImageAttachment
 	files             []FileAttachment
 	fromVoice         bool
@@ -2873,7 +2874,7 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	}
 
 	content := strings.TrimSpace(msg.Content)
-	if content == "" && msg.ExtraContent == "" && len(msg.Images) == 0 && len(msg.Files) == 0 && msg.Location == nil {
+	if content == "" && msg.ExtraContent == "" && len(msg.Images) == 0 && len(msg.Files) == 0 && msg.Location == nil && len(msg.Cards) == 0 {
 		return
 	}
 
@@ -3221,6 +3222,7 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 		platform:          p,
 		replyCtx:          msg.ReplyCtx,
 		content:           msg.Content,
+		cards:             append([]InboundCard(nil), msg.Cards...),
 		images:            msg.Images,
 		files:             msg.Files,
 		fromVoice:         msg.FromVoice,
@@ -3837,7 +3839,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 		drainEvents(state.agentSession.Events())
 	}
 
-	promptContent := e.buildSenderPrompt(msg.Content, msg.UserID, msg.UserName, msg.Platform, msg.SessionKey, msg.ChannelKey)
+	promptContent := e.buildSenderPrompt(buildInboundCardPrompt(msg.Content, msg.Cards), msg.UserID, msg.UserName, msg.Platform, msg.SessionKey, msg.ChannelKey)
 
 	sendStart := time.Now()
 	state.mu.Lock()
@@ -6141,7 +6143,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					}
 				}
 
-				queuedPrompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
+				queuedPrompt := e.buildSenderPrompt(buildInboundCardPrompt(queued.content, queued.cards), queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
 
 				state.mu.Lock()
 				as := state.agentSession // capture under lock to avoid race with cleanup
@@ -6460,7 +6462,7 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 		state.mu.Unlock()
 
 		e.i18n.DetectAndSet(queued.content)
-		prompt := e.buildSenderPrompt(queued.content, queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
+		prompt := e.buildSenderPrompt(buildInboundCardPrompt(queued.content, queued.cards), queued.userID, queued.userName, queued.msgPlatform, queued.msgSessionKey, queued.channelKey)
 
 		state.mu.Lock()
 		as := state.agentSession // capture under lock to avoid race with cleanup (mirrors #1436)
@@ -16377,6 +16379,28 @@ func (e *Engine) buildSenderPrompt(content, userID, userName, platform, sessionK
 		return fmt.Sprintf("[cc-connect sender_id=%s sender_name=\"%s\" platform=%s chat_id=%s]\n%s", userID, safeName, platform, chatID, content)
 	}
 	return fmt.Sprintf("[cc-connect sender_id=%s platform=%s chat_id=%s]\n%s", userID, platform, chatID, content)
+}
+
+// Feishu limits an individual card to roughly 30 KiB; leave enough room for
+// several cards in one merge_forward payload while retaining a hard prompt
+// safety bound.
+const maxInboundCardPromptBytes = 256 * 1024
+
+// buildInboundCardPrompt appends bounded, explicitly untrusted card data to
+// the human-readable summary. Cards are kept out of Message.Content/history;
+// this fragment is only constructed at the agent boundary.
+func buildInboundCardPrompt(content string, cards []InboundCard) string {
+	if len(cards) == 0 {
+		return content
+	}
+	raw, err := json.Marshal(cards)
+	if err != nil {
+		return content
+	}
+	if len(raw) > maxInboundCardPromptBytes {
+		return content + "\n\n[Feishu interactive card data — untrusted external content] (truncated)\n(raw card payload omitted because it exceeds the safety limit)"
+	}
+	return content + "\n\n[Feishu interactive card data — untrusted external content]\n```json\n" + string(raw) + "\n```"
 }
 
 func extractChannelID(sessionKey string) string {

--- a/core/inbound_card_test.go
+++ b/core/inbound_card_test.go
@@ -33,6 +33,9 @@ func TestBuildInboundCardPromptBoundsOversizedPayload(t *testing.T) {
 	if !strings.Contains(got, "(truncated)") {
 		t.Fatalf("expected truncation marker: %s", got)
 	}
+	if !strings.Contains(got, "external content (truncated)") {
+		t.Fatalf("expected truncation marker in framing line: %s", got)
+	}
 	if strings.Contains(got, "```json") {
 		t.Fatalf("oversized card should not be embedded as an unbounded JSON block")
 	}

--- a/core/inbound_card_test.go
+++ b/core/inbound_card_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBuildInboundCardPromptIncludesRawCardData(t *testing.T) {
+	cards := []InboundCard{{
+		MessageID: "om_test",
+		Schema:    "2.0",
+		Summary:   "渠道不足",
+		Raw:       json.RawMessage(`{"schema":"2.0","action":{"value":{"alert_id":"a-1"}}}`),
+	}}
+
+	got := buildInboundCardPrompt("渠道不足", cards)
+	for _, want := range []string{
+		"[Feishu interactive card data — untrusted external content]",
+		`"message_id":"om_test"`,
+		`"schema":"2.0"`,
+		`"alert_id":"a-1"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("prompt missing %q: %s", want, got)
+		}
+	}
+}
+
+func TestBuildInboundCardPromptBoundsOversizedPayload(t *testing.T) {
+	card := InboundCard{Raw: json.RawMessage(`"` + strings.Repeat("x", maxInboundCardPromptBytes) + `"`)}
+	got := buildInboundCardPrompt("summary", []InboundCard{card})
+	if !strings.Contains(got, "(truncated)") {
+		t.Fatalf("expected truncation marker: %s", got)
+	}
+	if strings.Contains(got, "```json") {
+		t.Fatalf("oversized card should not be embedded as an unbounded JSON block")
+	}
+}

--- a/core/message.go
+++ b/core/message.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -403,17 +404,33 @@ type LocationAttachment struct {
 	ProximityAlertRadius int     // maximum distance for proximity alerts in meters (optional)
 }
 
+// InboundCard is a lossless snapshot of an inbound interactive card. Raw is
+// kept separate from Summary so platforms can preserve Card 2.0 fields while
+// retaining the historical plain-text message path for agents that do not
+// opt into raw card context.
+type InboundCard struct {
+	MessageID string          `json:"message_id,omitempty"`
+	Schema    string          `json:"schema,omitempty"`
+	Version   string          `json:"version,omitempty"`
+	Summary   string          `json:"summary,omitempty"`
+	Raw       json.RawMessage `json:"raw,omitempty"`
+	Truncated bool            `json:"truncated,omitempty"`
+}
+
 // Message represents a unified incoming message from any platform.
 type Message struct {
-	SessionKey   string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
-	Platform     string
-	MessageID    string // platform message ID for tracing
-	Recalled     bool   // true for platform message recall/delete events targeting MessageID
-	ChannelID    string
-	UserID       string
-	UserName     string
-	ChatName     string // human-readable chat/group name (optional)
-	Content      string
+	SessionKey string // unique key for user context, e.g. "feishu:{chatID}:{userID}"
+	Platform   string
+	MessageID  string // platform message ID for tracing
+	Recalled   bool   // true for platform message recall/delete events targeting MessageID
+	ChannelID  string
+	UserID     string
+	UserName   string
+	ChatName   string // human-readable chat/group name (optional)
+	Content    string
+	// Cards contains lossless inbound interactive-card payloads. It is
+	// additive: existing platforms leave it empty and continue using Content.
+	Cards        []InboundCard
 	Images       []ImageAttachment   // attached images (if any)
 	Files        []FileAttachment    // attached files (if any)
 	Audio        *AudioAttachment    // voice message (if any)

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -115,7 +115,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # done_emoji = "none"          # 可选：agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 # image_batch_window_ms = 500  # 可选：连续多图合批窗口（默认 500ms，详见下文）
 # inbound_card_mode = "both"   # 可选：summary（默认）| raw | both；保留入站飞书 Card 2.0 原始 JSON
-# inbound_card_max_bytes = 0    # 可选：单卡原始 JSON 上限，0 表示不截断
+# inbound_card_max_bytes = 32768    # 可选：单卡原始 JSON 上限；显式设为 0 表示不截断
 ```
 
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -114,6 +114,8 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # progress_style = "legacy"  # 可选：legacy | compact | card
 # done_emoji = "none"          # 可选：agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 # image_batch_window_ms = 500  # 可选：连续多图合批窗口（默认 500ms，详见下文）
+# inbound_card_mode = "both"   # 可选：summary（默认）| raw | both；保留入站飞书 Card 2.0 原始 JSON
+# inbound_card_max_bytes = 0    # 可选：单卡原始 JSON 上限，0 表示不截断
 ```
 
 > 如果应用没有交互卡片权限，或后台未配置卡片回调，可将 `enable_feishu_card = false`，让所有命令统一走纯文本回复，避免卡片发送失败后用户看不到内容。
@@ -124,6 +126,7 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
 > `done_emoji` 设置后，agent 每次完成回复时会在用户消息上添加指定表情（如 `"Done"` → ✅）。先移除 "OnIt" 表情（如果有），再添加 done 表情。在 quiet 模式下特别有用，因为飞书卡片原地更新不触发推送，done 表情可以通知用户 agent 已完成。设为 `"none"` 或不配置则禁用。
 > `image_batch_window_ms` 控制连续多张图片合并成一条 agent 消息的等待窗口（默认 500ms）。飞书手机端一次连发多张图时，每张图是独立事件；cc-connect 会在窗口内将它们合并成一条多图消息再分发给 agent。如果你的网络/设备发送间隔超过 500ms 且仍被拆成多轮回复（每张图独立处理），可调高到 800–1200ms；如果以单图为主、希望响应更快，可适当调低。设为 `0` 时回退到默认 500ms。
+> `inbound_card_mode = "both"` 只影响已经通过正常入站门控（群聊仍需真实 @ 机器人）的消息：`interactive` 和 `merge_forward` 中的交互卡会保留原始 JSON，并同时提供可读摘要；不会打开全群消息接收。`raw` 只把原始卡片交给 agent，`summary` 保持旧行为。`inbound_card_max_bytes` 可限制单卡原始 JSON 大小，超限时会在注入 agent 前安全截断。
 
 ---
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -113,6 +113,8 @@ type replyContext struct {
 	bootstrapThread bool
 }
 
+const defaultInboundCardMaxBytes = 32 * 1024
+
 type Platform struct {
 	mu                         sync.RWMutex
 	platformName               string
@@ -368,9 +370,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	if inboundCardMode != "summary" && inboundCardMode != "raw" && inboundCardMode != "both" {
 		return nil, fmt.Errorf("%s: invalid inbound_card_mode %q (want summary, raw, or both)", name, inboundCardMode)
 	}
-	// Zero means lossless/unbounded at the platform boundary. The engine still
-	// applies its prompt safety cap when serializing cards for the agent.
-	inboundCardMaxBytes := 0
+	inboundCardMaxBytes := defaultInboundCardMaxBytes
 	if raw, ok := opts["inbound_card_max_bytes"]; ok {
 		switch v := raw.(type) {
 		case int:
@@ -2049,13 +2049,15 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 		text := extractInteractiveCardText(content)
 		cards := append([]core.InboundCard(nil), quoted.cards...)
 		// Event payloads may contain only a lossy summary. Fetch the raw-card
-		// variant so alert metadata and action values survive end-to-end.
-		if fetched := p.fetchSingleMessage(ctx, messageID); fetched != nil {
-			if fetched.text != "" {
-				text = fetched.text
-			}
-			if fetched.card != nil && p.inboundCardMode != "summary" {
-				cards = append(cards, *fetched.card)
+		// variant when raw card data is requested or no usable summary is present.
+		if p.inboundCardMode != "summary" || text == "" || text == "[interactive card]" {
+			if fetched := p.fetchSingleMessage(ctx, messageID); fetched != nil {
+				if fetched.text != "" {
+					text = fetched.text
+				}
+				if fetched.card != nil && p.inboundCardMode != "summary" {
+					cards = append(cards, *fetched.card)
+				}
 			}
 		}
 		if len(cards) == 0 && p.inboundCardMode != "summary" {
@@ -3361,12 +3363,14 @@ func (p *Platform) formatMergeForwardTree(ctx context.Context, parentID string, 
 				if p.inboundCardMode != "summary" {
 					*cards = append(*cards, card)
 				}
-			} else if fetched := p.fetchSingleMessage(ctx, msgID); fetched != nil {
-				if fetched.text != "" {
-					text = fetched.text
-				}
-				if fetched.card != nil && p.inboundCardMode != "summary" {
-					*cards = append(*cards, *fetched.card)
+			} else if p.inboundCardMode != "summary" || text == "" || text == "[interactive card]" {
+				if fetched := p.fetchSingleMessage(ctx, msgID); fetched != nil {
+					if fetched.text != "" {
+						text = fetched.text
+					}
+					if fetched.card != nil && p.inboundCardMode != "summary" {
+						*cards = append(*cards, *fetched.card)
+					}
 				}
 			}
 			if p.inboundCardMode == "raw" {

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -3373,9 +3373,9 @@ func (p *Platform) formatMergeForwardTree(ctx context.Context, parentID string, 
 				text = "[interactive card]"
 			}
 			if text != "" {
-				sb.WriteString(fmt.Sprintf("%s[%s] %s:\n", indent, ts, senderName))
+				fmt.Fprintf(sb, "%s[%s] %s:\n", indent, ts, senderName)
 				for _, line := range strings.Split(text, "\n") {
-					sb.WriteString(fmt.Sprintf("%s    %s\n", indent, line))
+					fmt.Fprintf(sb, "%s    %s\n", indent, line)
 				}
 			}
 

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -121,6 +121,8 @@ type Platform struct {
 	appSecret                  string
 	progressStyle              string
 	useInteractiveCard         bool
+	inboundCardMode            string // summary (default), raw, or both
+	inboundCardMaxBytes        int
 	self                       core.Platform
 	reactionEmoji              string
 	doneEmoji                  string
@@ -359,6 +361,31 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	allowChat, _ := opts["allow_chat"].(string)
 	groupOnly, _ := opts["group_only"].(bool)
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
+	inboundCardMode := "summary"
+	if v, ok := opts["inbound_card_mode"].(string); ok && strings.TrimSpace(v) != "" {
+		inboundCardMode = strings.ToLower(strings.TrimSpace(v))
+	}
+	if inboundCardMode != "summary" && inboundCardMode != "raw" && inboundCardMode != "both" {
+		return nil, fmt.Errorf("%s: invalid inbound_card_mode %q (want summary, raw, or both)", name, inboundCardMode)
+	}
+	// Zero means lossless/unbounded at the platform boundary. The engine still
+	// applies its prompt safety cap when serializing cards for the agent.
+	inboundCardMaxBytes := 0
+	if raw, ok := opts["inbound_card_max_bytes"]; ok {
+		switch v := raw.(type) {
+		case int:
+			inboundCardMaxBytes = v
+		case int64:
+			inboundCardMaxBytes = int(v)
+		case float64:
+			inboundCardMaxBytes = int(v)
+		default:
+			return nil, fmt.Errorf("%s: invalid inbound_card_max_bytes %v", name, raw)
+		}
+	}
+	if inboundCardMaxBytes < 0 {
+		return nil, fmt.Errorf("%s: inbound_card_max_bytes must be >= 0", name)
+	}
 	// require_mention = false is equivalent to group_reply_all = true:
 	// both mean "respond to all group messages without needing an @mention".
 	if v, ok := opts["require_mention"].(bool); ok && !v {
@@ -471,6 +498,8 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		appSecret:                  appSecret,
 		progressStyle:              progressStyle,
 		useInteractiveCard:         useInteractiveCard,
+		inboundCardMode:            inboundCardMode,
+		inboundCardMaxBytes:        inboundCardMaxBytes,
 		reactionEmoji:              reactionEmoji,
 		doneEmoji:                  doneEmoji,
 		allowFrom:                  allowFrom,
@@ -1372,6 +1401,7 @@ func (p *Platform) dispatchImageBatchEntry(entry *imageBatchEntry) {
 		UserID:    entry.userID, UserName: entry.userName, ChatName: entry.chatName,
 		Content:           "",
 		ExtraContent:      entry.quoted.text,
+		Cards:             entry.quoted.cards,
 		OnAccepted:        entry.onAccepted,
 		Images:            append(entry.quoted.images, entry.images...),
 		ReplyCtx:          entry.rctx,
@@ -1852,8 +1882,16 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 	// exception: earlier unmentioned messages were never dispatched to the
 	// agent, so bootstrap its context from the parent/root reply chain once.
 	var quoted quotedMessage
-	if parentID != "" && (!p.threadIsolation || !isThreadSessionKey(sessionKey) || rctx.bootstrapThread) {
-		quoted = p.fetchQuotedMessage(ctx, parentID)
+	if parentID != "" {
+		switch {
+		case !p.threadIsolation || !isThreadSessionKey(sessionKey) || rctx.bootstrapThread:
+			quoted = p.fetchQuotedMessage(ctx, parentID)
+		case p.threadIsolation && isThreadSessionKey(sessionKey) && p.inboundCardMode != "summary":
+			// Keep only cards from an already-engaged thread. The root may be an
+			// alert card that could not mention this bot; ordinary text was already
+			// handled by the session and must not be re-ingested.
+			quoted = p.fetchQuotedCards(ctx, parentID)
+		}
 	}
 	historyText := p.formatGroupHistory(groupHistoryCtx)
 	dispatchCore := func(msg *core.Message) {
@@ -1882,7 +1920,7 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 		// zero file-resource API calls.
 		approvedFileMetas := p.filterQuotedFilesForUser(quoted.files, mentions, userID)
 		quotedFiles := p.downloadQuotedFiles(ctx, approvedFileMetas)
-		if text == "" && historyText == "" && quoted.text == "" && len(quoted.images) == 0 && len(quotedFiles) == 0 {
+		if text == "" && historyText == "" && quoted.text == "" && len(quoted.cards) == 0 && len(quoted.images) == 0 && len(quotedFiles) == 0 {
 			slog.Debug(p.tag()+": dropping empty text after mention stripping",
 				"message_id", messageID,
 				"raw_text_len", len(textBody.Text),
@@ -1898,7 +1936,7 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quoted.text, Images: quoted.images, Files: quotedFiles, ReplyCtx: rctx,
+			Content: text, ExtraContent: quoted.text, Cards: quoted.cards, Images: quoted.images, Files: quotedFiles, ReplyCtx: rctx,
 			UserMessageTimeMs: createTimeMs,
 		})
 
@@ -1932,7 +1970,7 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 				userName:     userName,
 				chatName:     chatName,
 				rctx:         rctx,
-				quoted:       quotedMessage{text: historyText, images: quoted.images},
+				quoted:       quotedMessage{text: historyText, cards: quoted.cards, images: quoted.images},
 				onAccepted:   groupHistoryCtx.onAccepted,
 				images:       []core.ImageAttachment{{MimeType: mimeType, Data: imgData}},
 				messageIDs:   []string{messageID},
@@ -1947,6 +1985,7 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 			UserID:    userID, UserName: userName, ChatName: chatName,
 			Content:           "",
 			ExtraContent:      quoted.text,
+			Cards:             quoted.cards,
 			Images:            append(quoted.images, core.ImageAttachment{MimeType: mimeType, Data: imgData}),
 			ReplyCtx:          rctx,
 			UserMessageTimeMs: createTimeMs,
@@ -1978,6 +2017,7 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
+			Cards: quoted.cards,
 			Audio: &core.AudioAttachment{
 				MimeType: "audio/opus",
 				Data:     audioData,
@@ -1991,7 +2031,7 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 	case "post":
 		textParts, images := p.parsePostContent(messageID, content)
 		text := stripMentions(strings.Join(textParts, "\n"), mentions, p.getBotOpenID())
-		if text == "" && historyText == "" && len(images) == 0 && quoted.text == "" && len(quoted.images) == 0 {
+		if text == "" && historyText == "" && len(images) == 0 && quoted.text == "" && len(quoted.cards) == 0 && len(quoted.images) == 0 {
 			return
 		}
 		// Flush any image batch buffered earlier in this session (#1686 P1-B).
@@ -2000,8 +2040,43 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quoted.text, Images: append(quoted.images, images...),
+			Content: text, ExtraContent: quoted.text, Cards: quoted.cards, Images: append(quoted.images, images...),
 			ReplyCtx:          rctx,
+			UserMessageTimeMs: createTimeMs,
+		})
+
+	case "interactive":
+		text := extractInteractiveCardText(content)
+		cards := append([]core.InboundCard(nil), quoted.cards...)
+		// Event payloads may contain only a lossy summary. Fetch the raw-card
+		// variant so alert metadata and action values survive end-to-end.
+		if fetched := p.fetchSingleMessage(ctx, messageID); fetched != nil {
+			if fetched.text != "" {
+				text = fetched.text
+			}
+			if fetched.card != nil && p.inboundCardMode != "summary" {
+				cards = append(cards, *fetched.card)
+			}
+		}
+		if len(cards) == 0 && p.inboundCardMode != "summary" {
+			if card, ok := parseInboundCard(content, messageID, p.inboundCardMaxBytes); ok {
+				card.Summary = text
+				cards = append(cards, card)
+			}
+		}
+		if p.inboundCardMode == "raw" {
+			text = "[interactive card]"
+		}
+		if text == "" {
+			text = "[interactive card]"
+		}
+		p.flushImageBatchForSession(sessionKey)
+		dispatchCore(&core.Message{
+			SessionKey: sessionKey, Platform: p.platformName,
+			MessageID: messageID,
+			UserID:    userID, UserName: userName, ChatName: chatName,
+			Content: text, ExtraContent: quoted.text, Cards: cards,
+			Images: quoted.images, ReplyCtx: rctx,
 			UserMessageTimeMs: createTimeMs,
 		})
 
@@ -2041,8 +2116,9 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 		})
 
 	case "merge_forward":
-		text, images, files := p.parseMergeForward(messageID)
-		if text == "" && len(images) == 0 && len(files) == 0 {
+		text, images, files, cards := p.parseMergeForward(ctx, messageID)
+		cards = append(append([]core.InboundCard(nil), quoted.cards...), cards...)
+		if text == "" && len(images) == 0 && len(files) == 0 && len(cards) == 0 {
 			slog.Warn(p.tag()+": merge_forward produced no content", "message_id", messageID)
 			return
 		}
@@ -2053,6 +2129,7 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
 			Content:           text,
+			Cards:             cards,
 			Images:            images,
 			Files:             files,
 			ReplyCtx:          rctx,
@@ -2078,7 +2155,7 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 				SessionKey: sessionKey, Platform: p.platformName,
 				MessageID: messageID,
 				UserID:    userID, UserName: userName, ChatName: chatName,
-				Content: "[sticker]", ExtraContent: quoted.text, ReplyCtx: rctx,
+				Content: "[sticker]", ExtraContent: quoted.text, Cards: quoted.cards, ReplyCtx: rctx,
 				UserMessageTimeMs: createTimeMs,
 			})
 			return
@@ -2128,7 +2205,7 @@ func (p *Platform) dispatchMessageWithHistory(ctx context.Context, msgType, cont
 			SessionKey: sessionKey, Platform: p.platformName,
 			MessageID: messageID,
 			UserID:    userID, UserName: userName, ChatName: chatName,
-			Content: text, ExtraContent: quoted.text, Images: images, ReplyCtx: rctx,
+			Content: text, ExtraContent: quoted.text, Cards: quoted.cards, Images: images, ReplyCtx: rctx,
 			UserMessageTimeMs: createTimeMs,
 		})
 
@@ -2368,6 +2445,7 @@ type chainMessage struct {
 	senderID   string // Feishu open_id (or app_id for bots) — used by the caller
 	// to enforce same-user privacy when forwarding quoted files.
 	text     string
+	card     *core.InboundCard
 	images   []core.ImageAttachment
 	files    []quotedFileMeta
 	parentID string
@@ -2390,6 +2468,7 @@ type quotedFileMeta struct {
 
 type quotedMessage struct {
 	text   string
+	cards  []core.InboundCard
 	images []core.ImageAttachment
 	files  []quotedFileMeta
 }
@@ -2433,11 +2512,26 @@ func (p *Platform) fetchQuotedMessage(ctx context.Context, parentID string) quot
 	if len(chain) == 0 {
 		return quotedMessage{}
 	}
+	var cards []core.InboundCard
+	if p.inboundCardMode != "summary" {
+		cards = collectReplyChainCards(chain)
+	}
 	return quotedMessage{
 		text:   formatReplyChain(chain),
+		cards:  cards,
 		images: collectReplyChainImages(chain),
 		files:  collectReplyChainFiles(chain),
 	}
+}
+
+// fetchQuotedCards retrieves only interactive cards from a quoted reply chain.
+// It keeps the root alert card available for already-engaged isolated threads.
+func (p *Platform) fetchQuotedCards(ctx context.Context, parentID string) quotedMessage {
+	chain := p.fetchReplyChain(ctx, parentID, maxReplyChainDepth)
+	if len(chain) == 0 {
+		return quotedMessage{}
+	}
+	return quotedMessage{cards: collectReplyChainCards(chain)}
 }
 
 // resolveBotSenderName returns a display name for a bot sender in a quoted
@@ -2494,6 +2588,7 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 
 	// Extract plain text based on message type.
 	var text string
+	var card *core.InboundCard
 	var images []core.ImageAttachment
 	var files []quotedFileMeta
 	switch item.MsgType {
@@ -2563,13 +2658,25 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		}
 	case "interactive":
 		text = extractInteractiveCardText(content)
+		if p.inboundCardMode != "summary" {
+			if parsedCard, ok := parseInboundCard(content, messageID, p.inboundCardMaxBytes); ok {
+				parsedCard.Summary = text
+				card = &parsedCard
+			}
+		}
+		if text == "" && card != nil {
+			text = "[interactive card]"
+		}
+		if p.inboundCardMode == "raw" {
+			text = "[interactive card]"
+		}
 	default:
 		text = fmt.Sprintf("[%s]", item.MsgType)
 	}
 	// Empty quoted payloads (no text, no images, no files) are dropped here:
 	// keeping a chainMessage with an empty text would otherwise produce an
 	// empty reply prefix and an empty files slice in the dispatch layer.
-	if text == "" && len(images) == 0 && len(files) == 0 {
+	if text == "" && card == nil && len(images) == 0 && len(files) == 0 {
 		return nil
 	}
 	if text == "" {
@@ -2597,6 +2704,7 @@ func (p *Platform) fetchSingleMessage(ctx context.Context, messageID string) *ch
 		senderType: item.Sender.SenderType,
 		senderID:   item.Sender.ID,
 		text:       text,
+		card:       card,
 		images:     images,
 		files:      files,
 		parentID:   item.ParentID,
@@ -2609,6 +2717,16 @@ func collectReplyChainImages(chain []chainMessage) []core.ImageAttachment {
 		images = append(images, msg.images...)
 	}
 	return images
+}
+
+func collectReplyChainCards(chain []chainMessage) []core.InboundCard {
+	var cards []core.InboundCard
+	for _, msg := range chain {
+		if msg.card != nil {
+			cards = append(cards, *msg.card)
+		}
+	}
+	return cards
 }
 
 // collectReplyChainFiles flattens file metadata from every chainMessage.
@@ -2763,11 +2881,16 @@ func extractPostPlainText(content string) string {
 func extractInteractiveCardText(content string) string {
 	// Try raw_card_content format: {"json_card": "<escaped JSON>", ...}
 	var wrapper struct {
-		JsonCard string `json:"json_card"`
+		JsonCard json.RawMessage `json:"json_card"`
 	}
 	cardJSON := content
-	if json.Unmarshal([]byte(content), &wrapper) == nil && wrapper.JsonCard != "" {
-		cardJSON = wrapper.JsonCard
+	if json.Unmarshal([]byte(content), &wrapper) == nil && len(wrapper.JsonCard) > 0 {
+		var nested string
+		if json.Unmarshal(wrapper.JsonCard, &nested) == nil {
+			cardJSON = nested
+		} else {
+			cardJSON = string(wrapper.JsonCard)
+		}
 	}
 
 	var card map[string]json.RawMessage
@@ -2849,9 +2972,12 @@ func extractInteractiveCardText(content string) string {
 func extractCardElements(elements []json.RawMessage, parts *[]string) {
 	for _, raw := range elements {
 		var elem struct {
-			Tag      string `json:"tag"`
-			Content  string `json:"content"`
-			Property struct {
+			Tag       string          `json:"tag"`
+			Content   string          `json:"content"`
+			Text      json.RawMessage `json:"text"`
+			Actions   json.RawMessage `json:"actions"`
+			Behaviors json.RawMessage `json:"behaviors"`
+			Property  struct {
 				Content   string            `json:"content"`
 				Contents  json.RawMessage   `json:"contents"`
 				Language  string            `json:"language"`
@@ -2871,6 +2997,14 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 			// Extract button label text and open_url from behaviors.
 			label := elem.Property.Content
 			if label == "" {
+				var textElem struct {
+					Content string `json:"content"`
+				}
+				if json.Unmarshal(elem.Text, &textElem) == nil {
+					label = textElem.Content
+				}
+			}
+			if label == "" {
 				// label may be in property.text.property.content
 				var textElem struct {
 					Property struct {
@@ -2882,15 +3016,25 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 				}
 			}
 			var openURL string
-			if len(elem.Property.Behaviors) > 0 {
+			behaviorsRaw := elem.Property.Behaviors
+			if len(behaviorsRaw) == 0 {
+				behaviorsRaw = elem.Behaviors
+			}
+			if len(behaviorsRaw) > 0 {
 				var behaviors []struct {
-					Type string `json:"type"`
-					URL  string `json:"url"`
+					Type       string `json:"type"`
+					URL        string `json:"url"`
+					DefaultURL string `json:"default_url"`
 				}
-				if json.Unmarshal(elem.Property.Behaviors, &behaviors) == nil {
+				if json.Unmarshal(behaviorsRaw, &behaviors) == nil {
 					for _, b := range behaviors {
-						if b.Type == "open_url" && b.URL != "" {
+						if b.Type == "open_url" {
 							openURL = b.URL
+							if openURL == "" {
+								openURL = b.DefaultURL
+							}
+						}
+						if openURL != "" {
 							break
 						}
 					}
@@ -2900,6 +3044,11 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 				*parts = append(*parts, fmt.Sprintf("[%s](%s)", label, openURL))
 			} else if label != "" {
 				*parts = append(*parts, label)
+			}
+		case "action":
+			var actions []json.RawMessage
+			if json.Unmarshal(elem.Actions, &actions) == nil {
+				extractCardElements(actions, parts)
 			}
 		case "code_block":
 			var lines []struct {
@@ -2940,6 +3089,14 @@ func extractCardElements(elements []json.RawMessage, parts *[]string) {
 			content := elem.Property.Content
 			if content == "" {
 				content = elem.Content
+			}
+			if content == "" && len(elem.Text) > 0 {
+				var textElem struct {
+					Content string `json:"content"`
+				}
+				if json.Unmarshal(elem.Text, &textElem) == nil {
+					content = textElem.Content
+				}
 			}
 			if content != "" {
 				*parts = append(*parts, content)
@@ -3025,22 +3182,22 @@ func extractCardListItems(itemsRaw json.RawMessage, parts *[]string) {
 // parseMergeForward fetches sub-messages of a merge_forward message via the
 // GET /open-apis/im/v1/messages/{message_id} API, then formats them into
 // readable text. Returns combined text, images, and files from the sub-messages.
-func (p *Platform) parseMergeForward(rootMessageID string) (string, []core.ImageAttachment, []core.FileAttachment) {
+func (p *Platform) parseMergeForward(ctx context.Context, rootMessageID string) (string, []core.ImageAttachment, []core.FileAttachment, []core.InboundCard) {
 	resp, err := p.client.Im.Message.Get(context.Background(),
 		larkim.NewGetMessageReqBuilder().
 			MessageId(rootMessageID).
 			Build())
 	if err != nil {
 		slog.Error(p.tag()+": fetch merge_forward sub-messages failed", "error", err)
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
 	if !resp.Success() {
 		slog.Error(p.tag()+": fetch merge_forward sub-messages failed", "code", resp.Code, "msg", resp.Msg)
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
 	if resp.Data == nil || len(resp.Data.Items) == 0 {
 		slog.Warn(p.tag()+": merge_forward has no sub-messages", "message_id", rootMessageID)
-		return "", nil, nil
+		return "", nil, nil, nil
 	}
 
 	items := resp.Data.Items
@@ -3075,12 +3232,13 @@ func (p *Platform) parseMergeForward(rootMessageID string) (string, []core.Image
 
 	var allImages []core.ImageAttachment
 	var allFiles []core.FileAttachment
+	var allCards []core.InboundCard
 	var sb strings.Builder
 	sb.WriteString("<forwarded_messages>\n")
-	p.formatMergeForwardTree(rootMessageID, childrenMap, nameMap, &sb, &allImages, &allFiles, 0)
+	p.formatMergeForwardTree(ctx, rootMessageID, childrenMap, nameMap, &sb, &allImages, &allFiles, &allCards, 0)
 	sb.WriteString("</forwarded_messages>")
 
-	return sb.String(), allImages, allFiles
+	return sb.String(), allImages, allFiles, allCards
 }
 
 // replaceMentions replaces @_user_N placeholders with real names from the Mentions list.
@@ -3094,7 +3252,7 @@ func replaceMentions(text string, mentions []*larkim.Mention) string {
 }
 
 // formatMergeForwardTree recursively formats the sub-message tree.
-func (p *Platform) formatMergeForwardTree(parentID string, childrenMap map[string][]*larkim.Message, nameMap map[string]string, sb *strings.Builder, images *[]core.ImageAttachment, files *[]core.FileAttachment, depth int) {
+func (p *Platform) formatMergeForwardTree(ctx context.Context, parentID string, childrenMap map[string][]*larkim.Message, nameMap map[string]string, sb *strings.Builder, images *[]core.ImageAttachment, files *[]core.FileAttachment, cards *[]core.InboundCard, depth int) {
 	if depth > 10 {
 		sb.WriteString(strings.Repeat("    ", depth) + "[nested forwarding truncated]\n")
 		return
@@ -3191,7 +3349,35 @@ func (p *Platform) formatMergeForwardTree(parentID string, childrenMap map[strin
 
 		case "merge_forward":
 			sb.WriteString(fmt.Sprintf("%s[%s] %s: [forwarded messages]\n", indent, ts, senderName))
-			p.formatMergeForwardTree(msgID, childrenMap, nameMap, sb, images, files, depth+1)
+			p.formatMergeForwardTree(ctx, msgID, childrenMap, nameMap, sb, images, files, cards, depth+1)
+
+		case "interactive":
+			text := extractInteractiveCardText(content)
+			card, parsed := parseInboundCard(content, msgID, p.inboundCardMaxBytes)
+			if parsed {
+				if card.Summary != "" {
+					text = card.Summary
+				}
+				if p.inboundCardMode != "summary" {
+					*cards = append(*cards, card)
+				}
+			} else if fetched := p.fetchSingleMessage(ctx, msgID); fetched != nil {
+				if fetched.text != "" {
+					text = fetched.text
+				}
+				if fetched.card != nil && p.inboundCardMode != "summary" {
+					*cards = append(*cards, *fetched.card)
+				}
+			}
+			if p.inboundCardMode == "raw" {
+				text = "[interactive card]"
+			}
+			if text != "" {
+				sb.WriteString(fmt.Sprintf("%s[%s] %s:\n", indent, ts, senderName))
+				for _, line := range strings.Split(text, "\n") {
+					sb.WriteString(fmt.Sprintf("%s    %s\n", indent, line))
+				}
+			}
 
 		default:
 			sb.WriteString(fmt.Sprintf("%s[%s] %s: [%s message]\n", indent, ts, senderName, msgType))

--- a/platform/feishu/inbound_card.go
+++ b/platform/feishu/inbound_card.go
@@ -1,0 +1,65 @@
+package feishu
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// parseInboundCard unwraps Feishu's raw_card_content response and keeps the
+// original card JSON separate from the readable summary. The raw payload is
+// intentionally omitted when it exceeds maxBytes; callers still receive the
+// summary and a truncation marker rather than invalid JSON.
+func parseInboundCard(content, messageID string, maxBytes int) (core.InboundCard, bool) {
+	raw := unwrapInboundCardJSON(content)
+	if len(raw) == 0 {
+		return core.InboundCard{}, false
+	}
+	var card map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &card); err != nil {
+		return core.InboundCard{}, false
+	}
+
+	var schema string
+	_ = json.Unmarshal(card["schema"], &schema)
+	version := "v1"
+	if schema == "2.0" {
+		version = "v2"
+	}
+	summary := extractInteractiveCardText(content)
+	if summary == "[interactive card]" || strings.TrimSpace(summary) == "" {
+		summary = extractInteractiveCardText(string(raw))
+	}
+
+	result := core.InboundCard{
+		MessageID: messageID,
+		Schema:    schema,
+		Version:   version,
+		Summary:   summary,
+	}
+	if maxBytes <= 0 || len(raw) <= maxBytes {
+		result.Raw = append(json.RawMessage(nil), raw...)
+	} else {
+		result.Truncated = true
+	}
+	return result, true
+}
+
+func unwrapInboundCardJSON(content string) []byte {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil
+	}
+	var wrapper struct {
+		JSONCard json.RawMessage `json:"json_card"`
+	}
+	if json.Unmarshal([]byte(content), &wrapper) == nil && len(wrapper.JSONCard) > 0 {
+		var nested string
+		if json.Unmarshal(wrapper.JSONCard, &nested) == nil {
+			return []byte(nested)
+		}
+		return append([]byte(nil), wrapper.JSONCard...)
+	}
+	return []byte(content)
+}

--- a/platform/feishu/inbound_card_dispatch_test.go
+++ b/platform/feishu/inbound_card_dispatch_test.go
@@ -1,0 +1,110 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+)
+
+func TestDispatchInteractiveFetchesAndPreservesRawCard(t *testing.T) {
+	const card = `{"schema":"2.0","body":{"elements":[{"tag":"div","text":{"tag":"plain_text","content":"告警正文"}},{"tag":"button","text":{"tag":"plain_text","content":"查看详情"},"behaviors":[{"type":"open_url","default_url":"https://example.test/alert"}],"value":{"alert_id":"alert-1"}}]}}`
+	got := make(chan *core.Message, 1)
+	var rawCardQuery bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/open-apis/im/v1/messages/om_interactive" {
+			rawCardQuery = r.URL.Query().Get("card_msg_content_type") == "raw_card_content"
+			writeInboundCardTestResponse(t, w, "om_interactive", card)
+			return
+		}
+		writeInboundCardTestResponse(t, w, "", "")
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName:    "feishu",
+		domain:          srv.URL,
+		appID:           "cli_card_test",
+		appSecret:       "secret-card-test",
+		inboundCardMode: "both",
+		client:          lark.NewClient("cli_card_test", "secret-card-test", lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+		handler:         func(_ core.Platform, msg *core.Message) { got <- msg },
+		userNameCache:   sync.Map{},
+		chatNameCache:   sync.Map{},
+		recalledMsgIDs:  map[string]time.Time{},
+		imageBatch:      map[string]*imageBatchEntry{},
+	}
+	p.dispatchMessage(
+		context.Background(), "interactive", `{"title":"lossy event summary"}`, nil,
+		"om_interactive", "feishu:oc_chat:ou_user", "ou_user", "oc_chat",
+		replyContext{messageID: "om_interactive", chatID: "oc_chat", sessionKey: "feishu:oc_chat:ou_user"}, "", time.Now().UnixMilli(),
+	)
+
+	select {
+	case msg := <-got:
+		if len(msg.Cards) != 1 || !strings.Contains(string(msg.Cards[0].Raw), `"alert_id":"alert-1"`) {
+			t.Fatalf("cards = %#v, want raw alert payload", msg.Cards)
+		}
+		if !strings.Contains(msg.Content, "告警正文") {
+			t.Fatalf("summary = %q, want card text", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for interactive card")
+	}
+	if !rawCardQuery {
+		t.Fatal("interactive fetch did not request raw_card_content")
+	}
+}
+
+func TestParseMergeForwardPreservesInteractiveChildren(t *testing.T) {
+	const card = `{"schema":"2.0","body":{"elements":[{"tag":"div","text":{"tag":"plain_text","content":"告警正文"}}],"action":{"value":{"alert_id":"alert-1"}}}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/open-apis/im/v1/messages/om_forward" {
+			writeInboundCardTestResponse(t, w, "", "")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code": 0,
+			"data": map[string]any{"items": []map[string]any{
+				{"message_id": "om_forward", "msg_type": "merge_forward", "sender": map[string]any{"id": "ou_sender", "sender_type": "app"}},
+				{"message_id": "om_child", "upper_message_id": "om_forward", "msg_type": "interactive", "sender": map[string]any{"id": "ou_sender", "sender_type": "app"}, "body": map[string]any{"content": `{"json_card":` + quoteInboundJSON(card) + `}`}},
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	p := &Platform{
+		platformName: "feishu", domain: srv.URL, appID: "cli_card_test", appSecret: "secret-card-test",
+		inboundCardMode: "both", client: lark.NewClient("cli_card_test", "secret-card-test", lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+		userNameCache: sync.Map{}, chatNameCache: sync.Map{}, recalledMsgIDs: map[string]time.Time{}, imageBatch: map[string]*imageBatchEntry{},
+	}
+	_, _, _, cards := p.parseMergeForward(context.Background(), "om_forward")
+	if len(cards) != 1 || !strings.Contains(string(cards[0].Raw), `"alert_id":"alert-1"`) {
+		t.Fatalf("cards = %#v, want forwarded raw alert card", cards)
+	}
+}
+
+func writeInboundCardTestResponse(t *testing.T, w http.ResponseWriter, messageID, card string) {
+	t.Helper()
+	items := []map[string]any{}
+	if messageID != "" {
+		items = append(items, map[string]any{
+			"message_id": messageID,
+			"msg_type":   "interactive",
+			"sender":     map[string]any{"id": "ou_sender", "sender_type": "app"},
+			"body":       map[string]any{"content": `{"json_card":` + quoteInboundJSON(card) + `}`},
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{"code": 0, "msg": "success", "data": map[string]any{"items": items}}); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/platform/feishu/inbound_card_dispatch_test.go
+++ b/platform/feishu/inbound_card_dispatch_test.go
@@ -63,6 +63,41 @@ func TestDispatchInteractiveFetchesAndPreservesRawCard(t *testing.T) {
 	}
 }
 
+func TestDispatchInteractiveSummarySkipsFetchWhenSummaryIsPresent(t *testing.T) {
+	var fetches int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/open-apis/im/v1/messages/om_interactive" {
+			fetches++
+		}
+		writeInboundCardTestResponse(t, w, "", "")
+	}))
+	defer srv.Close()
+
+	got := make(chan *core.Message, 1)
+	p := &Platform{
+		platformName: "feishu", domain: srv.URL, appID: "cli_card_test", appSecret: "secret-card-test",
+		inboundCardMode: "summary", client: lark.NewClient("cli_card_test", "secret-card-test", lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client())),
+		handler:       func(_ core.Platform, msg *core.Message) { got <- msg },
+		userNameCache: sync.Map{}, chatNameCache: sync.Map{}, recalledMsgIDs: map[string]time.Time{}, imageBatch: map[string]*imageBatchEntry{},
+	}
+	content := `{"schema":"2.0","body":{"elements":[{"tag":"div","text":{"tag":"plain_text","content":"告警摘要"}}]}}`
+	p.dispatchMessage(context.Background(), "interactive", content, nil,
+		"om_interactive", "feishu:oc_chat:ou_user", "ou_user", "oc_chat",
+		replyContext{messageID: "om_interactive", chatID: "oc_chat", sessionKey: "feishu:oc_chat:ou_user"}, "", time.Now().UnixMilli())
+
+	select {
+	case msg := <-got:
+		if !strings.Contains(msg.Content, "告警摘要") {
+			t.Fatalf("summary = %q, want card text", msg.Content)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for interactive card")
+	}
+	if fetches != 0 {
+		t.Fatalf("summary mode made %d fetches, want 0", fetches)
+	}
+}
+
 func TestParseMergeForwardPreservesInteractiveChildren(t *testing.T) {
 	const card = `{"schema":"2.0","body":{"elements":[{"tag":"div","text":{"tag":"plain_text","content":"告警正文"}}],"action":{"value":{"alert_id":"alert-1"}}}}`
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/platform/feishu/inbound_card_test.go
+++ b/platform/feishu/inbound_card_test.go
@@ -1,0 +1,46 @@
+package feishu
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseInboundCardPreservesRawCard20(t *testing.T) {
+	card := `{"schema":"2.0","body":{"elements":[{"tag":"div","text":{"tag":"plain_text","content":"渠道不足"}},{"tag":"button","text":{"tag":"plain_text","content":"查看详情"},"behaviors":[{"type":"open_url","default_url":"https://example.test/alert"}],"value":{"alert_id":"alert-1"}}]}}`
+	content := `{"json_card":` + quoteInboundJSON(card) + `}`
+
+	got, ok := parseInboundCard(content, "om_test", 64*1024)
+	if !ok {
+		t.Fatal("parseInboundCard returned false")
+	}
+	if got.Schema != "2.0" || got.Version != "v2" {
+		t.Fatalf("schema/version = %q/%q", got.Schema, got.Version)
+	}
+	if got.MessageID != "om_test" || !strings.Contains(got.Summary, "渠道不足") {
+		t.Fatalf("parsed card metadata/summary = %#v", got)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(got.Raw, &decoded); err != nil {
+		t.Fatalf("raw card is not valid JSON: %v", err)
+	}
+	if decoded["schema"] != "2.0" || !strings.Contains(string(got.Raw), `"alert_id":"alert-1"`) {
+		t.Fatalf("raw card lost alert payload: %s", got.Raw)
+	}
+}
+
+func TestUnwrapInboundCardJSONAcceptsPlainAndWrapper(t *testing.T) {
+	plain := `{"schema":"2.0"}`
+	if string(unwrapInboundCardJSON(plain)) != plain {
+		t.Fatalf("plain card changed")
+	}
+	wrapper := `{"json_card":` + quoteInboundJSON(plain) + `}`
+	if string(unwrapInboundCardJSON(wrapper)) != plain {
+		t.Fatalf("wrapped card was not unwrapped")
+	}
+}
+
+func quoteInboundJSON(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -31,6 +31,25 @@ func TestNew_DefaultsToInteractivePlatform(t *testing.T) {
 	}
 }
 
+func TestNew_DefaultsInboundCardMaxBytes(t *testing.T) {
+	pAny, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret"})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	var p *Platform
+	switch value := pAny.(type) {
+	case *Platform:
+		p = value
+	case *interactivePlatform:
+		p = value.Platform
+	default:
+		t.Fatalf("platform type = %T, want Feishu platform", pAny)
+	}
+	if p.inboundCardMaxBytes != defaultInboundCardMaxBytes {
+		t.Fatalf("inboundCardMaxBytes = %d, want %d", p.inboundCardMaxBytes, defaultInboundCardMaxBytes)
+	}
+}
+
 func TestNew_CanDisableInteractiveCards(t *testing.T) {
 	p, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret", "enable_feishu_card": false})
 	if err != nil {


### PR DESCRIPTION
## Problem

Feishu alert cards arrive as `interactive` messages, but the inbound path only retained a lossy summary (and ignored card-only payloads in some paths). Important alert fields such as action values and links therefore never reached the agent.

## Changes

- Preserve inbound Feishu Card 2.0 payloads as a separate `InboundCard` value with message ID, schema/version, readable summary, raw JSON, and truncation metadata.
- Fetch `raw_card_content` for direct interactive messages and quoted reply chains.
- Preserve nested interactive cards in `merge_forward` messages.
- Support `inbound_card_mode = "summary" | "raw" | "both"` and a bounded raw-card size option.
- Inject raw cards into the agent prompt as explicitly untrusted, size-bounded JSON.

## Tests

- `go test -count=1 ./platform/feishu`
- Targeted core, Feishu card, merge-forward, and Codex app-server tests

Baseline: `4000b2338aa6e850c99df54f8b0ed6ed7460b401` (current upstream `main`).
