### PR TITLE
feat(feishu): configurable local card hooks for instant button feedback

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1012,6 +1012,20 @@ app_secret = "your-feishu-app-secret"
 # domain = "https://open.feishu.cn"  # Optional runtime API/WebSocket base URL override / 可选：运行时 API/WebSocket 域名覆盖
 # enable_feishu_card = true  # Enable Feishu interactive cards (default: true); set false to force plain-text replies
 #                              # 启用飞书交互式卡片（默认 true）；设为 false 时强制回退纯文本回复
+# card_hook_dir = ""         # Optional directory of local hook scripts for instant card-button feedback.
+#                              # A button value like {"action":"cmd:...","hook":"myscript.sh"} runs that script
+#                              # synchronously on click: the full button value JSON goes to the script's stdin;
+#                              # if stdout is a JSON object it is returned as the replacement card immediately
+#                              # (sub-second feedback, no agent round-trip). Any failure (missing script, timeout,
+#                              # non-JSON output) falls back to normal dispatch, so hooks never block messages.
+#                              # Scripts must stay inside this directory (absolute paths and ".." are rejected).
+#                              # Empty (default) disables the feature. Also applies to the lark platform.
+#                              # 可选：本地钩子脚本目录，用于卡片按钮的即时反馈。按钮 value 含 {"hook":"myscript.sh"}
+#                              # 时，点击同步执行该脚本：完整 value JSON 走 stdin；stdout 为 JSON 对象则立即作为
+#                              # 替换卡片返回（亚秒级反馈，不经过 agent）。任何失败（脚本不存在/超时/输出非 JSON）
+#                              # 都自动回退正常派发，绝不阻塞消息。脚本必须位于该目录内（绝对路径与 ".." 会被拒绝）。
+#                              # 留空（默认）即关闭该功能。lark 平台同样适用。
+# card_hook_timeout_ms = 3000  # Card hook execution timeout in ms, range [100, 30000] / 钩子脚本执行超时（毫秒），范围 [100, 30000]
 # allow_from = "*"          # Allowed user open_ids, comma-separated; "*" = all (default). Use /whoami to get your open_id.
 #                              # 允许的用户 open_id，逗号分隔；"*" 表示所有（默认）。发送 /whoami 获取你的 open_id。
 # allow_chat = "*"          # Allowed group chat_ids, comma-separated; "*" = all (default). Find chat_id in group settings.

--- a/platform/feishu/card_hook_test.go
+++ b/platform/feishu/card_hook_test.go
@@ -1,0 +1,103 @@
+package feishu
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeHookScript(t *testing.T, dir, name, body string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSafeHookPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "hooks")
+	cases := []struct {
+		name string
+		want string
+		ok   bool
+	}{
+		{"survey.sh", filepath.Join(dir, "survey.sh"), true},
+		{"sub/vote.sh", filepath.Join(dir, "sub", "vote.sh"), true},
+		{"", "", false},
+		{"/etc/passwd", "", false},
+		{"../escape.sh", "", false},
+		{"a/../../escape.sh", "", false},
+		{".", "", false},
+	}
+	for _, c := range cases {
+		got, err := safeHookPath(dir, c.name)
+		if c.ok {
+			if err != nil || got != c.want {
+				t.Errorf("safeHookPath(%q) = %q, %v; want %q, nil", c.name, got, err, c.want)
+			}
+		} else if err == nil {
+			t.Errorf("safeHookPath(%q) = %q; want error", c.name, got)
+		}
+	}
+}
+
+func TestRunCardHookJSONCard(t *testing.T) {
+	dir := t.TempDir()
+	writeHookScript(t, dir, "echo.sh", "#!/bin/sh\ncat >/dev/null\necho '{\"elements\":[{\"tag\":\"div\"}]}'\n")
+	p := &Platform{cardHookDir: dir, cardHookTimeout: 3 * time.Second}
+	card, err := p.runCardHook("echo.sh", map[string]any{"hook": "echo.sh", "answer": "A"})
+	if err != nil {
+		t.Fatalf("runCardHook: %v", err)
+	}
+	if _, ok := card["elements"].([]any); !ok {
+		t.Errorf("card = %#v, want elements array", card)
+	}
+}
+
+// The hook must receive the full button value as JSON on stdin so it can act on
+// the clicked option without an agent round-trip.
+func TestRunCardHookReceivesValueOnStdin(t *testing.T) {
+	dir := t.TempDir()
+	writeHookScript(t, dir, "mirror.sh", "#!/bin/sh\ncat\n")
+	p := &Platform{cardHookDir: dir, cardHookTimeout: 3 * time.Second}
+	card, err := p.runCardHook("mirror.sh", map[string]any{"hook": "mirror.sh", "answer": "B"})
+	if err != nil {
+		t.Fatalf("runCardHook: %v", err)
+	}
+	if card["answer"] != "B" {
+		t.Errorf("stdin value = %#v, want answer=B echoed back", card)
+	}
+}
+
+func TestRunCardHookNonJSONStdout(t *testing.T) {
+	dir := t.TempDir()
+	writeHookScript(t, dir, "plain.sh", "#!/bin/sh\necho 'not json'\n")
+	p := &Platform{cardHookDir: dir, cardHookTimeout: 3 * time.Second}
+	if _, err := p.runCardHook("plain.sh", nil); err == nil {
+		t.Error("non-JSON stdout: want error")
+	}
+}
+
+func TestRunCardHookMissingScript(t *testing.T) {
+	p := &Platform{cardHookDir: t.TempDir(), cardHookTimeout: time.Second}
+	if _, err := p.runCardHook("nope.sh", nil); err == nil {
+		t.Error("missing script: want error")
+	}
+}
+
+func TestRunCardHookTimeout(t *testing.T) {
+	dir := t.TempDir()
+	writeHookScript(t, dir, "slow.sh", "#!/bin/sh\nsleep 5\n")
+	p := &Platform{cardHookDir: dir, cardHookTimeout: 200 * time.Millisecond}
+	start := time.Now()
+	if _, err := p.runCardHook("slow.sh", nil); err == nil {
+		t.Error("slow hook: want timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("hook took %v; want it cut off near the 200ms timeout", elapsed)
+	}
+}

--- a/platform/feishu/feishu.go
+++ b/platform/feishu/feishu.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -116,13 +118,17 @@ type replyContext struct {
 }
 
 type Platform struct {
-	mu                         sync.RWMutex
-	platformName               string
-	domain                     string
-	appID                      string
-	appSecret                  string
-	progressStyle              string
-	useInteractiveCard         bool
+	mu                 sync.RWMutex
+	platformName       string
+	domain             string
+	appID              string
+	appSecret          string
+	progressStyle      string
+	useInteractiveCard bool
+	// cardHookDir: optional directory of local hook scripts for instant card-action
+	// feedback (see runCardHook). Empty disables the feature entirely.
+	cardHookDir                string
+	cardHookTimeout            time.Duration
 	self                       core.Platform
 	reactionEmoji              string
 	ackEmoji                   string
@@ -423,6 +429,29 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		useInteractiveCard = v
 	}
 
+	// Card hook: optional local scripts for instant card-action feedback.
+	// An empty card_hook_dir (the default) keeps the feature fully disabled.
+	cardHookDir, _ := opts["card_hook_dir"].(string)
+	cardHookDir = strings.TrimSpace(cardHookDir)
+	if cardHookDir != "" {
+		abs, absErr := filepath.Abs(cardHookDir)
+		if absErr != nil {
+			return nil, fmt.Errorf("%s: invalid card_hook_dir %q: %w", name, cardHookDir, absErr)
+		}
+		cardHookDir = abs
+	}
+	cardHookTimeout := 3 * time.Second
+	if raw, ok := opts["card_hook_timeout_ms"]; ok {
+		ms, msErr := coerceMilliseconds(raw)
+		if msErr != nil {
+			return nil, fmt.Errorf("%s: invalid card_hook_timeout_ms %v: %w", name, raw, msErr)
+		}
+		if ms < 100 || ms > 30000 {
+			return nil, fmt.Errorf("%s: card_hook_timeout_ms must be within [100, 30000], got %d", name, ms)
+		}
+		cardHookTimeout = time.Duration(ms) * time.Millisecond
+	}
+
 	imageBatchWindow := defaultImageBatchWindow
 	if raw, ok := opts["image_batch_window_ms"]; ok {
 		ms, err := coerceMilliseconds(raw)
@@ -479,6 +508,8 @@ func newPlatform(name, domain string, opts map[string]any) (core.Platform, error
 		appSecret:                  appSecret,
 		progressStyle:              progressStyle,
 		useInteractiveCard:         useInteractiveCard,
+		cardHookDir:                cardHookDir,
+		cardHookTimeout:            cardHookTimeout,
 		reactionEmoji:              reactionEmoji,
 		ackEmoji:                   ackEmoji,
 		doneEmoji:                  doneEmoji,
@@ -967,6 +998,22 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 			ReplyCtx:   rctx,
 		})
 
+		// Card hook: synchronously run a local script from card_hook_dir and use
+		// its stdout JSON as the replacement card, giving instant click feedback
+		// without an agent round-trip. Any failure falls back to normal dispatch.
+		if p.cardHookDir != "" {
+			if hookName, _ := event.Event.Action.Value["hook"].(string); hookName != "" {
+				cardMap, hookErr := p.runCardHook(hookName, event.Event.Action.Value)
+				if hookErr != nil {
+					slog.Warn(p.tag()+": card hook failed", "hook", hookName, "error", hookErr)
+				} else if cardMap != nil {
+					return &callback.CardActionTriggerResponse{
+						Card: &callback.Card{Type: "raw", Data: cardMap},
+					}, nil
+				}
+			}
+		}
+
 		if ac, ok := event.Event.Action.Value["after_click"].(map[string]any); ok {
 			if title, _ := ac["title"].(string); title != "" {
 				color, _ := ac["color"].(string)
@@ -993,6 +1040,56 @@ func (p *Platform) onCardAction(event *callback.CardActionTriggerEvent) (*callba
 	}
 
 	return nil, nil
+}
+
+// runCardHook executes a local hook script from cardHookDir synchronously.
+// The full button value is passed as JSON on stdin; if stdout parses as a JSON
+// object it is returned as the raw replacement card. The caller treats any
+// error as "no card" and falls back to normal agent dispatch, so a broken or
+// slow hook (bounded by cardHookTimeout) never blocks message handling.
+func (p *Platform) runCardHook(name string, value map[string]any) (map[string]any, error) {
+	script, err := safeHookPath(p.cardHookDir, name)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), p.cardHookTimeout)
+	defer cancel()
+	input, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, "bash", script)
+	cmd.Dir = p.cardHookDir
+	// If a killed hook leaves children holding the output pipes, Output() would
+	// block until they exit; WaitDelay caps that grace period so the timeout
+	// above actually holds.
+	cmd.WaitDelay = time.Second
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("hook exec: %w", err)
+	}
+	var card map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(out), &card); err != nil {
+		return nil, fmt.Errorf("hook stdout not json: %w", err)
+	}
+	return card, nil
+}
+
+// safeHookPath resolves name inside dir, rejecting empty names, absolute paths,
+// and anything that would escape dir after cleaning (e.g. "..", "a/../..").
+func safeHookPath(dir, name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("empty hook name")
+	}
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("hook %q must be relative to card_hook_dir", name)
+	}
+	clean := filepath.Clean(filepath.Join(dir, name))
+	if clean == dir || !strings.HasPrefix(clean, dir+string(filepath.Separator)) {
+		return "", fmt.Errorf("hook %q escapes card_hook_dir", name)
+	}
+	return clean, nil
 }
 
 func (p *Platform) addReaction(messageID string) string {


### PR DESCRIPTION
## Motivation

Interactive cards (surveys, polls, approvals) currently need a full agent round-trip on every button click before the card updates — typically several seconds, and the update itself becomes just another chat message.

This PR adds an opt-in mechanism for **sub-second, in-place card updates driven by a local script**, no agent involved. It has been running in production on a personal deployment for 14+ days driving multi-question survey cards (10 questions; clicks feel instant and the agent is never interrupted).

## How it works

A button value that carries a `hook` field triggers synchronous local execution when clicked:

```json
{"action": "cmd:whatever", "hook": "survey.sh", "q": 3, "choice": "B"}
```

- The **full button value** is piped to the script's stdin as JSON.
- If the script's **stdout parses as a JSON object**, it is returned as the replacement card in the card-action callback response (instant in-place update, buttons included — which `after_click` can't do since it only renders text).
- Any failure (missing script, timeout, non-JSON output) **logs a warning and falls back to normal dispatch** — a broken hook can never block message handling.

## Configuration (opt-in, zero behavior change by default)

```toml
[projects.platforms.options]
card_hook_dir = "/path/to/hooks"      # empty (default) = feature disabled
card_hook_timeout_ms = 3000              # range [100, 30000], default 3000
```

Applies to both `feishu` and `lark` platforms (shared code path).

## Safety

- Hook names must resolve **inside `card_hook_dir`**: absolute paths and `..` traversal are rejected (`safeHookPath`).
- Execution is bounded by `card_hook_timeout_ms`; `cmd.WaitDelay` additionally caps the grace period so a killed hook that leaves pipe-holding children cannot stall the timeout (covered by a test).
- Scripts run via `bash` with the hook dir as cwd.

## Tests

6 new unit tests in `platform/feishu/card_hook_test.go`: path-traversal rejection, JSON card passthrough, stdin protocol (value JSON echoed back), non-JSON output, missing script, and real timeout enforcement. `go build ./...` and `go vet` pass; full `go test ./...` passes except two timing-sensitive tests in `agent/antigravity` / `agent/codex` that occasionally flake under parallel full-suite load on my machine, before and after this change — unrelated.

## 中文说明

新增可选的卡片本地钩子：按钮 value 带 `hook` 字段时，点击同步执行 `card_hook_dir` 下的脚本，stdin 收到完整 value JSON，stdout 为 JSON 对象则直接作为替换卡片返回——亚秒级原地刷新卡片（可带按钮，弥补 after_click 只能文字的不足），完全不占用 agent。默认关闭（`card_hook_dir` 为空零行为变化），失败自动回退正常派发，路径安全护栏 + 超时封顶 + 6 个单元测试。