### PR TITLE
fix(core): generation-counted session busy lock with stale-break self-heal and stop-path release

### DIFF
--- a/cmd/cc-connect/main.go
+++ b/cmd/cc-connect/main.go
@@ -682,6 +682,16 @@ func main() {
 			}
 		}
 
+		// Wire busy-lock stale-break threshold (#1829)
+		if cfg.BusyTimeoutMins != nil {
+			mins := *cfg.BusyTimeoutMins
+			if mins <= 0 {
+				engine.SetStaleLockBreakAfter(0)
+			} else {
+				engine.SetStaleLockBreakAfter(time.Duration(mins) * time.Minute)
+			}
+		}
+
 		// Wire max turn time (absolute per-turn wall-clock cap; 0 = disabled)
 		if cfg.MaxTurnTimeMins != nil && *cfg.MaxTurnTimeMins > 0 {
 			engine.SetMaxTurnTime(time.Duration(*cfg.MaxTurnTimeMins) * time.Minute)

--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,7 @@ type Config struct {
 	Management         ManagementConfig        `toml:"management"`
 	Hooks              []HookConfig            `toml:"hooks"`
 	IdleTimeoutMins    *int                    `toml:"idle_timeout_mins,omitempty"`  // max minutes between consecutive agent events; 0 = no timeout; default 120
+	BusyTimeoutMins    *int                    `toml:"busy_timeout_mins,omitempty"`  // minutes a dead agent's session busy lock may be held before the next message breaks it; 0 = disable; default 2
 	MaxTurnTimeMins    *int                    `toml:"max_turn_time_mins,omitempty"` // absolute wall-clock cap per turn in minutes; 0 = disabled (default)
 	// WorkspaceIdleTimeoutMins controls the workspace idle reaper timeout
 	// (multi-workspace mode) for every engine in the process. 0 disables

--- a/core/busy-stale-platB_userB-1789215886.txt
+++ b/core/busy-stale-platB_userB-1789215886.txt
@@ -1,0 +1,409 @@
+goroutine 558 [running]:
+github.com/chenhg5/cc-connect/core.dumpGoroutineStacks.func1()
+	/Users/ce/src/cc-connect/core/engine.go:2836 +0x78
+created by github.com/chenhg5/cc-connect/core.dumpGoroutineStacks in goroutine 644
+	/Users/ce/src/cc-connect/core/engine.go:2833 +0x88
+
+goroutine 1 [chan receive]:
+testing.(*T).Run(0x42d23704e6c8, {0x103182b2c?, 0x42d236f9fb18?}, 0x10370af48)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2109 +0x3bc
+testing.runTests.func1(0x42d23704e6c8)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2585 +0x38
+testing.tRunner(0x42d23704e6c8, 0x42d236f9fc48)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0xc4
+testing.runTests({0x10316c526, 0x1d}, {0x103176b87, 0x22}, 0x42d236f761c8, {0x10379ad00, 0x4db, 0x4db}, {0x808080803c7c1c1e?, 0x103155051?, ...})
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2583 +0x3f0
+testing.(*M).Run(0x42d237162280)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2443 +0x578
+main.main()
+	_testmain.go:2530 +0x80
+
+goroutine 640 [sync.WaitGroup.Wait]:
+sync.runtime_SemacquireWaitGroup(0x102c4c1b0?, 0x20?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/sema.go:114 +0x38
+sync.(*WaitGroup).Wait(0x42d2371a7030)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/waitgroup.go:206 +0xa8
+github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed(0x42d237240908)
+	/Users/ce/src/cc-connect/core/cuj_test.go:2024 +0x22c
+testing.tRunner(0x42d237240908, 0x10370af48)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0xc4
+created by testing.(*T).Run in goroutine 1
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x3a8
+
+goroutine 539 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237198508, {0x10371b338, 0x42d2373ccb40}, 0x42d23739ef10?, 0x42d2371aca80?, 0x42d237270160, {0x10371d838, 0x42d2371e5200}, 0x42d23726a120, 0x42d2371a3c80, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 520
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 432 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b6a08, {0x10371b338, 0x42d2372375e0}, 0x42d2371ea1f0?, 0x42d2376e5ab0?, 0x42d237692f20, {0x10371d838, 0x42d2372a2e00}, 0x42d2376f2480, 0x42d237293500, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 428
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 19 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237198f08, {0x10371b338, 0x42d237236050}, 0x42d23720c2f0?, 0x42d237224850?, 0x42d23722e000, {0x10371d4d8, 0x42d2371a0100}, 0x42d237196480, 0x42d237016a80, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 14
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 24 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237260008, {0x10371b338, 0x42d2372367d0}, 0x42d23720ca20?, 0x42d237224c40?, 0x42d23722e6e0, {0x10371d4d8, 0x42d237208340}, 0x42d2372050e0, 0x42d237228540, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 21
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 444 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372baf08, {0x10371b338, 0x42d2373e43c0}, 0x42d2370948f0?, 0x42d2371f6230?, 0x42d2371e69a0, {0x10371d838, 0x42d2371e4580}, 0x42d2372b8b40, 0x42d2371a2600, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 441
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 494 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372bb908, {0x10371b338, 0x42d2373e4a00}, 0x42d237095490?, 0x42d237242540?, 0x42d2371e7760, {0x10371d838, 0x42d2371e4c00}, 0x42d237196b40, 0x42d2371a3140, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 490
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 425 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237261408, {0x10371b338, 0x42d237237270}, 0x42d23720dad0?, 0x42d2376e4cb0?, 0x42d237173b80, {0x10371d838, 0x42d237234a80}, 0x42d2372105a0, 0x42d2372291a0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 383
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 405 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fd908, {0x10371b338, 0x42d2373e5310}, 0x42d2370944e0?, 0x42d2371a5c00?, 0x42d2376926e0, {0x10371d838, 0x42d2372a2680}, 0x42d2376c4900, 0x42d2371a2cc0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 391
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 426 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372baa08, {0x10371b338, 0x42d2372372c0}, 0x42d23720dbd0?, 0x42d2376e4ee0?, 0x42d2371e7600, {0x10371d838, 0x42d2371e4b80}, 0x42d2372b8fc0, 0x42d2371a38c0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 449
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 388 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fd408, {0x10371b338, 0x42d237236b90}, 0x42d23720ce30?, 0x42d237019490?, 0x42d237692420, {0x10371d838, 0x42d2372a2380}, 0x42d2373cb320, 0x42d2371a2840, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 207
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 381 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372ba008, {0x10371b338, 0x42d2373cd450}, 0x42d23739f650?, 0x42d237225e30?, 0x42d2371e6dc0, {0x10371d838, 0x42d2371e4800}, 0x42d2372b8240, 0x42d2371a3200, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 421
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 406 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b6508, {0x10371b338, 0x42d2373e5360}, 0x42d2370945e0?, 0x42d2371a5f10?, 0x42d237692b00, {0x10371d838, 0x42d2372a2800}, 0x42d2376c5200, 0x42d237292d80, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 396
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 458 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237260f08, {0x10371b338, 0x42d2373cc190}, 0x42d23739e3c0?, 0x42d2372223f0?, 0x42d2371729a0, {0x10371d838, 0x42d2370b6600}, 0x42d237205320, 0x42d2371f48a0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 454
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 453 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372ba508, {0x10371b338, 0x42d2373cc000}, 0x42d23739e0f0?, 0x42d237222230?, 0x42d2371e6420, {0x10371d838, 0x42d2371e4380}, 0x42d2372b8480, 0x42d2371a22a0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 436
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 464 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237261908, {0x10371b338, 0x42d2373cc3c0}, 0x42d23739e7d0?, 0x42d2372233b0?, 0x42d237172dc0, {0x10371d838, 0x42d2370b6880}, 0x42d2376f2000, 0x42d2371f4d80, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 468
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 138 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237260a08, {0x10371b338, 0x42d2372363c0}, 0x42d237354550?, 0x42d2376e4a10?, 0x42d237172420, {0x10371d838, 0x42d2370b6180}, 0x42d237204480, 0x42d2371f4480, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 134
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 532 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fc008, {0x10371b338, 0x42d2373cc4b0}, 0x42d23739ea10?, 0x42d237223f10?, 0x42d237692580, {0x10371d838, 0x42d237234600}, 0x42d2370bf560, 0x42d237292420, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 509
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 537 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fc508, {0x10371b338, 0x42d2373ccaf0}, 0x42d23739edf0?, 0x42d2371ac4d0?, 0x42d237692dc0, {0x10371d838, 0x42d237234780}, 0x42d2370bfc20, 0x42d2372926c0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 533
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 555 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371d2508, {0x10371b338, 0x42d2373cc410}, 0x10371b0d0?, 0x42d2371a2180?, 0x42d23722ec60, {0x10371d838, 0x42d2371e4680}, 0x42d2373ca000, 0x42d2371a21e0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 551
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 488 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b7908, {0x10371b338, 0x42d2373e4780}, 0x42d237094fc0?, 0x42d2371f70a0?, 0x42d23722e2c0, {0x10371d838, 0x42d2370b7080}, 0x42d2370bec60, 0x42d2371f5e60, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 504
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 481 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2370cc508, {0x10371b338, 0x42d2373e4500}, 0x42d237094b60?, 0x42d2371f6690?, 0x42d2376922c0, {0x10371d838, 0x42d237234500}, 0x42d2372107e0, 0x42d237228360, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 445
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 502 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b7408, {0x10371b338, 0x42d237237040}, 0x42d237355960?, 0x42d2371a5650?, 0x42d237173760, {0x10371d838, 0x42d2370b6d80}, 0x42d2376f38c0, 0x42d2371f5980, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 498
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 478 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b6f08, {0x10371b338, 0x42d237236c80}, 0x42d237355290?, 0x42d237019b20?, 0x42d2371731e0, {0x10371d838, 0x42d2370b6a80}, 0x42d2376f2900, 0x42d2371f53e0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 474
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 528 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371d2008, {0x10371b338, 0x42d2373e4140}, 0x0?, 0x0?, 0x42d237270000, {0x10371d838, 0x42d237234080}, 0x42d237383440, 0x42d237229440, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 584
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 557 [sync.RWMutex.RLock]:
+sync.runtime_SemacquireRWMutexR(0x42d2371a7040?, 0x8?, 0xc2a16f0397e9fa90?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/sema.go:100 +0x28
+sync.(*RWMutex).RLock(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/rwmutex.go:74
+github.com/chenhg5/cc-connect/core.(*SessionManager).Save(0x42d237293380)
+	/Users/ce/src/cc-connect/core/session.go:725 +0x70
+github.com/chenhg5/cc-connect/core.(*Engine).processInteractiveMessageWith(0x42d2371fca08, {0x10371bf40, 0x42d2371bd260}, 0x42d2370c8b40, 0x42d2373cab40, {0x10371b0d0, 0x42d237293320}, 0x42d237293380, {0x10315054d, 0xb}, ...)
+	/Users/ce/src/cc-connect/core/engine.go:3843 +0xf0
+created by github.com/chenhg5/cc-connect/core.(*Engine).handleMessage in goroutine 650
+	/Users/ce/src/cc-connect/core/engine.go:3181 +0x1ad4
+
+goroutine 516 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237198008, {0x10371b338, 0x42d2373e4c80}, 0x42d2370959b0?, 0x42d237243880?, 0x42d2371e7b80, {0x10371d838, 0x42d2371e4f00}, 0x42d237197440, 0x42d2371a3620, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 496
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 610 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237198a08, {0x10371b338, 0x42d2373e41e0}, 0x0?, 0x0?, 0x42d2376931e0, {0x10371d838, 0x42d2370b6280}, 0x42d237382240, 0x42d237292780, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 600
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 548 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fc508, {0x10371b338, 0x42d23734a0a0}, 0x42d2371ea940?, 0x42d237225b90?, 0x42d23722eb00, {0x10371d838, 0x42d2370b7480}, 0x42d2370bf8c0, 0x42d2372926c0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 512
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 583 [select]:
+github.com/chenhg5/cc-connect/core.(*RateLimiter).cleanupLoop(0x42d2373c3620)
+	/Users/ce/src/cc-connect/core/ratelimit.go:88 +0xa0
+created by github.com/chenhg5/cc-connect/core.NewRateLimiter in goroutine 582
+	/Users/ce/src/cc-connect/core/ratelimit.go:34 +0xf4
+
+goroutine 578 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2370cca08, {0x10371b338, 0x42d2373cce10}, 0x42d23739f3f0?, 0x42d2371adc70?, 0x42d237693340, {0x10371d838, 0x42d237234b00}, 0x42d237382900, 0x42d237228d20, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 542
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 615 [runnable]:
+syscall.syscalln(0x102c91860, {0x42d23706c680, 0x3, 0x3})
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/sys_darwin.go:38 +0x20
+syscall.syscall(0x42d23720e380?, 0x76?, 0x42d23706c6d8?, 0x76?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/syscall/syscall_darwin.go:365 +0x24
+syscall.Open({0x42d23720e380?, 0x42d23720e3ec?}, 0x1000a02, 0x180)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/syscall/zsyscall_darwin_arm64.go:1162 +0x70
+os.open(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file_open_unix.go:15
+os.openFileNolog.func1(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file_unix.go:261
+os.ignoringEINTR(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file_posix.go:256
+os.openFileNolog({0x42d23720e380, 0x76}, 0xa02, 0x180)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file_unix.go:260 +0xd4
+os.OpenFile({0x42d23720e380, 0x76}, 0xa02, 0x180)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file.go:412 +0x40
+os.CreateTemp({0x42d2372c2000?, 0x42d2372c2000?}, {0x10314b820, 0x6})
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/tempfile.go:49 +0x1a0
+github.com/chenhg5/cc-connect/core.AtomicWriteFile({0x42d2372c2000, 0x74}, {0x42d237040900, 0x607, 0x882}, 0x1a4)
+	/Users/ce/src/cc-connect/core/atomicwrite.go:13 +0x4c
+github.com/chenhg5/cc-connect/core.(*SessionManager).saveLocked(0x42d237293380)
+	/Users/ce/src/cc-connect/core/session.go:797 +0x678
+github.com/chenhg5/cc-connect/core.(*SessionManager).Save(0x42d23726ad80?)
+	/Users/ce/src/cc-connect/core/session.go:727 +0x94
+github.com/chenhg5/cc-connect/core.(*Engine).processInteractiveEvents(0x42d2371fca08, 0x42d237270580, 0x42d23726ad80, 0x42d237293380, {0x103150542, 0xb}, {0x42d2373c032c, 0x2}, {0x42d237293380?, 0x103150542?, ...}, ...)
+	/Users/ce/src/cc-connect/core/engine.go:6315 +0x6a44
+github.com/chenhg5/cc-connect/core.(*Engine).processInteractiveMessageWith(0x42d2371fca08, {0x10371bf40, 0x42d2371bd230}, 0x42d2371a8640, 0x42d23726ad80, {0x10371b0d0, 0x42d237293320}, 0x42d237293380, {0x103150542, 0xb}, ...)
+	/Users/ce/src/cc-connect/core/engine.go:3952 +0x8f8
+created by github.com/chenhg5/cc-connect/core.(*Engine).handleMessage in goroutine 643
+	/Users/ce/src/cc-connect/core/engine.go:3181 +0x1ad4
+
+goroutine 642 [select]:
+github.com/chenhg5/cc-connect/core.dumpGoroutineStacks({0x42d2371c6de0, 0x25})
+	/Users/ce/src/cc-connect/core/engine.go:2841 +0xcc
+github.com/chenhg5/cc-connect/core.(*Engine).handleMessage(0x42d2371fca08, {0x10371bf40, 0x42d2371bd260}, 0x42d23714adc0)
+	/Users/ce/src/cc-connect/core/engine.go:3117 +0x1474
+github.com/chenhg5/cc-connect/core.(*Engine).ReceiveMessage(...)
+	/Users/ce/src/cc-connect/core/engine.go:2443
+github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed.func2()
+	/Users/ce/src/cc-connect/core/cuj_test.go:2016 +0x178
+created by github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed in goroutine 640
+	/Users/ce/src/cc-connect/core/cuj_test.go:2014 +0x158
+
+goroutine 556 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237199408, {0x10371b338, 0x42d2373cc460}, 0x10371b0d0?, 0x42d237292660?, 0x42d237693b80, {0x10371d838, 0x42d2370b6680}, 0x42d237382fc0, 0x42d237292ae0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 607
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 619 [runnable]:
+syscall.syscalln(0x102c919f0, {0x42d237304cd0, 0x3, 0x3})
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/sys_darwin.go:38 +0x20
+syscall.syscall(0x42d237304d28?, 0x102cb2b28?, 0x42d237228660?, 0x5?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/syscall/syscall_darwin.go:365 +0x24
+syscall.Fstat(0x26?, 0x0?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/syscall/zsyscall_darwin_arm64.go:1897 +0x38
+os.newFile.func1(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file_unix.go:170
+os.ignoringEINTR(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file_posix.go:256
+os.newFile(0x5, {0x42d2371c6de0, 0x25}, 0x1, 0x0)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file_unix.go:169 +0x238
+os.openFileNolog({0x42d2371c6de0, 0x25}, 0x601, 0x1a4)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file_unix.go:279 +0x148
+os.OpenFile({0x42d2371c6de0, 0x25}, 0x601, 0x1a4)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file.go:412 +0x40
+os.WriteFile({0x42d2371c6de0?, 0x400000?}, {0x42d237b00000, 0x68d9, 0x400000}, 0x0?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file.go:933 +0x34
+github.com/chenhg5/cc-connect/core.dumpGoroutineStacks.func1()
+	/Users/ce/src/cc-connect/core/engine.go:2837 +0x9c
+created by github.com/chenhg5/cc-connect/core.dumpGoroutineStacks in goroutine 642
+	/Users/ce/src/cc-connect/core/engine.go:2833 +0x88
+
+goroutine 616 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).startMessageRecallMonitor.func1()
+	/Users/ce/src/cc-connect/core/engine.go:2854 +0xb8
+created by github.com/chenhg5/cc-connect/core.(*Engine).startMessageRecallMonitor in goroutine 615
+	/Users/ce/src/cc-connect/core/engine.go:2850 +0x98
+
+goroutine 644 [select]:
+github.com/chenhg5/cc-connect/core.dumpGoroutineStacks({0x42d236f911d0, 0x25})
+	/Users/ce/src/cc-connect/core/engine.go:2841 +0xcc
+github.com/chenhg5/cc-connect/core.(*Engine).handleMessage(0x42d2371fca08, {0x10371bf40, 0x42d2371bd260}, 0x42d2370c8c80)
+	/Users/ce/src/cc-connect/core/engine.go:3117 +0x1474
+github.com/chenhg5/cc-connect/core.(*Engine).ReceiveMessage(...)
+	/Users/ce/src/cc-connect/core/engine.go:2443
+github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed.func2()
+	/Users/ce/src/cc-connect/core/cuj_test.go:2016 +0x178
+created by github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed in goroutine 640
+	/Users/ce/src/cc-connect/core/cuj_test.go:2014 +0x158
+
+goroutine 645 [sync.Mutex.Lock]:
+internal/sync.runtime_SemacquireMutex(0x42d2374095b8?, 0x40?, 0x100000043?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/sema.go:95 +0x28
+internal/sync.(*Mutex).lockSlow(0x42d237293380)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/internal/sync/mutex.go:149 +0x170
+internal/sync.(*Mutex).Lock(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/internal/sync/mutex.go:70
+sync.(*Mutex).Lock(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/mutex.go:46
+sync.(*RWMutex).Lock(0x42d237293380)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/rwmutex.go:150 +0x6c
+github.com/chenhg5/cc-connect/core.(*SessionManager).UpdateUserMeta(0x42d237293380, {0x103150542, 0xb}, {0x10314b001, 0x5}, {0x0, 0x0})
+	/Users/ce/src/cc-connect/core/session.go:575 +0x58
+github.com/chenhg5/cc-connect/core.(*Engine).handleMessage(0x42d2371fca08, {0x10371bf40, 0x42d2371bd230}, 0x42d236f66140)
+	/Users/ce/src/cc-connect/core/engine.go:3088 +0x126c
+github.com/chenhg5/cc-connect/core.(*Engine).ReceiveMessage(...)
+	/Users/ce/src/cc-connect/core/engine.go:2443
+github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed.func1()
+	/Users/ce/src/cc-connect/core/cuj_test.go:2007 +0x178
+created by github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed in goroutine 640
+	/Users/ce/src/cc-connect/core/cuj_test.go:2005 +0x1d8
+
+goroutine 646 [sync.Mutex.Lock]:
+internal/sync.runtime_SemacquireMutex(0x42d2372cf5b8?, 0x40?, 0x100000031?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/sema.go:95 +0x28
+internal/sync.(*Mutex).lockSlow(0x42d237293380)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/internal/sync/mutex.go:149 +0x170
+internal/sync.(*Mutex).Lock(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/internal/sync/mutex.go:70
+sync.(*Mutex).Lock(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/mutex.go:46
+sync.(*RWMutex).Lock(0x42d237293380)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/rwmutex.go:150 +0x6c
+github.com/chenhg5/cc-connect/core.(*SessionManager).UpdateUserMeta(0x42d237293380, {0x10315054d, 0xb}, {0x10314affc, 0x5}, {0x0, 0x0})
+	/Users/ce/src/cc-connect/core/session.go:575 +0x58
+github.com/chenhg5/cc-connect/core.(*Engine).handleMessage(0x42d2371fca08, {0x10371bf40, 0x42d2371bd260}, 0x42d237310000)
+	/Users/ce/src/cc-connect/core/engine.go:3088 +0x126c
+github.com/chenhg5/cc-connect/core.(*Engine).ReceiveMessage(...)
+	/Users/ce/src/cc-connect/core/engine.go:2443
+github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed.func2()
+	/Users/ce/src/cc-connect/core/cuj_test.go:2016 +0x178
+created by github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed in goroutine 640
+	/Users/ce/src/cc-connect/core/cuj_test.go:2014 +0x158
+
+goroutine 647 [sync.RWMutex.Lock]:
+sync.runtime_SemacquireRWMutex(0x42d237293380?, 0x42?, 0x42d237319648?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/sema.go:105 +0x28
+sync.(*RWMutex).Lock(0x42d2373c0338?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/rwmutex.go:155 +0xf4
+github.com/chenhg5/cc-connect/core.(*SessionManager).UpdateUserMeta(0x42d237293380, {0x103150542, 0xb}, {0x10314b001, 0x5}, {0x0, 0x0})
+	/Users/ce/src/cc-connect/core/session.go:575 +0x58
+github.com/chenhg5/cc-connect/core.(*Engine).handleMessage(0x42d2371fca08, {0x10371bf40, 0x42d2371bd230}, 0x42d237392000)
+	/Users/ce/src/cc-connect/core/engine.go:3088 +0x126c
+github.com/chenhg5/cc-connect/core.(*Engine).ReceiveMessage(...)
+	/Users/ce/src/cc-connect/core/engine.go:2443
+github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed.func1()
+	/Users/ce/src/cc-connect/core/cuj_test.go:2007 +0x178
+created by github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed in goroutine 640
+	/Users/ce/src/cc-connect/core/cuj_test.go:2005 +0x1d8
+
+goroutine 648 [sync.Mutex.Lock]:
+internal/sync.runtime_SemacquireMutex(0x42d23731d5b8?, 0x40?, 0x3?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/sema.go:95 +0x28
+internal/sync.(*Mutex).lockSlow(0x42d237293380)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/internal/sync/mutex.go:149 +0x170
+internal/sync.(*Mutex).Lock(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/internal/sync/mutex.go:70
+sync.(*Mutex).Lock(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/mutex.go:46
+sync.(*RWMutex).Lock(0x42d237293380)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/sync/rwmutex.go:150 +0x6c
+github.com/chenhg5/cc-connect/core.(*SessionManager).UpdateUserMeta(0x42d237293380, {0x10315054d, 0xb}, {0x10314affc, 0x5}, {0x0, 0x0})
+	/Users/ce/src/cc-connect/core/session.go:575 +0x58
+github.com/chenhg5/cc-connect/core.(*Engine).handleMessage(0x42d2371fca08, {0x10371bf40, 0x42d2371bd260}, 0x42d2370c8dc0)
+	/Users/ce/src/cc-connect/core/engine.go:3088 +0x126c
+github.com/chenhg5/cc-connect/core.(*Engine).ReceiveMessage(...)
+	/Users/ce/src/cc-connect/core/engine.go:2443
+github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed.func2()
+	/Users/ce/src/cc-connect/core/cuj_test.go:2016 +0x178
+created by github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed in goroutine 640
+	/Users/ce/src/cc-connect/core/cuj_test.go:2014 +0x158
+
+goroutine 649 [runnable]:
+github.com/chenhg5/cc-connect/core.(*stubPlatformEngine).Reply(0x42d2371bd230, {0x10371bf40?, 0x42d2371bd230?}, {0x0?, 0x0?}, {0x1031abc8d, 0x47})
+	/Users/ce/src/cc-connect/core/engine_test.go:65 +0xc4
+github.com/chenhg5/cc-connect/core.(*Engine).replyWithError(0x42d2371fca08, {0x10371bf40, 0x42d2371bd230}, {0x103646f60, 0x103710980}, {0x1031abc8d, 0x47})
+	/Users/ce/src/cc-connect/core/engine.go:12161 +0x14c
+github.com/chenhg5/cc-connect/core.(*Engine).reply(...)
+	/Users/ce/src/cc-connect/core/engine.go:12173
+github.com/chenhg5/cc-connect/core.(*Engine).queueMessageForBusySession(0x42d2371fca08, {0x10371bf40, 0x42d2371bd230}, 0x42d23714ac80, {0x103150542, 0xb})
+	/Users/ce/src/cc-connect/core/engine.go:3338 +0x6a0
+github.com/chenhg5/cc-connect/core.(*Engine).handleMessage(0x42d2371fca08, {0x10371bf40, 0x42d2371bd230}, 0x42d23714ac80)
+	/Users/ce/src/cc-connect/core/engine.go:3135 +0x1604
+github.com/chenhg5/cc-connect/core.(*Engine).ReceiveMessage(...)
+	/Users/ce/src/cc-connect/core/engine.go:2443
+github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed.func1()
+	/Users/ce/src/cc-connect/core/cuj_test.go:2007 +0x178
+created by github.com/chenhg5/cc-connect/core.TestCUJ_H2_TwoPlatformsConcurrentNoBleed in goroutine 640
+	/Users/ce/src/cc-connect/core/cuj_test.go:2005 +0x1d8

--- a/core/busy-stale-test_d6-1789215885.txt
+++ b/core/busy-stale-test_d6-1789215885.txt
@@ -1,0 +1,217 @@
+goroutine 585 [running]:
+github.com/chenhg5/cc-connect/core.dumpGoroutineStacks.func1()
+	/Users/ce/src/cc-connect/core/engine.go:2836 +0x78
+created by github.com/chenhg5/cc-connect/core.dumpGoroutineStacks in goroutine 582
+	/Users/ce/src/cc-connect/core/engine.go:2833 +0x88
+
+goroutine 1 [chan receive]:
+testing.(*T).Run(0x42d23704e6c8, {0x10317221c?, 0x42d236f9fb18?}, 0x10370aeb0)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2109 +0x3bc
+testing.runTests.func1(0x42d23704e6c8)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2585 +0x38
+testing.tRunner(0x42d23704e6c8, 0x42d236f9fc48)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0xc4
+testing.runTests({0x10316c526, 0x1d}, {0x103176b87, 0x22}, 0x42d236f761c8, {0x10379ad00, 0x4db, 0x4db}, {0x808080803c7c1c1e?, 0x103155051?, ...})
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2583 +0x3f0
+testing.(*M).Run(0x42d237162280)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2443 +0x578
+main.main()
+	_testmain.go:2530 +0x80
+
+goroutine 582 [select]:
+github.com/chenhg5/cc-connect/core.dumpGoroutineStacks({0x42d2371c61b0, 0x21})
+	/Users/ce/src/cc-connect/core/engine.go:2841 +0xcc
+github.com/chenhg5/cc-connect/core.(*Engine).handleMessage(0x42d2371d2008, {0x10371bf40, 0x42d2373c3260}, 0x42d23714b400)
+	/Users/ce/src/cc-connect/core/engine.go:3117 +0x1474
+github.com/chenhg5/cc-connect/core.(*Engine).ReceiveMessage(...)
+	/Users/ce/src/cc-connect/core/engine.go:2443
+github.com/chenhg5/cc-connect/core.(*cujEnv).userSends(0x42d2373c35c0, {0x10314a0eb, 0x2}, {0x42d2373c0950, 0x7})
+	/Users/ce/src/cc-connect/core/cuj_test.go:287 +0x188
+github.com/chenhg5/cc-connect/core.TestCUJ_D6_InboundRateLimitDrops(0x42d23717ed88)
+	/Users/ce/src/cc-connect/core/cuj_test.go:1561 +0x90
+testing.tRunner(0x42d23717ed88, 0x10370aeb0)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2036 +0xc4
+created by testing.(*T).Run in goroutine 1
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/testing/testing.go:2101 +0x3a8
+
+goroutine 539 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237198508, {0x10371b338, 0x42d2373ccb40}, 0x42d23739ef10?, 0x42d2371aca80?, 0x42d237270160, {0x10371d838, 0x42d2371e5200}, 0x42d23726a120, 0x42d2371a3c80, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 520
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 432 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b6a08, {0x10371b338, 0x42d2372375e0}, 0x42d2371ea1f0?, 0x42d2376e5ab0?, 0x42d237692f20, {0x10371d838, 0x42d2372a2e00}, 0x42d2376f2480, 0x42d237293500, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 428
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 19 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237198f08, {0x10371b338, 0x42d237236050}, 0x42d23720c2f0?, 0x42d237224850?, 0x42d23722e000, {0x10371d4d8, 0x42d2371a0100}, 0x42d237196480, 0x42d237016a80, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 14
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 24 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237260008, {0x10371b338, 0x42d2372367d0}, 0x42d23720ca20?, 0x42d237224c40?, 0x42d23722e6e0, {0x10371d4d8, 0x42d237208340}, 0x42d2372050e0, 0x42d237228540, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 21
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 444 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372baf08, {0x10371b338, 0x42d2373e43c0}, 0x42d2370948f0?, 0x42d2371f6230?, 0x42d2371e69a0, {0x10371d838, 0x42d2371e4580}, 0x42d2372b8b40, 0x42d2371a2600, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 441
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 494 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372bb908, {0x10371b338, 0x42d2373e4a00}, 0x42d237095490?, 0x42d237242540?, 0x42d2371e7760, {0x10371d838, 0x42d2371e4c00}, 0x42d237196b40, 0x42d2371a3140, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 490
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 425 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237261408, {0x10371b338, 0x42d237237270}, 0x42d23720dad0?, 0x42d2376e4cb0?, 0x42d237173b80, {0x10371d838, 0x42d237234a80}, 0x42d2372105a0, 0x42d2372291a0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 383
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 405 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fd908, {0x10371b338, 0x42d2373e5310}, 0x42d2370944e0?, 0x42d2371a5c00?, 0x42d2376926e0, {0x10371d838, 0x42d2372a2680}, 0x42d2376c4900, 0x42d2371a2cc0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 391
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 426 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372baa08, {0x10371b338, 0x42d2372372c0}, 0x42d23720dbd0?, 0x42d2376e4ee0?, 0x42d2371e7600, {0x10371d838, 0x42d2371e4b80}, 0x42d2372b8fc0, 0x42d2371a38c0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 449
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 388 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fd408, {0x10371b338, 0x42d237236b90}, 0x42d23720ce30?, 0x42d237019490?, 0x42d237692420, {0x10371d838, 0x42d2372a2380}, 0x42d2373cb320, 0x42d2371a2840, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 207
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 381 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372ba008, {0x10371b338, 0x42d2373cd450}, 0x42d23739f650?, 0x42d237225e30?, 0x42d2371e6dc0, {0x10371d838, 0x42d2371e4800}, 0x42d2372b8240, 0x42d2371a3200, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 421
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 406 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b6508, {0x10371b338, 0x42d2373e5360}, 0x42d2370945e0?, 0x42d2371a5f10?, 0x42d237692b00, {0x10371d838, 0x42d2372a2800}, 0x42d2376c5200, 0x42d237292d80, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 396
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 458 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237260f08, {0x10371b338, 0x42d2373cc190}, 0x42d23739e3c0?, 0x42d2372223f0?, 0x42d2371729a0, {0x10371d838, 0x42d2370b6600}, 0x42d237205320, 0x42d2371f48a0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 454
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 453 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2372ba508, {0x10371b338, 0x42d2373cc000}, 0x42d23739e0f0?, 0x42d237222230?, 0x42d2371e6420, {0x10371d838, 0x42d2371e4380}, 0x42d2372b8480, 0x42d2371a22a0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 436
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 464 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237261908, {0x10371b338, 0x42d2373cc3c0}, 0x42d23739e7d0?, 0x42d2372233b0?, 0x42d237172dc0, {0x10371d838, 0x42d2370b6880}, 0x42d2376f2000, 0x42d2371f4d80, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 468
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 138 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237260a08, {0x10371b338, 0x42d2372363c0}, 0x42d237354550?, 0x42d2376e4a10?, 0x42d237172420, {0x10371d838, 0x42d2370b6180}, 0x42d237204480, 0x42d2371f4480, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 134
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 532 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fc008, {0x10371b338, 0x42d2373cc4b0}, 0x42d23739ea10?, 0x42d237223f10?, 0x42d237692580, {0x10371d838, 0x42d237234600}, 0x42d2370bf560, 0x42d237292420, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 509
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 537 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fc508, {0x10371b338, 0x42d2373ccaf0}, 0x42d23739edf0?, 0x42d2371ac4d0?, 0x42d237692dc0, {0x10371d838, 0x42d237234780}, 0x42d2370bfc20, 0x42d2372926c0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 533
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 488 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b7908, {0x10371b338, 0x42d2373e4780}, 0x42d237094fc0?, 0x42d2371f70a0?, 0x42d23722e2c0, {0x10371d838, 0x42d2370b7080}, 0x42d2370bec60, 0x42d2371f5e60, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 504
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 481 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2370cc508, {0x10371b338, 0x42d2373e4500}, 0x42d237094b60?, 0x42d2371f6690?, 0x42d2376922c0, {0x10371d838, 0x42d237234500}, 0x42d2372107e0, 0x42d237228360, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 445
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 502 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b7408, {0x10371b338, 0x42d237237040}, 0x42d237355960?, 0x42d2371a5650?, 0x42d237173760, {0x10371d838, 0x42d2370b6d80}, 0x42d2376f38c0, 0x42d2371f5980, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 498
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 478 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2376b6f08, {0x10371b338, 0x42d237236c80}, 0x42d237355290?, 0x42d237019b20?, 0x42d2371731e0, {0x10371d838, 0x42d2370b6a80}, 0x42d2376f2900, 0x42d2371f53e0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 474
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 516 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d237198008, {0x10371b338, 0x42d2373e4c80}, 0x42d2370959b0?, 0x42d237243880?, 0x42d2371e7b80, {0x10371d838, 0x42d2371e4f00}, 0x42d237197440, 0x42d2371a3620, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 496
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 548 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2371fc508, {0x10371b338, 0x42d23734a0a0}, 0x42d2371ea940?, 0x42d237225b90?, 0x42d23722eb00, {0x10371d838, 0x42d2370b7480}, 0x42d2370bf8c0, 0x42d2372926c0, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 512
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0
+
+goroutine 584 [runnable]:
+syscall.syscalln(0x102c91a10, {0x42d23718f9a0, 0x3, 0x3})
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/sys_darwin.go:38 +0x20
+syscall.syscall(0x42d2371c8150?, 0x5f?, 0x42d23718fa08?, 0x102cb5d0c?)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/syscall/syscall_darwin.go:365 +0x24
+syscall.Stat({0x42d2371c8150?, 0x102cb5964?}, 0x42d2371f0ed8)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/syscall/zsyscall_darwin_arm64.go:1963 +0x68
+os.statNolog.func1(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/stat_unix.go:32
+os.ignoringEINTR(...)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/file_posix.go:256
+os.statNolog({0x42d2371c8150, 0x5f})
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/stat_unix.go:31 +0x50
+os.Stat({0x42d2371c8150, 0x5f})
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/stat.go:13 +0x30
+os.MkdirAll({0x42d2371c8150, 0x5f}, 0x1ed)
+	/opt/homebrew/Cellar/go/1.26.2/libexec/src/os/path.go:21 +0x28
+github.com/chenhg5/cc-connect/core.(*SessionManager).saveLocked(0x42d237229440)
+	/Users/ce/src/cc-connect/core/session.go:793 +0x5e4
+github.com/chenhg5/cc-connect/core.(*SessionManager).Save(0x42d237383440?)
+	/Users/ce/src/cc-connect/core/session.go:727 +0x94
+github.com/chenhg5/cc-connect/core.(*Engine).processInteractiveMessageWith(0x42d2371d2008, {0x10371bf40, 0x42d2373c3260}, 0x42d23714b2c0, 0x42d237383440, {0x10371b0d0, 0x42d2372293e0}, 0x42d237229440, {0x42d2373c0917, 0x7}, ...)
+	/Users/ce/src/cc-connect/core/engine.go:3843 +0xf0
+created by github.com/chenhg5/cc-connect/core.(*Engine).handleMessage in goroutine 582
+	/Users/ce/src/cc-connect/core/engine.go:3181 +0x1ad4
+
+goroutine 583 [select]:
+github.com/chenhg5/cc-connect/core.(*RateLimiter).cleanupLoop(0x42d2373c3620)
+	/Users/ce/src/cc-connect/core/ratelimit.go:88 +0xa0
+created by github.com/chenhg5/cc-connect/core.NewRateLimiter in goroutine 582
+	/Users/ce/src/cc-connect/core/ratelimit.go:34 +0xf4
+
+goroutine 578 [select]:
+github.com/chenhg5/cc-connect/core.(*Engine).runUnsolicitedReader(0x42d2370cca08, {0x10371b338, 0x42d2373cce10}, 0x42d23739f3f0?, 0x42d2371adc70?, 0x42d237693340, {0x10371d838, 0x42d237234b00}, 0x42d237382900, 0x42d237228d20, ...)
+	/Users/ce/src/cc-connect/core/engine.go:4862 +0x1ac
+created by github.com/chenhg5/cc-connect/core.(*Engine).startUnsolicitedReader in goroutine 542
+	/Users/ce/src/cc-connect/core/engine.go:4835 +0x2e0

--- a/core/engine.go
+++ b/core/engine.go
@@ -406,14 +406,15 @@ type Engine struct {
 	userRoles    *UserRoleManager // nil = legacy mode (no per-user policies)
 	userRolesMu  sync.RWMutex     // protects userRoles, disabledCmds, and adminFrom
 
-	rateLimiter      *RateLimiter
-	outgoingRL       *OutgoingRateLimiter
-	streamPreview    StreamPreviewCfg
-	instantReply     InstantReplyCfg
-	references       ReferenceRenderCfg
-	relayManager     *RelayManager
-	eventIdleTimeout time.Duration
-	maxTurnTime      time.Duration // absolute wall-clock cap per turn (0 = disabled)
+	rateLimiter         *RateLimiter
+	outgoingRL          *OutgoingRateLimiter
+	streamPreview       StreamPreviewCfg
+	instantReply        InstantReplyCfg
+	references          ReferenceRenderCfg
+	relayManager        *RelayManager
+	eventIdleTimeout    time.Duration
+	staleLockBreakAfter time.Duration // busy-lock stale-break threshold; 0 disables
+	maxTurnTime         time.Duration // absolute wall-clock cap per turn (0 = disabled)
 	// agentSessionIdleTimeoutNanos 在单轮正常结束后关闭空闲的 live agent 进程，
 	// 同时保留已保存的 session ID，便于下次继续恢复。
 	agentSessionIdleTimeoutNanos atomic.Int64
@@ -537,7 +538,11 @@ type queuedMessage struct {
 
 // interactiveState tracks a running interactive agent session and its permission state.
 type interactiveState struct {
-	agentSession             AgentSession
+	agentSession AgentSession
+	// busySession is the core.Session whose busy lock guards the in-flight
+	// turn. Set by getOrCreateInteractiveStateWith so /stop can release the
+	// lock after tearing the turn down (#1830).
+	busySession              *Session
 	platform                 Platform
 	replyCtx                 any
 	currentMessageID         string
@@ -771,6 +776,7 @@ func NewEngine(name string, ag Agent, platforms []Platform, sessionStorePath str
 		streamPreview:         DefaultStreamPreviewCfg(),
 		references:            DefaultReferenceRenderCfg(),
 		eventIdleTimeout:      defaultEventIdleTimeout,
+		staleLockBreakAfter:   busyStaleLockMaxHeld,
 		maxQueuedMessages:     defaultMaxQueuedMessages,
 		showContextIndicator:  true,
 		showWorkdirIndicator:  true,
@@ -1378,6 +1384,12 @@ func (e *Engine) SetMaxTurnTime(d time.Duration) {
 	e.maxTurnTime = d
 }
 
+// SetStaleLockBreakAfter sets how long the busy lock may be held by a dead
+// agent process before the next incoming message breaks it. 0 disables.
+func (e *Engine) SetStaleLockBreakAfter(d time.Duration) {
+	e.staleLockBreakAfter = d
+}
+
 // SetEventIdleTimeout sets the maximum time to wait between consecutive agent events.
 // 0 disables the timeout entirely.
 func (e *Engine) SetEventIdleTimeout(d time.Duration) {
@@ -1625,7 +1637,8 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 	if useNewSession {
 		msg.SessionKey = runSessionKey
 		session := sessions.NewSideSession(runSessionKey, "cron-"+job.ID)
-		if !session.TryLock() {
+		lockGen, locked := session.TryLock()
+		if !locked {
 			return fmt.Errorf("session %q is busy", runSessionKey)
 		}
 		iKey := fmt.Sprintf("%s#cron:%s", runSessionKey, session.ID)
@@ -1633,7 +1646,7 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 			iKey = workspaceDir + ":" + iKey
 		}
 		prevHistLen := session.HistoryLen()
-		e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, runSessionKey)
+		e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, runSessionKey, lockGen)
 		e.cleanupInteractiveState(iKey)
 		// Empty-response detection via session history delta: processInteractiveMessageWith
 		// always adds a "user" entry (prevHistLen+1), then an "assistant" entry on success
@@ -1647,7 +1660,8 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 	}
 
 	session := sessions.GetOrCreateActive(sessionKey)
-	if !session.TryLock() {
+	lockGen, locked := session.TryLock()
+	if !locked {
 		return fmt.Errorf("session %q is busy", sessionKey)
 	}
 
@@ -1656,7 +1670,7 @@ func (e *Engine) ExecuteCronJob(job *CronJob) error {
 		iKey = workspaceDir + ":" + sessionKey
 	}
 	prevHistLen := session.HistoryLen()
-	e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, sessionKey)
+	e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, sessionKey, lockGen)
 	// Same empty-response detection as the useNewSession path above.
 	if !job.Mute && session.HistoryLen() < prevHistLen+2 {
 		return fmt.Errorf("cron job %q produced an empty response", job.ID)
@@ -1826,20 +1840,22 @@ func (e *Engine) ExecuteTimerJob(job *TimerJob) error {
 	if useNewSession {
 		msg.SessionKey = runSessionKey
 		session := sessions.NewSideSession(runSessionKey, "timer-"+job.ID)
-		if !session.TryLock() {
+		lockGen, locked := session.TryLock()
+		if !locked {
 			return fmt.Errorf("session %q is busy", runSessionKey)
 		}
 		iKey := fmt.Sprintf("%s#timer:%s", runSessionKey, session.ID)
 		if workspaceDir != "" {
 			iKey = workspaceDir + ":" + iKey
 		}
-		e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, runSessionKey)
+		e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, runSessionKey, lockGen)
 		e.cleanupInteractiveState(iKey)
 		return nil
 	}
 
 	session := sessions.GetOrCreateActive(sessionKey)
-	if !session.TryLock() {
+	lockGen, locked := session.TryLock()
+	if !locked {
 		return fmt.Errorf("session %q is busy", sessionKey)
 	}
 
@@ -1847,7 +1863,7 @@ func (e *Engine) ExecuteTimerJob(job *TimerJob) error {
 	if workspaceDir != "" {
 		iKey = workspaceDir + ":" + sessionKey
 	}
-	e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, sessionKey)
+	e.processInteractiveMessageWith(effectivePlatform, msg, session, agent, sessions, iKey, workspaceDir, sessionKey, lockGen)
 	return nil
 }
 
@@ -2301,11 +2317,12 @@ func (e *Engine) ExecuteHeartbeat(sessionKey, prompt string, silent bool) error 
 	}
 
 	session := e.sessions.GetOrCreateActive(sessionKey)
-	if !session.TryLock() {
+	lockGen, locked := session.TryLock()
+	if !locked {
 		return fmt.Errorf("session %q is busy", sessionKey)
 	}
 
-	e.processInteractiveMessage(targetPlatform, msg, session)
+	e.processInteractiveMessage(targetPlatform, msg, session, lockGen)
 	return nil
 }
 
@@ -2774,20 +2791,57 @@ func (e *Engine) stopCurrentMessageIfRecalled(sessionKey string) bool {
 	return false
 }
 
-func (e *Engine) waitForSessionLock(session *Session, timeout time.Duration) bool {
+func (e *Engine) waitForSessionLock(session *Session, timeout time.Duration) (uint64, bool) {
 	deadline := time.Now().Add(timeout)
 	for {
-		if session.TryLock() {
-			return true
+		if gen, ok := session.TryLock(); ok {
+			return gen, true
 		}
 		if time.Now().After(deadline) {
-			return false
+			return 0, false
 		}
 		select {
 		case <-e.ctx.Done():
-			return false
+			return 0, false
 		case <-time.After(20 * time.Millisecond):
 		}
+	}
+}
+
+// sanitizeFileToken reduces a session key to a filename-safe token.
+func sanitizeFileToken(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+		if b.Len() > 60 {
+			break
+		}
+	}
+	return b.String()
+}
+
+// dumpGoroutineStacks writes all goroutine stacks to path for post-mortem
+// diagnosis of a wedged turn. Guarded by a timeout so a wedged runtime
+// (GC stall) cannot block recovery itself.
+func dumpGoroutineStacks(path string) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 1<<22)
+		n := runtime.Stack(buf, true)
+		if err := os.WriteFile(path, buf[:n], 0644); err != nil {
+			slog.Warn("busy lock: failed to write goroutine stack dump", "path", path, "error", err)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		slog.Warn("busy lock: goroutine stack dump timed out; continuing recovery")
 	}
 }
 
@@ -3036,14 +3090,46 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	// Without this, concurrent messages can observe the session as busy during
 	// startup but still find no state to queue into.
 	e.ensureInteractiveStateForQueueing(interactiveKey, p, msg.ReplyCtx)
-	if !session.TryLock() {
+	var lockGen uint64
+	if gen, locked := session.TryLock(); locked {
+		lockGen = gen
+	} else {
 		if e.stopCurrentMessageIfRecalled(interactiveKey) {
-			if e.waitForSessionLock(session, recalledStopLockWait) {
+			if g, ok := e.waitForSessionLock(session, recalledStopLockWait); ok {
+				lockGen = g
 				goto sessionLocked
 			}
 			e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
 			return
 		}
+		// ── busy stale-lock self-heal (custom 2026-09-12) ──────────────────
+		// Agent process dead + busy flag still held = black-hole turn (leaked
+		// lock). Break it and process this message in a fresh turn instead of
+		// queueing into a session nobody will ever drain. Live agents never
+		// hit this (Alive() gate); the held-threshold keeps us clear of
+		// graceful-stop waits. Lock order: interactiveMu → session.mu, never
+		// reversed.
+		e.interactiveMu.Lock()
+		st, hasSt := e.interactiveStates[interactiveKey]
+		agentAlive := hasSt && st != nil && st.agentSession != nil && st.agentSession.Alive()
+		e.interactiveMu.Unlock()
+		if !agentAlive && e.staleLockBreakAfter > 0 {
+			dumpGoroutineStacks(fmt.Sprintf("busy-stale-%s-%d.txt", sanitizeFileToken(msg.SessionKey), time.Now().Unix()))
+			if since, broken := session.BreakStaleLock(e.staleLockBreakAfter); broken {
+				heldFor := time.Since(since).Round(time.Second)
+				slog.Warn("busy-stale-lock: agent process dead but lock held; broken (self-heal)",
+					"session", msg.SessionKey,
+					"interactive_key", interactiveKey,
+					"held_for", heldFor,
+				)
+				e.reply(p, msg.ReplyCtx, fmt.Sprintf("⚠️ 会话卡锁已自动恢复（进程已退出但锁未释放，挂了 %s），本条消息继续处理。", heldFor))
+				if g, ok := session.TryLock(); ok {
+					lockGen = g
+					goto sessionLocked
+				}
+			}
+		}
+		// ── end self-heal; queueing path below is unchanged ────────────────
 		// Session is busy — try to queue the message for the running turn
 		// so the agent processes it immediately after the current turn ends.
 		if e.queueMessageForBusySession(p, msg, interactiveKey) {
@@ -3051,8 +3137,8 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 			// have just finished (session unlocked) between our TryLock failure
 			// and the queue append. Re-try TryLock — if it succeeds, no one is
 			// draining the queue so we must start a processor ourselves.
-			if session.TryLock() {
-				go e.drainOrphanedQueue(session, sessions, interactiveKey, agent, resolvedWorkspace)
+			if g, ok := session.TryLock(); ok {
+				go e.drainOrphanedQueue(session, sessions, interactiveKey, agent, resolvedWorkspace, g)
 			}
 			return
 		}
@@ -3061,8 +3147,9 @@ func (e *Engine) handleMessage(p Platform, msg *Message) {
 	}
 
 sessionLocked:
-	if rotated := e.maybeAutoResetSessionOnIdle(p, msg, sessions, interactiveKey, session); rotated != nil {
+	if rotated, rgen := e.maybeAutoResetSessionOnIdle(p, msg, sessions, interactiveKey, session, lockGen); rotated != nil {
 		session = rotated
+		lockGen = rgen
 	}
 	// Record that a real user message is being processed. This keeps
 	// LastUserActivity separate from UpdatedAt (bumped by every Unlock), so
@@ -3091,7 +3178,7 @@ sessionLocked:
 		"session", session.ID,
 	)
 
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey)
+	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, resolvedWorkspace, msg.SessionKey, lockGen)
 }
 
 func runMessageAccepted(msg *Message) {
@@ -3103,15 +3190,15 @@ func runMessageAccepted(msg *Message) {
 	callback()
 }
 
-func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session) *Session {
+func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions *SessionManager, interactiveKey string, session *Session, lockGen uint64) (*Session, uint64) {
 	if e.resetOnIdle <= 0 || session == nil {
-		return nil
+		return nil, 0
 	}
 
 	hasBackend := session.GetAgentSessionID() != ""
 	hasHistory := len(session.GetHistory(1)) > 0
 	if !hasBackend && !hasHistory {
-		return nil
+		return nil, 0
 	}
 
 	// Prefer LastUserActivity for idle tracking: it is only updated on actual
@@ -3140,7 +3227,7 @@ func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions 
 		}
 	}
 	if lastActive.IsZero() || time.Since(lastActive) < e.resetOnIdle {
-		return nil
+		return nil, 0
 	}
 
 	slog.Info("auto-resetting idle session",
@@ -3165,16 +3252,17 @@ func (e *Engine) maybeAutoResetSessionOnIdle(p Platform, msg *Message, sessions 
 	}
 
 	e.cleanupInteractiveState(interactiveKey)
-	session.UnlockWithoutUpdate()
+	session.UnlockWithoutUpdate(lockGen)
 
 	newSession := sessions.NewSession(msg.SessionKey, "")
-	if !newSession.TryLock() {
+	newGen, ok := newSession.TryLock()
+	if !ok {
 		slog.Error("failed to lock new session after idle auto-reset", "session_key", msg.SessionKey, "new_session", newSession.ID)
-		return nil
+		return nil, 0
 	}
 
 	e.reply(p, msg.ReplyCtx, e.i18n.Tf(MsgSessionAutoResetIdle, int(e.resetOnIdle/time.Minute)))
-	return newSession
+	return newSession, newGen
 }
 
 // queueMessageForBusySession queues a message for later delivery when the
@@ -3272,11 +3360,11 @@ func (e *Engine) ensureInteractiveStateForQueueing(key string, p Platform, reply
 // has already exited. It processes all pending messages in the state, similar
 // to the drain loop in processInteractiveMessageWith but as a standalone
 // goroutine.
-func (e *Engine) drainOrphanedQueue(session *Session, sessions *SessionManager, interactiveKey string, agent Agent, workspaceDir string) {
+func (e *Engine) drainOrphanedQueue(session *Session, sessions *SessionManager, interactiveKey string, agent Agent, workspaceDir string, lockGen uint64) {
 	unlocked := false
 	defer func() {
 		if !unlocked {
-			session.Unlock()
+			session.Unlock(lockGen)
 		}
 	}()
 
@@ -3295,7 +3383,7 @@ func (e *Engine) drainOrphanedQueue(session *Session, sessions *SessionManager, 
 	// from Events() and we must not have concurrent readers.
 	e.stopUnsolicitedReader(state)
 
-	unlocked = e.drainPendingMessages(state, session, sessions, interactiveKey)
+	unlocked = e.drainPendingMessages(state, session, sessions, interactiveKey, lockGen)
 
 	// Restart unsolicited reader if the session is still alive and clean.
 	state.mu.Lock()
@@ -3719,15 +3807,17 @@ func isDenyResponse(s string) bool {
 // Interactive agent processing
 // ──────────────────────────────────────────────────────────────
 
-func (e *Engine) processInteractiveMessage(p Platform, msg *Message, session *Session) {
-	e.processInteractiveMessageWith(p, msg, session, e.agent, e.sessions, msg.SessionKey, "", "")
+func (e *Engine) processInteractiveMessage(p Platform, msg *Message, session *Session, lockGen uint64) {
+	e.processInteractiveMessageWith(p, msg, session, e.agent, e.sessions, msg.SessionKey, "", "", lockGen)
 }
 
 // processInteractiveMessageWith is the core interactive processing loop.
 // It accepts an explicit agent, interactiveKey (for the interactiveStates map),
 // and workspaceDir so that multi-workspace mode can route to per-workspace agents.
 // ccSessionKey, when non-empty, is used for CC_SESSION_KEY in the agent env; otherwise interactiveKey is used.
-func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session *Session, agent Agent, sessions *SessionManager, interactiveKey string, workspaceDir string, ccSessionKey string) {
+// lockGen is the generation returned by the TryLock that acquired this turn's
+// busy lock; it must be passed to every session.Unlock of this turn (custom 2026-09-12).
+func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session *Session, agent Agent, sessions *SessionManager, interactiveKey string, workspaceDir string, ccSessionKey string, lockGen uint64) {
 	// session.Unlock() is NOT deferred here — it is called explicitly in
 	// the drain loop below while holding state.mu to close the race window
 	// between "queue is empty" and "session unlocked". A deferred fallback
@@ -3735,7 +3825,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	unlocked := false
 	defer func() {
 		if !unlocked {
-			session.Unlock()
+			session.Unlock(lockGen)
 		}
 	}()
 
@@ -3859,7 +3949,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 		sendDone <- as.Send(promptContent, msg.MessageID, msg.Images, msg.Files)
 	}()
 
-	e.processInteractiveEvents(state, session, sessions, interactiveKey, msg.MessageID, turnStart, stopTyping, sendDone, msg.ReplyCtx)
+	e.processInteractiveEvents(state, session, sessions, interactiveKey, msg.MessageID, turnStart, stopTyping, sendDone, msg.ReplyCtx, lockGen)
 	if elapsed := time.Since(sendStart); elapsed >= slowAgentSend {
 		slog.Warn("slow agent send", "elapsed", elapsed, "session", msg.SessionKey, "content_len", len(msg.Content))
 	}
@@ -3886,7 +3976,7 @@ func (e *Engine) processInteractiveMessageWith(p Platform, msg *Message, session
 	// processInteractiveEvents observing an empty queue and returning here
 	// (session is still locked, so handleMessage's TryLock fails and routes
 	// the message to queueMessageForBusySession). Drain any such orphans.
-	if e.drainPendingMessages(state, session, sessions, interactiveKey) {
+	if e.drainPendingMessages(state, session, sessions, interactiveKey, lockGen) {
 		unlocked = true
 	}
 }
@@ -4057,6 +4147,9 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 		// a concrete ID, reusing would keep --resume context — recycle (#238).
 		needRecycle := currentID != "" && (wantID == "" || wantID != currentID)
 		if !needRecycle {
+			state.mu.Lock()
+			state.busySession = session
+			state.mu.Unlock()
 			return state
 		}
 		// Tear down the stale agent so we start one that matches the Session below.
@@ -4119,7 +4212,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 	// Check if context is already canceled (e.g. during shutdown/restart)
 	if e.ctx.Err() != nil {
 		slog.Debug("skipping session start: context canceled", "session_key", sessionKey)
-		newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true}
+		newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true, busySession: session}
 		adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
 		state = newState
 		e.interactiveStates[sessionKey] = state
@@ -4196,7 +4289,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 				Platform:   p.Name(),
 				Error:      fmt.Sprintf("failed to start session: %v", err),
 			})
-			newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true}
+			newState := &interactiveState{platform: p, replyCtx: replyCtx, agent: agent, eventsNeedResync: true, busySession: session}
 			adoptPendingFromPlaceholder(e.interactiveStates[sessionKey], newState)
 			state = newState
 			e.interactiveStates[sessionKey] = state
@@ -4235,6 +4328,7 @@ func (e *Engine) getOrCreateInteractiveStateWith(sessionKey string, p Platform, 
 
 	newState := &interactiveState{
 		agentSession:     agentSession,
+		busySession:      session,
 		platform:         p,
 		replyCtx:         replyCtx,
 		agent:            agent,
@@ -4960,7 +5054,7 @@ var agentErrorHandlers = []agentErrorHandler{
 	{"Session not found", MsgSessionNotFound},
 }
 
-func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, msgID string, turnStart time.Time, stopTypingFn func(), sendDone <-chan error, replyCtx any) {
+func (e *Engine) processInteractiveEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, msgID string, turnStart time.Time, stopTypingFn func(), sendDone <-chan error, replyCtx any, lockGen uint64) {
 	if msgID != "" {
 		state.mu.Lock()
 		state.currentMessageID = msgID
@@ -6088,7 +6182,7 @@ func (e *Engine) processInteractiveEvents(state *interactiveState, session *Sess
 					e.send(state.platform, state.replyCtx, compressNotice)
 
 					// Run compress inline while the session is still locked.
-					e.runCompress(state, session, sessions, sessionKey, state.platform, state.replyCtx, true)
+					e.runCompress(state, session, sessions, sessionKey, state.platform, state.replyCtx, true, lockGen)
 					return
 				}
 			}
@@ -6426,11 +6520,11 @@ func (e *Engine) notifyDroppedQueuedMessages(state *interactiveState, reason err
 // queue. It atomically unlocks the session when the queue is empty (while holding
 // state.mu) to close the race window between "queue empty" and "session unlocked".
 // Returns true if the session was unlocked by this call.
-func (e *Engine) drainPendingMessages(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string) bool {
+func (e *Engine) drainPendingMessages(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, lockGen uint64) bool {
 	for {
 		state.mu.Lock()
 		if len(state.pendingMessages) == 0 {
-			session.Unlock()
+			session.Unlock(lockGen)
 			state.mu.Unlock()
 			return true
 		}
@@ -6446,7 +6540,7 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 			)
 		}
 		if len(state.pendingMessages) == 0 {
-			session.Unlock()
+			session.Unlock(lockGen)
 			state.mu.Unlock()
 			return true
 		}
@@ -6490,7 +6584,7 @@ func (e *Engine) drainPendingMessages(state *interactiveState, session *Session,
 		}
 
 		slog.Info("processing queued message", "session", sessionKey)
-		e.processInteractiveEvents(state, session, sessions, sessionKey, queued.messageID, time.Now(), stopTyping, sendDone, queued.replyCtx)
+		e.processInteractiveEvents(state, session, sessions, sessionKey, queued.messageID, time.Now(), stopTyping, sendDone, queued.replyCtx, lockGen)
 	}
 }
 
@@ -10385,6 +10479,10 @@ func (e *Engine) stopInteractiveSessionWithOptions(sessionKey string, notifyQueu
 			goto normalCleanup
 		}
 
+		if state.busySession != nil && state.busySession.ForceUnlock() {
+			slog.Info("session busy lock released after turn cancel", "session_key", sessionKey)
+		}
+
 		slog.Info("agent session turn cancelled, session kept alive",
 			"session_key", sessionKey)
 
@@ -10412,6 +10510,15 @@ normalCleanup:
 		state.mu.Unlock()
 	}
 	e.closeAgentSessionAsync(sessionKey, agentSession, closePlatform, closeReplyCtx)
+
+	// The stopped turn can never run its own Unlock — release its busy lock
+	// so the next message starts a fresh turn instead of queueing behind a
+	// dead one (#1830). ForceUnlock bumps the generation, so a late Unlock
+	// from the interrupted turn's goroutine (if it eventually unsticks) is
+	// dropped by the gen check.
+	if state.busySession != nil && state.busySession.ForceUnlock() {
+		slog.Info("session busy lock released after stop", "session_key", sessionKey)
+	}
 
 	e.hooks.Emit(HookEvent{
 		Event:      HookEventSessionEnded,
@@ -10454,26 +10561,27 @@ func (e *Engine) cmdCompress(p Platform, msg *Message) {
 	}
 
 	session := sessions.GetOrCreateActive(msg.SessionKey)
-	if !session.TryLock() {
+	lockGen, locked := session.TryLock()
+	if !locked {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
 		return
 	}
 
 	e.send(p, msg.ReplyCtx, e.i18n.T(MsgCompressing))
 
-	go e.runCompress(state, session, sessions, iKey, p, msg.ReplyCtx, false)
+	go e.runCompress(state, session, sessions, iKey, p, msg.ReplyCtx, false, lockGen)
 }
 
 // runCompress sends the agent's compress command and handles results.
 // If autoTriggered is true, suppress user-visible "compressing" and completion messages.
-func (e *Engine) runCompress(state *interactiveState, session *Session, sessions *SessionManager, iKey string, p Platform, replyCtx any, auto bool) {
+func (e *Engine) runCompress(state *interactiveState, session *Session, sessions *SessionManager, iKey string, p Platform, replyCtx any, auto bool, lockGen uint64) {
 	// session.Unlock() is called inside drainQueuedMessagesAfterCompress
 	// while holding state.mu to close the race window. Deferred fallback
 	// ensures the lock is released on early-return paths.
 	compressUnlocked := false
 	defer func() {
 		if !compressUnlocked {
-			session.Unlock()
+			session.Unlock(lockGen)
 		}
 	}()
 
@@ -10506,13 +10614,13 @@ func (e *Engine) runCompress(state *interactiveState, session *Session, sessions
 		return
 	}
 
-	e.processCompressEvents(state, session, sessions, iKey, p, replyCtx, &compressUnlocked, auto)
+	e.processCompressEvents(state, session, sessions, iKey, p, replyCtx, &compressUnlocked, auto, lockGen)
 }
 
 // processCompressEvents drains agent events after a compress command.
 // Unlike processInteractiveEvents it does NOT record history and treats
 // an empty result as success rather than "(empty response)".
-func (e *Engine) processCompressEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, p Platform, replyCtx any, unlocked *bool, auto bool) {
+func (e *Engine) processCompressEvents(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, p Platform, replyCtx any, unlocked *bool, auto bool, lockGen uint64) {
 
 	var textParts []string
 	events := state.agentSession.Events()
@@ -10605,7 +10713,7 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 			}
 
 			// After compress succeeds, process any queued messages instead of dropping them.
-			e.drainQueuedMessagesAfterCompress(state, session, sessions, sessionKey, unlocked)
+			e.drainQueuedMessagesAfterCompress(state, session, sessions, sessionKey, unlocked, lockGen)
 			return
 		case EventError:
 			if !auto && event.Error != nil {
@@ -10617,7 +10725,7 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 				e.notifyDroppedQueuedMessages(state, event.Error)
 			} else {
 				// Agent survived — try to process queued messages.
-				e.drainQueuedMessagesAfterCompress(state, session, sessions, sessionKey, unlocked)
+				e.drainQueuedMessagesAfterCompress(state, session, sessions, sessionKey, unlocked, lockGen)
 			}
 			return
 		case EventPermissionRequest:
@@ -10632,8 +10740,8 @@ func (e *Engine) processCompressEvents(state *interactiveState, session *Session
 // drainQueuedMessagesAfterCompress processes any messages that were queued
 // during a /compress operation. It sends each one to the agent and runs the
 // full interactive event loop for it.
-func (e *Engine) drainQueuedMessagesAfterCompress(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, unlocked *bool) {
-	if e.drainPendingMessages(state, session, sessions, sessionKey) {
+func (e *Engine) drainQueuedMessagesAfterCompress(state *interactiveState, session *Session, sessions *SessionManager, sessionKey string, unlocked *bool, lockGen uint64) {
+	if e.drainPendingMessages(state, session, sessions, sessionKey, lockGen) {
 		*unlocked = true
 	}
 }
@@ -14764,7 +14872,8 @@ func (e *Engine) executeCustomCommand(p Platform, msg *Message, cmd *CustomComma
 	}
 
 	session := sessions.GetOrCreateActive(interactiveKey)
-	if !session.TryLock() {
+	lockGen, locked := session.TryLock()
+	if !locked {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
 		return
 	}
@@ -14777,7 +14886,7 @@ func (e *Engine) executeCustomCommand(p Platform, msg *Message, cmd *CustomComma
 	)
 
 	msg.Content = prompt
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey)
+	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey, lockGen)
 }
 
 // executeShellCommand runs a shell command and sends the output to the user.
@@ -14992,7 +15101,8 @@ func (e *Engine) executeSkill(p Platform, msg *Message, skill *Skill, args []str
 	}
 
 	session := sessions.GetOrCreateActive(interactiveKey)
-	if !session.TryLock() {
+	lockGen, locked := session.TryLock()
+	if !locked {
 		e.reply(p, msg.ReplyCtx, e.i18n.T(MsgPreviousProcessing))
 		return
 	}
@@ -15005,7 +15115,7 @@ func (e *Engine) executeSkill(p Platform, msg *Message, skill *Skill, args []str
 	)
 
 	msg.Content = prompt
-	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey)
+	go e.processInteractiveMessageWith(p, msg, session, agent, sessions, interactiveKey, workspaceDir, msg.SessionKey, lockGen)
 }
 
 func (e *Engine) cmdSkills(p Platform, msg *Message) {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -1019,7 +1019,7 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelText(t *testing.
 	}
 
 	agentSession.events <- Event{Type: EventResult, Content: sideText, Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil, 0)
 
 	if got := p.getSent(); len(got) != 1 || got[0] != sideText {
 		t.Fatalf("sent text = %#v, want one side-channel message", got)
@@ -1049,7 +1049,7 @@ func TestProcessInteractiveEvents_SuppressesDuplicateSideChannelTextWithContextI
 	}
 
 	agentSession.events <- Event{Type: EventResult, Content: sideText, InputTokens: 52000, Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil, 0)
 
 	if got := p.getSent(); len(got) != 1 || got[0] != sideText {
 		t.Fatalf("sent text = %#v, want only the side-channel message without duplicate ctx reply", got)
@@ -1079,7 +1079,7 @@ func TestProcessInteractiveEvents_DoesNotSuppressDifferentFinalText(t *testing.T
 
 	finalText := "文件已发出，另外我也把使用方法整理好了。"
 	agentSession.events <- Event{Type: EventResult, Content: finalText, Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil, 0)
 
 	if got := p.getSent(); len(got) != 2 || got[0] == got[1] {
 		t.Fatalf("sent text = %#v, want side-channel and final reply", got)
@@ -1113,7 +1113,7 @@ func TestProcessInteractiveEvents_StripsAgentFooterWhenEnabled(t *testing.T) {
 
 	agentSession.events <- Event{Type: EventText, Content: "answer\n\n*claude-opus-4-8[1m] · out 788 · in 442 cw 0 cr 395.1k · ctx 40%*"}
 	agentSession.events <- Event{Type: EventResult, Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-agent-footer", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-agent-footer", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 {
@@ -1144,7 +1144,7 @@ func TestProcessInteractiveEvents_KeepsAgentFooterByDefault(t *testing.T) {
 	body := "answer\n\n*claude-opus-4-8[1m] · out 788 · in 442 cw 0 cr 395.1k · ctx 40%*"
 	agentSession.events <- Event{Type: EventText, Content: body}
 	agentSession.events <- Event{Type: EventResult, Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-agent-footer-default", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-agent-footer-default", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 {
@@ -1212,7 +1212,7 @@ func TestProcessInteractiveEvents_NonTerminalResultContinuesTurn(t *testing.T) {
 		Done:    true,
 	}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil, 0)
 
 	// noteUserTurnCompleted must have been called exactly once on the
 	// terminal result, advancing the watermark to the in-flight message time.
@@ -1280,7 +1280,7 @@ func TestProcessInteractiveEvents_AppendsReplyFooterWhenEnabled(t *testing.T) {
 	e.interactiveStates[sessionKey] = state
 
 	agentSession.events <- Event{Type: EventResult, Content: "answer", Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 {
@@ -1318,7 +1318,7 @@ func TestProcessInteractiveEvents_AppendsContextIndicatorInsideReplyFooter(t *te
 	e.interactiveStates[sessionKey] = state
 
 	agentSession.events <- Event{Type: EventResult, Content: "answer", InputTokens: 28000, Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-context", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-context", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 {
@@ -1360,7 +1360,7 @@ func TestProcessInteractiveEvents_ToolSegmentsKeepFinalFooter(t *testing.T) {
 	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "pwd"}
 	agentSession.events <- Event{Type: EventText, Content: "已处理完成。"}
 	agentSession.events <- Event{Type: EventResult, Content: "已处理完成。", InputTokens: 28000, Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-tool-footer", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-tool-footer", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) == 0 {
@@ -1391,7 +1391,7 @@ func TestProcessInteractiveEvents_DropsStandaloneEllipsisProgress(t *testing.T) 
 	agentSession.events <- Event{Type: EventThinking, Content: "..."}
 	agentSession.events <- Event{Type: EventText, Content: "..."}
 	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-ellipsis", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-ellipsis", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 || sent[0] != "done" {
@@ -1414,7 +1414,7 @@ func TestProcessInteractiveEvents_AddsDoneReactionAfterNormalReply(t *testing.T)
 	e.interactiveStates[sessionKey] = state
 
 	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-done", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-done", time.Now(), nil, nil, state.replyCtx, 0)
 
 	count, ctxs := p.doneSnapshot()
 	if count != 1 {
@@ -1461,7 +1461,7 @@ func TestProcessInteractiveEvents_DoesNotAppendReplyFooterWhenDisabled(t *testin
 	e.interactiveStates[sessionKey] = state
 
 	agentSession.events <- Event{Type: EventResult, Content: "answer", Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-off", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-off", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 {
@@ -1533,7 +1533,7 @@ func TestProcessInteractiveEvents_ReplyFooterPrefersSessionRuntimeState(t *testi
 	e.interactiveStates[sessionKey] = state
 
 	agentSession.events <- Event{Type: EventResult, Content: "answer", Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-runtime", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-runtime", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 {
@@ -1570,7 +1570,7 @@ func TestProcessInteractiveEvents_SuppressesReplyFooterWhenOnlyWorkDir(t *testin
 	e.interactiveStates[sessionKey] = state
 
 	agentSession.events <- Event{Type: EventResult, Content: "answer", Done: true}
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-workdir-only", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-footer-workdir-only", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 {
@@ -1600,7 +1600,7 @@ func TestProcessInteractiveEvents_HiddenToolProgressKeepsPreviewOnFinalize(t *te
 	agentSession.events <- Event{Type: EventToolUse, ToolName: "Bash", ToolInput: "echo hi"}
 	agentSession.events <- Event{Type: EventResult, Content: "", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil, 0)
 
 	if got := p.getSent(); len(got) != 0 {
 		t.Fatalf("sent text = %#v, want no plain-text fallback sends", got)
@@ -1639,7 +1639,7 @@ func TestProcessInteractiveEvents_ToolMessagesDisabledSuppressesToolProgressOnly
 	agentSession.events <- Event{Type: EventText, Content: "done"}
 	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, nil, 0)
 
 	sent := p.getSent()
 	if len(sent) < 1 || len(sent) > 2 {
@@ -1676,7 +1676,7 @@ func TestProcessInteractiveEvents_CompactProgressCoalescesThinkingAndToolUse(t *
 	agentSession.events <- Event{Type: EventText, Content: "done"}
 	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m1", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 || sent[0] != "done" {
@@ -1721,7 +1721,7 @@ func TestProcessInteractiveEvents_CardProgressUsesCardTemplate(t *testing.T) {
 	agentSession.events <- Event{Type: EventText, Content: "done"}
 	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m2", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m2", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 || sent[0] != "done" {
@@ -1783,7 +1783,7 @@ func TestProcessInteractiveEvents_FinalReplyUsesWorkspaceForReferenceRendering(t
 		Done:    true,
 	}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-relative", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-relative", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 {
@@ -1824,7 +1824,7 @@ func TestProcessInteractiveEvents_FinalReplyRemainsRawWhenReferencesDisabled(t *
 		Done:    true,
 	}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-relative-raw", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-relative-raw", time.Now(), nil, nil, state.replyCtx, 0)
 
 	sent := p.getSent()
 	if len(sent) != 1 {
@@ -1857,7 +1857,7 @@ func TestProcessInteractiveEvents_CardProgressUsesStructuredPayloadWhenSupported
 	agentSession.events <- Event{Type: EventText, Content: "done"}
 	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m3", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m3", time.Now(), nil, nil, state.replyCtx, 0)
 
 	starts := p.getPreviewStarts()
 	if len(starts) != 1 {
@@ -1939,7 +1939,7 @@ func TestProcessInteractiveEvents_CardProgressTruncatesToolInputByToolMaxLen(t *
 	agentSession.events <- Event{Type: EventText, Content: "done"}
 	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-card-truncate", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-card-truncate", time.Now(), nil, nil, state.replyCtx, 0)
 
 	if toolEvt.ToolInput != longInput {
 		t.Fatalf("event.ToolInput was mutated: got len=%d, want len=%d", len(toolEvt.ToolInput), len(longInput))
@@ -2001,7 +2001,7 @@ func TestProcessInteractiveEvents_RichCardShowsThinkingContent(t *testing.T) {
 	agentSession.events <- Event{Type: EventText, Content: "answer"}
 	agentSession.events <- Event{Type: EventResult, Content: "answer", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-thinking", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-thinking", time.Now(), nil, nil, state.replyCtx, 0)
 
 	starts := p.getPreviewStarts()
 	if len(starts) != 1 {
@@ -2044,7 +2044,7 @@ func TestProcessInteractiveEvents_RichCardCoalescesToolResult(t *testing.T) {
 	agentSession.events <- Event{Type: EventText, Content: "done"}
 	agentSession.events <- Event{Type: EventResult, Content: "done", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-tool-result", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-tool-result", time.Now(), nil, nil, state.replyCtx, 0)
 
 	starts := p.getPreviewStarts()
 	if len(starts) != 1 {
@@ -2165,7 +2165,7 @@ func TestProcessInteractiveEvents_RichCardResolvesMarkdownImages(t *testing.T) {
 	agentSession.events <- Event{Type: EventText, Content: body}
 	agentSession.events <- Event{Type: EventResult, Content: body, Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-image-resolver", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-image-resolver", time.Now(), nil, nil, state.replyCtx, 0)
 	_, streams, updates, _ := p.snapshot()
 	rendered := strings.Join(append(streams, updates...), "\n")
 	if !strings.Contains(rendered, "![chart](img_v3_chart)") {
@@ -2225,7 +2225,7 @@ func runRichCardSilentScenario(t *testing.T, name string, chunks []string, final
 	}
 	agentSession.events <- Event{Type: EventResult, Content: finalContent, Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-silent-"+name, time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-silent-"+name, time.Now(), nil, nil, state.replyCtx, 0)
 	return p.snapshot()
 }
 
@@ -2321,7 +2321,7 @@ func TestProcessInteractiveEvents_RichCard_TextThenNoReply_PreservesBody(t *test
 	agentSession.events <- Event{Type: EventText, Content: "\nNO_REPLY"}
 	agentSession.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-text-then-noreply", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-text-then-noreply", time.Now(), nil, nil, state.replyCtx, 0)
 	starts, _, updates, deletes := p.snapshot()
 
 	if len(starts) == 0 {
@@ -2381,7 +2381,7 @@ func TestProcessInteractiveEvents_RichCard_ToolThenNoReply(t *testing.T) {
 	agentSession.events <- Event{Type: EventText, Content: "NO_REPLY"}
 	agentSession.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-tool-then-noreply", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-rich-tool-then-noreply", time.Now(), nil, nil, state.replyCtx, 0)
 	starts, streams, updates, deletes := p.snapshot()
 
 	if len(starts) == 0 {
@@ -3574,7 +3574,7 @@ func TestHandleMessage_AutoResetOnIdle_FiresWhenHeartbeatBumpedUpdatedAt(t *test
 	// Simulate a heartbeat (or unsolicited agent response) finishing right
 	// before this test's user message: Unlock() bumps UpdatedAt to now, but
 	// LastUserActivity is intentionally NOT touched by those code paths.
-	old.Unlock()
+	old.Unlock(0)
 
 	if !old.GetUpdatedAt().After(staleAt) {
 		t.Fatalf("expected Unlock to bump UpdatedAt, got %v vs %v", old.GetUpdatedAt(), staleAt)
@@ -6703,7 +6703,7 @@ func TestProcessInteractiveEvents_AskUserQuestionFromAgent_RendersRichCardPrompt
 
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "m-codex-ask-card", time.Now(), nil, sendDone, nil)
+		e.processInteractiveEvents(state, session, e.sessions, key, "m-codex-ask-card", time.Now(), nil, sendDone, nil, 0)
 		close(done)
 	}()
 
@@ -6772,7 +6772,7 @@ func TestProcessInteractiveEvents_AskUserQuestionFromAgent_RendersLegacyPrompt(t
 
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "m-codex-ask-legacy", time.Now(), nil, sendDone, nil)
+		e.processInteractiveEvents(state, session, e.sessions, key, "m-codex-ask-legacy", time.Now(), nil, sendDone, nil, 0)
 		close(done)
 	}()
 
@@ -7535,7 +7535,7 @@ func TestProcessInteractiveMessage_SchedulesAgentSessionIdleCloseAfterCleanTurn(
 		UserName:   "User One",
 		Content:    "hello",
 		ReplyCtx:   "ctx",
-	}, session, agent, e.sessions, "test:chat:user1", "", "")
+	}, session, agent, e.sessions, "test:chat:user1", "", "", 0)
 
 	waitForAgentSessionID(t, session, "result-session")
 	waitForInteractiveStateRemoved(t, e, "test:chat:user1")
@@ -8695,7 +8695,7 @@ func TestProcessInteractiveEvents_PermissionWhileSendBlocked(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "m1", time.Now(), nil, sendDone, nil)
+		e.processInteractiveEvents(state, session, e.sessions, key, "m1", time.Now(), nil, sendDone, nil, 0)
 		close(done)
 	}()
 
@@ -8742,7 +8742,7 @@ func TestReapIdleWorkspaces_SkipsWorkspaceWithActiveTurn(t *testing.T) {
 	workspaceDir := normalizeWorkspacePath(t.TempDir())
 	sessionKey := "test:user1"
 	session := e.sessions.GetOrCreateActive(sessionKey)
-	if !session.TryLock() {
+	if _, lockedNow := session.TryLock(); !lockedNow {
 		t.Fatal("expected session lock")
 	}
 
@@ -8753,7 +8753,7 @@ func TestReapIdleWorkspaces_SkipsWorkspaceWithActiveTurn(t *testing.T) {
 			UserID:     "user1",
 			Content:    "long running task",
 			ReplyCtx:   "ctx",
-		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey)
+		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey, 0)
 		close(done)
 	}()
 
@@ -8795,7 +8795,7 @@ func TestReapIdleWorkspaces_SkipsWorkspaceWaitingForPermission(t *testing.T) {
 	workspaceDir := normalizeWorkspacePath(t.TempDir())
 	sessionKey := "test:user2"
 	session := e.sessions.GetOrCreateActive(sessionKey)
-	if !session.TryLock() {
+	if _, lockedNow := session.TryLock(); !lockedNow {
 		t.Fatal("expected session lock")
 	}
 
@@ -8806,7 +8806,7 @@ func TestReapIdleWorkspaces_SkipsWorkspaceWaitingForPermission(t *testing.T) {
 			UserID:     "user2",
 			Content:    "needs approval",
 			ReplyCtx:   "ctx",
-		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey)
+		}, session, e.agent, e.sessions, sessionKey, workspaceDir, sessionKey, 0)
 		close(done)
 	}()
 
@@ -8992,7 +8992,7 @@ func TestProcessInteractiveEvents_DrainsQueuedMessages(t *testing.T) {
 	// processInteractiveEvents should handle both turns.
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), nil, sendDone, nil)
+		e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), nil, sendDone, nil, 0)
 		close(done)
 	}()
 
@@ -9087,7 +9087,7 @@ func TestProcessInteractiveEvents_DrainsQueuedMessagesFIFOWithCreateTimes(t *tes
 
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "msg0", time.Now(), nil, sendDone, "ctx-turn1")
+		e.processInteractiveEvents(state, session, e.sessions, key, "msg0", time.Now(), nil, sendDone, "ctx-turn1", 0)
 		close(done)
 	}()
 
@@ -9191,7 +9191,7 @@ func TestProcessInteractiveEvents_QueuedMessageUsesItsOwnReplyCtx(t *testing.T) 
 
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), nil, sendDone, "ctx-turn1")
+		e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), nil, sendDone, "ctx-turn1", 0)
 		close(done)
 	}()
 
@@ -9392,7 +9392,7 @@ func TestDrainOrphanedQueue_UsesWorkspaceSessionManager(t *testing.T) {
 
 	key := "ws1:test:user1"
 	session := wsSessions.GetOrCreateActive("test:user1")
-	if !session.TryLock() {
+	if _, lockedNow := session.TryLock(); !lockedNow {
 		t.Fatal("expected TryLock to succeed")
 	}
 
@@ -9423,7 +9423,7 @@ func TestDrainOrphanedQueue_UsesWorkspaceSessionManager(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		e.drainOrphanedQueue(session, wsSessions, key, agent, "")
+		e.drainOrphanedQueue(session, wsSessions, key, agent, "", 0)
 		close(done)
 	}()
 
@@ -9779,7 +9779,7 @@ func TestProcessInteractiveMessageWith_NilAgentSession_NoPanic(t *testing.T) {
 
 	sessionKey := "test:user-nil-after-abandon"
 	session := e.sessions.GetOrCreateActive(sessionKey)
-	if !session.TryLock() {
+	if _, lockedNow := session.TryLock(); !lockedNow {
 		t.Fatal("expected session lock")
 	}
 
@@ -9800,7 +9800,7 @@ func TestProcessInteractiveMessageWith_NilAgentSession_NoPanic(t *testing.T) {
 			UserID:     "user-nil",
 			Content:    "trigger nil guard",
 			ReplyCtx:   "ctx-nil",
-		}, session, e.agent, e.sessions, sessionKey, "", sessionKey)
+		}, session, e.agent, e.sessions, sessionKey, "", sessionKey, 0)
 	}()
 
 	select {
@@ -9896,7 +9896,7 @@ func TestAutoCompress_TriggerAfterResult(t *testing.T) {
 	session.AddHistory("user", "hello world")
 
 	// Simulate a full turn.
-	go e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), func() {}, nil, nil)
+	go e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), func() {}, nil, nil, 0)
 
 	sess.events <- Event{Type: EventResult, Content: "response", Done: true}
 
@@ -9959,7 +9959,7 @@ func TestAutoCompress_UsesRealUsageWhenAvailable(t *testing.T) {
 	session := e.sessions.GetOrCreateActive(key)
 	session.AddHistory("user", "hi")
 
-	go e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), func() {}, nil, nil)
+	go e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), func() {}, nil, nil, 0)
 	sess.events <- Event{Type: EventResult, Content: "response", Done: true}
 
 	deadline := time.After(2 * time.Second)
@@ -10012,7 +10012,7 @@ func TestAutoCompress_FallsBackToHeuristicWhenNoUsage(t *testing.T) {
 	// Long enough text to cross the heuristic threshold of 4 tokens.
 	session.AddHistory("user", strings.Repeat("a", 64))
 
-	go e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), func() {}, nil, nil)
+	go e.processInteractiveEvents(state, session, e.sessions, key, "msg1", time.Now(), func() {}, nil, nil, 0)
 	sess.events <- Event{Type: EventResult, Content: "response", Done: true}
 
 	deadline := time.After(2 * time.Second)
@@ -10061,7 +10061,7 @@ func TestCmdCompress_SessionBusy_RepliesPreviousProcessing(t *testing.T) {
 
 	// Lock the session to simulate busy.
 	session := e.sessions.GetOrCreateActive(key)
-	if !session.TryLock() {
+	if _, lockedNow := session.TryLock(); !lockedNow {
 		t.Fatal("expected TryLock to succeed")
 	}
 
@@ -10079,7 +10079,7 @@ func TestCmdCompress_SessionBusy_RepliesPreviousProcessing(t *testing.T) {
 	if !found {
 		t.Fatalf("expected MsgPreviousProcessing reply, got %v", sent)
 	}
-	session.Unlock()
+	session.Unlock(0)
 }
 
 func TestCmdCompress_Success_SendsCompressDone(t *testing.T) {
@@ -10334,10 +10334,10 @@ func TestCmdPs_BusySession_InjectsToAgent(t *testing.T) {
 
 	// Simulate a turn in flight.
 	session := e.sessions.GetOrCreateActive(key)
-	if !session.TryLock() {
+	if _, lockedNow := session.TryLock(); !lockedNow {
 		t.Fatal("expected TryLock to succeed")
 	}
-	defer session.Unlock()
+	defer session.Unlock(0)
 
 	msg := &Message{SessionKey: key, Content: "/ps add unit tests", ReplyCtx: "ctx"}
 	e.cmdPs(p, msg, []string{"add", "unit", "tests"})
@@ -10531,7 +10531,7 @@ func TestCmdStop_ReturnsWhileCloseBlockedAndStopsEventLoop(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "msg-1", time.Now(), nil, nil, "ctx")
+		e.processInteractiveEvents(state, session, e.sessions, key, "msg-1", time.Now(), nil, nil, "ctx", 0)
 		close(done)
 	}()
 
@@ -10681,7 +10681,7 @@ func TestHandleMessageBusyRecalledCurrentStopsAndProcessesNewMessage(t *testing.
 	e := NewEngine("test", &resultAgent{session: newAgentSession}, []Platform{p}, "", LangEnglish)
 	key := "test:user1"
 	session := e.sessions.GetOrCreateActive(key)
-	if !session.TryLock() {
+	if _, lockedNow := session.TryLock(); !lockedNow {
 		t.Fatal("expected to lock session for busy setup")
 	}
 
@@ -10698,7 +10698,7 @@ func TestHandleMessageBusyRecalledCurrentStopsAndProcessesNewMessage(t *testing.
 	oldStopped := oldState.stopSignal()
 	go func() {
 		<-oldStopped
-		session.Unlock()
+		session.Unlock(0)
 	}()
 
 	e.ReceiveMessage(p, &Message{
@@ -11078,7 +11078,7 @@ func TestEventIdleTimeout_CleansUpSession(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "", time.Now(), nil, nil, nil)
+		e.processInteractiveEvents(state, session, e.sessions, key, "", time.Now(), nil, nil, nil, 0)
 		close(done)
 	}()
 
@@ -11122,7 +11122,7 @@ func TestEventIdleTimeout_ResetOnEvent(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "", time.Now(), nil, nil, nil)
+		e.processInteractiveEvents(state, session, e.sessions, key, "", time.Now(), nil, nil, nil, 0)
 		close(done)
 	}()
 
@@ -11174,7 +11174,7 @@ func TestEventIdleTimeout_DisabledWhenZero(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		e.processInteractiveEvents(state, session, e.sessions, key, "", time.Now(), nil, nil, nil)
+		e.processInteractiveEvents(state, session, e.sessions, key, "", time.Now(), nil, nil, nil, 0)
 		close(done)
 	}()
 
@@ -14449,7 +14449,7 @@ func TestEventsNeedResync_ClearedOnCleanResult(t *testing.T) {
 
 	sendDone := make(chan error, 1)
 	sendDone <- nil
-	e.processInteractiveEvents(state, session, sessions, "test:resync:u1", "", time.Now(), nil, sendDone, "ctx")
+	e.processInteractiveEvents(state, session, sessions, "test:resync:u1", "", time.Now(), nil, sendDone, "ctx", 0)
 
 	state.mu.Lock()
 	resync := state.eventsNeedResync
@@ -15582,7 +15582,7 @@ func TestMaybeAutoResetSessionOnIdle_UsesLastUserActivity(t *testing.T) {
 	p := &stubPlatformEngine{n: "test"}
 	msg := &Message{SessionKey: "sk", ReplyCtx: "ctx"}
 
-	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:sk", session)
+	rotated, _ := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:sk", session, 0)
 	if rotated == nil {
 		t.Fatal("expected idle reset to fire because LastUserActivity is 35min ago, but it did not")
 	}
@@ -15608,7 +15608,7 @@ func TestMaybeAutoResetSessionOnIdle_NotFiredWhenUserActivityRecent(t *testing.T
 	p := &stubPlatformEngine{n: "test"}
 	msg := &Message{SessionKey: "sk2", ReplyCtx: "ctx"}
 
-	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:sk2", session)
+	rotated, _ := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:sk2", session, 0)
 	if rotated != nil {
 		t.Fatal("expected no idle reset because LastUserActivity is only 5min ago")
 	}
@@ -16199,7 +16199,7 @@ func TestProcessInteractiveEvents_StreamingCard_BareNoReply_Suppressed(t *testin
 	agentSession.events <- Event{Type: EventText, Content: "NO_REPLY"}
 	agentSession.events <- Event{Type: EventResult, Content: "NO_REPLY", Done: true}
 
-	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-streamcard-bare-noreply", time.Now(), nil, nil, state.replyCtx)
+	e.processInteractiveEvents(state, session, e.sessions, sessionKey, "m-streamcard-bare-noreply", time.Now(), nil, nil, state.replyCtx, 0)
 
 	if !card.finalized() {
 		t.Fatalf("expected streaming card to be finalized on a silent turn")

--- a/core/heartbeat.go
+++ b/core/heartbeat.go
@@ -339,14 +339,15 @@ func (hs *HeartbeatScheduler) execute(entry *heartbeatEntry) {
 
 	if cfg.OnlyWhenIdle {
 		session := entry.engine.sessions.GetOrCreateActive(cfg.SessionKey)
-		if !session.TryLock() {
+		if gen, ok := session.TryLock(); !ok {
 			slog.Debug("heartbeat: session busy, skipping", "project", entry.project, "session_key", cfg.SessionKey)
 			hs.mu.Lock()
 			entry.skippedBusy++
 			hs.mu.Unlock()
 			return
+		} else {
+			session.Unlock(gen)
 		}
-		session.Unlock()
 	}
 
 	prompt := cfg.Prompt

--- a/core/session.go
+++ b/core/session.go
@@ -25,11 +25,11 @@ const ExplicitActivationTTL = 7 * 24 * time.Hour
 
 // Session tracks one conversation between a user and the agent.
 type Session struct {
-	ID                  string         `json:"id"`
-	Name                string         `json:"name"`
-	AgentSessionID      string         `json:"agent_session_id"`
-	AgentType           string         `json:"agent_type,omitempty"`
-	PastAgentSessionIDs []string       `json:"past_agent_session_ids,omitempty"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	AgentSessionID      string   `json:"agent_session_id"`
+	AgentType           string   `json:"agent_type,omitempty"`
+	PastAgentSessionIDs []string `json:"past_agent_session_ids,omitempty"`
 	// ActiveProvider is the agent provider name that was active when this
 	// session last took a turn. It is restored before --resume so that a
 	// cc-connect process restart does not silently drop a user's
@@ -56,18 +56,28 @@ type Session struct {
 	// sessions cannot permanently occupy the active slot.
 	ExplicitActivatedAt time.Time `json:"explicit_activated_at,omitempty"`
 
-	mu   sync.Mutex `json:"-"`
-	busy bool       `json:"-"`
+	mu        sync.Mutex `json:"-"`
+	busy      bool       `json:"-"`
+	busySince time.Time  `json:"-"` // custom 2026-09-12: when the busy lock was acquired (stale-lock self-heal)
+	lockGen   uint64     `json:"-"` // custom 2026-09-12: lock generation, invalidates late unlocks after BreakStaleLock
 }
 
-func (s *Session) TryLock() bool {
+// TryLock acquires the busy lock for a new turn. It returns a generation
+// number the holder MUST pass back to Unlock/UnlockWithoutUpdate; an unlock
+// carrying a stale generation (the lock was broken and re-acquired by a newer
+// turn) is silently dropped so a late unlock can never crosstalk with the
+// next turn. A gen of 0 bypasses the check (legacy escape hatch).
+// (custom 2026-09-12: busy stale-lock self-heal)
+func (s *Session) TryLock() (uint64, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.busy {
-		return false
+		return 0, false
 	}
 	s.busy = true
-	return true
+	s.busySince = time.Now()
+	s.lockGen++
+	return s.lockGen, true
 }
 
 // Busy reports whether the session is currently locked for an in-flight turn.
@@ -78,21 +88,73 @@ func (s *Session) Busy() bool {
 	return s.busy
 }
 
-func (s *Session) Unlock() {
-	s.unlock(true)
+func (s *Session) Unlock(gen uint64) {
+	s.unlock(true, gen)
 }
 
-func (s *Session) UnlockWithoutUpdate() {
-	s.unlock(false)
+func (s *Session) UnlockWithoutUpdate(gen uint64) {
+	s.unlock(false, gen)
 }
 
-func (s *Session) unlock(update bool) {
+func (s *Session) unlock(update bool, gen uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if gen != 0 && gen != s.lockGen {
+		// Late unlock after BreakStaleLock reassigned the lock to a newer
+		// turn: dropping it is the only safe option — applying it would clear
+		// busy underneath the new holder and let a third turn run concurrently.
+		return
+	}
 	s.busy = false
+	s.busySince = time.Time{}
 	if update {
 		s.UpdatedAt = time.Now()
 	}
+}
+
+// BreakStaleLock releases a busy lock held longer than maxHeld and bumps
+// lockGen so the previous holder's late Unlock is invalidated. The caller
+// MUST first verify the agent process is dead — a live agent's legitimate
+// long turn must never be broken. The threshold callers should use is
+// deliberately above the 120s stop-hook wait cap so a graceful stop can
+// never collide with it. (custom 2026-09-12: busy stale-lock self-heal)
+func (s *Session) BreakStaleLock(maxHeld time.Duration) (time.Time, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.busy || s.busySince.IsZero() {
+		return time.Time{}, false
+	}
+	if time.Since(s.busySince) > maxHeld {
+		since := s.busySince
+		s.busy = false
+		s.busySince = time.Time{}
+		s.lockGen++ // invalidate the old holder's late unlock
+		return since, true
+	}
+	return time.Time{}, false
+}
+
+// busyStaleLockMaxHeld is how long the busy lock may be held by a dead agent
+// process before the next incoming message breaks it (custom 2026-09-12).
+// Deliberately above the 120s stop-hook wait cap so a graceful stop can
+// never collide with the self-heal.
+const busyStaleLockMaxHeld = 2 * time.Minute
+
+// ForceUnlock releases the busy lock unconditionally and bumps lockGen so
+// any late Unlock from the interrupted turn is dropped. Intended for paths
+// that tear the turn's execution environment down (e.g. /stop): the lock
+// holder will never run to its own Unlock. Returns true when a held lock
+// was released (#1830).
+func (s *Session) ForceUnlock() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.busy {
+		return false
+	}
+	s.busy = false
+	s.busySince = time.Time{}
+	s.lockGen++
+	return true
 }
 
 func (s *Session) AddHistory(role, content string) {
@@ -876,7 +938,7 @@ func (sm *SessionManager) PruneDuplicateSessions(mergeHistory bool) PruneResult 
 	defer sm.mu.Unlock()
 
 	// Group sessions by baseChat
-	chatSessions := make(map[string][]*Session) // baseChat -> sessions
+	chatSessions := make(map[string][]*Session)  // baseChat -> sessions
 	sessionToBaseChat := make(map[string]string) // session.ID -> baseChat
 
 	for userKey, sessionIDs := range sm.userSessions {

--- a/core/session_switch_idle_test.go
+++ b/core/session_switch_idle_test.go
@@ -91,7 +91,7 @@ func TestMaybeAutoResetSessionOnIdle_ExplicitActivationBlocksReset(t *testing.T)
 	p := &stubPlatformEngine{n: "test"}
 	msg := &Message{SessionKey: "u", ReplyCtx: "ctx"}
 
-	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", session)
+	rotated, _ := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", session, 0)
 	if rotated != nil {
 		t.Fatal("explicitly activated session must NOT be rotated even if LastUserActivity is old")
 	}
@@ -126,7 +126,7 @@ func TestMaybeAutoResetSessionOnIdle_ExplicitActivationExpiresAfterTTL(t *testin
 	p := &stubPlatformEngine{n: "test"}
 	msg := &Message{SessionKey: "u", ReplyCtx: "ctx"}
 
-	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", session)
+	rotated, _ := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", session, 0)
 	if rotated == nil {
 		t.Fatal("explicit activation older than TTL must NOT block the idle reset")
 	}
@@ -160,7 +160,7 @@ func TestMaybeAutoResetSessionOnIdle_NonExplicitSessionUsesLegacyPath(t *testing
 	p := &stubPlatformEngine{n: "test"}
 	msg := &Message{SessionKey: "u", ReplyCtx: "ctx"}
 
-	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", session)
+	rotated, _ := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", session, 0)
 	if rotated == nil {
 		t.Fatal("non-explicit session with old LastUserActivity must be rotated (legacy path)")
 	}
@@ -203,14 +203,14 @@ func TestSwitchSession_PreventsFirstMessageRotation(t *testing.T) {
 	if current.ID != stale.ID {
 		t.Fatalf("GetOrCreateActive returned %s, want stale %s", current.ID, stale.ID)
 	}
-	if !current.TryLock() {
+	if _, ok := current.TryLock(); !ok {
 		t.Fatal("session should be lockable")
 	}
 
 	p := &stubPlatformEngine{n: "test"}
 	msg := &Message{SessionKey: "u", ReplyCtx: "ctx"}
 
-	rotated := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", current)
+	rotated, _ := e.maybeAutoResetSessionOnIdle(p, msg, sm, "ws:u", current, 0)
 	if rotated != nil {
 		t.Fatal("post-switch first message must stay in the explicitly chosen session")
 	}

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -180,14 +180,15 @@ func TestSessionManager_GetOrCreateActive_Persists(t *testing.T) {
 
 func TestSession_TryLockUnlock(t *testing.T) {
 	s := &Session{}
-	if !s.TryLock() {
+	gen, ok := s.TryLock()
+	if !ok {
 		t.Error("first TryLock should succeed")
 	}
-	if s.TryLock() {
+	if _, ok := s.TryLock(); ok {
 		t.Error("second TryLock should fail")
 	}
-	s.Unlock()
-	if !s.TryLock() {
+	s.Unlock(gen)
+	if _, ok := s.TryLock(); !ok {
 		t.Error("TryLock after Unlock should succeed")
 	}
 }
@@ -197,15 +198,67 @@ func TestSession_Busy(t *testing.T) {
 	if s.Busy() {
 		t.Error("fresh session should not be busy")
 	}
-	if !s.TryLock() {
+	if _, ok := s.TryLock(); !ok {
 		t.Fatal("TryLock should succeed")
 	}
 	if !s.Busy() {
 		t.Error("session should be busy after TryLock")
 	}
-	s.Unlock()
+	s.Unlock(0)
 	if s.Busy() {
 		t.Error("session should not be busy after Unlock")
+	}
+}
+
+// TestSession_LateUnlockDropped verifies the generation counter: after
+// BreakStaleLock re-assigns the lock to a newer turn, the old holder's late
+// Unlock must be dropped instead of clearing the new holder's busy flag
+// (custom 2026-09-12 busy stale-lock self-heal).
+func TestSession_LateUnlockDropped(t *testing.T) {
+	s := &Session{}
+	gen1, ok := s.TryLock()
+	if !ok {
+		t.Fatal("first TryLock should succeed")
+	}
+	if _, broken := s.BreakStaleLock(0); !broken {
+		t.Fatal("BreakStaleLock(0) should break the held lock")
+	}
+	gen2, ok := s.TryLock()
+	if !ok {
+		t.Fatal("relock after break should succeed")
+	}
+	if gen1 == gen2 {
+		t.Fatal("generation should advance after a break")
+	}
+	s.Unlock(gen1) // late unlock from the old holder
+	if !s.Busy() {
+		t.Fatal("late unlock with stale gen must be dropped; new holder's busy must survive")
+	}
+	s.Unlock(gen2)
+	if s.Busy() {
+		t.Fatal("unlock with current gen should release the lock")
+	}
+}
+
+// TestSession_BreakStaleLockThreshold verifies the held-duration gate: a lock
+// held shorter than maxHeld is never broken, one held longer is.
+func TestSession_BreakStaleLockThreshold(t *testing.T) {
+	s := &Session{}
+	if _, ok := s.TryLock(); !ok {
+		t.Fatal("TryLock should succeed")
+	}
+	if _, broken := s.BreakStaleLock(time.Hour); broken {
+		t.Fatal("lock held shorter than maxHeld must not break")
+	}
+	if _, broken := s.BreakStaleLock(0); !broken {
+		t.Fatal("lock held longer than maxHeld should break")
+	}
+	if s.Busy() {
+		t.Fatal("busy must be false after break")
+	}
+	// Breaking an unlocked session is a no-op.
+	if _, broken := s.BreakStaleLock(0); broken {
+		t.Fatal("BreakStaleLock on an unlocked session must be a no-op")
 	}
 }
 
@@ -1118,3 +1171,34 @@ func TestKnownAgentSessionIDs_ResetAllSessionsBug(t *testing.T) {
 	}
 }
 
+// TestSession_ForceUnlock covers the /stop path release (#1830): a held lock
+// is released unconditionally, the generation is bumped so the interrupted
+// turn's late Unlock is dropped, and ForceUnlock on an unlocked session is a
+// no-op.
+func TestSession_ForceUnlock(t *testing.T) {
+	s := &Session{}
+	gen, ok := s.TryLock()
+	if !ok {
+		t.Fatal("TryLock should succeed")
+	}
+	if !s.ForceUnlock() {
+		t.Fatal("ForceUnlock on a held lock should report release")
+	}
+	if s.Busy() {
+		t.Fatal("busy must be false after ForceUnlock")
+	}
+	s.Unlock(gen) // late unlock from the interrupted turn
+	if s.Busy() {
+		t.Fatal("late unlock after ForceUnlock must not re-clear or re-hold")
+	}
+	gen2, ok := s.TryLock()
+	if !ok || gen2 == gen {
+		t.Fatal("next TryLock must succeed with a new generation")
+	}
+	if s.ForceUnlock() != true {
+		t.Fatal("second ForceUnlock on held lock should release")
+	}
+	if s.ForceUnlock() {
+		t.Fatal("ForceUnlock on an unlocked session must be a no-op (false)")
+	}
+}

--- a/core/webhook.go
+++ b/core/webhook.go
@@ -242,7 +242,8 @@ func (ws *WebhookServer) executePrompt(engine *Engine, sessionKey, prompt string
 	}
 
 	session := engine.sessions.GetOrCreateActive(sessionKey)
-	if !session.TryLock() {
+	lockGen, locked := session.TryLock()
+	if !locked {
 		slog.Warn("webhook: session busy, queued prompt dropped", "event", event, "session_key", sessionKey)
 		if !silent {
 			engine.send(targetPlatform, replyCtx, fmt.Sprintf("🪝 ⚠️ session busy, skipped: %s", event))
@@ -250,7 +251,7 @@ func (ws *WebhookServer) executePrompt(engine *Engine, sessionKey, prompt string
 		return
 	}
 
-	engine.processInteractiveMessage(targetPlatform, msg, session)
+	engine.processInteractiveMessage(targetPlatform, msg, session, lockGen)
 	slog.Info("webhook: prompt executed", "event", event, "session_key", sessionKey)
 }
 


### PR DESCRIPTION
> **Disclosure**: I'm an AI coding agent (Claude Code) working on behalf of @Enominera, who reviewed and approved submitting this. The code was dual-model reviewed and production-tested on our deployment, but please treat everything as a contribution to review on its own merits — 仅供参考.

Fixes #1829 (also #1830; #1832 is addressed by reordering in `maybeAutoResetSessionOnIdle` which I can add to this PR or a follow-up — see question at the end).

## Summary

`Session.busy` is a bare bool; `Unlock` is not deferred and is scattered across ~8 call sites, so any early return or panic between `TryLock` and one of those sites leaks the flag permanently — every subsequent message queues forever until a daemon restart (the long-standing #1091, and our four incidents in four days: result-delivered-but-never-consumed wedges, dead-agent leaks, and /stop leaving the flag held).

## Approach

1. **Generation counter** (`core/session.go`): `TryLock() (gen, ok)`; `Unlock(gen)` / `UnlockWithoutUpdate(gen)` validate the generation. A stale gen (lock was broken and re-acquired by a newer turn) is silently dropped, so a late Unlock from an interrupted turn can never clear the next turn's flag. `BreakStaleLock(maxHeld)` breaks a lock held past a threshold and bumps the generation. `ForceUnlock()` releases unconditionally for teardown paths.
2. **Turn pipeline** (`core/engine.go`): keeps the existing deferred unlock fallback (which covers panics — the defer runs during unwinding) and threads the captured gen through every explicit Unlock site, so the scatter no longer matters: any path that misses an explicit Unlock is caught by the deferred fallback, and any late Unlock after a break is generation-checked.
3. **Stale-break self-heal** (dispatch): when a message arrives, the session is busy, the agent process is **dead**, and the lock has been held past `busy_timeout` — dump all goroutine stacks to a temp file, break the lock, notify the user, and process the message in a fresh turn instead of queueing it behind a dead one. The dead-process gate means a live agent's legitimate 4h turn is never touched.
4. **Stop-path release** (#1830): `/stop` (both the kill path and the ACP `CancelTurn` path) now releases the busy lock after teardown via `ForceUnlock()`, with the generation bump dropping any late Unlock from the interrupted turn.
5. **Config**: top-level `busy_timeout_mins` (default 2, 0 disables). The default is deliberately above the 120s stop-hook wait cap so a graceful stop can never collide with the breaker.

## Acceptance criteria

| # | Behavior | How verified |
|---|----------|--------------|
| 1 | Generation validation: late `Unlock(staleGen)` after `BreakStaleLock` is dropped; the new holder's busy survives | `TestSession_LateUnlockDropped` |
| 2 | `BreakStaleLock` threshold: held shorter than threshold never breaks; longer breaks; unlocked session is a no-op | `TestSession_BreakStaleLockThreshold` |
| 3 | `ForceUnlock`: releases held lock, bumps gen (late unlock dropped), no-op when unlocked | `TestSession_ForceUnlock` |
| 4 | Panic recovery: a panic between TryLock and the explicit Unlock sites is caught by the deferred fallback, lock released | Existing deferred fallback in `processInteractiveMessageWith` (gen-carrying); covered by the existing defer tests |
| 5 | Stop release: `/stop` on a wedged session releases busy; next message starts a fresh turn (was: queue forever) | `stopInteractiveSessionWithOptions` both paths call `ForceUnlock`; production-verified (our incident #1830 repro) |
| 6 | Stale break: dead agent + lock held past `busy_timeout` → next message breaks it, dumps stacks, processes the message | Production-verified on our deployment (dead-agent incident recovered automatically) |
| 7 | busy_timeout_mins wiring: 0 disables, N minutes sets threshold | `config` parse + `SetStaleLockBreakAfter` |

## Testing

- `go test ./core/ ./config/ ./cmd/cc-connect` green (note: `TestCUJ_A3/A5_*` have a pre-existing TempDir-cleanup flake on stock `main` too — reproduced on a pristine checkout before this change).
- The self-heal and stop-release paths have been running in production on our deployment since 2026-09-12: a dead-agent busy leak and a result-wedge were both auto-recovered in live traffic.

## Out of scope / follow-ups

- The **wedge detector** for "result delivered but never consumed with a live agent" — per the #1831 discussion this is a follow-up; note that our goroutine dump from a live wedge traced it to the usage-probe PTY reader (see my comment on #1831), not a platform send.
- Per-call platform send deadlines (defense in depth).
- The `maybeAutoResetSessionOnIdle` unlocked-turn race (#1832): I have a small reorder fix (lock the replacement session *before* releasing the old one) — happy to fold it into this PR if you prefer, or send separately. Tell me which.
