### PR TITLE
fix(slack): dedup a message delivered as both app_mention and message

### DIFF
--- a/platform/slack/slack.go
+++ b/platform/slack/slack.go
@@ -41,6 +41,12 @@ type Platform struct {
 	channelNameCache map[string]string
 	channelCacheMu   sync.RWMutex
 	userNameCache    sync.Map // userID -> display name
+	// dedup drops the second delivery of a message that Slack reports through
+	// more than one subscription. A message that @-mentions the bot arrives as
+	// BOTH an app_mention event and a message event, and the two are handled
+	// independently below; without this guard each mention starts a turn and
+	// then queues a duplicate against the still-busy session.
+	dedup core.MessageDedup
 }
 
 func New(opts map[string]any) (core.Platform, error) {
@@ -112,6 +118,16 @@ func (p *Platform) buildSessionKey(channel, user, threadTS string) string {
 	default:
 		return fmt.Sprintf("slack:%s:%s", channel, user)
 	}
+}
+
+// dedupKey identifies one Slack message. A message ts is only unique within its
+// channel, so both parts are needed. An empty ts yields an empty key, which
+// core.MessageDedup never treats as a duplicate.
+func dedupKey(channel, ts string) string {
+	if ts == "" {
+		return ""
+	}
+	return channel + ":" + ts
 }
 
 // threadRootTS returns the thread parent timestamp for an event: the existing
@@ -197,6 +213,12 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 					return
 				}
 
+				if p.dedup.IsDuplicate(dedupKey(ev.Channel, ev.TimeStamp)) {
+					slog.Debug("slack: duplicate message ignored", "source", "app_mention",
+						"channel", ev.Channel, "ts", ev.TimeStamp)
+					return
+				}
+
 				threadTS := threadRootTS(ev.ThreadTimeStamp, ev.TimeStamp)
 				sessionKey := p.buildSessionKey(ev.Channel, ev.User, threadTS)
 
@@ -256,6 +278,12 @@ func (p *Platform) handleEvent(evt socketmode.Event) {
 
 				if !core.AllowList(p.allowFrom, ev.User) {
 					slog.Debug("slack: message from unauthorized user", "user", ev.User)
+					return
+				}
+
+				if p.dedup.IsDuplicate(dedupKey(ev.Channel, ev.TimeStamp)) {
+					slog.Debug("slack: duplicate message ignored", "source", "message",
+						"channel", ev.Channel, "ts", ev.TimeStamp)
 					return
 				}
 

--- a/platform/slack/slack_test.go
+++ b/platform/slack/slack_test.go
@@ -2,11 +2,16 @@ package slack
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+
+	"github.com/chenhg5/cc-connect/core"
 )
 
 func TestStripAppMentionText(t *testing.T) {
@@ -194,5 +199,117 @@ func TestProcessSlackFileShares_EmptyMimeBecomesOctetStream(t *testing.T) {
 	})
 	if len(docs) != 1 || docs[0].MimeType != "application/octet-stream" {
 		t.Fatalf("got %+v", docs)
+	}
+}
+
+// newDedupTestPlatform returns a Platform wired for handleEvent tests: the name
+// caches are pre-seeded so resolveUserName / resolveChannelNameForMsg never
+// reach for the (nil) API client.
+func newDedupTestPlatform(t *testing.T) (*Platform, *[]*core.Message) {
+	t.Helper()
+	var got []*core.Message
+	p := &Platform{
+		allowFrom:        "*",
+		sessionScope:     "channel",
+		channelNameCache: map[string]string{"C1": "product"},
+	}
+	p.userNameCache.Store("U1", "Jim")
+	p.handler = func(_ core.Platform, msg *core.Message) { got = append(got, msg) }
+	return p, &got
+}
+
+// freshTS returns a Slack ts that is newer than core.StartTime, so the adapter's
+// post-restart old-message filter does not drop the event before the dedup guard.
+func freshTS(seq int) string {
+	return fmt.Sprintf("%d.%06d", time.Now().Add(time.Minute).Unix(), seq)
+}
+
+// mentionEvent builds the socketmode event Slack delivers for the app_mention
+// subscription; messageEvent builds the one it delivers for message.channels.
+// A message that @-mentions the bot produces both.
+func mentionEvent(channel, user, ts, text string) socketmode.Event {
+	return socketmode.Event{
+		Type: socketmode.EventTypeEventsAPI,
+		Data: slackevents.EventsAPIEvent{
+			Type: slackevents.CallbackEvent,
+			InnerEvent: slackevents.EventsAPIInnerEvent{
+				Data: &slackevents.AppMentionEvent{
+					User: user, Channel: channel, TimeStamp: ts, Text: text,
+				},
+			},
+		},
+	}
+}
+
+func messageEvent(channel, user, ts, text string) socketmode.Event {
+	return socketmode.Event{
+		Type: socketmode.EventTypeEventsAPI,
+		Data: slackevents.EventsAPIEvent{
+			Type: slackevents.CallbackEvent,
+			InnerEvent: slackevents.EventsAPIInnerEvent{
+				Data: &slackevents.MessageEvent{
+					User: user, Channel: channel, TimeStamp: ts, Text: text,
+				},
+			},
+		},
+	}
+}
+
+// A message that mentions the bot arrives twice — once as app_mention, once as
+// message. Before the dedup guard both were dispatched: the first started a
+// turn and the second hit the still-busy session, so every mention drew a
+// "message queued" reply and burned a second turn.
+func TestHandleEvent_MentionDeliveredTwiceDispatchesOnce(t *testing.T) {
+	p, got := newDedupTestPlatform(t)
+	ts := freshTS(1)
+	text := "a quick intro to <@UBOT> for the team"
+
+	p.handleEvent(mentionEvent("C1", "U1", ts, text))
+	p.handleEvent(messageEvent("C1", "U1", ts, text))
+
+	if len(*got) != 1 {
+		t.Fatalf("dispatched %d times, want 1", len(*got))
+	}
+	if (*got)[0].MessageID != ts {
+		t.Errorf("MessageID = %q, want %q", (*got)[0].MessageID, ts)
+	}
+}
+
+// Order must not matter: Slack does not guarantee which subscription lands first.
+func TestHandleEvent_MentionDedupIsOrderIndependent(t *testing.T) {
+	p, got := newDedupTestPlatform(t)
+	ts := freshTS(1)
+
+	p.handleEvent(messageEvent("C1", "U1", ts, "hello <@UBOT>"))
+	p.handleEvent(mentionEvent("C1", "U1", ts, "hello <@UBOT>"))
+
+	if len(*got) != 1 {
+		t.Fatalf("dispatched %d times, want 1", len(*got))
+	}
+}
+
+// The guard must key on the message, not the channel: distinct messages still
+// get through, including the same ts seen in two different channels.
+func TestHandleEvent_DistinctMessagesStillDispatch(t *testing.T) {
+	p, got := newDedupTestPlatform(t)
+	p.channelNameCache["C2"] = "other"
+
+	p.handleEvent(messageEvent("C1", "U1", freshTS(1), "first"))
+	p.handleEvent(messageEvent("C1", "U1", freshTS(2), "second"))
+	p.handleEvent(messageEvent("C2", "U1", freshTS(1), "same ts, other channel"))
+
+	if len(*got) != 3 {
+		t.Fatalf("dispatched %d times, want 3", len(*got))
+	}
+}
+
+func TestDedupKey(t *testing.T) {
+	if got := dedupKey("C1", "123.456"); got != "C1:123.456" {
+		t.Errorf("dedupKey = %q, want %q", got, "C1:123.456")
+	}
+	// An empty ts must produce an empty key — core.MessageDedup never treats
+	// the empty string as a duplicate, so such events are never swallowed.
+	if got := dedupKey("C1", ""); got != "" {
+		t.Errorf("dedupKey with empty ts = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
## Problem

When a Slack app subscribes to **both** `app_mention` and `message.channels`, a message that `@`-mentions the bot is delivered twice. `handleEvent` has an independent handler for each event type, and both build a `core.Message` with `MessageID = ev.TimeStamp` and call `p.handler` — so one mention is dispatched twice, ~250ms apart:

```
13:59:13.728  message received   msg_id=1789045151.985149  content_len=650
13:59:13.729  processing message
13:59:13.975  message received   msg_id=1789045151.985149  content_len=650
13:59:13.976  message queued for busy session               queue_depth=1
```

The first dispatch starts a turn. The second finds the session busy, so the user gets an unprompted **"📬 Message received — will process after the current task finishes."** on every mention, and the duplicate is then re-run from the queue. Two agent turns per mention, and the agent sees the same message twice in its context.

Observed on a live shared channel — the correlation with mentions is exact:

| message | mentions the bot? | dispatches |
|---|---|---|
| `hi <@OTHERBOT>` | no | 1 |
| `haha Kai isn't responsive atm…` | no | 1 |
| `I'm trying to talk to <@OTHERBOT>, not you <@BOT>` | **yes** | **2** |
| `Got you.\nA quick intro to <@BOT>…` | **yes** | **2** |

This is easy to miss in logs: `stripAppMentionText` only strips a mention at the *start* of the text, so for a mid-sentence mention both copies have identical `content_len` and the duplicate looks like a logging artifact.

## Fix

Route both handlers through `core.MessageDedup`, which `dingtalk`, `feishu`, `weixin`, `matrix`, `qq`, `wecom` and the other adapters already use — `slack` was one of the few that never got wired up. The key is `channel + ts`, since a Slack `ts` is only unique within its channel.

This also covers Socket Mode redelivery of an unacked event, which the adapter had no guard against either.

## Tests

Four new tests drive `handleEvent` end-to-end with a stub handler (name caches pre-seeded so the resolvers never reach the API client):

- a mention arriving as both events dispatches once
- dedup is order-independent (Slack does not guarantee which subscription lands first)
- distinct messages still dispatch, including the same `ts` in two different channels
- `dedupKey` returns an empty key for an empty `ts`, which `MessageDedup` never treats as a duplicate

Verified they fail without the guard. `go build ./...`, `go vet ./platform/slack/` and `go test ./platform/slack/` are clean.

## Known limitation, deliberately not addressed

The two handlers also differ in `Content`: `app_mention` passes it through `stripAppMentionText` while the message handler passes `ev.Text` verbatim. After dedup, a leading bot mention is therefore stripped only if the `app_mention` event happens to land first. Unifying that changes what the agent sees for existing users, so I kept this fix narrow — happy to follow up separately if you'd like it made deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)