### PR TITLE
feat(core): busy_ack_skip_prefixes to silence queued-acks for automated actions

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -706,6 +706,7 @@ func main() {
 		}
 		resetIdle, defaulted := resolveResetOnIdle(proj.ResetOnIdleMins)
 		engine.SetResetOnIdle(resetIdle)
+		engine.SetBusyAckSkipPrefixes(proj.BusyAckSkipPrefixes)
 		if defaulted {
 			slog.Info("project: reset_on_idle_mins not set, applying default — set reset_on_idle_mins = 0 to opt out, see docs/usage.md",
 				"project", proj.Name, "default_minutes", defaultResetOnIdleMins)
@@ -1788,6 +1789,7 @@ func reloadConfig(configPath, projName string, engine *core.Engine) (*core.Confi
 	}
 	resetIdle, defaulted := resolveResetOnIdle(proj.ResetOnIdleMins)
 	engine.SetResetOnIdle(resetIdle)
+	engine.SetBusyAckSkipPrefixes(proj.BusyAckSkipPrefixes)
 	if defaulted {
 		slog.Info("project: reset_on_idle_mins not set, applying default — set reset_on_idle_mins = 0 to opt out, see docs/usage.md",
 			"project", proj.Name, "default_minutes", defaultResetOnIdleMins)

--- a/config.example.toml
+++ b/config.example.toml
@@ -189,6 +189,21 @@ level = "info" # debug, info, warn, error
 # [[projects]]
 # agent_session_idle_timeout_mins = 30
 
+# Suppress the "message queued" acknowledgment for selected message prefixes.
+# When a message arrives while the agent is busy, cc-connect normally replies
+# with a queued-ack so the user knows it was received. For high-frequency
+# automated card actions (e.g. instant-feedback survey buttons dispatched as
+# commands) that ack is pure noise, so it can be skipped per prefix. Note that
+# card buttons dispatch their command as "cmd:<text>", so include both forms
+# if you use both paths. Messages are still queued and drained as usual —
+# only the acknowledgment is suppressed. Empty (default) acks everything.
+# 当消息在 agent 忙碌期间到达时，cc-connect 通常会回复一条"已入队"回执。对于高频的
+# 自动化卡片动作（例如即时反馈的问卷按钮派发为命令），这条回执是纯噪音，可按前缀
+# 跳过。注意卡片按钮会以 "cmd:<文本>" 形式派发命令，两种形式都用到就都写上。
+# 消息照常入队和补发，只是不回执。留空（默认）则每条都回执。
+# [[projects]]
+# busy_ack_skip_prefixes = ["【问卷】", "cmd:【问卷】"]
+
 # =============================================================================
 # OS-user isolation via run_as_user (Linux/macOS only)
 # 通过 run_as_user 实现 OS 用户隔离（仅限 Linux/macOS）

--- a/config/config.go
+++ b/config/config.go
@@ -486,6 +486,13 @@ type ProjectConfig struct {
 	// the current session has been inactive for the specified number of minutes.
 	// 0 or nil disables the behavior.
 	ResetOnIdleMins *int `toml:"reset_on_idle_mins,omitempty"`
+	// BusyAckSkipPrefixes suppresses the "message queued" acknowledgment that is
+	// normally sent when a message arrives while the agent is busy, for messages
+	// whose content starts with any of these prefixes. Intended for high-frequency
+	// automated card actions (e.g. instant-feedback survey buttons dispatched as
+	// commands) where the ack would be pure noise for the user. Empty (default)
+	// keeps the acknowledgment for every message.
+	BusyAckSkipPrefixes []string `toml:"busy_ack_skip_prefixes,omitempty"`
 	// AgentSessionIdleTimeoutMins 在指定分钟数后关闭空闲的 live agent 进程，
 	// 同时保留已保存的 session ID，便于下一条消息继续恢复。0 或 nil 表示禁用。
 	AgentSessionIdleTimeoutMins *int `toml:"agent_session_idle_timeout_mins,omitempty"`
@@ -1049,6 +1056,11 @@ func (c *Config) validateInternal(permissive bool) error {
 		}
 		if proj.ResetOnIdleMins != nil && *proj.ResetOnIdleMins < 0 {
 			return fmt.Errorf("config: %s.reset_on_idle_mins must be >= 0", prefix)
+		}
+		for _, pfx := range proj.BusyAckSkipPrefixes {
+			if strings.TrimSpace(pfx) == "" {
+				return fmt.Errorf("config: %s.busy_ack_skip_prefixes must not contain empty entries", prefix)
+			}
 		}
 		if proj.AgentSessionIdleTimeoutMins != nil && *proj.AgentSessionIdleTimeoutMins < 0 {
 			return fmt.Errorf("config: %s.agent_session_idle_timeout_mins must be >= 0", prefix)

--- a/core/busy_ack_prefix_test.go
+++ b/core/busy_ack_prefix_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestQueueMessageForBusySession_SkipPrefixesSuppressAck(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("qs-skip-prefix")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+	e.SetBusyAckSkipPrefixes([]string{"【问卷】", "cmd:【问卷】"})
+
+	key := "test:skip-prefix-user"
+	state := &interactiveState{agentSession: sess, platform: p, replyCtx: "ctx"}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	// Matching prefixes: queued silently — no busy ack reply.
+	for _, content := range []string{
+		"【问卷】[卡:3] Q1｜选项A",
+		"cmd:【问卷】[卡:3] Q2｜选项B",
+	} {
+		msg := &Message{SessionKey: key, Content: content, ReplyCtx: "ctx"}
+		if !e.queueMessageForBusySession(p, msg, key) {
+			t.Fatalf("expected %q to be queued, got false", content)
+		}
+		if got := len(p.getSent()); got != 0 {
+			t.Fatalf("after %q: platform replies = %d, want 0 (no busy ack for skipped prefix)", content, got)
+		}
+	}
+	state.mu.Lock()
+	depth := len(state.pendingMessages)
+	state.mu.Unlock()
+	if depth != 2 {
+		t.Fatalf("queue depth = %d, want 2 (messages queued despite suppressed ack)", depth)
+	}
+
+	// Non-matching content still gets the busy ack (default behavior preserved).
+	if !e.queueMessageForBusySession(p, &Message{SessionKey: key, Content: "regular question", ReplyCtx: "ctx"}, key) {
+		t.Fatal("expected regular message to be queued")
+	}
+	sent := p.getSent()
+	if len(sent) != 1 || !strings.Contains(sent[0], e.i18n.T(MsgMessageQueued)) {
+		t.Fatalf("platform replies = %#v, want exactly one busy-ack", sent)
+	}
+}
+
+// Without any configured prefixes every queued message is acknowledged,
+// exactly as before the option existed.
+func TestQueueMessageForBusySession_DefaultAcksEverything(t *testing.T) {
+	p := &stubPlatformEngine{n: "test"}
+	sess := newQueuingSession("qs-ack-default")
+	agent := &controllableAgent{nextSession: sess}
+	e := NewEngine("test", agent, []Platform{p}, "", LangEnglish)
+
+	key := "test:ack-default-user"
+	state := &interactiveState{agentSession: sess, platform: p, replyCtx: "ctx"}
+	e.interactiveMu.Lock()
+	e.interactiveStates[key] = state
+	e.interactiveMu.Unlock()
+
+	msg := &Message{SessionKey: key, Content: "【问卷】should still ack without config", ReplyCtx: "ctx"}
+	if !e.queueMessageForBusySession(p, msg, key) {
+		t.Fatal("expected message to be queued")
+	}
+	sent := p.getSent()
+	if len(sent) != 1 || !strings.Contains(sent[0], e.i18n.T(MsgMessageQueued)) {
+		t.Fatalf("platform replies = %#v, want exactly one busy-ack", sent)
+	}
+}
+
+func TestHasAnyPrefix(t *testing.T) {
+	prefixes := []string{"a:", ""}
+	cases := []struct {
+		s    string
+		want bool
+	}{
+		{"a:hello", true},
+		{"a:", true},
+		{"b:a:hello", false},
+		{"hello", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := hasAnyPrefix(c.s, prefixes); got != c.want {
+			t.Errorf("hasAnyPrefix(%q) = %v, want %v", c.s, got, c.want)
+		}
+	}
+	if hasAnyPrefix("anything", nil) {
+		t.Error("hasAnyPrefix with nil prefixes should be false")
+	}
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -428,6 +428,7 @@ type Engine struct {
 	autoCompressMaxTokens int
 	autoCompressMinGap    time.Duration
 	resetOnIdle           time.Duration
+	busyAckSkipPrefixes   []string
 
 	// Reply footer composition flags. The footer renders up to two lines:
 	//   line 1 — model · [effort ·] out/in/cw/cr · ctx%   (gated by showContextIndicator)
@@ -954,6 +955,15 @@ func (e *Engine) SetResetOnIdle(d time.Duration) {
 		return
 	}
 	e.resetOnIdle = d
+}
+
+// SetBusyAckSkipPrefixes suppresses the "message queued" acknowledgment that is
+// normally sent when a message arrives while the agent is busy, for messages
+// whose content starts with any of the given prefixes. Useful for high-frequency
+// automated card actions (e.g. instant-feedback survey buttons) where the ack
+// would be pure noise. nil keeps the acknowledgment for every message (default).
+func (e *Engine) SetBusyAckSkipPrefixes(prefixes []string) {
+	e.busyAckSkipPrefixes = prefixes
 }
 
 // SetAgentSessionIdleTimeout 配置单轮正常结束后的 live agent 空闲关闭时间。
@@ -3247,8 +3257,20 @@ func (e *Engine) queueMessageForBusySession(p Platform, msg *Message, interactiv
 		"user", msg.UserName,
 		"queue_depth", queueDepth,
 	)
-	e.reply(p, msg.ReplyCtx, e.i18n.T(MsgMessageQueued))
+	if !hasAnyPrefix(msg.Content, e.busyAckSkipPrefixes) {
+		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgMessageQueued))
+	}
 	return true
+}
+
+// hasAnyPrefix reports whether s starts with any non-empty prefix.
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if p != "" && strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // ensureInteractiveStateForQueueing creates a placeholder interactiveState


### PR DESCRIPTION
## Motivation

Messages arriving while the agent is busy get a "message queued" acknowledgment so the user knows they were received. That's the right default for humans typing — but for **high-frequency automated card actions** the ack is pure noise.

Concrete case from my deployment: multi-question survey cards whose buttons dispatch commands (each click already updates the card synchronously via the card callback, similar to what #1828 generalizes). A user answering 8 questions in quick succession while a turn is running gets 8 queued-ack chat messages they don't care about, and each one yanks the chat viewport to the bottom — actively harmful UX.

## What this adds

An opt-in per-project list:

```toml
[[projects]]
busy_ack_skip_prefixes = ["【问卷】", "cmd:【问卷】"]
```

- Messages whose content starts with any listed prefix are **still queued and drained exactly as before** — only the acknowledgment reply is suppressed.
- Card buttons dispatch their command as `cmd:<text>`, so deployments using both paths list both prefixes (documented).
- Empty/unset (default) acks every message — **zero behavior change** for existing configs.

## Implementation

- `Engine.SetBusyAckSkipPrefixes` + `hasAnyPrefix` helper guarding the single `MsgMessageQueued` reply in `queueMessageForBusySession`.
- Wired from project config at both engine construction sites in `cmd/cc-connect/main.go`.
- Config validation rejects empty entries.
- Bilingual docs in `config.example.toml` next to `agent_session_idle_timeout_mins`.
- Tests: prefix suppression (both forms), default acks-everything preserved, `hasAnyPrefix` edge cases. `go test ./core/ ./config/` green.

## 中文说明

新增可选的项目级配置 `busy_ack_skip_prefixes`：agent 忙碌期间到达的消息若命中前缀（如高频问卷按钮派发的命令），照常入队和补发，只是不再回"已入队"回执——连点 8 题不再刷 8 条噪音回执、聊天窗口不再被拽底。默认不配置=每条都回执，零行为变化。