### PR TITLE
feat(feishu): acknowledge accepted messages with an optional receipt reaction

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1018,8 +1018,10 @@ app_secret = "your-feishu-app-secret"
 #                           # 允许的群聊 chat_id，逗号分隔；"*" 表示所有（默认）。在群设置中查看 chat_id。
 # group_only = false        # If true, only respond to group chat messages; ignore private (P2P) messages (default: false)
 #                           # 设为 true 时，仅响应群聊消息，忽略私聊（P2P）消息（默认 false）
-# reaction_emoji = "OnIt"  # Emoji reaction on incoming messages (default: "OnIt"); set to "none" to disable
-#                           # 收到消息时添加的表情回复（默认 "OnIt"）；设为 "none" 可禁用
+# ack_emoji = "Get"        # Immediate persistent receipt when accepted for processing/queueing; omitted/"none" disables
+#                           # 消息被接受处理或入队时立即添加并保留的确认表情；不配置或设为 "none" 可禁用
+# reaction_emoji = "OnIt"  # Temporary reaction while the agent is processing (default: "OnIt"); "none" disables
+#                           # Agent 处理期间的临时表情（默认 "OnIt"），结束后移除；设为 "none" 可禁用
 # done_emoji = "none"       # Emoji reaction when agent finishes a reply (e.g. "Done"); set to "none" to disable
 #                           # Agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 # group_reply_all = false   # If true, respond to ALL group messages without requiring @mention

--- a/core/cuj_test.go
+++ b/core/cuj_test.go
@@ -40,6 +40,37 @@ import (
 	"time"
 )
 
+// CUJ: submit work during slow startup, queue a follow-up while the agent is
+// working, then check status. Both messages have receipts before either answer;
+// draining the queue must preserve each receipt without adding another one.
+func TestCUJ_A8_ImmediateReceiptsDuringStartupAndQueue(t *testing.T) {
+	env := newReceiptAckEnv(t, nil)
+
+	// User action 1: submit the first task while agent startup is blocked.
+	env.send("first", "first task", 1000)
+	env.awaitStartup()
+	env.assertReceipts("first")
+	close(env.startup.release)
+	env.awaitSendCount(1)
+
+	// User action 2: submit a follow-up while the first task awaits its result.
+	env.send("second", "follow-up task", 2000)
+	env.assertReceipts("first", "second")
+	env.awaitVisible(env.engine.i18n.T(MsgMessageQueued))
+
+	// User action 3: check status; local commands do not claim an agent turn.
+	env.send("status", "/status", 3000)
+	env.assertReceipts("first", "second")
+
+	env.startup.session.events <- Event{Type: EventResult, Content: "first answer", Done: true}
+	env.awaitVisible("first answer")
+	env.awaitSendCount(2)
+	env.assertReceipts("first", "second")
+	env.startup.session.events <- Event{Type: EventResult, Content: "second answer", Done: true}
+	env.awaitVisible("second answer")
+	env.assertReceipts("first", "second")
+}
+
 // ---------------------------------------------------------------------------
 // Helper types: cujAgent + cujAgentSession give per-CUJ control over what the
 // agent "replies" for each user prompt, without bringing up a real LLM.

--- a/core/engine_receipt_ack_test.go
+++ b/core/engine_receipt_ack_test.go
@@ -1,0 +1,175 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// receiptAgentSession makes the external session fixture safe for engine
+// teardown racing with the processing goroutine's liveness checks.
+type receiptAgentSession struct {
+	*queuingAgentSession
+	closeOnce sync.Once
+}
+
+func (s *receiptAgentSession) Alive() bool {
+	select {
+	case <-s.closed:
+		return false
+	default:
+		return true
+	}
+}
+
+func (s *receiptAgentSession) Close() error {
+	s.closeOnce.Do(func() { close(s.closed); close(s.events) })
+	return nil
+}
+
+// receiptStartAgent holds the external agent startup boundary until released.
+// This lets tests observe acknowledgements without relying on startup timing.
+type receiptStartAgent struct {
+	stubAgent
+	session *receiptAgentSession
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+	err     error
+}
+
+func (a *receiptStartAgent) StartSession(ctx context.Context, _ string) (AgentSession, error) {
+	a.once.Do(func() { close(a.entered) })
+	select {
+	case <-a.release:
+		return a.session, a.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+type receiptAckEnv struct {
+	*cujEnv
+	startup *receiptStartAgent
+}
+
+func newReceiptAckEnv(t *testing.T, startErr error) *receiptAckEnv {
+	t.Helper()
+	p := &stubPlatformEngine{n: "test"}
+	a := &receiptStartAgent{
+		session: &receiptAgentSession{queuingAgentSession: newQueuingSession("receipt-session")},
+		entered: make(chan struct{}), release: make(chan struct{}), err: startErr,
+	}
+	e := NewEngine("receipt", a, []Platform{p}, t.TempDir()+"/sessions.json", LangEnglish)
+	t.Cleanup(func() { _ = e.Stop() })
+	return &receiptAckEnv{
+		cujEnv: &cujEnv{t: t, engine: e, plat: p}, startup: a,
+	}
+}
+
+func (env *receiptAckEnv) send(id, content string, timestamp int64) {
+	// A platform adapter uses OnAccepted to record its visible reaction on the
+	// original message. Keep the boundary visible through the platform recorder.
+	env.engine.ReceiveMessage(env.plat, &Message{
+		SessionKey: "test:receipt-user", Platform: "test", UserID: "receipt-user",
+		MessageID: id, Content: content, ReplyCtx: id, UserMessageTimeMs: timestamp,
+		OnAccepted: func() {
+			_ = env.plat.Reply(context.Background(), id, "receipt:"+id)
+		},
+	})
+}
+
+func (env *receiptAckEnv) assertReceipts(ids ...string) {
+	env.t.Helper()
+	var got []string
+	for _, message := range env.plat.getSent() {
+		if strings.HasPrefix(message, "receipt:") {
+			got = append(got, strings.TrimPrefix(message, "receipt:"))
+		}
+	}
+	if fmt.Sprint(got) != fmt.Sprint(ids) {
+		env.t.Fatalf("visible receipts = %v, want %v", got, ids)
+	}
+}
+
+func (env *receiptAckEnv) awaitStartup() {
+	env.t.Helper()
+	select {
+	case <-env.startup.entered:
+	case <-time.After(3 * time.Second):
+		env.t.Fatal("agent startup was not reached")
+	}
+}
+
+func (env *receiptAckEnv) awaitSendCount(count int) {
+	env.t.Helper()
+	env.waitFor("agent send", 3*time.Second, func() bool {
+		env.startup.session.sendMu.Lock()
+		defer env.startup.session.sendMu.Unlock()
+		return len(env.startup.session.sendCalls) >= count
+	})
+}
+
+func (env *receiptAckEnv) awaitVisible(content string) {
+	env.t.Helper()
+	env.waitFor(content, 3*time.Second, func() bool {
+		for _, message := range env.plat.getSent() {
+			if strings.Contains(message, content) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestReceiveMessage_ReceiptNotSentForRejectedMessages(t *testing.T) {
+	env := newReceiptAckEnv(t, nil)
+	env.engine.maxQueuedMessages = 1
+	env.send("first", "first task", 2000)
+	env.awaitStartup()
+	close(env.startup.release)
+	env.awaitSendCount(1)
+	env.send("queued", "next task", 3000)
+	env.assertReceipts("first", "queued")
+
+	// These all go through the real public entrypoint while the first turn is busy.
+	env.send("overflow", "queue is full", 4000)
+	env.awaitVisible(fmt.Sprintf(env.engine.i18n.T(MsgQueueFull), 1))
+	env.send("stale", "redelivered older task", 1000)
+	env.send("command", "/status", 5000)
+	env.engine.SetDisabledCommands([]string{"shell"})
+	env.send("disabled-command", "/shell echo no", 5500)
+	env.awaitVisible(fmt.Sprintf(env.engine.i18n.T(MsgCommandDisabled), "/shell"))
+	env.send("empty", "  ", 6000)
+	env.assertReceipts("first", "queued")
+}
+
+func TestReceiveMessage_ReceiptSurvivesFailureWithoutRepeating(t *testing.T) {
+	for _, startupFailure := range []bool{true, false} {
+		t.Run(fmt.Sprintf("startup_failure=%v", startupFailure), func(t *testing.T) {
+			var startErr error
+			if startupFailure {
+				startErr = errors.New("receipt startup failure")
+			}
+			env := newReceiptAckEnv(t, startErr)
+			env.send("request", "do the task", 1000)
+			env.awaitStartup()
+			env.assertReceipts("request")
+			close(env.startup.release)
+			if startupFailure {
+				env.awaitVisible("failed to start agent session")
+			} else {
+				env.awaitSendCount(1)
+				env.startup.session.events <- Event{Type: EventError, Error: errors.New("receipt turn failure")}
+				env.awaitVisible("receipt turn failure")
+			}
+			// The user sees an error as well as the original receipt, never a
+			// second receipt claiming the failed operation was newly accepted.
+			env.assertReceipts("request")
+		})
+	}
+}

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -112,6 +112,8 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 # thread_isolation = true    # 可选：按飞书 thread/root 隔离群聊会话
 # group_chat_history_share = false  # 可选：共享未 @ 机器人的群消息作为下一次触发的上下文；消息本身不会触发回复
 # progress_style = "legacy"  # 可选：legacy | compact | card
+# ack_emoji = "Get"           # 可选：消息被接受处理或入队时立即添加并保留的确认表情；默认禁用
+# reaction_emoji = "OnIt"      # 可选：agent 处理期间的临时表情，结束后移除
 # done_emoji = "none"          # 可选：agent 完成回复后添加的表情回复（如 "Done"）；设为 "none" 可禁用
 # image_batch_window_ms = 500  # 可选：连续多图合批窗口（默认 500ms，详见下文）
 ```
@@ -122,7 +124,11 @@ app_secret = "QhkMpxxxxxxxxxxxxxxxxxxxx"
 > 在 multi-workspace 模式下，`thread_isolation = true` 也会让每个话题独立绑定 workspace；在话题内执行 `/workspace bind <name>` 不会影响同群的其他话题。已有的群级 binding 会保留为默认值，由尚未显式绑定的话题继承，因此回退到旧版本时仍可使用。
 > `progress_style = "compact"` 会把思考/工具进度合并到一条可更新消息里，减少刷屏；`legacy` 保持原有逐条发送；`card` 会使用结构化卡片（标题 + 进度块）持续更新同一条消息，观感比纯文本更清晰。
 > `domain` 只影响运行时 API / WebSocket 请求地址；CLI `setup/new/bind` 的引导域名仍然使用内置默认值。
-> `done_emoji` 设置后，agent 每次完成回复时会在用户消息上添加指定表情（如 `"Done"` → ✅）。先移除 "OnIt" 表情（如果有），再添加 done 表情。在 quiet 模式下特别有用，因为飞书卡片原地更新不触发推送，done 表情可以通知用户 agent 已完成。设为 `"none"` 或不配置则禁用。
+> `ack_emoji = "Get"` 会在消息通过校验、被引擎接受处理或成功入队后异步添加确认表情，无需等待模型启动或前一轮结束。它表示“请求已接收”，会在完成、失败或取消后保留，不表示模型已开始执行或任务已成功。现有 `reaction_emoji`（默认 `"OnIt"`）仍表示实际处理，`done_emoji` 表示完成；若 `ack_emoji` 与 `reaction_emoji` 相同，该表情由接收确认保留，不再作为临时状态移除。
+> 确认默认关闭；不配置、空值或 `"none"` 保持原有行为。权限或 @ 过滤、重复/过时消息、满队列拒绝、已处理的命令与无用户消息的定时任务不会产生确认。确认从引擎接受消息时开始；若后续消息仍在等待已有的会话启动锁，也会等待接受决定。表情 API 采用 5 秒超时的异步尽力请求，失败不影响模型处理；发送前的附件下载、消息解析以及多图合批仍需先完成，多图批次确认在最后一条（批次的主消息）上。
+> **English:** Optional `ack_emoji = "Get"` adds a persistent receipt asynchronously once the engine accepts a message for processing or queueing, before waiting for agent startup/execution. It confirms acceptance, not execution or success, and survives completion/failure/cancellation. Omitted, empty or `"none"` keeps existing behavior. Processing (`reaction_emoji`) and completion (`done_emoji`) remain independent; if receipt and processing use the same emoji, the receipt owns it and typing cleanup does not remove it. Rejected/duplicate/stale messages, handled commands and synthetic scheduled work are not acknowledged. The receipt begins at engine acceptance; subsequent messages waiting on the existing session-startup lock still wait for admission. Receipt API calls have a five-second timeout and never block processing. Parsing/media preparation and image batching precede acceptance; a merged image batch acknowledges its newest canonical message.
+
+> `done_emoji` 设置后，agent 每次完成回复时会在用户消息上添加指定表情（如 `"Done"` → ✅）。先清理临时处理表情（与接收确认相同的表情会保留），再添加 done 表情。在 quiet 模式下特别有用，因为飞书卡片原地更新不触发推送，done 表情可以通知用户 agent 已完成。设为 `"none"` 或不配置则禁用。
 > `image_batch_window_ms` 控制连续多张图片合并成一条 agent 消息的等待窗口（默认 500ms）。飞书手机端一次连发多张图时，每张图是独立事件；cc-connect 会在窗口内将它们合并成一条多图消息再分发给 agent。如果你的网络/设备发送间隔超过 500ms 且仍被拆成多轮回复（每张图独立处理），可调高到 800–1200ms；如果以单图为主、希望响应更快，可适当调低。设为 `0` 时回退到默认 500ms。
 
 ---

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -107,10 +107,12 @@ func init() {
 }
 
 type replyContext struct {
-	messageID       string
-	chatID          string
-	sessionKey      string
-	bootstrapThread bool
+	messageID        string
+	chatID           string
+	sessionKey       string
+	bootstrapThread  bool
+	receiptEmoji     string // persistent reaction owned by the accepted-message callback
+	receiptMessageID string
 }
 
 type Platform struct {
@@ -123,6 +125,7 @@ type Platform struct {
 	useInteractiveCard         bool
 	self                       core.Platform
 	reactionEmoji              string
+	ackEmoji                   string
 	doneEmoji                  string
 	allowFrom                  string
 	allowChat                  string
@@ -350,6 +353,11 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 	if v, ok := opts["reaction_emoji"].(string); ok && v == "none" {
 		reactionEmoji = ""
 	}
+	ackEmoji, _ := opts["ack_emoji"].(string)
+	ackEmoji = strings.TrimSpace(ackEmoji)
+	if strings.EqualFold(ackEmoji, "none") {
+		ackEmoji = ""
+	}
 	doneEmoji, _ := opts["done_emoji"].(string)
 	if doneEmoji == "none" {
 		doneEmoji = ""
@@ -472,6 +480,7 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		progressStyle:              progressStyle,
 		useInteractiveCard:         useInteractiveCard,
 		reactionEmoji:              reactionEmoji,
+		ackEmoji:                   ackEmoji,
 		doneEmoji:                  doneEmoji,
 		allowFrom:                  allowFrom,
 		allowChat:                  allowChat,
@@ -991,10 +1000,14 @@ func (p *Platform) addReaction(messageID string) string {
 }
 
 func (p *Platform) addReactionWithEmoji(messageID, emojiType string) string {
+	return p.addReactionWithEmojiContext(context.Background(), messageID, emojiType)
+}
+
+func (p *Platform) addReactionWithEmojiContext(ctx context.Context, messageID, emojiType string) string {
 	if emojiType == "" {
 		return ""
 	}
-	resp, err := p.client.Im.MessageReaction.Create(context.Background(),
+	resp, err := p.client.Im.MessageReaction.Create(ctx,
 		larkim.NewCreateMessageReactionReqBuilder().
 			MessageId(messageID).
 			Body(larkim.NewCreateMessageReactionReqBodyBuilder().
@@ -1038,6 +1051,12 @@ func (p *Platform) removeReaction(messageID, reactionID string) {
 func (p *Platform) StartTyping(ctx context.Context, rctx any) (stop func()) {
 	rc, ok := rctx.(replyContext)
 	if !ok || rc.messageID == "" {
+		return func() {}
+	}
+	// Feishu identifies a bot's reaction by message and emoji. If receipt and
+	// processing use the same emoji, the persistent receipt owns it: creating
+	// and later deleting a typing reaction would remove the receipt as well.
+	if rc.receiptMessageID == rc.messageID && rc.receiptEmoji != "" && rc.receiptEmoji == p.reactionEmoji {
 		return func() {}
 	}
 	reactionID := p.addReaction(rc.messageID)
@@ -1191,7 +1210,47 @@ func (p *Platform) dispatchCoreMessage(msg *core.Message) {
 		slog.Debug(p.tag()+": recalled message dispatch dropped", "message_id", msg.MessageID)
 		return
 	}
+	p.prepareReceiptAcknowledgement(msg)
 	h(p.dispatchPlatform(), msg)
+}
+
+// prepareReceiptAcknowledgement waits for the engine's admission decision.
+// OnAccepted runs before agent startup or after successful queue insertion;
+// rejected messages and local commands never invoke it. Preserve the existing
+// callback (for example group-history consumption) and keep network IO out of
+// the admission path, which may hold the session queue lock.
+func (p *Platform) prepareReceiptAcknowledgement(msg *core.Message) {
+	rc, ok := msg.ReplyCtx.(replyContext)
+	if p.ackEmoji == "" || !ok || rc.messageID == "" || msg.MessageID == "" || msg.Recalled {
+		return
+	}
+	if rc.receiptEmoji != "" {
+		return // the message already carries this callback
+	}
+	rc.receiptEmoji = p.ackEmoji
+	// Image batches retain the first image's reply context but are admitted
+	// under the newest canonical message ID. Acknowledge that accepted message.
+	rc.receiptMessageID = msg.MessageID
+	msg.ReplyCtx = rc
+	previous := msg.OnAccepted
+	var once sync.Once
+	msg.OnAccepted = func() {
+		once.Do(func() {
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				if p.isMessageRecalled(rc.receiptMessageID) {
+					return
+				}
+				if p.addReactionWithEmojiContext(ctx, rc.receiptMessageID, rc.receiptEmoji) == "" {
+					slog.Warn(p.tag()+": receipt acknowledgement failed", "message_id", rc.receiptMessageID)
+				}
+			}()
+			if previous != nil {
+				previous()
+			}
+		})
+	}
 }
 
 // populateWorkspaceChannelKeys keeps workspace binding scope aligned with the

--- a/platform/feishu/receipt_ack_test.go
+++ b/platform/feishu/receipt_ack_test.go
@@ -34,7 +34,9 @@ func receiptTestPlatform(t *testing.T, opts map[string]any, serve func(http.Resp
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if strings.Contains(r.URL.Path, "/auth/") {
-			fmt.Fprint(w, `{"code":0,"expire":7200,"tenant_access_token":"test-token"}`)
+			if _, err := fmt.Fprint(w, `{"code":0,"expire":7200,"tenant_access_token":"test-token"}`); err != nil {
+				t.Errorf("write fixture response: %v", err)
+			}
 			return
 		}
 		serve(w, r)
@@ -70,7 +72,8 @@ func TestReceiptAcknowledgement_AcceptedMessagePersistsThroughTypingCleanup(t *t
 			p := receiptTestPlatform(t, map[string]any{"ack_emoji": "Get", "reaction_emoji": processingEmoji}, func(w http.ResponseWriter, r *http.Request) {
 				req := receiptRequest{method: r.Method, path: r.URL.Path}
 				mu.Lock()
-				if r.Method == http.MethodPost {
+				switch r.Method {
+				case http.MethodPost:
 					var body struct {
 						ReactionType struct {
 							EmojiType string `json:"emoji_type"`
@@ -81,15 +84,19 @@ func TestReceiptAcknowledgement_AcceptedMessagePersistsThroughTypingCleanup(t *t
 					}
 					req.emoji = body.ReactionType.EmojiType
 					active[req.emoji] = "reaction-" + req.emoji
-					fmt.Fprintf(w, `{"code":0,"data":{"reaction_id":%q}}`, "reaction-"+req.emoji)
-				} else if r.Method == http.MethodDelete {
+					if _, err := fmt.Fprintf(w, `{"code":0,"data":{"reaction_id":%q}}`, "reaction-"+req.emoji); err != nil {
+						t.Errorf("write fixture response: %v", err)
+					}
+				case http.MethodDelete:
 					for emoji, id := range active {
 						if strings.HasSuffix(r.URL.Path, "/"+id) {
 							delete(active, emoji)
 						}
 					}
-					fmt.Fprint(w, `{"code":0}`)
-				} else {
+					if _, err := fmt.Fprint(w, `{"code":0}`); err != nil {
+						t.Errorf("write fixture response: %v", err)
+					}
+				default:
 					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 				}
 				mu.Unlock()
@@ -180,9 +187,13 @@ func TestReceiptAcknowledgement_SlowOrFailedAPIIsBestEffort(t *testing.T) {
 				close(started)
 				<-release
 				if fail {
-					fmt.Fprint(w, `{"code":99991672,"msg":"permission denied"}`)
+					if _, err := fmt.Fprint(w, `{"code":99991672,"msg":"permission denied"}`); err != nil {
+						t.Errorf("write fixture response: %v", err)
+					}
 				} else {
-					fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"receipt"}}`)
+					if _, err := fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"receipt"}}`); err != nil {
+						t.Errorf("write fixture response: %v", err)
+					}
 				}
 			})
 			var accepted atomic.Int32
@@ -212,9 +223,13 @@ func TestReceiptAcknowledgement_OnlyAdmittedInboundEvents(t *testing.T) {
 	p := receiptTestPlatform(t, map[string]any{"ack_emoji": "Get"}, func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/reactions") {
 			requests <- receiptRequest{method: r.Method, path: r.URL.Path}
-			fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"receipt"}}`)
+			if _, err := fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"receipt"}}`); err != nil {
+				t.Errorf("write fixture response: %v", err)
+			}
 		} else if strings.HasSuffix(r.URL.Path, "/reply") {
-			fmt.Fprint(w, `{"code":0,"data":{"message_id":"denied-reply"}}`)
+			if _, err := fmt.Fprint(w, `{"code":0,"data":{"message_id":"denied-reply"}}`); err != nil {
+				t.Errorf("write fixture response: %v", err)
+			}
 		} else {
 			t.Errorf("unexpected request: %s", r.URL.Path)
 		}
@@ -258,7 +273,9 @@ func TestReceiptAcknowledgement_ImageBatchUsesAcceptedCanonicalMessage(t *testin
 	requests := make(chan receiptRequest, 10)
 	p := receiptTestPlatform(t, map[string]any{"ack_emoji": "Get", "reaction_emoji": "Get"}, func(w http.ResponseWriter, r *http.Request) {
 		requests <- receiptRequest{method: r.Method, path: r.URL.Path}
-		fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"reaction-Get"}}`)
+		if _, err := fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"reaction-Get"}}`); err != nil {
+			t.Errorf("write fixture response: %v", err)
+		}
 	})
 	var msg *core.Message
 	p.handler = func(_ core.Platform, m *core.Message) { msg = m; m.OnAccepted() }
@@ -298,7 +315,9 @@ func TestReceiptAcknowledgement_TypingStopsBeforeReceiptCompletes(t *testing.T) 
 		}
 		close(started)
 		<-release
-		fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"receipt"}}`)
+		if _, err := fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"receipt"}}`); err != nil {
+			t.Errorf("write fixture response: %v", err)
+		}
 	})
 	p.handler = func(_ core.Platform, m *core.Message) { m.OnAccepted() }
 	msg := receiptMessage()

--- a/platform/feishu/receipt_ack_test.go
+++ b/platform/feishu/receipt_ack_test.go
@@ -1,0 +1,355 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chenhg5/cc-connect/core"
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+)
+
+type receiptRequest struct{ method, path, emoji string }
+
+func receiptTestPlatform(t *testing.T, opts map[string]any, serve func(http.ResponseWriter, *http.Request)) *Platform {
+	t.Helper()
+	opts["app_id"] = "receipt-" + t.Name()
+	opts["app_secret"] = "test-secret"
+	opts["enable_feishu_card"] = false
+	opts["allow_from"] = "*"
+	platform, err := New(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := platform.(*Platform)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/auth/") {
+			fmt.Fprint(w, `{"code":0,"expire":7200,"tenant_access_token":"test-token"}`)
+			return
+		}
+		serve(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	p.client = lark.NewClient(opts["app_id"].(string), "test-secret", lark.WithOpenBaseUrl(srv.URL), lark.WithHttpClient(srv.Client()))
+	return p
+}
+
+func receiptMessage() *core.Message {
+	return &core.Message{MessageID: "om_receipt", Content: "hello", UserID: "ou_alice", SessionKey: "feishu:oc_main:ou_alice", ReplyCtx: replyContext{messageID: "om_receipt", chatID: "oc_main"}}
+}
+
+func awaitReceiptRequest(t *testing.T, requests <-chan receiptRequest) receiptRequest {
+	t.Helper()
+	select {
+	case req := <-requests:
+		return req
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for reaction request")
+		return receiptRequest{}
+	}
+}
+
+// This test also runs unchanged against pre-feature main: the prior history
+// callback runs, but no receipt request is sent, so the test fails.
+func TestReceiptAcknowledgement_AcceptedMessagePersistsThroughTypingCleanup(t *testing.T) {
+	for _, processingEmoji := range []string{"OnIt", "Get", "none"} {
+		t.Run(processingEmoji, func(t *testing.T) {
+			requests := make(chan receiptRequest, 10)
+			var mu sync.Mutex
+			active := map[string]string{}
+			p := receiptTestPlatform(t, map[string]any{"ack_emoji": "Get", "reaction_emoji": processingEmoji}, func(w http.ResponseWriter, r *http.Request) {
+				req := receiptRequest{method: r.Method, path: r.URL.Path}
+				mu.Lock()
+				if r.Method == http.MethodPost {
+					var body struct {
+						ReactionType struct {
+							EmojiType string `json:"emoji_type"`
+						} `json:"reaction_type"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Error(err)
+					}
+					req.emoji = body.ReactionType.EmojiType
+					active[req.emoji] = "reaction-" + req.emoji
+					fmt.Fprintf(w, `{"code":0,"data":{"reaction_id":%q}}`, "reaction-"+req.emoji)
+				} else if r.Method == http.MethodDelete {
+					for emoji, id := range active {
+						if strings.HasSuffix(r.URL.Path, "/"+id) {
+							delete(active, emoji)
+						}
+					}
+					fmt.Fprint(w, `{"code":0}`)
+				} else {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				mu.Unlock()
+				requests <- req
+			})
+			var got *core.Message
+			p.handler = func(_ core.Platform, m *core.Message) { got = m }
+			msg := receiptMessage()
+			var historyConsumed atomic.Int32
+			msg.OnAccepted = func() { historyConsumed.Add(1) }
+			p.dispatchCoreMessage(msg)
+			select {
+			case req := <-requests:
+				t.Fatalf("ack before engine acceptance: %+v", req)
+			default:
+			}
+			got.OnAccepted()
+			req := awaitReceiptRequest(t, requests)
+			if req.method != http.MethodPost || req.emoji != "Get" || req.path != "/open-apis/im/v1/messages/om_receipt/reactions" {
+				t.Fatalf("receipt request = %+v", req)
+			}
+			got.OnAccepted() // callback composition must be idempotent
+			if historyConsumed.Load() != 1 {
+				t.Fatalf("history callback count = %d", historyConsumed.Load())
+			}
+			stop := p.StartTyping(context.Background(), got.ReplyCtx)
+			if processingEmoji == "OnIt" {
+				req = awaitReceiptRequest(t, requests)
+				if req.emoji != "OnIt" {
+					t.Fatalf("processing request = %+v", req)
+				}
+			}
+			stop()
+			if processingEmoji == "OnIt" {
+				req = awaitReceiptRequest(t, requests)
+				if req.method != http.MethodDelete || !strings.HasSuffix(req.path, "/reaction-OnIt") {
+					t.Fatalf("cleanup = %+v", req)
+				}
+			}
+			mu.Lock()
+			if len(active) != 1 || active["Get"] == "" {
+				t.Errorf("receipt removed or processing reaction leaked: %v", active)
+			}
+			mu.Unlock()
+			select {
+			case req := <-requests:
+				t.Errorf("unexpected duplicate reaction: %+v", req)
+			default:
+			}
+		})
+	}
+}
+
+func TestReceiptAcknowledgement_DisabledAndSyntheticMessages(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		opts      map[string]any
+		synthetic bool
+	}{
+		{"omitted", map[string]any{}, false}, {"empty", map[string]any{"ack_emoji": ""}, false},
+		{"none", map[string]any{"ack_emoji": "none"}, false}, {"case and space", map[string]any{"ack_emoji": " NONE "}, false},
+		{"synthetic", map[string]any{"ack_emoji": "Get"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := receiptTestPlatform(t, tc.opts, func(w http.ResponseWriter, r *http.Request) { t.Errorf("unexpected API call: %s", r.URL.Path) })
+			p.handler = func(_ core.Platform, m *core.Message) {}
+			msg := receiptMessage()
+			if tc.synthetic {
+				msg.MessageID = ""
+			}
+			p.dispatchCoreMessage(msg)
+			if msg.OnAccepted != nil {
+				t.Fatal("receipt callback attached to disabled/synthetic message")
+			}
+		})
+	}
+}
+
+func TestReceiptAcknowledgement_SlowOrFailedAPIIsBestEffort(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		t.Run(fmt.Sprint(fail), func(t *testing.T) {
+			started := make(chan struct{})
+			release := make(chan struct{})
+			var releaseOnce sync.Once
+			unblock := func() { releaseOnce.Do(func() { close(release) }) }
+			defer unblock()
+			p := receiptTestPlatform(t, map[string]any{"ack_emoji": "Get"}, func(w http.ResponseWriter, r *http.Request) {
+				close(started)
+				<-release
+				if fail {
+					fmt.Fprint(w, `{"code":99991672,"msg":"permission denied"}`)
+				} else {
+					fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"receipt"}}`)
+				}
+			})
+			var accepted atomic.Int32
+			p.handler = func(_ core.Platform, m *core.Message) { m.OnAccepted(); accepted.Add(1) }
+			done := make(chan struct{})
+			go func() { p.dispatchCoreMessage(receiptMessage()); close(done) }()
+			select {
+			case <-started:
+			case <-time.After(2 * time.Second):
+				t.Fatal("receipt request not started")
+			}
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("receipt HTTP request blocked engine admission")
+			}
+			if accepted.Load() != 1 {
+				t.Fatal("normal message processing did not continue")
+			}
+			unblock()
+		})
+	}
+}
+
+func TestReceiptAcknowledgement_OnlyAdmittedInboundEvents(t *testing.T) {
+	requests := make(chan receiptRequest, 10)
+	p := receiptTestPlatform(t, map[string]any{"ack_emoji": "Get"}, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/reactions") {
+			requests <- receiptRequest{method: r.Method, path: r.URL.Path}
+			fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"receipt"}}`)
+		} else if strings.HasSuffix(r.URL.Path, "/reply") {
+			fmt.Fprint(w, `{"code":0,"data":{"message_id":"denied-reply"}}`)
+		} else {
+			t.Errorf("unexpected request: %s", r.URL.Path)
+		}
+	})
+	p.botOpenID = "ou_bot"
+	p.allowChat = "oc_main"
+	p.allowFrom = "ou_alice"
+	p.userNameCache.Store("ou_alice", "Alice")
+	p.chatNameCache.Store("oc_main", "Main group")
+	var delivered atomic.Int32
+	p.handler = func(_ core.Platform, m *core.Message) { delivered.Add(1); m.OnAccepted() }
+	send := func(id, user, chat string, mentioned bool) {
+		t.Helper()
+		event := makeGroupHistoryEvent(t, id, user, "text", `{"text":"hello"}`, chat, "", mentioned)
+		if err := p.onMessage(context.Background(), event); err != nil {
+			t.Fatal(err)
+		}
+	}
+	send("valid", "ou_alice", "oc_main", true)
+	if req := awaitReceiptRequest(t, requests); req.path != "/open-apis/im/v1/messages/valid/reactions" {
+		t.Fatalf("acknowledged wrong message: %+v", req)
+	}
+	send("valid", "ou_alice", "oc_main", true) // duplicate delivery
+	send("no-mention", "ou_alice", "oc_main", false)
+	send("forbidden-chat", "ou_alice", "oc_other", true)
+	send("forbidden-user", "ou_other", "oc_main", true)
+	p.markMessageRecalled("recalled")
+	send("recalled", "ou_alice", "oc_main", true)
+	// All these rejection gates run synchronously in onMessage, before dispatch.
+	if delivered.Load() != 1 {
+		t.Fatalf("delivered %d events, want only the accepted event", delivered.Load())
+	}
+	select {
+	case req := <-requests:
+		t.Fatalf("rejected message acknowledged: %+v", req)
+	default:
+	}
+}
+
+func TestReceiptAcknowledgement_ImageBatchUsesAcceptedCanonicalMessage(t *testing.T) {
+	requests := make(chan receiptRequest, 10)
+	p := receiptTestPlatform(t, map[string]any{"ack_emoji": "Get", "reaction_emoji": "Get"}, func(w http.ResponseWriter, r *http.Request) {
+		requests <- receiptRequest{method: r.Method, path: r.URL.Path}
+		fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"reaction-Get"}}`)
+	})
+	var msg *core.Message
+	p.handler = func(_ core.Platform, m *core.Message) { msg = m; m.OnAccepted() }
+	// The batching layer keeps the first reply context but admits the last ID.
+	// Recalling the first member must not hide receipt of the accepted batch.
+	p.markMessageRecalled("om_first")
+	p.dispatchImageBatchEntry(&imageBatchEntry{
+		sessionKey: "feishu:oc_main:ou_alice", userID: "ou_alice", messageIDs: []string{"om_first", "om_last"},
+		images: []core.ImageAttachment{{Data: []byte("first")}, {Data: []byte("last")}},
+		rctx:   replyContext{messageID: "om_first", chatID: "oc_main"},
+	})
+	if req := awaitReceiptRequest(t, requests); req.path != "/open-apis/im/v1/messages/om_last/reactions" {
+		t.Fatalf("receipt target=%+v", req)
+	}
+	stop := p.StartTyping(context.Background(), msg.ReplyCtx)
+	if req := awaitReceiptRequest(t, requests); req.path != "/open-apis/im/v1/messages/om_first/reactions" {
+		t.Fatalf("typing target=%+v", req)
+	}
+	stop()
+	if req := awaitReceiptRequest(t, requests); req.method != http.MethodDelete || req.path != "/open-apis/im/v1/messages/om_first/reactions/reaction-Get" {
+		t.Fatalf("cleanup must not delete canonical receipt: %+v", req)
+	}
+}
+
+func TestReceiptAcknowledgement_TypingStopsBeforeReceiptCompletes(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(release) }) }
+	defer unblock()
+	var requests atomic.Int32
+	p := receiptTestPlatform(t, map[string]any{"ack_emoji": "Get", "reaction_emoji": "Get"}, func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Method != http.MethodPost {
+			t.Errorf("receipt deleted: %s", r.Method)
+			return
+		}
+		close(started)
+		<-release
+		fmt.Fprint(w, `{"code":0,"data":{"reaction_id":"receipt"}}`)
+	})
+	p.handler = func(_ core.Platform, m *core.Message) { m.OnAccepted() }
+	msg := receiptMessage()
+	p.dispatchCoreMessage(msg)
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("receipt not started")
+	}
+	// Both operations must complete even though the identical-emoji receipt
+	// request is still in flight. There must be no second create/delete request.
+	stopped := make(chan struct{})
+	go func() { stop := p.StartTyping(context.Background(), msg.ReplyCtx); stop(); close(stopped) }()
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("typing waited for pending receipt")
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("%d reaction requests, want just the receipt", requests.Load())
+	}
+	unblock()
+}
+
+type receiptDeadlineTransport struct{ observed chan time.Duration }
+
+func (rt *receiptDeadlineTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if strings.Contains(r.URL.Path, "/auth/") {
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(`{"code":0,"expire":7200,"tenant_access_token":"test-token"}`))}, nil
+	}
+	deadline, ok := r.Context().Deadline()
+	if !ok {
+		rt.observed <- 0
+	} else {
+		rt.observed <- time.Until(deadline)
+	}
+	return nil, errors.New("simulated receipt network failure")
+}
+
+func TestReceiptAcknowledgement_HTTPRequestHasBoundedDeadline(t *testing.T) {
+	p := receiptTestPlatform(t, map[string]any{"ack_emoji": "Get"}, func(w http.ResponseWriter, r *http.Request) { t.Error("unexpected real HTTP request") })
+	observed := make(chan time.Duration, 1)
+	p.client = lark.NewClient("deadline-test", "test-secret", lark.WithHttpClient(&http.Client{Transport: &receiptDeadlineTransport{observed: observed}}))
+	p.handler = func(_ core.Platform, m *core.Message) { m.OnAccepted() }
+	p.dispatchCoreMessage(receiptMessage())
+	select {
+	case remaining := <-observed:
+		if remaining <= 0 || remaining > 5*time.Second {
+			t.Fatalf("receipt request deadline remaining=%v, want (0,5s]", remaining)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("receipt request did not reach transport")
+	}
+}


### PR DESCRIPTION
## Summary

Feishu/Lark users currently wait for agent-session startup or their queued turn before seeing the processing reaction. Add optional `ack_emoji` to send a persistent receipt asynchronously as soon as the engine accepts their message for processing or queueing, so a slow response does not look like a lost request.

This uses the existing `Message.OnAccepted` callback, preserving group-history consumption, without changing core production code or the existing processing/completion lifecycle. Closes #1807.

## Type of change

- [x] New feature (non-breaking, opt-in)

## Manual / user-visible behavior change

```toml
[projects.platforms.options]
ack_emoji = "Get"        # accepted/queued; persistent receipt
reaction_emoji = "OnIt" # existing processing indicator
# done_emoji = "Done"   # existing optional completion notification
```

- Omitted, empty or `"none"` leaves existing behavior unchanged.
- Accepted messages receive their own receipt before agent startup or while waiting behind an active turn. Ignored, unauthorized, duplicate/stale messages, full-queue rejections and handled local commands do not produce receipts. Synthetic scheduled work is not given a receipt.
- The receipt confirms acceptance, not successful execution. It remains after completion, failure or cancellation. Reaction API calls run outside the admission/queue lock with a five-second timeout, and failures do not interrupt agent work.
- When receipt and processing emojis match on the same message, the persistent receipt owns the reaction; typing cleanup does not remove it, including when the receipt HTTP call is still pending.
- An image batch acknowledges its newest canonical message, while preserving its existing reply/typing context.

### Timing boundaries

Receipt starts at **engine acceptance**, after existing parsing/media preparation and image batching. The engine currently holds its shared interactive-state lock during `StartSession`: the first message is acknowledged before that startup, but subsequent messages waiting on that existing lock still wait for admission. Once a session is running, a follow-up accepted into its queue is acknowledged before its turn starts. This PR does not refactor that lock or claim socket-arrival acknowledgement.

## Testing

### Automated tests

- `platform/feishu/receipt_ack_test.go`: HTTP-backed adapter tests for acceptance-only dispatch, preservation of the existing callback, one-shot receipt creation, default/disabled/synthetic behavior, authorization/mention/dedup/recall gates, slow/failed APIs, HTTP context deadline, different/same/disabled processing emojis, pending-receipt cleanup ordering, and canonical image-batch IDs.
- `core/engine_receipt_ack_test.go`: existing engine acceptance contract through `ReceiveMessage`; rejected queue/stale/command/empty inputs, startup failures and turn failures.
- `TestCUJ_A8_ImmediateReceiptsDuringStartupAndQueue` in `core/cuj_test.go`: three user actions with visible receipts before answers, a queued follow-up, and no repeated receipt on queue drain/completion.

### Before/after regression proof

Copied the unchanged adapter test to isolated pre-feature main (`4000b2338aa6e850c99df54f8b0ed6ed7460b401`). `TestReceiptAcknowledgement_AcceptedMessagePersistsThroughTypingCleanup/OnIt` compiles and fails because the receipt request never arrives; it passes with this implementation. The core contract tests intentionally also apply to existing core behavior.

### Validation

On macOS arm64 with Go 1.27.1:

```sh
go test -p 1 ./...
go test ./core -run TestCUJ -count=1
go test -race -p 1 ./core ./platform/feishu -run 'TestCUJ_A8|TestReceiveMessage_Receipt|TestReceiptAcknowledgement' -count=1
go build ./...
go vet ./...
```

The first full-suite invocation found missing generated `web/dist` assets in the fresh worktree. Reused the previously built assets from an identical `web` source tree, then reran validation. No web source or generated assets are part of this PR. An additional all-CUJ race run hit `TestCUJ_A5_FileReachesAgent` temporary-directory cleanup failures, including with serial packages. The same failure reproduces on unchanged pre-feature main with `go test -race ./core -run TestCUJ_A5_FileReachesAgent -count=3`. The full normal suite, explicit all-CUJ normal run, and new-feature race suite are the validation gates above; the unrelated legacy test is unchanged. Live Feishu delivery has not been exercised as part of this PR; the reaction API boundary is tested with HTTP fixtures.

## Checklist

- [x] Build, full suite, targeted race/CUJ suite, vet, gofmt and diff checks pass
- [x] Regression test fails before the feature and passes afterwards
- [x] No new hardcoded platform/agent names in core; no core production changes
- [x] Configuration example and Chinese/English behavior documentation updated
- [x] No new user-facing text strings requiring i18n
- [x] No secrets or credentials in source
