### PR TITLE
fix(qqbot): forward quoted image attachments to agents

### DIFF
--- a/core/cuj_test.go
+++ b/core/cuj_test.go
@@ -29,6 +29,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -127,6 +128,7 @@ type cujAgentSession struct {
 
 	// observed
 	sentPrompts []string
+	sentImages  [][]ImageAttachment
 	closeCount  int
 }
 
@@ -147,9 +149,10 @@ func newCUJAgentSession() *cujAgentSession {
 	}
 }
 
-func (s *cujAgentSession) Send(prompt string, _ string, _ []ImageAttachment, _ []FileAttachment) error {
+func (s *cujAgentSession) Send(prompt string, _ string, images []ImageAttachment, _ []FileAttachment) error {
 	s.mu.Lock()
 	s.sentPrompts = append(s.sentPrompts, prompt)
+	s.sentImages = append(s.sentImages, cloneCUJImages(images))
 	reply := s.reply
 	delay := s.delayMs
 	override := s.nextEventOverride
@@ -208,6 +211,27 @@ func (s *cujAgentSession) getSentPrompts() []string {
 	defer s.mu.Unlock()
 	out := make([]string, len(s.sentPrompts))
 	copy(out, s.sentPrompts)
+	return out
+}
+
+// Copy attachment bytes as well as the slice so observations remain independent
+// of later caller mutations and can be read safely while the session is running.
+func cloneCUJImages(images []ImageAttachment) []ImageAttachment {
+	out := make([]ImageAttachment, len(images))
+	for i, image := range images {
+		out[i] = image
+		out[i].Data = append([]byte(nil), image.Data...)
+	}
+	return out
+}
+
+func (s *cujAgentSession) getSentImages() [][]ImageAttachment {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]ImageAttachment, len(s.sentImages))
+	for i, images := range s.sentImages {
+		out[i] = cloneCUJImages(images)
+	}
 	return out
 }
 
@@ -1120,36 +1144,60 @@ func TestCUJ_A2_MultiTurnAgentReceivesHistory(t *testing.T) {
 	}
 }
 
-// CUJ-A3 · User uploads image → engine routes it to the agent.
-// (No real vision LLM; we assert the image attachment reaches the agent.)
+// CUJ-A3 · User sends text with an image, an image alone, then text alone.
+// Each turn receives a reply, and only that turn's images reach the agent.
 func TestCUJ_A3_ImageReachesAgent(t *testing.T) {
-	plat := &stubPlatformEngine{n: "test"}
-	agent := &cujAgent{}
-	dir := t.TempDir()
-	e := NewEngine("test", agent, []Platform{plat}, dir+"/sessions.json", LangEnglish)
-
-	msg := &Message{
-		SessionKey: "test:img", Platform: "test", MessageID: "img1",
-		UserID: "img", UserName: "img",
-		Content:  "what is in this image",
-		Images:   []ImageAttachment{{MimeType: "image/png", Data: []byte("\x89PNG fake"), FileName: "chart.png"}},
-		ReplyCtx: "ctx",
+	env := newCUJEnv(t)
+	t.Cleanup(func() { _ = env.engine.Stop() })
+	turns := []struct {
+		content string
+		images  []ImageAttachment
+	}{
+		{
+			content: "what is in this image",
+			images:  []ImageAttachment{{MimeType: "image/png", Data: []byte("\x89PNG chart"), FileName: "chart.png"}},
+		},
+		{
+			images: []ImageAttachment{{MimeType: "image/jpeg", Data: []byte("\xff\xd8 screenshot"), FileName: "screenshot.jpg"}},
+		},
+		{content: "thanks, no new image this time"},
 	}
-	e.ReceiveMessage(plat, msg)
+	for i, turn := range turns {
+		env.engine.ReceiveMessage(env.plat, &Message{
+			SessionKey: "test:img", Platform: "test", MessageID: fmt.Sprintf("img%d", i+1),
+			UserID: "img", UserName: "img", Content: turn.content,
+			Images: turn.images, ReplyCtx: "ctx",
+		})
+		env.waitFor(fmt.Sprintf("reply to image journey turn %d", i+1), 2*time.Second, func() bool {
+			count := 0
+			for _, reply := range env.plat.getSent() {
+				if reply == "ok" {
+					count++
+				}
+			}
+			return count >= i+1
+		})
 
-	deadline := time.After(2 * time.Second)
-	for {
-		agent.mu.Lock()
-		n := len(agent.sessions)
-		agent.mu.Unlock()
-		if n > 0 {
-			break
+		env.agent.mu.Lock()
+		if len(env.agent.sessions) != 1 {
+			n := len(env.agent.sessions)
+			env.agent.mu.Unlock()
+			t.Fatalf("turn %d: agent sessions = %d, want one continued session", i+1, n)
 		}
-		select {
-		case <-deadline:
-			t.Fatal("agent never received the message with image")
-		default:
-			time.Sleep(10 * time.Millisecond)
+		sess := env.agent.sessions[0]
+		env.agent.mu.Unlock()
+		sent := sess.getSentImages()
+		if len(sent) != i+1 {
+			t.Fatalf("turn %d: agent received %d sends, want %d", i+1, len(sent), i+1)
+		}
+		got := sent[i]
+		if len(got) != len(turn.images) {
+			t.Fatalf("turn %d: agent received %d images, want %d", i+1, len(got), len(turn.images))
+		}
+		for j, want := range turn.images {
+			if got[j].MimeType != want.MimeType || got[j].FileName != want.FileName || !bytes.Equal(got[j].Data, want.Data) {
+				t.Fatalf("turn %d image %d: got %#v, want %#v", i+1, j+1, got[j], want)
+			}
 		}
 	}
 }

--- a/docs/qqbot.md
+++ b/docs/qqbot.md
@@ -95,6 +95,16 @@ In group chats, the bot **only receives messages when @mentioned**. This is a li
 每个用户在每个群中拥有独立的会话。
 Each user gets an independent session per group.
 
+### 引用图片 / Replying to an image
+
+如果 QQ 客户端无法同时发送图片和 @，可以先发送图片，再引用/回复该图片并 @机器人。当 QQ 事件携带被引用消息的图片附件时，cc-connect 会将原图交给 Agent；正文为空也可以处理图片。
+
+If your QQ client cannot send an image and an @mention together, send the image first, then reply to that image and @mention the bot. When the QQ event includes the quoted image attachments, cc-connect forwards the images to the agent, including when the current message has no text.
+
+当前消息与引用消息中的相同图片 URL 只下载一次。仅处理本次事件显式携带的图片，不读取未推送的群历史，也不会将空 @ 与上一张群图片自动关联。
+
+Image URLs shared by the current and quoted messages are downloaded once. Only images explicitly included in the event are forwarded; cc-connect does not fetch unreceived group history or associate an empty @mention with the last group image.
+
 ## 私聊 / Private Messages (C2C)
 
 支持一对一私聊消息，无需 @提及。

--- a/platform/qqbot/image_attachments_test.go
+++ b/platform/qqbot/image_attachments_test.go
@@ -1,0 +1,31 @@
+package qqbot
+
+import "testing"
+
+func TestMessageImageAttachments_NormalizesAndDeduplicatesURLs(t *testing.T) {
+	quoteType := msgTypeQuote
+	got := messageImageAttachments(
+		[]attachment{{ContentType: "image/png", URL: " https://example.com/image.png "}},
+		&messageReference{Message: &quotedMessage{Attachments: []attachment{
+			{ContentType: "image/png", URL: "example.com/image.png"},
+			{ContentType: "image/png", URL: ""},
+		}}},
+		&quoteType,
+		[]msgElement{{Attachments: []attachment{{ContentType: "image/png", URL: "https://example.com/image.png"}}}},
+	)
+	if len(got) != 1 || got[0].URL != "https://example.com/image.png" {
+		t.Fatalf("images = %#v, want one normalized image URL", got)
+	}
+}
+
+func TestMessageImageAttachments_DoesNotExpandQuotedFiles(t *testing.T) {
+	quoteType := msgTypeQuote
+	files := []attachment{{ContentType: "application/pdf", URL: "https://example.com/file.pdf"}}
+	got := messageImageAttachments(nil,
+		&messageReference{Message: &quotedMessage{Attachments: files}},
+		&quoteType, []msgElement{{Attachments: files}},
+	)
+	if len(got) != 0 {
+		t.Fatalf("quoted non-image attachments = %#v, want none", got)
+	}
+}

--- a/platform/qqbot/qqbot.go
+++ b/platform/qqbot/qqbot.go
@@ -1201,7 +1201,7 @@ func (p *Platform) handleGroupMessage(data json.RawMessage) {
 		quotedText = quotedTextFromElements(d.MsgElements)
 	}
 	content = prependQuotedMessage(quotedText, content)
-	images := downloadAttachmentImages(d.Attachments)
+	images := downloadAttachmentImages(messageImageAttachments(d.Attachments, d.MessageReference, d.MessageType, d.MsgElements))
 	files := downloadAttachmentFiles(d.Attachments)
 	p.cacheMessage(d.ID, contentOrAttachmentSummary(content, d.Attachments))
 
@@ -1288,7 +1288,7 @@ func (p *Platform) handleC2CMessage(data json.RawMessage) {
 	content = prependQuotedMessage(quotedText, content)
 
 	// Download image and file attachments
-	images := downloadAttachmentImages(d.Attachments)
+	images := downloadAttachmentImages(messageImageAttachments(d.Attachments, d.MessageReference, d.MessageType, d.MsgElements))
 	files := downloadAttachmentFiles(d.Attachments)
 	p.cacheMessage(d.ID, contentOrAttachmentSummary(content, d.Attachments))
 
@@ -1485,6 +1485,47 @@ type attachment struct {
 	ContentType string `json:"content_type"`
 	URL         string `json:"url"`
 	Filename    string `json:"filename"`
+}
+
+// messageImageAttachments combines current images with images explicitly carried
+// by this event's quoted message. It never looks up an unrelated previous message.
+func messageImageAttachments(current []attachment, ref *messageReference, messageType *int, elements []msgElement) []attachment {
+	var images []attachment
+	seen := make(map[string]struct{})
+	add := func(attachments []attachment) {
+		for _, att := range attachments {
+			if !strings.HasPrefix(att.ContentType, "image/") {
+				continue
+			}
+			url := strings.TrimSpace(att.URL)
+			if url == "" {
+				continue
+			}
+			// Match the downloader's handling of QQ URLs without a scheme.
+			if !strings.HasPrefix(url, "http") {
+				url = "https://" + url
+			}
+			if _, exists := seen[url]; exists {
+				continue
+			}
+			seen[url] = struct{}{}
+			att.URL = url
+			images = append(images, att)
+		}
+	}
+	add(current)
+	if ref != nil {
+		for _, quoted := range []*quotedMessage{ref.Message, ref.ReferencedMessage, ref.SourceMessage} {
+			if quoted != nil {
+				add(quoted.Attachments)
+			}
+		}
+	}
+	// Official QQ quote payloads place the referenced message in element zero.
+	if messageType != nil && *messageType == msgTypeQuote && len(elements) > 0 {
+		add(elements[0].Attachments)
+	}
+	return images
 }
 
 // downloadAttachmentImages downloads all image attachments and returns ImageAttachments.

--- a/platform/qqbot/quoted_images_test.go
+++ b/platform/qqbot/quoted_images_test.go
@@ -1,0 +1,107 @@
+package qqbot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+)
+
+func TestHandleMessage_QuotedImageAttachments(t *testing.T) {
+	for _, surface := range []string{"group", "c2c"} {
+		t.Run(surface, func(t *testing.T) {
+			for _, tc := range []struct {
+				name       string
+				quotedType bool
+				current    []string
+				elements   [][]string
+				reference  string
+				want       []string
+			}{
+				{name: "quoted image with empty current text", quotedType: true, elements: [][]string{{"quoted.png"}}, want: []string{"/quoted.png"}},
+				{name: "reference message", reference: "message", want: []string{"/reference.png"}},
+				{name: "reference referenced_message", reference: "referenced_message", want: []string{"/reference.png"}},
+				{name: "reference source_message", reference: "source_message", want: []string{"/reference.png"}},
+				{name: "current and quoted image", quotedType: true, current: []string{"current.png"}, elements: [][]string{{"quoted.png"}}, want: []string{"/current.png", "/quoted.png"}},
+				{name: "duplicate URL across all sources", quotedType: true, current: []string{"reference.png", "reference.png"}, reference: "message", elements: [][]string{{"reference.png"}}, want: []string{"/reference.png"}},
+				{name: "nonquote elements ignored", current: []string{"current.png"}, elements: [][]string{{"ignored.png"}}, want: []string{"/current.png"}},
+				{name: "only element zero belongs to quote", quotedType: true, elements: [][]string{{"quoted.png"}, {"ignored.png"}}, want: []string{"/quoted.png"}},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					var requested []string
+					var requestedMu sync.Mutex
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						requestedMu.Lock()
+						requested = append(requested, r.URL.Path)
+						requestedMu.Unlock()
+						w.Header().Set("Content-Type", "image/png")
+						_, _ = w.Write([]byte(r.URL.Path))
+					}))
+					defer server.Close()
+					originalClient := core.HTTPClient
+					core.HTTPClient = server.Client()
+					t.Cleanup(func() { core.HTTPClient = originalClient })
+					attachments := func(names []string) []map[string]any {
+						var result []map[string]any
+						for _, name := range names {
+							result = append(result, map[string]any{"content_type": "image/png", "url": server.URL + "/" + name})
+						}
+						return result
+					}
+					payload := map[string]any{
+						"id": "new-message", "timestamp": time.Now().Format(time.RFC3339),
+						"content": "", "attachments": attachments(tc.current),
+						"author": map[string]any{"user_openid": "user-1", "member_openid": "user-1"},
+					}
+					if surface == "group" {
+						payload["group_openid"] = "group-1"
+						payload["content"] = "<@!bot123> "
+					}
+					if tc.quotedType {
+						payload["message_type"] = msgTypeQuote
+					}
+					if tc.reference != "" {
+						payload["message_reference"] = map[string]any{
+							"message_id": "original-message",
+							tc.reference: map[string]any{"attachments": attachments([]string{"reference.png"})},
+						}
+					}
+					var elements []map[string]any
+					for _, names := range tc.elements {
+						elements = append(elements, map[string]any{"attachments": attachments(names)})
+					}
+					payload["msg_elements"] = elements
+					var received *core.Message
+					p := &Platform{allowFrom: "*"}
+					p.handler = func(_ core.Platform, msg *core.Message) { received = msg }
+					data, err := json.Marshal(payload)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if surface == "group" {
+						p.handleGroupMessage(data)
+					} else {
+						p.handleC2CMessage(data)
+					}
+					if received == nil {
+						t.Fatal("quoted image was not delivered to the agent")
+					}
+					var imageBodies []string
+					for _, image := range received.Images {
+						imageBodies = append(imageBodies, string(image.Data))
+					}
+					requestedMu.Lock()
+					defer requestedMu.Unlock()
+					if !reflect.DeepEqual(imageBodies, tc.want) || !reflect.DeepEqual(requested, tc.want) {
+						t.Fatalf("images = %v, requests = %v, want %v", imageBodies, requested, tc.want)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

QQ group and C2C handlers currently download images only from the current message's `attachments`. An image explicitly carried in a quoted message is lost before the agent receives it. This forwards quoted image attachments alongside current images and deduplicates their normalized URLs.

The change uses the existing `message_reference` representations and the first `msg_elements` entry for quote messages (`message_type = 103`). It does not fetch chat history or change quoted-file handling.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

### Automated tests added or updated

- `TestHandleMessage_QuotedImageAttachments` in `platform/qqbot/quoted_images_test.go`: exercises both group and C2C handlers using HTTP-backed payload fixtures; covers empty current text, the supported nested reference fields, combined current/quoted images, URL deduplication, and quote-element boundaries. Checks both downloaded bytes and download requests.
- `TestMessageImageAttachments_NormalizesAndDeduplicatesURLs` and `TestMessageImageAttachments_DoesNotExpandQuotedFiles` in `platform/qqbot/image_attachments_test.go`.
- `TestCUJ_A3_ImageReachesAgent` in `core/cuj_test.go`: strengthens the existing journey with three turns (text with an image, image alone, text alone), actual agent attachment assertions, platform-visible replies, and no stale attachment carryover.

### Regression proof

- [x] Added only `TestHandleMessage_QuotedImageAttachments` to an isolated checkout of pre-fix main (`4000b2338aa6e850c99df54f8b0ed6ed7460b401`). It compiles and fails because quoted images are missing. The same test passes with the fix.

### Critical User Journeys impact

- [x] A — basic conversation
- [x] Updated the existing image journey to cover image-only input and subsequent turns.
- [x] All `TestCUJ` tests pass with `-race`.

Validation on macOS arm64, Go 1.27.1:

```sh
go build ./...
go vet ./...
go test -p 1 ./...
go test -race ./platform/qqbot ./core -run 'TestMessageImageAttachments|TestHandleMessage_QuotedImageAttachments|TestCUJ' -count=1
```

An initial full-suite run alongside build/race checks hit timeouts and temporary-directory cleanup failures in existing antigravity, file-journey, and media-pipeline tests. The full suite passed when rerun with package parallelism limited to one; no unrelated code was changed.

## Manual / user-visible behavior change

When a QQ client cannot send an image and an @mention together, a user can reply to an image and @mention the bot. If the event includes that quoted image, it reaches the agent even when the current message has no text. The same attachment handling applies to C2C replies.

The documentation explains this event-dependent behavior. An empty @mention does not implicitly select the last image in a group. Validation uses payload fixtures and the engine journey; live QQ client behavior has not been verified as part of this PR.

## Checklist

- [x] `go build ./...` passes
- [x] Full test suite passes with `-p 1`; changed image flow and CUJs also pass with `-race`
- [x] `go vet ./...`, `gofmt`, and `git diff --check` pass
- [x] Regression test fails before the fix and passes after it
- [x] No new hardcoded platform/agent names in `core/`
- [x] No new production UI strings; documentation is bilingual
- [x] No secrets / credentials in source

## Related

The quote payload shape is documented in Tencent's [QQ Bot Agent SDK DTO](https://github.com/tencent-connect/qqbot-agent-sdk/blob/main/src/qqbot_agent_sdk/dto.py#L149-L159).
