### PR TITLE
fix(core): keep original user post time in conversation history

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -535,6 +535,16 @@ type queuedMessage struct {
 	userMessageTimeMs int64  // Feishu create_time ms (optional); see Message.UserMessageTimeMs
 }
 
+// userMessageTimestamp converts a platform message creation time (Unix ms)
+// into a history timestamp. Zero/negative values fall back to the zero time
+// so the caller can stamp time.Now() instead.
+func userMessageTimestamp(timeMs int64) time.Time {
+	if timeMs <= 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(timeMs)
+}
+
 // interactiveState tracks a running interactive agent session and its permission state.
 type interactiveState struct {
 	agentSession             AgentSession
@@ -3746,7 +3756,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	turnStart := time.Now()
 
 	e.i18n.DetectAndSet(msg.Content)
-	session.AddHistory("user", msg.Content)
+	session.AddHistoryAt("user", msg.Content, userMessageTimestamp(msg.UserMessageTimeMs))
 	// Persist user message immediately so crashes between user input and
 	// assistant reply don't lose it (the assistant-side Save below depends
 	// on the turn completing without a process crash).
@@ -6215,9 +6225,9 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					e.send(queued.platform, queued.replyCtx, replyContent)
 				}
 
-				session.AddHistory("user", queued.content)
+				session.AddHistoryAt("user", queued.content, userMessageTimestamp(queued.userMessageTimeMs))
 				// Persist queued user message immediately (mirror of the
-				// initial AddHistory("user",...) save above).
+				// initial AddHistoryAt("user",...) save above).
 				sessions.Save()
 
 				if idleTimer != nil {
@@ -6473,7 +6483,7 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 
 		drainEvents(as.Events())
 
-		session.AddHistory("user", queued.content)
+		session.AddHistoryAt("user", queued.content, userMessageTimestamp(queued.userMessageTimeMs))
 
 		sendDone := make(chan error, 1)
 		go func() {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -9108,6 +9108,95 @@ func TestProcessInteractiveEvents_DrainsQueuedMessagesFIFOWithCreateTimes(t *tes
 	}
 }
 
+// TestProcessInteractiveEvents_DrainPreservesQueuedUserMessageTime verifies
+// that a user message queued behind an in-flight turn is stamped in history
+// with its original platform post time (queued.userMessageTimeMs), not the
+// time the queue was drained (which used to be the previous turn's response
+// time).
+func TestProcessInteractiveEvents_DrainPreservesQueuedUserMessageTime(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("qs-drain-time")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:user1"
+	session := e.sessions.GetOrCreateActive(key)
+	state := &interactiveState{
+		agentSession:                 sess,
+		platform:                     p,
+		replyCtx:                     "ctx-turn1",
+		currentTurnUserMessageTimeMs: 1_000,
+		pendingMessages: []queuedMessage{
+			{platform: p, replyCtx: "ctx-msg1", content: "msg1", userMessageTimeMs: 2_000},
+			{platform: p, replyCtx: "ctx-msg2", content: "msg2", userMessageTimeMs: 3_000},
+		},
+	}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	waitSendCount := func(n int) bool {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			sess.sendMu.Lock()
+			got := len(sess.sendCalls)
+			sess.sendMu.Unlock()
+			if got >= n {
+				return true
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		return false
+	}
+
+	go func() {
+		sess.events <- Event{Type: EventResult, Content: "response0", Done: true}
+		if waitSendCount(1) {
+			sess.events <- Event{Type: EventResult, Content: "response1", Done: true}
+		}
+		if waitSendCount(2) {
+			sess.events <- Event{Type: EventResult, Content: "response2", Done: true}
+		}
+	}()
+
+	session.AddHistory("user", "initial-msg")
+	sendDone := make(chan error, 1)
+	sendDone <- nil
+
+	done := make(chan struct{})
+	go func() {
+		e.processInteractiveEvents(state, session, e.sessions, key, "msg0", time.Now(), nil, sendDone, "ctx-turn1")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processInteractiveEvents did not complete in time")
+	}
+
+	// The drained queued user entries must keep their original post times.
+	want := map[string]time.Time{
+		"msg1": time.UnixMilli(2_000),
+		"msg2": time.UnixMilli(3_000),
+	}
+	got := map[string]time.Time{}
+	for _, h := range session.GetHistory(0) {
+		if h.Role == "user" {
+			got[h.Content] = h.Timestamp
+		}
+	}
+	for content, wantTS := range want {
+		gotTS, ok := got[content]
+		if !ok {
+			t.Fatalf("user history entry for %q not found", content)
+		}
+		if !gotTS.Equal(wantTS) {
+			t.Fatalf("queued user entry %q timestamp = %v, want original post time %v", content, gotTS, wantTS)
+		}
+	}
+}
+
 // replyCtxRecordingPlatform records (replyCtx, content) for each Send/Reply
 // so tests can assert which trigger context was used for which message.
 type replyCtxRecordingPlatform struct {

--- a/core/session.go
+++ b/core/session.go
@@ -96,13 +96,31 @@ func (s *Session) unlock(update bool) {
 }
 
 func (s *Session) AddHistory(role, content string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.History = append(s.History, HistoryEntry{
+	s.AddHistoryAt(role, content, time.Time{})
+}
+
+// AddHistoryAt appends an entry to the conversation history with an explicit
+// timestamp. A zero ts falls back to time.Now().
+func (s *Session) AddHistoryAt(role, content string, ts time.Time) {
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	s.AddHistoryEntry(HistoryEntry{
 		Role:      role,
 		Content:   content,
-		Timestamp: time.Now(),
+		Timestamp: ts,
 	})
+}
+
+// AddHistoryEntry appends a pre-built entry to the conversation history.
+// A zero Timestamp falls back to time.Now().
+func (s *Session) AddHistoryEntry(entry HistoryEntry) {
+	if entry.Timestamp.IsZero() {
+		entry.Timestamp = time.Now()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.History = append(s.History, entry)
 }
 
 // recordPastAgentSessionID saves the current AgentSessionID to PastAgentSessionIDs


### PR DESCRIPTION
User history entries were stamped with time.Now() at processing time, so a message queued behind a long turn got the previous turn's response time as its timestamp. Stamp user entries with the platform message creation time (Message.UserMessageTimeMs) instead:

- core/session.go: add AddHistoryAt/AddHistoryEntry helpers (zero time falls back to time.Now()); AddHistory now delegates to them.
- core/engine.go: add userMessageTimestamp() helper and use the original post time at the direct path and both queue-drain sites.

<!--
Thanks for contributing! Please fill in the sections below.
The reviewer will use the checklist at the bottom to gate merge.
-->

## Summary

<!-- 1-3 sentences explaining WHAT this PR does and WHY. -->

## Type of change

<!-- Mark all that apply: -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Internal refactor / chore (no user-visible change)

## Testing

<!-- Explain how you verified the change. Be specific. -->

### Automated tests added in this PR

<!-- List the test functions you added or modified. -->

- `TestX_Y_Z` in `path/to/file_test.go` — what it asserts

### For bug fixes only — regression test

<!-- A bug fix PR MUST include a regression test that:
     (1) fails on the pre-fix code, and
     (2) passes on the fixed code.
     Name it so the bug is searchable later. -->

- Regression test name: `Test...`
- Manual verification this test catches the regression:
  - [ ] Reverted the fix locally; the regression test failed as expected.

### Critical User Journeys (CUJ) impact

<!-- See AGENTS.md → "Critical User Journeys (CUJ)" and the inventory in
     projects/cc-connect/agents/qa-cursor/release-gate/CUJ-INVENTORY.md.
     Mark which CUJ groups this PR touches: -->

- [ ] No CUJ touched (small refactor, doc change, etc.)
- [ ] A — basic conversation
- [ ] B — session lifecycle (`/new` `/switch` `/list` `/history` etc.)
- [ ] C — agent execution control (`/mode` `/cancel` `/stop` permissions)
- [ ] D — security & permissions (`allow_from` `admin_from` `banned_words` rate limits)
- [ ] E — scheduled tasks (`/cron` `/timer`)
- [ ] F — config switching (`/lang` `/provider` `/model` reload)
- [ ] G — error handling & robustness (LLM failure, ws reconnect, agent crash)
- [ ] H — multi-platform / multi-project isolation
- [ ] I — UI rendering correctness (cards, streaming, display modes)

If any CUJ group is touched, confirm:

- [ ] `go test ./core/ -run TestCUJ` passes locally.
- [ ] If the change alters an existing user-visible flow, the corresponding
      CUJ test was updated (or a new CUJ added) to cover the new behavior.

## Manual / user-visible behavior change

<!-- Describe what a user will see or do differently after this PR.
     If none, write "None". -->

## Checklist (reviewer will verify)

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (with `-race` if touching concurrency)
- [ ] AGENTS.md Pre-Commit Checklist items are satisfied
- [ ] No new hardcoded platform/agent names in `core/`
- [ ] i18n strings have all-language translations (if any new user-facing text)
- [ ] No secrets / credentials in source

## Related

<!-- Link to issue, RFC, design doc, prior PR, etc. -->

- Issue:
- Related PR:
