### PR TITLE
feat(max): make inbound attachment download cap configurable

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1204,6 +1204,11 @@ app_secret = "your-feishu-app-secret"
 #                     # 允许的 MAX 用户 ID，如 "66624886,12345678"；"*" 表示所有
 # api_base = "https://platform-api.max.ru"   # optional override / 可选覆盖默认 API
 #
+# max_attachment_size_mb = 50   # optional: inbound attachment download cap (MiB).
+#                               # Default: core default (50). Raise to receive
+#                               # larger files/images/voice from users.
+# max_attachment_size_mb = 50   # 可选：接收附件的下载上限（MiB），默认 50，调大可接收更大文件
+#
 # --- Webhook mode (optional) ---
 # Set webhook_url to switch from long-poll to webhook. Required for high-traffic
 # bots since MAX throttles long-poll to 2 RPS from 2026-05-11.

--- a/platform/max/max.go
+++ b/platform/max/max.go
@@ -31,12 +31,11 @@ const (
 	// pollTimeout, otherwise transient MAX backend lag pushes header arrival
 	// past the deadline and the client cancels the long-poll, triggering a
 	// retry storm.
-	httpTimeout = 90 * time.Second
+	httpTimeout             = 90 * time.Second
 	initialReconnectBackoff = time.Second
 	maxReconnectBackoff     = 30 * time.Second
 	stableConnectionWindow  = 10 * time.Second
 	typingInterval          = 4 * time.Second
-	maxAttachmentBytes      = 25 * 1024 * 1024 // 25 MiB cap per downloaded attachment
 	attachmentDownloadTO    = 60 * time.Second
 	attachmentUploadTO      = 5 * time.Minute
 	// attachmentReadyDelay is the pause between CDN upload and POST /messages.
@@ -67,6 +66,7 @@ type Platform struct {
 	webhookPath         string
 	webhookSecret       string
 	resubscribeInterval time.Duration
+	maxAttachmentBytes  int64 // inbound per-attachment download cap; from max_attachment_size_mb
 
 	mu           sync.RWMutex
 	handler      core.MessageHandler
@@ -135,6 +135,25 @@ func New(opts map[string]any) (core.Platform, error) {
 		resubscribeInterval = d
 	}
 
+	// Inbound attachment download cap. Defaults to the shared
+	// core.DefaultMaxAttachmentSize (50 MiB); override per-platform with
+	// max_attachment_size_mb (MiB).
+	maxAttachBytes := core.DefaultMaxAttachmentSize
+	if raw, ok := opts["max_attachment_size_mb"]; ok {
+		var mb int64
+		switch v := raw.(type) {
+		case int64:
+			mb = v
+		case int:
+			mb = int64(v)
+		case float64:
+			mb = int64(v)
+		}
+		if mb > 0 {
+			maxAttachBytes = mb << 20
+		}
+	}
+
 	return &Platform{
 		token:               token,
 		apiBase:             apiBase,
@@ -144,6 +163,7 @@ func New(opts map[string]any) (core.Platform, error) {
 		webhookPath:         webhookPath,
 		webhookSecret:       webhookSecret,
 		resubscribeInterval: resubscribeInterval,
+		maxAttachmentBytes:  maxAttachBytes,
 		client:              &http.Client{Timeout: httpTimeout},
 		uploadClient:        &http.Client{Timeout: attachmentUploadTO},
 	}, nil
@@ -1176,7 +1196,7 @@ func audioFormatFromMime(mime, filename string) string {
 }
 
 // downloadAttachment GETs an arbitrary URL (typically a pre-signed CDN link
-// from MAX), capping the response at maxAttachmentBytes. The URLs MAX serves
+// from MAX), capping the response at p.maxAttachmentBytes. The URLs MAX serves
 // for image/file payloads are already authenticated, so no bot token is
 // attached to the request.
 func (p *Platform) downloadAttachment(ctx context.Context, url string) ([]byte, string, error) {
@@ -1197,12 +1217,12 @@ func (p *Platform) downloadAttachment(ctx context.Context, url string) ([]byte, 
 	if resp.StatusCode != http.StatusOK {
 		return nil, "", fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAttachmentBytes+1))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, p.maxAttachmentBytes+1))
 	if err != nil {
 		return nil, "", err
 	}
-	if len(data) > maxAttachmentBytes {
-		return nil, "", fmt.Errorf("attachment exceeds %d bytes", maxAttachmentBytes)
+	if int64(len(data)) > p.maxAttachmentBytes {
+		return nil, "", fmt.Errorf("attachment exceeds %d bytes", p.maxAttachmentBytes)
 	}
 	return data, resp.Header.Get("Content-Type"), nil
 }

--- a/platform/max/max_test.go
+++ b/platform/max/max_test.go
@@ -272,9 +272,10 @@ func (m *mockAPI) handleUploads(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleCDN mimics per-kind MAX CDN response shapes:
-//   image: {"photos": {"<id>": {"token": "..."}}}
-//   file:  {"token": "..."}
-//   video/audio: XML "<retval>1</retval>" (token comes from /uploads instead)
+//
+//	image: {"photos": {"<id>": {"token": "..."}}}
+//	file:  {"token": "..."}
+//	video/audio: XML "<retval>1</retval>" (token comes from /uploads instead)
 func (m *mockAPI) handleCDN(w http.ResponseWriter, r *http.Request) {
 	atomic.AddInt32(&m.cdnCalls, 1)
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
@@ -666,7 +667,6 @@ func TestSendAudio(t *testing.T) {
 	}
 }
 
-
 func TestNormalizeLineBreaks(t *testing.T) {
 	cases := []struct {
 		name, in, want string
@@ -787,6 +787,29 @@ func TestNewWebhookPathDefaults(t *testing.T) {
 		}
 		if got := p.(*Platform).webhookPath; got != c.want {
 			t.Errorf("webhook_path=%q: got %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNewMaxAttachmentSize(t *testing.T) {
+	cases := []struct {
+		name string
+		opts map[string]any
+		want int64
+	}{
+		{"default", map[string]any{"token": "t"}, core.DefaultMaxAttachmentSize},
+		{"override int", map[string]any{"token": "t", "max_attachment_size_mb": 100}, int64(100) << 20},
+		{"override int64", map[string]any{"token": "t", "max_attachment_size_mb": int64(64)}, int64(64) << 20},
+		{"override float", map[string]any{"token": "t", "max_attachment_size_mb": 32.0}, int64(32) << 20},
+		{"zero keeps default", map[string]any{"token": "t", "max_attachment_size_mb": 0}, core.DefaultMaxAttachmentSize},
+	}
+	for _, c := range cases {
+		p, err := New(c.opts)
+		if err != nil {
+			t.Fatalf("%s: New: %v", c.name, err)
+		}
+		if got := p.(*Platform).maxAttachmentBytes; got != c.want {
+			t.Errorf("%s: maxAttachmentBytes = %d, want %d", c.name, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

The MAX platform hard-coded its **inbound** attachment download limit at 25 MiB (`maxAttachmentBytes` in `platform/max/max.go`), below the project-wide `core.DefaultMaxAttachmentSize` (50 MiB) used elsewhere (e.g. the send side / `max_attachment_size_mb`). Any file, image, or voice message larger than 25 MiB that a user sends to a MAX bot is rejected during download with `attachment exceeds N bytes` and never reaches the agent — with no way to raise the limit via config.

Observed in production: a ~30 MiB `.docx` sent to the bot failed with
`max: file download failed error="attachment exceeds 26214400 bytes"`.

## Change

- Default the inbound cap to the shared `core.DefaultMaxAttachmentSize` (50 MiB) instead of the hard-coded 25 MiB, so MAX is consistent with the rest of cc-connect.
- Add a per-platform override `max_attachment_size_mb` (MiB), matching the naming of the existing global send-side option. `0`/unset keeps the default.
- Document the option in `config.example.toml` (EN + 中文) and add `TestNewMaxAttachmentSize`.

No behaviour change for existing configs below 25 MiB; the default simply rises from 25 → 50 MiB and becomes tunable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GehKUtQ1YRKccv5PbHhHix