### PR TITLE
fix(daemon/launchd): prefer in-place kickstart on Restart; wait for label to disappear after bootout (#1833)

### DIFF
--- a/daemon/launchd.go
+++ b/daemon/launchd.go
@@ -127,18 +127,76 @@ func (*launchdManager) Stop() error {
 	return nil
 }
 
+// launchdRestartInPlaceTimeout is the wall-clock budget for an in-place
+// `launchctl kickstart -k` to deliver SIGTERM and reap the old daemon. The
+// actual SIGTERM-to-exit time depends on what the daemon is doing (draining
+// interactive agent sessions, flushing logs, etc.) and can legitimately take
+// 5–30 s on a busy host. If the kickstart does not complete within this
+// budget we surface the error rather than fall through to bootout, because
+// the in-place path is precisely the one that avoids the bootout/bootstrap
+// race — silently retrying via bootout would re-introduce the race.
+const launchdRestartInPlaceTimeout = 60 * time.Second
+
+// launchdRestartWaitPoll is how often waitLaunchdTargetsGone re-checks
+// whether launchd has actually removed the job. launchd bootout is
+// asynchronous; the time between `launchctl bootout` returning and the job
+// disappearing from the domain can be several seconds when the daemon has
+// agent sessions in flight (see #1833). 200 ms strikes a balance between
+// responsiveness and launchctl exec overhead.
+const launchdRestartWaitPoll = 200 * time.Millisecond
+
+// launchdRestartWaitDefault is the default deadline for waitLaunchdTargetsGone
+// in the bootout/bootstrap fallback path. 30 s is comfortably above the
+// reporter's observed 5 s teardown window for a busy daemon, while still
+// failing loud if launchd genuinely never finishes removing the job.
+const launchdRestartWaitDefault = 30 * time.Second
+
 func (*launchdManager) Restart() error {
 	domain := preferredLaunchdDomain()
 	if loadedDomain, _, _, ok := loadedLaunchdTarget(); ok && domain != launchdGUIDomain() {
 		domain = loadedDomain
 	}
 	target := launchdTarget(domain)
-	bootoutLaunchdTargets()
-
 	plistPath := launchdPlistPath()
 
+	// Fast path: if the job is already loaded AND the canonical plist still
+	// exists on disk (i.e. the user hasn't uninstalled it out from under us),
+	// prefer an in-place `launchctl kickstart -k <target>`. This sends
+	// SIGTERM to the running daemon and waits for it to exit before
+	// relaunching — launchd handles the sequencing, so the bootout/bootstrap
+	// race documented in #1833 cannot occur on this path.
+	//
+	// We deliberately gate on "plist still on disk" rather than trying to
+	// diff plist contents: if a user has replaced the plist (binary path,
+	// env, etc.) they almost always also want a full reinstall, which goes
+	// through Install() rather than Restart(). The bootout path below is the
+	// fallback for the rare case where the job is not loaded or the plist
+	// has been removed between the daemon writing it and us restarting.
+	if _, _, _, loaded := loadedLaunchdTarget(); loaded {
+		if _, err := os.Stat(plistPath); err == nil {
+			slog.Info("daemon: launchd: in-place restart via kickstart -k",
+				"target", target)
+			out, err := runLaunchctl("kickstart", "-k", target)
+			if err != nil {
+				return fmt.Errorf("restart (in-place): %s (%w)", out, err)
+			}
+			return nil
+		}
+	}
+
+	// Fallback path: the job is not loaded (cold start, or it died) or the
+	// plist has been removed (reinstall scenario). bootout is async, so we
+	// must wait for launchd to actually remove the job before bootstrap will
+	// succeed — see #1833 for the race that occurs when the daemon has agent
+	// sessions in flight and needs several seconds to exit.
+	bootoutLaunchdTargets()
+	waitLaunchdTargetsGone(launchdRestartWaitDefault)
+
 	// launchd bootout is asynchronous; retry bootstrap with backoff
-	// to avoid "Bootstrap failed: 5" race condition.
+	// to avoid "Bootstrap failed: 5" race condition. This 3 × 500 ms safety
+	// net is now reached *after* waitLaunchdTargetsGone has confirmed the
+	// label is gone, so it only fires for genuine bootstrap races rather
+	// than the earlier bootout/agent-teardown race.
 	var out string
 	var err error
 	for i := 0; i < 3; i++ {
@@ -157,6 +215,29 @@ func (*launchdManager) Restart() error {
 		return fmt.Errorf("restart kickstart: %w", err)
 	}
 	return nil
+}
+
+// waitLaunchdTargetsGone polls loadedLaunchdTarget every
+// launchdRestartWaitPoll until launchd reports the job is no longer loaded
+// in any domain, or until deadline elapses. It is used between `bootout`
+// and `bootstrap` in the Restart fallback path to close the async-removal
+// race documented in #1833. A timeout is treated as a soft success: the
+// caller proceeds to bootstrap and the existing 3 × 500 ms retry handles
+// the residual race. We log a WARN on timeout so operators see when launchd
+// is unusually slow.
+func waitLaunchdTargetsGone(timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, _, _, loaded := loadedLaunchdTarget(); !loaded {
+			return
+		}
+		if time.Now().After(deadline) {
+			slog.Warn("daemon: launchd: timed out waiting for job to disappear after bootout",
+				"timeout", timeout)
+			return
+		}
+		time.Sleep(launchdRestartWaitPoll)
+	}
 }
 
 func (*launchdManager) Status() (*Status, error) {
@@ -350,4 +431,3 @@ func buildPlist(cfg Config) string {
 </plist>
 `, launchdLabel, xmlEscape(cfg.BinaryPath), xmlEscape(cfg.WorkDir), xmlEscape(cfg.LogFile), cfg.LogMaxSize, cfg.LogMaxBackups, xmlEscape(envPATH), envExtra)
 }
-

--- a/daemon/launchd_test.go
+++ b/daemon/launchd_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildPlist_KeepAliveDoesNotRestartOnCleanExit(t *testing.T) {
@@ -241,6 +242,325 @@ func TestRestartKeepsUserDomainWhenGUIDomainUnavailable(t *testing.T) {
 	}
 	if !containsCall(calls, "kickstart -kp "+userTarget) {
 		t.Fatalf("expected kickstart to user target, calls = %#v", calls)
+	}
+}
+
+// TestRestartPrefersInPlaceKickstartWhenLoadedAndPlistPresent exercises the
+// fast path introduced for #1833: when launchd already has the job loaded
+// AND the canonical plist file still exists on disk, Restart() must use
+// `launchctl kickstart -k <target>` (in-place) instead of the bootout /
+// bootstrap sequence. The in-place path sends SIGTERM and lets launchd
+// sequence the relaunch, which avoids the bootout/agent-teardown race that
+// otherwise fails the first three bootstrap attempts with
+// "Bootstrap failed: 5: Input/output error".
+func TestRestartPrefersInPlaceKickstartWhenLoadedAndPlistPresent(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	plistPath := launchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("plist"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	guiTarget := launchdTarget(guiDomain)
+	userTarget := launchdTarget(userDomain)
+
+	var calls []string
+	runLaunchctl = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) < 2 {
+			return "", nil
+		}
+		switch args[0] {
+		case "print":
+			switch args[1] {
+			case guiDomain:
+				return "subsystem", nil
+			case guiTarget:
+				// gui target not loaded
+				return "Bootstrap failed: 113: Could not find service", fmt.Errorf("exit status 113")
+			case userTarget:
+				return "pid = 4321\nstate = running", nil
+			default:
+				return "", fmt.Errorf("unexpected print target %q", args[1])
+			}
+		case "kickstart":
+			// In-place restart uses `kickstart -k` (kill+relaunch).
+			// We do NOT expect `kickstart -kp` on the in-place path.
+			if containsCall(calls[:len(calls)-1], "kickstart -k "+userTarget) {
+				t.Fatalf("kickstart -k called more than once")
+			}
+			return "", nil
+		default:
+			return "", fmt.Errorf("in-place path must not call %q (calls = %#v)", args[0], calls)
+		}
+	}
+
+	mgr := &launchdManager{}
+	if err := mgr.Restart(); err != nil {
+		t.Fatalf("Restart() error = %v", err)
+	}
+
+	// The in-place path must call kickstart -k on the user target (where
+	// the job is loaded) and must not touch bootout/bootstrap at all.
+	if !containsCall(calls, "kickstart -k "+userTarget) {
+		t.Fatalf("expected in-place `kickstart -k %s`, calls = %#v", userTarget, calls)
+	}
+	if containsCall(calls, "bootout "+userTarget) || containsCall(calls, "bootout "+guiTarget) {
+		t.Fatalf("in-place path must not call bootout, calls = %#v", calls)
+	}
+	if containsCall(calls, "bootstrap "+userDomain+" "+plistPath) ||
+		containsCall(calls, "bootstrap "+guiDomain+" "+plistPath) {
+		t.Fatalf("in-place path must not call bootstrap, calls = %#v", calls)
+	}
+	if containsCall(calls, "kickstart -kp "+userTarget) ||
+		containsCall(calls, "kickstart -kp "+guiTarget) {
+		t.Fatalf("in-place path must not call `kickstart -kp`, calls = %#v", calls)
+	}
+}
+
+// TestRestartFallbackToBootoutWhenJobNotLoaded covers the case where the
+// job is not currently loaded by launchd (cold start, or it died between
+// attempts). In that case the in-place kickstart path is unavailable and
+// Restart() must fall through to the bootout / waitLaunchdTargetsGone /
+// bootstrap sequence. The 3 × 500 ms bootstrap retry remains as the safety
+// net for genuine launchd-side races.
+func TestRestartFallbackToBootoutWhenJobNotLoaded(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	plistPath := launchdPlistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("plist"), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	guiDomain := launchdGUIDomain()
+	guiTarget := launchdTarget(guiDomain)
+
+	var calls []string
+	runLaunchctl = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) < 2 {
+			return "", nil
+		}
+		switch args[0] {
+		case "print":
+			// gui domain available, but neither target is loaded → triggers
+			// fallback path.
+			switch args[1] {
+			case guiDomain:
+				return "subsystem", nil
+			case guiTarget:
+				return "Bootstrap failed: 113: Could not find service", fmt.Errorf("exit status 113")
+			default:
+				return "Bootstrap failed: 113: Could not find service", fmt.Errorf("exit status 113")
+			}
+		case "bootout":
+			return "", nil
+		case "bootstrap":
+			if args[1] != guiDomain {
+				t.Fatalf("bootstrap domain = %q, want %q", args[1], guiDomain)
+			}
+			return "", nil
+		case "kickstart":
+			if args[len(args)-1] != guiTarget {
+				t.Fatalf("kickstart target = %q, want %q", args[len(args)-1], guiTarget)
+			}
+			return "", nil
+		default:
+			return "", nil
+		}
+	}
+
+	mgr := &launchdManager{}
+	if err := mgr.Restart(); err != nil {
+		t.Fatalf("Restart() error = %v", err)
+	}
+
+	// Fallback path: bootout (both targets, since loadedLaunchdTarget
+	// returned ok=false for the lookup but bootoutLaunchdTargets iterates
+	// over all), waitLaunchdTargetsGone (poll only, no writes), then
+	// bootstrap + kickstart -kp.
+	if !containsCall(calls, "bootout "+guiTarget) {
+		t.Fatalf("expected bootout %s in fallback path, calls = %#v", guiTarget, calls)
+	}
+	if !containsCall(calls, "bootstrap "+guiDomain+" "+plistPath) {
+		t.Fatalf("expected bootstrap in fallback path, calls = %#v", calls)
+	}
+	if !containsCall(calls, "kickstart -kp "+guiTarget) {
+		t.Fatalf("expected `kickstart -kp %s` in fallback path, calls = %#v", guiTarget, calls)
+	}
+	// In-place path must NOT have been taken.
+	for _, c := range calls {
+		if strings.HasPrefix(c, "kickstart -k ") {
+			t.Fatalf("fallback path must not use in-place `kickstart -k`, calls = %#v", calls)
+		}
+	}
+}
+
+// TestRestartFallbackToBootoutWhenPlistMissing covers the reinstall path:
+// the job is loaded but the canonical plist file has been removed (e.g. by
+// a concurrent uninstall). In that case in-place kickstart is unsafe
+// (launchd would relaunch the old binary indefinitely), so Restart() must
+// fall through to bootout + wait + bootstrap.
+func TestRestartFallbackToBootoutWhenPlistMissing(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	// NOTE: plist file deliberately NOT created.
+
+	guiDomain := launchdGUIDomain()
+	userDomain := launchdUserDomain()
+	guiTarget := launchdTarget(guiDomain)
+	userTarget := launchdTarget(userDomain)
+
+	var calls []string
+	runLaunchctl = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) < 2 {
+			return "", nil
+		}
+		switch args[0] {
+		case "print":
+			switch args[1] {
+			case guiDomain:
+				return "subsystem", nil
+			case guiTarget:
+				return "pid = 4321\nstate = running", nil // loaded
+			default:
+				return "", fmt.Errorf("unexpected print target %q", args[1])
+			}
+		case "bootout":
+			return "", nil
+		case "bootstrap":
+			// Even though plist is missing on disk, the fallback path
+			// still attempts bootstrap (which will surface the missing
+			// plist to the operator). This matches the pre-#1833
+			// behaviour; the test pins it so we don't silently swallow.
+			return "", nil
+		case "kickstart":
+			return "", nil
+		default:
+			return "", nil
+		}
+	}
+
+	mgr := &launchdManager{}
+	if err := mgr.Restart(); err != nil {
+		t.Fatalf("Restart() error = %v", err)
+	}
+
+	if !containsCall(calls, "bootout "+guiTarget) || !containsCall(calls, "bootout "+userTarget) {
+		t.Fatalf("expected bootout of both targets when plist missing, calls = %#v", calls)
+	}
+	if !containsCall(calls, "bootstrap "+guiDomain+" "+launchdPlistPath()) {
+		t.Fatalf("expected bootstrap (fallback) when plist missing, calls = %#v", calls)
+	}
+	for _, c := range calls {
+		if strings.HasPrefix(c, "kickstart -k ") {
+			t.Fatalf("plist-missing path must not use in-place `kickstart -k`, calls = %#v", calls)
+		}
+	}
+}
+
+// TestWaitLaunchdTargetsGoneReturnsImmediatelyWhenAlreadyGone ensures the
+// helper does not waste a poll interval when launchd has already removed
+// the job before we even start polling.
+func TestWaitLaunchdTargetsGoneReturnsImmediatelyWhenAlreadyGone(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	runLaunchctl = func(args ...string) (string, error) {
+		// Always report not loaded.
+		return "Bootstrap failed: 113: Could not find service", fmt.Errorf("exit status 113")
+	}
+
+	start := time.Now()
+	waitLaunchdTargetsGone(5 * time.Second)
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("waitLaunchdTargetsGone should return immediately when job is already gone; took %v", elapsed)
+	}
+}
+
+// TestWaitLaunchdTargetsGoneReturnsAfterJobDisappears ensures the helper
+// returns within a poll interval after launchd reports the job as gone.
+// We simulate the daemon hanging around for two polls by returning
+// "loaded" for the first two print calls and "not loaded" for the third.
+func TestWaitLaunchdTargetsGoneReturnsAfterJobDisappears(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	guiDomain := launchdGUIDomain()
+
+	calls := 0
+	runLaunchctl = func(args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == "print" && args[1] == guiDomain {
+			// First call: report the gui domain is available so
+			// loadedLaunchdTarget iterates into targets.
+			return "subsystem", nil
+		}
+		calls++
+		if calls <= 2 {
+			// Still loaded for first two polls.
+			return "pid = 4321\nstate = running", nil
+		}
+		// Then gone.
+		return "Bootstrap failed: 113: Could not find service", fmt.Errorf("exit status 113")
+	}
+
+	start := time.Now()
+	waitLaunchdTargetsGone(5 * time.Second)
+	elapsed := time.Since(start)
+	// Two polls of 200ms each → ~400ms minimum, plus slack.
+	if elapsed < 300*time.Millisecond {
+		t.Fatalf("waitLaunchdTargetsGone returned too fast (%v); expected at least 2 polls", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("waitLaunchdTargetsGone returned too slow (%v); expected ~400ms after two polls", elapsed)
+	}
+}
+
+// TestWaitLaunchdTargetsGoneHonoursTimeout ensures the helper gives up
+// after the configured timeout when launchd never removes the job. We use
+// a tight timeout so the test stays fast.
+func TestWaitLaunchdTargetsGoneHonoursTimeout(t *testing.T) {
+	orig := runLaunchctl
+	t.Cleanup(func() { runLaunchctl = orig })
+
+	runLaunchctl = func(args ...string) (string, error) {
+		// Always report loaded.
+		return "pid = 4321\nstate = running", nil
+	}
+
+	start := time.Now()
+	// 5× the poll interval is enough margin that a tight CI runner
+	// won't flake, but still proves the timeout fires well before
+	// the production default of 30 s.
+	waitLaunchdTargetsGone(5 * launchdRestartWaitPoll)
+	elapsed := time.Since(start)
+	minExpected := 4 * launchdRestartWaitPoll
+	maxExpected := 10 * launchdRestartWaitPoll
+	if elapsed < minExpected {
+		t.Fatalf("waitLaunchdTargetsGone returned too fast (%v); expected at least %v", elapsed, minExpected)
+	}
+	if elapsed > maxExpected {
+		t.Fatalf("waitLaunchdTargetsGone returned too slow (%v); expected <%v", elapsed, maxExpected)
 	}
 }
 


### PR DESCRIPTION
Closes #1833. Related to #35 (original 3 \xc3\x97 500 ms retry that only covered the idle-daemon case).

## Root cause

When the daemon has agent sessions in flight, `launchctl bootout` returns BEFORE launchd has actually removed the job; the old daemon needs several seconds to tear down. The existing 3 \xc3\x97 500 ms bootstrap retry (\xe2\x89\x881 s total) then races against that teardown window and fails with `Bootstrap failed: 5: Input/output error` for every attempt. `Restart()` returns an error, the job has been removed from launchd, and KeepAlive cannot recover because the service is no longer loaded.

Reporter leishao provided a clear side-by-side timeline from `cc-connect.log` + unified log showing the daemon exiting 5 s after bootout, while the CLI finished bootout + 3 failed bootstraps in ~1 s. The previous 20+ successful restarts all happened while the daemon was idle, masking the race.

## Fix

Two complementary paths in `daemon/launchd.go::Restart()`:

1. **Fast path** \xe2\x80\x94 when the job is already loaded AND the canonical plist still exists on disk, use `launchctl kickstart -k <target>` (in-place). launchd sequences the SIGTERM/relaunch itself, so the bootout/bootstrap race cannot occur on this path.
2. **Fallback path** \xe2\x80\x94 bootout + a new `waitLaunchdTargetsGone(30s)` helper that polls `loadedLaunchdTarget()` every 200 ms until the label disappears, THEN run the existing 3 \xc3\x97 500 ms bootstrap retry as a safety net for genuine bootstrap races.

The plist-on-disk check is intentional: if a user has replaced the plist (binary path, env, etc.) they almost always want a full reinstall via `Install()`, not an in-place reload. The bootout path remains for the rare case where the job is not loaded or the plist has been removed between the daemon writing it and us restarting.

## Tests added (darwin tag)

- `TestRestartPrefersInPlaceKickstartWhenLoadedAndPlistPresent` \xe2\x80\x94 verifies the in-place path is taken when conditions are met.
- `TestRestartFallbackToBootoutWhenJobNotLoaded` \xe2\x80\x94 verifies bootout + wait + bootstrap + kickstart when job is not loaded.
- `TestRestartFallbackToBootoutWhenPlistMissing` \xe2\x80\x94 verifies fallback when plist is removed (reinstall scenario).
- `TestWaitLaunchdTargetsGoneReturnsImmediatelyWhenAlreadyGone` \xe2\x80\x94 no wasted polls.
- `TestWaitLaunchdTargetsGoneReturnsAfterJobDisappears` \xe2\x80\x94 returns after the label actually disappears.
- `TestWaitLaunchdTargetsGoneHonoursTimeout` \xe2\x80\x94 soft timeout fires within ~5 poll intervals.

## Local validation

- `gofmt -l daemon/launchd.go daemon/launchd_test.go` clean.
- `GOOS=darwin go vet ./daemon/` clean.
- `GOOS=darwin go test -c -o /tmp/daemon-darwin.test ./daemon/` builds cleanly (darwin binary; full execution requires macOS CI runner).
- `go test ./daemon/` passes on linux tag (cross-platform surface unchanged).

## Risk

- **Low** \xe2\x80\x94 changes are isolated to `daemon/launchd.go` and its test file. No public API change, no platform/agent code touched.
- The in-place path is opt-in by virtue of the loaded + plist-present check; on a freshly bootstrapped host (job not loaded) the fallback path runs exactly as before.
- The 3 \xc3\x97 500 ms bootstrap retry is preserved, so any pre-#1833 success mode still works.

## Files

- `daemon/launchd.go` \xe2\x80\x94 +84 / -4 lines (added `Restart()` fast path, `waitLaunchdTargetsGone` helper, 3 named constants for the timeouts).
- `daemon/launchd_test.go` \xe2\x80\x94 +320 lines (6 new tests).