### PR TITLE
feat(feishu): add catchup polling to compensate WebSocket push losses

### DIFF
--- a/platform/feishu/catchup.go
+++ b/platform/feishu/catchup.go
@@ -1,0 +1,288 @@
+package feishu
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+// Feishu's WebSocket push (im.message.receive_v1) is best-effort: events can
+// be silently dropped even while the connection looks healthy (see
+// larksuite/oapi-sdk-go#195 and larksuite/node-sdk#164, where Feishu's own
+// server logs show "app not online" failures against connected clients).
+// The catch-up poller below is a compensation channel: every few minutes it
+// lists recent messages of the operator-configured chats over the REST API
+// and re-injects anything the WebSocket path missed.
+//
+// Injection reuses the exact same dispatchMessage path as WebSocket-delivered
+// events, and is guarded by:
+//   - dedup by message_id (core.MessageDedup), so a message delivered by both
+//     the WebSocket and a poll is processed exactly once, whichever arrives first;
+//   - the stale-message guard (core.IsOldMessage), so a poll right after a
+//     restart does not replay historical traffic.
+
+const (
+	catchupInterval = 3 * time.Minute  // how often the poller runs
+	catchupLookback = 5 * time.Minute  // how far back each poll window reaches (overlaps the interval on purpose; dedup absorbs the overlap)
+	catchupBuffer   = 30 * time.Second // exclude the most recent slice to avoid racing in-flight messages the WebSocket will still deliver
+	catchupPageSize = 50
+)
+
+// startCatchupPoller starts a background goroutine that periodically fetches
+// recent messages from each configured chat and injects any qualifying
+// messages missed by the WebSocket push path.
+//
+// It only runs on the primary owner of the shared WebSocket connection
+// (isWSPrimary): secondary platforms in a shared-WS group receive fanned-out
+// events from the primary, so a poller per platform would re-inject every
+// missed message once per sibling. Both catchup chat options empty means the
+// feature is disabled.
+func (p *Platform) startCatchupPoller() {
+	if p.catchupChats == "" && p.catchupP2PChats == "" {
+		return
+	}
+	if !p.isWSPrimary {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.mu.Lock()
+	p.catchupCancel = cancel
+	p.mu.Unlock()
+
+	go func() {
+		slog.Info(p.tag()+": catchup poller started",
+			"interval", catchupInterval, "lookback", catchupLookback)
+		defer cancel()
+		ticker := time.NewTicker(catchupInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				p.pollAllCatchupChats(ctx)
+			}
+		}
+	}()
+}
+
+// stopCatchupPoller cancels the background poller, if running.
+func (p *Platform) stopCatchupPoller() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.catchupCancel != nil {
+		p.catchupCancel()
+		p.catchupCancel = nil
+	}
+}
+
+func (p *Platform) pollAllCatchupChats(ctx context.Context) {
+	p2p := map[string]bool{}
+	for _, chatID := range strings.Split(p.catchupP2PChats, ",") {
+		chatID = strings.TrimSpace(chatID)
+		if chatID != "" {
+			p2p[chatID] = true
+		}
+	}
+	seen := map[string]bool{}
+	for _, chatID := range strings.Split(p.catchupChats+","+p.catchupP2PChats, ",") {
+		chatID = strings.TrimSpace(chatID)
+		if chatID == "" || seen[chatID] {
+			continue
+		}
+		seen[chatID] = true
+		if err := p.pollChatForMissedMessages(ctx, chatID, p2p[chatID]); err != nil {
+			slog.Warn(p.tag()+": catchup: poll error", "chat_id", chatID, "error", err)
+		}
+	}
+}
+
+// pollChatForMissedMessages lists recent messages of one chat over the REST
+// API and re-injects the ones the WebSocket push path missed. isP2P selects
+// the qualification rule: group chats require an explicit @bot mention, while
+// p2p chats have no mention list so every user message qualifies.
+func (p *Platform) pollChatForMissedMessages(ctx context.Context, chatID string, isP2P bool) error {
+	botOpenID := p.getBotOpenID()
+	if botOpenID == "" {
+		// Without the bot open_id we cannot run the group mention gate.
+		// Skip rather than fail open: injecting every group message would
+		// turn the bot into a loud responder (issue #1618 class of bug).
+		return nil
+	}
+
+	endTime := time.Now().Add(-catchupBuffer).Unix()
+	startTime := time.Now().Add(-catchupLookback).Unix()
+
+	req := larkim.NewListMessageReqBuilder().
+		ContainerIdType("chat").
+		ContainerId(chatID).
+		StartTime(fmt.Sprintf("%d", startTime)).
+		EndTime(fmt.Sprintf("%d", endTime)).
+		PageSize(catchupPageSize).
+		Build()
+
+	var items []*larkim.Message
+	if err := p.withFreshTenantAccessTokenRetry(ctx, "catchup list messages",
+		func(client *lark.Client, options ...larkcore.RequestOptionFunc) error {
+			resp, err := client.Im.Message.List(ctx, req, options...)
+			if err != nil {
+				return err
+			}
+			if !resp.Success() {
+				return fmt.Errorf("list messages: code=%d msg=%s", resp.Code, resp.Msg)
+			}
+			if resp.Data != nil {
+				items = resp.Data.Items
+			}
+			return nil
+		}); err != nil {
+		return err
+	}
+
+	injected := 0
+	for _, msg := range items {
+		if msg == nil || msg.MessageId == nil || msg.CreateTime == nil {
+			continue
+		}
+		if msg.Deleted != nil && *msg.Deleted {
+			continue
+		}
+		// Never re-inject the bot's own messages: the WebSocket push path
+		// never delivers them, and doing so from the poller would create a
+		// self-reply loop (especially in p2p chats, where every message
+		// qualifies).
+		if !catchupSenderQualifies(msg.Sender) {
+			continue
+		}
+		if !catchupMessageQualifies(isP2P, msg.Mentions, botOpenID) {
+			continue
+		}
+		createMs, err := strconv.ParseInt(*msg.CreateTime, 10, 64)
+		if err != nil {
+			continue
+		}
+		msgTime := time.Unix(createMs/1000, (createMs%1000)*int64(time.Millisecond))
+		if core.IsOldMessage(msgTime) {
+			continue
+		}
+		if p.dedup.IsDuplicate(*msg.MessageId) {
+			continue
+		}
+		p.injectCatchupMessage(ctx, msg, chatID, createMs, isP2P)
+		injected++
+	}
+
+	if injected > 0 {
+		slog.Info(p.tag()+": catchup: injected missed messages",
+			"chat_id", chatID, "count", injected)
+	}
+	return nil
+}
+
+// catchupMessageQualifies reports whether a REST-fetched message should be
+// re-injected. Group messages require the bot to appear in the mention list;
+// p2p messages skip the mention check entirely because Feishu's REST API
+// never returns a mention list for p2p messages.
+func catchupMessageQualifies(isP2P bool, mentions []*larkim.Mention, botOpenID string) bool {
+	if isP2P {
+		return true
+	}
+	return isBotMentionedInList(mentions, botOpenID)
+}
+
+// catchupSenderQualifies reports whether a message sender should be considered
+// for catch-up injection. Messages sent by the app itself are excluded so the
+// poller can never echo the bot's own replies back into the agent.
+func catchupSenderQualifies(sender *larkim.Sender) bool {
+	return sender == nil || sender.SenderType == nil || *sender.SenderType != "app"
+}
+
+// isBotMentionedInList checks if the bot is mentioned in a REST API message's
+// mention list. The REST Mention.Id field is a *string containing the open_id
+// directly, unlike the WebSocket event's Mentions[].Id which is a *UserId
+// struct.
+func isBotMentionedInList(mentions []*larkim.Mention, botOpenID string) bool {
+	for _, m := range mentions {
+		if m != nil && m.Id != nil && *m.Id == botOpenID {
+			return true
+		}
+	}
+	return false
+}
+
+// injectCatchupMessage dispatches a REST API message through the same
+// dispatchMessage path used by WebSocket-delivered messages.
+func (p *Platform) injectCatchupMessage(ctx context.Context, msg *larkim.Message, chatID string, createTimeMs int64, isP2P bool) {
+	msgType := stringValue(msg.MsgType)
+	content := ""
+	if msg.Body != nil && msg.Body.Content != nil {
+		content = *msg.Body.Content
+	}
+	mentions := convertRESTMentions(msg.Mentions)
+	messageID := stringValue(msg.MessageId)
+	parentID := stringValue(msg.ParentId)
+
+	userID := ""
+	if msg.Sender != nil && msg.Sender.Id != nil {
+		userID = *msg.Sender.Id
+	}
+
+	chatType := "group"
+	if isP2P {
+		chatType = "p2p"
+	}
+	eventMsg := &larkim.EventMessage{
+		MessageId: msg.MessageId,
+		RootId:    msg.RootId,
+		ChatType:  &chatType,
+	}
+	sessionKey := p.makeSessionKey(eventMsg, chatID, userID)
+	rctx := replyContext{
+		messageID:  messageID,
+		chatID:     chatID,
+		sessionKey: sessionKey,
+	}
+
+	slog.Info(p.tag()+": catchup: injecting missed message",
+		"message_id", messageID,
+		"chat_id", chatID,
+		"msg_type", msgType,
+	)
+
+	go p.dispatchMessage(ctx, msgType, content, mentions, messageID, sessionKey, userID, chatID, rctx, parentID, createTimeMs)
+}
+
+// convertRESTMentions converts REST API []*larkim.Mention to the
+// []*larkim.MentionEvent shape dispatchMessage expects. REST Mention.Id is a
+// *string (open_id directly); MentionEvent.Id is a *UserId with an OpenId
+// field.
+func convertRESTMentions(mentions []*larkim.Mention) []*larkim.MentionEvent {
+	result := make([]*larkim.MentionEvent, 0, len(mentions))
+	for _, m := range mentions {
+		if m == nil {
+			continue
+		}
+		var userID *larkim.UserId
+		if m.Id != nil {
+			openID := *m.Id
+			userID = &larkim.UserId{OpenId: &openID}
+		}
+		result = append(result, &larkim.MentionEvent{
+			Key:       m.Key,
+			Id:        userID,
+			Name:      m.Name,
+			TenantKey: m.TenantKey,
+		})
+	}
+	return result
+}

--- a/platform/feishu/catchup_test.go
+++ b/platform/feishu/catchup_test.go
@@ -1,0 +1,132 @@
+package feishu
+
+import (
+	"testing"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+func TestIsBotMentionedInList(t *testing.T) {
+	const botID = "ou_bot123"
+
+	t.Run("nil mentions", func(t *testing.T) {
+		if isBotMentionedInList(nil, botID) {
+			t.Fatal("expected nil mentions to not contain the bot")
+		}
+	})
+	t.Run("empty mentions", func(t *testing.T) {
+		if isBotMentionedInList([]*larkim.Mention{}, botID) {
+			t.Fatal("expected empty mentions to not contain the bot")
+		}
+	})
+	t.Run("bot not in list", func(t *testing.T) {
+		mentions := []*larkim.Mention{{Id: strPtr("ou_other")}}
+		if isBotMentionedInList(mentions, botID) {
+			t.Fatal("expected mention list without the bot to not match")
+		}
+	})
+	t.Run("bot in list", func(t *testing.T) {
+		mentions := []*larkim.Mention{
+			{Id: strPtr("ou_other")},
+			{Id: strPtr(botID)},
+		}
+		if !isBotMentionedInList(mentions, botID) {
+			t.Fatal("expected mention list containing the bot to match")
+		}
+	})
+	t.Run("nil mention id skipped", func(t *testing.T) {
+		mentions := []*larkim.Mention{{Id: nil}, {Id: strPtr(botID)}}
+		if !isBotMentionedInList(mentions, botID) {
+			t.Fatal("expected nil mention id to be skipped and the bot to match")
+		}
+	})
+}
+
+// TestCatchupMessageQualifies pins the p2p vs group qualification rules of the
+// catch-up poller: p2p messages must skip the mention check entirely (the
+// REST API never returns a mention list for p2p chats), while group messages
+// must still require an explicit @bot mention.
+func TestCatchupMessageQualifies(t *testing.T) {
+	const botID = "ou_bot123"
+
+	t.Run("p2p skips the mention check", func(t *testing.T) {
+		// No mention list at all — the normal shape of a p2p message.
+		if !catchupMessageQualifies(true, nil, botID) {
+			t.Fatal("expected p2p message without mentions to qualify")
+		}
+		// Mention list mentioning someone else — still qualifies: p2p
+		// messages never carry a meaningful bot mention.
+		mentions := []*larkim.Mention{{Id: strPtr("ou_someone_else")}}
+		if !catchupMessageQualifies(true, mentions, botID) {
+			t.Fatal("expected p2p message with unrelated mentions to qualify")
+		}
+	})
+
+	t.Run("group requires the bot mention", func(t *testing.T) {
+		if catchupMessageQualifies(false, nil, botID) {
+			t.Fatal("expected group message without mentions to be rejected")
+		}
+		mentions := []*larkim.Mention{{Id: strPtr("ou_other_user")}}
+		if catchupMessageQualifies(false, mentions, botID) {
+			t.Fatal("expected group message mentioning someone else to be rejected")
+		}
+		botMentions := []*larkim.Mention{
+			{Id: strPtr("ou_other_user")},
+			{Id: strPtr(botID)},
+		}
+		if !catchupMessageQualifies(false, botMentions, botID) {
+			t.Fatal("expected group message mentioning the bot to qualify")
+		}
+	})
+}
+
+// TestCatchupSenderQualifies verifies that the poller never re-injects the
+// bot's own messages, which would create a self-reply loop (the WebSocket
+// push path never delivers the app's own messages).
+func TestCatchupSenderQualifies(t *testing.T) {
+	appSender := &larkim.Sender{SenderType: strPtr("app")}
+	if catchupSenderQualifies(appSender) {
+		t.Fatal("expected app-sent messages to be excluded from catchup injection")
+	}
+
+	userSender := &larkim.Sender{SenderType: strPtr("user")}
+	if !catchupSenderQualifies(userSender) {
+		t.Fatal("expected user-sent messages to qualify for catchup injection")
+	}
+
+	if !catchupSenderQualifies(nil) {
+		t.Fatal("expected unknown sender to qualify (fail open for user messages)")
+	}
+}
+
+func TestConvertRESTMentions(t *testing.T) {
+	t.Run("nil input returns empty slice", func(t *testing.T) {
+		got := convertRESTMentions(nil)
+		if len(got) != 0 {
+			t.Fatalf("expected empty result, got %d entries", len(got))
+		}
+	})
+	t.Run("converts open_id string to UserId struct", func(t *testing.T) {
+		key, name, openID := "@_user_1", "Alice", "ou_abc"
+		got := convertRESTMentions([]*larkim.Mention{{Key: &key, Id: &openID, Name: &name}})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 mention, got %d", len(got))
+		}
+		if got[0].Key == nil || *got[0].Key != key {
+			t.Fatalf("expected key %q, got %v", key, got[0].Key)
+		}
+		if got[0].Name == nil || *got[0].Name != name {
+			t.Fatalf("expected name %q, got %v", name, got[0].Name)
+		}
+		if got[0].Id == nil || got[0].Id.OpenId == nil || *got[0].Id.OpenId != openID {
+			t.Fatalf("expected open_id %q, got %v", openID, got[0].Id)
+		}
+	})
+	t.Run("nil mention entry skipped", func(t *testing.T) {
+		id := "ou_x"
+		got := convertRESTMentions([]*larkim.Mention{nil, {Id: &id}})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 mention, got %d", len(got))
+		}
+	})
+}

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -114,18 +114,26 @@ type replyContext struct {
 }
 
 type Platform struct {
-	mu                         sync.RWMutex
-	platformName               string
-	domain                     string
-	appID                      string
-	appSecret                  string
-	progressStyle              string
-	useInteractiveCard         bool
-	self                       core.Platform
-	reactionEmoji              string
-	doneEmoji                  string
-	allowFrom                  string
-	allowChat                  string
+	mu                 sync.RWMutex
+	platformName       string
+	domain             string
+	appID              string
+	appSecret          string
+	progressStyle      string
+	useInteractiveCard bool
+	self               core.Platform
+	reactionEmoji      string
+	doneEmoji          string
+	allowFrom          string
+	allowChat          string
+	// catchupChats / catchupP2PChats are comma-separated chat IDs for the
+	// catch-up poller (platform/feishu/catchup.go), a REST-polling compensation
+	// channel for messages the best-effort WebSocket push drops. Group chats go
+	// in catchup_chats (@bot mention required), p2p chats in catchup_chats_p2p
+	// (every user message qualifies). Both empty = disabled.
+	catchupChats               string
+	catchupP2PChats            string
+	catchupCancel              context.CancelFunc
 	groupOnly                  bool
 	groupReplyAll              bool
 	respondToAtEveryoneAndHere bool
@@ -357,6 +365,8 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	allowFrom, _ := opts["allow_from"].(string)
 	core.CheckAllowFrom(name, allowFrom)
 	allowChat, _ := opts["allow_chat"].(string)
+	catchupChats, _ := opts["catchup_chats"].(string)
+	catchupP2PChats, _ := opts["catchup_chats_p2p"].(string)
 	groupOnly, _ := opts["group_only"].(bool)
 	groupReplyAll, _ := opts["group_reply_all"].(bool)
 	// require_mention = false is equivalent to group_reply_all = true:
@@ -475,6 +485,8 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		doneEmoji:                  doneEmoji,
 		allowFrom:                  allowFrom,
 		allowChat:                  allowChat,
+		catchupChats:               strings.TrimSpace(catchupChats),
+		catchupP2PChats:            strings.TrimSpace(catchupP2PChats),
 		groupOnly:                  groupOnly,
 		groupReplyAll:              groupReplyAll,
 		respondToAtEveryoneAndHere: respondToAtEveryoneAndHere,
@@ -664,7 +676,15 @@ func (p *Platform) Start(handler core.MessageHandler) error {
 		return p.startWebhookMode()
 	}
 
-	return p.startWebSocketMode()
+	if err := p.startWebSocketMode(); err != nil {
+		return err
+	}
+	// Start the catch-up poller after the WebSocket connection is up: it
+	// compensates for messages the WebSocket push path drops. It is a no-op
+	// unless catchup_chats / catchup_chats_p2p are configured, and only runs
+	// on the primary owner of the shared WebSocket connection.
+	p.startCatchupPoller()
+	return nil
 }
 
 func (p *Platform) shouldUseWebhookMode() bool {
@@ -5404,6 +5424,8 @@ func (p *Platform) Stop() error {
 	// goroutine could outlive the platform and leak into the next
 	// start cycle.
 	p.stopGroupFilterSupervisor()
+	// Stop the catch-up poller so it doesn't outlive the platform.
+	p.stopCatchupPoller()
 	if p.isWSPrimary {
 		remaining := unregisterSharedWS(p)
 		if remaining > 0 {


### PR DESCRIPTION
## Summary

Feishu/Lark's WebSocket push of `im.message.receive_v1` is best-effort and silently drops events even while the long connection looks healthy — Feishu's own server logs show `app not online` push failures against connected clients (see [larksuite/oapi-sdk-go#195](https://github.com/larksuite/oapi-sdk-go/issues/195) and [larksuite/node-sdk#164](https://github.com/larksuite/node-sdk/issues/164)). Users experience the bot ignoring @mentions / DMs with no error anywhere on the cc-connect side.

This PR adds an opt-in REST catch-up poller as a compensation channel: every 3 minutes it lists recent messages of the configured chats via `Im.Message.List` and re-injects anything the WebSocket path missed, through the exact same dispatch path (dedup + stale-message guards included).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Design

- **New file `platform/feishu/catchup.go`**
  - Poll interval **3 min**, lookback window **5 min** (overlaps the interval on purpose — dedup absorbs the overlap), trailing buffer **30 s** so in-flight messages the WebSocket will still deliver aren't raced.
  - Two new platform options:
    - `catchup_chats` — comma-separated **group** chat IDs; a polled message is re-injected only if the bot appears in the REST mention list (`Mention.Id` is a plain `open_id` string on the REST shape, unlike the WS `UserId` struct).
    - `catchup_chats_p2p` — comma-separated **p2p** chat IDs; every user message qualifies because the REST API never returns a mention list for p2p.
  - Guards before injection, mirroring the WS path (`onMessage`):
    - `core.MessageDedup` by `message_id` — a message delivered by both WS and poll is processed exactly once, whichever arrives first;
    - `core.IsOldMessage` — a poll right after restart never replays history;
    - deleted messages and app-sent messages (`sender_type == "app"`) are skipped — the latter prevents the poller from echoing the bot's own replies back into the agent (the WS push never delivers the app's own messages).
  - Injection goes through `dispatchMessage` (same text/post/image/... parsing, name resolution, session keys), with REST mentions converted to `MentionEvent` and the correct `chat_type` (`group`/`p2p`) fed into `makeSessionKey`.
  - REST calls reuse `withFreshTenantAccessTokenRetry` for transparent token refresh.
- **Shared-WS aware** (`feishu.go`): the poller starts only on the **primary owner** of the shared WebSocket connection (`isWSPrimary`, see `ws_shared.go`), so platforms sharing one `app_id` never re-inject each other's missed events. It starts after `startWebSocketMode` succeeds and is stopped in `Stop()`.
- Both options default to empty = **disabled**; no behavior change for existing configs.

### Config example

```toml
[[projects.platforms]]
type = "feishu"

[projects.platforms.options]
app_id = "cli_xxx"
app_secret = "xxx"
# Optional: catch-up polling to compensate WebSocket push loss
catchup_chats = "oc_group1,oc_group2"   # group chats, @bot mention required
catchup_chats_p2p = "oc_p2p1"           # p2p chats, every user message qualifies
```

Requires the `im:message:readonly` (or existing `im:message`) scope, and bot `open_id` discovery must have succeeded for the group mention gate (the poller skips rather than fails open when it is unknown).

## Testing

### Automated tests added in this PR

- `TestCatchupMessageQualifies` in `platform/feishu/catchup_test.go` — pins the p2p vs group rules: **p2p messages skip the mention check** (qualify with no mentions / unrelated mentions), **group messages still require the bot mention** (rejected without mentions or with someone else mentioned; accepted when the bot is mentioned).
- `TestCatchupSenderQualifies` — app-sent messages are excluded (self-reply-loop guard), user messages and unknown senders qualify.
- `TestIsBotMentionedInList` — REST mention-list matching incl. nil/empty lists and nil IDs.
- `TestConvertRESTMentions` — REST `Mention` → `MentionEvent` conversion incl. nil-entry skipping.

### Test results

```
$ go build ./...            # passes
$ go vet ./platform/feishu/...  # passes
$ go test ./platform/feishu/... # ok 36.2s
$ go test ./core/ -run TestCUJ  # ok
```

`go test ./...` has pre-existing failures on clean `main` unrelated to this change, reproduced locally before applying the patch:

- `web` / `cmd/cc-connect`: `web/embed.go: pattern all:dist: no matching files found` (frontend `dist` not built in this environment)
- `agent/acp` `TestCursorCLI_ACPHandshake`: requires an authenticated Cursor CLI (`context deadline exceeded`)
- `daemon` `TestLaunchdStatusUsesUserDomainWhenGUIDomainUnavailable`: macOS launchd environment-dependent

### Critical User Journeys (CUJ) impact

- [x] A — basic conversation (new optional injection path into the existing dispatch flow; disabled unless `catchup_chats*` is configured)
- [ ] B / C / D / E / F / G / H / I

Confirmed: `go test ./core/ -run TestCUJ` passes locally.

## Manual / user-visible behavior change

None unless the new options are set. With `catchup_chats` / `catchup_chats_p2p` configured, messages that Feishu's WebSocket push dropped are delivered (up to ~5 minutes late) instead of being lost; log lines `catchup: injecting missed message` / `catchup: injected missed messages` make the compensation observable. Upstream SDK issues for reference: [larksuite/oapi-sdk-go#195](https://github.com/larksuite/oapi-sdk-go/issues/195), [larksuite/node-sdk#164](https://github.com/larksuite/node-sdk/issues/164).

## Checklist (reviewer will verify)

- [x] `go build ./...` passes
- [x] `go test ./...` passes (`platform/feishu` fully green; pre-existing environment-only failures listed above exist on clean `main`)
- [x] AGENTS.md Pre-Commit Checklist items are satisfied
- [x] No new hardcoded platform/agent names in `core/` (change is confined to `platform/feishu/`)
- [x] i18n strings: N/A (no new user-facing UI strings)
- [x] No secrets / credentials in source

## Related

- larksuite/oapi-sdk-go#195 — WS push drops with `app not online` while the client is connected
- larksuite/node-sdk#164 — same failure mode observed server-side