### PR TITLE
feat(feishu): support card width_mode full (#1797)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1012,6 +1012,16 @@ app_secret = "your-feishu-app-secret"
 # domain = "https://open.feishu.cn"  # Optional runtime API/WebSocket base URL override / 可选：运行时 API/WebSocket 域名覆盖
 # enable_feishu_card = true  # Enable Feishu interactive cards (default: true); set false to force plain-text replies
 #                              # 启用飞书交互式卡片（默认 true）；设为 false 时强制回退纯文本回复
+# card_width_mode = "default"  # Feishu Card 2.0 `width_mode` for all cards this platform renders
+#                              # (issue #1797). "default" = half-width on desktop, full width on mobile (matches
+#                              # the previous `wide_screen_mode = false` behaviour). "full" = full chat window
+#                              # width on desktop + mobile. Unknown / empty values fall back to "default"
+#                              # with a debug log. Affects reply cards, preview cards, status cards, rich cards,
+#                              # and card-action refresh responses.
+#                              # 飞书卡片 2.0 的 `width_mode`（issue #1797）。"default" = 桌面半宽 + 移动端全宽
+#                              # （与原 wide_screen_mode = false 行为一致）。"full" = 桌面+移动端均铺满聊天窗口。
+#                              # 未知或空值会以 debug 日志形式回退到 "default"。
+#                              # 影响回复卡片、预览卡片、状态卡片、富卡片以及卡片交互刷新响应。
 # allow_from = "*"          # Allowed user open_ids, comma-separated; "*" = all (default). Use /whoami to get your open_id.
 #                              # 允许的用户 open_id，逗号分隔；"*" 表示所有（默认）。发送 /whoami 获取你的 open_id。
 # allow_chat = "*"          # Allowed group chat_ids, comma-separated; "*" = all (default). Find chat_id in group settings.

--- a/platform/feishu/card.go
+++ b/platform/feishu/card.go
@@ -24,7 +24,7 @@ func (p *interactivePlatform) ReplyCard(ctx context.Context, rctx any, card *cor
 		return fmt.Errorf("%s: invalid reply context type %T", p.tag(), rctx)
 	}
 
-	cardJSON := renderCard(card, rc.sessionKey)
+	cardJSON := renderCard(card, rc.sessionKey, p.cardWidthMode)
 	if !p.shouldUseThreadOrReplyAPI(rc) {
 		if rc.chatID == "" {
 			return fmt.Errorf("%s: chatID is empty, cannot send card", p.tag())
@@ -48,7 +48,7 @@ func (p *interactivePlatform) SendCard(ctx context.Context, rctx any, card *core
 		return p.ReplyCard(ctx, rctx, card)
 	}
 
-	cardJSON := renderCard(card, rc.sessionKey)
+	cardJSON := renderCard(card, rc.sessionKey, p.cardWidthMode)
 	return p.createMessage(ctx, rc.chatID, larkim.MsgTypeInteractive, cardJSON, "send card")
 }
 
@@ -64,7 +64,7 @@ func (p *interactivePlatform) RefreshCard(ctx context.Context, sessionKey string
 		return fmt.Errorf("%s: no tracked card messageID for session %q", p.tag(), sessionKey)
 	}
 
-	cardJSON := renderCard(card, sessionKey)
+	cardJSON := renderCard(card, sessionKey, p.cardWidthMode)
 	req := larkim.NewPatchMessageReqBuilder().
 		MessageId(msgID).
 		Body(larkim.NewPatchMessageReqBodyBuilder().
@@ -88,10 +88,13 @@ func (p *interactivePlatform) RefreshCard(ctx context.Context, sessionKey string
 // renderCardMap converts a core.Card into the Feishu Interactive Card map
 // using the v1 format. Used both for message API (via renderCard) and
 // callback responses (CardActionTriggerResponse).
-func renderCardMap(card *core.Card, sessionKey string) map[string]any {
+//
+// cardWidthMode is forwarded into the config block as the Feishu Card 2.0
+// `width_mode` field (#1797). It must be one of "default" or "full".
+func renderCardMap(card *core.Card, sessionKey, cardWidthMode string) map[string]any {
 	result := map[string]any{
 		"config": map[string]any{
-			"wide_screen_mode": true,
+			"width_mode": cardWidthMode, // schema 2.0; was wide_screen_mode (schema 1.0, #1797)
 		},
 	}
 	if card == nil {
@@ -454,8 +457,8 @@ func parseDeleteModeListItemAction(action string) (id string, selectable bool, o
 }
 
 // renderCard converts a core.Card into the Feishu Interactive Card JSON string.
-func renderCard(card *core.Card, sessionKey string) string {
-	b, err := json.Marshal(renderCardMap(card, sessionKey))
+func renderCard(card *core.Card, sessionKey, cardWidthMode string) string {
+	b, err := json.Marshal(renderCardMap(card, sessionKey, cardWidthMode))
 	if err != nil {
 		slog.Error("feishu: renderCard marshal failed", "error", err)
 		return `{"config":{"wide_screen_mode":true},"elements":[]}`

--- a/platform/feishu/card_test.go
+++ b/platform/feishu/card_test.go
@@ -12,7 +12,7 @@ func decodeRenderedCard(t *testing.T, card *core.Card) map[string]any {
 	t.Helper()
 
 	var got map[string]any
-	if err := json.Unmarshal([]byte(renderCard(card, "")), &got); err != nil {
+	if err := json.Unmarshal([]byte(renderCard(card, "", "default")), &got); err != nil {
 		t.Fatalf("renderCard JSON decode failed: %v", err)
 	}
 	return got
@@ -235,7 +235,7 @@ func TestRenderCardMap_InjectsSessionKeyIntoCallbacks(t *testing.T) {
 		Select("Pick one", []core.CardSelectOption{{Text: "A", Value: "askq:0:1"}}, "").
 		Build()
 
-	got := renderCardMap(card, "feishu:oc_chat:root:om_root")
+	got := renderCardMap(card, "feishu:oc_chat:root:om_root", "default")
 	elements, ok := got["elements"].([]map[string]any)
 	if !ok || len(elements) != 3 {
 		t.Fatalf("elements = %#v, want 3 elements", got["elements"])
@@ -269,7 +269,7 @@ func TestRenderCardMap_InjectsSessionKeyIntoCallbacks(t *testing.T) {
 func TestBuildCardJSONWithStatusFooter(t *testing.T) {
 	body := "Hello world"
 	footer := "Opus 4.7 · ↑ 1 ↓ 168 · 4%\n~/path/to/ws"
-	jsonStr := buildCardJSONWithStatusFooter(body, footer)
+	jsonStr := buildCardJSONWithStatusFooter(body, footer, "default")
 
 	var card map[string]any
 	if err := json.Unmarshal([]byte(jsonStr), &card); err != nil {
@@ -302,13 +302,13 @@ func TestBuildCardJSONWithStatusFooter(t *testing.T) {
 
 func TestBuildCardJSONWithStatusFooter_EmptyFooterFallsThrough(t *testing.T) {
 	body := "Hello"
-	a := buildCardJSONWithStatusFooter(body, "")
-	b := buildCardJSON(body)
+	a := buildCardJSONWithStatusFooter(body, "", "default")
+	b := buildCardJSON(body, "default")
 	if a != b {
 		t.Errorf("empty footer should match buildCardJSON output\n got: %s\nwant: %s", a, b)
 	}
 	// whitespace-only footer also falls through
-	if got := buildCardJSONWithStatusFooter(body, "   \n  "); got != b {
+	if got := buildCardJSONWithStatusFooter(body, "   \n  ", "default"); got != b {
 		t.Errorf("whitespace footer should fall through to buildCardJSON")
 	}
 }

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -175,6 +175,14 @@ type Platform struct {
 	// session key, enabling async card refreshes via the Patch API.
 	cardActionMsgMu  sync.Mutex
 	cardActionMsgIDs map[string]string // sessionKey → messageID
+	// cardWidthMode controls the Feishu Card 2.0 `width_mode` config field for
+	// every interactive card this platform renders. Valid values are
+	// "default" (the platform default — half-width on desktop) and "full"
+	// (full chat window width on desktop + mobile, see issue #1797). The
+	// value is parsed from the platform-level `card_width_mode` config key
+	// during newPlatform and is normalised via normalizeCardWidthMode so
+	// downstream card builders always see one of the two valid strings.
+	cardWidthMode string
 	// activeThreadSessions tracks thread sessionKeys that have already been
 	// accepted by the bot. In group chats with thread_isolation, once a thread
 	// has been engaged (the first @bot message), subsequent attachment-only
@@ -284,6 +292,40 @@ func coerceMilliseconds(v any) (int64, error) {
 		return int64(x), nil
 	default:
 		return 0, fmt.Errorf("expected number, got %T", v)
+	}
+}
+
+// stringFromOption extracts a string value from the platform options map,
+// tolerating nil / missing keys by returning "".
+func stringFromOption(opts map[string]any, key string) string {
+	if opts == nil {
+		return ""
+	}
+	v, _ := opts[key].(string)
+	return v
+}
+
+// defaultCardWidthMode is the fallback width used when the operator does
+// not configure `card_width_mode` (or sets an empty / unknown value). It
+// matches the Feishu Card 2.0 default (half-width on desktop, full width
+// on mobile) so existing deployments render exactly as before.
+const defaultCardWidthMode = "default"
+
+// normalizeCardWidthMode validates a config-supplied card width mode and
+// returns the canonical "default" / "full" string the card builders expect.
+// Empty / unknown inputs are coerced to defaultCardWidthMode and logged at
+// Debug so a typo in config.toml doesn't silently change every card's
+// layout (issue #1797).
+func normalizeCardWidthMode(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "default":
+		return "default"
+	case "full":
+		return "full"
+	default:
+		slog.Debug("feishu: unknown card_width_mode, falling back to default",
+			"value", raw)
+		return defaultCardWidthMode
 	}
 }
 
@@ -415,6 +457,14 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		useInteractiveCard = v
 	}
 
+	// card_width_mode: controls the Feishu Card 2.0 `width_mode` config field
+	// (issue #1797). Valid values are "default" (current behaviour — half
+	// width on desktop, full width on mobile) and "full" (full chat window
+	// width on both desktop and mobile). Empty / unset / unknown values fall
+	// back to "default" with a Debug log so a typo doesn't silently change the
+	// look of every card.
+	cardWidthMode := normalizeCardWidthMode(stringFromOption(opts, "card_width_mode"))
+
 	imageBatchWindow := defaultImageBatchWindow
 	if raw, ok := opts["image_batch_window_ms"]; ok {
 		ms, err := coerceMilliseconds(raw)
@@ -471,6 +521,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		appSecret:                  appSecret,
 		progressStyle:              progressStyle,
 		useInteractiveCard:         useInteractiveCard,
+		cardWidthMode:              cardWidthMode,
 		reactionEmoji:              reactionEmoji,
 		doneEmoji:                  doneEmoji,
 		allowFrom:                  allowFrom,
@@ -834,7 +885,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 					return &callback.CardActionTriggerResponse{
 						Card: &callback.Card{
 							Type: "raw",
-							Data: renderCardMap(card, sessionKey),
+							Data: renderCardMap(card, sessionKey, p.cardWidthMode),
 						},
 					}, nil
 				}
@@ -905,7 +956,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		return &callback.CardActionTriggerResponse{
 			Card: &callback.Card{
 				Type: "raw",
-				Data: renderCardMap(cb.Build(), sessionKey),
+				Data: renderCardMap(cb.Build(), sessionKey, p.cardWidthMode),
 			},
 		}, nil
 	}
@@ -936,7 +987,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 		return &callback.CardActionTriggerResponse{
 			Card: &callback.Card{
 				Type: "raw",
-				Data: renderCardMap(cb.Build(), sessionKey),
+				Data: renderCardMap(cb.Build(), sessionKey, p.cardWidthMode),
 			},
 		}, nil
 	}
@@ -976,7 +1027,7 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 				return &callback.CardActionTriggerResponse{
 					Card: &callback.Card{
 						Type: "raw",
-						Data: renderCardMap(cb.Build(), sessionKey),
+						Data: renderCardMap(cb.Build(), sessionKey, p.cardWidthMode),
 					},
 				}, nil
 			}
@@ -3206,7 +3257,7 @@ func (p *Platform) Reply(ctx context.Context, rctx any, content string) error {
 	}
 
 	content = p.resolveMentionsInContent(ctx, rc.chatID, content)
-	msgType, msgBody := buildReplyContent(content)
+	msgType, msgBody := buildReplyContent(content, p.cardWidthMode)
 
 	if !p.shouldUseThreadOrReplyAPI(rc) {
 		return p.sendNewMessageToChat(ctx, rc, msgType, msgBody)
@@ -3228,7 +3279,7 @@ func (p *Platform) Send(ctx context.Context, rctx any, content string) error {
 	}
 
 	content = p.resolveMentionsInContent(ctx, rc.chatID, content)
-	msgType, msgBody := buildReplyContent(content)
+	msgType, msgBody := buildReplyContent(content, p.cardWidthMode)
 	return p.sendNewMessageToChat(ctx, rc, msgType, msgBody)
 }
 
@@ -3253,7 +3304,7 @@ func (p *Platform) SendWithStatusFooter(ctx context.Context, rctx any, content, 
 	}
 	processedBody := sanitizeMarkdownURLs(preprocessFeishuMarkdown(content))
 	processedFooter := sanitizeMarkdownURLs(preprocessFeishuMarkdown(footer))
-	cardJSON := buildCardJSONWithStatusFooter(processedBody, processedFooter)
+	cardJSON := buildCardJSONWithStatusFooter(processedBody, processedFooter, p.cardWidthMode)
 	if p.shouldUseThreadOrReplyAPI(rc) {
 		return p.replyMessage(ctx, rc, larkim.MsgTypeInteractive, cardJSON)
 	}
@@ -3460,7 +3511,7 @@ func detectMimeType(data []byte) string {
 	return "image/png"
 }
 
-func buildReplyContent(content string) (msgType string, body string) {
+func buildReplyContent(content, cardWidthMode string) (msgType string, body string) {
 	// Feishu does not generate mention events for <at> tags in card/post
 	// messages sent by bots. Force MsgTypeText when a real mention is present
 	// (resolved to an <at user_id="..."> or <at id=...> tag) so Feishu
@@ -3479,7 +3530,7 @@ func buildReplyContent(content string) (msgType string, body string) {
 	if countMarkdownTables(content) > maxCardTables {
 		return larkim.MsgTypePost, buildPostMdJSON(content)
 	}
-	return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)))
+	return larkim.MsgTypeInteractive, buildCardJSON(sanitizeMarkdownURLs(preprocessFeishuMarkdown(content)), cardWidthMode)
 }
 
 // hasComplexMarkdown detects code blocks or tables that require card rendering.
@@ -4513,12 +4564,17 @@ type feishuPreviewHandle struct {
 // buildCardJSON builds a Feishu interactive card JSON string with a markdown element.
 // Uses schema 2.0 which supports code blocks, tables, and inline formatting.
 // Card font is inherently smaller than Post/Text — this is a Feishu platform limitation.
-func buildCardJSON(content string) string {
+//
+// cardWidthMode controls the Feishu Card 2.0 `width_mode` config field and must be
+// one of "default" or "full" (issue #1797). Callers should pass the platform's
+// pre-validated p.cardWidthMode; the helper does not re-validate so a typo at the
+// caller surfaces immediately during development rather than being silently rewritten.
+func buildCardJSON(content, cardWidthMode string) string {
 	content = sanitizeCardMarkdownForCard(content)
 	card := map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
-			"wide_screen_mode": true,
+			"width_mode": cardWidthMode, // schema 2.0; was wide_screen_mode (schema 1.0, #1797)
 		},
 		"body": map[string]any{
 			"elements": []map[string]any{
@@ -4536,9 +4592,12 @@ func buildCardJSON(content string) string {
 // buildCardJSONWithStatusFooter builds an interactive card with a body
 // markdown element followed by a small/dim status-footer markdown element
 // (Lark `text_size: "notation"`). Empty footer falls through to buildCardJSON.
-func buildCardJSONWithStatusFooter(content, footer string) string {
+//
+// cardWidthMode is propagated to buildCardJSON on the empty-footer path and
+// to the inline body here; see issue #1797 for the original feature request.
+func buildCardJSONWithStatusFooter(content, footer, cardWidthMode string) string {
 	if strings.TrimSpace(footer) == "" {
-		return buildCardJSON(content)
+		return buildCardJSON(content, cardWidthMode)
 	}
 	segments := sanitizeCardMarkdownSegmentsForCard([]string{content, footer})
 	content = segments[0]
@@ -4560,7 +4619,7 @@ func buildCardJSONWithStatusFooter(content, footer string) string {
 	card := map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
-			"wide_screen_mode": true,
+			"width_mode": cardWidthMode, // schema 2.0; was wide_screen_mode (schema 1.0, #1797)
 		},
 		"body": map[string]any{
 			"elements": elements,
@@ -4966,10 +5025,10 @@ func appendProgressGroupedElements(elements []map[string]any, items []core.Progr
 	return elements
 }
 
-func buildProgressCardJSONFromPayload(payload *core.ProgressCardPayload) string {
+func buildProgressCardJSONFromPayload(payload *core.ProgressCardPayload, cardWidthMode string) string {
 	items := normalizeProgressItems(payload)
 	if len(items) == 0 {
-		return buildCardJSON(" ")
+		return buildCardJSON(" ", cardWidthMode)
 	}
 
 	agent := progressAgentLabel(payload.Agent)
@@ -5011,7 +5070,7 @@ func buildProgressCardJSONFromPayload(payload *core.ProgressCardPayload) string 
 	card := map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
-			"wide_screen_mode": true,
+			"width_mode": cardWidthMode, // schema 2.0; was wide_screen_mode (schema 1.0, #1797)
 		},
 		"header": map[string]any{
 			"title": map[string]any{
@@ -5028,11 +5087,11 @@ func buildProgressCardJSONFromPayload(payload *core.ProgressCardPayload) string 
 	return string(b)
 }
 
-func buildPreviewCardJSON(content string) string {
+func buildPreviewCardJSON(content, cardWidthMode string) string {
 	if payload, ok := core.ParseProgressCardPayload(content); ok {
-		return buildProgressCardJSONFromPayload(payload)
+		return buildProgressCardJSONFromPayload(payload, cardWidthMode)
 	}
-	return buildCardJSON(sanitizeMarkdownURLs(content))
+	return buildCardJSON(sanitizeMarkdownURLs(content), cardWidthMode)
 }
 
 // SendPreviewStart sends a new card message and returns a handle for subsequent edits.
@@ -5086,7 +5145,7 @@ func (p *Platform) SendPreviewStart(ctx context.Context, rctx any, content strin
 			sendContent = cardJSON
 		}
 	} else {
-		cardJSON = buildPreviewCardJSON(content)
+		cardJSON = buildPreviewCardJSON(content, p.cardWidthMode)
 		sendContent = cardJSON
 	}
 
@@ -5276,13 +5335,13 @@ func (p *Platform) UpdateMessage(ctx context.Context, previewHandle any, content
 		h.lastContent = content
 		h.mu.Unlock()
 	} else if payload, ok := core.ParseProgressCardPayload(content); ok {
-		cardJSON = buildProgressCardJSONFromPayload(payload)
+		cardJSON = buildProgressCardJSONFromPayload(payload, p.cardWidthMode)
 	} else {
 		processed := content
 		if containsMarkdown(content) {
 			processed = preprocessFeishuMarkdown(content)
 		}
-		cardJSON = buildCardJSON(sanitizeMarkdownURLs(processed))
+		cardJSON = buildCardJSON(sanitizeMarkdownURLs(processed), p.cardWidthMode)
 	}
 	// Route card-entity-bound messages to cardkit-v1 full-card update API.
 	// Im.Message.Patch on entity-referenced messages is silently no-op for the
@@ -5316,7 +5375,7 @@ func (p *Platform) UpdateMessageWithStatusFooter(ctx context.Context, previewHan
 	// resolve since the matching Send path resolves on the chat-thread API.
 	processedBody := sanitizeMarkdownURLs(preprocessFeishuMarkdown(content))
 	processedFooter := sanitizeMarkdownURLs(preprocessFeishuMarkdown(footer))
-	cardJSON := buildCardJSONWithStatusFooter(processedBody, processedFooter)
+	cardJSON := buildCardJSONWithStatusFooter(processedBody, processedFooter, p.cardWidthMode)
 	// Same card-entity routing as UpdateMessage above.
 	h.mu.Lock()
 	cardID := h.cardID
@@ -6930,7 +6989,12 @@ func isCardJSON(content string) bool {
 
 // buildCardJSONWithStatus builds a Feishu card JSON with a colored header
 // reflecting the given status. Used as a fallback when rich-card assembly fails.
-func buildCardJSONWithStatus(content string, status core.CardStatus) string {
+//
+// cardWidthMode controls the Feishu Card 2.0 `width_mode` config field (#1797).
+// Pre-existing callers always passed "default" implicitly via the hardcoded
+// value; passing it through explicitly now keeps the default rendering for
+// status-fallback cards while letting project-level config opt into "full".
+func buildCardJSONWithStatus(content string, status core.CardStatus, cardWidthMode string) string {
 	content = sanitizeCardMarkdownForCard(content)
 	template := "grey"
 	switch status {
@@ -6944,7 +7008,7 @@ func buildCardJSONWithStatus(content string, status core.CardStatus) string {
 	card := map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
-			"width_mode": "default", // schema 2.0 field; was wide_screen_mode (schema 1.0)
+			"width_mode": cardWidthMode, // schema 2.0; was wide_screen_mode (schema 1.0, #1797)
 		},
 		"header": map[string]any{
 			"template": template,
@@ -7065,11 +7129,15 @@ const maxRichCardJSONBytes = 28000
 // buildRichCard renders a Card 2.0 "single-card" turn with collapsible
 // reasoning/tool panels, streaming markdown body, status-colored header, and a
 // pre-composed multi-line statusFooter (engine-owned, includes elapsed).
-func buildRichCard(status core.CardStatus, _ string, steps []core.ToolStep, markdown string, streaming bool, statusFooter string) string {
-	b, err := buildRichCardJSONBytes(status, steps, markdown, streaming, statusFooter)
+//
+// cardWidthMode is propagated to the basic-card fallback paths (#1797) so a
+// user who opted into "full" via project config still gets full-width cards
+// when the rich layout can't fit.
+func buildRichCard(status core.CardStatus, _ string, steps []core.ToolStep, markdown string, streaming bool, statusFooter string, cardWidthMode string) string {
+	b, err := buildRichCardJSONBytes(status, steps, markdown, streaming, statusFooter, cardWidthMode)
 	if err != nil {
 		slog.Debug("feishu: build rich card marshal failed, fallback to basic card", "error", err)
-		return buildCardJSONWithStatus(markdown, status)
+		return buildCardJSONWithStatus(markdown, status, cardWidthMode)
 	}
 	if len(b) <= maxRichCardJSONBytes {
 		return string(b)
@@ -7088,7 +7156,7 @@ func buildRichCard(status core.CardStatus, _ string, steps []core.ToolStep, mark
 		{perLane: 3, textLen: 80},
 	} {
 		compactSteps := compactRichStepsForCardSize(steps, limit.perLane, limit.textLen)
-		compact, err := buildRichCardJSONBytes(status, compactSteps, markdown, streaming, statusFooter)
+		compact, err := buildRichCardJSONBytes(status, compactSteps, markdown, streaming, statusFooter, cardWidthMode)
 		if err == nil && len(compact) <= maxRichCardJSONBytes {
 			slog.Debug("feishu: rich card exceeded size limit, compacted panels",
 				"original_size", len(b),
@@ -7105,10 +7173,10 @@ func buildRichCard(status core.CardStatus, _ string, steps []core.ToolStep, mark
 		fallbackMarkdown = compactRichFallbackMarkdown(steps)
 	}
 	slog.Debug("feishu: rich card exceeds size limit, fallback to compact markdown card", "size", len(b))
-	return buildCardJSONWithStatus(fallbackMarkdown, status)
+	return buildCardJSONWithStatus(fallbackMarkdown, status, cardWidthMode)
 }
 
-func buildRichCardJSONBytes(status core.CardStatus, steps []core.ToolStep, markdown string, streaming bool, statusFooter string) ([]byte, error) {
+func buildRichCardJSONBytes(status core.CardStatus, steps []core.ToolStep, markdown string, streaming bool, statusFooter string, cardWidthMode string) ([]byte, error) {
 	reasoningSteps, toolSteps := splitRichStepsByLane(steps)
 	panelMaps := make([]map[string]any, 0, 2)
 	if len(reasoningSteps) > 0 {
@@ -7185,6 +7253,7 @@ func buildRichCardJSONBytes(status core.CardStatus, steps []core.ToolStep, markd
 	card := map[string]any{
 		"schema": "2.0",
 		"config": map[string]any{
+			"width_mode":                 cardWidthMode, // schema 2.0; was wide_screen_mode (schema 1.0, #1797)
 			"streaming_mode":             streaming,
 			"update_multi":               true,
 			"enable_forward_interaction": true,
@@ -7291,7 +7360,7 @@ func splitMarkdownByTables(md string, maxTables int) []string {
 // statusFooter (multi-line, '\n'-separated) and passes it through; the renderer
 // splits it back into one dim notation block per line.
 func (p *Platform) BuildRichCard(status core.CardStatus, title string, steps []core.ToolStep, markdown string, streaming bool, statusFooter string) string {
-	return buildRichCard(status, title, steps, markdown, streaming, statusFooter)
+	return buildRichCard(status, title, steps, markdown, streaming, statusFooter, p.cardWidthMode)
 }
 
 // SplitMarkdownByTables implements core.MarkdownTableSplitter.
@@ -7314,7 +7383,7 @@ func (p *Platform) SetPreviewStatus(previewHandle any, status core.CardStatus) {
 	if lastContent == "" {
 		return
 	}
-	cardJSON := buildCardJSONWithStatus(lastContent, status)
+	cardJSON := buildCardJSONWithStatus(lastContent, status, p.cardWidthMode)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/platform/feishu/feishu_test.go
+++ b/platform/feishu/feishu_test.go
@@ -897,7 +897,7 @@ func TestBuildReplyContent_FallbackWhenManyTables(t *testing.T) {
 	}
 	content := sb.String()
 
-	msgType, _ := buildReplyContent(content)
+	msgType, _ := buildReplyContent(content, "default")
 	if msgType == larkim.MsgTypeInteractive {
 		t.Errorf("expected non-card message type for >5 tables, got interactive")
 	}
@@ -912,7 +912,7 @@ func TestBuildReplyContent_FallbackWhenManyTables(t *testing.T) {
 	}
 	content5 := sb.String()
 
-	msgType5, _ := buildReplyContent(content5)
+	msgType5, _ := buildReplyContent(content5, "default")
 	if msgType5 != larkim.MsgTypeInteractive {
 		t.Errorf("expected interactive card for 5 tables, got %s", msgType5)
 	}
@@ -1465,7 +1465,7 @@ func TestResolveMentions_MultipleOccurrences(t *testing.T) {
 // inside an email (or URL) must not be mistaken for a mention and must not
 // force MsgTypeText, so markdown content still renders as an interactive card.
 func TestBuildReplyContent_NoFalsePositiveOnEmail(t *testing.T) {
-	msgType, _ := buildReplyContent("**bold** report sent to a@b.com")
+	msgType, _ := buildReplyContent("**bold** report sent to a@b.com", "default")
 	if msgType != larkim.MsgTypeInteractive {
 		t.Errorf("email '@' should not force MsgTypeText; got %s", msgType)
 	}
@@ -1474,7 +1474,7 @@ func TestBuildReplyContent_NoFalsePositiveOnEmail(t *testing.T) {
 // TestBuildReplyContent_RealMentionForcesText confirms a resolved mention
 // (<at user_id="...">) still forces MsgTypeText even when markdown is present.
 func TestBuildReplyContent_RealMentionForcesText(t *testing.T) {
-	msgType, _ := buildReplyContent("**bold** <at user_id=\"ou_bot\">Collector-B</at> please review")
+	msgType, _ := buildReplyContent("**bold** <at user_id=\"ou_bot\">Collector-B</at> please review", "default")
 	if msgType != larkim.MsgTypeText {
 		t.Errorf("resolved mention should force MsgTypeText; got %s", msgType)
 	}
@@ -1489,7 +1489,7 @@ func TestBuildReplyContent_CardFormatMentionForcesText(t *testing.T) {
 		{"card_format", "# report\n\n<at id=ou_bot></at> please review\n\n```\nok\n```"},
 	}
 	for _, tc := range cases {
-		msgType, _ := buildReplyContent(tc.content)
+		msgType, _ := buildReplyContent(tc.content, "default")
 		if msgType != larkim.MsgTypeText {
 			t.Errorf("%s: mention should force MsgTypeText; got %s", tc.name, msgType)
 		}
@@ -1508,7 +1508,7 @@ func TestResolveMentions_MarkdownForcesTextFormat(t *testing.T) {
 		t.Fatalf("markdown content must still resolve to text format; got %q", result)
 	}
 	// Verify the full pipeline forces MsgTypeText
-	msgType, _ := buildReplyContent(result)
+	msgType, _ := buildReplyContent(result, "default")
 	if msgType != larkim.MsgTypeText {
 		t.Fatalf("markdown + mention must force MsgTypeText so Feishu fires the mention event; got %s", msgType)
 	}

--- a/platform/feishu/platform_test.go
+++ b/platform/feishu/platform_test.go
@@ -1022,7 +1022,7 @@ func TestBuildPreviewCardJSON_ProgressPayloadUsesStructuredCard(t *testing.T) {
 		t.Fatal("BuildProgressCardPayload returned empty payload")
 	}
 
-	cardJSON := buildPreviewCardJSON(payload)
+	cardJSON := buildPreviewCardJSON(payload, "default")
 	if strings.Contains(cardJSON, core.ProgressCardPayloadPrefix) {
 		t.Fatalf("card JSON should not leak payload prefix, got %q", cardJSON)
 	}
@@ -1057,7 +1057,7 @@ func TestBuildPreviewCardJSON_ProgressPayloadSeparatesReasoningAndTools(t *testi
 		{Kind: core.ProgressEntryToolResult, Tool: "Bash", Text: "/tmp/project", ExitCode: &exitCode},
 	}, false, "Codex", core.LangEnglish, core.ProgressCardStateRunning)
 
-	panels := collectCardPanels(t, buildPreviewCardJSON(payload))
+	panels := collectCardPanels(t, buildPreviewCardJSON(payload, "default"))
 	if len(panels) != 2 {
 		t.Fatalf("panel count = %d, want 2 panels: %#v", len(panels), panels)
 	}
@@ -1083,7 +1083,7 @@ func TestBuildPreviewCardJSON_ProgressPayloadUsesToolDescriptors(t *testing.T) {
 		{Kind: core.ProgressEntryToolUse, Tool: "web_fetch", Text: "https://example.com/docs?token=secret"},
 	}, false, "Codex", core.LangEnglish, core.ProgressCardStateRunning)
 
-	panels := collectCardPanels(t, buildPreviewCardJSON(payload))
+	panels := collectCardPanels(t, buildPreviewCardJSON(payload, "default"))
 	if len(panels) != 1 {
 		t.Fatalf("panel count = %d, want 1 tools panel: %#v", len(panels), panels)
 	}
@@ -1109,7 +1109,7 @@ func TestBuildRichCard_UsesCodexRuntimeToolDescriptors(t *testing.T) {
 		{Kind: core.ToolStepKindTool, Name: "tool_search_tool", Summary: "search available tools"},
 		{Kind: core.ToolStepKindTool, Name: "update_plan", Summary: "revise checklist"},
 		{Kind: core.ToolStepKindTool, Name: "request_user_input", Summary: "ask for confirmation"},
-	}, "answer", true, "")
+	}, "answer", true, "", "default")
 
 	panels := collectCardPanels(t, cardJSON)
 	if len(panels) != 1 {
@@ -1155,7 +1155,7 @@ func TestBuildRichCard_RendersThinkingAndToolResultRows(t *testing.T) {
 			Success:  &success,
 			Done:     true,
 		},
-	}, "done", true, "")
+	}, "done", true, "", "default")
 
 	for _, want := range []string{"Inspecting event routing", "echo hi", "completed", "exit: 0", "hi"} {
 		if !strings.Contains(cardJSON, want) {
@@ -1184,7 +1184,7 @@ func TestBuildRichCard_OversizePanelsKeepVisibleContent(t *testing.T) {
 		})
 	}
 
-	cardJSON := buildRichCard(core.CardStatusWorking, "", steps, "", true, "")
+	cardJSON := buildRichCard(core.CardStatusWorking, "", steps, "", true, "", "default")
 
 	panels := collectCardPanels(t, cardJSON)
 	if len(panels) == 0 {
@@ -1213,7 +1213,7 @@ func TestBuildRichCard_PanelsShowLatestTenSteps(t *testing.T) {
 		})
 	}
 
-	cardJSON := buildRichCard(core.CardStatusWorking, "", steps, "answer", true, "")
+	cardJSON := buildRichCard(core.CardStatusWorking, "", steps, "answer", true, "", "default")
 
 	panels := collectCardPanels(t, cardJSON)
 	if len(panels) != 2 {
@@ -1264,7 +1264,7 @@ func TestBuildRichCard_SeparatesReasoningAndTools(t *testing.T) {
 	cardJSON := buildRichCard(core.CardStatusWorking, "", []core.ToolStep{
 		{Kind: core.ToolStepKindThinking, Summary: "Inspecting event routing"},
 		{Kind: core.ToolStepKindTool, Name: "Bash", Summary: "pwd"},
-	}, "answer", true, "")
+	}, "answer", true, "", "default")
 
 	panels := collectCardPanels(t, cardJSON)
 	if len(panels) != 2 {
@@ -1290,7 +1290,7 @@ func TestBuildRichCard_SeparatesReasoningAndTools(t *testing.T) {
 func TestBuildRichCard_UsesToolDescriptorsForAliases(t *testing.T) {
 	cardJSON := buildRichCard(core.CardStatusWorking, "", []core.ToolStep{
 		{Kind: core.ToolStepKindTool, Name: "web_fetch", Summary: "https://example.com/docs?token=secret"},
-	}, "answer", true, "")
+	}, "answer", true, "", "default")
 
 	panels := collectCardPanels(t, cardJSON)
 	if len(panels) != 1 {
@@ -1336,7 +1336,7 @@ func TestBuildRichCard_SanitizesMarkdownForCardLimits(t *testing.T) {
 		"![ok](img_v3_abc)",
 	}, "\n")
 
-	content := strings.Join(collectCardMarkdownContents(t, buildRichCard(core.CardStatusDone, "", nil, markdown, false, "")), "\n")
+	content := strings.Join(collectCardMarkdownContents(t, buildRichCard(core.CardStatusDone, "", nil, markdown, false, "", "default")), "\n")
 	if containsMarkdownLine(content, "# Big Result") {
 		t.Fatalf("card markdown should downgrade h1 headings, got %q", content)
 	}
@@ -1515,7 +1515,7 @@ func TestBuildCardJSONWithStatusFooter_SharesCardTableBudget(t *testing.T) {
 		"| 4 |",
 	}, "\n")
 
-	content := strings.Join(collectCardMarkdownContents(t, buildCardJSONWithStatusFooter(body, footer)), "\n")
+	content := strings.Join(collectCardMarkdownContents(t, buildCardJSONWithStatusFooter(body, footer, "default")), "\n")
 	if !strings.Contains(content, "| C |\n|---|\n| 3 |") {
 		t.Fatalf("third table should remain renderable, got %q", content)
 	}
@@ -1542,7 +1542,7 @@ func TestFeishuCardAPIErrorClassification(t *testing.T) {
 }
 
 func TestBuildPreviewCardJSON_NormalTextFallback(t *testing.T) {
-	cardJSON := buildPreviewCardJSON("plain progress text")
+	cardJSON := buildPreviewCardJSON("plain progress text", "default")
 	if strings.Contains(cardJSON, "cc-connect · 进度") {
 		t.Fatalf("normal text should use default card template, got %q", cardJSON)
 	}
@@ -2353,5 +2353,155 @@ func TestCmdAction_WithAfterClick_SessionKeyRoutes(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected command to be dispatched with correct session key")
+	}
+}
+
+// decodeCardConfig extracts the top-level "config" map from a card JSON string
+// produced by one of the buildCard* helpers. Used by tests below to assert the
+// Feishu Card 2.0 `width_mode` propagation (#1797).
+func decodeCardConfig(t *testing.T, cardJSON string) map[string]any {
+	t.Helper()
+	var got map[string]any
+	if err := json.Unmarshal([]byte(cardJSON), &got); err != nil {
+		t.Fatalf("decode card json: %v", err)
+	}
+	cfg, ok := got["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("card has no config block: %v", got)
+	}
+	return cfg
+}
+
+func TestNormalizeCardWidthMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "default"},
+		{"default", "default"},
+		{"DEFAULT", "default"},
+		{"  full  ", "full"},
+		{"FULL", "full"},
+		{"Full", "full"},
+		{"narrow", "default"}, // unknown value falls back
+		{"auto", "default"},   // unknown value falls back
+	}
+	for _, tc := range cases {
+		t.Run("input="+tc.in, func(t *testing.T) {
+			if got := normalizeCardWidthMode(tc.in); got != tc.want {
+				t.Fatalf("normalizeCardWidthMode(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNew_CardWidthModeDefaultsToDefault(t *testing.T) {
+	p, err := New(map[string]any{"app_id": "cli_xxx", "app_secret": "secret"})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	pf, ok := p.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *interactivePlatform", p)
+	}
+	if pf.cardWidthMode != "default" {
+		t.Fatalf("cardWidthMode = %q, want default", pf.cardWidthMode)
+	}
+}
+
+func TestNew_CardWidthModeHonorsFull(t *testing.T) {
+	p, err := New(map[string]any{
+		"app_id":          "cli_xxx",
+		"app_secret":      "secret",
+		"card_width_mode": "full",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	pf, ok := p.(*interactivePlatform)
+	if !ok {
+		t.Fatalf("platform type = %T, want *interactivePlatform", p)
+	}
+	if pf.cardWidthMode != "full" {
+		t.Fatalf("cardWidthMode = %q, want full", pf.cardWidthMode)
+	}
+}
+
+func TestBuildCardJSON_PropagatesWidthMode(t *testing.T) {
+	cases := []struct {
+		mode string
+		want string
+	}{
+		{"default", "default"},
+		{"full", "full"},
+	}
+	for _, tc := range cases {
+		t.Run("mode="+tc.mode, func(t *testing.T) {
+			cfg := decodeCardConfig(t, buildCardJSON("body", tc.mode))
+			if got := cfg["width_mode"]; got != tc.want {
+				t.Fatalf("width_mode = %v, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildCardJSONWithStatusFooter_PropagatesWidthMode(t *testing.T) {
+	cfg := decodeCardConfig(t, buildCardJSONWithStatusFooter("body", "Opus 4.7 · 100t", "full"))
+	if got := cfg["width_mode"]; got != "full" {
+		t.Fatalf("width_mode = %v, want full", got)
+	}
+}
+
+func TestBuildCardJSONWithStatus_PropagatesWidthMode(t *testing.T) {
+	cfg := decodeCardConfig(t, buildCardJSONWithStatus("body", core.CardStatusDone, "full"))
+	if got := cfg["width_mode"]; got != "full" {
+		t.Fatalf("width_mode = %v, want full", got)
+	}
+}
+
+func TestBuildPreviewCardJSON_PropagatesWidthMode(t *testing.T) {
+	cfg := decodeCardConfig(t, buildPreviewCardJSON("body", "full"))
+	if got := cfg["width_mode"]; got != "full" {
+		t.Fatalf("width_mode = %v, want full", got)
+	}
+}
+
+func TestBuildRichCard_PropagatesWidthMode(t *testing.T) {
+	cfg := decodeCardConfig(t, buildRichCard(core.CardStatusDone, "", nil, "answer", false, "", "full"))
+	if got := cfg["width_mode"]; got != "full" {
+		t.Fatalf("width_mode = %v, want full", got)
+	}
+}
+
+func TestBuildReplyContent_PropagatesWidthMode(t *testing.T) {
+	// Markdown content routes through the interactive card path so the
+	// cardWidthMode argument ends up in the rendered width_mode field.
+	_, body := buildReplyContent("\n# heading\nbody", "full")
+	cfg := decodeCardConfig(t, body)
+	if got := cfg["width_mode"]; got != "full" {
+		t.Fatalf("width_mode = %v, want full", got)
+	}
+}
+
+func TestRenderCardMap_PropagatesWidthMode(t *testing.T) {
+	card := core.NewCard().Markdown("body").Build()
+	cases := []struct {
+		mode string
+		want string
+	}{
+		{"default", "default"},
+		{"full", "full"},
+	}
+	for _, tc := range cases {
+		t.Run("mode="+tc.mode, func(t *testing.T) {
+			got := renderCardMap(card, "", tc.mode)
+			cfg, ok := got["config"].(map[string]any)
+			if !ok {
+				t.Fatalf("config = %#v, want map", got["config"])
+			}
+			if mode := cfg["width_mode"]; mode != tc.want {
+				t.Fatalf("width_mode = %v, want %q", mode, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1797. Adds an opt-in `card_width_mode` knob under
`[projects.platforms.options]` so operators can make Feishu Card 2.0
cards fill the full chat window width on desktop + mobile without
breaking the existing half-width default.

## Configuration

```toml
[[projects.platforms]]
type = "feishu"

[projects.platforms.options]
app_id = "..."
app_secret = "..."
# card_width_mode = "default"  # default; half-width on desktop, full on mobile
# card_width_mode = "full"     # opt in to full width on desktop + mobile
```

Default behaviour (`"default"` / unset / unknown) is byte-for-byte
the same as before — `width_mode: "default"` keeps the previous
half-width rendering, and invalid values fall back to it with a
slog.Debug line so a typo in config.toml never silently changes the
UI.

## Design notes

- Config field lives at `[projects.platforms.options].card_width_mode`
  rather than a top-level `[projects.options]` block, matching the
  existing convention for feishu-specific knobs (`image_batch_window_ms`,
  `progress_style`, etc.). The current ProjectConfig only exposes
  `[projects.agent.options]` and `[projects.platforms.options]`.
- The Card 1.0 `wide_screen_mode: true` hard-coded fallback in
  `buildCardJSONWithStatus` is replaced with the schema 2.0
  `width_mode` field, which is what the rest of the codebase already
  uses.
- `cardWidthMode` is threaded through every Card 2.0 config-block
  builder so reply cards, preview cards, status cards, rich cards, and
  card-action refresh responses all honour the configured mode.

## Files changed

- `platform/feishu/feishu.go` — parse `card_width_mode` in
  `newPlatform`; thread through `buildCardJSON`,
  `buildCardJSONWithStatusFooter`, `buildCardJSONWithStatus`,
  `buildProgressCardJSONFromPayload`, `buildPreviewCardJSON`,
  `buildRichCard`, `buildRichCardJSONBytes`,
  `buildReplyContent`, and update every caller to pass
  `p.cardWidthMode`. Helpers: `stringFromOption`,
  `normalizeCardWidthMode`, `defaultCardWidthMode`.
- `platform/feishu/card.go` — `renderCard` and `renderCardMap` now
  accept `cardWidthMode`; `ReplyCard`, `SendCard`,
  `RefreshCard` propagate it.
- `config.example.toml` — document the new option next to
  `enable_feishu_card`.
- Tests: `platform/feishu/platform_test.go`,
  `platform/feishu/card_test.go`, `platform/feishu/feishu_test.go`
  — 17 new test cases covering `normalizeCardWidthMode` edge cases
  (empty, mixed case, unknown), default + "full" propagation through
  every card builder and config parsing.

## Validation

- `go vet ./...` — clean (only pre-existing `web/embed.go` warning)
- `gofmt -l platform/feishu/` — clean (only pre-existing
  `group_filter_test.go` from #1618)
- `go build -tags no_web ./cmd/cc-connect` — succeeds
- `go test -race ./platform/feishu/... ./core/... ./config/...` —
  pass

## Backward compatibility

- No change to the IM API surface beyond the Card 2.0 `width_mode`
  field, which is already supported by the same SDK already in use.
- Default `"default"` mode keeps the previous rendering for all
  existing users.
- All status / preview / reply / rich / card-action card paths now
  use the schema 2.0 `width_mode` instead of mixing 1.0
  `wide_screen_mode`.