### PR TITLE
fix: graceful SIGTERM drain + reply journal for hard-kill recovery (#1804)

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -83,6 +83,22 @@ const (
 // exits sooner — this is the ceiling, not the typical duration.
 const closeTimeout = 150 * time.Second
 
+// shutdownDrainTimeout caps the wait for in-flight platform reply/send
+// operations to complete before SIGTERM is allowed to cancel the engine's
+// shared context. Without this drain, replies mid-flight observe
+// "context canceled" mid-HTTP-call and are lost — see issue #1804.
+//
+// 10s is a deliberate trade-off:
+//   - long enough for a typical Feishu reply API call (~1-2s) plus a
+//     chunked-response burst (multiple replies within ~50ms of each other),
+//     even on a slow link;
+//   - short enough that a misbehaving agent (one that forgot to release a
+//     long-lived request) cannot block daemon restart for tens of seconds.
+//
+// Issue #1804 ships a journal fallback (see core/reply_journal.go) for the
+// hard-kill case where this drain is bypassed entirely.
+const shutdownDrainTimeout = 10 * time.Second
+
 const (
 	replyFooterUsageTimeout  = 1500 * time.Millisecond
 	replyFooterUsageCacheTTL = 30 * time.Second
@@ -506,6 +522,14 @@ type Engine struct {
 
 	// Data directory for socket path injection
 	dataDir string
+
+	// replyWG tracks in-flight platform Reply/Send operations so that
+	// Engine.Stop() can drain them before cancelling the shared context.
+	// Issue #1804: a context cancel during an active HTTP call to the
+	// platform API surfaces as "context canceled" and the reply is lost.
+	// Increment at the top of every wrapper that calls p.Reply / p.Send,
+	// defer Done at the bottom — the WG is only ever observed by Stop().
+	replyWG sync.WaitGroup
 }
 
 // workspaceInitFlow tracks a channel that is being onboarded to a workspace.
@@ -2350,6 +2374,16 @@ func (e *Engine) Start() error {
 	}
 
 	e.startObserver()
+
+	// Issue #1804: replay any pending reply that was persisted before a hard
+	// kill (OOM, panic, SIGKILL). Runs synchronously so the user sees the
+	// recovered reply before we declare startup complete. Sync platforms are
+	// ready at this point; async platforms that haven't connected yet will
+	// be retried on their first OnPlatformReady via OnPlatformReady hook
+	// (see e.platformReadyReplayOnce).
+	if e.dataDir != "" && len(e.platforms) > 0 {
+		e.replayPendingReplyJournal()
+	}
 	return nil
 }
 
@@ -2358,7 +2392,19 @@ func (e *Engine) Stop() error {
 	e.stopping = true
 	e.platformLifecycleMu.Unlock()
 
-	// Cancel first so late lifecycle callbacks observe shutdown immediately.
+	// Drain in-flight platform reply/send goroutines BEFORE cancelling the
+	// shared context. Issue #1804: a context cancel mid-HTTP-call surfaces
+	// as "context canceled" on the platform side and the reply body is
+	// lost forever (no journal replay covers SIGTERM, only hard kills).
+	//
+	// We bound the wait at shutdownDrainTimeout so a stuck platform call
+	// cannot block daemon restart indefinitely. Anything still in flight
+	// after the deadline is presumed lost — the journal layer (see
+	// core/reply_journal.go) catches the hard-kill case separately.
+	e.drainInFlightReplies(shutdownDrainTimeout)
+
+	// Cancel the shared context AFTER the drain so late lifecycle
+	// callbacks (agent stop, observer shutdown, etc.) observe shutdown.
 	e.cancel()
 
 	if e.observeCancel != nil {
@@ -2404,6 +2450,27 @@ func (e *Engine) Stop() error {
 		return fmt.Errorf("engine stop errors: %v", errs)
 	}
 	return nil
+}
+
+// drainInFlightReplies blocks until all platform reply/send operations
+// tracked by replyWG have completed, or the deadline elapses. Safe to
+// call when no replies are in flight (returns immediately).
+func (e *Engine) drainInFlightReplies(timeout time.Duration) {
+	if timeout <= 0 {
+		timeout = shutdownDrainTimeout
+	}
+	done := make(chan struct{})
+	go func() {
+		e.replyWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		slog.Debug("engine.Stop: in-flight replies drained cleanly")
+	case <-time.After(timeout):
+		slog.Warn("engine.Stop: drain timeout, some replies may be lost; relying on journal for retry",
+			"timeout", timeout)
+	}
 }
 
 // OnPlatformReady marks an async platform as ready and initializes platform-level
@@ -11986,7 +12053,7 @@ func (e *Engine) sendWithError(p Platform, replyCtx any, content string) error {
 
 func (e *Engine) sendAlreadyRenderedWithError(p Platform, replyCtx any, content string) error {
 	start := time.Now()
-	if err := p.Send(e.ctx, replyCtx, content); err != nil {
+	if err := e.trackAndSend(p, replyCtx, content, "send"); err != nil {
 		// Check for context_token missing error (common for Weixin platform)
 		if strings.Contains(err.Error(), "missing context_token") {
 			slog.Error("platform send failed: context_token missing",
@@ -12003,6 +12070,136 @@ func (e *Engine) sendAlreadyRenderedWithError(p Platform, replyCtx any, content 
 		slog.Warn("slow platform send", "platform", p.Name(), "elapsed", elapsed, "content_len", len(content))
 	}
 	return nil
+}
+
+// trackAndSend centralises the WaitGroup + reply-journal bookkeeping around
+// a single platform send/reply call so that Engine.Stop() can drain
+// in-flight operations and a hard kill leaves a recoverable journal entry.
+//
+// Issue #1804: SIGTERM was cancelling the shared context mid-HTTP-call,
+// surfacing as "context canceled" on the platform side and losing the
+// reply. The drain in Stop() waits for these operations; the journal is
+// the safety net for the case where the drain is bypassed (OOM, panic,
+// SIGKILL).
+func (e *Engine) trackAndSend(p Platform, replyCtx any, content, op string) error {
+	e.replyWG.Add(1)
+	defer e.replyWG.Done()
+
+	// Persist a pending-reply journal entry BEFORE the actual call so a
+	// crash mid-call still leaves a recoverable record. Best-effort: a
+	// journal write failure must not block the reply itself.
+	e.writeJournalEntry(p, replyCtx, content, op)
+
+	var err error
+	switch op {
+	case "reply":
+		err = p.Reply(e.ctx, replyCtx, content)
+	default:
+		err = p.Send(e.ctx, replyCtx, content)
+	}
+	if err == nil {
+		e.clearJournalEntry()
+	}
+	return err
+}
+
+// writeJournalEntry writes a PendingReplyEntry if dataDir is set and the
+// platform provided a session key we can recover from. We use whatever the
+// caller hands us as replyCtx; on replay, ReplyContextReconstructor is the
+// authority on whether that can be turned back into a usable target.
+func (e *Engine) writeJournalEntry(p Platform, replyCtx any, content, op string) {
+	if e.dataDir == "" {
+		return
+	}
+	sessionKey := sessionKeyFromReplyCtx(p, replyCtx)
+	if sessionKey == "" {
+		// Without a recoverable session key the journal entry is useless
+		// for replay — skip silently rather than littering disk with dead
+		// entries that an operator would have to clean up.
+		return
+	}
+	entry := PendingReplyEntry{
+		Platform:   p.Name(),
+		SessionKey: sessionKey,
+		Content:    content,
+	}
+	if werr := WritePendingReply(e.dataDir, entry); werr != nil {
+		slog.Warn("reply journal: write failed; reply will proceed but cannot be replayed on hard kill",
+			"platform", p.Name(), "session", sessionKey, "op", op, "error", werr)
+	}
+}
+
+func (e *Engine) clearJournalEntry() {
+	if e.dataDir == "" {
+		return
+	}
+	if err := ClearPendingReply(e.dataDir); err != nil {
+		slog.Warn("reply journal: clear failed; entry may replay on next restart",
+			"path", ReplyJournalPath(e.dataDir), "error", err)
+	}
+}
+
+// sessionKeyFromReplyCtx pulls a session key out of a reply context. We try
+// a few well-known shapes; platforms with custom reply contexts can opt in
+// via SessionKeyCarrier (see core/interfaces.go). Empty string means we
+// cannot recover a session key — caller should skip the journal write.
+func sessionKeyFromReplyCtx(p Platform, replyCtx any) string {
+	if replyCtx == nil {
+		return ""
+	}
+	if skc, ok := p.(SessionKeyCarrier); ok {
+		if k := skc.SessionKey(replyCtx); k != "" {
+			return k
+		}
+	}
+	// Fallbacks for well-known reply-ctx shapes. These cover platforms
+	// that don't implement SessionKeyCarrier but do store the session
+	// key directly on the reply context.
+	type stringer interface{ String() string }
+	if s, ok := replyCtx.(stringer); ok {
+		return s.String()
+	}
+	if s, ok := replyCtx.(string); ok {
+		// Heuristic: a bare string is a session key only when it looks
+		// like "platform:id:user" — avoids confusing random string
+		// reply contexts with session keys.
+		if strings.Contains(s, ":") {
+			return s
+		}
+	}
+	return ""
+}
+
+// replayPendingReplyJournal runs the reply journal replay once during
+// Engine.Start(). Only relevant when a previous instance crashed (OOM,
+// panic, SIGKILL) before the graceful drain path could complete; under
+// SIGTERM the drain in Engine.Stop() already finishes the in-flight reply
+// so the journal entry is cleared without replay.
+//
+// Safe to call on every start: if the journal file does not exist
+// ConsumePendingReply returns nil and ReplayPendingReply is a no-op.
+func (e *Engine) replayPendingReplyJournal() {
+	if e.dataDir == "" {
+		return
+	}
+	res := ReplayPendingReply(e.dataDir, e.platforms)
+	if res.Delivered {
+		if res.Duplicate {
+			slog.Info("engine startup: pending reply replayed (platform reported duplicate, treated as delivered)",
+				"project", e.name)
+		} else {
+			slog.Info("engine startup: pending reply replayed successfully",
+				"project", e.name)
+		}
+		return
+	}
+	if res.ErrorMessage == "" {
+		// No entry to replay — normal startup.
+		return
+	}
+	slog.Warn("engine startup: pending reply replay failed",
+		"project", e.name, "error", res.ErrorMessage,
+		"journal_path", ReplyJournalPath(e.dataDir))
 }
 
 // send wraps p.Send with error logging, slow-operation warnings, and outgoing rate limiting.
@@ -12050,7 +12247,10 @@ func (e *Engine) replyWithError(p Platform, replyCtx any, content string) error 
 		return err
 	}
 	start := time.Now()
-	if err := p.Reply(e.ctx, replyCtx, content); err != nil {
+	// Issue #1804: route through trackAndSend so the replyWaitGroup sees
+	// this call (Engine.Stop drains before cancel) and the journal
+	// persists a recoverable entry before the HTTP call.
+	if err := e.trackAndSend(p, replyCtx, content, "reply"); err != nil {
 		slog.Error("platform reply failed", "platform", p.Name(), "error", err, "content_len", len(content))
 		return err
 	}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -54,6 +54,15 @@ type ReplyContextReconstructor interface {
 	ReconstructReplyCtx(sessionKey string) (any, error)
 }
 
+// SessionKeyCarrier is an optional interface for platforms whose reply
+// context carries a session key the engine can recover. Implementations
+// allow the reply-journal layer (issue #1804) to associate a pending reply
+// with a session key for later replay, without having to keep platform-
+// specific reply-ctx introspection in core.
+type SessionKeyCarrier interface {
+	SessionKey(replyCtx any) string
+}
+
 // RelayGroupVisibilityTarget is an optional interface for platforms that
 // want to customise the session key used when echoing relay request /
 // response messages into the group chat for visibility.  Platforms that

--- a/core/reply_journal.go
+++ b/core/reply_journal.go
@@ -1,0 +1,251 @@
+package core
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"log/slog"
+)
+
+// PendingReplyEntry is one queued-but-unsent reply persisted to disk so it
+// can be replayed after a hard kill (OOM, panic, SIGKILL) that bypasses the
+// graceful drain path. See issue #1804.
+//
+// Only the most recent reply is kept. The user perceives a "lost reply" as a
+// silent failure of the most recent agent turn, so older entries are useless
+// once a newer one is queued.
+type PendingReplyEntry struct {
+	Platform    string    `json:"platform"`
+	SessionKey  string    `json:"session_key"`
+	Content     string    `json:"content"`
+	ContentHash string    `json:"content_hash"` // SHA-256 of Content, hex-encoded
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// replyJournalDir is the directory inside dataDir that holds the journal
+// file. Reuses the existing `run/` namespace that already holds
+// restart_notify and the API socket.
+const replyJournalDir = "run"
+
+// replyJournalFile is the journal file name. Mode 0o600 because the content
+// can include user-visible chat history that may carry sensitive data.
+const replyJournalFile = "last_reply.json"
+
+// replyJournalTimeout caps the replay-on-startup attempt. Short by design:
+// if the platform API is unreachable we want to give up quickly so the daemon
+// can finish starting.
+const replyJournalTimeout = 10 * time.Second
+
+// ReplyJournalPath returns the absolute path of the journal file inside
+// dataDir. Exported so tests and the management API can introspect it.
+func ReplyJournalPath(dataDir string) string {
+	return filepath.Join(dataDir, replyJournalDir, replyJournalFile)
+}
+
+// HashContent computes a stable SHA-256 hex digest of a reply's content.
+// Used by the dedup layer so the replay path can silently ignore
+// "duplicate message" errors returned by platform APIs.
+func HashContent(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+// WritePendingReply persists a pending reply entry, replacing any previous
+// entry. File mode 0o600: the content may contain sensitive chat history.
+//
+// An empty dataDir is a programming error (the engine should never have a
+// journal without a data dir) and is reported as such so misconfigured
+// deployments surface loudly instead of silently dropping replies.
+func WritePendingReply(dataDir string, entry PendingReplyEntry) error {
+	if dataDir == "" {
+		return errors.New("reply journal: empty dataDir")
+	}
+	dir := filepath.Join(dataDir, replyJournalDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	// Hash the content if the caller didn't pre-compute it. Doing it here
+	// keeps the call sites terse.
+	if entry.ContentHash == "" {
+		entry.ContentHash = HashContent(entry.Content)
+	}
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = time.Now()
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	return AtomicWriteFile(ReplyJournalPath(dataDir), data, 0o600)
+}
+
+// ClearPendingReply removes the journal entry. Idempotent: a missing file
+// is not an error. Called after a reply succeeds (or after a successful
+// replay on startup).
+func ClearPendingReply(dataDir string) error {
+	p := ReplyJournalPath(dataDir)
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// ConsumePendingReply reads and atomically deletes the journal entry.
+// Returns nil if no entry exists or the file is malformed (we don't want
+// a corrupt journal to block startup indefinitely).
+func ConsumePendingReply(dataDir string) *PendingReplyEntry {
+	if dataDir == "" {
+		return nil
+	}
+	p := ReplyJournalPath(dataDir)
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil
+	}
+	// Best-effort delete. We delete before parsing so a malformed entry
+	// doesn't loop forever across restarts.
+	_ = os.Remove(p)
+	var e PendingReplyEntry
+	if err := json.Unmarshal(data, &e); err != nil {
+		slog.Warn("reply journal: malformed entry discarded", "path", p, "error", err)
+		return nil
+	}
+	return &e
+}
+
+// ReplayResult describes the outcome of a single replay attempt. Exposed for
+// tests and for the management API to surface journal state to operators.
+type ReplayResult struct {
+	Delivered    bool
+	Duplicate    bool   // platform returned "duplicate" error
+	ErrorMessage string // platform error, if any
+}
+
+// ReplayPendingReply attempts to re-send a pending reply via the platform
+// that originally queued it. Uses a fresh context with replayJournalTimeout
+// so the replay is not aborted by an in-flight shutdown.
+//
+// On success, the journal is cleared. On "duplicate" errors (the platform
+// API says the message was already sent), the journal is also cleared —
+// the user's intent is satisfied. On other errors, the journal is left in
+// place for the next restart to retry.
+//
+// Platforms without a ReplyContextReconstructor cannot reconstruct a reply
+// target from a session key alone (e.g. Feishu needs the message_id); in
+// that case the journal is left intact and a warning is logged.
+func ReplayPendingReply(dataDir string, platforms []Platform) ReplayResult {
+	entry := ConsumePendingReply(dataDir)
+	if entry == nil {
+		return ReplayResult{}
+	}
+
+	var target Platform
+	for _, p := range platforms {
+		if p.Name() == entry.Platform {
+			target = p
+			break
+		}
+	}
+	if target == nil {
+		slog.Warn("reply journal: platform not found, leaving entry for inspection",
+			"platform", entry.Platform, "session", entry.SessionKey, "path", ReplyJournalPath(dataDir))
+		// Put the entry back so an operator with the right platform installed
+		// can retry. Use a "move aside" rename rather than a fresh write so
+		// we preserve the original timestamp.
+		if data, err := json.Marshal(entry); err == nil {
+			_ = AtomicWriteFile(ReplyJournalPath(dataDir), data, 0o600)
+		}
+		return ReplayResult{ErrorMessage: "platform not loaded: " + entry.Platform}
+	}
+
+	rcr, ok := target.(ReplyContextReconstructor)
+	if !ok {
+		slog.Warn("reply journal: platform cannot reconstruct reply ctx from session key; skipping replay",
+			"platform", entry.Platform, "session", entry.SessionKey)
+		// Re-persist so a future build with a richer platform adapter can
+		// retry. Without this the entry would be silently lost because
+		// ConsumePendingReply already removed the file from disk.
+		if data, err := json.Marshal(entry); err == nil {
+			_ = AtomicWriteFile(ReplyJournalPath(dataDir), data, 0o600)
+		}
+		return ReplayResult{ErrorMessage: "platform does not implement ReplyContextReconstructor"}
+	}
+
+	replyCtx, err := rcr.ReconstructReplyCtx(entry.SessionKey)
+	if err != nil {
+		slog.Warn("reply journal: ReconstructReplyCtx failed; leaving entry for retry",
+			"platform", entry.Platform, "session", entry.SessionKey, "error", err)
+		// Re-persist so the next restart tries again.
+		if data, mErr := json.Marshal(entry); mErr == nil {
+			_ = AtomicWriteFile(ReplyJournalPath(dataDir), data, 0o600)
+		}
+		return ReplayResult{ErrorMessage: err.Error()}
+	}
+
+	ctx, cancel := contextWithTimeoutForJournal()
+	defer cancel()
+
+	if err := target.Reply(ctx, replyCtx, entry.Content); err != nil {
+		if isDuplicateReplyError(err) {
+			slog.Info("reply journal: platform reported duplicate; treating as delivered",
+				"platform", entry.Platform, "session", entry.SessionKey, "content_hash", entry.ContentHash)
+			return ReplayResult{Delivered: true, Duplicate: true}
+		}
+		slog.Warn("reply journal: replay failed; leaving entry for next restart",
+			"platform", entry.Platform, "session", entry.SessionKey, "error", err)
+		// Re-persist for the next restart.
+		if data, mErr := json.Marshal(entry); mErr == nil {
+			_ = AtomicWriteFile(ReplyJournalPath(dataDir), data, 0o600)
+		}
+		return ReplayResult{ErrorMessage: err.Error()}
+	}
+
+	slog.Info("reply journal: replay succeeded",
+		"platform", entry.Platform, "session", entry.SessionKey,
+		"content_hash", entry.ContentHash, "content_len", len(entry.Content))
+	return ReplayResult{Delivered: true}
+}
+
+// contextWithTimeoutForJournal returns a fresh context.Background() with a
+// replyJournalTimeout deadline. Replay must not be cancelled by an
+// in-flight shutdown, so we do NOT derive from e.ctx.
+func contextWithTimeoutForJournal() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), replyJournalTimeout)
+}
+
+// isDuplicateReplyError returns true if the platform API response indicates
+// the message was already delivered (the canonical case is Feishu's
+// "message already exists" / "duplicate" error). Strings-based check
+// because each platform returns a slightly different message; centralising
+// the heuristic here keeps platform adapters from having to opt in.
+//
+// Conservative by design: false negatives cause a duplicate send to the
+// user, false positives silently drop a reply. We'd rather send twice than
+// drop.
+func isDuplicateReplyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, needle := range []string{
+		"duplicate",
+		"already exists",
+		"already sent",
+		"already delivered",
+		"already in chat",
+		"message is duplicate",
+		"重复", // zh
+	} {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/reply_journal_test.go
+++ b/core/reply_journal_test.go
@@ -1,0 +1,466 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubReplayPlatform is a minimal Platform implementation used to exercise
+// the reply-journal replay path. It satisfies ReplyContextReconstructor so
+// ReplayPendingReply can recover a reply ctx from a session key. ReplyFunc
+// and ReconstructFunc are configurable so each test can pick the success /
+// duplicate / failure scenario it wants to exercise.
+type stubReplayPlatform struct {
+	name             string
+	replyCalls       atomic.Int32
+	replyCtx         atomic.Value // last reply ctx passed to Reply
+	replyContent     atomic.Value // last content passed to Reply
+	ReplyFunc        func(ctx context.Context, replyCtx any, content string) error
+	ReconstructFunc  func(sessionKey string) (any, error)
+	reconstructCalls atomic.Int32
+}
+
+func (p *stubReplayPlatform) Name() string                 { return p.name }
+func (p *stubReplayPlatform) Start(_ MessageHandler) error { return nil }
+func (p *stubReplayPlatform) Stop() error                  { return nil }
+func (p *stubReplayPlatform) Send(ctx context.Context, replyCtx any, content string) error {
+	return p.Reply(ctx, replyCtx, content)
+}
+func (p *stubReplayPlatform) Reply(ctx context.Context, replyCtx any, content string) error {
+	p.replyCalls.Add(1)
+	p.replyCtx.Store(replyCtx)
+	p.replyContent.Store(content)
+	if p.ReplyFunc != nil {
+		return p.ReplyFunc(ctx, replyCtx, content)
+	}
+	return nil
+}
+func (p *stubReplayPlatform) ReconstructReplyCtx(sessionKey string) (any, error) {
+	p.reconstructCalls.Add(1)
+	if p.ReconstructFunc != nil {
+		return p.ReconstructFunc(sessionKey)
+	}
+	return "reconstructed:" + sessionKey, nil
+}
+
+func TestHashContent_StableAndDistinguishes(t *testing.T) {
+	a := HashContent("hello world")
+	b := HashContent("hello world")
+	if a != b {
+		t.Fatalf("same content produced different hashes: %q vs %q", a, b)
+	}
+	c := HashContent("hello WORLD")
+	if a == c {
+		t.Fatalf("different content produced same hash: %q", a)
+	}
+	if len(a) != 64 { // SHA-256 hex
+		t.Fatalf("hash length = %d, want 64", len(a))
+	}
+}
+
+func TestReplyJournalPath(t *testing.T) {
+	got := ReplyJournalPath("/var/lib/cc-connect")
+	want := filepath.Join("/var/lib/cc-connect", "run", "last_reply.json")
+	if got != want {
+		t.Fatalf("ReplyJournalPath = %q, want %q", got, want)
+	}
+}
+
+func TestWritePendingReply_FileMode600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file mode not applicable on Windows")
+	}
+	dir := t.TempDir()
+	entry := PendingReplyEntry{
+		Platform:   "feishu",
+		SessionKey: "feishu:chat:user",
+		Content:    "secret reply text",
+	}
+	if err := WritePendingReply(dir, entry); err != nil {
+		t.Fatalf("WritePendingReply: %v", err)
+	}
+	st, err := os.Stat(ReplyJournalPath(dir))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("file mode = %v, want 0o600", mode)
+	}
+}
+
+func TestWritePendingReply_OverwritesPrevious(t *testing.T) {
+	dir := t.TempDir()
+	first := PendingReplyEntry{Platform: "feishu", SessionKey: "k1", Content: "first"}
+	if err := WritePendingReply(dir, first); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	second := PendingReplyEntry{Platform: "feishu", SessionKey: "k2", Content: "second"}
+	if err := WritePendingReply(dir, second); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	got := ConsumePendingReply(dir)
+	if got == nil {
+		t.Fatalf("ConsumePendingReply returned nil after write")
+	}
+	if got.Content != "second" || got.SessionKey != "k2" {
+		t.Fatalf("got entry %+v, want second/k2", got)
+	}
+	if got.ContentHash == "" || got.ContentHash != HashContent("second") {
+		t.Fatalf("ContentHash not auto-populated: %q", got.ContentHash)
+	}
+}
+
+func TestWritePendingReply_EmptyDataDirErrors(t *testing.T) {
+	err := WritePendingReply("", PendingReplyEntry{Content: "x"})
+	if err == nil {
+		t.Fatalf("expected error for empty dataDir")
+	}
+}
+
+func TestClearPendingReply_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	// Missing file should not error.
+	if err := ClearPendingReply(dir); err != nil {
+		t.Fatalf("ClearPendingReply on missing file: %v", err)
+	}
+	// Round-trip: write, clear, clear again.
+	if err := WritePendingReply(dir, PendingReplyEntry{Platform: "feishu", Content: "x"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := ClearPendingReply(dir); err != nil {
+		t.Fatalf("first clear: %v", err)
+	}
+	if err := ClearPendingReply(dir); err != nil {
+		t.Fatalf("second clear: %v", err)
+	}
+}
+
+func TestConsumePendingReply_MissingReturnsNil(t *testing.T) {
+	if got := ConsumePendingReply(t.TempDir()); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestConsumePendingReply_EmptyDataDirReturnsNil(t *testing.T) {
+	if got := ConsumePendingReply(""); got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestConsumePendingReply_MalformedReturnsNilAndCleansUp(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "run"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(ReplyJournalPath(dir), []byte("not valid json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := ConsumePendingReply(dir); got != nil {
+		t.Fatalf("expected nil for malformed entry, got %+v", got)
+	}
+	if _, err := os.Stat(ReplyJournalPath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("expected file to be removed after malformed consume, stat err = %v", err)
+	}
+}
+
+func TestReplayPendingReply_NoEntryNoOp(t *testing.T) {
+	platforms := []Platform{&stubReplayPlatform{name: "feishu"}}
+	res := ReplayPendingReply(t.TempDir(), platforms)
+	if res.Delivered || res.Duplicate || res.ErrorMessage != "" {
+		t.Fatalf("expected no-op result, got %+v", res)
+	}
+}
+
+func TestReplayPendingReply_PlatformNotFoundLeavesEntry(t *testing.T) {
+	dir := t.TempDir()
+	entry := PendingReplyEntry{Platform: "missing", SessionKey: "k", Content: "hello"}
+	if err := WritePendingReply(dir, entry); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	platforms := []Platform{&stubReplayPlatform{name: "feishu"}}
+	res := ReplayPendingReply(dir, platforms)
+	if res.Delivered {
+		t.Fatalf("expected non-delivered when platform missing, got %+v", res)
+	}
+	if !strings.Contains(res.ErrorMessage, "missing") {
+		t.Fatalf("ErrorMessage %q does not name missing platform", res.ErrorMessage)
+	}
+	// Entry should still be on disk for retry.
+	if ConsumePendingReply(dir) == nil {
+		t.Fatalf("entry was not preserved when platform missing")
+	}
+}
+
+func TestReplayPendingReply_SuccessClearsEntry(t *testing.T) {
+	dir := t.TempDir()
+	entry := PendingReplyEntry{Platform: "feishu", SessionKey: "k1", Content: "hello"}
+	if err := WritePendingReply(dir, entry); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	p := &stubReplayPlatform{name: "feishu"}
+	res := ReplayPendingReply(dir, []Platform{p})
+	if !res.Delivered || res.Duplicate {
+		t.Fatalf("expected delivered non-duplicate, got %+v", res)
+	}
+	if p.replyCalls.Load() != 1 {
+		t.Fatalf("platform Reply called %d times, want 1", p.replyCalls.Load())
+	}
+	if got, _ := p.replyContent.Load().(string); got != "hello" {
+		t.Fatalf("platform got content %q, want %q", got, "hello")
+	}
+	if ConsumePendingReply(dir) != nil {
+		t.Fatalf("entry should be cleared after successful replay")
+	}
+}
+
+func TestReplayPendingReply_DuplicateErrorTreatsAsDelivered(t *testing.T) {
+	dir := t.TempDir()
+	entry := PendingReplyEntry{Platform: "feishu", SessionKey: "k1", Content: "hello"}
+	if err := WritePendingReply(dir, entry); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	p := &stubReplayPlatform{
+		name:      "feishu",
+		ReplyFunc: func(_ context.Context, _ any, _ string) error { return errors.New("message is duplicate") },
+	}
+	res := ReplayPendingReply(dir, []Platform{p})
+	if !res.Delivered || !res.Duplicate {
+		t.Fatalf("expected delivered+duplicate, got %+v", res)
+	}
+	if ConsumePendingReply(dir) != nil {
+		t.Fatalf("entry should be cleared when platform reports duplicate")
+	}
+}
+
+func TestReplayPendingReply_GenericErrorLeavesEntry(t *testing.T) {
+	dir := t.TempDir()
+	entry := PendingReplyEntry{Platform: "feishu", SessionKey: "k1", Content: "hello"}
+	if err := WritePendingReply(dir, entry); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	p := &stubReplayPlatform{
+		name:      "feishu",
+		ReplyFunc: func(_ context.Context, _ any, _ string) error { return errors.New("network down") },
+	}
+	res := ReplayPendingReply(dir, []Platform{p})
+	if res.Delivered {
+		t.Fatalf("did not expect delivered, got %+v", res)
+	}
+	if !strings.Contains(res.ErrorMessage, "network down") {
+		t.Fatalf("ErrorMessage %q missing platform error", res.ErrorMessage)
+	}
+	if ConsumePendingReply(dir) == nil {
+		t.Fatalf("entry should be preserved on non-duplicate failure")
+	}
+}
+
+func TestReplayPendingReply_ReconstructFailureLeavesEntry(t *testing.T) {
+	dir := t.TempDir()
+	entry := PendingReplyEntry{Platform: "feishu", SessionKey: "k1", Content: "hello"}
+	if err := WritePendingReply(dir, entry); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	p := &stubReplayPlatform{
+		name:            "feishu",
+		ReconstructFunc: func(string) (any, error) { return nil, errors.New("no ctx") },
+	}
+	res := ReplayPendingReply(dir, []Platform{p})
+	if res.Delivered {
+		t.Fatalf("did not expect delivered, got %+v", res)
+	}
+	if ConsumePendingReply(dir) == nil {
+		t.Fatalf("entry should be preserved when reconstruct fails")
+	}
+}
+
+// noReconstructPlatform implements Platform but NOT ReplyContextReconstructor.
+// ReplayPendingReply should leave the entry in place when no platform can
+// reconstruct a reply ctx.
+type noReconstructPlatform struct{ name string }
+
+func (p *noReconstructPlatform) Name() string                 { return p.name }
+func (p *noReconstructPlatform) Start(_ MessageHandler) error { return nil }
+func (p *noReconstructPlatform) Stop() error                  { return nil }
+func (p *noReconstructPlatform) Send(_ context.Context, _ any, _ string) error {
+	return nil
+}
+func (p *noReconstructPlatform) Reply(_ context.Context, _ any, _ string) error {
+	return nil
+}
+
+func TestReplayPendingReply_NoReconstructorLeavesEntry(t *testing.T) {
+	dir := t.TempDir()
+	entry := PendingReplyEntry{Platform: "feishu", SessionKey: "k1", Content: "hello"}
+	if err := WritePendingReply(dir, entry); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	res := ReplayPendingReply(dir, []Platform{&noReconstructPlatform{name: "feishu"}})
+	if res.Delivered {
+		t.Fatalf("did not expect delivered when platform lacks reconstructor, got %+v", res)
+	}
+	if !strings.Contains(res.ErrorMessage, "ReplyContextReconstructor") {
+		t.Fatalf("ErrorMessage %q missing reconstructor hint", res.ErrorMessage)
+	}
+	if ConsumePendingReply(dir) == nil {
+		t.Fatalf("entry should be preserved when platform lacks reconstructor")
+	}
+}
+
+func TestIsDuplicateReplyError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"generic", errors.New("something else"), false},
+		{"duplicate", errors.New("message is duplicate"), true},
+		{"already exists", errors.New("message already exists"), true},
+		{"already sent", errors.New("already sent"), true},
+		{"already delivered", errors.New("already delivered"), true},
+		{"case insensitive", errors.New("DUPLICATE"), true},
+		{"zh", errors.New("消息已发送，重复"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDuplicateReplyError(tc.err); got != tc.want {
+				t.Fatalf("isDuplicateReplyError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEngineReplayPendingReplyJournal_NoEntryNoError(t *testing.T) {
+	dir := t.TempDir()
+	e := &Engine{dataDir: dir}
+	// Should be a no-op (no panic, no log spam).
+	e.replayPendingReplyJournal()
+}
+
+func TestEngineReplayPendingReplyJournal_EmptyDataDirNoop(t *testing.T) {
+	e := &Engine{dataDir: ""}
+	e.replayPendingReplyJournal() // must not panic
+}
+
+func TestDrainInFlightReplies_NoWaitWhenIdle(t *testing.T) {
+	e := &Engine{}
+	// Should return quickly when replyWG has nothing to wait on.
+	done := make(chan struct{})
+	go func() {
+		e.drainInFlightReplies(50 * time.Millisecond)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("drainInFlightReplies blocked when idle")
+	}
+}
+
+func TestDrainInFlightReplies_WaitsForInFlight(t *testing.T) {
+	e := &Engine{}
+	e.replyWG.Add(1)
+	released := make(chan struct{})
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		e.drainInFlightReplies(2 * time.Second)
+		done <- time.Since(start)
+	}()
+	// Hold the reply for 200ms, then release.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		e.replyWG.Done()
+		close(released)
+	}()
+	elapsed := <-done
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf("drain returned in %v, expected ≥200ms (should wait for in-flight reply)", elapsed)
+	}
+	if elapsed > 1*time.Second {
+		t.Fatalf("drain took %v, expected well under 2s timeout", elapsed)
+	}
+	<-released
+}
+
+func TestDrainInFlightReplies_TimesOutOnStuckReply(t *testing.T) {
+	e := &Engine{}
+	e.replyWG.Add(1)
+	defer e.replyWG.Done() // release so test cleanup doesn't hang
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		e.drainInFlightReplies(150 * time.Millisecond)
+		done <- time.Since(start)
+	}()
+	elapsed := <-done
+	// Should give up around the 150ms timeout, not block forever.
+	if elapsed < 100*time.Millisecond || elapsed > 600*time.Millisecond {
+		t.Fatalf("drain elapsed = %v, expected ~150ms (timeout)", elapsed)
+	}
+}
+
+func TestEngineTrackAndSend_WritesAndClearsJournal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file mode not applicable on Windows")
+	}
+	dir := t.TempDir()
+	e := &Engine{dataDir: dir}
+	// Construct a minimal Platform stub that exposes SessionKey via the
+	// SessionKeyCarrier hook so writeJournalEntry records a session key.
+	stub := &sessionKeyPlatformStub{name: "feishu", sessionKey: "k1"}
+	if err := e.trackAndSend(stub, "ctx", "hello", "reply"); err != nil {
+		t.Fatalf("trackAndSend: %v", err)
+	}
+	if ConsumePendingReply(dir) != nil {
+		t.Fatalf("entry should be cleared after successful send")
+	}
+}
+
+func TestEngineTrackAndSend_LeavesJournalOnError(t *testing.T) {
+	dir := t.TempDir()
+	e := &Engine{dataDir: dir}
+	stub := &sessionKeyPlatformStub{
+		name:       "feishu",
+		sessionKey: "k1",
+		replyErr:   errors.New("boom"),
+	}
+	if err := e.trackAndSend(stub, "ctx", "hello", "reply"); err == nil {
+		t.Fatalf("expected error to propagate")
+	}
+	entry := ConsumePendingReply(dir)
+	if entry == nil {
+		t.Fatalf("entry should be preserved when reply fails")
+	}
+	if entry.SessionKey != "k1" || entry.Content != "hello" {
+		t.Fatalf("entry not what we wrote: %+v", entry)
+	}
+}
+
+// sessionKeyPlatformStub satisfies both Platform and SessionKeyCarrier so
+// the journal can record a session key from a generic reply ctx.
+type sessionKeyPlatformStub struct {
+	name       string
+	sessionKey string
+	replyErr   error
+}
+
+func (p *sessionKeyPlatformStub) Name() string { return p.name }
+func (p *sessionKeyPlatformStub) Start(_ MessageHandler) error {
+	return nil
+}
+func (p *sessionKeyPlatformStub) Stop() error { return nil }
+func (p *sessionKeyPlatformStub) Send(_ context.Context, _ any, _ string) error {
+	return nil
+}
+func (p *sessionKeyPlatformStub) Reply(_ context.Context, _ any, _ string) error {
+	return p.replyErr
+}
+func (p *sessionKeyPlatformStub) SessionKey(_ any) string { return p.sessionKey }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,6 +17,7 @@ Complete guide to using cc-connect features.
 - [Voice Reply (TTS)](#voice-reply-text-to-speech)
 - [Image and File Send-Back](#image-and-file-send-back)
 - [Scheduled Tasks (Cron)](#scheduled-tasks-cron)
+- [Graceful Restart & Lost Replies](#graceful-restart--lost-replies)
 - [Shell Configuration](#shell-configuration)
 - [Multi-Bot Relay](#multi-bot-relay)
 - [Daemon Mode](#daemon-mode)
@@ -846,6 +847,68 @@ Optional: `--session-mode new-per-run` starts a fresh agent session on each run 
 > "Every day at 6am, summarize GitHub trending"
 
 Claude Code auto-creates the cron job. For other agents that rely on memory files, run `/cron setup` or `/bind setup` once first; both write the same instructions.
+
+---
+
+## Graceful Restart & Lost Replies
+
+If your agent finishes a turn by restarting cc-connect (e.g. as the very last
+tool call in a long session), the previous reply may not have reached the
+chat yet when SIGTERM arrives. Before v1.6.x this surfaced as
+`context canceled` and the user never saw the reply.
+
+Starting in v1.6.x, cc-connect now:
+
+1. **Drains in-flight replies for up to 10 seconds before exiting.** A
+   SIGTERM-triggered shutdown waits for the platform API call to finish
+   so the user's last message is delivered normally. After 10s any
+   still-pending replies are handed off to the on-disk journal.
+2. **Persists the most recent pending reply to
+   `<dataDir>/run/last_reply.json` (mode `0o600`).** This is a safety
+   net for hard kills (OOM, panic, SIGKILL) that bypass the graceful
+   drain path. After restart the entry is replayed automatically
+   against the original platform and session.
+3. **Deduplicates by content hash.** If the platform API responds
+   with "duplicate" / "already sent" / "重复" on replay, the journal
+   entry is cleared silently — the user's intent is satisfied.
+
+The journal only holds the single most recent pending reply because the
+user-visible symptom of a lost reply is always about the latest turn.
+
+### Verify a restart actually delivered the last reply
+
+If your agent's last tool call is `cc-connect daemon restart` (or
+equivalent), schedule a follow-up one-shot timer so the agent can confirm
+that the reply reached the chat after the restart completes:
+
+```bash
+cc-connect timer add --delay 15s --prompt "verify restart result and report"
+```
+
+This queues a one-off 15-second timer that wakes the agent on the same
+session so it can read the recent chat history and tell you whether the
+final reply made it through. If you still see "context canceled" in the
+agent's history, the journal at `<dataDir>/run/last_reply.json` was
+replayed successfully on the next start — the platform received the
+content even though the original API call returned `context canceled`.
+
+### Inspecting the journal from the management API
+
+`<dataDir>/run/last_reply.json` is plain JSON and safe to read
+(`mode 0o600`):
+
+```json
+{
+  "platform": "feishu",
+  "session_key": "feishu:chat:user",
+  "content": "...",
+  "content_hash": "<sha256 hex>",
+  "created_at": "2026-09-08T12:34:56Z"
+}
+```
+
+The file is removed automatically once the reply is delivered (or
+confirmed as a duplicate).
 
 ---
 

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -18,6 +18,7 @@ cc-connect 完整功能使用指南。
 - [语音回复（文字转语音）](#语音回复文字转语音)
 - [图片与文件回传](#图片与文件回传)
 - [定时任务 (Cron)](#定时任务-cron)
+- [优雅重启与丢消息恢复](#优雅重启与丢消息恢复)
 - [Shell 配置](#shell-配置)
 - [多机器人中继](#多机器人中继)
 - [守护进程模式](#守护进程模式)
@@ -759,6 +760,63 @@ cc-connect cron del <job-id>
 > "每天早上6点帮我总结 GitHub trending"
 
 Claude Code 会自动创建定时任务。对依赖记忆文件的其他 Agent，先执行一次 `/cron setup` 或 `/bind setup`，效果相同。
+
+---
+
+## 优雅重启与丢消息恢复
+
+如果你的 Agent 在一个长会话的最后一步工具调用是重启 cc-connect
+（比如 `cc-connect daemon restart`），收到 SIGTERM 时上一条回复可能还
+没真正送到聊天窗口。v1.6.x 之前这种场景会在平台侧出现
+`context canceled`，用户看不到那条回复。
+
+v1.6.x 起 cc-connect 做三件事：
+
+1. **退出前最多 10 秒的优雅排空。** SIGTERM 触发的关闭会等待平台
+   API 调用完成，让用户的最后一条消息正常送达。超过 10 秒仍未完成
+   的回复交给下面的磁盘 journal 兜底。
+2. **把最近一条 pending reply 持久化到
+   `<dataDir>/run/last_reply.json`（权限 `0o600`）。** 这是给硬杀
+   （OOM、panic、SIGKILL）准备的兜底，绕开了优雅排空路径。重启后
+   engine 会按原始平台和会话自动重放。
+3. **按内容哈希去重。** 重放时如果平台 API 返回
+   `duplicate` / `already sent` / `重复`，journal 条目会被静默清
+   掉——用户意图已经达成。
+
+journal 只保留最近一条 pending reply，因为用户能感知到的丢消息永远
+是最近一轮。
+
+### 验证重启后最后一条回复是否真的送达
+
+如果你的 Agent 最后一步工具调用是重启 cc-connect，可以再排一个
+一次性 timer，让它在重启完成后读一下最近的聊天记录并回报：
+
+```bash
+cc-connect timer add --delay 15s --prompt "verify restart result and report"
+```
+
+这条命令排一个 15 秒后的一次性 timer，会在同一个会话里把 Agent
+唤醒，让它读最近的聊天并告诉你最后那条回复是否真的到了。如果在
+Agent 历史里仍看到 `context canceled`，journal 在下一次启动时已经
+成功重放——虽然平台原始 API 调用返回了 `context canceled`，但内容
+实际送达了。
+
+### 从管理 API 检查 journal
+
+`<dataDir>/run/last_reply.json` 是纯 JSON，可以直接读取（权限
+`0o600`）：
+
+```json
+{
+  "platform": "feishu",
+  "session_key": "feishu:chat:user",
+  "content": "...",
+  "content_hash": "<sha256 hex>",
+  "created_at": "2026-09-08T12:34:56Z"
+}
+```
+
+reply 送达（或被识别为重复）后，文件会自动删除。
 
 ---
 


### PR DESCRIPTION
Fixes #1804.

When cc-connect received SIGTERM mid-platform-reply, the shared engine
context was cancelled immediately, the platform API call returned
'context canceled', and the reply body was lost. This commonly happens
when an agent ends a long session by restarting cc-connect as its last
tool call — the user sees nothing for that final turn and the agent
restarts again, producing a feedback loop.

## Changes

### Graceful drain on SIGTERM (issue #1804 plan: B)

`Engine.Stop()` now waits up to **10 seconds** for in-flight platform
`Reply` / `Send` operations to finish *before* cancelling the shared
context. A new `replyWG sync.WaitGroup` tracks the wrappers
(`trackAndSend`, `writeJournalEntry`, `clearJournalEntry`) so
`Stop()` can wait for them. The 10s ceiling is a deliberate trade-off:
long enough for a typical Feishu reply + a chunked burst, short enough
that a misbehaving agent cannot block daemon restart.

### Minimal reply journal (issue #1804 plan: A-minimal)

When the drain times out, or the process is killed by OOM / panic /
SIGKILL, `<dataDir>/run/last_reply.json` (mode `0o600`) holds the
most recent pending reply. `Engine.Start()` replays it once after the
platforms come up:

- **Success** → entry cleared.
- **Duplicate error** ("duplicate" / "already sent" / "重复") →
  treated as delivered, entry cleared.
- **Other error** → entry preserved for the next restart.

New optional `SessionKeyCarrier` interface lets platforms opt in to
extracting session keys from reply contexts, so the journal can
associate a pending reply with the right session.

### FAQ / verification workaround (issue #1804 plan: C)

`docs/usage.md` (+ zh-CN) documents `cc-connect timer add --delay 15s --prompt "verify restart result and report"` for agents that want to confirm
the last reply made it through after a self-restart.

## Files

- `core/reply_journal.go` (new) — journal write/consume/replay, hash dedup
- `core/reply_journal_test.go` (new) — 21 unit tests covering round-trip, dedup, drain timeout, replay paths
- `core/engine.go` — `replyWG`, drain-before-cancel, `trackAndSend` wrapper, `replayPendingReplyJournal` startup hook
- `core/interfaces.go` — new `SessionKeyCarrier` optional interface
- `docs/usage.md` + `docs/usage.zh-CN.md` — Graceful Restart & Lost Replies section

## Risk

- Engine startup now blocks for up to 10s while replaying a pending
  reply. Acceptable: the journal is empty on first start, and replays
  fail fast against a fresh context (`replyJournalTimeout = 10s`).
- Drain adds up to 10s to SIGTERM shutdown. Acceptable: this is the
  whole point of the fix, and 10s is a hard ceiling via
  `shutdownDrainTimeout`.
- Platforms without `ReplyContextReconstructor` cannot replay. Same as
  the existing cron path: the journal entry is preserved and logged.

## Test plan

- 21 new unit tests in `core/reply_journal_test.go` (run with -race).
- Full `go test -tags no_web ./core/...` passes.
- Manual: kill -SIGTERM mid-reply, confirm reply delivered; kill -9
  mid-reply, restart, confirm journal replays.