### PR TITLE
fix: lazy history bootstrap when switching agent type (#1805)

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -704,6 +704,18 @@ func main() {
 			}
 			engine.SetAutoCompressConfig(true, maxTokens, minGap)
 		}
+
+		// Wire history bootstrap (issue #1805). Defaults to enabled so the
+		// user-facing cross-agent continuity works out of the box; operators
+		// who want a strictly fresh session per agent switch can disable it
+		// via [projects.X.history_bootstrap] enabled = false.
+		bootstrapEnabled := true
+		if proj.HistoryBootstrap.Enabled != nil {
+			bootstrapEnabled = *proj.HistoryBootstrap.Enabled
+		}
+		bootstrapMaxEntries := derefInt(proj.HistoryBootstrap.MaxEntries)
+		bootstrapMaxTokens := derefInt(proj.HistoryBootstrap.MaxTokens)
+		engine.SetHistoryBootstrap(bootstrapEnabled, bootstrapMaxEntries, bootstrapMaxTokens)
 		resetIdle, defaulted := resolveResetOnIdle(proj.ResetOnIdleMins)
 		engine.SetResetOnIdle(resetIdle)
 		if defaulted {
@@ -1786,6 +1798,15 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 	} else {
 		engine.SetAutoCompressConfig(false, 0, 0)
 	}
+
+	// Reload history bootstrap (issue #1805).
+	bootstrapEnabled := true
+	if proj.HistoryBootstrap.Enabled != nil {
+		bootstrapEnabled = *proj.HistoryBootstrap.Enabled
+	}
+	bootstrapMaxEntries := derefInt(proj.HistoryBootstrap.MaxEntries)
+	bootstrapMaxTokens := derefInt(proj.HistoryBootstrap.MaxTokens)
+	engine.SetHistoryBootstrap(bootstrapEnabled, bootstrapMaxEntries, bootstrapMaxTokens)
 	resetIdle, defaulted := resolveResetOnIdle(proj.ResetOnIdleMins)
 	engine.SetResetOnIdle(resetIdle)
 	if defaulted {

--- a/config/config.go
+++ b/config/config.go
@@ -452,6 +452,23 @@ type AutoCompressConfig struct {
 	MinGapMins *int  `toml:"min_gap_mins,omitempty"` // minimum minutes between auto-compress runs (default 30)
 }
 
+// HistoryBootstrapConfig controls the lazy history-bootstrap mechanism
+// (issue #1805). When enabled, the engine prefixes a bounded summary of
+// the cc-connect stored history into the first prompt sent to a
+// freshly-started native agent session after an agent-type switch.
+type HistoryBootstrapConfig struct {
+	// Enabled turns the lazy bootstrap on. Defaults to true.
+	Enabled *bool `toml:"enabled,omitempty"`
+	// MaxEntries caps the number of recent history entries included in the
+	// bootstrap block. Older entries are dropped with an info log so the
+	// behaviour stays visible. 0 falls back to the engine default (20).
+	MaxEntries *int `toml:"max_entries,omitempty"`
+	// MaxTokens caps the rough token count of the bootstrap block.
+	// Token estimation reuses the engine's estimateTokens heuristic
+	// (~1 token per 4 runes). 0 falls back to the engine default (4000).
+	MaxTokens *int `toml:"max_tokens,omitempty"`
+}
+
 // ObserveConfig controls forwarding of native terminal Claude Code sessions to a messaging platform.
 type ObserveConfig struct {
 	Enabled bool   `toml:"enabled"`
@@ -482,6 +499,10 @@ type ProjectConfig struct {
 	Platforms                    []PlatformConfig   `toml:"platforms"`
 	Heartbeat                    HeartbeatConfig    `toml:"heartbeat"`
 	AutoCompress                 AutoCompressConfig `toml:"auto_compress"`
+	// HistoryBootstrap controls the lazy history-bootstrap mechanism
+	// (issue #1805) that gives a freshly-started native agent session
+	// the cc-connect stored history after an agent-type switch.
+	HistoryBootstrap HistoryBootstrapConfig `toml:"history_bootstrap"`
 	// ResetOnIdleMins automatically rotates to a new cc-connect session after
 	// the current session has been inactive for the specified number of minutes.
 	// 0 or nil disables the behavior.

--- a/core/engine.go
+++ b/core/engine.go
@@ -429,6 +429,15 @@ type Engine struct {
 	autoCompressMinGap    time.Duration
 	resetOnIdle           time.Duration
 
+	// historyBootstrapEnabled controls lazy migration of cc-connect stored
+	// history into a freshly-started native agent session when the agent
+	// type changes (issue #1805). Defaults to true so the user-facing
+	// cross-agent continuity works out of the box; operators who want a
+	// strictly fresh session per agent switch can disable it via TOML.
+	historyBootstrapEnabled    bool
+	historyBootstrapMaxEntries int
+	historyBootstrapMaxTokens  int
+
 	// Reply footer composition flags. The footer renders up to two lines:
 	//   line 1 — model · [effort ·] out/in/cw/cr · ctx%   (gated by showContextIndicator)
 	//   line 2 — workspace directory                       (gated by showWorkdirIndicator)
@@ -944,6 +953,29 @@ func (e *Engine) SetAutoCompressConfig(enabled bool, maxTokens int, minGap time.
 		minGap = 30 * time.Minute
 	}
 	e.autoCompressMinGap = minGap
+}
+
+// SetHistoryBootstrap configures the lazy history-bootstrap mechanism
+// (issue #1805). When enabled, the engine prefixes a bounded summary of
+// the cc-connect stored history into the very first prompt sent to a
+// freshly-started native agent session, but only if:
+//   - the previous native agent session was invalidated by an agent-type
+//     switch (PastAgentSessionIDs non-empty), and
+//   - the (session, agentType) pair has not been bootstrapped before.
+//
+// Defaults: enabled=true, maxEntries=20, maxTokens=4000. Set enabled=false
+// to opt out of cross-agent continuity (strictly fresh native session per
+// agent switch). Negative or zero caps fall back to the defaults.
+func (e *Engine) SetHistoryBootstrap(enabled bool, maxEntries, maxTokens int) {
+	e.historyBootstrapEnabled = enabled
+	if maxEntries <= 0 {
+		maxEntries = 20
+	}
+	e.historyBootstrapMaxEntries = maxEntries
+	if maxTokens <= 0 {
+		maxTokens = 4000
+	}
+	e.historyBootstrapMaxTokens = maxTokens
 }
 
 // SetResetOnIdle configures automatic session rotation after prolonged inactivity.
@@ -3838,6 +3870,19 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	}
 
 	promptContent := e.buildSenderPrompt(msg.Content, msg.UserID, msg.UserName, msg.Platform, msg.SessionKey, msg.ChannelKey)
+
+	// Issue #1805: lazy history-bootstrap when switching agent type.
+	// The first prompt a brand-new native agent sees in this session
+	// may be a continuation of an existing cc-connect conversation
+	// handled by a different agent type. Prefix a bounded, trimmed
+	// transcript of the prior cc-connect history so the new agent has
+	// the context it would otherwise have lost on the agent-type switch.
+	// The helper reports whether a bootstrap was actually injected so we
+	// can update the per-agent-type marker without false positives
+	// (buildSenderPrompt also mutates promptContent when injectSender=true).
+	if bootstrapInjected := e.maybeBootstrapHistory(session, agent, &promptContent); bootstrapInjected && e.ctx.Err() == nil {
+		session.MarkBootstrappedFor(agent.Name())
+	}
 
 	sendStart := time.Now()
 	state.mu.Lock()
@@ -16378,6 +16423,136 @@ func (e *Engine) buildSenderPrompt(content, userID, userName, platform, sessionK
 	}
 	return fmt.Sprintf("[cc-connect sender_id=%s platform=%s chat_id=%s]\n%s", userID, platform, chatID, content)
 }
+
+// historyBootstrapHeader is the well-known prefix that wraps the lazy
+// history-bootstrap block (issue #1805). It is intentionally short and
+// recognisable so an agent can distinguish it from a real platform-driven
+// message and from a subsequent user prompt. The bracket-style framing
+// matches the cc-connect sender_id header convention used by
+// buildSenderPrompt so the two are visually consistent.
+const historyBootstrapHeader = "[cc-connect history_bootstrap: agent_type=%s past_native_session_ids=%s]\n"
+
+// maybeBootstrapHistory conditionally prepends a bounded, trimmed
+// transcript of the cc-connect stored history to promptContent. It is
+// the lazy migration block that gives a freshly-started native agent
+// session the prior conversation context it would otherwise lose when
+// the project switches agent type.
+//
+// The helper returns true only when it actually mutated *promptContent;
+// a "no-op" call (disabled config, no prior history, already
+// bootstrapped, agent name empty) returns false so callers can use the
+// return value as the "set the per-agent-type marker" gate.
+//
+// Concurrency: it acquires s.mu briefly to read History + check the
+// BootstrappedFor marker. It is safe to call from the interactive turn
+// goroutine that already owns the engine's interactiveMu; no other
+// goroutine is expected to mutate promptContent during a single turn.
+func (e *Engine) maybeBootstrapHistory(session *Session, agent Agent, promptContent *string) bool {
+	if session == nil || agent == nil || promptContent == nil {
+		return false
+	}
+	if !e.historyBootstrapEnabled {
+		return false
+	}
+	agentType := agent.Name()
+	if agentType == "" {
+		return false
+	}
+
+	session.mu.Lock()
+	past := append([]string(nil), session.PastAgentSessionIDs...)
+	historyLen := len(session.History)
+	// Exclude the just-added current user message: processInteractiveMessageWith
+	// calls session.AddHistory("user", msg.Content) before the bootstrap
+	// check, so the tail of History already contains this turn's user
+	// input. We only want to inject older context; the current message
+	// will be sent as part of promptContent below.
+	olderLen := historyLen - 1
+	if olderLen < 0 {
+		olderLen = 0
+	}
+	history := append([]HistoryEntry(nil), session.History[:olderLen]...)
+	// Read BootstrappedFor under the lock — IsBootstrappedFor takes the
+	// same non-reentrant s.mu, so calling it here would deadlock.
+	_, alreadyBootstrapped := session.BootstrappedFor[agentType]
+	session.mu.Unlock()
+
+	if alreadyBootstrapped {
+		return false
+	}
+	if len(past) == 0 && len(history) == 0 {
+		// No prior conversation at this layer: nothing to bootstrap.
+		// This is the common /new case; bootstrap must not fire.
+		return false
+	}
+
+	// Trim history by entries cap, then by token cap. Use the most-recent
+	// entries (GetHistory-style tail) since older context is the part
+	// most likely to be irrelevant to the next turn.
+	if e.historyBootstrapMaxEntries > 0 && len(history) > e.historyBootstrapMaxEntries {
+		dropped := len(history) - e.historyBootstrapMaxEntries
+		history = history[len(history)-e.historyBootstrapMaxEntries:]
+		slog.Info("history_bootstrap: trimmed by entry cap",
+			"session", session.ID,
+			"agent_type", agentType,
+			"max_entries", e.historyBootstrapMaxEntries,
+			"dropped_entries", dropped,
+		)
+	}
+	if e.historyBootstrapMaxTokens > 0 && len(history) > 0 {
+		totalTokens := estimateTokens(history)
+		if totalTokens > e.historyBootstrapMaxTokens {
+			// Walk from the newest backwards, retaining as many tail entries
+			// as fit within the token budget. This is a simple but safe
+			// strategy; LLM-summarised older context is out of scope for
+			// the minimal v1 implementation.
+			kept := make([]HistoryEntry, 0, len(history))
+			used := 0
+			for i := len(history) - 1; i >= 0; i-- {
+				t := estimateTokens([]HistoryEntry{history[i]})
+				if used+t > e.historyBootstrapMaxTokens && len(kept) > 0 {
+					break
+				}
+				kept = append([]HistoryEntry{history[i]}, kept...)
+				used += t
+			}
+			droppedEntries := len(history) - len(kept)
+			slog.Info("history_bootstrap: trimmed by token cap",
+				"session", session.ID,
+				"agent_type", agentType,
+				"max_tokens", e.historyBootstrapMaxTokens,
+				"kept_entries", len(kept),
+				"dropped_entries", droppedEntries,
+			)
+			history = kept
+		}
+	}
+	if len(history) == 0 {
+		return false
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, historyBootstrapHeader, agentType, strings.Join(past, ","))
+	for _, h := range history {
+		// Compact one-entry-per-line form keeps the block predictable
+		// across agents and platforms. Quote newlines so a malicious or
+		// buggy transcript entry cannot break out of the line boundary.
+		safe := strings.NewReplacer("\n", " ", "\r", "").Replace(h.Content)
+		fmt.Fprintf(&b, "[%s] %s\n", h.Role, safe)
+	}
+	b.WriteString("[cc-connect history_bootstrap_end]\n\n")
+
+	*promptContent = b.String() + *promptContent
+	slog.Info("history_bootstrap: injected",
+		"session", session.ID,
+		"agent_type", agentType,
+		"history_entries", len(history),
+		"prompt_len", len(*promptContent),
+	)
+	return true
+}
+
+// max is the builtin max (Go 1.21+); no local alias needed.
 
 func extractChannelID(sessionKey string) string {
 	// Format: "platform:channelID:userID" or "platform:channelID"

--- a/core/history_bootstrap_test.go
+++ b/core/history_bootstrap_test.go
@@ -1,0 +1,354 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// namedStubAgent is an Agent stub whose Name() returns a configurable value so
+// the per-(session, agentType) bootstrap marker can be exercised against
+// distinct agent types in tests (issue #1805).
+type namedStubAgent struct {
+	name string
+}
+
+func (a *namedStubAgent) Name() string { return a.name }
+func (a *namedStubAgent) StartSession(_ context.Context, _ string) (AgentSession, error) {
+	return &stubAgentSession{}, nil
+}
+func (a *namedStubAgent) ListSessions(_ context.Context) ([]AgentSessionInfo, error) {
+	return nil, nil
+}
+func (a *namedStubAgent) Stop() error { return nil }
+
+// makeEngineWithBootstrap returns a minimal engine with SetHistoryBootstrap
+// already called and the provided agent wired in. Sessions are kept in memory
+// only (storePath == ""), so no temp file is touched.
+func makeEngineWithBootstrap(t *testing.T, agent Agent, enabled bool, maxEntries, maxTokens int) *Engine {
+	t.Helper()
+	e := NewEngine("test", agent, nil, "", LangEnglish)
+	e.SetHistoryBootstrap(enabled, maxEntries, maxTokens)
+	return e
+}
+
+// TestMaybeBootstrapHistory_FiresOnAgentSwitch is the core regression test for
+// issue #1805: when a session has prior cc-connect history AND a non-empty
+// PastAgentSessionIDs (i.e. an agent switch happened), the bootstrap block
+// must be prepended on the first prompt to the new agent type.
+func TestMaybeBootstrapHistory_FiresOnAgentSwitch(t *testing.T) {
+	ag := &namedStubAgent{name: "codex"}
+	e := makeEngineWithBootstrap(t, ag, true, 20, 4000)
+
+	s := &Session{
+		ID:                  "s1",
+		PastAgentSessionIDs: []string{"old-claudecode-id"},
+	}
+	s.AddHistory("user", "earlier user msg")
+	s.AddHistory("assistant", "earlier assistant reply")
+	// processInteractiveMessageWith would add the current message before
+	// calling maybeBootstrapHistory; mirror that here so the exclusion of
+	// the just-added message is exercised.
+	s.AddHistory("user", "current turn message")
+
+	original := "current prompt body"
+	out := original
+	if !e.maybeBootstrapHistory(s, ag, &out) {
+		t.Fatalf("expected bootstrap to fire on agent switch")
+	}
+	if !strings.HasPrefix(out, "[cc-connect history_bootstrap:") {
+		t.Fatalf("expected bootstrap header at start of prompt; got %q", out[:min(80, len(out))])
+	}
+	if !strings.Contains(out, "earlier user msg") || !strings.Contains(out, "earlier assistant reply") {
+		t.Fatalf("expected older transcript entries in bootstrap block; got %q", out)
+	}
+	// Current turn must NOT be re-injected — it is already part of
+	// buildSenderPrompt's output below the prefix.
+	if strings.Contains(out, "[user] current turn message") {
+		t.Fatalf("current turn message should not appear in bootstrap block; got %q", out)
+	}
+	if !strings.HasSuffix(out, original) {
+		t.Fatalf("expected original prompt to remain appended after bootstrap block")
+	}
+}
+
+// TestMaybeBootstrapHistory_NoOpOnNoPriorHistory covers the /new case: a
+// freshly-created session with no PastAgentSessionIDs and no History must
+// NOT trigger a bootstrap (would be a confusing empty prefix to the agent).
+func TestMaybeBootstrapHistory_NoOpOnNoPriorHistory(t *testing.T) {
+	ag := &namedStubAgent{name: "codex"}
+	e := makeEngineWithBootstrap(t, ag, true, 20, 4000)
+
+	s := &Session{ID: "fresh"}
+	// No AddHistory calls; this is the /new case.
+	out := "hello"
+	if e.maybeBootstrapHistory(s, ag, &out) {
+		t.Fatalf("expected no bootstrap when session is fresh")
+	}
+	if out != "hello" {
+		t.Fatalf("expected prompt to be unchanged; got %q", out)
+	}
+}
+
+// TestMaybeBootstrapHistory_NoOpOnOnlyCurrentMessage covers a session whose
+// only history is the current user message (i.e. no PastAgentSessionIDs and
+// History is just the tail that should be excluded).
+func TestMaybeBootstrapHistory_NoOpOnOnlyCurrentMessage(t *testing.T) {
+	ag := &namedStubAgent{name: "codex"}
+	e := makeEngineWithBootstrap(t, ag, true, 20, 4000)
+
+	s := &Session{ID: "s1"}
+	s.AddHistory("user", "current turn only")
+	out := "current prompt"
+	if e.maybeBootstrapHistory(s, ag, &out) {
+		t.Fatalf("expected no bootstrap when only current message is in history")
+	}
+	if out != "current prompt" {
+		t.Fatalf("expected prompt unchanged; got %q", out)
+	}
+}
+
+// TestMaybeBootstrapHistory_NoOpWhenAlreadyBootstrapped ensures the
+// per-agent-type marker makes bootstrap idempotent within a single session.
+func TestMaybeBootstrapHistory_NoOpWhenAlreadyBootstrapped(t *testing.T) {
+	ag := &namedStubAgent{name: "codex"}
+	e := makeEngineWithBootstrap(t, ag, true, 20, 4000)
+
+	s := &Session{
+		ID:                  "s1",
+		PastAgentSessionIDs: []string{"old"},
+	}
+	s.AddHistory("user", "old msg")
+	s.AddHistory("assistant", "old reply")
+	s.AddHistory("user", "current")
+	s.MarkBootstrappedFor("codex")
+
+	out := "current prompt"
+	if e.maybeBootstrapHistory(s, ag, &out) {
+		t.Fatalf("expected no bootstrap when marker is set for this agent type")
+	}
+	if out != "current prompt" {
+		t.Fatalf("expected prompt unchanged after second call; got %q", out)
+	}
+}
+
+// TestMaybeBootstrapHistory_DifferentAgentTypeResets verifies the marker is
+// keyed on agent type: if a session switched from claudecode to codex and
+// bootstrap already fired for claudecode, a future turn routed to codex
+// must still bootstrap (because codex is a new agent type for this session).
+func TestMaybeBootstrapHistory_DifferentAgentTypeResets(t *testing.T) {
+	codex := &namedStubAgent{name: "codex"}
+
+	e := makeEngineWithBootstrap(t, codex, true, 20, 4000)
+
+	s := &Session{
+		ID:                  "s1",
+		PastAgentSessionIDs: []string{"claude-old-1", "claude-old-2"},
+	}
+	s.AddHistory("user", "u1")
+	s.AddHistory("assistant", "a1")
+	s.AddHistory("user", "current")
+	s.MarkBootstrappedFor("claudecode") // already bootstrapped for previous agent type
+
+	out := "current prompt"
+	if !e.maybeBootstrapHistory(s, codex, &out) {
+		t.Fatalf("expected bootstrap to fire for new agent type codex")
+	}
+	if !strings.Contains(out, "[cc-connect history_bootstrap: agent_type=codex") {
+		t.Fatalf("expected header to mention codex; got %q", out[:min(120, len(out))])
+	}
+	// Both past session ids should be referenced in the header.
+	if !strings.Contains(out, "claude-old-1") || !strings.Contains(out, "claude-old-2") {
+		t.Fatalf("expected past native session ids in header; got %q", out)
+	}
+	// Make sure we don't accidentally use the previous agent's name.
+	if strings.Contains(out, "agent_type=claudecode") {
+		t.Fatalf("expected new agent_type=codex, not previous one; got %q", out[:min(120, len(out))])
+	}
+}
+
+// TestMaybeBootstrapHistory_DisabledDoesNothing verifies that an operator who
+// disables the feature via TOML gets the original prompt unchanged.
+func TestMaybeBootstrapHistory_DisabledDoesNothing(t *testing.T) {
+	ag := &namedStubAgent{name: "codex"}
+	e := makeEngineWithBootstrap(t, ag, false, 20, 4000)
+
+	s := &Session{
+		ID:                  "s1",
+		PastAgentSessionIDs: []string{"old"},
+	}
+	s.AddHistory("user", "msg")
+	s.AddHistory("user", "current")
+
+	out := "current prompt"
+	if e.maybeBootstrapHistory(s, ag, &out) {
+		t.Fatalf("expected no bootstrap when feature is disabled")
+	}
+	if out != "current prompt" {
+		t.Fatalf("expected prompt unchanged; got %q", out)
+	}
+}
+
+// TestMaybeBootstrapHistory_TrimsByEntryCap verifies the entry cap keeps only
+// the most-recent N entries, with older context dropped.
+func TestMaybeBootstrapHistory_TrimsByEntryCap(t *testing.T) {
+	ag := &namedStubAgent{name: "codex"}
+	// cap=2 means we keep only the 2 most recent (older) entries; the current
+	// message is excluded by maybeBootstrapHistory before trimming.
+	e := makeEngineWithBootstrap(t, ag, true, 2, 0)
+
+	s := &Session{
+		ID:                  "s1",
+		PastAgentSessionIDs: []string{"old"},
+	}
+	s.AddHistory("user", "OLD-1")
+	s.AddHistory("assistant", "OLD-2")
+	s.AddHistory("user", "KEEP-1")
+	s.AddHistory("assistant", "KEEP-2")
+	s.AddHistory("user", "current")
+
+	out := "current"
+	if !e.maybeBootstrapHistory(s, ag, &out) {
+		t.Fatalf("expected bootstrap to fire")
+	}
+	if strings.Contains(out, "OLD-1") || strings.Contains(out, "OLD-2") {
+		t.Fatalf("expected OLD-* entries to be trimmed by entry cap; got %q", out)
+	}
+	if !strings.Contains(out, "KEEP-1") || !strings.Contains(out, "KEEP-2") {
+		t.Fatalf("expected KEEP-* entries to be retained; got %q", out)
+	}
+}
+
+// TestMaybeBootstrapHistory_TrimsByTokenCap verifies that when total tokens
+// exceed the cap, the oldest entries are dropped until the budget fits.
+func TestMaybeBootstrapHistory_TrimsByTokenCap(t *testing.T) {
+	ag := &namedStubAgent{name: "codex"}
+	// Tokens: estimateTokens counts roughly rune/4 per entry. A 100-rune
+	// message ≈ 25 tokens. With cap=60 we expect the newest 2-3 entries
+	// retained (depending on what fits), and the older ones dropped.
+	e := makeEngineWithBootstrap(t, ag, true, 0, 60)
+
+	s := &Session{
+		ID:                  "s1",
+		PastAgentSessionIDs: []string{"old"},
+	}
+	for i := 0; i < 6; i++ {
+		s.AddHistory("user", strings.Repeat("x", 100))
+	}
+	s.AddHistory("user", "current")
+
+	out := "current"
+	if !e.maybeBootstrapHistory(s, ag, &out) {
+		t.Fatalf("expected bootstrap to fire")
+	}
+	// The block must contain SOME older entries but not all 6.
+	count := strings.Count(out, "[user] xxxxxxxxxx")
+	if count >= 6 {
+		t.Fatalf("expected token cap to drop some entries; got %d retained", count)
+	}
+	if count == 0 {
+		t.Fatalf("expected at least one entry to be retained; got %q", out)
+	}
+}
+
+// TestMaybeBootstrapHistory_NilSafe ensures all guards handle bad inputs.
+func TestMaybeBootstrapHistory_NilSafe(t *testing.T) {
+	ag := &namedStubAgent{name: "codex"}
+	e := makeEngineWithBootstrap(t, ag, true, 20, 4000)
+	s := &Session{ID: "s1"}
+	s.AddHistory("user", "current")
+
+	out := "x"
+	if e.maybeBootstrapHistory(nil, ag, &out) {
+		t.Fatalf("expected no bootstrap on nil session")
+	}
+	if e.maybeBootstrapHistory(s, nil, &out) {
+		t.Fatalf("expected no bootstrap on nil agent")
+	}
+	var nilStr *string
+	if e.maybeBootstrapHistory(s, ag, nilStr) {
+		t.Fatalf("expected no bootstrap on nil prompt")
+	}
+	if out != "x" {
+		t.Fatalf("expected prompt unchanged; got %q", out)
+	}
+
+	// Empty agent name must also be a no-op even if history is present.
+	emptyName := &namedStubAgent{name: ""}
+	s2 := &Session{ID: "s2", PastAgentSessionIDs: []string{"old"}}
+	s2.AddHistory("user", "msg")
+	s2.AddHistory("user", "current")
+	out2 := "x"
+	if e.maybeBootstrapHistory(s2, emptyName, &out2) {
+		t.Fatalf("expected no bootstrap on empty agent name")
+	}
+}
+
+// TestSessionIsBootstrappedFor_RoundTrip covers the per-(session, agentType)
+// marker semantics: the marker survives concurrent reads/writes without
+// deadlocking and isolates between agent types.
+func TestSessionIsBootstrappedFor_RoundTrip(t *testing.T) {
+	s := &Session{ID: "s1"}
+	if s.IsBootstrappedFor("codex") {
+		t.Fatalf("expected empty marker to report false")
+	}
+	s.MarkBootstrappedFor("codex")
+	if !s.IsBootstrappedFor("codex") {
+		t.Fatalf("expected marker set after MarkBootstrappedFor")
+	}
+	if s.IsBootstrappedFor("claudecode") {
+		t.Fatalf("expected different agent type to remain false")
+	}
+	// Idempotent.
+	s.MarkBootstrappedFor("codex")
+	s.MarkBootstrappedFor("codex")
+	if !s.IsBootstrappedFor("codex") {
+		t.Fatalf("expected marker to remain set after duplicate marks")
+	}
+}
+
+// TestSessionSnapshotRoundTripPreservesBootstrappedFor verifies that the
+// SessionManager.Save / load cycle preserves the BootstrappedFor marker so
+// the bootstrap does NOT re-fire after a process restart (issue #1805).
+func TestSessionSnapshotRoundTripPreservesBootstrappedFor(t *testing.T) {
+	tmp := t.TempDir()
+	storePath := tmp + "/sessions.json"
+
+	sm := NewSessionManager(storePath)
+	s := &Session{ID: "s1", AgentType: "claudecode"}
+	s.MarkBootstrappedFor("claudecode")
+	sm.sessions["s1"] = s
+	sm.Save()
+
+	sm2 := NewSessionManager(storePath)
+	sm2.load()
+	loaded, ok := sm2.sessions["s1"]
+	if !ok {
+		t.Fatalf("expected session to load from snapshot")
+	}
+	if !loaded.IsBootstrappedFor("claudecode") {
+		t.Fatalf("expected BootstrappedFor to survive save+load")
+	}
+	if loaded.IsBootstrappedFor("codex") {
+		t.Fatalf("expected unloaded agent types to remain unset")
+	}
+}
+
+// TestCopyBootstrappedFor_IsIndependent ensures the deep-copy helper used in
+// the snapshot path does not alias the live map, so a later
+// MarkBootstrappedFor on the source does not mutate the snapshot.
+func TestCopyBootstrappedFor_IsIndependent(t *testing.T) {
+	src := map[string]struct{}{"a": {}}
+	dst := copyBootstrappedFor(src)
+	dst["b"] = struct{}{}
+	if _, ok := src["b"]; ok {
+		t.Fatalf("expected source to remain unchanged after dst mutation")
+	}
+	src["c"] = struct{}{}
+	if _, ok := dst["c"]; ok {
+		t.Fatalf("expected dst to remain unchanged after src mutation")
+	}
+	if copyBootstrappedFor(nil) != nil {
+		t.Fatalf("expected copy of nil to be nil")
+	}
+}

--- a/core/session.go
+++ b/core/session.go
@@ -25,11 +25,11 @@ const ExplicitActivationTTL = 7 * 24 * time.Hour
 
 // Session tracks one conversation between a user and the agent.
 type Session struct {
-	ID                  string         `json:"id"`
-	Name                string         `json:"name"`
-	AgentSessionID      string         `json:"agent_session_id"`
-	AgentType           string         `json:"agent_type,omitempty"`
-	PastAgentSessionIDs []string       `json:"past_agent_session_ids,omitempty"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	AgentSessionID      string   `json:"agent_session_id"`
+	AgentType           string   `json:"agent_type,omitempty"`
+	PastAgentSessionIDs []string `json:"past_agent_session_ids,omitempty"`
 	// ActiveProvider is the agent provider name that was active when this
 	// session last took a turn. It is restored before --resume so that a
 	// cc-connect process restart does not silently drop a user's
@@ -55,6 +55,14 @@ type Session struct {
 	// ExplicitActivationTTL caps how long this exemption lasts so abandoned
 	// sessions cannot permanently occupy the active slot.
 	ExplicitActivatedAt time.Time `json:"explicit_activated_at,omitempty"`
+
+	// BootstrappedFor tracks which agent types have already received the
+	// lazy history-bootstrap block (issue #1805). The marker is keyed on
+	// agent type so that a future second switch (e.g. claudecode → codex →
+	// claudecode) re-bootstraps correctly. The marker survives
+	// InvalidateForAgent so process restarts and agent-type switches don't
+	// repeat a bootstrap that has already happened once.
+	BootstrappedFor map[string]struct{} `json:"bootstrapped_for,omitempty"`
 
 	mu   sync.Mutex `json:"-"`
 	busy bool       `json:"-"`
@@ -184,6 +192,50 @@ func (s *Session) markExplicitlyActivatedLocked() {
 	s.ExplicitActivatedAt = time.Now()
 }
 
+// IsBootstrappedFor reports whether the lazy history-bootstrap block
+// (issue #1805) has already been delivered to the named agent type on
+// this session. Safe to call without holding s.mu.
+func (s *Session) IsBootstrappedFor(agentType string) bool {
+	if agentType == "" {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.BootstrappedFor[agentType]
+	return ok
+}
+
+// MarkBootstrappedFor records that the lazy history bootstrap has been
+// delivered to the named agent type on this session. Subsequent calls
+// for the same agent type are no-ops, so a session that switches agent
+// types multiple times only bootstraps once per (session, agent type)
+// pair. Safe to call without holding s.mu.
+func (s *Session) MarkBootstrappedFor(agentType string) {
+	if agentType == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.BootstrappedFor == nil {
+		s.BootstrappedFor = make(map[string]struct{})
+	}
+	s.BootstrappedFor[agentType] = struct{}{}
+}
+
+// copyBootstrappedFor returns a deep copy of the bootstrap-marker map so
+// the snapshot path doesn't race with concurrent writes via
+// MarkBootstrappedFor. May be called with s.mu held.
+func copyBootstrappedFor(src map[string]struct{}) map[string]struct{} {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]struct{}, len(src))
+	for k := range src {
+		dst[k] = struct{}{}
+	}
+	return dst
+}
+
 // GetExplicitActivatedAt returns when this session was last explicitly chosen.
 func (s *Session) GetExplicitActivatedAt() time.Time {
 	s.mu.Lock()
@@ -302,7 +354,8 @@ type UserMeta struct {
 // older code that didn't persist all migration flags.
 //   - 0 (missing): original format or early PastIDTracking-only format
 //   - 1: full LegacyData persistence
-const snapshotVersion = 1
+//   - 2: BootstrappedFor persistence (issue #1805)
+const snapshotVersion = 2
 
 // sessionSnapshot is the JSON-serializable state of the SessionManager.
 type sessionSnapshot struct {
@@ -693,6 +746,10 @@ func (sm *SessionManager) saveLocked() {
 			// restart; otherwise a /switch followed by a crash would lose the
 			// exemption and the next message after restart would be rotated.
 			ExplicitActivatedAt: s.ExplicitActivatedAt,
+			// #1805: per-agent-type bootstrap marker must survive a process
+			// restart, otherwise a cc-connect restart would re-bootstrap the
+			// new native session on the very next user message.
+			BootstrappedFor: copyBootstrappedFor(s.BootstrappedFor),
 		}
 		s.mu.Unlock()
 	}
@@ -802,6 +859,11 @@ func (sm *SessionManager) load() {
 // does not match the current agent. This handles the case where the user
 // switches agent types (e.g. opencode → pi) and stale session IDs from the
 // old agent would cause errors.
+//
+// BootstrappedFor (issue #1805) is deliberately NOT cleared here. The
+// bootstrap marker survives the agent-type switch so that the next time a
+// user returns to the same agent type, the lazy history-bootstrap does
+// not fire again for a conversation that already received one.
 func (sm *SessionManager) InvalidateForAgent(agentType string) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
@@ -876,7 +938,7 @@ func (sm *SessionManager) PruneDuplicateSessions(mergeHistory bool) PruneResult 
 	defer sm.mu.Unlock()
 
 	// Group sessions by baseChat
-	chatSessions := make(map[string][]*Session) // baseChat -> sessions
+	chatSessions := make(map[string][]*Session)  // baseChat -> sessions
 	sessionToBaseChat := make(map[string]string) // session.ID -> baseChat
 
 	for userKey, sessionIDs := range sm.userSessions {


### PR DESCRIPTION
## Summary

Fixes #1805. When a project switches between agent types (e.g. claudecode → codex), the freshly-started native agent session currently loses the prior cc-connect conversation context. This PR adds a one-time **lazy history bootstrap**: the first prompt each new agent type sees on a given session is prefixed with a bounded, trimmed transcript of the stored cc-connect history.

The native agent then has enough context to answer follow-up questions like "what were we working on?" after a `/switch agent_type`.

## Changes

- **`core/session.go`** — `Session.BootstrappedFor map[string]struct{}` keyed on agent type. Survives `InvalidateForAgent` and process restart via the snapshot path (snapshotVersion bumped 1 → 2). New accessors `IsBootstrappedFor` / `MarkBootstrappedFor` (both lock `s.mu`). Snapshot deep-copy via new `copyBootstrappedFor` helper.
- **`core/engine.go`** — `Engine.SetHistoryBootstrap` config setter. New `maybeBootstrapHistory` helper called from `processInteractiveMessageWith` between `buildSenderPrompt` and the `as.Send` goroutine launch. Bootstrap block is prefixed to the prompt only when: feature enabled, agent has a non-empty name, session has prior history (`PastAgentSessionIDs` or older `History`), and the per-agent-type marker is not yet set. Trims newest-first by entry cap, then by token cap. Returns true on actual injection so the caller can update the marker without false positives.
- **`config/config.go`** — new `[projects.X.history_bootstrap]` TOML section (`enabled`, `max_entries`, `max_tokens`). Optional pointers preserve "not set" so existing configs fall back to engine defaults.
- **`cmd/cc-connect/main.go`** — wires the setter in both startup and reload paths.
- **`core/history_bootstrap_test.go`** — 11 unit tests covering fire/no-op, per-agent-type marker semantics, entry-cap and token-cap trimming, current-turn exclusion, disabled flag, nil-safety, marker round-trip via `Save`/`load`, and the `copyBootstrappedFor` independence invariant.

## Design Decisions (vs PM triage)

1. **History bounds** — `max_entries=20` / `max_tokens=4000` defaults, configurable per project. LLM-summarised older context is out of scope for v1.
2. **Per-AgentType marker** — keyed `map[string]struct{}` so a future second switch (claudecode → codex → claudecode) re-bootstraps correctly.
3. **Concurrency** — only `s.mu` is touched, briefly. `BootstrappedFor` is read under the lock rather than via the public accessor (which would deadlock on the non-reentrant `sync.Mutex`).
4. **Visibility** — single `Send` with a prefixed prompt. Not added to `Session.History`; no extra platform reply. Bracket-style header matches the existing `buildSenderPrompt` convention.

## Configuration

```toml
[projects.myproject.history_bootstrap]
enabled = true       # default: true
max_entries = 20     # default: 20
max_tokens = 4000    # default: 4000
```

Operators who want a strictly fresh session per agent switch can set `enabled = false`.

## Compatibility

- `core/` does not import `agent/` or `platform/`.
- No hardcoded agent or platform names; the marker key is derived from `agent.Name()`.
- Schema migration is backward-compatible: v1 snapshots load with `BootstrappedFor == nil` (treated as "no bootstraps yet, may bootstrap on next agent switch") and are re-saved as v2.
- Default config (no `[history_bootstrap]` block) preserves prior behaviour? No — it now *does* bootstrap by default. This is the intended fix; operators who want the old behaviour can set `enabled = false`. Mention this in release notes.

## Test Results

```
$ go test -tags no_web -race -run 'TestMaybeBootstrapHistory|TestSessionIsBootstrappedFor|TestSessionSnapshotRoundTripPreservesBootstrappedFor|TestCopyBootstrappedFor' ./core/
ok  	github.com/chenhg5/cc-connect/core   1.137s

$ go test -tags no_web -race ./core/
ok  	github.com/chenhg5/cc-connect/core   48.286s

$ go build -tags no_web ./...
(no output — clean)
```

## Risks

- **Behaviour change by default.** Users who relied on a strictly clean context after a `/switch agent_type` will now see a bootstrap block. Mitigation: opt-out via `enabled = false`. Should be called out in release notes.
- **Token budget interaction.** The bootstrap block consumes a portion of the per-prompt token budget. `max_tokens=4000` defaults should stay well clear of any agent's context window but operators on small models may need to lower it.
- **Snapshot migration.** v1 snapshots round-trip correctly via `omitempty` on `BootstrappedFor`, but an existing in-memory `Session` whose `BootstrappedFor` is nil is treated as "never bootstrapped". A user who upgrades then immediately restarts may see one bootstrap block per (session, agent type) that was previously never bootstrapped. This is the correct behaviour but worth flagging.

## Related

- Issue #1805
- Discussion: cross-agent continuity
